### PR TITLE
[Docker] Install TraceLens during docker build

### DIFF
--- a/docker/Dockerfile.rocm70_9-1
+++ b/docker/Dockerfile.rocm70_9-1
@@ -27,6 +27,9 @@ RUN yum update -y --skip-broken \
     hip-runtime-amd \
     rocm-core || echo "Updated available ROCm packages"
 
+RUN python3.10 -m pip install git+https://github.com/AMD-AGI/TraceLens.git
+RUN python3.10 -m pip install openpyxl
+
 # Update environment variables to ensure new ROCm is used
 ENV ROCM_HOME=/opt/rocm
 ENV PATH=$ROCM_HOME/bin:$PATH


### PR DESCRIPTION
Installs `TraceLens` as part of the docker build process so that scripts depending on it do not require a manual installation to run.