### PR TITLE
AORTA-21: Add comms-compute overlap workload with distributed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ bash scripts/launch_rocm.sh config/default.yaml
 python -m aorta.hw_queue_eval list                          # List workloads
 python -m aorta.hw_queue_eval run hetero_kernels --streams 8
 python -m aorta.hw_queue_eval sweep hetero_kernels --streams 1,2,4,8,16
+
+# Comm-compute overlap (simulated collectives)
+python -m aorta.hw_queue_eval run comms_compute_overlap --streams 4 --profile
+
+# Comm-compute overlap (real NCCL collectives via torchrun)
+torchrun --nproc_per_node=8 -m aorta.hw_queue_eval run comms_compute_overlap \
+    --streams 4 --real-collectives --async-op --backend nccl \
+    --process-groups "[0,1,2,3,4,5,6,7]" --profile --profile-dir traces/
 ```
 
 ## Example Analysis

--- a/docs/hw-queue-eval.md
+++ b/docs/hw-queue-eval.md
@@ -180,7 +180,4 @@ src/aorta/
     │   ├── pipeline/         # Async dataload, ZeRO, etc.
     │   └── latency_sensitive/ # Hetero kernels, tiny kernels
     └── cli.py                # Command-line interface
-
-scripts/
-└── run_comms_compute_coverage.sh  # Exhaustive parameter coverage test
 ```

--- a/docs/hw-queue-eval.md
+++ b/docs/hw-queue-eval.md
@@ -47,6 +47,7 @@ python -m aorta.hw_queue_eval profile hetero_kernels --streams 8
 
 | Workload | Description |
 | --- | --- |
+| `comms_compute_overlap` | Configurable comm-compute overlap with GEMM and collectives |
 | `fsdp_tp` | FSDP + Tensor Parallelism (3D parallelism) with actual collectives |
 | `moe` | Mixture of Experts with 8-16 parallel expert streams |
 | `activation_ckpt` | Activation checkpointing with recomputation patterns |
@@ -99,6 +100,48 @@ Each run collects:
 
 # Output
 --output results.json
+
+# Profiling
+--profile --profile-dir traces/
+```
+
+### Comm-Compute Overlap Options
+
+These options apply to the `comms_compute_overlap` workload:
+
+```bash
+# Workload mode
+--mode comms_compute        # or: compute_only, comms_only
+
+# GEMM configuration
+--mm-dim 2048,2048,2048     # M,N,K dimensions (single value for square)
+--num-compute 10            # GEMMs per iteration per compute stream
+--comp-dtype bfloat16       # float32, float16, bfloat16
+
+# Communication configuration
+--comm-size 128M            # supports K/M/G suffix
+--num-coll 1                # collectives per iteration
+--comm-dtype bfloat16       # float32, float16, bfloat16
+
+# Stream control
+--compute-streams 2         # independent of --streams
+
+# Distributed mode (requires torchrun)
+--real-collectives          # use real NCCL/RCCL collectives
+--async-op                  # non-blocking collectives
+--backend nccl              # nccl or gloo
+--process-groups "[0,1,2,3],[4,5,6,7]"
+```
+
+Example with all options:
+
+```bash
+torchrun --nproc_per_node=8 -m aorta.hw_queue_eval run comms_compute_overlap \
+    --streams 4 --real-collectives --async-op --backend nccl \
+    --process-groups "[0,1,2,3,4,5,6,7]" \
+    --compute-streams 2 --comp-dtype bfloat16 --comm-dtype bfloat16 \
+    --mm-dim 4096,4096,4096 --num-compute 10 --comm-size 128M \
+    --profile --profile-dir traces/
 ```
 
 ## Analysis
@@ -120,17 +163,24 @@ bash scripts/hw_queue/profile_queues.sh hetero_kernels 8
 ## Architecture
 
 ```
-src/aorta/hw_queue_eval/
-├── core/
-│   ├── harness.py        # Execution harness
-│   ├── metrics.py        # Metrics collection
-│   └── torch_profiler.py # Profiler integration
-├── workloads/
-│   ├── base.py           # Base workload classes
-│   ├── registry.py       # Workload discovery
-│   ├── distributed/      # FSDP, MoE, etc.
-│   ├── inference/        # Speculative decode, RAG, etc.
-│   ├── pipeline/         # Async dataload, ZeRO, etc.
-│   └── latency_sensitive/ # Hetero kernels, tiny kernels
-└── cli.py                # Command-line interface
+src/aorta/
+├── utils/
+│   ├── distributed.py       # torch.distributed init, process groups
+│   └── ...
+└── hw_queue_eval/
+    ├── core/
+    │   ├── harness.py        # Execution harness
+    │   ├── metrics.py        # Metrics collection
+    │   └── torch_profiler.py # Profiler integration (rank-aware traces)
+    ├── workloads/
+    │   ├── base.py           # Base workload classes
+    │   ├── registry.py       # Workload discovery
+    │   ├── distributed/      # FSDP, MoE, comm-compute overlap, etc.
+    │   ├── inference/        # Speculative decode, RAG, etc.
+    │   ├── pipeline/         # Async dataload, ZeRO, etc.
+    │   └── latency_sensitive/ # Hetero kernels, tiny kernels
+    └── cli.py                # Command-line interface
+
+scripts/
+└── run_comms_compute_coverage.sh  # Exhaustive parameter coverage test
 ```

--- a/docs/hw-queue-eval.md
+++ b/docs/hw-queue-eval.md
@@ -47,7 +47,7 @@ python -m aorta.hw_queue_eval profile hetero_kernels --streams 8
 
 | Workload | Description |
 | --- | --- |
-| `comms_compute_overlap` | Configurable comm-compute overlap with GEMM and collectives |
+| `comms_compute_overlap` | Configurable comms-compute overlap with GEMM and collectives |
 | `fsdp_tp` | FSDP + Tensor Parallelism (3D parallelism) with actual collectives |
 | `moe` | Mixture of Experts with 8-16 parallel expert streams |
 | `activation_ckpt` | Activation checkpointing with recomputation patterns |
@@ -105,7 +105,7 @@ Each run collects:
 --profile --profile-dir traces/
 ```
 
-### Comm-Compute Overlap Options
+### Comms-Compute Overlap Options
 
 These options apply to the `comms_compute_overlap` workload:
 

--- a/src/aorta/hw_queue_eval/cli.py
+++ b/src/aorta/hw_queue_eval/cli.py
@@ -71,12 +71,19 @@ PRIORITY_WORKLOADS = {
 
 def _parse_size(value: str) -> int:
     """Parse a size string with optional K/M/G suffix into bytes."""
+    original = value
     value = value.strip().upper()
     multipliers = {"K": 1024, "M": 1024 ** 2, "G": 1024 ** 3}
-    for suffix, mult in multipliers.items():
-        if value.endswith(suffix):
-            return int(float(value[:-1]) * mult)
-    return int(value)
+    try:
+        for suffix, mult in multipliers.items():
+            if value.endswith(suffix):
+                return int(float(value[:-1]) * mult)
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Invalid size value '{original}'. "
+            "Expected an integer or a number with K/M/G suffix, e.g. '128M' or '1024'."
+        ) from None
 
 
 def get_workload_instance(name: str, **kwargs):

--- a/src/aorta/hw_queue_eval/cli.py
+++ b/src/aorta/hw_queue_eval/cli.py
@@ -9,6 +9,11 @@ Example usage:
     python -m aorta.hw_queue_eval run hetero_kernels --streams 8 --profile
     python -m aorta.hw_queue_eval run moe --streams 16 --profile --profile-dir traces/
 
+    # Run with real distributed collectives (requires torchrun)
+    torchrun --nproc_per_node=4 -m aorta.hw_queue_eval run comms_compute_overlap \\
+        --streams 4 --real-collectives --async-op --backend nccl \\
+        --process-groups "[0,1,2,3]" --profile --profile-dir traces/
+
     # Run stream count sweep
     python -m aorta.hw_queue_eval sweep hetero_kernels --streams 1,2,4,8,16,32
 
@@ -64,6 +69,16 @@ PRIORITY_WORKLOADS = {
 }
 
 
+def _parse_size(value: str) -> int:
+    """Parse a size string with optional K/M/G suffix into bytes."""
+    value = value.strip().upper()
+    multipliers = {"K": 1024, "M": 1024 ** 2, "G": 1024 ** 3}
+    for suffix, mult in multipliers.items():
+        if value.endswith(suffix):
+            return int(float(value[:-1]) * mult)
+    return int(value)
+
+
 def get_workload_instance(name: str, **kwargs):
     """Get a workload instance by name."""
     from aorta.hw_queue_eval.workloads.registry import get_workload
@@ -105,20 +120,106 @@ def cli():
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
 @click.option("--profile", "-p", is_flag=True, help="Enable PyTorch profiler (generates Chrome trace and TensorBoard logs)")
 @click.option("--profile-dir", default="profiles", help="Output directory for profiler traces")
+@click.option("--real-collectives", is_flag=True,
+              help="Use real torch.distributed collectives (requires torchrun)")
+@click.option("--async-op", is_flag=True,
+              help="Issue non-blocking collectives (only with --real-collectives)")
+@click.option("--backend", type=click.Choice(["nccl", "gloo"]), default="nccl",
+              help="Distributed backend (only with --real-collectives)")
+@click.option("--process-groups", default=None,
+              help='Process group spec, e.g. "[0,1,2,3],[4,5,6,7]"')
+@click.option("--mode", "wl_mode", default=None,
+              type=click.Choice(["compute_only", "comms_only", "comms_compute"]),
+              help="Workload mode (comms_compute_overlap only)")
+@click.option("--mm-dim", default=None,
+              help="GEMM dimensions M,N,K e.g. 2048,2048,2048")
+@click.option("--num-compute", default=None, type=int,
+              help="Number of GEMM ops per iteration per compute stream")
+@click.option("--num-coll", default=None, type=int,
+              help="Number of collective ops per iteration")
+@click.option("--comm-size", default=None, type=str,
+              help="Communication tensor size in bytes (supports M/G suffix, e.g. 128M)")
+@click.option("--compute-streams", default=None, type=int,
+              help="Number of compute streams (independent of --streams)")
+@click.option("--comp-dtype", default=None,
+              type=click.Choice(["float32", "float16", "bfloat16"]),
+              help="Data type for compute (GEMM) tensors")
+@click.option("--comm-dtype", default=None,
+              type=click.Choice(["float32", "float16", "bfloat16"]),
+              help="Data type for communication tensors")
 def run(workload: str, streams: int, iterations: int, warmup: int,
         output: Optional[str], device: str, sync_mode: str, quiet: bool,
-        profile: bool, profile_dir: str):
+        profile: bool, profile_dir: str,
+        real_collectives: bool, async_op: bool, backend: str,
+        process_groups: Optional[str],
+        wl_mode: Optional[str], mm_dim: Optional[str],
+        num_compute: Optional[int], num_coll: Optional[int],
+        comm_size: Optional[str], compute_streams: Optional[int],
+        comp_dtype: Optional[str], comm_dtype: Optional[str]):
     """Run a single workload evaluation.
 
     WORKLOAD: Name of the workload to run (e.g., hetero_kernels, fsdp_tp)
+
+    For distributed mode (real NCCL/RCCL collectives), launch via torchrun:
+
+        torchrun --nproc_per_node=4 -m aorta.hw_queue_eval run comms_compute_overlap
+            --streams 4 --real-collectives --backend nccl
     """
+    import os
+
     from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
     from aorta.hw_queue_eval.core.torch_profiler import TorchProfilerWrapper, generate_profile_summary
     from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
 
+    # --- Distributed device auto-detection ---
+    # When --real-collectives is set, override device to cuda:{LOCAL_RANK}
+    # so that each torchrun process uses its own GPU.
+    dist_rank = 0
+    if real_collectives:
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        dist_rank = int(os.environ.get("RANK", "0"))
+        device = f"cuda:{local_rank}"
+
+    # Only rank 0 prints verbose output in distributed mode
+    is_main = dist_rank == 0
+
     try:
-        # Get workload
-        wl = get_workload_instance(workload)
+        # Get workload -- pass applicable kwargs
+        kwargs = {}
+        if real_collectives:
+            kwargs.update(
+                simulate_collectives=False,
+                async_op=async_op,
+                backend=backend,
+                process_groups=process_groups,
+            )
+
+        # Workload-specific parameters (only set when explicitly provided)
+        if wl_mode is not None:
+            kwargs["mode"] = wl_mode
+        if mm_dim is not None:
+            parts = [int(x.strip()) for x in mm_dim.split(",")]
+            if len(parts) == 1:
+                kwargs["mm_dim"] = (parts[0], parts[0], parts[0])
+            elif len(parts) == 3:
+                kwargs["mm_dim"] = tuple(parts)
+            else:
+                click.echo("Error: --mm-dim must be M,N,K or a single value", err=True)
+                sys.exit(1)
+        if num_compute is not None:
+            kwargs["num_compute_per_iter"] = num_compute
+        if num_coll is not None:
+            kwargs["num_coll_per_iter"] = num_coll
+        if comm_size is not None:
+            kwargs["comm_size_bytes"] = _parse_size(comm_size)
+        if compute_streams is not None:
+            kwargs["compute_streams"] = compute_streams
+        if comp_dtype is not None:
+            kwargs["comp_data_type"] = comp_dtype
+        if comm_dtype is not None:
+            kwargs["comm_data_type"] = comm_dtype
+
+        wl = get_workload_instance(workload, **kwargs)
         info = WorkloadRegistry.get_info(workload)
 
         # Check stream count compatibility
@@ -129,29 +230,36 @@ def run(workload: str, streams: int, iterations: int, warmup: int,
             )
             sys.exit(1)
 
-        # Print header with workload info
-        click.echo("=" * 70)
-        click.echo("GPU HARDWARE QUEUE EVALUATION")
-        click.echo("=" * 70)
-        click.echo()
-        click.echo(f"WORKLOAD: {workload}")
-        click.echo(f"  {info.description}")
-        click.echo()
-        click.echo("PURPOSE:")
-        _print_workload_purpose(workload, info)
-        click.echo()
-        click.echo("TEST CONFIGURATION:")
-        click.echo(f"  Concurrent streams:     {streams} (recommended: {info.recommended_streams})")
-        click.echo(f"  Measurement iterations: {iterations}")
-        click.echo(f"  Warmup iterations:      {warmup}")
-        click.echo(f"  Device:                 {device}")
-        click.echo(f"  Switch sensitivity:     {info.switch_latency_sensitivity}")
-        click.echo()
-        click.echo("-" * 70)
-        click.echo("Running workload...")
-        if profile:
-            click.echo("  (Profiling enabled - will generate Chrome trace and TensorBoard logs)")
-        click.echo()
+        # Print header with workload info (rank 0 only in distributed mode)
+        if is_main:
+            click.echo("=" * 70)
+            click.echo("GPU HARDWARE QUEUE EVALUATION")
+            click.echo("=" * 70)
+            click.echo()
+            click.echo(f"WORKLOAD: {workload}")
+            click.echo(f"  {info.description}")
+            click.echo()
+            click.echo("PURPOSE:")
+            _print_workload_purpose(workload, info)
+            click.echo()
+            click.echo("TEST CONFIGURATION:")
+            click.echo(f"  Concurrent streams:     {streams} (recommended: {info.recommended_streams})")
+            click.echo(f"  Measurement iterations: {iterations}")
+            click.echo(f"  Warmup iterations:      {warmup}")
+            click.echo(f"  Device:                 {device}")
+            click.echo(f"  Switch sensitivity:     {info.switch_latency_sensitivity}")
+            if real_collectives:
+                world_size = int(os.environ.get("WORLD_SIZE", "1"))
+                click.echo(f"  Distributed:            yes (backend={backend}, world_size={world_size})")
+                click.echo(f"  Async collectives:      {async_op}")
+                if process_groups:
+                    click.echo(f"  Process groups:         {process_groups}")
+            click.echo()
+            click.echo("-" * 70)
+            click.echo("Running workload...")
+            if profile:
+                click.echo("  (Profiling enabled - will generate Chrome trace and TensorBoard logs)")
+            click.echo()
 
         # Create harness
         config = HarnessConfig(
@@ -191,94 +299,95 @@ def run(workload: str, streams: int, iterations: int, warmup: int,
         # Run regular benchmark (always, for metrics)
         result = harness.run_workload(wl)
 
-        # Print results with interpretation
-        click.echo("-" * 70)
-        click.echo("RESULTS")
-        click.echo("-" * 70)
-        click.echo()
+        # Print results with interpretation (rank 0 only)
+        if is_main:
+            click.echo("-" * 70)
+            click.echo("RESULTS")
+            click.echo("-" * 70)
+            click.echo()
 
-        click.echo("THROUGHPUT:")
-        click.echo(f"  {result.throughput:,.2f} {result.throughput_unit}")
-        click.echo(f"  (Higher is better - measures how much work completed per second)")
-        click.echo()
+            click.echo("THROUGHPUT:")
+            click.echo(f"  {result.throughput:,.2f} {result.throughput_unit}")
+            click.echo(f"  (Higher is better - measures how much work completed per second)")
+            click.echo()
 
-        click.echo("LATENCY (per iteration):")
-        click.echo(f"  Mean:  {result.latency_ms['mean']:.3f} ms")
-        click.echo(f"  P50:   {result.latency_ms['p50']:.3f} ms  (median - 50% of iterations faster than this)")
-        click.echo(f"  P95:   {result.latency_ms['p95']:.3f} ms  (95% of iterations faster than this)")
-        click.echo(f"  P99:   {result.latency_ms['p99']:.3f} ms  (99% of iterations faster than this)")
-        click.echo(f"  (Lower is better - time to complete one iteration across all {streams} streams)")
-        click.echo()
+            click.echo("LATENCY (per iteration):")
+            click.echo(f"  Mean:  {result.latency_ms['mean']:.3f} ms")
+            click.echo(f"  P50:   {result.latency_ms['p50']:.3f} ms  (median - 50% of iterations faster than this)")
+            click.echo(f"  P95:   {result.latency_ms['p95']:.3f} ms  (95% of iterations faster than this)")
+            click.echo(f"  P99:   {result.latency_ms['p99']:.3f} ms  (99% of iterations faster than this)")
+            click.echo(f"  (Lower is better - time to complete one iteration across all {streams} streams)")
+            click.echo()
 
-        # Latency variance analysis
-        latency_ratio = result.latency_ms['p99'] / result.latency_ms['p50'] if result.latency_ms['p50'] > 0 else 1
-        if latency_ratio > 2.0:
-            click.echo(f"  WARNING: High latency variance (P99/P50 = {latency_ratio:.1f}x)")
-            click.echo(f"    This may indicate queue contention or scheduling issues")
-        elif latency_ratio > 1.5:
-            click.echo(f"  Note: Moderate latency variance (P99/P50 = {latency_ratio:.1f}x)")
-        click.echo()
+            # Latency variance analysis
+            latency_ratio = result.latency_ms['p99'] / result.latency_ms['p50'] if result.latency_ms['p50'] > 0 else 1
+            if latency_ratio > 2.0:
+                click.echo(f"  WARNING: High latency variance (P99/P50 = {latency_ratio:.1f}x)")
+                click.echo(f"    This may indicate queue contention or scheduling issues")
+            elif latency_ratio > 1.5:
+                click.echo(f"  Note: Moderate latency variance (P99/P50 = {latency_ratio:.1f}x)")
+            click.echo()
 
-        click.echo("QUEUE SWITCH ANALYSIS:")
-        if result.switch_latency:
-            switch_overhead = result.switch_latency['estimated_switch_overhead_ms']
-            inter_gap = result.switch_latency['inter_stream_gap_ms']
-            intra_gap = result.switch_latency['intra_stream_gap_ms']
+            click.echo("QUEUE SWITCH ANALYSIS:")
+            if result.switch_latency:
+                switch_overhead = result.switch_latency['estimated_switch_overhead_ms']
+                inter_gap = result.switch_latency['inter_stream_gap_ms']
+                intra_gap = result.switch_latency['intra_stream_gap_ms']
 
-            click.echo(f"  Inter-stream gap: {inter_gap:.3f} ms (avg gap between kernels on DIFFERENT streams)")
-            click.echo(f"  Intra-stream gap: {intra_gap:.3f} ms (avg gap between kernels on SAME stream)")
-            click.echo(f"  Est. switch overhead: {switch_overhead:.3f} ms")
+                click.echo(f"  Inter-stream gap: {inter_gap:.3f} ms (avg gap between kernels on DIFFERENT streams)")
+                click.echo(f"  Intra-stream gap: {intra_gap:.3f} ms (avg gap between kernels on SAME stream)")
+                click.echo(f"  Est. switch overhead: {switch_overhead:.3f} ms")
 
-            if switch_overhead > 0.1:
-                click.echo(f"  Significant queue switch overhead detected")
-                click.echo(f"    This suggests hardware queue contention at {streams} streams")
-            elif switch_overhead > 0.01:
-                click.echo(f"  Moderate queue switch overhead")
+                if switch_overhead > 0.1:
+                    click.echo(f"  Significant queue switch overhead detected")
+                    click.echo(f"    This suggests hardware queue contention at {streams} streams")
+                elif switch_overhead > 0.01:
+                    click.echo(f"  Moderate queue switch overhead")
+                else:
+                    click.echo(f"  Minimal queue switch overhead")
             else:
-                click.echo(f"  Minimal queue switch overhead")
-        else:
-            click.echo(f"  (Not enough data to estimate switch overhead)")
-        click.echo()
-
-        click.echo("TIMING:")
-        click.echo(f"  Total measurement time: {result.total_time_ms:.2f} ms ({result.total_time_ms/1000:.2f} sec)")
-        click.echo()
-
-        # Summary
-        click.echo("-" * 70)
-        click.echo("INTERPRETATION")
-        click.echo("-" * 70)
-        _print_interpretation(workload, info, result, streams)
-
-        # Print profile results if profiling was enabled
-        if profile and profile_result:
+                click.echo(f"  (Not enough data to estimate switch overhead)")
             click.echo()
+
+            click.echo("TIMING:")
+            click.echo(f"  Total measurement time: {result.total_time_ms:.2f} ms ({result.total_time_ms/1000:.2f} sec)")
+            click.echo()
+
+            # Summary
             click.echo("-" * 70)
-            click.echo("PROFILER OUTPUT")
+            click.echo("INTERPRETATION")
             click.echo("-" * 70)
-            click.echo()
-            click.echo(generate_profile_summary(profile_result))
+            _print_interpretation(workload, info, result, streams)
 
-        # Save to file if requested
-        if output:
-            result.to_json(output)
-            click.echo()
-            click.echo(f"Results saved to: {output}")
+            # Print profile results if profiling was enabled
+            if profile and profile_result:
+                click.echo()
+                click.echo("-" * 70)
+                click.echo("PROFILER OUTPUT")
+                click.echo("-" * 70)
+                click.echo()
+                click.echo(generate_profile_summary(profile_result))
 
-        click.echo()
-        click.echo("=" * 70)
-        click.echo("To compare with different stream counts, run:")
-        click.echo(f"  python -m aorta.hw_queue_eval sweep {workload} --streams 1,2,4,8,16,32")
-        if profile:
+            # Save to file if requested
+            if output:
+                result.to_json(output)
+                click.echo()
+                click.echo(f"Results saved to: {output}")
+
             click.echo()
-            click.echo("Profile traces saved to:")
-            if profile_result and profile_result.chrome_trace_path:
-                click.echo(f"  Chrome trace: {profile_result.chrome_trace_path}")
-                click.echo(f"    View: Open chrome://tracing and load the JSON file")
-            if profile_result and profile_result.tensorboard_dir:
-                click.echo(f"  TensorBoard: {profile_result.tensorboard_dir}")
-                click.echo(f"    View: tensorboard --logdir={profile_result.tensorboard_dir}")
-        click.echo("=" * 70)
+            click.echo("=" * 70)
+            click.echo("To compare with different stream counts, run:")
+            click.echo(f"  python -m aorta.hw_queue_eval sweep {workload} --streams 1,2,4,8,16,32")
+            if profile:
+                click.echo()
+                click.echo("Profile traces saved to:")
+                if profile_result and profile_result.chrome_trace_path:
+                    click.echo(f"  Chrome trace: {profile_result.chrome_trace_path}")
+                    click.echo(f"    View: Open chrome://tracing and load the JSON file")
+                if profile_result and profile_result.tensorboard_dir:
+                    click.echo(f"  TensorBoard: {profile_result.tensorboard_dir}")
+                    click.echo(f"    View: tensorboard --logdir={profile_result.tensorboard_dir}")
+            click.echo("=" * 70)
 
     except KeyError as e:
         click.echo(f"Error: Workload not found: {e}", err=True)
@@ -352,6 +461,12 @@ def _print_workload_purpose(workload: str, info) -> None:
         "torch_compile": (
             "  Multi-region torch.compile execution. Tests interaction between\n"
             "  compiled code and manual stream management."
+        ),
+        "comms_compute_overlap": (
+            "  Synthetic comm-compute overlap benchmark. Runs GEMM compute on\n"
+            "  dedicated streams while collective communication runs on a separate\n"
+            "  stream. Supports simulated or real NCCL/RCCL collectives, async ops,\n"
+            "  and configurable process groups."
         ),
     }
     click.echo(purposes.get(workload, f"  Tests {info.category} patterns with {info.switch_latency_sensitivity} switch sensitivity."))

--- a/src/aorta/hw_queue_eval/cli.py
+++ b/src/aorta/hw_queue_eval/cli.py
@@ -194,30 +194,45 @@ def run(workload: str, streams: int, iterations: int, warmup: int,
                 process_groups=process_groups,
             )
 
-        # Workload-specific parameters (only set when explicitly provided)
-        if wl_mode is not None:
-            kwargs["mode"] = wl_mode
-        if mm_dim is not None:
-            parts = [int(x.strip()) for x in mm_dim.split(",")]
-            if len(parts) == 1:
-                kwargs["mm_dim"] = (parts[0], parts[0], parts[0])
-            elif len(parts) == 3:
-                kwargs["mm_dim"] = tuple(parts)
-            else:
-                click.echo("Error: --mm-dim must be M,N,K or a single value", err=True)
+        # Workload-specific parameters (comms_compute_overlap only)
+        _overlap_opts = (
+            wl_mode, mm_dim, num_compute, num_coll,
+            comm_size, compute_streams, comp_dtype, comm_dtype,
+        )
+        if any(v is not None for v in _overlap_opts):
+            if workload != "comms_compute_overlap":
+                click.echo(
+                    f"Error: Options --mode, --mm-dim, --num-compute, --num-coll, "
+                    f"--comm-size, --compute-streams, --comp-dtype, --comm-dtype "
+                    f"are only valid for the comms_compute_overlap workload, "
+                    f"not '{workload}'.",
+                    err=True,
+                )
                 sys.exit(1)
-        if num_compute is not None:
-            kwargs["num_compute_per_iter"] = num_compute
-        if num_coll is not None:
-            kwargs["num_coll_per_iter"] = num_coll
-        if comm_size is not None:
-            kwargs["comm_size_bytes"] = _parse_size(comm_size)
-        if compute_streams is not None:
-            kwargs["compute_streams"] = compute_streams
-        if comp_dtype is not None:
-            kwargs["comp_data_type"] = comp_dtype
-        if comm_dtype is not None:
-            kwargs["comm_data_type"] = comm_dtype
+
+            if wl_mode is not None:
+                kwargs["mode"] = wl_mode
+            if mm_dim is not None:
+                parts = [int(x.strip()) for x in mm_dim.split(",")]
+                if len(parts) == 1:
+                    kwargs["mm_dim"] = (parts[0], parts[0], parts[0])
+                elif len(parts) == 3:
+                    kwargs["mm_dim"] = tuple(parts)
+                else:
+                    click.echo("Error: --mm-dim must be M,N,K or a single value", err=True)
+                    sys.exit(1)
+            if num_compute is not None:
+                kwargs["num_compute_per_iter"] = num_compute
+            if num_coll is not None:
+                kwargs["num_coll_per_iter"] = num_coll
+            if comm_size is not None:
+                kwargs["comm_size_bytes"] = _parse_size(comm_size)
+            if compute_streams is not None:
+                kwargs["compute_streams"] = compute_streams
+            if comp_dtype is not None:
+                kwargs["comp_data_type"] = comp_dtype
+            if comm_dtype is not None:
+                kwargs["comm_data_type"] = comm_dtype
 
         wl = get_workload_instance(workload, **kwargs)
         info = WorkloadRegistry.get_info(workload)

--- a/src/aorta/hw_queue_eval/cli.py
+++ b/src/aorta/hw_queue_eval/cli.py
@@ -75,15 +75,23 @@ def _parse_size(value: str) -> int:
     value = value.strip().upper()
     multipliers = {"K": 1024, "M": 1024 ** 2, "G": 1024 ** 3}
     try:
+        result: int
         for suffix, mult in multipliers.items():
             if value.endswith(suffix):
-                return int(float(value[:-1]) * mult)
-        return int(value)
+                result = int(float(value[:-1]) * mult)
+                break
+        else:
+            result = int(value)
     except (TypeError, ValueError):
         raise ValueError(
             f"Invalid size value '{original}'. "
             "Expected an integer or a number with K/M/G suffix, e.g. '128M' or '1024'."
         ) from None
+    if result < 0:
+        raise ValueError(
+            f"Invalid size value '{original}'. Size must be non-negative."
+        )
+    return result
 
 
 def get_workload_instance(name: str, **kwargs):
@@ -220,7 +228,14 @@ def run(workload: str, streams: int, iterations: int, warmup: int,
             if wl_mode is not None:
                 kwargs["mode"] = wl_mode
             if mm_dim is not None:
-                parts = [int(x.strip()) for x in mm_dim.split(",")]
+                try:
+                    parts = [int(x.strip()) for x in mm_dim.split(",")]
+                except ValueError:
+                    click.echo(
+                        "Error: --mm-dim must contain integers, e.g. '2048,2048,2048'",
+                        err=True,
+                    )
+                    sys.exit(1)
                 if len(parts) == 1:
                     kwargs["mm_dim"] = (parts[0], parts[0], parts[0])
                 elif len(parts) == 3:
@@ -228,13 +243,25 @@ def run(workload: str, streams: int, iterations: int, warmup: int,
                 else:
                     click.echo("Error: --mm-dim must be M,N,K or a single value", err=True)
                     sys.exit(1)
+                if any(d <= 0 for d in kwargs["mm_dim"]):
+                    click.echo("Error: --mm-dim dimensions must be positive integers", err=True)
+                    sys.exit(1)
             if num_compute is not None:
+                if num_compute <= 0:
+                    click.echo("Error: --num-compute must be a positive integer", err=True)
+                    sys.exit(1)
                 kwargs["num_compute_per_iter"] = num_compute
             if num_coll is not None:
+                if num_coll <= 0:
+                    click.echo("Error: --num-coll must be a positive integer", err=True)
+                    sys.exit(1)
                 kwargs["num_coll_per_iter"] = num_coll
             if comm_size is not None:
                 kwargs["comm_size_bytes"] = _parse_size(comm_size)
             if compute_streams is not None:
+                if compute_streams <= 0:
+                    click.echo("Error: --compute-streams must be a positive integer", err=True)
+                    sys.exit(1)
                 kwargs["compute_streams"] = compute_streams
             if comp_dtype is not None:
                 kwargs["comp_data_type"] = comp_dtype

--- a/src/aorta/hw_queue_eval/core/torch_profiler.py
+++ b/src/aorta/hw_queue_eval/core/torch_profiler.py
@@ -151,8 +151,11 @@ class TorchProfilerWrapper:
         Returns:
             ProfilerResult with paths to generated traces
         """
+        from aorta.utils.distributed import get_rank, is_distributed
+
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        run_name = f"{name}_{timestamp}"
+        rank_prefix = f"rank{get_rank()}_" if is_distributed() else ""
+        run_name = f"{rank_prefix}{name}_{timestamp}"
 
         result = ProfilerResult()
 
@@ -301,8 +304,11 @@ class TorchProfilerWrapper:
         Returns:
             ProfilerResult after context exits
         """
+        from aorta.utils.distributed import get_rank, is_distributed
+
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        run_name = f"{name}_{timestamp}"
+        rank_prefix = f"rank{get_rank()}_" if is_distributed() else ""
+        run_name = f"{rank_prefix}{name}_{timestamp}"
 
         with profile(
             activities=self.config.get_activities(),

--- a/src/aorta/hw_queue_eval/workloads/__init__.py
+++ b/src/aorta/hw_queue_eval/workloads/__init__.py
@@ -2,7 +2,7 @@
 Workload implementations for hardware queue evaluation.
 
 Workload categories:
-- distributed: FSDP, TP, MoE, gradient accumulation patterns
+- distributed: Comm-compute overlap, FSDP, TP, MoE, gradient accumulation
 - inference: Speculative decoding, continuous batching, RAG pipelines
 - pipeline: Async data loading, ZeRO offload, torch.compile patterns
 - latency_sensitive: Heterogeneous kernels, graph subgraph execution

--- a/src/aorta/hw_queue_eval/workloads/distributed/__init__.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/__init__.py
@@ -2,6 +2,7 @@
 Distributed training workloads for hardware queue evaluation.
 
 These workloads simulate patterns from distributed training:
+- Comm-compute overlap with configurable GEMM and collectives
 - FSDP + Tensor Parallelism (3D parallelism)
 - Mixture of Experts (MoE) with parallel expert execution
 - Activation checkpointing with recomputation streams
@@ -9,11 +10,13 @@ These workloads simulate patterns from distributed training:
 """
 
 from aorta.hw_queue_eval.workloads.distributed.activation_ckpt import ActivationCheckpointWorkload
+from aorta.hw_queue_eval.workloads.distributed.comms_compute_overlap import CommsComputeOverlapWorkload
 from aorta.hw_queue_eval.workloads.distributed.fsdp_tp import FSDPTPWorkload
 from aorta.hw_queue_eval.workloads.distributed.grad_accum import GradientAccumulationWorkload
 from aorta.hw_queue_eval.workloads.distributed.moe import MoEWorkload
 
 __all__ = [
+    "CommsComputeOverlapWorkload",
     "FSDPTPWorkload",
     "MoEWorkload",
     "ActivationCheckpointWorkload",

--- a/src/aorta/hw_queue_eval/workloads/distributed/comms_compute_overlap.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/comms_compute_overlap.py
@@ -289,6 +289,16 @@ class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
         if self.mode != "compute_only":
             elem_size = torch.tensor([], dtype=self.comm_data_type).element_size()
             num_elements = max(1, self.comm_size_bytes // elem_size)
+            # Two buffers (comm + scratch) are allocated
+            alloc_bytes = num_elements * elem_size * 2
+            if alloc_bytes > 4 * 1024 ** 3:
+                logger.warning(
+                    "Comm tensor allocation is %.1f GiB (comm_size_bytes=%d, "
+                    "dtype=%s). This may cause out-of-memory errors.",
+                    alloc_bytes / 1024 ** 3,
+                    self.comm_size_bytes,
+                    self.comm_data_type,
+                )
             comm_device = self._get_device_for_stream(self._comm_stream_idx)
             self._comm_tensor = torch.randn(
                 num_elements, dtype=self.comm_data_type, device=comm_device
@@ -385,6 +395,8 @@ class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
             return 0.0
 
         if self.mode == "comms_only":
+            if self._comm_tensor.nelement() == 0:
+                return 0.0
             total_bytes = (
                 iterations
                 * self.num_coll_per_iter

--- a/src/aorta/hw_queue_eval/workloads/distributed/comms_compute_overlap.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/comms_compute_overlap.py
@@ -200,14 +200,41 @@ class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
             # Process groups
             if self._pg_spec is not None:
                 pg_ranks = parse_process_groups(self._pg_spec)
+
+                # Validate that every rank belongs to exactly one group
+                rank_to_pgs: Dict[int, List[int]] = {
+                    r: [] for r in range(self._world_size)
+                }
+                for pg_id, ranks in pg_ranks.items():
+                    for r in ranks:
+                        if 0 <= r < self._world_size:
+                            rank_to_pgs[r].append(pg_id)
+
+                unassigned = [r for r, pgs in rank_to_pgs.items() if not pgs]
+                multi = {r: pgs for r, pgs in rank_to_pgs.items() if len(pgs) > 1}
+                if unassigned or multi:
+                    parts = [
+                        "Invalid process group spec: each rank must belong "
+                        "to exactly one group."
+                    ]
+                    if unassigned:
+                        parts.append(f" Unassigned ranks: {sorted(unassigned)}.")
+                    if multi:
+                        parts.append(
+                            " Ranks in multiple groups: "
+                            + ", ".join(
+                                f"{r}: {pg_ids}"
+                                for r, pg_ids in sorted(multi.items())
+                            )
+                            + "."
+                        )
+                    raise RuntimeError("".join(parts))
+
                 self._process_groups = create_process_groups(
                     pg_ranks, backend=self._backend
                 )
-                for pg_id, ranks in pg_ranks.items():
-                    if self._rank in ranks:
-                        self._active_group = self._process_groups[pg_id]
-                        break
-            if self._active_group is None:
+                self._active_group = self._process_groups[rank_to_pgs[self._rank][0]]
+            else:
                 self._active_group = dist.group.WORLD
         else:
             self._setup_multi_gpu(stream_count, device, self.use_multi_gpu)

--- a/src/aorta/hw_queue_eval/workloads/distributed/comms_compute_overlap.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/comms_compute_overlap.py
@@ -21,11 +21,14 @@ When ``simulate_collectives=False`` the workload uses real
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
 from torch.profiler import record_function
+
+logger = logging.getLogger(__name__)
 
 from aorta.hw_queue_eval.workloads.base import DistributedWorkload, MultiGPUMixin
 from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
@@ -79,7 +82,7 @@ class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
     name = "comms_compute_overlap"
     description = "Comm-compute overlap with configurable GEMM and collectives"
     category = "distributed"
-    min_streams = 2
+    min_streams = 1
     max_streams = 32
     recommended_streams = 4
     switch_latency_sensitivity = "high"
@@ -197,43 +200,38 @@ class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
 
             self._setup_multi_gpu(stream_count, device, use_multi_gpu=False)
 
-            # Process groups
+            # Process groups -- overlapping groups are allowed (e.g.
+            # the same ranks can appear in multiple groups).  The workload
+            # uses the first group that contains this rank as the active
+            # group for collectives.
             if self._pg_spec is not None:
                 pg_ranks = parse_process_groups(self._pg_spec)
 
-                # Validate that every rank belongs to exactly one group
-                rank_to_pgs: Dict[int, List[int]] = {
-                    r: [] for r in range(self._world_size)
-                }
+                # Validate that all ranks are within [0, world_size)
                 for pg_id, ranks in pg_ranks.items():
                     for r in ranks:
-                        if 0 <= r < self._world_size:
-                            rank_to_pgs[r].append(pg_id)
-
-                unassigned = [r for r, pgs in rank_to_pgs.items() if not pgs]
-                multi = {r: pgs for r, pgs in rank_to_pgs.items() if len(pgs) > 1}
-                if unassigned or multi:
-                    parts = [
-                        "Invalid process group spec: each rank must belong "
-                        "to exactly one group."
-                    ]
-                    if unassigned:
-                        parts.append(f" Unassigned ranks: {sorted(unassigned)}.")
-                    if multi:
-                        parts.append(
-                            " Ranks in multiple groups: "
-                            + ", ".join(
-                                f"{r}: {pg_ids}"
-                                for r, pg_ids in sorted(multi.items())
+                        if not (0 <= r < self._world_size):
+                            raise RuntimeError(
+                                f"Invalid process group spec: rank {r} is out of "
+                                f"range for world size {self._world_size} "
+                                f"(valid ranks: 0..{self._world_size - 1})."
                             )
-                            + "."
-                        )
-                    raise RuntimeError("".join(parts))
 
                 self._process_groups = create_process_groups(
                     pg_ranks, backend=self._backend
                 )
-                self._active_group = self._process_groups[rank_to_pgs[self._rank][0]]
+
+                # Pick the first group this rank belongs to
+                for pg_id, ranks in pg_ranks.items():
+                    if self._rank in ranks:
+                        self._active_group = self._process_groups[pg_id]
+                        break
+
+                if self._active_group is None:
+                    raise RuntimeError(
+                        f"Rank {self._rank} does not belong to any of the "
+                        f"specified process groups: {self._pg_spec}"
+                    )
             else:
                 self._active_group = dist.group.WORLD
         else:
@@ -243,8 +241,17 @@ class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
         self._comm_stream_idx = 0
 
         if self._requested_compute_streams is not None:
-            # Explicit compute stream count (independent of total streams)
+
             self._num_compute_streams = self._requested_compute_streams
+            # Warn if compute streams exceed available harness streams
+            avail = stream_count if self.mode == "compute_only" else max(0, stream_count - 1)
+            if avail > 0 and self._num_compute_streams > avail:
+                logger.warning(
+                    "compute_streams=%d exceeds available streams=%d; "
+                    "multiple GEMM sets will serialize on shared streams.",
+                    self._num_compute_streams,
+                    avail,
+                )
         elif self.mode == "comms_only":
             self._num_compute_streams = 0
         elif self.mode == "compute_only":
@@ -337,6 +344,11 @@ class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
     ) -> None:
         """Dispatch GEMM compute across compute streams."""
         num_available = len(streams) - compute_stream_offset
+        if num_available <= 0:
+            raise ValueError(
+                f"No compute streams available: {len(streams)} total streams "
+                f"with compute_stream_offset={compute_stream_offset}."
+            )
         for i in range(self._num_compute_streams):
             stream = streams[compute_stream_offset + (i % num_available)]
             a = self._A[i]
@@ -361,6 +373,14 @@ class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
         return "TFLOPS"
 
     def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        """Compute throughput from iteration count and elapsed time.
+
+        In ``comms_only`` mode the metric is raw data throughput (GB/s).
+        In simulation mode this reflects local memory bandwidth of the
+        copy+add mock; with real collectives it reflects the end-to-end
+        collective data rate (which depends on the algorithm, topology,
+        and world size -- not just point-to-point link bandwidth).
+        """
         if total_time_sec <= 0:
             return 0.0
 

--- a/src/aorta/hw_queue_eval/workloads/distributed/comms_compute_overlap.py
+++ b/src/aorta/hw_queue_eval/workloads/distributed/comms_compute_overlap.py
@@ -1,0 +1,406 @@
+"""
+Comms-Compute Overlap Workload
+
+Pattern: Overlap collective communication with compute (GEMM) on separate CUDA streams.
+Supports three modes:
+  - compute_only:  Run only compute kernels (no communication)
+  - comms_only:    Run only collective operations (no compute)
+  - comms_compute: Overlap communication and compute on independent streams
+
+Stream assignment (comms_compute mode with compute_streams=N):
+  - Stream 0: Communication (collective operations)
+  - Streams 1..N: Compute (GEMM operations distributed round-robin)
+
+The number of compute streams can be set independently of the total stream
+count passed by the harness via the ``compute_streams`` parameter.
+
+When ``simulate_collectives=False`` the workload uses real
+``torch.distributed`` collectives (NCCL / RCCL) and must be launched via
+``torchrun``.  Each rank runs on ``cuda:{LOCAL_RANK}``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+from torch.profiler import record_function
+
+from aorta.hw_queue_eval.workloads.base import DistributedWorkload, MultiGPUMixin
+from aorta.hw_queue_eval.workloads.registry import WorkloadRegistry
+from aorta.utils.distributed import (
+    cleanup_distributed,
+    create_process_groups,
+    get_local_rank,
+    get_rank,
+    get_world_size,
+    init_distributed,
+    is_distributed,
+    parse_process_groups,
+)
+
+_DTYPE_MAP = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "fp32": torch.float32,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+}
+
+
+def _resolve_dtype(value) -> torch.dtype:
+    """Accept a ``torch.dtype`` or a string name and return a ``torch.dtype``."""
+    if isinstance(value, torch.dtype):
+        return value
+    if isinstance(value, str):
+        key = value.lower().strip()
+        if key in _DTYPE_MAP:
+            return _DTYPE_MAP[key]
+        raise ValueError(
+            f"Unsupported dtype string '{value}'. "
+            f"Supported: {list(_DTYPE_MAP.keys())}"
+        )
+    raise TypeError(f"Expected torch.dtype or str, got {type(value)}")
+
+
+@WorkloadRegistry.register
+class CommsComputeOverlapWorkload(MultiGPUMixin, DistributedWorkload):
+    """
+    Configurable comm-compute overlap benchmark.
+
+    Dispatches collective communication and GEMM compute on separate CUDA
+    streams so that both can execute concurrently.  The workload is fully
+    parameterised so callers can sweep matrix sizes, compute-to-comm ratios,
+    and stream counts to characterise overlap behaviour.
+    """
+
+    name = "comms_compute_overlap"
+    description = "Comm-compute overlap with configurable GEMM and collectives"
+    category = "distributed"
+    min_streams = 2
+    max_streams = 32
+    recommended_streams = 4
+    switch_latency_sensitivity = "high"
+    memory_requirements_gb = 2.0
+    multi_gpu_capable = True
+
+    # -- Construction --------------------------------------------------------
+
+    def __init__(
+        self,
+        mode: str = "comms_compute",
+        kernel: str = "gemm",
+        mm_dim: Tuple[int, int, int] = (2048, 2048, 2048),
+        num_compute_per_iter: int = 10,
+        num_coll_per_iter: int = 1,
+        collective: str = "all_reduce",
+        comm_size_bytes: int = 128 * 1024 * 1024,  # 128 MiB default
+        simulate_collectives: bool = True,
+        async_op: bool = False,
+        backend: str = "nccl",
+        process_groups: Optional[str] = None,
+        compute_streams: Optional[int] = None,
+        comp_data_type: str | torch.dtype = torch.float32,
+        comm_data_type: str | torch.dtype = torch.float32,
+        use_multi_gpu: bool = True,
+    ):
+        """
+        Args:
+            mode: One of ``"compute_only"``, ``"comms_only"``, ``"comms_compute"``.
+            kernel: Compute kernel; currently only ``"gemm"`` (expandable later).
+            mm_dim: ``(M, N, K)`` dimensions for the GEMM  A[M,K] x B[K,N].
+            num_compute_per_iter: Number of GEMM ops per iteration per compute stream.
+            num_coll_per_iter: Number of collective ops per iteration on the comm stream.
+            collective: Collective op; currently only ``"all_reduce"`` (expandable later).
+            comm_size_bytes: Size (in bytes) of the tensor used for the collective.
+            simulate_collectives: If ``True`` (default), mock the collective; else use
+                real ``torch.distributed`` collectives (requires ``torchrun``).
+            async_op: If ``True``, issue non-blocking collectives and wait at the
+                end of the iteration.
+            backend: Distributed backend (``"nccl"`` or ``"gloo"``).
+            process_groups: Process-group specification string, e.g.
+                ``"[0,1,2,3],[4,5,6,7]"``.
+            compute_streams: Number of compute streams.  When ``None`` (default)
+                the count is derived from the total stream count (all streams
+                minus the comm stream in ``comms_compute`` mode).  Set explicitly
+                to decouple compute parallelism from the harness stream count.
+            comp_data_type: Data-type for compute (GEMM) tensors.  Accepts a
+                ``torch.dtype`` or a string like ``"float32"``, ``"bfloat16"``,
+                ``"float16"``.
+            comm_data_type: Data-type for the communication tensor.
+            use_multi_gpu: Distribute work across all visible GPUs (simulation
+                mode only).
+        """
+        if mode not in ("compute_only", "comms_only", "comms_compute"):
+            raise ValueError(
+                f"mode must be one of 'compute_only', 'comms_only', "
+                f"'comms_compute', got '{mode}'"
+            )
+        if kernel != "gemm":
+            raise ValueError(f"kernel must be 'gemm' (expandable later), got '{kernel}'")
+        if collective != "all_reduce":
+            raise ValueError(
+                f"collective must be 'all_reduce' (expandable later), got '{collective}'"
+            )
+
+        super().__init__(simulate_collectives=simulate_collectives)
+
+        self.mode = mode
+        self.kernel = kernel
+        self.mm_dim = mm_dim
+        self.num_compute_per_iter = num_compute_per_iter
+        self.num_coll_per_iter = num_coll_per_iter
+        self.collective = collective
+        self.comm_size_bytes = comm_size_bytes
+        self.use_multi_gpu = use_multi_gpu
+        self._requested_compute_streams: Optional[int] = compute_streams
+        self.comp_data_type: torch.dtype = _resolve_dtype(comp_data_type)
+        self.comm_data_type: torch.dtype = _resolve_dtype(comm_data_type)
+
+        # Distributed-specific parameters
+        self._async_op: bool = async_op
+        self._backend: str = backend
+        self._pg_spec: Optional[str] = process_groups
+
+        # Populated during setup()
+        self._A: List[torch.Tensor] = []
+        self._B: List[torch.Tensor] = []
+        self._C: List[torch.Tensor] = []
+        self._comm_tensor: torch.Tensor = torch.empty(0)
+        self._comm_scratch: torch.Tensor = torch.empty(0)
+        self._num_compute_streams: int = 0
+        self._comm_stream_idx: int = 0
+
+        # Distributed state (populated in setup when simulate_collectives=False)
+        self._process_groups: Dict[int, dist.ProcessGroup] = {}
+        self._active_group: Optional[dist.ProcessGroup] = None
+        self._pending_ops: List[dist.Work] = []
+        self._rank: int = 0
+        self._world_size: int = 1
+
+    # -- Workload interface --------------------------------------------------
+
+    def setup(self, stream_count: int, device: str = "cuda:0") -> None:
+        """Allocate tensors and decide stream layout."""
+        self._stream_count = stream_count
+        self._is_setup = True
+
+        # --- Distributed initialisation (real collectives only) ---
+        if not self._simulate_collectives:
+            init_distributed(backend=self._backend)
+            self._rank = get_rank()
+            self._world_size = get_world_size()
+            local_rank = get_local_rank()
+            device = f"cuda:{local_rank}"
+
+            self._setup_multi_gpu(stream_count, device, use_multi_gpu=False)
+
+            # Process groups
+            if self._pg_spec is not None:
+                pg_ranks = parse_process_groups(self._pg_spec)
+                self._process_groups = create_process_groups(
+                    pg_ranks, backend=self._backend
+                )
+                for pg_id, ranks in pg_ranks.items():
+                    if self._rank in ranks:
+                        self._active_group = self._process_groups[pg_id]
+                        break
+            if self._active_group is None:
+                self._active_group = dist.group.WORLD
+        else:
+            self._setup_multi_gpu(stream_count, device, self.use_multi_gpu)
+
+        # --- Stream layout ---
+        self._comm_stream_idx = 0
+
+        if self._requested_compute_streams is not None:
+            # Explicit compute stream count (independent of total streams)
+            self._num_compute_streams = self._requested_compute_streams
+        elif self.mode == "comms_only":
+            self._num_compute_streams = 0
+        elif self.mode == "compute_only":
+            self._num_compute_streams = stream_count
+        else:
+            self._num_compute_streams = max(1, stream_count - 1)
+
+        m, n, k = self.mm_dim
+
+        # --- Allocate compute tensors (one set per compute stream) ---
+        self._A = []
+        self._B = []
+        self._C = []
+
+        if self.mode != "comms_only":
+            for i in range(self._num_compute_streams):
+                stream_idx = i if self.mode == "compute_only" else i + 1
+                target_device = self._get_device_for_stream(
+                    stream_idx % stream_count
+                )
+
+                a = torch.randn(m, k, dtype=self.comp_data_type, device=target_device)
+                b = torch.randn(k, n, dtype=self.comp_data_type, device=target_device)
+                c = torch.empty(m, n, dtype=self.comp_data_type, device=target_device)
+
+                self._A.append(a)
+                self._B.append(b)
+                self._C.append(c)
+
+                self._tensors[f"A_{i}"] = a
+                self._tensors[f"B_{i}"] = b
+                self._tensors[f"C_{i}"] = c
+
+        # --- Allocate communication tensors ---
+        if self.mode != "compute_only":
+            elem_size = torch.tensor([], dtype=self.comm_data_type).element_size()
+            num_elements = max(1, self.comm_size_bytes // elem_size)
+            comm_device = self._get_device_for_stream(self._comm_stream_idx)
+            self._comm_tensor = torch.randn(
+                num_elements, dtype=self.comm_data_type, device=comm_device
+            )
+            self._comm_scratch = torch.empty_like(self._comm_tensor)
+            self._tensors["comm"] = self._comm_tensor
+            self._tensors["comm_scratch"] = self._comm_scratch
+
+    def run_iteration(self, streams: List[torch.cuda.Stream]) -> None:
+        """
+        Execute one iteration.
+
+        Depending on the mode the iteration dispatches:
+        - **comms_only**: collectives on stream 0
+        - **compute_only**: GEMMs across all streams
+        - **comms_compute**: collectives on stream 0, GEMMs on streams 1..N
+        """
+        with record_function(f"comms_compute_overlap::{self.mode}"):
+            if self.mode == "comms_only":
+                self._run_comms(streams)
+            elif self.mode == "compute_only":
+                self._run_compute(streams, compute_stream_offset=0)
+            else:
+                self._run_comms(streams)
+                self._run_compute(streams, compute_stream_offset=1)
+
+            if self._pending_ops:
+                self._complete_pending_ops()
+
+    # -- Internal helpers ----------------------------------------------------
+
+    def _run_comms(self, streams: List[torch.cuda.Stream]) -> None:
+        """Dispatch collective operations on the comm stream."""
+        comm_stream = streams[self._comm_stream_idx]
+        with torch.cuda.stream(comm_stream):
+            for coll_idx in range(self.num_coll_per_iter):
+                with record_function(f"comms::all_reduce#{coll_idx}"):
+                    if self._simulate_collectives:
+                        self._comm_scratch.copy_(self._comm_tensor)
+                        self._comm_tensor.add_(self._comm_scratch)
+                    else:
+                        work = dist.all_reduce(
+                            self._comm_tensor,
+                            op=dist.ReduceOp.SUM,
+                            group=self._active_group,
+                            async_op=self._async_op,
+                        )
+                        if self._async_op and work is not None:
+                            self._pending_ops.append(work)
+
+    def _run_compute(
+        self, streams: List[torch.cuda.Stream], compute_stream_offset: int
+    ) -> None:
+        """Dispatch GEMM compute across compute streams."""
+        num_available = len(streams) - compute_stream_offset
+        for i in range(self._num_compute_streams):
+            stream = streams[compute_stream_offset + (i % num_available)]
+            a = self._A[i]
+            b = self._B[i]
+            c = self._C[i]
+            with torch.cuda.stream(stream):
+                with record_function(f"compute::gemm#stream{compute_stream_offset + i}"):
+                    for _ in range(self.num_compute_per_iter):
+                        torch.mm(a, b, out=c)
+
+    def _complete_pending_ops(self) -> None:
+        """Wait for all outstanding async collective handles."""
+        for work in self._pending_ops:
+            work.wait()
+        self._pending_ops.clear()
+
+    # -- Metrics -------------------------------------------------------------
+
+    def get_throughput_unit(self) -> str:
+        if self.mode == "comms_only":
+            return "GB/s"
+        return "TFLOPS"
+
+    def compute_throughput(self, iterations: int, total_time_sec: float) -> float:
+        if total_time_sec <= 0:
+            return 0.0
+
+        if self.mode == "comms_only":
+            total_bytes = (
+                iterations
+                * self.num_coll_per_iter
+                * self._comm_tensor.nelement()
+                * self._comm_tensor.element_size()
+            )
+            return total_bytes / (total_time_sec * 1e9)  # GB/s
+
+        m, n, k = self.mm_dim
+        flops_per_gemm = 2 * m * n * k
+        total_flops = (
+            iterations
+            * self.num_compute_per_iter
+            * self._num_compute_streams
+            * flops_per_gemm
+        )
+        return total_flops / (total_time_sec * 1e12)  # TFLOPS
+
+    # -- Configuration -------------------------------------------------------
+
+    def get_config(self) -> Dict[str, Any]:
+        config = {
+            "name": self.name,
+            "mode": self.mode,
+            "kernel": self.kernel,
+            "collective": self.collective,
+            "mm_dim": self.mm_dim,
+            "comp_data_type": str(self.comp_data_type),
+            "comm_data_type": str(self.comm_data_type),
+            "num_compute_per_iter": self.num_compute_per_iter,
+            "num_coll_per_iter": self.num_coll_per_iter,
+            "comm_size_bytes": self.comm_size_bytes,
+            "num_compute_streams": self._num_compute_streams,
+            "requested_compute_streams": self._requested_compute_streams,
+            "simulate_collectives": self._simulate_collectives,
+            "async_op": self._async_op,
+            "backend": self._backend,
+            "process_groups": self._pg_spec,
+            "rank": self._rank,
+            "world_size": self._world_size,
+            "stream_count": self._stream_count,
+        }
+        config.update(self._get_multi_gpu_config())
+        return config
+
+    def validate_correctness(
+        self, baseline_result: Any, test_result: Any
+    ) -> Tuple[bool, str]:
+        """Quick sanity check: verify GEMM outputs are finite."""
+        if not self._is_setup:
+            return True, "Not set up; skipping validation"
+
+        for i, c in enumerate(self._C):
+            if not torch.isfinite(c).all():
+                return False, f"Compute stream {i} GEMM output contains non-finite values"
+
+        return True, "Correctness validation passed"
+
+    def cleanup(self) -> None:
+        """Release resources and tear down distributed state."""
+        super().cleanup()
+        self._pending_ops.clear()
+        self._process_groups.clear()
+        self._active_group = None
+        if not self._simulate_collectives:
+            cleanup_distributed()

--- a/src/aorta/utils/__init__.py
+++ b/src/aorta/utils/__init__.py
@@ -9,6 +9,16 @@ This module provides shared utilities for:
 """
 
 from .config import load_config, merge_cli_overrides
+from .distributed import (
+    cleanup_distributed,
+    create_process_groups,
+    get_local_rank,
+    get_rank,
+    get_world_size,
+    init_distributed,
+    is_distributed,
+    parse_process_groups,
+)
 from .device import (
     # Constants
     BACKEND_NAME,
@@ -55,6 +65,15 @@ __all__ = [
     # Config
     "load_config",
     "merge_cli_overrides",
+    # Distributed
+    "init_distributed",
+    "cleanup_distributed",
+    "is_distributed",
+    "get_rank",
+    "get_world_size",
+    "get_local_rank",
+    "parse_process_groups",
+    "create_process_groups",
     # Logging
     "setup_logging",
     # Device - constants

--- a/src/aorta/utils/distributed.py
+++ b/src/aorta/utils/distributed.py
@@ -1,0 +1,149 @@
+"""
+Distributed initialization and process group utilities.
+
+Provides helpers for ``torch.distributed`` setup so that workloads and the
+CLI do not need to duplicate boilerplate.  All functions are safe to call
+in non-distributed (single-process) contexts -- they return sensible
+defaults (rank 0, world size 1) when ``torch.distributed`` is not
+initialised.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, List, Optional
+
+import torch
+import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Initialisation / teardown
+# ---------------------------------------------------------------------------
+
+def init_distributed(backend: str = "nccl") -> None:
+    """Initialise ``torch.distributed`` from environment variables.
+
+    Reads ``RANK``, ``WORLD_SIZE``, ``LOCAL_RANK``, ``MASTER_ADDR``, and
+    ``MASTER_PORT`` (all set automatically by ``torchrun``).  If the
+    process group is already initialised this is a no-op.
+
+    After initialisation, ``torch.cuda.set_device`` is called with the
+    local rank so that each process owns its own GPU.
+
+    Args:
+        backend: Communication backend (``"nccl"`` or ``"gloo"``).
+    """
+    if dist.is_initialized():
+        return
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+
+    dist.init_process_group(backend=backend)
+    logger.info(
+        "Distributed init: rank=%d  world_size=%d  local_rank=%d  backend=%s",
+        dist.get_rank(),
+        dist.get_world_size(),
+        local_rank,
+        backend,
+    )
+
+
+def cleanup_distributed() -> None:
+    """Destroy the default process group if it exists."""
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def is_distributed() -> bool:
+    """Return ``True`` when ``torch.distributed`` is initialised."""
+    return dist.is_initialized()
+
+
+# ---------------------------------------------------------------------------
+# Rank / world-size helpers (safe in non-distributed mode)
+# ---------------------------------------------------------------------------
+
+def get_rank() -> int:
+    """Return the global rank, or ``0`` when not distributed."""
+    return dist.get_rank() if dist.is_initialized() else 0
+
+
+def get_world_size() -> int:
+    """Return the world size, or ``1`` when not distributed."""
+    return dist.get_world_size() if dist.is_initialized() else 1
+
+
+def get_local_rank() -> int:
+    """Return the local rank from the ``LOCAL_RANK`` env var, or ``0``."""
+    return int(os.environ.get("LOCAL_RANK", "0"))
+
+
+# ---------------------------------------------------------------------------
+# Process-group helpers
+# ---------------------------------------------------------------------------
+
+def parse_process_groups(spec: str) -> Dict[int, List[int]]:
+    """Parse a process-group specification string.
+
+    The format mirrors the one used by *multistream_bench*::
+
+        "[0,1,2,3],[4,5,6,7]"
+
+    Returns a dict mapping a zero-based group id to the list of ranks in
+    that group.  For example the string above produces
+    ``{0: [0,1,2,3], 1: [4,5,6,7]}``.
+
+    Args:
+        spec: Comma-separated bracket groups, e.g. ``"[0,1],[2,3]"``.
+
+    Returns:
+        Mapping from group id to list of ranks.
+    """
+    groups: Dict[int, List[int]] = {}
+    # Split on "],["  -- handles "[0,1],[2,3]" and "[0,1] , [2,3]"
+    raw_groups = spec.replace(" ", "").strip("[]").split("],[")
+    for idx, raw in enumerate(raw_groups):
+        ranks = [int(r) for r in raw.split(",") if r]
+        groups[idx] = ranks
+    return groups
+
+
+def create_process_groups(
+    group_ranks: Dict[int, List[int]],
+    backend: Optional[str] = None,
+) -> Dict[int, dist.ProcessGroup]:
+    """Create ``torch.distributed`` process groups from a rank mapping.
+
+    Every rank in the world must call this function collectively (even if
+    it does not belong to a particular group) because ``dist.new_group``
+    is a collective operation.
+
+    Args:
+        group_ranks: Mapping from group id to list of ranks (as returned
+            by :func:`parse_process_groups`).
+        backend: Optional backend override for the new groups.
+
+    Returns:
+        Mapping from group id to the created ``ProcessGroup``.
+    """
+    if not dist.is_initialized():
+        raise RuntimeError(
+            "torch.distributed must be initialised before creating process groups"
+        )
+
+    world_size = dist.get_world_size()
+    groups: Dict[int, dist.ProcessGroup] = {}
+
+    for pg_id, ranks in group_ranks.items():
+        if len(ranks) == world_size:
+            # Re-use the default group when the group spans all ranks
+            groups[pg_id] = dist.group.WORLD
+        else:
+            groups[pg_id] = dist.new_group(ranks=ranks, backend=backend)
+
+    return groups

--- a/src/aorta/utils/distributed.py
+++ b/src/aorta/utils/distributed.py
@@ -31,8 +31,9 @@ def init_distributed(backend: str = "nccl") -> None:
     ``MASTER_PORT`` (all set automatically by ``torchrun``).  If the
     process group is already initialised this is a no-op.
 
-    After initialisation, ``torch.cuda.set_device`` is called with the
-    local rank so that each process owns its own GPU.
+    When CUDA is available and the local rank is within the device count,
+    ``torch.cuda.set_device`` is called so that each process owns its own
+    GPU.
 
     Args:
         backend: Communication backend (``"nccl"`` or ``"gloo"``).
@@ -41,7 +42,9 @@ def init_distributed(backend: str = "nccl") -> None:
         return
 
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    torch.cuda.set_device(local_rank)
+
+    if torch.cuda.is_available() and local_rank < torch.cuda.device_count():
+        torch.cuda.set_device(local_rank)
 
     dist.init_process_group(backend=backend)
     logger.info(
@@ -103,12 +106,41 @@ def parse_process_groups(spec: str) -> Dict[int, List[int]]:
 
     Returns:
         Mapping from group id to list of ranks.
+
+    Raises:
+        ValueError: If the spec is empty, contains empty groups, or has
+            non-integer tokens.
     """
+    cleaned = spec.replace(" ", "")
+    if not cleaned:
+        raise ValueError("Process-group spec must be a non-empty string.")
+
+    stripped = cleaned.strip()
+    if stripped in ("[]", "[", "]"):
+        raise ValueError(
+            f"Process-group spec {spec!r} does not contain any ranks."
+        )
+
     groups: Dict[int, List[int]] = {}
-    # Split on "],["  -- handles "[0,1],[2,3]" and "[0,1] , [2,3]"
-    raw_groups = spec.replace(" ", "").strip("[]").split("],[")
+    inner = stripped.strip("[]")
+    raw_groups = inner.split("],[")
+
     for idx, raw in enumerate(raw_groups):
-        ranks = [int(r) for r in raw.split(",") if r]
+        if not raw:
+            raise ValueError(
+                f"Empty process group at index {idx} in spec {spec!r}."
+            )
+        try:
+            ranks = [int(r) for r in raw.split(",") if r]
+        except ValueError as exc:
+            raise ValueError(
+                f"Non-integer rank in process-group spec {spec!r} "
+                f"(group {idx}: {raw!r})."
+            ) from exc
+        if not ranks:
+            raise ValueError(
+                f"Empty process group at index {idx} in spec {spec!r}."
+            )
         groups[idx] = ranks
     return groups
 
@@ -130,6 +162,10 @@ def create_process_groups(
 
     Returns:
         Mapping from group id to the created ``ProcessGroup``.
+
+    Raises:
+        RuntimeError: If ``torch.distributed`` is not initialised.
+        ValueError: If any group contains duplicate or out-of-range ranks.
     """
     if not dist.is_initialized():
         raise RuntimeError(
@@ -137,11 +173,23 @@ def create_process_groups(
         )
 
     world_size = dist.get_world_size()
+    all_ranks = set(range(world_size))
     groups: Dict[int, dist.ProcessGroup] = {}
 
     for pg_id, ranks in group_ranks.items():
-        if len(ranks) == world_size:
-            # Re-use the default group when the group spans all ranks
+        rank_set = set(ranks)
+        if len(rank_set) != len(ranks):
+            raise ValueError(
+                f"Duplicate ranks in process group {pg_id}: {ranks}"
+            )
+        out_of_range = [r for r in rank_set if r < 0 or r >= world_size]
+        if out_of_range:
+            raise ValueError(
+                f"Out-of-range rank(s) in process group {pg_id}: "
+                f"{sorted(out_of_range)} (world size is {world_size})"
+            )
+
+        if rank_set == all_ranks:
             groups[pg_id] = dist.group.WORLD
         else:
             groups[pg_id] = dist.new_group(ranks=ranks, backend=backend)

--- a/src/aorta/utils/distributed.py
+++ b/src/aorta/utils/distributed.py
@@ -141,6 +141,12 @@ def parse_process_groups(spec: str) -> Dict[int, List[int]]:
             raise ValueError(
                 f"Empty process group at index {idx} in spec {spec!r}."
             )
+        negative = [r for r in ranks if r < 0]
+        if negative:
+            raise ValueError(
+                f"Negative rank(s) {negative} in process-group spec {spec!r} "
+                f"(group {idx})."
+            )
         groups[idx] = ranks
     return groups
 

--- a/tests/hw_queue_eval/test_workloads.py
+++ b/tests/hw_queue_eval/test_workloads.py
@@ -464,6 +464,11 @@ class TestParseProcessGroups:
         with pytest.raises(ValueError, match="Non-integer"):
             parse_process_groups("[0,1.5,2]")
 
+    def test_negative_rank_raises(self):
+        from aorta.utils.distributed import parse_process_groups
+        with pytest.raises(ValueError, match="Negative rank"):
+            parse_process_groups("[0,-1,2]")
+
     def test_large_ranks(self):
         from aorta.utils.distributed import parse_process_groups
         assert parse_process_groups("[100,200,300]") == {0: [100, 200, 300]}
@@ -510,6 +515,11 @@ class TestParseSize:
         from aorta.hw_queue_eval.cli import _parse_size
         with pytest.raises(ValueError, match="Invalid size"):
             _parse_size("M")
+
+    def test_negative_value_raises(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        with pytest.raises(ValueError, match="non-negative"):
+            _parse_size("-10M")
 
 
 class TestWorkloadRegistry:

--- a/tests/hw_queue_eval/test_workloads.py
+++ b/tests/hw_queue_eval/test_workloads.py
@@ -410,6 +410,108 @@ class TestCommsComputeOverlapWorkload:
         workload.cleanup()
 
 
+class TestParseProcessGroups:
+    """Tests for the process-group spec parser."""
+
+    def test_single_group(self):
+        from aorta.utils.distributed import parse_process_groups
+        assert parse_process_groups("[0,1,2,3]") == {0: [0, 1, 2, 3]}
+
+    def test_two_groups(self):
+        from aorta.utils.distributed import parse_process_groups
+        assert parse_process_groups("[0,1],[2,3]") == {0: [0, 1], 1: [2, 3]}
+
+    def test_four_groups(self):
+        from aorta.utils.distributed import parse_process_groups
+        result = parse_process_groups("[0,1],[2,3],[4,5],[6,7]")
+        assert result == {0: [0, 1], 1: [2, 3], 2: [4, 5], 3: [6, 7]}
+
+    def test_single_rank_groups(self):
+        from aorta.utils.distributed import parse_process_groups
+        assert parse_process_groups("[0],[1],[2]") == {0: [0], 1: [1], 2: [2]}
+
+    def test_whitespace_handling(self):
+        from aorta.utils.distributed import parse_process_groups
+        assert parse_process_groups(" [ 0 , 1 ] , [ 2 , 3 ] ") == {0: [0, 1], 1: [2, 3]}
+
+    def test_empty_string_raises(self):
+        from aorta.utils.distributed import parse_process_groups
+        with pytest.raises(ValueError, match="non-empty"):
+            parse_process_groups("")
+
+    def test_whitespace_only_raises(self):
+        from aorta.utils.distributed import parse_process_groups
+        with pytest.raises(ValueError, match="non-empty"):
+            parse_process_groups("   ")
+
+    def test_empty_brackets_raises(self):
+        from aorta.utils.distributed import parse_process_groups
+        with pytest.raises(ValueError, match="does not contain any ranks"):
+            parse_process_groups("[]")
+
+    def test_empty_group_in_list_raises(self):
+        from aorta.utils.distributed import parse_process_groups
+        with pytest.raises(ValueError, match="Empty process group"):
+            parse_process_groups("[0,1],[],[2,3]")
+
+    def test_non_integer_rank_raises(self):
+        from aorta.utils.distributed import parse_process_groups
+        with pytest.raises(ValueError, match="Non-integer"):
+            parse_process_groups("[0,abc,2]")
+
+    def test_float_rank_raises(self):
+        from aorta.utils.distributed import parse_process_groups
+        with pytest.raises(ValueError, match="Non-integer"):
+            parse_process_groups("[0,1.5,2]")
+
+    def test_large_ranks(self):
+        from aorta.utils.distributed import parse_process_groups
+        assert parse_process_groups("[100,200,300]") == {0: [100, 200, 300]}
+
+    def test_preserves_order(self):
+        from aorta.utils.distributed import parse_process_groups
+        assert parse_process_groups("[3,1,2,0]") == {0: [3, 1, 2, 0]}
+
+
+class TestParseSize:
+    """Tests for the CLI _parse_size helper."""
+
+    def test_plain_integer(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        assert _parse_size("1024") == 1024
+
+    def test_megabytes(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        assert _parse_size("128M") == 128 * 1024 * 1024
+
+    def test_gigabytes(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        assert _parse_size("1G") == 1024 ** 3
+
+    def test_lowercase_suffix(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        assert _parse_size("64m") == 64 * 1024 * 1024
+
+    def test_fractional_with_suffix(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        assert _parse_size("1.5G") == int(1.5 * 1024 ** 3)
+
+    def test_invalid_string_raises(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        with pytest.raises(ValueError, match="Invalid size"):
+            _parse_size("abc")
+
+    def test_empty_string_raises(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        with pytest.raises(ValueError, match="Invalid size"):
+            _parse_size("")
+
+    def test_suffix_only_raises(self):
+        from aorta.hw_queue_eval.cli import _parse_size
+        with pytest.raises(ValueError, match="Invalid size"):
+            _parse_size("M")
+
+
 class TestWorkloadRegistry:
     """Tests for workload registry."""
 

--- a/tests/hw_queue_eval/test_workloads.py
+++ b/tests/hw_queue_eval/test_workloads.py
@@ -225,6 +225,191 @@ class TestGraphSubgraphsWorkload:
         assert result.throughput > 0
 
 
+class TestCommsComputeOverlapWorkload:
+    """Tests for the comms_compute_overlap workload (simulated collectives)."""
+
+    # Tests for real collectives (simulate_collectives=False) are not
+    # included here because they require multi-process launch via torchrun
+    # (torch.distributed.init_process_group needs RANK, WORLD_SIZE, etc.
+    # env vars).  The existing test suite runs as a single pytest process.
+
+    @pytest.mark.parametrize("stream_count", [2, 4, 8])
+    def test_runs_at_various_stream_counts(self, stream_count):
+        """Test workload runs without error at different stream counts."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "comms_compute_overlap",
+            mm_dim=(512, 512, 512),
+            num_compute_per_iter=2,
+            comm_size_bytes=1 * 1024 * 1024,
+        )
+
+        config = HarnessConfig(
+            stream_count=stream_count,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+        assert result.stream_count == stream_count
+
+    @pytest.mark.parametrize("mode", ["compute_only", "comms_only", "comms_compute"])
+    def test_all_modes(self, mode):
+        """Test all three workload modes run without error."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "comms_compute_overlap",
+            mode=mode,
+            mm_dim=(512, 512, 512),
+            num_compute_per_iter=2,
+            comm_size_bytes=1 * 1024 * 1024,
+        )
+
+        config = HarnessConfig(
+            stream_count=4,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+
+    def test_produces_valid_metrics(self):
+        """Test that metrics are valid."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "comms_compute_overlap",
+            mm_dim=(512, 512, 512),
+            num_compute_per_iter=2,
+            comm_size_bytes=1 * 1024 * 1024,
+        )
+
+        config = HarnessConfig(
+            stream_count=4,
+            warmup_iterations=2,
+            measurement_iterations=10,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.latency_ms["mean"] > 0
+        assert result.latency_ms["p50"] > 0
+        assert result.latency_ms["p99"] >= result.latency_ms["p50"]
+        assert result.throughput_unit == "TFLOPS"
+
+    def test_comms_only_throughput_unit(self):
+        """Test comms_only mode reports GB/s."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "comms_compute_overlap",
+            mode="comms_only",
+            comm_size_bytes=1 * 1024 * 1024,
+        )
+
+        config = HarnessConfig(
+            stream_count=4,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput_unit == "GB/s"
+
+    def test_correctness_validation(self):
+        """Test correctness validation passes."""
+        workload = get_workload(
+            "comms_compute_overlap",
+            mm_dim=(512, 512, 512),
+            num_compute_per_iter=2,
+            comm_size_bytes=1 * 1024 * 1024,
+        )
+        workload.setup(stream_count=4, device="cuda:0")
+
+        is_correct, message = workload.validate_correctness(None, None)
+
+        assert is_correct
+        workload.cleanup()
+
+    @pytest.mark.parametrize("compute_streams", [1, 2, 4])
+    def test_explicit_compute_streams(self, compute_streams):
+        """Test decoupled compute stream count."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "comms_compute_overlap",
+            mm_dim=(512, 512, 512),
+            num_compute_per_iter=2,
+            compute_streams=compute_streams,
+            comm_size_bytes=1 * 1024 * 1024,
+        )
+
+        config = HarnessConfig(
+            stream_count=8,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+
+    @pytest.mark.parametrize("comp_dt,comm_dt", [
+        ("float32", "float32"),
+        ("bfloat16", "bfloat16"),
+        ("float16", "float32"),
+    ])
+    def test_data_types(self, comp_dt, comm_dt):
+        """Test various compute and comm data type combinations."""
+        from aorta.hw_queue_eval.core.harness import HarnessConfig, StreamHarness
+
+        workload = get_workload(
+            "comms_compute_overlap",
+            mm_dim=(512, 512, 512),
+            num_compute_per_iter=2,
+            comp_data_type=comp_dt,
+            comm_data_type=comm_dt,
+            comm_size_bytes=1 * 1024 * 1024,
+        )
+
+        config = HarnessConfig(
+            stream_count=4,
+            warmup_iterations=2,
+            measurement_iterations=5,
+        )
+        harness = StreamHarness(config)
+        result = harness.run_workload(workload)
+
+        assert result.throughput > 0
+
+    def test_get_config(self):
+        """Test that get_config returns expected keys."""
+        workload = get_workload(
+            "comms_compute_overlap",
+            mm_dim=(1024, 1024, 1024),
+            compute_streams=2,
+            comp_data_type="bfloat16",
+            comm_data_type="float16",
+        )
+        workload.setup(stream_count=4, device="cuda:0")
+
+        config = workload.get_config()
+
+        assert config["name"] == "comms_compute_overlap"
+        assert config["mm_dim"] == (1024, 1024, 1024)
+        assert config["num_compute_streams"] == 2
+        assert "bfloat16" in config["comp_data_type"]
+        assert "float16" in config["comm_data_type"]
+        workload.cleanup()
+
+
 class TestWorkloadRegistry:
     """Tests for workload registry."""
 


### PR DESCRIPTION
Introduce a configurable comm-compute overlap workload to hw_queue_eval that runs GEMM compute on dedicated streams while collective communication runs on a separate stream. This is the simplest workload for measuring overlap efficiency and GPU queue scheduling quality.

Key features:
- Three modes: compute_only, comms_only, comms_compute
- Real NCCL/RCCL collectives via torchrun (--real-collectives)
- Async non-blocking collectives with deferred wait (--async-op)
- Arbitrary process group topologies (--process-groups)
- Independent compute stream count (--compute-streams)
- Separate data types for compute and comm (--comp-dtype, --comm-dtype)
- Configurable GEMM dimensions, iteration counts, and message sizes
- Rank-aware profiler trace filenames in distributed mode

Signed-off-by: Vivek Khandelwal <vivek.khandelwal@amd.com>