### PR TITLE
L0: scaffold aorta CLI + workloads entry-point group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,18 @@ keywords = ["gpu", "rocm", "amd", "pytorch", "cuda", "benchmark", "fsdp", "distr
 # Base dependencies (PyTorch installed separately - see requirements.txt)
 dependencies = [
     "pyyaml>=6.0",
-    "click>=8.0.0",  # For aorta-report CLI
+    "click>=8.0.0",  # For aorta CLI
 ]
 
 [project.scripts]
-aorta-report = "aorta.report:main"
+aorta = "aorta.cli:main"
+
+# Plugin discovery: workloads register here via aorta.workloads entry-point group.
+# Engineer task A2 adds the first one (fsdp). Private workloads
+# (meta_recom_repro, precision_swaitcnt_test) register from aorta-internal's
+# pyproject.toml under the same group, separate package.
+[project.entry-points."aorta.workloads"]
+fsdp = "aorta.workloads.fsdp:FsdpWorkload"
 
 [project.optional-dependencies]
 # For analysis/visualization scripts

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -1,0 +1,20 @@
+"""Entry point for the `aorta` console script."""
+
+import click
+
+from aorta.cli import env, run, triage
+
+
+@click.group()
+@click.version_option(package_name="aorta")
+def main() -> None:
+    """AORTA - GPU debugging platform for ROCm."""
+
+
+main.add_command(env.env)
+main.add_command(run.run)
+main.add_command(triage.triage)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -1,0 +1,25 @@
+"""`aorta env` - environment capture and comparison."""
+
+import click
+
+
+@click.group()
+def env() -> None:
+    """Capture and compare GPU/library environment for trial reproducibility."""
+
+
+@env.command()
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, writable=True),
+    default="env.json",
+    show_default=True,
+    help="Path to write env.json.",
+)
+def probe(output: str) -> None:
+    """Capture current GPU + library + env-var state to env.json.
+
+    Implemented by task A1 (instrumentation/environment.py).
+    """
+    raise click.ClickException("aorta env probe - not yet implemented (task A1)")

--- a/src/aorta/cli/run.py
+++ b/src/aorta/cli/run.py
@@ -1,0 +1,54 @@
+"""`aorta run` - universal workload runner."""
+
+import click
+
+
+@click.command()
+@click.option(
+    "--workload",
+    required=True,
+    help="Workload name (from aorta.workloads entry-point group).",
+)
+@click.option(
+    "--trials",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Number of trials per (docker, mitigation) cell.",
+)
+@click.option(
+    "--dockers",
+    default="",
+    help="Comma-separated docker image names. Empty = current environment.",
+)
+@click.option(
+    "--mitigations",
+    default="",
+    help="Comma-separated mitigation names from aorta_internal.mitigations.",
+)
+@click.option(
+    "--steps",
+    type=int,
+    default=None,
+    help="Steps per trial (workload-specific; passes through to workload config).",
+)
+@click.option(
+    "--results-dir",
+    type=click.Path(file_okay=False, writable=True),
+    default="results",
+    show_default=True,
+    help="Directory to write per-trial JSON.",
+)
+def run(
+    workload: str,
+    trials: int,
+    dockers: str,
+    mitigations: str,
+    steps: int | None,
+    results_dir: str,
+) -> None:
+    """Run a workload across trials x dockers x mitigations.
+
+    Implemented by task B1 (cli/run.py + run/dispatcher.py).
+    """
+    raise click.ClickException("aorta run - not yet implemented (task B1)")

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -1,0 +1,63 @@
+"""`aorta triage` - mitigation matrix runner. (Optimize mode deferred to P1 per D11.)"""
+
+import click
+
+
+@click.group()
+def triage() -> None:
+    """Triage matrix runner for mitigation x docker x trials sweeps."""
+
+
+@triage.command(name="run")
+@click.option(
+    "--mode",
+    type=click.Choice(["matrix"]),
+    default="matrix",
+    show_default=True,
+    help="matrix = full contingency table. 'optimize' deferred to P1 per D11.",
+)
+@click.option("--workload", required=True, help="Workload name.")
+@click.option(
+    "--mitigations",
+    required=True,
+    help="Comma-separated mitigation names. Include 'none' for baseline.",
+)
+@click.option(
+    "--dockers",
+    required=True,
+    help="Comma-separated docker image names.",
+)
+@click.option(
+    "--trials",
+    type=int,
+    default=8,
+    show_default=True,
+    help="Trials per cell.",
+)
+@click.option(
+    "--steps",
+    type=int,
+    default=None,
+    help="Steps per trial.",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, writable=True),
+    default="triage_results",
+    show_default=True,
+    help="Directory for matrix.json + matrix.md output.",
+)
+def triage_run(
+    mode: str,
+    workload: str,
+    mitigations: str,
+    dockers: str,
+    trials: int,
+    steps: int | None,
+    output_dir: str,
+) -> None:
+    """Run the triage matrix: sweep mitigations x dockers x trials, output contingency table.
+
+    Implemented by task B2 (triage/runner.py + triage/matrix.py).
+    """
+    raise click.ClickException("aorta triage run - not yet implemented (task B2)")


### PR DESCRIPTION
## Summary
- Scaffolds `src/aorta/cli/` Click skeleton with env/run/triage subcommand stubs (each raises ClickException pointing at the implementing task: A1, B1, B2)
- Replaces `aorta-report` console script with `aorta = aorta.cli:main` in pyproject.toml
- Declares `[project.entry-points."aorta.workloads"]` plugin discovery group with `fsdp` slot (resolves once `FsdpWorkload` lands via task A2)
- Baseline tag `pre-mvp-restructure` was created on main before this branch as a rollback point

## Test plan
- [ ] `pip install -e .` succeeds
- [ ] `aorta --help` lists env, run, triage
- [ ] `aorta env probe` raises "not yet implemented (task A1)"
- [ ] `aorta run --workload fsdp` raises "not yet implemented (task B1)"
- [ ] `aorta triage run --mode matrix --workload fsdp --mitigations none --dockers local` raises "not yet implemented (task B2)"
- [ ] `aorta-report` console script no longer exists (removed per plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)