### PR TITLE
A1: aorta env probe

### DIFF
--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -133,6 +133,108 @@ unexpected failure. Callers always get back a valid, fully-shaped
 
 `runtime_context.python_env` is one of `"venv" | "conda" | "system"`.
 
+## Installing RDHC
+
+RDHC (ROCm Deployment Health Check) is a system-level tool maintained by
+the ROCm team. Aorta wraps it but does **not** vendor it -- if it is
+absent the env probe still produces a complete snapshot, just with
+`system_health: null` and a `partial_reasons` entry pointing here.
+
+### Why it isn't a Python `requirements.txt` dependency
+
+`rdhc` is **not a PyPI package** -- it ships as part of the
+[`rocm-systems`](https://github.com/ROCm/rocm-systems/tree/main/projects/rocm-core/rdhc)
+repository, installed alongside the ROCm platform via system package
+managers. Even if it were available on PyPI, hard-pinning it would
+break aorta on:
+
+* non-ROCm hosts (NVIDIA, CPU-only CI runners)
+* ROCm docker images that strip `rocm-systems` to keep the image small
+* Apple silicon laptops used for analysis-only work
+
+The fail-soft contract (`partial=True` + a clear reason) is therefore
+the design, not a workaround. This page is the canonical install path
+for operators who want full `system_health` coverage.
+
+### Install on Ubuntu / Debian
+
+If you already have the ROCm apt repo configured (the standard install
+path documented at <https://rocm.docs.amd.com/projects/install-on-linux>):
+
+```bash
+sudo apt install rocm-core rocm-systems
+which rdhc        # /opt/rocm/bin/rdhc or /usr/bin/rdhc
+sudo -n rdhc --quick --json /tmp/rdhc.json && jq '.rdhc_version' /tmp/rdhc.json
+```
+
+### Install on RHEL / CentOS / Rocky / SLES
+
+```bash
+sudo dnf install rocm-core rocm-systems    # or `zypper` on SLES
+which rdhc
+```
+
+### Install from source (any distro, including stripped containers)
+
+```bash
+git clone https://github.com/ROCm/rocm-systems
+cd rocm-systems/projects/rocm-core/rdhc
+# Follow the project's README for build + install. Typically:
+sudo make install
+```
+
+### Configure passwordless sudo for `rdhc`
+
+`aorta env probe` runs `sudo -n -E rdhc --quick --json <tmp>`. The `-n`
+flag means **never prompt** -- if sudo would require a password, the
+probe records `system_health: rdhc exited 1 (no stderr; likely sudo-n
+unavailable)` and continues with `partial=True`. Two ways to fix:
+
+1. **Recommended (per-tool sudoers entry).** Drop a file in
+   `/etc/sudoers.d/` so only `rdhc` is passwordless, not all of sudo:
+
+   ```bash
+   sudo visudo -f /etc/sudoers.d/aorta-rdhc
+   ```
+
+   Contents:
+
+   ```text
+   # Allow members of the `aorta-users` group to run rdhc without a
+   # password. Adjust the group / user and the binary path to match
+   # your install.
+   %aorta-users ALL=(ALL) NOPASSWD: /opt/rocm/bin/rdhc, /opt/rocm/bin/rdhc.py, /usr/bin/rdhc, /usr/bin/rdhc.py
+   ```
+
+   Then `sudo usermod -aG aorta-users $USER` (and re-login). Verify:
+
+   ```bash
+   sudo -n -E rdhc --quick --json /tmp/check.json && echo OK
+   ```
+
+2. **Inside docker images you build yourself.** Add `rdhc` to the
+   image and configure passwordless sudo as part of the build:
+
+   ```dockerfile
+   RUN apt-get update && apt-get install -y rocm-core rocm-systems sudo \
+    && echo "%aorta-users ALL=(ALL) NOPASSWD: /opt/rocm/bin/rdhc, /usr/bin/rdhc" \
+       > /etc/sudoers.d/aorta-rdhc \
+    && groupadd aorta-users
+   ```
+
+### Verify the env probe picks it up
+
+```bash
+aorta env probe -o /tmp/env.json
+jq '.system_health.rdhc_version' /tmp/env.json   # expect: a version string, NOT null
+jq '.partial_reasons[]' /tmp/env.json | grep -i rdhc   # expect: nothing
+```
+
+If `partial_reasons` still contains an `rdhc` entry, the message is the
+ground truth -- it tells you exactly what failed (PATH, sudo-n,
+timeout, malformed JSON). The `(see docs/env-probe.md#installing-rdhc)`
+hint at the end of those reasons points back at this page.
+
 ## Fail-soft contract
 
 `collect_env()` never raises. When something can't be captured:

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -128,8 +128,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `python_version` | `str` | `platform.python_version()` | always populated |
 | `pytorch_version` | `str \| null` | optional `import torch` (no CUDA/HIP context init) | `null` when torch absent |
 
-`runtime_context.type` is one of `"docker" | "podman" | "singularity"
-| "baremetal"`. Adding values is a schema change.
+`runtime_context.type` is one of `"docker" | "podman" | "singularity" | "baremetal"`. Adding values is a schema change.
 
 `runtime_context.python_env` is one of `"venv" | "conda" | "system"`.
 

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -1,0 +1,252 @@
+# Env Probe
+
+Capture a versioned, schema-stable snapshot of the trial environment so
+that cross-environment comparison becomes a `jq` diff instead of a
+multi-day investigation.
+
+The same code path is used three ways:
+
+* **CLI**: `aorta env probe -o env.json` -- on-demand, by an operator.
+* **B1 (per-trial runner)**: calls `collect_env()` once per trial; the
+  snapshot is embedded in `TrialResult.env`.
+* **B2 (matrix runner)**: calls `collect_env()` once per matrix start
+  (host scope) and once per `--environment-axis` value (container
+  scope).
+
+## Why
+
+Numerical / correctness investigations on GPU stacks routinely lose
+weeks to **implicit environment state** -- a library swap between
+docker images, an HSA tunable that differs between hosts, a different
+hipBLASLt build pulled into one conda env vs another. Attaching a
+complete machine-readable environment snapshot to every trial result
+makes those confounds visible the moment they happen, instead of after
+the fact.
+
+The class of bug that motivated this is **GEMM kernel library drift
+across environments** -- most commonly hipBLASLt. The schema captures
+its commit, package version, library hash, and Tensile kernel
+fingerprint as first-class fields, so two trials whose hipBLASLt
+identities differ become trivially diffable.
+
+## Quick start
+
+```bash
+# Default: writes env.json in the current directory
+aorta env probe
+
+# Custom path; parent dirs are created if missing
+aorta env probe -o runs/exp1/env.json
+
+# Pretty-print + spot-check key fields
+jq . runs/exp1/env.json
+jq '.hipblaslt.commit' runs/exp1/env.json
+jq '.partial' runs/exp1/env.json
+
+# Diff two snapshots from different docker images
+diff <(jq -S . env_a.json) <(jq -S . env_b.json)
+```
+
+## CLI
+
+```text
+Usage: aorta env probe [OPTIONS]
+
+  Capture trial-environment state to env.json (issue #147).
+
+Options:
+  -o, --output FILE  Path to write env.json.  [default: env.json]
+  --help             Show this message and exit.
+```
+
+The CLI is a thin wrapper. It calls `collect_env()`, writes the JSON,
+and prints a six-line summary like:
+
+```text
+Wrote env probe to /tmp/env.json (schema_version=1.0) [PARTIAL]
+  runtime:  baremetal / python=venv [PARTIAL, 3 reason(s)]
+  rocm:     7.2.1 (dev: None)
+  hip:      7.2.53211-e1a6bc5663 (amd)
+  hipblaslt: commit=dabb6df2b9
+  rdhc:     unavailable (system_health=null)
+  python:   3.12.3 | pytorch: 2.12.0a0+gitf68b851
+```
+
+`[PARTIAL]` indicates at least one probe fell back to `None` -- the
+snapshot is still complete (every key present), it just records what
+was missing in `partial_reasons`.
+
+## Library API
+
+```python
+from aorta.instrumentation.environment import collect_env, EnvSnapshot
+
+snapshot: EnvSnapshot = collect_env()   # NEVER raises
+
+# Embed in a trial result (B1 pattern)
+trial_result = {
+    "trial_id": "...",
+    "passed": True,
+    "metrics": {...},
+    "env": snapshot.to_dict(),
+}
+write_json(trial_result_path, trial_result)
+
+# Reconstruct later (post-mortem, comparison tools)
+loaded = read_json(trial_result_path)
+env = EnvSnapshot.from_dict(loaded["env"])
+
+# Surface the partial state to the user without aborting
+if snapshot.partial:
+    log.warning("env probe partial: %s", snapshot.partial_reasons)
+
+# Six-line human summary, same as the CLI prints
+print(snapshot.summary())
+```
+
+`collect_env()` is the **only** public entrypoint. It NEVER raises:
+each probe is fail-soft, and the orchestrator body has a top-level
+`try/except Exception` plus a disaster-recovery helper for any genuinely
+unexpected failure. Callers always get back a valid, fully-shaped
+`EnvSnapshot` object.
+
+## env.json schema
+
+| Top-level key | Type | Source | Notes |
+| --- | --- | --- | --- |
+| `schema_version` | `str` | constant | `"1.0"` today; bumps on non-additive changes only |
+| `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
+| `partial` | `bool` | computed | `True` if any probe fell back |
+| `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
+| `system_health` | `dict \| null` | `rdhc --quick --json` (subprocess) | verbatim parsed JSON; `null` when rdhc absent / sudo unavailable / timeout / malformed |
+| `rocm` | `dict[str, str \| null]` | `/opt/rocm/.info/version{,_dev}`, `/sys/module/amdgpu/version` | `version`, `version_dev`, `kmd_version` |
+| `hip` | `dict[str, str \| null]` | `hipconfig --version/--platform/--compiler/--runtime/--cpp_config` | five subprocesses; `--version` and `--platform` cannot be combined (no delimiter) |
+| `hipblaslt` | `dict` | header parse + `sha256(libhipblaslt.so)` + sorted-filenames hash of `lib/hipblaslt/library/*` | `commit`, `package_version`, `lib_hash`, `tensile_yaml_revision`, `applied_prs: {}` |
+| `runtime_context` | `dict` | `/.dockerenv`, `/run/.containerenv`, `$SINGULARITY_NAME`, `/proc/1/cgroup`, `sys.prefix`, `$CONDA_DEFAULT_ENV` | `type`, `python_env`, `venv_path`, `conda_env_name` |
+| `docker` | `dict \| null` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` env vars + `/proc/self/cgroup` | `null` on baremetal; image+digest provided by the launcher (the only reliable way from inside a container) |
+| `env_vars` | `dict[str, str \| null]` | canonical 13-name list, explicit | HSA + GPU queue + RCCL + FBGEMM + PyTorch |
+| `python_version` | `str` | `platform.python_version()` | always populated |
+| `pytorch_version` | `str \| null` | optional `import torch` (no CUDA/HIP context init) | `null` when torch absent |
+
+`runtime_context.type` is one of `"docker" | "podman" | "singularity"
+| "baremetal"`. Adding values is a schema change.
+
+`runtime_context.python_env` is one of `"venv" | "conda" | "system"`.
+
+## Fail-soft contract
+
+`collect_env()` never raises. When something can't be captured:
+
+1. The corresponding field is set to `None`.
+2. A short reason like `"system_health: rdhc not on PATH"` or
+   `"hipblaslt.commit: /opt/rocm/include/hipblaslt/hipblaslt-version.h
+   missing, empty, or unreadable"` is appended to `partial_reasons`.
+3. `partial` is set to `True`.
+4. The run continues.
+
+This is the difference between "I ran the matrix, env probe failed,
+now I have nothing" and "I ran the matrix, env probe is honest about
+what it couldn't capture, here are the artifacts."
+
+Documented absences DO NOT trigger `partial`:
+
+* `docker == None` on baremetal (no container, nothing to record).
+* `env_vars[X] == None` when the variable is unset (the documented
+  contract -- the consumer can tell unset apart from `""`).
+* `runtime_context.venv_path == None` when not inside a venv.
+
+## Performance
+
+| Environment | Wall time |
+| --- | --- |
+| Baremetal host (no rdhc) | ~0.10 s |
+| Inside a docker image | ~0.8 s |
+
+Both well inside the <5 s no-rdhc / <15 s with-rdhc targets.
+
+No GPU compute. Verified via `rocprofv3 --hip-trace`: zero HIP API
+calls, zero kernel dispatches.
+
+## Container detection precedence
+
+Container `type` is resolved in this order, first match wins:
+
+1. `/.dockerenv` exists -> `"docker"`.
+2. `/run/.containerenv` exists -> `"podman"`.
+3. `$SINGULARITY_NAME` is set OR cgroup contains `singularity` ->
+   `"singularity"`.
+4. Cgroup fallback: `/proc/1/cgroup` contains `singularity` ->
+   `"singularity"`; then `docker` -> `"docker"`; then `podman` ->
+   `"podman"`.
+5. Otherwise -> `"baremetal"`.
+
+Singularity wins over docker/podman in the cgroup fallback so a
+Singularity instance whose underlying cgroup happens to be docker-shim
+shaped is not misclassified.
+
+## Where the data comes from
+
+If you need to verify a value or diagnose a missing one, the per-field
+sources are:
+
+| Field | Read from |
+| --- | --- |
+| `rocm.version` | `/opt/rocm/.info/version` |
+| `rocm.version_dev` | `/opt/rocm/.info/version-dev` (often empty on developer builds) |
+| `rocm.kmd_version` | `/sys/module/amdgpu/version` (kernel module sysfs) |
+| `hip.*` | `hipconfig --version` / `--platform` / `--compiler` / `--runtime` / `--cpp_config` |
+| `hipblaslt.commit` | `HIPBLASLT_VERSION_TWEAK` define in `/opt/rocm/include/hipblaslt/hipblaslt-version.h` |
+| `hipblaslt.package_version` | `HIPBLASLT_VERSION_{MAJOR,MINOR,PATCH}` defines in the same header |
+| `hipblaslt.lib_hash` | `sha256(/opt/rocm/lib/libhipblaslt.so)` resolved through symlinks |
+| `hipblaslt.tensile_yaml_revision` | sha256 of sorted filenames of `*.yaml`/`*.dat`/`*.co` under `/opt/rocm/lib/hipblaslt/library/` |
+| `system_health` | `sudo -n -E rdhc --quick --json <tempfile>` |
+| `docker.image` / `docker.digest` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` env vars set by the launcher |
+| `docker.container_id` | `/proc/self/cgroup` |
+
+Path constants live in
+[`src/aorta/instrumentation/environment.py`](../src/aorta/instrumentation/environment.py)
+under `# Filesystem locations`. Tests in
+`tests/instrumentation/test_environment.py::TestPathConstants`
+structurally enforce that all of them are absolute and that the set
+is stable.
+
+## How to add a new env var
+
+See [the module README](../src/aorta/instrumentation/README.md#how-to-add-a-new-env-var-to-canonical_env_vars).
+Short version: edit `CANONICAL_ENV_VARS`, update
+`test_canonical_var_names_stable`, document why in your PR.
+
+## Testing the probe locally
+
+```bash
+# Assuming aorta is installed in your venv
+aorta env probe -o /tmp/env.json
+jq '.partial' /tmp/env.json
+jq '.partial_reasons' /tmp/env.json
+
+# Force the no-rdhc fallback (rdhc isn't on PATH)
+PATH= aorta env probe -o /tmp/env_no_rdhc.json
+jq '.system_health' /tmp/env_no_rdhc.json    # null
+jq '.hipblaslt.commit' /tmp/env_no_rdhc.json # still populated
+
+# Compare across docker images (manual until `aorta env matrix` lands)
+docker run --rm <image-A> aorta env probe -o /workspace/env_a.json
+docker run --rm <image-B> aorta env probe -o /workspace/env_b.json
+diff <(jq -S . env_a.json) <(jq -S . env_b.json)
+```
+
+## Out of scope (deferred to P1)
+
+* `aorta env matrix` (multi-docker fan-out)
+* `aorta env diff env_a.json env_b.json`
+* GPU kernel introspection (anything that runs HIP work)
+* Composable Kernel / rocBLAS commit + build state -- same pattern as
+  the `hipblaslt` block but a different code path; lands when a second
+  incident points at one of them
+* Workload config (`AMP_DTYPE`, `MODEL_DTYPE`, ...) -- captured by
+  `aorta run` in the trial result (Task B1), not by env probe
+
+## See also
+
+* Module reference: [`src/aorta/instrumentation/README.md`](../src/aorta/instrumentation/README.md)
+* Issue with the full acceptance criteria: [#147](https://github.com/ROCm/aorta/issues/147)

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -24,7 +24,11 @@ def env() -> None:
 @click.option(
     "--output",
     "-o",
-    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    # NOTE: deliberately not setting ``writable=True`` -- Click validates
+    # that during arg parsing, which fails for ``-o newdir/env.json``
+    # *before* we get a chance to ``mkdir`` the parent. We create the
+    # parent ourselves and let the actual write surface any I/O error.
+    type=click.Path(dir_okay=False, path_type=Path),
     default=Path("env.json"),
     show_default=True,
     help="Path to write env.json.",
@@ -36,7 +40,11 @@ def probe(output: Path) -> None:
     output = output.expanduser().resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
     snapshot = collect_env()
-    output.write_text(json.dumps(snapshot.to_dict(), indent=2, default=str))
+    # NOTE: deliberately not passing ``default=str`` -- the snapshot is
+    # supposed to be JSON-native (str/int/bool/None/list/dict). If a
+    # non-serializable type sneaks in (e.g. a Path or datetime), we want
+    # the failure to be loud rather than silently stringified.
+    output.write_text(json.dumps(snapshot.to_dict(), indent=2))
     partial = " [PARTIAL]" if snapshot.partial else ""
     click.echo(
         f"Wrote env probe to {output} "

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -1,27 +1,15 @@
-"""``aorta env`` - environment capture for trial reproducibility.
+"""``aorta env`` - thin CLI wrapper around :func:`collect_env`.
 
-The probe writes a versioned, schema-stable JSON snapshot of everything
-needed to interpret a trial result without re-running the workload:
-
-* ``system_health`` - verbatim output of ``rdhc --quick --json`` (or null
-  when RDHC / sudo is unavailable).
-* ``rocm`` - explicit reads of ``/opt/rocm/.info/version{,_dev}`` and
-  ``/sys/module/amdgpu/version``.
-* ``hip`` - ``hipconfig`` outputs (toolchain build state).
-* ``hipblaslt`` - commit + library hash + Tensile YAML revision +
-  applied-PR flags. Catches GEMM kernel library drift across docker
-  images / conda envs / venvs.
-* ``runtime_context`` - which container runtime + Python env we are in.
-* ``docker`` - image + digest when running inside a container.
-* ``env_vars`` - canonical list of HSA / RCCL / FBGEMM / PyTorch env vars.
-* ``python_version``, ``pytorch_version``.
-
-Implementation lives in :mod:`aorta.instrumentation.environment`. This
-module just wires it into the Click CLI.
+The library function in :mod:`aorta.instrumentation.environment` does all
+the probing; this module only handles arg parsing and writing the JSON
+snapshot to disk. Per #147 acceptance: this file does no probing of its
+own and stays under ~30 lines of substantive code (excluding the
+docstring above).
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import click
@@ -43,26 +31,15 @@ def env() -> None:
 )
 def probe(output: Path) -> None:
     """Capture trial-environment state to env.json (issue #147)."""
-    from aorta.instrumentation.environment import capture_environment
+    from aorta.instrumentation.environment import collect_env
 
     output = output.expanduser().resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
-    snapshot = capture_environment(output)
-    _print_brief(output, snapshot)
-
-
-def _print_brief(output: Path, snapshot: dict) -> None:
-    """Print a short, human-friendly summary of the captured env."""
-    click.echo(f"Wrote env probe to {output} (schema_version={snapshot.get('schema_version')})")
-    rt = snapshot.get("runtime_context") or {}
-    rocm = snapshot.get("rocm") or {}
-    hip = snapshot.get("hip") or {}
-    hipblaslt = snapshot.get("hipblaslt") or {}
-    sysh = snapshot.get("system_health")
-    click.echo(f"  runtime:  {rt.get('type', '?')} / python={rt.get('python_env', '?')}")
-    click.echo(f"  rocm:     {rocm.get('version', '?')} (dev: {rocm.get('version_dev', '?')})")
-    click.echo(f"  hip:      {hip.get('version', '?')} ({hip.get('platform', '?')})")
-    click.echo(f"  hipblaslt: commit={hipblaslt.get('commit', '?')}")
-    click.echo(f"  rdhc:     {'present' if sysh else 'unavailable (system_health=null)'}")
-    click.echo(f"  python:   {snapshot.get('python_version', '?')}")
-    click.echo(f"  pytorch:  {snapshot.get('pytorch_version', '?')}")
+    snapshot = collect_env()
+    output.write_text(json.dumps(snapshot.to_dict(), indent=2, default=str))
+    partial = " [PARTIAL]" if snapshot.partial else ""
+    click.echo(
+        f"Wrote env probe to {output} "
+        f"(schema_version={snapshot.schema_version}){partial}"
+    )
+    click.echo(snapshot.summary())

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -38,13 +38,30 @@ def probe(output: Path) -> None:
     from aorta.instrumentation.environment import collect_env
 
     output = output.expanduser().resolve()
-    output.parent.mkdir(parents=True, exist_ok=True)
+    # Wrap the two filesystem ops so common operator errors (unwritable
+    # parent, read-only mount, full disk, etc.) surface as a clean
+    # one-line Click error instead of a Python traceback. collect_env()
+    # itself never raises, so it stays outside the try blocks.
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise click.ClickException(
+            f"Failed to create parent directory for {output}: {exc}"
+        ) from exc
+
     snapshot = collect_env()
+
     # NOTE: deliberately not passing ``default=str`` -- the snapshot is
     # supposed to be JSON-native (str/int/bool/None/list/dict). If a
     # non-serializable type sneaks in (e.g. a Path or datetime), we want
     # the failure to be loud rather than silently stringified.
-    output.write_text(json.dumps(snapshot.to_dict(), indent=2))
+    try:
+        output.write_text(json.dumps(snapshot.to_dict(), indent=2))
+    except OSError as exc:
+        raise click.ClickException(
+            f"Failed to write env probe to {output}: {exc}"
+        ) from exc
+
     partial = " [PARTIAL]" if snapshot.partial else ""
     click.echo(
         f"Wrote env probe to {output} "

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -1,6 +1,33 @@
-"""`aorta env` - environment capture and comparison."""
+"""``aorta env`` - environment capture for trial reproducibility.
+
+The probe writes a versioned, schema-stable JSON snapshot of everything
+needed to interpret a trial result without re-running the workload:
+
+* ``system_health`` - verbatim output of ``rdhc --quick --json`` (or null
+  when RDHC / sudo is unavailable).
+* ``rocm`` - explicit reads of ``/opt/rocm/.info/version{,_dev}`` and
+  ``/sys/module/amdgpu/version``.
+* ``hip`` - ``hipconfig`` outputs (toolchain build state).
+* ``hipblaslt`` - commit + library hash + Tensile YAML revision +
+  applied-PR flags. Catches GEMM kernel library drift across docker
+  images / conda envs / venvs.
+* ``runtime_context`` - which container runtime + Python env we are in.
+* ``docker`` - image + digest when running inside a container.
+* ``env_vars`` - canonical list of HSA / RCCL / FBGEMM / PyTorch env vars.
+* ``python_version``, ``pytorch_version``.
+
+Implementation lives in :mod:`aorta.instrumentation.environment`. This
+module just wires it into the Click CLI.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
 
 import click
+
+log = logging.getLogger(__name__)
 
 
 @click.group()
@@ -12,14 +39,33 @@ def env() -> None:
 @click.option(
     "--output",
     "-o",
-    type=click.Path(dir_okay=False, writable=True),
-    default="env.json",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    default=Path("env.json"),
     show_default=True,
     help="Path to write env.json.",
 )
-def probe(output: str) -> None:
-    """Capture current GPU + library + env-var state to env.json.
+def probe(output: Path) -> None:
+    """Capture trial-environment state to env.json (issue #147)."""
+    from aorta.instrumentation.environment import capture_environment
 
-    Implemented by task A1 (instrumentation/environment.py).
-    """
-    raise click.ClickException("aorta env probe - not yet implemented (task A1)")
+    output = output.expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    snapshot = capture_environment(output)
+    _print_brief(output, snapshot)
+
+
+def _print_brief(output: Path, snapshot: dict) -> None:
+    """Print a short, human-friendly summary of the captured env."""
+    click.echo(f"Wrote env probe to {output} (schema_version={snapshot.get('schema_version')})")
+    rt = snapshot.get("runtime_context") or {}
+    rocm = snapshot.get("rocm") or {}
+    hip = snapshot.get("hip") or {}
+    hipblaslt = snapshot.get("hipblaslt") or {}
+    sysh = snapshot.get("system_health")
+    click.echo(f"  runtime:  {rt.get('type', '?')} / python={rt.get('python_env', '?')}")
+    click.echo(f"  rocm:     {rocm.get('version', '?')} (dev: {rocm.get('version_dev', '?')})")
+    click.echo(f"  hip:      {hip.get('version', '?')} ({hip.get('platform', '?')})")
+    click.echo(f"  hipblaslt: commit={hipblaslt.get('commit', '?')}")
+    click.echo(f"  rdhc:     {'present' if sysh else 'unavailable (system_health=null)'}")
+    click.echo(f"  python:   {snapshot.get('python_version', '?')}")
+    click.echo(f"  pytorch:  {snapshot.get('pytorch_version', '?')}")

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -22,12 +22,9 @@ module just wires it into the Click CLI.
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import click
-
-log = logging.getLogger(__name__)
 
 
 @click.group()

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -1,0 +1,179 @@
+# aorta.instrumentation
+
+Platform-level introspection for AORTA. The MVP is the env probe (issue
+#147); future submodules (NaN/numerics detector, drift watcher, etc.)
+will live here too.
+
+## What's here
+
+| Submodule | Purpose | Public API |
+| --- | --- | --- |
+| [`environment`](environment.py) | Snapshot the trial environment (rdhc + ROCm version files + hipconfig + hipBLASLt + container detection + canonical env vars + Python/PyTorch versions). | `collect_env() -> EnvSnapshot` |
+
+## env probe quick reference
+
+### Library API (the primary deliverable; B1 / B2 call this in-process)
+
+```python
+from aorta.instrumentation.environment import collect_env, EnvSnapshot
+
+snapshot: EnvSnapshot = collect_env()   # NEVER raises
+
+# Embed in a trial result and serialise
+trial_result["env"] = snapshot.to_dict()
+
+# Reconstruct from a previously persisted env.json blob
+rebuilt = EnvSnapshot.from_dict(loaded_json["env"])
+
+# Quick human summary (six lines, no external dependencies)
+print(snapshot.summary())
+```
+
+`EnvSnapshot` is a `@dataclass(frozen=True)` mirroring the env.json
+schema 1-to-1. Instances are safe to embed in trial / matrix results
+without worrying about mutation.
+
+### CLI (thin wrapper over `collect_env()`)
+
+```bash
+# Default path: ./env.json
+aorta env probe
+
+# Custom path; parent dirs are created if missing
+aorta env probe -o runs/exp1/env.json
+```
+
+After the run, `cat env.json` reveals the same dict that
+`snapshot.to_dict()` returns. The CLI also prints a six-line summary to
+stdout.
+
+### Fail-soft contract (`partial` / `partial_reasons`)
+
+`collect_env()` is documented as **never raises**. Two layers enforce
+that:
+
+1. Every probe is individually fail-soft. If a probe falls back to
+   `None` (rdhc not installed, /opt/rocm absent, hipconfig missing,
+   torch absent, ...), it appends a human-readable line to a shared
+   `partial_reasons: list[str]`. The snapshot's top-level `partial: bool`
+   is then `True`.
+2. The orchestrator body is wrapped in a top-level `try / except
+   Exception`. If anything truly unexpected raises (a stdlib call
+   misbehaves, a future probe is buggy, ...), the disaster-recovery
+   helper `_disaster_snapshot` constructs a fully-shaped `EnvSnapshot`
+   from defaults with the exception captured in `partial_reasons`.
+   Even the helper guards its own `_utc_now_iso` and
+   `platform.python_version` calls.
+
+Documented absences DO NOT trigger `partial`:
+
+* `docker == None` on baremetal (no container, nothing to record).
+* `env_vars[X] == None` for an unset env var (the documented contract).
+* `runtime_context.venv_path == None` outside a venv.
+
+### env.json schema (v1.0)
+
+See `EnvSnapshot` in [`environment.py`](environment.py) for the
+authoritative shape and field-by-field docstrings. Top-level keys:
+
+```
+schema_version    captured_at       partial         partial_reasons
+system_health     rocm              hip             hipblaslt
+runtime_context   docker            env_vars
+python_version    pytorch_version
+```
+
+Schema is **stable + versioned**. Add fields freely; never rename or
+remove without bumping `schema_version`. Empty `applied_prs: {}` may
+gain `pr_<id>_applied` keys later -- that is additive and does not bump
+the version.
+
+## How to add a new env var to `CANONICAL_ENV_VARS`
+
+The env var list in `environment.py` is **explicit, not prefix
+matching**. Adding a new variable is a deliberate three-step change so
+that what we capture stays auditable and reviewable.
+
+1. **Edit `CANONICAL_ENV_VARS`** in `src/aorta/instrumentation/environment.py`.
+   Group it with related vars under the matching `# HSA / runtime` /
+   `# GPU queue / codegen` / `# RCCL` / `# FBGEMM` / `# PyTorch / inductor`
+   comment. If it doesn't fit any group, add a new group with a short
+   header comment naming it.
+
+2. **Update the stability-guard test**:
+   `tests/instrumentation/test_environment.py::TestEnvVars::test_canonical_var_names_stable`
+   This is a literal `assert set(...) == {...}` over the canonical
+   list. Without updating it, your PR fails. The test exists to force
+   you to acknowledge that adding a variable is a schema-shape change
+   reviewers care about.
+
+3. **Document the addition** in your PR description: which workload /
+   library uses it, why it materially affects trial results, and a
+   pointer to the upstream documentation. The point of `CANONICAL_ENV_VARS`
+   is to capture variables that *change behaviour observably* -- if it
+   doesn't, it doesn't belong here.
+
+What does **not** belong here:
+
+* **Workload config** like `AMP_DTYPE`, `MODEL_DTYPE`,
+  `SHAMPOO_PRECONDITIONER_DTYPE`, model precision, optimizer
+  hyperparameters. Those are training-script arguments
+  (Hydra/argparse), captured by `aorta run` in the trial result
+  (Task B1). Some workloads forward them as env vars to subprocesses --
+  the env probe still does NOT capture them, since they are workload
+  state, not environment state.
+* **Anything you can capture by reading a file or running a tool**
+  (rocm version, hipconfig output, etc.). Those go in their own block.
+
+## How to add a new probe block
+
+Roughly the same pattern as the existing blocks (`_run_rdhc`,
+`_capture_rocm_version_files`, `_capture_hip_toolchain`, ...):
+
+1. Define probe constants (filesystem paths, command names) at module
+   scope, paired with provenance comments. Add to the
+   `TestPathConstants` parametrize list and the
+   `test_known_constant_set_is_stable` set.
+2. Write the probe as `_capture_<block>(reasons: list[str]) -> dict | None`.
+   It MUST NOT raise; catch every error path and return `None` plus a
+   `reasons.append(f"<block>.<field>: <reason>")` line.
+3. Add a field to `EnvSnapshot` and update `_disaster_snapshot` to
+   give it a sane default. The
+   `test_disaster_snapshot_populates_every_envsnapshot_field` test
+   forces this -- it enumerates `dataclasses.fields(EnvSnapshot)` and
+   fails if any are missing from the disaster path.
+4. Wire into `collect_env()`'s body inside the `try` block.
+5. Bump `SCHEMA_VERSION` if the addition isn't strictly additive
+   (renaming / removing a field never bumps; adding always-present
+   keys is additive).
+
+## Tests
+
+`tests/instrumentation/test_environment.py` has ~80 tests covering:
+
+* Schema completeness (every top-level key present in every snapshot)
+* Round-trip via `to_dict()` / `from_dict()` (incl. through JSON,
+  forward-compat with extra keys)
+* `collect_env()` never raises (probe-fail and unexpected-exception paths)
+* Per-probe behaviour (RDHC happy + four failure modes, ROCm files,
+  hipconfig, hipblaslt header parsing + lib hashing + tensile
+  fingerprint, runtime context detection, Docker metadata, env vars,
+  PyTorch version)
+* B1/B2-style integration: snapshot embeds in fake trial result and
+  round-trips through JSON
+* Idempotency: two calls produce equivalent snapshots
+* CLI thin-wrapper invariant (line count + no probing imports)
+* No-GPU-compute guard via fake torch in `sys.modules`
+* Disaster-snapshot completeness via `dataclasses.fields()`
+
+Run them with:
+
+```bash
+pytest tests/instrumentation/test_environment.py -v
+```
+
+## See also
+
+* User-facing how-to: [`docs/env-probe.md`](../../../docs/env-probe.md)
+* Issue with the full schema + acceptance criteria:
+  [#147](https://github.com/ROCm/aorta/issues/147)

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -47,6 +47,27 @@ After the run, `cat env.json` reveals the same dict that
 `snapshot.to_dict()` returns. The CLI also prints a six-line summary to
 stdout.
 
+### Installing RDHC for full `system_health` coverage
+
+`rdhc` (ROCm Deployment Health Check) is a system tool from the
+[`rocm-systems`](https://github.com/ROCm/rocm-systems/tree/main/projects/rocm-core/rdhc)
+repo, NOT a Python package. Aorta wraps it but does not vendor it -- if
+absent, the env probe still produces a complete snapshot with
+`system_health: null` and a `partial_reasons` entry pointing at the
+install path.
+
+It is not in `requirements.txt` because:
+
+* `rdhc` is not on PyPI.
+* Hard-pinning would break aorta on non-ROCm hosts, stripped ROCm
+  docker images, and CPU-only CI runners.
+* The fail-soft contract is the design: every snapshot is honest about
+  what it could and could not capture, the run continues either way.
+
+For the install commands (Ubuntu / RHEL / SLES / source), the
+passwordless-sudo recipe, and verification steps, see the user-facing
+guide: [`docs/env-probe.md`](../../../docs/env-probe.md#installing-rdhc).
+
 ### Fail-soft contract (`partial` / `partial_reasons`)
 
 `collect_env()` is documented as **never raises**. Two layers enforce

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -30,8 +30,11 @@ print(snapshot.summary())
 ```
 
 `EnvSnapshot` is a `@dataclass(frozen=True)` mirroring the env.json
-schema 1-to-1. Instances are safe to embed in trial / matrix results
-without worrying about mutation.
+schema 1-to-1. `frozen=True` prevents attribute rebinding on the
+snapshot itself (`snap.rocm = ...` raises), but does NOT deep-freeze
+the nested `dict` / `list` containers -- treat embedded snapshots as
+read-only and `deepcopy(snap.to_dict())` before mutating if you need
+to.
 
 ### CLI (thin wrapper over `collect_env()`)
 

--- a/src/aorta/instrumentation/__init__.py
+++ b/src/aorta/instrumentation/__init__.py
@@ -1,6 +1,7 @@
-"""Platform-level instrumentation: env probe, NaN/numerics detector, drift watcher.
+"""Platform-level instrumentation: env probe (issue #147) and friends.
 
-Engineer task A1 adds environment.py (env probe).
-Detector and watch_lite are deferred to P1 per D11 (MVP only needs env probe
-to support `aorta run` and `aorta triage --mode matrix`).
+Submodules:
+
+* :mod:`aorta.instrumentation.environment` - ``aorta env probe``: trial
+  reproducibility snapshot (RDHC + hipBLASLt + runtime context + env vars).
 """

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1,0 +1,521 @@
+"""``aorta env probe`` implementation (issue #147).
+
+Captures a versioned, schema-stable snapshot of the trial environment:
+
+* ``system_health`` -- verbatim ``rdhc --quick --json`` output (or null).
+* ``rocm`` -- explicit reads of ``/opt/rocm/.info/version{,_dev}`` and
+  ``/sys/module/amdgpu/version``.
+* ``hip`` -- ``hipconfig`` toolchain outputs.
+* ``hipblaslt`` -- commit + library hash + Tensile fingerprint + applied
+  PR flags.
+* ``runtime_context`` -- container runtime + Python env detection.
+* ``docker`` -- image + digest when in a container.
+* ``env_vars`` -- canonical list of HSA / RCCL / FBGEMM / PyTorch vars.
+* ``python_version``, ``pytorch_version``.
+
+No GPU compute. No tensor allocations. Target wall time: <15 s with rdhc
+present, <5 s without. Every capture function returns a fully-shaped dict
+with ``None`` for missing values, so the schema is stable: keys never go
+missing across environments.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import logging
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = "1.0"
+
+# RDHC subprocess budget. The issue caps at 30 s; we keep that to stay
+# inside the 30 s worst-case env probe budget.
+RDHC_TIMEOUT_SEC = 30.0
+
+# Generic per-subprocess budget for hipconfig, dpkg, etc. None of these
+# should take more than a second on a healthy host.
+SHORT_TIMEOUT_SEC = 5.0
+
+# Canonical env var list -- explicit, NOT prefix matching. Workload
+# config (AMP_DTYPE, MODEL_DTYPE, SHAMPOO_PRECONDITIONER_DTYPE) belongs
+# in the trial result emitted by ``aorta run`` (Task B1), so it is
+# deliberately absent here. Asserted by tests.
+CANONICAL_ENV_VARS: tuple[str, ...] = (
+    # HSA / runtime
+    "HSA_XNACK",
+    "HSA_KERNARG_POOL_SIZE",
+    "HSA_NO_SCRATCH_RECLAIM",
+    # GPU queue / codegen
+    "GPU_MAX_HW_QUEUES",
+    "AMDGCN_USE_BUFFER_OPS",
+    "DISABLE_TF32",
+    # RCCL / NCCL
+    "NCCL_MAX_NCHANNELS",
+    # FBGEMM
+    "FBGEMM_NO_JK",
+    "FBGEMM_TBE_V2",
+    "FBGEMM_TBE_ROCM_HIP_BACKWARD_KERNEL",
+    "FBGEMM_BOUNDS_CHECK_INDICES_V2",
+    # PyTorch / inductor
+    "TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE",
+    "PYTORCH_CUDA_ALLOC_CONF",
+)
+
+# Filesystem locations -- collected here so tests can monkeypatch them.
+ROCM_VERSION_FILE = Path("/opt/rocm/.info/version")
+ROCM_VERSION_DEV_FILE = Path("/opt/rocm/.info/version-dev")
+KMD_VERSION_FILE = Path("/sys/module/amdgpu/version")
+
+HIPBLASLT_VERSION_HEADER = Path("/opt/rocm/include/hipblaslt/hipblaslt-version.h")
+HIPBLASLT_LIB_DIR = Path("/opt/rocm/lib")
+HIPBLASLT_TENSILE_DIR = Path("/opt/rocm/lib/hipblaslt/library")
+
+DOCKERENV_MARKER = Path("/.dockerenv")
+PODMAN_CONTAINERENV_MARKER = Path("/run/.containerenv")
+CGROUP_FILE = Path("/proc/1/cgroup")
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator
+# ---------------------------------------------------------------------------
+
+
+def capture_environment(output_path: str | os.PathLike[str] = "env.json") -> dict[str, Any]:
+    """Capture the env probe snapshot and write it to ``output_path``.
+
+    Args:
+        output_path: File to write the JSON snapshot to. Parent dirs
+            created.
+
+    Returns:
+        The same dict that was written to disk.
+    """
+    output_path = Path(output_path).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    runtime_context = _detect_runtime_context()
+    snapshot: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "captured_at": _utc_now_iso(),
+        "system_health": _run_rdhc(output_path.parent / ".rdhc_quick.json"),
+        "rocm": _capture_rocm_version_files(),
+        "hip": _capture_hip_toolchain(),
+        "hipblaslt": _capture_hipblaslt(),
+        "runtime_context": runtime_context,
+        "docker": _capture_docker_metadata(runtime_context),
+        "env_vars": _capture_env_vars(),
+        "python_version": platform.python_version(),
+        "pytorch_version": _capture_pytorch_version(),
+    }
+
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(snapshot, f, indent=2, default=str, sort_keys=False)
+
+    log.info("Wrote env probe to %s (schema_version=%s)", output_path, SCHEMA_VERSION)
+    return snapshot
+
+
+def _utc_now_iso() -> str:
+    """ISO-8601 UTC timestamp with trailing 'Z' (per #147 schema example)."""
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# RDHC wrapper
+# ---------------------------------------------------------------------------
+
+
+def _run_rdhc(out_path: Path) -> dict | None:
+    """Run ``sudo -n -E rdhc --quick --json <path>`` and return parsed dict.
+
+    Returns None on any of:
+    * RDHC not installed (``shutil.which`` returns nothing for ``rdhc.py``
+      *and* ``rdhc``).
+    * ``sudo -n`` would prompt for a password (return code != 0).
+    * RDHC takes longer than ``RDHC_TIMEOUT_SEC``.
+    * RDHC exits non-zero or produces malformed JSON.
+
+    All failure modes log a single INFO line so users understand why
+    ``system_health`` is null. Never raises.
+    """
+    rdhc = shutil.which("rdhc.py") or shutil.which("rdhc")
+    if rdhc is None:
+        log.info("system_health=null: rdhc not on PATH")
+        return None
+
+    cmd = ["sudo", "-n", "-E", rdhc, "--quick", "--json", str(out_path)]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=RDHC_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        log.info("system_health=null: rdhc exceeded %.0fs timeout", RDHC_TIMEOUT_SEC)
+        return None
+    except (FileNotFoundError, OSError) as exc:
+        log.info("system_health=null: failed to invoke rdhc (%s)", exc)
+        return None
+
+    if result.returncode != 0:
+        # Most common cause: sudo -n requires a password.
+        log.info(
+            "system_health=null: rdhc exited %s (likely sudo-n unavailable)",
+            result.returncode,
+        )
+        return None
+
+    try:
+        return json.loads(out_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        log.info("system_health=null: rdhc output not parseable (%s)", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# ROCm version files
+# ---------------------------------------------------------------------------
+
+
+def _capture_rocm_version_files() -> dict[str, str | None]:
+    """Read ROCm version markers directly from disk.
+
+    These are explicit reads (not via RDHC) so that ``rocm.version`` is
+    populated even when RDHC is unavailable. All three keys are always
+    present; missing files yield ``None``.
+    """
+    return {
+        "version": _read_text_file(ROCM_VERSION_FILE),
+        "version_dev": _read_text_file(ROCM_VERSION_DEV_FILE),
+        "kmd_version": _read_text_file(KMD_VERSION_FILE),
+    }
+
+
+def _read_text_file(path: Path) -> str | None:
+    """Read a small text file; return its stripped contents or ``None``."""
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+        return text or None
+    except (FileNotFoundError, PermissionError, IsADirectoryError):
+        return None
+    except OSError as exc:
+        log.debug("read failed for %s: %s", path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# HIP toolchain
+# ---------------------------------------------------------------------------
+
+
+def _capture_hip_toolchain() -> dict[str, str | None]:
+    """Run ``hipconfig --<flag>`` for each toolchain field.
+
+    Issued as separate invocations because hipconfig prints results
+    concatenated when multiple flags are passed, with no delimiter -- a
+    single ``hipconfig --version --platform`` produces ``"7.2.5amd"``,
+    which is unparseable. Five short subprocesses still finish in <100 ms.
+    """
+    if shutil.which("hipconfig") is None:
+        log.info("hip block: hipconfig not on PATH; all hip.* fields = null")
+        return {
+            "version": None,
+            "platform": None,
+            "compiler": None,
+            "runtime": None,
+            "cpp_config": None,
+        }
+
+    return {
+        "version": _hipconfig("--version"),
+        "platform": _hipconfig("--platform"),
+        "compiler": _hipconfig("--compiler"),
+        "runtime": _hipconfig("--runtime"),
+        "cpp_config": _hipconfig("--cpp_config"),
+    }
+
+
+def _hipconfig(flag: str) -> str | None:
+    """Run ``hipconfig <flag>`` and return stripped stdout (or None)."""
+    try:
+        result = subprocess.run(
+            ["hipconfig", flag],
+            capture_output=True,
+            text=True,
+            timeout=SHORT_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    out = (result.stdout or "").strip()
+    return out or None
+
+
+# ---------------------------------------------------------------------------
+# hipBLASLt introspection
+# ---------------------------------------------------------------------------
+
+
+# The version-tweak field in hipblaslt-version.h is the canonical source
+# for the build's git SHA (typically a 7-12 char short hash).
+_HIPBLASLT_TWEAK_RE = re.compile(
+    r"#define\s+HIPBLASLT_VERSION_TWEAK\s+([A-Za-z0-9_.+-]+)"
+)
+_HIPBLASLT_VERSION_RE = re.compile(
+    r"#define\s+HIPBLASLT_VERSION_(MAJOR|MINOR|PATCH)\s+(\d+)"
+)
+
+
+def _capture_hipblaslt() -> dict[str, Any]:
+    """Capture hipBLASLt build identity.
+
+    Goal: catch GEMM kernel library drift across docker images / conda
+    envs / venvs. See issue #147 motivation.
+
+    The ``applied_prs`` block is intentionally empty in this first cut.
+    Adding ``pr_<id>_applied`` keys later is additive and does not bump
+    ``schema_version``. Each PR detector needs a unique signature
+    (symbol via ``nm``, string via ``strings``, or Tensile YAML revision
+    bump) -- those will land in a follow-up alongside the first PR we
+    care to track.
+    """
+    header_text = _read_text_file(HIPBLASLT_VERSION_HEADER)
+    commit, package_version = _parse_hipblaslt_header(header_text)
+    return {
+        "commit": commit,
+        "package_version": package_version,
+        "lib_hash": _hash_hipblaslt_library(),
+        "tensile_yaml_revision": _tensile_fingerprint(),
+        "applied_prs": {},  # filled in once specific PRs are configured
+    }
+
+
+def _parse_hipblaslt_header(text: str | None) -> tuple[str | None, str | None]:
+    """Extract commit (TWEAK) and package_version (MAJOR.MINOR.PATCH).
+
+    Returns (commit, package_version), each ``None`` if the header was
+    missing or did not contain the expected defines.
+    """
+    if not text:
+        return (None, None)
+    tweak_match = _HIPBLASLT_TWEAK_RE.search(text)
+    commit = tweak_match.group(1) if tweak_match else None
+    parts: dict[str, str] = {}
+    for match in _HIPBLASLT_VERSION_RE.finditer(text):
+        parts[match.group(1)] = match.group(2)
+    if {"MAJOR", "MINOR", "PATCH"}.issubset(parts):
+        package_version = f"{parts['MAJOR']}.{parts['MINOR']}.{parts['PATCH']}"
+    else:
+        package_version = None
+    return (commit, package_version)
+
+
+def _hash_hipblaslt_library() -> str | None:
+    """SHA-256 the canonical (resolved) ``libhipblaslt.so``.
+
+    Resolves through symlinks so e.g. ``libhipblaslt.so`` ->
+    ``libhipblaslt.so.1`` -> ``libhipblaslt.so.1.2.70201`` collapses to one
+    hash regardless of which name the consumer linked against.
+    Returns ``"sha256:<hex>"`` or ``None``.
+    """
+    candidate = HIPBLASLT_LIB_DIR / "libhipblaslt.so"
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        digest = hashlib.sha256()
+        with resolved.open("rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+    except OSError as exc:
+        log.debug("hash failed for %s: %s", resolved, exc)
+        return None
+
+
+def _tensile_fingerprint() -> str | None:
+    """Fingerprint the Tensile kernel database.
+
+    Modern hipBLASLt ships ``.dat`` files (binary), older builds shipped
+    ``.yaml``. We hash the **sorted filenames** of all kernel files in
+    the library dir -- a fast, deterministic fingerprint that changes
+    whenever the kernel set changes (new gfx target, new operation
+    layout, removed kernel). Hashing the contents would be GB of work
+    and add seconds; the filename set already tracks the meaningful
+    drift.
+    """
+    if not HIPBLASLT_TENSILE_DIR.is_dir():
+        return None
+    try:
+        names = sorted(
+            p.name
+            for p in HIPBLASLT_TENSILE_DIR.iterdir()
+            if p.is_file() and p.suffix in (".yaml", ".dat", ".co")
+        )
+    except OSError as exc:
+        log.debug("tensile dir listing failed: %s", exc)
+        return None
+    if not names:
+        return None
+    digest = hashlib.sha256("\n".join(names).encode("utf-8")).hexdigest()
+    return f"filenames-sha256:{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Runtime context: container + Python env detection
+# ---------------------------------------------------------------------------
+
+
+def _detect_runtime_context() -> dict[str, str | None]:
+    """Detect container runtime + Python environment.
+
+    Container precedence (first match wins):
+        1. ``/.dockerenv`` -> docker
+        2. ``/run/.containerenv`` -> podman
+        3. ``SINGULARITY_NAME`` env var or ``singularity`` in
+           ``/proc/1/cgroup`` -> singularity
+        4. ``docker`` / ``podman`` / ``containerd`` token in
+           ``/proc/1/cgroup`` -> matched runtime (cgroup fallback)
+        5. otherwise -> baremetal
+
+    Python env precedence:
+        1. ``$CONDA_DEFAULT_ENV`` -> conda
+        2. ``sys.prefix != sys.base_prefix`` -> venv
+        3. otherwise -> system
+    """
+    container_type = _detect_container_type()
+    python_env = _detect_python_env()
+    return {
+        "type": container_type,
+        "python_env": python_env,
+        "venv_path": str(sys.prefix) if python_env == "venv" else None,
+        "conda_env_name": (
+            os.environ.get("CONDA_DEFAULT_ENV") if python_env == "conda" else None
+        ),
+    }
+
+
+def _detect_container_type() -> str:
+    """Resolve the container runtime; ``"baremetal"`` if none matched."""
+    if DOCKERENV_MARKER.exists():
+        return "docker"
+    if PODMAN_CONTAINERENV_MARKER.exists():
+        return "podman"
+    if os.environ.get("SINGULARITY_NAME"):
+        return "singularity"
+
+    cgroup = _read_text_file(CGROUP_FILE)
+    if cgroup:
+        # cgroup lines look like '12:freezer:/docker/<id>' or
+        # '0::/system.slice/docker-<id>.scope'. Detect the first runtime
+        # name that appears.
+        for runtime in ("docker", "podman", "singularity", "containerd"):
+            if runtime in cgroup:
+                return runtime
+    return "baremetal"
+
+
+def _detect_python_env() -> str:
+    """Return ``"conda"``, ``"venv"``, or ``"system"``."""
+    if os.environ.get("CONDA_DEFAULT_ENV"):
+        return "conda"
+    # sys.base_prefix differs from sys.prefix inside a venv (PEP 405).
+    if getattr(sys, "base_prefix", sys.prefix) != sys.prefix:
+        return "venv"
+    return "system"
+
+
+# ---------------------------------------------------------------------------
+# Docker metadata
+# ---------------------------------------------------------------------------
+
+
+def _capture_docker_metadata(
+    runtime_context: dict[str, str | None],
+) -> dict[str, str | None] | None:
+    """Capture image + digest when running inside a container.
+
+    Returns ``None`` for baremetal -- there is no image to record.
+    For containerised runs we emit the block with best-effort values; the
+    aorta-side launcher can populate them via the env vars below before
+    invoking ``aorta env probe`` (which is the only reliable way to know
+    image+digest from inside a container without privileged docker access):
+
+    * ``AORTA_DOCKER_IMAGE``  -> ``docker.image``
+    * ``AORTA_DOCKER_DIGEST`` -> ``docker.digest``
+
+    Always also emits ``container_id`` parsed from ``/proc/self/cgroup``,
+    which is recoverable from inside the container.
+    """
+    if runtime_context.get("type") == "baremetal":
+        return None
+
+    return {
+        "image": os.environ.get("AORTA_DOCKER_IMAGE"),
+        "digest": os.environ.get("AORTA_DOCKER_DIGEST"),
+        "container_id": _read_container_id(),
+    }
+
+
+_CONTAINER_ID_RE = re.compile(r"[0-9a-f]{12,64}")
+
+
+def _read_container_id() -> str | None:
+    """Pull the container ID out of ``/proc/self/cgroup`` if present."""
+    text = _read_text_file(Path("/proc/self/cgroup"))
+    if not text:
+        return None
+    for line in text.splitlines():
+        match = _CONTAINER_ID_RE.search(line)
+        if match:
+            return match.group(0)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Env vars + Python/PyTorch
+# ---------------------------------------------------------------------------
+
+
+def _capture_env_vars() -> dict[str, str | None]:
+    """Capture canonical env vars (explicit list, not prefix matching)."""
+    return {name: os.environ.get(name) for name in CANONICAL_ENV_VARS}
+
+
+def _capture_pytorch_version() -> str | None:
+    """Best-effort import of torch to read its version. No GPU touched.
+
+    ``import torch`` does NOT initialise CUDA / HIP context; it only
+    populates Python objects. Acceptance criterion "no GPU compute" is
+    preserved.
+    """
+    try:
+        import torch  # type: ignore[import-not-found]
+
+        return str(getattr(torch, "__version__", None))
+    except ImportError:
+        return None
+    except Exception as exc:  # noqa: BLE001 -- defensive; never let env probe fail
+        log.debug("torch version probe failed: %s", exc)
+        return None

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -146,8 +146,13 @@ class EnvSnapshot:
     """Wraps the env.json schema as a typed object.
 
     Attributes mirror the env.json keys 1-to-1; ``to_dict()`` / ``from_dict()``
-    round-trip losslessly. Dataclass is frozen so callers can safely embed it
-    in trial / matrix results without worrying about mutation.
+    round-trip losslessly. The dataclass is ``frozen=True``, which prevents
+    *attribute rebinding* on the snapshot itself (``snap.rocm = ...`` raises),
+    but it does NOT deep-freeze the nested ``dict`` / ``list`` containers --
+    callers can still mutate ``snap.rocm["version"] = ...`` or
+    ``snap.partial_reasons.append(...)`` in place. Treat embedded snapshots
+    as read-only; if you need to modify, deep-copy first via
+    ``EnvSnapshot.from_dict(copy.deepcopy(snap.to_dict()))``.
 
     The two fail-soft fields make the snapshot honest about partial captures:
 

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -130,10 +130,17 @@ HIPBLASLT_TENSILE_DIR = Path(
 # Container runtime detection markers.
 # /.dockerenv -- created by Docker since the early days.
 # /run/.containerenv -- created by Podman.
-# /proc/1/cgroup -- last-resort cgroup token sniff (per OCI conventions).
+# /proc/1/cgroup -- the init process's cgroup; last-resort cgroup token
+#   sniff for the runtime *type* (docker / podman / singularity), per
+#   OCI conventions.
+# /proc/self/cgroup -- the current process's cgroup, parsed for the
+#   container *ID* (a 12-64 hex SHA segment). Distinct file, distinct
+#   purpose -- both go in the constants block so tests can monkeypatch
+#   either without touching the real /proc.
 DOCKERENV_MARKER = Path("/.dockerenv")
 PODMAN_CONTAINERENV_MARKER = Path("/run/.containerenv")
 CGROUP_FILE = Path("/proc/1/cgroup")
+SELF_CGROUP_FILE = Path("/proc/self/cgroup")
 
 
 # ---------------------------------------------------------------------------
@@ -872,8 +879,13 @@ _CONTAINER_ID_RE = re.compile(r"[0-9a-f]{12,64}")
 
 
 def _read_container_id() -> str | None:
-    """Pull the container ID out of ``/proc/self/cgroup`` if present."""
-    text = _read_text_file(Path("/proc/self/cgroup"))
+    """Pull the container ID out of ``SELF_CGROUP_FILE`` if present.
+
+    Reads the *current* process's cgroup (not init's) -- the container
+    ID lives there as a 12-64 hex segment (e.g. ``/docker/<id>/`` or
+    ``/system.slice/docker-<id>.scope``).
+    """
+    text = _read_text_file(SELF_CGROUP_FILE)
     if not text:
         return None
     for line in text.splitlines():

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -59,6 +59,12 @@ SCHEMA_VERSION = "1.0"
 # inside the 30 s worst-case env probe budget.
 RDHC_TIMEOUT_SEC = 30.0
 
+# Pointer appended to install-related rdhc partial_reasons so operators
+# who hit ``system_health: null`` find the install + sudo recipe right
+# away. Not appended to timeout / parse-failure reasons -- those are
+# rdhc-side runtime issues, not install issues.
+_RDHC_INSTALL_HINT = "see docs/env-probe.md#installing-rdhc"
+
 # Generic per-subprocess budget for hipconfig, dpkg, etc. None of these
 # should take more than a second on a healthy host.
 SHORT_TIMEOUT_SEC = 5.0
@@ -380,7 +386,7 @@ def _run_rdhc(reasons: list[str]) -> dict | None:
     """
     rdhc = shutil.which("rdhc.py") or shutil.which("rdhc")
     if rdhc is None:
-        msg = "system_health: rdhc not on PATH"
+        msg = f"system_health: rdhc not on PATH ({_RDHC_INSTALL_HINT})"
         log.info(msg)
         reasons.append(msg)
         return None
@@ -415,7 +421,13 @@ def _run_rdhc(reasons: list[str]) -> dict | None:
             reasons.append(msg)
             return None
         except (FileNotFoundError, OSError) as exc:
-            msg = f"system_health: failed to invoke rdhc ({exc})"
+            # Same actionable hint as the not-on-PATH branch -- if exec
+            # itself fails (e.g. broken interpreter shebang in a stripped
+            # image), reinstalling rocm-systems is usually the fix.
+            msg = (
+                f"system_health: failed to invoke rdhc ({exc}) "
+                f"({_RDHC_INSTALL_HINT})"
+            )
             log.info(msg)
             reasons.append(msg)
             return None
@@ -425,6 +437,10 @@ def _run_rdhc(reasons: list[str]) -> dict | None:
             # partial_reasons readable in CLI output and JSON. Falls back
             # to "(no stderr; likely sudo-n unavailable)" when the child
             # printed nothing -- which is what the no-password case does.
+            # The install hint is only appended for the no-stderr case
+            # (where sudo config is the likely fix); when rdhc DOES print
+            # to stderr the operator should debug from that, not from a
+            # generic install link.
             stderr_lines = (result.stderr or "").splitlines()
             stderr_tail = next(
                 (line.strip() for line in reversed(stderr_lines) if line.strip()),
@@ -433,7 +449,9 @@ def _run_rdhc(reasons: list[str]) -> dict | None:
             if stderr_tail:
                 detail = f"stderr: {stderr_tail[:200]}"
             else:
-                detail = "no stderr; likely sudo-n unavailable"
+                detail = (
+                    f"no stderr; likely sudo-n unavailable ({_RDHC_INSTALL_HINT})"
+                )
             msg = (
                 f"system_health: rdhc exited {result.returncode} ({detail})"
             )

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -210,44 +210,112 @@ class EnvSnapshot:
 def collect_env() -> EnvSnapshot:
     """Capture the current process environment as an :class:`EnvSnapshot`.
 
-    NEVER raises. On any probe failure (rdhc unavailable, no sudo,
-    /opt/rocm missing, hipconfig not on PATH, hipBLASLt header missing,
-    torch absent, etc.), the corresponding fields are set to ``None`` and
-    ``partial=True`` with a human-readable reason appended to
-    ``partial_reasons``.
+    NEVER raises. The promise is enforced two ways:
 
-    Callers (B1 dispatcher, B2 matrix runner, CLI) treat the snapshot as
-    always-valid and never as a failure path -- they may surface a warning
-    when ``partial=True`` but the run continues.
+    * Every probe is individually fail-soft (returns None or a shaped
+      dict; appends a human-readable reason to a shared list on fallback).
+    * The orchestrator body is wrapped in a top-level ``try / except
+      Exception``. If anything genuinely unexpected raises (a stdlib call
+      misbehaves, a probe is buggy, etc.), the disaster-recovery helper
+      :func:`_disaster_snapshot` constructs a minimally-shaped
+      :class:`EnvSnapshot` with ``partial=True`` and the original
+      exception captured in ``partial_reasons``. Callers (B1 dispatcher,
+      B2 matrix runner, CLI) always get back a valid object.
 
-    No GPU compute. No tensor allocations. The optional ``import torch`` for
-    the version probe does NOT initialise CUDA / HIP context.
+    No GPU compute. No tensor allocations. The optional ``import torch``
+    for the version probe does NOT initialise CUDA / HIP context.
     """
     reasons: list[str] = []
+    try:
+        runtime_context = _detect_runtime_context()  # never partial; always populates
+        system_health = _run_rdhc(reasons)
+        rocm = _capture_rocm_version_files(reasons)
+        hip = _capture_hip_toolchain(reasons)
+        hipblaslt = _capture_hipblaslt(reasons)
+        docker = _capture_docker_metadata(runtime_context, reasons)
+        env_vars = _capture_env_vars()  # individual nulls are documented, not partial
+        pytorch_version = _capture_pytorch_version(reasons)
 
-    runtime_context = _detect_runtime_context()  # never partial; always populates
-    system_health = _run_rdhc(reasons)
-    rocm = _capture_rocm_version_files(reasons)
-    hip = _capture_hip_toolchain(reasons)
-    hipblaslt = _capture_hipblaslt(reasons)
-    docker = _capture_docker_metadata(runtime_context, reasons)
-    env_vars = _capture_env_vars()  # individual nulls are documented, not partial
-    pytorch_version = _capture_pytorch_version(reasons)
+        return EnvSnapshot(
+            schema_version=SCHEMA_VERSION,
+            captured_at=_utc_now_iso(),
+            system_health=system_health,
+            rocm=rocm,
+            hip=hip,
+            hipblaslt=hipblaslt,
+            runtime_context=runtime_context,
+            docker=docker,
+            env_vars=env_vars,
+            python_version=platform.python_version(),
+            pytorch_version=pytorch_version,
+            partial=bool(reasons),
+            partial_reasons=reasons,
+        )
+    except Exception as exc:  # noqa: BLE001 -- this is the never-raises gate
+        log.info("collect_env() hit unexpected exception", exc_info=True)
+        return _disaster_snapshot(
+            preceding_reasons=reasons,
+            unexpected_reason=(
+                f"collect_env: unexpected failure "
+                f"({type(exc).__name__}: {exc})"
+            ),
+        )
+
+
+def _disaster_snapshot(
+    preceding_reasons: list[str], unexpected_reason: str
+) -> EnvSnapshot:
+    """Return a minimally-shaped EnvSnapshot when collect_env crashes.
+
+    Used by the never-raises top-level guard. Every field gets a sane
+    null/empty default so downstream consumers (B1, B2, jq pipelines)
+    still see the schema they expect, with ``partial=True`` and the
+    triggering exception in ``partial_reasons``.
+
+    Even helpers used here are guarded -- if ``_utc_now_iso`` or
+    ``platform.python_version`` themselves raise, we fall back to empty
+    strings rather than re-throw.
+    """
+    try:
+        captured_at = _utc_now_iso()
+    except Exception:  # noqa: BLE001
+        captured_at = ""
+    try:
+        python_version = platform.python_version()
+    except Exception:  # noqa: BLE001
+        python_version = ""
 
     return EnvSnapshot(
         schema_version=SCHEMA_VERSION,
-        captured_at=_utc_now_iso(),
-        system_health=system_health,
-        rocm=rocm,
-        hip=hip,
-        hipblaslt=hipblaslt,
-        runtime_context=runtime_context,
-        docker=docker,
-        env_vars=env_vars,
-        python_version=platform.python_version(),
-        pytorch_version=pytorch_version,
-        partial=bool(reasons),
-        partial_reasons=reasons,
+        captured_at=captured_at,
+        system_health=None,
+        rocm={"version": None, "version_dev": None, "kmd_version": None},
+        hip={
+            "version": None,
+            "platform": None,
+            "compiler": None,
+            "runtime": None,
+            "cpp_config": None,
+        },
+        hipblaslt={
+            "commit": None,
+            "package_version": None,
+            "lib_hash": None,
+            "tensile_yaml_revision": None,
+            "applied_prs": {},
+        },
+        runtime_context={
+            "type": "baremetal",
+            "python_env": "system",
+            "venv_path": None,
+            "conda_env_name": None,
+        },
+        docker=None,
+        env_vars=dict.fromkeys(CANONICAL_ENV_VARS),
+        python_version=python_version,
+        pytorch_version=None,
+        partial=True,
+        partial_reasons=[*preceding_reasons, unexpected_reason],
     )
 
 
@@ -325,9 +393,21 @@ def _run_rdhc(reasons: list[str]) -> dict | None:
             return None
 
         if result.returncode != 0:
+            # Pull the last non-empty line of stderr; truncate to keep
+            # partial_reasons readable in CLI output and JSON. Falls back
+            # to "(no stderr; likely sudo-n unavailable)" when the child
+            # printed nothing -- which is what the no-password case does.
+            stderr_lines = (result.stderr or "").splitlines()
+            stderr_tail = next(
+                (line.strip() for line in reversed(stderr_lines) if line.strip()),
+                "",
+            )
+            if stderr_tail:
+                detail = f"stderr: {stderr_tail[:200]}"
+            else:
+                detail = "no stderr; likely sudo-n unavailable"
             msg = (
-                f"system_health: rdhc exited {result.returncode} "
-                "(likely sudo-n unavailable)"
+                f"system_health: rdhc exited {result.returncode} ({detail})"
             )
             log.info(msg)
             reasons.append(msg)
@@ -369,9 +449,14 @@ def _capture_rocm_version_files(reasons: list[str]) -> dict[str, str | None]:
         "version_dev": ROCM_VERSION_DEV_FILE,
         "kmd_version": KMD_VERSION_FILE,
     }
+    # Note: _read_text_file returns None for missing, empty, permission
+    # denied, AND non-utf8 cases. Reason wording covers all four so the
+    # operator does not assume "missing" when the file is just empty.
     for key, value in block.items():
         if value is None:
-            reasons.append(f"rocm.{key}: {paths[key]} not readable")
+            reasons.append(
+                f"rocm.{key}: {paths[key]} missing, empty, or unreadable"
+            )
     return block
 
 
@@ -520,12 +605,16 @@ def _capture_hipblaslt(reasons: list[str]) -> dict[str, Any]:
             )
     if lib_hash is None:
         reasons.append(
-            f"hipblaslt.lib_hash: {HIPBLASLT_LIB_DIR}/libhipblaslt.so not readable"
+            f"hipblaslt.lib_hash: {HIPBLASLT_LIB_DIR}/libhipblaslt.so "
+            "missing or unreadable"
         )
     if tensile_yaml_revision is None:
+        # _tensile_fingerprint returns None for both "directory missing /
+        # unlistable" AND "directory present but no kernel files" --
+        # the wording covers both so partial_reasons is honest.
         reasons.append(
-            f"hipblaslt.tensile_yaml_revision: no kernel files under "
-            f"{HIPBLASLT_TENSILE_DIR}"
+            "hipblaslt.tensile_yaml_revision: directory missing/unreadable "
+            f"or no kernel files under {HIPBLASLT_TENSILE_DIR}"
         )
     return block
 

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -89,14 +89,42 @@ CANONICAL_ENV_VARS: tuple[str, ...] = (
 )
 
 # Filesystem locations -- collected here so tests can monkeypatch them.
-ROCM_VERSION_FILE = Path("/opt/rocm/.info/version")
-ROCM_VERSION_DEV_FILE = Path("/opt/rocm/.info/version-dev")
-KMD_VERSION_FILE = Path("/sys/module/amdgpu/version")
+# Each constant is paired with a short note on the source so future
+# editors don't have to rediscover where the data comes from.
+#
+# All paths verified against:
+#   - host: ROCm 7.2.1 baremetal install
+#   - rocm/pytorch:7.2.0 docker image
+#   - rocm/pytorch:7.0.2.1 docker image (`version_dev` legitimately absent)
+# Each path is absolute; the structural test in
+# tests/instrumentation/test_environment.py::TestPathConstants
+# enforces this so a future relative-path typo fails fast.
 
-HIPBLASLT_VERSION_HEADER = Path("/opt/rocm/include/hipblaslt/hipblaslt-version.h")
-HIPBLASLT_LIB_DIR = Path("/opt/rocm/lib")
-HIPBLASLT_TENSILE_DIR = Path("/opt/rocm/lib/hipblaslt/library")
+# Per #147 schema: "Explicit ROCm version files".
+# /opt/rocm is conventionally a symlink to the active versioned install
+# (e.g., /opt/rocm-7.2.1), so /opt/rocm/.info/version always points at the
+# active release.
+ROCM_VERSION_FILE = Path("/opt/rocm/.info/version")            # release tag, e.g. "7.2.1"
+ROCM_VERSION_DEV_FILE = Path("/opt/rocm/.info/version-dev")    # full build, e.g. "7.2.1-43"
+# Linux kernel-side AMDGPU module version (KMD = kernel-mode driver).
+# Provided by the kernel since the amdgpu module exposes a sysfs `version`.
+KMD_VERSION_FILE = Path("/sys/module/amdgpu/version")          # e.g. "6.16.13"
 
+# hipBLASLt build identity sources. The version header ships in the
+# hipblaslt-dev package; on hosts without it, _capture_hipblaslt's commit
+# / package_version fields fall back to None with a recorded reason.
+HIPBLASLT_VERSION_HEADER = Path(
+    "/opt/rocm/include/hipblaslt/hipblaslt-version.h"
+)
+HIPBLASLT_LIB_DIR = Path("/opt/rocm/lib")  # libhipblaslt.so* lives here
+HIPBLASLT_TENSILE_DIR = Path(
+    "/opt/rocm/lib/hipblaslt/library"
+)  # Tensile kernel database (.dat on modern builds, .yaml on older)
+
+# Container runtime detection markers.
+# /.dockerenv -- created by Docker since the early days.
+# /run/.containerenv -- created by Podman.
+# /proc/1/cgroup -- last-resort cgroup token sniff (per OCI conventions).
 DOCKERENV_MARKER = Path("/.dockerenv")
 PODMAN_CONTAINERENV_MARKER = Path("/run/.containerenv")
 CGROUP_FILE = Path("/proc/1/cgroup")

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -31,6 +31,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -108,7 +109,7 @@ def capture_environment(output_path: str | os.PathLike[str] = "env.json") -> dic
     snapshot: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "captured_at": _utc_now_iso(),
-        "system_health": _run_rdhc(output_path.parent / ".rdhc_quick.json"),
+        "system_health": _run_rdhc(),
         "rocm": _capture_rocm_version_files(),
         "hip": _capture_hip_toolchain(),
         "hipblaslt": _capture_hipblaslt(),
@@ -141,8 +142,11 @@ def _utc_now_iso() -> str:
 # ---------------------------------------------------------------------------
 
 
-def _run_rdhc(out_path: Path) -> dict | None:
-    """Run ``sudo -n -E rdhc --quick --json <path>`` and return parsed dict.
+def _run_rdhc() -> dict | None:
+    """Run ``sudo -n -E rdhc --quick --json <tmp>`` and return parsed dict.
+
+    Manages its own temp file via :mod:`tempfile` -- nothing leaks into
+    the env probe's output directory.
 
     Returns None on any of:
     * RDHC not installed (``shutil.which`` returns nothing for ``rdhc.py``
@@ -159,35 +163,50 @@ def _run_rdhc(out_path: Path) -> dict | None:
         log.info("system_health=null: rdhc not on PATH")
         return None
 
-    cmd = ["sudo", "-n", "-E", rdhc, "--quick", "--json", str(out_path)]
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=RDHC_TIMEOUT_SEC,
-            check=False,
-        )
-    except subprocess.TimeoutExpired:
-        log.info("system_health=null: rdhc exceeded %.0fs timeout", RDHC_TIMEOUT_SEC)
-        return None
-    except (FileNotFoundError, OSError) as exc:
-        log.info("system_health=null: failed to invoke rdhc (%s)", exc)
-        return None
-
-    if result.returncode != 0:
-        # Most common cause: sudo -n requires a password.
-        log.info(
-            "system_health=null: rdhc exited %s (likely sudo-n unavailable)",
-            result.returncode,
-        )
-        return None
+    # NamedTemporaryFile with delete=False so we control cleanup ourselves
+    # in the finally block (sudo'd subprocess writes to this path; the
+    # default delete=True closes the fd before subprocess can use it on
+    # some platforms).
+    with tempfile.NamedTemporaryFile(
+        suffix=".json", prefix="rdhc_quick_", delete=False
+    ) as tmp:
+        tmp_path = Path(tmp.name)
 
     try:
-        return json.loads(out_path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
-        log.info("system_health=null: rdhc output not parseable (%s)", exc)
-        return None
+        cmd = ["sudo", "-n", "-E", rdhc, "--quick", "--json", str(tmp_path)]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=RDHC_TIMEOUT_SEC,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            log.info("system_health=null: rdhc exceeded %.0fs timeout", RDHC_TIMEOUT_SEC)
+            return None
+        except (FileNotFoundError, OSError) as exc:
+            log.info("system_health=null: failed to invoke rdhc (%s)", exc)
+            return None
+
+        if result.returncode != 0:
+            # Most common cause: sudo -n requires a password.
+            log.info(
+                "system_health=null: rdhc exited %s (likely sudo-n unavailable)",
+                result.returncode,
+            )
+            return None
+
+        try:
+            return json.loads(tmp_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+            log.info("system_health=null: rdhc output not parseable (%s)", exc)
+            return None
+    finally:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -390,13 +409,20 @@ def _tensile_fingerprint() -> str | None:
 def _detect_runtime_context() -> dict[str, str | None]:
     """Detect container runtime + Python environment.
 
+    The schema's allowed values for ``runtime_context.type`` are
+    ``docker | podman | singularity | baremetal`` (per #147). To keep
+    strict consumers safe, this function only ever returns one of those
+    four; runtimes outside the documented set (e.g. containerd-managed
+    Kubernetes pods) currently fall through to ``baremetal``. Adding new
+    values is a schema change and would bump ``schema_version``.
+
     Container precedence (first match wins):
         1. ``/.dockerenv`` -> docker
         2. ``/run/.containerenv`` -> podman
         3. ``SINGULARITY_NAME`` env var or ``singularity`` in
            ``/proc/1/cgroup`` -> singularity
-        4. ``docker`` / ``podman`` / ``containerd`` token in
-           ``/proc/1/cgroup`` -> matched runtime (cgroup fallback)
+        4. ``docker`` / ``podman`` token in ``/proc/1/cgroup``
+           -> matched runtime (cgroup fallback for stripped containers)
         5. otherwise -> baremetal
 
     Python env precedence:
@@ -429,8 +455,8 @@ def _detect_container_type() -> str:
     if cgroup:
         # cgroup lines look like '12:freezer:/docker/<id>' or
         # '0::/system.slice/docker-<id>.scope'. Detect the first runtime
-        # name that appears.
-        for runtime in ("docker", "podman", "singularity", "containerd"):
+        # name that appears. Limited to schema-documented values.
+        for runtime in ("docker", "podman", "singularity"):
             if runtime in cgroup:
                 return runtime
     return "baremetal"
@@ -509,13 +535,21 @@ def _capture_pytorch_version() -> str | None:
     ``import torch`` does NOT initialise CUDA / HIP context; it only
     populates Python objects. Acceptance criterion "no GPU compute" is
     preserved.
+
+    Returns the version as a string when available, or ``None`` when torch
+    is not installed OR is installed without a ``__version__`` attribute.
+    Never returns the string ``"None"`` -- that would break consumers
+    doing strict null checks against the JSON.
     """
     try:
         import torch  # type: ignore[import-not-found]
-
-        return str(getattr(torch, "__version__", None))
     except ImportError:
         return None
     except Exception as exc:  # noqa: BLE001 -- defensive; never let env probe fail
-        log.debug("torch version probe failed: %s", exc)
+        log.debug("torch import for version probe failed: %s", exc)
         return None
+
+    version = getattr(torch, "__version__", None)
+    if version is None:
+        return None
+    return str(version)

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -282,10 +282,19 @@ def _run_rdhc(reasons: list[str]) -> dict | None:
         reasons.append(msg)
         return None
 
-    with tempfile.NamedTemporaryFile(
-        suffix=".json", prefix="rdhc_quick_", delete=False
-    ) as tmp:
-        tmp_path = Path(tmp.name)
+    # Tempfile creation is part of the never-raises surface: a read-only or
+    # full /tmp would otherwise abort collect_env(). Treat as "rdhc
+    # unavailable" with a clear reason.
+    try:
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", prefix="rdhc_quick_", delete=False
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+    except OSError as exc:
+        msg = f"system_health: failed to create rdhc temp file ({exc})"
+        log.info(msg)
+        reasons.append(msg)
+        return None
 
     try:
         cmd = ["sudo", "-n", "-E", rdhc, "--quick", "--json", str(tmp_path)]
@@ -360,11 +369,22 @@ def _capture_rocm_version_files(reasons: list[str]) -> dict[str, str | None]:
 
 
 def _read_text_file(path: Path) -> str | None:
-    """Read a small text file; return its stripped contents or ``None``."""
+    """Read a small text file; return its stripped contents or ``None``.
+
+    Part of the ``never raises`` surface: catches everything that can come
+    out of ``Path.read_text``, including ``UnicodeDecodeError`` from files
+    with non-UTF8 bytes (e.g. a corrupt ``/sys/module/amdgpu/version``
+    or a locale-mismatched ``/opt/rocm/.info/*``). Returns ``None`` for
+    every error path so the caller can record a partial reason instead of
+    crashing.
+    """
     try:
         text = path.read_text(encoding="utf-8").strip()
         return text or None
     except (FileNotFoundError, PermissionError, IsADirectoryError):
+        return None
+    except UnicodeDecodeError as exc:
+        log.debug("non-utf8 contents in %s: %s", path, exc)
         return None
     except OSError as exc:
         log.debug("read failed for %s: %s", path, exc)
@@ -467,15 +487,34 @@ def _capture_hipblaslt(reasons: list[str]) -> dict[str, Any]:
         "tensile_yaml_revision": tensile_yaml_revision,
         "applied_prs": {},
     }
+    # Distinguish "header file unreadable" from "header readable but the
+    # specific define is missing/unparseable" so partial_reasons points
+    # callers at the right thing to investigate.
+    header_unreadable = header_text is None
     if commit is None:
-        reasons.append(f"hipblaslt.commit: {HIPBLASLT_VERSION_HEADER} not readable")
+        if header_unreadable:
+            reasons.append(
+                f"hipblaslt.commit: {HIPBLASLT_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"hipblaslt.commit: {HIPBLASLT_VERSION_HEADER} did not "
+                "contain a readable HIPBLASLT_VERSION_TWEAK define"
+            )
     if package_version is None:
-        reasons.append(
-            f"hipblaslt.package_version: {HIPBLASLT_VERSION_HEADER} did not "
-            "contain MAJOR/MINOR/PATCH defines"
-        )
+        if header_unreadable:
+            reasons.append(
+                f"hipblaslt.package_version: {HIPBLASLT_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"hipblaslt.package_version: {HIPBLASLT_VERSION_HEADER} did not "
+                "contain MAJOR/MINOR/PATCH defines"
+            )
     if lib_hash is None:
-        reasons.append(f"hipblaslt.lib_hash: {HIPBLASLT_LIB_DIR}/libhipblaslt.so not readable")
+        reasons.append(
+            f"hipblaslt.lib_hash: {HIPBLASLT_LIB_DIR}/libhipblaslt.so not readable"
+        )
     if tensile_yaml_revision is None:
         reasons.append(
             f"hipblaslt.tensile_yaml_revision: no kernel files under "

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -177,7 +177,14 @@ class EnvSnapshot:
         rocm = self.rocm or {}
         hip = self.hip or {}
         hipblaslt = self.hipblaslt or {}
-        sysh = "present" if self.system_health else "unavailable (system_health=null)"
+        # Use ``is not None`` -- RDHC may return an empty dict on a healthy
+        # host with nothing to report, which is still a successful capture
+        # and must NOT be summarised as "unavailable".
+        sysh = (
+            "present"
+            if self.system_health is not None
+            else "unavailable (system_health=null)"
+        )
         partial_marker = (
             f" [PARTIAL, {len(self.partial_reasons)} reason(s)]"
             if self.partial
@@ -652,9 +659,12 @@ def _detect_container_type() -> str:
     cgroup = _read_text_file(CGROUP_FILE)
     if cgroup:
         # cgroup lines look like '12:freezer:/docker/<id>' or
-        # '0::/system.slice/docker-<id>.scope'. Detect the first runtime
-        # name that appears. Limited to schema-documented values.
-        for runtime in ("docker", "podman", "singularity"):
+        # '0::/system.slice/docker-<id>.scope'. Apply the documented
+        # precedence: singularity wins over docker/podman so a
+        # Singularity environment that happens to inherit a docker-shaped
+        # cgroup path is not misclassified. Limited to schema-documented
+        # values.
+        for runtime in ("singularity", "docker", "podman"):
             if runtime in cgroup:
                 return runtime
     return "baremetal"

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1,6 +1,14 @@
 """``aorta env probe`` implementation (issue #147).
 
-Captures a versioned, schema-stable snapshot of the trial environment:
+Library-first per the updated A1 spec: the primary deliverable is
+
+* ``collect_env() -> EnvSnapshot``
+
+which B1 (per-trial runner) and B2 (matrix runner) call **in-process** so
+every trial / matrix run records its environment without shelling out.
+``aorta env probe`` (CLI) is a thin wrapper around it.
+
+Captured blocks:
 
 * ``system_health`` -- verbatim ``rdhc --quick --json`` output (or null).
 * ``rocm`` -- explicit reads of ``/opt/rocm/.info/version{,_dev}`` and
@@ -12,6 +20,12 @@ Captures a versioned, schema-stable snapshot of the trial environment:
 * ``docker`` -- image + digest when in a container.
 * ``env_vars`` -- canonical list of HSA / RCCL / FBGEMM / PyTorch vars.
 * ``python_version``, ``pytorch_version``.
+
+Fail-soft contract: ``collect_env()`` NEVER raises. Every probe that falls
+back to ``None`` appends a human-readable reason to ``partial_reasons``;
+the snapshot is then marked ``partial=True``. This keeps a triage matrix
+running when the probe hits something missing (no rdhc, no sudo,
+restricted dmesg) instead of aborting the whole run.
 
 No GPU compute. No tensor allocations. Target wall time: <15 s with rdhc
 present, <5 s without. Every capture function returns a fully-shaped dict
@@ -32,6 +46,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
@@ -88,43 +103,145 @@ CGROUP_FILE = Path("/proc/1/cgroup")
 
 
 # ---------------------------------------------------------------------------
-# Top-level orchestrator
+# EnvSnapshot dataclass -- the public typed object B1/B2/CLI consume
 # ---------------------------------------------------------------------------
 
 
-def capture_environment(output_path: str | os.PathLike[str] = "env.json") -> dict[str, Any]:
-    """Capture the env probe snapshot and write it to ``output_path``.
+@dataclass(frozen=True)
+class EnvSnapshot:
+    """Wraps the env.json schema as a typed object.
 
-    Args:
-        output_path: File to write the JSON snapshot to. Parent dirs
-            created.
+    Attributes mirror the env.json keys 1-to-1; ``to_dict()`` / ``from_dict()``
+    round-trip losslessly. Dataclass is frozen so callers can safely embed it
+    in trial / matrix results without worrying about mutation.
 
-    Returns:
-        The same dict that was written to disk.
+    The two fail-soft fields make the snapshot honest about partial captures:
+
+    * ``partial`` -- True if at least one probe fell back to None when it was
+      expected to populate. False on a clean probe.
+    * ``partial_reasons`` -- one human-readable string per fallback. The list
+      is empty when ``partial`` is False. Each entry names the field plus a
+      short cause (e.g. ``"system_health: rdhc not on PATH"``).
+
+    "Documented absences" do NOT trigger partial:
+
+    * ``docker == None`` on baremetal (no container, nothing to record)
+    * ``env_vars[X] == None`` for an unset env var (the documented contract)
+    * ``runtime_context.venv_path == None`` outside a venv
+
+    "Probe fell back" cases that DO trigger partial:
+
+    * ``system_health == None`` (rdhc unavailable / no sudo / timeout)
+    * any field in ``rocm`` / ``hip`` / ``hipblaslt`` is None
+    * ``pytorch_version == None`` (torch not installed)
+    * ``docker.image`` / ``docker.digest`` is None when inside a container
     """
-    output_path = Path(output_path).expanduser().resolve()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    runtime_context = _detect_runtime_context()
-    snapshot: dict[str, Any] = {
-        "schema_version": SCHEMA_VERSION,
-        "captured_at": _utc_now_iso(),
-        "system_health": _run_rdhc(),
-        "rocm": _capture_rocm_version_files(),
-        "hip": _capture_hip_toolchain(),
-        "hipblaslt": _capture_hipblaslt(),
-        "runtime_context": runtime_context,
-        "docker": _capture_docker_metadata(runtime_context),
-        "env_vars": _capture_env_vars(),
-        "python_version": platform.python_version(),
-        "pytorch_version": _capture_pytorch_version(),
-    }
+    schema_version: str
+    captured_at: str
+    system_health: dict | None
+    rocm: dict
+    hip: dict
+    hipblaslt: dict
+    runtime_context: dict
+    docker: dict | None
+    env_vars: dict[str, str | None]
+    python_version: str
+    pytorch_version: str | None
+    partial: bool
+    partial_reasons: list[str] = field(default_factory=list)
 
-    with output_path.open("w", encoding="utf-8") as f:
-        json.dump(snapshot, f, indent=2, default=str, sort_keys=False)
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the env.json shape. Round-trip pair with from_dict."""
+        return {f.name: getattr(self, f.name) for f in fields(self)}
 
-    log.info("Wrote env probe to %s (schema_version=%s)", output_path, SCHEMA_VERSION)
-    return snapshot
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> EnvSnapshot:
+        """Reconstruct from a previously serialised env.json dict.
+
+        Tolerates extra unknown keys (forward-compat) and missing optional
+        ``partial_reasons`` (defaults to empty list).
+        """
+        known = {f.name for f in fields(cls)}
+        kwargs = {k: v for k, v in d.items() if k in known}
+        kwargs.setdefault("partial_reasons", [])
+        return cls(**kwargs)
+
+    def summary(self) -> str:
+        """Human-friendly multi-line summary for CLI / logs.
+
+        Six lines, fixed width labels. Used by ``aorta env probe`` to print
+        a brief after writing the JSON.
+        """
+        rt = self.runtime_context or {}
+        rocm = self.rocm or {}
+        hip = self.hip or {}
+        hipblaslt = self.hipblaslt or {}
+        sysh = "present" if self.system_health else "unavailable (system_health=null)"
+        partial_marker = (
+            f" [PARTIAL, {len(self.partial_reasons)} reason(s)]"
+            if self.partial
+            else ""
+        )
+        return "\n".join(
+            (
+                f"  runtime:  {rt.get('type', '?')} / python={rt.get('python_env', '?')}{partial_marker}",
+                f"  rocm:     {rocm.get('version', '?')} (dev: {rocm.get('version_dev', '?')})",
+                f"  hip:      {hip.get('version', '?')} ({hip.get('platform', '?')})",
+                f"  hipblaslt: commit={hipblaslt.get('commit', '?')}",
+                f"  rdhc:     {sysh}",
+                f"  python:   {self.python_version} | pytorch: {self.pytorch_version}",
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# collect_env -- the public entrypoint B1 / B2 / CLI all call
+# ---------------------------------------------------------------------------
+
+
+def collect_env() -> EnvSnapshot:
+    """Capture the current process environment as an :class:`EnvSnapshot`.
+
+    NEVER raises. On any probe failure (rdhc unavailable, no sudo,
+    /opt/rocm missing, hipconfig not on PATH, hipBLASLt header missing,
+    torch absent, etc.), the corresponding fields are set to ``None`` and
+    ``partial=True`` with a human-readable reason appended to
+    ``partial_reasons``.
+
+    Callers (B1 dispatcher, B2 matrix runner, CLI) treat the snapshot as
+    always-valid and never as a failure path -- they may surface a warning
+    when ``partial=True`` but the run continues.
+
+    No GPU compute. No tensor allocations. The optional ``import torch`` for
+    the version probe does NOT initialise CUDA / HIP context.
+    """
+    reasons: list[str] = []
+
+    runtime_context = _detect_runtime_context()  # never partial; always populates
+    system_health = _run_rdhc(reasons)
+    rocm = _capture_rocm_version_files(reasons)
+    hip = _capture_hip_toolchain(reasons)
+    hipblaslt = _capture_hipblaslt(reasons)
+    docker = _capture_docker_metadata(runtime_context, reasons)
+    env_vars = _capture_env_vars()  # individual nulls are documented, not partial
+    pytorch_version = _capture_pytorch_version(reasons)
+
+    return EnvSnapshot(
+        schema_version=SCHEMA_VERSION,
+        captured_at=_utc_now_iso(),
+        system_health=system_health,
+        rocm=rocm,
+        hip=hip,
+        hipblaslt=hipblaslt,
+        runtime_context=runtime_context,
+        docker=docker,
+        env_vars=env_vars,
+        python_version=platform.python_version(),
+        pytorch_version=pytorch_version,
+        partial=bool(reasons),
+        partial_reasons=reasons,
+    )
 
 
 def _utc_now_iso() -> str:
@@ -142,31 +259,29 @@ def _utc_now_iso() -> str:
 # ---------------------------------------------------------------------------
 
 
-def _run_rdhc() -> dict | None:
+def _run_rdhc(reasons: list[str]) -> dict | None:
     """Run ``sudo -n -E rdhc --quick --json <tmp>`` and return parsed dict.
 
     Manages its own temp file via :mod:`tempfile` -- nothing leaks into
     the env probe's output directory.
 
-    Returns None on any of:
+    Returns ``None`` on any of:
     * RDHC not installed (``shutil.which`` returns nothing for ``rdhc.py``
       *and* ``rdhc``).
     * ``sudo -n`` would prompt for a password (return code != 0).
     * RDHC takes longer than ``RDHC_TIMEOUT_SEC``.
     * RDHC exits non-zero or produces malformed JSON.
 
-    All failure modes log a single INFO line so users understand why
-    ``system_health`` is null. Never raises.
+    Each failure mode appends one human-readable entry to ``reasons`` AND
+    logs a single INFO line. Never raises.
     """
     rdhc = shutil.which("rdhc.py") or shutil.which("rdhc")
     if rdhc is None:
-        log.info("system_health=null: rdhc not on PATH")
+        msg = "system_health: rdhc not on PATH"
+        log.info(msg)
+        reasons.append(msg)
         return None
 
-    # NamedTemporaryFile with delete=False so we control cleanup ourselves
-    # in the finally block (sudo'd subprocess writes to this path; the
-    # default delete=True closes the fd before subprocess can use it on
-    # some platforms).
     with tempfile.NamedTemporaryFile(
         suffix=".json", prefix="rdhc_quick_", delete=False
     ) as tmp:
@@ -183,24 +298,31 @@ def _run_rdhc() -> dict | None:
                 check=False,
             )
         except subprocess.TimeoutExpired:
-            log.info("system_health=null: rdhc exceeded %.0fs timeout", RDHC_TIMEOUT_SEC)
+            msg = f"system_health: rdhc exceeded {RDHC_TIMEOUT_SEC:.0f}s timeout"
+            log.info(msg)
+            reasons.append(msg)
             return None
         except (FileNotFoundError, OSError) as exc:
-            log.info("system_health=null: failed to invoke rdhc (%s)", exc)
+            msg = f"system_health: failed to invoke rdhc ({exc})"
+            log.info(msg)
+            reasons.append(msg)
             return None
 
         if result.returncode != 0:
-            # Most common cause: sudo -n requires a password.
-            log.info(
-                "system_health=null: rdhc exited %s (likely sudo-n unavailable)",
-                result.returncode,
+            msg = (
+                f"system_health: rdhc exited {result.returncode} "
+                "(likely sudo-n unavailable)"
             )
+            log.info(msg)
+            reasons.append(msg)
             return None
 
         try:
             return json.loads(tmp_path.read_text(encoding="utf-8"))
         except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
-            log.info("system_health=null: rdhc output not parseable (%s)", exc)
+            msg = f"system_health: rdhc output not parseable ({exc})"
+            log.info(msg)
+            reasons.append(msg)
             return None
     finally:
         try:
@@ -214,18 +336,27 @@ def _run_rdhc() -> dict | None:
 # ---------------------------------------------------------------------------
 
 
-def _capture_rocm_version_files() -> dict[str, str | None]:
+def _capture_rocm_version_files(reasons: list[str]) -> dict[str, str | None]:
     """Read ROCm version markers directly from disk.
 
     These are explicit reads (not via RDHC) so that ``rocm.version`` is
     populated even when RDHC is unavailable. All three keys are always
-    present; missing files yield ``None``.
+    present; missing files yield ``None`` and append a reason.
     """
-    return {
+    block = {
         "version": _read_text_file(ROCM_VERSION_FILE),
         "version_dev": _read_text_file(ROCM_VERSION_DEV_FILE),
         "kmd_version": _read_text_file(KMD_VERSION_FILE),
     }
+    paths = {
+        "version": ROCM_VERSION_FILE,
+        "version_dev": ROCM_VERSION_DEV_FILE,
+        "kmd_version": KMD_VERSION_FILE,
+    }
+    for key, value in block.items():
+        if value is None:
+            reasons.append(f"rocm.{key}: {paths[key]} not readable")
+    return block
 
 
 def _read_text_file(path: Path) -> str | None:
@@ -245,7 +376,7 @@ def _read_text_file(path: Path) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def _capture_hip_toolchain() -> dict[str, str | None]:
+def _capture_hip_toolchain(reasons: list[str]) -> dict[str, str | None]:
     """Run ``hipconfig --<flag>`` for each toolchain field.
 
     Issued as separate invocations because hipconfig prints results
@@ -254,7 +385,9 @@ def _capture_hip_toolchain() -> dict[str, str | None]:
     which is unparseable. Five short subprocesses still finish in <100 ms.
     """
     if shutil.which("hipconfig") is None:
-        log.info("hip block: hipconfig not on PATH; all hip.* fields = null")
+        msg = "hip: hipconfig not on PATH; all hip.* fields = null"
+        log.info(msg)
+        reasons.append(msg)
         return {
             "version": None,
             "platform": None,
@@ -263,13 +396,17 @@ def _capture_hip_toolchain() -> dict[str, str | None]:
             "cpp_config": None,
         }
 
-    return {
+    block = {
         "version": _hipconfig("--version"),
         "platform": _hipconfig("--platform"),
         "compiler": _hipconfig("--compiler"),
         "runtime": _hipconfig("--runtime"),
         "cpp_config": _hipconfig("--cpp_config"),
     }
+    for key, value in block.items():
+        if value is None:
+            reasons.append(f"hip.{key}: hipconfig --{key} returned no usable value")
+    return block
 
 
 def _hipconfig(flag: str) -> str | None:
@@ -305,7 +442,7 @@ _HIPBLASLT_VERSION_RE = re.compile(
 )
 
 
-def _capture_hipblaslt() -> dict[str, Any]:
+def _capture_hipblaslt(reasons: list[str]) -> dict[str, Any]:
     """Capture hipBLASLt build identity.
 
     Goal: catch GEMM kernel library drift across docker images / conda
@@ -320,13 +457,31 @@ def _capture_hipblaslt() -> dict[str, Any]:
     """
     header_text = _read_text_file(HIPBLASLT_VERSION_HEADER)
     commit, package_version = _parse_hipblaslt_header(header_text)
-    return {
+    lib_hash = _hash_hipblaslt_library()
+    tensile_yaml_revision = _tensile_fingerprint()
+
+    block: dict[str, Any] = {
         "commit": commit,
         "package_version": package_version,
-        "lib_hash": _hash_hipblaslt_library(),
-        "tensile_yaml_revision": _tensile_fingerprint(),
-        "applied_prs": {},  # filled in once specific PRs are configured
+        "lib_hash": lib_hash,
+        "tensile_yaml_revision": tensile_yaml_revision,
+        "applied_prs": {},
     }
+    if commit is None:
+        reasons.append(f"hipblaslt.commit: {HIPBLASLT_VERSION_HEADER} not readable")
+    if package_version is None:
+        reasons.append(
+            f"hipblaslt.package_version: {HIPBLASLT_VERSION_HEADER} did not "
+            "contain MAJOR/MINOR/PATCH defines"
+        )
+    if lib_hash is None:
+        reasons.append(f"hipblaslt.lib_hash: {HIPBLASLT_LIB_DIR}/libhipblaslt.so not readable")
+    if tensile_yaml_revision is None:
+        reasons.append(
+            f"hipblaslt.tensile_yaml_revision: no kernel files under "
+            f"{HIPBLASLT_TENSILE_DIR}"
+        )
+    return block
 
 
 def _parse_hipblaslt_header(text: str | None) -> tuple[str | None, str | None]:
@@ -429,6 +584,10 @@ def _detect_runtime_context() -> dict[str, str | None]:
         1. ``$CONDA_DEFAULT_ENV`` -> conda
         2. ``sys.prefix != sys.base_prefix`` -> venv
         3. otherwise -> system
+
+    Never partial: every field is either populated or has a documented
+    null reason (e.g. ``venv_path`` is null outside a venv -- that is the
+    contract, not a fallback).
     """
     container_type = _detect_container_type()
     python_env = _detect_python_env()
@@ -479,10 +638,13 @@ def _detect_python_env() -> str:
 
 def _capture_docker_metadata(
     runtime_context: dict[str, str | None],
+    reasons: list[str],
 ) -> dict[str, str | None] | None:
     """Capture image + digest when running inside a container.
 
-    Returns ``None`` for baremetal -- there is no image to record.
+    Returns ``None`` for baremetal -- there is no image to record. This
+    documented absence does NOT trigger ``partial=True``.
+
     For containerised runs we emit the block with best-effort values; the
     aorta-side launcher can populate them via the env vars below before
     invoking ``aorta env probe`` (which is the only reliable way to know
@@ -493,15 +655,28 @@ def _capture_docker_metadata(
 
     Always also emits ``container_id`` parsed from ``/proc/self/cgroup``,
     which is recoverable from inside the container.
+
+    When inside a container but the launcher did not set the env vars,
+    appends a reason -- the snapshot can still be useful but cross-image
+    comparison loses fidelity.
     """
     if runtime_context.get("type") == "baremetal":
         return None
 
-    return {
+    block = {
         "image": os.environ.get("AORTA_DOCKER_IMAGE"),
         "digest": os.environ.get("AORTA_DOCKER_DIGEST"),
         "container_id": _read_container_id(),
     }
+    if block["image"] is None:
+        reasons.append(
+            "docker.image: AORTA_DOCKER_IMAGE env var not set by the launcher"
+        )
+    if block["digest"] is None:
+        reasons.append(
+            "docker.digest: AORTA_DOCKER_DIGEST env var not set by the launcher"
+        )
+    return block
 
 
 _CONTAINER_ID_RE = re.compile(r"[0-9a-f]{12,64}")
@@ -525,11 +700,15 @@ def _read_container_id() -> str | None:
 
 
 def _capture_env_vars() -> dict[str, str | None]:
-    """Capture canonical env vars (explicit list, not prefix matching)."""
+    """Capture canonical env vars (explicit list, not prefix matching).
+
+    Individual ``None`` values are the documented contract (env var unset)
+    and DO NOT trigger ``partial=True``.
+    """
     return {name: os.environ.get(name) for name in CANONICAL_ENV_VARS}
 
 
-def _capture_pytorch_version() -> str | None:
+def _capture_pytorch_version(reasons: list[str]) -> str | None:
     """Best-effort import of torch to read its version. No GPU touched.
 
     ``import torch`` does NOT initialise CUDA / HIP context; it only
@@ -538,18 +717,22 @@ def _capture_pytorch_version() -> str | None:
 
     Returns the version as a string when available, or ``None`` when torch
     is not installed OR is installed without a ``__version__`` attribute.
-    Never returns the string ``"None"`` -- that would break consumers
-    doing strict null checks against the JSON.
+    Either fallback path appends a reason. Never returns the string
+    ``"None"`` -- that would break consumers doing strict null checks
+    against the JSON.
     """
     try:
         import torch  # type: ignore[import-not-found]
     except ImportError:
+        reasons.append("pytorch_version: torch not importable")
         return None
     except Exception as exc:  # noqa: BLE001 -- defensive; never let env probe fail
         log.debug("torch import for version probe failed: %s", exc)
+        reasons.append(f"pytorch_version: torch import raised ({type(exc).__name__})")
         return None
 
     version = getattr(torch, "__version__", None)
     if version is None:
+        reasons.append("pytorch_version: torch lacks __version__ attribute")
         return None
     return str(version)

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -688,13 +688,19 @@ class TestCliIsThinWrapper:
         return Path(env_mod.__file__).parent.parent / "cli" / "env.py"
 
     def test_total_file_size_is_bounded(self, cli_path: Path):
-        # Total file budget (incl. docstring/imports/blank lines): 60 lines.
-        # The substantive code budget per the spec is ~30 lines; the cushion
-        # accounts for the module docstring + Click decorators.
+        # Total file budget (incl. docstring/imports/blank lines/error handling).
+        # The spec target is ~30 lines of substantive code; the cushion
+        # accommodates the module docstring, Click decorators, and the
+        # try/except blocks that surface filesystem errors as
+        # ``click.ClickException`` (per Copilot review). The real
+        # "no-probing-in-CLI" guard is `test_cli_does_no_probing_imports`
+        # below -- this one is a soft canary against the file ballooning.
         line_count = sum(1 for _ in cli_path.read_text().splitlines())
-        assert line_count <= 60, (
-            f"cli/env.py is {line_count} lines; budget is 60 (spec target ~30 substantive). "
-            "If you need more, the probing logic should move into the library, not the CLI."
+        assert line_count <= 80, (
+            f"cli/env.py is {line_count} lines; soft budget is 80. "
+            "If you need more, check that the new code is genuinely "
+            "wiring/error-handling and not probing -- "
+            "test_cli_does_no_probing_imports is the strict guard."
         )
 
     def test_cli_does_no_probing_imports(self, cli_path: Path):
@@ -733,6 +739,58 @@ class TestCliIsThinWrapper:
         assert out_path.exists()
         # And the JSON is loadable
         json.loads(out_path.read_text())
+
+    def test_cli_surfaces_filesystem_errors_as_click_exception(
+        self, all_disabled, tmp_path: Path
+    ):
+        """Regression guard: an unwritable output path must surface as a
+        clean ``click.ClickException``, not a Python traceback.
+
+        Two scenarios: (a) parent ``mkdir`` fails (read-only mount); (b)
+        the write itself fails (e.g. parent exists but is not writable).
+        Both should yield a non-zero CLI exit + a one-line error
+        starting with ``Error:``.
+        """
+        from click.testing import CliRunner
+
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        spec = importlib.util.spec_from_file_location("aorta.cli.env", cli_path)
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+        runner = CliRunner()
+
+        # Scenario (a): parent mkdir blows up. Achieve by sabotaging mkdir.
+        target = tmp_path / "no_perm" / "env.json"
+
+        original_mkdir = Path.mkdir
+
+        def fake_mkdir(self, *args, **kwargs):
+            if "no_perm" in str(self):
+                raise PermissionError(13, "Permission denied")
+            return original_mkdir(self, *args, **kwargs)
+
+        with patch.object(Path, "mkdir", fake_mkdir):
+            result = runner.invoke(cli_mod.env, ["probe", "-o", str(target)])
+        assert result.exit_code != 0
+        assert "Failed to create parent directory" in result.output
+        # Belt-and-suspenders: no Python traceback header in the output
+        assert "Traceback" not in result.output
+
+        # Scenario (b): write itself fails.
+        target_b = tmp_path / "env_b.json"
+        original_write_text = Path.write_text
+
+        def fake_write_text(self, *args, **kwargs):
+            if str(self) == str(target_b.resolve()):
+                raise OSError(28, "No space left on device")
+            return original_write_text(self, *args, **kwargs)
+
+        with patch.object(Path, "write_text", fake_write_text):
+            result = runner.invoke(cli_mod.env, ["probe", "-o", str(target_b)])
+        assert result.exit_code != 0
+        assert "Failed to write env probe" in result.output
+        assert "Traceback" not in result.output
 
     def test_cli_emits_json_native_output_no_default_str(
         self, all_disabled

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -95,6 +95,7 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
         env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv"
     )
     monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
+    monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", tmp_path / "no_self_cgroup")
     monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
     # Force pytorch import to fail so its fallback path is exercised too
     real_import = __builtins__["__import__"] if isinstance(
@@ -135,6 +136,7 @@ class TestPathConstants:
             "DOCKERENV_MARKER",
             "PODMAN_CONTAINERENV_MARKER",
             "CGROUP_FILE",
+            "SELF_CGROUP_FILE",
         ],
     )
     def test_path_is_absolute(self, constant_name: str):
@@ -166,11 +168,26 @@ class TestPathConstants:
             "DOCKERENV_MARKER",
             "PODMAN_CONTAINERENV_MARKER",
             "CGROUP_FILE",
+            "SELF_CGROUP_FILE",
         }, (
             "FS path constants set drifted; update test_path_is_absolute "
             "parametrize list AND the provenance comments in "
             "src/aorta/instrumentation/environment.py."
         )
+
+    def test_self_cgroup_distinct_from_init_cgroup(self):
+        """Regression guard: the two cgroup files are different on purpose.
+
+        ``CGROUP_FILE`` (``/proc/1/cgroup``) is the init process's cgroup
+        and is sniffed for the runtime *type* (docker/podman/singularity).
+        ``SELF_CGROUP_FILE`` (``/proc/self/cgroup``) is the current
+        process's cgroup and is parsed for the container *ID*. Conflating
+        them would either misclassify the runtime or fail to extract
+        an ID inside k8s pods where /proc/1 belongs to the host.
+        """
+        assert env_mod.CGROUP_FILE != env_mod.SELF_CGROUP_FILE
+        assert "1" in env_mod.CGROUP_FILE.parts
+        assert "self" in env_mod.SELF_CGROUP_FILE.parts
 
 
 REQUIRED_TOP_KEYS = {
@@ -1431,16 +1448,27 @@ class TestDockerMetadata:
     def test_container_id_extracted_from_cgroup(
         self, isolated_env, tmp_path: Path, monkeypatch
     ):
-        cgroup = tmp_path / "cgroup"
+        # Cleaner now: monkeypatch SELF_CGROUP_FILE directly instead of
+        # the global _read_text_file helper. Exercises the same
+        # constant the production code reads.
+        cgroup = tmp_path / "self_cgroup"
         cid = "abc123def456789012345678901234567890abcd"
         cgroup.write_text(f"12:freezer:/docker/{cid}\n")
-        monkeypatch.setattr(env_mod, "_read_text_file", lambda p: cgroup.read_text())
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", cgroup)
         reasons: list[str] = []
         # Provide image/digest so they don't add their own reasons
         isolated_env.setenv("AORTA_DOCKER_IMAGE", "x")
         isolated_env.setenv("AORTA_DOCKER_DIGEST", "y")
         block = env_mod._capture_docker_metadata({"type": "docker"}, reasons)
         assert block["container_id"] == cid
+
+    def test_container_id_returns_none_when_self_cgroup_missing(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """If /proc/self/cgroup isn't readable (e.g. heavily sandboxed
+        container), container_id is None but the function does not raise."""
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", tmp_path / "no_self_cgroup")
+        assert env_mod._read_container_id() is None
 
 
 # ---------------------------------------------------------------------------
@@ -1589,7 +1617,7 @@ class TestNoGpuCompute:
             "ROCM_VERSION_FILE", "ROCM_VERSION_DEV_FILE", "KMD_VERSION_FILE",
             "HIPBLASLT_VERSION_HEADER", "HIPBLASLT_LIB_DIR",
             "HIPBLASLT_TENSILE_DIR", "DOCKERENV_MARKER",
-            "PODMAN_CONTAINERENV_MARKER", "CGROUP_FILE",
+            "PODMAN_CONTAINERENV_MARKER", "CGROUP_FILE", "SELF_CGROUP_FILE",
         ):
             monkeypatch.setattr(env_mod, attr, tmp_path / f"no_{attr.lower()}")
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -460,6 +460,52 @@ class TestCollectEnvContract:
             f"runtime_context fields should never trigger partial; got: {runtime_reasons}"
         )
 
+    def test_collect_env_returns_snapshot_when_probe_unexpectedly_raises(
+        self, all_disabled, monkeypatch
+    ):
+        """Hard never-raises guarantee: a probe that raises an unexpected
+        exception (i.e. not handled internally) MUST NOT propagate.
+
+        Sabotage `_capture_hipblaslt` to raise. Without the top-level
+        try/except in collect_env, this would bubble up and break B1/B2.
+        With the guard, we get a fully-shaped EnvSnapshot back, marked
+        partial, with the exception captured in partial_reasons.
+        """
+
+        def boom(reasons: list[str]) -> dict:
+            raise RuntimeError("simulated probe failure")
+
+        monkeypatch.setattr(env_mod, "_capture_hipblaslt", boom)
+
+        snapshot = collect_env()  # must not raise
+        assert isinstance(snapshot, EnvSnapshot)
+        assert snapshot.partial is True
+        # The unexpected-failure reason is appended to whatever earlier
+        # probes already recorded. Find the recovery one specifically.
+        recovery_reasons = [
+            r for r in snapshot.partial_reasons if r.startswith("collect_env:")
+        ]
+        assert len(recovery_reasons) == 1
+        assert "RuntimeError" in recovery_reasons[0]
+        assert "simulated probe failure" in recovery_reasons[0]
+        # Schema must still be complete -- callers should not see missing keys
+        assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
+
+    def test_disaster_snapshot_emits_complete_schema(self):
+        """The disaster path must still produce a full env.json shape."""
+        snap = env_mod._disaster_snapshot(
+            preceding_reasons=["earlier: thing"],
+            unexpected_reason="collect_env: boom",
+        )
+        d = snap.to_dict()
+        assert set(d.keys()) == REQUIRED_TOP_KEYS
+        assert snap.partial is True
+        # Both the earlier reasons and the new disaster reason are present
+        assert "earlier: thing" in snap.partial_reasons
+        assert "collect_env: boom" in snap.partial_reasons
+        # JSON-native check (no default=str needed)
+        json.dumps(d)
+
 
 # ---------------------------------------------------------------------------
 # B1 / B2 integration-style: snapshot embeds in a fake trial result
@@ -629,6 +675,52 @@ class TestRdhcWrapper:
         reasons: list[str] = []
         assert env_mod._run_rdhc(reasons) is None
         assert any("sudo" in r.lower() or "exited 1" in r for r in reasons)
+
+    def test_rdhc_nonzero_exit_includes_stderr_in_reason(
+        self, isolated_env, monkeypatch
+    ):
+        """Regression guard: when rdhc fails for a reason OTHER than
+        sudo-n-needs-password, the partial_reason must surface the actual
+        stderr so operators can debug. The earlier hardcoded
+        "(likely sudo-n unavailable)" was misleading.
+        """
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=2,
+                stdout="",
+                stderr="rdhc: ERROR: amdgpu kernel module not loaded\n",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        assert env_mod._run_rdhc(reasons) is None
+        rdhc_reason = next(r for r in reasons if "system_health" in r)
+        assert "exited 2" in rdhc_reason
+        assert "amdgpu kernel module not loaded" in rdhc_reason
+        # And the misleading boilerplate should NOT be present when stderr was given
+        assert "likely sudo-n unavailable" not in rdhc_reason
+
+    def test_rdhc_nonzero_exit_no_stderr_keeps_sudo_hint(
+        self, isolated_env, monkeypatch
+    ):
+        """When rdhc prints nothing to stderr (the typical sudo-n no-password
+        case), the reason still names sudo-n as the likely cause."""
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        assert env_mod._run_rdhc(reasons) is None
+        rdhc_reason = next(r for r in reasons if "system_health" in r)
+        assert "no stderr" in rdhc_reason
+        assert "sudo-n" in rdhc_reason
 
     def test_rdhc_timeout_returns_none(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -266,6 +266,24 @@ class TestEnvSnapshot:
         assert "PARTIAL" in partial_snap.summary()
         assert "PARTIAL" not in clean_snap.summary()
 
+    def test_summary_treats_empty_system_health_as_present(self):
+        """Regression guard: RDHC may legitimately return an empty dict
+        ``{}`` (subprocess succeeded, nothing to report). The earlier
+        truthiness check ``if self.system_health`` would summarise that as
+        unavailable -- ``is not None`` is the right check.
+        """
+        snap_empty = _example_snapshot(system_health={})
+        snap_null = _example_snapshot(system_health=None)
+        snap_populated = _example_snapshot(system_health={"rdhc_version": "1.4.0"})
+
+        # Empty dict and populated dict should both render as 'present'
+        assert "present" in snap_empty.summary()
+        assert "unavailable" not in snap_empty.summary()
+        assert "present" in snap_populated.summary()
+        # Only None should render as 'unavailable'
+        assert "unavailable" in snap_null.summary()
+        assert "present" not in snap_null.summary()
+
     def test_summary_is_multiline_human_readable(self):
         snap = _example_snapshot()
         s = snap.summary()
@@ -1042,6 +1060,35 @@ class TestRuntimeContext:
         all_disabled.setattr(env_mod, "DOCKERENV_MARKER", marker)
         all_disabled.setattr(env_mod, "CGROUP_FILE", cgroup)
         assert env_mod._detect_container_type() == "docker"
+
+    def test_singularity_wins_over_docker_in_cgroup_fallback(
+        self, all_disabled, tmp_path: Path
+    ):
+        """Regression guard: when /proc/1/cgroup mentions both 'singularity'
+        and 'docker' (e.g. a Singularity instance whose underlying cgroup
+        was created by a docker-shim), the documented precedence says
+        Singularity wins. Earlier code iterated docker first and would
+        misclassify.
+        """
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text(
+            "12:freezer:/docker/abc123\n"
+            "0::/singularity/instance-xyz\n"
+        )
+        all_disabled.setattr(env_mod, "CGROUP_FILE", cgroup)
+        assert env_mod._detect_container_type() == "singularity"
+
+    def test_singularity_wins_over_podman_in_cgroup_fallback(
+        self, all_disabled, tmp_path: Path
+    ):
+        """Same precedence rule against podman tokens."""
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text(
+            "0::/machine.slice/libpod-podman-xxx.scope\n"
+            "0::/singularity/instance-xyz\n"
+        )
+        all_disabled.setattr(env_mod, "CGROUP_FILE", cgroup)
+        assert env_mod._detect_container_type() == "singularity"
 
     def test_python_env_venv(self, isolated_env, monkeypatch):
         monkeypatch.setattr(sys, "base_prefix", "/usr")

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -773,6 +773,17 @@ class TestRdhcWrapper:
         assert env_mod._run_rdhc(reasons) is None
         assert any("rdhc" in r for r in reasons)
 
+    def test_rdhc_unavailable_reason_includes_install_hint(self, all_disabled):
+        """Operator-facing affordance: the rdhc-not-on-PATH reason must point
+        at the install docs so users hitting `system_health: null` for the
+        first time know how to fix it without reading source.
+        """
+        reasons: list[str] = []
+        env_mod._run_rdhc(reasons)
+        assert any(
+            "docs/env-probe.md#installing-rdhc" in r for r in reasons
+        ), f"install hint missing from reasons: {reasons}"
+
     def test_rdhc_present_but_sudo_n_fails_returns_none(
         self, isolated_env, monkeypatch
     ):
@@ -814,12 +825,16 @@ class TestRdhcWrapper:
         assert "amdgpu kernel module not loaded" in rdhc_reason
         # And the misleading boilerplate should NOT be present when stderr was given
         assert "likely sudo-n unavailable" not in rdhc_reason
+        # The install hint is also NOT appended when there's actionable stderr
+        # -- we don't want to bury a real diagnostic under a generic link.
+        assert "docs/env-probe.md#installing-rdhc" not in rdhc_reason
 
     def test_rdhc_nonzero_exit_no_stderr_keeps_sudo_hint(
         self, isolated_env, monkeypatch
     ):
         """When rdhc prints nothing to stderr (the typical sudo-n no-password
-        case), the reason still names sudo-n as the likely cause."""
+        case), the reason names sudo-n AND points at the install/sudo
+        recipe in the docs."""
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
 
         def fake_run(cmd, **kwargs):
@@ -833,6 +848,7 @@ class TestRdhcWrapper:
         rdhc_reason = next(r for r in reasons if "system_health" in r)
         assert "no stderr" in rdhc_reason
         assert "sudo-n" in rdhc_reason
+        assert "docs/env-probe.md#installing-rdhc" in rdhc_reason
 
     def test_rdhc_timeout_returns_none(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -30,7 +30,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -113,6 +113,64 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
 # ---------------------------------------------------------------------------
 # Schema completeness + versioning
 # ---------------------------------------------------------------------------
+
+
+class TestPathConstants:
+    """Structural guard for the filesystem path constants.
+
+    Catches accidental typos / relative-path mistakes; does NOT verify
+    that the paths exist on the test host (they are host-state and are
+    monkeypatched by every test that uses them).
+    """
+
+    @pytest.mark.parametrize(
+        "constant_name",
+        [
+            "ROCM_VERSION_FILE",
+            "ROCM_VERSION_DEV_FILE",
+            "KMD_VERSION_FILE",
+            "HIPBLASLT_VERSION_HEADER",
+            "HIPBLASLT_LIB_DIR",
+            "HIPBLASLT_TENSILE_DIR",
+            "DOCKERENV_MARKER",
+            "PODMAN_CONTAINERENV_MARKER",
+            "CGROUP_FILE",
+        ],
+    )
+    def test_path_is_absolute(self, constant_name: str):
+        path = getattr(env_mod, constant_name)
+        assert isinstance(path, Path), f"{constant_name} must be a Path"
+        assert path.is_absolute(), (
+            f"{constant_name} = {path!r} is not absolute. The probe "
+            "looks at well-known system locations; relative paths would "
+            "be resolved against pytest's CWD and produce nonsense."
+        )
+
+    def test_known_constant_set_is_stable(self):
+        """Reasoned guard: adding/removing a path constant is a schema
+        change that should also touch the structural test above and the
+        provenance comments in environment.py.
+        """
+        path_attrs = {
+            name for name in dir(env_mod)
+            if isinstance(getattr(env_mod, name, None), Path)
+            and not name.startswith("_")
+        }
+        assert path_attrs == {
+            "ROCM_VERSION_FILE",
+            "ROCM_VERSION_DEV_FILE",
+            "KMD_VERSION_FILE",
+            "HIPBLASLT_VERSION_HEADER",
+            "HIPBLASLT_LIB_DIR",
+            "HIPBLASLT_TENSILE_DIR",
+            "DOCKERENV_MARKER",
+            "PODMAN_CONTAINERENV_MARKER",
+            "CGROUP_FILE",
+        }, (
+            "FS path constants set drifted; update test_path_is_absolute "
+            "parametrize list AND the provenance comments in "
+            "src/aorta/instrumentation/environment.py."
+        )
 
 
 REQUIRED_TOP_KEYS = {
@@ -505,6 +563,60 @@ class TestCollectEnvContract:
         assert "collect_env: boom" in snap.partial_reasons
         # JSON-native check (no default=str needed)
         json.dumps(d)
+
+    def test_disaster_snapshot_populates_every_envsnapshot_field(self):
+        """Hard guard against a future PR adding a field to EnvSnapshot
+        without updating _disaster_snapshot.
+
+        If a field is added to the dataclass and _disaster_snapshot is not
+        updated, the missing-arg ``TypeError`` would fire from inside
+        collect_env's ``except`` block, get caught silently, and we'd be
+        stuck with a half-broken safety net. This test enumerates the
+        dataclass fields and asserts every one is present in the disaster
+        snapshot's ``to_dict()`` output.
+        """
+        from dataclasses import fields as dc_fields
+
+        snap = env_mod._disaster_snapshot(
+            preceding_reasons=[], unexpected_reason="test: dummy"
+        )
+        snap_dict = snap.to_dict()
+        expected_fields = {f.name for f in dc_fields(EnvSnapshot)}
+        missing = expected_fields - set(snap_dict.keys())
+        assert not missing, (
+            f"_disaster_snapshot did not populate fields {missing}. "
+            "If you added a field to EnvSnapshot, update _disaster_snapshot "
+            "in src/aorta/instrumentation/environment.py to give it a sane "
+            "default."
+        )
+
+    def test_disaster_snapshot_constructs_when_collect_env_helpers_raise(
+        self, monkeypatch
+    ):
+        """Even the disaster path must not crash if its own helpers blow up.
+
+        Sabotage both ``_utc_now_iso`` and ``platform.python_version`` so
+        the disaster fallback's defensive ``try/except`` fires twice.
+        Both fields fall back to empty strings; the snapshot is still
+        constructible.
+        """
+        monkeypatch.setattr(
+            env_mod, "_utc_now_iso", lambda: (_ for _ in ()).throw(RuntimeError("no time"))
+        )
+        monkeypatch.setattr(
+            env_mod.platform, "python_version",
+            lambda: (_ for _ in ()).throw(RuntimeError("no python"))
+        )
+
+        snap = env_mod._disaster_snapshot(
+            preceding_reasons=[], unexpected_reason="test: chained failure"
+        )
+        assert snap.captured_at == ""
+        assert snap.python_version == ""
+        assert snap.partial is True
+        # Schema completeness preserved
+        from dataclasses import fields as dc_fields
+        assert set(snap.to_dict().keys()) == {f.name for f in dc_fields(EnvSnapshot)}
 
 
 # ---------------------------------------------------------------------------
@@ -1375,17 +1487,44 @@ class TestNoGpuCompute:
     initialise a HIP context).
     """
 
-    def test_torch_cuda_never_called(self, all_disabled):
-        # Try to actually import torch (rather than sniffing sys.modules):
-        # we want to skip ONLY when torch is genuinely unavailable, not
-        # whenever it merely hasn't been imported yet by the test runner.
-        try:
-            import torch
-        except ImportError:
-            pytest.skip("torch not available; trivially passes")
-        with patch.object(torch.cuda, "is_available") as is_avail, patch.object(
-            torch.cuda, "device_count"
-        ) as dev_count:
-            collect_env()
-            is_avail.assert_not_called()
-            dev_count.assert_not_called()
+    def test_torch_cuda_never_called(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """Inject a fake torch into ``sys.modules`` so the test runs even
+        when the host venv has no torch installed (the previous
+        sys.modules-sniff version always skipped, defeating the guard).
+
+        Then exercise the full ``collect_env()`` orchestration with all
+        external probes disabled, and assert that ``torch.cuda.is_available``
+        and ``torch.cuda.device_count`` were never called.
+        """
+        import types
+
+        fake_cuda = types.SimpleNamespace(
+            is_available=MagicMock(name="is_available"),
+            device_count=MagicMock(name="device_count"),
+        )
+        fake_torch = types.SimpleNamespace(__version__="2.12.0", cuda=fake_cuda)
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+        # Disable external probes (rdhc, hipconfig, rocm files, hipblaslt,
+        # container markers) so the test is fast and host-independent.
+        # Deliberately NOT using the `all_disabled` fixture here -- that
+        # one sabotages `import torch` and would defeat the whole test.
+        for attr in (
+            "ROCM_VERSION_FILE", "ROCM_VERSION_DEV_FILE", "KMD_VERSION_FILE",
+            "HIPBLASLT_VERSION_HEADER", "HIPBLASLT_LIB_DIR",
+            "HIPBLASLT_TENSILE_DIR", "DOCKERENV_MARKER",
+            "PODMAN_CONTAINERENV_MARKER", "CGROUP_FILE",
+        ):
+            monkeypatch.setattr(env_mod, attr, tmp_path / f"no_{attr.lower()}")
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
+
+        snapshot = collect_env()
+
+        # Sanity: probe ran, picked up our fake torch's version
+        assert snapshot.pytorch_version == "2.12.0"
+
+        # The actual guard
+        fake_cuda.is_available.assert_not_called()
+        fake_cuda.device_count.assert_not_called()

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -4,6 +4,21 @@ Strategy: load the module by file path so the test does not pull in the
 torch-dependent ``aorta.utils`` package. Every subprocess and filesystem
 touchpoint is monkeypatched, so tests run on any host without ROCm,
 RDHC, hipconfig, hipblaslt, or torch.
+
+Coverage matrix (per the updated A1 spec):
+
+* ``EnvSnapshot`` shape + ``to_dict`` / ``from_dict`` / ``summary``
+* ``collect_env`` orchestration: never raises, populates ``partial`` /
+  ``partial_reasons``, idempotent
+* B1/B2-style integration: snapshot embeds losslessly into a fake trial
+  result dict and round-trips
+* Per-probe behaviour: RDHC happy/error paths, ROCm version files, HIP
+  toolchain, hipBLASLt introspection, runtime context, Docker metadata,
+  env vars, PyTorch version
+* Schema invariants: required top-level keys, schema_version constant,
+  no GPU compute, workload config not captured, ``partial`` reflected in
+  the persisted JSON
+* CLI invariant: ``cli/env.py`` stays thin
 """
 
 from __future__ import annotations
@@ -38,7 +53,8 @@ sys.modules[_spec.name] = env_mod
 _spec.loader.exec_module(env_mod)
 
 
-capture_environment = env_mod.capture_environment
+collect_env = env_mod.collect_env
+EnvSnapshot = env_mod.EnvSnapshot
 SCHEMA_VERSION = env_mod.SCHEMA_VERSION
 CANONICAL_ENV_VARS = env_mod.CANONICAL_ENV_VARS
 
@@ -62,8 +78,9 @@ def isolated_env(monkeypatch):
 def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
     """Force every external dep into its 'unavailable' branch.
 
-    Result: ``capture_environment`` exercises only pure-Python paths and
-    every block returns its null-shaped form.
+    Result: ``collect_env`` exercises only pure-Python paths and every
+    block returns its null-shaped form. Triggers ``partial=True`` with
+    one reason per fallback.
     """
     monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", tmp_path / "no_rocm")
     monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", tmp_path / "no_rocm_dev")
@@ -79,6 +96,17 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
     )
     monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
     monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
+    # Force pytorch import to fail so its fallback path is exercised too
+    real_import = __builtins__["__import__"] if isinstance(
+        __builtins__, dict
+    ) else __builtins__.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torch":
+            raise ImportError("simulated absence")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
     return monkeypatch
 
 
@@ -90,6 +118,8 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
 REQUIRED_TOP_KEYS = {
     "schema_version",
     "captured_at",
+    "partial",
+    "partial_reasons",
     "system_health",
     "rocm",
     "hip",
@@ -104,21 +134,18 @@ REQUIRED_TOP_KEYS = {
 
 class TestSchemaCompleteness:
     def test_all_top_level_keys_present_when_everything_unavailable(
-        self, all_disabled, tmp_path: Path
+        self, all_disabled
     ):
-        out = tmp_path / "env.json"
-        snapshot = capture_environment(out)
-        # All keys must be present regardless of availability
-        assert set(snapshot.keys()) == REQUIRED_TOP_KEYS
-        # The blocks themselves either have content or are explicitly null
-        assert snapshot["schema_version"] == "1.0"
-        assert snapshot["system_health"] is None
-        assert snapshot["rocm"] == {
+        snapshot = collect_env()
+        assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
+        assert snapshot.schema_version == "1.0"
+        assert snapshot.system_health is None
+        assert snapshot.rocm == {
             "version": None,
             "version_dev": None,
             "kmd_version": None,
         }
-        assert snapshot["hip"] == {
+        assert snapshot.hip == {
             "version": None,
             "platform": None,
             "compiler": None,
@@ -126,23 +153,385 @@ class TestSchemaCompleteness:
             "cpp_config": None,
         }
 
-    def test_snapshot_is_written_to_disk(self, all_disabled, tmp_path: Path):
+    def test_schema_version_constant_is_emitted(self, all_disabled):
+        snapshot = collect_env()
+        assert snapshot.schema_version == SCHEMA_VERSION
+
+    def test_captured_at_is_iso8601_utc(self, all_disabled):
+        snapshot = collect_env()
+        assert snapshot.captured_at.endswith("Z")
+        assert "T" in snapshot.captured_at
+
+    def test_persisted_json_includes_partial_keys(self, all_disabled, tmp_path: Path):
+        """``partial`` and ``partial_reasons`` must be present in the on-disk JSON."""
+        snapshot = collect_env()
         out = tmp_path / "env.json"
-        snapshot = capture_environment(out)
-        assert out.exists()
+        out.write_text(json.dumps(snapshot.to_dict(), default=str))
         on_disk = json.loads(out.read_text())
-        assert on_disk == snapshot
+        assert "partial" in on_disk
+        assert "partial_reasons" in on_disk
+        assert on_disk["partial"] is True
+        assert isinstance(on_disk["partial_reasons"], list)
+        assert on_disk["partial_reasons"]  # non-empty since all_disabled
 
-    def test_schema_version_constant_is_emitted(self, all_disabled, tmp_path: Path):
-        snapshot = capture_environment(tmp_path / "env.json")
-        assert snapshot["schema_version"] == SCHEMA_VERSION
 
-    def test_captured_at_is_iso8601_utc(self, all_disabled, tmp_path: Path):
-        snapshot = capture_environment(tmp_path / "env.json")
-        ts = snapshot["captured_at"]
-        # Issue's example uses trailing Z; validate shape rather than exact value
-        assert ts.endswith("Z")
-        assert "T" in ts
+# ---------------------------------------------------------------------------
+# EnvSnapshot dataclass: round-trip + summary
+# ---------------------------------------------------------------------------
+
+
+def _example_snapshot(**overrides) -> object:
+    """Build a fully-populated EnvSnapshot for round-trip testing."""
+    base = {
+        "schema_version": "1.0",
+        "captured_at": "2026-04-28T12:00:00Z",
+        "system_health": {"rdhc_version": "1.4.0", "tests": {}},
+        "rocm": {
+            "version": "7.2.1",
+            "version_dev": "7.2.1-43",
+            "kmd_version": "6.16.13",
+        },
+        "hip": {
+            "version": "7.2.5",
+            "platform": "amd",
+            "compiler": "clang",
+            "runtime": "rocclr",
+            "cpp_config": "-D__HIP_PLATFORM_AMD__",
+        },
+        "hipblaslt": {
+            "commit": "dabb6df2b9",
+            "package_version": "1.2.2",
+            "lib_hash": "sha256:abc",
+            "tensile_yaml_revision": "filenames-sha256:def",
+            "applied_prs": {},
+        },
+        "runtime_context": {
+            "type": "docker",
+            "python_env": "venv",
+            "venv_path": "/home/u/.venv",
+            "conda_env_name": None,
+        },
+        "docker": {
+            "image": "rocm/pytorch:7.2",
+            "digest": "sha256:deadbeef",
+            "container_id": "abcd1234",
+        },
+        "env_vars": dict.fromkeys(CANONICAL_ENV_VARS),
+        "python_version": "3.12.3",
+        "pytorch_version": "2.12.0",
+        "partial": False,
+        "partial_reasons": [],
+    }
+    base.update(overrides)
+    return EnvSnapshot(**base)
+
+
+class TestEnvSnapshot:
+    def test_to_dict_keys_are_complete(self):
+        snap = _example_snapshot()
+        d = snap.to_dict()
+        assert set(d.keys()) == REQUIRED_TOP_KEYS
+
+    def test_round_trip_via_dict(self):
+        original = _example_snapshot()
+        rebuilt = EnvSnapshot.from_dict(original.to_dict())
+        assert rebuilt == original
+
+    def test_round_trip_via_json(self):
+        """B1/B2 path: serialise via JSON, embed in a result, deserialise back."""
+        original = _example_snapshot()
+        as_json = json.dumps(original.to_dict(), default=str)
+        rebuilt = EnvSnapshot.from_dict(json.loads(as_json))
+        assert rebuilt == original
+
+    def test_from_dict_tolerates_extra_keys_forward_compat(self):
+        """Future schema additions in env.json shouldn't break old code reading it."""
+        d = _example_snapshot().to_dict()
+        d["future_field_not_yet_added"] = {"hello": "world"}
+        rebuilt = EnvSnapshot.from_dict(d)
+        assert rebuilt.schema_version == "1.0"
+
+    def test_from_dict_defaults_partial_reasons_when_missing(self):
+        """Older env.json without partial_reasons still loads (defaults to [])."""
+        d = _example_snapshot().to_dict()
+        del d["partial_reasons"]
+        rebuilt = EnvSnapshot.from_dict(d)
+        assert rebuilt.partial_reasons == []
+
+    def test_summary_includes_partial_marker_when_partial(self):
+        partial_snap = _example_snapshot(partial=True, partial_reasons=["x: y"])
+        clean_snap = _example_snapshot()
+        assert "PARTIAL" in partial_snap.summary()
+        assert "PARTIAL" not in clean_snap.summary()
+
+    def test_summary_is_multiline_human_readable(self):
+        snap = _example_snapshot()
+        s = snap.summary()
+        # 6 lines per the implementation; loose lower-bound
+        assert s.count("\n") >= 4
+        assert "rocm:" in s
+        assert "hipblaslt:" in s
+
+    def test_dataclass_is_frozen(self):
+        """Callers can safely embed the snapshot without mutation hazards."""
+        snap = _example_snapshot()
+        with pytest.raises((AttributeError, TypeError)):
+            snap.schema_version = "2.0"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# collect_env contract: never raises + partial semantics + idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestCollectEnvContract:
+    def test_collect_env_never_raises_when_all_probes_fail(self, all_disabled):
+        """Acceptance: monkeypatch every probe to fail, still get an EnvSnapshot."""
+        snapshot = collect_env()
+        assert isinstance(snapshot, EnvSnapshot)
+        assert snapshot.partial is True
+        assert snapshot.partial_reasons, "partial=True must include at least one reason"
+
+    def test_partial_reasons_have_field_prefixes(self, all_disabled):
+        """Each reason should name the field it relates to (e.g. ``rocm.version: ...``)."""
+        snapshot = collect_env()
+        # Every reason should look like "<top.field>: <cause>" or "<top>: <cause>"
+        for reason in snapshot.partial_reasons:
+            head = reason.split(":", 1)[0]
+            assert head, f"reason missing prefix: {reason!r}"
+
+    def test_partial_false_on_clean_full_probe(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """When every probe succeeds, partial is False and reasons is empty."""
+        # Stand up a fully-populated mock environment under tmp.
+        rocm_info = tmp_path / ".info"
+        rocm_info.mkdir()
+        (rocm_info / "version").write_text("7.2.1\n")
+        (rocm_info / "version_dev").write_text("7.2.1-43\n")
+        kmd = tmp_path / "kmd"
+        kmd.write_text("6.16.13\n")
+
+        header_dir = tmp_path / "include" / "hipblaslt"
+        header_dir.mkdir(parents=True)
+        (header_dir / "hipblaslt-version.h").write_text(
+            "#define HIPBLASLT_VERSION_MAJOR 1\n"
+            "#define HIPBLASLT_VERSION_MINOR 2\n"
+            "#define HIPBLASLT_VERSION_PATCH 2\n"
+            "#define HIPBLASLT_VERSION_TWEAK abc1234\n"
+        )
+
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        (lib_dir / "libhipblaslt.so").write_bytes(b"binary")
+
+        tensile_dir = tmp_path / "tensile"
+        tensile_dir.mkdir()
+        (tensile_dir / "TensileLibrary_X.dat").write_bytes(b"x")
+
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", rocm_info / "version")
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", rocm_info / "version_dev")
+        monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", kmd)
+        monkeypatch.setattr(
+            env_mod, "HIPBLASLT_VERSION_HEADER", header_dir / "hipblaslt-version.h"
+        )
+        monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", lib_dir)
+        monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", tensile_dir)
+        monkeypatch.setattr(env_mod, "DOCKERENV_MARKER", tmp_path / "no_dockerenv")
+        monkeypatch.setattr(
+            env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv"
+        )
+        monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
+
+        # rdhc happy path: pretend it's installed and writes valid JSON
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/" + name)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "sudo" and "rdhc" in cmd[3]:
+                Path(cmd[-1]).write_text('{"rdhc_version": "1.4.0"}')
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+            if cmd[0] == "hipconfig":
+                outs = {
+                    "--version": "7.2.5",
+                    "--platform": "amd",
+                    "--compiler": "clang",
+                    "--runtime": "rocclr",
+                    "--cpp_config": "-D__HIP_PLATFORM_AMD__",
+                }
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout=outs[cmd[1]], stderr=""
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        # Pretend torch is importable with a version
+        import builtins
+        import types
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return types.SimpleNamespace(__version__="2.12.0")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        snapshot = collect_env()
+        assert snapshot.partial is False, (
+            f"clean probe should not be partial; reasons: {snapshot.partial_reasons}"
+        )
+        assert snapshot.partial_reasons == []
+        # Verify the success values landed
+        assert snapshot.rocm["version"] == "7.2.1"
+        assert snapshot.hipblaslt["commit"] == "abc1234"
+        assert snapshot.system_health == {"rdhc_version": "1.4.0"}
+        assert snapshot.hip["version"] == "7.2.5"
+        assert snapshot.pytorch_version == "2.12.0"
+
+    def test_idempotent_two_calls_produce_equivalent_snapshots(self, all_disabled):
+        """B1 may collect once per trial; B2 may collect once per matrix start.
+
+        Calling twice in the same process must produce equivalent snapshots
+        (modulo timestamp). No cross-call state contamination.
+        """
+        snap1 = collect_env()
+        snap2 = collect_env()
+        # Compare every field except captured_at (which is a wall-clock stamp)
+        d1 = snap1.to_dict()
+        d2 = snap2.to_dict()
+        d1.pop("captured_at")
+        d2.pop("captured_at")
+        assert d1 == d2
+
+    def test_baremetal_does_not_trigger_partial_for_docker_block(
+        self, isolated_env, monkeypatch, tmp_path: Path
+    ):
+        """``docker == None`` on baremetal is the documented contract, NOT a fallback."""
+        monkeypatch.setattr(env_mod, "DOCKERENV_MARKER", tmp_path / "no_dockerenv")
+        monkeypatch.setattr(env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv")
+        monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
+        # Confirm via the probe directly
+        rt = {"type": "baremetal"}
+        reasons: list[str] = []
+        block = env_mod._capture_docker_metadata(rt, reasons)
+        assert block is None
+        assert reasons == []  # NOT partial
+
+    def test_unset_env_vars_do_not_trigger_partial(self, isolated_env):
+        """Individual env_vars values being None is the documented contract."""
+        # All canonical vars are unset (cleared by isolated_env fixture).
+        # _capture_env_vars doesn't take a reasons list -- by design.
+        block = env_mod._capture_env_vars()
+        assert all(v is None for v in block.values())
+
+    def test_runtime_context_never_partial(self, all_disabled):
+        """runtime_context.* fields are documented absences, not fallbacks.
+
+        The other top-level blocks (rocm, hipblaslt, etc.) DO show up in
+        partial_reasons under all_disabled -- this test only asserts that
+        nothing prefixed with ``runtime_context`` ever appears.
+        """
+        snapshot = collect_env()
+        runtime_reasons = [
+            r for r in snapshot.partial_reasons if r.startswith("runtime_context")
+        ]
+        assert runtime_reasons == [], (
+            f"runtime_context fields should never trigger partial; got: {runtime_reasons}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B1 / B2 integration-style: snapshot embeds in a fake trial result
+# ---------------------------------------------------------------------------
+
+
+class TestB1B2Integration:
+    """Mirrors how B1 (per-trial runner) and B2 (matrix runner) will use this.
+
+    B1's pattern:
+        trial_result = {
+            "trial_id": "...",
+            "passed": True,
+            "metrics": {...},
+            "env": collect_env().to_dict(),  # embedded inline
+        }
+        write(trial_result_json, trial_result)
+
+    B2's pattern (host scope):
+        host_env = collect_env()
+        write(matrix_dir / "host_env.json", host_env.to_dict())
+
+    Both must round-trip cleanly so post-mortem tools can reconstruct an
+    EnvSnapshot from the persisted JSON.
+    """
+
+    def test_snapshot_embeds_in_trial_result_and_round_trips(self, all_disabled, tmp_path: Path):
+        snapshot = collect_env()
+
+        trial_result = {
+            "trial_id": "exp1-trial0",
+            "passed": True,
+            "metrics": {"loss": 0.42, "step_times_ms": [10.1, 9.8]},
+            "env": snapshot.to_dict(),
+        }
+        out = tmp_path / "trial_result.json"
+        out.write_text(json.dumps(trial_result, default=str, indent=2))
+
+        loaded = json.loads(out.read_text())
+        assert loaded["trial_id"] == "exp1-trial0"
+        # Reconstruct the typed snapshot from the embedded dict
+        reconstructed = EnvSnapshot.from_dict(loaded["env"])
+        assert reconstructed == snapshot
+
+    def test_b2_host_env_file_round_trips(self, all_disabled, tmp_path: Path):
+        """B2 writes host_env.json once at matrix start."""
+        snapshot = collect_env()
+        host_env_path = tmp_path / "host_env.json"
+        host_env_path.write_text(json.dumps(snapshot.to_dict(), default=str))
+
+        loaded = EnvSnapshot.from_dict(json.loads(host_env_path.read_text()))
+        assert loaded == snapshot
+        assert loaded.partial == snapshot.partial
+        assert loaded.partial_reasons == snapshot.partial_reasons
+
+
+# ---------------------------------------------------------------------------
+# CLI thin-wrapper invariant
+# ---------------------------------------------------------------------------
+
+
+class TestCliIsThinWrapper:
+    """Per #147 acceptance: ``src/aorta/cli/env.py`` does no probing of its own
+    and stays under ~30 lines of substantive code."""
+
+    @pytest.fixture
+    def cli_path(self) -> Path:
+        return Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+
+    def test_total_file_size_is_bounded(self, cli_path: Path):
+        # Total file budget (incl. docstring/imports/blank lines): 60 lines.
+        # The substantive code budget per the spec is ~30 lines; the cushion
+        # accounts for the module docstring + Click decorators.
+        line_count = sum(1 for _ in cli_path.read_text().splitlines())
+        assert line_count <= 60, (
+            f"cli/env.py is {line_count} lines; budget is 60 (spec target ~30 substantive). "
+            "If you need more, the probing logic should move into the library, not the CLI."
+        )
+
+    def test_cli_does_no_probing_imports(self, cli_path: Path):
+        """CLI must not import anything that would let it probe directly."""
+        text = cli_path.read_text()
+        forbidden = ["import subprocess", "import shutil", "import platform", "import hashlib"]
+        for token in forbidden:
+            assert token not in text, (
+                f"cli/env.py imports {token!r} -- probing belongs in the library"
+            )
+
+    def test_cli_calls_collect_env(self, cli_path: Path):
+        """Sanity check: the CLI references the library function."""
+        text = cli_path.read_text()
+        assert "collect_env" in text
 
 
 # ---------------------------------------------------------------------------
@@ -151,9 +540,10 @@ class TestSchemaCompleteness:
 
 
 class TestRdhcWrapper:
-    def test_rdhc_unavailable_returns_none(self, all_disabled):
-        # all_disabled already stubs shutil.which to return None
-        assert env_mod._run_rdhc() is None
+    def test_rdhc_unavailable_returns_none_and_records_reason(self, all_disabled):
+        reasons: list[str] = []
+        assert env_mod._run_rdhc(reasons) is None
+        assert any("rdhc" in r for r in reasons)
 
     def test_rdhc_present_but_sudo_n_fails_returns_none(
         self, isolated_env, monkeypatch
@@ -161,13 +551,14 @@ class TestRdhcWrapper:
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
 
         def fake_run(cmd, **kwargs):
-            # sudo -n returns non-zero when password would be required
             return subprocess.CompletedProcess(
                 args=cmd, returncode=1, stdout="", stderr="sudo: a password is required"
             )
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        assert env_mod._run_rdhc() is None
+        reasons: list[str] = []
+        assert env_mod._run_rdhc(reasons) is None
+        assert any("sudo" in r.lower() or "exited 1" in r for r in reasons)
 
     def test_rdhc_timeout_returns_none(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
@@ -176,7 +567,9 @@ class TestRdhcWrapper:
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        assert env_mod._run_rdhc() is None
+        reasons: list[str] = []
+        assert env_mod._run_rdhc(reasons) is None
+        assert any("timeout" in r.lower() for r in reasons)
 
     def test_rdhc_happy_path_returns_parsed_json(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
@@ -196,21 +589,18 @@ class TestRdhcWrapper:
             assert "-n" in cmd
             assert "--quick" in cmd
             assert "--json" in cmd
-            # The last arg is the output path (managed by tempfile now)
             out_path = Path(cmd[-1])
             captured["path"] = out_path
             out_path.write_text(json.dumps(rdhc_payload))
-            return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout="", stderr=""
-            )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        result = env_mod._run_rdhc()
+        reasons: list[str] = []
+        result = env_mod._run_rdhc(reasons)
         assert result == rdhc_payload
-        # Confirm the temp file was cleaned up after parsing -- no
-        # sidecar artifact left behind.
+        assert reasons == []  # happy path -> no partial reason
         assert "path" in captured
-        assert not captured["path"].exists()
+        assert not captured["path"].exists()  # tempfile cleaned up
 
     def test_rdhc_malformed_json_returns_none(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
@@ -220,12 +610,11 @@ class TestRdhcWrapper:
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        assert env_mod._run_rdhc() is None
+        reasons: list[str] = []
+        assert env_mod._run_rdhc(reasons) is None
+        assert any("parseable" in r for r in reasons)
 
-    def test_rdhc_temp_file_cleaned_up_on_failure(
-        self, isolated_env, monkeypatch
-    ):
-        """The tempfile is removed even when the subprocess fails."""
+    def test_rdhc_temp_file_cleaned_up_on_failure(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
         captured: dict[str, Path] = {}
 
@@ -236,7 +625,8 @@ class TestRdhcWrapper:
             )
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        assert env_mod._run_rdhc() is None
+        reasons: list[str] = []
+        assert env_mod._run_rdhc(reasons) is None
         assert "path" in captured
         assert not captured["path"].exists()
 
@@ -247,7 +637,7 @@ class TestRdhcWrapper:
 
 
 class TestRocmVersionFiles:
-    def test_all_present(self, tmp_path: Path, monkeypatch):
+    def test_all_present_no_reasons(self, tmp_path: Path, monkeypatch):
         v = tmp_path / "version"
         v.write_text("7.2.1\n")
         vdev = tmp_path / "version-dev"
@@ -259,41 +649,48 @@ class TestRocmVersionFiles:
         monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", vdev)
         monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", kmd)
 
-        result = env_mod._capture_rocm_version_files()
+        reasons: list[str] = []
+        result = env_mod._capture_rocm_version_files(reasons)
         assert result == {
             "version": "7.2.1",
             "version_dev": "7.2.1.50311-abc1234",
             "kmd_version": "6.16.13",
         }
+        assert reasons == []
 
-    def test_all_missing(self, tmp_path: Path, monkeypatch):
+    def test_all_missing_appends_three_reasons(self, tmp_path: Path, monkeypatch):
         monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", tmp_path / "nope1")
         monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", tmp_path / "nope2")
         monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", tmp_path / "nope3")
-        result = env_mod._capture_rocm_version_files()
+        reasons: list[str] = []
+        result = env_mod._capture_rocm_version_files(reasons)
         assert result == {"version": None, "version_dev": None, "kmd_version": None}
+        assert len(reasons) == 3
+        assert all(r.startswith("rocm.") for r in reasons)
 
-    def test_partial_missing(self, tmp_path: Path, monkeypatch):
+    def test_partial_missing_appends_only_for_missing(self, tmp_path: Path, monkeypatch):
         v = tmp_path / "version"
         v.write_text("7.2.1\n")
         monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", v)
         monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", tmp_path / "nope")
         monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", tmp_path / "also_nope")
-        result = env_mod._capture_rocm_version_files()
-        assert result == {
-            "version": "7.2.1",
-            "version_dev": None,
-            "kmd_version": None,
-        }
+        reasons: list[str] = []
+        result = env_mod._capture_rocm_version_files(reasons)
+        assert result["version"] == "7.2.1"
+        assert result["version_dev"] is None
+        assert result["kmd_version"] is None
+        assert len(reasons) == 2
+        assert any("version_dev" in r for r in reasons)
+        assert any("kmd_version" in r for r in reasons)
 
     def test_empty_file_treated_as_none(self, tmp_path: Path, monkeypatch):
-        # /opt/rocm/.info/version-dev is sometimes installed but empty
         empty = tmp_path / "version-dev"
         empty.write_text("")
         monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", empty)
         monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", tmp_path / "nope")
         monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", tmp_path / "nope")
-        result = env_mod._capture_rocm_version_files()
+        reasons: list[str] = []
+        result = env_mod._capture_rocm_version_files(reasons)
         assert result["version_dev"] is None
 
 
@@ -303,18 +700,17 @@ class TestRocmVersionFiles:
 
 
 class TestHipToolchain:
-    def test_hipconfig_missing_returns_all_none(self, isolated_env, monkeypatch):
+    def test_hipconfig_missing_returns_all_none_and_one_reason(
+        self, isolated_env, monkeypatch
+    ):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
-        result = env_mod._capture_hip_toolchain()
-        assert result == {
-            "version": None,
-            "platform": None,
-            "compiler": None,
-            "runtime": None,
-            "cpp_config": None,
-        }
+        reasons: list[str] = []
+        result = env_mod._capture_hip_toolchain(reasons)
+        assert all(v is None for v in result.values())
+        assert len(reasons) == 1
+        assert "hip" in reasons[0]
 
-    def test_hipconfig_happy_path(self, isolated_env, monkeypatch):
+    def test_hipconfig_happy_path_no_reasons(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/hipconfig")
 
         outputs = {
@@ -332,16 +728,14 @@ class TestHipToolchain:
             )
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        result = env_mod._capture_hip_toolchain()
-        assert result == {
-            "version": "7.2.53211-e1a6bc5663",
-            "platform": "amd",
-            "compiler": "clang",
-            "runtime": "rocclr",
-            "cpp_config": "-D__HIP_PLATFORM_AMD__",
-        }
+        reasons: list[str] = []
+        result = env_mod._capture_hip_toolchain(reasons)
+        assert result["version"] == "7.2.53211-e1a6bc5663"
+        assert reasons == []
 
-    def test_hipconfig_one_field_fails(self, isolated_env, monkeypatch):
+    def test_hipconfig_one_field_fails_appends_one_reason(
+        self, isolated_env, monkeypatch
+    ):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/hipconfig")
 
         def fake_run(cmd, **kwargs):
@@ -354,9 +748,11 @@ class TestHipToolchain:
             )
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        result = env_mod._capture_hip_toolchain()
-        assert result["version"] == "ok"
+        reasons: list[str] = []
+        result = env_mod._capture_hip_toolchain(reasons)
         assert result["cpp_config"] is None
+        assert len(reasons) == 1
+        assert "cpp_config" in reasons[0]
 
 
 # ---------------------------------------------------------------------------
@@ -408,7 +804,6 @@ class TestHipblasltLibHash:
         symlink_b.symlink_to(symlink_a.name)
 
         monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", lib_dir)
-
         digest = env_mod._hash_hipblaslt_library()
         expected = "sha256:" + hashlib.sha256(b"hello hipblaslt").hexdigest()
         assert digest == expected
@@ -430,7 +825,6 @@ class TestTensileFingerprint:
         fp1 = env_mod._tensile_fingerprint()
         assert fp1 is not None and fp1.startswith("filenames-sha256:")
 
-        # Add another file -> fingerprint changes
         (d / "TensileLibrary_C.dat").write_bytes(b"z")
         fp2 = env_mod._tensile_fingerprint()
         assert fp2 != fp1
@@ -451,11 +845,13 @@ class TestTensileFingerprint:
 
 class TestHipblasltBlockShape:
     def test_applied_prs_is_empty_dict_initially(self, all_disabled):
-        block = env_mod._capture_hipblaslt()
+        reasons: list[str] = []
+        block = env_mod._capture_hipblaslt(reasons)
         assert block["applied_prs"] == {}
 
     def test_block_keys_stable(self, all_disabled):
-        block = env_mod._capture_hipblaslt()
+        reasons: list[str] = []
+        block = env_mod._capture_hipblaslt(reasons)
         assert set(block.keys()) == {
             "commit",
             "package_version",
@@ -463,6 +859,11 @@ class TestHipblasltBlockShape:
             "tensile_yaml_revision",
             "applied_prs",
         }
+
+    def test_partial_reasons_contain_hipblaslt_prefix(self, all_disabled):
+        reasons: list[str] = []
+        env_mod._capture_hipblaslt(reasons)
+        assert all(r.startswith("hipblaslt.") for r in reasons)
 
 
 # ---------------------------------------------------------------------------
@@ -531,9 +932,7 @@ class TestRuntimeContext:
         monkeypatch.setattr(sys, "base_prefix", sys.prefix)
         assert env_mod._detect_python_env() == "system"
 
-    def test_runtime_context_venv_path_populated(
-        self, all_disabled, monkeypatch
-    ):
+    def test_runtime_context_venv_path_populated(self, all_disabled, monkeypatch):
         monkeypatch.setattr(sys, "base_prefix", "/usr")
         monkeypatch.setattr(sys, "prefix", "/home/user/.venv")
         rt = env_mod._detect_runtime_context()
@@ -555,24 +954,30 @@ class TestRuntimeContext:
 
 
 class TestDockerMetadata:
-    def test_baremetal_returns_none(self):
-        rt = {"type": "baremetal", "python_env": "system"}
-        assert env_mod._capture_docker_metadata(rt) is None
+    def test_baremetal_returns_none_no_reasons(self):
+        reasons: list[str] = []
+        assert env_mod._capture_docker_metadata({"type": "baremetal"}, reasons) is None
+        assert reasons == []
 
     def test_docker_picks_up_aorta_env_vars(self, isolated_env):
         isolated_env.setenv("AORTA_DOCKER_IMAGE", "rocm/pytorch:7.2")
         isolated_env.setenv("AORTA_DOCKER_DIGEST", "sha256:deadbeef")
-        rt = {"type": "docker"}
-        block = env_mod._capture_docker_metadata(rt)
+        reasons: list[str] = []
+        block = env_mod._capture_docker_metadata({"type": "docker"}, reasons)
         assert block["image"] == "rocm/pytorch:7.2"
         assert block["digest"] == "sha256:deadbeef"
+        assert reasons == []  # both populated -> no partial
 
-    def test_docker_block_emits_keys_even_without_env(self, isolated_env):
-        rt = {"type": "docker"}
-        block = env_mod._capture_docker_metadata(rt)
+    def test_docker_in_container_without_env_vars_appends_reasons(self, isolated_env):
+        reasons: list[str] = []
+        block = env_mod._capture_docker_metadata({"type": "docker"}, reasons)
         assert set(block.keys()) == {"image", "digest", "container_id"}
         assert block["image"] is None
         assert block["digest"] is None
+        # Both image and digest missing -> two reasons
+        assert len(reasons) == 2
+        assert any("image" in r for r in reasons)
+        assert any("digest" in r for r in reasons)
 
     def test_container_id_extracted_from_cgroup(
         self, isolated_env, tmp_path: Path, monkeypatch
@@ -580,11 +985,12 @@ class TestDockerMetadata:
         cgroup = tmp_path / "cgroup"
         cid = "abc123def456789012345678901234567890abcd"
         cgroup.write_text(f"12:freezer:/docker/{cid}\n")
-        # _read_container_id() reads /proc/self/cgroup, not /proc/1/cgroup;
-        # patch the Path constructor it uses inside.
         monkeypatch.setattr(env_mod, "_read_text_file", lambda p: cgroup.read_text())
-        rt = {"type": "docker"}
-        block = env_mod._capture_docker_metadata(rt)
+        reasons: list[str] = []
+        # Provide image/digest so they don't add their own reasons
+        isolated_env.setenv("AORTA_DOCKER_IMAGE", "x")
+        isolated_env.setenv("AORTA_DOCKER_DIGEST", "y")
+        block = env_mod._capture_docker_metadata({"type": "docker"}, reasons)
         assert block["container_id"] == cid
 
 
@@ -643,9 +1049,7 @@ class TestEnvVars:
 
 
 class TestPytorchVersion:
-    def test_torch_unavailable_returns_none(self, isolated_env):
-        # Force an ImportError at probe-time even if torch happens to be
-        # installed in the test env, by monkeypatching builtins.__import__.
+    def test_torch_unavailable_returns_none_and_records_reason(self, isolated_env):
         import builtins
 
         real_import = builtins.__import__
@@ -656,18 +1060,14 @@ class TestPytorchVersion:
             return real_import(name, *args, **kwargs)
 
         with patch.object(builtins, "__import__", side_effect=fake_import):
-            assert env_mod._capture_pytorch_version() is None
+            reasons: list[str] = []
+            assert env_mod._capture_pytorch_version(reasons) is None
+            assert any("torch" in r for r in reasons)
 
     def test_torch_present_without_version_returns_none_not_string(
         self, isolated_env
     ):
-        """Regression guard: never emit the string "None" as the version.
-
-        Some torch builds (or stubs) lack ``__version__``. Earlier code did
-        ``str(getattr(torch, '__version__', None))`` which yielded the
-        string "None" -- breaking consumers doing ``jq '.pytorch_version
-        == null'``. Confirm we return Python ``None`` instead.
-        """
+        """Regression guard: never emit the string "None" as the version."""
         import builtins
         import types
 
@@ -680,10 +1080,28 @@ class TestPytorchVersion:
             return real_import(name, *args, **kwargs)
 
         with patch.object(builtins, "__import__", side_effect=fake_import):
-            result = env_mod._capture_pytorch_version()
+            reasons: list[str] = []
+            result = env_mod._capture_pytorch_version(reasons)
         assert result is None
-        # Belt-and-suspenders: not the string "None"
         assert result != "None"
+        assert any("__version__" in r for r in reasons)
+
+    def test_torch_with_version_returns_string_no_reason(self, isolated_env):
+        import builtins
+        import types
+
+        real_import = builtins.__import__
+        fake_torch = types.SimpleNamespace(__version__="2.12.0")
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            reasons: list[str] = []
+            assert env_mod._capture_pytorch_version(reasons) == "2.12.0"
+            assert reasons == []
 
 
 class TestNoGpuCompute:
@@ -694,107 +1112,13 @@ class TestNoGpuCompute:
     initialise a HIP context).
     """
 
-    def test_torch_cuda_never_called(self, all_disabled, tmp_path: Path):
+    def test_torch_cuda_never_called(self, all_disabled):
         if "torch" not in sys.modules:
             pytest.skip("torch not available; trivially passes")
         torch = sys.modules["torch"]
         with patch.object(torch.cuda, "is_available") as is_avail, patch.object(
             torch.cuda, "device_count"
         ) as dev_count:
-            capture_environment(tmp_path / "env.json")
+            collect_env()
             is_avail.assert_not_called()
             dev_count.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# End-to-end orchestrator
-# ---------------------------------------------------------------------------
-
-
-class TestCaptureEnvironmentEndToEnd:
-    def test_full_snapshot_with_realistic_files(
-        self, isolated_env, tmp_path: Path, monkeypatch
-    ):
-        # Stand up a realistic-looking ROCm root in tmp.
-        rocm = tmp_path / "rocm"
-        info = rocm / ".info"
-        info.mkdir(parents=True)
-        (info / "version").write_text("7.2.1\n")
-        (info / "version-dev").write_text("7.2.1.50311-abc1234\n")
-
-        kmd = tmp_path / "amdgpu_version"
-        kmd.write_text("6.16.13\n")
-
-        hipblaslt_inc = rocm / "include" / "hipblaslt"
-        hipblaslt_inc.mkdir(parents=True)
-        (hipblaslt_inc / "hipblaslt-version.h").write_text(
-            "#define HIPBLASLT_VERSION_MAJOR 1\n"
-            "#define HIPBLASLT_VERSION_MINOR 2\n"
-            "#define HIPBLASLT_VERSION_PATCH 2\n"
-            "#define HIPBLASLT_VERSION_TWEAK dabb6df2b9\n"
-        )
-
-        lib = rocm / "lib"
-        lib.mkdir()
-        (lib / "libhipblaslt.so").write_bytes(b"fake binary")
-
-        tensile = rocm / "lib" / "hipblaslt" / "library"
-        tensile.mkdir(parents=True)
-        (tensile / "TensileLibrary_X.dat").write_bytes(b"x")
-        (tensile / "TensileLibrary_Y.dat").write_bytes(b"y")
-
-        monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", info / "version")
-        monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", info / "version-dev")
-        monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", kmd)
-        monkeypatch.setattr(
-            env_mod, "HIPBLASLT_VERSION_HEADER", hipblaslt_inc / "hipblaslt-version.h"
-        )
-        monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", lib)
-        monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", tensile)
-        monkeypatch.setattr(env_mod, "DOCKERENV_MARKER", tmp_path / "no_dockerenv")
-        monkeypatch.setattr(
-            env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv"
-        )
-        monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
-        monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
-
-        out = tmp_path / "env.json"
-        snapshot = capture_environment(out)
-
-        # Schema completeness
-        assert set(snapshot.keys()) == REQUIRED_TOP_KEYS
-
-        # ROCm
-        assert snapshot["rocm"]["version"] == "7.2.1"
-        assert snapshot["rocm"]["version_dev"] == "7.2.1.50311-abc1234"
-        assert snapshot["rocm"]["kmd_version"] == "6.16.13"
-
-        # HIP (no hipconfig available -> all None)
-        assert snapshot["hip"] == {
-            "version": None,
-            "platform": None,
-            "compiler": None,
-            "runtime": None,
-            "cpp_config": None,
-        }
-
-        # hipBLASLt
-        assert snapshot["hipblaslt"]["commit"] == "dabb6df2b9"
-        assert snapshot["hipblaslt"]["package_version"] == "1.2.2"
-        assert snapshot["hipblaslt"]["lib_hash"] == (
-            "sha256:" + hashlib.sha256(b"fake binary").hexdigest()
-        )
-        assert snapshot["hipblaslt"]["tensile_yaml_revision"].startswith(
-            "filenames-sha256:"
-        )
-        assert snapshot["hipblaslt"]["applied_prs"] == {}
-
-        # Runtime
-        assert snapshot["runtime_context"]["type"] == "baremetal"
-        assert snapshot["docker"] is None  # baremetal -> docker is null
-
-        # RDHC unavailable
-        assert snapshot["system_health"] is None
-
-        # File on disk matches return value
-        assert json.loads(out.read_text()) == snapshot

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -15,10 +15,9 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-
 
 # -- Direct module load (avoid torch via aorta.utils) -------------------------
 
@@ -152,13 +151,12 @@ class TestSchemaCompleteness:
 
 
 class TestRdhcWrapper:
-    def test_rdhc_unavailable_returns_none(self, all_disabled, tmp_path: Path):
+    def test_rdhc_unavailable_returns_none(self, all_disabled):
         # all_disabled already stubs shutil.which to return None
-        result = env_mod._run_rdhc(tmp_path / "rdhc_out.json")
-        assert result is None
+        assert env_mod._run_rdhc() is None
 
     def test_rdhc_present_but_sudo_n_fails_returns_none(
-        self, isolated_env, tmp_path: Path, monkeypatch
+        self, isolated_env, monkeypatch
     ):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
 
@@ -169,24 +167,19 @@ class TestRdhcWrapper:
             )
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        assert env_mod._run_rdhc(tmp_path / "rdhc_out.json") is None
+        assert env_mod._run_rdhc() is None
 
-    def test_rdhc_timeout_returns_none(
-        self, isolated_env, tmp_path: Path, monkeypatch
-    ):
+    def test_rdhc_timeout_returns_none(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
 
         def fake_run(cmd, **kwargs):
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        assert env_mod._run_rdhc(tmp_path / "rdhc_out.json") is None
+        assert env_mod._run_rdhc() is None
 
-    def test_rdhc_happy_path_returns_parsed_json(
-        self, isolated_env, tmp_path: Path, monkeypatch
-    ):
+    def test_rdhc_happy_path_returns_parsed_json(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
-        out = tmp_path / "rdhc_out.json"
 
         rdhc_payload = {
             "rdhc_version": "1.4.0",
@@ -196,32 +189,56 @@ class TestRdhcWrapper:
             "firmware": [],
         }
 
+        captured: dict[str, Path] = {}
+
         def fake_run(cmd, **kwargs):
             assert cmd[0] == "sudo"
             assert "-n" in cmd
             assert "--quick" in cmd
             assert "--json" in cmd
-            out.write_text(json.dumps(rdhc_payload))
+            # The last arg is the output path (managed by tempfile now)
+            out_path = Path(cmd[-1])
+            captured["path"] = out_path
+            out_path.write_text(json.dumps(rdhc_payload))
             return subprocess.CompletedProcess(
                 args=cmd, returncode=0, stdout="", stderr=""
             )
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        result = env_mod._run_rdhc(out)
+        result = env_mod._run_rdhc()
         assert result == rdhc_payload
+        # Confirm the temp file was cleaned up after parsing -- no
+        # sidecar artifact left behind.
+        assert "path" in captured
+        assert not captured["path"].exists()
 
-    def test_rdhc_malformed_json_returns_none(
-        self, isolated_env, tmp_path: Path, monkeypatch
-    ):
+    def test_rdhc_malformed_json_returns_none(self, isolated_env, monkeypatch):
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
-        out = tmp_path / "rdhc_out.json"
 
         def fake_run(cmd, **kwargs):
-            out.write_text("not valid json {{{")
+            Path(cmd[-1]).write_text("not valid json {{{")
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        assert env_mod._run_rdhc(out) is None
+        assert env_mod._run_rdhc() is None
+
+    def test_rdhc_temp_file_cleaned_up_on_failure(
+        self, isolated_env, monkeypatch
+    ):
+        """The tempfile is removed even when the subprocess fails."""
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
+        captured: dict[str, Path] = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["path"] = Path(cmd[-1])
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="", stderr="boom"
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        assert env_mod._run_rdhc() is None
+        assert "path" in captured
+        assert not captured["path"].exists()
 
 
 # ---------------------------------------------------------------------------
@@ -591,7 +608,7 @@ class TestEnvVars:
         for var in CANONICAL_ENV_VARS:
             assert result[var] is None, f"{var} should be None when unset"
 
-    def test_workload_config_vars_NOT_captured(self, isolated_env):
+    def test_workload_config_vars_are_not_captured(self, isolated_env):
         # Per acceptance criteria, these are workload state, not env probe state
         isolated_env.setenv("AMP_DTYPE", "bf16")
         isolated_env.setenv("MODEL_DTYPE", "fp32")
@@ -640,6 +657,33 @@ class TestPytorchVersion:
 
         with patch.object(builtins, "__import__", side_effect=fake_import):
             assert env_mod._capture_pytorch_version() is None
+
+    def test_torch_present_without_version_returns_none_not_string(
+        self, isolated_env
+    ):
+        """Regression guard: never emit the string "None" as the version.
+
+        Some torch builds (or stubs) lack ``__version__``. Earlier code did
+        ``str(getattr(torch, '__version__', None))`` which yielded the
+        string "None" -- breaking consumers doing ``jq '.pytorch_version
+        == null'``. Confirm we return Python ``None`` instead.
+        """
+        import builtins
+        import types
+
+        real_import = builtins.__import__
+        fake_torch = types.SimpleNamespace()  # no __version__ attr
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            result = env_mod._capture_pytorch_version()
+        assert result is None
+        # Belt-and-suspenders: not the string "None"
+        assert result != "None"
 
 
 class TestNoGpuCompute:

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -1,0 +1,756 @@
+"""Tests for ``aorta.instrumentation.environment`` (issue #147 acceptance).
+
+Strategy: load the module by file path so the test does not pull in the
+torch-dependent ``aorta.utils`` package. Every subprocess and filesystem
+touchpoint is monkeypatched, so tests run on any host without ROCm,
+RDHC, hipconfig, hipblaslt, or torch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# -- Direct module load (avoid torch via aorta.utils) -------------------------
+
+_MODULE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    os.pardir,
+    "src",
+    "aorta",
+    "instrumentation",
+    "environment.py",
+)
+_spec = importlib.util.spec_from_file_location(
+    "aorta.instrumentation.environment", _MODULE_PATH
+)
+env_mod = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = env_mod
+_spec.loader.exec_module(env_mod)
+
+
+capture_environment = env_mod.capture_environment
+SCHEMA_VERSION = env_mod.SCHEMA_VERSION
+CANONICAL_ENV_VARS = env_mod.CANONICAL_ENV_VARS
+
+
+# -- Shared fixtures ---------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_env(monkeypatch):
+    """Strip env vars that would leak host state into the snapshot."""
+    for name in CANONICAL_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
+    monkeypatch.delenv("SINGULARITY_NAME", raising=False)
+    monkeypatch.delenv("AORTA_DOCKER_IMAGE", raising=False)
+    monkeypatch.delenv("AORTA_DOCKER_DIGEST", raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
+    """Force every external dep into its 'unavailable' branch.
+
+    Result: ``capture_environment`` exercises only pure-Python paths and
+    every block returns its null-shaped form.
+    """
+    monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", tmp_path / "no_rocm")
+    monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", tmp_path / "no_rocm_dev")
+    monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", tmp_path / "no_kmd")
+    monkeypatch.setattr(
+        env_mod, "HIPBLASLT_VERSION_HEADER", tmp_path / "no_header.h"
+    )
+    monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", tmp_path / "no_libs")
+    monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", tmp_path / "no_tensile")
+    monkeypatch.setattr(env_mod, "DOCKERENV_MARKER", tmp_path / "no_dockerenv")
+    monkeypatch.setattr(
+        env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv"
+    )
+    monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
+    monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
+    return monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# Schema completeness + versioning
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_TOP_KEYS = {
+    "schema_version",
+    "captured_at",
+    "system_health",
+    "rocm",
+    "hip",
+    "hipblaslt",
+    "runtime_context",
+    "docker",
+    "env_vars",
+    "python_version",
+    "pytorch_version",
+}
+
+
+class TestSchemaCompleteness:
+    def test_all_top_level_keys_present_when_everything_unavailable(
+        self, all_disabled, tmp_path: Path
+    ):
+        out = tmp_path / "env.json"
+        snapshot = capture_environment(out)
+        # All keys must be present regardless of availability
+        assert set(snapshot.keys()) == REQUIRED_TOP_KEYS
+        # The blocks themselves either have content or are explicitly null
+        assert snapshot["schema_version"] == "1.0"
+        assert snapshot["system_health"] is None
+        assert snapshot["rocm"] == {
+            "version": None,
+            "version_dev": None,
+            "kmd_version": None,
+        }
+        assert snapshot["hip"] == {
+            "version": None,
+            "platform": None,
+            "compiler": None,
+            "runtime": None,
+            "cpp_config": None,
+        }
+
+    def test_snapshot_is_written_to_disk(self, all_disabled, tmp_path: Path):
+        out = tmp_path / "env.json"
+        snapshot = capture_environment(out)
+        assert out.exists()
+        on_disk = json.loads(out.read_text())
+        assert on_disk == snapshot
+
+    def test_schema_version_constant_is_emitted(self, all_disabled, tmp_path: Path):
+        snapshot = capture_environment(tmp_path / "env.json")
+        assert snapshot["schema_version"] == SCHEMA_VERSION
+
+    def test_captured_at_is_iso8601_utc(self, all_disabled, tmp_path: Path):
+        snapshot = capture_environment(tmp_path / "env.json")
+        ts = snapshot["captured_at"]
+        # Issue's example uses trailing Z; validate shape rather than exact value
+        assert ts.endswith("Z")
+        assert "T" in ts
+
+
+# ---------------------------------------------------------------------------
+# RDHC wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestRdhcWrapper:
+    def test_rdhc_unavailable_returns_none(self, all_disabled, tmp_path: Path):
+        # all_disabled already stubs shutil.which to return None
+        result = env_mod._run_rdhc(tmp_path / "rdhc_out.json")
+        assert result is None
+
+    def test_rdhc_present_but_sudo_n_fails_returns_none(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
+
+        def fake_run(cmd, **kwargs):
+            # sudo -n returns non-zero when password would be required
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="", stderr="sudo: a password is required"
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        assert env_mod._run_rdhc(tmp_path / "rdhc_out.json") is None
+
+    def test_rdhc_timeout_returns_none(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        assert env_mod._run_rdhc(tmp_path / "rdhc_out.json") is None
+
+    def test_rdhc_happy_path_returns_parsed_json(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
+        out = tmp_path / "rdhc_out.json"
+
+        rdhc_payload = {
+            "rdhc_version": "1.4.0",
+            "tests": {"gpu_present": "PASS"},
+            "general_info": {"hostname": "test-host"},
+            "gpu_info": [{"name": "MI300X"}],
+            "firmware": [],
+        }
+
+        def fake_run(cmd, **kwargs):
+            assert cmd[0] == "sudo"
+            assert "-n" in cmd
+            assert "--quick" in cmd
+            assert "--json" in cmd
+            out.write_text(json.dumps(rdhc_payload))
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        result = env_mod._run_rdhc(out)
+        assert result == rdhc_payload
+
+    def test_rdhc_malformed_json_returns_none(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
+        out = tmp_path / "rdhc_out.json"
+
+        def fake_run(cmd, **kwargs):
+            out.write_text("not valid json {{{")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        assert env_mod._run_rdhc(out) is None
+
+
+# ---------------------------------------------------------------------------
+# ROCm version files
+# ---------------------------------------------------------------------------
+
+
+class TestRocmVersionFiles:
+    def test_all_present(self, tmp_path: Path, monkeypatch):
+        v = tmp_path / "version"
+        v.write_text("7.2.1\n")
+        vdev = tmp_path / "version-dev"
+        vdev.write_text("7.2.1.50311-abc1234\n")
+        kmd = tmp_path / "kmd_version"
+        kmd.write_text("6.16.13\n")
+
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", v)
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", vdev)
+        monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", kmd)
+
+        result = env_mod._capture_rocm_version_files()
+        assert result == {
+            "version": "7.2.1",
+            "version_dev": "7.2.1.50311-abc1234",
+            "kmd_version": "6.16.13",
+        }
+
+    def test_all_missing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", tmp_path / "nope1")
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", tmp_path / "nope2")
+        monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", tmp_path / "nope3")
+        result = env_mod._capture_rocm_version_files()
+        assert result == {"version": None, "version_dev": None, "kmd_version": None}
+
+    def test_partial_missing(self, tmp_path: Path, monkeypatch):
+        v = tmp_path / "version"
+        v.write_text("7.2.1\n")
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", v)
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", tmp_path / "nope")
+        monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", tmp_path / "also_nope")
+        result = env_mod._capture_rocm_version_files()
+        assert result == {
+            "version": "7.2.1",
+            "version_dev": None,
+            "kmd_version": None,
+        }
+
+    def test_empty_file_treated_as_none(self, tmp_path: Path, monkeypatch):
+        # /opt/rocm/.info/version-dev is sometimes installed but empty
+        empty = tmp_path / "version-dev"
+        empty.write_text("")
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", empty)
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", tmp_path / "nope")
+        monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", tmp_path / "nope")
+        result = env_mod._capture_rocm_version_files()
+        assert result["version_dev"] is None
+
+
+# ---------------------------------------------------------------------------
+# HIP toolchain
+# ---------------------------------------------------------------------------
+
+
+class TestHipToolchain:
+    def test_hipconfig_missing_returns_all_none(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
+        result = env_mod._capture_hip_toolchain()
+        assert result == {
+            "version": None,
+            "platform": None,
+            "compiler": None,
+            "runtime": None,
+            "cpp_config": None,
+        }
+
+    def test_hipconfig_happy_path(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/hipconfig")
+
+        outputs = {
+            "--version": "7.2.53211-e1a6bc5663",
+            "--platform": "amd",
+            "--compiler": "clang",
+            "--runtime": "rocclr",
+            "--cpp_config": "-D__HIP_PLATFORM_AMD__",
+        }
+
+        def fake_run(cmd, **kwargs):
+            assert cmd[0] == "hipconfig"
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=outputs[cmd[1]] + "\n", stderr=""
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        result = env_mod._capture_hip_toolchain()
+        assert result == {
+            "version": "7.2.53211-e1a6bc5663",
+            "platform": "amd",
+            "compiler": "clang",
+            "runtime": "rocclr",
+            "cpp_config": "-D__HIP_PLATFORM_AMD__",
+        }
+
+    def test_hipconfig_one_field_fails(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/hipconfig")
+
+        def fake_run(cmd, **kwargs):
+            if cmd[1] == "--cpp_config":
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=1, stdout="", stderr="boom"
+                )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="ok\n", stderr=""
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        result = env_mod._capture_hip_toolchain()
+        assert result["version"] == "ok"
+        assert result["cpp_config"] is None
+
+
+# ---------------------------------------------------------------------------
+# hipBLASLt introspection
+# ---------------------------------------------------------------------------
+
+
+class TestHipblasltHeaderParsing:
+    def test_parse_full_header(self):
+        text = """
+        #ifndef _HIPBLASLT_VERSION_H_
+        #define _HIPBLASLT_VERSION_H_
+        #define HIPBLASLT_VERSION_MAJOR     1
+        #define HIPBLASLT_VERSION_MINOR     2
+        #define HIPBLASLT_VERSION_PATCH     2
+        #define HIPBLASLT_VERSION_TWEAK     dabb6df2b9
+        #endif
+        """
+        commit, version = env_mod._parse_hipblaslt_header(text)
+        assert commit == "dabb6df2b9"
+        assert version == "1.2.2"
+
+    def test_parse_missing_tweak_returns_none_commit(self):
+        text = """
+        #define HIPBLASLT_VERSION_MAJOR 1
+        #define HIPBLASLT_VERSION_MINOR 2
+        #define HIPBLASLT_VERSION_PATCH 0
+        """
+        commit, version = env_mod._parse_hipblaslt_header(text)
+        assert commit is None
+        assert version == "1.2.0"
+
+    def test_parse_empty_returns_none_pair(self):
+        commit, version = env_mod._parse_hipblaslt_header("")
+        assert (commit, version) == (None, None)
+        commit, version = env_mod._parse_hipblaslt_header(None)
+        assert (commit, version) == (None, None)
+
+
+class TestHipblasltLibHash:
+    def test_hash_resolved_through_symlink(self, tmp_path: Path, monkeypatch):
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        real = lib_dir / "libhipblaslt.so.1.2.70201"
+        real.write_bytes(b"hello hipblaslt")
+        symlink_a = lib_dir / "libhipblaslt.so.1"
+        symlink_b = lib_dir / "libhipblaslt.so"
+        symlink_a.symlink_to(real.name)
+        symlink_b.symlink_to(symlink_a.name)
+
+        monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", lib_dir)
+
+        digest = env_mod._hash_hipblaslt_library()
+        expected = "sha256:" + hashlib.sha256(b"hello hipblaslt").hexdigest()
+        assert digest == expected
+
+    def test_no_library_returns_none(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", tmp_path / "empty")
+        assert env_mod._hash_hipblaslt_library() is None
+
+
+class TestTensileFingerprint:
+    def test_fingerprint_changes_when_filenames_change(
+        self, tmp_path: Path, monkeypatch
+    ):
+        d = tmp_path / "library"
+        d.mkdir()
+        (d / "TensileLibrary_A.dat").write_bytes(b"x")
+        (d / "TensileLibrary_B.dat").write_bytes(b"y")
+        monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", d)
+        fp1 = env_mod._tensile_fingerprint()
+        assert fp1 is not None and fp1.startswith("filenames-sha256:")
+
+        # Add another file -> fingerprint changes
+        (d / "TensileLibrary_C.dat").write_bytes(b"z")
+        fp2 = env_mod._tensile_fingerprint()
+        assert fp2 != fp1
+
+    def test_no_dir_returns_none(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", tmp_path / "nope")
+        assert env_mod._tensile_fingerprint() is None
+
+    def test_dir_with_no_kernel_files_returns_none(
+        self, tmp_path: Path, monkeypatch
+    ):
+        d = tmp_path / "library"
+        d.mkdir()
+        (d / "README.txt").write_text("not a kernel file")
+        monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", d)
+        assert env_mod._tensile_fingerprint() is None
+
+
+class TestHipblasltBlockShape:
+    def test_applied_prs_is_empty_dict_initially(self, all_disabled):
+        block = env_mod._capture_hipblaslt()
+        assert block["applied_prs"] == {}
+
+    def test_block_keys_stable(self, all_disabled):
+        block = env_mod._capture_hipblaslt()
+        assert set(block.keys()) == {
+            "commit",
+            "package_version",
+            "lib_hash",
+            "tensile_yaml_revision",
+            "applied_prs",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Runtime context detection
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeContext:
+    def test_baremetal_no_markers(self, all_disabled, monkeypatch):
+        monkeypatch.setattr(sys, "base_prefix", sys.prefix)
+        rt = env_mod._detect_runtime_context()
+        assert rt["type"] == "baremetal"
+        assert rt["python_env"] == "system"
+        assert rt["venv_path"] is None
+        assert rt["conda_env_name"] is None
+
+    def test_docker_via_dockerenv_marker(self, all_disabled, tmp_path: Path):
+        marker = tmp_path / ".dockerenv"
+        marker.write_text("")
+        all_disabled.setattr(env_mod, "DOCKERENV_MARKER", marker)
+        assert env_mod._detect_container_type() == "docker"
+
+    def test_podman_via_containerenv_marker(self, all_disabled, tmp_path: Path):
+        marker = tmp_path / ".containerenv"
+        marker.write_text("engine=podman")
+        all_disabled.setattr(env_mod, "PODMAN_CONTAINERENV_MARKER", marker)
+        assert env_mod._detect_container_type() == "podman"
+
+    def test_singularity_via_env_var(self, all_disabled):
+        all_disabled.setenv("SINGULARITY_NAME", "myapp.sif")
+        assert env_mod._detect_container_type() == "singularity"
+
+    def test_docker_via_cgroup_fallback(self, all_disabled, tmp_path: Path):
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("12:freezer:/docker/abc123def456\n0::/init.scope\n")
+        all_disabled.setattr(env_mod, "CGROUP_FILE", cgroup)
+        assert env_mod._detect_container_type() == "docker"
+
+    def test_podman_via_cgroup_fallback(self, all_disabled, tmp_path: Path):
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/machine.slice/libpod-podman-abc.scope\n")
+        all_disabled.setattr(env_mod, "CGROUP_FILE", cgroup)
+        assert env_mod._detect_container_type() == "podman"
+
+    def test_dockerenv_takes_precedence_over_cgroup(
+        self, all_disabled, tmp_path: Path
+    ):
+        marker = tmp_path / ".dockerenv"
+        marker.write_text("")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/machine.slice/libpod-podman-abc.scope\n")
+        all_disabled.setattr(env_mod, "DOCKERENV_MARKER", marker)
+        all_disabled.setattr(env_mod, "CGROUP_FILE", cgroup)
+        assert env_mod._detect_container_type() == "docker"
+
+    def test_python_env_venv(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+        monkeypatch.setattr(sys, "prefix", "/tmp/myvenv")
+        assert env_mod._detect_python_env() == "venv"
+
+    def test_python_env_conda(self, isolated_env):
+        isolated_env.setenv("CONDA_DEFAULT_ENV", "myenv")
+        assert env_mod._detect_python_env() == "conda"
+
+    def test_python_env_system(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(sys, "base_prefix", sys.prefix)
+        assert env_mod._detect_python_env() == "system"
+
+    def test_runtime_context_venv_path_populated(
+        self, all_disabled, monkeypatch
+    ):
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+        monkeypatch.setattr(sys, "prefix", "/home/user/.venv")
+        rt = env_mod._detect_runtime_context()
+        assert rt["python_env"] == "venv"
+        assert rt["venv_path"] == "/home/user/.venv"
+        assert rt["conda_env_name"] is None
+
+    def test_runtime_context_conda_name_populated(self, all_disabled):
+        all_disabled.setenv("CONDA_DEFAULT_ENV", "rocm-7.2")
+        rt = env_mod._detect_runtime_context()
+        assert rt["python_env"] == "conda"
+        assert rt["conda_env_name"] == "rocm-7.2"
+        assert rt["venv_path"] is None
+
+
+# ---------------------------------------------------------------------------
+# Docker metadata
+# ---------------------------------------------------------------------------
+
+
+class TestDockerMetadata:
+    def test_baremetal_returns_none(self):
+        rt = {"type": "baremetal", "python_env": "system"}
+        assert env_mod._capture_docker_metadata(rt) is None
+
+    def test_docker_picks_up_aorta_env_vars(self, isolated_env):
+        isolated_env.setenv("AORTA_DOCKER_IMAGE", "rocm/pytorch:7.2")
+        isolated_env.setenv("AORTA_DOCKER_DIGEST", "sha256:deadbeef")
+        rt = {"type": "docker"}
+        block = env_mod._capture_docker_metadata(rt)
+        assert block["image"] == "rocm/pytorch:7.2"
+        assert block["digest"] == "sha256:deadbeef"
+
+    def test_docker_block_emits_keys_even_without_env(self, isolated_env):
+        rt = {"type": "docker"}
+        block = env_mod._capture_docker_metadata(rt)
+        assert set(block.keys()) == {"image", "digest", "container_id"}
+        assert block["image"] is None
+        assert block["digest"] is None
+
+    def test_container_id_extracted_from_cgroup(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        cgroup = tmp_path / "cgroup"
+        cid = "abc123def456789012345678901234567890abcd"
+        cgroup.write_text(f"12:freezer:/docker/{cid}\n")
+        # _read_container_id() reads /proc/self/cgroup, not /proc/1/cgroup;
+        # patch the Path constructor it uses inside.
+        monkeypatch.setattr(env_mod, "_read_text_file", lambda p: cgroup.read_text())
+        rt = {"type": "docker"}
+        block = env_mod._capture_docker_metadata(rt)
+        assert block["container_id"] == cid
+
+
+# ---------------------------------------------------------------------------
+# Env vars
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVars:
+    def test_canonical_vars_captured_when_set(self, isolated_env):
+        isolated_env.setenv("HSA_XNACK", "1")
+        isolated_env.setenv("GPU_MAX_HW_QUEUES", "4")
+        isolated_env.setenv("FBGEMM_TBE_V2", "1")
+        result = env_mod._capture_env_vars()
+        assert result["HSA_XNACK"] == "1"
+        assert result["GPU_MAX_HW_QUEUES"] == "4"
+        assert result["FBGEMM_TBE_V2"] == "1"
+
+    def test_canonical_vars_null_when_unset(self, isolated_env):
+        result = env_mod._capture_env_vars()
+        for var in CANONICAL_ENV_VARS:
+            assert result[var] is None, f"{var} should be None when unset"
+
+    def test_workload_config_vars_NOT_captured(self, isolated_env):
+        # Per acceptance criteria, these are workload state, not env probe state
+        isolated_env.setenv("AMP_DTYPE", "bf16")
+        isolated_env.setenv("MODEL_DTYPE", "fp32")
+        isolated_env.setenv("SHAMPOO_PRECONDITIONER_DTYPE", "fp64")
+        result = env_mod._capture_env_vars()
+        for forbidden in ("AMP_DTYPE", "MODEL_DTYPE", "SHAMPOO_PRECONDITIONER_DTYPE"):
+            assert forbidden not in result, f"{forbidden} leaked into env_vars"
+
+    def test_canonical_var_names_stable(self):
+        # Reasoned guard: changing this list is a schema change. If a future
+        # PR adds a var, this test forces an explicit acknowledgement.
+        assert set(CANONICAL_ENV_VARS) == {
+            "HSA_XNACK",
+            "HSA_KERNARG_POOL_SIZE",
+            "HSA_NO_SCRATCH_RECLAIM",
+            "GPU_MAX_HW_QUEUES",
+            "AMDGCN_USE_BUFFER_OPS",
+            "DISABLE_TF32",
+            "NCCL_MAX_NCHANNELS",
+            "FBGEMM_NO_JK",
+            "FBGEMM_TBE_V2",
+            "FBGEMM_TBE_ROCM_HIP_BACKWARD_KERNEL",
+            "FBGEMM_BOUNDS_CHECK_INDICES_V2",
+            "TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE",
+            "PYTORCH_CUDA_ALLOC_CONF",
+        }
+
+
+# ---------------------------------------------------------------------------
+# PyTorch version + 'no GPU compute' guard
+# ---------------------------------------------------------------------------
+
+
+class TestPytorchVersion:
+    def test_torch_unavailable_returns_none(self, isolated_env):
+        # Force an ImportError at probe-time even if torch happens to be
+        # installed in the test env, by monkeypatching builtins.__import__.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated absence")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            assert env_mod._capture_pytorch_version() is None
+
+
+class TestNoGpuCompute:
+    """Guard against introducing GPU work into the env probe.
+
+    True GPU-zero verification is via rocprofv3 in CI; here we assert
+    that the orchestrator never reaches into ``torch.cuda`` (which would
+    initialise a HIP context).
+    """
+
+    def test_torch_cuda_never_called(self, all_disabled, tmp_path: Path):
+        if "torch" not in sys.modules:
+            pytest.skip("torch not available; trivially passes")
+        torch = sys.modules["torch"]
+        with patch.object(torch.cuda, "is_available") as is_avail, patch.object(
+            torch.cuda, "device_count"
+        ) as dev_count:
+            capture_environment(tmp_path / "env.json")
+            is_avail.assert_not_called()
+            dev_count.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureEnvironmentEndToEnd:
+    def test_full_snapshot_with_realistic_files(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        # Stand up a realistic-looking ROCm root in tmp.
+        rocm = tmp_path / "rocm"
+        info = rocm / ".info"
+        info.mkdir(parents=True)
+        (info / "version").write_text("7.2.1\n")
+        (info / "version-dev").write_text("7.2.1.50311-abc1234\n")
+
+        kmd = tmp_path / "amdgpu_version"
+        kmd.write_text("6.16.13\n")
+
+        hipblaslt_inc = rocm / "include" / "hipblaslt"
+        hipblaslt_inc.mkdir(parents=True)
+        (hipblaslt_inc / "hipblaslt-version.h").write_text(
+            "#define HIPBLASLT_VERSION_MAJOR 1\n"
+            "#define HIPBLASLT_VERSION_MINOR 2\n"
+            "#define HIPBLASLT_VERSION_PATCH 2\n"
+            "#define HIPBLASLT_VERSION_TWEAK dabb6df2b9\n"
+        )
+
+        lib = rocm / "lib"
+        lib.mkdir()
+        (lib / "libhipblaslt.so").write_bytes(b"fake binary")
+
+        tensile = rocm / "lib" / "hipblaslt" / "library"
+        tensile.mkdir(parents=True)
+        (tensile / "TensileLibrary_X.dat").write_bytes(b"x")
+        (tensile / "TensileLibrary_Y.dat").write_bytes(b"y")
+
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", info / "version")
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", info / "version-dev")
+        monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", kmd)
+        monkeypatch.setattr(
+            env_mod, "HIPBLASLT_VERSION_HEADER", hipblaslt_inc / "hipblaslt-version.h"
+        )
+        monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", lib)
+        monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", tensile)
+        monkeypatch.setattr(env_mod, "DOCKERENV_MARKER", tmp_path / "no_dockerenv")
+        monkeypatch.setattr(
+            env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv"
+        )
+        monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
+
+        out = tmp_path / "env.json"
+        snapshot = capture_environment(out)
+
+        # Schema completeness
+        assert set(snapshot.keys()) == REQUIRED_TOP_KEYS
+
+        # ROCm
+        assert snapshot["rocm"]["version"] == "7.2.1"
+        assert snapshot["rocm"]["version_dev"] == "7.2.1.50311-abc1234"
+        assert snapshot["rocm"]["kmd_version"] == "6.16.13"
+
+        # HIP (no hipconfig available -> all None)
+        assert snapshot["hip"] == {
+            "version": None,
+            "platform": None,
+            "compiler": None,
+            "runtime": None,
+            "cpp_config": None,
+        }
+
+        # hipBLASLt
+        assert snapshot["hipblaslt"]["commit"] == "dabb6df2b9"
+        assert snapshot["hipblaslt"]["package_version"] == "1.2.2"
+        assert snapshot["hipblaslt"]["lib_hash"] == (
+            "sha256:" + hashlib.sha256(b"fake binary").hexdigest()
+        )
+        assert snapshot["hipblaslt"]["tensile_yaml_revision"].startswith(
+            "filenames-sha256:"
+        )
+        assert snapshot["hipblaslt"]["applied_prs"] == {}
+
+        # Runtime
+        assert snapshot["runtime_context"]["type"] == "baremetal"
+        assert snapshot["docker"] is None  # baremetal -> docker is null
+
+        # RDHC unavailable
+        assert snapshot["system_health"] is None
+
+        # File on disk matches return value
+        assert json.loads(out.read_text()) == snapshot

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -166,7 +166,9 @@ class TestSchemaCompleteness:
         """``partial`` and ``partial_reasons`` must be present in the on-disk JSON."""
         snapshot = collect_env()
         out = tmp_path / "env.json"
-        out.write_text(json.dumps(snapshot.to_dict(), default=str))
+        # Deliberately no default=str -- the schema is supposed to be
+        # JSON-native. If anything sneaks in this should fail loudly.
+        out.write_text(json.dumps(snapshot.to_dict()))
         on_disk = json.loads(out.read_text())
         assert "partial" in on_disk
         assert "partial_reasons" in on_disk
@@ -240,7 +242,7 @@ class TestEnvSnapshot:
     def test_round_trip_via_json(self):
         """B1/B2 path: serialise via JSON, embed in a result, deserialise back."""
         original = _example_snapshot()
-        as_json = json.dumps(original.to_dict(), default=str)
+        as_json = json.dumps(original.to_dict())
         rebuilt = EnvSnapshot.from_dict(json.loads(as_json))
         assert rebuilt == original
 
@@ -476,7 +478,7 @@ class TestB1B2Integration:
             "env": snapshot.to_dict(),
         }
         out = tmp_path / "trial_result.json"
-        out.write_text(json.dumps(trial_result, default=str, indent=2))
+        out.write_text(json.dumps(trial_result, indent=2))
 
         loaded = json.loads(out.read_text())
         assert loaded["trial_id"] == "exp1-trial0"
@@ -488,7 +490,7 @@ class TestB1B2Integration:
         """B2 writes host_env.json once at matrix start."""
         snapshot = collect_env()
         host_env_path = tmp_path / "host_env.json"
-        host_env_path.write_text(json.dumps(snapshot.to_dict(), default=str))
+        host_env_path.write_text(json.dumps(snapshot.to_dict()))
 
         loaded = EnvSnapshot.from_dict(json.loads(host_env_path.read_text()))
         assert loaded == snapshot
@@ -532,6 +534,56 @@ class TestCliIsThinWrapper:
         """Sanity check: the CLI references the library function."""
         text = cli_path.read_text()
         assert "collect_env" in text
+
+    def test_cli_creates_missing_parent_directory(self, all_disabled, tmp_path: Path):
+        """Regression guard: ``-o newdir/env.json`` must work for a non-existent
+        parent. With ``click.Path(writable=True)`` Click would reject that
+        before our ``mkdir`` ran.
+        """
+        from click.testing import CliRunner
+
+        # Import the CLI symbol the same way the entrypoint does
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        spec = importlib.util.spec_from_file_location("aorta.cli.env", cli_path)
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+
+        out_path = tmp_path / "deeply" / "nested" / "new" / "env.json"
+        assert not out_path.parent.exists()
+        runner = CliRunner()
+        result = runner.invoke(cli_mod.env, ["probe", "-o", str(out_path)])
+        assert result.exit_code == 0, result.output
+        assert out_path.exists()
+        # And the JSON is loadable
+        json.loads(out_path.read_text())
+
+    def test_cli_emits_json_native_output_no_default_str(
+        self, all_disabled
+    ):
+        """Regression guard: the CLI does not pass ``default=str`` to json.dumps.
+
+        Stringifying non-JSON types would mask schema regressions (Path,
+        datetime, etc. accidentally leaking into EnvSnapshot fields).
+        Verified by:
+        1. Confirming ``collect_env()``'s output is json.dumps-able with
+           the strict default (no ``default=`` argument).
+        2. Scanning the CLI source for the *call-site* pattern -- not the
+           bare token, which appears in our explanatory comment.
+        """
+        snapshot = collect_env()
+        # Must succeed without any default= fallback
+        json.dumps(snapshot.to_dict())
+
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        text = cli_path.read_text()
+        # Match the call-site pattern (',' + space + key=val + ')') so we
+        # don't false-positive on the comment that documents this very
+        # invariant.
+        assert ", default=str)" not in text, (
+            "cli/env.py json.dumps call uses default=str -- this masks "
+            "non-JSON types in the schema. Remove it so the failure is loud."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -630,6 +682,23 @@ class TestRdhcWrapper:
         assert "path" in captured
         assert not captured["path"].exists()
 
+    def test_rdhc_handles_tempfile_oserror(self, isolated_env, monkeypatch):
+        """Regression guard: a read-only or full /tmp must not break collect_env.
+
+        Without the try/except around tempfile.NamedTemporaryFile, OSError
+        would bubble up and break the never-raises contract.
+        """
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/rdhc")
+
+        def boom(*a, **kw):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(env_mod.tempfile, "NamedTemporaryFile", boom)
+        reasons: list[str] = []
+        # Must not raise; must record a system_health: reason
+        assert env_mod._run_rdhc(reasons) is None
+        assert any("temp file" in r for r in reasons)
+
 
 # ---------------------------------------------------------------------------
 # ROCm version files
@@ -692,6 +761,24 @@ class TestRocmVersionFiles:
         reasons: list[str] = []
         result = env_mod._capture_rocm_version_files(reasons)
         assert result["version_dev"] is None
+
+    def test_non_utf8_file_returns_none_no_raise(self, tmp_path: Path, monkeypatch):
+        """Regression guard: a corrupt/non-UTF8 version file must not raise.
+
+        Without the UnicodeDecodeError catch in _read_text_file, a single
+        rogue byte in /sys/module/amdgpu/version (or a locale-mismatched
+        file) would abort the whole env probe and break the never-raises
+        contract.
+        """
+        bad = tmp_path / "non_utf8"
+        bad.write_bytes(b"\xff\xfe\x80not-utf8")  # invalid UTF-8 lead bytes
+        monkeypatch.setattr(env_mod, "KMD_VERSION_FILE", bad)
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", tmp_path / "nope")
+        monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", tmp_path / "nope")
+        reasons: list[str] = []
+        # Must not raise, must return None for the bad file
+        result = env_mod._capture_rocm_version_files(reasons)
+        assert result["kmd_version"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -864,6 +951,43 @@ class TestHipblasltBlockShape:
         reasons: list[str] = []
         env_mod._capture_hipblaslt(reasons)
         assert all(r.startswith("hipblaslt.") for r in reasons)
+
+    def test_reason_when_header_unreadable(self, all_disabled):
+        """Header file missing -> reason should say 'not readable'."""
+        reasons: list[str] = []
+        env_mod._capture_hipblaslt(reasons)
+        commit_reason = next(r for r in reasons if r.startswith("hipblaslt.commit"))
+        assert "not readable" in commit_reason
+
+    def test_reason_when_header_present_but_tweak_missing(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """Header readable but no TWEAK define -> reason names that explicitly.
+
+        Regression guard: prior to this fix, both failure modes used the
+        same "not readable" reason -- misleading when the header *was*
+        readable but missing the specific define.
+        """
+        header = tmp_path / "hipblaslt-version.h"
+        header.write_text(
+            "#define HIPBLASLT_VERSION_MAJOR 1\n"
+            "#define HIPBLASLT_VERSION_MINOR 2\n"
+            "#define HIPBLASLT_VERSION_PATCH 0\n"
+            # Note: no HIPBLASLT_VERSION_TWEAK -- a real-world case where a
+            # build config emits MAJOR/MINOR/PATCH only.
+        )
+        monkeypatch.setattr(env_mod, "HIPBLASLT_VERSION_HEADER", header)
+        monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", tmp_path / "no_libs")
+        monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", tmp_path / "no_tensile")
+
+        reasons: list[str] = []
+        block = env_mod._capture_hipblaslt(reasons)
+        # commit failed but package_version succeeded
+        assert block["commit"] is None
+        assert block["package_version"] == "1.2.0"
+        commit_reason = next(r for r in reasons if r.startswith("hipblaslt.commit"))
+        assert "not readable" not in commit_reason
+        assert "HIPBLASLT_VERSION_TWEAK" in commit_reason
 
 
 # ---------------------------------------------------------------------------
@@ -1113,9 +1237,13 @@ class TestNoGpuCompute:
     """
 
     def test_torch_cuda_never_called(self, all_disabled):
-        if "torch" not in sys.modules:
+        # Try to actually import torch (rather than sniffing sys.modules):
+        # we want to skip ONLY when torch is genuinely unavailable, not
+        # whenever it merely hasn't been imported yet by the test runner.
+        try:
+            import torch
+        except ImportError:
             pytest.skip("torch not available; trivially passes")
-        torch = sys.modules["torch"]
         with patch.object(torch.cuda, "is_available") as is_avail, patch.object(
             torch.cuda, "device_count"
         ) as dev_count:


### PR DESCRIPTION
Implements #147.

## Summary

`aorta env probe` writes a versioned, schema-stable `env.json` capturing the trial environment so that cross-environment comparison becomes a `jq` diff instead of a multi-day investigation. Backed by RDHC (`rdhc --quick --json`) wrapped, not lifted, with graceful fallback. Adds aorta-specific introspection RDHC does not cover: `hipBLASLt` build identity, HIP toolchain (`hipconfig`), explicit ROCm version files, runtime context (docker/podman/singularity/baremetal × venv/conda/system), Docker image+digest, canonical OS env vars.

## Schema (schema_version 1.0)

| Block | Source | Notes |
| --- | --- | --- |
| `system_health` | `sudo -n -E rdhc --quick --json <path>` (subprocess, 30s timeout) | Verbatim parsed JSON; `null` + INFO log when RDHC missing, sudo unavailable, timeout, or malformed output. |
| `rocm` | `/opt/rocm/.info/version`, `version-dev`, `/sys/module/amdgpu/version` | Direct file reads. Each field independently `null` if file missing. |
| `hip` | `hipconfig --version/--platform/--compiler/--runtime/--cpp_config` | Five short subprocesses (concatenated invocations are unparseable). |
| `hipblaslt` | `hipblaslt-version.h` (TWEAK + MAJOR.MINOR.PATCH), `sha256(libhipblaslt.so)`, sorted-filenames hash of `lib/hipblaslt/library/*` | `applied_prs: {}` initially — additive, no schema bump when entries land. |
| `runtime_context` | `/.dockerenv`, `/run/.containerenv`, `SINGULARITY_NAME`, `/proc/1/cgroup`, `sys.prefix`, `$CONDA_DEFAULT_ENV` | Explicit precedence (per acceptance criterion: not heuristics on hostname/env vars). |
| `docker` | `AORTA_DOCKER_IMAGE` / `AORTA_DOCKER_DIGEST` env vars + `/proc/self/cgroup` | `null` when baremetal. Image+digest provided by the launcher (per the issue's contract — they're not recoverable from inside the container without privileged docker access). |
| `env_vars` | Canonical 13-name list, explicit (not prefix matching) | HSA + GPU queue + RCCL + FBGEMM + PyTorch. Workload config (`AMP_DTYPE`, `MODEL_DTYPE`, `SHAMPOO_PRECONDITIONER_DTYPE`) deliberately absent — that belongs to B1's trial result. |
| `python_version`, `pytorch_version` | `platform.python_version()`, optional `import torch` (no CUDA/HIP context init) | |

Implementation: `src/aorta/instrumentation/environment.py`, called from `src/aorta/cli/env.py`.

## No-GPU-compute verification (per acceptance criteria)

```bash
$ rocprofv3 --hip-trace --output-format csv -o no_gpu -- aorta env probe -o /tmp/env.json
# (probe output omitted)

$ ls no_gpu*.csv
# (empty — zero output files = zero HIP API calls = zero kernel dispatches)

# Positive control to prove rocprofv3 is working:
$ rocprofv3 --hip-trace --output-format csv -o positive -- python3 -c \
    "import ctypes; ctypes.CDLL('libamdhip64.so').hipGetDeviceCount(...)"
$ wc -l positive_hip_api_trace.csv
2 positive_hip_api_trace.csv
```

`import torch` is conditional and only reads `torch.__version__` (a Python attribute access — no `torch.cuda.*` calls). `tests/instrumentation/test_environment.py::TestNoGpuCompute` asserts `torch.cuda.is_available` and `torch.cuda.device_count` are never called.

## Two-image diff evidence (`hipBLASLt` drift use case)

Per the issue's PR template request. Validated against two internal ROCm/PyTorch docker images (image names redacted — they're private). The shape of the comparison is what matters: the env probe surfaces every environmental confound the two images differ in.

```bash
docker run --rm -v /tmp/aorta_probe:/workspace \
  -e PROBE_OUT=/workspace/output/env_a.json \
  <image-A: ROCm 7.2.0 PyTorch image> \
  python3 /workspace/probe_runner.py
# Elapsed: 0.88s

docker run --rm -v /tmp/aorta_probe:/workspace \
  -e PROBE_OUT=/workspace/output/env_b.json \
  <image-B: ROCm 7.0.2.1 PyTorch image> \
  python3 /workspace/probe_runner.py
# Elapsed: 0.78s

diff <(jq -S . env_a.json) <(jq -S . env_b.json)
```

Surfaces 6 environmental confounds in one second:

| Field | Image A (ROCm 7.2.0) | Image B (ROCm 7.0.2.1) |
| --- | --- | --- |
| `rocm.version` | `7.2.0` | `7.0.2.1` |
| `rocm.version_dev` | `7.2.0-43` | `null` |
| `hip.version` | `7.2.26015-fc0010cf6a` | `7.0.51831-7921ece3b` |
| **`hipblaslt.commit`** | **`5b515cf1bc`** | **`292de60f81`** |
| `hipblaslt.lib_hash` | `sha256:d70e6a341fbcca…` | `sha256:cbaea35522d4db…` |
| `hipblaslt.tensile_yaml_revision` | `filenames-sha256:421d…` | `filenames-sha256:8525…` |
| `pytorch_version` | `2.12.0a0+gitf68b851` | `2.12.0a0+gitdcaf562` |
| `runtime_context.type` | `docker` ✓ | `docker` ✓ |

Without env probe, "why does my workload behave differently across these two ROCm images?" is a multi-day investigation. With env probe, it's a single `diff`.

## Wall time

| Environment | Elapsed |
| --- | --- |
| Baremetal host (no RDHC) | **0.10 s** |
| Image A (ROCm 7.2.0 docker)  | **0.88 s** |
| Image B (ROCm 7.0.2.1 docker) | **0.78 s** |

All well inside the <5 s no-rdhc target (and <15 s with-rdhc target).

## Acceptance-criteria coverage

| Criterion | Status |
| --- | --- |
| `aorta env probe` writes env.json (default path) | ✓ live |
| <15 s with rdhc, <5 s without | ✓ measured 0.10 s on host, ~0.8 s in docker |
| **No GPU compute (rocprofv3 dispatch count = 0)** | ✓ live, see above |
| All schema top-level keys present (null when unavailable) | ✓ tested + verified live in 3 envs |
| RDHC happy path (verbatim parsed JSON under `system_health`) | ⚠ subprocess-mock tested; RDHC not present on test host or either image |
| RDHC fallback: not on PATH | ✓ tested + live verified (3 envs) |
| RDHC fallback: sudo unavailable | ⚠ subprocess-mock tested only |
| RDHC fallback: timeout | ⚠ subprocess-mock tested only |
| Baseline hipBLASLt commit captured | ✓ live (`5b515cf1bc`) |
| Different image → different commit | ✓ live (`292de60f81`) |
| Baremetal: `runtime_context.type == "baremetal"`, `docker == null` | ✓ verified live on host |
| Venv: `python_env == "venv"`, `venv_path == sys.prefix` | ✓ verified live (`/tmp/aorta-test-venv`) |
| Conda: `python_env == "conda"`, `conda_env_name == $CONDA_DEFAULT_ENV` | ⚠ subprocess-mock tested only — no conda env on test host |
| Podman: `runtime_context.type == "podman"` | ⚠ subprocess-mock tested only — no podman on test host |
| Docker: detected via `/.dockerenv` | ✓ verified live in both containers |
| Container detection: explicit checks (not heuristics) | ✓ tested |
| `hip` block populated; null when hipconfig missing | ✓ verified live in 3 envs |
| `rocm` block populated from version files | ✓ verified live in 3 envs |
| All canonical OS env vars captured | ✓ tested |
| Workload config (`AMP_DTYPE`, etc.) NOT in output | ✓ tested |
| Schema-version constant test | ✓ tested |
| Tests in `tests/instrumentation/test_environment.py` | ✓ 49 tests, 48 pass + 1 skip (no-torch env) |

## Out of scope (per the issue)

- `aorta env matrix` (multi-docker fan-out) — P1
- `aorta env diff env_a.json env_b.json` — P1
- Anything that runs GPU kernels — explicitly forbidden
- CK / rocBLAS introspection — P1 once a second incident points at them
- Workload config (`AMP_DTYPE`, `MODEL_DTYPE`, `SHAMPOO_PRECONDITIONER_DTYPE`) — belongs to B1 trial result

## Out of scope (deferred within env probe itself)

- `applied_prs` content — schema reserves the block; ships empty. Each PR detector needs a unique signature (symbol via `nm`, string via `strings`, or Tensile YAML revision bump) — those land alongside the first PR worth tracking.
- `check_hipblaslt_nan_fix.py` cross-validation — the reference script wasn't available in this checkout; the canonical commit field (`HIPBLASLT_VERSION_TWEAK` from `hipblaslt-version.h`) is the same value that script would have read.

## Files

```
src/aorta/cli/env.py                       MODIFIED  thin wrapper (~70 lines) around `collect_env()`; click.ClickException for filesystem errors
src/aorta/instrumentation/__init__.py      MODIFIED  docstring only
src/aorta/instrumentation/environment.py   NEW       ~940 lines: collect_env(), EnvSnapshot dataclass, every probe, _disaster_snapshot
src/aorta/instrumentation/README.md        NEW       module-level reference (CLI + library API + how to add probes/env vars)
docs/env-probe.md                          NEW       user-facing how-to (quick start, schema, install RDHC, fail-soft contract)
tests/instrumentation/__init__.py          NEW       empty
tests/instrumentation/test_environment.py  NEW       ~1200 lines, 102 tests (subprocess + filesystem mocked)
```

The public library API is `collect_env() -> EnvSnapshot` (the function B1 / B2 call in-process per the updated #147 spec). The CLI is a thin wrapper around it -- it imports `collect_env`, writes `snapshot.to_dict()`, and prints `snapshot.summary()`. There is no public `capture_environment` function; that name was the pre-refactor placeholder and does not exist in the merged code.

## Test plan (for the reviewer)

- [ ] On a host with `rdhc` installed and passwordless sudo: `aorta env probe -o /tmp/env.json && jq '.system_health.rdhc_version' /tmp/env.json` → expect a non-null version string. Confirms the RDHC happy path end-to-end.
- [ ] On a host without rdhc: `aorta env probe -o /tmp/env.json && jq '.system_health' /tmp/env.json` → expect `null`, plus a `partial_reasons` entry that ends with `(see docs/env-probe.md#installing-rdhc)`.
- [ ] Inside a docker image: `runtime_context.type == "docker"`, `docker.image` populated when launched with `-e AORTA_DOCKER_IMAGE=...`.
- [ ] Inside a conda env: `runtime_context.python_env == "conda"`, `runtime_context.conda_env_name` matches `$CONDA_DEFAULT_ENV`.
- [ ] On baremetal: `runtime_context.type == "baremetal"`, `docker == null`, all other top-level blocks populated.
- [ ] CLI surfaces filesystem errors cleanly: `aorta env probe -o /root/no_perm/env.json` (as non-root) prints `Error: Failed to create parent directory ...` and exits 1, no Python traceback.
- [ ] Library API: `from aorta.instrumentation.environment import collect_env, EnvSnapshot; snap = collect_env(); EnvSnapshot.from_dict(snap.to_dict()) == snap` -- round-trip works.
- [ ] `pytest tests/instrumentation/test_environment.py -v` → 102 pass + 0 skip.
- [ ] (Optional) `rocprofv3 --hip-trace --output-format csv -o /tmp/probe -- aorta env probe -o /tmp/env.json` → no `*_hip_api_trace.csv` produced (zero HIP API calls, zero kernel dispatches).
