### PR TITLE
B3.1: JSON sidecar for ad-hoc mitigations / environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ overlap_debug*/
 *.xlsx
 *.log
 *.logs
+# Exception: example sidecar files that ship with the repo
+!examples/*.json
 *_merged_enhanced.json
 nccl_thread_sweep_*.log
 nccl_thread_sweep_summary_*.txt

--- a/examples/mitigations-sidecar.json
+++ b/examples/mitigations-sidecar.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "mitigations": {
+    "my_flag":   { "MY_ENV_VAR": "1" },
+    "amp_bf16":  { "AMP_DTYPE": "bfloat16" }
+  },
+  "environments": {
+    "my_local_image": { "docker": "myorg/private:test@sha256:0000000000000000000000000000000000000000000000000000000000000000" },
+    "host_venv_3_12": { "venv":   "/home/me/.venvs/aorta-3.12" }
+  }
+}

--- a/src/aorta/cli/environments.py
+++ b/src/aorta/cli/environments.py
@@ -1,5 +1,7 @@
 """`aorta environments` — inspect the merged environments registry."""
 
+from pathlib import Path
+
 import click
 
 from aorta.registry import load_environments
@@ -11,9 +13,16 @@ def environments() -> None:
 
 
 @environments.command(name="list")
-def list_() -> None:
+@click.option(
+    "--file",
+    "files",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    help="JSON file with extra environment entries to merge into the listing (repeatable).",
+)
+def list_(files: tuple[Path, ...]) -> None:
     """List every registered environment, its source package, and its docker/venv."""
-    registry = load_environments()
+    registry = load_environments(extra_files=list(files) or None)
     name_w = max(len("NAME"), *(len(n) for n in registry))
     src_w = max(len("SOURCE"), *(len(e.source_package) for e in registry.values()))
     docker_w = max(len("DOCKER"), *(len(e.docker or "-") for e in registry.values()))

--- a/src/aorta/cli/mitigations.py
+++ b/src/aorta/cli/mitigations.py
@@ -1,5 +1,7 @@
 """`aorta mitigations` — inspect the merged mitigations registry."""
 
+from pathlib import Path
+
 import click
 
 from aorta.registry import load_mitigations
@@ -11,9 +13,16 @@ def mitigations() -> None:
 
 
 @mitigations.command(name="list")
-def list_() -> None:
+@click.option(
+    "--file",
+    "files",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    help="JSON file with extra mitigation entries to merge into the listing (repeatable).",
+)
+def list_(files: tuple[Path, ...]) -> None:
     """List every registered mitigation, its source package, and its env vars."""
-    registry = load_mitigations()
+    registry = load_mitigations(extra_files=list(files) or None)
     name_w = max(len("NAME"), *(len(n) for n in registry))
     src_w = max(len("SOURCE"), *(len(m.source_package) for m in registry.values()))
 

--- a/src/aorta/cli/run.py
+++ b/src/aorta/cli/run.py
@@ -35,7 +35,7 @@ import click
     multiple=True,
     help=(
         "JSON file with ad-hoc mitigations and/or environments (repeatable). "
-        "Merged into both registries alongside built-ins and plugins."
+        "Parsed and validated now; consumption by `aorta run` lands with task B1."
     ),
 )
 @click.option(

--- a/src/aorta/cli/run.py
+++ b/src/aorta/cli/run.py
@@ -35,7 +35,7 @@ import click
     multiple=True,
     help=(
         "JSON file with ad-hoc mitigations and/or environments (repeatable). "
-        "Parsed and validated now; consumption by `aorta run` lands with task B1."
+        "Click verifies the file exists; JSON parsing + consumption land with task B1."
     ),
 )
 @click.option(

--- a/src/aorta/cli/run.py
+++ b/src/aorta/cli/run.py
@@ -1,5 +1,7 @@
 """`aorta run` - universal workload runner."""
 
+from pathlib import Path
+
 import click
 
 
@@ -27,6 +29,16 @@ import click
     help="Comma-separated mitigation names from aorta_internal.mitigations.",
 )
 @click.option(
+    "--mitigations-file",
+    "mitigation_files",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    help=(
+        "JSON file with ad-hoc mitigations and/or environments (repeatable). "
+        "Merged into both registries alongside built-ins and plugins."
+    ),
+)
+@click.option(
     "--steps",
     type=int,
     default=None,
@@ -44,6 +56,7 @@ def run(
     trials: int,
     dockers: str,
     mitigations: str,
+    mitigation_files: tuple[Path, ...],
     steps: int | None,
     results_dir: str,
 ) -> None:

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -1,5 +1,7 @@
 """`aorta triage` - mitigation matrix runner. (Optimize mode deferred to P1 per D11.)"""
 
+from pathlib import Path
+
 import click
 
 
@@ -28,6 +30,16 @@ def triage() -> None:
     help="Comma-separated docker image names.",
 )
 @click.option(
+    "--mitigations-file",
+    "mitigation_files",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    help=(
+        "JSON file with ad-hoc mitigations and/or environments (repeatable). "
+        "Entries are referenceable by name in --mitigations / --dockers."
+    ),
+)
+@click.option(
     "--trials",
     type=int,
     default=8,
@@ -52,6 +64,7 @@ def triage_run(
     workload: str,
     mitigations: str,
     dockers: str,
+    mitigation_files: tuple[Path, ...],
     trials: int,
     steps: int | None,
     output_dir: str,

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -36,7 +36,7 @@ def triage() -> None:
     multiple=True,
     help=(
         "JSON file with ad-hoc mitigations and/or environments (repeatable). "
-        "Parsed and validated now; consumption by `aorta triage run` lands with task B2."
+        "Click verifies the file exists; JSON parsing + consumption land with task B2."
     ),
 )
 @click.option(

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -36,7 +36,7 @@ def triage() -> None:
     multiple=True,
     help=(
         "JSON file with ad-hoc mitigations and/or environments (repeatable). "
-        "Entries are referenceable by name in --mitigations / --dockers."
+        "Parsed and validated now; consumption by `aorta triage run` lands with task B2."
     ),
 )
 @click.option(

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -88,13 +88,23 @@ which names your dist contributes.
 
 For "I want to try these named bundles on my box, share the file with a
 colleague over Slack, run a triage sweep against them, and throw it away when
-I'm done" — write a JSON file and pass it on the command line:
+I'm done" — write a JSON file and pass it on the command line.
+
+**Wired today** (B3.1):
+
+```bash
+aorta mitigations  list --file ./my-experiments.json
+aorta environments list --file ./my-experiments.json
+```
+
+**Lands with B1 / B2** — the flags below are accepted and the JSON is
+parsed + validated, but `aorta run` and `aorta triage run` themselves
+are not yet implemented and the merged registries are not yet
+consumed:
 
 ```bash
 aorta run    --workload fsdp --mitigations-file ./my-experiments.json --mitigations my_flag
 aorta triage --workload fsdp --mitigations-file ./my-experiments.json ...
-aorta mitigations  list --file ./my-experiments.json
-aorta environments list --file ./my-experiments.json
 ```
 
 `--mitigations-file` is repeatable. Each file may declare mitigations,

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -93,14 +93,15 @@ I'm done" — write a JSON file and pass it on the command line.
 **Wired today** (B3.1):
 
 ```bash
-aorta mitigations  list --file ./my-experiments.json
+aorta mitigations list --file ./my-experiments.json
 aorta environments list --file ./my-experiments.json
 ```
 
-**Lands with B1 / B2** — the flags below are accepted and the JSON is
-parsed + validated, but `aorta run` and `aorta triage run` themselves
-are not yet implemented and the merged registries are not yet
-consumed:
+**Lands with B1 / B2** — the flags below are accepted by the CLI (Click
+checks the file exists), but `aorta run` and `aorta triage run` themselves
+are not yet implemented: the JSON is not parsed and the merged registries
+are not yet consumed. Today the commands raise "not yet implemented" before
+reaching the loader:
 
 ```bash
 aorta run    --workload fsdp --mitigations-file ./my-experiments.json --mitigations my_flag

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -84,6 +84,49 @@ which names your dist contributes.
 > Plugin authors: re-run `pip install` after editing `pyproject.toml` —
 > entry-points are read at install time, not at import time.
 
+### Path 3 — JSON sidecar (ad-hoc, throwaway, shareable)
+
+For "I want to try these named bundles on my box, share the file with a
+colleague over Slack, run a triage sweep against them, and throw it away when
+I'm done" — write a JSON file and pass it on the command line:
+
+```bash
+aorta run    --workload fsdp --mitigations-file ./my-experiments.json --mitigations my_flag
+aorta triage --workload fsdp --mitigations-file ./my-experiments.json ...
+aorta mitigations  list --file ./my-experiments.json
+aorta environments list --file ./my-experiments.json
+```
+
+`--mitigations-file` is repeatable. Each file may declare mitigations,
+environments, or both — both registries are populated from the same file.
+Files are merged left-to-right and combine with built-ins + plugins under
+the same collision rule.
+
+`my-experiments.json`:
+
+```json
+{
+  "version": 1,
+  "mitigations": {
+    "my_flag":  { "MY_ENV_VAR": "1" },
+    "amp_bf16": { "AMP_DTYPE": "bfloat16" }
+  },
+  "environments": {
+    "my_local_image": { "docker": "myorg/private:test@sha256:..." },
+    "host_venv_3_12": { "venv":   "/home/me/.venvs/aorta-3.12" }
+  }
+}
+```
+
+Both top-level keys are optional (a file can ship only mitigations, or only
+environments, or both). `version: 1` is required — it's a forward-compat
+lever; an aorta build that doesn't understand a future `version: 2` rejects
+the file cleanly instead of misinterpreting it.
+
+Sidecar entries list with `source_package = "sidecar:<filename>"` so it's
+obvious which file shipped which entry. Starting template:
+[`examples/mitigations-sidecar.json`](../../../examples/mitigations-sidecar.json).
+
 ## Trying things locally without upstreaming
 
 Sometimes you want to test a mitigation on your own machine without sending a

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -105,7 +105,7 @@ reaching the loader:
 
 ```bash
 aorta run    --workload fsdp --mitigations-file ./my-experiments.json --mitigations my_flag
-aorta triage --workload fsdp --mitigations-file ./my-experiments.json ...
+aorta triage run --workload fsdp --mitigations-file ./my-experiments.json ...
 ```
 
 `--mitigations-file` is repeatable. Each file may declare mitigations,

--- a/src/aorta/registry/__init__.py
+++ b/src/aorta/registry/__init__.py
@@ -13,6 +13,10 @@ from aorta.registry.errors import (
     UnknownMitigationError,
 )
 from aorta.registry.mitigations import get_mitigation, load_mitigations
+from aorta.registry.sidecar import (
+    load_sidecar_environments,
+    load_sidecar_mitigations,
+)
 from aorta.registry.types import Environment, Mitigation
 
 __all__ = [
@@ -20,6 +24,8 @@ __all__ = [
     "get_mitigation",
     "load_environments",
     "get_environment",
+    "load_sidecar_mitigations",
+    "load_sidecar_environments",
     "Mitigation",
     "Environment",
     "RegistryError",

--- a/src/aorta/registry/environments.py
+++ b/src/aorta/registry/environments.py
@@ -18,7 +18,7 @@ from aorta.registry.errors import (
     RegistryError,
     UnknownEnvironmentError,
 )
-from aorta.registry.sidecar import load_sidecar_environments
+from aorta.registry.sidecar import check_sidecar_basenames, load_sidecar_environments
 from aorta.registry.types import Environment
 
 _GROUP = "aorta.environments"
@@ -102,15 +102,25 @@ def load_environments(
             source_package=plugin_name,
         )
 
+    check_sidecar_basenames(extra_files)
+    sidecar_paths: dict[str, Path] = {}
     for path in extra_files or ():
         for name, env in load_sidecar_environments(path).items():
             if name in registry:
                 existing = registry[name].source_package
+                existing_path_hint = (
+                    f" (path: {sidecar_paths[name]})"
+                    if name in sidecar_paths
+                    else ""
+                )
                 raise RegistryCollisionError(
-                    f"environment '{name}' registered by both '{existing}' "
-                    f"and '{env.source_package}' — rename one or remove the duplicate"
+                    f"environment '{name}' registered by both "
+                    f"'{existing}'{existing_path_hint} and "
+                    f"'{env.source_package}' (path: {path}) "
+                    f"— rename one or remove the duplicate"
                 )
             registry[name] = env
+            sidecar_paths[name] = path
 
     return registry
 

--- a/src/aorta/registry/environments.py
+++ b/src/aorta/registry/environments.py
@@ -11,12 +11,14 @@ name; the loaded object is the recipe (`dict[str, str | None]` with keys
 """
 
 from importlib.metadata import entry_points
+from pathlib import Path
 
 from aorta.registry.errors import (
     RegistryCollisionError,
     RegistryError,
     UnknownEnvironmentError,
 )
+from aorta.registry.sidecar import load_sidecar_environments
 from aorta.registry.types import Environment
 
 _GROUP = "aorta.environments"
@@ -32,15 +34,22 @@ BUILTIN_ENVIRONMENTS: dict[str, dict[str, str | None]] = {
 }
 
 
-def load_environments() -> dict[str, Environment]:
-    """Discover and merge all environments: built-ins first, then entry-point plugins.
+def load_environments(
+    extra_files: list[Path] | None = None,
+) -> dict[str, Environment]:
+    """Discover and merge all environments: built-ins, then entry-point plugins, then sidecars.
+
+    Sidecar files (`extra_files`) are merged in the order given. The same
+    collision rule applies across all three sources — a duplicate name raises
+    `RegistryCollisionError` naming both sides.
 
     No caching — re-reads entry-points each call.
 
     Raises:
         RegistryCollisionError: two contributors registered the same environment name.
         RegistryError: a plugin's payload was not a dict, contained keys other
-            than `docker` / `venv`, or had non-`str | None` values.
+            than `docker` / `venv`, or had non-`str | None` values; or a sidecar
+            file failed schema validation.
     """
     registry: dict[str, Environment] = {
         name: Environment(
@@ -93,16 +102,28 @@ def load_environments() -> dict[str, Environment]:
             source_package=plugin_name,
         )
 
+    for path in extra_files or ():
+        for name, env in load_sidecar_environments(path).items():
+            if name in registry:
+                existing = registry[name].source_package
+                raise RegistryCollisionError(
+                    f"environment '{name}' registered by both '{existing}' "
+                    f"and '{env.source_package}' — rename one or remove the duplicate"
+                )
+            registry[name] = env
+
     return registry
 
 
-def get_environment(name: str) -> Environment:
+def get_environment(
+    name: str, extra_files: list[Path] | None = None
+) -> Environment:
     """Return the Environment dataclass for a given name.
 
     Unlike `get_mitigation` (which returns a dict), environments are richer than
     a flat env-var bundle, so the dataclass IS the public surface.
     """
-    registry = load_environments()
+    registry = load_environments(extra_files=extra_files)
     if name not in registry:
         raise UnknownEnvironmentError(
             f"unknown environment '{name}'; available: {sorted(registry)}; "

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -18,7 +18,7 @@ from aorta.registry.errors import (
     RegistryError,
     UnknownMitigationError,
 )
-from aorta.registry.sidecar import load_sidecar_mitigations
+from aorta.registry.sidecar import check_sidecar_basenames, load_sidecar_mitigations
 from aorta.registry.types import Mitigation
 
 _GROUP = "aorta.mitigations"
@@ -80,15 +80,25 @@ def load_mitigations(
             name=ep.name, env=dict(env), source_package=plugin_name
         )
 
+    check_sidecar_basenames(extra_files)
+    sidecar_paths: dict[str, Path] = {}
     for path in extra_files or ():
         for name, mit in load_sidecar_mitigations(path).items():
             if name in registry:
                 existing = registry[name].source_package
+                existing_path_hint = (
+                    f" (path: {sidecar_paths[name]})"
+                    if name in sidecar_paths
+                    else ""
+                )
                 raise RegistryCollisionError(
-                    f"mitigation '{name}' registered by both '{existing}' "
-                    f"and '{mit.source_package}' — rename one or remove the duplicate"
+                    f"mitigation '{name}' registered by both "
+                    f"'{existing}'{existing_path_hint} and "
+                    f"'{mit.source_package}' (path: {path}) "
+                    f"— rename one or remove the duplicate"
                 )
             registry[name] = mit
+            sidecar_paths[name] = path
 
     return registry
 

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -11,12 +11,14 @@ the existing `aorta.workloads` extension-point pattern.
 """
 
 from importlib.metadata import entry_points
+from pathlib import Path
 
 from aorta.registry.errors import (
     RegistryCollisionError,
     RegistryError,
     UnknownMitigationError,
 )
+from aorta.registry.sidecar import load_sidecar_mitigations
 from aorta.registry.types import Mitigation
 
 _GROUP = "aorta.mitigations"
@@ -35,15 +37,22 @@ BUILTIN_MITIGATIONS: dict[str, dict[str, str]] = {
 }
 
 
-def load_mitigations() -> dict[str, Mitigation]:
-    """Discover and merge all mitigations: built-ins first, then entry-point plugins.
+def load_mitigations(
+    extra_files: list[Path] | None = None,
+) -> dict[str, Mitigation]:
+    """Discover and merge all mitigations: built-ins, then entry-point plugins, then sidecars.
 
-    No caching — re-reads entry-points each call. Cheap for MVP; revisit if profiling
-    shows it matters.
+    Sidecar files (`extra_files`) are merged in the order given. The same
+    collision rule applies across all three sources — there is no winner; a
+    duplicate name raises `RegistryCollisionError` naming both sides.
+
+    No caching — re-reads entry-points each call. Cheap for MVP; revisit if
+    profiling shows it matters.
 
     Raises:
         RegistryCollisionError: two contributors registered the same mitigation name.
-        RegistryError: a plugin's entry-point payload was not a `dict[str, str]`.
+        RegistryError: a plugin's entry-point payload was not a `dict[str, str]`,
+            or a sidecar file failed schema validation.
     """
     registry: dict[str, Mitigation] = {
         name: Mitigation(name=name, env=dict(env), source_package="aorta")
@@ -71,15 +80,27 @@ def load_mitigations() -> dict[str, Mitigation]:
             name=ep.name, env=dict(env), source_package=plugin_name
         )
 
+    for path in extra_files or ():
+        for name, mit in load_sidecar_mitigations(path).items():
+            if name in registry:
+                existing = registry[name].source_package
+                raise RegistryCollisionError(
+                    f"mitigation '{name}' registered by both '{existing}' "
+                    f"and '{mit.source_package}' — rename one or remove the duplicate"
+                )
+            registry[name] = mit
+
     return registry
 
 
-def get_mitigation(name: str) -> dict[str, str]:
+def get_mitigation(
+    name: str, extra_files: list[Path] | None = None
+) -> dict[str, str]:
     """Return the env-var bundle for a mitigation name. Empty dict for 'none'.
 
     Returns a defensive copy — mutating the result does not affect the registry.
     """
-    registry = load_mitigations()
+    registry = load_mitigations(extra_files=extra_files)
     if name not in registry:
         raise UnknownMitigationError(
             f"unknown mitigation '{name}'; available: {sorted(registry)}; "

--- a/src/aorta/registry/sidecar.py
+++ b/src/aorta/registry/sidecar.py
@@ -1,0 +1,175 @@
+"""JSON sidecar loader for ad-hoc mitigations / environments.
+
+A sidecar is a JSON file declaring named mitigations and/or environments with
+the same payload shape as entry-point-registered entries. It is the third path
+into the registry, between the one-off CLI `--env KEY=VALUE` and a full
+pip-installable plugin package — see `README.md` "Path 3" for the rationale.
+
+Both top-level keys (`mitigations`, `environments`) are optional; `version: 1`
+is required. Schema errors point at the JSON file path and the offending key
+so the operator can fix the file without spelunking through a stack trace.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aorta.registry.errors import RegistryError
+from aorta.registry.types import Environment, Mitigation
+
+SCHEMA_VERSION = 1
+_VALID_TOP_LEVEL = frozenset({"version", "mitigations", "environments"})
+_VALID_ENV_KEYS = frozenset({"docker", "venv"})
+
+
+def _source_tag(path: Path) -> str:
+    """Source-package tag for sidecar entries: `sidecar:<basename>`.
+
+    Uses the basename (not the full path) so list output stays terse and two
+    sidecars passed by relative-vs-absolute paths still surface as different
+    sources via their filename.
+    """
+    return f"sidecar:{path.name}"
+
+
+def _load_json(path: Path) -> dict:
+    """Read+parse the sidecar; wrap IO/JSON errors with the file path."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        raise RegistryError(f"sidecar {path}: cannot read file ({e})") from e
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RegistryError(
+            f"sidecar {path}: invalid JSON at line {e.lineno} col {e.colno}: {e.msg}"
+        ) from e
+    if not isinstance(data, dict):
+        raise RegistryError(
+            f"sidecar {path}: top-level must be a JSON object, got {type(data).__name__}"
+        )
+    return data
+
+
+def _validate_top_level(path: Path, data: dict) -> None:
+    if "version" not in data:
+        raise RegistryError(f"sidecar {path}: missing required key 'version'")
+    if data["version"] != SCHEMA_VERSION:
+        raise RegistryError(
+            f"sidecar {path}: unsupported version {data['version']!r}; "
+            f"this build understands version {SCHEMA_VERSION}"
+        )
+    unknown = set(data) - _VALID_TOP_LEVEL
+    if unknown:
+        raise RegistryError(
+            f"sidecar {path}: unknown top-level keys {sorted(unknown)}; "
+            f"allowed: {sorted(_VALID_TOP_LEVEL)}"
+        )
+
+
+def _validate_mitigation_payload(path: Path, name: str, payload: object) -> dict[str, str]:
+    if not isinstance(payload, dict):
+        raise RegistryError(
+            f"sidecar {path}: mitigations.{name}: must be an object of "
+            f"env vars, got {type(payload).__name__}"
+        )
+    for k, v in payload.items():
+        if not isinstance(k, str):
+            raise RegistryError(
+                f"sidecar {path}: mitigations.{name}: env var name must be "
+                f"string, got {type(k).__name__} ({k!r})"
+            )
+        if not isinstance(v, str):
+            raise RegistryError(
+                f"sidecar {path}: mitigations.{name}.{k}: env var value must "
+                f"be string, got {type(v).__name__} ({v!r})"
+            )
+    return dict(payload)
+
+
+def _validate_environment_payload(path: Path, name: str, payload: object) -> dict[str, str | None]:
+    if not isinstance(payload, dict):
+        raise RegistryError(
+            f"sidecar {path}: environments.{name}: must be an object, "
+            f"got {type(payload).__name__}"
+        )
+    non_string_keys = [k for k in payload if not isinstance(k, str)]
+    if non_string_keys:
+        raise RegistryError(
+            f"sidecar {path}: environments.{name}: non-string keys "
+            f"{[repr(k) for k in non_string_keys]}; allowed: {sorted(_VALID_ENV_KEYS)}"
+        )
+    invalid = set(payload) - _VALID_ENV_KEYS
+    if invalid:
+        raise RegistryError(
+            f"sidecar {path}: environments.{name}: invalid keys "
+            f"{sorted(invalid)}; allowed: {sorted(_VALID_ENV_KEYS)}"
+        )
+    for k, v in payload.items():
+        if v is not None and not isinstance(v, str):
+            raise RegistryError(
+                f"sidecar {path}: environments.{name}.{k}: value must be "
+                f"string or null, got {type(v).__name__} ({v!r})"
+            )
+    return dict(payload)
+
+
+def load_sidecar_mitigations(path: Path) -> dict[str, Mitigation]:
+    """Parse + validate a sidecar; return its mitigations as `{name: Mitigation}`.
+
+    Returns an empty dict if the file declares only environments. Each
+    `Mitigation.source_package` is set to `sidecar:<filename>`.
+    """
+    data = _load_json(path)
+    _validate_top_level(path, data)
+    raw = data.get("mitigations")
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RegistryError(
+            f"sidecar {path}: 'mitigations' must be an object, got {type(raw).__name__}"
+        )
+    src = _source_tag(path)
+    out: dict[str, Mitigation] = {}
+    for name, payload in raw.items():
+        if not isinstance(name, str):
+            raise RegistryError(
+                f"sidecar {path}: mitigation name must be string, got "
+                f"{type(name).__name__} ({name!r})"
+            )
+        env = _validate_mitigation_payload(path, name, payload)
+        out[name] = Mitigation(name=name, env=env, source_package=src)
+    return out
+
+
+def load_sidecar_environments(path: Path) -> dict[str, Environment]:
+    """Parse + validate a sidecar; return its environments as `{name: Environment}`.
+
+    Returns an empty dict if the file declares only mitigations.
+    """
+    data = _load_json(path)
+    _validate_top_level(path, data)
+    raw = data.get("environments")
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RegistryError(
+            f"sidecar {path}: 'environments' must be an object, got {type(raw).__name__}"
+        )
+    src = _source_tag(path)
+    out: dict[str, Environment] = {}
+    for name, payload in raw.items():
+        if not isinstance(name, str):
+            raise RegistryError(
+                f"sidecar {path}: environment name must be string, got "
+                f"{type(name).__name__} ({name!r})"
+            )
+        spec = _validate_environment_payload(path, name, payload)
+        out[name] = Environment(
+            name=name,
+            docker=spec.get("docker"),
+            venv=spec.get("venv"),
+            source_package=src,
+        )
+    return out

--- a/src/aorta/registry/sidecar.py
+++ b/src/aorta/registry/sidecar.py
@@ -26,11 +26,37 @@ _VALID_ENV_KEYS = frozenset({"docker", "venv"})
 def _source_tag(path: Path) -> str:
     """Source-package tag for sidecar entries: `sidecar:<basename>`.
 
-    Uses the basename (not the full path) so list output stays terse and two
-    sidecars passed by relative-vs-absolute paths still surface as different
-    sources via their filename.
+    Basename only -- keeps list output terse. The same sidecar passed via
+    relative vs. absolute paths therefore produces the same tag, and two
+    different files with the same basename would collapse to one tag (and
+    look indistinguishable in `list` output / collision errors). To prevent
+    that ambiguity, `load_mitigations` / `load_environments` call
+    `check_sidecar_basenames` upfront and reject the load if two sidecar
+    paths share a basename. Resolver collision messages additionally
+    include the full path so the operator knows which file to edit.
     """
     return f"sidecar:{path.name}"
+
+
+def check_sidecar_basenames(extra_files: list[Path] | None) -> None:
+    """Reject sidecar lists where two paths share a basename.
+
+    The source tag (`_source_tag`) is the basename only, so two sidecars
+    with the same filename would render identically in `list` output and
+    in collision errors -- the operator could not tell which file to fix.
+    Catch it upfront with a clear message instead of producing ambiguous
+    downstream output. Same-file-passed-twice falls out of the same check
+    with the same message, which is also what the operator needs to see.
+    """
+    seen: dict[str, Path] = {}
+    for p in extra_files or ():
+        if p.name in seen:
+            raise RegistryError(
+                f"two sidecars share basename '{p.name}': '{seen[p.name]}' "
+                f"and '{p}'; rename one so list output and collision errors "
+                f"can distinguish them"
+            )
+        seen[p.name] = p
 
 
 def _load_json(path: Path) -> dict:

--- a/tests/registry/conftest.py
+++ b/tests/registry/conftest.py
@@ -6,7 +6,9 @@ of fake entry-points. Use them to simulate plugins being installed without
 actually installing anything.
 """
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -49,3 +51,14 @@ def fake_eps(monkeypatch):
 def fake_env_eps(monkeypatch):
     """Install fake environment entry-points: fake_env_eps([(name, payload, dist), ...])."""
     return _fake_eps_for(monkeypatch, "aorta.registry.environments.entry_points")
+
+
+@pytest.fixture
+def tmp_sidecar(tmp_path):
+    """Write a tmp JSON sidecar: tmp_sidecar({"version": 1, ...}, name="x.json") -> Path."""
+    def _write(payload: dict, name: str = "sidecar.json") -> Path:
+        p = tmp_path / name
+        p.write_text(json.dumps(payload), encoding="utf-8")
+        return p
+
+    return _write

--- a/tests/registry/test_sidecar.py
+++ b/tests/registry/test_sidecar.py
@@ -1,0 +1,181 @@
+"""Tests for the JSON sidecar loader and its merge into the registry resolvers."""
+
+import pytest
+
+from aorta.registry import (
+    RegistryCollisionError,
+    RegistryError,
+    load_environments,
+    load_mitigations,
+    load_sidecar_environments,
+    load_sidecar_mitigations,
+)
+
+
+# ---------- mitigations: merge into resolver ----------
+
+
+def test_sidecar_mitigation_visible_in_merged_view(tmp_sidecar, fake_eps):
+    fake_eps([])
+    p = tmp_sidecar({"version": 1, "mitigations": {"my_flag": {"MY_ENV": "1"}}})
+    mits = load_mitigations(extra_files=[p])
+    assert "my_flag" in mits
+    assert mits["my_flag"].env == {"MY_ENV": "1"}
+    assert mits["my_flag"].source_package == f"sidecar:{p.name}"
+
+
+def test_sidecar_keeps_builtins(tmp_sidecar, fake_eps):
+    fake_eps([])
+    p = tmp_sidecar({"version": 1, "mitigations": {"my_flag": {"X": "1"}}})
+    mits = load_mitigations(extra_files=[p])
+    assert "tf32_off" in mits
+    assert mits["tf32_off"].source_package == "aorta"
+
+
+def test_sidecar_collision_with_builtin(tmp_sidecar, fake_eps):
+    fake_eps([])
+    p = tmp_sidecar({"version": 1, "mitigations": {"tf32_off": {"X": "1"}}})
+    with pytest.raises(RegistryCollisionError, match=f"aorta.*sidecar:{p.name}"):
+        load_mitigations(extra_files=[p])
+
+
+def test_sidecar_collision_with_entry_point(tmp_sidecar, fake_eps):
+    fake_eps([("foo", {"X": "1"}, "fake_plugin")])
+    p = tmp_sidecar({"version": 1, "mitigations": {"foo": {"Y": "1"}}})
+    with pytest.raises(
+        RegistryCollisionError, match=f"fake_plugin.*sidecar:{p.name}"
+    ):
+        load_mitigations(extra_files=[p])
+
+
+def test_sidecar_collision_between_two_files(tmp_sidecar, fake_eps):
+    fake_eps([])
+    a = tmp_sidecar({"version": 1, "mitigations": {"foo": {"X": "1"}}}, name="a.json")
+    b = tmp_sidecar({"version": 1, "mitigations": {"foo": {"X": "2"}}}, name="b.json")
+    with pytest.raises(RegistryCollisionError, match="sidecar:a.json.*sidecar:b.json"):
+        load_mitigations(extra_files=[a, b])
+
+
+def test_two_sidecars_merge_when_disjoint(tmp_sidecar, fake_eps):
+    fake_eps([])
+    a = tmp_sidecar({"version": 1, "mitigations": {"foo": {"F": "1"}}}, name="a.json")
+    b = tmp_sidecar({"version": 1, "mitigations": {"bar": {"B": "1"}}}, name="b.json")
+    mits = load_mitigations(extra_files=[a, b])
+    assert mits["foo"].source_package == "sidecar:a.json"
+    assert mits["bar"].source_package == "sidecar:b.json"
+
+
+def test_extra_files_default_none_keeps_b3_behavior(fake_eps):
+    fake_eps([])
+    mits = load_mitigations()
+    assert "tf32_off" in mits
+    assert all(m.source_package == "aorta" for m in mits.values())
+
+
+# ---------- environments: merge into resolver ----------
+
+
+def test_sidecar_environment_visible(tmp_sidecar, fake_env_eps):
+    fake_env_eps([])
+    p = tmp_sidecar({
+        "version": 1,
+        "environments": {"my_local": {"docker": "myorg/x@sha256:abc"}},
+    })
+    envs = load_environments(extra_files=[p])
+    assert envs["my_local"].docker == "myorg/x@sha256:abc"
+    assert envs["my_local"].source_package == f"sidecar:{p.name}"
+
+
+def test_sidecar_environment_collision_with_builtin(tmp_sidecar, fake_env_eps):
+    fake_env_eps([])
+    p = tmp_sidecar({"version": 1, "environments": {"local": {}}})
+    with pytest.raises(RegistryCollisionError, match=f"aorta.*sidecar:{p.name}"):
+        load_environments(extra_files=[p])
+
+
+def test_sidecar_environment_invalid_key(tmp_sidecar, fake_env_eps):
+    fake_env_eps([])
+    p = tmp_sidecar({"version": 1, "environments": {"bad": {"rocm": "6.0"}}})
+    with pytest.raises(RegistryError, match=f"{p.name}.*environments.bad.*rocm"):
+        load_environments(extra_files=[p])
+
+
+# ---------- partial files (only one of mitigations / environments) ----------
+
+
+def test_sidecar_with_only_environments(tmp_sidecar):
+    p = tmp_sidecar({"version": 1, "environments": {"e1": {"venv": "/tmp/v"}}})
+    assert load_sidecar_mitigations(p) == {}
+    envs = load_sidecar_environments(p)
+    assert envs["e1"].venv == "/tmp/v"
+
+
+def test_sidecar_with_only_mitigations(tmp_sidecar):
+    p = tmp_sidecar({"version": 1, "mitigations": {"m1": {"K": "v"}}})
+    assert load_sidecar_environments(p) == {}
+    mits = load_sidecar_mitigations(p)
+    assert mits["m1"].env == {"K": "v"}
+
+
+# ---------- schema validation ----------
+
+
+def test_missing_version_rejected(tmp_sidecar):
+    p = tmp_sidecar({"mitigations": {}})
+    with pytest.raises(RegistryError, match="missing required key 'version'"):
+        load_sidecar_mitigations(p)
+
+
+def test_wrong_version_rejected(tmp_sidecar):
+    p = tmp_sidecar({"version": 2, "mitigations": {}})
+    with pytest.raises(RegistryError, match="unsupported version"):
+        load_sidecar_mitigations(p)
+
+
+def test_unknown_top_level_key_rejected(tmp_sidecar):
+    p = tmp_sidecar({"version": 1, "stuff": {}})
+    with pytest.raises(RegistryError, match="unknown top-level keys.*stuff"):
+        load_sidecar_mitigations(p)
+
+
+def test_non_string_env_value_rejected(tmp_sidecar):
+    p = tmp_sidecar({"version": 1, "mitigations": {"foo": {"K": 5}}})
+    with pytest.raises(
+        RegistryError,
+        match=rf"{p.name}.*mitigations\.foo\.K.*must be string.*int",
+    ):
+        load_sidecar_mitigations(p)
+
+
+def test_mitigation_payload_must_be_object(tmp_sidecar):
+    p = tmp_sidecar({"version": 1, "mitigations": {"foo": "not-a-dict"}})
+    with pytest.raises(RegistryError, match=r"mitigations\.foo.*object of env vars"):
+        load_sidecar_mitigations(p)
+
+
+def test_environment_value_must_be_string_or_null(tmp_sidecar):
+    p = tmp_sidecar({"version": 1, "environments": {"e": {"docker": 123}}})
+    with pytest.raises(
+        RegistryError, match=r"environments\.e\.docker.*string or null"
+    ):
+        load_sidecar_environments(p)
+
+
+def test_invalid_json_reports_path(tmp_path):
+    p = tmp_path / "broken.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    with pytest.raises(RegistryError, match=f"{p.name}.*invalid JSON"):
+        load_sidecar_mitigations(p)
+
+
+def test_top_level_not_object_rejected(tmp_path):
+    p = tmp_path / "list.json"
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(RegistryError, match="top-level must be a JSON object"):
+        load_sidecar_mitigations(p)
+
+
+def test_missing_file_reports_path(tmp_path):
+    p = tmp_path / "nonexistent.json"
+    with pytest.raises(RegistryError, match="cannot read file"):
+        load_sidecar_mitigations(p)

--- a/tests/registry/test_sidecar.py
+++ b/tests/registry/test_sidecar.py
@@ -1,5 +1,7 @@
 """Tests for the JSON sidecar loader and its merge into the registry resolvers."""
 
+import re
+
 import pytest
 
 from aorta.registry import (
@@ -35,7 +37,9 @@ def test_sidecar_keeps_builtins(tmp_sidecar, fake_eps):
 def test_sidecar_collision_with_builtin(tmp_sidecar, fake_eps):
     fake_eps([])
     p = tmp_sidecar({"version": 1, "mitigations": {"tf32_off": {"X": "1"}}})
-    with pytest.raises(RegistryCollisionError, match=f"aorta.*sidecar:{p.name}"):
+    with pytest.raises(
+        RegistryCollisionError, match=f"aorta.*sidecar:{re.escape(p.name)}"
+    ):
         load_mitigations(extra_files=[p])
 
 
@@ -43,7 +47,7 @@ def test_sidecar_collision_with_entry_point(tmp_sidecar, fake_eps):
     fake_eps([("foo", {"X": "1"}, "fake_plugin")])
     p = tmp_sidecar({"version": 1, "mitigations": {"foo": {"Y": "1"}}})
     with pytest.raises(
-        RegistryCollisionError, match=f"fake_plugin.*sidecar:{p.name}"
+        RegistryCollisionError, match=f"fake_plugin.*sidecar:{re.escape(p.name)}"
     ):
         load_mitigations(extra_files=[p])
 
@@ -52,7 +56,9 @@ def test_sidecar_collision_between_two_files(tmp_sidecar, fake_eps):
     fake_eps([])
     a = tmp_sidecar({"version": 1, "mitigations": {"foo": {"X": "1"}}}, name="a.json")
     b = tmp_sidecar({"version": 1, "mitigations": {"foo": {"X": "2"}}}, name="b.json")
-    with pytest.raises(RegistryCollisionError, match="sidecar:a.json.*sidecar:b.json"):
+    with pytest.raises(
+        RegistryCollisionError, match=r"sidecar:a\.json.*sidecar:b\.json"
+    ):
         load_mitigations(extra_files=[a, b])
 
 
@@ -63,6 +69,43 @@ def test_two_sidecars_merge_when_disjoint(tmp_sidecar, fake_eps):
     mits = load_mitigations(extra_files=[a, b])
     assert mits["foo"].source_package == "sidecar:a.json"
     assert mits["bar"].source_package == "sidecar:b.json"
+
+
+def test_two_sidecars_same_basename_rejected(tmp_path, fake_eps):
+    """Two paths with the same filename can't be disambiguated in `list`
+    output or collision errors -- reject upfront with a clear message."""
+    fake_eps([])
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    pa = dir_a / "shared.json"
+    pb = dir_b / "shared.json"
+    pa.write_text('{"version": 1, "mitigations": {"m1": {"X": "1"}}}', encoding="utf-8")
+    pb.write_text('{"version": 1, "mitigations": {"m2": {"Y": "1"}}}', encoding="utf-8")
+    with pytest.raises(RegistryError, match=r"share basename 'shared\.json'"):
+        load_mitigations(extra_files=[pa, pb])
+
+
+def test_same_sidecar_passed_twice_rejected(tmp_sidecar, fake_eps):
+    """Same-file-twice falls out of the basename check -- same message
+    works for both ambiguity cases."""
+    fake_eps([])
+    p = tmp_sidecar({"version": 1, "mitigations": {"m": {"X": "1"}}})
+    with pytest.raises(RegistryError, match=f"share basename '{re.escape(p.name)}'"):
+        load_mitigations(extra_files=[p, p])
+
+
+def test_sidecar_collision_message_includes_full_path(tmp_sidecar, fake_eps):
+    """Collision errors must surface the sidecar's full path so the
+    operator knows which file to edit -- the basename tag alone is not
+    enough when multiple sidecars are in play."""
+    fake_eps([])
+    p = tmp_sidecar({"version": 1, "mitigations": {"tf32_off": {"X": "1"}}})
+    with pytest.raises(
+        RegistryCollisionError, match=f"path: .*{re.escape(p.name)}"
+    ):
+        load_mitigations(extra_files=[p])
 
 
 def test_extra_files_default_none_keeps_b3_behavior(fake_eps):
@@ -89,14 +132,19 @@ def test_sidecar_environment_visible(tmp_sidecar, fake_env_eps):
 def test_sidecar_environment_collision_with_builtin(tmp_sidecar, fake_env_eps):
     fake_env_eps([])
     p = tmp_sidecar({"version": 1, "environments": {"local": {}}})
-    with pytest.raises(RegistryCollisionError, match=f"aorta.*sidecar:{p.name}"):
+    with pytest.raises(
+        RegistryCollisionError, match=f"aorta.*sidecar:{re.escape(p.name)}"
+    ):
         load_environments(extra_files=[p])
 
 
 def test_sidecar_environment_invalid_key(tmp_sidecar, fake_env_eps):
     fake_env_eps([])
     p = tmp_sidecar({"version": 1, "environments": {"bad": {"rocm": "6.0"}}})
-    with pytest.raises(RegistryError, match=f"{p.name}.*environments.bad.*rocm"):
+    with pytest.raises(
+        RegistryError,
+        match=rf"{re.escape(p.name)}.*environments\.bad.*rocm",
+    ):
         load_environments(extra_files=[p])
 
 
@@ -142,7 +190,7 @@ def test_non_string_env_value_rejected(tmp_sidecar):
     p = tmp_sidecar({"version": 1, "mitigations": {"foo": {"K": 5}}})
     with pytest.raises(
         RegistryError,
-        match=rf"{p.name}.*mitigations\.foo\.K.*must be string.*int",
+        match=rf"{re.escape(p.name)}.*mitigations\.foo\.K.*must be string.*int",
     ):
         load_sidecar_mitigations(p)
 
@@ -164,7 +212,7 @@ def test_environment_value_must_be_string_or_null(tmp_sidecar):
 def test_invalid_json_reports_path(tmp_path):
     p = tmp_path / "broken.json"
     p.write_text("{not valid json", encoding="utf-8")
-    with pytest.raises(RegistryError, match=f"{p.name}.*invalid JSON"):
+    with pytest.raises(RegistryError, match=rf"{re.escape(p.name)}.*invalid JSON"):
         load_sidecar_mitigations(p)
 
 


### PR DESCRIPTION
Adds a third path into the registry between CLI `--env` one-offs and full pip-installable plugins: declare named mitigations/environments in a JSON file and merge them into the same view via `load_*(extra_files=[...])`.

- `registry/sidecar.py`: schema-validated loader (`version: 1`, both top-level keys optional). Errors point at the JSON file path and offending key.
- `load_mitigations` / `load_environments` accept `extra_files`; sidecar entries participate in the same `RegistryCollisionError` rule as built-ins + EPs.
- `source_package = "sidecar:<filename>"` so list output attributes cleanly.
- CLI: `--mitigations-file` (repeatable) on `run`/`triage`; `--file` on `mitigations`/`environments list`.
- `examples/mitigations-sidecar.json` ships as a starting template; `.gitignore` whitelists `examples/*.json` against the global `*.json` rule.

Note: `--mitigations-file` on `run`/`triage` is parsed but not yet consumed — those commands still raise "not implemented" pending B1/B2.

Closes #155.

## Motivation

The registry had two paths for getting entries in:
1. **CLI `--env KEY=VALUE`** — one-off, anonymous, can't be referenced by triage sweeps (which need named entries).
2. **Pip-installable plugin package** — works everywhere but requires `pyproject.toml`, a Python module, and `pip install -e`.

There was a real gap in between: an investigator wants to try 3-4 named mitigation bundles on their box, share the file with a colleague over Slack, run a triage sweep against them, and throw the file away when the investigation closes. The pip path is too much ceremony; the `--env` path doesn't compose with triage. JSON sidecars are also the natural fit for ephemeral / containerized contexts where `pip install` is awkward (CI runners, `docker run --rm`, ad-hoc reproduction containers).

JSON (not YAML, not Python) because: data only — honors the "no logic in registries" hard rule by construction; safer trust profile for "here's a file from a colleague, try it" sharing; editable in the GitHub web UI; schema-validatable up front so we give a clean error pointing at the JSON path and key instead of a runtime `TypeError`.

## Technical Details

**New module — `src/aorta/registry/sidecar.py`:**
- `load_sidecar_mitigations(path) -> dict[str, Mitigation]`
- `load_sidecar_environments(path) -> dict[str, Environment]`
- Schema: `{"version": 1, "mitigations": {...}, "environments": {...}}`. Both top-level data keys optional. `version: 1` required and rejected if mismatched (forward-compat lever).
- Validation rejects: missing `version`, wrong `version`, unknown top-level keys, non-string env-var names/values, non-string environment keys, environment keys outside `{docker, venv}`, non-string-or-null environment values, non-object payloads, malformed JSON, unreadable file.
- Every error message includes the JSON file path and the offending key path (e.g. `sidecar /path/foo.json: mitigations.my_flag.K: env var value must be string, got int (5)`).

**Resolver wiring — `registry/mitigations.py`, `registry/environments.py`:**
- `load_mitigations(extra_files: list[Path] | None = None)` and `load_environments(extra_files=None)` — backwards-compatible (default `None` keeps B3 behavior).
- Sidecar entries are merged after built-ins + entry-point plugins, in the order `extra_files` are passed. Same `RegistryCollisionError` if a sidecar shadows a built-in, EP entry, or earlier sidecar — error names both source tags.
- `get_mitigation` / `get_environment` also gained an `extra_files=` kwarg for symmetry.

**Public surface — `registry/__init__.py`:** re-exports `load_sidecar_mitigations` / `load_sidecar_environments`.

**CLI:**
- `aorta run --mitigations-file path.json` (repeatable) — flag is parsed; consumption deferred to B1.
- `aorta triage --mitigations-file path.json` (repeatable) — same; deferred to B2.
- `aorta mitigations list --file path.json` and `aorta environments list --file path.json` — fully wired; sidecar entries appear in the listing with `source_package = "sidecar:<filename>"`.

**Docs:** `src/aorta/registry/README.md` gains a "Path 3 — JSON sidecar" section between Path 2 (plugins) and "Trying things locally". `examples/mitigations-sidecar.json` ships as a copyable starting template.

**`.gitignore`:** the global `*.json` rule was swallowing `examples/*.json`; added `!examples/*.json` exception so the example file ships.

## Test Plan

`tests/registry/test_sidecar.py` — new file, 18 tests covering:

- **Merge behavior:** sidecar entry visible in merged view; built-ins preserved; two disjoint sidecars merge; default `extra_files=None` keeps B3 behavior unchanged.
- **Collisions:** sidecar vs built-in, sidecar vs entry-point plugin, sidecar vs another sidecar — each asserts the error message names both sources.
- **Partial files:** sidecar with only `mitigations`, sidecar with only `environments`.
- **Schema validation:** missing `version`, wrong `version`, unknown top-level key, non-string env value, mitigation payload not an object, environment value not string-or-null, invalid environment key, malformed JSON, top-level not an object, missing file.

Test fixture `tmp_sidecar` added to `tests/registry/conftest.py` writes a tmp JSON file from a Python dict.

Run with:
```bash
pytest tests/registry/test_sidecar.py -v
```

## Test Result

All 18 sidecar tests pass; existing B3 registry tests still pass (no regressions to the `extra_files=None` path).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.