### PR TITLE
fixes testcase failures

### DIFF
--- a/src/aorta/hw_queue_eval/core/metrics.py
+++ b/src/aorta/hw_queue_eval/core/metrics.py
@@ -285,6 +285,16 @@ class MetricsCollector:
             Tuple[int, torch.cuda.Event, torch.cuda.Event, Optional[str]]
         ] = []
 
+        # Deferred iteration event pairs awaiting sync before elapsed_time
+        self._deferred_iterations: List[
+            Tuple[
+                torch.cuda.Event,  # start
+                torch.cuda.Event,  # end
+                torch.cuda.Event,  # baseline
+                List[Tuple[int, torch.cuda.Event, torch.cuda.Event, Optional[str]]],
+            ]
+        ] = []
+
     def start_iteration(self) -> None:
         """Mark the start of an iteration."""
         self._current_iteration_kernels = []
@@ -320,42 +330,63 @@ class MetricsCollector:
         Mark the end of an iteration and process timings.
 
         Args:
-            sync: If True, synchronize device before processing timings
+            sync: If True, synchronize device before processing timings.
+                  When False, timing computation is deferred until the next
+                  sync or until results are queried.
         """
         self._iteration_end_event = torch.cuda.Event(enable_timing=True)
         self._iteration_end_event.record()
 
+        # Store events for this iteration; actual elapsed_time calls require
+        # the events to have completed, so we defer until after a sync.
+        self._deferred_iterations.append((
+            self._iteration_start_event,
+            self._iteration_end_event,
+            self._baseline_event,
+            list(self._pending_events),
+        ))
+
         if sync:
             torch.cuda.synchronize(self.device)
+            self._flush_deferred()
 
-        # Process pending kernel timings
-        for stream_id, start_event, end_event, kernel_name in self._pending_events:
-            # Get times relative to baseline
-            start_ms = self._baseline_event.elapsed_time(start_event)
-            end_ms = self._baseline_event.elapsed_time(end_event)
-            duration_ms = start_event.elapsed_time(end_event)
+    def _flush_deferred(self) -> None:
+        """Resolve deferred event pairs into concrete timing data.
 
-            timing = KernelTiming(
-                stream_id=stream_id,
-                kernel_name=kernel_name,
-                start_ms=start_ms,
-                end_ms=end_ms,
-                duration_ms=duration_ms,
-            )
-            self._current_iteration_kernels.append(timing)
+        Synchronizes the device if there are pending iterations, since
+        ``elapsed_time`` requires events to have completed.
+        """
+        if not self._deferred_iterations:
+            return
 
-        self._kernel_timings.append(self._current_iteration_kernels)
+        torch.cuda.synchronize(self.device)
 
-        # Record iteration time
-        iteration_time = self._iteration_start_event.elapsed_time(self._iteration_end_event)
-        self._iteration_times_ms.append(iteration_time)
+        for start_ev, end_ev, baseline_ev, pending in self._deferred_iterations:
+            iteration_kernels: List[KernelTiming] = []
+            for stream_id, k_start, k_end, kernel_name in pending:
+                start_ms = baseline_ev.elapsed_time(k_start)
+                end_ms = baseline_ev.elapsed_time(k_end)
+                duration_ms = k_start.elapsed_time(k_end)
+                iteration_kernels.append(KernelTiming(
+                    stream_id=stream_id,
+                    kernel_name=kernel_name,
+                    start_ms=start_ms,
+                    end_ms=end_ms,
+                    duration_ms=duration_ms,
+                ))
 
-        # Compute per-stream times for this iteration
-        stream_times = [0.0] * self.num_streams
-        for kt in self._current_iteration_kernels:
-            if 0 <= kt.stream_id < self.num_streams:
-                stream_times[kt.stream_id] += kt.duration_ms
-        self._per_stream_times_ms.append(stream_times)
+            self._kernel_timings.append(iteration_kernels)
+
+            iteration_time = start_ev.elapsed_time(end_ev)
+            self._iteration_times_ms.append(iteration_time)
+
+            stream_times = [0.0] * self.num_streams
+            for kt in iteration_kernels:
+                if 0 <= kt.stream_id < self.num_streams:
+                    stream_times[kt.stream_id] += kt.duration_ms
+            self._per_stream_times_ms.append(stream_times)
+
+        self._deferred_iterations.clear()
 
     def compute_latency_metrics(self) -> LatencyMetrics:
         """
@@ -364,6 +395,7 @@ class MetricsCollector:
         Returns:
             LatencyMetrics object with computed statistics
         """
+        self._flush_deferred()
         return LatencyMetrics.from_samples(self._iteration_times_ms)
 
     def compute_switch_latency(self) -> SwitchLatencyMetrics:
@@ -376,6 +408,7 @@ class MetricsCollector:
         Returns:
             SwitchLatencyMetrics object with computed values
         """
+        self._flush_deferred()
         # Flatten all kernel timings from all iterations
         all_timings = []
         for iteration_kernels in self._kernel_timings:
@@ -404,18 +437,22 @@ class MetricsCollector:
 
     def get_per_stream_times(self) -> List[List[float]]:
         """Get per-stream times for each iteration."""
+        self._flush_deferred()
         return self._per_stream_times_ms
 
     def get_iteration_times(self) -> List[float]:
         """Get per-iteration times in milliseconds."""
+        self._flush_deferred()
         return self._iteration_times_ms
 
     def get_total_time_ms(self) -> float:
         """Get total time across all iterations in milliseconds."""
+        self._flush_deferred()
         return sum(self._iteration_times_ms)
 
     def get_kernel_timings(self) -> List[List[KernelTiming]]:
         """Get all recorded kernel timings by iteration."""
+        self._flush_deferred()
         return self._kernel_timings
 
     def clear(self) -> None:
@@ -425,6 +462,7 @@ class MetricsCollector:
         self._per_stream_times_ms = []
         self._current_iteration_kernels = []
         self._pending_events = []
+        self._deferred_iterations = []
 
     def get_summary(self) -> Dict[str, Any]:
         """

--- a/src/aorta/hw_queue_eval/core/metrics.py
+++ b/src/aorta/hw_queue_eval/core/metrics.py
@@ -347,7 +347,6 @@ class MetricsCollector:
         ))
 
         if sync:
-            torch.cuda.synchronize(self.device)
             self._flush_deferred()
 
     def _flush_deferred(self) -> None:
@@ -430,6 +429,7 @@ class MetricsCollector:
         Returns:
             ThroughputMetrics object
         """
+        self._flush_deferred()
         total_count = count_per_iteration * len(self._iteration_times_ms)
         total_time_sec = sum(self._iteration_times_ms) / 1000.0
 

--- a/src/aorta/hw_queue_eval/workloads/inference/speculative_decode.py
+++ b/src/aorta/hw_queue_eval/workloads/inference/speculative_decode.py
@@ -219,38 +219,42 @@ class SpeculativeDecodeWorkload(MultiGPUMixin, InferenceWorkload):
 
             self._draft_tokens = torch.cat(draft_tokens, dim=1)
 
+        # Determine device for each phase
+        verify_device = self._get_device_for_stream(self._verify_streams[0])
+        accept_device = self._get_device_for_stream(self._accept_stream)
+        cache_device = self._get_device_for_stream(self._cache_stream)
+
         # Step 2: Main model verifies all K tokens in parallel
         verify_stream.wait_stream(draft_stream)
 
         with torch.cuda.stream(verify_stream):
-            # Verify all draft tokens in one forward pass
-            verify_input = torch.cat([context, self._draft_tokens], dim=1)
+            # Move tensors to verify device if they live on a different GPU
+            ctx_v = context.to(verify_device, non_blocking=True)
+            draft_v = self._draft_tokens.to(verify_device, non_blocking=True)
+
+            verify_input = torch.cat([ctx_v, draft_v], dim=1)
             main_logits = self._main_model(verify_input)
 
-            # Get logits at draft positions
-            draft_start = context.size(1)
+            draft_start = ctx_v.size(1)
             verify_logits = main_logits[:, draft_start - 1:-1, :]
 
         # Step 3: Accept/reject logic
         accept_stream.wait_stream(verify_stream)
 
         with torch.cuda.stream(accept_stream):
-            # Simplified accept/reject: compare main vs draft predictions
-            main_preds = verify_logits.argmax(dim=-1)
+            main_preds = verify_logits.to(accept_device, non_blocking=True).argmax(dim=-1)
+            draft_a = self._draft_tokens.to(accept_device, non_blocking=True)
 
-            # Find first mismatch
-            matches = (main_preds == self._draft_tokens)
-            # Count accepted tokens (all matching up to first mismatch)
-            # For simplicity, just compute the mask
+            matches = (main_preds == draft_a)
             accept_mask = matches.cumprod(dim=1)
 
         # Step 4: Update KV cache (simulated)
         cache_stream.wait_stream(accept_stream)
 
         with torch.cuda.stream(cache_stream):
-            # In real implementation, this would update KV cache
-            # Here we just do some computation to simulate cache ops
-            cache_update = self._draft_tokens * accept_mask.long()
+            draft_c = self._draft_tokens.to(cache_device, non_blocking=True)
+            mask_c = accept_mask.to(cache_device, non_blocking=True).long()
+            cache_update = draft_c * mask_c
 
     def get_throughput_unit(self) -> str:
         return "tokens/sec"

--- a/src/aorta/hw_queue_eval/workloads/inference/speculative_decode.py
+++ b/src/aorta/hw_queue_eval/workloads/inference/speculative_decode.py
@@ -149,9 +149,13 @@ class SpeculativeDecodeWorkload(MultiGPUMixin, InferenceWorkload):
         if not self._verify_streams:
             self._verify_streams = [0]
 
-        # Use draft stream's device for draft model
+        # Cache per-phase devices (fixed after setup, avoids repeated lookups)
         draft_device = self._get_device_for_stream(self._draft_streams[0])
         verify_device = self._get_device_for_stream(self._verify_streams[0])
+        self._draft_device = draft_device
+        self._verify_device = verify_device
+        self._accept_device = self._get_device_for_stream(self._accept_stream)
+        self._cache_device = self._get_device_for_stream(self._cache_stream)
 
         # Create models
         self._draft_model = SimpleLM(
@@ -219,16 +223,14 @@ class SpeculativeDecodeWorkload(MultiGPUMixin, InferenceWorkload):
 
             self._draft_tokens = torch.cat(draft_tokens, dim=1)
 
-        # Determine device for each phase
-        verify_device = self._get_device_for_stream(self._verify_streams[0])
-        accept_device = self._get_device_for_stream(self._accept_stream)
-        cache_device = self._get_device_for_stream(self._cache_stream)
+        verify_device = self._verify_device
+        accept_device = self._accept_device
+        cache_device = self._cache_device
 
         # Step 2: Main model verifies all K tokens in parallel
         verify_stream.wait_stream(draft_stream)
 
         with torch.cuda.stream(verify_stream):
-            # Move tensors to verify device if they live on a different GPU
             ctx_v = context.to(verify_device, non_blocking=True)
             draft_v = self._draft_tokens.to(verify_device, non_blocking=True)
 
@@ -242,7 +244,8 @@ class SpeculativeDecodeWorkload(MultiGPUMixin, InferenceWorkload):
         accept_stream.wait_stream(verify_stream)
 
         with torch.cuda.stream(accept_stream):
-            main_preds = verify_logits.to(accept_device, non_blocking=True).argmax(dim=-1)
+            # argmax on verify device first to avoid transferring full [B, K, vocab] tensor
+            main_preds = verify_logits.argmax(dim=-1).to(accept_device, non_blocking=True)
             draft_a = self._draft_tokens.to(accept_device, non_blocking=True)
 
             matches = (main_preds == draft_a)

--- a/src/aorta/hw_queue_eval/workloads/inference/speculative_decode.py
+++ b/src/aorta/hw_queue_eval/workloads/inference/speculative_decode.py
@@ -239,13 +239,14 @@ class SpeculativeDecodeWorkload(MultiGPUMixin, InferenceWorkload):
 
             draft_start = ctx_v.size(1)
             verify_logits = main_logits[:, draft_start - 1:-1, :]
+            # Reduce on verify_stream so argmax is ordered after the forward pass
+            main_preds = verify_logits.argmax(dim=-1)
 
         # Step 3: Accept/reject logic
         accept_stream.wait_stream(verify_stream)
 
         with torch.cuda.stream(accept_stream):
-            # argmax on verify device first to avoid transferring full [B, K, vocab] tensor
-            main_preds = verify_logits.argmax(dim=-1).to(accept_device, non_blocking=True)
+            main_preds = main_preds.to(accept_device, non_blocking=True)
             draft_a = self._draft_tokens.to(accept_device, non_blocking=True)
 
             matches = (main_preds == draft_a)


### PR DESCRIPTION
Following testcases were failing on main, so this commit fixes them:
```
FAILED tests/hw_queue_eval/test_metrics.py::TestMetricsCollector::test_collector_basic - RuntimeError: Both events must be completed before calculating elapsed time.
FAILED tests/hw_queue_eval/test_metrics.py::TestMetricsCollector::test_collector_clear - RuntimeError: Both events must be completed before calculating elapsed time.
FAILED tests/hw_queue_eval/test_workloads.py::TestSpeculativeDecodeWorkload::test_runs_at_various_stream_counts[4] - RuntimeError: Expected all tensors to be on the same device, but got index is on cuda:0, different from other tensors on cuda:2 (when checking argument in method wrapper_CUDA__index_select)
FAILED tests/hw_queue_eval/test_workloads.py::TestSpeculativeDecodeWorkload::test_runs_at_various_stream_counts[6] - RuntimeError: Expected all tensors to be on the same device, but got index is on cuda:0, different from other tensors on cuda:2 (when checking argument in method wrapper_CUDA__index_select)
FAILED tests/hw_queue_eval/test_workloads.py::TestSpeculativeDecodeWorkload::test_runs_at_various_stream_counts[8] - RuntimeError: Expected all tensors to be on the same device, but got index is on cuda:0, different from other tensors on cuda:2 (when checking argument in method wrapper_CUDA__index_select)
```