### PR TITLE
Add config for multi-node FSDP+DDP

### DIFF
--- a/config/distributed_multinode.yaml
+++ b/config/distributed_multinode.yaml
@@ -1,0 +1,97 @@
+logging:
+  level: INFO
+training:
+  epochs: 1
+  batch_size: 448
+  gradient_accumulation: 4
+  mixed_precision: bf16
+  max_steps: 2000
+  grad_clip_norm: 1.0
+  output_dir: artifacts/optuna_tracelens_sweep_fixed/trial_0000
+  log_interval: 20
+  additional_compute_streams: 4
+  lightweight_op_waves: 4
+optimizer:
+  lr: 0.0002
+  weight_decay: 0.01
+  betas:
+  - 0.9
+  - 0.985
+scheduler:
+  warmup_steps: 200
+  total_steps: 2200
+dataset:
+  num_samples: 200000
+  sequence_length: 176
+  dense_dim: 256
+  sparse_features: 48
+  vocab_size: 350000
+  num_dense_features: 32
+  seed: 2025
+model:
+  vocab_size: 350000
+  embedding_dim: 256
+  num_dense_features: 32
+  dense_dim: 256
+  model_dim: 1536
+  num_heads: 32
+  num_layers: 48
+  dropout: 0.1
+  mlp_hidden_dim: 4608
+fsdp:
+  sharding_strategy: hybrid_shard
+  backward_prefetch: BACKWARD_PRE
+  use_orig_params: true
+  limit_all_gathers: false
+  forward_prefetch: true
+  sync_module_states: true
+  param_init_device: meta
+distributed:
+  backend: nccl
+  mode: fsdp
+  bucket_cap_mb: 8
+  gradient_as_bucket_view: true
+  static_graph: true
+  find_unused_parameters: false
+compile:
+  enabled: true
+  backend: inductor
+  mode: max-autotune
+  fullgraph: false
+  dynamic: false
+streams:
+  num_streams: 8
+  high_priority:
+  - allreduce
+  - reducescatter
+  stream_assignments:
+    compute:
+    - dev6_stream3
+    - dev6_stream9
+    - dev6_stream25
+    communication:
+    - dev6_stream13
+    - dev6_stream17
+    - dev6_stream26
+    reducescatter:
+    - dev6_stream22
+    aux:
+    - dev6_stream0
+dataloader:
+  num_workers: 8
+  pin_memory: true
+profiling:
+  enabled: true
+  wait: 5
+  warmup: 5 
+  active: 1
+  repeat: 1
+  record_shapes: false
+  profile_memory: false
+  with_stack: false
+  with_flops: false
+  tensorboard: false
+  chrome_trace: true
+  trace_filename: customer_trace.json
+tracelens:
+  enabled: true

--- a/config/multi_node/distributed_multinode.yaml
+++ b/config/multi_node/distributed_multinode.yaml
@@ -83,7 +83,7 @@ dataloader:
 profiling:
   enabled: true
   wait: 5
-  warmup: 5 
+  warmup: 5
   active: 1
   repeat: 1
   record_shapes: false


### PR DESCRIPTION
## Motivation

Adds a config for multi-node comms-compute overlap runs that uses both FSDP and DDP

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
