### PR TITLE
fix docker compose command

### DIFF
--- a/scripts/gemm_analysis/README.md
+++ b/scripts/gemm_analysis/README.md
@@ -15,8 +15,8 @@ Analyze GEMM kernel performance across multiple NCCL configurations.
 
 ```bash
 cd /home/oyazdanb/aorta/docker
-docker-compose -f docker-compose.rocm70.yaml build
-docker-compose -f docker-compose.rocm70.yaml up -d
+docker compose -f docker-compose.rocm70.yaml build
+docker compose -f docker-compose.rocm70.yaml up -d
 docker exec -it training-overlap-bugs-rocm70 bash
 ```
 


### PR DESCRIPTION
## Motivation

docker-compose command fails with following error:
```
> docker-compose -f docker-compose.rocm70.yaml build -p vivekag
Command 'docker-compose' not found, but can be installed with:
snap install docker          # version 28.4.0, or
apt  install docker-compose  # version 1.29.2-1
See 'snap info docker' for additional versions.
```

## Technical Details

Once docker-compose is installed using following command, `docker compose` command is available:
```
mkdir -p ~/.docker/cli-plugins/
sudo curl -L "https://github.com/docker/compose/releases/download/v2.40.3/docker-compose-$(uname -s)-$(uname -m)"  -o ~/.docker/cli-plugins/docker-compose
sudo chmod +x ~/.docker/cli-plugins/docker-compose
```

