### PR TITLE
B3: mitigations + environments registry + extension-point resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ src/aorta/
 ├── hw_queue_eval/     # Hardware queue evaluation framework
 ├── models/            # Synthetic ranking transformer
 ├── profiling/         # Stream profiler for overlap measurement
+├── registry/          # Mitigations + environments registry (extension points)
+├── cli/               # `aorta` CLI command groups
 └── utils/             # Config loading, timing, device detection
 
 config/                # YAML configurations for different scenarios

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -2,7 +2,7 @@
 
 import click
 
-from aorta.cli import env, run, triage
+from aorta.cli import env, environments, mitigations, run, triage
 
 
 @click.group()
@@ -12,6 +12,8 @@ def main() -> None:
 
 
 main.add_command(env.env)
+main.add_command(environments.environments)
+main.add_command(mitigations.mitigations)
 main.add_command(run.run)
 main.add_command(triage.triage)
 

--- a/src/aorta/cli/environments.py
+++ b/src/aorta/cli/environments.py
@@ -1,0 +1,30 @@
+"""`aorta environments` — inspect the merged environments registry."""
+
+import click
+
+from aorta.registry import load_environments
+
+
+@click.group()
+def environments() -> None:
+    """Inspect the merged environments registry (built-ins + plugins)."""
+
+
+@environments.command(name="list")
+def list_() -> None:
+    """List every registered environment, its source package, and its docker/venv."""
+    registry = load_environments()
+    name_w = max(len("NAME"), *(len(n) for n in registry))
+    src_w = max(len("SOURCE"), *(len(e.source_package) for e in registry.values()))
+    docker_w = max(len("DOCKER"), *(len(e.docker or "-") for e in registry.values()))
+
+    click.echo(
+        f"{'NAME'.ljust(name_w)}  {'SOURCE'.ljust(src_w)}  "
+        f"{'DOCKER'.ljust(docker_w)}  VENV"
+    )
+    for name in sorted(registry):
+        e = registry[name]
+        click.echo(
+            f"{name.ljust(name_w)}  {e.source_package.ljust(src_w)}  "
+            f"{(e.docker or '-').ljust(docker_w)}  {e.venv or '-'}"
+        )

--- a/src/aorta/cli/mitigations.py
+++ b/src/aorta/cli/mitigations.py
@@ -1,0 +1,24 @@
+"""`aorta mitigations` — inspect the merged mitigations registry."""
+
+import click
+
+from aorta.registry import load_mitigations
+
+
+@click.group()
+def mitigations() -> None:
+    """Inspect the merged mitigations registry (built-ins + plugins)."""
+
+
+@mitigations.command(name="list")
+def list_() -> None:
+    """List every registered mitigation, its source package, and its env vars."""
+    registry = load_mitigations()
+    name_w = max(len("NAME"), *(len(n) for n in registry))
+    src_w = max(len("SOURCE"), *(len(m.source_package) for m in registry.values()))
+
+    click.echo(f"{'NAME'.ljust(name_w)}  {'SOURCE'.ljust(src_w)}  ENV")
+    for name in sorted(registry):
+        m = registry[name]
+        env_str = " ".join(f"{k}={v}" for k, v in sorted(m.env.items())) or "(none)"
+        click.echo(f"{name.ljust(name_w)}  {m.source_package.ljust(src_w)}  {env_str}")

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -1,0 +1,177 @@
+# `aorta.registry` — mitigations + environments
+
+Two small registries that ship with aorta:
+
+- **Mitigations** (`name → env vars`) — process-level flags applied just before
+  the workload subprocess launches. Examples: `tf32_off`, `xnack`.
+- **Environments** (`name → docker / venv recipe`) — baseline state of the
+  process or container the workload runs in. Examples: `local`, `default`.
+
+Both follow the same shape: built-ins ship from this package; external
+contributions arrive via Python entry-points and are merged at runtime.
+
+## Adding a mitigation
+
+There are two paths. **For most contributions, Path 2 (plugin) is the right
+answer** — Path 1 is reserved for runtime-level flags that benefit every
+workload.
+
+### Path 1 — built-in (runtime-level flags only)
+
+Built-ins are for env vars read by a **runtime or library** — ROCm, hipBLASLt,
+PyTorch, NCCL, OpenMP, the Linux kernel — **not** by workload Python code.
+
+The defining property: setting the var produces the same effect regardless of
+which workload runs. If your workload's training script has to call
+`os.environ.get(...)` for the var to take effect, it is NOT a built-in
+candidate — it's a plugin candidate (Path 2).
+
+| Qualifies as built-in | Does NOT qualify (use Path 2) |
+|---|---|
+| `DISABLE_TF32` (hipBLASLt reads it) | `AMP_DTYPE` (only the workload's Python reads it) |
+| `HSA_XNACK` (ROCm runtime reads it) | `SHAMPOO_PRECONDITIONER_DTYPE` (only meta-recom reads it) |
+| `CUDA_LAUNCH_BLOCKING` (PyTorch reads it) | Any custom flag your workload introspects |
+| `NCCL_DEBUG`, `OMP_NUM_THREADS`, `LD_PRELOAD` | Anything that's a silent no-op on workloads that don't read it |
+
+If a Path 1 candidate qualifies, edit `src/aorta/registry/mitigations.py` and
+add one entry to the dict:
+
+```python
+BUILTIN_MITIGATIONS = {
+    "none":     {},
+    "tf32_off": {"DISABLE_TF32": "1"},
+    "xnack":    {"HSA_XNACK": "1"},
+    "no_sdma":  {"HSA_ENABLE_SDMA": "0"},   # <-- your addition
+}
+```
+
+Open a PR. Adding a built-in requires sign-off from an aorta core maintainer —
+the bar is "would this benefit any aorta user, on any workload?".
+
+> **No need to clone:** you can do this entirely in the GitHub web UI. Navigate
+> to `src/aorta/registry/mitigations.py`, click the pencil icon, edit the dict,
+> scroll down, fill in a PR title, click "Propose changes". Done.
+
+### Path 2 — plugin (everything else)
+
+For workload-coupled flags, customer-specific recipes, experimental things, or
+anything where you maintain your own Python package: ship the mitigation from
+your package via the `aorta.mitigations` entry-point group.
+
+In your package's `pyproject.toml`:
+
+```toml
+[project.entry-points."aorta.mitigations"]
+my_mits = "my_package.mitigations:get_all"
+```
+
+In your package's source:
+
+```python
+# my_package/mitigations.py
+def get_all() -> dict[str, dict[str, str]]:
+    return {
+        "my_flag": {"MY_ENV_VAR": "1"},
+    }
+```
+
+After `pip install` (or `pip install -e .`), your mitigation appears in
+`aorta mitigations list` tagged with your package name.
+
+> Plugin authors: re-run `pip install` after editing `pyproject.toml` —
+> entry-points are read at install time, not at import time.
+
+## Trying things locally without upstreaming
+
+Sometimes you want to test a mitigation on your own machine without sending a
+PR or publishing a package. Two options:
+
+### One-off — CLI override
+
+For "is this even worth pursuing" experiments:
+
+```bash
+aorta run --workload fsdp --env HSA_ENABLE_SDMA=0
+```
+
+No registry involvement. The flag isn't named, isn't tracked, doesn't appear
+in `aorta mitigations list`. Doesn't work for triage sweeps (which need
+named entries).
+
+### Repeated local use — throwaway plugin package
+
+Make a tiny folder anywhere:
+
+```
+my-local-mits/
+├── pyproject.toml
+└── my_mits.py
+```
+
+`pyproject.toml`:
+
+```toml
+[project]
+name = "my-local-mits"
+version = "0.1"
+
+[project.entry-points."aorta.mitigations"]
+local = "my_mits:get_all"
+```
+
+`my_mits.py`:
+
+```python
+def get_all():
+    return {
+        "no_sdma": {"HSA_ENABLE_SDMA": "0"},
+    }
+```
+
+Then once:
+
+```bash
+pip install -e my-local-mits/
+```
+
+After that, your mitigations work everywhere — `--mitigation` flags, triage
+sweeps, the lot. Nothing leaves your machine. To remove: `pip uninstall
+my-local-mits`.
+
+This is just Path 2 with a throwaway local package. Same workflow applies to
+workloads via the `aorta.workloads` entry-point group.
+
+## Adding an environment
+
+Same two paths, with `aorta.environments` as the entry-point group. Plugin
+payloads must use only the keys `docker` and `venv`; anything else (e.g.
+`rocm`) raises `RegistryError` at load time. ROCm version is implicit in
+the docker image digest or in the host the venv runs on — capture it from
+`aorta env probe` at runtime, not via static declaration.
+
+## Collisions
+
+If two contributors register the same name (built-in vs plugin, or plugin vs
+plugin), `load_mitigations()` / `load_environments()` raises
+`RegistryCollisionError` naming both packages. There is no winner — the human
+resolves it by renaming or removing one of the entries. This is intentional:
+silent overrides cause hours of "why does my mitigation behave wrong"
+debugging.
+
+## Verifying what's registered
+
+```bash
+aorta mitigations list
+aorta environments list
+```
+
+Each shows every registered entry plus its source package — useful when
+debugging "did my plugin actually load?".
+
+## Hard rule: no logic in registries
+
+These modules contain only **data + lookup**. No environment manipulation, no
+docker invocation, no validation of whether `DISABLE_TF32=1` is a "good"
+value. Logic that consumes the registry data lives in the dispatchers (the
+mitigation harness, the workload runtime). Mixing the two would make the
+registry untestable in isolation and impossible to mock.

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -58,25 +58,28 @@ For workload-coupled flags, customer-specific recipes, experimental things, or
 anything where you maintain your own Python package: ship the mitigation from
 your package via the `aorta.mitigations` entry-point group.
 
-In your package's `pyproject.toml`:
+In your package's `pyproject.toml` — **one entry-point per mitigation**, the
+EP name IS the mitigation name (mirrors how `aorta.workloads` registers
+workloads):
 
 ```toml
 [project.entry-points."aorta.mitigations"]
-my_mits = "my_package.mitigations:get_all"
+my_flag    = "my_package.mitigations:MY_FLAG"
+other_flag = "my_package.mitigations:OTHER_FLAG"
 ```
 
-In your package's source:
+In your package's source — each entry is a plain `dict[str, str]` of env vars:
 
 ```python
 # my_package/mitigations.py
-def get_all() -> dict[str, dict[str, str]]:
-    return {
-        "my_flag": {"MY_ENV_VAR": "1"},
-    }
+MY_FLAG: dict[str, str]    = {"MY_ENV_VAR": "1"}
+OTHER_FLAG: dict[str, str] = {"OTHER_FLAG": "verbose"}
 ```
 
-After `pip install` (or `pip install -e .`), your mitigation appears in
-`aorta mitigations list` tagged with your package name.
+After `pip install` (or `pip install -e .`), each mitigation appears in
+`aorta mitigations list` tagged with your package name. `pip show -f
+my_package` lists every entry-point individually, so you can see at a glance
+which names your dist contributes.
 
 > Plugin authors: re-run `pip install` after editing `pyproject.toml` —
 > entry-points are read at install time, not at import time.
@@ -116,16 +119,13 @@ name = "my-local-mits"
 version = "0.1"
 
 [project.entry-points."aorta.mitigations"]
-local = "my_mits:get_all"
+no_sdma = "my_mits:NO_SDMA"
 ```
 
 `my_mits.py`:
 
 ```python
-def get_all():
-    return {
-        "no_sdma": {"HSA_ENABLE_SDMA": "0"},
-    }
+NO_SDMA = {"HSA_ENABLE_SDMA": "0"}
 ```
 
 Then once:

--- a/src/aorta/registry/__init__.py
+++ b/src/aorta/registry/__init__.py
@@ -1,0 +1,29 @@
+"""Public API for the mitigations + environments registry.
+
+Import everything you need from here. Sub-modules (`mitigations.py`,
+`environments.py`, `types.py`, `errors.py`) are internal plumbing and may be
+reorganized; the names in `__all__` are the supported public surface.
+"""
+
+from aorta.registry.environments import get_environment, load_environments
+from aorta.registry.errors import (
+    RegistryCollisionError,
+    RegistryError,
+    UnknownEnvironmentError,
+    UnknownMitigationError,
+)
+from aorta.registry.mitigations import get_mitigation, load_mitigations
+from aorta.registry.types import Environment, Mitigation
+
+__all__ = [
+    "load_mitigations",
+    "get_mitigation",
+    "load_environments",
+    "get_environment",
+    "Mitigation",
+    "Environment",
+    "RegistryError",
+    "RegistryCollisionError",
+    "UnknownMitigationError",
+    "UnknownEnvironmentError",
+]

--- a/src/aorta/registry/environments.py
+++ b/src/aorta/registry/environments.py
@@ -4,9 +4,10 @@ Mirrors the mitigations registry. Plugin payloads are validated against
 `_VALID_ENV_KEYS` — only `docker` and `venv` are accepted. ROCm version is
 intentionally not a valid key (see `Environment` docstring).
 
-Plugin authors register a function in their `pyproject.toml` under the
-`aorta.environments` entry-point group. The function returns a dict of
-`environment_name -> {docker?: str, venv?: str}`.
+Plugin authors register one entry-point per environment in their `pyproject.toml`
+under the `aorta.environments` group. The entry-point name IS the environment
+name; the loaded object is the recipe (`dict[str, str | None]` with keys
+`docker` and/or `venv`). Mirrors the `aorta.workloads` extension-point pattern.
 """
 
 from importlib.metadata import entry_points
@@ -38,8 +39,8 @@ def load_environments() -> dict[str, Environment]:
 
     Raises:
         RegistryCollisionError: two contributors registered the same environment name.
-        RegistryError: a plugin's payload was not a dict, or contained keys other
-            than `docker` / `venv`.
+        RegistryError: a plugin's payload was not a dict, contained keys other
+            than `docker` / `venv`, or had non-`str | None` values.
     """
     registry: dict[str, Environment] = {
         name: Environment(
@@ -52,32 +53,38 @@ def load_environments() -> dict[str, Environment]:
     }
 
     for ep in entry_points(group=_GROUP):
-        payload = ep.load()
-        if not isinstance(payload, dict):
-            raise RegistryError(
-                f"plugin '{ep.dist.name}' entry-point '{ep.name}' returned "
-                f"{type(payload).__name__}, expected dict[str, dict[str, str | None]]"
-            )
+        spec = ep.load()
         plugin_name = ep.dist.name
-        for env_name, spec in payload.items():
-            invalid = set(spec) - _VALID_ENV_KEYS
-            if invalid:
-                raise RegistryError(
-                    f"plugin '{plugin_name}' environment '{env_name}' has invalid "
-                    f"keys {sorted(invalid)}; allowed keys: {sorted(_VALID_ENV_KEYS)}"
-                )
-            if env_name in registry:
-                existing = registry[env_name].source_package
-                raise RegistryCollisionError(
-                    f"environment '{env_name}' registered by both '{existing}' "
-                    f"and '{plugin_name}' — rename one or remove the duplicate"
-                )
-            registry[env_name] = Environment(
-                name=env_name,
-                docker=spec.get("docker"),
-                venv=spec.get("venv"),
-                source_package=plugin_name,
+        if not isinstance(spec, dict):
+            raise RegistryError(
+                f"plugin '{plugin_name}' environment '{ep.name}' must resolve to "
+                f"dict[str, str | None]; got {type(spec).__name__}"
             )
+        invalid = set(spec) - _VALID_ENV_KEYS
+        if invalid:
+            raise RegistryError(
+                f"plugin '{plugin_name}' environment '{ep.name}' has invalid "
+                f"keys {sorted(invalid)}; allowed keys: {sorted(_VALID_ENV_KEYS)}"
+            )
+        bad_values = {k: v for k, v in spec.items() if v is not None and not isinstance(v, str)}
+        if bad_values:
+            raise RegistryError(
+                f"plugin '{plugin_name}' environment '{ep.name}' has non-string values "
+                f"{ {k: type(v).__name__ for k, v in bad_values.items()} }; "
+                f"each value must be `str | None`"
+            )
+        if ep.name in registry:
+            existing = registry[ep.name].source_package
+            raise RegistryCollisionError(
+                f"environment '{ep.name}' registered by both '{existing}' "
+                f"and '{plugin_name}' — rename one or remove the duplicate"
+            )
+        registry[ep.name] = Environment(
+            name=ep.name,
+            docker=spec.get("docker"),
+            venv=spec.get("venv"),
+            source_package=plugin_name,
+        )
 
     return registry
 

--- a/src/aorta/registry/environments.py
+++ b/src/aorta/registry/environments.py
@@ -60,6 +60,13 @@ def load_environments() -> dict[str, Environment]:
                 f"plugin '{plugin_name}' environment '{ep.name}' must resolve to "
                 f"dict[str, str | None]; got {type(spec).__name__}"
             )
+        non_string_keys = [k for k in spec if not isinstance(k, str)]
+        if non_string_keys:
+            raise RegistryError(
+                f"plugin '{plugin_name}' environment '{ep.name}' has non-string "
+                f"keys {[repr(k) for k in non_string_keys]}; allowed keys: "
+                f"{sorted(_VALID_ENV_KEYS)}"
+            )
         invalid = set(spec) - _VALID_ENV_KEYS
         if invalid:
             raise RegistryError(

--- a/src/aorta/registry/environments.py
+++ b/src/aorta/registry/environments.py
@@ -1,0 +1,97 @@
+"""Environments registry: built-ins + entry-point discovery + collision detection.
+
+Mirrors the mitigations registry. Plugin payloads are validated against
+`_VALID_ENV_KEYS` — only `docker` and `venv` are accepted. ROCm version is
+intentionally not a valid key (see `Environment` docstring).
+
+Plugin authors register a function in their `pyproject.toml` under the
+`aorta.environments` entry-point group. The function returns a dict of
+`environment_name -> {docker?: str, venv?: str}`.
+"""
+
+from importlib.metadata import entry_points
+
+from aorta.registry.errors import (
+    RegistryCollisionError,
+    RegistryError,
+    UnknownEnvironmentError,
+)
+from aorta.registry.types import Environment
+
+_GROUP = "aorta.environments"
+_VALID_ENV_KEYS = frozenset({"docker", "venv"})
+
+# Built-in environments. `local` and `default` are both "current process, no
+# overrides" — `default` is reserved as a site-configurable alias. Customer
+# docker recipes (nan-repro, hipblaslt-develop) ship from aorta-internal via
+# the `aorta.environments` entry-point group, NOT here.
+BUILTIN_ENVIRONMENTS: dict[str, dict[str, str | None]] = {
+    "local":   {},
+    "default": {},
+}
+
+
+def load_environments() -> dict[str, Environment]:
+    """Discover and merge all environments: built-ins first, then entry-point plugins.
+
+    No caching — re-reads entry-points each call.
+
+    Raises:
+        RegistryCollisionError: two contributors registered the same environment name.
+        RegistryError: a plugin's payload was not a dict, or contained keys other
+            than `docker` / `venv`.
+    """
+    registry: dict[str, Environment] = {
+        name: Environment(
+            name=name,
+            docker=spec.get("docker"),
+            venv=spec.get("venv"),
+            source_package="aorta",
+        )
+        for name, spec in BUILTIN_ENVIRONMENTS.items()
+    }
+
+    for ep in entry_points(group=_GROUP):
+        payload = ep.load()
+        if not isinstance(payload, dict):
+            raise RegistryError(
+                f"plugin '{ep.dist.name}' entry-point '{ep.name}' returned "
+                f"{type(payload).__name__}, expected dict[str, dict[str, str | None]]"
+            )
+        plugin_name = ep.dist.name
+        for env_name, spec in payload.items():
+            invalid = set(spec) - _VALID_ENV_KEYS
+            if invalid:
+                raise RegistryError(
+                    f"plugin '{plugin_name}' environment '{env_name}' has invalid "
+                    f"keys {sorted(invalid)}; allowed keys: {sorted(_VALID_ENV_KEYS)}"
+                )
+            if env_name in registry:
+                existing = registry[env_name].source_package
+                raise RegistryCollisionError(
+                    f"environment '{env_name}' registered by both '{existing}' "
+                    f"and '{plugin_name}' — rename one or remove the duplicate"
+                )
+            registry[env_name] = Environment(
+                name=env_name,
+                docker=spec.get("docker"),
+                venv=spec.get("venv"),
+                source_package=plugin_name,
+            )
+
+    return registry
+
+
+def get_environment(name: str) -> Environment:
+    """Return the Environment dataclass for a given name.
+
+    Unlike `get_mitigation` (which returns a dict), environments are richer than
+    a flat env-var bundle, so the dataclass IS the public surface.
+    """
+    registry = load_environments()
+    if name not in registry:
+        raise UnknownEnvironmentError(
+            f"unknown environment '{name}'; available: {sorted(registry)}; "
+            f"if you expected a plugin-contributed entry, ensure the plugin is installed"
+        )
+    return registry[name]

--- a/src/aorta/registry/errors.py
+++ b/src/aorta/registry/errors.py
@@ -1,0 +1,9 @@
+"""Exceptions raised by the registry."""
+
+
+class RegistryError(Exception):
+    """Base class for all registry-related errors."""
+
+
+class UnknownMitigationError(KeyError):
+    """Raised when a mitigation name is not in the merged registry."""

--- a/src/aorta/registry/errors.py
+++ b/src/aorta/registry/errors.py
@@ -5,11 +5,23 @@ class RegistryError(Exception):
     """Base class for all registry-related errors."""
 
 
-class UnknownMitigationError(KeyError):
+class _PlainStrKeyError(KeyError):
+    """KeyError variant that str()s as the plain message.
+
+    `KeyError.__str__` reprs its args (so `str(KeyError("foo"))` is `"'foo'"`),
+    which makes CLI/user-facing messages ugly. Subclasses still behave like a
+    KeyError for `except` purposes; callers just get clean text from `str(e)`.
+    """
+
+    def __str__(self) -> str:
+        return self.args[0] if self.args else ""
+
+
+class UnknownMitigationError(_PlainStrKeyError):
     """Raised when a mitigation name is not in the merged registry."""
 
 
-class UnknownEnvironmentError(KeyError):
+class UnknownEnvironmentError(_PlainStrKeyError):
     """Raised when an environment name is not in the merged registry."""
 
 

--- a/src/aorta/registry/errors.py
+++ b/src/aorta/registry/errors.py
@@ -9,5 +9,9 @@ class UnknownMitigationError(KeyError):
     """Raised when a mitigation name is not in the merged registry."""
 
 
+class UnknownEnvironmentError(KeyError):
+    """Raised when an environment name is not in the merged registry."""
+
+
 class RegistryCollisionError(RegistryError):
-    """Raised when two contributors register the same mitigation name."""
+    """Raised when two contributors register the same name in any registry."""

--- a/src/aorta/registry/errors.py
+++ b/src/aorta/registry/errors.py
@@ -7,3 +7,7 @@ class RegistryError(Exception):
 
 class UnknownMitigationError(KeyError):
     """Raised when a mitigation name is not in the merged registry."""
+
+
+class RegistryCollisionError(RegistryError):
+    """Raised when two contributors register the same mitigation name."""

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -1,10 +1,24 @@
-"""Mitigations registry: dict literal of name -> env var bundle, plus a lookup helper.
+"""Mitigations registry: built-ins + entry-point discovery + collision detection.
 
-Iteration 1 ships only the built-ins and a synchronous lookup. Entry-point
-discovery (`load_mitigations()`, collisions) arrives in iteration 2.
+`load_mitigations()` returns the merged registry of built-ins and plugin
+contributions, keyed by name. Each entry carries its `source_package` so
+collision errors can name the conflicting parties.
+
+Plugin authors register a function in their `pyproject.toml` under the
+`aorta.mitigations` entry-point group. The function returns a dict of
+`mitigation_name -> {env_var_name: value}`.
 """
 
-from aorta.registry.errors import UnknownMitigationError
+from importlib.metadata import entry_points
+
+from aorta.registry.errors import (
+    RegistryCollisionError,
+    RegistryError,
+    UnknownMitigationError,
+)
+from aorta.registry.types import Mitigation
+
+_GROUP = "aorta.mitigations"
 
 # Only true runtime-level flags belong here — env vars consumed by hipBLASLt or
 # the ROCm runtime, transparent to the workload. Workload-internal env vars
@@ -18,17 +32,52 @@ BUILTIN_MITIGATIONS: dict[str, dict[str, str]] = {
 }
 
 
+def load_mitigations() -> dict[str, Mitigation]:
+    """Discover and merge all mitigations: built-ins first, then entry-point plugins.
+
+    No caching — re-reads entry-points each call. Cheap for MVP; revisit if profiling
+    shows it matters.
+
+    Raises:
+        RegistryCollisionError: two contributors registered the same mitigation name.
+        RegistryError: a plugin's entry-point payload was not a dict.
+    """
+    registry: dict[str, Mitigation] = {
+        name: Mitigation(name=name, env=dict(env), source_package="aorta")
+        for name, env in BUILTIN_MITIGATIONS.items()
+    }
+
+    for ep in entry_points(group=_GROUP):
+        payload = ep.load()
+        if not isinstance(payload, dict):
+            raise RegistryError(
+                f"plugin '{ep.dist.name}' entry-point '{ep.name}' returned "
+                f"{type(payload).__name__}, expected dict[str, dict[str, str]]"
+            )
+        plugin_name = ep.dist.name
+        for mit_name, env in payload.items():
+            if mit_name in registry:
+                existing = registry[mit_name].source_package
+                raise RegistryCollisionError(
+                    f"mitigation '{mit_name}' registered by both '{existing}' "
+                    f"and '{plugin_name}' — rename one or remove the duplicate"
+                )
+            registry[mit_name] = Mitigation(
+                name=mit_name, env=dict(env), source_package=plugin_name
+            )
+
+    return registry
+
+
 def get_mitigation(name: str) -> dict[str, str]:
     """Return the env-var bundle for a mitigation name. Empty dict for 'none'.
 
     Returns a defensive copy — mutating the result does not affect the registry.
-
-    Iteration 1 reads only built-ins. Iteration 2 routes through
-    `load_mitigations()` to also see entry-point-registered plugins.
     """
-    if name not in BUILTIN_MITIGATIONS:
+    registry = load_mitigations()
+    if name not in registry:
         raise UnknownMitigationError(
-            f"unknown mitigation '{name}'; available: {sorted(BUILTIN_MITIGATIONS)}; "
+            f"unknown mitigation '{name}'; available: {sorted(registry)}; "
             f"if you expected a plugin-contributed entry, ensure the plugin is installed"
         )
-    return dict(BUILTIN_MITIGATIONS[name])
+    return dict(registry[name].env)

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -20,11 +20,13 @@ from aorta.registry.types import Mitigation
 
 _GROUP = "aorta.mitigations"
 
-# Only true runtime-level flags belong here — env vars consumed by hipBLASLt or
-# the ROCm runtime, transparent to the workload. Workload-internal env vars
-# (e.g. AMP_DTYPE, SHAMPOO_PRECONDITIONER_DTYPE) only "work" if the workload's
-# training script literally reads os.environ for them; those belong with the
-# workload's own package, registered via the `aorta.mitigations` entry-point group.
+# Only runtime-level flags belong here — env vars read by a runtime or library
+# (ROCm, hipBLASLt, PyTorch, NCCL, OpenMP, the kernel, etc.), transparent to
+# the workload. Workload-internal env vars (e.g. AMP_DTYPE,
+# SHAMPOO_PRECONDITIONER_DTYPE) only "work" if the workload's training script
+# literally reads os.environ for them; those belong with the workload's own
+# package, registered via the `aorta.mitigations` entry-point group.
+# See src/aorta/registry/README.md for the full criterion.
 BUILTIN_MITIGATIONS: dict[str, dict[str, str]] = {
     "none":     {},
     "tf32_off": {"DISABLE_TF32": "1"},  # consumed by hipBLASLt itself

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -4,9 +4,10 @@
 contributions, keyed by name. Each entry carries its `source_package` so
 collision errors can name the conflicting parties.
 
-Plugin authors register a function in their `pyproject.toml` under the
-`aorta.mitigations` entry-point group. The function returns a dict of
-`mitigation_name -> {env_var_name: value}`.
+Plugin authors register one entry-point per mitigation in their `pyproject.toml`
+under the `aorta.mitigations` group. The entry-point name IS the mitigation
+name; the loaded object is the env-var bundle (`dict[str, str]`). This mirrors
+the existing `aorta.workloads` extension-point pattern.
 """
 
 from importlib.metadata import entry_points
@@ -42,7 +43,7 @@ def load_mitigations() -> dict[str, Mitigation]:
 
     Raises:
         RegistryCollisionError: two contributors registered the same mitigation name.
-        RegistryError: a plugin's entry-point payload was not a dict.
+        RegistryError: a plugin's entry-point payload was not a `dict[str, str]`.
     """
     registry: dict[str, Mitigation] = {
         name: Mitigation(name=name, env=dict(env), source_package="aorta")
@@ -50,23 +51,25 @@ def load_mitigations() -> dict[str, Mitigation]:
     }
 
     for ep in entry_points(group=_GROUP):
-        payload = ep.load()
-        if not isinstance(payload, dict):
-            raise RegistryError(
-                f"plugin '{ep.dist.name}' entry-point '{ep.name}' returned "
-                f"{type(payload).__name__}, expected dict[str, dict[str, str]]"
-            )
+        env = ep.load()
         plugin_name = ep.dist.name
-        for mit_name, env in payload.items():
-            if mit_name in registry:
-                existing = registry[mit_name].source_package
-                raise RegistryCollisionError(
-                    f"mitigation '{mit_name}' registered by both '{existing}' "
-                    f"and '{plugin_name}' — rename one or remove the duplicate"
-                )
-            registry[mit_name] = Mitigation(
-                name=mit_name, env=dict(env), source_package=plugin_name
+        if not isinstance(env, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in env.items()
+        ):
+            raise RegistryError(
+                f"plugin '{plugin_name}' mitigation '{ep.name}' must resolve to "
+                f"dict[str, str]; got {type(env).__name__}"
+                + (f" with non-string entries {dict(env)!r}" if isinstance(env, dict) else "")
             )
+        if ep.name in registry:
+            existing = registry[ep.name].source_package
+            raise RegistryCollisionError(
+                f"mitigation '{ep.name}' registered by both '{existing}' "
+                f"and '{plugin_name}' — rename one or remove the duplicate"
+            )
+        registry[ep.name] = Mitigation(
+            name=ep.name, env=dict(env), source_package=plugin_name
+        )
 
     return registry
 

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -1,0 +1,34 @@
+"""Mitigations registry: dict literal of name -> env var bundle, plus a lookup helper.
+
+Iteration 1 ships only the built-ins and a synchronous lookup. Entry-point
+discovery (`load_mitigations()`, collisions) arrives in iteration 2.
+"""
+
+from aorta.registry.errors import UnknownMitigationError
+
+# Only true runtime-level flags belong here — env vars consumed by hipBLASLt or
+# the ROCm runtime, transparent to the workload. Workload-internal env vars
+# (e.g. AMP_DTYPE, SHAMPOO_PRECONDITIONER_DTYPE) only "work" if the workload's
+# training script literally reads os.environ for them; those belong with the
+# workload's own package, registered via the `aorta.mitigations` entry-point group.
+BUILTIN_MITIGATIONS: dict[str, dict[str, str]] = {
+    "none":     {},
+    "tf32_off": {"DISABLE_TF32": "1"},  # consumed by hipBLASLt itself
+    "xnack":    {"HSA_XNACK": "1"},     # consumed by ROCm runtime
+}
+
+
+def get_mitigation(name: str) -> dict[str, str]:
+    """Return the env-var bundle for a mitigation name. Empty dict for 'none'.
+
+    Returns a defensive copy — mutating the result does not affect the registry.
+
+    Iteration 1 reads only built-ins. Iteration 2 routes through
+    `load_mitigations()` to also see entry-point-registered plugins.
+    """
+    if name not in BUILTIN_MITIGATIONS:
+        raise UnknownMitigationError(
+            f"unknown mitigation '{name}'; available: {sorted(BUILTIN_MITIGATIONS)}; "
+            f"if you expected a plugin-contributed entry, ensure the plugin is installed"
+        )
+    return dict(BUILTIN_MITIGATIONS[name])

--- a/src/aorta/registry/types.py
+++ b/src/aorta/registry/types.py
@@ -1,0 +1,20 @@
+"""Data types for the mitigations + environments registry.
+
+Iteration 1 only defines `Mitigation` — `Environment` arrives in iteration 3.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Mitigation:
+    """A named bundle of environment variables that modifies workload behavior.
+
+    `frozen=True` prevents reassigning attributes (e.g. `m.name = "x"` raises),
+    but the `env` dict itself is still mutable in place. Callers should treat
+    `env` as read-only; `get_mitigation()` returns a defensive copy.
+    """
+
+    name: str
+    env: dict[str, str]
+    source_package: str  # "aorta" for built-ins, dist name for entry-point contributors

--- a/src/aorta/registry/types.py
+++ b/src/aorta/registry/types.py
@@ -1,7 +1,4 @@
-"""Data types for the mitigations + environments registry.
-
-Iteration 1 only defines `Mitigation` — `Environment` arrives in iteration 3.
-"""
+"""Data types for the mitigations + environments registry."""
 
 from dataclasses import dataclass
 
@@ -18,3 +15,19 @@ class Mitigation:
     name: str
     env: dict[str, str]
     source_package: str  # "aorta" for built-ins, dist name for entry-point contributors
+
+
+@dataclass(frozen=True)
+class Environment:
+    """A baseline process / container recipe for a workload run.
+
+    `docker` and `venv` are independent ways of describing the baseline; either,
+    both, or neither may be set (built-in `local` has neither — current process).
+    No `rocm` field: ROCm version is implicit in the docker image digest or in
+    the host the venv runs on; capture it from `aorta env probe` at runtime.
+    """
+
+    name: str
+    docker: str | None = None
+    venv: str | None = None
+    source_package: str = "aorta"

--- a/tests/registry/conftest.py
+++ b/tests/registry/conftest.py
@@ -1,0 +1,48 @@
+"""Shared fixtures for registry tests — fake entry-point discovery.
+
+The `fake_eps` fixture patches `aorta.registry.mitigations.entry_points` with
+a controlled list of fake entry-points. Use it to simulate plugins being
+installed without actually installing anything.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+
+@dataclass
+class _FakeDist:
+    name: str
+
+
+@dataclass
+class _FakeEntryPoint:
+    name: str
+    payload: dict
+    dist: _FakeDist
+
+    def load(self):
+        return self.payload
+
+
+@pytest.fixture
+def fake_eps(monkeypatch):
+    """Install a controlled list of fake mitigation entry-points.
+
+    Usage:
+        fake_eps([(ep_name, payload_dict, dist_name), ...])
+
+    Each tuple becomes one fake EntryPoint exposing the payload as its `.load()`
+    return value and the dist name as `.dist.name`.
+    """
+    def _install(specs):
+        eps = [
+            _FakeEntryPoint(name=n, payload=p, dist=_FakeDist(name=d))
+            for n, p, d in specs
+        ]
+        monkeypatch.setattr(
+            "aorta.registry.mitigations.entry_points",
+            lambda group: eps,
+        )
+
+    return _install

--- a/tests/registry/conftest.py
+++ b/tests/registry/conftest.py
@@ -7,6 +7,7 @@ actually installing anything.
 """
 
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
@@ -19,7 +20,7 @@ class _FakeDist:
 @dataclass
 class _FakeEntryPoint:
     name: str
-    payload: dict
+    payload: Any  # tests pass non-dict payloads (e.g. str) to exercise validation
     dist: _FakeDist
 
     def load(self):

--- a/tests/registry/conftest.py
+++ b/tests/registry/conftest.py
@@ -1,8 +1,9 @@
 """Shared fixtures for registry tests — fake entry-point discovery.
 
-The `fake_eps` fixture patches `aorta.registry.mitigations.entry_points` with
-a controlled list of fake entry-points. Use it to simulate plugins being
-installed without actually installing anything.
+The `fake_eps` and `fake_env_eps` fixtures patch the `entry_points` lookup in
+the mitigations and environments modules respectively, with a controlled list
+of fake entry-points. Use them to simulate plugins being installed without
+actually installing anything.
 """
 
 from dataclasses import dataclass
@@ -25,24 +26,25 @@ class _FakeEntryPoint:
         return self.payload
 
 
-@pytest.fixture
-def fake_eps(monkeypatch):
-    """Install a controlled list of fake mitigation entry-points.
-
-    Usage:
-        fake_eps([(ep_name, payload_dict, dist_name), ...])
-
-    Each tuple becomes one fake EntryPoint exposing the payload as its `.load()`
-    return value and the dist name as `.dist.name`.
-    """
+def _fake_eps_for(monkeypatch, module_path: str):
+    """Build a factory that, when called, installs fake entry-points at module_path."""
     def _install(specs):
         eps = [
             _FakeEntryPoint(name=n, payload=p, dist=_FakeDist(name=d))
             for n, p, d in specs
         ]
-        monkeypatch.setattr(
-            "aorta.registry.mitigations.entry_points",
-            lambda group: eps,
-        )
+        monkeypatch.setattr(module_path, lambda group: eps)
 
     return _install
+
+
+@pytest.fixture
+def fake_eps(monkeypatch):
+    """Install fake mitigation entry-points: fake_eps([(name, payload, dist), ...])."""
+    return _fake_eps_for(monkeypatch, "aorta.registry.mitigations.entry_points")
+
+
+@pytest.fixture
+def fake_env_eps(monkeypatch):
+    """Install fake environment entry-points: fake_env_eps([(name, payload, dist), ...])."""
+    return _fake_eps_for(monkeypatch, "aorta.registry.environments.entry_points")

--- a/tests/registry/test_environments.py
+++ b/tests/registry/test_environments.py
@@ -39,7 +39,7 @@ def test_get_environment_unknown_raises(fake_env_eps):
 
 def test_load_environments_discovers_plugin(fake_env_eps):
     fake_env_eps([
-        ("envs", {"nan-repro": {"docker": "rocm/private@sha256:abc"}}, "fake_internal"),
+        ("nan-repro", {"docker": "rocm/private@sha256:abc"}, "fake_internal"),
     ])
     result = load_environments()
     assert result["nan-repro"].docker == "rocm/private@sha256:abc"
@@ -48,14 +48,32 @@ def test_load_environments_discovers_plugin(fake_env_eps):
 
 def test_collision_between_plugins_raises(fake_env_eps):
     fake_env_eps([
-        ("a", {"shared": {"docker": "img:1"}}, "plugin_a"),
-        ("b", {"shared": {"docker": "img:2"}}, "plugin_b"),
+        ("shared", {"docker": "img:1"}, "plugin_a"),
+        ("shared", {"docker": "img:2"}, "plugin_b"),
     ])
     with pytest.raises(RegistryCollisionError, match="plugin_a.*plugin_b"):
         load_environments()
 
 
+def test_collision_plugin_vs_builtin_raises(fake_env_eps):
+    fake_env_eps([("local", {}, "plugin_x")])
+    with pytest.raises(RegistryCollisionError, match="aorta.*plugin_x"):
+        load_environments()
+
+
 def test_invalid_key_raises(fake_env_eps):
-    fake_env_eps([("p", {"bad": {"rocm": "6.0"}}, "plugin_x")])
+    fake_env_eps([("bad", {"rocm": "6.0"}, "plugin_x")])
     with pytest.raises(RegistryError, match="plugin_x.*rocm"):
+        load_environments()
+
+
+def test_non_string_value_raises(fake_env_eps):
+    fake_env_eps([("bad", {"docker": 123}, "plugin_x")])
+    with pytest.raises(RegistryError, match="plugin_x.*bad.*non-string"):
+        load_environments()
+
+
+def test_non_dict_payload_raises(fake_env_eps):
+    fake_env_eps([("bad", "not-a-dict", "plugin_x")])
+    with pytest.raises(RegistryError, match="plugin_x.*bad.*str"):
         load_environments()

--- a/tests/registry/test_environments.py
+++ b/tests/registry/test_environments.py
@@ -67,6 +67,12 @@ def test_invalid_key_raises(fake_env_eps):
         load_environments()
 
 
+def test_non_string_key_raises_cleanly(fake_env_eps):
+    fake_env_eps([("bad", {1: "x", "docker": "img"}, "plugin_x")])
+    with pytest.raises(RegistryError, match="plugin_x.*non-string keys"):
+        load_environments()
+
+
 def test_non_string_value_raises(fake_env_eps):
     fake_env_eps([("bad", {"docker": 123}, "plugin_x")])
     with pytest.raises(RegistryError, match="plugin_x.*bad.*non-string"):

--- a/tests/registry/test_environments.py
+++ b/tests/registry/test_environments.py
@@ -1,0 +1,61 @@
+"""Tests for the environments registry."""
+
+import pytest
+
+from aorta.registry.errors import (
+    RegistryCollisionError,
+    RegistryError,
+    UnknownEnvironmentError,
+)
+from aorta.registry.environments import get_environment, load_environments
+from aorta.registry.types import Environment
+
+
+def test_load_environments_includes_builtins(fake_env_eps):
+    fake_env_eps([])
+    result = load_environments()
+    assert "local" in result
+    assert "default" in result
+    assert result["local"].source_package == "aorta"
+
+
+def test_get_environment_returns_dataclass(fake_env_eps):
+    fake_env_eps([])
+    env = get_environment("local")
+    assert isinstance(env, Environment)
+    assert env.docker is None
+    assert env.venv is None
+    assert env.source_package == "aorta"
+
+
+def test_get_environment_unknown_raises(fake_env_eps):
+    fake_env_eps([])
+    with pytest.raises(UnknownEnvironmentError) as exc:
+        get_environment("not_a_real_env")
+    msg = str(exc.value)
+    assert "available:" in msg
+    assert "plugin" in msg
+
+
+def test_load_environments_discovers_plugin(fake_env_eps):
+    fake_env_eps([
+        ("envs", {"nan-repro": {"docker": "rocm/private@sha256:abc"}}, "fake_internal"),
+    ])
+    result = load_environments()
+    assert result["nan-repro"].docker == "rocm/private@sha256:abc"
+    assert result["nan-repro"].source_package == "fake_internal"
+
+
+def test_collision_between_plugins_raises(fake_env_eps):
+    fake_env_eps([
+        ("a", {"shared": {"docker": "img:1"}}, "plugin_a"),
+        ("b", {"shared": {"docker": "img:2"}}, "plugin_b"),
+    ])
+    with pytest.raises(RegistryCollisionError, match="plugin_a.*plugin_b"):
+        load_environments()
+
+
+def test_invalid_key_raises(fake_env_eps):
+    fake_env_eps([("p", {"bad": {"rocm": "6.0"}}, "plugin_x")])
+    with pytest.raises(RegistryError, match="plugin_x.*rocm"):
+        load_environments()

--- a/tests/registry/test_mitigations.py
+++ b/tests/registry/test_mitigations.py
@@ -1,9 +1,12 @@
-"""Tests for the mitigations registry (iteration 1 — built-ins only)."""
+"""Tests for the mitigations registry."""
 
 import pytest
 
-from aorta.registry.errors import UnknownMitigationError
-from aorta.registry.mitigations import get_mitigation
+from aorta.registry.errors import (
+    RegistryCollisionError,
+    UnknownMitigationError,
+)
+from aorta.registry.mitigations import get_mitigation, load_mitigations
 
 
 def test_get_mitigation_returns_env_vars():
@@ -20,3 +23,32 @@ def test_get_mitigation_unknown_raises_with_helpful_message():
     msg = str(exc.value)
     assert "available:" in msg
     assert "plugin" in msg
+
+
+def test_load_mitigations_includes_builtins(fake_eps):
+    fake_eps([])
+    result = load_mitigations()
+    assert "tf32_off" in result
+    assert result["tf32_off"].source_package == "aorta"
+
+
+def test_load_mitigations_discovers_plugin(fake_eps):
+    fake_eps([("plug", {"foo": {"FOO": "1"}}, "fake_plugin")])
+    result = load_mitigations()
+    assert result["foo"].env == {"FOO": "1"}
+    assert result["foo"].source_package == "fake_plugin"
+
+
+def test_collision_between_plugins_raises(fake_eps):
+    fake_eps([
+        ("a", {"foo": {"X": "1"}}, "plugin_a"),
+        ("b", {"foo": {"X": "2"}}, "plugin_b"),
+    ])
+    with pytest.raises(RegistryCollisionError, match="plugin_a.*plugin_b"):
+        load_mitigations()
+
+
+def test_collision_plugin_vs_builtin_raises(fake_eps):
+    fake_eps([("p", {"tf32_off": {"X": "1"}}, "plugin_x")])
+    with pytest.raises(RegistryCollisionError, match="aorta.*plugin_x"):
+        load_mitigations()

--- a/tests/registry/test_mitigations.py
+++ b/tests/registry/test_mitigations.py
@@ -1,0 +1,22 @@
+"""Tests for the mitigations registry (iteration 1 — built-ins only)."""
+
+import pytest
+
+from aorta.registry.errors import UnknownMitigationError
+from aorta.registry.mitigations import get_mitigation
+
+
+def test_get_mitigation_returns_env_vars():
+    assert get_mitigation("tf32_off") == {"DISABLE_TF32": "1"}
+
+
+def test_get_mitigation_none_is_empty_dict():
+    assert get_mitigation("none") == {}
+
+
+def test_get_mitigation_unknown_raises_with_helpful_message():
+    with pytest.raises(UnknownMitigationError) as exc:
+        get_mitigation("not_a_real_mitigation")
+    msg = str(exc.value)
+    assert "available:" in msg
+    assert "plugin" in msg

--- a/tests/registry/test_mitigations.py
+++ b/tests/registry/test_mitigations.py
@@ -4,6 +4,7 @@ import pytest
 
 from aorta.registry.errors import (
     RegistryCollisionError,
+    RegistryError,
     UnknownMitigationError,
 )
 from aorta.registry.mitigations import get_mitigation, load_mitigations
@@ -33,7 +34,7 @@ def test_load_mitigations_includes_builtins(fake_eps):
 
 
 def test_load_mitigations_discovers_plugin(fake_eps):
-    fake_eps([("plug", {"foo": {"FOO": "1"}}, "fake_plugin")])
+    fake_eps([("foo", {"FOO": "1"}, "fake_plugin")])
     result = load_mitigations()
     assert result["foo"].env == {"FOO": "1"}
     assert result["foo"].source_package == "fake_plugin"
@@ -41,14 +42,26 @@ def test_load_mitigations_discovers_plugin(fake_eps):
 
 def test_collision_between_plugins_raises(fake_eps):
     fake_eps([
-        ("a", {"foo": {"X": "1"}}, "plugin_a"),
-        ("b", {"foo": {"X": "2"}}, "plugin_b"),
+        ("foo", {"X": "1"}, "plugin_a"),
+        ("foo", {"X": "2"}, "plugin_b"),
     ])
     with pytest.raises(RegistryCollisionError, match="plugin_a.*plugin_b"):
         load_mitigations()
 
 
 def test_collision_plugin_vs_builtin_raises(fake_eps):
-    fake_eps([("p", {"tf32_off": {"X": "1"}}, "plugin_x")])
+    fake_eps([("tf32_off", {"X": "1"}, "plugin_x")])
     with pytest.raises(RegistryCollisionError, match="aorta.*plugin_x"):
+        load_mitigations()
+
+
+def test_non_string_env_value_raises(fake_eps):
+    fake_eps([("bad", {"K": 123}, "plugin_x")])
+    with pytest.raises(RegistryError, match="plugin_x.*bad.*dict\\[str, str\\]"):
+        load_mitigations()
+
+
+def test_non_dict_payload_raises(fake_eps):
+    fake_eps([("bad", "not-a-dict", "plugin_x")])
+    with pytest.raises(RegistryError, match="plugin_x.*bad.*str"):
         load_mitigations()

--- a/tests/registry/test_mitigations.py
+++ b/tests/registry/test_mitigations.py
@@ -24,6 +24,8 @@ def test_get_mitigation_unknown_raises_with_helpful_message():
     msg = str(exc.value)
     assert "available:" in msg
     assert "plugin" in msg
+    # str() must NOT wrap message in quotes (KeyError's default repr behavior)
+    assert not msg.startswith("'") and not msg.endswith("'")
 
 
 def test_load_mitigations_includes_builtins(fake_eps):


### PR DESCRIPTION
## Summary

Adds two small registries to `aorta` (mitigations + environments) plus a resolver that merges built-ins with plugin contributions discovered via Python entry-points. Mirrors the existing `aorta.workloads` extension-point pattern.

## Issue

https://github.com/ROCm/aorta/issues/153

## Built-ins shipped

**Mitigations** (group: `aorta.mitigations`):
- `none` → `{}` — baseline
- `tf32_off` → `{DISABLE_TF32: "1"}` — consumed by hipBLASLt
- `xnack` → `{HSA_XNACK: "1"}` — consumed by ROCm runtime

Workload-coupled env vars (e.g. `AMP_DTYPE`, `SHAMPOO_PRECONDITIONER_DTYPE`) are intentionally NOT public built-ins — they belong with whichever workload package consumes them.

**Environments** (group: `aorta.environments`):
- `local` → current process, no overrides
- `default` → site-configurable alias (currently same as `local`)

No `rocm` field — ROCm version is implicit in the docker image digest or the host the venv runs on; capture it from `aorta env probe` at runtime.

## Public API surface

```python
from aorta.registry import (
    load_mitigations, get_mitigation,
    load_environments, get_environment,
    Mitigation, Environment,
    RegistryError, RegistryCollisionError,
    UnknownMitigationError, UnknownEnvironmentError,
)
```

## CLI

`aorta mitigations list` and `aorta environments list` print the merged registry with each entry's `source_package` — lets plugin authors verify their plugin loaded, and lets non-experts see what's available.

## Spec

See `tasks/public/B3-mitigations-dict.md` for the full specification (in the workspace tasks repo).

## Test plan

- [x] `pytest tests/registry/ -v` — 13+ tests passing locally
- [ ] CI passes
- [ ] Smoke test `aorta mitigations list` and `aorta environments list` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)