### PR TITLE
env probe: schema 1.1 — full ROCm/PyTorch identity capture

### DIFF
--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -40,7 +40,7 @@ aorta env probe -o runs/exp1/env.json
 
 # Pretty-print + spot-check key fields
 jq . runs/exp1/env.json
-jq '.hipblaslt.commit' runs/exp1/env.json
+jq '.hipblaslt.rocm_release_tweak' runs/exp1/env.json   # schema 1.1: was .commit in 1.0
 jq '.partial' runs/exp1/env.json
 
 # Diff two snapshots from different docker images
@@ -56,25 +56,52 @@ Usage: aorta env probe [OPTIONS]
 
 Options:
   -o, --output FILE  Path to write env.json.  [default: env.json]
+  -v, --verbose      After the brief, also print the full snapshot
+                     JSON to stdout.
   --help             Show this message and exit.
 ```
 
 The CLI is a thin wrapper. It calls `collect_env()`, writes the JSON,
-and prints a six-line summary like:
+and prints a multi-line per-block brief (~18 lines on a populated host).
+After the brief, any `partial_reasons` entries are echoed inline so the
+operator can act on them without `jq`'ing the JSON. A closing
+`[PARTIAL, N reason(s)]` (or `[OK]`) marker repeats the probe state at
+end-of-output. Sample:
 
 ```text
-Wrote env probe to /tmp/env.json (schema_version=1.0) [PARTIAL]
-  runtime:  baremetal / python=venv [PARTIAL, 3 reason(s)]
-  rocm:     7.2.1 (dev: None)
-  hip:      7.2.53211-e1a6bc5663 (amd)
-  hipblaslt: commit=dabb6df2b9
-  rdhc:     unavailable (system_health=null)
-  python:   3.12.3 | pytorch: 2.12.0a0+gitf68b851
+Wrote env probe to /tmp/env.json (schema_version=1.1) [PARTIAL]
+  runtime:   baremetal / python=venv
+  rocm:      7.2.1 (dev: None)
+  hip:       7.2.53211-e1a6bc5663 (amd)
+  hipblaslt: 1.2.2 rocm_release_tweak=dabb6df2b9
+  rocblas:   5.2.0 rocm_release_tweak=dabb6df2b9
+  miopen:    3.5.1 rocm_release_tweak=dabb6df2b9
+  rccl:      2.27.7 (code=22707)
+  gpu_arch:  ['gfx942'] (counts={'gfx942': 8})
+  host:      kernel=5.15.0-174-generic machine=x86_64  glibc=2.35
+  ck:        system=1.2.0/23d531c8  ck_tile=yes  libtorch_hip=4067 ck:: syms
+  tensile:   kernel_db=filenames-sha256:743a8d…  [Tensile pip pkg: (not installed); build-time tool, normal]
+  triton:    3.5.1+rocm7.2.1.gita272dfa8
+  fbgemm:    in PyTorch: USE_FBGEMM=True USE_FBGEMM_GENAI=True  [fbgemm_gpu pip pkg: (not installed); separate from torch's vendored copy]
+  aiter:     (not installed) [aiter pip pkg; optional ROCm inference lib]
+  aotriton:  bundled=0.11.1 present=True images_dir=True  [AOTRITON_INSTALLED_PREFIX=(unset)]
+  rdhc:      unavailable (system_health=null)
+  python:    3.12.13 | pytorch: 2.9.1+rocm7.2.1.gitff65f5bc
+  torch build: git_commit=ff65f5bc install=wheel [third_party SHAs: set AORTA_PYTORCH_SRC=<src> or look up github.com/pytorch/pytorch/tree/ff65f5bc/third_party/<name>]
+
+Partial reasons:
+  - system_health: rdhc exited 1 (stderr: sudo: a password is required)
+  - rocm.version_dev: /opt/rocm/.info/version-dev missing, empty, or unreadable
+  - pytorch_build.submodule_commits: wheel install -- direct SHAs not recoverable; ...
+
+[PARTIAL, 3 reason(s)]
 ```
 
 `[PARTIAL]` indicates at least one probe fell back to `None` -- the
 snapshot is still complete (every key present), it just records what
-was missing in `partial_reasons`.
+was missing in `partial_reasons`. Run with `-v`/`--verbose` to also
+dump the full snapshot JSON to stdout (useful for remote operators
+who want to copy-paste without reading `env.json` from disk).
 
 ## Library API
 
@@ -100,7 +127,8 @@ env = EnvSnapshot.from_dict(loaded["env"])
 if snapshot.partial:
     log.warning("env probe partial: %s", snapshot.partial_reasons)
 
-# Six-line human summary, same as the CLI prints
+# Multi-line human summary, same as the CLI prints (~18 lines on a
+# populated host -- one labelled cell per top-level block).
 print(snapshot.summary())
 ```
 
@@ -114,19 +142,31 @@ unexpected failure. Callers always get back a valid, fully-shaped
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | `"1.0"` today; bumps on non-additive changes only |
+| `schema_version` | `str` | constant | Currently `"1.1"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
 | `system_health` | `dict \| null` | `rdhc --quick --json` (subprocess) | verbatim parsed JSON; `null` when rdhc absent / sudo unavailable / timeout / malformed |
 | `rocm` | `dict[str, str \| null]` | `/opt/rocm/.info/version{,_dev}`, `/sys/module/amdgpu/version` | `version`, `version_dev`, `kmd_version` |
 | `hip` | `dict[str, str \| null]` | `hipconfig --version/--platform/--compiler/--runtime/--cpp_config` | five subprocesses; `--version` and `--platform` cannot be combined (no delimiter) |
-| `hipblaslt` | `dict` | header parse + `sha256(libhipblaslt.so)` + sorted-filenames hash of `lib/hipblaslt/library/*` | `commit`, `package_version`, `lib_hash`, `tensile_yaml_revision`, `applied_prs: {}` |
+| `hipblaslt` | `dict` | header parse + `sha256(libhipblaslt.so)` + sorted-filenames hash of `lib/hipblaslt/library/*` | `rocm_release_tweak` (NOT a per-hipBLASLt commit -- it's the ROCm release identifier shared across every library in a release; see note below), `package_version`, `lib_hash`, `kernel_db_revision`, `applied_prs: {}` |
+| `rocblas` | `dict` | header parse + `sha256(librocblas.so)` + sorted-filenames hash of `lib/rocblas/library/*` | Same shape as `hipblaslt`. Header lives at `include/rocblas/internal/rocblas-version.h`. |
+| `miopen` | `dict` | header parse + `sha256(libMIOpen.so)` + sorted-filenames hash of `share/miopen/db/*.txt` | `rocm_release_tweak`, `package_version`, `lib_hash`, `kernel_db_revision`. MIOpen drives convolution kernels on ROCm; kernel-DB drift changes which conv kernel runs. |
+| `rccl` | `dict` | header parse for `NCCL_VERSION_CODE` + `sha256(librccl.so)` | `version_code` (raw int, e.g. `22707`), `version` (decoded `"2.27.7"`), `lib_hash`. RCCL is AMD's NCCL-compatible collectives library. |
+| `gpu_arch` | `dict` | `rocm_agent_enumerator` subprocess (no `/dev/kfd` access typically required) | `agent_count`, `gfx_targets` (sorted unique), `agent_arch_counts` (per-arch distribution -- captures both homogeneous and mixed-arch boxes). |
+| `host` | `dict` | `os.uname()` + `os.confstr("CS_GNU_LIBC_VERSION")` | `kernel_release`, `kernel_version`, `machine`, `glibc_version`. Kernel + glibc drift is the #1 confound for compiled-against-vs-runtime issues with C++ extensions. |
+| `composable_kernel` | `dict` | header at `include/ck/version.h` + `nm -D` of `libtorch_hip.so` piped through `c++filt` + `torch.__config__.show()` flag scan | Two sub-blocks (`system: {version, commit, ck_tile_present}`, `pytorch_bundled: {present, symbol_count}`) plus top-level `pytorch_use_ck_sdpa` / `pytorch_use_ck_gemm` booleans (build-time flags baked into the wheel; NOT runtime env vars). System and bundled CK can drift independently. |
+| `tensile` | `dict` | optional `import Tensile` + sorted-filenames hash over the union of hipBLASLt + rocBLAS kernel DBs | `package_version` (usually `null` outside builders), `kernel_db_combined_hash` |
+| `triton` | `dict` | `import triton; triton.__version__` | `package_version`. ROCm Triton fork bakes the source commit into `__version__`. |
+| `fbgemm` | `dict` | optional `import fbgemm_gpu` + parse of `torch.__config__.show()` for `-DUSE_FBGEMM*` defines | `package_version`, `pytorch_use_fbgemm`, `pytorch_use_fbgemm_genai`. The two booleans capture the build-time decision baked into the PyTorch wheel even when `fbgemm_gpu` isn't a separate pip package. |
+| `aiter` | `dict` | `import aiter; aiter.__version__` | `package_version`. Most installs record `null`; absence is silent. |
+| `aotriton` | `dict` | scan of `<torch>/lib/libaotriton_v2.so*` filenames + `sha256` of the resolved file + presence of `<torch>/lib/aotriton.images/` + `$AOTRITON_INSTALLED_PREFIX` | Default ROCm Flash Attention backend. Bundled in the wheel via `cmake/External/aotriton.cmake` (NOT a `third_party/` git submodule). Fields: `bundled_present`, `bundled_version`, `bundled_lib_hash`, `bundled_images_dir_present`, `installed_prefix`. CK is the alternative backend (toggled via `TORCH_ROCM_FA_PREFER_CK=1`). |
 | `runtime_context` | `dict` | `/.dockerenv`, `/run/.containerenv`, `$SINGULARITY_NAME`, `/proc/1/cgroup`, `sys.prefix`, `$CONDA_DEFAULT_ENV` | `type`, `python_env`, `venv_path`, `conda_env_name` |
 | `docker` | `dict \| null` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` env vars + `/proc/self/cgroup` | `null` on baremetal; image+digest provided by the launcher (the only reliable way from inside a container) |
-| `env_vars` | `dict[str, str \| null]` | canonical 13-name list, explicit | HSA + GPU queue + RCCL + FBGEMM + PyTorch |
+| `env_vars` | `dict[str, str \| null]` | explicit canonical list (currently 31 names; see `CANONICAL_ENV_VARS` in `environment.py` for the live set) | GPU scoping + HSA / runtime + GPU queue / codegen + NCCL/RCCL + FBGEMM + MIOpen + SDPA backend selection + GEMM backend preference + hipBLASLt autotune + PyTorch / inductor. Build-time cmake flags (`USE_ROCM_CK_SDPA`, `USE_ROCM_CK_GEMM`, `USE_FBGEMM*`) are NOT in this list -- they're surfaced under their respective library blocks instead, parsed from `torch.__config__.show()`. |
 | `python_version` | `str` | `platform.python_version()` | always populated |
 | `pytorch_version` | `str \| null` | optional `import torch` (no CUDA/HIP context init) | `null` when torch absent |
+| `pytorch_build` | `dict` | `torch.version.{git_version,hip,cuda,debug}` + install-kind detection + optional `git -C <src>/third_party/<sub> rev-parse HEAD` | `git_commit` is the linchpin -- pins every vendored submodule deterministically. See "PyTorch source-tree submodule probing" below. |
 
 `runtime_context.type` is one of `"docker" | "podman" | "singularity" | "baremetal"`. Adding values is a schema change.
 
@@ -182,6 +222,55 @@ cd rocm-systems/projects/rocm-core/rdhc
 sudo make install
 ```
 
+### Install rdhc's Python deps into the **system** Python
+
+`rdhc` is a Python script (`#!/usr/bin/env python3`) that imports
+`prettytable` and `PyYAML`. The probe runs it via
+`sudo -n -E rdhc --quick --json <tmp>`. Under sudo, `secure_path` in
+`/etc/sudoers` overrides the calling shell's `PATH` (and `-E` does NOT
+override `secure_path` for the `PATH` variable specifically), so
+`#!/usr/bin/env python3` resolves to **system** `python3`
+(`/usr/bin/python3`), NOT whatever venv or conda env aorta itself runs
+in. Installing `prettytable` into your venv has zero effect on the
+subprocess that rdhc actually runs in.
+
+Install rdhc's deps into the system Python where they'll be visible:
+
+```bash
+# rdhc ships its own requirements.txt with the apt/dnf package
+sudo pip3 install -r /opt/rocm/share/rdhc/requirements.txt
+
+# Verify rdhc can now import everything it needs
+/opt/rocm/bin/rdhc --quick --json /tmp/rdhc_check.json && echo OK
+```
+
+If `pip3 install` is blocked by PEP 668 ("externally-managed
+environment"), you have two options that keep rdhc on system python:
+either pass `--break-system-packages` (acceptable for these two
+packages -- `prettytable` and `PyYAML` are well-behaved) or install
+distro packages where versions are recent enough (`apt install
+python3-prettytable python3-yaml`; check `prettytable>=3.14.0` -- on
+Ubuntu 22.04 the apt version is too old, use pip).
+
+### Ubuntu 24.04 + venv: known sudo `-E` PATH gotcha
+
+On Ubuntu 24.04, the default sudoers `secure_path` is even stricter
+about `PATH` preservation than on 22.04, and `sudo -E` does NOT
+preserve the venv's `PATH` even when `aorta env probe` is invoked from
+inside one. Symptom: `system_health: rdhc exited 1` with stderr like
+`prettytable not installed`, even though both rdhc and prettytable
+appear available in the calling shell.
+
+Two fixes:
+
+1. **Install the deps into system Python (recommended)** -- per the
+   section above. Once they're in `/usr/lib/python3/...`, sudo's PATH
+   reset doesn't matter.
+2. Replace `-E` with `--preserve-env=PATH` if you want the venv's
+   `python3` to be the one rdhc runs in. Aorta does not do this
+   automatically yet (planned follow-up); to override, wrap rdhc in a
+   small script and point the sudoers rule at the wrapper.
+
 ### Configure passwordless sudo for `rdhc`
 
 `aorta env probe` runs `sudo -n -E rdhc --quick --json <tmp>`. The `-n`
@@ -234,6 +323,163 @@ ground truth -- it tells you exactly what failed (PATH, sudo-n,
 timeout, malformed JSON). The `(see docs/env-probe.md#installing-rdhc)`
 hint at the end of those reasons points back at this page.
 
+## Schema changelog
+
+Mirrors the in-code comment at `SCHEMA_VERSION` in
+`src/aorta/instrumentation/environment.py`. Recorded here so consumers
+tracking schema evolution don't have to read source.
+
+### `1.1` (current)
+
+Renames (non-additive -- bumped from `1.0`):
+
+* `hipblaslt.commit` -> `hipblaslt.rocm_release_tweak`
+* `rocblas.commit` -> `rocblas.rocm_release_tweak`
+* `miopen.commit` -> `miopen.rocm_release_tweak`
+  (the value is the ROCm-release-shared identifier, not a per-library
+  upstream commit; the old name misled consumers)
+* `hipblaslt.tensile_yaml_revision` -> `hipblaslt.kernel_db_revision`
+* `rocblas.tensile_yaml_revision` -> `rocblas.kernel_db_revision`
+  (matches `miopen.kernel_db_revision`; modern hipBLASLt/rocBLAS ship
+  `.dat` not `.yaml`, so the old name was inaccurate too)
+
+`env_vars` removals (env_vars is an explicit allowlist; removing is a
+breaking change):
+
+* `USE_ROCM_CK_SDPA` and `USE_ROCM_CK_GEMM` -- these are build-time
+  cmake flags, NOT runtime env vars. Setting them in the workload's
+  environment does nothing. Replaced with
+  `composable_kernel.pytorch_use_ck_sdpa` and `pytorch_use_ck_gemm`
+  booleans, parsed from `torch.__config__.show()`.
+
+Additive changes (no bump strictly required, recorded here for
+visibility):
+
+* New top-level blocks: `rocblas`, `composable_kernel`, `tensile`,
+  `triton`, `fbgemm`, `aiter`, `aotriton`, `miopen`, `rccl`,
+  `gpu_arch`, `host`, `pytorch_build`.
+* `env_vars` gained 22 entries (was 13 in 1.0; now 31): GPU scoping
+  (`HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`,
+  `HSA_OVERRIDE_GFX_VERSION`), launch (`HIP_LAUNCH_BLOCKING`),
+  PyTorch ROCm arch + inductor (`PYTORCH_ROCM_ARCH`), MIOpen
+  (`MIOPEN_SYSTEM_DB_PATH`, `MIOPEN_USER_DB_PATH`,
+  `MIOPEN_DEBUG_DISABLE_FIND_DB`, `MIOPEN_FIND_MODE`), SDPA backend
+  (`TORCH_ROCM_FA_PREFER_CK`,
+  `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL`), GEMM backend +
+  autotune (`TORCH_BLAS_PREFER_HIPBLASLT`,
+  `TORCH_HIPBLASLT_TUNING_FILE`,
+  `TORCH_HIPBLASLT_TUNING_OVERRIDE_FILE`), and NCCL/RCCL
+  (`NCCL_P2P_LEVEL`, `NCCL_IB_HCA`, `NCCL_SOCKET_IFNAME`,
+  `RCCL_MSCCL_ENABLE`).
+* `host.glibc_version` strips the redundant `"glibc "` prefix from
+  the value (the field name carries the unit). On 1.0 this was
+  `"glibc 2.35"`; on 1.1 it's `"2.35"`.
+
+### `1.0` (initial release)
+
+Original probe blocks: `system_health`, `rocm`, `hip`, `hipblaslt`,
+`runtime_context`, `docker`, `env_vars`, `python_version`,
+`pytorch_version`. 13 canonical env vars. See git history for the
+original A1 PR (#152).
+
+## Field-naming notes
+
+### `*.rocm_release_tweak` is a release identifier, not a per-library commit
+
+The `hipblaslt`, `rocblas`, and `miopen` blocks each have a
+`rocm_release_tweak` field parsed from `<LIB>_VERSION_TWEAK` defines
+in their respective headers. **Despite the name suggesting "git
+tweak", AMD sets these macros to the ROCm release identifier** -- so
+in any given ROCm release, `hipblaslt.rocm_release_tweak ==
+rocblas.rocm_release_tweak == miopen.rocm_release_tweak`. It is NOT a
+per-library upstream commit SHA.
+
+For per-library binary-level drift detection, use:
+
+* `<lib>.lib_hash` -- changes any time the binary changes, even
+  within the same release tweak (catches local rebuilds, debug
+  variants, cherry-picked patches).
+* `<lib>.kernel_db_revision` (hipblaslt/rocblas) /
+  `miopen.kernel_db_revision` -- catches kernel-DB drift independent
+  of the lib binary.
+* `<lib>.applied_prs` -- a forward-compat slot for explicit PR
+  detectors when a specific patch warrants tracking.
+
+The `composable_kernel.system.commit` field IS a real upstream commit
+(40-char SHA), because CK ships its own `CK_COMMIT_ID` define populated
+from the upstream submodule.
+
+### `hip.version` vs `pytorch_build.hip_version` are deliberately both captured
+
+* `hip.version` -- the **system-installed** HIP version (from
+  `hipconfig --version`). What ROCm is installed on the host.
+* `pytorch_build.hip_version` -- the **compile-time** HIP version
+  PyTorch was built against (from `torch.version.hip`). What the wheel
+  expects.
+
+These will be equal on a host where torch was built against the
+installed HIP. They diverge -- and reveal a real bug class -- when
+someone runs a wheel built against HIP 7.1 on a host with HIP 7.2
+installed (the wheel may load but dispatch to mismatched API surfaces).
+Capturing both is intentional.
+
+## PyTorch source-tree submodule probing
+
+`pytorch_build.git_commit` (always available on any installed PyTorch)
+is the lookup key that pins every vendored `third_party/` submodule
+deterministically -- including AMD-relevant ones like `composable_kernel`,
+`aiter`, and `fbgemm`. The probe captures it from
+`torch.version.git_version`.
+
+To go further and capture the actual bound submodule SHAs in-process,
+point the probe at a PyTorch source tree:
+
+```bash
+# Explicit (recommended): tell aorta where the checkout lives
+AORTA_PYTORCH_SRC=/path/to/pytorch aorta env probe -o env.json
+```
+
+When set, the probe runs `git -C $AORTA_PYTORCH_SRC/third_party/<sub>
+rev-parse HEAD` for each entry in `CANONICAL_PYTORCH_SUBMODULES` and
+records the SHA in `pytorch_build.submodule_commits.<sub>`.
+`pytorch_build.submodule_commits._source = "git"` records the
+provenance.
+
+For pip-installed wheels (the common case), the probe falls back
+gracefully: every `submodule_commits.<sub>` is `null`, and a single
+`partial_reasons` line emits a copy-pasteable URL template:
+
+```
+pytorch_build.submodule_commits: wheel install -- direct SHAs not
+recoverable; resolve via
+github.com/pytorch/pytorch/tree/<git_commit>/third_party/<name>
+(set AORTA_PYTORCH_SRC=<src> to enable in-process probing)
+```
+
+`<git_commit>` is the captured `pytorch_build.git_commit` (substituted
+in if known). The operator can paste the URL into a browser to see the
+exact bound commit for any submodule on the GitHub tree.
+
+**Auto-detection** also covers two cases without `AORTA_PYTORCH_SRC`:
+
+* **Editable installs** (`pip install -e /path/to/pytorch`): detected
+  via the `direct_url.json` marker in `torch-<version>.dist-info/`.
+  `install_kind = "editable"`.
+* **Source-shadowed imports** (running `python -c "import torch"` from
+  inside a checkout where the local `torch/` dir wins over the wheel):
+  detected by walking up from `torch.__file__` for a sibling `.git` +
+  `third_party/`. `install_kind = "source"`.
+
+Adding a new submodule to track is a deliberate three-step change
+(mirrors `CANONICAL_ENV_VARS`):
+
+1. Add to `CANONICAL_PYTORCH_SUBMODULES` in
+   `src/aorta/instrumentation/environment.py`.
+2. Update `TestPytorchBuildBlockShape::test_canonical_submodules_constant_is_stable`
+   AND `test_submodule_commits_keys_stable` in the test file.
+3. Justify in your PR -- which submodule, why it materially affects
+   trial results.
+
 ## Fail-soft contract
 
 `collect_env()` never raises. When something can't be captured:
@@ -260,13 +506,24 @@ Documented absences DO NOT trigger `partial`:
 
 | Environment | Wall time |
 | --- | --- |
-| Baremetal host (no rdhc) | ~0.10 s |
-| Inside a docker image | ~0.8 s |
+| Baremetal host (no rdhc), warm cache | ~2.2 s |
+| Inside a docker image | ~3 s |
 
-Both well inside the <5 s no-rdhc / <15 s with-rdhc targets.
+Most of the time goes to the bundled-CK probe, which runs `nm -D
+--defined-only` over `libtorch_hip.so` (~400 MB on a typical ROCm wheel)
+and pipes the output through `c++filt`. Cold-cache nm over a
+several-hundred-MB binary can stretch to several seconds; the per-tool
+budget for nm/c++filt is `NM_TIMEOUT_SEC = 30 s` (vs `SHORT_TIMEOUT_SEC
+= 5 s` for the smaller subprocesses) so the probe stays inside the
+< 15 s overall target on contended I/O.
 
-No GPU compute. Verified via `rocprofv3 --hip-trace`: zero HIP API
-calls, zero kernel dispatches.
+Without the bundled-CK probe (e.g. when binutils is stripped from the
+container, or for a CPU-only PyTorch wheel), the probe completes in
+under 0.5 s.
+
+No GPU compute. `import torch` will `dlopen` the HIP runtime libraries
+(so `pmap` shows them in the process), but verified via `rocprofv3
+--hip-trace`: zero HIP API calls and zero kernel dispatches.
 
 ## Container detection precedence
 
@@ -296,10 +553,44 @@ sources are:
 | `rocm.version_dev` | `/opt/rocm/.info/version-dev` (often empty on developer builds) |
 | `rocm.kmd_version` | `/sys/module/amdgpu/version` (kernel module sysfs) |
 | `hip.*` | `hipconfig --version` / `--platform` / `--compiler` / `--runtime` / `--cpp_config` |
-| `hipblaslt.commit` | `HIPBLASLT_VERSION_TWEAK` define in `/opt/rocm/include/hipblaslt/hipblaslt-version.h` |
+| `hipblaslt.rocm_release_tweak` | `HIPBLASLT_VERSION_TWEAK` define in `/opt/rocm/include/hipblaslt/hipblaslt-version.h` |
 | `hipblaslt.package_version` | `HIPBLASLT_VERSION_{MAJOR,MINOR,PATCH}` defines in the same header |
 | `hipblaslt.lib_hash` | `sha256(/opt/rocm/lib/libhipblaslt.so)` resolved through symlinks |
-| `hipblaslt.tensile_yaml_revision` | sha256 of sorted filenames of `*.yaml`/`*.dat`/`*.co` under `/opt/rocm/lib/hipblaslt/library/` |
+| `hipblaslt.kernel_db_revision` | sha256 of sorted filenames of `*.yaml`/`*.dat`/`*.co` under `/opt/rocm/lib/hipblaslt/library/` |
+| `rocblas.rocm_release_tweak` | `ROCBLAS_VERSION_TWEAK` define in `/opt/rocm/include/rocblas/internal/rocblas-version.h` |
+| `rocblas.package_version` | `ROCBLAS_VERSION_{MAJOR,MINOR,PATCH}` defines in the same header |
+| `rocblas.lib_hash` | `sha256(/opt/rocm/lib/librocblas.so)` resolved through symlinks |
+| `rocblas.kernel_db_revision` | sha256 of sorted filenames of `*.yaml`/`*.dat`/`*.co` under `/opt/rocm/lib/rocblas/library/` |
+| `miopen.rocm_release_tweak` | `MIOPEN_VERSION_TWEAK` define in `/opt/rocm/include/miopen/version.h` |
+| `miopen.package_version` | `MIOPEN_VERSION_{MAJOR,MINOR,PATCH}` defines in the same header |
+| `miopen.lib_hash` | `sha256(/opt/rocm/lib/libMIOpen.so)` resolved through symlinks |
+| `miopen.kernel_db_revision` | sha256 of sorted filenames of `*.txt` under `/opt/rocm/share/miopen/db/` (changes when conv-kernel set changes; the `MIOPEN_SYSTEM_DB_PATH` env var overrides this directory at runtime) |
+| `rccl.version_code` / `rccl.version` | `NCCL_VERSION_CODE` define in `/opt/rocm/include/rccl/rccl.h`, decoded into `MAJOR.MINOR.PATCH` |
+| `rccl.lib_hash` | `sha256(/opt/rocm/lib/librccl.so)` resolved through symlinks |
+| `gpu_arch.*` | `rocm_agent_enumerator` subprocess (one gfx-target per detected GPU on stdout); `gfx000` placeholder filtered out |
+| `host.kernel_release` / `kernel_version` / `machine` | `os.uname()` |
+| `host.glibc_version` | `os.confstr("CS_GNU_LIBC_VERSION")` with the redundant `"glibc "` prefix stripped (so the value is the bare version string, e.g. `"2.35"`); returns `null` on non-glibc systems like musl / macOS |
+| `composable_kernel.pytorch_use_ck_sdpa` / `.pytorch_use_ck_gemm` | substring search in `torch.__config__.show()` for `-DUSE_ROCM_CK_SDPA` / `-DUSE_ROCM_CK_GEMM`. Build-time flags baked into the PyTorch wheel; setting these as runtime env vars does NOT change behavior. `False` is meaningful (built without the CK SDPA/GEMM path -- dispatches to AOTriton / non-CK rocBLAS instead). |
+| `composable_kernel.system.version` | `CK_VERSION_{MAJOR,MINOR,PATCH}` defines in `/opt/rocm/include/ck/version.h` |
+| `composable_kernel.system.commit` | `CK_COMMIT_ID` define in the same header (full 40-char SHA) |
+| `composable_kernel.system.ck_tile_present` | existence of `/opt/rocm/include/ck_tile/core/config.hpp` |
+| `composable_kernel.pytorch_bundled.symbol_count` | `nm -D --defined-only` of `<torch>/lib/libtorch_hip.so` piped through `c++filt`, counting lines containing `ck::`. `null` when torch absent, lib missing, or binutils stripped from the container. |
+| `tensile.package_version` | `import Tensile; Tensile.__version__` (rare; build-time tool) |
+| `tensile.kernel_db_combined_hash` | sorted-filenames sha256 over the union of the hipBLASLt + rocBLAS kernel DBs (each filename namespaced by parent dir basename) |
+| `triton.package_version` | `import triton; triton.__version__` (ROCm fork puts source commit into the version string) |
+| `fbgemm.package_version` | `import fbgemm_gpu; fbgemm_gpu.__version__` (commonly `null` -- FBGEMM is vendored inside PyTorch) |
+| `fbgemm.pytorch_use_fbgemm` / `fbgemm.pytorch_use_fbgemm_genai` | substring search in `torch.__config__.show()` for the `-DUSE_FBGEMM` and `-DUSE_FBGEMM_GENAI` defines. `False` is meaningful (built-without); `null` only when torch is absent. |
+| `aiter.package_version` | `import aiter; aiter.__version__` |
+| `aotriton.bundled_version` | parsed from `<torch>/lib/libaotriton_v2.so.MAJOR.MINOR.PATCH` filename (highest-versioned wins) |
+| `aotriton.bundled_lib_hash` | `sha256(<torch>/lib/libaotriton_v2.so*)` resolved through symlinks |
+| `aotriton.bundled_images_dir_present` | existence of `<torch>/lib/aotriton.images/` |
+| `aotriton.installed_prefix` | value of `$AOTRITON_INSTALLED_PREFIX` (operator override pointing PyTorch at a system AOTriton install; `null` for the default bundled-wins case) |
+| `pytorch_build.git_commit` | `torch.version.git_version` (always available on installed torch) |
+| `pytorch_build.hip_version` / `.cuda_version` / `.debug` | `torch.version.{hip,cuda,debug}` |
+| `pytorch_build.install_kind` | `"wheel"` (default), `"editable"` (PEP 660 `direct_url.json` + `dir_info.editable=True`), `"source"` (`AORTA_PYTORCH_SRC` env var or walked-up `.git`+`third_party/`), `"unknown"` (torch import failed) |
+| `pytorch_build.source_path` | The detected/configured PyTorch source root; `null` for wheel installs |
+| `pytorch_build.submodule_commits.{composable_kernel,aiter,fbgemm}` | `git -C <source>/third_party/<name> rev-parse HEAD` when a source tree is detected; otherwise `null` and a `partial_reasons` line emits the GitHub URL template for manual lookup |
+| `pytorch_build.submodule_commits._source` | Provenance tag: `"git"` when populated from a source tree, `null` for wheel installs |
 | `system_health` | `sudo -n -E rdhc --quick --json <tempfile>` |
 | `docker.image` / `docker.digest` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` env vars set by the launcher |
 | `docker.container_id` | `/proc/self/cgroup` |
@@ -341,9 +632,6 @@ diff <(jq -S . env_a.json) <(jq -S . env_b.json)
 * `aorta env matrix` (multi-docker fan-out)
 * `aorta env diff env_a.json env_b.json`
 * GPU kernel introspection (anything that runs HIP work)
-* Composable Kernel / rocBLAS commit + build state -- same pattern as
-  the `hipblaslt` block but a different code path; lands when a second
-  incident points at one of them
 * Workload config (`AMP_DTYPE`, `MODEL_DTYPE`, ...) -- captured by
   `aorta run` in the trial result (Task B1), not by env probe
 

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -33,7 +33,13 @@ def env() -> None:
     show_default=True,
     help="Path to write env.json.",
 )
-def probe(output: Path) -> None:
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="After the brief, also print the full snapshot JSON to stdout.",
+)
+def probe(output: Path, verbose: bool) -> None:
     """Capture trial-environment state to env.json (issue #147)."""
     from aorta.instrumentation.environment import collect_env
 
@@ -55,8 +61,9 @@ def probe(output: Path) -> None:
     # supposed to be JSON-native (str/int/bool/None/list/dict). If a
     # non-serializable type sneaks in (e.g. a Path or datetime), we want
     # the failure to be loud rather than silently stringified.
+    snapshot_dict = snapshot.to_dict()
     try:
-        output.write_text(json.dumps(snapshot.to_dict(), indent=2))
+        output.write_text(json.dumps(snapshot_dict, indent=2))
     except OSError as exc:
         raise click.ClickException(
             f"Failed to write env probe to {output}: {exc}"
@@ -68,3 +75,27 @@ def probe(output: Path) -> None:
         f"(schema_version={snapshot.schema_version}){partial}"
     )
     click.echo(snapshot.summary())
+
+    # Always inline the partial_reasons -- they are action items and
+    # forcing the operator to ``jq env.json`` to read them is friction.
+    # Costs nothing (the list is already in memory).
+    if snapshot.partial:
+        click.echo("\nPartial reasons:")
+        for reason in snapshot.partial_reasons:
+            click.echo(f"  - {reason}")
+
+    if verbose:
+        click.echo("\n--- Full snapshot ---")
+        click.echo(json.dumps(snapshot_dict, indent=2))
+
+    # Closing marker -- repeats the [PARTIAL] state at end-of-output so
+    # an operator scrolled to the bottom (especially after --verbose
+    # dumps the full JSON) immediately sees probe status without
+    # scrolling back up. Matches the marker shown next to the "Wrote
+    # env probe..." line.
+    if snapshot.partial:
+        click.echo(
+            f"\n[PARTIAL, {len(snapshot.partial_reasons)} reason(s)]"
+        )
+    else:
+        click.echo("\n[OK]")

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -8,7 +8,27 @@ will live here too.
 
 | Submodule | Purpose | Public API |
 | --- | --- | --- |
-| [`environment`](environment.py) | Snapshot the trial environment (rdhc + ROCm version files + hipconfig + hipBLASLt + container detection + canonical env vars + Python/PyTorch versions). | `collect_env() -> EnvSnapshot` |
+| [`environment`](environment.py) | ROCm + ML stack version snapshot + container/python env detection. See block list below. | `collect_env() -> EnvSnapshot` |
+
+**`environment` blocks** (every snapshot includes all of these; missing
+values become `None` plus a `partial_reasons` line):
+
+* System: `rdhc` health snapshot, ROCm version files, HIP toolchain,
+  container/python env detection, canonical env-var capture.
+* GEMM/kernel libraries: `hipBLASLt`, `rocBLAS`, `MIOpen` (conv
+  kernels), `RCCL` (collectives), `Composable Kernel` (with both
+  `system` and `pytorch_bundled` sub-blocks), `Tensile` (cross-library
+  kernel-DB fingerprint).
+* GPU + host: `gpu_arch` (gfx-target distribution via
+  `rocm_agent_enumerator`), `host` (kernel + glibc + machine arch).
+* PyTorch ecosystem: `Triton`, `FBGEMM` (pip + PyTorch build flags),
+  `AITER`, `AOTriton` (default ROCm Flash Attention backend; bundled
+  in `<torch>/lib/libaotriton_v2.so*` via cmake-fetched dep, not a
+  submodule), `pytorch_version`, `pytorch_build` (structured:
+  git_commit from `torch.version.git_version` + per-submodule SHAs
+  from `git -C <src>/third_party/<sub> rev-parse HEAD` when
+  `AORTA_PYTORCH_SRC` points at a source tree, otherwise GitHub URL
+  template for manual lookup).
 
 ## env probe quick reference
 
@@ -25,7 +45,8 @@ trial_result["env"] = snapshot.to_dict()
 # Reconstruct from a previously persisted env.json blob
 rebuilt = EnvSnapshot.from_dict(loaded_json["env"])
 
-# Quick human summary (six lines, no external dependencies)
+# Quick human summary (multi-line per-block brief, ~18 lines on a
+# populated host; no external dependencies)
 print(snapshot.summary())
 ```
 
@@ -47,8 +68,10 @@ aorta env probe -o runs/exp1/env.json
 ```
 
 After the run, `cat env.json` reveals the same dict that
-`snapshot.to_dict()` returns. The CLI also prints a six-line summary to
-stdout.
+`snapshot.to_dict()` returns. The CLI also prints a per-block summary
+brief to stdout (currently ~18 lines on a populated host -- one labelled
+cell per top-level block); see [`docs/env-probe.md#cli`](../../../docs/env-probe.md#cli)
+for the live example output.
 
 ### Installing RDHC for full `system_health` coverage
 
@@ -95,7 +118,7 @@ Documented absences DO NOT trigger `partial`:
 * `env_vars[X] == None` for an unset env var (the documented contract).
 * `runtime_context.venv_path == None` outside a venv.
 
-### env.json schema (v1.0)
+### env.json schema (v1.1)
 
 See `EnvSnapshot` in [`environment.py`](environment.py) for the
 authoritative shape and field-by-field docstrings. Top-level keys:
@@ -103,9 +126,17 @@ authoritative shape and field-by-field docstrings. Top-level keys:
 ```
 schema_version    captured_at       partial         partial_reasons
 system_health     rocm              hip             hipblaslt
+rocblas           miopen            rccl            composable_kernel
+tensile           triton            fbgemm          aiter
+aotriton          gpu_arch          host
 runtime_context   docker            env_vars
-python_version    pytorch_version
+python_version    pytorch_version   pytorch_build
 ```
+
+For the per-version field history (renames, env-var additions /
+removals), see the changelog comment next to `SCHEMA_VERSION` in
+`environment.py` or the "Schema changelog" section of
+[`docs/env-probe.md`](../../../docs/env-probe.md#schema-changelog).
 
 Schema is **stable + versioned**. Add fields freely; never rename or
 remove without bumping `schema_version`. Empty `applied_prs: {}` may
@@ -173,7 +204,9 @@ Roughly the same pattern as the existing blocks (`_run_rdhc`,
 
 ## Tests
 
-`tests/instrumentation/test_environment.py` has ~80 tests covering:
+`tests/instrumentation/test_environment.py` has ~150 tests (run
+`pytest --collect-only -q tests/instrumentation/test_environment.py | tail -1`
+for the live count) covering:
 
 * Schema completeness (every top-level key present in every snapshot)
 * Round-trip via `to_dict()` / `from_dict()` (incl. through JSON,

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -16,6 +16,15 @@ Captured blocks:
 * ``hip`` -- ``hipconfig`` toolchain outputs.
 * ``hipblaslt`` -- commit + library hash + Tensile fingerprint + applied
   PR flags.
+* ``rocblas`` -- mirror of ``hipblaslt`` for the rocBLAS library.
+* ``composable_kernel`` -- two sub-blocks: ``system`` (header version +
+  commit + ck_tile presence from the composablekernel-dev install) and
+  ``pytorch_bundled`` (CK symbol count inside ``libtorch_hip.so``).
+* ``tensile`` -- optional pip version + combined kernel-DB fingerprint
+  across hipBLASLt and rocBLAS.
+* ``triton``, ``fbgemm``, ``aiter`` -- Python-package version probes.
+  ``fbgemm`` also surfaces the ``-DUSE_FBGEMM`` / ``-DUSE_FBGEMM_GENAI``
+  build-time flags from ``torch.__config__.show()``.
 * ``runtime_context`` -- container runtime + Python env detection.
 * ``docker`` -- image + digest when in a container.
 * ``env_vars`` -- canonical list of HSA / RCCL / FBGEMM / PyTorch vars.
@@ -53,7 +62,28 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"
+# 1.0 -> 1.1 (this commit):
+#   - Renamed hipblaslt/rocblas/miopen.commit -> .rocm_release_tweak
+#     (the field's value is the ROCm-release-shared identifier, not a
+#     per-library upstream commit -- the old name misled consumers).
+#   - Renamed hipblaslt/rocblas.tensile_yaml_revision -> .kernel_db_revision
+#     (modern builds ship .dat not .yaml; matches miopen's naming).
+#   - Removed USE_ROCM_CK_SDPA from env_vars (it's a build-time cmake
+#     flag, not a runtime env var). Replaced with `pytorch_use_ck_sdpa`
+#     and `pytorch_use_ck_gemm` booleans inside the composable_kernel
+#     block, parsed from `torch.__config__.show()` (same pattern as the
+#     existing `fbgemm.pytorch_use_fbgemm*` fields).
+#   - Added top-level `host`, `miopen`, `rccl`, `gpu_arch`, `aotriton`,
+#     `pytorch_build`, `composable_kernel`, `tensile`, `triton`,
+#     `fbgemm`, `aiter`, `rocblas` blocks. All purely additive.
+#   - Added 7 new env vars to CANONICAL_ENV_VARS (HIP_VISIBLE_DEVICES,
+#     ROCR_VISIBLE_DEVICES, HSA_OVERRIDE_GFX_VERSION,
+#     HIP_LAUNCH_BLOCKING, MIOPEN_FIND_MODE, TORCH_HIPBLASLT_TUNING_FILE,
+#     TORCH_HIPBLASLT_TUNING_OVERRIDE_FILE) plus the SDPA/Tuning/MIOpen
+#     family from earlier.
+#   - host.glibc_version no longer carries the redundant "glibc "
+#     prefix; the value is the bare version string (e.g. "2.35").
 
 # RDHC subprocess budget. The issue caps at 30 s; we keep that to stay
 # inside the 30 s worst-case env probe budget.
@@ -69,26 +99,60 @@ _RDHC_INSTALL_HINT = "see docs/env-probe.md#installing-rdhc"
 # should take more than a second on a healthy host.
 SHORT_TIMEOUT_SEC = 5.0
 
+# Larger budget for subprocesses that scan multi-hundred-MB binaries.
+# `nm -D` over a ~400 MB libtorch_hip.so finishes in ~1 s on a warm
+# page cache but can stretch past 5 s on cold cache or contended I/O;
+# `c++filt` demangling the resulting symbol list is similarly bursty.
+# Both falling back silently to "no CK in PyTorch" when they timeout
+# would look identical to a CPU-only wheel -- so give them headroom.
+NM_TIMEOUT_SEC = 30.0
+
 # Canonical env var list -- explicit, NOT prefix matching. Workload
 # config (AMP_DTYPE, MODEL_DTYPE, SHAMPOO_PRECONDITIONER_DTYPE) belongs
 # in the trial result emitted by ``aorta run`` (Task B1), so it is
 # deliberately absent here. Asserted by tests.
 CANONICAL_ENV_VARS: tuple[str, ...] = (
+    # GPU scoping (most common cause of "you see N GPUs, I see M")
+    "HIP_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
     # HSA / runtime
     "HSA_XNACK",
     "HSA_KERNARG_POOL_SIZE",
     "HSA_NO_SCRATCH_RECLAIM",
-    # GPU queue / codegen
+    "HSA_OVERRIDE_GFX_VERSION",  # forces a different gfx target than the silicon
+    # GPU queue / codegen / build target
     "GPU_MAX_HW_QUEUES",
     "AMDGCN_USE_BUFFER_OPS",
     "DISABLE_TF32",
+    "PYTORCH_ROCM_ARCH",
+    "HIP_LAUNCH_BLOCKING",  # forces synchronous launches; trace-debug leftover
     # RCCL / NCCL
     "NCCL_MAX_NCHANNELS",
+    "NCCL_P2P_LEVEL",
+    "NCCL_IB_HCA",
+    "NCCL_SOCKET_IFNAME",
+    "RCCL_MSCCL_ENABLE",
     # FBGEMM
     "FBGEMM_NO_JK",
     "FBGEMM_TBE_V2",
     "FBGEMM_TBE_ROCM_HIP_BACKWARD_KERNEL",
     "FBGEMM_BOUNDS_CHECK_INDICES_V2",
+    # MIOpen kernel DB + selection-mode
+    "MIOPEN_SYSTEM_DB_PATH",
+    "MIOPEN_USER_DB_PATH",
+    "MIOPEN_DEBUG_DISABLE_FIND_DB",
+    "MIOPEN_FIND_MODE",  # NORMAL/FAST/HYBRID/DYNAMIC -> different conv kernels
+    # SDPA / Flash Attention backend selection (CK vs AOTriton).
+    # Note: USE_ROCM_CK_SDPA / USE_ROCM_CK_GEMM are NOT here -- they're
+    # build-time cmake flags consumed when the PyTorch wheel is built,
+    # not runtime env vars. Captured under
+    # composable_kernel.{pytorch_use_ck_sdpa,pytorch_use_ck_gemm}.
+    "TORCH_ROCM_FA_PREFER_CK",
+    "TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL",
+    # GEMM backend preference + hipBLASLt autotune pinning
+    "TORCH_BLAS_PREFER_HIPBLASLT",
+    "TORCH_HIPBLASLT_TUNING_FILE",
+    "TORCH_HIPBLASLT_TUNING_OVERRIDE_FILE",
     # PyTorch / inductor
     "TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE",
     "PYTORCH_CUDA_ALLOC_CONF",
@@ -110,6 +174,11 @@ CANONICAL_ENV_VARS: tuple[str, ...] = (
 # /opt/rocm is conventionally a symlink to the active versioned install
 # (e.g., /opt/rocm-7.2.1), so /opt/rocm/.info/version always points at the
 # active release.
+# Canonical ROCm bin dir used for fallback lookup of binaries (e.g.
+# rocm_agent_enumerator) when the operator's PATH doesn't include
+# /opt/rocm/bin (a common state when /etc/profile.d/rocm.sh hasn't
+# been sourced -- happens in non-login shells).
+ROCM_BIN_DIR = Path("/opt/rocm/bin")
 ROCM_VERSION_FILE = Path("/opt/rocm/.info/version")            # release tag, e.g. "7.2.1"
 ROCM_VERSION_DEV_FILE = Path("/opt/rocm/.info/version-dev")    # full build, e.g. "7.2.1-43"
 # Linux kernel-side AMDGPU module version (KMD = kernel-mode driver).
@@ -126,6 +195,101 @@ HIPBLASLT_LIB_DIR = Path("/opt/rocm/lib")  # libhipblaslt.so* lives here
 HIPBLASLT_TENSILE_DIR = Path(
     "/opt/rocm/lib/hipblaslt/library"
 )  # Tensile kernel database (.dat on modern builds, .yaml on older)
+
+# rocBLAS build identity sources. Mirrors the hipBLASLt layout exactly --
+# header in the rocblas-dev package (note the `internal/` subdir, unlike
+# hipblaslt), runtime lib in /opt/rocm/lib, and a Tensile kernel database
+# at /opt/rocm/lib/rocblas/library/. The same fail-soft contract applies:
+# missing -dev package -> commit/package_version fall back to None with a
+# recorded reason; the runtime lib + kernel DB ship with the runtime
+# rocblas package and are usually still present in stripped images.
+ROCBLAS_VERSION_HEADER = Path(
+    "/opt/rocm/include/rocblas/internal/rocblas-version.h"
+)
+ROCBLAS_LIB_DIR = Path("/opt/rocm/lib")  # librocblas.so* lives here
+ROCBLAS_TENSILE_DIR = Path(
+    "/opt/rocm/lib/rocblas/library"
+)  # rocBLAS Tensile kernel database
+
+# Composable Kernel (CK) is shipped header-only via the
+# composablekernel-dev package -- there is no libck.so to hash. CK_TILE
+# is a sub-component of CK with no separate version header; we record
+# its presence as a boolean by checking for its core config header.
+# When the -dev package is stripped from the container, both keys fall
+# back to None / False with a recorded reason.
+CK_VERSION_HEADER = Path("/opt/rocm/include/ck/version.h")
+CK_TILE_CONFIG_HEADER = Path("/opt/rocm/include/ck_tile/core/config.hpp")
+
+# Filename of the PyTorch-built HIP shared library, looked up relative to
+# `torch.__file__` at runtime by the composable_kernel probe (we never
+# initialise HIP context to find it -- pure path arithmetic).
+PYTORCH_HIP_LIB_NAME = "libtorch_hip.so"
+
+# AOTriton is the default Flash Attention backend on ROCm. Unlike CK
+# / FBGEMM / AITER, AOTriton is NOT a PyTorch git submodule -- it's
+# fetched at PyTorch build time via cmake/External/aotriton.cmake and
+# bundled into the wheel as <torch>/lib/libaotriton_v2.so.MAJOR.MINOR.PATCH
+# alongside an `aotriton.images/` directory of pre-compiled kernel images.
+# Version is parsed from the filename (no header in the wheel install).
+# The AOTRITON_INSTALLED_PREFIX env var lets operators point PyTorch at
+# a system AOTriton install; we record its value so cross-env diffs
+# surface the override.
+AOTRITON_LIB_PREFIX = "libaotriton_v2.so"
+AOTRITON_IMAGES_DIR_NAME = "aotriton.images"
+AOTRITON_INSTALLED_PREFIX_ENV = "AOTRITON_INSTALLED_PREFIX"
+
+# MIOpen build identity sources. Same shape as hipBLASLt: header in the
+# -dev package, runtime lib in /opt/rocm/lib, kernel database under
+# /opt/rocm/share/miopen/db/. Kernel DB files are .txt / .fdb.txt
+# (gfx-target named) -- distinct suffix family from Tensile's .dat/.yaml.
+MIOPEN_VERSION_HEADER = Path("/opt/rocm/include/miopen/version.h")
+MIOPEN_LIB_DIR = Path("/opt/rocm/lib")  # libMIOpen.so* lives here (capital M, capital O)
+MIOPEN_KERNEL_DB_DIR = Path("/opt/rocm/share/miopen/db")
+MIOPEN_KERNEL_DB_SUFFIXES: tuple[str, ...] = (".txt",)  # .fdb.txt also matches via final suffix
+
+# RCCL is AMD's NCCL-compatible collective comms library. Header is at
+# /opt/rocm/include/rccl/rccl.h (same name as upstream NCCL's). Version
+# is encoded as a single integer macro NCCL_VERSION_CODE -- decoded
+# below via _decode_nccl_version_code.
+RCCL_VERSION_HEADER = Path("/opt/rocm/include/rccl/rccl.h")
+RCCL_LIB_DIR = Path("/opt/rocm/lib")  # librccl.so*
+
+# `rocm_agent_enumerator` returns one gfx-target name per detected GPU
+# (e.g. "gfx942\ngfx942\n..."). Works without /dev/kfd access on most
+# hosts (the kernel module exposes the architecture via sysfs). Probed
+# via subprocess; fail-soft to None when binary missing or returns empty.
+ROCM_AGENT_ENUMERATOR_BIN = "rocm_agent_enumerator"
+
+# Env var an operator sets to point at a PyTorch source checkout. When
+# present and `<path>/third_party/` exists, the pytorch_build probe runs
+# `git -C <src>/third_party/<sub> rev-parse HEAD` for each canonical
+# submodule below, recording the actual bound commit SHAs. Without it,
+# pip-installed wheels fall back to the GitHub-URL recovery hint.
+AORTA_PYTORCH_SRC_ENV = "AORTA_PYTORCH_SRC"
+
+# Canonical AMD-relevant submodules under PyTorch's third_party/.
+# Verified against pytorch/.gitmodules on `main` (Dec 2025): these are
+# the AMD/ROCm-relevant entries. Adding a new submodule is a deliberate
+# schema-shape change -- mirror the CANONICAL_ENV_VARS workflow:
+#   1. add to this tuple
+#   2. update `test_canonical_pytorch_submodules_stable`
+#   3. justify in PR description
+# Cross-vendor (fbgemm) is included because its ROCm path is a major
+# drift surface; the upstream commit can drift independently of PyTorch
+# even when both are on the same release tag.
+CANONICAL_PYTORCH_SUBMODULES: tuple[str, ...] = (
+    "composable_kernel",
+    "aiter",
+    "fbgemm",
+)
+
+# GitHub URL template printed in `partial_reasons` when the PyTorch
+# source tree is not on disk. The operator reading the partial entry
+# can substitute the captured `git_commit` and resolve the bound
+# submodule SHAs via the GitHub web tree without leaving the doc.
+_PYTORCH_SUBMODULE_LOOKUP_HINT = (
+    "github.com/pytorch/pytorch/tree/<git_commit>/third_party/<name>"
+)
 
 # Container runtime detection markers.
 # /.dockerenv -- created by Docker since the early days.
@@ -189,11 +353,23 @@ class EnvSnapshot:
     rocm: dict
     hip: dict
     hipblaslt: dict
+    rocblas: dict
+    composable_kernel: dict
+    tensile: dict
+    triton: dict
+    fbgemm: dict
+    aiter: dict
+    aotriton: dict
+    miopen: dict
+    rccl: dict
+    gpu_arch: dict
     runtime_context: dict
+    host: dict
     docker: dict | None
     env_vars: dict[str, str | None]
     python_version: str
     pytorch_version: str | None
+    pytorch_build: dict
     partial: bool
     partial_reasons: list[str] = field(default_factory=list)
 
@@ -216,13 +392,32 @@ class EnvSnapshot:
     def summary(self) -> str:
         """Human-friendly multi-line summary for CLI / logs.
 
-        Six lines, fixed width labels. Used by ``aorta env probe`` to print
-        a brief after writing the JSON.
+        Fixed-width labels, ~18 lines on a populated host (one cell
+        per top-level block). Used by
+        ``aorta env probe`` to print a brief after writing the JSON.
+
+        Covers every top-level identity block so an operator running the
+        probe doesn't have to ``jq env.json`` to see the new GEMM /
+        kernel-library fingerprints. Hashes are truncated to 6 hex chars
+        for line-width; the full values live in the JSON.
         """
         rt = self.runtime_context or {}
         rocm = self.rocm or {}
         hip = self.hip or {}
         hipblaslt = self.hipblaslt or {}
+        rocblas = self.rocblas or {}
+        ck = self.composable_kernel or {}
+        ck_sys = ck.get("system") or {}
+        ck_bundled = ck.get("pytorch_bundled") or {}
+        tensile = self.tensile or {}
+        triton = self.triton or {}
+        fbgemm = self.fbgemm or {}
+        aiter = self.aiter or {}
+        aotriton = self.aotriton or {}
+        miopen = self.miopen or {}
+        rccl = self.rccl or {}
+        gpu_arch = self.gpu_arch or {}
+        host = self.host or {}
         # Use ``is not None`` -- RDHC may return an empty dict on a healthy
         # host with nothing to report, which is still a successful capture
         # and must NOT be summarised as "unavailable".
@@ -231,20 +426,126 @@ class EnvSnapshot:
             if self.system_health is not None
             else "unavailable (system_health=null)"
         )
-        partial_marker = (
-            f" [PARTIAL, {len(self.partial_reasons)} reason(s)]"
-            if self.partial
-            else ""
-        )
+        # Partial state is signalled in two places already: the "Wrote
+        # env probe to ... [PARTIAL]" header line printed by the CLI
+        # before the summary, and the closing "[PARTIAL, N reason(s)]"
+        # marker printed after the partial_reasons list. A third copy
+        # on the runtime: line was redundant.
+
+        def short_hash(value: str | None) -> str:
+            """Truncate ``filenames-sha256:abcdef…``-style hashes for display."""
+            if not value:
+                return str(value)
+            if ":" in value:
+                kind, hex_part = value.split(":", 1)
+                if len(hex_part) > 8:
+                    return f"{kind}:{hex_part[:6]}…"
+            return value
+
+        def pkg_state(version: str | None) -> str:
+            """Render a Python-package version cell self-explanatorily.
+
+            `pip=None` was confusing -- the `None` is the JSON null
+            value, but operators read it as "no info captured". Replace
+            with a literal "(not installed)" marker so the meaning is
+            obvious without needing to read the schema.
+            """
+            return version if version else "(not installed)"
+
         return "\n".join(
             (
-                f"  runtime:  {rt.get('type', '?')} / python={rt.get('python_env', '?')}{partial_marker}",
-                f"  rocm:     {rocm.get('version', '?')} (dev: {rocm.get('version_dev', '?')})",
-                f"  hip:      {hip.get('version', '?')} ({hip.get('platform', '?')})",
-                f"  hipblaslt: commit={hipblaslt.get('commit', '?')}",
-                f"  rdhc:     {sysh}",
-                f"  python:   {self.python_version} | pytorch: {self.pytorch_version}",
+                f"  runtime:   {rt.get('type', '?')} / python={rt.get('python_env', '?')}",
+                f"  rocm:      {rocm.get('version', '?')} (dev: {rocm.get('version_dev', '?')})",
+                f"  hip:       {hip.get('version', '?')} ({hip.get('platform', '?')})",
+                # ROCm release tweak (HIPBLASLT_VERSION_TWEAK et al.)
+                # is the same string across every library in a release,
+                # not a per-library upstream commit. lib_hash is the
+                # per-binary signal (in the JSON, not the brief).
+                f"  hipblaslt: {hipblaslt.get('package_version', '?')} rocm_release_tweak={hipblaslt.get('rocm_release_tweak', '?')}",
+                f"  rocblas:   {rocblas.get('package_version', '?')} rocm_release_tweak={rocblas.get('rocm_release_tweak', '?')}",
+                f"  miopen:    {miopen.get('package_version', '?')} rocm_release_tweak={miopen.get('rocm_release_tweak', '?')}",
+                f"  rccl:      {rccl.get('version', '?')} (code={rccl.get('version_code', '?')})",
+                # gpu_arch: dedup'd targets are the meaningful diff
+                # signal (homogeneous vs mixed-arch hosts); count tells
+                # how many GPUs were detected. Both null when the
+                # rocm_agent_enumerator probe failed.
+                f"  gpu_arch:  {gpu_arch.get('gfx_targets') or '?'} "
+                f"(counts={gpu_arch.get('agent_arch_counts') or '?'})",
+                f"  host:      kernel={host.get('kernel_release') or '?'} "
+                f"machine={host.get('machine') or '?'}  "
+                f"glibc={host.get('glibc_version') or '?'}",
+                # CK has two layers -- system headers (composablekernel-dev
+                # apt pkg) and the copy compiled into libtorch_hip.so via
+                # PyTorch's third_party/composable_kernel submodule. Both
+                # can drift independently.
+                f"  ck:        system={ck_sys.get('version', '?')}/{(ck_sys.get('commit') or '?')[:8]}  "
+                f"ck_tile={'yes' if ck_sys.get('ck_tile_present') else 'no'}  "
+                f"libtorch_hip={ck_bundled.get('symbol_count', '?')} ck:: syms",
+                # Tensile generates kernels at rocBLAS / hipBLASLt build
+                # time; we fingerprint the union of their kernel DBs.
+                # The Tensile pip package itself is a build tool --
+                # almost never on production hosts -- so the
+                # not-installed state is annotated as expected.
+                f"  tensile:   kernel_db={short_hash(tensile.get('kernel_db_combined_hash'))}  "
+                f"[Tensile pip pkg: {pkg_state(tensile.get('package_version'))}; "
+                f"build-time tool, normal]",
+                f"  triton:    {pkg_state(triton.get('package_version'))}",
+                # FBGEMM has TWO surfaces and they're different artifacts:
+                #   1) FBGEMM the C++ lib is vendored inside the PyTorch
+                #      wheel (third_party/fbgemm) -- the USE_FBGEMM /
+                #      USE_FBGEMM_GENAI flags below confirm whether the
+                #      build pulled it in.
+                #   2) `fbgemm_gpu` the PyPI Python package is a
+                #      separate distribution; rarely needed alongside
+                #      PyTorch. Annotate the not-installed state so a
+                #      reader doesn't think "FBGEMM is missing" when
+                #      USE_FBGEMM=True (which means it IS here).
+                f"  fbgemm:    in PyTorch: USE_FBGEMM={fbgemm.get('pytorch_use_fbgemm')} "
+                f"USE_FBGEMM_GENAI={fbgemm.get('pytorch_use_fbgemm_genai')}  "
+                f"[fbgemm_gpu pip pkg: {pkg_state(fbgemm.get('package_version'))}; "
+                f"separate from torch's vendored copy]",
+                # AITER (AMD's CK-based inference kernel lib) is
+                # optional -- some inference stacks pull it in, training
+                # / stock inference don't. Annotate to avoid alarming
+                # readers who see "not installed".
+                f"  aiter:     {pkg_state(aiter.get('package_version'))} "
+                f"[aiter pip pkg; optional ROCm inference lib]",
+                # AOTriton: default ROCm Flash Attention backend.
+                # Bundled in the wheel; system override possible via
+                # AOTRITON_INSTALLED_PREFIX (rare).
+                f"  aotriton:  bundled={aotriton.get('bundled_version', '?')} "
+                f"present={aotriton.get('bundled_present')} "
+                f"images_dir={aotriton.get('bundled_images_dir_present')}  "
+                f"[AOTRITON_INSTALLED_PREFIX={aotriton.get('installed_prefix') or '(unset)'}]",
+                f"  rdhc:      {sysh}",
+                f"  python:    {self.python_version} | pytorch: {self.pytorch_version}",
+                f"  torch build: {self._summary_pytorch_build_line()}",
             )
+        )
+
+    def _summary_pytorch_build_line(self) -> str:
+        """Single-line summary of the structured pytorch_build block."""
+        pb = self.pytorch_build or {}
+        commit = pb.get("git_commit")
+        commit_short = commit[:8] if commit else "?"
+        kind = pb.get("install_kind", "?")
+        subs = pb.get("submodule_commits") or {}
+        sub_source = subs.get("_source")
+        if sub_source == "git":
+            sub_pairs = []
+            for name, sha in subs.items():
+                if name == "_source" or not sha:
+                    continue
+                sub_pairs.append(f"{name}={sha[:8]}")
+            sub_str = " ".join(sub_pairs) if sub_pairs else "(none)"
+            return (
+                f"git_commit={commit_short} install={kind} | "
+                f"submodules({sub_source}): {sub_str}"
+            )
+        return (
+            f"git_commit={commit_short} install={kind} "
+            f"[third_party SHAs: set AORTA_PYTORCH_SRC=<src> or look up "
+            f"github.com/pytorch/pytorch/tree/{commit_short}/third_party/<name>]"
         )
 
 
@@ -278,9 +579,21 @@ def collect_env() -> EnvSnapshot:
         rocm = _capture_rocm_version_files(reasons)
         hip = _capture_hip_toolchain(reasons)
         hipblaslt = _capture_hipblaslt(reasons)
+        rocblas = _capture_rocblas(reasons)
+        composable_kernel = _capture_composable_kernel(reasons)
+        tensile = _capture_tensile(reasons)
+        triton = _capture_triton(reasons)
+        fbgemm = _capture_fbgemm(reasons)
+        aiter = _capture_aiter(reasons)
+        aotriton = _capture_aotriton(reasons)
+        miopen = _capture_miopen(reasons)
+        rccl = _capture_rccl(reasons)
+        gpu_arch = _capture_gpu_arch(reasons)
+        host = _capture_host(reasons)
         docker = _capture_docker_metadata(runtime_context, reasons)
         env_vars = _capture_env_vars()  # individual nulls are documented, not partial
         pytorch_version = _capture_pytorch_version(reasons)
+        pytorch_build = _capture_pytorch_build(reasons)
 
         return EnvSnapshot(
             schema_version=SCHEMA_VERSION,
@@ -289,11 +602,23 @@ def collect_env() -> EnvSnapshot:
             rocm=rocm,
             hip=hip,
             hipblaslt=hipblaslt,
+            rocblas=rocblas,
+            composable_kernel=composable_kernel,
+            tensile=tensile,
+            triton=triton,
+            fbgemm=fbgemm,
+            aiter=aiter,
+            aotriton=aotriton,
+            miopen=miopen,
+            rccl=rccl,
+            gpu_arch=gpu_arch,
+            host=host,
             runtime_context=runtime_context,
             docker=docker,
             env_vars=env_vars,
             python_version=platform.python_version(),
             pytorch_version=pytorch_version,
+            pytorch_build=pytorch_build,
             partial=bool(reasons),
             partial_reasons=reasons,
         )
@@ -344,11 +669,59 @@ def _disaster_snapshot(
             "cpp_config": None,
         },
         hipblaslt={
-            "commit": None,
+            "rocm_release_tweak": None,
             "package_version": None,
             "lib_hash": None,
-            "tensile_yaml_revision": None,
+            "kernel_db_revision": None,
             "applied_prs": {},
+        },
+        rocblas={
+            "rocm_release_tweak": None,
+            "package_version": None,
+            "lib_hash": None,
+            "kernel_db_revision": None,
+            "applied_prs": {},
+        },
+        composable_kernel={
+            "system": {
+                "version": None,
+                "commit": None,
+                "ck_tile_present": False,
+            },
+            "pytorch_bundled": {"present": False, "symbol_count": None},
+            "pytorch_use_ck_sdpa": None,
+            "pytorch_use_ck_gemm": None,
+        },
+        tensile={"package_version": None, "kernel_db_combined_hash": None},
+        triton={"package_version": None},
+        fbgemm={
+            "package_version": None,
+            "pytorch_use_fbgemm": None,
+            "pytorch_use_fbgemm_genai": None,
+        },
+        aiter={"package_version": None},
+        aotriton={
+            "bundled_present": False,
+            "bundled_version": None,
+            "bundled_lib_hash": None,
+            "bundled_images_dir_present": False,
+            "installed_prefix": None,
+        },
+        miopen={
+            "rocm_release_tweak": None,
+            "package_version": None,
+            "lib_hash": None,
+            "kernel_db_revision": None,
+        },
+        rccl={
+            "version_code": None,
+            "version": None,
+            "lib_hash": None,
+        },
+        gpu_arch={
+            "agent_count": None,
+            "gfx_targets": None,
+            "agent_arch_counts": None,
         },
         runtime_context={
             "type": "baremetal",
@@ -356,10 +729,28 @@ def _disaster_snapshot(
             "venv_path": None,
             "conda_env_name": None,
         },
+        host={
+            "kernel_release": None,
+            "kernel_version": None,
+            "machine": None,
+            "glibc_version": None,
+        },
         docker=None,
         env_vars=dict.fromkeys(CANONICAL_ENV_VARS),
         python_version=python_version,
         pytorch_version=None,
+        pytorch_build={
+            "git_commit": None,
+            "hip_version": None,
+            "cuda_version": None,
+            "debug": None,
+            "install_kind": "unknown",
+            "source_path": None,
+            "submodule_commits": {
+                **{name: None for name in CANONICAL_PYTORCH_SUBMODULES},
+                "_source": None,
+            },
+        },
         partial=True,
         partial_reasons=[*preceding_reasons, unexpected_reason],
     )
@@ -611,12 +1002,65 @@ _HIPBLASLT_VERSION_RE = re.compile(
     r"#define\s+HIPBLASLT_VERSION_(MAJOR|MINOR|PATCH)\s+(\d+)"
 )
 
+# rocBLAS uses the same TWEAK/MAJOR/MINOR/PATCH layout in its header.
+_ROCBLAS_TWEAK_RE = re.compile(
+    r"#define\s+ROCBLAS_VERSION_TWEAK\s+([A-Za-z0-9_.+-]+)"
+)
+_ROCBLAS_VERSION_RE = re.compile(
+    r"#define\s+ROCBLAS_VERSION_(MAJOR|MINOR|PATCH)\s+(\d+)"
+)
+
+# CK uses a different shape: full 40-char SHA in CK_COMMIT_ID (not a
+# truncated TWEAK), and three MAJOR/MINOR/PATCH defines just like the
+# others. Allow 7-40 hex chars so dev builds with abbreviated SHAs still
+# parse.
+_CK_COMMIT_RE = re.compile(r"#define\s+CK_COMMIT_ID\s+([A-Fa-f0-9]{7,40})")
+_CK_VERSION_RE = re.compile(r"#define\s+CK_VERSION_(MAJOR|MINOR|PATCH)\s+(\d+)")
+
+# MIOpen header has the same MAJOR/MINOR/PATCH/TWEAK shape as hipBLASLt.
+_MIOPEN_TWEAK_RE = re.compile(
+    r"#define\s+MIOPEN_VERSION_TWEAK\s+([A-Za-z0-9_.+-]+)"
+)
+_MIOPEN_VERSION_RE = re.compile(
+    r"#define\s+MIOPEN_VERSION_(MAJOR|MINOR|PATCH)\s+(\d+)"
+)
+
+# RCCL/NCCL pack the version into a single int macro. Capture both the
+# raw code and a decoded MAJOR.MINOR.PATCH string.
+_NCCL_VERSION_CODE_RE = re.compile(r"#define\s+NCCL_VERSION_CODE\s+(\d+)")
+
+# `-DUSE_FBGEMM` and `-DUSE_FBGEMM_GENAI` mean different things, so the
+# plain-FBGEMM check needs a trailing word boundary (otherwise it would
+# false-positive on `-DUSE_FBGEMM_GENAI`). The GENAI one is unique enough.
+_FBGEMM_DEFINE_RE = re.compile(r"-DUSE_FBGEMM(?![A-Za-z0-9_])")
+_FBGEMM_GENAI_DEFINE_RE = re.compile(r"-DUSE_FBGEMM_GENAI(?![A-Za-z0-9_])")
+
+# CK SDPA / GEMM are build-time cmake flags (consumed when the PyTorch
+# wheel is built, NOT runtime env vars). Detect from the same
+# torch.__config__.show() text the FBGEMM probe scans.
+_CK_SDPA_DEFINE_RE = re.compile(r"-DUSE_ROCM_CK_SDPA(?![A-Za-z0-9_])")
+_CK_GEMM_DEFINE_RE = re.compile(r"-DUSE_ROCM_CK_GEMM(?![A-Za-z0-9_])")
+
+# Match libaotriton_v2.so.<MAJOR>.<MINOR>.<PATCH>. Anchored so a stray
+# debug-suffixed variant (e.g. .so.0.11.1.dbg) would NOT match -- we
+# want a clean version cell.
+_AOTRITON_VERSION_RE = re.compile(r"libaotriton_v2\.so\.(\d+\.\d+\.\d+)$")
+
 
 def _capture_hipblaslt(reasons: list[str]) -> dict[str, Any]:
     """Capture hipBLASLt build identity.
 
     Goal: catch GEMM kernel library drift across docker images / conda
     envs / venvs. See issue #147 motivation.
+
+    NOTE on ``rocm_release_tweak`` vs ``commit``: AMD sets
+    ``HIPBLASLT_VERSION_TWEAK`` to the **ROCm release identifier**, not
+    to hipBLASLt's upstream git SHA. In a given ROCm release every
+    library shares the same TWEAK -- so this field is the right name
+    for "which ROCm release built this library", not "which upstream
+    hipBLASLt commit". For per-library upstream SHA tracking, see
+    ``lib_hash`` (changes any time the binary changes) and the
+    ``applied_prs`` slot (filled in when a specific PR detector lands).
 
     The ``applied_prs`` block is intentionally empty in this first cut.
     Adding ``pr_<id>_applied`` keys later is additive and does not bump
@@ -626,29 +1070,32 @@ def _capture_hipblaslt(reasons: list[str]) -> dict[str, Any]:
     care to track.
     """
     header_text = _read_text_file(HIPBLASLT_VERSION_HEADER)
-    commit, package_version = _parse_hipblaslt_header(header_text)
+    rocm_release_tweak, package_version = _parse_hipblaslt_header(header_text)
     lib_hash = _hash_hipblaslt_library()
-    tensile_yaml_revision = _tensile_fingerprint()
+    # Renamed from `tensile_yaml_revision` in schema 1.1: modern
+    # hipBLASLt ships .dat (binary), not .yaml; the field shape is the
+    # same kernel-DB filename fingerprint as miopen.kernel_db_revision.
+    kernel_db_revision = _tensile_fingerprint()
 
     block: dict[str, Any] = {
-        "commit": commit,
+        "rocm_release_tweak": rocm_release_tweak,
         "package_version": package_version,
         "lib_hash": lib_hash,
-        "tensile_yaml_revision": tensile_yaml_revision,
+        "kernel_db_revision": kernel_db_revision,
         "applied_prs": {},
     }
     # Distinguish "header file unreadable" from "header readable but the
     # specific define is missing/unparseable" so partial_reasons points
     # callers at the right thing to investigate.
     header_unreadable = header_text is None
-    if commit is None:
+    if rocm_release_tweak is None:
         if header_unreadable:
             reasons.append(
-                f"hipblaslt.commit: {HIPBLASLT_VERSION_HEADER} not readable"
+                f"hipblaslt.rocm_release_tweak: {HIPBLASLT_VERSION_HEADER} not readable"
             )
         else:
             reasons.append(
-                f"hipblaslt.commit: {HIPBLASLT_VERSION_HEADER} did not "
+                f"hipblaslt.rocm_release_tweak: {HIPBLASLT_VERSION_HEADER} did not "
                 "contain a readable HIPBLASLT_VERSION_TWEAK define"
             )
     if package_version is None:
@@ -666,29 +1113,37 @@ def _capture_hipblaslt(reasons: list[str]) -> dict[str, Any]:
             f"hipblaslt.lib_hash: {HIPBLASLT_LIB_DIR}/libhipblaslt.so "
             "missing or unreadable"
         )
-    if tensile_yaml_revision is None:
+    if kernel_db_revision is None:
         # _tensile_fingerprint returns None for both "directory missing /
         # unlistable" AND "directory present but no kernel files" --
         # the wording covers both so partial_reasons is honest.
         reasons.append(
-            "hipblaslt.tensile_yaml_revision: directory missing/unreadable "
+            "hipblaslt.kernel_db_revision: directory missing/unreadable "
             f"or no kernel files under {HIPBLASLT_TENSILE_DIR}"
         )
     return block
 
 
-def _parse_hipblaslt_header(text: str | None) -> tuple[str | None, str | None]:
-    """Extract commit (TWEAK) and package_version (MAJOR.MINOR.PATCH).
+def _parse_version_header(
+    text: str | None,
+    tweak_re: re.Pattern[str],
+    version_re: re.Pattern[str],
+) -> tuple[str | None, str | None]:
+    """Extract (commit, MAJOR.MINOR.PATCH) from a ROCm version header.
 
-    Returns (commit, package_version), each ``None`` if the header was
-    missing or did not contain the expected defines.
+    Generalised over the regex pair so the same logic serves hipblaslt,
+    rocblas, and CK (which use TWEAK / VERSION_TWEAK / COMMIT_ID with
+    slightly different naming but the same layout).
+
+    Returns ``(commit, package_version)``, each ``None`` if the header
+    was missing or did not contain the expected defines.
     """
     if not text:
         return (None, None)
-    tweak_match = _HIPBLASLT_TWEAK_RE.search(text)
+    tweak_match = tweak_re.search(text)
     commit = tweak_match.group(1) if tweak_match else None
     parts: dict[str, str] = {}
-    for match in _HIPBLASLT_VERSION_RE.finditer(text):
+    for match in version_re.finditer(text):
         parts[match.group(1)] = match.group(2)
     if {"MAJOR", "MINOR", "PATCH"}.issubset(parts):
         package_version = f"{parts['MAJOR']}.{parts['MINOR']}.{parts['PATCH']}"
@@ -697,18 +1152,26 @@ def _parse_hipblaslt_header(text: str | None) -> tuple[str | None, str | None]:
     return (commit, package_version)
 
 
-def _hash_hipblaslt_library() -> str | None:
-    """SHA-256 the canonical (resolved) ``libhipblaslt.so``.
+def _parse_hipblaslt_header(text: str | None) -> tuple[str | None, str | None]:
+    """Backward-compat wrapper. Kept so existing tests keep their call shape."""
+    return _parse_version_header(text, _HIPBLASLT_TWEAK_RE, _HIPBLASLT_VERSION_RE)
 
-    Resolves through symlinks so e.g. ``libhipblaslt.so`` ->
-    ``libhipblaslt.so.1`` -> ``libhipblaslt.so.1.2.70201`` collapses to one
-    hash regardless of which name the consumer linked against.
-    Returns ``"sha256:<hex>"`` or ``None``.
+
+def _hash_file_path(path: Path) -> str | None:
+    """SHA-256 a specific file path, resolving symlinks first.
+
+    Distinct from ``_hash_shared_library`` -- this one hashes a
+    **caller-supplied** Path. Use it when the caller has already done
+    a smarter selection than the glob+string-sort fallback in
+    ``_hash_shared_library`` (e.g. AOTriton's version-tuple sort that
+    correctly orders ``0.10.0`` after ``0.9.0``). Returns
+    ``"sha256:<hex>"`` or ``None``.
     """
-    candidate = HIPBLASLT_LIB_DIR / "libhipblaslt.so"
     try:
-        resolved = candidate.resolve(strict=True)
+        resolved = path.resolve(strict=True)
     except (FileNotFoundError, OSError):
+        return None
+    if not resolved.is_file():
         return None
     try:
         digest = hashlib.sha256()
@@ -721,32 +1184,107 @@ def _hash_hipblaslt_library() -> str | None:
         return None
 
 
-def _tensile_fingerprint() -> str | None:
-    """Fingerprint the Tensile kernel database.
+def _hash_shared_library(lib_dir: Path, soname: str) -> str | None:
+    """SHA-256 a shared library, resolving symlinks first.
 
-    Modern hipBLASLt ships ``.dat`` files (binary), older builds shipped
-    ``.yaml``. We hash the **sorted filenames** of all kernel files in
-    the library dir -- a fast, deterministic fingerprint that changes
-    whenever the kernel set changes (new gfx target, new operation
-    layout, removed kernel). Hashing the contents would be GB of work
-    and add seconds; the filename set already tracks the meaningful
-    drift.
+    Tries the unversioned ``soname`` (e.g. ``libfoo.so``) first; if
+    absent, falls back to the highest-versioned matching filename
+    (``libfoo.so.1.2.70201`` etc.). The unversioned ``.so`` symlink is
+    typically shipped only with ``-dev`` packages (it's a build-time
+    link target); stripped runtime-only images keep just the versioned
+    files. Without this fallback, the probe would record
+    ``lib_hash=None`` plus a misleading "missing or unreadable" reason
+    on a host where the library is fully present and being used.
+
+    Resolves through symlinks so e.g. ``libfoo.so`` -> ``libfoo.so.1`` ->
+    ``libfoo.so.1.2.3`` collapses to one hash regardless of which name
+    the consumer linked against. Returns ``"sha256:<hex>"`` or ``None``.
     """
-    if not HIPBLASLT_TENSILE_DIR.is_dir():
+    # Build candidate list: unversioned first, then any versioned
+    # filenames sorted descending so the highest-versioned wins. String
+    # sort works for the conventional ``soname.MAJOR.MINOR.PATCH``
+    # layout since each component is left-padded by the package version
+    # numbering (and where it does not, "good enough" still picks a
+    # real file deterministically).
+    candidates: list[Path] = [lib_dir / soname]
+    try:
+        versioned = sorted(lib_dir.glob(f"{soname}.*"), reverse=True)
+    except OSError as exc:
+        log.debug("glob failed for %s/%s.*: %s", lib_dir, soname, exc)
+        versioned = []
+    candidates.extend(versioned)
+
+    seen_resolved: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (FileNotFoundError, OSError):
+            continue
+        # Symlink chains may collapse to the same file; only hash once.
+        if resolved in seen_resolved:
+            continue
+        seen_resolved.add(resolved)
+        if not resolved.is_file():
+            continue
+        try:
+            digest = hashlib.sha256()
+            with resolved.open("rb") as f:
+                for chunk in iter(lambda: f.read(1 << 20), b""):
+                    digest.update(chunk)
+            return f"sha256:{digest.hexdigest()}"
+        except OSError as exc:
+            log.debug("hash failed for %s: %s", resolved, exc)
+            continue
+    return None
+
+
+def _hash_hipblaslt_library() -> str | None:
+    """Backward-compat wrapper. Kept so existing tests keep their call shape."""
+    return _hash_shared_library(HIPBLASLT_LIB_DIR, "libhipblaslt.so")
+
+
+def _kernel_db_filename_fingerprint(
+    directory: Path,
+    suffixes: tuple[str, ...] = (".yaml", ".dat", ".co"),
+) -> str | None:
+    """Fingerprint a Tensile-style kernel database by sorted filenames.
+
+    Modern hipBLASLt / rocBLAS ship ``.dat`` files (binary), older builds
+    shipped ``.yaml``; some toolchains also drop ``.co`` (code objects).
+    We hash the **sorted filenames** -- a fast, deterministic fingerprint
+    that changes whenever the kernel set changes (new gfx target, new
+    operation layout, removed kernel). Hashing the contents would be GB
+    of work and add seconds; the filename set already tracks the
+    meaningful drift.
+
+    Assumes a **flat layout** -- only the top-level directory is scanned
+    (no recursion). Verified flat on ROCm 5.x / 6.x / 7.x for both
+    ``/opt/rocm/lib/hipblaslt/library/`` and
+    ``/opt/rocm/lib/rocblas/library/``. If a future release switches to
+    per-gfx-target subdirectories, swap ``iterdir()`` for ``rglob("*")``
+    -- but doing so unconditionally would also pull in unrelated cache
+    files some packagers drop alongside the kernel DB.
+    """
+    if not directory.is_dir():
         return None
     try:
         names = sorted(
             p.name
-            for p in HIPBLASLT_TENSILE_DIR.iterdir()
-            if p.is_file() and p.suffix in (".yaml", ".dat", ".co")
+            for p in directory.iterdir()
+            if p.is_file() and p.suffix in suffixes
         )
     except OSError as exc:
-        log.debug("tensile dir listing failed: %s", exc)
+        log.debug("kernel-db dir listing failed for %s: %s", directory, exc)
         return None
     if not names:
         return None
     digest = hashlib.sha256("\n".join(names).encode("utf-8")).hexdigest()
     return f"filenames-sha256:{digest}"
+
+
+def _tensile_fingerprint() -> str | None:
+    """Backward-compat wrapper. Kept so existing tests keep their call shape."""
+    return _kernel_db_filename_fingerprint(HIPBLASLT_TENSILE_DIR)
 
 
 # ---------------------------------------------------------------------------
@@ -909,12 +1447,103 @@ def _capture_env_vars() -> dict[str, str | None]:
     return {name: os.environ.get(name) for name in CANONICAL_ENV_VARS}
 
 
-def _capture_pytorch_version(reasons: list[str]) -> str | None:
-    """Best-effort import of torch to read its version. No GPU touched.
+def _capture_python_package_version(
+    package_name: str,
+    reasons: list[str],
+    *,
+    reason_prefix: str | None = None,
+    suppress_missing: bool = False,
+) -> str | None:
+    """Best-effort import of a Python package to read its ``__version__``.
 
-    ``import torch`` does NOT initialise CUDA / HIP context; it only
-    populates Python objects. Acceptance criterion "no GPU compute" is
-    preserved.
+    The same fail-soft contract as ``_capture_pytorch_version``: catches
+    ImportError + any other unexpected import-time exception, never
+    initialises GPU context (uses ``__import__`` directly so caller
+    behaviour is identical to ``import package_name``), and never returns
+    the string ``"None"``.
+
+    Args:
+        package_name: The module name to import (e.g. ``"triton"``).
+        reasons: Shared partial-reasons list to append to on any fallback.
+        reason_prefix: The prefix used when appending to ``reasons``.
+            Defaults to ``f"{package_name}_version"`` (mirrors the existing
+            ``pytorch_version: ...`` shape). Pass an explicit string when
+            the snapshot field is named differently from the package
+            (e.g. ``"fbgemm.package_version"``).
+        suppress_missing: When True, don't append a partial reason for a
+            plain ``ImportError`` -- the absence of this package is the
+            documented common case (used for fbgemm_gpu / aiter, which
+            most stock installs lack). Other failures (broken __version__,
+            unexpected exception) still record a reason.
+    """
+    prefix = reason_prefix or f"{package_name}_version"
+    # ``__import__`` returns the *top-level* module for dotted names
+    # (so ``__import__("a.b.c")`` returns ``a``, not ``a.b.c``). Every
+    # caller passes a top-level package name (torch, triton, fbgemm_gpu,
+    # aiter, Tensile), so this is fine. Switch to ``importlib`` if you
+    # ever need to probe a leaf module's ``__version__``.
+    try:
+        mod = __import__(package_name)
+    except ImportError:
+        if not suppress_missing:
+            reasons.append(f"{prefix}: {package_name} not importable")
+        return None
+    except Exception as exc:  # noqa: BLE001 -- defensive; never let env probe fail
+        log.debug("%s import for version probe failed: %s", package_name, exc)
+        reasons.append(
+            f"{prefix}: {package_name} import raised ({type(exc).__name__})"
+        )
+        return None
+
+    version = getattr(mod, "__version__", None)
+    if version is None:
+        reasons.append(
+            f"{prefix}: {package_name} lacks __version__ attribute"
+        )
+        return None
+    return str(version)
+
+
+def _safe_import_torch(reasons: list[str], probe_name: str) -> Any | None:
+    """Try ``import torch``; return the module or ``None``.
+
+    Centralised so every probe that needs torch (composable_kernel,
+    aotriton, fbgemm flag scan, CK flag scan, pytorch_build) can use a
+    single fail-soft import path. Three outcomes:
+
+    * ``ImportError`` -> return ``None`` **silently**. The
+      ``pytorch_version`` probe already records torch absence; every
+      other probe shares that signal and shouldn't double-count.
+    * Any other ``Exception`` (broken install, partial wheel,
+      C-extension load failure) -> log + record one
+      ``"<probe_name>: torch import raised (<exc-type>)"`` reason and
+      return ``None``.
+    * Success -> return the imported module.
+
+    The probe_name string is the partial-reason prefix (e.g.
+    ``"composable_kernel.pytorch_bundled"``,
+    ``"aotriton"``). Use the same prefix the rest of that probe uses
+    so partial_reasons stay grep-consistent.
+    """
+    try:
+        return __import__("torch")
+    except ImportError:
+        return None
+    except Exception as exc:  # noqa: BLE001 -- defensive; never let env probe fail
+        log.debug("torch import for %s probe failed: %s", probe_name, exc)
+        reasons.append(f"{probe_name}: torch import raised ({type(exc).__name__})")
+        return None
+
+
+def _capture_pytorch_version(reasons: list[str]) -> str | None:
+    """Best-effort import of torch to read its version. No GPU work.
+
+    ``import torch`` will ``dlopen`` HIP runtime libraries (so the
+    process's loaded-libraries list grows), but it does NOT allocate
+    device memory, launch kernels, or otherwise produce HIP API calls
+    that ``rocprofv3 --hip-trace`` would record. The acceptance
+    criterion "no GPU compute" -- meaning zero kernel dispatches and
+    zero device allocations -- is preserved.
 
     Returns the version as a string when available, or ``None`` when torch
     is not installed OR is installed without a ``__version__`` attribute.
@@ -922,18 +1551,1168 @@ def _capture_pytorch_version(reasons: list[str]) -> str | None:
     ``"None"`` -- that would break consumers doing strict null checks
     against the JSON.
     """
-    try:
-        import torch  # type: ignore[import-not-found]
-    except ImportError:
-        reasons.append("pytorch_version: torch not importable")
-        return None
-    except Exception as exc:  # noqa: BLE001 -- defensive; never let env probe fail
-        log.debug("torch import for version probe failed: %s", exc)
-        reasons.append(f"pytorch_version: torch import raised ({type(exc).__name__})")
-        return None
+    return _capture_python_package_version(
+        "torch", reasons, reason_prefix="pytorch_version"
+    )
 
-    version = getattr(torch, "__version__", None)
-    if version is None:
-        reasons.append("pytorch_version: torch lacks __version__ attribute")
+
+# ---------------------------------------------------------------------------
+# rocBLAS introspection -- mirrors the hipBLASLt block 1:1
+# ---------------------------------------------------------------------------
+
+
+def _capture_rocblas(reasons: list[str]) -> dict[str, Any]:
+    """Capture rocBLAS build identity.
+
+    Same shape and contract as ``_capture_hipblaslt`` -- two trials with
+    different rocBLAS Tensile databases or different librocblas.so
+    contents become trivially diffable. Reuses the generic
+    ``_parse_version_header`` / ``_hash_shared_library`` /
+    ``_kernel_db_filename_fingerprint`` helpers.
+
+    See ``_capture_hipblaslt`` for the ``rocm_release_tweak`` vs
+    upstream-commit distinction -- ``ROCBLAS_VERSION_TWEAK`` is the
+    same ROCm-release-shared identifier, NOT a per-rocBLAS commit.
+
+    The header lives at ``/opt/rocm/include/rocblas/internal/rocblas-version.h``
+    (note the ``internal/`` subdir, unlike hipblaslt). It ships with
+    ``rocblas-dev``; the runtime lib + Tensile DB ship with the runtime
+    ``rocblas`` package and are usually present even in stripped images.
+
+    ``applied_prs`` is intentionally empty in this first cut, mirroring
+    the hipblaslt convention.
+    """
+    header_text = _read_text_file(ROCBLAS_VERSION_HEADER)
+    rocm_release_tweak, package_version = _parse_version_header(
+        header_text, _ROCBLAS_TWEAK_RE, _ROCBLAS_VERSION_RE
+    )
+    lib_hash = _hash_shared_library(ROCBLAS_LIB_DIR, "librocblas.so")
+    # Renamed from `tensile_yaml_revision` in schema 1.1 -- see hipblaslt
+    # block for the rationale.
+    kernel_db_revision = _kernel_db_filename_fingerprint(ROCBLAS_TENSILE_DIR)
+
+    block: dict[str, Any] = {
+        "rocm_release_tweak": rocm_release_tweak,
+        "package_version": package_version,
+        "lib_hash": lib_hash,
+        "kernel_db_revision": kernel_db_revision,
+        "applied_prs": {},
+    }
+    header_unreadable = header_text is None
+    if rocm_release_tweak is None:
+        if header_unreadable:
+            reasons.append(
+                f"rocblas.rocm_release_tweak: {ROCBLAS_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"rocblas.rocm_release_tweak: {ROCBLAS_VERSION_HEADER} did not "
+                "contain a readable ROCBLAS_VERSION_TWEAK define"
+            )
+    if package_version is None:
+        if header_unreadable:
+            reasons.append(
+                f"rocblas.package_version: {ROCBLAS_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"rocblas.package_version: {ROCBLAS_VERSION_HEADER} did not "
+                "contain MAJOR/MINOR/PATCH defines"
+            )
+    if lib_hash is None:
+        reasons.append(
+            f"rocblas.lib_hash: {ROCBLAS_LIB_DIR}/librocblas.so "
+            "missing or unreadable"
+        )
+    if kernel_db_revision is None:
+        reasons.append(
+            "rocblas.kernel_db_revision: directory missing/unreadable "
+            f"or no kernel files under {ROCBLAS_TENSILE_DIR}"
+        )
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Composable Kernel (CK) -- two layers: system headers + PyTorch-bundled
+# ---------------------------------------------------------------------------
+
+
+def _capture_composable_kernel(reasons: list[str]) -> dict[str, Any]:
+    """Capture Composable Kernel identity at both layers.
+
+    CK ships in two places that can drift independently:
+
+    * **system**: header-only install at ``/opt/rocm/include/ck/`` from
+      the ``composablekernel-dev`` apt package. Other ROCm libs
+      (rocBLAS, hipBLASLt, MIOpen) statically link CK kernels built
+      against this version at *their* build time.
+    * **pytorch_bundled**: vendored as a git submodule at
+      ``third_party/composable_kernel/`` inside the PyTorch source tree;
+      compiled into ``libtorch_hip.so`` at PyTorch wheel build time.
+      Distinct from the system version -- often a different commit.
+
+    Both are knowable from the installed environment without running any
+    HIP code; both are recorded so cross-env diffs surface either drift.
+
+    The two sub-blocks fail independently: a host with the
+    ``composablekernel-dev`` package stripped will see ``system.*`` go
+    null + reason while ``pytorch_bundled.*`` populates from the wheel
+    on disk, and vice versa for a CPU-only PyTorch install with the
+    system CK package present.
+    """
+    # ------- system sub-block -------
+    header_text = _read_text_file(CK_VERSION_HEADER)
+    sys_version, sys_commit = _parse_ck_header(header_text)
+    ck_tile_present = CK_TILE_CONFIG_HEADER.exists()
+    system_block: dict[str, Any] = {
+        "version": sys_version,
+        "commit": sys_commit,
+        "ck_tile_present": ck_tile_present,
+    }
+    header_unreadable = header_text is None
+    if sys_version is None:
+        if header_unreadable:
+            reasons.append(
+                f"composable_kernel.system.version: {CK_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"composable_kernel.system.version: {CK_VERSION_HEADER} did not "
+                "contain MAJOR/MINOR/PATCH defines"
+            )
+    if sys_commit is None:
+        if header_unreadable:
+            reasons.append(
+                f"composable_kernel.system.commit: {CK_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"composable_kernel.system.commit: {CK_VERSION_HEADER} did not "
+                "contain a readable CK_COMMIT_ID define"
+            )
+
+    # ------- pytorch_bundled sub-block -------
+    bundled_block = _probe_pytorch_bundled_ck(reasons)
+
+    # ------- build-time PyTorch CK dispatch flags -------
+    # These are -DUSE_ROCM_CK_{SDPA,GEMM} cmake flags baked into the
+    # wheel, NOT runtime env vars (a common misconception -- setting
+    # USE_ROCM_CK_SDPA in the workload's env does nothing). Mirrors
+    # the fbgemm.pytorch_use_fbgemm{,_genai} pattern.
+    use_ck_sdpa, use_ck_gemm = _read_pytorch_ck_flags(reasons)
+
+    return {
+        "system": system_block,
+        "pytorch_bundled": bundled_block,
+        "pytorch_use_ck_sdpa": use_ck_sdpa,
+        "pytorch_use_ck_gemm": use_ck_gemm,
+    }
+
+
+def _read_pytorch_ck_flags(reasons: list[str]) -> tuple[bool | None, bool | None]:
+    """Parse ``torch.__config__.show()`` for the CK build-time flags.
+
+    Returns ``(use_ck_sdpa, use_ck_gemm)``. Both ``None`` when torch is
+    absent or ``__config__`` raises (rare). When torch is present, the
+    booleans reflect whether ``-DUSE_ROCM_CK_SDPA`` / ``-DUSE_ROCM_CK_GEMM``
+    appear in CXX_FLAGS. ``False`` is meaningful (a wheel deliberately
+    built with the CK SDPA/GEMM path disabled, dispatching to AOTriton
+    or non-CK rocBLAS instead); distinct from ``None`` (couldn't ask).
+    """
+    torch_mod = _safe_import_torch(reasons, "composable_kernel.pytorch_use_ck_sdpa")
+    if torch_mod is None:
+        return (None, None)
+    config = getattr(torch_mod, "__config__", None)
+    show = getattr(config, "show", None)
+    if show is None:
+        reasons.append(
+            "composable_kernel.pytorch_use_ck_sdpa: torch.__config__.show unavailable"
+        )
+        return (None, None)
+    try:
+        config_text = show()
+    except Exception as exc:  # noqa: BLE001
+        log.debug("torch.__config__.show() raised: %s", exc)
+        reasons.append(
+            f"composable_kernel.pytorch_use_ck_sdpa: torch.__config__.show() raised "
+            f"({type(exc).__name__})"
+        )
+        return (None, None)
+    use_ck_sdpa = bool(_CK_SDPA_DEFINE_RE.search(config_text))
+    use_ck_gemm = bool(_CK_GEMM_DEFINE_RE.search(config_text))
+    return (use_ck_sdpa, use_ck_gemm)
+
+
+def _parse_ck_header(text: str | None) -> tuple[str | None, str | None]:
+    """Extract (version_str, commit) from CK's version.h.
+
+    Note the ordering vs. ``_parse_version_header``: CK records the
+    *version* as MAJOR.MINOR.PATCH and the *commit* as a separate full-SHA
+    define, so the helper returns version first to match how the
+    ``composable_kernel.system`` sub-block is shaped.
+    """
+    if not text:
+        return (None, None)
+    parts: dict[str, str] = {}
+    for match in _CK_VERSION_RE.finditer(text):
+        parts[match.group(1)] = match.group(2)
+    if {"MAJOR", "MINOR", "PATCH"}.issubset(parts):
+        version = f"{parts['MAJOR']}.{parts['MINOR']}.{parts['PATCH']}"
+    else:
+        version = None
+    commit_match = _CK_COMMIT_RE.search(text)
+    commit = commit_match.group(1) if commit_match else None
+    return (version, commit)
+
+
+def _probe_pytorch_bundled_ck(reasons: list[str]) -> dict[str, Any]:
+    """Look for ``ck::`` symbols inside ``libtorch_hip.so``.
+
+    Strategy: locate the lib via ``torch.__file__`` (no HIP context init),
+    then run ``nm -D <lib>`` piped through ``c++filt`` and count
+    occurrences of the ``ck::`` namespace prefix. Falls back to
+    ``present=False, symbol_count=None`` plus a partial reason whenever
+    any step is unavailable (torch broken, binutils stripped from the
+    container, subprocess timeout).
+
+    Documented absences that **do not** trigger ``partial=True``:
+
+    * ``import torch`` raises ImportError (already captured by the
+      ``pytorch_version`` probe -- no need to duplicate the reason).
+    * ``torch.version.hip is None`` (this is a CPU-only PyTorch wheel,
+      so ``libtorch_hip.so`` is legitimately absent by design).
+
+    ``-D`` (dynamic symbols only) is much faster than the full symbol
+    table on a multi-hundred-MB lib while still covering every CK kernel
+    that's actually exposed for dispatch.
+    """
+    default = {"present": False, "symbol_count": None}
+
+    # Locate libtorch_hip.so via torch.__file__. The helper shares the
+    # same no-HIP-context guarantee as _capture_python_package_version
+    # (only does __import__, never touches torch.cuda).
+    torch_mod = _safe_import_torch(reasons, "composable_kernel.pytorch_bundled")
+    if torch_mod is None:
+        return default
+
+    # CPU-only PyTorch wheel -- there is no HIP code to fingerprint.
+    # ``torch.version.hip`` is the canonical "was this wheel built with
+    # HIP?" signal (None when not). Treat as a documented absence so a
+    # CPU-only wheel doesn't flip ``partial=True`` for the bundled-CK
+    # probe -- but the consumer can still see it from the
+    # ``pytorch_bundled.present=False`` field.
+    torch_version = getattr(torch_mod, "version", None)
+    if torch_version is not None and getattr(torch_version, "hip", None) is None:
+        return default
+
+    torch_file = getattr(torch_mod, "__file__", None)
+    if not torch_file:
+        reasons.append(
+            "composable_kernel.pytorch_bundled: torch.__file__ unavailable"
+        )
+        return default
+
+    lib_path = Path(torch_file).parent / "lib" / PYTORCH_HIP_LIB_NAME
+    if not lib_path.exists():
+        # torch.version.hip claimed HIP support but the lib is missing.
+        # That's not a CPU-only wheel (we caught those above) -- it's a
+        # broken / incomplete install worth flagging.
+        reasons.append(
+            f"composable_kernel.pytorch_bundled: {lib_path} not found "
+            "(torch.version.hip claims HIP but the runtime lib is missing)"
+        )
+        return default
+
+    nm = shutil.which("nm")
+    cxxfilt = shutil.which("c++filt")
+    if nm is None or cxxfilt is None:
+        reasons.append(
+            "composable_kernel.pytorch_bundled: nm/c++filt not on PATH "
+            "(install binutils for symbol-count detection)"
+        )
+        return default
+
+    try:
+        nm_proc = subprocess.run(
+            [nm, "-D", "--defined-only", str(lib_path)],
+            capture_output=True,
+            text=True,
+            timeout=NM_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        reasons.append(
+            f"composable_kernel.pytorch_bundled: nm invocation failed ({exc})"
+        )
+        return default
+    if nm_proc.returncode != 0:
+        reasons.append(
+            f"composable_kernel.pytorch_bundled: nm exited "
+            f"{nm_proc.returncode} on {lib_path}"
+        )
+        return default
+
+    try:
+        cxxfilt_proc = subprocess.run(
+            [cxxfilt],
+            input=nm_proc.stdout,
+            capture_output=True,
+            text=True,
+            timeout=NM_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        reasons.append(
+            f"composable_kernel.pytorch_bundled: c++filt invocation failed ({exc})"
+        )
+        return default
+    if cxxfilt_proc.returncode != 0:
+        reasons.append(
+            f"composable_kernel.pytorch_bundled: c++filt exited "
+            f"{cxxfilt_proc.returncode}"
+        )
+        return default
+
+    # Count exported symbols in the `ck::` namespace. We use a substring
+    # check (not a regex) for speed; demangled symbols routinely look
+    # like "ck::tensor_operation::..." so any line containing "ck::" is a
+    # CK symbol. This will also include symbols from other namespaces
+    # whose template parameters contain "ck::", but those are themselves
+    # CK-related by construction (they reference CK types), so they count.
+    symbol_count = sum(
+        1 for line in cxxfilt_proc.stdout.splitlines() if "ck::" in line
+    )
+    return {
+        "present": symbol_count > 0,
+        "symbol_count": symbol_count,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tensile -- pip-probe + cross-library kernel-DB fingerprint
+# ---------------------------------------------------------------------------
+
+
+def _capture_tensile(reasons: list[str]) -> dict[str, Any]:
+    """Capture Tensile build-time identity.
+
+    Tensile is a build-time Python tool that generates GEMM kernels for
+    rocBLAS and hipBLASLt; it is not a runtime artifact. Two surfaces:
+
+    * ``package_version``: pip-probe ``Tensile`` if it happens to be
+      installed (rare on production hosts; common on rocBLAS builders).
+      Suppressed from partial_reasons because absence is the norm.
+    * ``kernel_db_combined_hash``: a single fingerprint over the union
+      of the hipBLASLt + rocBLAS kernel databases, so any drift in the
+      Tensile *output* is captured even when Tensile itself isn't on
+      disk. Marked partial only when *both* dirs are missing.
+    """
+    package_version = _capture_python_package_version(
+        "Tensile",
+        reasons,
+        reason_prefix="tensile.package_version",
+        suppress_missing=True,
+    )
+    combined_hash = _combined_kernel_db_fingerprint(
+        [HIPBLASLT_TENSILE_DIR, ROCBLAS_TENSILE_DIR]
+    )
+    if combined_hash is None:
+        reasons.append(
+            "tensile.kernel_db_combined_hash: no kernel files under "
+            f"{HIPBLASLT_TENSILE_DIR} or {ROCBLAS_TENSILE_DIR}"
+        )
+    return {
+        "package_version": package_version,
+        "kernel_db_combined_hash": combined_hash,
+    }
+
+
+def _combined_kernel_db_fingerprint(
+    directories: list[Path],
+    suffixes: tuple[str, ...] = (".yaml", ".dat", ".co"),
+) -> str | None:
+    """SHA-256 the sorted union of ``(library_name, filename)`` pairs.
+
+    Tagging each filename with its **library's** name (the parent dir's
+    basename, since each library puts its kernel DB under
+    ``<library>/library/``) keeps the fingerprint distinguishable when
+    the same kernel name appears in multiple libraries' databases.
+    Using ``d.name`` directly would collapse to ``"library"`` for both
+    hipBLASLt and rocBLAS -- ``d.parent.name`` is what makes this work.
+
+    Returns ``None`` only when *every* input directory is missing or
+    empty.
+    """
+    pairs: list[str] = []
+    for d in directories:
+        if not d.is_dir():
+            continue
+        # `d` is e.g. /opt/rocm/lib/hipblaslt/library; the meaningful
+        # tag is the library name one level up.
+        tag = d.parent.name or d.name
+        try:
+            for p in d.iterdir():
+                if p.is_file() and p.suffix in suffixes:
+                    pairs.append(f"{tag}/{p.name}")
+        except OSError as exc:
+            log.debug("combined kernel-db listing failed for %s: %s", d, exc)
+            continue
+    if not pairs:
         return None
-    return str(version)
+    pairs.sort()
+    digest = hashlib.sha256("\n".join(pairs).encode("utf-8")).hexdigest()
+    return f"filenames-sha256:{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Triton / FBGEMM / AITER -- pure Python-package version probes
+# ---------------------------------------------------------------------------
+
+
+def _capture_triton(reasons: list[str]) -> dict[str, str | None]:
+    """Capture Triton package version.
+
+    The ROCm Triton fork puts the source commit into ``__version__``
+    (e.g. ``"3.5.1+rocm7.2.1.gita272dfa8"``), so this single field
+    captures both the upstream version and the fork commit. No header
+    parsing needed.
+    """
+    return {
+        "package_version": _capture_python_package_version(
+            "triton", reasons, reason_prefix="triton.package_version"
+        ),
+    }
+
+
+def _capture_fbgemm(reasons: list[str]) -> dict[str, Any]:
+    """Capture FBGEMM identity.
+
+    FBGEMM is usually vendored inside the PyTorch wheel rather than
+    installed as a separate ``fbgemm_gpu`` pip package. So we capture
+    both surfaces:
+
+    * ``package_version``: pip-probe ``fbgemm_gpu``; absence is
+      suppressed from partial_reasons (the common case for stock
+      ``pip install torch`` is no separate fbgemm_gpu).
+    * ``pytorch_use_fbgemm`` / ``pytorch_use_fbgemm_genai``: parsed
+      from ``torch.__config__.show()`` -- whether the PyTorch wheel was
+      built with ``-DUSE_FBGEMM`` / ``-DUSE_FBGEMM_GENAI``. These reflect
+      the actual code paths compiled into ``libtorch_cpu.so`` /
+      ``libtorch_hip.so``, regardless of whether fbgemm_gpu is
+      separately installed.
+    """
+    package_version = _capture_python_package_version(
+        "fbgemm_gpu",
+        reasons,
+        reason_prefix="fbgemm.package_version",
+        suppress_missing=True,
+    )
+    use_fbgemm, use_fbgemm_genai = _read_pytorch_fbgemm_flags(reasons)
+    return {
+        "package_version": package_version,
+        "pytorch_use_fbgemm": use_fbgemm,
+        "pytorch_use_fbgemm_genai": use_fbgemm_genai,
+    }
+
+
+def _read_pytorch_fbgemm_flags(
+    reasons: list[str],
+) -> tuple[bool | None, bool | None]:
+    """Parse ``torch.__config__.show()`` for the FBGEMM compile-time flags.
+
+    Returns ``(use_fbgemm, use_fbgemm_genai)``. Both are ``None`` when
+    torch is absent or ``__config__`` raises (rare). When torch is
+    present, the booleans reflect whether ``-DUSE_FBGEMM`` /
+    ``-DUSE_FBGEMM_GENAI`` appear in the build's CXX_FLAGS. ``False``
+    is a meaningful answer (a ROCm wheel deliberately built without
+    FBGEMM-GENAI), distinct from ``None`` (couldn't ask).
+    """
+    torch_mod = _safe_import_torch(reasons, "fbgemm.pytorch_use_fbgemm")
+    if torch_mod is None:
+        return (None, None)
+    config = getattr(torch_mod, "__config__", None)
+    show = getattr(config, "show", None)
+    if show is None:
+        reasons.append(
+            "fbgemm.pytorch_use_fbgemm: torch.__config__.show unavailable"
+        )
+        return (None, None)
+    try:
+        config_text = show()
+    except Exception as exc:  # noqa: BLE001
+        log.debug("torch.__config__.show() raised: %s", exc)
+        reasons.append(
+            f"fbgemm.pytorch_use_fbgemm: torch.__config__.show() raised "
+            f"({type(exc).__name__})"
+        )
+        return (None, None)
+    use_fbgemm = bool(_FBGEMM_DEFINE_RE.search(config_text))
+    use_fbgemm_genai = bool(_FBGEMM_GENAI_DEFINE_RE.search(config_text))
+    return (use_fbgemm, use_fbgemm_genai)
+
+
+def _capture_aiter(reasons: list[str]) -> dict[str, str | None]:
+    """Capture AITER (AMD Iterative kernel library) version.
+
+    AITER is a PyPI-distributed ROCm inference kernel library built on
+    top of CK. Most environments don't have it installed; absence is
+    suppressed from partial_reasons.
+
+    Note: upstream PyTorch now vendors AITER as a third_party/ submodule
+    too -- see :func:`_capture_pytorch_build` for the bundled-commit
+    probe. This block only covers the standalone pip distribution.
+    """
+    return {
+        "package_version": _capture_python_package_version(
+            "aiter",
+            reasons,
+            reason_prefix="aiter.package_version",
+            suppress_missing=True,
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# PyTorch build identity -- structured complement to ``pytorch_version``
+# ---------------------------------------------------------------------------
+
+
+def _capture_pytorch_build(reasons: list[str]) -> dict[str, Any]:
+    """Capture structured PyTorch build identity.
+
+    Complements the flat ``pytorch_version`` field with the build
+    metadata that ``torch.version`` exposes (always available on a
+    PyTorch install) plus per-submodule SHAs from the source tree (when
+    available). Reproducibility-critical for two reasons:
+
+    * ``git_commit`` is the linchpin: it deterministically pins every
+      vendored submodule. An operator with only ``env.json`` can resolve
+      ``third_party/composable_kernel``, ``third_party/aiter``, and
+      ``third_party/fbgemm`` to specific commits via the GitHub tree at
+      that SHA -- no source tree required.
+    * ``submodule_commits.*`` give the answer directly when a source
+      tree is available (set ``AORTA_PYTORCH_SRC=/path/to/pytorch``, or
+      auto-detected for editable / source installs).
+
+    No GPU work. ``import torch`` populates Python objects; this probe
+    only reads attributes off the imported module and runs ``git``
+    subprocesses against a filesystem path.
+    """
+    install_kind, source_path = _detect_pytorch_install_kind()
+
+    # torch.version.* fields. Defaults if torch is absent or the
+    # `version` attribute is missing.
+    git_commit: str | None = None
+    hip_version: str | None = None
+    cuda_version: str | None = None
+    debug: bool | None = None
+
+    # pytorch_version probe already records ImportError; helper stays
+    # silent on that path. Records a reason only for unexpected
+    # import-time exceptions.
+    torch_mod = _safe_import_torch(reasons, "pytorch_build")
+    if torch_mod is not None:
+        version = getattr(torch_mod, "version", None)
+        if version is None:
+            reasons.append(
+                "pytorch_build: torch.version unavailable (unexpectedly old build?)"
+            )
+        else:
+            git_commit = getattr(version, "git_version", None) or None
+            hip_version = getattr(version, "hip", None) or None
+            cuda_version = getattr(version, "cuda", None) or None
+            debug = getattr(version, "debug", None)
+            if git_commit is None:
+                reasons.append(
+                    "pytorch_build.git_commit: torch.version.git_version is null"
+                )
+
+    submodule_commits = _capture_pytorch_submodules(
+        install_kind, source_path, git_commit, reasons
+    )
+
+    return {
+        "git_commit": git_commit,
+        "hip_version": hip_version,
+        "cuda_version": cuda_version,
+        "debug": debug,
+        "install_kind": install_kind,
+        "source_path": str(source_path) if source_path else None,
+        "submodule_commits": submodule_commits,
+    }
+
+
+def _detect_pytorch_install_kind() -> tuple[str, Path | None]:
+    """Determine how PyTorch is installed.
+
+    Returns ``(install_kind, source_path)``:
+
+    * ``"source"`` -- explicit ``$AORTA_PYTORCH_SRC`` points at a tree
+      with ``third_party/``; OR walking up from ``torch.__file__`` finds
+      a ``.git`` + ``third_party/`` combo (common for `python -c "import
+      torch"` from inside a checkout where the local torch dir shadows
+      the installed wheel).
+    * ``"editable"`` -- the install metadata's ``direct_url.json`` (PEP
+      660) marks the install as editable AND the URL points at a
+      directory with ``third_party/``.
+    * ``"wheel"`` -- default. The ``third_party/`` tree is not on disk;
+      submodule SHAs are recoverable only via the wheel's
+      ``git_commit`` + GitHub lookup.
+    * ``"unknown"`` -- torch import failed; we can't introspect.
+
+    Cheap and side-effect-free: zero subprocesses, only stat() + a
+    single small JSON read for the editable-install marker.
+    """
+    src_env = os.environ.get(AORTA_PYTORCH_SRC_ENV)
+    if src_env:
+        candidate = Path(src_env).expanduser()
+        if (candidate / "third_party").is_dir():
+            return ("source", candidate.resolve())
+        # Honour the env-var intent but fall through if the directory
+        # doesn't actually have third_party/. The reasons list will
+        # catch it from _capture_pytorch_submodules.
+
+    try:
+        torch_mod = __import__("torch")
+    except Exception:  # noqa: BLE001 -- ImportError + any unexpected failure both yield "unknown"
+        return ("unknown", None)
+
+    torch_file = getattr(torch_mod, "__file__", None)
+    if not torch_file:
+        return ("unknown", None)
+    torch_dir = Path(torch_file).parent
+
+    # Editable install marker (PEP 660). The .dist-info layout puts a
+    # `direct_url.json` next to METADATA when `pip install -e` was used.
+    torch_version = getattr(torch_mod, "__version__", "") or ""
+    if torch_version:
+        direct_url = (
+            torch_dir.parent / f"torch-{torch_version}.dist-info" / "direct_url.json"
+        )
+        if direct_url.exists():
+            try:
+                data = json.loads(direct_url.read_text(encoding="utf-8"))
+                if data.get("dir_info", {}).get("editable") and "url" in data:
+                    src = Path(data["url"].removeprefix("file://"))
+                    if (src / "third_party").is_dir():
+                        return ("editable", src.resolve())
+            except (OSError, json.JSONDecodeError) as exc:
+                log.debug("editable-install detection: %s", exc)
+
+    # Walk up from torch.__file__ looking for a .git + third_party
+    # combo (catches imports from inside a source checkout).
+    for parent in (torch_dir.parent, torch_dir.parent.parent):
+        if (parent / ".git").exists() and (parent / "third_party").is_dir():
+            return ("source", parent.resolve())
+
+    return ("wheel", None)
+
+
+def _capture_pytorch_submodules(
+    install_kind: str,
+    source_path: Path | None,
+    git_commit: str | None,
+    reasons: list[str],
+) -> dict[str, str | None | dict | None]:
+    """Resolve third_party submodule SHAs.
+
+    Layered:
+
+    * source / editable: ``git -C <src>/third_party/<name> rev-parse
+      HEAD`` per submodule. ``_source = "git"`` records the provenance.
+    * wheel / unknown: every submodule is ``None`` and a single
+      partial_reasons line tells the operator how to look the SHAs up
+      via the GitHub tree at the captured ``git_commit``. The reason
+      uses the literal URL template so the operator never has to leave
+      the env.json to find the recovery path.
+    """
+    result: dict[str, Any] = {name: None for name in CANONICAL_PYTORCH_SUBMODULES}
+    result["_source"] = None
+
+    if install_kind in ("source", "editable") and source_path is not None:
+        third_party = source_path / "third_party"
+        if not third_party.is_dir():
+            reasons.append(
+                f"pytorch_build.submodule_commits: {third_party} missing "
+                f"on detected {install_kind} tree at {source_path}"
+            )
+            return result
+
+        ok_count = 0
+        missing: list[str] = []
+        for name in CANONICAL_PYTORCH_SUBMODULES:
+            sub_dir = third_party / name
+            if not sub_dir.exists():
+                # Submodule pin may post-date this commit; record but
+                # don't make it noisy.
+                missing.append(name)
+                continue
+            sha = _git_rev_parse_head(sub_dir)
+            if sha:
+                result[name] = sha
+                ok_count += 1
+            else:
+                missing.append(name)
+        if ok_count > 0:
+            result["_source"] = "git"
+        if missing:
+            reasons.append(
+                "pytorch_build.submodule_commits: source tree at "
+                f"{source_path} has no readable git checkout for: "
+                + ", ".join(missing)
+            )
+        return result
+
+    # Wheel / unknown: print the recovery hint with the captured commit
+    # substituted in (when known). Operators reading partial_reasons
+    # get a copy-pasteable URL.
+    if install_kind == "wheel":
+        commit = git_commit or "<git_commit>"
+        url_template = _PYTORCH_SUBMODULE_LOOKUP_HINT.replace(
+            "<git_commit>", commit
+        )
+        reasons.append(
+            "pytorch_build.submodule_commits: wheel install -- direct "
+            "SHAs not recoverable; resolve via "
+            f"{url_template} (set {AORTA_PYTORCH_SRC_ENV}=<src> to enable "
+            "in-process probing)"
+        )
+    elif install_kind == "unknown":
+        reasons.append(
+            "pytorch_build.submodule_commits: torch import failed -- "
+            "submodule SHAs unrecoverable"
+        )
+    return result
+
+
+def _capture_aotriton(reasons: list[str]) -> dict[str, Any]:
+    """Capture AOTriton identity (default ROCm Flash Attention backend).
+
+    AOTriton is fetched at PyTorch build time via
+    ``cmake/External/aotriton.cmake`` and bundled into the wheel as
+    ``<torch>/lib/libaotriton_v2.so.MAJOR.MINOR.PATCH`` plus an
+    ``aotriton.images/`` directory of pre-compiled kernel images.
+    Operators can override the bundled copy by setting
+    ``AOTRITON_INSTALLED_PREFIX`` to a system install root.
+
+    Captured fields (all always present; absent values become null +
+    partial reason where partial):
+
+    * ``bundled_present`` -- ``libaotriton_v2.so*`` exists in the
+      torch wheel's lib dir.
+    * ``bundled_version`` -- parsed from the filename
+      (``libaotriton_v2.so.0.11.1`` -> ``"0.11.1"``).
+    * ``bundled_lib_hash`` -- sha256 of the resolved file (changes
+      whenever AOTriton is rebuilt, even at the same version string).
+    * ``bundled_images_dir_present`` -- whether
+      ``<torch>/lib/aotriton.images/`` is shipped (it always should be;
+      absence indicates a non-default packaging).
+    * ``installed_prefix`` -- value of ``$AOTRITON_INSTALLED_PREFIX``,
+      or ``null`` when unset (the common case -- bundled wins).
+    """
+    default = {
+        "bundled_present": False,
+        "bundled_version": None,
+        "bundled_lib_hash": None,
+        "bundled_images_dir_present": False,
+        "installed_prefix": os.environ.get(AOTRITON_INSTALLED_PREFIX_ENV),
+    }
+
+    # AOTriton has no presence without torch loaded; documented absence
+    # -- the helper silently returns None on ImportError (the
+    # pytorch_version probe already records that), only records a
+    # reason for unexpected import-time exceptions.
+    torch_mod = _safe_import_torch(reasons, "aotriton")
+    if torch_mod is None:
+        return default
+
+    # CPU-only torch wheel won't ship AOTriton. Treat the same way as
+    # the bundled-CK probe: torch.version.hip is None -> skip silently.
+    torch_version = getattr(torch_mod, "version", None)
+    if torch_version is not None and getattr(torch_version, "hip", None) is None:
+        return default
+
+    torch_file = getattr(torch_mod, "__file__", None)
+    if not torch_file:
+        reasons.append("aotriton: torch.__file__ unavailable")
+        return default
+
+    lib_dir = Path(torch_file).parent / "lib"
+
+    # Find every libaotriton_v2.so* file. Pick the best-versioned for
+    # the version+hash; record presence/absence of the images dir.
+    try:
+        candidates = sorted(lib_dir.glob(f"{AOTRITON_LIB_PREFIX}*"))
+    except OSError as exc:
+        log.debug("aotriton glob failed in %s: %s", lib_dir, exc)
+        reasons.append(f"aotriton: failed to scan {lib_dir} ({exc})")
+        return default
+
+    images_dir = lib_dir / AOTRITON_IMAGES_DIR_NAME
+    images_present = images_dir.is_dir()
+
+    if not candidates:
+        # libtorch_hip.so was present (the CK probe verified that) but
+        # AOTriton isn't bundled -- unusual but possible (custom build,
+        # AOTriton disabled). Worth flagging but not catastrophic.
+        reasons.append(
+            f"aotriton.bundled: no {AOTRITON_LIB_PREFIX}* in {lib_dir} "
+            "(custom PyTorch build with AOTriton disabled?)"
+        )
+        block = dict(default)
+        block["bundled_images_dir_present"] = images_present
+        return block
+
+    # Pick the highest-versioned file by parsing the suffix (so
+    # `libaotriton_v2.so.0.11.1` wins over `libaotriton_v2.so.0.10.0`
+    # if both exist, regardless of mtime).
+    versioned: list[tuple[tuple[int, int, int], Path]] = []
+    for cand in candidates:
+        m = _AOTRITON_VERSION_RE.search(cand.name)
+        if m:
+            try:
+                parts = tuple(int(p) for p in m.group(1).split("."))
+                if len(parts) == 3:
+                    versioned.append((parts, cand))  # type: ignore[arg-type]
+            except ValueError:
+                continue
+
+    if versioned:
+        versioned.sort(key=lambda x: x[0], reverse=True)
+        best_path = versioned[0][1]
+        bundled_version = ".".join(str(p) for p in versioned[0][0])
+    else:
+        # Only an unversioned `libaotriton_v2.so` symlink exists; we
+        # can still hash it but won't get a version string.
+        best_path = candidates[0]
+        bundled_version = None
+        reasons.append(
+            f"aotriton.bundled_version: no versioned filename in {lib_dir} "
+            "matching libaotriton_v2.so.MAJOR.MINOR.PATCH"
+        )
+
+    # Hash the **specific** ``best_path`` we just chose by version-tuple
+    # sort. Don't fall back to ``_hash_shared_library``'s string-sort
+    # glob -- that picks the wrong file for any pair like
+    # ``libaotriton_v2.so.0.10.0`` vs ``libaotriton_v2.so.0.9.0``
+    # (lexically "0.9.0" > "0.10.0" because '9' > '1'), which would
+    # leave bundled_version and bundled_lib_hash describing different
+    # files for the same record.
+    lib_hash = _hash_file_path(best_path)
+    if lib_hash is None:
+        reasons.append(
+            f"aotriton.bundled_lib_hash: {best_path} unreadable"
+        )
+
+    return {
+        "bundled_present": True,
+        "bundled_version": bundled_version,
+        "bundled_lib_hash": lib_hash,
+        "bundled_images_dir_present": images_present,
+        "installed_prefix": os.environ.get(AOTRITON_INSTALLED_PREFIX_ENV),
+    }
+
+
+def _capture_miopen(reasons: list[str]) -> dict[str, Any]:
+    """Capture MIOpen build identity.
+
+    Same shape as hipBLASLt -- header parse + lib hash + kernel-DB
+    fingerprint. MIOpen is the GPU primitives library backing PyTorch's
+    convolution (and certain fused) kernels on ROCm; its version drift
+    is a major confound when training-loss numerics differ between
+    environments.
+
+    The kernel database lives under ``/opt/rocm/share/miopen/db/`` as
+    ``.txt`` and ``.fdb.txt`` files keyed by gfx target -- the
+    ``MIOPEN_SYSTEM_DB_PATH`` env var (in CANONICAL_ENV_VARS) overrides
+    this path at runtime, which is captured separately so a cross-env
+    diff catches the override.
+    """
+    header_text = _read_text_file(MIOPEN_VERSION_HEADER)
+    rocm_release_tweak, package_version = _parse_version_header(
+        header_text, _MIOPEN_TWEAK_RE, _MIOPEN_VERSION_RE
+    )
+    lib_hash = _hash_shared_library(MIOPEN_LIB_DIR, "libMIOpen.so")
+    kernel_db_revision = _kernel_db_filename_fingerprint(
+        MIOPEN_KERNEL_DB_DIR, suffixes=MIOPEN_KERNEL_DB_SUFFIXES
+    )
+
+    block: dict[str, Any] = {
+        # Like hipblaslt and rocblas, this is the ROCm release identifier
+        # that's shared across the whole release's library set -- NOT a
+        # per-MIOpen upstream commit. lib_hash is the per-binary signal.
+        "rocm_release_tweak": rocm_release_tweak,
+        "package_version": package_version,
+        "lib_hash": lib_hash,
+        "kernel_db_revision": kernel_db_revision,
+    }
+    header_unreadable = header_text is None
+    if rocm_release_tweak is None:
+        if header_unreadable:
+            reasons.append(
+                f"miopen.rocm_release_tweak: {MIOPEN_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"miopen.rocm_release_tweak: {MIOPEN_VERSION_HEADER} did not "
+                "contain a readable MIOPEN_VERSION_TWEAK define"
+            )
+    if package_version is None:
+        if header_unreadable:
+            reasons.append(
+                f"miopen.package_version: {MIOPEN_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"miopen.package_version: {MIOPEN_VERSION_HEADER} did not "
+                "contain MAJOR/MINOR/PATCH defines"
+            )
+    if lib_hash is None:
+        reasons.append(
+            f"miopen.lib_hash: {MIOPEN_LIB_DIR}/libMIOpen.so missing or unreadable"
+        )
+    if kernel_db_revision is None:
+        reasons.append(
+            "miopen.kernel_db_revision: directory missing/unreadable or no "
+            f".txt files under {MIOPEN_KERNEL_DB_DIR}"
+        )
+    return block
+
+
+def _capture_rccl(reasons: list[str]) -> dict[str, Any]:
+    """Capture RCCL identity (AMD's NCCL-compatible collectives lib).
+
+    The header packs the version into a single ``NCCL_VERSION_CODE``
+    integer (e.g. ``22707`` -> ``2.27.7``). We capture both the raw
+    integer (machine-comparable) and the decoded string (human-readable)
+    plus the runtime lib hash. No kernel DB.
+    """
+    header_text = _read_text_file(RCCL_VERSION_HEADER)
+    version_code, version_str = _parse_rccl_header(header_text)
+    lib_hash = _hash_shared_library(RCCL_LIB_DIR, "librccl.so")
+
+    block: dict[str, Any] = {
+        "version_code": version_code,
+        "version": version_str,
+        "lib_hash": lib_hash,
+    }
+    if version_code is None:
+        if header_text is None:
+            reasons.append(
+                f"rccl.version_code: {RCCL_VERSION_HEADER} not readable"
+            )
+        else:
+            reasons.append(
+                f"rccl.version_code: {RCCL_VERSION_HEADER} did not contain "
+                "a readable NCCL_VERSION_CODE define"
+            )
+    if lib_hash is None:
+        reasons.append(
+            f"rccl.lib_hash: {RCCL_LIB_DIR}/librccl.so missing or unreadable"
+        )
+    return block
+
+
+def _parse_rccl_header(text: str | None) -> tuple[int | None, str | None]:
+    """Extract (NCCL_VERSION_CODE int, decoded MAJOR.MINOR.PATCH).
+
+    NCCL/RCCL version encoding (per the upstream NCCL_VERSION macro):
+
+    * X <= 2 AND Y <= 8:  code = X * 1000  + Y * 100  + Z   (legacy)
+    * else:               code = X * 10000 + Y * 100  + Z   (modern)
+
+    Detect which scheme by inspecting the magnitude of the trailing
+    digits -- modern codes for X=2 are >= 20000 (since Y >= 9 implies
+    Y*100 >= 900, so code >= 20900). Legacy maxes out around 2899
+    (X=2, Y=8, Z=99).
+    """
+    if not text:
+        return (None, None)
+    m = _NCCL_VERSION_CODE_RE.search(text)
+    if not m:
+        return (None, None)
+    try:
+        code = int(m.group(1))
+    except ValueError:
+        return (None, None)
+
+    # Disambiguate scheme by code magnitude.
+    if code >= 10000:
+        major = code // 10000
+        minor = (code % 10000) // 100
+        patch = code % 100
+    else:
+        major = code // 1000
+        minor = (code % 1000) // 100
+        patch = code % 100
+    return (code, f"{major}.{minor}.{patch}")
+
+
+def _capture_gpu_arch(reasons: list[str]) -> dict[str, Any]:
+    """Capture detected GPU architecture(s) via rocm_agent_enumerator.
+
+    The binary prints one gfx-target per detected GPU on stdout (e.g.
+    ``gfx942\\ngfx942\\n...``). On most hosts this works without
+    ``/dev/kfd`` access since the kernel module exposes the architecture
+    via sysfs -- on hosts where it does require kfd, the probe records
+    the failure and falls through to None.
+
+    Always returns a fully-shaped dict; populated values are None
+    plus a partial reason on failure.
+    """
+    default = {
+        "agent_count": None,
+        "gfx_targets": None,
+        "agent_arch_counts": None,
+    }
+
+    bin_path = shutil.which(ROCM_AGENT_ENUMERATOR_BIN)
+    if bin_path is None:
+        # Try the canonical ROCM_BIN_DIR explicitly -- not always on
+        # PATH for users who haven't sourced /etc/profile.d/rocm.sh.
+        fallback = ROCM_BIN_DIR / ROCM_AGENT_ENUMERATOR_BIN
+        if fallback.exists():
+            bin_path = str(fallback)
+        else:
+            reasons.append(
+                f"gpu_arch: {ROCM_AGENT_ENUMERATOR_BIN} not on PATH "
+                f"(install rocminfo / rocm-core, or add {ROCM_BIN_DIR} to PATH)"
+            )
+            return default
+
+    try:
+        proc = subprocess.run(
+            [bin_path],
+            capture_output=True,
+            text=True,
+            timeout=SHORT_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        reasons.append(f"gpu_arch: {ROCM_AGENT_ENUMERATOR_BIN} invocation failed ({exc})")
+        return default
+
+    if proc.returncode != 0:
+        # Common failure: not in render group / no /dev/kfd access.
+        # Surface the stderr tail so the operator can act on it.
+        stderr_tail = (proc.stderr or "").strip().splitlines()
+        tail = stderr_tail[-1] if stderr_tail else "(no stderr)"
+        reasons.append(
+            f"gpu_arch: {ROCM_AGENT_ENUMERATOR_BIN} exited "
+            f"{proc.returncode} ({tail[:200]})"
+        )
+        return default
+
+    # Parse: one gfx-target per line. Filter empty lines and the
+    # "gfx000" placeholder (sometimes printed for the host CPU agent).
+    raw = [line.strip() for line in (proc.stdout or "").splitlines()]
+    targets = [t for t in raw if t and t != "gfx000"]
+    if not targets:
+        reasons.append(
+            f"gpu_arch: {ROCM_AGENT_ENUMERATOR_BIN} returned no GPU targets"
+        )
+        return default
+
+    # `gfx_targets` is the sorted unique set for quick equality checks
+    # ("did both hosts have the same arch lineup?"). `agent_arch_counts`
+    # captures the distribution -- on a homogeneous box this is a
+    # one-key dict like {"gfx942": 8}; on a mixed box it surfaces the
+    # exact mix ({"gfx1100": 1, "gfx942": 6}). Strictly more compact
+    # than carrying around an N-element flat list when N is large.
+    counts: dict[str, int] = {}
+    for t in targets:
+        counts[t] = counts.get(t, 0) + 1
+    return {
+        "agent_count": len(targets),
+        "gfx_targets": sorted(set(targets)),
+        "agent_arch_counts": dict(sorted(counts.items())),
+    }
+
+
+def _capture_host(reasons: list[str]) -> dict[str, Any]:
+    """Capture host-system identity (kernel + glibc + machine arch).
+
+    Trivially derived from stdlib, but materially useful for cross-env
+    debugging:
+
+    * ``kernel_release`` (e.g. ``"5.15.0-174-generic"``): some ROCm
+      releases break against older kernels, especially around amdgpu
+      module changes. Today this only appears inside the ``rdhc``
+      ``dkms_status`` blob, which is null on hosts without rdhc set
+      up -- a fallback here is essential.
+    * ``kernel_version`` (e.g. ``"#184-Ubuntu SMP Fri Mar 13 ..."``):
+      the build-id flavour, distinguishes patched kernels at the same
+      release tag.
+    * ``machine`` (``"x86_64"`` / ``"aarch64"``): basic but matters
+      when the same source tree gets built for multiple targets.
+    * ``glibc_version`` (e.g. ``"glibc 2.35"``): C++ extensions
+      compiled against a newer glibc fail to load on older hosts. The
+      most common "compiled-against vs runtime drift" confound after
+      HIP/ROCm versions themselves.
+    """
+    block: dict[str, Any] = {
+        "kernel_release": None,
+        "kernel_version": None,
+        "machine": None,
+        "glibc_version": None,
+    }
+    try:
+        uname = os.uname()
+    except (AttributeError, OSError) as exc:
+        log.debug("os.uname() failed: %s", exc)
+        reasons.append(f"host.kernel_release: os.uname() failed ({exc})")
+    else:
+        block["kernel_release"] = uname.release
+        block["kernel_version"] = uname.version
+        block["machine"] = uname.machine
+
+    # os.confstr is POSIX-only; on Linux it returns the GNU libc
+    # version string (e.g. "glibc 2.35"). Catch broad exceptions:
+    # confstr can raise OSError on unsupported names, AttributeError
+    # on Windows, ValueError on bad input.
+    try:
+        glibc = os.confstr("CS_GNU_LIBC_VERSION")
+    except (AttributeError, OSError, ValueError) as exc:
+        log.debug("os.confstr(CS_GNU_LIBC_VERSION) failed: %s", exc)
+        reasons.append(f"host.glibc_version: os.confstr failed ({exc})")
+    else:
+        # Strip the redundant ``glibc `` prefix (the field name already
+        # says glibc -- the value should be the bare version string,
+        # e.g. "2.35"). Falls back to the raw return when prefix
+        # absent (e.g. on a non-glibc libc that confstr happens to
+        # answer for).
+        if glibc:
+            stripped = glibc.removeprefix("glibc ").strip()
+            block["glibc_version"] = stripped or None
+        else:
+            reasons.append(
+                "host.glibc_version: os.confstr(CS_GNU_LIBC_VERSION) returned empty"
+            )
+    return block
+
+
+def _git_rev_parse_head(repo_or_submodule_dir: Path) -> str | None:
+    """Run ``git -C <dir> rev-parse HEAD``. Fail-soft.
+
+    Works for both ``.git`` directories AND submodules (which have a
+    ``.git`` *file* pointing at the parent's ``.git/modules/...``).
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_or_submodule_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=SHORT_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        log.debug("git rev-parse failed for %s: %s", repo_or_submodule_dir, exc)
+        return None
+    if proc.returncode != 0:
+        return None
+    sha = (proc.stdout or "").strip()
+    # Hard-validate to a hex SHA so a misconfigured `git` aliasing
+    # rev-parse to something else can't poison the snapshot.
+    if not sha or not all(c in "0123456789abcdefABCDEF" for c in sha):
+        return None
+    return sha

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -77,11 +77,19 @@ SCHEMA_VERSION = "1.1"
 #   - Added top-level `host`, `miopen`, `rccl`, `gpu_arch`, `aotriton`,
 #     `pytorch_build`, `composable_kernel`, `tensile`, `triton`,
 #     `fbgemm`, `aiter`, `rocblas` blocks. All purely additive.
-#   - Added 7 new env vars to CANONICAL_ENV_VARS (HIP_VISIBLE_DEVICES,
-#     ROCR_VISIBLE_DEVICES, HSA_OVERRIDE_GFX_VERSION,
-#     HIP_LAUNCH_BLOCKING, MIOPEN_FIND_MODE, TORCH_HIPBLASLT_TUNING_FILE,
-#     TORCH_HIPBLASLT_TUNING_OVERRIDE_FILE) plus the SDPA/Tuning/MIOpen
-#     family from earlier.
+#   - Expanded CANONICAL_ENV_VARS across GPU scoping
+#     (HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES /
+#     HSA_OVERRIDE_GFX_VERSION), launch (HIP_LAUNCH_BLOCKING), build
+#     target (PYTORCH_ROCM_ARCH), MIOpen kernel-DB selection
+#     (MIOPEN_SYSTEM_DB_PATH / MIOPEN_USER_DB_PATH /
+#     MIOPEN_DEBUG_DISABLE_FIND_DB / MIOPEN_FIND_MODE), SDPA backend
+#     (TORCH_ROCM_FA_PREFER_CK / TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL),
+#     hipBLASLt autotune (TORCH_BLAS_PREFER_HIPBLASLT /
+#     TORCH_HIPBLASLT_TUNING_FILE / TORCH_HIPBLASLT_TUNING_OVERRIDE_FILE),
+#     and NCCL/RCCL extras (NCCL_P2P_LEVEL / NCCL_IB_HCA /
+#     NCCL_SOCKET_IFNAME / RCCL_MSCCL_ENABLE). Removed USE_ROCM_CK_SDPA
+#     (build-time cmake flag, see above). See CANONICAL_ENV_VARS for
+#     the full set.
 #   - host.glibc_version no longer carries the redundant "glibc "
 #     prefix; the value is the bare version string (e.g. "2.35").
 
@@ -1184,6 +1192,30 @@ def _hash_file_path(path: Path) -> str | None:
         return None
 
 
+def _parse_soname_version(filename: str, soname: str) -> tuple[int, ...] | None:
+    """Parse the dotted-decimal suffix of a versioned soname.
+
+    ``("libfoo.so.1.2.70201", "libfoo.so") -> (1, 2, 70201)``. Returns
+    ``None`` when the suffix isn't pure dotted-decimal (e.g. a debug
+    build with a trailing tag) so callers can fall back to lex sort.
+
+    Used to sort versioned-soname siblings by integer-tuple instead of
+    lexicographically -- otherwise ``libfoo.so.5.10.0`` ranks below
+    ``libfoo.so.5.9.0`` (because ``"1" < "9"`` as strings) and a
+    multi-version install would record the wrong file's hash.
+    """
+    prefix = soname + "."
+    if not filename.startswith(prefix):
+        return None
+    suffix = filename[len(prefix):]
+    if not suffix:
+        return None
+    try:
+        return tuple(int(p) for p in suffix.split("."))
+    except ValueError:
+        return None
+
+
 def _hash_shared_library(lib_dir: Path, soname: str) -> str | None:
     """SHA-256 a shared library, resolving symlinks first.
 
@@ -1200,19 +1232,30 @@ def _hash_shared_library(lib_dir: Path, soname: str) -> str | None:
     ``libfoo.so.1.2.3`` collapses to one hash regardless of which name
     the consumer linked against. Returns ``"sha256:<hex>"`` or ``None``.
     """
-    # Build candidate list: unversioned first, then any versioned
-    # filenames sorted descending so the highest-versioned wins. String
-    # sort works for the conventional ``soname.MAJOR.MINOR.PATCH``
-    # layout since each component is left-padded by the package version
-    # numbering (and where it does not, "good enough" still picks a
-    # real file deterministically).
+    # Build candidate list: unversioned first, then versioned files
+    # ranked highest-first by integer-tuple (NOT lexicographic) so a
+    # mid-upgrade pair like ``.so.5.10.0`` vs ``.so.5.9.0`` resolves to
+    # the actually-newer file. Any sibling whose suffix isn't pure
+    # dotted-decimal falls into a second tier and is lex-sorted -- it's
+    # an oddly-named file and we still want a deterministic pick.
     candidates: list[Path] = [lib_dir / soname]
     try:
-        versioned = sorted(lib_dir.glob(f"{soname}.*"), reverse=True)
+        siblings = list(lib_dir.glob(f"{soname}.*"))
     except OSError as exc:
         log.debug("glob failed for %s/%s.*: %s", lib_dir, soname, exc)
-        versioned = []
-    candidates.extend(versioned)
+        siblings = []
+    parsed: list[tuple[tuple[int, ...], Path]] = []
+    unparsed: list[Path] = []
+    for path in siblings:
+        version = _parse_soname_version(path.name, soname)
+        if version is None:
+            unparsed.append(path)
+        else:
+            parsed.append((version, path))
+    parsed.sort(key=lambda x: x[0], reverse=True)
+    unparsed.sort(reverse=True)
+    candidates.extend(p for _, p in parsed)
+    candidates.extend(unparsed)
 
     seen_resolved: set[Path] = set()
     for candidate in candidates:

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -90,6 +90,26 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
     )
     monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", tmp_path / "no_libs")
     monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", tmp_path / "no_tensile")
+    monkeypatch.setattr(
+        env_mod, "ROCBLAS_VERSION_HEADER", tmp_path / "no_rocblas_header.h"
+    )
+    monkeypatch.setattr(env_mod, "ROCBLAS_LIB_DIR", tmp_path / "no_rocblas_libs")
+    monkeypatch.setattr(
+        env_mod, "ROCBLAS_TENSILE_DIR", tmp_path / "no_rocblas_tensile"
+    )
+    monkeypatch.setattr(env_mod, "CK_VERSION_HEADER", tmp_path / "no_ck.h")
+    monkeypatch.setattr(
+        env_mod, "CK_TILE_CONFIG_HEADER", tmp_path / "no_ck_tile.hpp"
+    )
+    monkeypatch.setattr(
+        env_mod, "MIOPEN_VERSION_HEADER", tmp_path / "no_miopen_version.h"
+    )
+    monkeypatch.setattr(env_mod, "MIOPEN_LIB_DIR", tmp_path / "no_miopen_libs")
+    monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", tmp_path / "no_miopen_db")
+    monkeypatch.setattr(
+        env_mod, "RCCL_VERSION_HEADER", tmp_path / "no_rccl.h"
+    )
+    monkeypatch.setattr(env_mod, "RCCL_LIB_DIR", tmp_path / "no_rccl_libs")
     monkeypatch.setattr(env_mod, "DOCKERENV_MARKER", tmp_path / "no_dockerenv")
     monkeypatch.setattr(
         env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv"
@@ -127,12 +147,23 @@ class TestPathConstants:
     @pytest.mark.parametrize(
         "constant_name",
         [
+            "ROCM_BIN_DIR",
             "ROCM_VERSION_FILE",
             "ROCM_VERSION_DEV_FILE",
             "KMD_VERSION_FILE",
             "HIPBLASLT_VERSION_HEADER",
             "HIPBLASLT_LIB_DIR",
             "HIPBLASLT_TENSILE_DIR",
+            "ROCBLAS_VERSION_HEADER",
+            "ROCBLAS_LIB_DIR",
+            "ROCBLAS_TENSILE_DIR",
+            "CK_VERSION_HEADER",
+            "CK_TILE_CONFIG_HEADER",
+            "MIOPEN_VERSION_HEADER",
+            "MIOPEN_LIB_DIR",
+            "MIOPEN_KERNEL_DB_DIR",
+            "RCCL_VERSION_HEADER",
+            "RCCL_LIB_DIR",
             "DOCKERENV_MARKER",
             "PODMAN_CONTAINERENV_MARKER",
             "CGROUP_FILE",
@@ -159,12 +190,23 @@ class TestPathConstants:
             and not name.startswith("_")
         }
         assert path_attrs == {
+            "ROCM_BIN_DIR",
             "ROCM_VERSION_FILE",
             "ROCM_VERSION_DEV_FILE",
             "KMD_VERSION_FILE",
             "HIPBLASLT_VERSION_HEADER",
             "HIPBLASLT_LIB_DIR",
             "HIPBLASLT_TENSILE_DIR",
+            "ROCBLAS_VERSION_HEADER",
+            "ROCBLAS_LIB_DIR",
+            "ROCBLAS_TENSILE_DIR",
+            "CK_VERSION_HEADER",
+            "CK_TILE_CONFIG_HEADER",
+            "MIOPEN_VERSION_HEADER",
+            "MIOPEN_LIB_DIR",
+            "MIOPEN_KERNEL_DB_DIR",
+            "RCCL_VERSION_HEADER",
+            "RCCL_LIB_DIR",
             "DOCKERENV_MARKER",
             "PODMAN_CONTAINERENV_MARKER",
             "CGROUP_FILE",
@@ -199,11 +241,23 @@ REQUIRED_TOP_KEYS = {
     "rocm",
     "hip",
     "hipblaslt",
+    "rocblas",
+    "composable_kernel",
+    "tensile",
+    "triton",
+    "fbgemm",
+    "aiter",
+    "aotriton",
+    "miopen",
+    "rccl",
+    "gpu_arch",
+    "host",
     "runtime_context",
     "docker",
     "env_vars",
     "python_version",
     "pytorch_version",
+    "pytorch_build",
 }
 
 
@@ -213,7 +267,7 @@ class TestSchemaCompleteness:
     ):
         snapshot = collect_env()
         assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
-        assert snapshot.schema_version == "1.0"
+        assert snapshot.schema_version == "1.1"
         assert snapshot.system_health is None
         assert snapshot.rocm == {
             "version": None,
@@ -260,7 +314,7 @@ class TestSchemaCompleteness:
 def _example_snapshot(**overrides) -> object:
     """Build a fully-populated EnvSnapshot for round-trip testing."""
     base = {
-        "schema_version": "1.0",
+        "schema_version": "1.1",
         "captured_at": "2026-04-28T12:00:00Z",
         "system_health": {"rdhc_version": "1.4.0", "tests": {}},
         "rocm": {
@@ -276,11 +330,68 @@ def _example_snapshot(**overrides) -> object:
             "cpp_config": "-D__HIP_PLATFORM_AMD__",
         },
         "hipblaslt": {
-            "commit": "dabb6df2b9",
+            "rocm_release_tweak": "dabb6df2b9",
             "package_version": "1.2.2",
             "lib_hash": "sha256:abc",
-            "tensile_yaml_revision": "filenames-sha256:def",
+            "kernel_db_revision": "filenames-sha256:def",
             "applied_prs": {},
+        },
+        "rocblas": {
+            "rocm_release_tweak": "dabb6df2b9",
+            "package_version": "5.2.0",
+            "lib_hash": "sha256:bbb",
+            "kernel_db_revision": "filenames-sha256:ccc",
+            "applied_prs": {},
+        },
+        "composable_kernel": {
+            "system": {
+                "version": "1.2.0",
+                "commit": "23d531c8ae9721ac990116751542ab63e11d27c8",
+                "ck_tile_present": True,
+            },
+            "pytorch_bundled": {"present": True, "symbol_count": 4067},
+            "pytorch_use_ck_sdpa": True,
+            "pytorch_use_ck_gemm": True,
+        },
+        "tensile": {
+            "package_version": None,
+            "kernel_db_combined_hash": "filenames-sha256:eee",
+        },
+        "triton": {"package_version": "3.5.1+rocm7.2.1.gita272dfa8"},
+        "fbgemm": {
+            "package_version": None,
+            "pytorch_use_fbgemm": True,
+            "pytorch_use_fbgemm_genai": True,
+        },
+        "aiter": {"package_version": None},
+        "aotriton": {
+            "bundled_present": True,
+            "bundled_version": "0.11.1",
+            "bundled_lib_hash": "sha256:abc",
+            "bundled_images_dir_present": True,
+            "installed_prefix": None,
+        },
+        "miopen": {
+            "rocm_release_tweak": "dabb6df2b9",
+            "package_version": "3.5.1",
+            "lib_hash": "sha256:miopenhash",
+            "kernel_db_revision": "filenames-sha256:miopendb",
+        },
+        "rccl": {
+            "version_code": 22707,
+            "version": "2.27.7",
+            "lib_hash": "sha256:rcclhash",
+        },
+        "gpu_arch": {
+            "agent_count": 8,
+            "gfx_targets": ["gfx942"],
+            "agent_arch_counts": {"gfx942": 8},
+        },
+        "host": {
+            "kernel_release": "5.15.0-174-generic",
+            "kernel_version": "#184-Ubuntu SMP Fri Mar 13 18:41:50 UTC 2026",
+            "machine": "x86_64",
+            "glibc_version": "2.35",
         },
         "runtime_context": {
             "type": "docker",
@@ -296,6 +407,20 @@ def _example_snapshot(**overrides) -> object:
         "env_vars": dict.fromkeys(CANONICAL_ENV_VARS),
         "python_version": "3.12.3",
         "pytorch_version": "2.12.0",
+        "pytorch_build": {
+            "git_commit": "ff65f5bc672795c5e5033900ea0a0c4f8566c8cf",
+            "hip_version": "7.2.53211-e1a6bc5663",
+            "cuda_version": None,
+            "debug": False,
+            "install_kind": "wheel",
+            "source_path": None,
+            "submodule_commits": {
+                "_source": None,
+                "composable_kernel": None,
+                "aiter": None,
+                "fbgemm": None,
+            },
+        },
         "partial": False,
         "partial_reasons": [],
     }
@@ -326,7 +451,7 @@ class TestEnvSnapshot:
         d = _example_snapshot().to_dict()
         d["future_field_not_yet_added"] = {"hello": "world"}
         rebuilt = EnvSnapshot.from_dict(d)
-        assert rebuilt.schema_version == "1.0"
+        assert rebuilt.schema_version == "1.1"
 
     def test_from_dict_defaults_partial_reasons_when_missing(self):
         """Older env.json without partial_reasons still loads (defaults to [])."""
@@ -335,10 +460,22 @@ class TestEnvSnapshot:
         rebuilt = EnvSnapshot.from_dict(d)
         assert rebuilt.partial_reasons == []
 
-    def test_summary_includes_partial_marker_when_partial(self):
+    def test_summary_does_not_duplicate_partial_marker(self):
+        """The brief returned by ``summary()`` is the *body* of what the
+        CLI prints. The CLI itself frames the brief with a header line
+        (``Wrote env probe to ... [PARTIAL]``) and a closing line
+        (``[PARTIAL, N reason(s)]``), so a third copy of "PARTIAL"
+        embedded in the summary body would be redundant. Asserts the
+        body stays clean of PARTIAL markers regardless of state.
+        """
         partial_snap = _example_snapshot(partial=True, partial_reasons=["x: y"])
         clean_snap = _example_snapshot()
-        assert "PARTIAL" in partial_snap.summary()
+        # Neither should leak "PARTIAL" into the body. The marker is
+        # the CLI's job, not summary()'s. (We do still want the field
+        # values themselves to differ -- the partial vs clean snapshot
+        # produce different `partial_reasons` lengths visible to the
+        # caller via .partial_reasons, which is what the CLI prints.)
+        assert "PARTIAL" not in partial_snap.summary()
         assert "PARTIAL" not in clean_snap.summary()
 
     def test_summary_treats_empty_system_health_as_present(self):
@@ -346,18 +483,30 @@ class TestEnvSnapshot:
         ``{}`` (subprocess succeeded, nothing to report). The earlier
         truthiness check ``if self.system_health`` would summarise that as
         unavailable -- ``is not None`` is the right check.
+
+        Asserts on the **rdhc:** line specifically rather than the
+        whole brief, because other lines (e.g. ``aotriton``) use
+        "present" as a field-name key (``bundled_present=True``) which
+        would false-positive a substring search across the full text.
         """
         snap_empty = _example_snapshot(system_health={})
         snap_null = _example_snapshot(system_health=None)
         snap_populated = _example_snapshot(system_health={"rdhc_version": "1.4.0"})
 
+        def rdhc_line(snap) -> str:
+            for line in snap.summary().splitlines():
+                if line.lstrip().startswith("rdhc:"):
+                    return line
+            raise AssertionError("no rdhc: line in summary")
+
         # Empty dict and populated dict should both render as 'present'
-        assert "present" in snap_empty.summary()
-        assert "unavailable" not in snap_empty.summary()
-        assert "present" in snap_populated.summary()
+        # in the rdhc line
+        assert "present" in rdhc_line(snap_empty)
+        assert "unavailable" not in rdhc_line(snap_empty)
+        assert "present" in rdhc_line(snap_populated)
         # Only None should render as 'unavailable'
-        assert "unavailable" in snap_null.summary()
-        assert "present" not in snap_null.summary()
+        assert "unavailable" in rdhc_line(snap_null)
+        assert "present" not in rdhc_line(snap_null)
 
     def test_summary_is_multiline_human_readable(self):
         snap = _example_snapshot()
@@ -419,10 +568,61 @@ class TestCollectEnvContract:
         lib_dir = tmp_path / "lib"
         lib_dir.mkdir()
         (lib_dir / "libhipblaslt.so").write_bytes(b"binary")
+        (lib_dir / "librocblas.so").write_bytes(b"rocblas-binary")
 
         tensile_dir = tmp_path / "tensile"
         tensile_dir.mkdir()
         (tensile_dir / "TensileLibrary_X.dat").write_bytes(b"x")
+
+        # rocblas inputs (header in its own internal/ subdir to mirror prod layout)
+        rocblas_header_dir = tmp_path / "include" / "rocblas" / "internal"
+        rocblas_header_dir.mkdir(parents=True)
+        (rocblas_header_dir / "rocblas-version.h").write_text(
+            "#define ROCBLAS_VERSION_MAJOR 5\n"
+            "#define ROCBLAS_VERSION_MINOR 2\n"
+            "#define ROCBLAS_VERSION_PATCH 0\n"
+            "#define ROCBLAS_VERSION_TWEAK dabb6df2b9\n"
+        )
+        rocblas_tensile_dir = tmp_path / "rocblas_tensile"
+        rocblas_tensile_dir.mkdir()
+        (rocblas_tensile_dir / "Kernels.so-000-gfx942.hsaco").write_bytes(b"k")
+        (rocblas_tensile_dir / "TensileLibrary_gfx942.dat").write_bytes(b"t")
+
+        # CK inputs (header-only)
+        ck_header_dir = tmp_path / "include" / "ck"
+        ck_header_dir.mkdir(parents=True)
+        (ck_header_dir / "version.h").write_text(
+            "#define CK_VERSION 1.2.0\n"
+            "#define CK_VERSION_MAJOR 1\n"
+            "#define CK_VERSION_MINOR 2\n"
+            "#define CK_VERSION_PATCH 0\n"
+            "#define CK_COMMIT_ID 23d531c8ae9721ac990116751542ab63e11d27c8\n"
+        )
+        ck_tile_dir = tmp_path / "include" / "ck_tile" / "core"
+        ck_tile_dir.mkdir(parents=True)
+        (ck_tile_dir / "config.hpp").write_text("// ck_tile config\n")
+
+        # MIOpen inputs
+        miopen_header_dir = tmp_path / "include" / "miopen"
+        miopen_header_dir.mkdir(parents=True)
+        (miopen_header_dir / "version.h").write_text(
+            "#define MIOPEN_VERSION_MAJOR 3\n"
+            "#define MIOPEN_VERSION_MINOR 5\n"
+            "#define MIOPEN_VERSION_PATCH 1\n"
+            "#define MIOPEN_VERSION_TWEAK dabb6df2b9\n"
+        )
+        (lib_dir / "libMIOpen.so").write_bytes(b"miopen-binary")
+        miopen_db_dir = tmp_path / "miopen_db"
+        miopen_db_dir.mkdir()
+        (miopen_db_dir / "gfx942_64.db.txt").write_text("kernel db")
+
+        # RCCL inputs
+        rccl_header_dir = tmp_path / "include" / "rccl"
+        rccl_header_dir.mkdir(parents=True)
+        (rccl_header_dir / "rccl.h").write_text(
+            "#define NCCL_VERSION_CODE 22707\n"
+        )
+        (lib_dir / "librccl.so").write_bytes(b"rccl-binary")
 
         monkeypatch.setattr(env_mod, "ROCM_VERSION_FILE", rocm_info / "version")
         monkeypatch.setattr(env_mod, "ROCM_VERSION_DEV_FILE", rocm_info / "version_dev")
@@ -432,6 +632,24 @@ class TestCollectEnvContract:
         )
         monkeypatch.setattr(env_mod, "HIPBLASLT_LIB_DIR", lib_dir)
         monkeypatch.setattr(env_mod, "HIPBLASLT_TENSILE_DIR", tensile_dir)
+        monkeypatch.setattr(
+            env_mod,
+            "ROCBLAS_VERSION_HEADER",
+            rocblas_header_dir / "rocblas-version.h",
+        )
+        monkeypatch.setattr(env_mod, "ROCBLAS_LIB_DIR", lib_dir)
+        monkeypatch.setattr(env_mod, "ROCBLAS_TENSILE_DIR", rocblas_tensile_dir)
+        monkeypatch.setattr(env_mod, "CK_VERSION_HEADER", ck_header_dir / "version.h")
+        monkeypatch.setattr(env_mod, "CK_TILE_CONFIG_HEADER", ck_tile_dir / "config.hpp")
+        monkeypatch.setattr(
+            env_mod, "MIOPEN_VERSION_HEADER", miopen_header_dir / "version.h"
+        )
+        monkeypatch.setattr(env_mod, "MIOPEN_LIB_DIR", lib_dir)
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", miopen_db_dir)
+        monkeypatch.setattr(
+            env_mod, "RCCL_VERSION_HEADER", rccl_header_dir / "rccl.h"
+        )
+        monkeypatch.setattr(env_mod, "RCCL_LIB_DIR", lib_dir)
         monkeypatch.setattr(env_mod, "DOCKERENV_MARKER", tmp_path / "no_dockerenv")
         monkeypatch.setattr(
             env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv"
@@ -459,18 +677,102 @@ class TestCollectEnvContract:
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
-        # Pretend torch is importable with a version
+        # Pretend torch is importable with a version. Also stand up the
+        # surfaces the new fbgemm / composable_kernel probes peek at:
+        #   * torch.__config__.show() returns a build string mentioning
+        #     -DUSE_FBGEMM and -DUSE_FBGEMM_GENAI (so fbgemm flags = True)
+        #   * torch.__file__ + a tmp libtorch_hip.so so the CK-bundled
+        #     probe finds something to run nm/c++filt against. We
+        #     redirect both subprocesses through ``fake_run`` so it
+        #     reports a tiny stdout containing one ck:: symbol.
         import builtins
         import types
+
+        fake_torch_dir = tmp_path / "fake_torch"
+        (fake_torch_dir / "lib").mkdir(parents=True)
+        (fake_torch_dir / "lib" / "libtorch_hip.so").write_bytes(b"fake")
+        # Stand up a fake bundled AOTriton (the new aotriton probe
+        # would otherwise add a partial reason for "no libaotriton_v2.so*").
+        (fake_torch_dir / "lib" / "libaotriton_v2.so.0.11.1").write_bytes(b"aot")
+        (fake_torch_dir / "lib" / "aotriton.images").mkdir()
+        fake_torch_init = fake_torch_dir / "__init__.py"
+        fake_torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __version__="2.12.0",
+            __file__=str(fake_torch_init),
+            __config__=types.SimpleNamespace(
+                show=lambda: "CXX_FLAGS=-DUSE_FBGEMM -DUSE_FBGEMM_GENAI"
+            ),
+            # torch.version.* surface required by _capture_pytorch_build.
+            # On a clean full probe we want no partial reasons, so set
+            # all four fields. install_kind will be "source" because we
+            # also create a fake third_party tree below.
+            version=types.SimpleNamespace(
+                git_version="ff65f5bc672795c5e5033900ea0a0c4f8566c8cf",
+                hip="7.2.5",
+                cuda=None,
+                debug=False,
+            ),
+        )
+
+        # Stand up a fake source tree with .git + third_party so
+        # _detect_pytorch_install_kind walks up from torch.__file__ and
+        # finds it. AORTA_PYTORCH_SRC is the explicit path; that's the
+        # cleaner option for tests.
+        fake_src = tmp_path / "fake_pytorch_src"
+        (fake_src / "third_party").mkdir(parents=True)
+        for name in ("composable_kernel", "aiter", "fbgemm"):
+            sub = fake_src / "third_party" / name
+            sub.mkdir()
+            (sub / ".git").write_text("gitdir: ../../.git/modules/" + name)
+        monkeypatch.setenv("AORTA_PYTORCH_SRC", str(fake_src))
 
         real_import = builtins.__import__
 
         def fake_import(name, *args, **kwargs):
             if name == "torch":
-                return types.SimpleNamespace(__version__="2.12.0")
+                return fake_torch
             return real_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        # Have shutil.which find nm/c++filt so the bundled-CK probe runs.
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/" + name)
+
+        # Wrap fake_run so nm + c++filt produce a synthetic ck:: hit.
+        original_fake_run = fake_run
+
+        def fake_run_with_nm(cmd, **kwargs):
+            if cmd[0].endswith("nm"):
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout="0000 T mangled_symbol\n", stderr="",
+                )
+            if cmd[0].endswith("c++filt"):
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout="ck::tensor_operation::SomeKernel\n", stderr="",
+                )
+            if cmd[0].endswith("rocm_agent_enumerator"):
+                # Mimic the real binary's stdout: one gfx target per
+                # GPU. The clean-probe fixture asserts no partial
+                # reasons fire, so we need a non-empty result here.
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout="gfx942\ngfx942\n", stderr="",
+                )
+            if cmd[0].endswith("git") and "rev-parse" in cmd:
+                # Synthesize a deterministic 40-char hex SHA per submodule
+                # path so _git_rev_parse_head's hex-validity check passes.
+                sub_name = Path(cmd[2]).name
+                fake_sha = (sub_name + "0" * 40)[:40].lower().replace("_", "0")
+                fake_sha = "".join(c if c in "0123456789abcdef" else "0" for c in fake_sha)
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout=fake_sha + "\n", stderr="",
+                )
+            return original_fake_run(cmd, **kwargs)
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run_with_nm)
 
         snapshot = collect_env()
         assert snapshot.partial is False, (
@@ -479,7 +781,12 @@ class TestCollectEnvContract:
         assert snapshot.partial_reasons == []
         # Verify the success values landed
         assert snapshot.rocm["version"] == "7.2.1"
-        assert snapshot.hipblaslt["commit"] == "abc1234"
+        assert snapshot.hipblaslt["rocm_release_tweak"] == "abc1234"
+        assert snapshot.rocblas["rocm_release_tweak"] == "dabb6df2b9"
+        assert snapshot.composable_kernel["system"]["version"] == "1.2.0"
+        assert snapshot.composable_kernel["pytorch_bundled"]["present"] is True
+        assert snapshot.fbgemm["pytorch_use_fbgemm"] is True
+        assert snapshot.fbgemm["pytorch_use_fbgemm_genai"] is True
         assert snapshot.system_health == {"rdhc_version": "1.4.0"}
         assert snapshot.hip["version"] == "7.2.5"
         assert snapshot.pytorch_version == "2.12.0"
@@ -707,14 +1014,16 @@ class TestCliIsThinWrapper:
     def test_total_file_size_is_bounded(self, cli_path: Path):
         # Total file budget (incl. docstring/imports/blank lines/error handling).
         # The spec target is ~30 lines of substantive code; the cushion
-        # accommodates the module docstring, Click decorators, and the
+        # accommodates the module docstring, Click decorators, the
         # try/except blocks that surface filesystem errors as
-        # ``click.ClickException`` (per Copilot review). The real
-        # "no-probing-in-CLI" guard is `test_cli_does_no_probing_imports`
-        # below -- this one is a soft canary against the file ballooning.
+        # ``click.ClickException`` (per Copilot review), the --verbose
+        # flag wiring, and the inline partial_reasons echo + closing
+        # status marker. The real "no-probing-in-CLI" guard is
+        # `test_cli_does_no_probing_imports` below -- this one is a
+        # soft canary against the file ballooning.
         line_count = sum(1 for _ in cli_path.read_text().splitlines())
-        assert line_count <= 80, (
-            f"cli/env.py is {line_count} lines; soft budget is 80. "
+        assert line_count <= 120, (
+            f"cli/env.py is {line_count} lines; soft budget is 120. "
             "If you need more, check that the new code is genuinely "
             "wiring/error-handling and not probing -- "
             "test_cli_does_no_probing_imports is the strict guard."
@@ -808,6 +1117,102 @@ class TestCliIsThinWrapper:
         assert result.exit_code != 0
         assert "Failed to write env probe" in result.output
         assert "Traceback" not in result.output
+
+    def test_cli_echoes_partial_reasons_inline(
+        self, all_disabled, tmp_path: Path
+    ):
+        """Operator running the probe should see WHY it's partial without
+        having to ``jq env.json``. partial_reasons is already in memory;
+        the CLI must print each one inline.
+        """
+        from click.testing import CliRunner
+
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        spec = importlib.util.spec_from_file_location("aorta.cli.env", cli_path)
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+
+        runner = CliRunner()
+        out_path = tmp_path / "env.json"
+        result = runner.invoke(cli_mod.env, ["probe", "-o", str(out_path)])
+        assert result.exit_code == 0, result.output
+        assert "Partial reasons:" in result.output
+        # At least one rdhc-style reason will appear (rdhc not on PATH
+        # under all_disabled). Each reason rendered as a bullet line.
+        bullet_lines = [
+            line for line in result.output.splitlines()
+            if line.startswith("  - ")
+        ]
+        assert bullet_lines, (
+            f"no '  - <reason>' bullet lines in output: {result.output}"
+        )
+
+    def test_cli_closing_marker_partial(self, all_disabled, tmp_path: Path):
+        """Closing line repeats the [PARTIAL, N] state at end-of-output
+        so it's visible after a long --verbose dump or a long
+        partial_reasons list.
+        """
+        from click.testing import CliRunner
+
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        spec = importlib.util.spec_from_file_location("aorta.cli.env", cli_path)
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+
+        runner = CliRunner()
+        out_path = tmp_path / "env.json"
+        result = runner.invoke(cli_mod.env, ["probe", "-o", str(out_path)])
+        assert result.exit_code == 0, result.output
+        # Last non-empty line is the closing marker.
+        last_line = next(
+            line for line in reversed(result.output.splitlines()) if line.strip()
+        )
+        assert last_line.startswith("[PARTIAL, ") and "reason(s)]" in last_line, (
+            f"closing marker missing or malformed: {last_line!r}"
+        )
+
+    def test_cli_verbose_flag_dumps_full_json(
+        self, all_disabled, tmp_path: Path
+    ):
+        """``aorta env probe -v`` should print the full JSON snapshot to
+        stdout in addition to the brief, so an operator on a remote box
+        can copy-paste without reading the JSON file.
+        """
+        from click.testing import CliRunner
+
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        spec = importlib.util.spec_from_file_location("aorta.cli.env", cli_path)
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+
+        runner = CliRunner()
+        out_path = tmp_path / "env.json"
+
+        # Without -v: no full snapshot block in stdout
+        plain = runner.invoke(cli_mod.env, ["probe", "-o", str(out_path)])
+        assert plain.exit_code == 0
+        assert "--- Full snapshot ---" not in plain.output
+
+        # With -v: full snapshot block appears and parses back as JSON
+        verbose = runner.invoke(
+            cli_mod.env, ["probe", "-o", str(out_path), "-v"]
+        )
+        assert verbose.exit_code == 0
+        assert "--- Full snapshot ---" in verbose.output
+        # The block after the marker must be the same JSON we wrote to file.
+        marker = "--- Full snapshot ---"
+        json_block = verbose.output.split(marker, 1)[1]
+        # Trim everything after the closing marker.
+        if "[PARTIAL, " in json_block:
+            json_block = json_block.split("\n[PARTIAL, ", 1)[0]
+        elif "[OK]" in json_block:
+            json_block = json_block.split("\n[OK]", 1)[0]
+        # Must be parseable JSON, and its keys match REQUIRED_TOP_KEYS.
+        parsed = json.loads(json_block)
+        assert set(parsed.keys()) == REQUIRED_TOP_KEYS
 
     def test_cli_emits_json_native_output_no_default_str(
         self, all_disabled
@@ -1253,10 +1658,10 @@ class TestHipblasltBlockShape:
         reasons: list[str] = []
         block = env_mod._capture_hipblaslt(reasons)
         assert set(block.keys()) == {
-            "commit",
+            "rocm_release_tweak",
             "package_version",
             "lib_hash",
-            "tensile_yaml_revision",
+            "kernel_db_revision",
             "applied_prs",
         }
 
@@ -1269,8 +1674,10 @@ class TestHipblasltBlockShape:
         """Header file missing -> reason should say 'not readable'."""
         reasons: list[str] = []
         env_mod._capture_hipblaslt(reasons)
-        commit_reason = next(r for r in reasons if r.startswith("hipblaslt.commit"))
-        assert "not readable" in commit_reason
+        tweak_reason = next(
+            r for r in reasons if r.startswith("hipblaslt.rocm_release_tweak")
+        )
+        assert "not readable" in tweak_reason
 
     def test_reason_when_header_present_but_tweak_missing(
         self, isolated_env, tmp_path: Path, monkeypatch
@@ -1295,12 +1702,14 @@ class TestHipblasltBlockShape:
 
         reasons: list[str] = []
         block = env_mod._capture_hipblaslt(reasons)
-        # commit failed but package_version succeeded
-        assert block["commit"] is None
+        # rocm_release_tweak failed but package_version succeeded
+        assert block["rocm_release_tweak"] is None
         assert block["package_version"] == "1.2.0"
-        commit_reason = next(r for r in reasons if r.startswith("hipblaslt.commit"))
-        assert "not readable" not in commit_reason
-        assert "HIPBLASLT_VERSION_TWEAK" in commit_reason
+        tweak_reason = next(
+            r for r in reasons if r.startswith("hipblaslt.rocm_release_tweak")
+        )
+        assert "not readable" not in tweak_reason
+        assert "HIPBLASLT_VERSION_TWEAK" in tweak_reason
 
 
 # ---------------------------------------------------------------------------
@@ -1504,17 +1913,47 @@ class TestEnvVars:
         # Reasoned guard: changing this list is a schema change. If a future
         # PR adds a var, this test forces an explicit acknowledgement.
         assert set(CANONICAL_ENV_VARS) == {
+            # GPU scoping
+            "HIP_VISIBLE_DEVICES",
+            "ROCR_VISIBLE_DEVICES",
+            # HSA / runtime
             "HSA_XNACK",
             "HSA_KERNARG_POOL_SIZE",
             "HSA_NO_SCRATCH_RECLAIM",
+            "HSA_OVERRIDE_GFX_VERSION",
+            # GPU queue / codegen / build target
             "GPU_MAX_HW_QUEUES",
             "AMDGCN_USE_BUFFER_OPS",
             "DISABLE_TF32",
+            "PYTORCH_ROCM_ARCH",
+            "HIP_LAUNCH_BLOCKING",
+            # RCCL / NCCL
             "NCCL_MAX_NCHANNELS",
+            "NCCL_P2P_LEVEL",
+            "NCCL_IB_HCA",
+            "NCCL_SOCKET_IFNAME",
+            "RCCL_MSCCL_ENABLE",
+            # FBGEMM
             "FBGEMM_NO_JK",
             "FBGEMM_TBE_V2",
             "FBGEMM_TBE_ROCM_HIP_BACKWARD_KERNEL",
             "FBGEMM_BOUNDS_CHECK_INDICES_V2",
+            # MIOpen
+            "MIOPEN_SYSTEM_DB_PATH",
+            "MIOPEN_USER_DB_PATH",
+            "MIOPEN_DEBUG_DISABLE_FIND_DB",
+            "MIOPEN_FIND_MODE",
+            # SDPA / Flash Attention backend selection
+            # Note: USE_ROCM_CK_SDPA / USE_ROCM_CK_GEMM are NOT here --
+            # they're build-time cmake flags, captured under
+            # composable_kernel.{pytorch_use_ck_sdpa,pytorch_use_ck_gemm}
+            "TORCH_ROCM_FA_PREFER_CK",
+            "TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL",
+            # GEMM backend preference + autotune pinning
+            "TORCH_BLAS_PREFER_HIPBLASLT",
+            "TORCH_HIPBLASLT_TUNING_FILE",
+            "TORCH_HIPBLASLT_TUNING_OVERRIDE_FILE",
+            # PyTorch / inductor
             "TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE",
             "PYTORCH_CUDA_ALLOC_CONF",
         }
@@ -1616,7 +2055,12 @@ class TestNoGpuCompute:
         for attr in (
             "ROCM_VERSION_FILE", "ROCM_VERSION_DEV_FILE", "KMD_VERSION_FILE",
             "HIPBLASLT_VERSION_HEADER", "HIPBLASLT_LIB_DIR",
-            "HIPBLASLT_TENSILE_DIR", "DOCKERENV_MARKER",
+            "HIPBLASLT_TENSILE_DIR",
+            "ROCBLAS_VERSION_HEADER", "ROCBLAS_LIB_DIR", "ROCBLAS_TENSILE_DIR",
+            "CK_VERSION_HEADER", "CK_TILE_CONFIG_HEADER",
+            "MIOPEN_VERSION_HEADER", "MIOPEN_LIB_DIR", "MIOPEN_KERNEL_DB_DIR",
+            "RCCL_VERSION_HEADER", "RCCL_LIB_DIR",
+            "DOCKERENV_MARKER",
             "PODMAN_CONTAINERENV_MARKER", "CGROUP_FILE", "SELF_CGROUP_FILE",
         ):
             monkeypatch.setattr(env_mod, attr, tmp_path / f"no_{attr.lower()}")
@@ -1630,3 +2074,1909 @@ class TestNoGpuCompute:
         # The actual guard
         fake_cuda.is_available.assert_not_called()
         fake_cuda.device_count.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# rocBLAS introspection -- mirrors the hipBLASLt block 1:1
+# ---------------------------------------------------------------------------
+
+
+class TestRocblasHeaderParsing:
+    def test_parse_full_header(self):
+        text = """
+        #ifndef _ROCBLAS_VERSION_H_
+        #define _ROCBLAS_VERSION_H_
+        #define ROCBLAS_VERSION_MAJOR     5
+        #define ROCBLAS_VERSION_MINOR     2
+        #define ROCBLAS_VERSION_PATCH     0
+        #define ROCBLAS_VERSION_TWEAK     dabb6df2b9
+        #endif
+        """
+        commit, version = env_mod._parse_version_header(
+            text, env_mod._ROCBLAS_TWEAK_RE, env_mod._ROCBLAS_VERSION_RE
+        )
+        assert commit == "dabb6df2b9"
+        assert version == "5.2.0"
+
+    def test_parse_missing_tweak_returns_none_commit(self):
+        text = """
+        #define ROCBLAS_VERSION_MAJOR 5
+        #define ROCBLAS_VERSION_MINOR 2
+        #define ROCBLAS_VERSION_PATCH 0
+        """
+        commit, version = env_mod._parse_version_header(
+            text, env_mod._ROCBLAS_TWEAK_RE, env_mod._ROCBLAS_VERSION_RE
+        )
+        assert commit is None
+        assert version == "5.2.0"
+
+    def test_parse_empty_returns_none_pair(self):
+        commit, version = env_mod._parse_version_header(
+            "", env_mod._ROCBLAS_TWEAK_RE, env_mod._ROCBLAS_VERSION_RE
+        )
+        assert (commit, version) == (None, None)
+
+
+class TestRocblasLibHash:
+    def test_hash_resolved_through_symlink(self, tmp_path: Path, monkeypatch):
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        real = lib_dir / "librocblas.so.5.2.70201"
+        real.write_bytes(b"hello rocblas")
+        symlink_a = lib_dir / "librocblas.so.5"
+        symlink_b = lib_dir / "librocblas.so"
+        symlink_a.symlink_to(real.name)
+        symlink_b.symlink_to(symlink_a.name)
+        monkeypatch.setattr(env_mod, "ROCBLAS_LIB_DIR", lib_dir)
+
+        digest = env_mod._hash_shared_library(env_mod.ROCBLAS_LIB_DIR, "librocblas.so")
+        expected = "sha256:" + hashlib.sha256(b"hello rocblas").hexdigest()
+        assert digest == expected
+
+    def test_no_library_returns_none(self, tmp_path: Path):
+        digest = env_mod._hash_shared_library(tmp_path / "empty", "librocblas.so")
+        assert digest is None
+
+    def test_stripped_image_falls_back_to_versioned_filename(
+        self, tmp_path: Path
+    ):
+        """Regression guard: stripped runtime images ship only the
+        versioned ``libfoo.so.MAJOR.MINOR.PATCH`` (the SONAME-versioned
+        ``.so.1`` symlink is created by ldconfig, the unversioned ``.so``
+        is ``-dev``-only). The probe must still hash the actual file.
+        """
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        # Only the versioned filename exists -- no unversioned `.so`,
+        # no SONAME `.so.1`. This is what `dpkg -L librocblas0` ships
+        # before ldconfig runs in a stripped image.
+        real = lib_dir / "librocblas.so.5.2.70201"
+        real.write_bytes(b"stripped-image bytes")
+
+        digest = env_mod._hash_shared_library(lib_dir, "librocblas.so")
+        expected = "sha256:" + hashlib.sha256(b"stripped-image bytes").hexdigest()
+        assert digest == expected, (
+            "stripped-image fallback failed: probe should hash "
+            "librocblas.so.5.2.70201 when the unversioned .so symlink is "
+            "missing (a -dev-only artifact)"
+        )
+
+    def test_picks_highest_versioned_when_multiple_present(
+        self, tmp_path: Path
+    ):
+        """When several versioned files exist (e.g. mid-upgrade state or
+        sideloaded debug build), pick the highest -- that's the file the
+        SONAME would normally point at after ldconfig runs.
+        """
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        (lib_dir / "librocblas.so.5.1.00000").write_bytes(b"old")
+        (lib_dir / "librocblas.so.5.2.70201").write_bytes(b"new")
+
+        digest = env_mod._hash_shared_library(lib_dir, "librocblas.so")
+        expected = "sha256:" + hashlib.sha256(b"new").hexdigest()
+        assert digest == expected
+
+
+class TestRocblasBlockShape:
+    def test_block_keys_stable(self, all_disabled):
+        reasons: list[str] = []
+        block = env_mod._capture_rocblas(reasons)
+        assert set(block.keys()) == {
+            "rocm_release_tweak",
+            "package_version",
+            "lib_hash",
+            "kernel_db_revision",
+            "applied_prs",
+        }
+        assert block["applied_prs"] == {}
+
+    def test_partial_reasons_use_rocblas_prefix(self, all_disabled):
+        reasons: list[str] = []
+        env_mod._capture_rocblas(reasons)
+        assert reasons, "expected reasons under all_disabled"
+        assert all(r.startswith("rocblas.") for r in reasons), reasons
+
+    def test_reason_distinguishes_unreadable_from_missing_define(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        header = tmp_path / "rocblas-version.h"
+        header.write_text(
+            "#define ROCBLAS_VERSION_MAJOR 5\n"
+            "#define ROCBLAS_VERSION_MINOR 2\n"
+            "#define ROCBLAS_VERSION_PATCH 0\n"
+            # No TWEAK on purpose
+        )
+        monkeypatch.setattr(env_mod, "ROCBLAS_VERSION_HEADER", header)
+        monkeypatch.setattr(env_mod, "ROCBLAS_LIB_DIR", tmp_path / "no_libs")
+        monkeypatch.setattr(env_mod, "ROCBLAS_TENSILE_DIR", tmp_path / "no_tensile")
+        reasons: list[str] = []
+        block = env_mod._capture_rocblas(reasons)
+        assert block["rocm_release_tweak"] is None
+        assert block["package_version"] == "5.2.0"
+        tweak_reason = next(
+            r for r in reasons if r.startswith("rocblas.rocm_release_tweak")
+        )
+        assert "not readable" not in tweak_reason
+        assert "ROCBLAS_VERSION_TWEAK" in tweak_reason
+
+
+# ---------------------------------------------------------------------------
+# Composable Kernel
+# ---------------------------------------------------------------------------
+
+
+class TestCKHeaderParsing:
+    def test_parse_full_header(self):
+        text = """
+        #define CK_VERSION 1.2.0
+        #define CK_VERSION_MAJOR 1
+        #define CK_VERSION_MINOR 2
+        #define CK_VERSION_PATCH 0
+        #define CK_COMMIT_ID 23d531c8ae9721ac990116751542ab63e11d27c8
+        """
+        version, commit = env_mod._parse_ck_header(text)
+        assert version == "1.2.0"
+        # Full 40-char SHA preserved (CK uses long form, unlike hipblaslt's 7-12 short)
+        assert commit == "23d531c8ae9721ac990116751542ab63e11d27c8"
+
+    def test_parse_short_commit_still_accepted(self):
+        text = "#define CK_COMMIT_ID abc1234\n"
+        version, commit = env_mod._parse_ck_header(text)
+        assert version is None
+        assert commit == "abc1234"
+
+    def test_parse_empty_returns_none_pair(self):
+        assert env_mod._parse_ck_header("") == (None, None)
+        assert env_mod._parse_ck_header(None) == (None, None)
+
+
+class TestCKBlockShape:
+    def test_block_has_two_subsections_plus_build_flags(self, all_disabled):
+        reasons: list[str] = []
+        block = env_mod._capture_composable_kernel(reasons)
+        assert set(block.keys()) == {
+            "system",
+            "pytorch_bundled",
+            "pytorch_use_ck_sdpa",
+            "pytorch_use_ck_gemm",
+        }
+        assert set(block["system"].keys()) == {"version", "commit", "ck_tile_present"}
+        assert set(block["pytorch_bundled"].keys()) == {"present", "symbol_count"}
+
+
+class TestCKPytorchBuildFlags:
+    """USE_ROCM_CK_SDPA / USE_ROCM_CK_GEMM are build-time cmake flags
+    consumed when the wheel is built -- NOT runtime env vars. The
+    composable_kernel block surfaces them via ``__config__.show()``
+    parsing, exactly like the FBGEMM flags. Setting them at runtime
+    in the workload's env does nothing.
+    """
+
+    def test_torch_absent_returns_null_pair_no_reason(
+        self, isolated_env, monkeypatch
+    ):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        sdpa, gemm = env_mod._read_pytorch_ck_flags(reasons)
+        assert sdpa is None
+        assert gemm is None
+        # No reason -- pytorch_version captures torch absence elsewhere.
+        assert reasons == []
+
+    def test_both_flags_on(self, isolated_env, monkeypatch):
+        import builtins
+        import types
+
+        config = types.SimpleNamespace(
+            show=lambda: "CXX_FLAGS=-DUSE_ROCM_CK_SDPA -DUSE_ROCM_CK_GEMM -O2"
+        )
+        fake_torch = types.SimpleNamespace(__config__=config)
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        sdpa, gemm = env_mod._read_pytorch_ck_flags(reasons)
+        assert sdpa is True
+        assert gemm is True
+
+    def test_one_flag_off_distinguishes_from_null(
+        self, isolated_env, monkeypatch
+    ):
+        """``False`` must be a meaningful answer (a wheel built without
+        the CK SDPA path is dispatching to AOTriton -- a real and
+        important state to surface), distinct from ``None`` (couldn't
+        ask).
+        """
+        import builtins
+        import types
+
+        config = types.SimpleNamespace(
+            show=lambda: "CXX_FLAGS=-DUSE_ROCM_CK_GEMM -O2"  # no SDPA
+        )
+        fake_torch = types.SimpleNamespace(__config__=config)
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        sdpa, gemm = env_mod._read_pytorch_ck_flags(reasons)
+        assert sdpa is False
+        assert gemm is True
+
+    def test_use_rocm_ck_sdpa_not_in_canonical_env_vars(self):
+        """Regression guard: schema 1.1 deliberately removed
+        USE_ROCM_CK_SDPA from CANONICAL_ENV_VARS because it's a
+        build-time cmake flag, not a runtime env var. If a future PR
+        re-adds it, this test catches the regression and forces a
+        deliberate review.
+        """
+        assert "USE_ROCM_CK_SDPA" not in CANONICAL_ENV_VARS
+        assert "USE_ROCM_CK_GEMM" not in CANONICAL_ENV_VARS
+
+    def test_partial_reasons_use_composable_kernel_prefix(self, all_disabled):
+        reasons: list[str] = []
+        env_mod._capture_composable_kernel(reasons)
+        # Only system.* should appear -- pytorch_bundled is silent when
+        # torch absence is already captured by pytorch_version.
+        prefixes = {r.split(":", 1)[0] for r in reasons}
+        assert prefixes <= {
+            "composable_kernel.system.version",
+            "composable_kernel.system.commit",
+        }, reasons
+
+    def test_ck_tile_present_when_header_exists(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        ck_tile_header = tmp_path / "ck_tile_config.hpp"
+        ck_tile_header.write_text("// header")
+        monkeypatch.setattr(env_mod, "CK_VERSION_HEADER", tmp_path / "no_ck.h")
+        monkeypatch.setattr(env_mod, "CK_TILE_CONFIG_HEADER", ck_tile_header)
+        reasons: list[str] = []
+        block = env_mod._capture_composable_kernel(reasons)
+        assert block["system"]["ck_tile_present"] is True
+
+
+class TestCKPytorchBundledProbe:
+    def test_torch_absent_returns_default_no_reason(
+        self, isolated_env, monkeypatch
+    ):
+        """Common case: torch not importable. We record no reason because
+        pytorch_version already captures the absence."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated absence")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._probe_pytorch_bundled_ck(reasons)
+        assert block == {"present": False, "symbol_count": None}
+        # Critical: no reason added (avoids duplicating pytorch_version's
+        # already-recorded absence)
+        assert reasons == []
+
+    def test_cpu_only_torch_does_not_flip_partial(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """A wheel with ``torch.version.hip is None`` is CPU-only by
+        design -- the absence of libtorch_hip.so is documented, not a
+        fallback. The probe should return the default block WITHOUT
+        appending a partial reason, mirroring the docker-on-baremetal
+        contract.
+        """
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        torch_dir.mkdir()
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        # No lib/libtorch_hip.so on purpose -- this is CPU-only torch.
+        # Critically, version.hip is None.
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            version=types.SimpleNamespace(hip=None, cuda=None),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._probe_pytorch_bundled_ck(reasons)
+        assert block == {"present": False, "symbol_count": None}
+        # Documented absence -- NO reason appended (consumer can read
+        # the CPU-only state from torch.version.hip themselves).
+        assert reasons == [], (
+            f"CPU-only torch should not trigger partial; got reasons: {reasons}"
+        )
+
+    def test_hip_torch_with_missing_lib_does_flip_partial(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """Inverse case: torch.version.hip claims HIP support but
+        libtorch_hip.so is gone. That's a broken/incomplete install --
+        partial=True with a clear reason is correct.
+        """
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        torch_dir.mkdir()
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            version=types.SimpleNamespace(hip="7.2.0", cuda=None),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._probe_pytorch_bundled_ck(reasons)
+        assert block == {"present": False, "symbol_count": None}
+        # This IS a partial -- claims HIP, lib gone. Reason should
+        # name the situation so an operator can act on it.
+        assert any("not found" in r and "claims HIP" in r for r in reasons), reasons
+
+    def test_nm_missing_records_reason(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """Stripped container (binutils not installed)."""
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        (torch_dir / "lib").mkdir(parents=True)
+        (torch_dir / "lib" / "libtorch_hip.so").write_bytes(b"x")
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(__file__=str(torch_init))
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
+        reasons: list[str] = []
+        block = env_mod._probe_pytorch_bundled_ck(reasons)
+        assert block == {"present": False, "symbol_count": None}
+        assert any("nm/c++filt" in r for r in reasons), reasons
+
+    def test_happy_path_counts_ck_symbols(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        (torch_dir / "lib").mkdir(parents=True)
+        (torch_dir / "lib" / "libtorch_hip.so").write_bytes(b"x")
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(__file__=str(torch_init))
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/" + name)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0].endswith("nm"):
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="raw\n", stderr=""
+                )
+            if cmd[0].endswith("c++filt"):
+                # Three demangled lines, two contain ck:: namespace
+                stdout = (
+                    "ck::tensor_operation::Foo\n"
+                    "std::vector<int>\n"
+                    "ck::Block::Bar\n"
+                )
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout=stdout, stderr=""
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        block = env_mod._probe_pytorch_bundled_ck(reasons)
+        assert block == {"present": True, "symbol_count": 2}
+        assert reasons == []
+
+
+# ---------------------------------------------------------------------------
+# Tensile
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedKernelDbFingerprint:
+    def test_both_dirs_present_combines_filenames(self, tmp_path: Path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "Kernels.so-000-gfx942.hsaco").write_bytes(b"x")
+        (b / "TensileLibrary_gfx942.dat").write_bytes(b"y")
+        fp = env_mod._combined_kernel_db_fingerprint([a, b])
+        assert fp is not None and fp.startswith("filenames-sha256:")
+
+    def test_one_dir_missing_still_fingerprints(self, tmp_path: Path):
+        a = tmp_path / "a"
+        a.mkdir()
+        (a / "TensileLibrary_X.dat").write_bytes(b"x")
+        fp = env_mod._combined_kernel_db_fingerprint([a, tmp_path / "missing"])
+        assert fp is not None
+
+    def test_both_dirs_missing_returns_none(self, tmp_path: Path):
+        assert env_mod._combined_kernel_db_fingerprint(
+            [tmp_path / "a", tmp_path / "b"]
+        ) is None
+
+    def test_dir_basename_namespaces_collisions(self, tmp_path: Path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        # Same filename in both dirs -- the (dir, file) tagging should
+        # produce a different fingerprint than putting both in one dir.
+        (a / "Kernels.dat").write_bytes(b"x")
+        (b / "Kernels.dat").write_bytes(b"x")
+        fp_separated = env_mod._combined_kernel_db_fingerprint([a, b])
+
+        c = tmp_path / "c"
+        c.mkdir()
+        (c / "Kernels.dat").write_bytes(b"x")
+        fp_alone = env_mod._combined_kernel_db_fingerprint([c])
+        assert fp_separated != fp_alone
+
+    def test_real_world_library_basename_does_not_collapse(
+        self, tmp_path: Path
+    ):
+        """Regression guard for the production layout:
+        /opt/rocm/lib/{hipblaslt,rocblas}/library/.
+
+        Both directories' immediate basename is ``library`` -- using
+        ``d.name`` directly would key every entry as ``library/<file>``
+        and make hipblaslt's and rocblas's same-named kernel files
+        indistinguishable. The fingerprint must use the parent
+        directory's name (``hipblaslt`` vs ``rocblas``) for tagging.
+        """
+        # Mirror the real prod layout exactly.
+        hipblaslt_dir = tmp_path / "hipblaslt" / "library"
+        rocblas_dir = tmp_path / "rocblas" / "library"
+        hipblaslt_dir.mkdir(parents=True)
+        rocblas_dir.mkdir(parents=True)
+        # A same-named kernel file in BOTH directories.
+        (hipblaslt_dir / "Kernels.dat").write_bytes(b"x")
+        (rocblas_dir / "Kernels.dat").write_bytes(b"x")
+
+        fp_combined = env_mod._combined_kernel_db_fingerprint(
+            [hipblaslt_dir, rocblas_dir]
+        )
+        # Compare against a hypothetical "I only saw the rocblas dir"
+        # fingerprint -- if the namespacing collapsed, both would be
+        # equal since "library/Kernels.dat" + "library/Kernels.dat"
+        # dedupes after sort().
+        fp_rocblas_only = env_mod._combined_kernel_db_fingerprint(
+            [rocblas_dir]
+        )
+        assert fp_combined != fp_rocblas_only, (
+            "Combined fingerprint collapsed when both directories share "
+            "the basename 'library'. The probe must tag by the library "
+            "name (parent dir), not the immediate basename."
+        )
+
+
+class TestTensileBlock:
+    def test_block_keys_stable(self, all_disabled):
+        reasons: list[str] = []
+        block = env_mod._capture_tensile(reasons)
+        assert set(block.keys()) == {"package_version", "kernel_db_combined_hash"}
+
+    def test_tensile_pip_absence_does_not_record_reason(self, all_disabled):
+        """Tensile is rarely on production hosts; suppress the import-miss reason."""
+        reasons: list[str] = []
+        env_mod._capture_tensile(reasons)
+        assert all("Tensile not importable" not in r for r in reasons)
+
+    def test_kernel_db_absent_records_reason(self, all_disabled):
+        reasons: list[str] = []
+        env_mod._capture_tensile(reasons)
+        assert any(
+            r.startswith("tensile.kernel_db_combined_hash:") for r in reasons
+        )
+
+
+# ---------------------------------------------------------------------------
+# Triton
+# ---------------------------------------------------------------------------
+
+
+class TestTritonBlock:
+    def test_triton_unavailable_returns_none_with_reason(
+        self, isolated_env, monkeypatch
+    ):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "triton":
+                raise ImportError("simulated absence")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_triton(reasons)
+        assert block == {"package_version": None}
+        assert any("triton" in r for r in reasons)
+
+    def test_triton_with_version_returns_string(self, isolated_env, monkeypatch):
+        import builtins
+        import types
+
+        real_import = builtins.__import__
+        fake_triton = types.SimpleNamespace(__version__="3.5.1+rocm7.2.1.gita272dfa8")
+
+        def fake_import(name, *args, **kwargs):
+            if name == "triton":
+                return fake_triton
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_triton(reasons)
+        assert block == {"package_version": "3.5.1+rocm7.2.1.gita272dfa8"}
+        assert reasons == []
+
+
+# ---------------------------------------------------------------------------
+# FBGEMM
+# ---------------------------------------------------------------------------
+
+
+class TestFbgemmBlock:
+    def test_block_keys_stable(self, all_disabled):
+        reasons: list[str] = []
+        block = env_mod._capture_fbgemm(reasons)
+        assert set(block.keys()) == {
+            "package_version",
+            "pytorch_use_fbgemm",
+            "pytorch_use_fbgemm_genai",
+        }
+
+    def test_fbgemm_gpu_absence_does_not_record_reason(self, all_disabled):
+        reasons: list[str] = []
+        env_mod._capture_fbgemm(reasons)
+        assert all("fbgemm_gpu not importable" not in r for r in reasons)
+
+    def test_torch_absent_returns_null_flags_no_extra_reason(
+        self, isolated_env, monkeypatch
+    ):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name in ("torch", "fbgemm_gpu"):
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_fbgemm(reasons)
+        assert block["pytorch_use_fbgemm"] is None
+        assert block["pytorch_use_fbgemm_genai"] is None
+        # No reason added -- pytorch_version captures torch absence elsewhere
+        assert reasons == []
+
+    def test_pytorch_use_fbgemm_parsed_from_config(
+        self, isolated_env, monkeypatch
+    ):
+        import builtins
+        import types
+
+        config = types.SimpleNamespace(
+            show=lambda: "BLAS_INFO=mkl, CXX_FLAGS=-DUSE_FBGEMM -DUSE_FBGEMM_GENAI -O2"
+        )
+        fake_torch = types.SimpleNamespace(__config__=config)
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            if name == "fbgemm_gpu":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_fbgemm(reasons)
+        assert block["pytorch_use_fbgemm"] is True
+        assert block["pytorch_use_fbgemm_genai"] is True
+
+    def test_pytorch_use_fbgemm_off_when_not_in_flags(
+        self, isolated_env, monkeypatch
+    ):
+        """A ROCm wheel built without FBGEMM should yield False (not None)."""
+        import builtins
+        import types
+
+        config = types.SimpleNamespace(
+            show=lambda: "BLAS_INFO=mkl, CXX_FLAGS=-O2 -DOTHER_FLAG"
+        )
+        fake_torch = types.SimpleNamespace(__config__=config)
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            if name == "fbgemm_gpu":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_fbgemm(reasons)
+        assert block["pytorch_use_fbgemm"] is False
+        assert block["pytorch_use_fbgemm_genai"] is False
+
+    def test_use_fbgemm_regex_does_not_match_genai_substring(self):
+        """Regression guard: -DUSE_FBGEMM (plain) must not false-positive on
+        -DUSE_FBGEMM_GENAI alone.
+        """
+        text = "CXX_FLAGS=-DUSE_FBGEMM_GENAI -O2"
+        assert env_mod._FBGEMM_DEFINE_RE.search(text) is None
+        assert env_mod._FBGEMM_GENAI_DEFINE_RE.search(text) is not None
+
+
+# ---------------------------------------------------------------------------
+# AITER
+# ---------------------------------------------------------------------------
+
+
+class TestAiterBlock:
+    def test_aiter_absence_does_not_record_reason(self, all_disabled):
+        """Most production hosts don't have aiter; suppress the noise."""
+        reasons: list[str] = []
+        block = env_mod._capture_aiter(reasons)
+        assert block == {"package_version": None}
+        assert all("aiter not importable" not in r for r in reasons)
+
+    def test_aiter_with_version_returns_string(self, isolated_env, monkeypatch):
+        import builtins
+        import types
+
+        real_import = builtins.__import__
+        fake_aiter = types.SimpleNamespace(__version__="0.1.4+rocm7.2.gitabc")
+
+        def fake_import(name, *args, **kwargs):
+            if name == "aiter":
+                return fake_aiter
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_aiter(reasons)
+        assert block == {"package_version": "0.1.4+rocm7.2.gitabc"}
+        assert reasons == []
+
+
+# ---------------------------------------------------------------------------
+# Real-torch integration -- complements TestPytorchVersion's monkeypatched
+# unit tests by exercising _capture_pytorch_version against the actual
+# torch wheel installed in the venv. Skipped when torch isn't importable.
+# ---------------------------------------------------------------------------
+
+
+class TestPytorchVersionRealTorch:
+    """Integration test: real `import torch`, real ``__version__``.
+
+    The unit tests in ``TestPytorchVersion`` use ``SimpleNamespace`` fakes
+    -- they cover the contract but cannot catch the class of bug where
+    real torch's ``__version__`` is some unusual type or where the real
+    install path masks an attribute the fake doesn't model. This class
+    runs the probe against the actual installed torch.
+
+    Tagged ``@pytest.mark.rocm`` so it can be deselected on hosts that
+    aren't validating ROCm builds (``pytest -m 'not rocm'``); on hosts
+    without torch installed it self-skips via ``pytest.importorskip``.
+    """
+
+    @pytest.mark.rocm
+    def test_capture_matches_real_torch_version(self):
+        torch = pytest.importorskip(
+            "torch",
+            reason="real-torch integration test requires torch in the venv",
+        )
+        reasons: list[str] = []
+        captured = env_mod._capture_pytorch_version(reasons)
+        assert captured is not None, (
+            f"probe returned None against real torch; reasons: {reasons}"
+        )
+        # The probe stringifies, but it should still equal the source
+        # ``__version__`` exactly -- never the literal "None", never
+        # truncated, never a repr().
+        assert captured == str(torch.__version__)
+        assert captured != "None"
+        assert reasons == []
+
+    @pytest.mark.rocm
+    def test_pytorch_build_git_commit_matches_real_torch(self):
+        """``pytorch_build.git_commit`` must equal ``torch.version.git_version``.
+        That field is the linchpin -- it deterministically pins every
+        third_party submodule for GitHub-tree lookup.
+        """
+        torch = pytest.importorskip("torch")
+        snapshot = collect_env()
+        expected = getattr(torch.version, "git_version", None) or None
+        assert snapshot.pytorch_build["git_commit"] == expected
+
+    @pytest.mark.rocm
+    def test_full_collect_env_against_real_torch(self):
+        """End-to-end: real collect_env() returns a snapshot whose
+        pytorch_version matches torch.__version__ exactly. Catches any
+        wiring break between _capture_pytorch_version and the
+        EnvSnapshot constructor that the unit tests miss.
+        """
+        torch = pytest.importorskip(
+            "torch",
+            reason="real-torch integration test requires torch in the venv",
+        )
+        snapshot = collect_env()
+        assert snapshot.pytorch_version == str(torch.__version__)
+        assert "pytorch_version" not in " ".join(snapshot.partial_reasons), (
+            "pytorch_version probe recorded a partial reason against the "
+            f"real torch install: {snapshot.partial_reasons}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers extracted during the refactor
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Host system (kernel + glibc + machine arch)
+# ---------------------------------------------------------------------------
+
+
+class TestHostBlock:
+    def test_block_keys_stable(self, all_disabled):
+        snapshot = collect_env()
+        assert set(snapshot.host.keys()) == {
+            "kernel_release",
+            "kernel_version",
+            "machine",
+            "glibc_version",
+        }
+
+    def test_real_host_populates_fields(self, all_disabled):
+        """Smoke test against the real host -- on any Linux/macOS test
+        runner ``os.uname()`` and ``os.confstr`` work, so all four
+        fields should be non-null. The all_disabled fixture doesn't
+        sabotage stdlib syscalls.
+        """
+        snapshot = collect_env()
+        host = snapshot.host
+        assert host["kernel_release"] is not None
+        assert host["machine"] is not None
+        # glibc may legitimately be empty on non-glibc systems (musl,
+        # macOS) -- assert only the field is present, not its value.
+        assert "glibc_version" in host
+
+    def test_uname_failure_records_reason(self, all_disabled, monkeypatch):
+        def boom():
+            raise OSError("no uname for you")
+
+        monkeypatch.setattr(env_mod.os, "uname", boom)
+        reasons: list[str] = []
+        block = env_mod._capture_host(reasons)
+        assert block["kernel_release"] is None
+        assert any(r.startswith("host.kernel_release") for r in reasons)
+
+    def test_glibc_version_strips_redundant_prefix(
+        self, all_disabled, monkeypatch
+    ):
+        """``os.confstr`` returns ``"glibc 2.35"`` on Linux. The
+        ``glibc `` prefix duplicates the field name -- store the bare
+        version string so consumers comparing across hosts do
+        ``"2.35" == "2.35"`` rather than dealing with a stray prefix.
+        """
+        monkeypatch.setattr(env_mod.os, "confstr", lambda name: "glibc 2.35")
+        reasons: list[str] = []
+        block = env_mod._capture_host(reasons)
+        assert block["glibc_version"] == "2.35"
+
+    def test_glibc_version_unprefixed_value_passes_through(
+        self, all_disabled, monkeypatch
+    ):
+        """Defensive: if confstr ever returns a bare version string
+        (some libcs / future Python versions might), don't munge it.
+        """
+        monkeypatch.setattr(env_mod.os, "confstr", lambda name: "2.42")
+        reasons: list[str] = []
+        block = env_mod._capture_host(reasons)
+        assert block["glibc_version"] == "2.42"
+
+
+# ---------------------------------------------------------------------------
+# MIOpen (deep-learning primitives -- conv kernels)
+# ---------------------------------------------------------------------------
+
+
+class TestMiopen:
+    def test_block_keys_stable(self, all_disabled):
+        snapshot = collect_env()
+        assert set(snapshot.miopen.keys()) == {
+            "rocm_release_tweak",
+            "package_version",
+            "lib_hash",
+            "kernel_db_revision",
+        }
+
+    def test_partial_reasons_use_miopen_prefix(self, all_disabled):
+        reasons: list[str] = []
+        env_mod._capture_miopen(reasons)
+        assert reasons
+        assert all(r.startswith("miopen.") for r in reasons), reasons
+
+    def test_full_capture_against_real_files(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        header_dir = tmp_path / "include"
+        header_dir.mkdir()
+        (header_dir / "version.h").write_text(
+            "#define MIOPEN_VERSION_MAJOR 3\n"
+            "#define MIOPEN_VERSION_MINOR 5\n"
+            "#define MIOPEN_VERSION_PATCH 1\n"
+            "#define MIOPEN_VERSION_TWEAK dabb6df2b9\n"
+        )
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        (lib_dir / "libMIOpen.so").write_bytes(b"miopen-bytes")
+        db_dir = tmp_path / "db"
+        db_dir.mkdir()
+        (db_dir / "gfx942_64.db.txt").write_text("k1")
+        (db_dir / "gfx942_64.HIP.fdb.txt").write_text("k2")
+
+        monkeypatch.setattr(env_mod, "MIOPEN_VERSION_HEADER", header_dir / "version.h")
+        monkeypatch.setattr(env_mod, "MIOPEN_LIB_DIR", lib_dir)
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", db_dir)
+        reasons: list[str] = []
+        block = env_mod._capture_miopen(reasons)
+        assert block["rocm_release_tweak"] == "dabb6df2b9"
+        assert block["package_version"] == "3.5.1"
+        assert block["lib_hash"] is not None
+        assert block["kernel_db_revision"] is not None
+        assert block["kernel_db_revision"].startswith("filenames-sha256:")
+        assert reasons == []
+
+
+# ---------------------------------------------------------------------------
+# RCCL (collectives, NCCL-compatible API)
+# ---------------------------------------------------------------------------
+
+
+class TestRccl:
+    def test_block_keys_stable(self, all_disabled):
+        snapshot = collect_env()
+        assert set(snapshot.rccl.keys()) == {
+            "version_code",
+            "version",
+            "lib_hash",
+        }
+
+    def test_decode_modern_version_code(self):
+        # 22707 = 2*10000 + 27*100 + 7  (modern scheme; X=2, Y>=9)
+        code, version = env_mod._parse_rccl_header(
+            "#define NCCL_VERSION_CODE 22707\n"
+        )
+        assert code == 22707
+        assert version == "2.27.7"
+
+    def test_decode_legacy_version_code(self):
+        # 2807 = 2*1000 + 8*100 + 7  (legacy scheme; X<=2, Y<=8)
+        code, version = env_mod._parse_rccl_header(
+            "#define NCCL_VERSION_CODE 2807\n"
+        )
+        assert code == 2807
+        assert version == "2.8.7"
+
+    def test_empty_header_returns_none_pair(self):
+        assert env_mod._parse_rccl_header("") == (None, None)
+        assert env_mod._parse_rccl_header(None) == (None, None)
+
+    def test_full_capture(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        header_dir = tmp_path / "include"
+        header_dir.mkdir()
+        (header_dir / "rccl.h").write_text(
+            "// rccl header\n"
+            "#define NCCL_VERSION_CODE 22707\n"
+        )
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        (lib_dir / "librccl.so").write_bytes(b"rccl-bytes")
+
+        monkeypatch.setattr(env_mod, "RCCL_VERSION_HEADER", header_dir / "rccl.h")
+        monkeypatch.setattr(env_mod, "RCCL_LIB_DIR", lib_dir)
+        reasons: list[str] = []
+        block = env_mod._capture_rccl(reasons)
+        assert block["version_code"] == 22707
+        assert block["version"] == "2.27.7"
+        assert block["lib_hash"] is not None
+        assert reasons == []
+
+
+# ---------------------------------------------------------------------------
+# GPU architecture detection (rocm_agent_enumerator)
+# ---------------------------------------------------------------------------
+
+
+class TestGpuArch:
+    def test_block_keys_stable(self, all_disabled):
+        snapshot = collect_env()
+        assert set(snapshot.gpu_arch.keys()) == {
+            "agent_count",
+            "gfx_targets",
+            "agent_arch_counts",
+        }
+
+    def test_binary_missing_records_reason(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
+        # Also stub the /opt/rocm/bin fallback by patching Path.exists
+        # to return False for the canonical path. Easiest: monkeypatch
+        # ROCM_AGENT_ENUMERATOR_BIN to a name that won't exist anywhere.
+        monkeypatch.setattr(
+            env_mod, "ROCM_AGENT_ENUMERATOR_BIN", "definitely_not_a_real_binary_xyz"
+        )
+        reasons: list[str] = []
+        block = env_mod._capture_gpu_arch(reasons)
+        assert block == {
+            "agent_count": None,
+            "gfx_targets": None,
+            "agent_arch_counts": None,
+        }
+        assert any("not on PATH" in r for r in reasons)
+
+    def test_happy_path_parses_one_per_line(
+        self, isolated_env, monkeypatch
+    ):
+        monkeypatch.setattr(
+            env_mod.shutil, "which",
+            lambda name: "/usr/bin/" + name,
+        )
+
+        def fake_run(cmd, **kwargs):
+            assert cmd[0].endswith("rocm_agent_enumerator")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0,
+                stdout="gfx942\ngfx942\ngfx942\ngfx942\n", stderr="",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        block = env_mod._capture_gpu_arch(reasons)
+        assert block["agent_count"] == 4
+        assert block["gfx_targets"] == ["gfx942"]
+        assert block["agent_arch_counts"] == {"gfx942": 4}
+        assert reasons == []
+
+    def test_filters_gfx000_placeholder(self, isolated_env, monkeypatch):
+        """Some hosts include a gfx000 placeholder for the host CPU
+        agent. It's not a GPU; drop it from the targets list.
+        """
+        monkeypatch.setattr(
+            env_mod.shutil, "which",
+            lambda name: "/usr/bin/" + name,
+        )
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0,
+                stdout="gfx000\ngfx942\ngfx942\n", stderr="",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        block = env_mod._capture_gpu_arch(reasons)
+        assert block["agent_count"] == 2  # gfx000 dropped
+        assert "gfx000" not in (block["agent_arch_counts"] or {})
+
+    def test_mixed_arch_host_captures_distribution(
+        self, isolated_env, monkeypatch
+    ):
+        """A host with mixed-arch GPUs (e.g. mi300x + rx7900) should
+        show both in `gfx_targets` AND the per-arch count in
+        `agent_arch_counts`. Catches the cross-environment confound
+        where two trials look identical except one ran on a different
+        second card.
+        """
+        monkeypatch.setattr(
+            env_mod.shutil, "which",
+            lambda name: "/usr/bin/" + name,
+        )
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0,
+                stdout="gfx1100\ngfx942\ngfx942\n", stderr="",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        block = env_mod._capture_gpu_arch(reasons)
+        assert block["gfx_targets"] == ["gfx1100", "gfx942"]
+        assert block["agent_arch_counts"] == {"gfx1100": 1, "gfx942": 2}
+
+    def test_no_kfd_access_records_stderr_tail(
+        self, isolated_env, monkeypatch
+    ):
+        """The most common failure: user not in render group, the
+        binary exits non-zero with a stderr message about /dev/kfd.
+        We surface that stderr so the operator knows what to fix.
+        """
+        monkeypatch.setattr(
+            env_mod.shutil, "which",
+            lambda name: "/usr/bin/" + name,
+        )
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1,
+                stdout="",
+                stderr="cannot open /dev/kfd: Permission denied\n",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        block = env_mod._capture_gpu_arch(reasons)
+        assert block["agent_count"] is None
+        assert any("Permission denied" in r for r in reasons), reasons
+
+
+# ---------------------------------------------------------------------------
+# AOTriton (default ROCm Flash Attention backend)
+# ---------------------------------------------------------------------------
+
+
+class TestAotritonBlockShape:
+    def test_block_keys_stable(self, all_disabled):
+        """Schema-shape guard. The aotriton block always has these keys
+        regardless of presence/absence of the bundled lib.
+        """
+        snapshot = collect_env()
+        assert set(snapshot.aotriton.keys()) == {
+            "bundled_present",
+            "bundled_version",
+            "bundled_lib_hash",
+            "bundled_images_dir_present",
+            "installed_prefix",
+        }
+
+
+class TestAotritonProbe:
+    def test_torch_absent_returns_default_no_reason(
+        self, isolated_env, monkeypatch
+    ):
+        """torch missing -> documented absence (already captured by
+        pytorch_version), aotriton probe stays silent.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_aotriton(reasons)
+        assert block["bundled_present"] is False
+        assert block["bundled_version"] is None
+        assert reasons == []
+
+    def test_cpu_only_torch_skips_silently(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """torch.version.hip is None -> CPU-only wheel, no AOTriton by
+        design. Mirrors the bundled-CK probe's CPU-only handling.
+        """
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        torch_dir.mkdir()
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            version=types.SimpleNamespace(hip=None, cuda=None),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_aotriton(reasons)
+        assert block["bundled_present"] is False
+        assert reasons == []
+
+    def test_happy_path_parses_version_and_hashes(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        (torch_dir / "lib").mkdir(parents=True)
+        (torch_dir / "lib" / "libaotriton_v2.so.0.11.1").write_bytes(b"aot")
+        (torch_dir / "lib" / "aotriton.images").mkdir()
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            version=types.SimpleNamespace(hip="7.2.5", cuda=None),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_aotriton(reasons)
+        assert block["bundled_present"] is True
+        assert block["bundled_version"] == "0.11.1"
+        assert block["bundled_lib_hash"] is not None
+        assert block["bundled_lib_hash"].startswith("sha256:")
+        assert block["bundled_images_dir_present"] is True
+        assert block["installed_prefix"] is None
+        assert reasons == []
+
+    def test_picks_highest_version_when_multiple_present(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        (torch_dir / "lib").mkdir(parents=True)
+        (torch_dir / "lib" / "libaotriton_v2.so.0.10.0").write_bytes(b"old")
+        (torch_dir / "lib" / "libaotriton_v2.so.0.11.1").write_bytes(b"new")
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            version=types.SimpleNamespace(hip="7.2.5", cuda=None),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_aotriton(reasons)
+        # Numeric-tuple sort: 0.11.1 > 0.10.0 even though string sort
+        # would say "0.11.1" < "0.10.0" (since '1' < '0' in second slot).
+        assert block["bundled_version"] == "0.11.1"
+
+    def test_version_and_hash_describe_the_same_file_under_minor_crossover(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """Regression guard for the round-4 bug:
+
+        bundled_version was version-tuple-sorted (correct), but
+        bundled_lib_hash was string-sort-sorted (wrong). For any pair
+        crossing a digit boundary, e.g. 0.9.0 vs 0.10.0:
+          - tuple sort picks 0.10.0
+          - string sort picks 0.9.0 (lexically '9' > '1')
+
+        That left bundled_version="0.10.0" while
+        bundled_lib_hash hashed the bytes of 0.9.0 -- the two fields
+        described different files for the same record. This test pins
+        the fix: both must point at 0.10.0.
+        """
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        (torch_dir / "lib").mkdir(parents=True)
+        (torch_dir / "lib" / "libaotriton_v2.so.0.9.0").write_bytes(b"NINE-zero")
+        (torch_dir / "lib" / "libaotriton_v2.so.0.10.0").write_bytes(b"TEN-zero")
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            version=types.SimpleNamespace(hip="7.2.5", cuda=None),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_aotriton(reasons)
+        assert block["bundled_version"] == "0.10.0"
+        # The hash MUST be of the 0.10.0 bytes, NOT the 0.9.0 bytes
+        # that string-sort would have chosen.
+        expected_hash = "sha256:" + hashlib.sha256(b"TEN-zero").hexdigest()
+        wrong_hash = "sha256:" + hashlib.sha256(b"NINE-zero").hexdigest()
+        assert block["bundled_lib_hash"] == expected_hash, (
+            f"bundled_lib_hash describes the wrong file -- the "
+            f"version-tuple-sort vs string-sort regression has reappeared. "
+            f"Expected hash of '0.10.0' bytes ({expected_hash!r}), got "
+            f"{block['bundled_lib_hash']!r}. If this is the wrong-side "
+            f"hash {wrong_hash!r}, _capture_aotriton fell back to "
+            f"_hash_shared_library's glob+string-sort instead of using "
+            f"_hash_file_path(best_path)."
+        )
+
+    def test_no_aotriton_in_lib_dir_records_reason(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """HIP torch but no libaotriton_v2.so* -> custom build with
+        AOTriton disabled. Worth flagging.
+        """
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        (torch_dir / "lib").mkdir(parents=True)
+        # No aotriton lib on purpose.
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            version=types.SimpleNamespace(hip="7.2.5", cuda=None),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_aotriton(reasons)
+        assert block["bundled_present"] is False
+        assert any("no libaotriton_v2.so" in r for r in reasons)
+
+    def test_installed_prefix_env_var_recorded(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """AOTRITON_INSTALLED_PREFIX is the operator's override pointing
+        PyTorch at a system AOTriton install. Capturing it is critical
+        for cross-env diffs (a host with the override set behaves
+        differently from one without).
+        """
+        import builtins
+        import types
+
+        torch_dir = tmp_path / "torch"
+        (torch_dir / "lib").mkdir(parents=True)
+        (torch_dir / "lib" / "libaotriton_v2.so.0.11.1").write_bytes(b"x")
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            version=types.SimpleNamespace(hip="7.2.5", cuda=None),
+        )
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setenv("AOTRITON_INSTALLED_PREFIX", "/opt/aotriton-0.12")
+        reasons: list[str] = []
+        block = env_mod._capture_aotriton(reasons)
+        assert block["installed_prefix"] == "/opt/aotriton-0.12"
+
+
+# ---------------------------------------------------------------------------
+# pytorch_build block (structured PyTorch identity + submodule SHAs)
+# ---------------------------------------------------------------------------
+
+
+class TestPytorchBuildBlockShape:
+    """Schema-shape and disaster-defaults guards."""
+
+    def test_block_keys_stable(self, all_disabled):
+        snapshot = collect_env()
+        assert set(snapshot.pytorch_build.keys()) == {
+            "git_commit",
+            "hip_version",
+            "cuda_version",
+            "debug",
+            "install_kind",
+            "source_path",
+            "submodule_commits",
+        }
+
+    def test_submodule_commits_keys_stable(self, all_disabled):
+        snapshot = collect_env()
+        subs = snapshot.pytorch_build["submodule_commits"]
+        # The canonical submodule list IS schema; bumping it is a
+        # deliberate change. Mirrors test_canonical_var_names_stable.
+        assert set(subs.keys()) == {
+            "_source",
+            "composable_kernel",
+            "aiter",
+            "fbgemm",
+        }
+
+    def test_canonical_submodules_constant_is_stable(self):
+        # If you add a third_party submodule to track, update both this
+        # set and TestPytorchBuildBlockShape.test_submodule_commits_keys_stable.
+        assert set(env_mod.CANONICAL_PYTORCH_SUBMODULES) == {
+            "composable_kernel",
+            "aiter",
+            "fbgemm",
+        }
+
+
+class TestDetectPytorchInstallKind:
+    def test_explicit_env_var_wins(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        src = tmp_path / "my_pytorch_src"
+        (src / "third_party").mkdir(parents=True)
+        monkeypatch.setenv("AORTA_PYTORCH_SRC", str(src))
+        kind, path = env_mod._detect_pytorch_install_kind()
+        assert kind == "source"
+        assert path == src.resolve()
+
+    def test_env_var_pointing_at_invalid_path_falls_through(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        # AORTA_PYTORCH_SRC set, but the dir has no third_party/ -- we
+        # honour the operator's intent only when the structure is valid.
+        bogus = tmp_path / "not_a_pytorch_tree"
+        bogus.mkdir()
+        monkeypatch.setenv("AORTA_PYTORCH_SRC", str(bogus))
+        # No torch in this environment -> falls to "unknown"; the point
+        # is we don't return ("source", bogus).
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated absence")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        kind, path = env_mod._detect_pytorch_install_kind()
+        assert kind == "unknown"
+
+    def test_torch_absent_returns_unknown(self, isolated_env, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        kind, path = env_mod._detect_pytorch_install_kind()
+        assert kind == "unknown"
+        assert path is None
+
+    def test_walk_up_finds_source_tree(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """`import torch` from inside a source checkout: torch.__file__
+        sits under a directory that has .git + third_party siblings.
+        """
+        import builtins
+        import types
+
+        # Layout: <tmp>/.git, <tmp>/third_party/, <tmp>/torch/__init__.py
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "third_party").mkdir()
+        torch_dir = tmp_path / "torch"
+        torch_dir.mkdir()
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            __version__="2.99.0",
+        )
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        kind, path = env_mod._detect_pytorch_install_kind()
+        assert kind == "source"
+        assert path == tmp_path.resolve()
+
+    def test_wheel_install_default(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """No env var, no .git, no third_party -- a stock wheel install."""
+        import builtins
+        import types
+
+        site = tmp_path / "site-packages"
+        site.mkdir()
+        torch_dir = site / "torch"
+        torch_dir.mkdir()
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            __version__="2.99.0",
+        )
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        kind, path = env_mod._detect_pytorch_install_kind()
+        assert kind == "wheel"
+        assert path is None
+
+
+class TestGitRevParseHead:
+    def test_happy_path_returns_full_sha(self, tmp_path: Path, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0,
+                stdout="ff65f5bc672795c5e5033900ea0a0c4f8566c8cf\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        sha = env_mod._git_rev_parse_head(tmp_path)
+        assert sha == "ff65f5bc672795c5e5033900ea0a0c4f8566c8cf"
+
+    def test_non_hex_output_rejected(self, tmp_path: Path, monkeypatch):
+        """Defensive: a misconfigured git aliasing rev-parse to something
+        else (unlikely but possible) must not poison the snapshot.
+        """
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="not-a-sha\n", stderr="",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        assert env_mod._git_rev_parse_head(tmp_path) is None
+
+    def test_git_missing_returns_none(self, tmp_path: Path, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        assert env_mod._git_rev_parse_head(tmp_path) is None
+
+    def test_nonzero_exit_returns_none(self, tmp_path: Path, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=128, stdout="", stderr="not a git repo",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        assert env_mod._git_rev_parse_head(tmp_path) is None
+
+
+class TestCapturePytorchSubmodules:
+    def test_source_tree_populates_via_git(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        third_party = tmp_path / "third_party"
+        third_party.mkdir()
+        for name in env_mod.CANONICAL_PYTORCH_SUBMODULES:
+            (third_party / name).mkdir()
+
+        sha_map = {
+            "composable_kernel": "1" * 40,
+            "aiter": "2" * 40,
+            "fbgemm": "3" * 40,
+        }
+
+        def fake_run(cmd, **kwargs):
+            sub_name = Path(cmd[2]).name
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0,
+                stdout=sha_map.get(sub_name, "") + "\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        result = env_mod._capture_pytorch_submodules(
+            "source", tmp_path, "abc1234", reasons
+        )
+        assert result["_source"] == "git"
+        assert result["composable_kernel"] == "1" * 40
+        assert result["aiter"] == "2" * 40
+        assert result["fbgemm"] == "3" * 40
+        assert reasons == []
+
+    def test_wheel_install_emits_url_template(self, isolated_env):
+        """No source tree -- partial reason must contain the GitHub URL
+        template with the captured commit substituted in. Operators
+        reading env.json get a copy-pasteable recovery URL.
+        """
+        reasons: list[str] = []
+        result = env_mod._capture_pytorch_submodules(
+            "wheel", None, "ff65f5bc672795c5e5033900ea0a0c4f8566c8cf", reasons
+        )
+        assert result["_source"] is None
+        for name in env_mod.CANONICAL_PYTORCH_SUBMODULES:
+            assert result[name] is None
+        assert len(reasons) == 1
+        reason = reasons[0]
+        assert "github.com/pytorch/pytorch/tree/" in reason
+        assert "ff65f5bc672795c5e5033900ea0a0c4f8566c8cf" in reason
+        assert "AORTA_PYTORCH_SRC" in reason
+
+    def test_wheel_install_unknown_commit_uses_placeholder(self, isolated_env):
+        """If git_commit is null too, the URL template still appears with
+        the literal `<git_commit>` placeholder so the operator at least
+        sees the recovery shape.
+        """
+        reasons: list[str] = []
+        env_mod._capture_pytorch_submodules("wheel", None, None, reasons)
+        assert any("<git_commit>" in r for r in reasons)
+
+    def test_unknown_install_kind_records_reason(self, isolated_env):
+        reasons: list[str] = []
+        env_mod._capture_pytorch_submodules("unknown", None, None, reasons)
+        assert any("torch import failed" in r for r in reasons)
+
+    def test_partial_submodule_set_records_missing(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """Source tree exists but only some submodules are checked out.
+        The missing ones land in a single-line reason, not N reasons.
+        """
+        third_party = tmp_path / "third_party"
+        third_party.mkdir()
+        # Only composable_kernel exists; aiter + fbgemm don't.
+        (third_party / "composable_kernel").mkdir()
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="a" * 40 + "\n", stderr="",
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        result = env_mod._capture_pytorch_submodules(
+            "source", tmp_path, "abc1234", reasons
+        )
+        assert result["composable_kernel"] == "a" * 40
+        assert result["aiter"] is None
+        assert result["fbgemm"] is None
+        assert result["_source"] == "git"
+        assert len(reasons) == 1
+        assert "aiter" in reasons[0]
+        assert "fbgemm" in reasons[0]
+
+
+class TestCapturePytorchBuildIntegration:
+    """The full block, exercised against fake torch."""
+
+    def test_torch_absent_returns_default_block(
+        self, isolated_env, monkeypatch
+    ):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_pytorch_build(reasons)
+        assert block["git_commit"] is None
+        assert block["install_kind"] == "unknown"
+        # The block-level probe must NOT add a generic "torch import
+        # raised" reason -- pytorch_version already records the absence
+        # and double-counting would noise up partial_reasons. The single
+        # reason that DOES fire is the submodule-commits one (a
+        # consumer-facing affordance saying SHAs are unrecoverable),
+        # which is a separate field-level signal.
+        assert not any(
+            r.startswith("pytorch_build: torch import raised") for r in reasons
+        )
+        sub_reasons = [
+            r for r in reasons if r.startswith("pytorch_build.submodule_commits")
+        ]
+        assert len(sub_reasons) == 1
+        assert "torch import failed" in sub_reasons[0]
+
+    def test_real_torch_version_fields_captured(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        import builtins
+        import types
+
+        site = tmp_path / "site"
+        site.mkdir()
+        torch_dir = site / "torch"
+        torch_dir.mkdir()
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        fake_torch = types.SimpleNamespace(
+            __file__=str(torch_init),
+            __version__="2.99.0",
+            version=types.SimpleNamespace(
+                git_version="ff65f5bc672795c5e5033900ea0a0c4f8566c8cf",
+                hip="7.2.5",
+                cuda=None,
+                debug=False,
+            ),
+        )
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_pytorch_build(reasons)
+        assert block["git_commit"] == "ff65f5bc672795c5e5033900ea0a0c4f8566c8cf"
+        assert block["hip_version"] == "7.2.5"
+        assert block["cuda_version"] is None
+        assert block["debug"] is False
+        assert block["install_kind"] == "wheel"
+        # Wheel install -> single recovery-URL reason
+        assert any(
+            "github.com/pytorch/pytorch/tree/" in r for r in reasons
+        )
+
+
+class TestSafeImportTorch:
+    """Centralised torch-import helper used by every probe that needs
+    torch (composable_kernel, aotriton, fbgemm-flag scan, CK-flag scan,
+    pytorch_build).
+    """
+
+    def test_import_error_silent(self, isolated_env, monkeypatch):
+        """ImportError -> None, no reason added (pytorch_version probe
+        records the absence elsewhere, this helper must not double-count).
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        result = env_mod._safe_import_torch(reasons, "test_probe")
+        assert result is None
+        assert reasons == []
+
+    def test_unexpected_exception_records_with_probe_name(
+        self, isolated_env, monkeypatch
+    ):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise RuntimeError("C ext load failed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        result = env_mod._safe_import_torch(reasons, "composable_kernel.foo")
+        assert result is None
+        assert len(reasons) == 1
+        assert reasons[0].startswith("composable_kernel.foo: torch import raised")
+        assert "RuntimeError" in reasons[0]
+
+    def test_success_returns_module(self, isolated_env, monkeypatch):
+        import builtins
+        import types
+
+        fake_torch = types.SimpleNamespace(__version__="2.99.0")
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        result = env_mod._safe_import_torch(reasons, "test_probe")
+        assert result is fake_torch
+        assert reasons == []
+
+
+class TestHashFilePath:
+    """Helper that hashes a caller-supplied Path (vs
+    ``_hash_shared_library`` which globs and string-sorts internally).
+    """
+
+    def test_hash_specific_file(self, tmp_path: Path):
+        f = tmp_path / "libfoo.so.0.10.0"
+        f.write_bytes(b"specific bytes")
+        digest = env_mod._hash_file_path(f)
+        expected = "sha256:" + hashlib.sha256(b"specific bytes").hexdigest()
+        assert digest == expected
+
+    def test_resolves_symlink(self, tmp_path: Path):
+        real = tmp_path / "real.so"
+        real.write_bytes(b"real bytes")
+        link = tmp_path / "link.so"
+        link.symlink_to(real)
+        digest = env_mod._hash_file_path(link)
+        expected = "sha256:" + hashlib.sha256(b"real bytes").hexdigest()
+        assert digest == expected
+
+    def test_missing_returns_none(self, tmp_path: Path):
+        assert env_mod._hash_file_path(tmp_path / "nonexistent") is None
+
+    def test_directory_returns_none(self, tmp_path: Path):
+        d = tmp_path / "adir"
+        d.mkdir()
+        assert env_mod._hash_file_path(d) is None
+
+
+class TestPythonPackageVersionHelper:
+    def test_suppress_missing_skips_import_reason(self, isolated_env, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "fakepkg":
+                raise ImportError("nope")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        result = env_mod._capture_python_package_version(
+            "fakepkg", reasons, suppress_missing=True
+        )
+        assert result is None
+        assert reasons == []
+
+    def test_suppress_missing_still_reports_other_failures(
+        self, isolated_env, monkeypatch
+    ):
+        """suppress_missing only swallows ImportError, not broken __version__."""
+        import builtins
+        import types
+
+        real_import = builtins.__import__
+        fake_mod = types.SimpleNamespace()  # no __version__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "brokenpkg":
+                return fake_mod
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        result = env_mod._capture_python_package_version(
+            "brokenpkg", reasons, suppress_missing=True
+        )
+        assert result is None
+        assert any("__version__" in r for r in reasons)
+
+    def test_custom_reason_prefix_used_in_output(
+        self, isolated_env, monkeypatch
+    ):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "fakepkg":
+                raise ImportError("nope")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        env_mod._capture_python_package_version(
+            "fakepkg", reasons, reason_prefix="custom.thing"
+        )
+        assert any(r.startswith("custom.thing:") for r in reasons)

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -2177,6 +2177,30 @@ class TestRocblasLibHash:
         expected = "sha256:" + hashlib.sha256(b"new").hexdigest()
         assert digest == expected
 
+    def test_picks_numerically_highest_across_digit_boundary(
+        self, tmp_path: Path
+    ):
+        """Regression guard: the version-suffix sort must be by integer
+        tuple, not lexicographic. ``5.10.0`` is newer than ``5.9.0`` but
+        sorts *before* it as a string (``"1" < "9"``), so a lex-sorted
+        fallback would record the older file's hash on a multi-version
+        install.
+        """
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        (lib_dir / "librocblas.so.5.9.0").write_bytes(b"old-five-nine")
+        (lib_dir / "librocblas.so.5.10.0").write_bytes(b"new-five-ten")
+
+        digest = env_mod._hash_shared_library(lib_dir, "librocblas.so")
+        expected = "sha256:" + hashlib.sha256(b"new-five-ten").hexdigest()
+        wrong = "sha256:" + hashlib.sha256(b"old-five-nine").hexdigest()
+        assert digest == expected, (
+            "lib_hash describes the wrong file -- the integer-tuple vs "
+            f"string-sort regression has reappeared. Expected {expected!r}, "
+            f"got {digest!r}. If this is the wrong-side hash {wrong!r}, "
+            "_hash_shared_library has reverted to lex-sorting its glob."
+        )
+
 
 class TestRocblasBlockShape:
     def test_block_keys_stable(self, all_disabled):


### PR DESCRIPTION
Extends the A1 env probe (#152) from 4 library blocks into a 22-block schema covering every ROCm + PyTorch identity surface that materially affects trial reproducibility on MI300/MI200 hosts. Goal: when two trials diverge, `diff <(jq -S . a.json) <(jq -S . b.json)` surfaces the cause directly, instead of multi-day investigations into implicit-environment drift.

## New top-level blocks

All follow the existing fail-soft contract — fully-shaped dict, `partial_reasons` line per missing field, never raises.

- **rocblas, miopen, rccl** — parallel to hipblaslt: header-parsed `rocm_release_tweak` + `package_version` + `lib_hash` (resolved through symlinks; falls through to versioned filenames in stripped images), plus a per-library kernel-DB filename fingerprint.

- **composable_kernel** — two sub-blocks.
  - `system` reads `/opt/rocm/include/ck/version.h` for version + 40-char SHA + `ck_tile_present`.
  - `pytorch_bundled` runs `nm -D | c++filt` over `libtorch_hip.so` to count `ck::` symbols actually compiled into the loaded wheel. The `nm`/`c++filt` pipeline gets its own `NM_TIMEOUT_SEC=30` budget (vs the default `SHORT_TIMEOUT_SEC=5`) because it scans a multi-hundred-MB binary.
  - Two sibling booleans `pytorch_use_ck_sdpa` / `pytorch_use_ck_gemm` parse `-DUSE_ROCM_CK_SDPA` / `-DUSE_ROCM_CK_GEMM` out of `torch.__config__.show()`. These are build-time cmake flags, not runtime env vars.

- **tensile** — optional pip probe + sorted-filenames sha256 over the union of the hipBLASLt + rocBLAS kernel DBs (parent-dir-namespaced by library so same-named files in both dirs do not collide).

- **triton, fbgemm, aiter** — pip-importable Python pkg version. fbgemm also surfaces `-DUSE_FBGEMM` / `-DUSE_FBGEMM_GENAI` build-time flags from `torch.__config__.show()` (FBGEMM is vendored inside the PyTorch wheel; the standalone `fbgemm_gpu` pip pkg is rarely installed alongside).

- **aotriton** — bundled in the PyTorch wheel at `TORCH_LIB/libaotriton_v2.so.MAJOR.MINOR.PATCH` via `cmake/External` (NOT a third_party submodule). Version parsed from filename via numeric-tuple sort; the `lib_hash` reuses the same precomputed best path via a new `_hash_file_path` helper to keep version + hash describing the same file. Captures `bundled_present`, `bundled_version`, `bundled_lib_hash`, `bundled_images_dir_present` (the `aotriton.images/` dir of pre-compiled kernel images), and the `AOTRITON_INSTALLED_PREFIX` env var (operator override).

- **gpu_arch** — `rocm_agent_enumerator` subprocess (works without `/dev/kfd` on most hosts; falls back to `/opt/rocm/bin` if not on PATH). Captures `agent_count`, `gfx_targets` (sorted unique), and `agent_arch_counts` (per-arch distribution: `gfx942: 8` on a homogeneous box; `gfx1100: 1, gfx942: 6` on a mixed-arch host). Filters the `gfx000` placeholder some hosts include for the host CPU agent.

- **host** — `kernel_release` + `kernel_version` + `machine` + `glibc_version` via `os.uname()` + `os.confstr(CS_GNU_LIBC_VERSION)`. Closes the gap where rdhc was the only firmware/kernel source on hosts with sudo unconfigured.

- **pytorch_build** — structured complement to `pytorch_version`. Always captures `git_commit` (from `torch.version.git_version`) + `hip_version` + `cuda_version` + `debug` + `install_kind`. When a PyTorch source tree is detected (`AORTA_PYTORCH_SRC` env var, PEP 660 editable-install marker, or walk-up `.git` + `third_party` from `torch.__file__`), additionally populates `submodule_commits` for `composable_kernel`, `aiter`, and `fbgemm` via `git -C third_party/SUBNAME rev-parse HEAD`. Wheel installs fall back to a `partial_reasons` line containing the literal GitHub-tree URL with the captured `git_commit` substituted in, so an operator reading `env.json` gets a copy-pasteable recovery URL without leaving the doc.

## Renames (schema 1.0 to 1.1)

See the `SCHEMA_VERSION` changelog comment in `environment.py` for the field-by-field history.

- `hipblaslt.commit` / `rocblas.commit` / `miopen.commit` renamed to `.rocm_release_tweak`. AMD sets the `*_VERSION_TWEAK` macro to the ROCm release identifier shared across every library in a release, NOT to per-library upstream commit SHAs. The old name misled consumers (every library in a given ROCm release shows the same value — useless for distinguishing per-library drift). `lib_hash` is the per-binary signal.
- `hipblaslt.tensile_yaml_revision` / `rocblas.tensile_yaml_revision` renamed to `.kernel_db_revision`. Matches `miopen.kernel_db_revision`; modern hipBLASLt and rocBLAS ship `.dat` files (binary), not `.yaml`.

## CANONICAL_ENV_VARS

Grows from 13 to 31 entries (18 additions, 0 removals against the merge base). New entries cover GPU scoping (`HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`, `HSA_OVERRIDE_GFX_VERSION`), launch (`HIP_LAUNCH_BLOCKING`), build target (`PYTORCH_ROCM_ARCH`), MIOpen kernel-DB selection (`MIOPEN_SYSTEM_DB_PATH`, `MIOPEN_USER_DB_PATH`, `MIOPEN_DEBUG_DISABLE_FIND_DB`, `MIOPEN_FIND_MODE`), SDPA backend (`TORCH_ROCM_FA_PREFER_CK`, `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL`), GEMM backend + autotune (`TORCH_BLAS_PREFER_HIPBLASLT`, `TORCH_HIPBLASLT_TUNING_FILE`, `TORCH_HIPBLASLT_TUNING_OVERRIDE_FILE`), and NCCL/RCCL extras (`NCCL_P2P_LEVEL`, `NCCL_IB_HCA`, `NCCL_SOCKET_IFNAME`, `RCCL_MSCCL_ENABLE`).

`USE_ROCM_CK_SDPA` is deliberately NOT in this list — it is a build-time cmake flag, not a runtime env var; setting it in the workload's environment does nothing. Captured instead under `composable_kernel.pytorch_use_ck_sdpa` and `composable_kernel.pytorch_use_ck_gemm`.

## Refactor

Extracted `_parse_version_header`, `_hash_shared_library`, `_hash_file_path`, `_kernel_db_filename_fingerprint`, `_capture_python_package_version`, `_safe_import_torch` as shared helpers used by every library and Python-pkg block. Existing `_parse_hipblaslt_header`, `_hash_hipblaslt_library`, `_tensile_fingerprint`, `_capture_pytorch_version` stay as one-line wrappers so the existing `TestHipblaslt*` and `TestPytorchVersion` test classes pass without edits.

## CLI

New `-v` / `--verbose` flag dumps the full snapshot JSON to stdout after the brief. `partial_reasons` echoed inline so the operator can fix issues without `jq`-ing `env.json`. Closing `[PARTIAL, N reason(s)]` or `[OK]` marker repeats the probe state at end-of-output.

`summary()` expanded from 6 lines to about 18 (one labelled cell per top-level block) so an operator running the probe sees the new GEMM/kernel-library identities without reading the JSON. Self-explanatory wording for absent-but-expected pip pkgs (e.g. `Tensile pip pkg: (not installed); build-time tool, normal` rather than `pip=None`). The `[PARTIAL, N reason(s)]` marker only appears at end-of-output, never duplicated on the runtime line.

## Tests

219 passing (107 original + 112 new) across `TestRocblas*`, `TestCK*`, `TestCKPytorchBuildFlags`, `TestCombinedKernelDbFingerprint`, `TestTensileBlock`, `TestTritonBlock`, `TestFbgemmBlock`, `TestAiterBlock`, `TestAotriton*`, `TestMiopen`, `TestRccl`, `TestGpuArch`, `TestHostBlock`, `TestPytorchBuildBlockShape`, `TestDetectPytorchInstallKind`, `TestGitRevParseHead`, `TestCapturePytorchSubmodules`, `TestCapturePytorchBuildIntegration`, `TestPytorchVersionRealTorch`, `TestSafeImportTorch`, `TestHashFilePath`, `TestPythonPackageVersionHelper`, plus stripped-image-fallback and integer-tuple-crossover regressions for `_hash_shared_library`, and the multi-version-crossover regression for `_capture_aotriton`.

## Docs

`docs/env-probe.md` schema table, sources-of-data table, CLI section, PyTorch source-tree submodule probing section, schema changelog, and field-naming notes (`rocm_release_tweak` vs `commit`; `hip.version` vs `pytorch_build.hip_version`) all updated. `src/aorta/instrumentation/README.md` schema-version block updated to v1.1 with all 22 top-level keys listed.

## Verification

Verified end-to-end on MI300X / ROCm 7.2.1 / PyTorch 2.9.1+rocm7.2.1: every block populates cleanly; `partial_reasons` contains only the expected pre-existing entries (rdhc-sudo, version_dev, wheel-install submodule recovery URL). Wall time about 2.2s warm baremetal, well inside the 15s overall target.

## Review follow-up (commit af69035)

Addresses the two Copilot review comments on this PR:

- `_hash_shared_library` now ranks versioned-soname siblings by integer tuple via a new `_parse_soname_version` helper, with lex-sort as a second tier for non-numeric suffixes. The previous reverse-lex glob picked `librocblas.so.5.9.0` over `librocblas.so.5.10.0` (because `"9"` is greater than `"1"` as strings). Same bug class already handled correctly for AOTriton; now the generic helper used by hipBLASLt, rocBLAS, MIOpen, and RCCL gets the same treatment. Regression test `test_picks_numerically_highest_across_digit_boundary` added.
- `SCHEMA_VERSION` changelog comment rewritten to describe the env-var delta by family rather than hardcoding an outdated count.
