### PR TITLE
L0: add Workload ABC + stub instrumentation/triage packages

### DIFF
--- a/src/aorta/instrumentation/__init__.py
+++ b/src/aorta/instrumentation/__init__.py
@@ -1,0 +1,6 @@
+"""Platform-level instrumentation: env probe, NaN/numerics detector, drift watcher.
+
+Engineer task A1 adds environment.py (env probe).
+Detector and watch_lite are deferred to P1 per D11 (MVP only needs env probe
+to support `aorta run` and `aorta triage --mode matrix`).
+"""

--- a/src/aorta/triage/__init__.py
+++ b/src/aorta/triage/__init__.py
@@ -1,0 +1,5 @@
+"""Triage matrix runner.
+
+Engineer task B2 adds runner.py and matrix.py (matrix mode only per D11).
+Optimize mode is deferred to P1.
+"""

--- a/src/aorta/workloads/__init__.py
+++ b/src/aorta/workloads/__init__.py
@@ -1,0 +1,12 @@
+"""Workloads registered under the `aorta.workloads` entry-point group.
+
+Public workloads live as submodules here (e.g., aorta.workloads.fsdp).
+Private workloads live in separate packages (e.g., aorta-internal) and
+register against the same entry-point group from their own pyproject.toml.
+
+The base contract for all workloads is in `_base.py`.
+"""
+
+from aorta.workloads._base import Workload, WorkloadResult
+
+__all__ = ["Workload", "WorkloadResult"]

--- a/src/aorta/workloads/_base.py
+++ b/src/aorta/workloads/_base.py
@@ -1,0 +1,100 @@
+"""Workload plugin contract.
+
+The `Workload` ABC is the shape every plugin under the `aorta.workloads`
+entry-point group must implement. `aorta run` discovers workloads via that
+group, instantiates the class with a config dict, and drives the
+setup -> run -> cleanup lifecycle once per trial.
+
+`WorkloadResult` is the per-trial return value. Generic enough to cover
+both correctness-flavored workloads (NaN, corruption, divergence) and
+perf-flavored workloads (timing, throughput). Workload-specific data goes
+in the `metrics` dict.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class WorkloadResult:
+    """Per-trial result returned by `Workload.run()`.
+
+    Attributes:
+        passed: True if the trial met the workload's success criterion.
+        failure_count: Number of failures observed (NaN events, corruption
+            counts, divergence steps, etc. - workload-defined).
+        first_failure_iteration: Iteration index of the first observed
+            failure, or None if the trial passed.
+        failure_details: Workload-specific structured failure records.
+            Each entry is a dict the workload populates (e.g., the iteration,
+            rank, expected vs actual values, layer name).
+        total_iterations: Total iterations the workload executed.
+        step_times_ms: Per-iteration step times in milliseconds. Consumed by
+            `aorta triage --mode matrix` for speed-confound detection.
+        elapsed_sec: Total wall-clock elapsed time for the trial.
+        metrics: Extension point for workload-specific scalars (overlap
+            ratio, throughput, NaN rate per phase, etc.).
+    """
+
+    passed: bool
+    failure_count: int = 0
+    first_failure_iteration: int | None = None
+    failure_details: list[dict[str, Any]] = field(default_factory=list)
+    total_iterations: int = 0
+    step_times_ms: list[float] = field(default_factory=list)
+    elapsed_sec: float = 0.0
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+
+class Workload(ABC):
+    """Base class for workloads registered under `aorta.workloads`.
+
+    Concrete workloads live in either the public `aorta.workloads.*`
+    namespace (e.g., `aorta.workloads.fsdp`) or in private plugin packages
+    (e.g., `aorta_internal.workloads.meta_recom_repro`). Both register
+    against the same entry-point group so `aorta run --workload <name>`
+    discovers them uniformly.
+
+    Lifecycle (driven by `aorta run`, once per trial):
+
+        wl = WorkloadClass(config)
+        wl.setup()
+        result = wl.run()
+        wl.cleanup()
+
+    Subclasses MUST implement `setup()` and `run()`. `cleanup()` is
+    optional and defaults to a no-op.
+    """
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Store the per-trial config dict.
+
+        Args:
+            config: Configuration for this trial, assembled by `aorta run`
+                from CLI flags, workload defaults, and any active mitigations.
+                Workload reads its own keys; unknown keys are ignored.
+        """
+        self.config = config
+
+    @abstractmethod
+    def setup(self) -> None:
+        """Allocate buffers, init distributed, prepare model.
+
+        Called once before `run()`. Workloads that need torch.distributed
+        init their own process group here.
+        """
+
+    @abstractmethod
+    def run(self) -> WorkloadResult:
+        """Execute the workload and return a result.
+
+        Implementations should fill in as many `WorkloadResult` fields as
+        applicable. At minimum, `passed` must be set.
+        """
+
+    def cleanup(self) -> None:
+        """Release resources held by `setup()`. Default no-op."""
+
+
+__all__ = ["Workload", "WorkloadResult"]


### PR DESCRIPTION
## Summary
- Adds `src/aorta/workloads/_base.py`: `Workload` ABC + `WorkloadResult` dataclass — the contract every plugin under the `aorta.workloads` entry-point group must implement
- Adds `src/aorta/workloads/__init__.py` re-exporting `Workload` and `WorkloadResult` for convenient imports
- Adds empty `src/aorta/instrumentation/__init__.py` and `src/aorta/triage/__init__.py` as package markers (engineer tasks A1 and B2 land code into these namespaces)
- Intentionally minimal: no `search_space() / objective() / objective_kind` methods (adaptive search has no MVP consumer; defer until needed)

## Test plan
*(Run in a Python 3.10+ env, e.g. the `ort13` conda env)*
- [x] `pip install -e .` succeeds
- [x] `python -c "from aorta.workloads import Workload, WorkloadResult; print(Workload.__abstractmethods__)"` prints `frozenset({'setup', 'run'})`
- [x] `python -c "from aorta.workloads import WorkloadResult; r = WorkloadResult(passed=True); print(r)"` prints a clean dataclass repr
- [x] `aorta --help` still works (regression check — this PR doesn't touch the CLI)
- [x] Existing `python -m aorta.race` and `python -m aorta.hw_queue_eval` still work (regression check)

## Why now
Engineers can't start tasks A1 (env probe), A2 (fsdp workload), B1 (aorta run), or B2 (triage matrix) until the `Workload` contract exists in code. This unblocks all four parallel tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)