### PR TITLE
update instructions for uv based installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,31 @@ scripts/               # Launch scripts, profiling, analysis tools
 analysis/              # Overlap report generation
 ```
 
+## Installation
+
+We recommend using [uv](https://github.com/astral-sh/uv) for fast, reliable Python environment management.
+
+```bash
+# Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Create and activate a virtual environment
+uv venv && source .venv/bin/activate
+
+# Install PyTorch nightly for ROCm 7.1
+uv pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1/
+
+# Install remaining dependencies
+uv pip install -r requirements.txt
+
+# For full installation including hw_queue_eval
+uv pip install -e ".[hw-queue]"
+```
+
 ## Development
 
 ```bash
-pip install -r requirements-dev.txt
+uv pip install -r requirements-dev.txt
 pre-commit install
 pytest tests/
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,18 +47,29 @@ This captures a profiler trace file locally.
 
 ## Local Installation (Analysis & Processing)
 
-For running analysis scripts and processing traces locally:
+For running analysis scripts and processing traces locally.
+
+We recommend using [uv](https://github.com/astral-sh/uv) for fast, reliable Python environment management.
 
 ```bash
+# Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
 # Clone the repository
 git clone https://github.com/ROCm/aorta.git
 cd aorta
 
+# Create and activate a virtual environment
+uv venv && source .venv/bin/activate
+
+# Install PyTorch nightly for ROCm 7.1
+uv pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1/
+
 # Install dependencies for analysis scripts
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 
 # For contributors: install development tools (pytest, pre-commit, etc.)
-pip install -r requirements-dev.txt
+uv pip install -r requirements-dev.txt
 pre-commit install
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,17 @@
 # Dependencies for local analysis and processing scripts
 # (Training dependencies are managed in Docker - see docker/Dockerfile.*)
-# Install with: pip install -r requirements.txt
+#
+# Install with uv (two steps to avoid pulling nvidia packages):
+#   uv pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1/
+#   uv pip install -r requirements.txt
 #
 # For full installation including hw_queue_eval:
-#   pip install -e ".[hw-queue]"
+#   uv pip install -e ".[hw-queue]"
 #
 # For development:
-#   pip install -e ".[all]"
+#   uv pip install -e ".[all]"
 
-# Base dependencies
-torch>=2.0.0
+# Base dependencies (PyTorch installed separately - see above)
 pyyaml>=6.0
 
 # For analysis scripts


### PR DESCRIPTION
Currently we only have Docker based installation instructions.
Use `uv` for better quality of life.