### PR TITLE
 Integrate hw_queue_eval GPU hardware queue evaluation framework as aorta subpackage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 build/
 dist/
 download/
-egg-info/
+*.egg-info/
 .eggs/
 *.egg
 MANIFEST

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,116 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aorta"
+version = "0.2.0"
+description = "PyTorch compute-communication overlap debugging toolkit with GPU hardware queue evaluation"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.12"
+authors = [
+    {name = "AMD ROCm Team"}
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: System :: Hardware",
+]
+keywords = ["gpu", "rocm", "amd", "pytorch", "cuda", "benchmark", "fsdp", "distributed-training", "hardware-queue"]
+
+# Base dependencies (original aorta)
+dependencies = [
+    "torch>=2.0.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+# For analysis/visualization scripts
+analysis = [
+    "matplotlib>=3.7.0",
+]
+
+# For hw_queue_eval subpackage
+hw-queue = [
+    "click>=8.0.0",
+    "numpy>=1.20.0",
+    "pandas>=1.3.0",
+    "tabulate>=0.9.0",
+]
+
+# For hw_queue_eval profiling features
+hw-queue-profiling = [
+    "aorta[hw-queue]",
+    "matplotlib>=3.5.0",
+    "seaborn>=0.12.0",
+]
+
+# Development dependencies
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+    "pytest-timeout>=2.1.0",
+    "pytest-xdist>=3.3.0",
+    "pre-commit>=3.0.0",
+    "black>=23.0.0",
+    "isort>=5.12.0",
+    "mypy>=1.0.0",
+    "ruff>=0.1.0",
+]
+
+# Full installation
+all = [
+    "aorta[analysis]",
+    "aorta[hw-queue]",
+    "aorta[hw-queue-profiling]",
+    "aorta[dev]",
+]
+
+[project.urls]
+Homepage = "https://github.com/ROCm/aorta"
+Documentation = "https://github.com/ROCm/aorta#readme"
+Repository = "https://github.com/ROCm/aorta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["aorta*"]
+
+[tool.setuptools.package-data]
+aorta = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = "-v --tb=short"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "gpu: marks tests that require GPU",
+    "rocm: marks tests that require ROCm specifically",
+    "hw_queue: marks hw_queue_eval tests",
+]
+
+[tool.black]
+line-length = 100
+target-version = ['py312']
+include = '\.pyi?$'
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "W", "I", "N", "UP", "B", "C4"]
+ignore = ["E501"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,3 +20,6 @@ markers =
     integration: Integration tests for full workflows
     slow: Tests that take a long time to run
     gemm: Tests for GEMM analysis pipeline
+    hw_queue: Tests for hw_queue_eval subpackage
+    gpu: Tests that require GPU hardware
+    rocm: Tests that require ROCm specifically

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,25 @@
 # Dependencies for local analysis and processing scripts
 # (Training dependencies are managed in Docker - see docker/Dockerfile.*)
 # Install with: pip install -r requirements.txt
+#
+# For full installation including hw_queue_eval:
+#   pip install -e ".[hw-queue]"
+#
+# For development:
+#   pip install -e ".[all]"
+
+# Base dependencies
+torch>=2.0.0
+pyyaml>=6.0
 
 # For analysis scripts
-pyyaml>=6.0
 matplotlib>=3.7.0
+
+# For hw_queue_eval (optional - install with: pip install -e ".[hw-queue]")
+# click>=8.0.0
+# numpy>=1.20.0
+# pandas>=1.3.0
+# tabulate>=0.9.0
 
 # For trace processing (merge_gpu_trace_ranks.py, etc.)
 # No additional deps - uses only Python standard library (json, argparse, pathlib)

--- a/scripts/hw_queue/compare_baselines.py
+++ b/scripts/hw_queue/compare_baselines.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+Compare baseline and test results for regression detection.
+
+Usage:
+    python compare_baselines.py baseline.json test.json [--threshold 0.05]
+    python compare_baselines.py results_dir/ --compare-latest
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Any, Tuple
+
+
+def load_results(filepath: Path) -> Dict[str, Any]:
+    """Load results from JSON file."""
+    with open(filepath) as f:
+        return json.load(f)
+
+
+def compare_single_result(
+    baseline: Dict[str, Any],
+    test: Dict[str, Any],
+    threshold: float
+) -> Tuple[bool, List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """
+    Compare single baseline and test result.
+
+    Returns:
+        (has_regression, regressions_list, improvements_list)
+    """
+    regressions = []
+    improvements = []
+
+    # Compare throughput
+    baseline_tp = baseline.get("throughput", 0)
+    test_tp = test.get("throughput", 0)
+
+    if isinstance(baseline_tp, dict):
+        baseline_tp = baseline_tp.get("value", 0)
+    if isinstance(test_tp, dict):
+        test_tp = test_tp.get("value", 0)
+
+    if baseline_tp > 0:
+        change = (test_tp - baseline_tp) / baseline_tp
+        if change < -threshold:
+            regressions.append({
+                "metric": "throughput",
+                "baseline": baseline_tp,
+                "test": test_tp,
+                "change_pct": change * 100
+            })
+        elif change > threshold:
+            improvements.append({
+                "metric": "throughput",
+                "baseline": baseline_tp,
+                "test": test_tp,
+                "change_pct": change * 100
+            })
+
+    # Compare latencies
+    for metric in ["p50", "p95", "p99"]:
+        baseline_lat = baseline.get("latency_ms", {}).get(metric,
+                       baseline.get("latency", {}).get(f"{metric}_ms", 0))
+        test_lat = test.get("latency_ms", {}).get(metric,
+                   test.get("latency", {}).get(f"{metric}_ms", 0))
+
+        if baseline_lat > 0:
+            change = (test_lat - baseline_lat) / baseline_lat
+            if change > threshold:  # Higher latency is regression
+                regressions.append({
+                    "metric": f"latency_{metric}",
+                    "baseline": baseline_lat,
+                    "test": test_lat,
+                    "change_pct": change * 100
+                })
+            elif change < -threshold:  # Lower latency is improvement
+                improvements.append({
+                    "metric": f"latency_{metric}",
+                    "baseline": baseline_lat,
+                    "test": test_lat,
+                    "change_pct": change * 100
+                })
+
+    return len(regressions) > 0, regressions, improvements
+
+
+def compare_sweep_results(
+    baseline_data: Dict[str, Any],
+    test_data: Dict[str, Any],
+    threshold: float
+) -> Dict[str, Any]:
+    """Compare sweep results (multiple stream counts)."""
+
+    baseline_results = baseline_data.get("results", [baseline_data])
+    test_results = test_data.get("results", [test_data])
+
+    all_regressions = []
+    all_improvements = []
+
+    for baseline, test in zip(baseline_results, test_results):
+        stream_count = baseline.get("stream_count", "unknown")
+        has_reg, regs, imps = compare_single_result(baseline, test, threshold)
+
+        for r in regs:
+            r["stream_count"] = stream_count
+            all_regressions.append(r)
+
+        for i in imps:
+            i["stream_count"] = stream_count
+            all_improvements.append(i)
+
+    return {
+        "has_regressions": len(all_regressions) > 0,
+        "regressions": all_regressions,
+        "improvements": all_improvements,
+        "baseline_file": str(baseline_data.get("_source_file", "unknown")),
+        "test_file": str(test_data.get("_source_file", "unknown")),
+    }
+
+
+def find_latest_results(results_dir: Path, workload: str = None) -> List[Path]:
+    """Find the latest result files in a directory."""
+    pattern = f"{workload}_*.json" if workload else "*.json"
+    files = sorted(results_dir.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+    return files
+
+
+def print_comparison(comparison: Dict[str, Any]) -> None:
+    """Print comparison results."""
+    print("\n" + "=" * 60)
+    print("COMPARISON RESULTS")
+    print("=" * 60)
+
+    if comparison["regressions"]:
+        print("\n🔴 REGRESSIONS DETECTED:")
+        for reg in comparison["regressions"]:
+            sc = reg.get("stream_count", "")
+            sc_str = f" (streams={sc})" if sc else ""
+            print(f"  - {reg['metric']}{sc_str}: {reg['baseline']:.3f} -> {reg['test']:.3f} ({reg['change_pct']:+.1f}%)")
+
+    if comparison["improvements"]:
+        print("\n🟢 Improvements:")
+        for imp in comparison["improvements"]:
+            sc = imp.get("stream_count", "")
+            sc_str = f" (streams={sc})" if sc else ""
+            print(f"  + {imp['metric']}{sc_str}: {imp['baseline']:.3f} -> {imp['test']:.3f} ({imp['change_pct']:+.1f}%)")
+
+    if not comparison["regressions"] and not comparison["improvements"]:
+        print("\n✓ No significant changes detected")
+
+    print()
+
+    if comparison["has_regressions"]:
+        print("RESULT: ❌ REGRESSIONS FOUND")
+    else:
+        print("RESULT: ✓ No regressions")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare baseline and test results for regressions"
+    )
+    parser.add_argument("baseline", help="Baseline results JSON file or directory")
+    parser.add_argument("test", nargs="?", help="Test results JSON file")
+    parser.add_argument("--threshold", type=float, default=0.05,
+                       help="Regression threshold (default: 0.05 = 5%%)")
+    parser.add_argument("--compare-latest", action="store_true",
+                       help="Compare two latest files in directory")
+    parser.add_argument("--workload", default=None,
+                       help="Filter by workload name")
+    parser.add_argument("--json", action="store_true",
+                       help="Output as JSON")
+
+    args = parser.parse_args()
+
+    baseline_path = Path(args.baseline)
+
+    if args.compare_latest or baseline_path.is_dir():
+        # Find latest files in directory
+        if not baseline_path.is_dir():
+            print(f"Error: {baseline_path} is not a directory", file=sys.stderr)
+            sys.exit(1)
+
+        files = find_latest_results(baseline_path, args.workload)
+        if len(files) < 2:
+            print("Error: Need at least 2 result files to compare", file=sys.stderr)
+            sys.exit(1)
+
+        test_file = files[0]
+        baseline_file = files[1]
+        print(f"Comparing: {baseline_file.name} (baseline) vs {test_file.name} (test)")
+    else:
+        if not args.test:
+            print("Error: Need both baseline and test files", file=sys.stderr)
+            sys.exit(1)
+
+        baseline_file = baseline_path
+        test_file = Path(args.test)
+
+    # Load and compare
+    baseline_data = load_results(baseline_file)
+    baseline_data["_source_file"] = str(baseline_file)
+
+    test_data = load_results(test_file)
+    test_data["_source_file"] = str(test_file)
+
+    comparison = compare_sweep_results(baseline_data, test_data, args.threshold)
+
+    if args.json:
+        print(json.dumps(comparison, indent=2))
+    else:
+        print_comparison(comparison)
+
+    # Exit with error code if regressions found
+    sys.exit(1 if comparison["has_regressions"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hw_queue/profile_queues.sh
+++ b/scripts/hw_queue/profile_queues.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Profile hardware queue usage with ROCm tools
+#
+# Usage:
+#   ./profile_queues.sh [workload] [stream_count] [output_dir]
+#
+# Examples:
+#   ./profile_queues.sh hetero_kernels 8 traces/
+#   ./profile_queues.sh moe 16 traces/moe/
+#
+# Environment variables:
+#   AMD_LOG_LEVEL: Set to 4 for detailed queue logging
+#   GPU_MAX_HW_QUEUES: Override max hardware queues
+
+set -e
+
+WORKLOAD="${1:-hetero_kernels}"
+STREAM_COUNT="${2:-8}"
+OUTPUT_DIR="${3:-traces}"
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Get timestamp
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+OUTPUT_PREFIX="${OUTPUT_DIR}/${WORKLOAD}_${STREAM_COUNT}s_${TIMESTAMP}"
+
+echo "=========================================="
+echo "Hardware Queue Profiling"
+echo "=========================================="
+echo "Workload:     $WORKLOAD"
+echo "Streams:      $STREAM_COUNT"
+echo "Output:       $OUTPUT_PREFIX.*"
+echo "=========================================="
+echo
+
+# Check if rocprof is available
+if ! command -v rocprof &> /dev/null; then
+    echo "Warning: rocprof not found. Creating standalone profiling script instead."
+
+    # Create standalone script
+    cat > "${OUTPUT_PREFIX}_profile.py" << 'SCRIPT'
+#!/usr/bin/env python3
+"""Auto-generated profiling script."""
+
+import sys
+sys.path.insert(0, '.')
+
+from aorta.hw_queue_eval.workloads.registry import get_workload
+from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+def main():
+    workload_name = "${WORKLOAD}"
+    stream_count = ${STREAM_COUNT}
+
+    workload = get_workload(workload_name)
+    config = HarnessConfig(
+        stream_count=stream_count,
+        warmup_iterations=5,
+        measurement_iterations=50,
+    )
+
+    harness = StreamHarness(config)
+    result = harness.run_workload(workload)
+
+    print(f"Throughput: {result.throughput:.2f} {result.throughput_unit}")
+    print(f"P99 Latency: {result.latency_ms['p99']:.3f} ms")
+
+if __name__ == "__main__":
+    main()
+SCRIPT
+
+    # Substitute variables
+    sed -i "s/\${WORKLOAD}/${WORKLOAD}/g" "${OUTPUT_PREFIX}_profile.py"
+    sed -i "s/\${STREAM_COUNT}/${STREAM_COUNT}/g" "${OUTPUT_PREFIX}_profile.py"
+    chmod +x "${OUTPUT_PREFIX}_profile.py"
+
+    echo "Created: ${OUTPUT_PREFIX}_profile.py"
+    echo
+    echo "Run with rocprof:"
+    echo "  rocprof --hip-trace -o ${OUTPUT_PREFIX}.csv python ${OUTPUT_PREFIX}_profile.py"
+    exit 0
+fi
+
+# Set ROCm environment for better tracing
+export AMD_LOG_LEVEL=4
+export HSA_TOOLS_LIB=""
+
+# Run with rocprof
+echo "Running profiler..."
+rocprof --hip-trace -o "${OUTPUT_PREFIX}.csv" \
+    python -m aorta.hw_queue_eval run "$WORKLOAD" \
+        --streams "$STREAM_COUNT" \
+        --iterations 50 \
+        --warmup 5
+
+echo
+echo "Profiling complete!"
+echo "Output files:"
+echo "  CSV:  ${OUTPUT_PREFIX}.csv"
+
+# Generate timeline if possible
+if command -v python3 &> /dev/null; then
+    echo
+    echo "Generating timeline..."
+    python3 -c "
+from aorta.hw_queue_eval.core.profiler import ROCmProfiler
+from pathlib import Path
+
+profiler = ROCmProfiler('${OUTPUT_DIR}')
+trace_file = Path('${OUTPUT_PREFIX}.csv')
+
+if trace_file.exists():
+    queue_info = profiler.parse_queue_info(trace_file)
+    print(f'  Queues used: {queue_info.num_queues}')
+    print(f'  Kernels per queue: {queue_info.kernels_per_queue}')
+
+    timeline = profiler.generate_timeline(trace_file)
+    print(f'  Timeline: {timeline}')
+" 2>/dev/null || echo "  (Timeline generation skipped)"
+fi

--- a/scripts/hw_queue/run_sweep.sh
+++ b/scripts/hw_queue/run_sweep.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Run stream count sweep for hardware queue evaluation
+#
+# Usage:
+#   ./run_sweep.sh [workload] [stream_counts] [output_dir]
+#
+# Examples:
+#   ./run_sweep.sh hetero_kernels "1,2,4,8,16,32" results/
+#   ./run_sweep.sh moe "4,8,16" results/moe/
+
+set -e
+
+WORKLOAD="${1:-hetero_kernels}"
+STREAM_COUNTS="${2:-1,2,4,8,16,32}"
+OUTPUT_DIR="${3:-results}"
+ITERATIONS="${ITERATIONS:-100}"
+WARMUP="${WARMUP:-10}"
+DEVICE="${DEVICE:-cuda:0}"
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Get timestamp for output file
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+OUTPUT_FILE="${OUTPUT_DIR}/${WORKLOAD}_sweep_${TIMESTAMP}.json"
+
+echo "=========================================="
+echo "Hardware Queue Evaluation - Stream Sweep"
+echo "=========================================="
+echo "Workload:      $WORKLOAD"
+echo "Stream counts: $STREAM_COUNTS"
+echo "Iterations:    $ITERATIONS (warmup: $WARMUP)"
+echo "Device:        $DEVICE"
+echo "Output:        $OUTPUT_FILE"
+echo "=========================================="
+echo
+
+# Run sweep
+python -m aorta.hw_queue_eval sweep "$WORKLOAD" \
+    --streams "$STREAM_COUNTS" \
+    --iterations "$ITERATIONS" \
+    --warmup "$WARMUP" \
+    --device "$DEVICE" \
+    --output "$OUTPUT_FILE"
+
+echo
+echo "Results saved to: $OUTPUT_FILE"

--- a/src/aorta/__init__.py
+++ b/src/aorta/__init__.py
@@ -1,4 +1,11 @@
-"""AORTA: PyTorch compute-communication overlap debugging toolkit."""
+"""AORTA: PyTorch compute-communication overlap debugging toolkit.
+
+This package provides:
+- FSDP2 training benchmarks for overlap debugging
+- GPU hardware queue evaluation framework (hw_queue_eval subpackage)
+"""
+
+__version__ = "0.2.0"
 
 from importlib import import_module
 from typing import Any
@@ -6,9 +13,13 @@ from typing import Any
 
 def load_training_entrypoint() -> Any:
     """Lazily import and return the default training entry point."""
-
     module = import_module("aorta.training.fsdp_trainer")
     return getattr(module, "main")
 
 
-__all__ = ["load_training_entrypoint"]
+def load_hw_queue_eval():
+    """Lazily import the hw_queue_eval subpackage."""
+    return import_module("aorta.hw_queue_eval")
+
+
+__all__ = ["load_training_entrypoint", "load_hw_queue_eval", "__version__"]

--- a/src/aorta/hw_queue_eval/__init__.py
+++ b/src/aorta/hw_queue_eval/__init__.py
@@ -1,0 +1,24 @@
+"""
+GPU Hardware Queue Concurrency Evaluation Framework
+
+A comprehensive framework for stress-testing AMD GPU hardware queue mapping
+with workloads requiring >4 concurrent hardware queues.
+"""
+
+__version__ = "0.1.0"
+__author__ = "AMD ROCm Team"
+
+from aorta.hw_queue_eval.core.harness import HarnessConfig, HarnessResult, StreamHarness
+from aorta.hw_queue_eval.core.metrics import LatencyMetrics, MetricsCollector, SwitchLatencyMetrics
+from aorta.hw_queue_eval.workloads.base import BaseWorkload
+
+__all__ = [
+    "HarnessConfig",
+    "HarnessResult",
+    "StreamHarness",
+    "LatencyMetrics",
+    "MetricsCollector",
+    "SwitchLatencyMetrics",
+    "BaseWorkload",
+    "__version__",
+]

--- a/src/aorta/hw_queue_eval/__main__.py
+++ b/src/aorta/hw_queue_eval/__main__.py
@@ -1,0 +1,11 @@
+"""
+Entry point for running hw_queue_eval as a module.
+
+Usage:
+    python -m aorta.hw_queue_eval [command] [options]
+"""
+
+from aorta.hw_queue_eval.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/aorta/hw_queue_eval/cli.py
+++ b/src/aorta/hw_queue_eval/cli.py
@@ -1,0 +1,780 @@
+"""
+Command-line interface for the hardware queue evaluation framework.
+
+Example usage:
+    # Run single workload with specific stream count
+    python -m aorta.hw_queue_eval run hetero_kernels --streams 8
+
+    # Run with PyTorch profiler (generates Chrome trace and TensorBoard logs)
+    python -m aorta.hw_queue_eval run hetero_kernels --streams 8 --profile
+    python -m aorta.hw_queue_eval run moe --streams 16 --profile --profile-dir traces/
+
+    # Run stream count sweep
+    python -m aorta.hw_queue_eval sweep hetero_kernels --streams 1,2,4,8,16,32
+
+    # Run all P0 workloads
+    python -m aorta.hw_queue_eval run-priority P0
+
+    # Compare baseline vs modified runtime
+    python -m aorta.hw_queue_eval compare --baseline results_baseline.json --test results_modified.json
+
+    # Profile with rocprof (ROCm-specific)
+    python -m aorta.hw_queue_eval profile hetero_kernels --streams 8 --output traces/
+
+    # List available workloads
+    python -m aorta.hw_queue_eval list
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import click
+
+from aorta.hw_queue_eval import __version__
+
+
+# Priority classifications for workloads
+PRIORITY_WORKLOADS = {
+    "P0": [  # Most critical - implement and test first
+        "hetero_kernels",
+        "tiny_kernel_stress",
+        "large_gemm_only",
+    ],
+    "P1": [  # High priority - important real-world patterns
+        "fsdp_tp",
+        "moe",
+        "speculative_decode",
+        "continuous_batch",
+    ],
+    "P2": [  # Medium priority - additional coverage
+        "activation_ckpt",
+        "grad_accum",
+        "rag_pipeline",
+        "graph_subgraphs",
+    ],
+    "P3": [  # Lower priority - nice to have
+        "async_dataload",
+        "zero_offload",
+        "torch_compile",
+    ],
+}
+
+
+def get_workload_instance(name: str, **kwargs):
+    """Get a workload instance by name."""
+    from aorta.hw_queue_eval.workloads.registry import get_workload
+    return get_workload(name, **kwargs)
+
+
+def list_available_workloads():
+    """List all available workloads."""
+    from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+    try:
+        from aorta.hw_queue_eval.workloads import distributed, inference, latency_sensitive, pipeline
+    except ImportError:
+        pass
+
+    return WorkloadRegistry.list_all()
+
+
+@click.group()
+@click.version_option(version=__version__)
+def cli():
+    """Hardware Queue Evaluation Framework for AMD ROCm.
+
+    Stress-test GPU hardware queue mapping with workloads
+    requiring high concurrent stream counts.
+    """
+    pass
+
+
+@cli.command()
+@click.argument("workload")
+@click.option("--streams", "-s", default=4, help="Number of streams")
+@click.option("--iterations", "-i", default=100, help="Measurement iterations")
+@click.option("--warmup", "-w", default=10, help="Warmup iterations")
+@click.option("--output", "-o", default=None, help="Output JSON file")
+@click.option("--device", "-d", default="cuda:0", help="Target device")
+@click.option("--sync-mode", type=click.Choice(["per_iteration", "end_only", "none"]),
+              default="per_iteration", help="Synchronization mode")
+@click.option("--quiet", "-q", is_flag=True, help="Minimal output")
+@click.option("--profile", "-p", is_flag=True, help="Enable PyTorch profiler (generates Chrome trace and TensorBoard logs)")
+@click.option("--profile-dir", default="profiles", help="Output directory for profiler traces")
+def run(workload: str, streams: int, iterations: int, warmup: int,
+        output: Optional[str], device: str, sync_mode: str, quiet: bool,
+        profile: bool, profile_dir: str):
+    """Run a single workload evaluation.
+
+    WORKLOAD: Name of the workload to run (e.g., hetero_kernels, fsdp_tp)
+    """
+    from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+    from aorta.hw_queue_eval.core.torch_profiler import TorchProfilerWrapper, generate_profile_summary
+    from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+    try:
+        # Get workload
+        wl = get_workload_instance(workload)
+        info = WorkloadRegistry.get_info(workload)
+
+        # Check stream count compatibility
+        if not wl.supports_stream_count(streams):
+            click.echo(
+                f"Error: Workload {workload} supports {wl.min_streams}-{wl.max_streams} streams",
+                err=True
+            )
+            sys.exit(1)
+
+        # Print header with workload info
+        click.echo("=" * 70)
+        click.echo("GPU HARDWARE QUEUE EVALUATION")
+        click.echo("=" * 70)
+        click.echo()
+        click.echo(f"WORKLOAD: {workload}")
+        click.echo(f"  {info.description}")
+        click.echo()
+        click.echo("PURPOSE:")
+        _print_workload_purpose(workload, info)
+        click.echo()
+        click.echo("TEST CONFIGURATION:")
+        click.echo(f"  Concurrent streams:     {streams} (recommended: {info.recommended_streams})")
+        click.echo(f"  Measurement iterations: {iterations}")
+        click.echo(f"  Warmup iterations:      {warmup}")
+        click.echo(f"  Device:                 {device}")
+        click.echo(f"  Switch sensitivity:     {info.switch_latency_sensitivity}")
+        click.echo()
+        click.echo("-" * 70)
+        click.echo("Running workload...")
+        if profile:
+            click.echo("  (Profiling enabled - will generate Chrome trace and TensorBoard logs)")
+        click.echo()
+
+        # Create harness
+        config = HarnessConfig(
+            stream_count=streams,
+            warmup_iterations=warmup,
+            measurement_iterations=iterations,
+            sync_mode=sync_mode,
+            device=device,
+        )
+        harness = StreamHarness(config)
+
+        # Run workload (with optional profiling)
+        profile_result = None
+        if profile:
+            import torch
+            from aorta.utils import create_streams
+
+            # Setup profiler
+            profiler_wrapper = TorchProfilerWrapper(output_dir=profile_dir)
+
+            # Setup workload and streams
+            wl.setup(streams, device)
+            cuda_streams = create_streams(streams, device)
+
+            # Profile the workload
+            def run_iteration():
+                wl.run_iteration(cuda_streams)
+                torch.cuda.synchronize()
+
+            profile_result = profiler_wrapper.profile_workload(
+                run_iteration,
+                name=f"{workload}_{streams}s",
+                iterations=iterations,
+                warmup=warmup,
+            )
+
+        # Run regular benchmark (always, for metrics)
+        result = harness.run_workload(wl)
+
+        # Print results with interpretation
+        click.echo("-" * 70)
+        click.echo("RESULTS")
+        click.echo("-" * 70)
+        click.echo()
+
+        click.echo("THROUGHPUT:")
+        click.echo(f"  {result.throughput:,.2f} {result.throughput_unit}")
+        click.echo(f"  (Higher is better - measures how much work completed per second)")
+        click.echo()
+
+        click.echo("LATENCY (per iteration):")
+        click.echo(f"  Mean:  {result.latency_ms['mean']:.3f} ms")
+        click.echo(f"  P50:   {result.latency_ms['p50']:.3f} ms  (median - 50% of iterations faster than this)")
+        click.echo(f"  P95:   {result.latency_ms['p95']:.3f} ms  (95% of iterations faster than this)")
+        click.echo(f"  P99:   {result.latency_ms['p99']:.3f} ms  (99% of iterations faster than this)")
+        click.echo(f"  (Lower is better - time to complete one iteration across all {streams} streams)")
+        click.echo()
+
+        # Latency variance analysis
+        latency_ratio = result.latency_ms['p99'] / result.latency_ms['p50'] if result.latency_ms['p50'] > 0 else 1
+        if latency_ratio > 2.0:
+            click.echo(f"  WARNING: High latency variance (P99/P50 = {latency_ratio:.1f}x)")
+            click.echo(f"    This may indicate queue contention or scheduling issues")
+        elif latency_ratio > 1.5:
+            click.echo(f"  Note: Moderate latency variance (P99/P50 = {latency_ratio:.1f}x)")
+        click.echo()
+
+        click.echo("QUEUE SWITCH ANALYSIS:")
+        if result.switch_latency:
+            switch_overhead = result.switch_latency['estimated_switch_overhead_ms']
+            inter_gap = result.switch_latency['inter_stream_gap_ms']
+            intra_gap = result.switch_latency['intra_stream_gap_ms']
+
+            click.echo(f"  Inter-stream gap: {inter_gap:.3f} ms (avg gap between kernels on DIFFERENT streams)")
+            click.echo(f"  Intra-stream gap: {intra_gap:.3f} ms (avg gap between kernels on SAME stream)")
+            click.echo(f"  Est. switch overhead: {switch_overhead:.3f} ms")
+
+            if switch_overhead > 0.1:
+                click.echo(f"  Significant queue switch overhead detected")
+                click.echo(f"    This suggests hardware queue contention at {streams} streams")
+            elif switch_overhead > 0.01:
+                click.echo(f"  Moderate queue switch overhead")
+            else:
+                click.echo(f"  Minimal queue switch overhead")
+        else:
+            click.echo(f"  (Not enough data to estimate switch overhead)")
+        click.echo()
+
+        click.echo("TIMING:")
+        click.echo(f"  Total measurement time: {result.total_time_ms:.2f} ms ({result.total_time_ms/1000:.2f} sec)")
+        click.echo()
+
+        # Summary
+        click.echo("-" * 70)
+        click.echo("INTERPRETATION")
+        click.echo("-" * 70)
+        _print_interpretation(workload, info, result, streams)
+
+        # Print profile results if profiling was enabled
+        if profile and profile_result:
+            click.echo()
+            click.echo("-" * 70)
+            click.echo("PROFILER OUTPUT")
+            click.echo("-" * 70)
+            click.echo()
+            click.echo(generate_profile_summary(profile_result))
+
+        # Save to file if requested
+        if output:
+            result.to_json(output)
+            click.echo()
+            click.echo(f"Results saved to: {output}")
+
+        click.echo()
+        click.echo("=" * 70)
+        click.echo("To compare with different stream counts, run:")
+        click.echo(f"  python -m aorta.hw_queue_eval sweep {workload} --streams 1,2,4,8,16,32")
+        if profile:
+            click.echo()
+            click.echo("Profile traces saved to:")
+            if profile_result and profile_result.chrome_trace_path:
+                click.echo(f"  Chrome trace: {profile_result.chrome_trace_path}")
+                click.echo(f"    View: Open chrome://tracing and load the JSON file")
+            if profile_result and profile_result.tensorboard_dir:
+                click.echo(f"  TensorBoard: {profile_result.tensorboard_dir}")
+                click.echo(f"    View: tensorboard --logdir={profile_result.tensorboard_dir}")
+        click.echo("=" * 70)
+
+    except KeyError as e:
+        click.echo(f"Error: Workload not found: {e}", err=True)
+        click.echo(f"Available workloads: {', '.join(list_available_workloads())}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"Error running workload: {e}", err=True)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+def _print_workload_purpose(workload: str, info) -> None:
+    """Print workload-specific purpose description."""
+    purposes = {
+        "hetero_kernels": (
+            "  Tests queue switch latency by interleaving tiny kernels (~10us) with\n"
+            "  large GEMMs (~10ms). Poor queue mapping causes 'convoy effect' where\n"
+            "  tiny kernels wait behind large ones on shared queues."
+        ),
+        "tiny_kernel_stress": (
+            "  Stress test with ONLY tiny kernels. Makes queue switch overhead the\n"
+            "  dominant factor. If throughput doesn't scale with streams, it indicates\n"
+            "  queue scheduling bottlenecks."
+        ),
+        "large_gemm_only": (
+            "  Compute-bound baseline with large GEMMs only. Should scale well with\n"
+            "  streams. Use this to establish baseline GPU compute capability."
+        ),
+        "fsdp_tp": (
+            "  Simulates FSDP + Tensor Parallelism (3D parallelism) with overlapped\n"
+            "  communication and compute. Tests stream coordination for distributed\n"
+            "  training patterns."
+        ),
+        "moe": (
+            "  Mixture of Experts with parallel expert execution. Each expert runs\n"
+            "  on its own stream. Tests high stream count scalability (8-16+ streams)."
+        ),
+        "speculative_decode": (
+            "  Draft + verify speculative decoding pattern. Has tight latency\n"
+            "  requirements - switch overhead directly impacts tokens/sec."
+        ),
+        "continuous_batch": (
+            "  Overlapped prefill (compute-heavy) and decode (memory-bound) phases.\n"
+            "  Tests ability to run different workload types concurrently."
+        ),
+        "activation_ckpt": (
+            "  Activation checkpointing with recomputation streams. Tests overlap\n"
+            "  of forward recomputation with backward gradient computation."
+        ),
+        "grad_accum": (
+            "  Gradient accumulation with early reduction. Tests overlapping\n"
+            "  gradient computation with all-reduce communication."
+        ),
+        "rag_pipeline": (
+            "  Multi-model RAG pipeline: embedding -> retrieval -> reranking -> generation.\n"
+            "  Tests concurrent execution of different model types."
+        ),
+        "graph_subgraphs": (
+            "  Independent computation subgraphs with no dependencies. Tests maximum\n"
+            "  parallel execution capability when work is fully parallelizable."
+        ),
+        "async_dataload": (
+            "  Async data loading with GPU preprocessing overlap. Tests ability to\n"
+            "  hide H2D transfer latency with concurrent compute."
+        ),
+        "zero_offload": (
+            "  ZeRO-offload memory management. Tests overlap of CPU<->GPU transfers\n"
+            "  with computation for memory-constrained training."
+        ),
+        "torch_compile": (
+            "  Multi-region torch.compile execution. Tests interaction between\n"
+            "  compiled code and manual stream management."
+        ),
+    }
+    click.echo(purposes.get(workload, f"  Tests {info.category} patterns with {info.switch_latency_sensitivity} switch sensitivity."))
+
+
+def _print_interpretation(workload: str, info, result, streams: int) -> None:
+    """Print interpretation guidance based on results."""
+    click.echo()
+
+    # General guidance
+    click.echo(f"This workload has '{info.switch_latency_sensitivity}' sensitivity to queue switch latency.")
+    click.echo()
+
+    if info.switch_latency_sensitivity == "critical":
+        click.echo("For CRITICAL sensitivity workloads like this:")
+        click.echo("  - Throughput should ideally scale linearly with stream count")
+        click.echo("  - Latency variance (P99/P50) should stay below 1.5x")
+        click.echo("  - Switch overhead > 0.1ms indicates queue contention")
+        click.echo()
+        click.echo("If throughput plateaus or latency spikes at higher stream counts,")
+        click.echo("it suggests the hardware queue limit has been reached.")
+
+    elif info.switch_latency_sensitivity == "high":
+        click.echo("For HIGH sensitivity workloads:")
+        click.echo("  - Some throughput degradation at high stream counts is expected")
+        click.echo("  - Watch for latency variance > 2x (P99/P50)")
+        click.echo("  - Communication/compute overlap effectiveness is key")
+
+    else:
+        click.echo("For MEDIUM/LOW sensitivity workloads:")
+        click.echo("  - Focus on overall throughput rather than latency variance")
+        click.echo("  - These workloads are less affected by queue switch overhead")
+
+    click.echo()
+    click.echo("NEXT STEPS:")
+    click.echo(f"  1. Run a sweep to find the optimal stream count:")
+    click.echo(f"     python -m aorta.hw_queue_eval sweep {workload} -s 1,2,4,8,16,32")
+    click.echo(f"  2. Compare results before/after runtime changes:")
+    click.echo(f"     python -m aorta.hw_queue_eval compare -b baseline.json -t test.json")
+
+
+@cli.command()
+@click.argument("workload")
+@click.option("--streams", "-s", default="1,2,4,8,16,32",
+              help="Comma-separated stream counts to test")
+@click.option("--iterations", "-i", default=100, help="Measurement iterations per config")
+@click.option("--warmup", "-w", default=10, help="Warmup iterations")
+@click.option("--output", "-o", default=None, help="Output JSON file")
+@click.option("--device", "-d", default="cuda:0", help="Target device")
+def sweep(workload: str, streams: str, iterations: int, warmup: int,
+          output: Optional[str], device: str):
+    """Run workload across multiple stream counts.
+
+    WORKLOAD: Name of the workload to sweep
+    """
+    from aorta.hw_queue_eval.core.harness import (
+        HarnessConfig, StreamHarness, analyze_sweep_results,
+        format_results_table, save_sweep_results
+    )
+
+    # Parse stream counts
+    stream_counts = [int(s.strip()) for s in streams.split(",")]
+
+    click.echo(f"Sweeping workload: {workload}")
+    click.echo(f"  Stream counts: {stream_counts}")
+    click.echo()
+
+    try:
+        wl = get_workload_instance(workload)
+
+        # Filter stream counts by workload limits
+        valid_counts = [c for c in stream_counts if wl.supports_stream_count(c)]
+        if not valid_counts:
+            click.echo(f"Error: No valid stream counts for {workload}", err=True)
+            click.echo(f"Workload supports {wl.min_streams}-{wl.max_streams} streams", err=True)
+            sys.exit(1)
+
+        if len(valid_counts) < len(stream_counts):
+            click.echo(f"Note: Filtered to valid stream counts: {valid_counts}")
+
+        # Run sweep
+        results = []
+        for count in valid_counts:
+            click.echo(f"Running with {count} streams...", nl=False)
+
+            config = HarnessConfig(
+                stream_count=count,
+                warmup_iterations=warmup,
+                measurement_iterations=iterations,
+                device=device,
+            )
+            harness = StreamHarness(config)
+            result = harness.run_workload(wl)
+            results.append(result)
+
+            click.echo(f" {result.throughput:.2f} {result.throughput_unit}")
+
+        # Print summary table
+        click.echo()
+        click.echo("Summary:")
+        click.echo(format_results_table(results))
+
+        # Analyze scaling
+        analysis = analyze_sweep_results(results)
+        click.echo()
+        click.echo("Scaling Analysis:")
+        click.echo(f"  Peak throughput at: {analysis.peak_stream_count} streams")
+        if analysis.inflection_point:
+            click.echo(f"  Inflection point: {analysis.inflection_point} streams")
+
+        # Save results
+        if output:
+            save_sweep_results(results, output)
+            click.echo(f"\nResults saved to: {output}")
+
+    except KeyError as e:
+        click.echo(f"Error: Workload not found: {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+@cli.command("run-priority")
+@click.argument("priority", type=click.Choice(["P0", "P1", "P2", "P3", "all"]))
+@click.option("--streams", "-s", default="1,2,4,8,16",
+              help="Comma-separated stream counts to test")
+@click.option("--iterations", "-i", default=50, help="Measurement iterations")
+@click.option("--output-dir", "-o", default="results", help="Output directory")
+@click.option("--device", "-d", default="cuda:0", help="Target device")
+def run_priority(priority: str, streams: str, iterations: int,
+                 output_dir: str, device: str):
+    """Run all workloads of a given priority level.
+
+    PRIORITY: Priority level (P0, P1, P2, P3, or 'all')
+    """
+    from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness, save_sweep_results
+
+    # Get workloads for priority
+    if priority == "all":
+        workloads = []
+        for p in ["P0", "P1", "P2", "P3"]:
+            workloads.extend(PRIORITY_WORKLOADS.get(p, []))
+    else:
+        workloads = PRIORITY_WORKLOADS.get(priority, [])
+
+    if not workloads:
+        click.echo(f"No workloads found for priority {priority}", err=True)
+        sys.exit(1)
+
+    # Parse stream counts
+    stream_counts = [int(s.strip()) for s in streams.split(",")]
+
+    # Create output directory
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    click.echo(f"Running {len(workloads)} workloads at priority {priority}")
+    click.echo(f"Stream counts: {stream_counts}")
+    click.echo(f"Output directory: {output_path}")
+    click.echo()
+
+    all_results = {}
+    failed = []
+
+    for workload_name in workloads:
+        click.echo(f"[{workload_name}]")
+
+        try:
+            wl = get_workload_instance(workload_name)
+            valid_counts = [c for c in stream_counts if wl.supports_stream_count(c)]
+
+            if not valid_counts:
+                click.echo(f"  Skipped (no valid stream counts)")
+                continue
+
+            results = []
+            for count in valid_counts:
+                click.echo(f"  {count} streams...", nl=False)
+
+                config = HarnessConfig(
+                    stream_count=count,
+                    warmup_iterations=10,
+                    measurement_iterations=iterations,
+                    device=device,
+                )
+                harness = StreamHarness(config)
+                result = harness.run_workload(wl)
+                results.append(result)
+                click.echo(f" {result.throughput:.2f} {result.throughput_unit}")
+
+            # Save results
+            output_file = output_path / f"{workload_name}_results.json"
+            save_sweep_results(results, output_file)
+            all_results[workload_name] = results
+
+        except Exception as e:
+            click.echo(f"  Error: {e}")
+            failed.append((workload_name, str(e)))
+
+    # Summary
+    click.echo()
+    click.echo("=" * 50)
+    click.echo(f"Completed: {len(all_results)}/{len(workloads)} workloads")
+    if failed:
+        click.echo(f"Failed: {len(failed)}")
+        for name, error in failed:
+            click.echo(f"  - {name}: {error}")
+
+
+@cli.command()
+@click.option("--baseline", "-b", required=True, help="Baseline results JSON")
+@click.option("--test", "-t", required=True, help="Test results JSON")
+@click.option("--threshold", default=0.05, help="Regression threshold (fraction)")
+def compare(baseline: str, test: str, threshold: float):
+    """Compare baseline and test results for regressions."""
+    from aorta.hw_queue_eval.core.metrics import compare_results
+
+    # Load results
+    with open(baseline) as f:
+        baseline_data = json.load(f)
+    with open(test) as f:
+        test_data = json.load(f)
+
+    # Handle both single result and sweep result formats
+    if "results" in baseline_data:
+        baseline_results = baseline_data["results"]
+        test_results = test_data.get("results", [])
+    else:
+        baseline_results = [baseline_data]
+        test_results = [test_data]
+
+    click.echo(f"Comparing results with {threshold*100:.1f}% threshold")
+    click.echo()
+
+    has_regressions = False
+
+    for i, (b, t) in enumerate(zip(baseline_results, test_results)):
+        stream_count = b.get("stream_count", i + 1)
+        comparison = compare_results(b, t, threshold)
+
+        click.echo(f"Stream count: {stream_count}")
+
+        if comparison["regressions"]:
+            has_regressions = True
+            click.echo("  REGRESSIONS:")
+            for reg in comparison["regressions"]:
+                click.echo(f"    - {reg['metric']}: {reg['baseline']:.3f} -> {reg['test']:.3f} "
+                          f"({reg['change_pct']:+.1f}%)")
+
+        if comparison["improvements"]:
+            click.echo("  Improvements:")
+            for imp in comparison["improvements"]:
+                click.echo(f"    + {imp['metric']}: {imp['baseline']:.3f} -> {imp['test']:.3f} "
+                          f"({imp['change_pct']:+.1f}%)")
+
+        if not comparison["regressions"] and not comparison["improvements"]:
+            click.echo("  No significant changes")
+
+        click.echo()
+
+    if has_regressions:
+        click.echo("RESULT: REGRESSIONS DETECTED", err=True)
+        sys.exit(1)
+    else:
+        click.echo("RESULT: No regressions detected")
+
+
+@cli.command("list")
+@click.option("--category", "-c", default=None,
+              help="Filter by category (distributed, inference, pipeline, latency_sensitive)")
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed information")
+def list_workloads(category: Optional[str], verbose: bool):
+    """List available workloads."""
+    from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+    # Import workload modules to register them
+    try:
+        from aorta.hw_queue_eval.workloads import distributed, inference, latency_sensitive, pipeline
+    except ImportError as e:
+        click.echo(f"Warning: Could not import all workloads: {e}", err=True)
+
+    workloads = WorkloadRegistry.list_all()
+
+    if category:
+        workloads = WorkloadRegistry.list_by_category(category)
+
+    if not workloads:
+        click.echo("No workloads found")
+        return
+
+    click.echo(f"Available workloads ({len(workloads)}):")
+    click.echo()
+
+    for name in sorted(workloads):
+        try:
+            info = WorkloadRegistry.get_info(name)
+
+            if verbose:
+                click.echo(f"  {name}")
+                click.echo(f"    Description: {info.description}")
+                click.echo(f"    Category: {info.category}")
+                click.echo(f"    Streams: {info.min_streams}-{info.max_streams} (recommended: {info.recommended_streams})")
+                click.echo(f"    Switch sensitivity: {info.switch_latency_sensitivity}")
+                click.echo()
+            else:
+                click.echo(f"  {name:<25} [{info.category}] {info.description}")
+
+        except Exception:
+            click.echo(f"  {name:<25} (error loading info)")
+
+
+@cli.command()
+@click.argument("workload")
+@click.option("--streams", "-s", default=8, help="Number of streams")
+@click.option("--output", "-o", default="profiles", help="Output directory")
+@click.option("--metrics", "-m", default=None,
+              help="Comma-separated hardware metrics to collect")
+def profile(workload: str, streams: int, output: str, metrics: Optional[str]):
+    """Profile a workload with ROCm tools.
+
+    WORKLOAD: Name of the workload to profile
+    """
+    from aorta.hw_queue_eval.core.profiler import ROCmProfiler, create_profiling_script
+
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    click.echo(f"Profiling workload: {workload}")
+    click.echo(f"  Streams: {streams}")
+    click.echo(f"  Output: {output_path}")
+
+    profiler = ROCmProfiler(output_path)
+
+    if not profiler.rocprof_available:
+        click.echo("Warning: rocprof not available. Creating profiling script instead.")
+
+        # Create a standalone script
+        script_path = create_profiling_script(workload, streams, output_path)
+        click.echo(f"\nCreated profiling script: {script_path}")
+        click.echo(f"Run with: rocprof --hip-trace -o {output_path}/{workload}.csv python {script_path}")
+        return
+
+    # Create and run profiling
+    script_path = create_profiling_script(workload, streams, output_path)
+
+    metrics_list = None
+    if metrics:
+        metrics_list = [m.strip() for m in metrics.split(",")]
+
+    click.echo("Running profiler...")
+
+    try:
+        trace_file = profiler.profile_with_rocprof(
+            ["python", str(script_path)],
+            metrics=metrics_list,
+            output_name=f"{workload}_{streams}s",
+        )
+
+        # Parse results
+        queue_info = profiler.parse_queue_info(trace_file)
+
+        click.echo()
+        click.echo("Queue Information:")
+        click.echo(f"  Number of queues used: {queue_info.num_queues}")
+        click.echo(f"  Kernels per queue: {queue_info.kernels_per_queue}")
+
+        # Generate timeline
+        timeline_file = profiler.generate_timeline(trace_file)
+        click.echo(f"\nTimeline generated: {timeline_file}")
+        click.echo(f"Trace file: {trace_file}")
+
+    except Exception as e:
+        click.echo(f"Error during profiling: {e}", err=True)
+        sys.exit(1)
+
+
+@cli.command()
+def info():
+    """Show environment and configuration information."""
+    import torch
+    from aorta.utils import get_device_properties, get_rocm_env_info, ensure_gpu_available
+
+    click.echo("Hardware Queue Evaluation Framework")
+    click.echo(f"Version: {__version__}")
+    click.echo()
+
+    # PyTorch info
+    click.echo("PyTorch:")
+    click.echo(f"  Version: {torch.__version__}")
+    click.echo(f"  CUDA available: {torch.cuda.is_available()}")
+    click.echo(f"  CUDA version: {torch.version.cuda}")
+
+    # ROCm info
+    rocm_info = get_rocm_env_info()
+    click.echo()
+    click.echo("ROCm:")
+    click.echo(f"  Is ROCm: {rocm_info['is_rocm']}")
+    if rocm_info['is_rocm']:
+        click.echo(f"  HIP version: {rocm_info['hip_version']}")
+        if 'env_vars' in rocm_info:
+            click.echo("  Environment variables:")
+            for var, val in rocm_info['env_vars'].items():
+                if val:
+                    click.echo(f"    {var}={val}")
+
+    # GPU info
+    if torch.cuda.is_available():
+        click.echo()
+        click.echo("GPU:")
+        for i in range(torch.cuda.device_count()):
+            device = f"cuda:{i}"
+            if ensure_gpu_available(device):
+                props = get_device_properties(device)
+                click.echo(f"  [{i}] {props.name}")
+                click.echo(f"      Memory: {props.total_memory_gb:.1f} GB")
+                click.echo(f"      Compute Units: {props.multi_processor_count}")
+
+
+def main():
+    """Entry point for the CLI."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aorta/hw_queue_eval/core/__init__.py
+++ b/src/aorta/hw_queue_eval/core/__init__.py
@@ -1,0 +1,46 @@
+"""
+Core components for the hardware queue evaluation framework.
+
+This module contains:
+- StreamHarness: Parameterized test harness for running workloads
+- MetricsCollector: Performance metrics collection and aggregation
+- ROCmProfiler: Integration with ROCm profiling tools
+- TorchProfilerWrapper: PyTorch profiler for Chrome/TensorBoard traces
+- Utility functions for stream management and timing
+"""
+
+from aorta.hw_queue_eval.core.harness import HarnessConfig, HarnessResult, StreamHarness
+from aorta.hw_queue_eval.core.metrics import LatencyMetrics, MetricsCollector, SwitchLatencyMetrics
+from aorta.hw_queue_eval.core.profiler import ROCmProfiler
+from aorta.hw_queue_eval.core.torch_profiler import (
+    ProfilerConfig,
+    ProfilerResult,
+    TorchProfilerWrapper,
+    generate_profile_summary,
+    profile_workload_run,
+)
+from aorta.utils import (
+    create_streams,
+    get_device_properties,
+    sync_all_streams,
+    TimingContext,
+)
+
+__all__ = [
+    "HarnessConfig",
+    "HarnessResult",
+    "StreamHarness",
+    "LatencyMetrics",
+    "MetricsCollector",
+    "SwitchLatencyMetrics",
+    "ROCmProfiler",
+    "ProfilerConfig",
+    "ProfilerResult",
+    "TorchProfilerWrapper",
+    "generate_profile_summary",
+    "profile_workload_run",
+    "create_streams",
+    "get_device_properties",
+    "sync_all_streams",
+    "TimingContext",
+]

--- a/src/aorta/hw_queue_eval/core/harness.py
+++ b/src/aorta/hw_queue_eval/core/harness.py
@@ -1,0 +1,576 @@
+"""
+Parameterized test harness for running workloads with configurable stream counts.
+
+This module provides:
+- HarnessConfig: Configuration for test runs
+- HarnessResult: Results from a test run
+- StreamHarness: Main harness for executing workloads
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+
+import torch
+
+from aorta.hw_queue_eval.core.metrics import (
+    LatencyMetrics,
+    MemoryMetrics,
+    MetricsCollector,
+    ScalingAnalysis,
+    SwitchLatencyMetrics,
+    ThroughputMetrics,
+)
+from aorta.utils import (
+    create_streams,
+    get_device_properties,
+    get_rocm_env_info,
+    reset_memory_stats,
+    sync_all_streams,
+    warmup_gpu,
+)
+
+if TYPE_CHECKING:
+    from aorta.hw_queue_eval.workloads.base import BaseWorkload
+
+
+@dataclass
+class HarnessConfig:
+    """Configuration for the stream harness."""
+
+    stream_count: int
+    warmup_iterations: int = 10
+    measurement_iterations: int = 100
+    sync_mode: str = "per_iteration"  # "per_iteration", "end_only", "none"
+    device: str = "cuda:0"
+    collect_kernel_timings: bool = True
+    warmup_gpu_before_run: bool = True
+    reset_memory_stats_before_run: bool = True
+
+    def __post_init__(self):
+        if self.stream_count < 1:
+            raise ValueError("stream_count must be at least 1")
+        if self.sync_mode not in ("per_iteration", "end_only", "none"):
+            raise ValueError(f"Invalid sync_mode: {self.sync_mode}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class HarnessResult:
+    """Results from a harness run."""
+
+    # Core metrics
+    throughput: float  # ops/sec or samples/sec (depends on workload)
+    throughput_unit: str
+    latency_ms: Dict[str, float]  # {"mean": x, "p50": x, "p95": x, "p99": x}
+    total_time_ms: float
+    stream_count: int
+
+    # Detailed metrics
+    per_stream_times_ms: List[float]
+    iteration_times_ms: List[float]
+    switch_latency: Optional[Dict[str, float]] = None
+    memory: Optional[Dict[str, float]] = None
+
+    # Metadata
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    workload_name: str = ""
+    timestamp: str = ""
+
+    @classmethod
+    def from_metrics(
+        cls,
+        throughput_metrics: ThroughputMetrics,
+        latency_metrics: LatencyMetrics,
+        collector: MetricsCollector,
+        stream_count: int,
+        workload_name: str = "",
+        memory_metrics: Optional[MemoryMetrics] = None,
+        switch_metrics: Optional[SwitchLatencyMetrics] = None,
+        extra_metadata: Optional[Dict[str, Any]] = None,
+    ) -> "HarnessResult":
+        """Create HarnessResult from metric objects."""
+        return cls(
+            throughput=throughput_metrics.value,
+            throughput_unit=throughput_metrics.unit,
+            latency_ms={
+                "mean": latency_metrics.mean_ms,
+                "p50": latency_metrics.p50_ms,
+                "p95": latency_metrics.p95_ms,
+                "p99": latency_metrics.p99_ms,
+                "min": latency_metrics.min_ms,
+                "max": latency_metrics.max_ms,
+                "std": latency_metrics.std_ms,
+            },
+            total_time_ms=collector.get_total_time_ms(),
+            stream_count=stream_count,
+            per_stream_times_ms=[
+                sum(times[i] for times in collector.get_per_stream_times())
+                for i in range(stream_count)
+            ]
+            if collector.get_per_stream_times()
+            else [],
+            iteration_times_ms=collector.get_iteration_times(),
+            switch_latency=switch_metrics.to_dict() if switch_metrics else None,
+            memory=memory_metrics.to_dict() if memory_metrics else None,
+            metadata=extra_metadata or {},
+            workload_name=workload_name,
+            timestamp=datetime.now().isoformat(),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+    def to_json(self, filepath: Optional[str | Path] = None) -> str:
+        """
+        Convert to JSON string, optionally saving to file.
+
+        Args:
+            filepath: Optional path to save JSON file
+
+        Returns:
+            JSON string
+        """
+        json_str = json.dumps(self.to_dict(), indent=2)
+        if filepath:
+            with open(filepath, "w") as f:
+                f.write(json_str)
+        return json_str
+
+
+class StreamHarness:
+    """
+    Base harness for running workloads with parameterized stream counts.
+
+    This harness handles:
+    - Stream creation and management
+    - Warmup and measurement phases
+    - Timing data collection
+    - Result aggregation
+
+    Usage:
+        config = HarnessConfig(stream_count=8)
+        harness = StreamHarness(config)
+
+        # Run with a workload object
+        result = harness.run_workload(workload)
+
+        # Or run with a callable
+        result = harness.run(my_function, arg1, arg2)
+
+        # Sweep across stream counts
+        results = harness.sweep(my_function, [1, 2, 4, 8, 16])
+    """
+
+    def __init__(self, config: HarnessConfig):
+        """
+        Initialize the harness.
+
+        Args:
+            config: HarnessConfig with run parameters
+        """
+        self.config = config
+        self.streams: List[torch.cuda.Stream] = []
+        self._initialized = False
+        self._metrics_collector: Optional[MetricsCollector] = None
+
+    def _initialize(self) -> None:
+        """Initialize streams and prepare for run."""
+        if self._initialized:
+            return
+
+        # Create streams
+        self.streams = create_streams(self.config.stream_count, self.config.device)
+
+        # Initialize metrics collector
+        self._metrics_collector = MetricsCollector(
+            num_streams=self.config.stream_count,
+            device=self.config.device,
+        )
+
+        # GPU warmup if requested
+        if self.config.warmup_gpu_before_run:
+            warmup_gpu(self.config.device)
+
+        # Reset memory stats if requested
+        if self.config.reset_memory_stats_before_run:
+            reset_memory_stats(self.config.device)
+
+        self._initialized = True
+
+    def _cleanup(self) -> None:
+        """Cleanup after run."""
+        # Sync all streams
+        sync_all_streams(self.streams)
+
+        # Clear stream references
+        self.streams = []
+        self._initialized = False
+
+    def run(
+        self,
+        workload_fn: Callable[[List[torch.cuda.Stream]], None],
+        throughput_fn: Optional[Callable[[int, float], float]] = None,
+        throughput_unit: str = "iterations/sec",
+        workload_name: str = "custom",
+        extra_metadata: Optional[Dict[str, Any]] = None,
+    ) -> HarnessResult:
+        """
+        Run a workload function with the configured stream count.
+
+        Args:
+            workload_fn: Function that takes a list of streams and executes work
+            throughput_fn: Optional function to compute throughput (iterations, time_sec) -> value
+            throughput_unit: Unit string for throughput
+            workload_name: Name for the workload
+            extra_metadata: Additional metadata to include in results
+
+        Returns:
+            HarnessResult with timing and metrics
+        """
+        self._initialize()
+
+        collector = self._metrics_collector
+        collector.clear()
+
+        # Warmup phase
+        for _ in range(self.config.warmup_iterations):
+            workload_fn(self.streams)
+            if self.config.sync_mode == "per_iteration":
+                sync_all_streams(self.streams)
+
+        # Sync after warmup
+        sync_all_streams(self.streams)
+        torch.cuda.synchronize(self.config.device)
+
+        # Reset memory stats after warmup
+        if self.config.reset_memory_stats_before_run:
+            reset_memory_stats(self.config.device)
+
+        # Measurement phase
+        for _ in range(self.config.measurement_iterations):
+            collector.start_iteration()
+
+            workload_fn(self.streams)
+
+            if self.config.sync_mode == "per_iteration":
+                sync_all_streams(self.streams)
+
+            collector.end_iteration(sync=(self.config.sync_mode == "per_iteration"))
+
+        # Final sync if using end_only mode
+        if self.config.sync_mode in ("end_only", "none"):
+            sync_all_streams(self.streams)
+            torch.cuda.synchronize(self.config.device)
+
+        # Compute metrics
+        latency_metrics = collector.compute_latency_metrics()
+        switch_metrics = collector.compute_switch_latency()
+        memory_metrics = MemoryMetrics.capture(self.config.device)
+
+        # Compute throughput
+        total_time_sec = collector.get_total_time_ms() / 1000.0
+        if throughput_fn:
+            throughput_value = throughput_fn(
+                self.config.measurement_iterations, total_time_sec
+            )
+        else:
+            throughput_value = self.config.measurement_iterations / total_time_sec
+
+        throughput_metrics = ThroughputMetrics(
+            value=throughput_value,
+            unit=throughput_unit,
+            raw_count=self.config.measurement_iterations,
+            duration_sec=total_time_sec,
+        )
+
+        # Build result
+        metadata = {
+            "config": self.config.to_dict(),
+            "device_info": get_device_properties(self.config.device).__dict__,
+            "rocm_info": get_rocm_env_info(),
+        }
+        if extra_metadata:
+            metadata.update(extra_metadata)
+
+        result = HarnessResult.from_metrics(
+            throughput_metrics=throughput_metrics,
+            latency_metrics=latency_metrics,
+            collector=collector,
+            stream_count=self.config.stream_count,
+            workload_name=workload_name,
+            memory_metrics=memory_metrics,
+            switch_metrics=switch_metrics,
+            extra_metadata=metadata,
+        )
+
+        self._cleanup()
+        return result
+
+    def run_workload(
+        self,
+        workload: "BaseWorkload",
+        extra_metadata: Optional[Dict[str, Any]] = None,
+    ) -> HarnessResult:
+        """
+        Run a BaseWorkload object with the configured stream count.
+
+        Args:
+            workload: Workload object implementing BaseWorkload
+            extra_metadata: Additional metadata to include in results
+
+        Returns:
+            HarnessResult with timing and metrics
+        """
+        self._initialize()
+
+        # Setup workload
+        workload.setup(self.config.stream_count, self.config.device)
+
+        collector = self._metrics_collector
+        collector.clear()
+
+        # Warmup phase
+        for _ in range(self.config.warmup_iterations):
+            workload.run_iteration(self.streams)
+            if self.config.sync_mode == "per_iteration":
+                sync_all_streams(self.streams)
+
+        # Sync after warmup
+        sync_all_streams(self.streams)
+        torch.cuda.synchronize(self.config.device)
+
+        # Reset memory stats after warmup
+        if self.config.reset_memory_stats_before_run:
+            reset_memory_stats(self.config.device)
+
+        # Measurement phase
+        for _ in range(self.config.measurement_iterations):
+            collector.start_iteration()
+
+            workload.run_iteration(self.streams)
+
+            if self.config.sync_mode == "per_iteration":
+                sync_all_streams(self.streams)
+
+            collector.end_iteration(sync=(self.config.sync_mode == "per_iteration"))
+
+        # Final sync
+        if self.config.sync_mode in ("end_only", "none"):
+            sync_all_streams(self.streams)
+            torch.cuda.synchronize(self.config.device)
+
+        # Compute metrics
+        latency_metrics = collector.compute_latency_metrics()
+        switch_metrics = collector.compute_switch_latency()
+        memory_metrics = MemoryMetrics.capture(self.config.device)
+
+        # Compute throughput using workload's method
+        total_time_sec = collector.get_total_time_ms() / 1000.0
+        throughput_value = workload.compute_throughput(
+            self.config.measurement_iterations, total_time_sec
+        )
+
+        throughput_metrics = ThroughputMetrics(
+            value=throughput_value,
+            unit=workload.get_throughput_unit(),
+            raw_count=self.config.measurement_iterations,
+            duration_sec=total_time_sec,
+        )
+
+        # Build result
+        metadata = {
+            "config": self.config.to_dict(),
+            "device_info": get_device_properties(self.config.device).__dict__,
+            "rocm_info": get_rocm_env_info(),
+            "workload_config": workload.get_config() if hasattr(workload, "get_config") else {},
+        }
+        if extra_metadata:
+            metadata.update(extra_metadata)
+
+        result = HarnessResult.from_metrics(
+            throughput_metrics=throughput_metrics,
+            latency_metrics=latency_metrics,
+            collector=collector,
+            stream_count=self.config.stream_count,
+            workload_name=workload.name,
+            memory_metrics=memory_metrics,
+            switch_metrics=switch_metrics,
+            extra_metadata=metadata,
+        )
+
+        # Cleanup workload
+        workload.cleanup()
+        self._cleanup()
+
+        return result
+
+    def sweep(
+        self,
+        workload_fn: Callable[[List[torch.cuda.Stream]], None],
+        stream_counts: List[int],
+        throughput_fn: Optional[Callable[[int, float], float]] = None,
+        throughput_unit: str = "iterations/sec",
+        workload_name: str = "custom",
+    ) -> List[HarnessResult]:
+        """
+        Run workload across multiple stream counts.
+
+        Args:
+            workload_fn: Function that takes a list of streams and executes work
+            stream_counts: List of stream counts to test
+            throughput_fn: Optional function to compute throughput
+            throughput_unit: Unit string for throughput
+            workload_name: Name for the workload
+
+        Returns:
+            List of HarnessResult objects, one per stream count
+        """
+        results = []
+
+        for count in stream_counts:
+            # Create new config with this stream count
+            config = HarnessConfig(
+                stream_count=count,
+                warmup_iterations=self.config.warmup_iterations,
+                measurement_iterations=self.config.measurement_iterations,
+                sync_mode=self.config.sync_mode,
+                device=self.config.device,
+                collect_kernel_timings=self.config.collect_kernel_timings,
+                warmup_gpu_before_run=self.config.warmup_gpu_before_run,
+                reset_memory_stats_before_run=self.config.reset_memory_stats_before_run,
+            )
+
+            harness = StreamHarness(config)
+            result = harness.run(
+                workload_fn=workload_fn,
+                throughput_fn=throughput_fn,
+                throughput_unit=throughput_unit,
+                workload_name=workload_name,
+            )
+            results.append(result)
+
+        return results
+
+    def sweep_workload(
+        self,
+        workload: "BaseWorkload",
+        stream_counts: Optional[List[int]] = None,
+    ) -> List[HarnessResult]:
+        """
+        Run a BaseWorkload across multiple stream counts.
+
+        Args:
+            workload: Workload object implementing BaseWorkload
+            stream_counts: List of stream counts to test.
+                          If None, uses [1, 2, 4, 8, 16, 32] filtered by workload limits.
+
+        Returns:
+            List of HarnessResult objects, one per stream count
+        """
+        if stream_counts is None:
+            stream_counts = [1, 2, 4, 8, 16, 32]
+
+        # Filter by workload's stream limits
+        stream_counts = [
+            c for c in stream_counts
+            if workload.min_streams <= c <= workload.max_streams
+        ]
+
+        results = []
+
+        for count in stream_counts:
+            # Create new config with this stream count
+            config = HarnessConfig(
+                stream_count=count,
+                warmup_iterations=self.config.warmup_iterations,
+                measurement_iterations=self.config.measurement_iterations,
+                sync_mode=self.config.sync_mode,
+                device=self.config.device,
+                collect_kernel_timings=self.config.collect_kernel_timings,
+                warmup_gpu_before_run=self.config.warmup_gpu_before_run,
+                reset_memory_stats_before_run=self.config.reset_memory_stats_before_run,
+            )
+
+            harness = StreamHarness(config)
+            result = harness.run_workload(workload)
+            results.append(result)
+
+        return results
+
+
+def analyze_sweep_results(results: List[HarnessResult]) -> ScalingAnalysis:
+    """
+    Analyze results from a stream count sweep.
+
+    Args:
+        results: List of HarnessResult from a sweep
+
+    Returns:
+        ScalingAnalysis with scaling characteristics
+    """
+    sweep_data = [(r.stream_count, r.throughput) for r in results]
+    return ScalingAnalysis.from_sweep_results(sweep_data)
+
+
+def format_results_table(results: List[HarnessResult]) -> str:
+    """
+    Format sweep results as a text table.
+
+    Args:
+        results: List of HarnessResult from a sweep
+
+    Returns:
+        Formatted table string
+    """
+    lines = []
+    lines.append(
+        f"{'Streams':>8} {'Throughput':>15} {'P50 (ms)':>12} {'P95 (ms)':>12} "
+        f"{'P99 (ms)':>12} {'Total (ms)':>12}"
+    )
+    lines.append("-" * 75)
+
+    for r in results:
+        lines.append(
+            f"{r.stream_count:>8} {r.throughput:>15.2f} {r.latency_ms['p50']:>12.3f} "
+            f"{r.latency_ms['p95']:>12.3f} {r.latency_ms['p99']:>12.3f} "
+            f"{r.total_time_ms:>12.2f}"
+        )
+
+    return "\n".join(lines)
+
+
+def save_sweep_results(
+    results: List[HarnessResult],
+    filepath: str | Path,
+    include_analysis: bool = True,
+) -> None:
+    """
+    Save sweep results to JSON file.
+
+    Args:
+        results: List of HarnessResult from a sweep
+        filepath: Path to output file
+        include_analysis: If True, include scaling analysis
+    """
+    data = {
+        "timestamp": datetime.now().isoformat(),
+        "workload": results[0].workload_name if results else "unknown",
+        "results": [r.to_dict() for r in results],
+    }
+
+    if include_analysis:
+        analysis = analyze_sweep_results(results)
+        data["analysis"] = analysis.to_dict()
+
+    with open(filepath, "w") as f:
+        json.dump(data, f, indent=2)

--- a/src/aorta/hw_queue_eval/core/metrics.py
+++ b/src/aorta/hw_queue_eval/core/metrics.py
@@ -1,0 +1,633 @@
+"""
+Performance metrics collection and aggregation.
+
+This module provides:
+- LatencyMetrics: Statistical latency measurements
+- SwitchLatencyMetrics: Queue switch overhead estimation
+- MetricsCollector: Collection and aggregation of performance data
+- Throughput computation utilities
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+
+@dataclass
+class LatencyMetrics:
+    """Statistical latency metrics in milliseconds."""
+
+    mean_ms: float
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    min_ms: float
+    max_ms: float
+    std_ms: float = 0.0
+    count: int = 0
+
+    @classmethod
+    def from_samples(cls, samples: List[float]) -> "LatencyMetrics":
+        """
+        Compute latency metrics from a list of samples.
+
+        Args:
+            samples: List of latency values in milliseconds
+
+        Returns:
+            LatencyMetrics object with computed statistics
+        """
+        if not samples:
+            return cls(
+                mean_ms=0.0,
+                p50_ms=0.0,
+                p95_ms=0.0,
+                p99_ms=0.0,
+                min_ms=0.0,
+                max_ms=0.0,
+                std_ms=0.0,
+                count=0,
+            )
+
+        sorted_samples = sorted(samples)
+        n = len(sorted_samples)
+
+        def percentile(p: float) -> float:
+            """Compute percentile using linear interpolation."""
+            if n == 1:
+                return sorted_samples[0]
+            idx = (n - 1) * p / 100
+            lower = int(idx)
+            upper = min(lower + 1, n - 1)
+            frac = idx - lower
+            return sorted_samples[lower] * (1 - frac) + sorted_samples[upper] * frac
+
+        return cls(
+            mean_ms=statistics.mean(samples),
+            p50_ms=percentile(50),
+            p95_ms=percentile(95),
+            p99_ms=percentile(99),
+            min_ms=min(samples),
+            max_ms=max(samples),
+            std_ms=statistics.stdev(samples) if len(samples) > 1 else 0.0,
+            count=len(samples),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class SwitchLatencyMetrics:
+    """
+    Metrics for measuring queue switch overhead.
+
+    These metrics help identify the cost of switching between hardware queues:
+    - inter_stream_gap_ms: Average gap between kernels on different streams
+    - intra_stream_gap_ms: Average gap between kernels on the same stream
+    - estimated_switch_overhead_ms: Difference suggests queue switch cost
+    """
+
+    inter_stream_gap_ms: float  # Average gap between kernels on different streams
+    intra_stream_gap_ms: float  # Average gap between kernels on same stream
+    estimated_switch_overhead_ms: float  # Difference suggests switch cost
+    inter_stream_samples: int = 0
+    intra_stream_samples: int = 0
+
+    @classmethod
+    def from_kernel_timings(
+        cls,
+        kernel_timings: List[Tuple[int, float, float]],  # (stream_id, start_ms, end_ms)
+    ) -> "SwitchLatencyMetrics":
+        """
+        Compute switch latency metrics from kernel timing data.
+
+        Args:
+            kernel_timings: List of (stream_id, start_time_ms, end_time_ms) tuples
+                           Times should be relative to a common baseline.
+
+        Returns:
+            SwitchLatencyMetrics with computed values
+        """
+        if len(kernel_timings) < 2:
+            return cls(
+                inter_stream_gap_ms=0.0,
+                intra_stream_gap_ms=0.0,
+                estimated_switch_overhead_ms=0.0,
+            )
+
+        # Sort by end time to find sequential kernel pairs
+        sorted_timings = sorted(kernel_timings, key=lambda x: x[2])
+
+        inter_stream_gaps = []
+        intra_stream_gaps = []
+
+        for i in range(1, len(sorted_timings)):
+            prev_stream, prev_start, prev_end = sorted_timings[i - 1]
+            curr_stream, curr_start, curr_end = sorted_timings[i]
+
+            # Gap is the time between end of previous kernel and start of next
+            gap = curr_start - prev_end
+
+            # Only consider positive gaps (overlapping kernels don't count)
+            if gap > 0:
+                if prev_stream == curr_stream:
+                    intra_stream_gaps.append(gap)
+                else:
+                    inter_stream_gaps.append(gap)
+
+        inter_avg = statistics.mean(inter_stream_gaps) if inter_stream_gaps else 0.0
+        intra_avg = statistics.mean(intra_stream_gaps) if intra_stream_gaps else 0.0
+
+        return cls(
+            inter_stream_gap_ms=inter_avg,
+            intra_stream_gap_ms=intra_avg,
+            estimated_switch_overhead_ms=max(0.0, inter_avg - intra_avg),
+            inter_stream_samples=len(inter_stream_gaps),
+            intra_stream_samples=len(intra_stream_gaps),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class ThroughputMetrics:
+    """Throughput metrics with configurable units."""
+
+    value: float
+    unit: str
+    raw_count: int
+    duration_sec: float
+
+    @classmethod
+    def compute(
+        cls, count: int, duration_sec: float, unit: str = "ops/sec"
+    ) -> "ThroughputMetrics":
+        """
+        Compute throughput from count and duration.
+
+        Args:
+            count: Number of operations/samples/tokens
+            duration_sec: Total duration in seconds
+            unit: Unit string for display
+
+        Returns:
+            ThroughputMetrics object
+        """
+        value = count / duration_sec if duration_sec > 0 else 0.0
+        return cls(value=value, unit=unit, raw_count=count, duration_sec=duration_sec)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class MemoryMetrics:
+    """GPU memory usage metrics."""
+
+    peak_allocated_gb: float
+    peak_reserved_gb: float
+    final_allocated_gb: float
+    final_reserved_gb: float
+
+    @classmethod
+    def capture(cls, device: str = "cuda:0") -> "MemoryMetrics":
+        """Capture current memory state."""
+        device_idx = torch.device(device).index or 0
+        return cls(
+            peak_allocated_gb=torch.cuda.max_memory_allocated(device_idx) / (1024**3),
+            peak_reserved_gb=torch.cuda.max_memory_reserved(device_idx) / (1024**3),
+            final_allocated_gb=torch.cuda.memory_allocated(device_idx) / (1024**3),
+            final_reserved_gb=torch.cuda.memory_reserved(device_idx) / (1024**3),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class KernelTiming:
+    """Timing information for a single kernel execution."""
+
+    stream_id: int
+    kernel_name: Optional[str]
+    start_ms: float  # Relative to baseline
+    end_ms: float  # Relative to baseline
+    duration_ms: float
+
+    @property
+    def elapsed_ms(self) -> float:
+        return self.duration_ms
+
+
+class MetricsCollector:
+    """
+    Collect and aggregate performance metrics across streams and iterations.
+
+    This collector tracks:
+    - Per-kernel timing data
+    - Per-stream aggregate timing
+    - Per-iteration timing
+    - Overall throughput and latency metrics
+
+    Usage:
+        collector = MetricsCollector(num_streams=4)
+
+        for iteration in range(num_iterations):
+            collector.start_iteration()
+
+            # Record kernel timings
+            collector.record_kernel_timing(stream_id=0, start_event, end_event)
+
+            collector.end_iteration()
+
+        # Get aggregated metrics
+        latency = collector.compute_latency_metrics()
+        switch = collector.compute_switch_latency()
+    """
+
+    def __init__(self, num_streams: int, device: str = "cuda:0"):
+        """
+        Initialize the metrics collector.
+
+        Args:
+            num_streams: Number of streams being used
+            device: Target device
+        """
+        self.num_streams = num_streams
+        self.device = device
+
+        # Timing data storage
+        self._kernel_timings: List[List[KernelTiming]] = []  # Per-iteration kernel timings
+        self._iteration_times_ms: List[float] = []
+        self._per_stream_times_ms: List[List[float]] = []  # Per-stream times per iteration
+
+        # Current iteration state
+        self._current_iteration_kernels: List[KernelTiming] = []
+        self._iteration_start_event: Optional[torch.cuda.Event] = None
+        self._iteration_end_event: Optional[torch.cuda.Event] = None
+        self._baseline_event: Optional[torch.cuda.Event] = None
+
+        # Event pairs for kernel timing
+        self._pending_events: List[
+            Tuple[int, torch.cuda.Event, torch.cuda.Event, Optional[str]]
+        ] = []
+
+    def start_iteration(self) -> None:
+        """Mark the start of an iteration."""
+        self._current_iteration_kernels = []
+        self._pending_events = []
+
+        # Create baseline event for relative timing
+        self._baseline_event = torch.cuda.Event(enable_timing=True)
+        self._baseline_event.record()
+
+        self._iteration_start_event = torch.cuda.Event(enable_timing=True)
+        self._iteration_start_event.record()
+
+    def record_kernel_timing(
+        self,
+        stream_id: int,
+        start_event: torch.cuda.Event,
+        end_event: torch.cuda.Event,
+        kernel_name: Optional[str] = None,
+    ) -> None:
+        """
+        Record timing for a kernel execution.
+
+        Args:
+            stream_id: ID of the stream the kernel ran on
+            start_event: Event recorded before kernel
+            end_event: Event recorded after kernel
+            kernel_name: Optional name/identifier for the kernel
+        """
+        self._pending_events.append((stream_id, start_event, end_event, kernel_name))
+
+    def end_iteration(self, sync: bool = True) -> None:
+        """
+        Mark the end of an iteration and process timings.
+
+        Args:
+            sync: If True, synchronize device before processing timings
+        """
+        self._iteration_end_event = torch.cuda.Event(enable_timing=True)
+        self._iteration_end_event.record()
+
+        if sync:
+            torch.cuda.synchronize(self.device)
+
+        # Process pending kernel timings
+        for stream_id, start_event, end_event, kernel_name in self._pending_events:
+            # Get times relative to baseline
+            start_ms = self._baseline_event.elapsed_time(start_event)
+            end_ms = self._baseline_event.elapsed_time(end_event)
+            duration_ms = start_event.elapsed_time(end_event)
+
+            timing = KernelTiming(
+                stream_id=stream_id,
+                kernel_name=kernel_name,
+                start_ms=start_ms,
+                end_ms=end_ms,
+                duration_ms=duration_ms,
+            )
+            self._current_iteration_kernels.append(timing)
+
+        self._kernel_timings.append(self._current_iteration_kernels)
+
+        # Record iteration time
+        iteration_time = self._iteration_start_event.elapsed_time(self._iteration_end_event)
+        self._iteration_times_ms.append(iteration_time)
+
+        # Compute per-stream times for this iteration
+        stream_times = [0.0] * self.num_streams
+        for kt in self._current_iteration_kernels:
+            if 0 <= kt.stream_id < self.num_streams:
+                stream_times[kt.stream_id] += kt.duration_ms
+        self._per_stream_times_ms.append(stream_times)
+
+    def compute_latency_metrics(self) -> LatencyMetrics:
+        """
+        Compute latency metrics from recorded iteration times.
+
+        Returns:
+            LatencyMetrics object with computed statistics
+        """
+        return LatencyMetrics.from_samples(self._iteration_times_ms)
+
+    def compute_switch_latency(self) -> SwitchLatencyMetrics:
+        """
+        Compute queue switch latency metrics.
+
+        This analyzes kernel timing patterns across streams to estimate
+        the overhead of switching between hardware queues.
+
+        Returns:
+            SwitchLatencyMetrics object with computed values
+        """
+        # Flatten all kernel timings from all iterations
+        all_timings = []
+        for iteration_kernels in self._kernel_timings:
+            for kt in iteration_kernels:
+                all_timings.append((kt.stream_id, kt.start_ms, kt.end_ms))
+
+        return SwitchLatencyMetrics.from_kernel_timings(all_timings)
+
+    def compute_throughput(
+        self, count_per_iteration: int, unit: str = "ops/sec"
+    ) -> ThroughputMetrics:
+        """
+        Compute throughput from recorded timings.
+
+        Args:
+            count_per_iteration: Number of operations/samples per iteration
+            unit: Unit string for the throughput metric
+
+        Returns:
+            ThroughputMetrics object
+        """
+        total_count = count_per_iteration * len(self._iteration_times_ms)
+        total_time_sec = sum(self._iteration_times_ms) / 1000.0
+
+        return ThroughputMetrics.compute(total_count, total_time_sec, unit)
+
+    def get_per_stream_times(self) -> List[List[float]]:
+        """Get per-stream times for each iteration."""
+        return self._per_stream_times_ms
+
+    def get_iteration_times(self) -> List[float]:
+        """Get per-iteration times in milliseconds."""
+        return self._iteration_times_ms
+
+    def get_total_time_ms(self) -> float:
+        """Get total time across all iterations in milliseconds."""
+        return sum(self._iteration_times_ms)
+
+    def get_kernel_timings(self) -> List[List[KernelTiming]]:
+        """Get all recorded kernel timings by iteration."""
+        return self._kernel_timings
+
+    def clear(self) -> None:
+        """Clear all recorded data."""
+        self._kernel_timings = []
+        self._iteration_times_ms = []
+        self._per_stream_times_ms = []
+        self._current_iteration_kernels = []
+        self._pending_events = []
+
+    def get_summary(self) -> Dict[str, Any]:
+        """
+        Get a summary of all collected metrics.
+
+        Returns:
+            Dictionary with metric summaries
+        """
+        latency = self.compute_latency_metrics()
+        switch = self.compute_switch_latency()
+
+        return {
+            "iterations": len(self._iteration_times_ms),
+            "total_time_ms": self.get_total_time_ms(),
+            "latency": latency.to_dict(),
+            "switch_latency": switch.to_dict(),
+            "per_stream_total_ms": [
+                sum(times[i] for times in self._per_stream_times_ms)
+                for i in range(self.num_streams)
+            ]
+            if self._per_stream_times_ms
+            else [],
+        }
+
+    def export_to_json(self, filepath: str | Path) -> None:
+        """
+        Export collected metrics to JSON file.
+
+        Args:
+            filepath: Path to output JSON file
+        """
+        data = {
+            "timestamp": datetime.now().isoformat(),
+            "num_streams": self.num_streams,
+            "device": self.device,
+            "summary": self.get_summary(),
+            "iteration_times_ms": self._iteration_times_ms,
+            "per_stream_times_ms": self._per_stream_times_ms,
+            "kernel_timings": [
+                [
+                    {
+                        "stream_id": kt.stream_id,
+                        "kernel_name": kt.kernel_name,
+                        "start_ms": kt.start_ms,
+                        "end_ms": kt.end_ms,
+                        "duration_ms": kt.duration_ms,
+                    }
+                    for kt in iteration_kernels
+                ]
+                for iteration_kernels in self._kernel_timings
+            ],
+        }
+
+        with open(filepath, "w") as f:
+            json.dump(data, f, indent=2)
+
+
+@dataclass
+class ScalingAnalysis:
+    """Analysis of throughput scaling across stream counts."""
+
+    stream_counts: List[int]
+    throughputs: List[float]
+    efficiencies: List[float]  # Relative to ideal linear scaling
+    inflection_point: Optional[int]  # Stream count where scaling breaks down
+    peak_stream_count: int  # Stream count with best throughput
+
+    @classmethod
+    def from_sweep_results(
+        cls, results: List[Tuple[int, float]]
+    ) -> "ScalingAnalysis":
+        """
+        Analyze scaling from sweep results.
+
+        Args:
+            results: List of (stream_count, throughput) tuples
+
+        Returns:
+            ScalingAnalysis with computed metrics
+        """
+        if not results:
+            return cls(
+                stream_counts=[],
+                throughputs=[],
+                efficiencies=[],
+                inflection_point=None,
+                peak_stream_count=0,
+            )
+
+        # Sort by stream count
+        sorted_results = sorted(results, key=lambda x: x[0])
+        stream_counts = [r[0] for r in sorted_results]
+        throughputs = [r[1] for r in sorted_results]
+
+        # Compute efficiency (relative to linear scaling from single-stream)
+        base_throughput = throughputs[0] / stream_counts[0] if throughputs else 0
+        efficiencies = []
+        for sc, tp in zip(stream_counts, throughputs):
+            ideal = base_throughput * sc
+            efficiency = tp / ideal if ideal > 0 else 0
+            efficiencies.append(efficiency)
+
+        # Find peak throughput
+        peak_idx = throughputs.index(max(throughputs)) if throughputs else 0
+        peak_stream_count = stream_counts[peak_idx] if stream_counts else 0
+
+        # Find inflection point (where efficiency drops significantly)
+        inflection_point = None
+        for i in range(1, len(efficiencies)):
+            if efficiencies[i] < 0.8 * efficiencies[i - 1]:  # 20% drop
+                inflection_point = stream_counts[i]
+                break
+
+        return cls(
+            stream_counts=stream_counts,
+            throughputs=throughputs,
+            efficiencies=efficiencies,
+            inflection_point=inflection_point,
+            peak_stream_count=peak_stream_count,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+def compare_results(
+    baseline: Dict[str, Any],
+    test: Dict[str, Any],
+    threshold: float = 0.05,
+) -> Dict[str, Any]:
+    """
+    Compare baseline and test results for regressions.
+
+    Args:
+        baseline: Baseline results dictionary
+        test: Test results dictionary
+        threshold: Regression threshold (fraction, e.g., 0.05 = 5%)
+
+    Returns:
+        Dictionary with comparison results including any regressions
+    """
+    comparison = {
+        "baseline": baseline,
+        "test": test,
+        "regressions": [],
+        "improvements": [],
+        "unchanged": [],
+    }
+
+    # Compare throughputs if available
+    if "throughput" in baseline and "throughput" in test:
+        baseline_tp = baseline["throughput"]
+        test_tp = test["throughput"]
+
+        if isinstance(baseline_tp, dict):
+            baseline_tp = baseline_tp.get("value", 0)
+        if isinstance(test_tp, dict):
+            test_tp = test_tp.get("value", 0)
+
+        if baseline_tp > 0:
+            change = (test_tp - baseline_tp) / baseline_tp
+            metric_info = {
+                "metric": "throughput",
+                "baseline": baseline_tp,
+                "test": test_tp,
+                "change_pct": change * 100,
+            }
+
+            if change < -threshold:
+                comparison["regressions"].append(metric_info)
+            elif change > threshold:
+                comparison["improvements"].append(metric_info)
+            else:
+                comparison["unchanged"].append(metric_info)
+
+    # Compare latencies
+    for latency_metric in ["p50_ms", "p95_ms", "p99_ms"]:
+        baseline_lat = baseline.get("latency", {}).get(latency_metric, 0)
+        test_lat = test.get("latency", {}).get(latency_metric, 0)
+
+        if baseline_lat > 0:
+            # For latency, increase is regression
+            change = (test_lat - baseline_lat) / baseline_lat
+            metric_info = {
+                "metric": f"latency_{latency_metric}",
+                "baseline": baseline_lat,
+                "test": test_lat,
+                "change_pct": change * 100,
+            }
+
+            if change > threshold:  # Latency increase is bad
+                comparison["regressions"].append(metric_info)
+            elif change < -threshold:  # Latency decrease is good
+                comparison["improvements"].append(metric_info)
+            else:
+                comparison["unchanged"].append(metric_info)
+
+    comparison["has_regressions"] = len(comparison["regressions"]) > 0
+    comparison["summary"] = (
+        f"{len(comparison['regressions'])} regressions, "
+        f"{len(comparison['improvements'])} improvements, "
+        f"{len(comparison['unchanged'])} unchanged"
+    )
+
+    return comparison

--- a/src/aorta/hw_queue_eval/core/profiler.py
+++ b/src/aorta/hw_queue_eval/core/profiler.py
@@ -1,0 +1,598 @@
+"""
+ROCm profiler integration for hardware queue visibility.
+
+This module provides:
+- ROCmProfiler: Wrapper for rocprof/roctracer
+- Trace parsing utilities for queue information
+- Timeline generation for visualization
+
+Environment variables used:
+- AMD_LOG_LEVEL=4: For queue-level logging
+- HSA_TOOLS_LIB: For profiler injection
+- ROCPROF_COUNTERS_PATH: Custom counter definitions
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from aorta.utils import IS_ROCM
+
+
+@dataclass
+class KernelTrace:
+    """Information about a traced kernel execution."""
+
+    kernel_name: str
+    start_ns: int
+    end_ns: int
+    duration_ns: int
+    queue_id: Optional[int] = None
+    stream_id: Optional[int] = None
+    grid_size: Optional[Tuple[int, int, int]] = None
+    block_size: Optional[Tuple[int, int, int]] = None
+    device_id: int = 0
+
+    @property
+    def start_ms(self) -> float:
+        return self.start_ns / 1_000_000
+
+    @property
+    def end_ms(self) -> float:
+        return self.end_ns / 1_000_000
+
+    @property
+    def duration_ms(self) -> float:
+        return self.duration_ns / 1_000_000
+
+
+@dataclass
+class QueueInfo:
+    """Information about hardware queue usage."""
+
+    num_queues: int
+    queue_ids: List[int]
+    kernels_per_queue: Dict[int, int]
+    queue_utilization: Dict[int, float]  # Fraction of time each queue was active
+
+    @classmethod
+    def from_traces(cls, traces: List[KernelTrace]) -> "QueueInfo":
+        """Compute queue info from kernel traces."""
+        if not traces:
+            return cls(
+                num_queues=0,
+                queue_ids=[],
+                kernels_per_queue={},
+                queue_utilization={},
+            )
+
+        queue_ids = set()
+        kernels_per_queue: Dict[int, int] = {}
+        queue_active_time: Dict[int, int] = {}
+
+        for trace in traces:
+            qid = trace.queue_id or 0
+            queue_ids.add(qid)
+            kernels_per_queue[qid] = kernels_per_queue.get(qid, 0) + 1
+            queue_active_time[qid] = queue_active_time.get(qid, 0) + trace.duration_ns
+
+        # Compute utilization
+        total_time = max(t.end_ns for t in traces) - min(t.start_ns for t in traces)
+        queue_utilization = {}
+        for qid in queue_ids:
+            if total_time > 0:
+                queue_utilization[qid] = queue_active_time.get(qid, 0) / total_time
+            else:
+                queue_utilization[qid] = 0.0
+
+        return cls(
+            num_queues=len(queue_ids),
+            queue_ids=sorted(queue_ids),
+            kernels_per_queue=kernels_per_queue,
+            queue_utilization=queue_utilization,
+        )
+
+
+@dataclass
+class ProfilerConfig:
+    """Configuration for profiling sessions."""
+
+    output_dir: Path
+    metrics: List[str] = field(default_factory=list)
+    trace_hip_api: bool = True
+    trace_hsa_api: bool = False
+    trace_kernels: bool = True
+    flush_interval_ms: int = 100
+    verbose: bool = False
+
+    def __post_init__(self):
+        self.output_dir = Path(self.output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+
+class ROCmProfiler:
+    """
+    Wrapper for ROCm profiling tools (rocprof, roctracer).
+
+    Provides functionality to:
+    - Profile commands and collect kernel traces
+    - Parse profiler output for queue information
+    - Generate timeline visualizations
+    """
+
+    # Common hardware counters for queue analysis
+    DEFAULT_METRICS = [
+        "GRBM_COUNT",
+        "GRBM_GUI_ACTIVE",
+        "SQ_WAVES",
+        "SQ_INSTS_VALU",
+    ]
+
+    def __init__(self, output_dir: Path | str):
+        """
+        Initialize the profiler.
+
+        Args:
+            output_dir: Directory for profiler output files
+        """
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self._check_rocm_tools()
+
+    def _check_rocm_tools(self) -> Dict[str, bool]:
+        """Check availability of ROCm profiling tools."""
+        tools = {
+            "rocprof": shutil.which("rocprof") is not None,
+            "roctracer": shutil.which("roctracer") is not None,
+            "rocprofv2": shutil.which("rocprofv2") is not None,
+        }
+        self._available_tools = tools
+        return tools
+
+    @property
+    def rocprof_available(self) -> bool:
+        """Check if rocprof is available."""
+        return self._available_tools.get("rocprof", False)
+
+    @property
+    def roctracer_available(self) -> bool:
+        """Check if roctracer is available."""
+        return self._available_tools.get("roctracer", False)
+
+    def profile_with_rocprof(
+        self,
+        command: List[str],
+        metrics: Optional[List[str]] = None,
+        output_name: Optional[str] = None,
+        hip_trace: bool = True,
+        hsa_trace: bool = False,
+    ) -> Path:
+        """
+        Run command under rocprof and return path to results.
+
+        Args:
+            command: Command to profile as list of strings
+            metrics: Optional list of hardware counters to collect
+            output_name: Optional name for output file (without extension)
+            hip_trace: Enable HIP API tracing
+            hsa_trace: Enable HSA API tracing
+
+        Returns:
+            Path to rocprof output file
+
+        Raises:
+            RuntimeError: If rocprof is not available or profiling fails
+        """
+        if not self.rocprof_available:
+            raise RuntimeError("rocprof is not available. Please install ROCm profiler.")
+
+        # Generate output filename
+        if output_name is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            output_name = f"rocprof_{timestamp}"
+
+        output_file = self.output_dir / f"{output_name}.csv"
+
+        # Build rocprof command
+        rocprof_cmd = ["rocprof"]
+
+        # Add tracing options
+        if hip_trace:
+            rocprof_cmd.append("--hip-trace")
+        if hsa_trace:
+            rocprof_cmd.append("--hsa-trace")
+
+        # Add metrics if specified
+        if metrics:
+            metrics_file = self._create_metrics_file(metrics, output_name)
+            rocprof_cmd.extend(["-i", str(metrics_file)])
+
+        # Output file
+        rocprof_cmd.extend(["-o", str(output_file)])
+
+        # Add the command to profile
+        rocprof_cmd.extend(command)
+
+        # Set environment for better tracing
+        env = os.environ.copy()
+        env["AMD_LOG_LEVEL"] = "4"
+
+        try:
+            result = subprocess.run(
+                rocprof_cmd,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=600,  # 10 minute timeout
+            )
+
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"rocprof failed with code {result.returncode}:\n"
+                    f"stdout: {result.stdout}\n"
+                    f"stderr: {result.stderr}"
+                )
+
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("Profiling timed out after 10 minutes")
+
+        return output_file
+
+    def _create_metrics_file(self, metrics: List[str], name: str) -> Path:
+        """Create a metrics input file for rocprof."""
+        metrics_file = self.output_dir / f"{name}_metrics.txt"
+
+        with open(metrics_file, "w") as f:
+            f.write("# Hardware counters for queue evaluation\n")
+            f.write("pmc: " + " ".join(metrics) + "\n")
+
+        return metrics_file
+
+    def parse_rocprof_csv(self, csv_file: Path) -> List[KernelTrace]:
+        """
+        Parse rocprof CSV output to extract kernel traces.
+
+        Args:
+            csv_file: Path to rocprof CSV output
+
+        Returns:
+            List of KernelTrace objects
+        """
+        traces = []
+
+        if not csv_file.exists():
+            return traces
+
+        with open(csv_file, "r") as f:
+            reader = csv.DictReader(f)
+
+            for row in reader:
+                try:
+                    # Handle different rocprof output formats
+                    kernel_name = row.get("KernelName", row.get("Name", "unknown"))
+
+                    # Time fields (in nanoseconds)
+                    start_ns = int(row.get("BeginNs", row.get("Start", 0)))
+                    end_ns = int(row.get("EndNs", row.get("End", 0)))
+
+                    # Queue/stream info
+                    queue_id = int(row.get("Queue", row.get("queue-id", 0)))
+                    stream_id = int(row.get("Stream", row.get("stream-id", 0)))
+
+                    # Grid/block dimensions
+                    grid_size = None
+                    block_size = None
+
+                    if "grd" in row:
+                        grid_str = row["grd"]
+                        if grid_str:
+                            parts = grid_str.split(",")
+                            if len(parts) >= 3:
+                                grid_size = (int(parts[0]), int(parts[1]), int(parts[2]))
+
+                    if "wgr" in row:
+                        block_str = row["wgr"]
+                        if block_str:
+                            parts = block_str.split(",")
+                            if len(parts) >= 3:
+                                block_size = (int(parts[0]), int(parts[1]), int(parts[2]))
+
+                    trace = KernelTrace(
+                        kernel_name=kernel_name,
+                        start_ns=start_ns,
+                        end_ns=end_ns,
+                        duration_ns=end_ns - start_ns,
+                        queue_id=queue_id,
+                        stream_id=stream_id,
+                        grid_size=grid_size,
+                        block_size=block_size,
+                        device_id=int(row.get("gpu-id", 0)),
+                    )
+                    traces.append(trace)
+
+                except (ValueError, KeyError) as e:
+                    # Skip malformed rows
+                    continue
+
+        return traces
+
+    def parse_hip_trace(self, trace_file: Path) -> List[Dict[str, Any]]:
+        """
+        Parse HIP API trace file.
+
+        Args:
+            trace_file: Path to HIP trace file
+
+        Returns:
+            List of HIP API call records
+        """
+        calls = []
+
+        if not trace_file.exists():
+            return calls
+
+        with open(trace_file, "r") as f:
+            for line in f:
+                # Parse roctracer HIP output format
+                # Format: <pid>:<tid> <timestamp> <duration> <api_name>:<args>
+                match = re.match(
+                    r"(\d+):(\d+)\s+(\d+)\s+(\d+)\s+(\w+)(?::(.*))?",
+                    line.strip()
+                )
+                if match:
+                    calls.append({
+                        "pid": int(match.group(1)),
+                        "tid": int(match.group(2)),
+                        "timestamp_ns": int(match.group(3)),
+                        "duration_ns": int(match.group(4)),
+                        "api_name": match.group(5),
+                        "args": match.group(6) if match.group(6) else "",
+                    })
+
+        return calls
+
+    def parse_queue_info(self, trace_file: Path) -> QueueInfo:
+        """
+        Parse profiler output to extract hardware queue information.
+
+        Args:
+            trace_file: Path to trace file (CSV or other format)
+
+        Returns:
+            QueueInfo with queue usage statistics
+        """
+        # Determine file type and parse accordingly
+        if trace_file.suffix == ".csv":
+            traces = self.parse_rocprof_csv(trace_file)
+        else:
+            # Try to parse as JSON
+            try:
+                with open(trace_file, "r") as f:
+                    data = json.load(f)
+                # Convert JSON format to traces
+                traces = self._json_to_traces(data)
+            except (json.JSONDecodeError, KeyError):
+                traces = []
+
+        return QueueInfo.from_traces(traces)
+
+    def _json_to_traces(self, data: Dict[str, Any]) -> List[KernelTrace]:
+        """Convert JSON profiler output to kernel traces."""
+        traces = []
+
+        # Handle Chrome trace format (used by some profilers)
+        if "traceEvents" in data:
+            for event in data["traceEvents"]:
+                if event.get("ph") == "X":  # Complete event
+                    traces.append(KernelTrace(
+                        kernel_name=event.get("name", "unknown"),
+                        start_ns=int(event.get("ts", 0) * 1000),  # us to ns
+                        end_ns=int((event.get("ts", 0) + event.get("dur", 0)) * 1000),
+                        duration_ns=int(event.get("dur", 0) * 1000),
+                        queue_id=event.get("args", {}).get("queue_id"),
+                        stream_id=event.get("args", {}).get("stream_id"),
+                    ))
+
+        return traces
+
+    def generate_timeline(
+        self,
+        trace_file: Path,
+        output_file: Optional[Path] = None,
+    ) -> Path:
+        """
+        Generate visual timeline of queue utilization.
+
+        Args:
+            trace_file: Path to trace file
+            output_file: Optional path for output HTML file
+
+        Returns:
+            Path to generated timeline file
+        """
+        traces = self.parse_rocprof_csv(trace_file)
+
+        if output_file is None:
+            output_file = self.output_dir / f"{trace_file.stem}_timeline.html"
+
+        # Generate Chrome trace format JSON
+        chrome_events = []
+
+        for trace in traces:
+            event = {
+                "name": trace.kernel_name,
+                "cat": "kernel",
+                "ph": "X",  # Complete event
+                "ts": trace.start_ns / 1000,  # Convert to microseconds
+                "dur": trace.duration_ns / 1000,
+                "pid": trace.device_id,
+                "tid": trace.queue_id or 0,
+                "args": {
+                    "queue_id": trace.queue_id,
+                    "stream_id": trace.stream_id,
+                },
+            }
+            chrome_events.append(event)
+
+        # Create HTML viewer
+        html_content = self._create_timeline_html(chrome_events)
+
+        with open(output_file, "w") as f:
+            f.write(html_content)
+
+        return output_file
+
+    def _create_timeline_html(self, events: List[Dict[str, Any]]) -> str:
+        """Create HTML file with embedded trace viewer."""
+        trace_json = json.dumps({"traceEvents": events})
+
+        return f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>GPU Queue Timeline</title>
+    <style>
+        body {{ font-family: Arial, sans-serif; margin: 20px; }}
+        h1 {{ color: #333; }}
+        .info {{ margin: 10px 0; }}
+        pre {{ background: #f5f5f5; padding: 10px; overflow-x: auto; }}
+    </style>
+</head>
+<body>
+    <h1>GPU Queue Timeline</h1>
+    <div class="info">
+        <p>This trace file can be viewed in Chrome's tracing tool:</p>
+        <ol>
+            <li>Open Chrome and navigate to <code>chrome://tracing</code></li>
+            <li>Click "Load" and select the JSON file, or paste the JSON below</li>
+        </ol>
+    </div>
+    <h2>Trace Data (JSON)</h2>
+    <pre>{trace_json}</pre>
+    <script>
+        // Save trace as downloadable JSON
+        const blob = new Blob(['{trace_json}'], {{type: 'application/json'}});
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'trace.json';
+        document.body.appendChild(a);
+    </script>
+</body>
+</html>
+"""
+
+    def get_queue_env_vars(self) -> Dict[str, str]:
+        """
+        Get environment variables to set for queue debugging.
+
+        Returns:
+            Dictionary of environment variable names and values
+        """
+        return {
+            "AMD_LOG_LEVEL": "4",
+            "HSA_TOOLS_LIB": "",  # Disable default tools
+            "GPU_MAX_HW_QUEUES": "",  # Let system decide
+            "HIP_VISIBLE_DEVICES": "0",  # Single GPU
+            "AMD_SERIALIZE_KERNEL": "3",  # Serialize for debugging
+        }
+
+
+def profile_python_command(
+    script_path: str,
+    args: List[str] = None,
+    output_dir: str = "profiles",
+    metrics: Optional[List[str]] = None,
+) -> Tuple[Path, QueueInfo]:
+    """
+    Convenience function to profile a Python script.
+
+    Args:
+        script_path: Path to Python script
+        args: Optional arguments for the script
+        output_dir: Directory for output files
+        metrics: Optional hardware metrics to collect
+
+    Returns:
+        Tuple of (trace_file_path, queue_info)
+    """
+    profiler = ROCmProfiler(output_dir)
+
+    command = ["python", script_path]
+    if args:
+        command.extend(args)
+
+    try:
+        trace_file = profiler.profile_with_rocprof(command, metrics=metrics)
+        queue_info = profiler.parse_queue_info(trace_file)
+        return trace_file, queue_info
+    except RuntimeError as e:
+        # Return empty results if profiling fails
+        print(f"Warning: Profiling failed: {e}")
+        return Path(output_dir) / "empty.csv", QueueInfo(
+            num_queues=0,
+            queue_ids=[],
+            kernels_per_queue={},
+            queue_utilization={},
+        )
+
+
+def create_profiling_script(
+    workload_name: str,
+    stream_count: int,
+    output_dir: Path,
+) -> Path:
+    """
+    Create a standalone Python script for profiling a workload.
+
+    Args:
+        workload_name: Name of the workload to profile
+        stream_count: Number of streams to use
+        output_dir: Directory for output
+
+    Returns:
+        Path to the created script
+    """
+    script_content = f'''#!/usr/bin/env python3
+"""Auto-generated profiling script for {workload_name}"""
+
+import torch
+from aorta.hw_queue_eval.workloads import get_workload
+from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+def main():
+    # Setup
+    workload = get_workload("{workload_name}")
+    config = HarnessConfig(
+        stream_count={stream_count},
+        warmup_iterations=5,
+        measurement_iterations=50,
+    )
+
+    # Run
+    harness = StreamHarness(config)
+    result = harness.run_workload(workload)
+
+    # Print summary
+    print(f"Throughput: {{result.throughput:.2f}} {{result.throughput_unit}}")
+    print(f"P99 Latency: {{result.latency_ms['p99']:.3f}} ms")
+
+if __name__ == "__main__":
+    main()
+'''
+
+    script_path = output_dir / f"profile_{workload_name}_{stream_count}s.py"
+    with open(script_path, "w") as f:
+        f.write(script_content)
+
+    script_path.chmod(0o755)
+    return script_path

--- a/src/aorta/hw_queue_eval/core/torch_profiler.py
+++ b/src/aorta/hw_queue_eval/core/torch_profiler.py
@@ -1,0 +1,459 @@
+"""
+PyTorch Profiler integration for detailed kernel and memory analysis.
+
+This module provides:
+- TorchProfilerWrapper: Easy-to-use profiler with trace export
+- Profile context managers for workload profiling
+- Trace export in Chrome/TensorBoard formats
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+
+import torch
+from torch.profiler import ProfilerActivity, profile
+
+
+@dataclass
+class ProfilerConfig:
+    """Configuration for PyTorch profiler."""
+
+    output_dir: Path
+    activities: List[str] = field(default_factory=lambda: ["cpu", "cuda"])
+    record_shapes: bool = True
+    profile_memory: bool = True
+    with_stack: bool = False  # Can be slow, enable for debugging
+    with_flops: bool = True
+    with_modules: bool = True
+
+    # Schedule settings (for multi-iteration profiling)
+    wait_iterations: int = 1
+    warmup_iterations: int = 1
+    active_iterations: int = 3
+    repeat: int = 1
+
+    # Export formats
+    export_chrome_trace: bool = True
+    export_tensorboard: bool = True
+    export_stacks: bool = False
+    export_memory_timeline: bool = True
+
+    def __post_init__(self):
+        self.output_dir = Path(self.output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_activities(self) -> List[ProfilerActivity]:
+        """Convert activity strings to ProfilerActivity enums."""
+        activity_map = {
+            "cpu": ProfilerActivity.CPU,
+            "cuda": ProfilerActivity.CUDA,
+        }
+        return [activity_map[a.lower()] for a in self.activities if a.lower() in activity_map]
+
+
+@dataclass
+class ProfilerResult:
+    """Results from profiling a workload."""
+
+    chrome_trace_path: Optional[Path] = None
+    tensorboard_dir: Optional[Path] = None
+    memory_timeline_path: Optional[Path] = None
+    stacks_path: Optional[Path] = None
+
+    # Summary statistics
+    total_cuda_time_ms: float = 0.0
+    total_cpu_time_ms: float = 0.0
+    peak_memory_mb: float = 0.0
+    num_cuda_kernels: int = 0
+
+    # Top operations
+    top_cuda_ops: List[Dict[str, Any]] = field(default_factory=list)
+    top_cpu_ops: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Memory events
+    memory_events: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "chrome_trace_path": str(self.chrome_trace_path) if self.chrome_trace_path else None,
+            "tensorboard_dir": str(self.tensorboard_dir) if self.tensorboard_dir else None,
+            "memory_timeline_path": str(self.memory_timeline_path) if self.memory_timeline_path else None,
+            "total_cuda_time_ms": self.total_cuda_time_ms,
+            "total_cpu_time_ms": self.total_cpu_time_ms,
+            "peak_memory_mb": self.peak_memory_mb,
+            "num_cuda_kernels": self.num_cuda_kernels,
+            "top_cuda_ops": self.top_cuda_ops,
+            "top_cpu_ops": self.top_cpu_ops,
+        }
+
+
+class TorchProfilerWrapper:
+    """
+    Wrapper around PyTorch profiler for easy workload profiling.
+
+    Usage:
+        profiler = TorchProfilerWrapper(output_dir="profiles/")
+
+        # Profile a workload
+        result = profiler.profile_workload(workload, streams, iterations=10)
+
+        # Or use context manager
+        with profiler.profile_context("my_run") as prof:
+            # ... run workload ...
+
+        print(f"Chrome trace: {result.chrome_trace_path}")
+        print(f"TensorBoard: {result.tensorboard_dir}")
+    """
+
+    def __init__(
+        self,
+        output_dir: str | Path = "profiles",
+        config: Optional[ProfilerConfig] = None,
+    ):
+        """
+        Initialize the profiler wrapper.
+
+        Args:
+            output_dir: Directory for output files
+            config: Optional ProfilerConfig (will be created if not provided)
+        """
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        if config is None:
+            config = ProfilerConfig(output_dir=self.output_dir)
+        self.config = config
+
+    def profile_workload(
+        self,
+        workload_fn: Callable,
+        name: str = "workload",
+        iterations: int = 5,
+        warmup: int = 2,
+    ) -> ProfilerResult:
+        """
+        Profile a workload function.
+
+        Args:
+            workload_fn: Function to profile (called repeatedly)
+            name: Name for output files
+            iterations: Number of iterations to profile
+            warmup: Warmup iterations before profiling
+
+        Returns:
+            ProfilerResult with paths to generated traces
+        """
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_name = f"{name}_{timestamp}"
+
+        result = ProfilerResult()
+
+        # Setup TensorBoard directory if enabled
+        if self.config.export_tensorboard:
+            tb_dir = self.output_dir / "tensorboard" / run_name
+            tb_dir.mkdir(parents=True, exist_ok=True)
+            result.tensorboard_dir = tb_dir
+
+        # Run warmup iterations without profiling
+        for _ in range(warmup):
+            workload_fn()
+
+        # Run profiler without on_trace_ready to allow manual export
+        # (on_trace_ready saves traces automatically which prevents manual export)
+        with profile(
+            activities=self.config.get_activities(),
+            record_shapes=self.config.record_shapes,
+            profile_memory=self.config.profile_memory,
+            with_stack=self.config.with_stack,
+            with_flops=self.config.with_flops,
+            with_modules=self.config.with_modules,
+        ) as prof:
+            for _ in range(iterations):
+                workload_fn()
+
+        # Export Chrome trace (can only be called once per profiler session)
+        # ROCm/HIP may auto-save traces, so handle gracefully
+        chrome_path = None
+        if self.config.export_chrome_trace:
+            chrome_path = self.output_dir / f"{run_name}_chrome_trace.json"
+            try:
+                prof.export_chrome_trace(str(chrome_path))
+                result.chrome_trace_path = chrome_path
+            except RuntimeError as e:
+                if "already saved" in str(e).lower():
+                    # Trace was auto-saved by ROCm/HIP profiler
+                    # Try to find auto-saved trace files
+                    import glob
+                    auto_traces = glob.glob(str(self.output_dir / "*.json"))
+                    if auto_traces:
+                        # Use the most recent one
+                        auto_traces.sort(key=os.path.getmtime, reverse=True)
+                        result.chrome_trace_path = Path(auto_traces[0])
+                    # Still extract statistics from profiler
+                else:
+                    raise
+
+        # Copy chrome trace to TensorBoard directory if needed
+        if self.config.export_tensorboard and result.tensorboard_dir and result.chrome_trace_path:
+            import shutil
+            tb_trace = result.tensorboard_dir / f"{run_name}.pt.trace.json"
+            try:
+                shutil.copy(result.chrome_trace_path, tb_trace)
+            except Exception:
+                pass  # Non-critical if copy fails
+
+        # Export stacks if enabled
+        if self.config.export_stacks and self.config.with_stack:
+            try:
+                stacks_path = self.output_dir / f"{run_name}_stacks.txt"
+                prof.export_stacks(str(stacks_path), "self_cuda_time_total")
+                result.stacks_path = stacks_path
+            except RuntimeError:
+                pass  # Stack export may fail if trace already saved
+
+        # Export memory timeline if enabled
+        if self.config.export_memory_timeline and self.config.profile_memory:
+            try:
+                memory_path = self.output_dir / f"{run_name}_memory_timeline.html"
+                prof.export_memory_timeline(str(memory_path))
+                result.memory_timeline_path = memory_path
+            except Exception:
+                # Memory timeline export may not be available in all versions
+                pass
+
+        # Extract summary statistics
+        result = self._extract_statistics(prof, result)
+
+        return result
+
+    def _extract_statistics(
+        self, prof: profile, result: ProfilerResult
+    ) -> ProfilerResult:
+        """Extract summary statistics from profiler."""
+
+        # Get key averages
+        key_averages = prof.key_averages()
+
+        # Calculate totals
+        total_cuda_time = 0
+        total_cpu_time = 0
+        num_cuda_kernels = 0
+
+        cuda_ops = []
+        cpu_ops = []
+
+        for event in key_averages:
+            if event.device_type == torch.device("cuda").type:
+                total_cuda_time += event.cuda_time_total
+                num_cuda_kernels += event.count
+                cuda_ops.append({
+                    "name": event.key,
+                    "cuda_time_ms": event.cuda_time_total / 1000,
+                    "cpu_time_ms": event.cpu_time_total / 1000,
+                    "count": event.count,
+                    "flops": getattr(event, "flops", 0),
+                })
+            else:
+                total_cpu_time += event.cpu_time_total
+                cpu_ops.append({
+                    "name": event.key,
+                    "cpu_time_ms": event.cpu_time_total / 1000,
+                    "count": event.count,
+                })
+
+        # Sort by time
+        cuda_ops.sort(key=lambda x: x["cuda_time_ms"], reverse=True)
+        cpu_ops.sort(key=lambda x: x["cpu_time_ms"], reverse=True)
+
+        result.total_cuda_time_ms = total_cuda_time / 1000
+        result.total_cpu_time_ms = total_cpu_time / 1000
+        result.num_cuda_kernels = num_cuda_kernels
+        result.top_cuda_ops = cuda_ops[:10]
+        result.top_cpu_ops = cpu_ops[:10]
+
+        # Get peak memory
+        if torch.cuda.is_available():
+            result.peak_memory_mb = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+        return result
+
+    @contextmanager
+    def profile_context(
+        self, name: str = "profile"
+    ) -> Generator[profile, None, ProfilerResult]:
+        """
+        Context manager for profiling.
+
+        Args:
+            name: Name for output files
+
+        Yields:
+            PyTorch profiler object
+
+        Returns:
+            ProfilerResult after context exits
+        """
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_name = f"{name}_{timestamp}"
+
+        with profile(
+            activities=self.config.get_activities(),
+            record_shapes=self.config.record_shapes,
+            profile_memory=self.config.profile_memory,
+            with_stack=self.config.with_stack,
+            with_flops=self.config.with_flops,
+            with_modules=self.config.with_modules,
+        ) as prof:
+            yield prof
+
+        # Export traces
+        result = ProfilerResult()
+
+        if self.config.export_chrome_trace:
+            chrome_path = self.output_dir / f"{run_name}_chrome_trace.json"
+            prof.export_chrome_trace(str(chrome_path))
+            result.chrome_trace_path = chrome_path
+
+        if self.config.export_tensorboard:
+            tb_dir = self.output_dir / "tensorboard" / run_name
+            tb_dir.mkdir(parents=True, exist_ok=True)
+            # Note: For single-shot profiling, we export chrome trace to TB dir
+            chrome_tb = tb_dir / "trace.json"
+            prof.export_chrome_trace(str(chrome_tb))
+            result.tensorboard_dir = tb_dir
+
+        return self._extract_statistics(prof, result)
+
+
+def profile_workload_run(
+    workload,
+    streams: List[torch.cuda.Stream],
+    output_dir: str | Path,
+    iterations: int = 10,
+    warmup: int = 3,
+    name: Optional[str] = None,
+) -> ProfilerResult:
+    """
+    Convenience function to profile a workload.
+
+    Args:
+        workload: BaseWorkload instance (must be setup)
+        streams: List of CUDA streams
+        output_dir: Output directory for traces
+        iterations: Profiling iterations
+        warmup: Warmup iterations
+        name: Optional name for output files
+
+    Returns:
+        ProfilerResult with paths to traces
+    """
+    if name is None:
+        name = workload.name
+
+    profiler = TorchProfilerWrapper(output_dir=output_dir)
+
+    def run_iteration():
+        workload.run_iteration(streams)
+        torch.cuda.synchronize()
+
+    return profiler.profile_workload(
+        run_iteration,
+        name=name,
+        iterations=iterations,
+        warmup=warmup,
+    )
+
+
+def generate_profile_summary(result: ProfilerResult) -> str:
+    """
+    Generate a human-readable summary of profiling results.
+
+    Args:
+        result: ProfilerResult from profiling
+
+    Returns:
+        Formatted summary string
+    """
+    lines = []
+    lines.append("=" * 70)
+    lines.append("PROFILING SUMMARY")
+    lines.append("=" * 70)
+    lines.append("")
+
+    lines.append("TIMING:")
+    lines.append(f"  Total CUDA time: {result.total_cuda_time_ms:.2f} ms")
+    lines.append(f"  Total CPU time:  {result.total_cpu_time_ms:.2f} ms")
+    lines.append(f"  CUDA kernels:    {result.num_cuda_kernels}")
+    lines.append("")
+
+    lines.append("MEMORY:")
+    lines.append(f"  Peak GPU memory: {result.peak_memory_mb:.2f} MB")
+    lines.append("")
+
+    if result.top_cuda_ops:
+        lines.append("TOP CUDA OPERATIONS (by time):")
+        for i, op in enumerate(result.top_cuda_ops[:5], 1):
+            flops_str = ""
+            if op.get("flops", 0) > 0:
+                gflops = op["flops"] / 1e9
+                flops_str = f" ({gflops:.2f} GFLOPS)"
+            lines.append(
+                f"  {i}. {op['name'][:40]:<40} "
+                f"{op['cuda_time_ms']:>8.2f} ms "
+                f"(x{op['count']}){flops_str}"
+            )
+        lines.append("")
+
+    lines.append("OUTPUT FILES:")
+    if result.chrome_trace_path:
+        lines.append(f"  Chrome trace:     {result.chrome_trace_path}")
+        lines.append(f"    View: chrome://tracing and load the JSON file")
+    if result.tensorboard_dir:
+        lines.append(f"  TensorBoard:      {result.tensorboard_dir}")
+        lines.append(f"    View: tensorboard --logdir={result.tensorboard_dir}")
+    if result.memory_timeline_path:
+        lines.append(f"  Memory timeline:  {result.memory_timeline_path}")
+        lines.append(f"    View: Open in browser")
+    if result.stacks_path:
+        lines.append(f"  Stack traces:     {result.stacks_path}")
+
+    lines.append("")
+    lines.append("=" * 70)
+
+    return "\n".join(lines)
+
+
+def export_kernel_summary(result: ProfilerResult, output_path: Path) -> None:
+    """
+    Export kernel summary to JSON file.
+
+    Args:
+        result: ProfilerResult from profiling
+        output_path: Path for output JSON
+    """
+    data = {
+        "summary": {
+            "total_cuda_time_ms": result.total_cuda_time_ms,
+            "total_cpu_time_ms": result.total_cpu_time_ms,
+            "peak_memory_mb": result.peak_memory_mb,
+            "num_cuda_kernels": result.num_cuda_kernels,
+        },
+        "top_cuda_ops": result.top_cuda_ops,
+        "top_cpu_ops": result.top_cpu_ops,
+        "output_files": {
+            "chrome_trace": str(result.chrome_trace_path) if result.chrome_trace_path else None,
+            "tensorboard": str(result.tensorboard_dir) if result.tensorboard_dir else None,
+            "memory_timeline": str(result.memory_timeline_path) if result.memory_timeline_path else None,
+        },
+    }
+
+    with open(output_path, "w") as f:
+        json.dump(data, f, indent=2)

--- a/src/aorta/hw_queue_eval/workloads/__init__.py
+++ b/src/aorta/hw_queue_eval/workloads/__init__.py
@@ -1,0 +1,19 @@
+"""
+Workload implementations for hardware queue evaluation.
+
+Workload categories:
+- distributed: FSDP, TP, MoE, gradient accumulation patterns
+- inference: Speculative decoding, continuous batching, RAG pipelines
+- pipeline: Async data loading, ZeRO offload, torch.compile patterns
+- latency_sensitive: Heterogeneous kernels, graph subgraph execution
+"""
+
+from aorta.hw_queue_eval.workloads.base import BaseWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry, get_workload, list_workloads
+
+__all__ = [
+    "BaseWorkload",
+    "WorkloadRegistry",
+    "get_workload",
+    "list_workloads",
+]

--- a/src/aorta/hw_queue_eval/workloads/base.py
+++ b/src/aorta/hw_queue_eval/workloads/base.py
@@ -1,0 +1,402 @@
+"""
+Abstract base class for all workloads.
+
+All workloads must implement this interface to be usable with the StreamHarness.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+
+@dataclass
+class WorkloadInfo:
+    """Metadata about a workload."""
+
+    name: str
+    description: str
+    category: str  # "distributed", "inference", "pipeline", "latency_sensitive"
+    min_streams: int
+    max_streams: int
+    recommended_streams: int
+    switch_latency_sensitivity: str  # "low", "medium", "high", "critical"
+    memory_requirements_gb: float = 0.0
+    multi_gpu_capable: bool = False
+
+
+class BaseWorkload(ABC):
+    """
+    Base class for all queue stress test workloads.
+
+    Subclasses must implement:
+    - setup(): Initialize workload state
+    - run_iteration(): Execute one iteration
+    - get_throughput_unit(): Return throughput unit string
+    - compute_throughput(): Compute throughput from timing data
+
+    Class attributes to set:
+    - name: Short identifier for the workload
+    - description: Human-readable description
+    - min_streams: Minimum number of streams supported
+    - max_streams: Maximum number of streams supported
+    - recommended_streams: Optimal number of streams
+    - switch_latency_sensitivity: How sensitive to queue switch latency
+    """
+
+    # Class attributes - override in subclasses
+    name: str = "base"
+    description: str = "Base workload - do not use directly"
+    category: str = "base"
+    min_streams: int = 1
+    max_streams: int = 32
+    recommended_streams: int = 4
+    switch_latency_sensitivity: str = "medium"  # "low", "medium", "high", "critical"
+    memory_requirements_gb: float = 1.0
+    multi_gpu_capable: bool = False
+
+    def __init__(self):
+        """Initialize the workload."""
+        self._device: str = "cuda:0"
+        self._stream_count: int = 0
+        self._is_setup: bool = False
+        self._tensors: Dict[str, torch.Tensor] = {}
+
+    @abstractmethod
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """
+        Initialize workload state, models, tensors.
+
+        This method is called once before iterations begin. It should:
+        - Allocate all necessary tensors
+        - Initialize models (if any)
+        - Setup any per-stream state
+
+        Args:
+            stream_count: Number of streams that will be used
+            device: Target device (e.g., "cuda:0")
+        """
+        pass
+
+    @abstractmethod
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one iteration of the workload across provided streams.
+
+        This method should dispatch work to the provided streams.
+        It should NOT synchronize streams - the harness handles that.
+
+        Args:
+            streams: List of CUDA/HIP streams to use
+        """
+        pass
+
+    @abstractmethod
+    def get_throughput_unit(self) -> str:
+        """
+        Return the unit for throughput measurement.
+
+        Examples: "samples/sec", "tokens/sec", "GFLOPS", "ops/sec"
+
+        Returns:
+            Unit string for throughput
+        """
+        pass
+
+    @abstractmethod
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        """
+        Compute throughput from iteration count and time.
+
+        Args:
+            iterations: Number of iterations completed
+            total_time_sec: Total time in seconds
+
+        Returns:
+            Throughput value (in units returned by get_throughput_unit)
+        """
+        pass
+
+    def cleanup(self) -> None:
+        """
+        Optional cleanup after workload completes.
+
+        Override this to release resources, clear caches, etc.
+        """
+        self._tensors.clear()
+        self._is_setup = False
+        torch.cuda.empty_cache()
+
+    def validate_correctness(
+        self, baseline_result: Any, test_result: Any
+    ) -> Tuple[bool, str]:
+        """
+        Compare results for numerical correctness.
+
+        Override this to implement workload-specific correctness checks.
+
+        Args:
+            baseline_result: Result from baseline run
+            test_result: Result from test run
+
+        Returns:
+            Tuple of (is_correct, message)
+        """
+        return True, "Correctness validation not implemented"
+
+    def get_info(self) -> WorkloadInfo:
+        """Get workload metadata."""
+        return WorkloadInfo(
+            name=self.name,
+            description=self.description,
+            category=self.category,
+            min_streams=self.min_streams,
+            max_streams=self.max_streams,
+            recommended_streams=self.recommended_streams,
+            switch_latency_sensitivity=self.switch_latency_sensitivity,
+            memory_requirements_gb=self.memory_requirements_gb,
+            multi_gpu_capable=self.multi_gpu_capable,
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        """
+        Get workload configuration.
+
+        Override to return workload-specific configuration.
+
+        Returns:
+            Dictionary with configuration parameters
+        """
+        return {
+            "name": self.name,
+            "stream_count": self._stream_count,
+            "device": self._device,
+        }
+
+    def supports_stream_count(self, count: int) -> bool:
+        """Check if workload supports the given stream count."""
+        return self.min_streams <= count <= self.max_streams
+
+    def _allocate_tensor(
+        self,
+        name: str,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        requires_grad: bool = False,
+    ) -> torch.Tensor:
+        """
+        Allocate a tensor and track it for cleanup.
+
+        Args:
+            name: Identifier for the tensor
+            shape: Tensor shape
+            dtype: Data type
+            requires_grad: Whether to track gradients
+
+        Returns:
+            Allocated tensor
+        """
+        tensor = torch.randn(
+            shape, dtype=dtype, device=self._device, requires_grad=requires_grad
+        )
+        self._tensors[name] = tensor
+        return tensor
+
+    def _get_tensor(self, name: str) -> torch.Tensor:
+        """Get a previously allocated tensor."""
+        if name not in self._tensors:
+            raise KeyError(f"Tensor '{name}' not found. Did you call setup()?")
+        return self._tensors[name]
+
+
+class SyntheticWorkload(BaseWorkload):
+    """
+    Base class for synthetic (non-model) workloads.
+
+    Provides utilities for creating simple kernel patterns.
+    """
+
+    category = "synthetic"
+
+    def __init__(self):
+        super().__init__()
+        self._ops_per_iteration: int = 0
+
+    def get_throughput_unit(self) -> str:
+        return "ops/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self._ops_per_iteration) / total_time_sec
+
+
+class ModelWorkload(BaseWorkload):
+    """
+    Base class for model-based workloads.
+
+    Provides utilities for:
+    - Model initialization
+    - Batch processing
+    - Gradient computation
+    """
+
+    category = "model"
+
+    def __init__(self):
+        super().__init__()
+        self._model: Optional[torch.nn.Module] = None
+        self._batch_size: int = 1
+        self._samples_per_iteration: int = 0
+
+    def get_throughput_unit(self) -> str:
+        return "samples/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self._samples_per_iteration) / total_time_sec
+
+    def cleanup(self) -> None:
+        """Cleanup model and tensors."""
+        super().cleanup()
+        self._model = None
+
+
+class DistributedWorkload(BaseWorkload):
+    """
+    Base class for distributed training workloads.
+
+    Provides utilities for:
+    - Mock collective operations
+    - Communication/compute overlap simulation
+    """
+
+    category = "distributed"
+    multi_gpu_capable = True
+
+    def __init__(self, simulate_collectives: bool = True):
+        """
+        Initialize distributed workload.
+
+        Args:
+            simulate_collectives: If True, mock collective operations with local copies.
+                                 If False, use actual NCCL/RCCL operations.
+        """
+        super().__init__()
+        self._simulate_collectives = simulate_collectives
+        self._comm_buffers: Dict[str, torch.Tensor] = {}
+
+    def _mock_all_reduce(
+        self, tensor: torch.Tensor, stream: torch.cuda.Stream
+    ) -> torch.Tensor:
+        """
+        Mock all-reduce operation.
+
+        In simulation mode, this just copies the tensor.
+        In real distributed mode, this would call NCCL/RCCL.
+
+        Args:
+            tensor: Tensor to reduce
+            stream: Stream to use
+
+        Returns:
+            Reduced tensor
+        """
+        with torch.cuda.stream(stream):
+            if self._simulate_collectives:
+                # Simulate collective with a copy and small computation
+                result = tensor.clone()
+                result.mul_(1.0)  # Force kernel execution
+            else:
+                # Would use torch.distributed here
+                result = tensor
+        return result
+
+    def _mock_all_gather(
+        self,
+        tensor: torch.Tensor,
+        stream: torch.cuda.Stream,
+        num_ranks: int = 8,
+    ) -> torch.Tensor:
+        """
+        Mock all-gather operation.
+
+        Args:
+            tensor: Local tensor
+            stream: Stream to use
+            num_ranks: Number of ranks (for output size)
+
+        Returns:
+            Gathered tensor (simulated)
+        """
+        with torch.cuda.stream(stream):
+            if self._simulate_collectives:
+                # Simulate by repeating tensor
+                result = tensor.repeat(num_ranks, *([1] * (tensor.dim() - 1)))
+            else:
+                result = tensor
+        return result
+
+    def cleanup(self) -> None:
+        """Cleanup communication buffers."""
+        super().cleanup()
+        self._comm_buffers.clear()
+
+
+class InferenceWorkload(BaseWorkload):
+    """
+    Base class for inference workloads.
+
+    Provides utilities for:
+    - Token generation patterns
+    - KV cache management
+    - Batch scheduling
+    """
+
+    category = "inference"
+
+    def __init__(self):
+        super().__init__()
+        self._tokens_per_iteration: int = 0
+        self._kv_cache: Dict[int, Tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def get_throughput_unit(self) -> str:
+        return "tokens/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self._tokens_per_iteration) / total_time_sec
+
+    def _init_kv_cache(
+        self,
+        num_layers: int,
+        batch_size: int,
+        max_seq_len: int,
+        num_heads: int,
+        head_dim: int,
+        dtype: torch.dtype = torch.float16,
+    ) -> None:
+        """Initialize KV cache for transformer inference."""
+        self._kv_cache = {}
+        for layer_idx in range(num_layers):
+            k_cache = torch.zeros(
+                (batch_size, num_heads, max_seq_len, head_dim),
+                dtype=dtype,
+                device=self._device,
+            )
+            v_cache = torch.zeros(
+                (batch_size, num_heads, max_seq_len, head_dim),
+                dtype=dtype,
+                device=self._device,
+            )
+            self._kv_cache[layer_idx] = (k_cache, v_cache)
+
+    def cleanup(self) -> None:
+        """Cleanup KV cache and other resources."""
+        super().cleanup()
+        self._kv_cache.clear()

--- a/src/aorta/hw_queue_eval/workloads/distributed/__init__.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/__init__.py
@@ -1,0 +1,21 @@
+"""
+Distributed training workloads for hardware queue evaluation.
+
+These workloads simulate patterns from distributed training:
+- FSDP + Tensor Parallelism (3D parallelism)
+- Mixture of Experts (MoE) with parallel expert execution
+- Activation checkpointing with recomputation streams
+- Gradient accumulation with early reduction
+"""
+
+from aorta.hw_queue_eval.workloads.distributed.activation_ckpt import ActivationCheckpointWorkload
+from aorta.hw_queue_eval.workloads.distributed.fsdp_tp import FSDPTPWorkload
+from aorta.hw_queue_eval.workloads.distributed.grad_accum import GradientAccumulationWorkload
+from aorta.hw_queue_eval.workloads.distributed.moe import MoEWorkload
+
+__all__ = [
+    "FSDPTPWorkload",
+    "MoEWorkload",
+    "ActivationCheckpointWorkload",
+    "GradientAccumulationWorkload",
+]

--- a/src/aorta/hw_queue_eval/workloads/distributed/activation_ckpt.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/activation_ckpt.py
@@ -1,0 +1,225 @@
+"""
+Activation Checkpointing Workload
+
+Pattern: Simulate activation checkpointing with recomputation streams
+- Forward compute streams
+- Recomputation streams during backward
+- Gradient streams
+
+This tests the overlap of recomputation with gradient computation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import DistributedWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class CheckpointBlock(nn.Module):
+    """A block that can be checkpointed."""
+
+    def __init__(self, hidden_size: int, expansion: int = 4):
+        super().__init__()
+        self.fc1 = nn.Linear(hidden_size, hidden_size * expansion)
+        self.fc2 = nn.Linear(hidden_size * expansion, hidden_size)
+        self.norm = nn.LayerNorm(hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.norm(x)
+        x = self.fc1(x)
+        x = torch.relu(x)
+        x = self.fc2(x)
+        return x + residual
+
+
+@WorkloadRegistry.register
+class ActivationCheckpointWorkload(DistributedWorkload):
+    """
+    Activation checkpointing with overlapped recomputation.
+
+    Simulates the pattern where:
+    - Forward pass saves only checkpoint boundaries
+    - Backward recomputes activations on demand
+    - Recomputation can overlap with gradient computation
+
+    Stream assignment:
+    - Streams 0-1: Forward compute
+    - Streams 2-3: Recomputation during backward
+    - Streams 4-5: Gradient computation
+    """
+
+    name = "activation_ckpt"
+    description = "Activation checkpointing with recomputation overlap"
+    category = "distributed"
+    min_streams = 4
+    max_streams = 12
+    recommended_streams = 6
+    switch_latency_sensitivity = "high"
+    memory_requirements_gb = 2.0
+
+    def __init__(
+        self,
+        num_blocks: int = 8,
+        hidden_size: int = 1024,
+        checkpoint_every: int = 2,  # Checkpoint every N blocks
+        batch_size: int = 4,
+        seq_length: int = 512,
+        simulate_collectives: bool = True,
+    ):
+        """
+        Initialize activation checkpointing workload.
+
+        Args:
+            num_blocks: Number of blocks in the model
+            hidden_size: Hidden dimension
+            checkpoint_every: Checkpoint frequency
+            batch_size: Batch size
+            seq_length: Sequence length
+            simulate_collectives: Mock collective operations
+        """
+        super().__init__(simulate_collectives)
+
+        self.num_blocks = num_blocks
+        self.hidden_size = hidden_size
+        self.checkpoint_every = checkpoint_every
+        self.batch_size = batch_size
+        self.seq_length = seq_length
+
+        self._blocks: List[CheckpointBlock] = []
+        self._checkpoints: Dict[int, torch.Tensor] = {}
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup model blocks and stream assignments."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Create blocks
+        self._blocks = []
+        for i in range(self.num_blocks):
+            block = CheckpointBlock(self.hidden_size).to(device)
+            block.eval()
+            self._blocks.append(block)
+
+        # Stream assignments
+        third = max(1, stream_count // 3)
+        self._forward_streams = list(range(0, third))
+        self._recompute_streams = list(range(third, 2 * third))
+        self._gradient_streams = list(range(2 * third, stream_count))
+
+        # Ensure at least one stream per type
+        if not self._recompute_streams:
+            self._recompute_streams = [0]
+        if not self._gradient_streams:
+            self._gradient_streams = [0]
+
+        # Input tensor
+        self._input = torch.randn(
+            self.batch_size, self.seq_length, self.hidden_size,
+            dtype=torch.float32, device=device, requires_grad=True
+        )
+        self._tensors["input"] = self._input
+
+        # Checkpoint storage
+        self._checkpoints = {}
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one iteration with checkpointing pattern.
+
+        1. Forward pass: compute and save checkpoints
+        2. Backward pass: recompute from checkpoints, compute gradients
+        """
+        forward_stream = streams[self._forward_streams[0]]
+        recompute_stream = streams[self._recompute_streams[0]]
+        gradient_stream = streams[self._gradient_streams[0]]
+
+        x = self._input
+        self._checkpoints = {0: x}
+
+        # Forward pass with checkpointing
+        with torch.cuda.stream(forward_stream):
+            for i, block in enumerate(self._blocks):
+                x = block(x)
+
+                # Save checkpoint at intervals
+                if (i + 1) % self.checkpoint_every == 0:
+                    self._checkpoints[i + 1] = x.detach().clone()
+
+            # Final output
+            output = x.sum()
+
+        # Simulate backward pass with recomputation
+        # In real checkpointing, this happens automatically
+        # Here we simulate the pattern
+
+        # Wait for forward to complete
+        recompute_stream.wait_stream(forward_stream)
+        gradient_stream.wait_stream(forward_stream)
+
+        # Backward: iterate blocks in reverse
+        # Recompute intermediate activations from checkpoints
+        num_segments = (self.num_blocks + self.checkpoint_every - 1) // self.checkpoint_every
+
+        for seg in range(num_segments - 1, -1, -1):
+            start_idx = seg * self.checkpoint_every
+            end_idx = min(start_idx + self.checkpoint_every, self.num_blocks)
+
+            # Get checkpoint for this segment
+            ckpt_key = start_idx
+            if ckpt_key in self._checkpoints:
+                ckpt = self._checkpoints[ckpt_key]
+            else:
+                ckpt = self._input
+
+            # Recompute activations for this segment
+            with torch.cuda.stream(recompute_stream):
+                recomputed = ckpt
+                for i in range(start_idx, end_idx):
+                    recomputed = self._blocks[i](recomputed)
+
+            # Overlap: compute gradients while next segment recomputes
+            recompute_stream.wait_stream(gradient_stream)
+
+            with torch.cuda.stream(gradient_stream):
+                # Simulate gradient computation
+                if recomputed.requires_grad:
+                    grad = torch.autograd.grad(
+                        recomputed.sum(), ckpt, retain_graph=True,
+                        allow_unused=True
+                    )[0]
+
+    def get_throughput_unit(self) -> str:
+        return "samples/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self.batch_size) / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "num_blocks": self.num_blocks,
+            "hidden_size": self.hidden_size,
+            "checkpoint_every": self.checkpoint_every,
+            "batch_size": self.batch_size,
+            "seq_length": self.seq_length,
+            "stream_assignment": {
+                "forward": self._forward_streams,
+                "recompute": self._recompute_streams,
+                "gradient": self._gradient_streams,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup model and checkpoints."""
+        super().cleanup()
+        self._blocks = []
+        self._checkpoints = {}

--- a/src/aorta/hw_queue_eval/workloads/distributed/fsdp_tp.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/fsdp_tp.py
@@ -1,0 +1,305 @@
+"""
+FSDP + Tensor Parallelism (3D Parallelism) Workload
+
+Pattern: Simulate overlapped communication and compute in distributed training
+- All-reduce streams for data parallelism
+- All-gather streams for FSDP shard gathering
+- Compute streams for forward/backward
+- Point-to-point streams for tensor parallelism
+
+This can run in single-GPU simulation mode (mock collectives)
+or multi-GPU mode with actual NCCL/RCCL operations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import DistributedWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class SimpleTransformerBlock(nn.Module):
+    """Simple transformer block for testing."""
+
+    def __init__(self, hidden_size: int, num_heads: int = 8, mlp_ratio: float = 4.0):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+
+        self.ln1 = nn.LayerNorm(hidden_size)
+        self.attn = nn.MultiheadAttention(hidden_size, num_heads, batch_first=True)
+        self.ln2 = nn.LayerNorm(hidden_size)
+
+        mlp_hidden = int(hidden_size * mlp_ratio)
+        self.mlp = nn.Sequential(
+            nn.Linear(hidden_size, mlp_hidden),
+            nn.GELU(),
+            nn.Linear(mlp_hidden, hidden_size),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Self-attention
+        residual = x
+        x = self.ln1(x)
+        x, _ = self.attn(x, x, x)
+        x = residual + x
+
+        # MLP
+        residual = x
+        x = self.ln2(x)
+        x = self.mlp(x)
+        x = residual + x
+
+        return x
+
+
+@WorkloadRegistry.register
+class FSDPTPWorkload(DistributedWorkload):
+    """
+    FSDP + Tensor Parallelism with overlapped comm/compute.
+
+    Simulates the stream usage pattern of 3D parallelism:
+    - Compute streams: Model forward/backward
+    - All-gather streams: FSDP shard gathering (prefetch)
+    - All-reduce streams: Gradient synchronization
+    - P2P streams: TP communication (if using TP)
+
+    Stream assignment (for 10 streams):
+    - Streams 0-1: Primary compute
+    - Streams 2-3: All-gather (FSDP)
+    - Streams 4-5: All-reduce (DP)
+    - Streams 6-7: Point-to-point (TP)
+    - Streams 8-9: Auxiliary/overlap
+    """
+
+    name = "fsdp_tp"
+    description = "FSDP + Tensor Parallelism with overlapped comm/compute"
+    category = "distributed"
+    min_streams = 4
+    max_streams = 16
+    recommended_streams = 10
+    switch_latency_sensitivity = "high"
+    memory_requirements_gb = 4.0
+
+    def __init__(
+        self,
+        model_size: str = "small",  # "small", "medium", "large"
+        simulate_collectives: bool = True,
+        overlap_comm_compute: bool = True,
+        num_layers: int = 4,
+        batch_size: int = 8,
+        seq_length: int = 512,
+    ):
+        """
+        Initialize FSDP+TP workload.
+
+        Args:
+            model_size: Model size preset
+            simulate_collectives: Mock collectives for single-GPU testing
+            overlap_comm_compute: Enable comm/compute overlap pattern
+            num_layers: Number of transformer layers
+            batch_size: Batch size
+            seq_length: Sequence length
+        """
+        super().__init__(simulate_collectives)
+
+        self.model_size = model_size
+        self.overlap_comm_compute = overlap_comm_compute
+        self.num_layers = num_layers
+        self.batch_size = batch_size
+        self.seq_length = seq_length
+
+        # Size presets
+        size_configs = {
+            "small": {"hidden_size": 512, "num_heads": 8},
+            "medium": {"hidden_size": 1024, "num_heads": 16},
+            "large": {"hidden_size": 2048, "num_heads": 32},
+        }
+        config = size_configs.get(model_size, size_configs["small"])
+        self.hidden_size = config["hidden_size"]
+        self.num_heads = config["num_heads"]
+
+        # Stream indices (will be populated in setup)
+        self._compute_streams: List[int] = []
+        self._allgather_streams: List[int] = []
+        self._allreduce_streams: List[int] = []
+        self._p2p_streams: List[int] = []
+
+        # Model layers
+        self._layers: List[SimpleTransformerBlock] = []
+        self._layer_weights: List[torch.Tensor] = []
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup model layers and stream assignments."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Assign streams to different roles
+        # Compute gets priority (first 1/4)
+        # Then all-gather (next 1/4)
+        # Then all-reduce (next 1/4)
+        # Then P2P/aux (remaining)
+        quarter = max(1, stream_count // 4)
+
+        self._compute_streams = list(range(0, quarter))
+        self._allgather_streams = list(range(quarter, 2 * quarter))
+        self._allreduce_streams = list(range(2 * quarter, 3 * quarter))
+        self._p2p_streams = list(range(3 * quarter, stream_count))
+
+        # Ensure at least one stream per type
+        if not self._allgather_streams:
+            self._allgather_streams = [0]
+        if not self._allreduce_streams:
+            self._allreduce_streams = [0]
+        if not self._p2p_streams:
+            self._p2p_streams = [0]
+
+        # Create model layers
+        self._layers = []
+        self._layer_weights = []
+
+        for i in range(self.num_layers):
+            layer = SimpleTransformerBlock(
+                self.hidden_size, self.num_heads
+            ).to(device)
+            layer.eval()  # No dropout for determinism
+            self._layers.append(layer)
+
+            # Create "shard" weights to gather (simulating FSDP)
+            shard = torch.randn(
+                self.hidden_size, self.hidden_size,
+                dtype=torch.float32, device=device
+            )
+            self._layer_weights.append(shard)
+            self._tensors[f"shard_{i}"] = shard
+
+        # Input tensor
+        self._input = torch.randn(
+            self.batch_size, self.seq_length, self.hidden_size,
+            dtype=torch.float32, device=device, requires_grad=True
+        )
+        self._tensors["input"] = self._input
+
+        # Gradient buffer
+        self._grad_buffer = torch.zeros(
+            self.hidden_size * self.hidden_size,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["grad_buffer"] = self._grad_buffer
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one training iteration with overlapped operations.
+
+        Pattern:
+        1. Prefetch all-gather for layer 0 weights
+        2. For each layer:
+           - Compute forward on compute stream
+           - Prefetch next layer's weights on all-gather stream
+        3. Backward pass with all-reduce overlap
+        """
+        if self.overlap_comm_compute:
+            self._run_overlapped(streams)
+        else:
+            self._run_sequential(streams)
+
+    def _run_overlapped(self, streams: List[torch.cuda.Stream]) -> None:
+        """Run with comm/compute overlap."""
+        compute_stream = streams[self._compute_streams[0]]
+        allgather_stream = streams[self._allgather_streams[0]]
+        allreduce_stream = streams[self._allreduce_streams[0]]
+
+        x = self._input
+
+        # Prefetch first layer weights
+        gathered_weights = self._mock_all_gather(
+            self._layer_weights[0], allgather_stream
+        )
+
+        # Forward pass with prefetching
+        for i, layer in enumerate(self._layers):
+            # Wait for this layer's weights (from previous prefetch)
+            compute_stream.wait_stream(allgather_stream)
+
+            # Compute forward
+            with torch.cuda.stream(compute_stream):
+                x = layer(x)
+
+            # Prefetch next layer's weights (if not last layer)
+            if i < len(self._layers) - 1:
+                gathered_weights = self._mock_all_gather(
+                    self._layer_weights[i + 1], allgather_stream
+                )
+
+        # Simulate backward pass with gradient computation
+        with torch.cuda.stream(compute_stream):
+            # Fake backward - just compute some gradients
+            loss = x.sum()
+            grad = torch.autograd.grad(loss, self._input, retain_graph=True)[0]
+
+        # All-reduce gradients (overlapped with next batch's forward)
+        with torch.cuda.stream(allreduce_stream):
+            reduced_grad = self._mock_all_reduce(
+                self._grad_buffer, allreduce_stream
+            )
+
+    def _run_sequential(self, streams: List[torch.cuda.Stream]) -> None:
+        """Run without overlap (baseline)."""
+        compute_stream = streams[self._compute_streams[0]]
+        allreduce_stream = streams[self._allreduce_streams[0]]
+
+        x = self._input
+
+        # Forward pass
+        with torch.cuda.stream(compute_stream):
+            for layer in self._layers:
+                x = layer(x)
+
+        # Backward
+        with torch.cuda.stream(compute_stream):
+            loss = x.sum()
+            grad = torch.autograd.grad(loss, self._input, retain_graph=True)[0]
+
+        # All-reduce (after backward completes)
+        compute_stream.synchronize()
+        with torch.cuda.stream(allreduce_stream):
+            reduced_grad = self._mock_all_reduce(
+                self._grad_buffer, allreduce_stream
+            )
+
+    def get_throughput_unit(self) -> str:
+        return "samples/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self.batch_size) / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "model_size": self.model_size,
+            "hidden_size": self.hidden_size,
+            "num_layers": self.num_layers,
+            "batch_size": self.batch_size,
+            "seq_length": self.seq_length,
+            "overlap_comm_compute": self.overlap_comm_compute,
+            "simulate_collectives": self._simulate_collectives,
+            "stream_assignment": {
+                "compute": self._compute_streams,
+                "allgather": self._allgather_streams,
+                "allreduce": self._allreduce_streams,
+                "p2p": self._p2p_streams,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup model and tensors."""
+        super().cleanup()
+        self._layers = []
+        self._layer_weights = []

--- a/src/aorta/hw_queue_eval/workloads/distributed/grad_accum.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/grad_accum.py
@@ -1,0 +1,212 @@
+"""
+Gradient Accumulation with Early Reduction Workload
+
+Pattern: Overlap gradient computation with reduction
+- Compute streams for microbatch forward/backward
+- Reduction streams for gradient accumulation
+- Enables early all-reduce before full accumulation
+
+This is common in large-batch training with gradient accumulation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import DistributedWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class SimpleMLP(nn.Module):
+    """Simple MLP for gradient accumulation testing."""
+
+    def __init__(self, input_size: int, hidden_size: int, output_size: int):
+        super().__init__()
+        self.fc1 = nn.Linear(input_size, hidden_size)
+        self.fc2 = nn.Linear(hidden_size, hidden_size)
+        self.fc3 = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.relu(self.fc1(x))
+        x = torch.relu(self.fc2(x))
+        return self.fc3(x)
+
+
+@WorkloadRegistry.register
+class GradientAccumulationWorkload(DistributedWorkload):
+    """
+    Gradient accumulation with early reduction pattern.
+
+    Simulates the pattern where:
+    - Multiple microbatches are processed
+    - Gradients are accumulated across microbatches
+    - All-reduce can start on early layers before all microbatches complete
+
+    Stream assignment:
+    - Streams 0-N/2: Compute (forward/backward)
+    - Streams N/2-N: Reduction (all-reduce overlap)
+    """
+
+    name = "grad_accum"
+    description = "Gradient accumulation with early reduction"
+    category = "distributed"
+    min_streams = 2
+    max_streams = 16
+    recommended_streams = 6
+    switch_latency_sensitivity = "medium"
+    memory_requirements_gb = 2.0
+
+    def __init__(
+        self,
+        num_microbatches: int = 4,
+        hidden_size: int = 2048,
+        batch_size: int = 32,  # Per microbatch
+        input_size: int = 1024,
+        output_size: int = 1000,
+        simulate_collectives: bool = True,
+    ):
+        """
+        Initialize gradient accumulation workload.
+
+        Args:
+            num_microbatches: Number of microbatches to accumulate
+            hidden_size: MLP hidden size
+            batch_size: Batch size per microbatch
+            input_size: Input feature size
+            output_size: Output size
+            simulate_collectives: Mock collective operations
+        """
+        super().__init__(simulate_collectives)
+
+        self.num_microbatches = num_microbatches
+        self.hidden_size = hidden_size
+        self.batch_size = batch_size
+        self.input_size = input_size
+        self.output_size = output_size
+
+        self._model: nn.Module = None
+        self._inputs: List[torch.Tensor] = []
+        self._grad_buffers: Dict[str, torch.Tensor] = {}
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup model and gradient buffers."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Create model
+        self._model = SimpleMLP(
+            self.input_size, self.hidden_size, self.output_size
+        ).to(device)
+
+        # Stream assignments
+        half = max(1, stream_count // 2)
+        self._compute_streams = list(range(0, half))
+        self._reduce_streams = list(range(half, stream_count))
+
+        if not self._reduce_streams:
+            self._reduce_streams = [0]
+
+        # Create input tensors for each microbatch
+        self._inputs = []
+        for i in range(self.num_microbatches):
+            inp = torch.randn(
+                self.batch_size, self.input_size,
+                dtype=torch.float32, device=device
+            )
+            self._inputs.append(inp)
+            self._tensors[f"input_{i}"] = inp
+
+        # Create gradient accumulation buffers
+        self._grad_buffers = {}
+        for name, param in self._model.named_parameters():
+            buf = torch.zeros_like(param)
+            self._grad_buffers[name] = buf
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute gradient accumulation with early reduction.
+
+        Pattern:
+        1. Process microbatches, accumulating gradients
+        2. Start reducing early layers while later microbatches process
+        """
+        # Zero gradient buffers
+        for buf in self._grad_buffers.values():
+            buf.zero_()
+
+        param_list = list(self._model.named_parameters())
+        num_params = len(param_list)
+
+        # Process microbatches
+        for mb_idx in range(self.num_microbatches):
+            compute_stream_idx = mb_idx % len(self._compute_streams)
+            compute_stream = streams[self._compute_streams[compute_stream_idx]]
+
+            with torch.cuda.stream(compute_stream):
+                # Forward
+                x = self._inputs[mb_idx]
+                output = self._model(x)
+                loss = output.sum() / self.num_microbatches
+
+                # Backward
+                loss.backward()
+
+                # Accumulate gradients
+                for name, param in self._model.named_parameters():
+                    if param.grad is not None:
+                        self._grad_buffers[name].add_(param.grad)
+                        param.grad = None
+
+            # Early reduction: reduce first half of params after half microbatches
+            if mb_idx == self.num_microbatches // 2:
+                reduce_stream = streams[self._reduce_streams[0]]
+                reduce_stream.wait_stream(compute_stream)
+
+                with torch.cuda.stream(reduce_stream):
+                    for i, (name, _) in enumerate(param_list[:num_params // 2]):
+                        buf = self._grad_buffers[name]
+                        self._mock_all_reduce(buf, reduce_stream)
+
+        # Final reduction for remaining params
+        last_compute_stream = streams[self._compute_streams[-1]]
+        reduce_stream = streams[self._reduce_streams[0]]
+        reduce_stream.wait_stream(last_compute_stream)
+
+        with torch.cuda.stream(reduce_stream):
+            for name, _ in param_list[num_params // 2:]:
+                buf = self._grad_buffers[name]
+                self._mock_all_reduce(buf, reduce_stream)
+
+    def get_throughput_unit(self) -> str:
+        return "samples/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        total_samples = iterations * self.num_microbatches * self.batch_size
+        return total_samples / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "num_microbatches": self.num_microbatches,
+            "hidden_size": self.hidden_size,
+            "batch_size": self.batch_size,
+            "input_size": self.input_size,
+            "output_size": self.output_size,
+            "stream_assignment": {
+                "compute": self._compute_streams,
+                "reduce": self._reduce_streams,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup model and buffers."""
+        super().cleanup()
+        self._model = None
+        self._inputs = []
+        self._grad_buffers = {}

--- a/src/aorta/hw_queue_eval/workloads/distributed/moe.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/moe.py
@@ -1,0 +1,256 @@
+"""
+Mixture of Experts Training Workload
+
+Pattern: Multiple expert MLPs execute in parallel
+- Each expert gets its own stream
+- All-to-all for token routing between experts
+- Gating network on separate stream
+
+With 8-16 experts, this naturally stresses high stream counts.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from aorta.hw_queue_eval.workloads.base import DistributedWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class ExpertMLP(nn.Module):
+    """Single expert MLP."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.fc1 = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.fc2 = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(F.gelu(self.fc1(x)))
+
+
+class GatingNetwork(nn.Module):
+    """Router/gating network for MoE."""
+
+    def __init__(self, hidden_size: int, num_experts: int):
+        super().__init__()
+        self.gate = nn.Linear(hidden_size, num_experts, bias=False)
+
+    def forward(self, x: torch.Tensor, top_k: int = 2) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Compute gating scores and select top-k experts.
+
+        Returns:
+            routing_weights: [batch, seq, top_k] - weights for selected experts
+            expert_indices: [batch, seq, top_k] - indices of selected experts
+        """
+        logits = self.gate(x)  # [batch, seq, num_experts]
+        routing_weights, expert_indices = torch.topk(
+            F.softmax(logits, dim=-1), top_k, dim=-1
+        )
+        # Normalize weights
+        routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+        return routing_weights, expert_indices
+
+
+@WorkloadRegistry.register
+class MoEWorkload(DistributedWorkload):
+    """
+    Mixture of Experts with parallel expert execution.
+
+    This workload stress-tests high stream counts by running each expert
+    on a separate stream. With 8-16 experts, this requires 8-16+ concurrent
+    streams for maximum parallelism.
+
+    Stream assignment:
+    - Stream 0: Gating network
+    - Streams 1-N: One per expert
+    - Remaining streams: All-to-all communication
+
+    The pattern is:
+    1. Gating computes routing weights
+    2. Tokens are dispatched to experts (all-to-all in distributed setting)
+    3. Each expert processes its tokens in parallel
+    4. Results are combined (another all-to-all)
+    """
+
+    name = "moe"
+    description = "Mixture of Experts with parallel expert execution"
+    category = "distributed"
+    min_streams = 4
+    max_streams = 32
+    recommended_streams = 16
+    switch_latency_sensitivity = "critical"
+    memory_requirements_gb = 8.0
+
+    def __init__(
+        self,
+        num_experts: int = 8,
+        hidden_size: int = 1024,
+        intermediate_size: int = 4096,
+        top_k: int = 2,
+        batch_size: int = 4,
+        seq_length: int = 512,
+        simulate_collectives: bool = True,
+    ):
+        """
+        Initialize MoE workload.
+
+        Args:
+            num_experts: Number of experts
+            hidden_size: Model hidden size
+            intermediate_size: Expert intermediate size
+            top_k: Number of experts per token
+            batch_size: Batch size
+            seq_length: Sequence length
+            simulate_collectives: Mock all-to-all operations
+        """
+        super().__init__(simulate_collectives)
+
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.top_k = top_k
+        self.batch_size = batch_size
+        self.seq_length = seq_length
+
+        self._gating: Optional[GatingNetwork] = None
+        self._experts: List[ExpertMLP] = []
+        self._expert_streams: List[int] = []
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup gating network and experts."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Create gating network
+        self._gating = GatingNetwork(self.hidden_size, self.num_experts).to(device)
+        self._gating.eval()
+
+        # Create experts
+        self._experts = []
+        for i in range(self.num_experts):
+            expert = ExpertMLP(self.hidden_size, self.intermediate_size).to(device)
+            expert.eval()
+            self._experts.append(expert)
+
+        # Assign streams to experts
+        # Stream 0 for gating, rest for experts (round-robin if fewer streams than experts)
+        self._gating_stream = 0
+        self._expert_streams = []
+        available_expert_streams = stream_count - 1  # Exclude gating stream
+
+        for i in range(self.num_experts):
+            stream_idx = 1 + (i % max(1, available_expert_streams))
+            self._expert_streams.append(stream_idx)
+
+        # Input tensor
+        self._input = torch.randn(
+            self.batch_size, self.seq_length, self.hidden_size,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["input"] = self._input
+
+        # Buffers for expert outputs
+        self._expert_outputs = []
+        for i in range(self.num_experts):
+            out = torch.zeros(
+                self.batch_size, self.seq_length, self.hidden_size,
+                dtype=torch.float32, device=device
+            )
+            self._expert_outputs.append(out)
+            self._tensors[f"expert_out_{i}"] = out
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one MoE forward pass.
+
+        1. Gating computes routing (stream 0)
+        2. Each expert processes assigned tokens (parallel streams)
+        3. Results are combined
+        """
+        gating_stream = streams[self._gating_stream]
+        x = self._input
+
+        # Step 1: Compute routing weights
+        with torch.cuda.stream(gating_stream):
+            routing_weights, expert_indices = self._gating(x, self.top_k)
+
+        # Wait for gating to complete before expert dispatch
+        for stream_idx in set(self._expert_streams):
+            streams[stream_idx].wait_stream(gating_stream)
+
+        # Step 2: Dispatch tokens to experts (parallel)
+        # In real MoE, this would involve all-to-all
+        # Here we simulate by having each expert process all tokens
+        # weighted by their routing weights
+
+        for expert_idx, expert in enumerate(self._experts):
+            stream_idx = self._expert_streams[expert_idx]
+            expert_stream = streams[stream_idx]
+
+            with torch.cuda.stream(expert_stream):
+                # Find tokens routed to this expert
+                # Simplified: process all tokens, will be masked by routing weights
+                expert_out = expert(x)
+
+                # Compute contribution from this expert
+                # Get mask for tokens using this expert
+                expert_mask = (expert_indices == expert_idx).any(dim=-1)  # [batch, seq]
+
+                # Get weights for this expert (where it's selected)
+                expert_weight = torch.zeros_like(expert_mask, dtype=torch.float32)
+                for k in range(self.top_k):
+                    mask_k = expert_indices[..., k] == expert_idx
+                    expert_weight = torch.where(
+                        mask_k, routing_weights[..., k], expert_weight
+                    )
+
+                # Weight the output
+                weighted_out = expert_out * expert_weight.unsqueeze(-1)
+                self._expert_outputs[expert_idx].copy_(weighted_out)
+
+        # Step 3: Combine expert outputs
+        # In distributed, this would be another all-to-all
+        # Use gating stream for combination
+        for stream_idx in set(self._expert_streams):
+            gating_stream.wait_stream(streams[stream_idx])
+
+        with torch.cuda.stream(gating_stream):
+            combined = torch.zeros_like(x)
+            for expert_out in self._expert_outputs:
+                combined = combined + expert_out
+
+    def get_throughput_unit(self) -> str:
+        return "tokens/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        tokens = iterations * self.batch_size * self.seq_length
+        return tokens / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "num_experts": self.num_experts,
+            "hidden_size": self.hidden_size,
+            "intermediate_size": self.intermediate_size,
+            "top_k": self.top_k,
+            "batch_size": self.batch_size,
+            "seq_length": self.seq_length,
+            "expert_stream_assignment": self._expert_streams,
+            "simulate_collectives": self._simulate_collectives,
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup experts and buffers."""
+        super().cleanup()
+        self._gating = None
+        self._experts = []
+        self._expert_outputs = []

--- a/src/aorta/hw_queue_eval/workloads/inference/__init__.py
+++ b/src/aorta/hw_queue_eval/workloads/inference/__init__.py
@@ -1,0 +1,18 @@
+"""
+Inference workloads for hardware queue evaluation.
+
+These workloads simulate patterns from LLM inference:
+- Speculative decoding with draft/verify models
+- Continuous batching with prefill/decode overlap
+- Multi-model RAG pipelines
+"""
+
+from aorta.hw_queue_eval.workloads.inference.continuous_batch import ContinuousBatchWorkload
+from aorta.hw_queue_eval.workloads.inference.rag_pipeline import RAGPipelineWorkload
+from aorta.hw_queue_eval.workloads.inference.speculative_decode import SpeculativeDecodeWorkload
+
+__all__ = [
+    "SpeculativeDecodeWorkload",
+    "ContinuousBatchWorkload",
+    "RAGPipelineWorkload",
+]

--- a/src/aorta/hw_queue_eval/workloads/inference/continuous_batch.py
+++ b/src/aorta/hw_queue_eval/workloads/inference/continuous_batch.py
@@ -1,0 +1,234 @@
+"""
+Continuous Batching Workload
+
+Pattern: Prefill and decode phases overlap for different requests
+- Prefill streams: Process new requests (compute-heavy)
+- Decode streams: Generate tokens for active requests (memory-bound)
+- Scheduling stream: Batch management
+
+This tests the ability to overlap compute-heavy and memory-bound operations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import InferenceWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class AttentionBlock(nn.Module):
+    """Single attention block for inference."""
+
+    def __init__(self, hidden_size: int, num_heads: int):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+
+        self.qkv = nn.Linear(hidden_size, 3 * hidden_size)
+        self.proj = nn.Linear(hidden_size, hidden_size)
+        self.ln = nn.LayerNorm(hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.ln(x)
+
+        B, S, _ = x.shape
+        qkv = self.qkv(x).reshape(B, S, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.unbind(dim=2)
+
+        # Scaled dot-product attention
+        q = q.transpose(1, 2)  # B, H, S, D
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        attn = torch.matmul(q, k.transpose(-2, -1)) / (self.head_dim ** 0.5)
+        attn = torch.softmax(attn, dim=-1)
+        out = torch.matmul(attn, v)
+
+        out = out.transpose(1, 2).reshape(B, S, self.hidden_size)
+        out = self.proj(out)
+
+        return residual + out
+
+
+@WorkloadRegistry.register
+class ContinuousBatchWorkload(InferenceWorkload):
+    """
+    Continuous batching with prefill/decode overlap.
+
+    Simulates a serving system where:
+    - New requests are prefilled (compute-heavy, long sequences)
+    - Active requests decode one token at a time (memory-bound)
+    - These phases overlap to maximize throughput
+
+    Stream assignment:
+    - Streams 0-2: Prefill (new requests)
+    - Streams 3-5: Decode (active requests)
+    - Streams 6-7: KV cache management
+    - Streams 8-9: Batch scheduling
+    """
+
+    name = "continuous_batch"
+    description = "Prefill/decode overlap in continuous batching"
+    category = "inference"
+    min_streams = 4
+    max_streams = 16
+    recommended_streams = 8
+    switch_latency_sensitivity = "high"
+    memory_requirements_gb = 6.0
+
+    def __init__(
+        self,
+        hidden_size: int = 1024,
+        num_layers: int = 8,
+        num_heads: int = 8,
+        prefill_batch_size: int = 2,
+        prefill_seq_length: int = 512,
+        decode_batch_size: int = 16,
+        max_seq_length: int = 2048,
+    ):
+        """
+        Initialize continuous batching workload.
+
+        Args:
+            hidden_size: Model hidden size
+            num_layers: Number of attention layers
+            num_heads: Number of attention heads
+            prefill_batch_size: Batch size for prefill
+            prefill_seq_length: Sequence length for prefill
+            decode_batch_size: Batch size for decode
+            max_seq_length: Maximum sequence length for KV cache
+        """
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.num_heads = num_heads
+        self.prefill_batch_size = prefill_batch_size
+        self.prefill_seq_length = prefill_seq_length
+        self.decode_batch_size = decode_batch_size
+        self.max_seq_length = max_seq_length
+
+        self._layers: List[AttentionBlock] = []
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup model and stream assignments."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Create attention layers
+        self._layers = []
+        for _ in range(self.num_layers):
+            layer = AttentionBlock(self.hidden_size, self.num_heads).to(device)
+            layer.eval()
+            self._layers.append(layer)
+
+        # Stream assignments
+        third = max(1, stream_count // 3)
+        self._prefill_streams = list(range(0, third))
+        self._decode_streams = list(range(third, 2 * third))
+        self._cache_streams = list(range(2 * third, stream_count))
+
+        if not self._decode_streams:
+            self._decode_streams = [0]
+        if not self._cache_streams:
+            self._cache_streams = [0]
+
+        # Prefill input
+        self._prefill_input = torch.randn(
+            self.prefill_batch_size, self.prefill_seq_length, self.hidden_size,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["prefill_input"] = self._prefill_input
+
+        # Decode input (single token per request)
+        self._decode_input = torch.randn(
+            self.decode_batch_size, 1, self.hidden_size,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["decode_input"] = self._decode_input
+
+        # KV cache (simplified)
+        self._init_kv_cache(
+            num_layers=self.num_layers,
+            batch_size=self.decode_batch_size + self.prefill_batch_size,
+            max_seq_len=self.max_seq_length,
+            num_heads=self.num_heads,
+            head_dim=self.hidden_size // self.num_heads,
+        )
+
+        # Tokens per iteration: prefill + decode
+        self._tokens_per_iteration = (
+            self.prefill_batch_size * self.prefill_seq_length +
+            self.decode_batch_size
+        )
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one iteration with overlapped prefill and decode.
+
+        Prefill and decode run in parallel on different streams.
+        """
+        prefill_stream = streams[self._prefill_streams[0]]
+        decode_stream = streams[self._decode_streams[0]]
+        cache_stream = streams[self._cache_streams[0]]
+
+        # Start prefill (compute-heavy)
+        with torch.cuda.stream(prefill_stream):
+            prefill_out = self._prefill_input
+            for layer in self._layers:
+                prefill_out = layer(prefill_out)
+
+        # Decode in parallel (memory-bound)
+        with torch.cuda.stream(decode_stream):
+            decode_out = self._decode_input
+            for layer in self._layers:
+                decode_out = layer(decode_out)
+
+        # KV cache update (overlapped)
+        # Wait for both to complete for cache coherence
+        cache_stream.wait_stream(prefill_stream)
+        cache_stream.wait_stream(decode_stream)
+
+        with torch.cuda.stream(cache_stream):
+            # Simulate cache operations
+            for layer_idx in range(min(2, self.num_layers)):
+                k_cache, v_cache = self._kv_cache[layer_idx]
+                # Small update operation
+                k_cache[:, :, 0, :] = k_cache[:, :, 0, :] * 0.99 + 0.01
+
+    def get_throughput_unit(self) -> str:
+        return "tokens/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self._tokens_per_iteration) / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "hidden_size": self.hidden_size,
+            "num_layers": self.num_layers,
+            "num_heads": self.num_heads,
+            "prefill_batch_size": self.prefill_batch_size,
+            "prefill_seq_length": self.prefill_seq_length,
+            "decode_batch_size": self.decode_batch_size,
+            "max_seq_length": self.max_seq_length,
+            "stream_assignment": {
+                "prefill": self._prefill_streams,
+                "decode": self._decode_streams,
+                "cache": self._cache_streams,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup model and cache."""
+        super().cleanup()
+        self._layers = []

--- a/src/aorta/hw_queue_eval/workloads/inference/rag_pipeline.py
+++ b/src/aorta/hw_queue_eval/workloads/inference/rag_pipeline.py
@@ -1,0 +1,308 @@
+"""
+Multi-Model RAG Pipeline Workload
+
+Pattern: Multiple models process different stages of RAG
+- Embedding model stream(s): Encode queries/documents
+- Retriever stream(s): Vector similarity search
+- Reranker stream(s): Score retrieved documents
+- Generator stream(s): Produce final response
+
+This tests concurrent execution of different model types.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from aorta.hw_queue_eval.workloads.base import InferenceWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class EmbeddingModel(nn.Module):
+    """Simple embedding model for encoding."""
+
+    def __init__(self, hidden_size: int, output_size: int):
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, output_size),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Mean pooling over sequence
+        return self.encoder(x.mean(dim=1))
+
+
+class RerankerModel(nn.Module):
+    """Cross-encoder reranker."""
+
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.scorer = nn.Sequential(
+            nn.Linear(hidden_size * 2, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, 1),
+        )
+
+    def forward(self, query: torch.Tensor, docs: torch.Tensor) -> torch.Tensor:
+        # query: [batch, hidden]
+        # docs: [batch, num_docs, hidden]
+        batch, num_docs, hidden = docs.shape
+        query_expanded = query.unsqueeze(1).expand(-1, num_docs, -1)
+        combined = torch.cat([query_expanded, docs], dim=-1)
+        scores = self.scorer(combined).squeeze(-1)
+        return scores
+
+
+class GeneratorModel(nn.Module):
+    """Simple generator for response generation."""
+
+    def __init__(self, hidden_size: int, vocab_size: int, num_layers: int = 4):
+        super().__init__()
+        self.hidden_size = hidden_size
+
+        self.layers = nn.ModuleList([
+            nn.TransformerEncoderLayer(
+                d_model=hidden_size,
+                nhead=8,
+                dim_feedforward=hidden_size * 4,
+                batch_first=True,
+            )
+            for _ in range(num_layers)
+        ])
+        self.lm_head = nn.Linear(hidden_size, vocab_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return self.lm_head(x)
+
+
+@WorkloadRegistry.register
+class RAGPipelineWorkload(InferenceWorkload):
+    """
+    Multi-model RAG pipeline simulation.
+
+    Simulates a RAG system with:
+    1. Query embedding (encode user query)
+    2. Document retrieval (vector similarity)
+    3. Reranking (cross-encoder scoring)
+    4. Generation (produce response)
+
+    Stream assignment:
+    - Streams 0-1: Embedding model
+    - Streams 2-3: Retrieval (vector ops)
+    - Streams 4-5: Reranker model
+    - Streams 6-7: Generator model
+    """
+
+    name = "rag_pipeline"
+    description = "Multi-model RAG pipeline"
+    category = "inference"
+    min_streams = 4
+    max_streams = 12
+    recommended_streams = 8
+    switch_latency_sensitivity = "high"
+    memory_requirements_gb = 4.0
+
+    def __init__(
+        self,
+        hidden_size: int = 768,
+        embedding_dim: int = 256,
+        vocab_size: int = 32000,
+        batch_size: int = 4,
+        query_length: int = 64,
+        num_docs: int = 100,
+        top_k: int = 10,
+        generation_length: int = 128,
+    ):
+        """
+        Initialize RAG pipeline workload.
+
+        Args:
+            hidden_size: Model hidden size
+            embedding_dim: Embedding dimension for retrieval
+            vocab_size: Vocabulary size for generator
+            batch_size: Batch size
+            query_length: Query sequence length
+            num_docs: Number of documents in corpus
+            top_k: Number of documents to retrieve
+            generation_length: Output generation length
+        """
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.embedding_dim = embedding_dim
+        self.vocab_size = vocab_size
+        self.batch_size = batch_size
+        self.query_length = query_length
+        self.num_docs = num_docs
+        self.top_k = top_k
+        self.generation_length = generation_length
+
+        self._embedding_model: Optional[EmbeddingModel] = None
+        self._reranker_model: Optional[RerankerModel] = None
+        self._generator_model: Optional[GeneratorModel] = None
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup models and document corpus."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Create models
+        self._embedding_model = EmbeddingModel(
+            self.hidden_size, self.embedding_dim
+        ).to(device)
+        self._embedding_model.eval()
+
+        self._reranker_model = RerankerModel(self.hidden_size).to(device)
+        self._reranker_model.eval()
+
+        self._generator_model = GeneratorModel(
+            self.hidden_size, self.vocab_size
+        ).to(device)
+        self._generator_model.eval()
+
+        # Stream assignments
+        quarter = max(1, stream_count // 4)
+        self._embed_streams = list(range(0, quarter))
+        self._retrieve_streams = list(range(quarter, 2 * quarter))
+        self._rerank_streams = list(range(2 * quarter, 3 * quarter))
+        self._generate_streams = list(range(3 * quarter, stream_count))
+
+        # Ensure at least one stream per stage
+        for stream_list in [self._retrieve_streams, self._rerank_streams, self._generate_streams]:
+            if not stream_list:
+                stream_list.append(0)
+
+        # Query input
+        self._query_input = torch.randn(
+            self.batch_size, self.query_length, self.hidden_size,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["query_input"] = self._query_input
+
+        # Document corpus (pre-embedded)
+        self._doc_embeddings = torch.randn(
+            self.num_docs, self.embedding_dim,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["doc_embeddings"] = self._doc_embeddings
+
+        # Document representations for reranking
+        self._doc_hidden = torch.randn(
+            self.num_docs, self.hidden_size,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["doc_hidden"] = self._doc_hidden
+
+        # Tokens per iteration
+        self._tokens_per_iteration = self.batch_size * self.generation_length
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one RAG iteration.
+
+        Pipeline stages run with dependencies:
+        1. Embed query
+        2. Retrieve documents
+        3. Rerank retrieved documents
+        4. Generate response
+        """
+        embed_stream = streams[self._embed_streams[0]]
+        retrieve_stream = streams[self._retrieve_streams[0]]
+        rerank_stream = streams[self._rerank_streams[0]]
+        generate_stream = streams[self._generate_streams[0]]
+
+        # Stage 1: Embed query
+        with torch.cuda.stream(embed_stream):
+            query_embedding = self._embedding_model(self._query_input)
+            # Normalize for similarity
+            query_embedding = F.normalize(query_embedding, dim=-1)
+
+        # Stage 2: Retrieve documents (wait for embedding)
+        retrieve_stream.wait_stream(embed_stream)
+
+        with torch.cuda.stream(retrieve_stream):
+            # Compute similarities
+            similarities = torch.matmul(
+                query_embedding, self._doc_embeddings.T
+            )  # [batch, num_docs]
+
+            # Get top-k
+            top_scores, top_indices = torch.topk(similarities, self.top_k, dim=-1)
+
+            # Gather top-k document representations
+            # [batch, top_k, hidden_size]
+            retrieved_docs = self._doc_hidden[top_indices.flatten()].reshape(
+                self.batch_size, self.top_k, self.hidden_size
+            )
+
+        # Stage 3: Rerank (wait for retrieval)
+        rerank_stream.wait_stream(retrieve_stream)
+
+        with torch.cuda.stream(rerank_stream):
+            query_hidden = self._query_input.mean(dim=1)  # [batch, hidden]
+            rerank_scores = self._reranker_model(query_hidden, retrieved_docs)
+
+            # Get reranked order
+            _, reranked_indices = torch.sort(rerank_scores, dim=-1, descending=True)
+
+            # Reorder documents
+            batch_indices = torch.arange(self.batch_size, device=self._device).unsqueeze(1)
+            reranked_docs = retrieved_docs[batch_indices, reranked_indices]
+
+        # Stage 4: Generate response (wait for reranking)
+        generate_stream.wait_stream(rerank_stream)
+
+        with torch.cuda.stream(generate_stream):
+            # Concatenate query and top reranked docs as context
+            context = torch.cat([
+                self._query_input,
+                reranked_docs[:, :3, :].expand(-1, -1, -1).reshape(
+                    self.batch_size, -1, self.hidden_size
+                )
+            ], dim=1)
+
+            # Generate
+            output_logits = self._generator_model(context)
+
+    def get_throughput_unit(self) -> str:
+        return "queries/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self.batch_size) / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "hidden_size": self.hidden_size,
+            "embedding_dim": self.embedding_dim,
+            "vocab_size": self.vocab_size,
+            "batch_size": self.batch_size,
+            "query_length": self.query_length,
+            "num_docs": self.num_docs,
+            "top_k": self.top_k,
+            "generation_length": self.generation_length,
+            "stream_assignment": {
+                "embed": self._embed_streams,
+                "retrieve": self._retrieve_streams,
+                "rerank": self._rerank_streams,
+                "generate": self._generate_streams,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup models."""
+        super().cleanup()
+        self._embedding_model = None
+        self._reranker_model = None
+        self._generator_model = None

--- a/src/aorta/hw_queue_eval/workloads/inference/speculative_decode.py
+++ b/src/aorta/hw_queue_eval/workloads/inference/speculative_decode.py
@@ -1,0 +1,273 @@
+"""
+Speculative Decoding Workload
+
+Pattern: Draft model generates K tokens, main model verifies in parallel
+- Draft stream(s): Small model forward passes
+- Verify stream(s): Main model forward for verification
+- Accept/reject stream: Token acceptance logic
+- KV cache stream: Cache management
+
+This has tight latency requirements - switch overhead directly impacts tokens/sec.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import InferenceWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class SimpleLM(nn.Module):
+    """Simple language model for speculative decoding simulation."""
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        num_layers: int,
+        num_heads: int,
+    ):
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+
+        self.embed = nn.Embedding(vocab_size, hidden_size)
+        self.layers = nn.ModuleList([
+            nn.TransformerEncoderLayer(
+                d_model=hidden_size,
+                nhead=num_heads,
+                dim_feedforward=hidden_size * 4,
+                batch_first=True,
+            )
+            for _ in range(num_layers)
+        ])
+        self.ln_f = nn.LayerNorm(hidden_size)
+        self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        use_cache: bool = False,
+    ) -> torch.Tensor:
+        """Forward pass returning logits."""
+        x = self.embed(input_ids)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.ln_f(x)
+        logits = self.lm_head(x)
+        return logits
+
+
+@WorkloadRegistry.register
+class SpeculativeDecodeWorkload(InferenceWorkload):
+    """
+    Draft + verify speculative decoding simulation.
+
+    Simulates the speculative decoding pattern:
+    1. Draft model generates K tokens speculatively
+    2. Main model verifies all K tokens in parallel
+    3. Accept/reject logic determines how many tokens to keep
+    4. KV cache is updated accordingly
+
+    Stream assignment:
+    - Streams 0-1: Draft model forward
+    - Streams 2-3: Main model verification
+    - Stream 4: Accept/reject computation
+    - Stream 5: KV cache management
+    """
+
+    name = "speculative_decode"
+    description = "Draft + verify speculative decoding"
+    category = "inference"
+    min_streams = 4
+    max_streams = 12
+    recommended_streams = 6
+    switch_latency_sensitivity = "high"
+    memory_requirements_gb = 4.0
+
+    def __init__(
+        self,
+        draft_hidden_size: int = 256,
+        draft_num_layers: int = 4,
+        main_hidden_size: int = 1024,
+        main_num_layers: int = 12,
+        speculation_length: int = 4,
+        batch_size: int = 1,
+        vocab_size: int = 32000,
+    ):
+        """
+        Initialize speculative decoding workload.
+
+        Args:
+            draft_hidden_size: Draft model hidden size
+            draft_num_layers: Draft model layers
+            main_hidden_size: Main model hidden size
+            main_num_layers: Main model layers
+            speculation_length: Number of tokens to speculate
+            batch_size: Batch size
+            vocab_size: Vocabulary size
+        """
+        super().__init__()
+
+        self.draft_hidden_size = draft_hidden_size
+        self.draft_num_layers = draft_num_layers
+        self.main_hidden_size = main_hidden_size
+        self.main_num_layers = main_num_layers
+        self.speculation_length = speculation_length
+        self.batch_size = batch_size
+        self.vocab_size = vocab_size
+
+        self._draft_model: Optional[SimpleLM] = None
+        self._main_model: Optional[SimpleLM] = None
+        self._input_ids: Optional[torch.Tensor] = None
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup draft and main models."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Create models
+        self._draft_model = SimpleLM(
+            vocab_size=self.vocab_size,
+            hidden_size=self.draft_hidden_size,
+            num_layers=self.draft_num_layers,
+            num_heads=4,
+        ).to(device)
+        self._draft_model.eval()
+
+        self._main_model = SimpleLM(
+            vocab_size=self.vocab_size,
+            hidden_size=self.main_hidden_size,
+            num_layers=self.main_num_layers,
+            num_heads=8,
+        ).to(device)
+        self._main_model.eval()
+
+        # Stream assignments
+        sixth = max(1, stream_count // 6)
+        self._draft_streams = list(range(0, min(2, stream_count)))
+        self._verify_streams = list(range(2, min(4, stream_count)))
+        self._accept_stream = min(4, stream_count - 1)
+        self._cache_stream = min(5, stream_count - 1)
+
+        if not self._verify_streams:
+            self._verify_streams = [0]
+
+        # Input: some context tokens
+        context_len = 128
+        self._input_ids = torch.randint(
+            0, self.vocab_size, (self.batch_size, context_len),
+            dtype=torch.long, device=device
+        )
+        self._tensors["input_ids"] = self._input_ids
+
+        # Buffers for speculated tokens
+        self._draft_tokens = torch.zeros(
+            self.batch_size, self.speculation_length,
+            dtype=torch.long, device=device
+        )
+        self._tensors["draft_tokens"] = self._draft_tokens
+
+        # Tokens per iteration = speculation_length (on average, accept rate ~70%)
+        self._tokens_per_iteration = int(self.speculation_length * 0.7 * self.batch_size)
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one speculative decoding iteration.
+
+        1. Draft model generates K tokens
+        2. Main model verifies all K in parallel
+        3. Accept/reject determines accepted tokens
+        """
+        draft_stream = streams[self._draft_streams[0]]
+        verify_stream = streams[self._verify_streams[0]]
+        accept_stream = streams[self._accept_stream]
+        cache_stream = streams[self._cache_stream]
+
+        context = self._input_ids
+
+        # Step 1: Draft model generates K tokens autoregressively
+        with torch.cuda.stream(draft_stream):
+            draft_input = context
+            draft_tokens = []
+
+            for k in range(self.speculation_length):
+                # Get logits for last position
+                logits = self._draft_model(draft_input)[:, -1, :]
+                # Greedy sampling
+                next_token = logits.argmax(dim=-1, keepdim=True)
+                draft_tokens.append(next_token)
+                # Append for next iteration
+                draft_input = torch.cat([draft_input, next_token], dim=1)
+
+            self._draft_tokens = torch.cat(draft_tokens, dim=1)
+
+        # Step 2: Main model verifies all K tokens in parallel
+        verify_stream.wait_stream(draft_stream)
+
+        with torch.cuda.stream(verify_stream):
+            # Verify all draft tokens in one forward pass
+            verify_input = torch.cat([context, self._draft_tokens], dim=1)
+            main_logits = self._main_model(verify_input)
+
+            # Get logits at draft positions
+            draft_start = context.size(1)
+            verify_logits = main_logits[:, draft_start - 1:-1, :]
+
+        # Step 3: Accept/reject logic
+        accept_stream.wait_stream(verify_stream)
+
+        with torch.cuda.stream(accept_stream):
+            # Simplified accept/reject: compare main vs draft predictions
+            main_preds = verify_logits.argmax(dim=-1)
+
+            # Find first mismatch
+            matches = (main_preds == self._draft_tokens)
+            # Count accepted tokens (all matching up to first mismatch)
+            # For simplicity, just compute the mask
+            accept_mask = matches.cumprod(dim=1)
+
+        # Step 4: Update KV cache (simulated)
+        cache_stream.wait_stream(accept_stream)
+
+        with torch.cuda.stream(cache_stream):
+            # In real implementation, this would update KV cache
+            # Here we just do some computation to simulate cache ops
+            cache_update = self._draft_tokens * accept_mask.long()
+
+    def get_throughput_unit(self) -> str:
+        return "tokens/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self._tokens_per_iteration) / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "draft_hidden_size": self.draft_hidden_size,
+            "draft_num_layers": self.draft_num_layers,
+            "main_hidden_size": self.main_hidden_size,
+            "main_num_layers": self.main_num_layers,
+            "speculation_length": self.speculation_length,
+            "batch_size": self.batch_size,
+            "vocab_size": self.vocab_size,
+            "stream_assignment": {
+                "draft": self._draft_streams,
+                "verify": self._verify_streams,
+                "accept": self._accept_stream,
+                "cache": self._cache_stream,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup models."""
+        super().cleanup()
+        self._draft_model = None
+        self._main_model = None

--- a/src/aorta/hw_queue_eval/workloads/latency_sensitive/__init__.py
+++ b/src/aorta/hw_queue_eval/workloads/latency_sensitive/__init__.py
@@ -1,0 +1,15 @@
+"""
+Latency-sensitive workloads for hardware queue evaluation.
+
+These workloads are specifically designed to stress queue switch latency:
+- Heterogeneous kernel mixing (tiny + large GEMMs)
+- Independent subgraph execution patterns
+"""
+
+from aorta.hw_queue_eval.workloads.latency_sensitive.graph_subgraphs import GraphSubgraphsWorkload
+from aorta.hw_queue_eval.workloads.latency_sensitive.hetero_kernels import HeterogeneousKernelWorkload
+
+__all__ = [
+    "HeterogeneousKernelWorkload",
+    "GraphSubgraphsWorkload",
+]

--- a/src/aorta/hw_queue_eval/workloads/latency_sensitive/graph_subgraphs.py
+++ b/src/aorta/hw_queue_eval/workloads/latency_sensitive/graph_subgraphs.py
@@ -1,0 +1,221 @@
+"""
+Independent Subgraph Execution Workload
+
+Pattern: Multiple independent computation subgraphs
+- Each subgraph can execute on its own stream
+- No dependencies between subgraphs within an iteration
+- Final aggregation combines results
+
+This tests maximum parallel execution when there are no dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import BaseWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class Subgraph(nn.Module):
+    """A self-contained computation subgraph."""
+
+    def __init__(self, input_size: int, hidden_size: int, output_size: int, num_layers: int = 2):
+        super().__init__()
+        layers = []
+        prev_size = input_size
+        for i in range(num_layers):
+            next_size = hidden_size if i < num_layers - 1 else output_size
+            layers.append(nn.Linear(prev_size, next_size))
+            if i < num_layers - 1:
+                layers.append(nn.ReLU())
+            prev_size = next_size
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+@WorkloadRegistry.register
+class GraphSubgraphsWorkload(BaseWorkload):
+    """
+    Independent subgraph execution pattern.
+
+    Simulates a computation graph that splits into independent
+    branches, each of which can execute in parallel:
+
+    Input -> Split -> [Subgraph 1]
+                  -> [Subgraph 2]
+                  -> [Subgraph 3]
+                  -> ...
+                  -> [Subgraph N] -> Aggregate -> Output
+
+    Each subgraph is assigned to its own stream for maximum
+    parallelism. This tests the hardware's ability to
+    execute truly independent work concurrently.
+
+    Stream assignment:
+    - Stream 0: Input/split
+    - Streams 1 to N-1: One per subgraph
+    - Stream N: Aggregation
+    """
+
+    name = "graph_subgraphs"
+    description = "Independent subgraph parallel execution"
+    category = "latency_sensitive"
+    min_streams = 4
+    max_streams = 32
+    recommended_streams = 8
+    switch_latency_sensitivity = "high"
+    memory_requirements_gb = 2.0
+
+    def __init__(
+        self,
+        num_subgraphs: int = 8,
+        input_size: int = 1024,
+        hidden_size: int = 2048,
+        output_size: int = 512,
+        batch_size: int = 32,
+        subgraph_layers: int = 3,
+    ):
+        """
+        Initialize subgraph workload.
+
+        Args:
+            num_subgraphs: Number of independent subgraphs
+            input_size: Input dimension
+            hidden_size: Hidden dimension in subgraphs
+            output_size: Output dimension per subgraph
+            batch_size: Batch size
+            subgraph_layers: Number of layers per subgraph
+        """
+        super().__init__()
+        self.num_subgraphs = num_subgraphs
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.output_size = output_size
+        self.batch_size = batch_size
+        self.subgraph_layers = subgraph_layers
+
+        self._subgraphs: List[Subgraph] = []
+        self._aggregator: nn.Module = None
+        self._subgraph_outputs: List[torch.Tensor] = []
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup subgraphs and stream assignments."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Create subgraphs
+        self._subgraphs = []
+        for i in range(self.num_subgraphs):
+            subgraph = Subgraph(
+                self.input_size,
+                self.hidden_size,
+                self.output_size,
+                self.subgraph_layers,
+            ).to(device)
+            subgraph.eval()
+            self._subgraphs.append(subgraph)
+
+        # Aggregation layer
+        self._aggregator = nn.Linear(
+            self.output_size * self.num_subgraphs, self.output_size
+        ).to(device)
+        self._aggregator.eval()
+
+        # Stream assignments
+        # Reserve first and last for input/aggregate
+        available_streams = stream_count - 2
+        self._input_stream = 0
+        self._subgraph_streams = []
+
+        for i in range(self.num_subgraphs):
+            # Round-robin assign subgraphs to available streams
+            stream_idx = 1 + (i % max(1, available_streams))
+            self._subgraph_streams.append(stream_idx)
+
+        self._aggregate_stream = stream_count - 1
+
+        # Input tensor
+        self._input = torch.randn(
+            self.batch_size, self.input_size,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["input"] = self._input
+
+        # Output buffers for each subgraph
+        self._subgraph_outputs = []
+        for i in range(self.num_subgraphs):
+            buf = torch.empty(
+                self.batch_size, self.output_size,
+                dtype=torch.float32, device=device
+            )
+            self._subgraph_outputs.append(buf)
+            self._tensors[f"subgraph_out_{i}"] = buf
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute all subgraphs in parallel, then aggregate.
+        """
+        input_stream = streams[self._input_stream]
+        aggregate_stream = streams[self._aggregate_stream]
+
+        # Input processing (could include splitting/routing)
+        with torch.cuda.stream(input_stream):
+            # Simple pass-through (in real use, might route different data)
+            x = self._input
+
+        # Execute all subgraphs in parallel
+        for i, (subgraph, stream_idx) in enumerate(
+            zip(self._subgraphs, self._subgraph_streams)
+        ):
+            subgraph_stream = streams[stream_idx]
+            subgraph_stream.wait_stream(input_stream)
+
+            with torch.cuda.stream(subgraph_stream):
+                self._subgraph_outputs[i] = subgraph(x)
+
+        # Aggregate: wait for all subgraphs
+        for stream_idx in set(self._subgraph_streams):
+            aggregate_stream.wait_stream(streams[stream_idx])
+
+        with torch.cuda.stream(aggregate_stream):
+            # Concatenate all outputs
+            concatenated = torch.cat(self._subgraph_outputs, dim=-1)
+            output = self._aggregator(concatenated)
+
+    def get_throughput_unit(self) -> str:
+        return "samples/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self.batch_size) / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "num_subgraphs": self.num_subgraphs,
+            "input_size": self.input_size,
+            "hidden_size": self.hidden_size,
+            "output_size": self.output_size,
+            "batch_size": self.batch_size,
+            "subgraph_layers": self.subgraph_layers,
+            "stream_assignment": {
+                "input": self._input_stream,
+                "subgraphs": self._subgraph_streams,
+                "aggregate": self._aggregate_stream,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup subgraphs."""
+        super().cleanup()
+        self._subgraphs = []
+        self._aggregator = None
+        self._subgraph_outputs = []

--- a/src/aorta/hw_queue_eval/workloads/latency_sensitive/hetero_kernels.py
+++ b/src/aorta/hw_queue_eval/workloads/latency_sensitive/hetero_kernels.py
@@ -1,0 +1,405 @@
+"""
+Heterogeneous Kernel Mixing Workload
+
+Pattern: Interleave tiny kernels (elementwise, ~10µs) with large GEMMs (~10ms)
+Goal: Test scheduler's ability to dispatch small kernels without convoy effect
+
+Stream assignment:
+- First half of streams: Large GEMM operations
+- Second half of streams: Tiny elementwise operations
+- Interleaved dispatch to stress queue switching
+
+Expected behavior with good queue mapping:
+- Tiny kernels should not wait for large GEMMs on other queues
+- Throughput should scale with stream count up to HW queue limit
+- Switch latency overhead should be minimal
+
+This is the most direct test for hardware queue switch latency issues.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+from aorta.hw_queue_eval.workloads.base import SyntheticWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+@WorkloadRegistry.register
+class HeterogeneousKernelWorkload(SyntheticWorkload):
+    """
+    Mixed tiny and large kernels to test convoy effect and switch latency.
+
+    This workload dispatches:
+    - Large GEMM operations (configurable size, ~10ms each)
+    - Tiny elementwise operations (configurable size, ~10µs each)
+
+    The pattern interleaves these operations across streams to stress
+    the hardware queue scheduler's ability to dispatch work efficiently.
+    """
+
+    name = "hetero_kernels"
+    description = "Mixed tiny and large kernels to test convoy effect"
+    category = "latency_sensitive"
+    min_streams = 2
+    max_streams = 64
+    recommended_streams = 8
+    switch_latency_sensitivity = "critical"
+    memory_requirements_gb = 4.0
+
+    def __init__(
+        self,
+        large_gemm_size: Tuple[int, int, int] = (4096, 4096, 4096),  # M, N, K
+        small_kernel_size: int = 1024,
+        large_to_small_ratio: int = 10,  # small kernels per large GEMM
+        interleave_pattern: str = "alternating",  # "alternating", "batched", "random"
+    ):
+        """
+        Initialize the heterogeneous kernel workload.
+
+        Args:
+            large_gemm_size: (M, N, K) dimensions for large GEMMs
+            small_kernel_size: Size of elementwise tensors
+            large_to_small_ratio: Number of small kernels per large GEMM
+            interleave_pattern: How to interleave operations
+        """
+        super().__init__()
+        self.large_gemm_size = large_gemm_size
+        self.small_kernel_size = small_kernel_size
+        self.large_to_small_ratio = large_to_small_ratio
+        self.interleave_pattern = interleave_pattern
+
+        # Will be set in setup()
+        self._large_tensors_a: List[torch.Tensor] = []
+        self._large_tensors_b: List[torch.Tensor] = []
+        self._small_tensors: List[torch.Tensor] = []
+        self._num_large_streams = 0
+        self._num_small_streams = 0
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """
+        Initialize tensors for large GEMMs and small elementwise ops.
+
+        Args:
+            stream_count: Number of streams to use
+            device: Target device
+        """
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Split streams between large and small kernels
+        self._num_large_streams = max(1, stream_count // 2)
+        self._num_small_streams = max(1, stream_count - self._num_large_streams)
+
+        m, n, k = self.large_gemm_size
+
+        # Allocate tensors for large GEMMs (one pair per large stream)
+        self._large_tensors_a = []
+        self._large_tensors_b = []
+        for i in range(self._num_large_streams):
+            a = torch.randn(m, k, dtype=torch.float32, device=device)
+            b = torch.randn(k, n, dtype=torch.float32, device=device)
+            self._large_tensors_a.append(a)
+            self._large_tensors_b.append(b)
+            self._tensors[f"large_a_{i}"] = a
+            self._tensors[f"large_b_{i}"] = b
+
+        # Allocate tensors for small elementwise ops
+        # Multiple tensors per small stream for the ratio
+        self._small_tensors = []
+        num_small_tensors = self._num_small_streams * self.large_to_small_ratio
+        for i in range(num_small_tensors):
+            t = torch.randn(self.small_kernel_size, dtype=torch.float32, device=device)
+            self._small_tensors.append(t)
+            self._tensors[f"small_{i}"] = t
+
+        # Compute ops per iteration for throughput calculation
+        # Large GEMM: 2*M*N*K FLOPs each
+        large_flops = 2 * m * n * k * self._num_large_streams
+        # Small ops: ~3 FLOPs per element (add, mul, add in fused op)
+        small_flops = 3 * self.small_kernel_size * num_small_tensors
+        self._ops_per_iteration = large_flops + small_flops
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one iteration with interleaved large and small kernels.
+
+        Args:
+            streams: List of CUDA/HIP streams
+        """
+        if self.interleave_pattern == "alternating":
+            self._run_alternating(streams)
+        elif self.interleave_pattern == "batched":
+            self._run_batched(streams)
+        else:
+            # Default to alternating
+            self._run_alternating(streams)
+
+    def _run_alternating(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Alternating pattern: dispatch large, then small, then large, etc.
+
+        This pattern maximizes the chance of convoy effects if queue
+        scheduling is poor.
+        """
+        large_streams = streams[: self._num_large_streams]
+        small_streams = streams[self._num_large_streams :]
+
+        if not small_streams:
+            small_streams = large_streams  # Fall back if only one stream type
+
+        small_idx = 0
+        num_small_per_large = self.large_to_small_ratio
+
+        # Interleave: for each large stream, dispatch GEMM then small kernels
+        for i, large_stream in enumerate(large_streams):
+            # Large GEMM on large stream
+            with torch.cuda.stream(large_stream):
+                a = self._large_tensors_a[i]
+                b = self._large_tensors_b[i]
+                # Use matmul to ensure GEMM kernel
+                c = torch.mm(a, b)
+
+            # Multiple small kernels on small streams
+            for j in range(num_small_per_large):
+                small_stream = small_streams[j % len(small_streams)]
+                tensor_idx = small_idx % len(self._small_tensors)
+
+                with torch.cuda.stream(small_stream):
+                    t = self._small_tensors[tensor_idx]
+                    # Fused elementwise operations (tiny kernel)
+                    result = torch.add(torch.mul(t, 2.0), 1.0)
+
+                small_idx += 1
+
+    def _run_batched(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Batched pattern: all large GEMMs, then all small kernels.
+
+        This pattern allows maximum overlap if queues are independent.
+        """
+        large_streams = streams[: self._num_large_streams]
+        small_streams = streams[self._num_large_streams :]
+
+        if not small_streams:
+            small_streams = large_streams
+
+        # First: all large GEMMs
+        for i, large_stream in enumerate(large_streams):
+            with torch.cuda.stream(large_stream):
+                a = self._large_tensors_a[i]
+                b = self._large_tensors_b[i]
+                c = torch.mm(a, b)
+
+        # Then: all small kernels
+        for i, t in enumerate(self._small_tensors):
+            small_stream = small_streams[i % len(small_streams)]
+            with torch.cuda.stream(small_stream):
+                result = torch.add(torch.mul(t, 2.0), 1.0)
+
+    def get_throughput_unit(self) -> str:
+        return "GFLOPS"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        """Compute throughput in GFLOPS."""
+        if total_time_sec <= 0:
+            return 0.0
+        total_flops = iterations * self._ops_per_iteration
+        return total_flops / (total_time_sec * 1e9)  # GFLOPS
+
+    def get_config(self) -> Dict[str, Any]:
+        """Get workload configuration."""
+        return {
+            "name": self.name,
+            "large_gemm_size": self.large_gemm_size,
+            "small_kernel_size": self.small_kernel_size,
+            "large_to_small_ratio": self.large_to_small_ratio,
+            "interleave_pattern": self.interleave_pattern,
+            "num_large_streams": self._num_large_streams,
+            "num_small_streams": self._num_small_streams,
+            "stream_count": self._stream_count,
+            "device": self._device,
+        }
+
+    def validate_correctness(
+        self, baseline_result: Any, test_result: Any
+    ) -> Tuple[bool, str]:
+        """
+        Validate correctness of kernel execution.
+
+        For this synthetic workload, we verify that:
+        1. Results are finite (no NaN/Inf)
+        2. GEMM produces expected output shape
+        """
+        # Run a quick validation iteration
+        if self._is_setup:
+            # Check large GEMM result shape and finiteness
+            for i in range(min(2, len(self._large_tensors_a))):
+                a = self._large_tensors_a[i]
+                b = self._large_tensors_b[i]
+                c = torch.mm(a, b)
+
+                if not torch.isfinite(c).all():
+                    return False, f"GEMM {i} produced non-finite values"
+
+                expected_shape = (self.large_gemm_size[0], self.large_gemm_size[1])
+                if c.shape != expected_shape:
+                    return False, f"GEMM {i} shape mismatch: {c.shape} vs {expected_shape}"
+
+            # Check small tensor ops
+            for i in range(min(2, len(self._small_tensors))):
+                t = self._small_tensors[i]
+                result = torch.add(torch.mul(t, 2.0), 1.0)
+
+                if not torch.isfinite(result).all():
+                    return False, f"Small op {i} produced non-finite values"
+
+        return True, "Correctness validation passed"
+
+
+@WorkloadRegistry.register
+class TinyKernelStressWorkload(SyntheticWorkload):
+    """
+    Stress test with only tiny kernels across many streams.
+
+    This tests the overhead of queue switching with minimal kernel time,
+    making switch latency the dominant factor.
+    """
+
+    name = "tiny_kernel_stress"
+    description = "Tiny kernels only - isolates queue switch overhead"
+    category = "latency_sensitive"
+    min_streams = 1
+    max_streams = 64
+    recommended_streams = 16
+    switch_latency_sensitivity = "critical"
+    memory_requirements_gb = 0.5
+
+    def __init__(
+        self,
+        tensor_size: int = 256,
+        ops_per_stream: int = 100,
+    ):
+        """
+        Initialize tiny kernel stress workload.
+
+        Args:
+            tensor_size: Size of each tensor
+            ops_per_stream: Operations per stream per iteration
+        """
+        super().__init__()
+        self.tensor_size = tensor_size
+        self.ops_per_stream = ops_per_stream
+        self._per_stream_tensors: List[List[torch.Tensor]] = []
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup tensors for each stream."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        self._per_stream_tensors = []
+        for stream_idx in range(stream_count):
+            stream_tensors = []
+            for op_idx in range(self.ops_per_stream):
+                t = torch.randn(self.tensor_size, dtype=torch.float32, device=device)
+                stream_tensors.append(t)
+                self._tensors[f"s{stream_idx}_op{op_idx}"] = t
+            self._per_stream_tensors.append(stream_tensors)
+
+        # FLOPs: ~5 per element per op (mul, add, abs, clamp, add)
+        self._ops_per_iteration = (
+            5 * self.tensor_size * self.ops_per_stream * stream_count
+        )
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """Execute tiny kernels across all streams."""
+        for stream_idx, stream in enumerate(streams):
+            tensors = self._per_stream_tensors[stream_idx]
+
+            with torch.cuda.stream(stream):
+                for t in tensors:
+                    # Chain of tiny ops
+                    result = torch.clamp(torch.abs(torch.add(torch.mul(t, 1.5), 0.5)), 0, 10)
+
+    def get_throughput_unit(self) -> str:
+        return "GFLOPS"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self._ops_per_iteration) / (total_time_sec * 1e9)
+
+
+@WorkloadRegistry.register
+class LargeGEMMOnlyWorkload(SyntheticWorkload):
+    """
+    Large GEMMs only - baseline for compute-bound behavior.
+
+    This establishes baseline throughput without switch overhead concerns.
+    """
+
+    name = "large_gemm_only"
+    description = "Large GEMMs only - compute-bound baseline"
+    category = "latency_sensitive"
+    min_streams = 1
+    max_streams = 16
+    recommended_streams = 4
+    switch_latency_sensitivity = "low"
+    memory_requirements_gb = 8.0
+
+    def __init__(
+        self,
+        gemm_size: Tuple[int, int, int] = (8192, 8192, 8192),
+    ):
+        """
+        Initialize large GEMM workload.
+
+        Args:
+            gemm_size: (M, N, K) dimensions
+        """
+        super().__init__()
+        self.gemm_size = gemm_size
+        self._matrices_a: List[torch.Tensor] = []
+        self._matrices_b: List[torch.Tensor] = []
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup GEMM matrices."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        m, n, k = self.gemm_size
+
+        self._matrices_a = []
+        self._matrices_b = []
+
+        for i in range(stream_count):
+            a = torch.randn(m, k, dtype=torch.float32, device=device)
+            b = torch.randn(k, n, dtype=torch.float32, device=device)
+            self._matrices_a.append(a)
+            self._matrices_b.append(b)
+            self._tensors[f"a_{i}"] = a
+            self._tensors[f"b_{i}"] = b
+
+        # 2*M*N*K FLOPs per GEMM
+        self._ops_per_iteration = 2 * m * n * k * stream_count
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """Execute large GEMMs on each stream."""
+        for i, stream in enumerate(streams):
+            with torch.cuda.stream(stream):
+                a = self._matrices_a[i]
+                b = self._matrices_b[i]
+                c = torch.mm(a, b)
+
+    def get_throughput_unit(self) -> str:
+        return "TFLOPS"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self._ops_per_iteration) / (total_time_sec * 1e12)

--- a/src/aorta/hw_queue_eval/workloads/pipeline/__init__.py
+++ b/src/aorta/hw_queue_eval/workloads/pipeline/__init__.py
@@ -1,0 +1,18 @@
+"""
+Pipeline workloads for hardware queue evaluation.
+
+These workloads simulate data pipeline and memory offload patterns:
+- Async data loading with GPU preprocessing
+- ZeRO-offload memory management patterns
+- torch.compile multi-region execution
+"""
+
+from aorta.hw_queue_eval.workloads.pipeline.async_dataload import AsyncDataLoadWorkload
+from aorta.hw_queue_eval.workloads.pipeline.torch_compile import TorchCompileWorkload
+from aorta.hw_queue_eval.workloads.pipeline.zero_offload import ZeROOffloadWorkload
+
+__all__ = [
+    "AsyncDataLoadWorkload",
+    "ZeROOffloadWorkload",
+    "TorchCompileWorkload",
+]

--- a/src/aorta/hw_queue_eval/workloads/pipeline/async_dataload.py
+++ b/src/aorta/hw_queue_eval/workloads/pipeline/async_dataload.py
@@ -1,0 +1,224 @@
+"""
+Async Data Loading Workload
+
+Pattern: Overlap CPU data loading with GPU preprocessing
+- Data transfer streams: H2D copies
+- Preprocessing streams: GPU data augmentation
+- Compute streams: Model forward/backward
+
+This tests the ability to hide data transfer latency.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import BaseWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class SimpleConvNet(nn.Module):
+    """Simple CNN for data pipeline testing."""
+
+    def __init__(self, in_channels: int = 3, num_classes: int = 1000):
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(in_channels, 64, 3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Conv2d(64, 128, 3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Conv2d(128, 256, 3, padding=1),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool2d(1),
+        )
+        self.classifier = nn.Linear(256, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        x = x.flatten(1)
+        return self.classifier(x)
+
+
+@WorkloadRegistry.register
+class AsyncDataLoadWorkload(BaseWorkload):
+    """
+    Async data loading with GPU preprocessing overlap.
+
+    Simulates a data pipeline where:
+    1. Data is transferred from CPU to GPU (H2D)
+    2. GPU preprocessing (augmentation, normalization)
+    3. Model training/inference
+
+    These stages are pipelined across multiple batches.
+
+    Stream assignment:
+    - Streams 0-1: Data transfer (H2D)
+    - Streams 2-3: GPU preprocessing
+    - Streams 4+: Compute (forward/backward)
+    """
+
+    name = "async_dataload"
+    description = "Async data loading with GPU preprocessing overlap"
+    category = "pipeline"
+    min_streams = 4
+    max_streams = 12
+    recommended_streams = 6
+    switch_latency_sensitivity = "medium"
+    memory_requirements_gb = 4.0
+
+    def __init__(
+        self,
+        batch_size: int = 32,
+        image_size: int = 224,
+        num_prefetch: int = 2,
+        num_classes: int = 1000,
+    ):
+        """
+        Initialize async data loading workload.
+
+        Args:
+            batch_size: Batch size per pipeline stage
+            image_size: Image dimensions (square)
+            num_prefetch: Number of batches to prefetch
+            num_classes: Number of output classes
+        """
+        super().__init__()
+        self.batch_size = batch_size
+        self.image_size = image_size
+        self.num_prefetch = num_prefetch
+        self.num_classes = num_classes
+
+        self._model = None
+        self._cpu_data: List[torch.Tensor] = []
+        self._gpu_buffers: List[torch.Tensor] = []
+        self._preprocessed: List[torch.Tensor] = []
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup model, CPU data, and GPU buffers."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Create model
+        self._model = SimpleConvNet(num_classes=self.num_classes).to(device)
+        self._model.eval()
+
+        # Stream assignments
+        third = max(1, stream_count // 3)
+        self._transfer_streams = list(range(0, third))
+        self._preprocess_streams = list(range(third, 2 * third))
+        self._compute_streams = list(range(2 * third, stream_count))
+
+        if not self._preprocess_streams:
+            self._preprocess_streams = [0]
+        if not self._compute_streams:
+            self._compute_streams = [0]
+
+        # Create CPU data (pinned memory for async transfer)
+        self._cpu_data = []
+        for i in range(self.num_prefetch):
+            data = torch.randn(
+                self.batch_size, 3, self.image_size, self.image_size,
+                dtype=torch.float32
+            ).pin_memory()
+            self._cpu_data.append(data)
+
+        # GPU buffers for receiving data
+        self._gpu_buffers = []
+        for i in range(self.num_prefetch):
+            buf = torch.empty(
+                self.batch_size, 3, self.image_size, self.image_size,
+                dtype=torch.float32, device=device
+            )
+            self._gpu_buffers.append(buf)
+            self._tensors[f"gpu_buffer_{i}"] = buf
+
+        # Preprocessed data buffers
+        self._preprocessed = []
+        for i in range(self.num_prefetch):
+            buf = torch.empty(
+                self.batch_size, 3, self.image_size, self.image_size,
+                dtype=torch.float32, device=device
+            )
+            self._preprocessed.append(buf)
+            self._tensors[f"preprocessed_{i}"] = buf
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one pipelined iteration.
+
+        Pipeline:
+        1. Transfer batch N+1 while processing batch N
+        2. Preprocess batch N while computing batch N-1
+        """
+        transfer_stream = streams[self._transfer_streams[0]]
+        preprocess_stream = streams[self._preprocess_streams[0]]
+        compute_stream = streams[self._compute_streams[0]]
+
+        # Process multiple batches in pipeline
+        for batch_idx in range(self.num_prefetch):
+            # Stage 1: Async transfer to GPU
+            with torch.cuda.stream(transfer_stream):
+                self._gpu_buffers[batch_idx].copy_(
+                    self._cpu_data[batch_idx], non_blocking=True
+                )
+
+            # Stage 2: GPU preprocessing (wait for transfer)
+            preprocess_stream.wait_stream(transfer_stream)
+
+            with torch.cuda.stream(preprocess_stream):
+                # Simulate preprocessing: normalize, augment
+                data = self._gpu_buffers[batch_idx]
+
+                # Normalize (ImageNet-style)
+                mean = torch.tensor([0.485, 0.456, 0.406], device=self._device).view(1, 3, 1, 1)
+                std = torch.tensor([0.229, 0.224, 0.225], device=self._device).view(1, 3, 1, 1)
+                normalized = (data - mean) / std
+
+                # Random horizontal flip simulation
+                flip_mask = torch.rand(self.batch_size, 1, 1, 1, device=self._device) > 0.5
+                flipped = torch.where(flip_mask, normalized.flip(-1), normalized)
+
+                self._preprocessed[batch_idx].copy_(flipped)
+
+            # Stage 3: Compute (wait for preprocessing)
+            compute_stream.wait_stream(preprocess_stream)
+
+            with torch.cuda.stream(compute_stream):
+                output = self._model(self._preprocessed[batch_idx])
+
+    def get_throughput_unit(self) -> str:
+        return "images/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        total_images = iterations * self.batch_size * self.num_prefetch
+        return total_images / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "batch_size": self.batch_size,
+            "image_size": self.image_size,
+            "num_prefetch": self.num_prefetch,
+            "num_classes": self.num_classes,
+            "stream_assignment": {
+                "transfer": self._transfer_streams,
+                "preprocess": self._preprocess_streams,
+                "compute": self._compute_streams,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup model and buffers."""
+        super().cleanup()
+        self._model = None
+        self._cpu_data = []
+        self._gpu_buffers = []
+        self._preprocessed = []

--- a/src/aorta/hw_queue_eval/workloads/pipeline/torch_compile.py
+++ b/src/aorta/hw_queue_eval/workloads/pipeline/torch_compile.py
@@ -1,0 +1,218 @@
+"""
+torch.compile Multi-Region Workload
+
+Pattern: Multiple compiled regions with stream-based coordination
+- Each compiled region may use internal streams
+- External coordination across regions via explicit streams
+
+This tests how compiled code interacts with manual stream management.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import BaseWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class CompiledRegion(nn.Module):
+    """A module that can be compiled with torch.compile."""
+
+    def __init__(self, hidden_size: int, expansion: int = 4):
+        super().__init__()
+        self.fc1 = nn.Linear(hidden_size, hidden_size * expansion)
+        self.fc2 = nn.Linear(hidden_size * expansion, hidden_size)
+        self.norm = nn.LayerNorm(hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.norm(x)
+        x = torch.gelu(self.fc1(x))
+        x = self.fc2(x)
+        return x + residual
+
+
+@WorkloadRegistry.register
+class TorchCompileWorkload(BaseWorkload):
+    """
+    Multi-region torch.compile execution.
+
+    Simulates a model with multiple compiled regions that
+    need to be coordinated across streams:
+
+    1. Region A computes independently
+    2. Region B depends on Region A output
+    3. Region C runs in parallel with Region B
+    4. Final merge depends on B and C
+
+    Stream assignment:
+    - Streams 0-1: Region A
+    - Streams 2-3: Region B
+    - Streams 4-5: Region C
+    - Streams 6+: Merge/coordination
+    """
+
+    name = "torch_compile"
+    description = "Multi-region compiled execution"
+    category = "pipeline"
+    min_streams = 4
+    max_streams = 12
+    recommended_streams = 8
+    switch_latency_sensitivity = "medium"
+    memory_requirements_gb = 2.0
+
+    def __init__(
+        self,
+        hidden_size: int = 1024,
+        batch_size: int = 16,
+        seq_length: int = 256,
+        use_compile: bool = False,  # Disabled by default (may not work in all envs)
+        compile_mode: str = "reduce-overhead",  # "default", "reduce-overhead", "max-autotune"
+    ):
+        """
+        Initialize torch.compile workload.
+
+        Args:
+            hidden_size: Hidden dimension
+            batch_size: Batch size
+            seq_length: Sequence length
+            use_compile: Whether to use torch.compile
+            compile_mode: Compilation mode
+        """
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.batch_size = batch_size
+        self.seq_length = seq_length
+        self.use_compile = use_compile
+        self.compile_mode = compile_mode
+
+        self._region_a: Optional[nn.Module] = None
+        self._region_b: Optional[nn.Module] = None
+        self._region_c: Optional[nn.Module] = None
+        self._merge_layer: Optional[nn.Module] = None
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup compiled regions."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Stream assignments
+        quarter = max(1, stream_count // 4)
+        self._region_a_streams = list(range(0, quarter))
+        self._region_b_streams = list(range(quarter, 2 * quarter))
+        self._region_c_streams = list(range(2 * quarter, 3 * quarter))
+        self._merge_streams = list(range(3 * quarter, stream_count))
+
+        for stream_list in [self._region_b_streams, self._region_c_streams, self._merge_streams]:
+            if not stream_list:
+                stream_list.append(0)
+
+        # Create regions
+        self._region_a = CompiledRegion(self.hidden_size).to(device)
+        self._region_b = CompiledRegion(self.hidden_size).to(device)
+        self._region_c = CompiledRegion(self.hidden_size).to(device)
+        self._merge_layer = nn.Linear(self.hidden_size * 2, self.hidden_size).to(device)
+
+        # Optionally compile
+        if self.use_compile:
+            try:
+                self._region_a = torch.compile(self._region_a, mode=self.compile_mode)
+                self._region_b = torch.compile(self._region_b, mode=self.compile_mode)
+                self._region_c = torch.compile(self._region_c, mode=self.compile_mode)
+            except Exception:
+                # Compilation may fail in some environments
+                pass
+
+        # Set to eval mode
+        self._region_a.eval()
+        self._region_b.eval()
+        self._region_c.eval()
+        self._merge_layer.eval()
+
+        # Input tensor
+        self._input = torch.randn(
+            self.batch_size, self.seq_length, self.hidden_size,
+            dtype=torch.float32, device=device
+        )
+        self._tensors["input"] = self._input
+
+        # Intermediate buffers
+        self._buf_a = torch.empty_like(self._input)
+        self._buf_b = torch.empty_like(self._input)
+        self._buf_c = torch.empty_like(self._input)
+        self._tensors["buf_a"] = self._buf_a
+        self._tensors["buf_b"] = self._buf_b
+        self._tensors["buf_c"] = self._buf_c
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute multi-region computation.
+
+        Graph:
+        input -> Region A -> Region B --\\
+                         \\-> Region C -> Merge -> output
+        """
+        stream_a = streams[self._region_a_streams[0]]
+        stream_b = streams[self._region_b_streams[0]]
+        stream_c = streams[self._region_c_streams[0]]
+        stream_merge = streams[self._merge_streams[0]]
+
+        # Region A: process input
+        with torch.cuda.stream(stream_a):
+            self._buf_a = self._region_a(self._input)
+
+        # Region B: depends on A
+        stream_b.wait_stream(stream_a)
+        with torch.cuda.stream(stream_b):
+            self._buf_b = self._region_b(self._buf_a)
+
+        # Region C: parallel to B, depends on A
+        stream_c.wait_stream(stream_a)
+        with torch.cuda.stream(stream_c):
+            self._buf_c = self._region_c(self._buf_a)
+
+        # Merge: depends on B and C
+        stream_merge.wait_stream(stream_b)
+        stream_merge.wait_stream(stream_c)
+
+        with torch.cuda.stream(stream_merge):
+            # Concatenate B and C outputs
+            merged = torch.cat([self._buf_b, self._buf_c], dim=-1)
+            output = self._merge_layer(merged)
+
+    def get_throughput_unit(self) -> str:
+        return "samples/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self.batch_size) / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "hidden_size": self.hidden_size,
+            "batch_size": self.batch_size,
+            "seq_length": self.seq_length,
+            "use_compile": self.use_compile,
+            "compile_mode": self.compile_mode,
+            "stream_assignment": {
+                "region_a": self._region_a_streams,
+                "region_b": self._region_b_streams,
+                "region_c": self._region_c_streams,
+                "merge": self._merge_streams,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup regions."""
+        super().cleanup()
+        self._region_a = None
+        self._region_b = None
+        self._region_c = None
+        self._merge_layer = None

--- a/src/aorta/hw_queue_eval/workloads/pipeline/zero_offload.py
+++ b/src/aorta/hw_queue_eval/workloads/pipeline/zero_offload.py
@@ -1,0 +1,216 @@
+"""
+ZeRO-Offload Workload
+
+Pattern: Overlap CPU offload/prefetch with GPU computation
+- Offload streams: GPU to CPU transfers (optimizer states)
+- Prefetch streams: CPU to GPU transfers (parameters)
+- Compute streams: Forward/backward computation
+
+This tests memory-bounded training scenarios with CPU offloading.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+
+from aorta.hw_queue_eval.workloads.base import BaseWorkload
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+
+class LargeLinearBlock(nn.Module):
+    """Large linear block for memory-heavy computation."""
+
+    def __init__(self, size: int):
+        super().__init__()
+        self.fc1 = nn.Linear(size, size)
+        self.fc2 = nn.Linear(size, size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.relu(self.fc1(x))
+        return self.fc2(x)
+
+
+@WorkloadRegistry.register
+class ZeROOffloadWorkload(BaseWorkload):
+    """
+    ZeRO-Offload memory management patterns.
+
+    Simulates the pattern where:
+    1. Optimizer states are offloaded to CPU after update
+    2. Parameters are prefetched to GPU before computation
+    3. Gradients are computed while next layer prefetches
+
+    Stream assignment:
+    - Streams 0-1: Offload (GPU->CPU)
+    - Streams 2-3: Prefetch (CPU->GPU)
+    - Streams 4+: Compute
+    """
+
+    name = "zero_offload"
+    description = "ZeRO-offload memory management patterns"
+    category = "pipeline"
+    min_streams = 4
+    max_streams = 12
+    recommended_streams = 6
+    switch_latency_sensitivity = "medium"
+    memory_requirements_gb = 8.0
+
+    def __init__(
+        self,
+        num_layers: int = 4,
+        layer_size: int = 4096,
+        batch_size: int = 16,
+    ):
+        """
+        Initialize ZeRO-Offload workload.
+
+        Args:
+            num_layers: Number of layers
+            layer_size: Size of each layer
+            batch_size: Batch size
+        """
+        super().__init__()
+        self.num_layers = num_layers
+        self.layer_size = layer_size
+        self.batch_size = batch_size
+
+        self._layers: List[LargeLinearBlock] = []
+        self._cpu_params: List[torch.Tensor] = []
+        self._gpu_params: List[torch.Tensor] = []
+        self._cpu_opt_states: List[torch.Tensor] = []
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Setup layers and offload buffers."""
+        self._stream_count = stream_count
+        self._device = device
+        self._is_setup = True
+
+        # Stream assignments
+        third = max(1, stream_count // 3)
+        self._offload_streams = list(range(0, third))
+        self._prefetch_streams = list(range(third, 2 * third))
+        self._compute_streams = list(range(2 * third, stream_count))
+
+        if not self._prefetch_streams:
+            self._prefetch_streams = [0]
+        if not self._compute_streams:
+            self._compute_streams = [0]
+
+        # Create layers (on GPU)
+        self._layers = []
+        for i in range(self.num_layers):
+            layer = LargeLinearBlock(self.layer_size).to(device)
+            self._layers.append(layer)
+
+        # CPU parameter storage (pinned memory)
+        self._cpu_params = []
+        for i in range(self.num_layers):
+            param = torch.randn(
+                self.layer_size, self.layer_size, dtype=torch.float32
+            ).pin_memory()
+            self._cpu_params.append(param)
+
+        # GPU parameter buffers
+        self._gpu_params = []
+        for i in range(self.num_layers):
+            buf = torch.empty(
+                self.layer_size, self.layer_size,
+                dtype=torch.float32, device=device
+            )
+            self._gpu_params.append(buf)
+            self._tensors[f"gpu_param_{i}"] = buf
+
+        # CPU optimizer states (momentum, etc.)
+        self._cpu_opt_states = []
+        for i in range(self.num_layers):
+            state = torch.zeros(
+                self.layer_size, self.layer_size, dtype=torch.float32
+            ).pin_memory()
+            self._cpu_opt_states.append(state)
+
+        # Input tensor
+        self._input = torch.randn(
+            self.batch_size, self.layer_size,
+            dtype=torch.float32, device=device, requires_grad=True
+        )
+        self._tensors["input"] = self._input
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one iteration with offload/prefetch pattern.
+
+        Pattern:
+        1. Prefetch layer N parameters while computing layer N-1
+        2. Offload layer N-1 states after backward
+        """
+        offload_stream = streams[self._offload_streams[0]]
+        prefetch_stream = streams[self._prefetch_streams[0]]
+        compute_stream = streams[self._compute_streams[0]]
+
+        x = self._input
+
+        # Forward pass with prefetching
+        for i in range(self.num_layers):
+            # Prefetch current layer parameters
+            with torch.cuda.stream(prefetch_stream):
+                self._gpu_params[i].copy_(self._cpu_params[i], non_blocking=True)
+
+            # Wait for prefetch then compute
+            compute_stream.wait_stream(prefetch_stream)
+
+            with torch.cuda.stream(compute_stream):
+                # Update layer weights from prefetched buffer
+                # (In real ZeRO, this would be more integrated)
+                x = self._layers[i](x)
+
+        # Backward pass with offloading
+        with torch.cuda.stream(compute_stream):
+            loss = x.sum()
+            loss.backward()
+
+        # Offload optimizer states
+        for i in range(self.num_layers):
+            # Wait for backward to complete for this layer
+            offload_stream.wait_stream(compute_stream)
+
+            with torch.cuda.stream(offload_stream):
+                # Simulate offloading gradient/optimizer state
+                for param in self._layers[i].parameters():
+                    if param.grad is not None:
+                        # Copy gradient to CPU (would update optimizer state)
+                        grad_cpu = param.grad.cpu()
+                        # Simulate optimizer step on CPU
+                        self._cpu_opt_states[i].add_(grad_cpu[:self.layer_size, :self.layer_size] * 0.01)
+                        param.grad = None
+
+    def get_throughput_unit(self) -> str:
+        return "samples/sec"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+        return (iterations * self.batch_size) / total_time_sec
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "num_layers": self.num_layers,
+            "layer_size": self.layer_size,
+            "batch_size": self.batch_size,
+            "stream_assignment": {
+                "offload": self._offload_streams,
+                "prefetch": self._prefetch_streams,
+                "compute": self._compute_streams,
+            },
+        }
+
+    def cleanup(self) -> None:
+        """Cleanup layers and buffers."""
+        super().cleanup()
+        self._layers = []
+        self._cpu_params = []
+        self._gpu_params = []
+        self._cpu_opt_states = []

--- a/src/aorta/hw_queue_eval/workloads/registry.py
+++ b/src/aorta/hw_queue_eval/workloads/registry.py
@@ -1,0 +1,176 @@
+"""
+Workload registry for discovering and instantiating workloads.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Type
+
+from aorta.hw_queue_eval.workloads.base import BaseWorkload, WorkloadInfo
+
+
+class WorkloadRegistry:
+    """
+    Registry for workload classes.
+
+    Allows discovering workloads by name, category, or characteristics.
+    """
+
+    _workloads: Dict[str, Type[BaseWorkload]] = {}
+    _instances: Dict[str, BaseWorkload] = {}
+
+    @classmethod
+    def register(cls, workload_class: Type[BaseWorkload]) -> Type[BaseWorkload]:
+        """
+        Register a workload class.
+
+        Can be used as a decorator:
+            @WorkloadRegistry.register
+            class MyWorkload(BaseWorkload):
+                ...
+
+        Args:
+            workload_class: Workload class to register
+
+        Returns:
+            The registered class (for decorator use)
+        """
+        name = workload_class.name
+        if name in cls._workloads:
+            # Allow re-registration (useful for reloading)
+            pass
+        cls._workloads[name] = workload_class
+        return workload_class
+
+    @classmethod
+    def get(cls, name: str, **kwargs) -> BaseWorkload:
+        """
+        Get a workload instance by name.
+
+        Args:
+            name: Workload name
+            **kwargs: Arguments to pass to workload constructor
+
+        Returns:
+            Workload instance
+
+        Raises:
+            KeyError: If workload not found
+        """
+        if name not in cls._workloads:
+            raise KeyError(
+                f"Workload '{name}' not found. Available: {list(cls._workloads.keys())}"
+            )
+
+        return cls._workloads[name](**kwargs)
+
+    @classmethod
+    def get_class(cls, name: str) -> Type[BaseWorkload]:
+        """Get workload class by name."""
+        if name not in cls._workloads:
+            raise KeyError(
+                f"Workload '{name}' not found. Available: {list(cls._workloads.keys())}"
+            )
+        return cls._workloads[name]
+
+    @classmethod
+    def list_all(cls) -> List[str]:
+        """List all registered workload names."""
+        return list(cls._workloads.keys())
+
+    @classmethod
+    def list_by_category(cls, category: str) -> List[str]:
+        """List workloads in a specific category."""
+        return [
+            name
+            for name, workload_cls in cls._workloads.items()
+            if workload_cls.category == category
+        ]
+
+    @classmethod
+    def list_by_sensitivity(cls, sensitivity: str) -> List[str]:
+        """List workloads by switch latency sensitivity."""
+        return [
+            name
+            for name, workload_cls in cls._workloads.items()
+            if workload_cls.switch_latency_sensitivity == sensitivity
+        ]
+
+    @classmethod
+    def get_info(cls, name: str) -> WorkloadInfo:
+        """Get workload info by name."""
+        workload_cls = cls.get_class(name)
+        return WorkloadInfo(
+            name=workload_cls.name,
+            description=workload_cls.description,
+            category=workload_cls.category,
+            min_streams=workload_cls.min_streams,
+            max_streams=workload_cls.max_streams,
+            recommended_streams=workload_cls.recommended_streams,
+            switch_latency_sensitivity=workload_cls.switch_latency_sensitivity,
+            memory_requirements_gb=workload_cls.memory_requirements_gb,
+            multi_gpu_capable=workload_cls.multi_gpu_capable,
+        )
+
+    @classmethod
+    def get_all_info(cls) -> Dict[str, WorkloadInfo]:
+        """Get info for all registered workloads."""
+        return {name: cls.get_info(name) for name in cls._workloads}
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all registered workloads."""
+        cls._workloads.clear()
+        cls._instances.clear()
+
+
+def get_workload(name: str, **kwargs) -> BaseWorkload:
+    """
+    Convenience function to get a workload by name.
+
+    Args:
+        name: Workload name
+        **kwargs: Arguments to pass to workload constructor
+
+    Returns:
+        Workload instance
+    """
+    return WorkloadRegistry.get(name, **kwargs)
+
+
+def list_workloads(category: Optional[str] = None) -> List[str]:
+    """
+    List available workloads.
+
+    Args:
+        category: Optional category filter
+
+    Returns:
+        List of workload names
+    """
+    if category:
+        return WorkloadRegistry.list_by_category(category)
+    return WorkloadRegistry.list_all()
+
+
+def register_all_workloads() -> None:
+    """
+    Register all built-in workloads.
+
+    This imports all workload modules to trigger registration.
+    """
+    # Import workload modules to trigger @register decorators
+    from aorta.hw_queue_eval.workloads import distributed, inference, latency_sensitive, pipeline
+
+
+# Auto-register on module import
+def _auto_register():
+    """Automatically register workloads if available."""
+    try:
+        register_all_workloads()
+    except ImportError:
+        # Workloads may not be implemented yet
+        pass
+
+
+_auto_register()

--- a/src/aorta/utils/__init__.py
+++ b/src/aorta/utils/__init__.py
@@ -1,18 +1,81 @@
-"""Utility helpers for the AORTA toolkit."""
+"""Utility helpers for the AORTA toolkit.
+
+This module provides shared utilities for:
+- Device discovery and GPU properties
+- Stream creation and management
+- GPU timing utilities
+- Configuration loading
+- Logging setup
+"""
 
 from .config import load_config, merge_cli_overrides
 from .device import (
+    # Constants
+    BACKEND_NAME,
+    IS_ROCM,
+    # Type aliases
+    Accelerator,
+    # Classes
+    DeviceProperties,
+    # Original aorta functions
     detect_accelerator,
+    ensure_gpu_available,
     get_device,
+    # Extended device utilities
+    get_device_properties,
     get_distributed_backend,
+    get_memory_stats,
+    get_rocm_env_info,
+    reset_memory_stats,
 )
 from .logging import setup_logging
+from .streams import (
+    create_streams,
+    cuda_stream_context,
+    get_stream_id,
+    sync_all_streams,
+    sync_stream,
+    warmup_gpu,
+)
+from .timing import (
+    CPUTimer,
+    EventTiming,
+    StreamTimer,
+    TimingContext,
+)
 
 __all__ = [
+    # Config
     "load_config",
     "merge_cli_overrides",
+    # Logging
+    "setup_logging",
+    # Device - constants
+    "IS_ROCM",
+    "BACKEND_NAME",
+    "Accelerator",
+    # Device - classes
+    "DeviceProperties",
+    # Device - functions (original aorta)
     "detect_accelerator",
     "get_device",
     "get_distributed_backend",
-    "setup_logging",
+    # Device - functions (extended)
+    "get_device_properties",
+    "ensure_gpu_available",
+    "get_memory_stats",
+    "reset_memory_stats",
+    "get_rocm_env_info",
+    # Streams
+    "create_streams",
+    "sync_all_streams",
+    "sync_stream",
+    "cuda_stream_context",
+    "get_stream_id",
+    "warmup_gpu",
+    # Timing
+    "EventTiming",
+    "TimingContext",
+    "StreamTimer",
+    "CPUTimer",
 ]

--- a/src/aorta/utils/device.py
+++ b/src/aorta/utils/device.py
@@ -1,10 +1,15 @@
-"""Device discovery helpers."""
+"""Device discovery and GPU property utilities.
+
+This module combines device detection for distributed training (original aorta)
+with comprehensive GPU property queries (from hw_queue_eval).
+"""
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import List, Literal
+from dataclasses import dataclass
+from typing import List, Literal, Optional, Tuple
 
 import torch
 
@@ -13,10 +18,18 @@ Accelerator = Literal["nvidia", "amd", "cpu"]
 
 log = logging.getLogger(__name__)
 
+# Detect if running on ROCm or CUDA
+IS_ROCM = hasattr(torch.version, "hip") and torch.version.hip is not None
+BACKEND_NAME = "ROCm/HIP" if IS_ROCM else "CUDA"
+
+
+# =============================================================================
+# Original aorta device utilities (for distributed training)
+# =============================================================================
+
 
 def detect_accelerator() -> Accelerator:
     """Detect the active accelerator type."""
-
     if not torch.cuda.is_available():
         return "cpu"
     if getattr(torch.version, "hip", None):
@@ -25,6 +38,7 @@ def detect_accelerator() -> Accelerator:
 
 
 def _visible_device_indices() -> List[int]:
+    """Return list of visible device indices from environment variables."""
     env = os.environ.get("CUDA_VISIBLE_DEVICES") or os.environ.get("HIP_VISIBLE_DEVICES")
     if env:
         indices = [token.strip() for token in env.split(",") if token.strip()]
@@ -43,8 +57,14 @@ def _visible_device_indices() -> List[int]:
 
 
 def get_device(local_rank: int) -> torch.device:
-    """Return the torch.device for the current process."""
+    """Return the torch.device for the current process.
 
+    Args:
+        local_rank: Local rank of the current process
+
+    Returns:
+        torch.device for the current process
+    """
     accelerator = detect_accelerator()
     if accelerator == "cpu":
         return torch.device("cpu")
@@ -68,11 +88,174 @@ def get_device(local_rank: int) -> torch.device:
 
 def get_distributed_backend() -> str:
     """Select the distributed backend based on accelerator."""
-
     accelerator = detect_accelerator()
     if accelerator == "cpu":
         return "gloo"
     return "nccl"
 
 
-__all__ = ["detect_accelerator", "get_device", "get_distributed_backend"]
+# =============================================================================
+# Extended device utilities (from hw_queue_eval)
+# =============================================================================
+
+
+@dataclass
+class DeviceProperties:
+    """GPU device properties relevant to queue evaluation and benchmarking."""
+
+    name: str
+    compute_capability: Tuple[int, int]
+    total_memory_gb: float
+    multi_processor_count: int
+    max_threads_per_mp: int
+    warp_size: int
+    is_rocm: bool
+    device_index: int
+
+    # ROCm-specific properties (may be None on CUDA)
+    gcn_arch: Optional[str] = None
+    compute_units: Optional[int] = None
+
+    def __str__(self) -> str:
+        backend = "ROCm" if self.is_rocm else "CUDA"
+        return (
+            f"{self.name} ({backend})\n"
+            f"  Memory: {self.total_memory_gb:.1f} GB\n"
+            f"  Compute Units/SMs: {self.multi_processor_count}\n"
+            f"  Warp/Wavefront Size: {self.warp_size}"
+        )
+
+
+def get_device_properties(device: str = "cuda:0") -> DeviceProperties:
+    """Get properties of the specified GPU device.
+
+    Args:
+        device: Device string (e.g., "cuda:0", "cuda:1")
+
+    Returns:
+        DeviceProperties object with device information
+    """
+    device_obj = torch.device(device)
+    device_idx = device_obj.index if device_obj.index is not None else 0
+
+    props = torch.cuda.get_device_properties(device_idx)
+
+    # Get compute capability
+    if IS_ROCM:
+        # ROCm reports capability differently
+        compute_cap = (props.major, props.minor)
+        gcn_arch = getattr(props, "gcnArchName", None)
+    else:
+        compute_cap = (props.major, props.minor)
+        gcn_arch = None
+
+    return DeviceProperties(
+        name=props.name,
+        compute_capability=compute_cap,
+        total_memory_gb=props.total_memory / (1024**3),
+        multi_processor_count=props.multi_processor_count,
+        max_threads_per_mp=props.max_threads_per_multi_processor,
+        warp_size=props.warp_size if hasattr(props, "warp_size") else 64 if IS_ROCM else 32,
+        is_rocm=IS_ROCM,
+        device_index=device_idx,
+        gcn_arch=gcn_arch,
+        compute_units=props.multi_processor_count if IS_ROCM else None,
+    )
+
+
+def ensure_gpu_available(device: str = "cuda:0") -> bool:
+    """Check if GPU is available and accessible.
+
+    Args:
+        device: Device string to check
+
+    Returns:
+        True if GPU is available and accessible
+    """
+    if not torch.cuda.is_available():
+        return False
+
+    try:
+        device_obj = torch.device(device)
+        device_idx = device_obj.index if device_obj.index is not None else 0
+        if device_idx >= torch.cuda.device_count():
+            return False
+        # Try to allocate a small tensor
+        with torch.cuda.device(device_idx):
+            _ = torch.empty(1, device=device)
+        return True
+    except Exception:
+        return False
+
+
+def get_memory_stats(device: str = "cuda:0") -> dict:
+    """Get current GPU memory statistics.
+
+    Args:
+        device: Device to query
+
+    Returns:
+        Dictionary with memory statistics
+    """
+    device_idx = torch.device(device).index or 0
+
+    return {
+        "allocated_gb": torch.cuda.memory_allocated(device_idx) / (1024**3),
+        "reserved_gb": torch.cuda.memory_reserved(device_idx) / (1024**3),
+        "max_allocated_gb": torch.cuda.max_memory_allocated(device_idx) / (1024**3),
+        "max_reserved_gb": torch.cuda.max_memory_reserved(device_idx) / (1024**3),
+    }
+
+
+def reset_memory_stats(device: str = "cuda:0") -> None:
+    """Reset memory statistics for device."""
+    device_idx = torch.device(device).index or 0
+    torch.cuda.reset_peak_memory_stats(device_idx)
+
+
+def get_rocm_env_info() -> dict:
+    """Get ROCm-specific environment information.
+
+    Returns:
+        Dictionary with ROCm environment details
+    """
+    info = {
+        "is_rocm": IS_ROCM,
+        "hip_version": getattr(torch.version, "hip", None),
+        "cuda_version": torch.version.cuda,
+        "torch_version": torch.__version__,
+    }
+
+    if IS_ROCM:
+        # ROCm-specific environment variables
+        rocm_env_vars = [
+            "ROCM_PATH",
+            "HIP_VISIBLE_DEVICES",
+            "AMD_LOG_LEVEL",
+            "HSA_TOOLS_LIB",
+            "GPU_MAX_HW_QUEUES",
+            "HSA_ENABLE_SDMA",
+        ]
+        info["env_vars"] = {var: os.environ.get(var) for var in rocm_env_vars}
+
+    return info
+
+
+__all__ = [
+    # Type aliases
+    "Accelerator",
+    # Constants
+    "IS_ROCM",
+    "BACKEND_NAME",
+    # Original aorta functions
+    "detect_accelerator",
+    "get_device",
+    "get_distributed_backend",
+    # Extended device utilities
+    "DeviceProperties",
+    "get_device_properties",
+    "ensure_gpu_available",
+    "get_memory_stats",
+    "reset_memory_stats",
+    "get_rocm_env_info",
+]

--- a/src/aorta/utils/streams.py
+++ b/src/aorta/utils/streams.py
@@ -1,0 +1,127 @@
+"""CUDA/HIP stream management utilities.
+
+This module provides utilities for:
+- Stream creation and management
+- Stream synchronization
+- GPU warmup operations
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator, List, Optional
+
+import torch
+
+
+def create_streams(
+    count: int, device: str = "cuda:0", priorities: Optional[List[int]] = None
+) -> List[torch.cuda.Stream]:
+    """Create a list of CUDA/HIP streams.
+
+    Args:
+        count: Number of streams to create
+        device: Target device
+        priorities: Optional list of priorities for each stream.
+                   Lower values = higher priority. If None, default priority is used.
+
+    Returns:
+        List of torch.cuda.Stream objects
+    """
+    device_obj = torch.device(device)
+
+    if priorities is not None and len(priorities) != count:
+        raise ValueError(f"priorities length ({len(priorities)}) must match count ({count})")
+
+    streams = []
+    for i in range(count):
+        priority = priorities[i] if priorities is not None else 0
+        # Note: PyTorch stream priority support is limited
+        # On ROCm, this maps to HIP stream priorities
+        stream = torch.cuda.Stream(device=device_obj, priority=priority)
+        streams.append(stream)
+
+    return streams
+
+
+def sync_all_streams(streams: List[torch.cuda.Stream]) -> None:
+    """Synchronize all streams.
+
+    Args:
+        streams: List of streams to synchronize
+    """
+    for stream in streams:
+        stream.synchronize()
+
+
+def sync_stream(stream: torch.cuda.Stream) -> None:
+    """Synchronize a single stream.
+
+    Args:
+        stream: Stream to synchronize
+    """
+    stream.synchronize()
+
+
+@contextmanager
+def cuda_stream_context(stream: torch.cuda.Stream) -> Generator[torch.cuda.Stream, None, None]:
+    """Context manager that sets the current CUDA stream.
+
+    Args:
+        stream: Stream to use as current
+
+    Yields:
+        The stream
+    """
+    with torch.cuda.stream(stream):
+        yield stream
+
+
+def get_stream_id(stream: torch.cuda.Stream) -> int:
+    """Get the underlying stream ID (pointer/handle).
+
+    This can be useful for debugging and correlating with profiler output.
+
+    Args:
+        stream: PyTorch CUDA stream
+
+    Returns:
+        Integer representation of the stream handle
+    """
+    return stream.cuda_stream
+
+
+def warmup_gpu(device: str = "cuda:0", iterations: int = 10) -> None:
+    """Warm up the GPU with simple operations.
+
+    This helps ensure consistent timing by:
+    - Triggering GPU frequency scaling
+    - Warming up the memory subsystem
+    - Initializing any lazy GPU state
+
+    Args:
+        device: Device to warm up
+        iterations: Number of warmup iterations
+    """
+    device_obj = torch.device(device)
+
+    # Create some tensors and do operations
+    for _ in range(iterations):
+        a = torch.randn(1024, 1024, device=device_obj)
+        b = torch.randn(1024, 1024, device=device_obj)
+        c = torch.mm(a, b)
+        torch.cuda.synchronize(device_obj)
+
+    # Clean up
+    del a, b, c
+    torch.cuda.empty_cache()
+
+
+__all__ = [
+    "create_streams",
+    "sync_all_streams",
+    "sync_stream",
+    "cuda_stream_context",
+    "get_stream_id",
+    "warmup_gpu",
+]

--- a/src/aorta/utils/timing.py
+++ b/src/aorta/utils/timing.py
@@ -1,0 +1,200 @@
+"""GPU timing utilities using CUDA/HIP events.
+
+This module provides utilities for:
+- Event-based GPU timing
+- Timing context managers
+- Multi-stream timing coordination
+- CPU-side timing
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Generator, List, Optional, Tuple
+
+import torch
+
+
+@dataclass
+class EventTiming:
+    """Timing data from a pair of CUDA/HIP events."""
+
+    start_event: torch.cuda.Event
+    end_event: torch.cuda.Event
+    stream_id: int
+    kernel_name: Optional[str] = None
+
+    def elapsed_ms(self) -> float:
+        """Get elapsed time in milliseconds between start and end events."""
+        return self.start_event.elapsed_time(self.end_event)
+
+
+@dataclass
+class TimingContext:
+    """Context manager for timing GPU operations.
+
+    Usage:
+        with TimingContext(stream, stream_id=0) as ctx:
+            # GPU operations
+            ...
+        elapsed = ctx.elapsed_ms()
+    """
+
+    stream: torch.cuda.Stream
+    stream_id: int = 0
+    kernel_name: Optional[str] = None
+    _start_event: torch.cuda.Event = field(init=False)
+    _end_event: torch.cuda.Event = field(init=False)
+    _completed: bool = field(init=False, default=False)
+
+    def __post_init__(self):
+        self._start_event = torch.cuda.Event(enable_timing=True)
+        self._end_event = torch.cuda.Event(enable_timing=True)
+
+    def __enter__(self) -> "TimingContext":
+        self._start_event.record(self.stream)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._end_event.record(self.stream)
+        self._completed = True
+
+    def elapsed_ms(self, sync: bool = True) -> float:
+        """Get elapsed time in milliseconds.
+
+        Args:
+            sync: If True, synchronize the stream before computing elapsed time
+
+        Returns:
+            Elapsed time in milliseconds
+        """
+        if not self._completed:
+            raise RuntimeError("Cannot get elapsed time before context manager exits")
+        if sync:
+            self._end_event.synchronize()
+        return self._start_event.elapsed_time(self._end_event)
+
+    def to_event_timing(self) -> EventTiming:
+        """Convert to EventTiming object."""
+        return EventTiming(
+            start_event=self._start_event,
+            end_event=self._end_event,
+            stream_id=self.stream_id,
+            kernel_name=self.kernel_name,
+        )
+
+
+class StreamTimer:
+    """Timer for recording multiple kernel timings across streams.
+
+    Usage:
+        timer = StreamTimer(num_streams=4)
+
+        # In workload execution
+        start, end = timer.create_events(stream_id=0)
+        start.record(stream)
+        # ... GPU operations ...
+        end.record(stream)
+
+        # After synchronization
+        timings = timer.get_all_timings()
+    """
+
+    def __init__(self, num_streams: int):
+        self.num_streams = num_streams
+        self._events: List[List[Tuple[torch.cuda.Event, torch.cuda.Event, Optional[str]]]] = [
+            [] for _ in range(num_streams)
+        ]
+
+    def create_events(
+        self, stream_id: int, kernel_name: Optional[str] = None
+    ) -> Tuple[torch.cuda.Event, torch.cuda.Event]:
+        """Create a pair of timing events for a stream.
+
+        Args:
+            stream_id: Index of the stream
+            kernel_name: Optional name for the kernel being timed
+
+        Returns:
+            Tuple of (start_event, end_event)
+        """
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        self._events[stream_id].append((start, end, kernel_name))
+        return start, end
+
+    def get_stream_timings(self, stream_id: int) -> List[Tuple[float, Optional[str]]]:
+        """Get all timings for a specific stream.
+
+        Args:
+            stream_id: Index of the stream
+
+        Returns:
+            List of (elapsed_ms, kernel_name) tuples
+        """
+        timings = []
+        for start, end, name in self._events[stream_id]:
+            elapsed = start.elapsed_time(end)
+            timings.append((elapsed, name))
+        return timings
+
+    def get_all_timings(self) -> List[List[Tuple[float, Optional[str]]]]:
+        """Get all timings for all streams.
+
+        Returns:
+            List of stream timings, where each element is a list of (elapsed_ms, kernel_name)
+        """
+        return [self.get_stream_timings(i) for i in range(self.num_streams)]
+
+    def get_total_time_per_stream(self) -> List[float]:
+        """Get total elapsed time for each stream."""
+        totals = []
+        for stream_id in range(self.num_streams):
+            stream_total = sum(t[0] for t in self.get_stream_timings(stream_id))
+            totals.append(stream_total)
+        return totals
+
+    def clear(self) -> None:
+        """Clear all recorded events."""
+        self._events = [[] for _ in range(self.num_streams)]
+
+
+class CPUTimer:
+    """Simple CPU-side timer for host-side measurements."""
+
+    def __init__(self):
+        self._start_time: Optional[float] = None
+        self._end_time: Optional[float] = None
+
+    def start(self) -> None:
+        """Start the timer."""
+        self._start_time = time.perf_counter()
+
+    def stop(self) -> None:
+        """Stop the timer."""
+        self._end_time = time.perf_counter()
+
+    def elapsed_ms(self) -> float:
+        """Get elapsed time in milliseconds."""
+        if self._start_time is None or self._end_time is None:
+            raise RuntimeError("Timer not started/stopped")
+        return (self._end_time - self._start_time) * 1000
+
+    @contextmanager
+    def measure(self) -> Generator["CPUTimer", None, None]:
+        """Context manager for CPU timing."""
+        self.start()
+        try:
+            yield self
+        finally:
+            self.stop()
+
+
+__all__ = [
+    "EventTiming",
+    "TimingContext",
+    "StreamTimer",
+    "CPUTimer",
+]

--- a/tests/hw_queue_eval/__init__.py
+++ b/tests/hw_queue_eval/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for the hardware queue evaluation framework.
+"""

--- a/tests/hw_queue_eval/test_harness.py
+++ b/tests/hw_queue_eval/test_harness.py
@@ -1,0 +1,247 @@
+"""
+Tests for the core harness functionality.
+
+Tests:
+- Stream creation and management
+- Timing accuracy
+- Result aggregation
+- Sweep functionality
+"""
+
+import pytest
+import torch
+
+# Skip all tests if CUDA is not available
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available"
+)
+
+
+class TestHarnessConfig:
+    """Tests for HarnessConfig."""
+
+    def test_valid_config(self):
+        """Test creating a valid config."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig
+
+        config = HarnessConfig(stream_count=4)
+        assert config.stream_count == 4
+        assert config.warmup_iterations == 10
+        assert config.measurement_iterations == 100
+
+    def test_invalid_stream_count(self):
+        """Test that stream_count < 1 raises error."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig
+
+        with pytest.raises(ValueError):
+            HarnessConfig(stream_count=0)
+
+    def test_invalid_sync_mode(self):
+        """Test that invalid sync_mode raises error."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig
+
+        with pytest.raises(ValueError):
+            HarnessConfig(stream_count=4, sync_mode="invalid")
+
+    def test_config_to_dict(self):
+        """Test config serialization."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig
+
+        config = HarnessConfig(stream_count=8, warmup_iterations=5)
+        d = config.to_dict()
+
+        assert d["stream_count"] == 8
+        assert d["warmup_iterations"] == 5
+
+
+class TestStreamHarness:
+    """Tests for StreamHarness."""
+
+    def test_harness_creates_correct_stream_count(self):
+        """Test that harness creates the correct number of streams."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        config = HarnessConfig(
+            stream_count=4,
+            warmup_iterations=1,
+            measurement_iterations=2,
+        )
+        harness = StreamHarness(config)
+        harness._initialize()
+
+        assert len(harness.streams) == 4
+        harness._cleanup()
+
+    def test_simple_workload_run(self):
+        """Test running a simple workload function."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        config = HarnessConfig(
+            stream_count=2,
+            warmup_iterations=1,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+
+        # Simple workload that does some GPU work
+        def simple_workload(streams):
+            for stream in streams:
+                with torch.cuda.stream(stream):
+                    a = torch.randn(100, 100, device="cuda")
+                    b = torch.mm(a, a)
+
+        result = harness.run(simple_workload, workload_name="test")
+
+        assert result.stream_count == 2
+        assert result.throughput > 0
+        assert result.total_time_ms > 0
+        assert "mean" in result.latency_ms
+
+    def test_harness_timing_accuracy(self):
+        """Verify timing is within expected tolerance."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        config = HarnessConfig(
+            stream_count=1,
+            warmup_iterations=2,
+            measurement_iterations=10,
+        )
+        harness = StreamHarness(config)
+
+        # Workload with known approximate duration
+        def timed_workload(streams):
+            with torch.cuda.stream(streams[0]):
+                # Do enough work to have measurable time
+                a = torch.randn(1000, 1000, device="cuda")
+                for _ in range(10):
+                    a = torch.mm(a, a)
+
+        result = harness.run(timed_workload)
+
+        # Total time should be positive and reasonable
+        assert result.total_time_ms > 0
+        assert result.total_time_ms < 60000  # Less than 60 seconds
+
+        # Iteration times should be consistent
+        times = result.iteration_times_ms
+        assert len(times) == 10
+        assert all(t > 0 for t in times)
+
+    def test_sweep_returns_results_for_all_counts(self):
+        """Test that sweep returns results for all stream counts."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        config = HarnessConfig(
+            stream_count=1,  # Will be overridden
+            warmup_iterations=1,
+            measurement_iterations=3,
+        )
+        harness = StreamHarness(config)
+
+        def simple_workload(streams):
+            for stream in streams:
+                with torch.cuda.stream(stream):
+                    torch.randn(50, 50, device="cuda")
+
+        stream_counts = [1, 2, 4]
+        results = harness.sweep(simple_workload, stream_counts)
+
+        assert len(results) == 3
+        assert results[0].stream_count == 1
+        assert results[1].stream_count == 2
+        assert results[2].stream_count == 4
+
+
+class TestHarnessResult:
+    """Tests for HarnessResult."""
+
+    def test_result_to_json(self):
+        """Test result JSON serialization."""
+        from aorta.hw_queue_eval.core.harness import HarnessResult
+        import json
+
+        result = HarnessResult(
+            throughput=1000.0,
+            throughput_unit="ops/sec",
+            latency_ms={"mean": 10.0, "p50": 9.0, "p95": 15.0, "p99": 20.0},
+            total_time_ms=1000.0,
+            stream_count=4,
+            per_stream_times_ms=[250.0, 250.0, 250.0, 250.0],
+            iteration_times_ms=[100.0] * 10,
+        )
+
+        json_str = result.to_json()
+        parsed = json.loads(json_str)
+
+        assert parsed["throughput"] == 1000.0
+        assert parsed["stream_count"] == 4
+
+    def test_result_to_dict(self):
+        """Test result dictionary conversion."""
+        from aorta.hw_queue_eval.core.harness import HarnessResult
+
+        result = HarnessResult(
+            throughput=500.0,
+            throughput_unit="samples/sec",
+            latency_ms={"mean": 5.0, "p50": 4.0, "p95": 8.0, "p99": 10.0},
+            total_time_ms=2000.0,
+            stream_count=8,
+            per_stream_times_ms=[250.0] * 8,
+            iteration_times_ms=[20.0] * 100,
+        )
+
+        d = result.to_dict()
+
+        assert d["throughput"] == 500.0
+        assert d["throughput_unit"] == "samples/sec"
+        assert d["stream_count"] == 8
+
+
+class TestAnalysisUtilities:
+    """Tests for result analysis utilities."""
+
+    def test_analyze_sweep_results(self):
+        """Test scaling analysis from sweep results."""
+        from aorta.hw_queue_eval.core.harness import HarnessResult, analyze_sweep_results
+
+        # Create mock results with diminishing returns
+        results = []
+        for streams, tp in [(1, 100), (2, 190), (4, 350), (8, 400), (16, 410)]:
+            results.append(HarnessResult(
+                throughput=tp,
+                throughput_unit="ops/sec",
+                latency_ms={"mean": 10.0, "p50": 9.0, "p95": 15.0, "p99": 20.0},
+                total_time_ms=1000.0,
+                stream_count=streams,
+                per_stream_times_ms=[100.0] * streams,
+                iteration_times_ms=[10.0] * 100,
+            ))
+
+        analysis = analyze_sweep_results(results)
+
+        assert analysis.stream_counts == [1, 2, 4, 8, 16]
+        assert analysis.peak_stream_count in [8, 16]  # Best throughput
+        assert len(analysis.efficiencies) == 5
+
+    def test_format_results_table(self):
+        """Test table formatting."""
+        from aorta.hw_queue_eval.core.harness import HarnessResult, format_results_table
+
+        results = [
+            HarnessResult(
+                throughput=100.0,
+                throughput_unit="ops/sec",
+                latency_ms={"mean": 10.0, "p50": 9.0, "p95": 15.0, "p99": 20.0, "min": 5.0, "max": 25.0, "std": 3.0},
+                total_time_ms=1000.0,
+                stream_count=4,
+                per_stream_times_ms=[250.0] * 4,
+                iteration_times_ms=[10.0] * 100,
+            )
+        ]
+
+        table = format_results_table(results)
+
+        assert "Streams" in table
+        assert "Throughput" in table
+        assert "100.00" in table

--- a/tests/hw_queue_eval/test_metrics.py
+++ b/tests/hw_queue_eval/test_metrics.py
@@ -1,0 +1,282 @@
+"""
+Tests for the metrics collection module.
+
+Tests:
+- Latency metrics computation
+- Switch latency estimation
+- Metrics collector functionality
+"""
+
+import pytest
+
+
+class TestLatencyMetrics:
+    """Tests for LatencyMetrics."""
+
+    def test_from_samples_empty(self):
+        """Test with empty sample list."""
+        from aorta.hw_queue_eval.core.metrics import LatencyMetrics
+
+        metrics = LatencyMetrics.from_samples([])
+
+        assert metrics.count == 0
+        assert metrics.mean_ms == 0.0
+
+    def test_from_samples_single(self):
+        """Test with single sample."""
+        from aorta.hw_queue_eval.core.metrics import LatencyMetrics
+
+        metrics = LatencyMetrics.from_samples([10.0])
+
+        assert metrics.count == 1
+        assert metrics.mean_ms == 10.0
+        assert metrics.p50_ms == 10.0
+        assert metrics.std_ms == 0.0
+
+    def test_from_samples_multiple(self):
+        """Test with multiple samples."""
+        from aorta.hw_queue_eval.core.metrics import LatencyMetrics
+
+        samples = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        metrics = LatencyMetrics.from_samples(samples)
+
+        assert metrics.count == 10
+        assert metrics.mean_ms == 5.5
+        assert metrics.min_ms == 1.0
+        assert metrics.max_ms == 10.0
+        assert metrics.p50_ms == pytest.approx(5.5, rel=0.1)
+
+    def test_to_dict(self):
+        """Test dictionary conversion."""
+        from aorta.hw_queue_eval.core.metrics import LatencyMetrics
+
+        metrics = LatencyMetrics(
+            mean_ms=10.0,
+            p50_ms=9.0,
+            p95_ms=15.0,
+            p99_ms=20.0,
+            min_ms=5.0,
+            max_ms=25.0,
+            count=100,
+        )
+
+        d = metrics.to_dict()
+
+        assert d["mean_ms"] == 10.0
+        assert d["p99_ms"] == 20.0
+        assert d["count"] == 100
+
+
+class TestSwitchLatencyMetrics:
+    """Tests for SwitchLatencyMetrics."""
+
+    def test_from_kernel_timings_empty(self):
+        """Test with empty timing list."""
+        from aorta.hw_queue_eval.core.metrics import SwitchLatencyMetrics
+
+        metrics = SwitchLatencyMetrics.from_kernel_timings([])
+
+        assert metrics.inter_stream_gap_ms == 0.0
+        assert metrics.intra_stream_gap_ms == 0.0
+
+    def test_from_kernel_timings_same_stream(self):
+        """Test with kernels on same stream."""
+        from aorta.hw_queue_eval.core.metrics import SwitchLatencyMetrics
+
+        # (stream_id, start_ms, end_ms)
+        timings = [
+            (0, 0.0, 10.0),
+            (0, 11.0, 20.0),
+            (0, 21.0, 30.0),
+        ]
+
+        metrics = SwitchLatencyMetrics.from_kernel_timings(timings)
+
+        assert metrics.intra_stream_samples > 0
+        assert metrics.intra_stream_gap_ms == pytest.approx(1.0, rel=0.1)
+
+    def test_from_kernel_timings_different_streams(self):
+        """Test with kernels on different streams."""
+        from aorta.hw_queue_eval.core.metrics import SwitchLatencyMetrics
+
+        # Alternating streams
+        timings = [
+            (0, 0.0, 10.0),
+            (1, 12.0, 22.0),
+            (0, 25.0, 35.0),
+            (1, 38.0, 48.0),
+        ]
+
+        metrics = SwitchLatencyMetrics.from_kernel_timings(timings)
+
+        assert metrics.inter_stream_samples > 0
+        assert metrics.inter_stream_gap_ms > 0
+
+
+class TestThroughputMetrics:
+    """Tests for ThroughputMetrics."""
+
+    def test_compute_basic(self):
+        """Test basic throughput computation."""
+        from aorta.hw_queue_eval.core.metrics import ThroughputMetrics
+
+        metrics = ThroughputMetrics.compute(1000, 10.0, "ops/sec")
+
+        assert metrics.value == 100.0
+        assert metrics.unit == "ops/sec"
+        assert metrics.raw_count == 1000
+        assert metrics.duration_sec == 10.0
+
+    def test_compute_zero_duration(self):
+        """Test with zero duration."""
+        from aorta.hw_queue_eval.core.metrics import ThroughputMetrics
+
+        metrics = ThroughputMetrics.compute(1000, 0.0, "ops/sec")
+
+        assert metrics.value == 0.0
+
+
+class TestMetricsCollector:
+    """Tests for MetricsCollector."""
+
+    def test_collector_basic(self):
+        """Test basic metrics collection."""
+        import torch
+        from aorta.hw_queue_eval.core.metrics import MetricsCollector
+
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        collector = MetricsCollector(num_streams=2)
+
+        for _ in range(5):
+            collector.start_iteration()
+            # Simulate some work
+            collector.end_iteration(sync=False)
+
+        times = collector.get_iteration_times()
+        assert len(times) == 5
+
+    def test_collector_compute_latency(self):
+        """Test latency computation."""
+        import torch
+        from aorta.hw_queue_eval.core.metrics import MetricsCollector
+
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        collector = MetricsCollector(num_streams=1)
+
+        for _ in range(10):
+            collector.start_iteration()
+            # Do some GPU work
+            a = torch.randn(100, 100, device="cuda")
+            _ = torch.mm(a, a)
+            collector.end_iteration()
+
+        latency = collector.compute_latency_metrics()
+
+        assert latency.count == 10
+        assert latency.mean_ms > 0
+
+    def test_collector_clear(self):
+        """Test clearing collected data."""
+        import torch
+        from aorta.hw_queue_eval.core.metrics import MetricsCollector
+
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        collector = MetricsCollector(num_streams=1)
+
+        collector.start_iteration()
+        collector.end_iteration(sync=False)
+
+        assert len(collector.get_iteration_times()) == 1
+
+        collector.clear()
+
+        assert len(collector.get_iteration_times()) == 0
+
+
+class TestScalingAnalysis:
+    """Tests for ScalingAnalysis."""
+
+    def test_from_sweep_results_empty(self):
+        """Test with empty results."""
+        from aorta.hw_queue_eval.core.metrics import ScalingAnalysis
+
+        analysis = ScalingAnalysis.from_sweep_results([])
+
+        assert analysis.stream_counts == []
+        assert analysis.peak_stream_count == 0
+
+    def test_from_sweep_results_scaling(self):
+        """Test with scaling results."""
+        from aorta.hw_queue_eval.core.metrics import ScalingAnalysis
+
+        # (stream_count, throughput) - linear scaling initially, then drops
+        results = [
+            (1, 100),
+            (2, 195),
+            (4, 380),
+            (8, 500),  # Starts to plateau
+            (16, 520),
+        ]
+
+        analysis = ScalingAnalysis.from_sweep_results(results)
+
+        assert analysis.stream_counts == [1, 2, 4, 8, 16]
+        assert len(analysis.efficiencies) == 5
+        # Efficiency should decrease as scaling breaks down
+        assert analysis.efficiencies[0] > analysis.efficiencies[-1]
+
+
+class TestCompareResults:
+    """Tests for result comparison."""
+
+    def test_no_regression(self):
+        """Test comparison with no regression."""
+        from aorta.hw_queue_eval.core.metrics import compare_results
+
+        baseline = {"throughput": 100.0, "latency": {"p50_ms": 10.0, "p95_ms": 15.0, "p99_ms": 20.0}}
+        test = {"throughput": 102.0, "latency": {"p50_ms": 10.0, "p95_ms": 15.0, "p99_ms": 20.0}}
+
+        comparison = compare_results(baseline, test, threshold=0.05)
+
+        assert not comparison["has_regressions"]
+
+    def test_throughput_regression(self):
+        """Test detection of throughput regression."""
+        from aorta.hw_queue_eval.core.metrics import compare_results
+
+        baseline = {"throughput": 100.0}
+        test = {"throughput": 90.0}  # 10% regression
+
+        comparison = compare_results(baseline, test, threshold=0.05)
+
+        assert comparison["has_regressions"]
+        assert len(comparison["regressions"]) > 0
+
+    def test_latency_regression(self):
+        """Test detection of latency regression."""
+        from aorta.hw_queue_eval.core.metrics import compare_results
+
+        baseline = {"latency": {"p99_ms": 10.0}}
+        test = {"latency": {"p99_ms": 12.0}}  # 20% increase
+
+        comparison = compare_results(baseline, test, threshold=0.05)
+
+        assert comparison["has_regressions"]
+
+    def test_improvement_detected(self):
+        """Test detection of improvements."""
+        from aorta.hw_queue_eval.core.metrics import compare_results
+
+        baseline = {"throughput": 100.0}
+        test = {"throughput": 120.0}  # 20% improvement
+
+        comparison = compare_results(baseline, test, threshold=0.05)
+
+        assert not comparison["has_regressions"]
+        assert len(comparison["improvements"]) > 0

--- a/tests/hw_queue_eval/test_workloads.py
+++ b/tests/hw_queue_eval/test_workloads.py
@@ -1,0 +1,306 @@
+"""
+Tests for workload implementations.
+
+Tests each workload to ensure:
+- Runs without error at various stream counts
+- Produces valid metrics
+- Correctness validation passes (where implemented)
+"""
+
+import pytest
+import torch
+
+# Skip all tests if CUDA is not available
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available"
+)
+
+
+def get_workload(name: str, **kwargs):
+    """Get a workload by name."""
+    from aorta.hw_queue_eval.workloads.registry import get_workload
+    return get_workload(name, **kwargs)
+
+
+class TestHeterogeneousKernelWorkload:
+    """Tests for the hetero_kernels workload."""
+
+    @pytest.mark.parametrize("stream_count", [2, 4, 8])
+    def test_runs_at_various_stream_counts(self, stream_count):
+        """Test workload runs without error."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload("hetero_kernels")
+
+        config = HarnessConfig(
+            stream_count=stream_count,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+        assert result.stream_count == stream_count
+
+    def test_produces_valid_metrics(self):
+        """Test that metrics are valid."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload("hetero_kernels")
+
+        config = HarnessConfig(
+            stream_count=4,
+            warmup_iterations=2,
+            measurement_iterations=10,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.latency_ms["mean"] > 0
+        assert result.latency_ms["p50"] > 0
+        assert result.latency_ms["p99"] >= result.latency_ms["p50"]
+        assert result.throughput_unit == "GFLOPS"
+
+    def test_correctness_validation(self):
+        """Test correctness validation."""
+        workload = get_workload("hetero_kernels")
+        workload.setup(stream_count=4, device="cuda:0")
+
+        is_correct, message = workload.validate_correctness(None, None)
+
+        assert is_correct
+        workload.cleanup()
+
+
+class TestTinyKernelStressWorkload:
+    """Tests for tiny_kernel_stress workload."""
+
+    @pytest.mark.parametrize("stream_count", [1, 4, 8, 16])
+    def test_runs_at_various_stream_counts(self, stream_count):
+        """Test workload runs at high stream counts."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload("tiny_kernel_stress")
+
+        config = HarnessConfig(
+            stream_count=stream_count,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+
+
+class TestFSDPTPWorkload:
+    """Tests for fsdp_tp workload."""
+
+    @pytest.mark.parametrize("stream_count", [4, 8, 10])
+    def test_runs_at_various_stream_counts(self, stream_count):
+        """Test FSDP+TP workload."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload("fsdp_tp", model_size="small")
+
+        config = HarnessConfig(
+            stream_count=stream_count,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+        assert result.throughput_unit == "samples/sec"
+
+
+class TestMoEWorkload:
+    """Tests for moe workload."""
+
+    @pytest.mark.parametrize("stream_count", [4, 8, 16])
+    def test_runs_at_various_stream_counts(self, stream_count):
+        """Test MoE workload with multiple experts."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "moe",
+            num_experts=8,
+            hidden_size=512,
+            batch_size=2,
+            seq_length=128,
+        )
+
+        config = HarnessConfig(
+            stream_count=stream_count,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+        assert result.throughput_unit == "tokens/sec"
+
+
+class TestSpeculativeDecodeWorkload:
+    """Tests for speculative_decode workload."""
+
+    @pytest.mark.parametrize("stream_count", [4, 6, 8])
+    def test_runs_at_various_stream_counts(self, stream_count):
+        """Test speculative decoding workload."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "speculative_decode",
+            draft_hidden_size=128,
+            draft_num_layers=2,
+            main_hidden_size=256,
+            main_num_layers=4,
+        )
+
+        config = HarnessConfig(
+            stream_count=stream_count,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+
+
+class TestContinuousBatchWorkload:
+    """Tests for continuous_batch workload."""
+
+    @pytest.mark.parametrize("stream_count", [4, 6, 8])
+    def test_runs_at_various_stream_counts(self, stream_count):
+        """Test continuous batching workload."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "continuous_batch",
+            hidden_size=256,
+            num_layers=2,
+            prefill_batch_size=1,
+            decode_batch_size=4,
+        )
+
+        config = HarnessConfig(
+            stream_count=stream_count,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+
+
+class TestGraphSubgraphsWorkload:
+    """Tests for graph_subgraphs workload."""
+
+    @pytest.mark.parametrize("stream_count", [4, 8, 12])
+    def test_runs_at_various_stream_counts(self, stream_count):
+        """Test independent subgraph execution."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "graph_subgraphs",
+            num_subgraphs=4,
+            hidden_size=512,
+            batch_size=16,
+        )
+
+        config = HarnessConfig(
+            stream_count=stream_count,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+
+
+class TestWorkloadRegistry:
+    """Tests for workload registry."""
+
+    def test_list_all_workloads(self):
+        """Test listing all workloads."""
+        from aorta.hw_queue_eval.workloads.registry import list_workloads
+
+        workloads = list_workloads()
+
+        assert len(workloads) > 0
+        assert "hetero_kernels" in workloads
+
+    def test_get_workload_info(self):
+        """Test getting workload info."""
+        from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+        info = WorkloadRegistry.get_info("hetero_kernels")
+
+        assert info.name == "hetero_kernels"
+        assert info.category == "latency_sensitive"
+        assert info.switch_latency_sensitivity == "critical"
+
+    def test_list_by_category(self):
+        """Test filtering by category."""
+        from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+
+        latency_sensitive = WorkloadRegistry.list_by_category("latency_sensitive")
+
+        assert "hetero_kernels" in latency_sensitive
+        assert "graph_subgraphs" in latency_sensitive
+
+    def test_unknown_workload_raises(self):
+        """Test that unknown workload raises KeyError."""
+        from aorta.hw_queue_eval.workloads.registry import get_workload
+
+        with pytest.raises(KeyError):
+            get_workload("nonexistent_workload")
+
+
+class TestWorkloadCleanup:
+    """Tests for workload cleanup."""
+
+    def test_cleanup_releases_memory(self):
+        """Test that cleanup releases GPU memory."""
+        workload = get_workload("hetero_kernels")
+        workload.setup(stream_count=4, device="cuda:0")
+
+        # Record memory before cleanup
+        before_cleanup = torch.cuda.memory_allocated()
+
+        workload.cleanup()
+        torch.cuda.empty_cache()
+
+        # Memory should be reduced after cleanup
+        after_cleanup = torch.cuda.memory_allocated()
+
+        assert after_cleanup <= before_cleanup
+
+
+class TestWorkloadStreamCompatibility:
+    """Tests for stream count compatibility."""
+
+    def test_supports_stream_count(self):
+        """Test stream count support checking."""
+        workload = get_workload("hetero_kernels")
+
+        assert workload.supports_stream_count(4)
+        assert workload.supports_stream_count(8)
+        assert not workload.supports_stream_count(0)
+        assert not workload.supports_stream_count(100)
+
+    def test_workload_limits(self):
+        """Test that workloads respect their limits."""
+        workload = get_workload("fsdp_tp")
+
+        assert workload.min_streams > 0
+        assert workload.max_streams >= workload.min_streams
+        assert workload.recommended_streams >= workload.min_streams
+        assert workload.recommended_streams <= workload.max_streams


### PR DESCRIPTION
 Motivation

  Integrate the hw_queue_eval GPU Hardware Queue Concurrency Evaluation Framework into the main aorta repository as a subpackage. This consolidates two related tools:
  - aorta: PyTorch compute-communication overlap debugging toolkit for FSDP2 training
  - hw_queue_eval: Framework for stress-testing AMD GPU hardware queue mapping with >4 concurrent streams to identify convoy effects and queue saturation

  The integration enables unified packaging while preserving backward compatibility for existing aorta users.

  Technical Details

  Package Structure:
  - Added hw_queue_eval as subpackage at src/aorta/hw_queue_eval/
  - Entry point: python -m aorta.hw_queue_eval
  - Optional dependencies via pip install aorta[hw-queue]

  Shared Utilities (aorta.utils):
  - device.py: Merged device detection with ROCm-specific helpers (IS_ROCM, BACKEND_NAME, DeviceProperties)
  - streams.py: New module for CUDA/HIP stream management (create_streams(), sync_all_streams(), cuda_stream_context())
  - timing.py: New module for GPU event-based timing (EventTiming, TimingContext, StreamTimer)

  Import Updates:
  - All hw_queue_eval.* imports changed to aorta.hw_queue_eval.*
  - All hw_queue_eval.core.utils imports changed to aorta.utils

  File Migrations:
  - Scripts moved to scripts/hw_queue/ (run_sweep.sh, profile_queues.sh, compare_baselines.py)
  - Tests moved to tests/hw_queue_eval/ (test_harness.py, test_metrics.py, test_workloads.py)

  Packaging:
  - Created pyproject.toml with Python >=3.12 requirement
  - Optional [hw-queue] extras: click, numpy, pandas, tabulate
  - Development extras: [dev], [all]

  Cleanup:
  - Removed unused plugins/ directory (dead/speculative code)
  - Updated .gitignore pattern from egg-info/ to *.egg-info/

  Test Plan

  1. Verified package installation with uv pip install -e ".[hw-queue]"
  2. Confirmed aorta imports correctly with version 0.2.0
  3. Verified hw_queue_eval subpackage loads successfully
  4. Tested CLI commands (list, run, sweep, info)
  5. Confirmed all 14 workloads registered
  6. Verified original train.py entry point unchanged
  7. Ran full test suite with python -m pytest tests/
  8. Grep-verified no dangling references to removed plugins module

```
python -m aorta.hw_queue_eval run large_gemm_only --streams 8

======================================================================
GPU HARDWARE QUEUE EVALUATION
======================================================================

WORKLOAD: large_gemm_only
  Large GEMMs only - compute-bound baseline

PURPOSE:
  Compute-bound baseline with large GEMMs only. Should scale well with
  streams. Use this to establish baseline GPU compute capability.

TEST CONFIGURATION:
  Concurrent streams:     8 (recommended: 4)
  Measurement iterations: 100
  Warmup iterations:      10
  Device:                 cuda:0
  Switch sensitivity:     low

----------------------------------------------------------------------
Running workload...
...
```
  Test Result

  ================= 15 passed, 46 skipped in 0.78s =================
  - 15 unit tests passed (metrics, harness logic, workload registration)
  - 46 tests skipped (require GPU hardware - marked with @pytest.mark.gpu)
  - No import errors or regressions detected