### PR TITLE
aorta: refactors docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,290 +1,61 @@
-# AORTA Compute-Communication Overlap Toolkit
+# AORTA
 
-This repository provides a production-ready benchmarking harness to debug compute-communication overlap issues in PyTorch FSDP2 workloads. It targets both NVIDIA CUDA and AMD ROCm 7 environments and delivers:
+GPU performance benchmarking and debugging toolkit for PyTorch workloads on AMD ROCm.
 
-- A synthetic large-scale ranking/recommendation workload with a transformer backbone (`train.py`).
-- Explicit multi-stream execution (compute, all-reduce, reduce-scatter, auxiliary/prefetch) with torch.cuda Events for microsecond timing.
-- Instrumented FSDP2 training loop that intercepts distributed collectives to bind them to dedicated streams.
-- Profiling artefacts (JSONL) capturing detailed overlap metrics per iteration.
-- ROCm-specific diagnostics via `rocm-smi` (optional) and cross-platform launch scripts.
-- Reporting utilities (`analysis/overlap_report.py`) to visualise overlap efficiency and compare AMD vs NVIDIA runs.
+## What It Does
 
-Implementation patterns throughout the repository take inspiration from publicly available examples in TorchRec and TorchTitan, which served as reference points while assembling this toolkit.
+**FSDP2 Compute-Communication Overlap Analysis**
+Debug why distributed training isn't overlapping compute with communication. Runs a synthetic transformer workload with explicit multi-stream execution, captures per-iteration timing, and generates overlap efficiency reports.
 
-**Why This Workload Helps**
-- Synthetic ranking features eliminate input variability, making any overlap shifts traceable to scheduling or communication changes instead of dataloader jitter.
-- The transformer encoder stack stresses both dense matmuls and collective-heavy layers, mirroring real recommendation models while remaining configurable.
-- Four-way stream orchestration (compute, all-reduce, reduce-scatter, auxiliary) reproduces production pipeline structure so captured traces expose true inter-stream contention.
-- FSDP2 parameter sharding amplifies communication volume, increasing the signal-to-noise ratio when measuring compute-comm overlap improvements or regressions.
-- Tunable hyperparameters in `config/default.yaml` let you scale model width, depth, or batch size to probe specific bottlenecks without touching application code.
+**Hardware Queue Evaluation**
+Stress-test GPU queue scheduling with 8-64+ concurrent streams. Includes 15 workloads covering distributed training patterns (FSDP, MoE, activation checkpointing), inference (speculative decoding, continuous batching), and latency-sensitive scenarios (heterogeneous kernels, tiny kernel dispatch).
 
-## Motivation:
-* Reports of sub-optimal overlap of comms and compute in their prod training workload
+## Quick Start
 
-  ![User Training Workload](analysis/figures/training_bad_overlap.png)
+```bash
+# FSDP2 overlap benchmark
+bash scripts/launch_rocm.sh config/default.yaml
+
+# Hardware queue evaluation
+python -m aorta.hw_queue_eval list                          # List workloads
+python -m aorta.hw_queue_eval run hetero_kernels --streams 8
+python -m aorta.hw_queue_eval sweep hetero_kernels --streams 1,2,4,8,16
+```
+
+## Documentation
+
+| Guide | Description |
+| --- | --- |
+| [Getting Started](docs/getting-started.md) | Prerequisites, Docker setup, installation |
+| [Running the Benchmark](docs/running-benchmark.md) | Launch scripts, torch.compile, direct invocation |
+| [Hardware Queue Eval](docs/hw-queue-eval.md) | Workloads, CLI usage, metrics |
+| [Configuration](docs/configuration.md) | FSDP tuning, RCCL variables, profiler settings |
+| [Profiling](docs/profiling.md) | Torch profiler, rocprofv3, overlap reports |
+| [Troubleshooting](docs/troubleshooting.md) | Common issues |
 
 ## Repository Layout
 
-- `config/default.yaml` – Baseline configuration for model, dataset, FSDP, and training hyperparameters.
-- `src/aorta/` – Python package containing models, data generation, utilities, profilers, and training loop.
-- `train.py` – CLI entry point used by launch scripts; wraps `aorta.training.fsdp_trainer`.
-- `scripts/launch_cuda.sh` / `scripts/launch_rocm.sh` – Convenience launchers for CUDA and ROCm nodes respectively.
-- `analysis/overlap_report.py` – Post-processing utility to generate summary statistics and plots from profiling logs.
-
-## Key Assumptions
-
-- PyTorch ≥ 2.2 with FSDP2 APIs is available on both CUDA (NCCL) and ROCm 7 (RCCL) systems.
-- TorchTitan components required by your wider stack are pre-installed (the synthetic workload does not import TorchTitan directly).
-- PyYAML, matplotlib, and ROCm tooling (`rocm-smi`, `rocminfo`) are present on the target machine; the code gracefully degrades when they are absent.
-- GPU nodes expose NCCL/RCCL capable interconnects and allow `torchrun --standalone` launch mode.
-- PyTorch ≥ 2.2 with `torch.compile` support is recommended if you intend to enable ahead-of-time compilation.
-- Sufficient GPU memory exists to host the configured model (see `config/default.yaml`). Adjust dimensions downward if required.
-- The synthetic dataset is intended for profiling and does not reflect production data distributions.
-- All processes run under a job launcher that sets `LOCAL_RANK` (e.g., `torchrun`, Slurm, or similar). Launch scripts handle this automatically.
-
-
-## Docker Setup
-* Pull Docker image and setup
-  This image contains all the necessary deps to train PyTorch models of varying complexity.
-  It contains the downloaded copy of the criteo dataset (not included in the steps below)
-  More importantly, it contains the bells and whistles to run and capture profiler traces for the training runs
-```bash
-cd docker
-docker compose up -d
 ```
-* Connect to the running container via CLI or vscode
+src/aorta/
+├── training/          # FSDP2 trainer with multi-stream overlap instrumentation
+├── hw_queue_eval/     # Hardware queue evaluation framework
+├── models/            # Synthetic ranking transformer
+├── profiling/         # Stream profiler for overlap measurement
+└── utils/             # Config loading, timing, device detection
 
-* Running torchrec benchmark training pipeline
-
-```bash
-python -m torchrec.distributed.benchmark.benchmark_train_pipeline --yaml_config=$ROOT/config/torchrec_dist/sparse_data_dist_base.yaml    --name="sparse_data_dist_q_contend$(git rev-parse --short HEAD || echo $USER)"
-```
-This captures a profiler trace file locally
-
-
-## Setup
-
-### Training (Docker)
-Training runs in Docker containers with all dependencies pre-installed.
-
-```bash
-# See Docker Setup section above for launching training
-docker compose -f docker/docker-compose.yaml up
+config/                # YAML configurations for different scenarios
+scripts/               # Launch scripts, profiling, analysis tools
+analysis/              # Overlap report generation
 ```
 
-### Local Analysis & Processing (Python)
-For running analysis scripts and processing traces locally:
+## Development
 
-```bash
-# Clone the repository
-git clone https://github.com/ROCm/aorta.git
-cd aorta
-
-# Install dependencies for analysis scripts
-pip install -r requirements.txt
-
-# For contributors: install development tools (pytest, pre-commit, etc.)
-pip install -r requirements-dev.txt
-pre-commit install
-```
-
-**What runs locally:**
-- `scripts/utils/merge_gpu_trace_ranks.py` - Merge distributed traces
-- `analysis/overlap_report.py` - Generate analysis reports
-- `scripts/analyze_*.py` - Analysis utilities
-- Test suite (`pytest tests/`)
-
-**What runs in Docker:**
-- `train.py` - Model training
-- Distributed workloads
-- GPU profiling
-
-### Additional Notes
-- On ROCm systems, verify `rocm-smi` and `rocminfo` are in `$PATH`.
-- Run scripts from the repository root so path bootstrapping works correctly.
-
-## Code Quality with Pre-commit
-
-This repository uses pre-commit hooks to ensure code quality. All pull requests must pass these checks.
-
-Pre-commit hooks are installed automatically when you run:
 ```bash
 pip install -r requirements-dev.txt
 pre-commit install
+pytest tests/
 ```
 
-### What Gets Checked
+---
 
-The pre-commit hooks automatically check for:
-
-- Trailing whitespace removal
-- End-of-file fixes
-- YAML syntax validation
-
-### Running Checks Manually
-
-To run all checks on your changes before committing:
-
-```bash
-pre-commit run --all-files
-```
-
-Or run checks only on staged files:
-
-```bash
-pre-commit run
-```
-
-### CI Enforcement
-
-All pull requests are automatically checked by CI. If the checks fail, you must fix the issues before merging. Run the checks locally to catch issues early.
-
-## Tuning Sweep
-![sweep](./docs/param_sweep.png)
-## Running the Benchmark
-
-### CUDA
-
-```bash
-bash scripts/launch_cuda.sh config/default.yaml
-```
-
-### ROCm 7
-
-```bash
-bash scripts/launch_rocm.sh config/default.yaml
-```
-
-Both scripts default to `config/default.yaml` but accept an override as the first argument. They query `torch.cuda.device_count()` to size `--nproc_per_node`, fall back gracefully when detection fails, and export `PYTHONPATH=$REPO_ROOT/src` so the in-repo `aorta` package is discoverable without installation.
-
-### Direct Invocation
-
-```bash
-torchrun --nproc_per_node 4 train.py --config config/default.yaml --override training.max_steps=100
-```
-
-Use dotted `--override` arguments to mutate configuration values without editing the YAML file.
-
-## Torch Compile Acceleration
-
-- Enable AOT compilation by toggling the `compile` block or CLI overrides:
-  ```bash
-  torchrun --nproc_per_node 4 train.py \
-    --config config/default.yaml \
-    --override compile.enabled=true compile.backend=inductor compile.mode=max-autotune
-  ```
-- The toolkit compiles the FSDP-wrapped model and falls back gracefully if `torch.compile` raises (logging the reason).
-- On ROCm, `torch.compile` with `backend=inductor` is still experimental; the launcher automatically downgrades to the safer `aot_eager` backend when necessary. You can override this by explicitly passing another backend (e.g., `compile.backend=aot_eager`).
-- Tune `compile.fullgraph`, `compile.dynamic`, or `compile.options` (passed directly to `torch.compile`) to match your workload characteristics.
-- Compilation occurs per rank, so expect extra time on the first iteration; subsequent steps reuse the optimized graph.
-
-## SDMA Prototype Benchmark
-
-- To measure theoretical compute/SDMA overlap on ROCm without modifying the full training loop, run the standalone benchmark:
-  ```bash
-  python scripts/run_sdma_prototype.py --device 0 --matrix-size 4096 --copy-mb 64
-  ```
-- The script launches GEMM-heavy kernels on one stream while issuing `hipMemcpyAsync` transfers on a high-priority stream, reporting the average duration with and without overlap plus the estimated savings.
-- Use `rocprofv3` (or `scripts/rocprof_capture.sh`) against this benchmark to inspect SDMA engine utilization and validate whether transfers run concurrently with compute on your hardware/driver stack.
-
-## Tuning for Overlap
-
-All knobs below can be adjusted via `config/default.yaml` or dotted `--override` arguments when invoking `train.py` or the launch scripts.
-
-| Category | Knob | Expected behaviour |
-| --- | --- | --- |
-| **FSDP scheduling** | `fsdp.forward_prefetch` | `true` prefetches parameters ahead of the forward pass, increasing chances of overlapping all-gathers with compute; `false` fetches on demand and may serialize. |
-| | `fsdp.limit_all_gathers` | Limits outstanding all-gathers. Disabling expands concurrency (at the cost of memory). |
-| | `fsdp.backward_prefetch` | `BACKWARD_PRE` launches next-layer communication during backprop; `BACKWARD_POST` waits until after gradients are computed. |
-| | `fsdp.sync_module_states` / `fsdp.use_orig_params` | Control how parameters are synchronised; flipping them primarily affects startup comm volume. |
-| **Workload intensity** | `training.batch_size`, `training.gradient_accumulation` | Scale compute duration per step. Larger batches increase GEMM time, potentially widening overlap windows once comm is in-flight. |
-| | `training.mixed_precision` (`bf16`/`fp16`/`none`) | Alters kernel type/footprint. Changing precision shifts VGPR/LDS usage, influencing scheduler fairness. |
-| | `training.max_steps`, `training.log_interval` | Control run length and logging frequency for targeted profiling (e.g., warm-up vs. steady state). |
-| **Distributed env** | `RCCL_*` environment variables (`RCCL_NUM_CHANNELS`, `RCCL_ENABLE_SDMA`, `RCCL_BUFFER_SIZE`, etc.) | Steer RCCL algorithm, channel count, and SDMA usage. Set via launch scripts so experiments are reproducible. |
-| | `training.output_dir` | Point to unique directories to keep profiler JSONL and artefacts isolated for each run. |
-| **Profiler** | `profiling.enabled`, `wait/warmup/active/repeat` | Adjust capture cadence. Smaller windows capture more frequently; larger windows reduce overhead and focus on steady state. |
-| | `profiling.tensorboard`, `profiling.chrome_trace` | Select output format. Chrome traces are disabled automatically on ROCm; enable only on CUDA systems. |
-| **SDMA experiments** | `scripts/run_sdma_prototype.py` (`--matrix-size`, `--copy-mb`, `--iterations`) | Isolate GEMM + SDMA overlap to benchmark hardware capability; use as baseline for comparison with full workloads. |
-
-### Additional scenarios to explore
-- **Kernel chunking / occupancy capping**: split large GEMMs or reduce active waves so the hardware scheduler has chances to issue communication kernels between compute launches.
-- **Async launch + wait pattern**: enqueue SDMA copies immediately after compute and inject a lightweight wait kernel just before the data is consumed (mirrors the approach described in the internal transcript).
-- **Stream isolation and priorities**: ensure collectives execute on dedicated HIP streams created with `torch.cuda.Stream(priority=…)`; prevents default-stream enqueueing and allows experimentation with priority hints.
-## Profiling Outputs
-
-Each rank writes `artifacts/rank_<rank>_metrics.jsonl` containing iteration-level telemetry:
-
-- Per-stream durations (ms) for compute, all-reduce, reduce-scatter, and auxiliary streams.
-- Overlap segments with concurrency statistics and utilisation ratios.
-- ROCm diagnostic output when enabled (rank-local).
-- Loss, learning rate, gradient norms, and global step counters.
-
-Events are captured using `torch.cuda.Event(enable_timing=True)` for microsecond fidelity. Distributed collectives are monkey-patched at runtime so that all-reduce and reduce-scatter operations execute on dedicated streams and contribute to overlap calculation.
-
-## Generating Reports
-
-Run the analyser to build summaries and plots from one or more log directories:
-
-```bash
-python analysis/overlap_report.py \
-  --log-dir artifacts_rocm --label rocm \
-  --log-dir artifacts_cuda --label cuda \
-  --output reports/2024-roc-vs-cuda \
-  --reference cuda --candidate rocm
-```
-
-This command emits:
-
-- `summary.json` with aggregate metrics per dataset plus comparative ratios.
-- `{label}_timeline.png` overlays showing compute and overlap durations per global step.
-
-Use these artefacts to pinpoint scheduling or synchronisation regressions between hardware backends.
-
-## Diagnostic Insights
-
-- **Overlap Ratio** (`overlap_ratio`) close to 1 indicates strong overlap; values near 0 imply communications block compute.
-- Compare `compute_allreduce_ms` vs `compute_reducescatter_ms` to determine which collective dominates stall time.
-- Inspect `active_segments` in the JSONL logs to align iteration windows with external profilers (e.g., ROCm tracer).
-- Cross-reference `rocm_smi_output` against overlap dips to correlate DVFS throttling or memory pressure with scheduling gaps.
-
-## Extending the Toolkit
-
-- Adjust model depth/width in `config/default.yaml` to stress-test memory and communication pressure.
-- Swap `MixedPrecision` modes via `training.mixed_precision` (`none`, `fp16`, or `bf16`).
-- Leverage the JSONL logs to integrate with external profilers or dashboards (e.g., Prometheus, Weights & Biases).
-- Implement custom communication hooks by editing `StreamProfiler.intercept_distributed_ops`.
-
-## Troubleshooting
-
-- **ImportError: No module named 'yaml'** – Install PyYAML or supply a JSON config instead.
-- **rocm-smi not found** – Install ROCm utilities or omit `--enable-rocm-metrics`.
-- **CUDA driver errors** – Verify `CUDA_DEVICE_MAX_CONNECTIONS=1` (set in launcher) to encourage overlap-friendly scheduling.
-- **Slow dataloading** – Increase `dataloader.num_workers` or reduce dataset volume.
-- **Invalid device ordinal** – Ensure launchers' `NPROC` does not exceed available GPUs; the toolkit remaps surplus local ranks modulo the visible devices, but persistent failures usually indicate mismatched visibility (`CUDA_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES`).
-
-## Torch Profiler Traces
-
-- Enable PyTorch's profiler by toggling the `profiling` block in your config or via CLI override:
-  ```bash
-  torchrun --nproc_per_node 4 train.py \
-    --config config/default.yaml \
-    --override profiling.enabled=true \
-    --override profiling.wait=1 \
-    --override profiling.warmup=1 \
-    --override profiling.active=2
-  ```
-- TensorBoard traces write to `artifacts/torch_profiler/rank*/` by default; launch `tensorboard --logdir artifacts/torch_profiler` and use the Profile tab for stream timelines.
-- Chrome traces can be enabled via `profiling.chrome_trace=true` (not recommended on ROCm; the toolkit disables them automatically to avoid known Kineto crashes). Adjust `wait`, `warmup`, `active`, and `repeat` to control capture cadence; shapes and memory statistics are recorded by default.
-
-## ROCm `rocprofv3` Capture
-
-- Use the wrapper script to profile an entire ROCm run:
-  ```bash
-  bash scripts/rocprof_capture.sh config/default.yaml --override training.max_steps=50
-  ```
-- Outputs land under `rocprof_traces/run_<timestamp>/`. Override location or extra flags with environment variables:
-  - `ROCPROF_OUTPUT_DIR=/path/to/out`
-  - `ROCPROF_ARGS="--att --kernel-trace --kernel-symbols"`
-- The script mirrors `launch_rocm.sh` but executes through `rocprofv3`, so you can merge traces with the JSONL metrics using the shared iteration timestamps.
-
-For deeper inspection, combine these scripts with `nsys`, `rocprof`, or PyTorch profiler traces using the iteration timestamps documented in the JSON traces.
+*The FSDP2 overlap workloads also run on NVIDIA CUDA for side-by-side comparison with ROCm.*

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,53 @@
+# Configuration Guide
+
+All configuration knobs can be adjusted via `config/default.yaml` or dotted `--override` arguments when invoking `train.py` or the launch scripts.
+
+## Configuration Reference
+
+| Category | Knob | Expected Behaviour |
+| --- | --- | --- |
+| **FSDP scheduling** | `fsdp.forward_prefetch` | `true` prefetches parameters ahead of the forward pass, increasing chances of overlapping all-gathers with compute; `false` fetches on demand and may serialize. |
+| | `fsdp.limit_all_gathers` | Limits outstanding all-gathers. Disabling expands concurrency (at the cost of memory). |
+| | `fsdp.backward_prefetch` | `BACKWARD_PRE` launches next-layer communication during backprop; `BACKWARD_POST` waits until after gradients are computed. |
+| | `fsdp.sync_module_states` / `fsdp.use_orig_params` | Control how parameters are synchronised; flipping them primarily affects startup comm volume. |
+| **Workload intensity** | `training.batch_size`, `training.gradient_accumulation` | Scale compute duration per step. Larger batches increase GEMM time, potentially widening overlap windows once comm is in-flight. |
+| | `training.mixed_precision` (`bf16`/`fp16`/`none`) | Alters kernel type/footprint. Changing precision shifts VGPR/LDS usage, influencing scheduler fairness. |
+| | `training.max_steps`, `training.log_interval` | Control run length and logging frequency for targeted profiling (e.g., warm-up vs. steady state). |
+| **Distributed env** | `RCCL_*` environment variables | Steer RCCL algorithm, channel count, and SDMA usage. Set via launch scripts so experiments are reproducible. |
+| | `training.output_dir` | Point to unique directories to keep profiler JSONL and artefacts isolated for each run. |
+| **Profiler** | `profiling.enabled`, `wait/warmup/active/repeat` | Adjust capture cadence. Smaller windows capture more frequently; larger windows reduce overhead and focus on steady state. |
+| | `profiling.tensorboard`, `profiling.chrome_trace` | Select output format. Chrome traces are disabled automatically on ROCm; enable only on CUDA systems. |
+| **SDMA experiments** | `scripts/run_sdma_prototype.py` args | `--matrix-size`, `--copy-mb`, `--iterations` - Isolate GEMM + SDMA overlap to benchmark hardware capability. |
+
+## RCCL Environment Variables
+
+Common RCCL variables to experiment with:
+
+- `RCCL_NUM_CHANNELS` - Number of channels for collective operations
+- `RCCL_ENABLE_SDMA` - Enable/disable SDMA engine usage
+- `RCCL_BUFFER_SIZE` - Buffer size for collective operations
+
+Set these via launch scripts to ensure reproducibility.
+
+## Tuning Scenarios
+
+### Kernel Chunking / Occupancy Capping
+
+Split large GEMMs or reduce active waves so the hardware scheduler has chances to issue communication kernels between compute launches.
+
+### Async Launch + Wait Pattern
+
+Enqueue SDMA copies immediately after compute and inject a lightweight wait kernel just before the data is consumed.
+
+### Stream Isolation and Priorities
+
+Ensure collectives execute on dedicated HIP streams created with `torch.cuda.Stream(priority=...)`. This prevents default-stream enqueueing and allows experimentation with priority hints.
+
+## Parameter Sweep
+
+![Parameter Sweep Results](param_sweep.png)
+
+## Next Steps
+
+- [Running the Benchmark](running-benchmark.md) - Launch training with your configuration
+- [Profiling Guide](profiling.md) - Capture and analyze performance data

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,79 @@
+# Getting Started
+
+This guide covers prerequisites, installation, and initial setup for AORTA.
+
+## Prerequisites
+
+- PyTorch >= 2.2 with FSDP2 APIs (CUDA/NCCL or ROCm 7/RCCL)
+- PyYAML, matplotlib
+- ROCm tooling (`rocm-smi`, `rocminfo`) on AMD systems
+- GPU nodes with NCCL/RCCL capable interconnects
+- Sufficient GPU memory for the configured model (see `config/default.yaml`)
+
+## Key Assumptions
+
+- TorchTitan components required by your wider stack are pre-installed (the synthetic workload does not import TorchTitan directly).
+- The code gracefully degrades when optional dependencies are absent.
+- All processes run under a job launcher that sets `LOCAL_RANK` (e.g., `torchrun`, Slurm, or similar).
+- The synthetic dataset is intended for profiling and does not reflect production data distributions.
+
+## Docker Setup (Recommended for Training)
+
+Training runs in Docker containers with all dependencies pre-installed.
+
+### Quick Start
+
+```bash
+cd docker
+docker compose up -d
+```
+
+Connect to the running container via CLI or VSCode.
+
+### Running TorchRec Benchmark
+
+```bash
+python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
+  --yaml_config=$ROOT/config/torchrec_dist/sparse_data_dist_base.yaml \
+  --name="sparse_data_dist_q_contend$(git rev-parse --short HEAD || echo $USER)"
+```
+
+This captures a profiler trace file locally.
+
+**What runs in Docker:**
+- `train.py` - Model training
+- Distributed workloads
+- GPU profiling
+
+## Local Installation (Analysis & Processing)
+
+For running analysis scripts and processing traces locally:
+
+```bash
+# Clone the repository
+git clone https://github.com/ROCm/aorta.git
+cd aorta
+
+# Install dependencies for analysis scripts
+pip install -r requirements.txt
+
+# For contributors: install development tools (pytest, pre-commit, etc.)
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+**What runs locally:**
+- `scripts/utils/merge_gpu_trace_ranks.py` - Merge distributed traces
+- `analysis/overlap_report.py` - Generate analysis reports
+- `scripts/analyze_*.py` - Analysis utilities
+- Test suite (`pytest tests/`)
+
+## Additional Notes
+
+- On ROCm systems, verify `rocm-smi` and `rocminfo` are in `$PATH`.
+- Run scripts from the repository root so path bootstrapping works correctly.
+
+## Next Steps
+
+- [Running the Benchmark](running-benchmark.md) - Launch your first training run
+- [Configuration Guide](configuration.md) - Customize model and training parameters

--- a/docs/hw-queue-eval.md
+++ b/docs/hw-queue-eval.md
@@ -1,0 +1,136 @@
+# Hardware Queue Evaluation
+
+A framework for stress-testing GPU hardware queue scheduling with workloads requiring high stream concurrency (8, 16, 32+ concurrent streams).
+
+## Purpose
+
+Modern GPU workloads increasingly rely on multiple concurrent streams for overlapping compute, communication, and data movement. This module measures:
+
+- Queue switch latency overhead
+- Throughput scaling with stream count
+- Scheduling behavior under high concurrency
+- Performance bottlenecks in queue dispatch
+
+## Quick Start
+
+```bash
+# List available workloads
+python -m aorta.hw_queue_eval list
+
+# Run a single workload
+python -m aorta.hw_queue_eval run hetero_kernels --streams 8
+
+# Sweep across stream counts
+python -m aorta.hw_queue_eval sweep hetero_kernels --streams 1,2,4,8,16
+
+# Run all P0 (critical) workloads
+python -m aorta.hw_queue_eval run-priority P0
+
+# Compare results
+python -m aorta.hw_queue_eval compare --baseline results_a.json --test results_b.json
+
+# Capture rocprof trace
+python -m aorta.hw_queue_eval profile hetero_kernels --streams 8
+```
+
+## Workloads
+
+### Priority P0 (Critical)
+
+| Workload | Description |
+| --- | --- |
+| `hetero_kernels` | Mixed tiny (~10us) and large (~10ms) GEMMs - tests convoy effect |
+| `tiny_kernel_stress` | Extreme small kernel dispatch stress test |
+| `large_gemm_only` | Pure GEMM baseline for throughput reference |
+
+### Distributed Training
+
+| Workload | Description |
+| --- | --- |
+| `fsdp_tp` | FSDP + Tensor Parallelism (3D parallelism) with actual collectives |
+| `moe` | Mixture of Experts with 8-16 parallel expert streams |
+| `activation_ckpt` | Activation checkpointing with recomputation patterns |
+| `grad_accum` | Gradient accumulation with early reduction |
+
+### Inference
+
+| Workload | Description |
+| --- | --- |
+| `speculative_decode` | Draft + verify decoding with tight latency requirements |
+| `continuous_batch` | Prefill/decode overlap with memory-bound operations |
+| `rag_pipeline` | Multi-model RAG pipelines |
+
+### Pipeline / System-Level
+
+| Workload | Description |
+| --- | --- |
+| `async_dataload` | Async data loading with GPU preprocessing |
+| `zero_offload` | ZeRO-style memory offload patterns |
+| `torch_compile` | Multi-region execution under torch.compile |
+
+### Latency-Sensitive
+
+| Workload | Description |
+| --- | --- |
+| `graph_subgraphs` | Independent subgraph execution patterns |
+
+## Metrics
+
+Each run collects:
+
+- **Latency**: Mean, P50, P95, P99 per-iteration
+- **Throughput**: Operations/sec, samples/sec
+- **Queue Switch Overhead**: Inter-stream vs intra-stream gaps
+- **Memory**: Peak, allocated, reserved
+- **Scaling Analysis**: Throughput per stream, efficiency curves
+
+## Configuration Options
+
+```bash
+# Stream count
+--streams 8
+
+# Synchronization mode
+--sync-mode per_iteration  # or: end_only, none
+
+# Iterations
+--iterations 100
+--warmup 10
+
+# Output
+--output results.json
+```
+
+## Analysis
+
+Compare sweep results:
+
+```bash
+python scripts/analyze_sweep_results.py \
+  --baseline sweep_v1.json \
+  --test sweep_v2.json
+```
+
+Profile with rocprofv3:
+
+```bash
+bash scripts/hw_queue/profile_queues.sh hetero_kernels 8
+```
+
+## Architecture
+
+```
+src/aorta/hw_queue_eval/
+├── core/
+│   ├── harness.py        # Execution harness
+│   ├── metrics.py        # Metrics collection
+│   └── torch_profiler.py # Profiler integration
+├── workloads/
+│   ├── base.py           # Base workload classes
+│   ├── registry.py       # Workload discovery
+│   ├── distributed/      # FSDP, MoE, etc.
+│   ├── inference/        # Speculative decode, RAG, etc.
+│   ├── pipeline/         # Async dataload, ZeRO, etc.
+│   └── latency_sensitive/ # Hetero kernels, tiny kernels
+└── cli.py                # Command-line interface
+```

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,104 @@
+# Profiling Guide
+
+This guide covers how to capture, analyze, and interpret profiling data from AORTA benchmark runs.
+
+## Profiling Outputs
+
+Each rank writes `artifacts/rank_<rank>_metrics.jsonl` containing iteration-level telemetry:
+
+- Per-stream durations (ms) for compute, all-reduce, reduce-scatter, and auxiliary streams
+- Overlap segments with concurrency statistics and utilisation ratios
+- ROCm diagnostic output when enabled (rank-local)
+- Loss, learning rate, gradient norms, and global step counters
+
+Events are captured using `torch.cuda.Event(enable_timing=True)` for microsecond fidelity. Distributed collectives are monkey-patched at runtime so that all-reduce and reduce-scatter operations execute on dedicated streams and contribute to overlap calculation.
+
+## Torch Profiler Traces
+
+Enable PyTorch's profiler by toggling the `profiling` block in your config or via CLI override:
+
+```bash
+torchrun --nproc_per_node 4 train.py \
+  --config config/default.yaml \
+  --override profiling.enabled=true \
+  --override profiling.wait=1 \
+  --override profiling.warmup=1 \
+  --override profiling.active=2
+```
+
+### Output Locations
+
+- TensorBoard traces write to `artifacts/torch_profiler/rank*/` by default
+- Launch `tensorboard --logdir artifacts/torch_profiler` and use the Profile tab for stream timelines
+
+### Chrome Traces
+
+- Enable via `profiling.chrome_trace=true`
+- **Not recommended on ROCm** - the toolkit disables them automatically to avoid known Kineto crashes
+- Adjust `wait`, `warmup`, `active`, and `repeat` to control capture cadence
+- Shapes and memory statistics are recorded by default
+
+## ROCm `rocprofv3` Capture
+
+Use the wrapper script to profile an entire ROCm run:
+
+```bash
+bash scripts/rocprof_capture.sh config/default.yaml --override training.max_steps=50
+```
+
+### Output Location
+
+Outputs land under `rocprof_traces/run_<timestamp>/`.
+
+### Environment Variables
+
+Override location or extra flags with environment variables:
+
+- `ROCPROF_OUTPUT_DIR=/path/to/out`
+- `ROCPROF_ARGS="--att --kernel-trace --kernel-symbols"`
+
+The script mirrors `launch_rocm.sh` but executes through `rocprofv3`, so you can merge traces with the JSONL metrics using the shared iteration timestamps.
+
+## Generating Reports
+
+Run the analyser to build summaries and plots from one or more log directories:
+
+```bash
+python analysis/overlap_report.py \
+  --log-dir artifacts_rocm --label rocm \
+  --log-dir artifacts_cuda --label cuda \
+  --output reports/2024-roc-vs-cuda \
+  --reference cuda --candidate rocm
+```
+
+### Report Outputs
+
+- `summary.json` - Aggregate metrics per dataset plus comparative ratios
+- `{label}_timeline.png` - Overlays showing compute and overlap durations per global step
+
+Use these artefacts to pinpoint scheduling or synchronisation regressions between hardware backends.
+
+## Diagnostic Insights
+
+### Key Metrics
+
+| Metric | Interpretation |
+| --- | --- |
+| **Overlap Ratio** (`overlap_ratio`) | Values close to 1 indicate strong overlap; values near 0 imply communications block compute |
+| **Compute All-Reduce** (`compute_allreduce_ms`) | Time spent in all-reduce operations |
+| **Compute Reduce-Scatter** (`compute_reducescatter_ms`) | Time spent in reduce-scatter operations |
+
+### Analysis Tips
+
+- Compare `compute_allreduce_ms` vs `compute_reducescatter_ms` to determine which collective dominates stall time
+- Inspect `active_segments` in the JSONL logs to align iteration windows with external profilers (e.g., ROCm tracer)
+- Cross-reference `rocm_smi_output` against overlap dips to correlate DVFS throttling or memory pressure with scheduling gaps
+
+### Advanced Profiling
+
+For deeper inspection, combine these scripts with `nsys`, `rocprof`, or PyTorch profiler traces using the iteration timestamps documented in the JSON traces.
+
+## Next Steps
+
+- [Troubleshooting](troubleshooting.md) - Common issues and solutions
+- [Configuration Guide](configuration.md) - Tune parameters for better overlap

--- a/docs/running-benchmark.md
+++ b/docs/running-benchmark.md
@@ -1,0 +1,70 @@
+# Running the Benchmark
+
+This guide covers different ways to launch the AORTA benchmark on CUDA and ROCm systems.
+
+## Quick Start
+
+### CUDA
+
+```bash
+bash scripts/launch_cuda.sh config/default.yaml
+```
+
+### ROCm 7
+
+```bash
+bash scripts/launch_rocm.sh config/default.yaml
+```
+
+Both scripts:
+- Default to `config/default.yaml` but accept an override as the first argument
+- Query `torch.cuda.device_count()` to size `--nproc_per_node`
+- Fall back gracefully when detection fails
+- Export `PYTHONPATH=$REPO_ROOT/src` so the `aorta` package is discoverable
+
+## Direct Invocation
+
+For more control over the launch:
+
+```bash
+torchrun --nproc_per_node 4 train.py --config config/default.yaml --override training.max_steps=100
+```
+
+Use dotted `--override` arguments to mutate configuration values without editing the YAML file.
+
+## Torch Compile Acceleration
+
+Enable AOT compilation by toggling the `compile` block or CLI overrides:
+
+```bash
+torchrun --nproc_per_node 4 train.py \
+  --config config/default.yaml \
+  --override compile.enabled=true compile.backend=inductor compile.mode=max-autotune
+```
+
+### Compile Behavior
+
+- The toolkit compiles the FSDP-wrapped model and falls back gracefully if `torch.compile` raises (logging the reason).
+- On ROCm, `torch.compile` with `backend=inductor` is still experimental; the launcher automatically downgrades to the safer `aot_eager` backend when necessary.
+- You can override this by explicitly passing another backend (e.g., `compile.backend=aot_eager`).
+- Tune `compile.fullgraph`, `compile.dynamic`, or `compile.options` (passed directly to `torch.compile`) to match your workload characteristics.
+- Compilation occurs per rank, so expect extra time on the first iteration; subsequent steps reuse the optimized graph.
+
+## SDMA Prototype Benchmark
+
+To measure theoretical compute/SDMA overlap on ROCm without modifying the full training loop:
+
+```bash
+python scripts/run_sdma_prototype.py --device 0 --matrix-size 4096 --copy-mb 64
+```
+
+The script:
+- Launches GEMM-heavy kernels on one stream while issuing `hipMemcpyAsync` transfers on a high-priority stream
+- Reports the average duration with and without overlap plus the estimated savings
+
+Use `rocprofv3` (or `scripts/rocprof_capture.sh`) against this benchmark to inspect SDMA engine utilization and validate whether transfers run concurrently with compute.
+
+## Next Steps
+
+- [Configuration Guide](configuration.md) - Tune model and training parameters
+- [Profiling Guide](profiling.md) - Capture and analyze traces

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,80 @@
+# Troubleshooting
+
+Common issues and solutions when running AORTA benchmarks.
+
+## Common Issues
+
+### ImportError: No module named 'yaml'
+
+**Solution:** Install PyYAML or supply a JSON config instead.
+
+```bash
+pip install pyyaml
+```
+
+### rocm-smi not found
+
+**Solution:** Install ROCm utilities or omit `--enable-rocm-metrics`.
+
+Ensure ROCm tools are in your `$PATH`:
+
+```bash
+export PATH=$PATH:/opt/rocm/bin
+```
+
+### CUDA driver errors
+
+**Solution:** Verify `CUDA_DEVICE_MAX_CONNECTIONS=1` (set in launcher) to encourage overlap-friendly scheduling.
+
+This is typically set automatically by the launch scripts, but you can verify:
+
+```bash
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+```
+
+### Slow dataloading
+
+**Solution:** Increase `dataloader.num_workers` or reduce dataset volume.
+
+```bash
+torchrun --nproc_per_node 4 train.py \
+  --config config/default.yaml \
+  --override dataloader.num_workers=8
+```
+
+### Invalid device ordinal
+
+**Cause:** Launchers' `NPROC` exceeds available GPUs.
+
+**Solution:** The toolkit remaps surplus local ranks modulo the visible devices, but persistent failures usually indicate mismatched visibility.
+
+Check your device visibility:
+
+```bash
+# CUDA
+echo $CUDA_VISIBLE_DEVICES
+
+# ROCm
+echo $HIP_VISIBLE_DEVICES
+```
+
+Ensure the launcher's `--nproc_per_node` matches your visible GPU count.
+
+## Extending the Toolkit
+
+- Adjust model depth/width in `config/default.yaml` to stress-test memory and communication pressure
+- Swap `MixedPrecision` modes via `training.mixed_precision` (`none`, `fp16`, or `bf16`)
+- Leverage the JSONL logs to integrate with external profilers or dashboards (e.g., Prometheus, Weights & Biases)
+- Implement custom communication hooks by editing `StreamProfiler.intercept_distributed_ops`
+
+## Getting Help
+
+If you encounter issues not covered here:
+
+1. Check that all prerequisites are installed (see [Getting Started](getting-started.md))
+2. Verify your configuration is valid (see [Configuration Guide](configuration.md))
+3. Review profiling outputs for error messages (see [Profiling Guide](profiling.md))
+4. Open an issue on the GitHub repository with:
+   - Your configuration file
+   - Error messages and stack traces
+   - Hardware/software environment details


### PR DESCRIPTION
Refactor Docs for clarity.

README now contains the many features of this repo. Including the earlier dist training FSDP2 and the new hw_queue_eval capabilities.

Also it's less of a dump and redirects to multiple sections.