### PR TITLE
L0: declare launch_mode + min_world_size on Workload ABC

### DIFF
--- a/src/aorta/workloads/_base.py
+++ b/src/aorta/workloads/_base.py
@@ -13,7 +13,7 @@ in the `metrics` dict.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 
 @dataclass
@@ -65,7 +65,20 @@ class Workload(ABC):
 
     Subclasses MUST implement `setup()` and `run()`. `cleanup()` is
     optional and defaults to a no-op.
+
+    Launch-mode declaration:
+        Workloads default to `launch_mode = "single_process"` — `aorta run`
+        is invoked once and runs without a torchrun wrapper. Workloads that
+        require torch.distributed (FSDP, DDP, etc.) override
+        `launch_mode = "distributed"` and set `min_world_size` to the
+        minimum rank count they need. `aorta run` validates the active
+        `WORLD_SIZE` env var against these declarations before calling
+        `setup()` and raises a clear error on mismatch (single_process
+        invoked under torchrun, or distributed invoked without).
     """
+
+    launch_mode: ClassVar[Literal["single_process", "distributed"]] = "single_process"
+    min_world_size: ClassVar[int] = 1
 
     def __init__(self, config: dict[str, Any]) -> None:
         """Store the per-trial config dict.


### PR DESCRIPTION
Workloads now declare their launch mode (single_process | distributed) and minimum required world size as class attributes. aorta run validates WORLD_SIZE env against these before calling setup(), so workloads do not have to hand-roll the check.

- Default is single_process / min_world_size=1 -- bare `aorta run` works unchanged for subprocess-style workloads.
- Distributed workloads (FSDP, DDP, ...) override the two attributes; setup() still owns init_process_group().
- Backward compatible: existing stub workloads inherit the safe default.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
