### PR TITLE
aorta.ebpf: integrate ebpfaultline kernel tracing into AORTA

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,11 @@ hw-queue-profiling = [
     "seaborn>=0.12.0",
 ]
 
+# For aorta.ebpf kernel tracing module.
+# The runtime requirements are the bpftrace binary and CAP_BPF/CAP_PERFMON
+# (or sudo); no Python deps beyond the base.
+ebpf = []
+
 # Development dependencies
 dev = [
     "pytest>=8.0.0",
@@ -103,7 +108,7 @@ where = ["src"]
 include = ["aorta*"]
 
 [tool.setuptools.package-data]
-aorta = ["py.typed"]
+aorta = ["py.typed", "ebpf/scripts/*.bt", "ebpf/scripts/PROVENANCE.md"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/aorta/ebpf/__init__.py
+++ b/src/aorta/ebpf/__init__.py
@@ -19,11 +19,11 @@ probe symbols may need adjustment for non-tested kernel versions.
 from .events import KernelEvent, KernelEventType
 from .parser import BpftraceLogParser
 from .runner import (
+    SCRIPTS_DIR,
     BpftraceConfig,
     BpftraceRunner,
     BpftraceScriptVariant,
     BpftraceUnavailableError,
-    SCRIPTS_DIR,
 )
 
 __all__ = [

--- a/src/aorta/ebpf/__init__.py
+++ b/src/aorta/ebpf/__init__.py
@@ -1,0 +1,38 @@
+"""eBPF kernel-tracing integration for AORTA.
+
+This package wraps the bpftrace scripts originally developed in the
+``ebpfaultline`` project, exposing them as a reusable Python API so that
+any AORTA workload can attach kernel-level GPU/KFD observability alongside
+the existing user-space profilers (``StreamProfiler``, ``ROCmProfiler``).
+
+Public surface:
+    - ``BpftraceRunner`` -- subprocess lifecycle wrapper for bpftrace.
+    - ``BpftraceConfig`` -- runner configuration dataclass.
+    - ``BpftraceScriptVariant`` -- enum of vendored ``.bt`` script variants.
+    - ``BpftraceLogParser`` -- structured parser for bpftrace stdout.
+    - ``KernelEvent`` / ``KernelEventType`` -- typed event records.
+
+The vendored scripts under ``scripts/`` target AMD ROCm KFD/amdgpu paths;
+probe symbols may need adjustment for non-tested kernel versions.
+"""
+
+from .events import KernelEvent, KernelEventType
+from .parser import BpftraceLogParser
+from .runner import (
+    BpftraceConfig,
+    BpftraceRunner,
+    BpftraceScriptVariant,
+    BpftraceUnavailableError,
+    SCRIPTS_DIR,
+)
+
+__all__ = [
+    "BpftraceConfig",
+    "BpftraceLogParser",
+    "BpftraceRunner",
+    "BpftraceScriptVariant",
+    "BpftraceUnavailableError",
+    "KernelEvent",
+    "KernelEventType",
+    "SCRIPTS_DIR",
+]

--- a/src/aorta/ebpf/events.py
+++ b/src/aorta/ebpf/events.py
@@ -1,0 +1,47 @@
+"""Kernel event types emitted by bpftrace log parsing."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class KernelEventType(enum.Enum):
+    """Event types observed by the bpftrace GPU tracing scripts."""
+
+    KFD_EVICT = "KFD_EVICT_QUEUES"
+    KFD_RESTORE = "KFD_RESTORE_QUEUES"
+    SVM_EVICT = "SVM_RANGE_EVICT_WORKER"
+    BO_MOVE = "BO_MOVE"
+    VM_FLUSH = "VM_FLUSH"
+    VM_UNMAP_TICK = "VM_UNMAP_TICK"
+    IOCTL_ERROR = "IOCTL_ERROR"
+    LONG_IOCTL = "LONG_IOCTL"
+    MMAP = "MMAP"
+    MUNMAP = "MUNMAP"
+    VM_HANDLE_MOVED = "VM_HANDLE_MOVED"
+    KFD_INTERRUPT = "KFD_INTERRUPT"
+    SIGNAL = "SIGNAL"
+    HEARTBEAT = "HEARTBEAT"
+    TICK = "TICK"
+
+
+@dataclass
+class KernelEvent:
+    """A single parsed event from bpftrace output.
+
+    Attributes:
+        timestamp_ns: Kernel-clock timestamp in nanoseconds.
+        event_type: Classified event type.
+        payload: Event-specific key-value data (e.g. pid, size, placement).
+        raw_line: The original unparsed log line.
+    """
+
+    timestamp_ns: int
+    event_type: KernelEventType
+    payload: dict[str, Any] = field(default_factory=dict)
+    raw_line: str = ""
+
+
+__all__ = ["KernelEventType", "KernelEvent"]

--- a/src/aorta/ebpf/parser.py
+++ b/src/aorta/ebpf/parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Optional
 
 from .events import KernelEvent, KernelEventType
 
@@ -34,9 +33,7 @@ _PATTERNS: list[tuple[re.Pattern[str], KernelEventType, list[str]]] = [
         ["pid"],
     ),
     (
-        re.compile(
-            rf"^{_TS} \*\*\* AMDGPU_BO_MOVE size=(\d+) old=(\d+) new=(\d+) \*\*\*"
-        ),
+        re.compile(rf"^{_TS} \*\*\* AMDGPU_BO_MOVE size=(\d+) old=(\d+) new=(\d+) \*\*\*"),
         KernelEventType.BO_MOVE,
         ["size", "old_placement", "new_placement"],
     ),
@@ -46,9 +43,7 @@ _PATTERNS: list[tuple[re.Pattern[str], KernelEventType, list[str]]] = [
         ["size", "old_placement", "new_placement"],
     ),
     (
-        re.compile(
-            rf"^{_TS} AMDGPU_VM_FLUSH vmid=(\d+) hub=(\d+) pd_addr=(0x[0-9a-fA-F]+)"
-        ),
+        re.compile(rf"^{_TS} AMDGPU_VM_FLUSH vmid=(\d+) hub=(\d+) pd_addr=(0x[0-9a-fA-F]+)"),
         KernelEventType.VM_FLUSH,
         ["vmid", "hub", "pd_addr"],
     ),
@@ -73,9 +68,7 @@ _PATTERNS: list[tuple[re.Pattern[str], KernelEventType, list[str]]] = [
         ["unmaps", "ptes"],
     ),
     (
-        re.compile(
-            rf"^{_TS} IOCTL_ERROR cmd=(0x[0-9a-fA-F]+) ret=(-?\d+) dur=(\d+)us"
-        ),
+        re.compile(rf"^{_TS} IOCTL_ERROR cmd=(0x[0-9a-fA-F]+) ret=(-?\d+) dur=(\d+)us"),
         KernelEventType.IOCTL_ERROR,
         ["cmd", "ret", "dur_us"],
     ),
@@ -90,9 +83,7 @@ _PATTERNS: list[tuple[re.Pattern[str], KernelEventType, list[str]]] = [
         ["cmd", "dur_us"],
     ),
     (
-        re.compile(
-            rf"^{_TS} MMAP len=(\d+) prot=(0x[0-9a-fA-F]+) flags=(0x[0-9a-fA-F]+)"
-        ),
+        re.compile(rf"^{_TS} MMAP len=(\d+) prot=(0x[0-9a-fA-F]+) flags=(0x[0-9a-fA-F]+)"),
         KernelEventType.MMAP,
         ["len", "prot", "flags"],
     ),
@@ -136,7 +127,7 @@ class BpftraceLogParser:
     unrelated_kprobe) by trying patterns in priority order.
     """
 
-    def parse_line(self, line: str) -> Optional[KernelEvent]:
+    def parse_line(self, line: str) -> KernelEvent | None:
         """Parse a single bpftrace output line.
 
         Returns a ``KernelEvent`` if the line matches a known pattern,

--- a/src/aorta/ebpf/parser.py
+++ b/src/aorta/ebpf/parser.py
@@ -1,0 +1,178 @@
+"""Parse structured log lines emitted by the vendored bpftrace scripts."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+from .events import KernelEvent, KernelEventType
+
+log = logging.getLogger(__name__)
+
+_TS = r"(\d+)"
+
+_PATTERNS: list[tuple[re.Pattern[str], KernelEventType, list[str]]] = [
+    (
+        re.compile(rf"^{_TS} \*\*\* KFD_EVICT_QUEUES pid=(\d+) comm=(\S+) \*\*\*"),
+        KernelEventType.KFD_EVICT,
+        ["pid", "comm"],
+    ),
+    (
+        re.compile(rf"^{_TS} \*\*\* KFD_RESTORE_QUEUES pid=(\d+) comm=(\S+) \*\*\*"),
+        KernelEventType.KFD_RESTORE,
+        ["pid", "comm"],
+    ),
+    (
+        re.compile(rf"^{_TS} \*\*\* SVM_RANGE_EVICT_WORKER pid=(\d+) comm=(\S+) \*\*\*"),
+        KernelEventType.SVM_EVICT,
+        ["pid", "comm"],
+    ),
+    (
+        re.compile(rf"^{_TS} \*\*\* KFD_EVICT_QUEUES pid=(\d+) \*\*\*"),
+        KernelEventType.KFD_EVICT,
+        ["pid"],
+    ),
+    (
+        re.compile(
+            rf"^{_TS} \*\*\* AMDGPU_BO_MOVE size=(\d+) old=(\d+) new=(\d+) \*\*\*"
+        ),
+        KernelEventType.BO_MOVE,
+        ["size", "old_placement", "new_placement"],
+    ),
+    (
+        re.compile(rf"^{_TS} BO_MOVE size=(\d+) old=(\d+) new=(\d+)"),
+        KernelEventType.BO_MOVE,
+        ["size", "old_placement", "new_placement"],
+    ),
+    (
+        re.compile(
+            rf"^{_TS} AMDGPU_VM_FLUSH vmid=(\d+) hub=(\d+) pd_addr=(0x[0-9a-fA-F]+)"
+        ),
+        KernelEventType.VM_FLUSH,
+        ["vmid", "hub", "pd_addr"],
+    ),
+    (
+        re.compile(rf"^{_TS} VM_FLUSH vmid=(\d+) hub=(\d+)"),
+        KernelEventType.VM_FLUSH,
+        ["vmid", "hub"],
+    ),
+    (
+        re.compile(rf"^{_TS} VM_UNMAP_COUNT=(\d+) VM_PTE_UPDATE_COUNT=(\d+)"),
+        KernelEventType.VM_UNMAP_TICK,
+        ["unmap_count", "pte_count"],
+    ),
+    (
+        re.compile(rf"^{_TS} TICK unmaps=(\d+) ptes=(\d+) openats=(\d+)"),
+        KernelEventType.TICK,
+        ["unmaps", "ptes", "openats"],
+    ),
+    (
+        re.compile(rf"^{_TS} TICK unmaps=(\d+) ptes=(\d+)"),
+        KernelEventType.TICK,
+        ["unmaps", "ptes"],
+    ),
+    (
+        re.compile(
+            rf"^{_TS} IOCTL_ERROR cmd=(0x[0-9a-fA-F]+) ret=(-?\d+) dur=(\d+)us"
+        ),
+        KernelEventType.IOCTL_ERROR,
+        ["cmd", "ret", "dur_us"],
+    ),
+    (
+        re.compile(rf"^{_TS} IOCTL_ERR ret=(-?\d+)"),
+        KernelEventType.IOCTL_ERROR,
+        ["ret"],
+    ),
+    (
+        re.compile(rf"^{_TS} LONG_IOCTL cmd=(0x[0-9a-fA-F]+) dur=(\d+)us"),
+        KernelEventType.LONG_IOCTL,
+        ["cmd", "dur_us"],
+    ),
+    (
+        re.compile(
+            rf"^{_TS} MMAP len=(\d+) prot=(0x[0-9a-fA-F]+) flags=(0x[0-9a-fA-F]+)"
+        ),
+        KernelEventType.MMAP,
+        ["len", "prot", "flags"],
+    ),
+    (
+        re.compile(rf"^{_TS} MUNMAP addr=(0x[0-9a-fA-F]+) len=(\d+)"),
+        KernelEventType.MUNMAP,
+        ["addr", "len"],
+    ),
+    (
+        re.compile(rf"^{_TS} AMDGPU_VM_HANDLE_MOVED pid=(\d+)"),
+        KernelEventType.VM_HANDLE_MOVED,
+        ["pid"],
+    ),
+    (
+        re.compile(rf"^{_TS} KFD_INTERRUPT pid=(\d+)"),
+        KernelEventType.KFD_INTERRUPT,
+        ["pid"],
+    ),
+    (
+        re.compile(rf"^{_TS} SIGNAL sig=(\d+)"),
+        KernelEventType.SIGNAL,
+        ["sig"],
+    ),
+    (
+        re.compile(rf"^{_TS} SIG=(\d+)"),
+        KernelEventType.SIGNAL,
+        ["sig"],
+    ),
+    (
+        re.compile(rf"^{_TS} HEARTBEAT alive"),
+        KernelEventType.HEARTBEAT,
+        [],
+    ),
+]
+
+
+class BpftraceLogParser:
+    """Stateless parser that converts bpftrace stdout lines into typed events.
+
+    Handles all vendored script variants (full, light, tp_only, 1kprobe,
+    unrelated_kprobe) by trying patterns in priority order.
+    """
+
+    def parse_line(self, line: str) -> Optional[KernelEvent]:
+        """Parse a single bpftrace output line.
+
+        Returns a ``KernelEvent`` if the line matches a known pattern,
+        or ``None`` for unrecognised / blank lines.
+        """
+        stripped = line.strip()
+        if not stripped:
+            return None
+
+        for pattern, event_type, field_names in _PATTERNS:
+            m = pattern.match(stripped)
+            if m is None:
+                continue
+
+            groups = m.groups()
+            ts_ns = int(groups[0])
+            payload: dict[str, object] = {}
+            for i, name in enumerate(field_names):
+                raw = groups[i + 1]
+                if raw.startswith("0x"):
+                    payload[name] = raw
+                else:
+                    try:
+                        payload[name] = int(raw)
+                    except ValueError:
+                        payload[name] = raw
+
+            return KernelEvent(
+                timestamp_ns=ts_ns,
+                event_type=event_type,
+                payload=payload,
+                raw_line=stripped,
+            )
+
+        log.debug("Unrecognised bpftrace line: %s", stripped)
+        return None
+
+
+__all__ = ["BpftraceLogParser"]

--- a/src/aorta/ebpf/runner.py
+++ b/src/aorta/ebpf/runner.py
@@ -33,7 +33,8 @@ SCRIPTS_DIR = Path(__file__).parent / "scripts"
 class BpftraceScriptVariant(enum.Enum):
     """Vendored bpftrace script variants.
 
-    Trade-offs (from ebpfaultline README and PIPELINE_ANALYSIS):
+    Trade-offs (see ``scripts/PROVENANCE.md`` for the per-variant
+    Heisenberg-risk table this list summarises):
       - ``FULL`` -- maximum visibility, but kprobes can serialize the kernel
         path enough to suppress non-deterministic GPU memory races.
       - ``LIGHT`` -- only the three KFD/SVM kprobes plus ioctl errors and

--- a/src/aorta/ebpf/runner.py
+++ b/src/aorta/ebpf/runner.py
@@ -1,0 +1,245 @@
+"""Subprocess-based wrapper around the vendored bpftrace scripts.
+
+The runner spawns ``sudo bpftrace <script> <pid>`` in a background thread,
+streams stdout line-by-line into a parser, and exposes start/stop lifecycle
+hooks suitable for being driven from a training loop.
+
+The runner does NOT load eBPF bytecode in-process; it leverages the existing
+bpftrace toolchain as a subprocess. This matches the operational model of
+the upstream ebpfaultline scripts.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import shutil
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from .events import KernelEvent
+from .parser import BpftraceLogParser
+
+log = logging.getLogger(__name__)
+
+
+SCRIPTS_DIR = Path(__file__).parent / "scripts"
+
+
+class BpftraceScriptVariant(enum.Enum):
+    """Vendored bpftrace script variants.
+
+    Trade-offs (from ebpfaultline README and PIPELINE_ANALYSIS):
+      - ``FULL`` -- maximum visibility, but kprobes can serialize the kernel
+        path enough to suppress non-deterministic GPU memory races.
+      - ``LIGHT`` -- only the three KFD/SVM kprobes plus ioctl errors and
+        signals; documented as the "smoking gun" path.
+      - ``TP_ONLY`` -- tracepoints only, no kprobes; minimal Heisenberg
+        effect; recommended default for production debugging.
+      - ``ONE_KPROBE`` -- TP_ONLY + a single eviction kprobe (experiment).
+      - ``UNRELATED_KPROBE`` -- TP_ONLY + an unrelated openat kprobe
+        (control experiment).
+    """
+
+    FULL = "gpu_cont.bt"
+    LIGHT = "gpu_cont_light.bt"
+    TP_ONLY = "gpu_cont_tp_only.bt"
+    ONE_KPROBE = "gpu_cont_1kprobe.bt"
+    UNRELATED_KPROBE = "gpu_cont_unrelated_kprobe.bt"
+
+
+@dataclass
+class BpftraceConfig:
+    """Configuration for a single ``BpftraceRunner`` invocation.
+
+    Attributes:
+        target_pid: PID of the process whose syscalls/signals are filtered.
+        variant: Which vendored bpftrace script to run.
+        use_sudo: Whether to prefix the command with ``sudo``. Defaults to
+            True; bpftrace usually requires CAP_BPF/CAP_PERFMON or root.
+        bpftrace_path: Optional explicit path to the ``bpftrace`` binary.
+            If None, the runner uses the first ``bpftrace`` found on PATH.
+        script_path: Optional explicit path to a ``.bt`` script (overrides
+            ``variant``). Useful for custom or experimental scripts.
+        extra_args: Extra arguments passed to bpftrace before the script.
+        sudo_args: Extra arguments passed to ``sudo`` (e.g. ``["-n"]`` for
+            non-interactive in CI).
+        startup_timeout_sec: How long to wait for bpftrace to print its
+            first attach line before considering startup failed.
+    """
+
+    target_pid: int
+    variant: BpftraceScriptVariant = BpftraceScriptVariant.TP_ONLY
+    use_sudo: bool = True
+    bpftrace_path: Optional[str] = None
+    script_path: Optional[Path] = None
+    extra_args: List[str] = field(default_factory=list)
+    sudo_args: List[str] = field(default_factory=lambda: ["-n"])
+    startup_timeout_sec: float = 10.0
+
+    def resolve_script_path(self) -> Path:
+        if self.script_path is not None:
+            return self.script_path
+        return SCRIPTS_DIR / self.variant.value
+
+
+class BpftraceUnavailableError(RuntimeError):
+    """Raised when the bpftrace binary cannot be located on PATH."""
+
+
+class BpftraceRunner:
+    """Spawn and manage a single bpftrace process.
+
+    Lifecycle:
+
+        runner = BpftraceRunner(BpftraceConfig(target_pid=1234))
+        runner.start()
+        # ... workload runs ...
+        events = runner.stop()
+    """
+
+    def __init__(
+        self,
+        config: BpftraceConfig,
+        *,
+        on_event: Optional[Callable[[KernelEvent], None]] = None,
+    ) -> None:
+        self.config = config
+        self._on_event = on_event
+        self._parser = BpftraceLogParser()
+
+        self._proc: Optional[subprocess.Popen[str]] = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._events_lock = threading.Lock()
+        self._events: List[KernelEvent] = []
+        self._raw_lines: List[str] = []
+        self._running = False
+
+    @staticmethod
+    def is_bpftrace_available(bpftrace_path: Optional[str] = None) -> bool:
+        """Return True if a bpftrace binary is reachable on PATH or at the path."""
+        if bpftrace_path:
+            return Path(bpftrace_path).is_file()
+        return shutil.which("bpftrace") is not None
+
+    def _build_command(self) -> List[str]:
+        bpftrace_bin = self.config.bpftrace_path or shutil.which("bpftrace")
+        if not bpftrace_bin:
+            raise BpftraceUnavailableError(
+                "bpftrace binary not found on PATH; install bpftrace or set "
+                "BpftraceConfig.bpftrace_path"
+            )
+
+        script_path = self.config.resolve_script_path()
+        if not script_path.exists():
+            raise FileNotFoundError(f"bpftrace script not found: {script_path}")
+
+        cmd: List[str] = []
+        if self.config.use_sudo:
+            cmd.append("sudo")
+            cmd.extend(self.config.sudo_args)
+        cmd.append(bpftrace_bin)
+        cmd.extend(self.config.extra_args)
+        cmd.append(str(script_path))
+        cmd.append(str(self.config.target_pid))
+        return cmd
+
+    def start(self) -> None:
+        """Spawn the bpftrace process and begin background log parsing."""
+        if self._running:
+            raise RuntimeError("BpftraceRunner already started")
+
+        cmd = self._build_command()
+        log.info("Starting bpftrace: %s", " ".join(cmd))
+
+        self._proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self._running = True
+
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop,
+            name=f"bpftrace-reader-{self.config.target_pid}",
+            daemon=True,
+        )
+        self._reader_thread.start()
+
+    def _reader_loop(self) -> None:
+        assert self._proc is not None
+        assert self._proc.stdout is not None
+        try:
+            for line in self._proc.stdout:
+                self._raw_lines.append(line)
+                event = self._parser.parse_line(line)
+                if event is None:
+                    continue
+                with self._events_lock:
+                    self._events.append(event)
+                if self._on_event is not None:
+                    try:
+                        self._on_event(event)
+                    except Exception:
+                        log.exception("on_event callback raised; continuing")
+        except Exception:
+            log.exception("bpftrace reader thread terminated unexpectedly")
+
+    def stop(self, timeout_sec: float = 5.0) -> List[KernelEvent]:
+        """Terminate the bpftrace process and return all collected events."""
+        if not self._running or self._proc is None:
+            return []
+
+        log.info("Stopping bpftrace (pid=%s)", self._proc.pid)
+        try:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=timeout_sec)
+            except subprocess.TimeoutExpired:
+                log.warning("bpftrace did not terminate in %.1fs; killing", timeout_sec)
+                self._proc.kill()
+                self._proc.wait(timeout=timeout_sec)
+        finally:
+            self._running = False
+            if self._reader_thread is not None:
+                self._reader_thread.join(timeout=timeout_sec)
+
+        with self._events_lock:
+            return list(self._events)
+
+    def snapshot_events(self) -> List[KernelEvent]:
+        """Return a copy of events collected so far without stopping."""
+        with self._events_lock:
+            return list(self._events)
+
+    def drain_events(self) -> List[KernelEvent]:
+        """Atomically remove and return all events accumulated so far."""
+        with self._events_lock:
+            events = self._events
+            self._events = []
+            return events
+
+    @property
+    def is_running(self) -> bool:
+        return self._running and self._proc is not None and self._proc.poll() is None
+
+    def __enter__(self) -> "BpftraceRunner":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+
+__all__ = [
+    "BpftraceConfig",
+    "BpftraceRunner",
+    "BpftraceScriptVariant",
+    "BpftraceUnavailableError",
+    "SCRIPTS_DIR",
+]

--- a/src/aorta/ebpf/runner.py
+++ b/src/aorta/ebpf/runner.py
@@ -136,7 +136,18 @@ class BpftraceRunner:
         return shutil.which("bpftrace") is not None
 
     def _build_command(self) -> list[str]:
-        bpftrace_bin = self.config.bpftrace_path or shutil.which("bpftrace")
+        if self.config.bpftrace_path:
+            if not Path(self.config.bpftrace_path).is_file():
+                raise BpftraceUnavailableError(
+                    "BpftraceConfig.bpftrace_path was set to "
+                    f"{self.config.bpftrace_path!r} but no regular file "
+                    "exists at that path; install bpftrace there or "
+                    "leave bpftrace_path unset to fall back to PATH lookup"
+                )
+            bpftrace_bin: str | None = self.config.bpftrace_path
+        else:
+            bpftrace_bin = shutil.which("bpftrace")
+
         if not bpftrace_bin:
             raise BpftraceUnavailableError(
                 "bpftrace binary not found on PATH; install bpftrace or set "
@@ -297,28 +308,38 @@ class BpftraceRunner:
     def stop(self, timeout_sec: float = 5.0) -> list[KernelEvent]:
         """Terminate the bpftrace process and return all collected events.
 
-        If the reader thread crashed mid-run the captured exception is
-        logged here -- ``stop()`` never re-raises so callers can rely on
-        this being safe to put in a ``finally`` block.
+        Contract: ``stop()`` never re-raises. Callers (notably the FSDP
+        trainer's distributed cleanup ``finally`` block) rely on this so
+        that an early-exited bpftrace, a sudo-killed subprocess, or a
+        ``ProcessLookupError`` race between ``poll()`` and ``terminate()``
+        cannot leak the rendezvous backend on every other rank.
+
+        Errors hit during shutdown are logged and swallowed, including
+        the previously surfaced ``_reader_exception`` from a crashed
+        reader thread.
         """
         if not self._running or self._proc is None:
             return []
 
         log.info("Stopping bpftrace (pid=%s)", self._proc.pid)
         try:
-            self._proc.terminate()
-            try:
-                self._proc.wait(timeout=timeout_sec)
-            except subprocess.TimeoutExpired:
-                log.warning("bpftrace did not terminate in %.1fs; killing", timeout_sec)
-                self._proc.kill()
-                self._proc.wait(timeout=timeout_sec)
+            self._terminate_proc(timeout_sec)
+        except BaseException:
+            # Belt-and-braces: ``_terminate_proc`` already swallows the
+            # documented races, but if anything else slips through we
+            # still must not propagate -- the docstring promises this
+            # method is finally-block-safe. Log with full traceback so
+            # the failure is observable.
+            log.exception("BpftraceRunner.stop() swallowed unexpected error")
         finally:
             self._running = False
-            if self._reader_thread is not None:
-                self._reader_thread.join(timeout=timeout_sec)
-            if self._stderr_thread is not None:
-                self._stderr_thread.join(timeout=timeout_sec)
+            try:
+                if self._reader_thread is not None:
+                    self._reader_thread.join(timeout=timeout_sec)
+                if self._stderr_thread is not None:
+                    self._stderr_thread.join(timeout=timeout_sec)
+            except BaseException:
+                log.exception("BpftraceRunner.stop() swallowed thread-join error")
 
         if self._reader_exception is not None:
             log.warning(
@@ -329,6 +350,50 @@ class BpftraceRunner:
 
         with self._events_lock:
             return list(self._events)
+
+    def _terminate_proc(self, timeout_sec: float) -> None:
+        """Best-effort ``terminate()`` -> ``wait()`` -> ``kill()`` sequence.
+
+        Each ``Popen`` call is guarded against ``ProcessLookupError``
+        because the kernel can reap the bpftrace child between our
+        ``poll()`` short-circuit (below) and the actual signal -- e.g.
+        sudo's bpftrace exits as soon as the traced PID dies.
+        """
+        assert self._proc is not None  # narrowed by caller
+
+        # ``poll()`` short-circuit: if bpftrace already exited we have
+        # nothing to terminate. This also avoids a guaranteed
+        # ``ProcessLookupError`` from ``terminate()`` on the post-exit
+        # PID-reuse-window OSes that send the signal eagerly.
+        if self._proc.poll() is not None:
+            return
+
+        try:
+            self._proc.terminate()
+        except ProcessLookupError:
+            return
+
+        try:
+            self._proc.wait(timeout=timeout_sec)
+            return
+        except subprocess.TimeoutExpired:
+            log.warning(
+                "bpftrace did not terminate in %.1fs; killing",
+                timeout_sec,
+            )
+
+        try:
+            self._proc.kill()
+        except ProcessLookupError:
+            return
+        try:
+            self._proc.wait(timeout=timeout_sec)
+        except subprocess.TimeoutExpired:
+            log.error(
+                "bpftrace did not exit even after SIGKILL within %.1fs; "
+                "leaving the subprocess to the OS reaper",
+                timeout_sec,
+            )
 
     def snapshot_events(self) -> list[KernelEvent]:
         """Return a copy of events collected so far without stopping."""

--- a/src/aorta/ebpf/runner.py
+++ b/src/aorta/ebpf/runner.py
@@ -16,9 +16,10 @@ import logging
 import shutil
 import subprocess
 import threading
+import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, List, Optional
 
 from .events import KernelEvent
 from .parser import BpftraceLogParser
@@ -74,10 +75,10 @@ class BpftraceConfig:
     target_pid: int
     variant: BpftraceScriptVariant = BpftraceScriptVariant.TP_ONLY
     use_sudo: bool = True
-    bpftrace_path: Optional[str] = None
-    script_path: Optional[Path] = None
-    extra_args: List[str] = field(default_factory=list)
-    sudo_args: List[str] = field(default_factory=lambda: ["-n"])
+    bpftrace_path: str | None = None
+    script_path: Path | None = None
+    extra_args: list[str] = field(default_factory=list)
+    sudo_args: list[str] = field(default_factory=lambda: ["-n"])
     startup_timeout_sec: float = 10.0
 
     def resolve_script_path(self) -> Path:
@@ -105,27 +106,35 @@ class BpftraceRunner:
         self,
         config: BpftraceConfig,
         *,
-        on_event: Optional[Callable[[KernelEvent], None]] = None,
+        on_event: Callable[[KernelEvent], None] | None = None,
     ) -> None:
         self.config = config
         self._on_event = on_event
         self._parser = BpftraceLogParser()
 
-        self._proc: Optional[subprocess.Popen[str]] = None
-        self._reader_thread: Optional[threading.Thread] = None
+        self._proc: subprocess.Popen[str] | None = None
+        self._reader_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
         self._events_lock = threading.Lock()
-        self._events: List[KernelEvent] = []
-        self._raw_lines: List[str] = []
+        self._events: list[KernelEvent] = []
+        self._raw_lines: list[str] = []
+        # Drained on its own thread; merging into stdout would either deadlock
+        # (stderr=PIPE never drained) or pollute the event parser with bpftrace
+        # status lines ("Attaching N probes..."). Holding them separately also
+        # lets ``stderr_text()`` surface the actual bpftrace diagnostics on
+        # startup / runtime failures.
+        self._stderr_lines: list[str] = []
+        self._reader_exception: BaseException | None = None
         self._running = False
 
     @staticmethod
-    def is_bpftrace_available(bpftrace_path: Optional[str] = None) -> bool:
+    def is_bpftrace_available(bpftrace_path: str | None = None) -> bool:
         """Return True if a bpftrace binary is reachable on PATH or at the path."""
         if bpftrace_path:
             return Path(bpftrace_path).is_file()
         return shutil.which("bpftrace") is not None
 
-    def _build_command(self) -> List[str]:
+    def _build_command(self) -> list[str]:
         bpftrace_bin = self.config.bpftrace_path or shutil.which("bpftrace")
         if not bpftrace_bin:
             raise BpftraceUnavailableError(
@@ -137,7 +146,7 @@ class BpftraceRunner:
         if not script_path.exists():
             raise FileNotFoundError(f"bpftrace script not found: {script_path}")
 
-        cmd: List[str] = []
+        cmd: list[str] = []
         if self.config.use_sudo:
             cmd.append("sudo")
             cmd.extend(self.config.sudo_args)
@@ -148,7 +157,20 @@ class BpftraceRunner:
         return cmd
 
     def start(self) -> None:
-        """Spawn the bpftrace process and begin background log parsing."""
+        """Spawn the bpftrace process and begin background log parsing.
+
+        Detects the common immediate-exit failure modes (binary missing on
+        PATH, ``sudo`` password prompt swallowed, "ERROR: Don't have
+        permission to run BPF program") by polling the subprocess for up
+        to ``BpftraceConfig.startup_timeout_sec``. If the process exits
+        during that window the captured stderr is bundled into the
+        ``RuntimeError`` so the operator sees bpftrace's own diagnostic
+        rather than an opaque "no events arrived" surprise later.
+
+        Returns as soon as either bpftrace produces its first stdout line
+        (the parser's signal that probes have attached) or the timeout
+        elapses without an early exit -- whichever comes first.
+        """
         if self._running:
             raise RuntimeError("BpftraceRunner already started")
 
@@ -171,6 +193,68 @@ class BpftraceRunner:
         )
         self._reader_thread.start()
 
+        # bpftrace can write a lot to stderr (probe-attach status lines,
+        # warnings about kernel-symbol mismatches). Without an active drain
+        # the OS pipe buffer fills (~64 KiB on Linux) and bpftrace blocks on
+        # write -- which looks to us like "events stopped arriving" with no
+        # other signal. Spawn a dedicated drainer.
+        self._stderr_thread = threading.Thread(
+            target=self._stderr_loop,
+            name=f"bpftrace-stderr-{self.config.target_pid}",
+            daemon=True,
+        )
+        self._stderr_thread.start()
+
+        self._await_startup()
+
+    def _await_startup(self) -> None:
+        """Block until bpftrace either attaches or exits during startup.
+
+        Three exit paths:
+          - subprocess returns rc != None during the window -> raise with
+            the captured stderr included so the operator can see why.
+          - reader thread dies before any line arrives (parser bug, OS-
+            level read failure) -> raise with the original exception
+            chained.
+          - first stdout line shows up OR the timeout elapses with the
+            process still alive -> return; assume bpftrace has attached.
+        """
+        assert self._proc is not None
+        deadline = time.monotonic() + self.config.startup_timeout_sec
+        poll_interval_sec = 0.1
+        while time.monotonic() < deadline:
+            rc = self._proc.poll()
+            if rc is not None:
+                self._running = False
+                # Give the stderr drainer a moment to flush so the
+                # RuntimeError carries bpftrace's own error message
+                # ("ERROR: Don't have permission...", "Could not open
+                # tracepoint...") instead of an empty string.
+                if self._stderr_thread is not None:
+                    self._stderr_thread.join(timeout=0.5)
+                stderr_text = self.stderr_text()
+                raise RuntimeError(
+                    f"bpftrace exited during startup with rc={rc}; "
+                    f"stderr: {stderr_text.rstrip() or '<empty>'}"
+                )
+            reader = self._reader_thread
+            if reader is not None and not reader.is_alive():
+                self._running = False
+                exc = self._reader_exception
+                raise RuntimeError("bpftrace reader thread exited during startup") from exc
+            if self._raw_lines:
+                return
+            time.sleep(poll_interval_sec)
+
+        # Healthy bpftrace can take longer than ``startup_timeout_sec`` to
+        # print its first event (e.g. when attaching a large probe set
+        # under ``FULL``). The poll loop above already proved the process
+        # didn't exit early, so accept this as "running but quiet".
+        log.debug(
+            "bpftrace produced no stdout within startup_timeout_sec=%.1fs; assuming attached.",
+            self.config.startup_timeout_sec,
+        )
+
     def _reader_loop(self) -> None:
         assert self._proc is not None
         assert self._proc.stdout is not None
@@ -187,11 +271,35 @@ class BpftraceRunner:
                         self._on_event(event)
                     except Exception:
                         log.exception("on_event callback raised; continuing")
-        except Exception:
+        except BaseException as exc:
+            # Surface to start()/is_running/stop() instead of letting the
+            # thread silently die. ``log.exception`` would otherwise let a
+            # caller-polling-``is_running`` see "still running" while no
+            # events accumulate -- the original C3 failure mode.
             log.exception("bpftrace reader thread terminated unexpectedly")
+            self._reader_exception = exc
 
-    def stop(self, timeout_sec: float = 5.0) -> List[KernelEvent]:
-        """Terminate the bpftrace process and return all collected events."""
+    def _stderr_loop(self) -> None:
+        assert self._proc is not None
+        assert self._proc.stderr is not None
+        try:
+            for line in self._proc.stderr:
+                self._stderr_lines.append(line)
+                log.debug("bpftrace stderr: %s", line.rstrip())
+        except Exception:
+            log.exception("bpftrace stderr drain thread terminated unexpectedly")
+
+    def stderr_text(self) -> str:
+        """Return bpftrace's stderr captured so far, joined into one string."""
+        return "".join(self._stderr_lines)
+
+    def stop(self, timeout_sec: float = 5.0) -> list[KernelEvent]:
+        """Terminate the bpftrace process and return all collected events.
+
+        If the reader thread crashed mid-run the captured exception is
+        logged here -- ``stop()`` never re-raises so callers can rely on
+        this being safe to put in a ``finally`` block.
+        """
         if not self._running or self._proc is None:
             return []
 
@@ -208,16 +316,25 @@ class BpftraceRunner:
             self._running = False
             if self._reader_thread is not None:
                 self._reader_thread.join(timeout=timeout_sec)
+            if self._stderr_thread is not None:
+                self._stderr_thread.join(timeout=timeout_sec)
+
+        if self._reader_exception is not None:
+            log.warning(
+                "bpftrace reader thread exited with %r; events collected up to "
+                "the failure are returned but the run was incomplete.",
+                self._reader_exception,
+            )
 
         with self._events_lock:
             return list(self._events)
 
-    def snapshot_events(self) -> List[KernelEvent]:
+    def snapshot_events(self) -> list[KernelEvent]:
         """Return a copy of events collected so far without stopping."""
         with self._events_lock:
             return list(self._events)
 
-    def drain_events(self) -> List[KernelEvent]:
+    def drain_events(self) -> list[KernelEvent]:
         """Atomically remove and return all events accumulated so far."""
         with self._events_lock:
             events = self._events
@@ -226,9 +343,21 @@ class BpftraceRunner:
 
     @property
     def is_running(self) -> bool:
-        return self._running and self._proc is not None and self._proc.poll() is None
+        """True iff the subprocess AND the reader thread are both alive.
 
-    def __enter__(self) -> "BpftraceRunner":
+        The reader-thread check was added with C3: a reader that died
+        with the subprocess still attached used to leave ``is_running``
+        stuck on True while no further events arrived, which is exactly
+        the silent-failure mode we want callers to be able to detect.
+        """
+        if not self._running or self._proc is None or self._proc.poll() is not None:
+            return False
+        reader = self._reader_thread
+        if reader is not None and not reader.is_alive():
+            return False
+        return True
+
+    def __enter__(self) -> BpftraceRunner:
         self.start()
         return self
 

--- a/src/aorta/ebpf/scripts/PROVENANCE.md
+++ b/src/aorta/ebpf/scripts/PROVENANCE.md
@@ -1,0 +1,32 @@
+# Vendored bpftrace scripts
+
+These `.bt` scripts are vendored verbatim from the [ebpfaultline](https://github.com/) project
+and are kept here so AORTA can ship them as part of its `aorta.ebpf` module without a
+runtime dependency on that repository.
+
+## Source
+
+- Upstream: `ebpfaultline-main/bpftrace/`
+- License: MIT (see upstream `README.md`)
+
+## Files
+
+| Script | Purpose | Heisenberg risk |
+|--------|---------|-----------------|
+| `gpu_cont.bt` | Full-fidelity tracer: KFD evict/restore, SVM eviction, BO move, VM flush, PTE storms, ioctl errors, signals. | **High** -- many kprobes can suppress non-deterministic GPU memory races. |
+| `gpu_cont_light.bt` | Lightweight: only the three KFD/SVM kprobes plus ioctl errors and signals. | Medium. |
+| `gpu_cont_tp_only.bt` | Tracepoints only, no kprobes; recommended default. | **Low**. |
+| `gpu_cont_1kprobe.bt` | TP_ONLY plus a single eviction kprobe (experiment). | Medium. |
+| `gpu_cont_unrelated_kprobe.bt` | TP_ONLY plus an unrelated `do_sys_openat2` kprobe (control). | Medium. |
+
+## Kernel compatibility
+
+The original scripts were validated on Linux **6.9.0-fbk6** with AMD ROCm.
+Kprobe symbols and tracepoint argument layouts can change across kernel
+versions; the Python `BpftraceRunner` will surface bpftrace errors via
+its stderr capture so issues are visible to the caller.
+
+## Updating
+
+When syncing newer upstream changes, copy the `.bt` files into this
+directory verbatim and update this file's `Source` reference.

--- a/src/aorta/ebpf/scripts/PROVENANCE.md
+++ b/src/aorta/ebpf/scripts/PROVENANCE.md
@@ -1,13 +1,17 @@
 # Vendored bpftrace scripts
 
-These `.bt` scripts are vendored verbatim from the [ebpfaultline](https://github.com/) project
-and are kept here so AORTA can ship them as part of its `aorta.ebpf` module without a
-runtime dependency on that repository.
+These `.bt` scripts are vendored verbatim from the `ebpfaultline` project
+(the `bpftrace/` subtree of the AMD-internal `ebpfaultline-main`
+distribution; not yet open-sourced as of this PR) and are kept here so
+AORTA can ship them as part of its `aorta.ebpf` module without a
+runtime dependency on that source tree.
 
 ## Source
 
-- Upstream: `ebpfaultline-main/bpftrace/`
-- License: MIT (see upstream `README.md`)
+- Upstream subtree: `ebpfaultline-main/bpftrace/` (AMD internal; replace
+  this entry with the canonical URL once the upstream project is
+  published).
+- License: MIT (see upstream `README.md`).
 
 ## Files
 

--- a/src/aorta/ebpf/scripts/gpu_cont.bt
+++ b/src/aorta/ebpf/scripts/gpu_cont.bt
@@ -1,0 +1,154 @@
+#!/usr/bin/env bpftrace
+/*
+ * GPU memory corruption detector for Shampoo NaN debugging.
+ * Probes verified on this kernel (6.9.0-fbk6).
+ *
+ * Hypothesis: NaN in Shampoo preconditioner is caused by lower-level
+ * memory corruption — page eviction, BO moves, or KFD queue eviction
+ * racing with active GPU compute.
+ *
+ * Usage:
+ *   sudo bpftrace gpu_cont.bt $PID
+ */
+
+/* ===== IOCTL ENTER/EXIT ===== */
+
+tracepoint:syscalls:sys_enter_ioctl
+/pid == $1/
+{
+    @ioctl_start[tid] = nsecs;
+    @ioctl_cmd[tid] = args->cmd;
+}
+
+tracepoint:syscalls:sys_exit_ioctl
+/pid == $1 && @ioctl_start[tid] > 0/
+{
+    $dur = (nsecs - @ioctl_start[tid]) / 1000;
+
+    if (args->ret != 0) {
+        printf("%llu IOCTL_ERROR cmd=0x%llx ret=%d dur=%dus\n",
+               nsecs, @ioctl_cmd[tid], args->ret, $dur);
+    } else if ($dur > 1000) {
+        printf("%llu LONG_IOCTL cmd=0x%llx dur=%dus\n",
+               nsecs, @ioctl_cmd[tid], $dur);
+    }
+
+    delete(@ioctl_start[tid]);
+    delete(@ioctl_cmd[tid]);
+}
+
+/* ===== MEMORY OPS (process-filtered) ===== */
+
+tracepoint:syscalls:sys_enter_mmap
+/pid == $1/
+{
+    printf("%llu MMAP len=%llu prot=0x%llx flags=0x%llx\n",
+           nsecs, args->len, args->prot, args->flags);
+}
+
+tracepoint:syscalls:sys_enter_munmap
+/pid == $1/
+{
+    printf("%llu MUNMAP addr=0x%llx len=%llu\n",
+           nsecs, args->addr, args->len);
+}
+
+/* ===== KFD QUEUE EVICTION / RESTORE =====
+ *
+ * Smoking gun probes: KFD evicts compute queues under memory pressure,
+ * then restores them. If restore races with active GPU work, the
+ * preconditioner's factor matrices can see stale/zeroed VRAM.
+ */
+
+kprobe:kfd_process_evict_queues
+{
+    printf("%llu *** KFD_EVICT_QUEUES pid=%d comm=%s ***\n", nsecs, pid, comm);
+}
+
+kprobe:kfd_process_restore_queues
+{
+    printf("%llu *** KFD_RESTORE_QUEUES pid=%d comm=%s ***\n", nsecs, pid, comm);
+}
+
+/* ===== SVM BO EVICTION WORKER =====
+ *
+ * SVM range eviction worker — GPU pages being moved/evicted.
+ */
+
+kprobe:svm_range_evict_svm_bo_worker
+{
+    printf("%llu *** SVM_RANGE_EVICT_WORKER pid=%d comm=%s ***\n", nsecs, pid, comm);
+}
+
+/* ===== AMDGPU BO MOVE (tracepoint — has placement info) =====
+ *
+ * TTM manages VRAM <-> GTT movement. A BO move while the GPU
+ * is reading factor matrices would produce NaN/garbage.
+ * old/new placement: 0=VRAM, 1=GTT, 2=SYSTEM
+ */
+
+tracepoint:amdgpu:amdgpu_bo_move
+{
+    printf("%llu *** AMDGPU_BO_MOVE size=%llu old=%u new=%u ***\n",
+           nsecs, args->bo_size, args->old_placement, args->new_placement);
+}
+
+/* ===== AMDGPU VM OPERATIONS ===== */
+
+/* VM_BO_UNMAP and VM_UPDATE_PTES are very high-frequency. Count them
+ * in 1-second windows instead of logging every one. */
+
+tracepoint:amdgpu:amdgpu_vm_bo_unmap
+{
+    @vm_unmap_count++;
+}
+
+tracepoint:amdgpu:amdgpu_vm_update_ptes
+{
+    @vm_pte_update_count++;
+}
+
+tracepoint:amdgpu:amdgpu_vm_flush
+{
+    printf("%llu AMDGPU_VM_FLUSH vmid=%u hub=%u pd_addr=0x%llx\n",
+           nsecs, args->vmid, args->vm_hub, args->pd_addr);
+}
+
+interval:s:1
+{
+    if (@vm_unmap_count > 0) {
+        printf("%llu VM_UNMAP_COUNT=%lld VM_PTE_UPDATE_COUNT=%lld (1s window)\n",
+               nsecs, @vm_unmap_count, @vm_pte_update_count);
+    }
+    @vm_unmap_count = 0;
+    @vm_pte_update_count = 0;
+}
+
+/* ===== GPU PAGE TABLE HANDLE MOVED ===== */
+
+kprobe:amdgpu_vm_handle_moved
+{
+    printf("%llu AMDGPU_VM_HANDLE_MOVED pid=%d\n", nsecs, pid);
+}
+
+/* ===== KFD INTERRUPT (GPU interrupts) ===== */
+
+kprobe:kfd_signal_event_interrupt
+{
+    printf("%llu KFD_INTERRUPT pid=%d\n", nsecs, pid);
+}
+
+/* ===== SIGNALS (process-filtered) ===== */
+
+tracepoint:signal:signal_deliver
+/pid == $1/
+{
+    printf("%llu SIGNAL sig=%d\n", nsecs, args->sig);
+}
+
+/* ===== HEARTBEAT ===== */
+
+interval:s:5
+{
+    printf("%llu HEARTBEAT alive\n", nsecs);
+}

--- a/src/aorta/ebpf/scripts/gpu_cont_1kprobe.bt
+++ b/src/aorta/ebpf/scripts/gpu_cont_1kprobe.bt
@@ -1,0 +1,47 @@
+#!/usr/bin/env bpftrace
+/*
+ * Experiment 3a: SINGLE kprobe on kfd_process_evict_queues + all tracepoints.
+ * Tests whether serializing just the eviction entry point suppresses NaN.
+ */
+
+/* THE ONE KPROBE */
+kprobe:kfd_process_evict_queues
+{
+    printf("%llu *** KFD_EVICT_QUEUES pid=%d ***\n", nsecs, pid);
+}
+
+/* === tracepoints (same as gpu_cont_tp_only.bt) === */
+
+tracepoint:amdgpu:amdgpu_bo_move
+{
+    printf("%llu BO_MOVE size=%llu old=%u new=%u\n",
+           nsecs, args->bo_size, args->old_placement, args->new_placement);
+}
+
+tracepoint:amdgpu:amdgpu_vm_flush
+{
+    printf("%llu VM_FLUSH vmid=%u hub=%u\n",
+           nsecs, args->vmid, args->vm_hub);
+}
+
+tracepoint:amdgpu:amdgpu_vm_bo_unmap { @unmap_count++; }
+tracepoint:amdgpu:amdgpu_vm_update_ptes { @pte_count++; }
+
+tracepoint:syscalls:sys_exit_ioctl
+/pid == $1 && args->ret != 0 && args->ret != -25/
+{
+    printf("%llu IOCTL_ERR ret=%d\n", nsecs, args->ret);
+}
+
+tracepoint:signal:signal_deliver
+/pid == $1/
+{
+    printf("%llu SIG=%d\n", nsecs, args->sig);
+}
+
+interval:s:5
+{
+    printf("%llu TICK unmaps=%lld ptes=%lld\n", nsecs, @unmap_count, @pte_count);
+    @unmap_count = 0;
+    @pte_count = 0;
+}

--- a/src/aorta/ebpf/scripts/gpu_cont_light.bt
+++ b/src/aorta/ebpf/scripts/gpu_cont_light.bt
@@ -1,0 +1,75 @@
+#!/usr/bin/env bpftrace
+/*
+ * LIGHTWEIGHT GPU memory corruption detector.
+ *
+ * The full gpu_cont.bt (with amdgpu_bo_move, vm_flush, etc.) adds enough
+ * global tracepoint overhead to suppress the NaN race condition — the same
+ * Heisenberg effect seen with gradient hooks and frequent syncs.
+ *
+ * This version only traces:
+ *   - KFD queue eviction/restore (low volume, ~200/run)
+ *   - SVM BO eviction worker (low volume)
+ *   - ioctl errors on the target PID only
+ *   - Signals on the target PID
+ *
+ * Usage:
+ *   sudo bpftrace gpu_cont_light.bt $PID
+ */
+
+/* ===== KFD QUEUE EVICTION / RESTORE ===== */
+
+kprobe:kfd_process_evict_queues
+{
+    printf("%llu *** KFD_EVICT_QUEUES pid=%d comm=%s ***\n", nsecs, pid, comm);
+}
+
+kprobe:kfd_process_restore_queues
+{
+    printf("%llu *** KFD_RESTORE_QUEUES pid=%d comm=%s ***\n", nsecs, pid, comm);
+}
+
+/* ===== SVM BO EVICTION WORKER ===== */
+
+kprobe:svm_range_evict_svm_bo_worker
+{
+    printf("%llu *** SVM_RANGE_EVICT_WORKER pid=%d comm=%s ***\n", nsecs, pid, comm);
+}
+
+/* ===== IOCTL ERRORS ONLY (PID-filtered) ===== */
+
+tracepoint:syscalls:sys_enter_ioctl
+/pid == $1/
+{
+    @ioctl_start[tid] = nsecs;
+    @ioctl_cmd[tid] = args->cmd;
+}
+
+tracepoint:syscalls:sys_exit_ioctl
+/pid == $1 && @ioctl_start[tid] > 0/
+{
+    $dur = (nsecs - @ioctl_start[tid]) / 1000;
+
+    /* Only log real GPU ioctl errors (skip 0x5401 TCGETS terminal checks) */
+    if (args->ret != 0 && @ioctl_cmd[tid] != 0x5401) {
+        printf("%llu IOCTL_ERROR cmd=0x%llx ret=%d dur=%dus\n",
+               nsecs, @ioctl_cmd[tid], args->ret, $dur);
+    }
+
+    delete(@ioctl_start[tid]);
+    delete(@ioctl_cmd[tid]);
+}
+
+/* ===== SIGNALS ===== */
+
+tracepoint:signal:signal_deliver
+/pid == $1/
+{
+    printf("%llu SIGNAL sig=%d\n", nsecs, args->sig);
+}
+
+/* ===== HEARTBEAT ===== */
+
+interval:s:10
+{
+    printf("%llu HEARTBEAT alive\n", nsecs);
+}

--- a/src/aorta/ebpf/scripts/gpu_cont_tp_only.bt
+++ b/src/aorta/ebpf/scripts/gpu_cont_tp_only.bt
@@ -1,0 +1,48 @@
+#!/usr/bin/env bpftrace
+/*
+ * Tracepoint-only GPU tracer. NO kprobes.
+ * Static tracepoints don't add synchronization barriers like kprobes do,
+ * so they should not suppress the NaN race condition.
+ */
+
+tracepoint:amdgpu:amdgpu_bo_move
+{
+    printf("%llu BO_MOVE size=%llu old=%u new=%u\n",
+           nsecs, args->bo_size, args->old_placement, args->new_placement);
+}
+
+tracepoint:amdgpu:amdgpu_vm_flush
+{
+    printf("%llu VM_FLUSH vmid=%u hub=%u\n",
+           nsecs, args->vmid, args->vm_hub);
+}
+
+tracepoint:amdgpu:amdgpu_vm_bo_unmap
+{
+    @unmap_count++;
+}
+
+tracepoint:amdgpu:amdgpu_vm_update_ptes
+{
+    @pte_count++;
+}
+
+/* PID-filtered ioctl errors only */
+tracepoint:syscalls:sys_exit_ioctl
+/pid == $1 && args->ret != 0 && args->ret != -25/
+{
+    printf("%llu IOCTL_ERR ret=%d\n", nsecs, args->ret);
+}
+
+tracepoint:signal:signal_deliver
+/pid == $1/
+{
+    printf("%llu SIG=%d\n", nsecs, args->sig);
+}
+
+interval:s:5
+{
+    printf("%llu TICK unmaps=%lld ptes=%lld\n", nsecs, @unmap_count, @pte_count);
+    @unmap_count = 0;
+    @pte_count = 0;
+}

--- a/src/aorta/ebpf/scripts/gpu_cont_unrelated_kprobe.bt
+++ b/src/aorta/ebpf/scripts/gpu_cont_unrelated_kprobe.bt
@@ -1,0 +1,50 @@
+#!/usr/bin/env bpftrace
+/*
+ * Experiment 3b: kprobe on UNRELATED function + all tracepoints.
+ * Tests whether ANY kprobe overhead suppresses NaN, or only KFD-path kprobes.
+ * Uses do_sys_openat2 (file open syscall) - completely unrelated to GPU.
+ */
+
+/* THE UNRELATED KPROBE */
+kprobe:do_sys_openat2
+/pid == $1/
+{
+    @openat_count++;
+}
+
+/* === tracepoints (same as gpu_cont_tp_only.bt) === */
+
+tracepoint:amdgpu:amdgpu_bo_move
+{
+    printf("%llu BO_MOVE size=%llu old=%u new=%u\n",
+           nsecs, args->bo_size, args->old_placement, args->new_placement);
+}
+
+tracepoint:amdgpu:amdgpu_vm_flush
+{
+    printf("%llu VM_FLUSH vmid=%u hub=%u\n",
+           nsecs, args->vmid, args->vm_hub);
+}
+
+tracepoint:amdgpu:amdgpu_vm_bo_unmap { @unmap_count++; }
+tracepoint:amdgpu:amdgpu_vm_update_ptes { @pte_count++; }
+
+tracepoint:syscalls:sys_exit_ioctl
+/pid == $1 && args->ret != 0 && args->ret != -25/
+{
+    printf("%llu IOCTL_ERR ret=%d\n", nsecs, args->ret);
+}
+
+tracepoint:signal:signal_deliver
+/pid == $1/
+{
+    printf("%llu SIG=%d\n", nsecs, args->sig);
+}
+
+interval:s:5
+{
+    printf("%llu TICK unmaps=%lld ptes=%lld openats=%lld\n", nsecs, @unmap_count, @pte_count, @openat_count);
+    @unmap_count = 0;
+    @pte_count = 0;
+    @openat_count = 0;
+}

--- a/src/aorta/profiling/__init__.py
+++ b/src/aorta/profiling/__init__.py
@@ -1,5 +1,11 @@
 """Profiling helpers exposed at package level."""
 
+from .kernel_profiler import KernelTraceConfig, KernelTraceProfiler
 from .stream_profiler import DistributedOpsInterceptor, StreamProfiler
 
-__all__ = ["StreamProfiler", "DistributedOpsInterceptor"]
+__all__ = [
+    "DistributedOpsInterceptor",
+    "KernelTraceConfig",
+    "KernelTraceProfiler",
+    "StreamProfiler",
+]

--- a/src/aorta/profiling/kernel_profiler.py
+++ b/src/aorta/profiling/kernel_profiler.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from aorta.ebpf import (
     BpftraceConfig,
@@ -75,10 +75,10 @@ class KernelTraceConfig:
     """
 
     enabled: bool = False
-    target_pid: Optional[int] = None
+    target_pid: int | None = None
     variant: BpftraceScriptVariant = BpftraceScriptVariant.TP_ONLY
     use_sudo: bool = True
-    bpftrace_path: Optional[str] = None
+    bpftrace_path: str | None = None
     keep_raw_events: bool = False
     skip_if_unavailable: bool = True
 
@@ -87,10 +87,10 @@ class KernelTraceConfig:
 class _IterationState:
     index: int
     start_ns: int
-    events: List[KernelEvent] = field(default_factory=list)
+    events: list[KernelEvent] = field(default_factory=list)
 
 
-_SUMMARY_COUNTER_TYPES: Dict[str, KernelEventType] = {
+_SUMMARY_COUNTER_TYPES: dict[str, KernelEventType] = {
     "kfd_evict": KernelEventType.KFD_EVICT,
     "kfd_restore": KernelEventType.KFD_RESTORE,
     "svm_evict": KernelEventType.SVM_EVICT,
@@ -121,10 +121,10 @@ class KernelTraceProfiler:
 
     def __init__(self, config: KernelTraceConfig) -> None:
         self.config = config
-        self._runner: Optional[BpftraceRunner] = None
-        self._iteration: Optional[_IterationState] = None
+        self._runner: BpftraceRunner | None = None
+        self._iteration: _IterationState | None = None
         self._started = False
-        self._all_events: List[KernelEvent] = []
+        self._all_events: list[KernelEvent] = []
 
     @property
     def enabled(self) -> bool:
@@ -171,7 +171,7 @@ class KernelTraceProfiler:
             self.config.variant.name,
         )
 
-    def stop(self) -> List[KernelEvent]:
+    def stop(self) -> list[KernelEvent]:
         """Stop the bpftrace process and return any remaining events."""
         if self._runner is None:
             return []
@@ -192,7 +192,7 @@ class KernelTraceProfiler:
         self._runner.drain_events()
         self._iteration = _IterationState(index=index, start_ns=time.monotonic_ns())
 
-    def end_iteration(self) -> Optional[Dict[str, Any]]:
+    def end_iteration(self) -> dict[str, Any] | None:
         if not self.enabled or self._iteration is None:
             self._iteration = None
             return None
@@ -207,10 +207,8 @@ class KernelTraceProfiler:
         self._iteration = None
         return record
 
-    def _serialize_iteration(
-        self, state: _IterationState, end_ns: int
-    ) -> Dict[str, Any]:
-        summary: Dict[str, int] = {key: 0 for key in _SUMMARY_COUNTER_TYPES}
+    def _serialize_iteration(self, state: _IterationState, end_ns: int) -> dict[str, Any]:
+        summary: dict[str, int] = dict.fromkeys(_SUMMARY_COUNTER_TYPES, 0)
         summary["pte_updates"] = 0
         summary["vm_unmaps"] = 0
 
@@ -224,17 +222,13 @@ class KernelTraceProfiler:
                 KernelEventType.VM_UNMAP_TICK,
             ):
                 summary["pte_updates"] += int(
-                    event.payload.get("ptes")
-                    or event.payload.get("pte_count")
-                    or 0
+                    event.payload.get("ptes") or event.payload.get("pte_count") or 0
                 )
                 summary["vm_unmaps"] += int(
-                    event.payload.get("unmaps")
-                    or event.payload.get("unmap_count")
-                    or 0
+                    event.payload.get("unmaps") or event.payload.get("unmap_count") or 0
                 )
 
-        record: Dict[str, Any] = {
+        record: dict[str, Any] = {
             "index": state.index,
             "elapsed_ns": end_ns - state.start_ns,
             "summary": summary,
@@ -245,11 +239,11 @@ class KernelTraceProfiler:
             record["event_count"] = len(state.events)
         return record
 
-    def all_events(self) -> List[KernelEvent]:
+    def all_events(self) -> list[KernelEvent]:
         """Return a copy of every event observed across the profiler's life."""
         return list(self._all_events)
 
-    def __enter__(self) -> "KernelTraceProfiler":
+    def __enter__(self) -> KernelTraceProfiler:
         self.start()
         return self
 
@@ -257,7 +251,7 @@ class KernelTraceProfiler:
         self.stop()
 
 
-def _event_to_dict(event: KernelEvent) -> Dict[str, Any]:
+def _event_to_dict(event: KernelEvent) -> dict[str, Any]:
     data = asdict(event)
     data["event_type"] = event.event_type.value
     return data

--- a/src/aorta/profiling/kernel_profiler.py
+++ b/src/aorta/profiling/kernel_profiler.py
@@ -1,0 +1,266 @@
+"""Per-iteration kernel-event profiler backed by bpftrace.
+
+``KernelTraceProfiler`` is the user-space peer of ``StreamProfiler``: it
+manages a long-lived ``BpftraceRunner`` and slices the resulting kernel
+events into per-iteration buckets so they can be merged into the same
+JSONL metrics stream produced by training loops.
+
+Lifecycle (mirrors ``StreamProfiler``):
+
+    profiler = KernelTraceProfiler(KernelTraceConfig(target_pid=os.getpid()))
+    profiler.start()
+    for step in range(N):
+        profiler.start_iteration(step)
+        # ... training work ...
+        record = profiler.end_iteration()
+    profiler.stop()
+
+The per-iteration record schema:
+
+    {
+      "index": <step>,
+      "elapsed_ns": <int>,
+      "events": [<KernelEvent.__dict__>, ...],
+      "summary": {
+        "kfd_evict": <int>,
+        "kfd_restore": <int>,
+        "svm_evict": <int>,
+        "bo_move": <int>,
+        "vm_flush": <int>,
+        "ioctl_error": <int>,
+        "signal": <int>,
+        "pte_updates": <int>,
+        "vm_unmaps": <int>,
+      },
+    }
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+from aorta.ebpf import (
+    BpftraceConfig,
+    BpftraceRunner,
+    BpftraceScriptVariant,
+    KernelEvent,
+    KernelEventType,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class KernelTraceConfig:
+    """Configuration for a ``KernelTraceProfiler``.
+
+    Attributes:
+        enabled: If False, the profiler is a no-op (useful for guarded
+            training loops where the flag is config-driven).
+        target_pid: PID to attach to. Defaults to the current process.
+        variant: bpftrace script variant; ``TP_ONLY`` is the recommended
+            default to minimise the Heisenberg effect on GPU memory races.
+        use_sudo: Whether to prefix the bpftrace command with ``sudo``.
+        bpftrace_path: Optional override for the bpftrace binary path.
+        keep_raw_events: If False, the per-iteration record only stores
+            the aggregated summary, not the full event list. Useful for
+            long runs where event volume could blow up the JSONL file.
+        skip_if_unavailable: If True, the profiler logs a warning and
+            silently disables itself when bpftrace is missing rather than
+            raising. Defaults to True so kernel tracing remains an opt-in
+            best-effort feature.
+    """
+
+    enabled: bool = False
+    target_pid: Optional[int] = None
+    variant: BpftraceScriptVariant = BpftraceScriptVariant.TP_ONLY
+    use_sudo: bool = True
+    bpftrace_path: Optional[str] = None
+    keep_raw_events: bool = False
+    skip_if_unavailable: bool = True
+
+
+@dataclass
+class _IterationState:
+    index: int
+    start_ns: int
+    events: List[KernelEvent] = field(default_factory=list)
+
+
+_SUMMARY_COUNTER_TYPES: Dict[str, KernelEventType] = {
+    "kfd_evict": KernelEventType.KFD_EVICT,
+    "kfd_restore": KernelEventType.KFD_RESTORE,
+    "svm_evict": KernelEventType.SVM_EVICT,
+    "bo_move": KernelEventType.BO_MOVE,
+    "vm_flush": KernelEventType.VM_FLUSH,
+    "ioctl_error": KernelEventType.IOCTL_ERROR,
+    "signal": KernelEventType.SIGNAL,
+    "vm_handle_moved": KernelEventType.VM_HANDLE_MOVED,
+    "kfd_interrupt": KernelEventType.KFD_INTERRUPT,
+    "long_ioctl": KernelEventType.LONG_IOCTL,
+    "mmap": KernelEventType.MMAP,
+    "munmap": KernelEventType.MUNMAP,
+}
+
+
+class KernelTraceProfiler:
+    """Bucket bpftrace kernel events by training iteration.
+
+    Designed to run alongside ``StreamProfiler`` with the same call
+    pattern; output is appended to the same per-iteration metrics dict
+    written by ``MetricsLogger``.
+
+    The profiler is safe to construct with ``enabled=False`` -- in that
+    mode every method becomes a no-op and ``end_iteration`` returns
+    ``None``. This makes it cheap to wire into existing training loops
+    behind a configuration flag.
+    """
+
+    def __init__(self, config: KernelTraceConfig) -> None:
+        self.config = config
+        self._runner: Optional[BpftraceRunner] = None
+        self._iteration: Optional[_IterationState] = None
+        self._started = False
+        self._all_events: List[KernelEvent] = []
+
+    @property
+    def enabled(self) -> bool:
+        return self.config.enabled and self._runner is not None
+
+    def start(self) -> None:
+        """Spawn the bpftrace process. Safe to call when disabled."""
+        if not self.config.enabled:
+            log.debug("KernelTraceProfiler disabled; skipping start")
+            return
+        if self._started:
+            return
+
+        if not BpftraceRunner.is_bpftrace_available(self.config.bpftrace_path):
+            msg = "bpftrace binary not available; kernel tracing will be skipped"
+            if self.config.skip_if_unavailable:
+                log.warning(msg)
+                return
+            raise RuntimeError(msg)
+
+        import os
+
+        target_pid = self.config.target_pid or os.getpid()
+        bpftrace_cfg = BpftraceConfig(
+            target_pid=target_pid,
+            variant=self.config.variant,
+            use_sudo=self.config.use_sudo,
+            bpftrace_path=self.config.bpftrace_path,
+        )
+        runner = BpftraceRunner(bpftrace_cfg)
+        try:
+            runner.start()
+        except Exception as exc:
+            if self.config.skip_if_unavailable:
+                log.warning("Failed to start bpftrace (%s); kernel tracing disabled", exc)
+                return
+            raise
+
+        self._runner = runner
+        self._started = True
+        log.info(
+            "KernelTraceProfiler started | pid=%d variant=%s",
+            target_pid,
+            self.config.variant.name,
+        )
+
+    def stop(self) -> List[KernelEvent]:
+        """Stop the bpftrace process and return any remaining events."""
+        if self._runner is None:
+            return []
+        events = self._runner.stop()
+        self._all_events.extend(events)
+        self._runner = None
+        self._started = False
+        return events
+
+    def start_iteration(self, index: int) -> None:
+        if not self.enabled:
+            return
+        if self._iteration is not None:
+            raise RuntimeError("Previous kernel-trace iteration not finalised")
+        # Drain any events queued before the iteration to avoid attributing
+        # them to this step.
+        assert self._runner is not None
+        self._runner.drain_events()
+        self._iteration = _IterationState(index=index, start_ns=time.monotonic_ns())
+
+    def end_iteration(self) -> Optional[Dict[str, Any]]:
+        if not self.enabled or self._iteration is None:
+            self._iteration = None
+            return None
+        assert self._runner is not None
+
+        end_ns = time.monotonic_ns()
+        events = self._runner.drain_events()
+        self._iteration.events = events
+        self._all_events.extend(events)
+
+        record = self._serialize_iteration(self._iteration, end_ns)
+        self._iteration = None
+        return record
+
+    def _serialize_iteration(
+        self, state: _IterationState, end_ns: int
+    ) -> Dict[str, Any]:
+        summary: Dict[str, int] = {key: 0 for key in _SUMMARY_COUNTER_TYPES}
+        summary["pte_updates"] = 0
+        summary["vm_unmaps"] = 0
+
+        for event in state.events:
+            for key, ev_type in _SUMMARY_COUNTER_TYPES.items():
+                if event.event_type is ev_type:
+                    summary[key] += 1
+                    break
+            if event.event_type in (
+                KernelEventType.TICK,
+                KernelEventType.VM_UNMAP_TICK,
+            ):
+                summary["pte_updates"] += int(
+                    event.payload.get("ptes")
+                    or event.payload.get("pte_count")
+                    or 0
+                )
+                summary["vm_unmaps"] += int(
+                    event.payload.get("unmaps")
+                    or event.payload.get("unmap_count")
+                    or 0
+                )
+
+        record: Dict[str, Any] = {
+            "index": state.index,
+            "elapsed_ns": end_ns - state.start_ns,
+            "summary": summary,
+        }
+        if self.config.keep_raw_events:
+            record["events"] = [_event_to_dict(ev) for ev in state.events]
+        else:
+            record["event_count"] = len(state.events)
+        return record
+
+    def all_events(self) -> List[KernelEvent]:
+        """Return a copy of every event observed across the profiler's life."""
+        return list(self._all_events)
+
+    def __enter__(self) -> "KernelTraceProfiler":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+
+def _event_to_dict(event: KernelEvent) -> Dict[str, Any]:
+    data = asdict(event)
+    data["event_type"] = event.event_type.value
+    return data
+
+
+__all__ = ["KernelTraceConfig", "KernelTraceProfiler"]

--- a/src/aorta/report/__init__.py
+++ b/src/aorta/report/__init__.py
@@ -1,5 +1,4 @@
-"""
-aorta-report: Unified CLI for TraceLens analysis and report generation.
+"""aorta-report: Unified CLI for TraceLens analysis and report generation.
 
 This package provides a command-line interface for:
 - Analyzing PyTorch profiler traces with TraceLens
@@ -10,10 +9,34 @@ This package provides a command-line interface for:
 Usage:
     aorta-report --help
     python -m aorta.report --help
+
+The ``cli`` / ``main`` re-exports below are loaded via PEP 562
+``__getattr__`` so that lightweight subpackages (notably the
+stdlib-only ``aorta.report.generators.kernel_report`` and
+``aorta.report.analysis.kernel_correlator``) can be imported on a base
+install without dragging in the heavy CLI chain (pandas / openpyxl /
+matplotlib via ``aorta.report.cli`` -> ``comparison.cli``). Issue
+surfaced by Copilot review on PR #162.
 """
+
+from __future__ import annotations
+
+from typing import Any
 
 __version__ = "0.1.0"
 
-from .cli import cli, main
-
 __all__ = ["cli", "main", "__version__"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"cli", "main"}:
+        from .cli import cli, main  # type: ignore[import-untyped]
+
+        globals()["cli"] = cli
+        globals()["main"] = main
+        return {"cli": cli, "main": main}[name]
+    raise AttributeError(f"module 'aorta.report' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/aorta/report/analysis/__init__.py
+++ b/src/aorta/report/analysis/__init__.py
@@ -4,6 +4,12 @@ from .tracelens_wrapper import TraceLensWrapper
 from .analyze_gemm import analyze_gemm_reports
 from .analyze_single import analyze_single_config
 from .analyze_sweep import analyze_sweep_config, discover_and_run_tracelens
+from .kernel_correlator import (
+    CorrelationFinding,
+    IterationRecord,
+    KernelEventCorrelator,
+    iter_findings_table,
+)
 
 __all__ = [
     "TraceLensWrapper",
@@ -11,4 +17,8 @@ __all__ = [
     "analyze_single_config",
     "analyze_sweep_config",
     "discover_and_run_tracelens",
+    "CorrelationFinding",
+    "IterationRecord",
+    "KernelEventCorrelator",
+    "iter_findings_table",
 ]

--- a/src/aorta/report/analysis/__init__.py
+++ b/src/aorta/report/analysis/__init__.py
@@ -1,15 +1,27 @@
-"""Analysis modules for TraceLens trace processing."""
+"""Analysis modules for TraceLens trace processing.
 
-from .tracelens_wrapper import TraceLensWrapper
-from .analyze_gemm import analyze_gemm_reports
-from .analyze_single import analyze_single_config
-from .analyze_sweep import analyze_sweep_config, discover_and_run_tracelens
+The GEMM / single-config / sweep analysers each pull pandas / numpy /
+openpyxl, which live behind ``aorta[report]``. ``kernel_correlator`` is
+deliberately stdlib-only so the NaN-correlation pipeline runs on a base
+install. To keep that promise, only the lightweight modules
+(``tracelens_wrapper``, ``kernel_correlator``) are imported eagerly here;
+the heavy ones resolve via PEP 562 ``__getattr__`` on first access.
+Issue surfaced by Copilot review on PR #162: importing any symbol from
+this package used to drag in pandas/openpyxl regardless of which
+analyser the caller actually wanted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
 from .kernel_correlator import (
     CorrelationFinding,
     IterationRecord,
     KernelEventCorrelator,
     iter_findings_table,
 )
+from .tracelens_wrapper import TraceLensWrapper
 
 __all__ = [
     "TraceLensWrapper",
@@ -22,3 +34,36 @@ __all__ = [
     "KernelEventCorrelator",
     "iter_findings_table",
 ]
+
+
+_LAZY_SOURCES = {
+    "analyze_gemm_reports": ("analyze_gemm", "analyze_gemm_reports"),
+    "analyze_single_config": ("analyze_single", "analyze_single_config"),
+    "analyze_sweep_config": ("analyze_sweep", "analyze_sweep_config"),
+    "discover_and_run_tracelens": ("analyze_sweep", "discover_and_run_tracelens"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve the heavy analysers on first access.
+
+    Same rationale as ``aorta.report.generators.__getattr__``: keeps the
+    kernel-trace path runnable on a base install while preserving the
+    package-level public surface for callers that have the extras.
+    """
+    try:
+        module_name, attr = _LAZY_SOURCES[name]
+    except KeyError as exc:
+        raise AttributeError(
+            f"module 'aorta.report.analysis' has no attribute {name!r}"
+        ) from exc
+    import importlib
+
+    module = importlib.import_module(f".{module_name}", __name__)
+    value = getattr(module, attr)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/aorta/report/analysis/kernel_correlator.py
+++ b/src/aorta/report/analysis/kernel_correlator.py
@@ -129,30 +129,74 @@ class KernelEventCorrelator:
         }
 
 
+def _coerce_int(value: Any, default: int = 0) -> int:
+    """Best-effort ``int()`` that survives explicit JSON ``null`` values.
+
+    ``dict.get(key, default)`` only returns ``default`` when the key is
+    absent; if the key is present with a JSON ``null``, ``.get()``
+    returns ``None`` and ``int(None)`` raises ``TypeError``. Older or
+    partial trainer schemas can emit explicit nulls, so coerce
+    defensively rather than dropping the whole row.
+    """
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    """``_coerce_int`` counterpart for floats; same null-safety rationale."""
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int_dict(raw: Any) -> dict[str, int]:
+    """Coerce a ``{name: count}`` dict, dropping any non-coercible value.
+
+    A JSON ``"foo": null`` for a kernel-event count is treated as zero
+    so the rest of the row is still usable.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): _coerce_int(v) for k, v in raw.items()}
+
+
+def _coerce_float_dict(raw: Any) -> dict[str, float]:
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): _coerce_float(v, 0.0) for k, v in raw.items()}
+
+
 def _payload_to_record(payload: dict[str, Any]) -> IterationRecord:
     profile = payload.get("profile") or {}
     overlap = profile.get("overlap") or {}
     kernel_trace = payload.get("kernel_trace") or {}
     summary = kernel_trace.get("summary") or {}
 
-    loss_raw = payload.get("loss")
-    try:
-        loss = float(loss_raw) if loss_raw is not None else float("nan")
-    except (TypeError, ValueError):
-        loss = float("nan")
+    # ``kernel_trace.get("event_count")`` may be an explicit ``null``
+    # (older/partial schema), in which case ``dict.get`` returns
+    # ``None`` rather than the fallback. Compute the fallback length
+    # eagerly so it is also used on the null branch.
+    raw_event_count = kernel_trace.get("event_count")
+    events_field = kernel_trace.get("events")
+    fallback_event_count = len(events_field) if isinstance(events_field, list) else 0
 
     return IterationRecord(
-        rank=int(payload.get("rank", 0)),
-        global_step=int(payload.get("global_step", 0)),
-        epoch=int(payload.get("epoch", 0)),
-        step=int(payload.get("step", 0)),
-        loss=loss,
-        overlap_ms={k: float(v) for k, v in (overlap.get("overlap_ms") or {}).items()},
-        per_stream_ms={k: float(v) for k, v in (overlap.get("per_stream_ms") or {}).items()},
-        kernel_summary={k: int(v) for k, v in summary.items()},
-        kernel_event_count=int(
-            kernel_trace.get("event_count", len(kernel_trace.get("events", [])))
-        ),
+        rank=_coerce_int(payload.get("rank")),
+        global_step=_coerce_int(payload.get("global_step")),
+        epoch=_coerce_int(payload.get("epoch")),
+        step=_coerce_int(payload.get("step")),
+        loss=_coerce_float(payload.get("loss"), float("nan")),
+        overlap_ms=_coerce_float_dict(overlap.get("overlap_ms")),
+        per_stream_ms=_coerce_float_dict(overlap.get("per_stream_ms")),
+        kernel_summary=_coerce_int_dict(summary),
+        kernel_event_count=_coerce_int(raw_event_count, fallback_event_count),
         raw=payload,
     )
 

--- a/src/aorta/report/analysis/kernel_correlator.py
+++ b/src/aorta/report/analysis/kernel_correlator.py
@@ -22,9 +22,10 @@ from __future__ import annotations
 import json
 import logging
 import math
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Iterator, List, Optional
+from typing import Any
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ class CorrelationFinding:
     """One iteration of interest plus the kernel events preceding it."""
 
     target: IterationRecord
-    preceding_window: List[IterationRecord]
+    preceding_window: list[IterationRecord]
     kernel_event_total: dict[str, int]
 
 
@@ -64,9 +65,9 @@ class KernelEventCorrelator:
     def __init__(self, lookback_iterations: int = 5) -> None:
         self.lookback_iterations = lookback_iterations
 
-    def load_metrics(self, path: Path) -> List[IterationRecord]:
+    def load_metrics(self, path: Path) -> list[IterationRecord]:
         """Parse a single ``rank_XX_metrics.jsonl`` file."""
-        records: List[IterationRecord] = []
+        records: list[IterationRecord] = []
         with path.open("r", encoding="utf-8") as fh:
             for line_no, raw_line in enumerate(fh, start=1):
                 raw_line = raw_line.strip()
@@ -80,22 +81,24 @@ class KernelEventCorrelator:
                 records.append(_payload_to_record(payload))
         return records
 
-    def load_metrics_glob(self, directory: Path, pattern: str = "rank_*_metrics.jsonl") -> List[IterationRecord]:
+    def load_metrics_glob(
+        self, directory: Path, pattern: str = "rank_*_metrics.jsonl"
+    ) -> list[IterationRecord]:
         """Load and concatenate every metrics file matching ``pattern``."""
-        all_records: List[IterationRecord] = []
+        all_records: list[IterationRecord] = []
         for path in sorted(directory.glob(pattern)):
             all_records.extend(self.load_metrics(path))
         all_records.sort(key=lambda r: (r.global_step, r.rank))
         return all_records
 
-    def find_failures(self, records: Iterable[IterationRecord]) -> List[CorrelationFinding]:
+    def find_failures(self, records: Iterable[IterationRecord]) -> list[CorrelationFinding]:
         """Return findings for each NaN iteration with preceding context."""
         sorted_records = sorted(records, key=lambda r: (r.rank, r.global_step))
-        per_rank: dict[int, List[IterationRecord]] = {}
+        per_rank: dict[int, list[IterationRecord]] = {}
         for record in sorted_records:
             per_rank.setdefault(record.rank, []).append(record)
 
-        findings: List[CorrelationFinding] = []
+        findings: list[CorrelationFinding] = []
         for rank, rank_records in per_rank.items():
             for idx, record in enumerate(rank_records):
                 if not record.is_nan:
@@ -147,7 +150,9 @@ def _payload_to_record(payload: dict[str, Any]) -> IterationRecord:
         overlap_ms={k: float(v) for k, v in (overlap.get("overlap_ms") or {}).items()},
         per_stream_ms={k: float(v) for k, v in (overlap.get("per_stream_ms") or {}).items()},
         kernel_summary={k: int(v) for k, v in summary.items()},
-        kernel_event_count=int(kernel_trace.get("event_count", len(kernel_trace.get("events", [])))),
+        kernel_event_count=int(
+            kernel_trace.get("event_count", len(kernel_trace.get("events", [])))
+        ),
         raw=payload,
     )
 

--- a/src/aorta/report/analysis/kernel_correlator.py
+++ b/src/aorta/report/analysis/kernel_correlator.py
@@ -1,0 +1,181 @@
+"""Correlate kernel-trace events with user-space training metrics.
+
+Reads ``rank_XX_metrics.jsonl`` produced by the FSDP trainer (and any
+other workload that emits the ``profile`` + ``kernel_trace`` schema) and
+produces:
+
+  - A per-iteration aggregate with kernel-event counts joined to the
+    user-space loss / overlap data.
+  - A simple "events preceding failure" view: for any iteration with
+    ``loss == NaN`` or ``failure``, list kernel events from a configurable
+    look-back window of preceding iterations.
+  - A summary table suitable for direct printing or downstream rendering
+    by the report generators.
+
+The module avoids a hard dependency on pandas/numpy so it is usable from
+the small ``aorta`` install footprint; richer rendering lives in
+``aorta.report.generators.kernel_report``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class IterationRecord:
+    """Flattened view of a single ``rank_XX_metrics.jsonl`` line."""
+
+    rank: int
+    global_step: int
+    epoch: int
+    step: int
+    loss: float
+    overlap_ms: dict[str, float] = field(default_factory=dict)
+    per_stream_ms: dict[str, float] = field(default_factory=dict)
+    kernel_summary: dict[str, int] = field(default_factory=dict)
+    kernel_event_count: int = 0
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_nan(self) -> bool:
+        return isinstance(self.loss, float) and math.isnan(self.loss)
+
+
+@dataclass
+class CorrelationFinding:
+    """One iteration of interest plus the kernel events preceding it."""
+
+    target: IterationRecord
+    preceding_window: List[IterationRecord]
+    kernel_event_total: dict[str, int]
+
+
+class KernelEventCorrelator:
+    """Join StreamProfiler overlap data with KernelTraceProfiler events."""
+
+    def __init__(self, lookback_iterations: int = 5) -> None:
+        self.lookback_iterations = lookback_iterations
+
+    def load_metrics(self, path: Path) -> List[IterationRecord]:
+        """Parse a single ``rank_XX_metrics.jsonl`` file."""
+        records: List[IterationRecord] = []
+        with path.open("r", encoding="utf-8") as fh:
+            for line_no, raw_line in enumerate(fh, start=1):
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    payload = json.loads(raw_line)
+                except json.JSONDecodeError as exc:
+                    log.warning("Skipping malformed line %d in %s: %s", line_no, path, exc)
+                    continue
+                records.append(_payload_to_record(payload))
+        return records
+
+    def load_metrics_glob(self, directory: Path, pattern: str = "rank_*_metrics.jsonl") -> List[IterationRecord]:
+        """Load and concatenate every metrics file matching ``pattern``."""
+        all_records: List[IterationRecord] = []
+        for path in sorted(directory.glob(pattern)):
+            all_records.extend(self.load_metrics(path))
+        all_records.sort(key=lambda r: (r.global_step, r.rank))
+        return all_records
+
+    def find_failures(self, records: Iterable[IterationRecord]) -> List[CorrelationFinding]:
+        """Return findings for each NaN iteration with preceding context."""
+        sorted_records = sorted(records, key=lambda r: (r.rank, r.global_step))
+        per_rank: dict[int, List[IterationRecord]] = {}
+        for record in sorted_records:
+            per_rank.setdefault(record.rank, []).append(record)
+
+        findings: List[CorrelationFinding] = []
+        for rank, rank_records in per_rank.items():
+            for idx, record in enumerate(rank_records):
+                if not record.is_nan:
+                    continue
+                start = max(0, idx - self.lookback_iterations)
+                window = rank_records[start:idx]
+                totals = _sum_kernel_summaries(window + [record])
+                findings.append(
+                    CorrelationFinding(
+                        target=record,
+                        preceding_window=window,
+                        kernel_event_total=totals,
+                    )
+                )
+            log.debug("Rank %d: %d findings", rank, sum(1 for r in rank_records if r.is_nan))
+        return findings
+
+    def summarise(self, records: Iterable[IterationRecord]) -> dict[str, Any]:
+        """Aggregate kernel-event totals across all iterations."""
+        records = list(records)
+        totals = _sum_kernel_summaries(records)
+        nan_iterations = [r for r in records if r.is_nan]
+        return {
+            "total_iterations": len(records),
+            "nan_iterations": len(nan_iterations),
+            "kernel_event_totals": totals,
+            "ranks": sorted({r.rank for r in records}),
+        }
+
+
+def _payload_to_record(payload: dict[str, Any]) -> IterationRecord:
+    profile = payload.get("profile") or {}
+    overlap = profile.get("overlap") or {}
+    kernel_trace = payload.get("kernel_trace") or {}
+    summary = kernel_trace.get("summary") or {}
+
+    loss_raw = payload.get("loss")
+    try:
+        loss = float(loss_raw) if loss_raw is not None else float("nan")
+    except (TypeError, ValueError):
+        loss = float("nan")
+
+    return IterationRecord(
+        rank=int(payload.get("rank", 0)),
+        global_step=int(payload.get("global_step", 0)),
+        epoch=int(payload.get("epoch", 0)),
+        step=int(payload.get("step", 0)),
+        loss=loss,
+        overlap_ms={k: float(v) for k, v in (overlap.get("overlap_ms") or {}).items()},
+        per_stream_ms={k: float(v) for k, v in (overlap.get("per_stream_ms") or {}).items()},
+        kernel_summary={k: int(v) for k, v in summary.items()},
+        kernel_event_count=int(kernel_trace.get("event_count", len(kernel_trace.get("events", [])))),
+        raw=payload,
+    )
+
+
+def _sum_kernel_summaries(records: Iterable[IterationRecord]) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for record in records:
+        for key, value in record.kernel_summary.items():
+            totals[key] = totals.get(key, 0) + int(value)
+    return totals
+
+
+def iter_findings_table(findings: Iterable[CorrelationFinding]) -> Iterator[dict[str, Any]]:
+    """Flatten findings into rows suitable for tabular rendering."""
+    for finding in findings:
+        target = finding.target
+        yield {
+            "rank": target.rank,
+            "global_step": target.global_step,
+            "loss": target.loss,
+            "lookback_iterations": len(finding.preceding_window),
+            **{f"kernel_{k}": v for k, v in finding.kernel_event_total.items()},
+        }
+
+
+__all__ = [
+    "CorrelationFinding",
+    "IterationRecord",
+    "KernelEventCorrelator",
+    "iter_findings_table",
+]

--- a/src/aorta/report/generators/__init__.py
+++ b/src/aorta/report/generators/__init__.py
@@ -2,6 +2,7 @@
 
 from .html_generator import generate_html, image_to_base64
 from .excel_report import create_final_excel_report
+from .kernel_report import generate_kernel_report
 from .plot_generator import (
     generate_plots,
     generate_summary_plots,
@@ -13,6 +14,7 @@ __all__ = [
     "generate_html",
     "image_to_base64",
     "create_final_excel_report",
+    "generate_kernel_report",
     "generate_plots",
     "generate_summary_plots",
     "generate_gemm_plots",

--- a/src/aorta/report/generators/__init__.py
+++ b/src/aorta/report/generators/__init__.py
@@ -1,14 +1,25 @@
-"""Report generators for HTML, Excel, and plots."""
+"""Report generators for HTML, Excel, plots, and kernel-trace.
 
-from .html_generator import generate_html, image_to_base64
-from .excel_report import create_final_excel_report
+The HTML / Excel / plot generators each pull a heavy optional dep
+(matplotlib, openpyxl, pandas) that is *not* part of the base ``aorta``
+install -- they live behind the ``aorta[report]`` extra. The kernel-
+trace generator, by contrast, deliberately depends only on the standard
+library so a NaN-correlation report can be produced on a stock host.
+
+To keep that promise, this module loads only the lightweight
+``generate_kernel_report`` symbol eagerly and uses a PEP 562
+``__getattr__`` shim to defer the heavy generators until they are
+actually requested. ``from aorta.report.generators import generate_html``
+still works for callers that have the extras installed; importing
+anything from a kernel-trace-only path no longer triggers the heavy
+chain (issue raised by Copilot review on PR #162).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
 from .kernel_report import generate_kernel_report
-from .plot_generator import (
-    generate_plots,
-    generate_summary_plots,
-    generate_gemm_plots,
-    generate_single_config_plots,
-)
 
 __all__ = [
     "generate_html",
@@ -20,3 +31,41 @@ __all__ = [
     "generate_gemm_plots",
     "generate_single_config_plots",
 ]
+
+
+_LAZY_SOURCES = {
+    "generate_html": ("html_generator", "generate_html"),
+    "image_to_base64": ("html_generator", "image_to_base64"),
+    "create_final_excel_report": ("excel_report", "create_final_excel_report"),
+    "generate_plots": ("plot_generator", "generate_plots"),
+    "generate_summary_plots": ("plot_generator", "generate_summary_plots"),
+    "generate_gemm_plots": ("plot_generator", "generate_gemm_plots"),
+    "generate_single_config_plots": ("plot_generator", "generate_single_config_plots"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve the heavy generators on first access.
+
+    Eagerly importing them at package init would force every consumer
+    of the kernel-trace path -- including the dependency-free CLI
+    subcommand -- to also have ``matplotlib`` / ``openpyxl`` / ``pandas``
+    installed. Deferring lets a base install get the kernel-trace
+    artefact bundle without those extras.
+    """
+    try:
+        module_name, attr = _LAZY_SOURCES[name]
+    except KeyError as exc:
+        raise AttributeError(
+            f"module 'aorta.report.generators' has no attribute {name!r}"
+        ) from exc
+    import importlib
+
+    module = importlib.import_module(f".{module_name}", __name__)
+    value = getattr(module, attr)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/aorta/report/generators/cli.py
+++ b/src/aorta/report/generators/cli.py
@@ -6,8 +6,9 @@ This module provides the 'generate' command group with subcommands:
   - plots: Generate visualization plots
 """
 
-import click
 from pathlib import Path
+
+import click
 
 
 @click.group()
@@ -337,7 +338,12 @@ def generate_kernel_trace(ctx, metrics_dir, output_dir, lookback_iterations, pat
             -i artifacts/run_2026_04_27/ \\
             -o artifacts/run_2026_04_27/kernel_report/
     """
-    from . import generate_kernel_report
+    # Import the leaf module rather than the ``generators`` package: the
+    # package ``__init__`` eagerly imports ``excel_report`` / ``plot_generator``
+    # / ``html_generator`` (pandas / openpyxl / matplotlib), which would
+    # defeat this subcommand's "runnable on the base install with no
+    # report extras" promise. Caught by Copilot review on PR #162.
+    from .kernel_report import generate_kernel_report
 
     quiet = ctx.obj.get("quiet", False)
     artifacts = generate_kernel_report(

--- a/src/aorta/report/generators/cli.py
+++ b/src/aorta/report/generators/cli.py
@@ -17,9 +17,10 @@ def generate(ctx):
 
     \b
     Commands:
-      html   - Generate HTML report with embedded images
-      excel  - Generate comprehensive Excel report
-      plots  - Generate visualization plots
+      html          - Generate HTML report with embedded images
+      excel         - Generate comprehensive Excel report
+      plots         - Generate visualization plots
+      kernel-trace  - Correlate kernel events with NaN iterations
     """
     pass
 
@@ -288,3 +289,65 @@ def generate_plots_cmd(ctx, input_file, excel_input, gemm_csv, output, plot_type
         raise click.ClickException(str(e))
     except Exception as e:
         raise click.ClickException(f"Error generating plots: {e}")
+
+
+@generate.command("kernel-trace")
+@click.option(
+    "-i",
+    "--metrics-dir",
+    "metrics_dir",
+    required=True,
+    type=click.Path(exists=True, file_okay=False),
+    help="Directory containing rank_*_metrics.jsonl files",
+)
+@click.option(
+    "-o",
+    "--output-dir",
+    "output_dir",
+    required=True,
+    type=click.Path(),
+    help="Output directory for the kernel-trace report bundle",
+)
+@click.option(
+    "--lookback",
+    "lookback_iterations",
+    default=5,
+    type=int,
+    show_default=True,
+    help="Number of preceding iterations to attach to each NaN finding",
+)
+@click.option(
+    "--pattern",
+    default="rank_*_metrics.jsonl",
+    show_default=True,
+    help="Glob pattern for the per-rank metrics files",
+)
+@click.pass_context
+def generate_kernel_trace(ctx, metrics_dir, output_dir, lookback_iterations, pattern):
+    """Correlate kernel events from bpftrace with training NaN iterations.
+
+    Reads ``rank_*_metrics.jsonl`` written by the FSDP trainer (when
+    ``--enable-kernel-trace`` is on) and emits a JSON summary, a CSV of
+    findings, and a self-contained HTML report.
+
+    Example:
+
+    \b
+        aorta-report generate kernel-trace \\
+            -i artifacts/run_2026_04_27/ \\
+            -o artifacts/run_2026_04_27/kernel_report/
+    """
+    from . import generate_kernel_report
+
+    quiet = ctx.obj.get("quiet", False)
+    artifacts = generate_kernel_report(
+        metrics_dir=Path(metrics_dir),
+        output_dir=Path(output_dir),
+        lookback_iterations=lookback_iterations,
+        pattern=pattern,
+    )
+
+    if not quiet:
+        click.echo("Kernel trace report artifacts:")
+        for name, path in artifacts.items():
+            click.echo(f"  {name}: {path}")

--- a/src/aorta/report/generators/kernel_report.py
+++ b/src/aorta/report/generators/kernel_report.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 
 import csv
 import html
+import io
 import json
 import logging
-from dataclasses import asdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable, List
+from typing import Any
 
 from ..analysis.kernel_correlator import (
     CorrelationFinding,
@@ -77,16 +78,7 @@ def generate_kernel_report(
     )
 
     csv_path = output_dir / "kernel_trace_findings.csv"
-    rows = list(iter_findings_table(findings))
-    if rows:
-        fieldnames = sorted({key for row in rows for key in row})
-        with csv_path.open("w", encoding="utf-8", newline="") as fh:
-            writer = csv.DictWriter(fh, fieldnames=fieldnames)
-            writer.writeheader()
-            for row in rows:
-                writer.writerow(row)
-    else:
-        csv_path.write_text("rank,global_step,loss\n", encoding="utf-8")
+    csv_path.write_text(_render_findings_csv(findings), encoding="utf-8")
 
     html_path = output_dir / "kernel_trace_report.html"
     html_path.write_text(
@@ -106,6 +98,56 @@ def generate_kernel_report(
         "findings_csv": csv_path,
         "html_report": html_path,
     }
+
+
+# Static columns that ``iter_findings_table`` always emits, in the
+# order downstream consumers (humans + spreadsheet pivots + the HTML
+# table further below) expect to see them. Keeping this in one place
+# ensures the with-findings header agrees with the no-findings
+# placeholder. Issue raised by Copilot on PR #162: previously the
+# populated path used ``sorted(...)`` of all keys, which produced a
+# different column order than the placeholder header
+# ``"rank,global_step,loss\n"`` and surprised CSV consumers.
+_FINDINGS_STATIC_COLUMNS: tuple[str, ...] = (
+    "rank",
+    "global_step",
+    "loss",
+    "lookback_iterations",
+)
+
+
+def _findings_csv_fieldnames(rows: list[dict[str, Any]]) -> list[str]:
+    """Static columns first, then sorted dynamic ``kernel_*`` columns.
+
+    All dynamic columns are guaranteed to be ``kernel_<event>`` strings
+    by ``iter_findings_table``; sort them so the column ordering is
+    deterministic across runs even if the underlying event-type set
+    changes between versions.
+    """
+    dynamic_cols = sorted(
+        {key for row in rows for key in row if key not in _FINDINGS_STATIC_COLUMNS}
+    )
+    return list(_FINDINGS_STATIC_COLUMNS) + dynamic_cols
+
+
+def _render_findings_csv(findings: Iterable[CorrelationFinding]) -> str:
+    """Serialise findings as CSV with a stable column order.
+
+    Always writes a header row whose static-column prefix matches
+    ``_FINDINGS_STATIC_COLUMNS`` -- including the no-findings case --
+    so a downstream pipeline can rely on ``rank,global_step,loss,
+    lookback_iterations`` being the leading columns regardless of
+    whether any NaN iterations were detected.
+    """
+    rows = list(iter_findings_table(findings))
+    fieldnames = _findings_csv_fieldnames(rows)
+
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buffer.getvalue()
 
 
 def _finding_to_dict(finding: CorrelationFinding) -> dict[str, Any]:
@@ -154,7 +196,7 @@ def _render_html(
     *,
     metrics_dir: Path,
     summary: dict[str, Any],
-    findings: List[CorrelationFinding],
+    findings: list[CorrelationFinding],
 ) -> str:
     parts: list[str] = [_HTML_HEAD]
     parts.append("<h1>Kernel Trace Report</h1>")

--- a/src/aorta/report/generators/kernel_report.py
+++ b/src/aorta/report/generators/kernel_report.py
@@ -1,0 +1,257 @@
+"""Generate kernel-trace correlation reports.
+
+Reads ``rank_*_metrics.jsonl`` files in a run directory and emits:
+
+  - A JSON summary keyed by rank (kernel-event totals, NaN counts).
+  - A CSV table of per-finding rows (one per NaN iteration with
+    preceding kernel-event counts).
+  - An HTML report rendering the same data alongside a small Markdown-
+    style narrative. The HTML is intentionally dependency-free so the
+    generator works with the base ``aorta`` install.
+
+The generator depends only on the standard library; ``aorta[report]``'s
+heavy plotting stack (matplotlib, pandas) is *not* required for kernel
+reports.
+"""
+
+from __future__ import annotations
+
+import csv
+import html
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Iterable, List
+
+from ..analysis.kernel_correlator import (
+    CorrelationFinding,
+    IterationRecord,
+    KernelEventCorrelator,
+    iter_findings_table,
+)
+
+log = logging.getLogger(__name__)
+
+
+def generate_kernel_report(
+    metrics_dir: Path,
+    output_dir: Path,
+    *,
+    lookback_iterations: int = 5,
+    pattern: str = "rank_*_metrics.jsonl",
+) -> dict[str, Path]:
+    """Build a kernel-trace report bundle for a single run directory.
+
+    Args:
+        metrics_dir: Directory containing the per-rank JSONL files.
+        output_dir: Where to write the report artifacts.
+        lookback_iterations: How many iterations of context to attach to
+            each NaN finding.
+        pattern: Glob pattern for the metrics files.
+
+    Returns:
+        Mapping of artifact name to its filesystem path.
+    """
+    metrics_dir = Path(metrics_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    correlator = KernelEventCorrelator(lookback_iterations=lookback_iterations)
+    records = correlator.load_metrics_glob(metrics_dir, pattern=pattern)
+    findings = correlator.find_failures(records)
+    summary = correlator.summarise(records)
+
+    summary_path = output_dir / "kernel_trace_summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "metrics_dir": str(metrics_dir),
+                "summary": summary,
+                "findings": [_finding_to_dict(f) for f in findings],
+            },
+            indent=2,
+            default=str,
+        ),
+        encoding="utf-8",
+    )
+
+    csv_path = output_dir / "kernel_trace_findings.csv"
+    rows = list(iter_findings_table(findings))
+    if rows:
+        fieldnames = sorted({key for row in rows for key in row})
+        with csv_path.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+    else:
+        csv_path.write_text("rank,global_step,loss\n", encoding="utf-8")
+
+    html_path = output_dir / "kernel_trace_report.html"
+    html_path.write_text(
+        _render_html(metrics_dir=metrics_dir, summary=summary, findings=findings),
+        encoding="utf-8",
+    )
+
+    log.info(
+        "Kernel report written: summary=%s findings=%s html=%s",
+        summary_path,
+        csv_path,
+        html_path,
+    )
+
+    return {
+        "summary_json": summary_path,
+        "findings_csv": csv_path,
+        "html_report": html_path,
+    }
+
+
+def _finding_to_dict(finding: CorrelationFinding) -> dict[str, Any]:
+    return {
+        "target": _record_summary(finding.target),
+        "preceding_window": [_record_summary(r) for r in finding.preceding_window],
+        "kernel_event_total": finding.kernel_event_total,
+    }
+
+
+def _record_summary(record: IterationRecord) -> dict[str, Any]:
+    return {
+        "rank": record.rank,
+        "global_step": record.global_step,
+        "loss": record.loss,
+        "kernel_summary": record.kernel_summary,
+        "kernel_event_count": record.kernel_event_count,
+        "overlap_ms": record.overlap_ms,
+    }
+
+
+_HTML_HEAD = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\">
+<title>Kernel Trace Report</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 2em; color: #222; }
+  h1, h2 { border-bottom: 1px solid #ccc; padding-bottom: 0.2em; }
+  table { border-collapse: collapse; margin: 1em 0; }
+  th, td { border: 1px solid #ccc; padding: 0.4em 0.7em; text-align: right; }
+  th { background: #f4f4f4; text-align: left; }
+  td.label { text-align: left; }
+  .nan { color: #b00020; font-weight: 600; }
+  .empty { color: #888; font-style: italic; }
+  pre { background: #f4f4f4; padding: 0.7em; border-radius: 4px; overflow-x: auto; }
+</style>
+</head>
+<body>
+"""
+
+_HTML_FOOT = "</body></html>\n"
+
+
+def _render_html(
+    *,
+    metrics_dir: Path,
+    summary: dict[str, Any],
+    findings: List[CorrelationFinding],
+) -> str:
+    parts: list[str] = [_HTML_HEAD]
+    parts.append("<h1>Kernel Trace Report</h1>")
+    parts.append(f"<p>Source: <code>{html.escape(str(metrics_dir))}</code></p>")
+
+    parts.append("<h2>Summary</h2>")
+    parts.append(_render_summary_table(summary))
+
+    parts.append("<h2>NaN Findings</h2>")
+    if not findings:
+        parts.append("<p class='empty'>No NaN iterations detected.</p>")
+    else:
+        parts.append(_render_findings_table(findings))
+        parts.append("<h2>Per-finding context</h2>")
+        for idx, finding in enumerate(findings):
+            parts.append(_render_finding_detail(idx, finding))
+
+    parts.append(_HTML_FOOT)
+    return "".join(parts)
+
+
+def _render_summary_table(summary: dict[str, Any]) -> str:
+    rows = [
+        ("Total iterations", summary.get("total_iterations", 0)),
+        ("NaN iterations", summary.get("nan_iterations", 0)),
+        ("Ranks", ", ".join(str(r) for r in summary.get("ranks", []))),
+    ]
+    out = ["<table>"]
+    for label, value in rows:
+        out.append(
+            f"<tr><td class='label'>{html.escape(label)}</td>"
+            f"<td>{html.escape(str(value))}</td></tr>"
+        )
+
+    totals = summary.get("kernel_event_totals", {})
+    if totals:
+        out.append("<tr><th class='label'>Kernel event</th><th>Count</th></tr>")
+        for key in sorted(totals):
+            out.append(
+                f"<tr><td class='label'>{html.escape(key)}</td>"
+                f"<td>{html.escape(str(totals[key]))}</td></tr>"
+            )
+    out.append("</table>")
+    return "".join(out)
+
+
+def _render_findings_table(findings: Iterable[CorrelationFinding]) -> str:
+    findings = list(findings)
+    if not findings:
+        return ""
+    keys = sorted({key for f in findings for key in f.kernel_event_total})
+    headers = ["rank", "global_step", "loss", "lookback"] + keys
+    out = ["<table><thead><tr>"]
+    for h in headers:
+        out.append(f"<th>{html.escape(h)}</th>")
+    out.append("</tr></thead><tbody>")
+    for f in findings:
+        cells = [
+            str(f.target.rank),
+            str(f.target.global_step),
+            f"<span class='nan'>{f.target.loss}</span>",
+            str(len(f.preceding_window)),
+        ]
+        for key in keys:
+            cells.append(str(f.kernel_event_total.get(key, 0)))
+        out.append("<tr>")
+        for cell in cells:
+            out.append(f"<td>{cell}</td>")
+        out.append("</tr>")
+    out.append("</tbody></table>")
+    return "".join(out)
+
+
+def _render_finding_detail(idx: int, finding: CorrelationFinding) -> str:
+    target = finding.target
+    out = [
+        f"<h3>Finding {idx + 1}: rank {target.rank}, step {target.global_step}</h3>",
+        "<p>Iterations preceding the NaN (most recent last):</p>",
+        "<table><thead><tr><th>step</th><th>loss</th><th>events</th></tr></thead><tbody>",
+    ]
+    for record in finding.preceding_window:
+        out.append(
+            "<tr>"
+            f"<td>{record.global_step}</td>"
+            f"<td>{record.loss}</td>"
+            f"<td class='label'>{html.escape(json.dumps(record.kernel_summary))}</td>"
+            "</tr>"
+        )
+    out.append(
+        "<tr>"
+        f"<td><b>{target.global_step}</b></td>"
+        f"<td><span class='nan'>{target.loss}</span></td>"
+        f"<td class='label'>{html.escape(json.dumps(target.kernel_summary))}</td>"
+        "</tr>"
+    )
+    out.append("</tbody></table>")
+    return "".join(out)
+
+
+__all__ = ["generate_kernel_report"]

--- a/src/aorta/training/fsdp_trainer.py
+++ b/src/aorta/training/fsdp_trainer.py
@@ -25,7 +25,9 @@ from torch.optim import AdamW
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 from aorta.data import SyntheticDatasetConfig, create_dataloader
+from aorta.ebpf import BpftraceScriptVariant
 from aorta.models import ModelConfig, RankingTransformerModel
+from aorta.profiling.kernel_profiler import KernelTraceConfig, KernelTraceProfiler
 from aorta.profiling.stream_profiler import StreamProfiler
 from aorta.utils import detect_accelerator, get_device, get_distributed_backend, load_config, merge_cli_overrides, setup_logging
 
@@ -107,6 +109,18 @@ class ProfilerConfig:
     tensorboard: bool = False
     chrome_trace: bool = True
     trace_filename: str = "trace.json"
+
+
+@dataclass
+class KernelTracingConfig:
+    """Per-trainer flags that translate to ``KernelTraceConfig``."""
+
+    enabled: bool = False
+    variant: str = "tp_only"
+    use_sudo: bool = True
+    keep_raw_events: bool = False
+    skip_if_unavailable: bool = True
+    bpftrace_path: Optional[str] = None
 
 
 def _parse_config(args: argparse.Namespace) -> Dict[str, Any]:
@@ -198,6 +212,25 @@ def _build_profiler_config(raw: Dict[str, Any]) -> ProfilerConfig:
         if field.name in section:
             setattr(cfg, field.name, section[field.name])
     return cfg
+
+
+def _build_kernel_tracing_config(raw: Dict[str, Any]) -> KernelTracingConfig:
+    section = raw.get("kernel_tracing", {})
+    cfg = KernelTracingConfig()
+    for field in dataclass_fields(KernelTracingConfig):
+        if field.name in section:
+            setattr(cfg, field.name, section[field.name])
+    return cfg
+
+
+def _resolve_kernel_trace_variant(name: str) -> BpftraceScriptVariant:
+    try:
+        return BpftraceScriptVariant[name.upper()]
+    except KeyError as exc:
+        valid = ", ".join(v.name.lower() for v in BpftraceScriptVariant)
+        raise ValueError(
+            f"Unknown kernel-tracing variant '{name}'. Valid options: {valid}"
+        ) from exc
 
 
 def dataclass_fields(cls) -> Iterable[Any]:
@@ -443,6 +476,7 @@ def training_loop(
     profiler: StreamProfiler,
     enable_rocm_metrics: bool,
     profiler_cfg: ProfilerConfig,
+    kernel_profiler: Optional[KernelTraceProfiler] = None,
 ) -> None:
     rank = environment["rank"]
     world_size = environment["world_size"]
@@ -479,6 +513,8 @@ def training_loop(
 
                 for step, cpu_batch in enumerate(dataloader):
                     profiler.start_iteration(global_step)
+                    if kernel_profiler is not None:
+                        kernel_profiler.start_iteration(global_step)
 
                     with profiler.range("aux", f"epoch{epoch}_step{step}_prefetch"):
                         batch = move_batch_to_device(cpu_batch, device)
@@ -578,6 +614,9 @@ def training_loop(
                     profiler.record_marker("compute", f"epoch{epoch}_step{step}_end")
 
                     iteration_profile = profiler.end_iteration()
+                    kernel_trace_record: Optional[Dict[str, Any]] = None
+                    if kernel_profiler is not None:
+                        kernel_trace_record = kernel_profiler.end_iteration()
 
                     iteration_payload = {
                         "rank": rank,
@@ -590,6 +629,8 @@ def training_loop(
                         "lr": optimizer.param_groups[0]["lr"],
                         "profile": iteration_profile,
                     }
+                    if kernel_trace_record is not None:
+                        iteration_payload["kernel_trace"] = kernel_trace_record
 
                     iteration_payload.update(collect_rocm_metrics(enable_rocm_metrics))
                     metrics_logger.log(iteration_payload)
@@ -790,11 +831,35 @@ def main_cli() -> None:  # pragma: no cover - CLI entry
         help="Configuration overrides as dotted key=value entries",
     )
     parser.add_argument("--enable-rocm-metrics", action="store_true", help="Collect rocm-smi metrics")
+    parser.add_argument(
+        "--enable-kernel-trace",
+        action="store_true",
+        help="Attach a bpftrace-based kernel-event profiler to this process. "
+             "Requires bpftrace and CAP_BPF/CAP_PERFMON or sudo on the host.",
+    )
+    parser.add_argument(
+        "--kernel-trace-variant",
+        type=str,
+        default=None,
+        help="Override the bpftrace script variant (full, light, tp_only, "
+             "one_kprobe, unrelated_kprobe). Defaults to tp_only.",
+    )
     args = parser.parse_args()
-    main(args, enable_rocm_metrics=args.enable_rocm_metrics)
+    main(
+        args,
+        enable_rocm_metrics=args.enable_rocm_metrics,
+        enable_kernel_trace=args.enable_kernel_trace,
+        kernel_trace_variant=args.kernel_trace_variant,
+    )
 
 
-def main(args: Optional[argparse.Namespace] = None, *, enable_rocm_metrics: bool = False) -> None:
+def main(
+    args: Optional[argparse.Namespace] = None,
+    *,
+    enable_rocm_metrics: bool = False,
+    enable_kernel_trace: bool = False,
+    kernel_trace_variant: Optional[str] = None,
+) -> None:
     if args is None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--config", type=str, required=True)
@@ -813,6 +878,11 @@ def main(args: Optional[argparse.Namespace] = None, *, enable_rocm_metrics: bool
     ddp_cfg = _build_ddp_config(config)
     compile_cfg = _build_compile_config(config)
     profiler_cfg = _build_profiler_config(config)
+    kernel_tracing_cfg = _build_kernel_tracing_config(config)
+    if enable_kernel_trace:
+        kernel_tracing_cfg.enabled = True
+    if kernel_trace_variant is not None:
+        kernel_tracing_cfg.variant = kernel_trace_variant
 
     log_level = config.get("logging", {}).get("level", "INFO")
     env = init_distributed(training_cfg, log_level)
@@ -845,6 +915,25 @@ def main(args: Optional[argparse.Namespace] = None, *, enable_rocm_metrics: bool
 
     profiler = StreamProfiler(env["device"])
 
+    kernel_profiler: Optional[KernelTraceProfiler] = None
+    if kernel_tracing_cfg.enabled:
+        try:
+            variant = _resolve_kernel_trace_variant(kernel_tracing_cfg.variant)
+        except ValueError as exc:
+            log.error("%s", exc)
+            raise
+        kernel_profiler = KernelTraceProfiler(
+            KernelTraceConfig(
+                enabled=True,
+                variant=variant,
+                use_sudo=kernel_tracing_cfg.use_sudo,
+                bpftrace_path=kernel_tracing_cfg.bpftrace_path,
+                keep_raw_events=kernel_tracing_cfg.keep_raw_events,
+                skip_if_unavailable=kernel_tracing_cfg.skip_if_unavailable,
+            )
+        )
+        kernel_profiler.start()
+
     try:
         training_loop(
             model,
@@ -856,8 +945,11 @@ def main(args: Optional[argparse.Namespace] = None, *, enable_rocm_metrics: bool
             profiler,
             enable_rocm_metrics,
             profiler_cfg,
+            kernel_profiler=kernel_profiler,
         )
     finally:
+        if kernel_profiler is not None:
+            kernel_profiler.stop()
         dist.barrier()
         dist.destroy_process_group()
 

--- a/src/aorta/training/fsdp_trainer.py
+++ b/src/aorta/training/fsdp_trainer.py
@@ -932,9 +932,18 @@ def main(
                 skip_if_unavailable=kernel_tracing_cfg.skip_if_unavailable,
             )
         )
-        kernel_profiler.start()
 
+    # ``kernel_profiler.start()`` is inside this ``try`` (rather than next
+    # to the construction above) so that ``finally`` always tears down the
+    # process group even when the profiler crashes during startup -- e.g.
+    # ``skip_if_unavailable=False`` with bpftrace missing, or the new
+    # ``BpftraceRunner._await_startup()`` raising on a permission failure.
+    # Without this, distributed launches could leak the rendezvous backend
+    # and hang every other rank on barrier. Flagged by Copilot review on
+    # PR #162.
     try:
+        if kernel_profiler is not None:
+            kernel_profiler.start()
         training_loop(
             model,
             optimizer,

--- a/src/aorta/training/fsdp_trainer.py
+++ b/src/aorta/training/fsdp_trainer.py
@@ -958,7 +958,13 @@ def main(
         )
     finally:
         if kernel_profiler is not None:
-            kernel_profiler.stop()
+            try:
+                kernel_profiler.stop()
+            except BaseException:
+                log.exception(
+                    "Failed to stop kernel profiler during distributed "
+                    "cleanup; continuing with process-group teardown"
+                )
         dist.barrier()
         dist.destroy_process_group()
 

--- a/tests/ebpf/test_events.py
+++ b/tests/ebpf/test_events.py
@@ -1,0 +1,59 @@
+"""Smoke tests for ``aorta.ebpf.events``.
+
+These pin the public surface (enum values, dataclass shape) so that the
+lower-level parser/runner tests keep meaning what they look like.
+"""
+
+from __future__ import annotations
+
+from aorta.ebpf import KernelEvent, KernelEventType
+
+
+class TestKernelEventType:
+    def test_enum_values_match_log_tokens(self):
+        # The parser keys patterns off these literal strings; if they
+        # drift, parser tests will fail in confusing ways. Lock them
+        # explicitly.
+        assert KernelEventType.KFD_EVICT.value == "KFD_EVICT_QUEUES"
+        assert KernelEventType.KFD_RESTORE.value == "KFD_RESTORE_QUEUES"
+        assert KernelEventType.SVM_EVICT.value == "SVM_RANGE_EVICT_WORKER"
+        assert KernelEventType.BO_MOVE.value == "BO_MOVE"
+        assert KernelEventType.VM_FLUSH.value == "VM_FLUSH"
+        assert KernelEventType.IOCTL_ERROR.value == "IOCTL_ERROR"
+
+    def test_full_membership_is_stable(self):
+        # Adding/removing event types should be a deliberate change with
+        # parser + summary keymap updates. This keeps that contract tight.
+        names = {member.name for member in KernelEventType}
+        assert names == {
+            "KFD_EVICT",
+            "KFD_RESTORE",
+            "SVM_EVICT",
+            "BO_MOVE",
+            "VM_FLUSH",
+            "VM_UNMAP_TICK",
+            "IOCTL_ERROR",
+            "LONG_IOCTL",
+            "MMAP",
+            "MUNMAP",
+            "VM_HANDLE_MOVED",
+            "KFD_INTERRUPT",
+            "SIGNAL",
+            "HEARTBEAT",
+            "TICK",
+        }
+
+
+class TestKernelEvent:
+    def test_defaults(self):
+        ev = KernelEvent(timestamp_ns=42, event_type=KernelEventType.HEARTBEAT)
+        assert ev.timestamp_ns == 42
+        assert ev.event_type is KernelEventType.HEARTBEAT
+        assert ev.payload == {}
+        assert ev.raw_line == ""
+
+    def test_payload_is_independent_per_instance(self):
+        a = KernelEvent(timestamp_ns=1, event_type=KernelEventType.TICK)
+        b = KernelEvent(timestamp_ns=2, event_type=KernelEventType.TICK)
+        a.payload["x"] = 1
+        assert "x" not in b.payload, "default_factory must not share state"

--- a/tests/ebpf/test_parser.py
+++ b/tests/ebpf/test_parser.py
@@ -1,0 +1,170 @@
+"""Tests for ``aorta.ebpf.parser.BpftraceLogParser``.
+
+The parser is a list of regex patterns iterated in order; ordering is
+load-bearing (specific patterns must match before their fallbacks). These
+tests pin both the per-pattern behaviour and the ordering contract --
+addressing review item C6.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aorta.ebpf import BpftraceLogParser, KernelEventType
+
+
+@pytest.fixture
+def parser() -> BpftraceLogParser:
+    return BpftraceLogParser()
+
+
+class TestParseSingleEvents:
+    def test_kfd_evict_with_comm(self, parser):
+        ev = parser.parse_line("1700000000123 *** KFD_EVICT_QUEUES pid=4321 comm=python ***")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.KFD_EVICT
+        assert ev.timestamp_ns == 1700000000123
+        assert ev.payload == {"pid": 4321, "comm": "python"}
+
+    def test_kfd_restore(self, parser):
+        ev = parser.parse_line("10 *** KFD_RESTORE_QUEUES pid=99 comm=foo ***")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.KFD_RESTORE
+        assert ev.payload["pid"] == 99
+
+    def test_svm_evict(self, parser):
+        ev = parser.parse_line("5 *** SVM_RANGE_EVICT_WORKER pid=11 comm=worker ***")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.SVM_EVICT
+
+    def test_bo_move_amdgpu_form(self, parser):
+        ev = parser.parse_line("12 *** AMDGPU_BO_MOVE size=4096 old=2 new=4 ***")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.BO_MOVE
+        assert ev.payload == {"size": 4096, "old_placement": 2, "new_placement": 4}
+
+    def test_bo_move_short_form(self, parser):
+        ev = parser.parse_line("13 BO_MOVE size=128 old=1 new=3")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.BO_MOVE
+        assert ev.payload["size"] == 128
+
+    def test_vm_flush_with_pd_addr(self, parser):
+        ev = parser.parse_line("20 AMDGPU_VM_FLUSH vmid=2 hub=0 pd_addr=0xffff800012345000")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.VM_FLUSH
+        assert ev.payload["pd_addr"] == "0xffff800012345000"
+        assert ev.payload["vmid"] == 2
+
+    def test_tick_with_openats(self, parser):
+        ev = parser.parse_line("99 TICK unmaps=3 ptes=44 openats=7")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.TICK
+        assert ev.payload == {"unmaps": 3, "ptes": 44, "openats": 7}
+
+    def test_tick_without_openats(self, parser):
+        ev = parser.parse_line("99 TICK unmaps=3 ptes=44")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.TICK
+        assert ev.payload == {"unmaps": 3, "ptes": 44}
+
+    def test_ioctl_error_long_form(self, parser):
+        ev = parser.parse_line("31 IOCTL_ERROR cmd=0xc0186444 ret=-22 dur=120us")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.IOCTL_ERROR
+        assert ev.payload == {"cmd": "0xc0186444", "ret": -22, "dur_us": 120}
+
+    def test_ioctl_error_short_form(self, parser):
+        ev = parser.parse_line("32 IOCTL_ERR ret=-5")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.IOCTL_ERROR
+        assert ev.payload == {"ret": -5}
+
+    def test_long_ioctl(self, parser):
+        ev = parser.parse_line("40 LONG_IOCTL cmd=0x1234 dur=2500us")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.LONG_IOCTL
+        assert ev.payload == {"cmd": "0x1234", "dur_us": 2500}
+
+    def test_mmap_munmap(self, parser):
+        mmap = parser.parse_line("50 MMAP len=4096 prot=0x3 flags=0x22")
+        assert mmap is not None
+        assert mmap.event_type is KernelEventType.MMAP
+        assert mmap.payload == {"len": 4096, "prot": "0x3", "flags": "0x22"}
+
+        munmap = parser.parse_line("51 MUNMAP addr=0x7fff00000000 len=2048")
+        assert munmap is not None
+        assert munmap.event_type is KernelEventType.MUNMAP
+        assert munmap.payload == {"addr": "0x7fff00000000", "len": 2048}
+
+    def test_signal_long_and_short_form(self, parser):
+        long_form = parser.parse_line("60 SIGNAL sig=11")
+        short_form = parser.parse_line("61 SIG=9")
+        assert long_form is not None and long_form.event_type is KernelEventType.SIGNAL
+        assert long_form.payload == {"sig": 11}
+        assert short_form is not None
+        assert short_form.event_type is KernelEventType.SIGNAL
+        assert short_form.payload == {"sig": 9}
+
+    def test_heartbeat(self, parser):
+        ev = parser.parse_line("70 HEARTBEAT alive")
+        assert ev is not None
+        assert ev.event_type is KernelEventType.HEARTBEAT
+        assert ev.payload == {}
+
+
+class TestUnknownAndEmpty:
+    def test_blank_line_returns_none(self, parser):
+        assert parser.parse_line("") is None
+        assert parser.parse_line("    \n") is None
+
+    def test_unknown_line_returns_none(self, parser):
+        assert parser.parse_line("Attaching 12 probes...") is None
+        assert parser.parse_line("WARNING: missing kernel symbol") is None
+
+
+class TestRawLineCapture:
+    def test_raw_line_is_stripped_form(self, parser):
+        ev = parser.parse_line("  10 HEARTBEAT alive  \n")
+        assert ev is not None
+        assert ev.raw_line == "10 HEARTBEAT alive"
+
+
+class TestPatternOrderingIsLoadBearing:
+    """C6: pattern order matters because more-specific patterns must win.
+
+    The parser declares `_PATTERNS` as a list iterated in-order. If a
+    refactor accidentally re-orders or de-duplicates entries, callers
+    silently lose ``comm=`` or ``pd_addr=`` payload fields. These tests
+    pin that contract.
+    """
+
+    def test_specific_kfd_evict_with_comm_wins_over_short_form(self, parser):
+        # Both patterns match a "KFD_EVICT_QUEUES pid=N" prefix; only the
+        # specific one captures `comm`. If the bare-pid pattern moved
+        # ahead of it, `comm` would silently disappear.
+        ev = parser.parse_line("1 *** KFD_EVICT_QUEUES pid=42 comm=trainer ***")
+        assert ev is not None
+        assert ev.payload.get("comm") == "trainer", (
+            "with-comm pattern must precede the bare-pid pattern in _PATTERNS"
+        )
+
+    def test_amdgpu_bo_move_form_wins_over_short_form(self, parser):
+        # Both ``*** AMDGPU_BO_MOVE size=... ***`` and the bare ``BO_MOVE
+        # size=...`` line should classify as BO_MOVE; the bare form is a
+        # fallback for stripped-down scripts. Verify both still win the
+        # right class regardless of which appears first in input.
+        amdgpu = parser.parse_line("1 *** AMDGPU_BO_MOVE size=64 old=1 new=2 ***")
+        bare = parser.parse_line("2 BO_MOVE size=64 old=1 new=2")
+        assert amdgpu is not None and amdgpu.event_type is KernelEventType.BO_MOVE
+        assert bare is not None and bare.event_type is KernelEventType.BO_MOVE
+
+    def test_long_form_ioctl_error_keeps_dur_us(self, parser):
+        # If ``IOCTL_ERR ret=-N`` (short form) preceded the long form
+        # in _PATTERNS, the dur_us would be lost on long-form lines.
+        ev = parser.parse_line("3 IOCTL_ERROR cmd=0x1 ret=-22 dur=99us")
+        assert ev is not None
+        assert "dur_us" in ev.payload, (
+            "long-form IOCTL_ERROR pattern must precede the short ret-only one"
+        )
+        assert ev.payload["dur_us"] == 99

--- a/tests/ebpf/test_runner.py
+++ b/tests/ebpf/test_runner.py
@@ -1,0 +1,524 @@
+"""Tests for ``aorta.ebpf.runner.BpftraceRunner``.
+
+Covers the C1-C4 fixes added in this PR:
+  - C1: ``startup_timeout_sec`` is enforced (previously documented but no-op).
+  - C2: stderr is drained on its own thread so the OS pipe buffer cannot fill.
+  - C3: reader-thread death is surfaced via ``is_running`` and logged from
+        ``stop()`` instead of being silently swallowed.
+  - C4: immediate-exit failures (binary missing on PATH, sudo prompt
+        swallowed, "ERROR: Don't have permission to run BPF program")
+        raise from ``start()`` with the captured stderr included.
+
+Subprocesses are simulated via a ``FakePopen`` so the tests do not
+require an actual ``bpftrace`` binary or any kernel privileges.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aorta.ebpf import (
+    SCRIPTS_DIR,
+    BpftraceConfig,
+    BpftraceRunner,
+    BpftraceScriptVariant,
+    BpftraceUnavailableError,
+)
+
+# ---------------------------------------------------------------------------
+# FakePopen: a controllable Popen replacement.
+# ---------------------------------------------------------------------------
+
+
+class FakePopen:
+    """In-memory stand-in for ``subprocess.Popen`` for runner tests.
+
+    Behaviour knobs (set on the class via the factory below):
+      - ``script_lines``: lines to feed on stdout, one per ``__iter__``
+        step. Use ``None`` as a sentinel to block the reader thread
+        until ``feed_stdout`` is called.
+      - ``stderr_lines``: same shape, for stderr.
+      - ``startup_rc``: if not None, ``poll()`` returns this immediately.
+    """
+
+    def __init__(
+        self,
+        cmd,
+        *,
+        stdout=None,
+        stderr=None,
+        text=None,
+        bufsize=None,
+        script_lines=(),
+        stderr_lines=(),
+        startup_rc=None,
+    ):
+        self._stdout_q: list[str] = list(script_lines)
+        self._stderr_q: list[str] = list(stderr_lines)
+        self._stdout_event = threading.Event()
+        self._stderr_event = threading.Event()
+        # If the fake process is already "exited" (startup_rc is set), the
+        # OS would have closed the pipes and the iterator would terminate
+        # after consuming the queue. Mirror that here so drain threads
+        # can exit during the start()-failure path.
+        already_exited = startup_rc is not None
+        self._stdout_done = already_exited
+        self._stderr_done = already_exited
+        self._returncode = startup_rc
+        self.pid = 12345
+        self.cmd = cmd
+
+        self.stdout = _BlockingLines(self._stdout_q, self._stdout_event, lambda: self._stdout_done)
+        self.stderr = _BlockingLines(self._stderr_q, self._stderr_event, lambda: self._stderr_done)
+
+    def poll(self):
+        return self._returncode
+
+    def terminate(self):
+        # Close both streams so reader threads can exit their for-loop.
+        self._stdout_done = True
+        self._stderr_done = True
+        self._stdout_event.set()
+        self._stderr_event.set()
+        if self._returncode is None:
+            self._returncode = 0
+
+    def kill(self):
+        self.terminate()
+
+    def wait(self, timeout=None):
+        return self._returncode if self._returncode is not None else 0
+
+    def feed_stdout(self, line: str) -> None:
+        self._stdout_q.append(line)
+        self._stdout_event.set()
+
+    def finish_stdout(self) -> None:
+        self._stdout_done = True
+        self._stdout_event.set()
+
+
+class _BlockingLines:
+    """Iterable that yields queued lines, blocking when empty until signalled."""
+
+    def __init__(self, queue, event, done_fn):
+        self._q = queue
+        self._event = event
+        self._done = done_fn
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        while True:
+            if self._q:
+                return self._q.pop(0)
+            if self._done():
+                raise StopIteration
+            self._event.wait(timeout=0.05)
+            self._event.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_runner(**cfg_kwargs) -> BpftraceRunner:
+    defaults: dict = {
+        "target_pid": 1234,
+        "variant": BpftraceScriptVariant.TP_ONLY,
+        "use_sudo": False,
+        "bpftrace_path": "/usr/bin/bpftrace",
+        "startup_timeout_sec": 0.5,
+    }
+    defaults.update(cfg_kwargs)
+    return BpftraceRunner(BpftraceConfig(**defaults))
+
+
+def _patch_popen(fake_factory):
+    return patch("aorta.ebpf.runner.subprocess.Popen", side_effect=fake_factory)
+
+
+# ---------------------------------------------------------------------------
+# Build-command + availability
+# ---------------------------------------------------------------------------
+
+
+class TestCommandBuilding:
+    def test_is_bpftrace_available_path_present(self, tmp_path: Path):
+        binary = tmp_path / "fake_bpftrace"
+        binary.touch()
+        assert BpftraceRunner.is_bpftrace_available(str(binary)) is True
+
+    def test_is_bpftrace_available_path_missing(self, tmp_path: Path):
+        assert BpftraceRunner.is_bpftrace_available(str(tmp_path / "nope")) is False
+
+    def test_unavailable_error_when_bpftrace_missing(self, tmp_path: Path):
+        cfg = BpftraceConfig(
+            target_pid=1,
+            variant=BpftraceScriptVariant.TP_ONLY,
+            use_sudo=False,
+            bpftrace_path=None,
+        )
+        runner = BpftraceRunner(cfg)
+        with patch("aorta.ebpf.runner.shutil.which", return_value=None):
+            with pytest.raises(BpftraceUnavailableError):
+                runner._build_command()
+
+    def test_script_path_must_exist(self, tmp_path: Path):
+        cfg = BpftraceConfig(
+            target_pid=1,
+            use_sudo=False,
+            bpftrace_path="/usr/bin/bpftrace",
+            script_path=tmp_path / "missing.bt",
+        )
+        runner = BpftraceRunner(cfg)
+        with pytest.raises(FileNotFoundError):
+            runner._build_command()
+
+    def test_sudo_prefix_added_when_requested(self):
+        cfg = BpftraceConfig(
+            target_pid=42,
+            variant=BpftraceScriptVariant.LIGHT,
+            use_sudo=True,
+            sudo_args=["-n"],
+            bpftrace_path="/usr/bin/bpftrace",
+        )
+        runner = BpftraceRunner(cfg)
+        cmd = runner._build_command()
+        assert cmd[:2] == ["sudo", "-n"]
+        assert cmd[2] == "/usr/bin/bpftrace"
+        assert cmd[-1] == "42"
+        assert cmd[-2].endswith("gpu_cont_light.bt")
+
+    def test_extra_args_pass_through_before_script(self):
+        cfg = BpftraceConfig(
+            target_pid=7,
+            use_sudo=False,
+            bpftrace_path="/usr/bin/bpftrace",
+            extra_args=["-q", "-B", "line"],
+        )
+        runner = BpftraceRunner(cfg)
+        cmd = runner._build_command()
+        # /usr/bin/bpftrace -q -B line <script> 7
+        assert cmd[0] == "/usr/bin/bpftrace"
+        assert cmd[1:4] == ["-q", "-B", "line"]
+        assert cmd[-1] == "7"
+
+    def test_resolve_script_path_uses_variant(self):
+        cfg = BpftraceConfig(
+            target_pid=1,
+            use_sudo=False,
+            variant=BpftraceScriptVariant.UNRELATED_KPROBE,
+            bpftrace_path="/usr/bin/bpftrace",
+        )
+        assert cfg.resolve_script_path() == SCRIPTS_DIR / "gpu_cont_unrelated_kprobe.bt"
+
+    def test_resolve_script_path_explicit_override_wins(self, tmp_path: Path):
+        custom = tmp_path / "custom.bt"
+        cfg = BpftraceConfig(
+            target_pid=1,
+            use_sudo=False,
+            script_path=custom,
+            bpftrace_path="/usr/bin/bpftrace",
+        )
+        assert cfg.resolve_script_path() == custom
+
+
+# ---------------------------------------------------------------------------
+# C1 + C4: startup detection
+# ---------------------------------------------------------------------------
+
+
+class TestStartupDetection:
+    """C1+C4: ``start()`` must surface immediate-exit failures."""
+
+    def test_immediate_exit_raises_with_stderr(self):
+        def factory(*args, **kwargs):
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                startup_rc=1,
+                stderr_lines=["ERROR: Don't have permission to run BPF program\n"],
+            )
+
+        runner = _make_runner()
+        with _patch_popen(factory):
+            with pytest.raises(RuntimeError) as excinfo:
+                runner.start()
+        # bpftrace's actual error must be reachable to the operator, not
+        # buried in some private buffer.
+        assert "permission" in str(excinfo.value).lower()
+        assert "rc=1" in str(excinfo.value)
+
+    def test_first_stdout_line_unblocks_start(self):
+        # Healthy startup: bpftrace prints attach noise quickly. start()
+        # must return as soon as it sees any line, not wait the whole
+        # startup_timeout_sec.
+        fake = {"obj": None}
+
+        def factory(*args, **kwargs):
+            fake["obj"] = FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=["10 HEARTBEAT alive\n"],
+            )
+            return fake["obj"]
+
+        runner = _make_runner(startup_timeout_sec=5.0)
+        t0 = time.monotonic()
+        with _patch_popen(factory):
+            runner.start()
+            elapsed = time.monotonic() - t0
+            try:
+                # If start() honoured the early-return signal, this will be
+                # well under the 5s timeout.
+                assert elapsed < 1.0, f"start() blocked for {elapsed:.2f}s"
+            finally:
+                runner.stop()
+
+    def test_timeout_without_first_line_proceeds(self):
+        # If the script attaches many probes and is silent, start() must
+        # still return after startup_timeout_sec rather than blocking
+        # forever. A short timeout makes this fast.
+        def factory(*args, **kwargs):
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=[],
+            )
+
+        runner = _make_runner(startup_timeout_sec=0.2)
+        with _patch_popen(factory):
+            t0 = time.monotonic()
+            runner.start()
+            try:
+                elapsed = time.monotonic() - t0
+                # Should be ~ startup_timeout_sec, not infinite.
+                assert 0.1 < elapsed < 1.0
+                assert runner.is_running
+            finally:
+                runner.stop()
+
+
+# ---------------------------------------------------------------------------
+# C2: stderr is drained on its own thread.
+# ---------------------------------------------------------------------------
+
+
+class TestStderrDraining:
+    def test_stderr_text_accessor_returns_drained_lines(self):
+        # The drain thread accumulates bpftrace's stderr without ever
+        # blocking the reader; verify the captured text is reachable.
+        def factory(*args, **kwargs):
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=["1 HEARTBEAT alive\n"],
+                stderr_lines=[
+                    "Attaching 12 probes...\n",
+                    "WARNING: kernel symbol mismatch\n",
+                ],
+            )
+
+        runner = _make_runner()
+        with _patch_popen(factory):
+            runner.start()
+            try:
+                # Give the stderr drain thread a moment to consume.
+                time.sleep(0.2)
+                stderr = runner.stderr_text()
+            finally:
+                runner.stop()
+        assert "Attaching" in stderr
+        assert "kernel symbol mismatch" in stderr
+
+    def test_chatty_stderr_does_not_deadlock_stdout(self):
+        # Pre-C2 failure mode: stderr=PIPE was never drained; a bpftrace
+        # that writes >64 KiB to stderr would block on write() and
+        # silently stop producing stdout events. Simulate by feeding a
+        # large stderr volume and checking we still receive stdout
+        # events afterwards.
+        big_stderr = ["x" * 256 + "\n"] * 512  # ~128 KiB
+
+        def factory(*args, **kwargs):
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=["1 HEARTBEAT alive\n", "2 HEARTBEAT alive\n"],
+                stderr_lines=big_stderr,
+            )
+
+        runner = _make_runner()
+        with _patch_popen(factory):
+            runner.start()
+            try:
+                time.sleep(0.3)
+                events = runner.snapshot_events()
+            finally:
+                runner.stop()
+        # Both heartbeats must have been parsed; pre-fix this would be 0
+        # because the reader thread would be blocked behind a stuffed
+        # stderr buffer.
+        assert len(events) == 2
+
+
+# ---------------------------------------------------------------------------
+# C3: reader-thread death surfaces.
+# ---------------------------------------------------------------------------
+
+
+class TestReaderThreadDeathSurfaces:
+    def test_is_running_false_when_reader_thread_dies(self):
+        def factory(*args, **kwargs):
+            # Empty stdout, drain thread will idle and stay alive.
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=[],
+            )
+
+        runner = _make_runner()
+        with _patch_popen(factory):
+            runner.start()
+            try:
+                # Forcibly mark the reader thread as not-alive by replacing
+                # the Thread object with a stub that reports dead. This
+                # simulates an exception that already dropped the thread.
+                class _DeadThread:
+                    def is_alive(self):
+                        return False
+
+                    def join(self, timeout=None):
+                        return None
+
+                runner._reader_thread = _DeadThread()
+                # is_running should now report False even though _proc
+                # is still healthy.
+                assert runner.is_running is False
+            finally:
+                runner.stop()
+
+    def test_stop_logs_reader_exception(self, caplog):
+        def factory(*args, **kwargs):
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=[],
+            )
+
+        runner = _make_runner()
+        import logging
+
+        with _patch_popen(factory):
+            runner.start()
+            runner._reader_exception = RuntimeError("synthetic parser crash")
+            with caplog.at_level(logging.WARNING, logger="aorta.ebpf.runner"):
+                runner.stop()
+
+        assert any("synthetic parser crash" in record.getMessage() for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# General lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_double_start_raises(self):
+        def factory(*args, **kwargs):
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=["1 HEARTBEAT alive\n"],
+            )
+
+        runner = _make_runner()
+        with _patch_popen(factory):
+            runner.start()
+            try:
+                with pytest.raises(RuntimeError, match="already started"):
+                    runner.start()
+            finally:
+                runner.stop()
+
+    def test_stop_on_unstarted_returns_empty(self):
+        runner = _make_runner()
+        assert runner.stop() == []
+
+    def test_drain_events_atomic_clear(self):
+        def factory(*args, **kwargs):
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=[
+                    "1 HEARTBEAT alive\n",
+                    "2 HEARTBEAT alive\n",
+                ],
+            )
+
+        runner = _make_runner()
+        with _patch_popen(factory):
+            runner.start()
+            try:
+                # Wait briefly for both lines to be parsed.
+                time.sleep(0.2)
+                first = runner.drain_events()
+                second = runner.drain_events()
+            finally:
+                runner.stop()
+        assert len(first) == 2
+        assert second == []
+
+    def test_on_event_callback_exceptions_are_isolated(self):
+        seen: list[str] = []
+
+        def buggy(event):
+            seen.append(event.event_type.name)
+            raise RuntimeError("callback explodes")
+
+        def factory(*args, **kwargs):
+            return FakePopen(
+                args[0],
+                **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")},
+                script_lines=["1 HEARTBEAT alive\n", "2 HEARTBEAT alive\n"],
+            )
+
+        cfg = BpftraceConfig(
+            target_pid=1,
+            use_sudo=False,
+            bpftrace_path="/usr/bin/bpftrace",
+            startup_timeout_sec=0.5,
+        )
+        runner = BpftraceRunner(cfg, on_event=buggy)
+        with _patch_popen(factory):
+            runner.start()
+            try:
+                time.sleep(0.2)
+                events = runner.snapshot_events()
+            finally:
+                runner.stop()
+        # Both events were parsed and stored even though the callback
+        # raised; the runner must keep going on user-callback errors.
+        assert len(events) == 2
+        assert seen == ["HEARTBEAT", "HEARTBEAT"]
+
+
+# ---------------------------------------------------------------------------
+# Vendored scripts ship as package data
+# ---------------------------------------------------------------------------
+
+
+class TestVendoredScriptsExist:
+    @pytest.mark.parametrize("variant", list(BpftraceScriptVariant))
+    def test_each_variant_resolves_to_an_existing_file(self, variant):
+        # If pyproject.toml's package-data glob ever drops the .bt files
+        # this would fail at the first installed-package use.
+        path = SCRIPTS_DIR / variant.value
+        assert path.exists(), f"vendored script missing: {path}"

--- a/tests/ebpf/test_runner.py
+++ b/tests/ebpf/test_runner.py
@@ -57,6 +57,9 @@ class FakePopen:
         script_lines=(),
         stderr_lines=(),
         startup_rc=None,
+        terminate_raises=None,
+        kill_raises=None,
+        wait_raises=None,
     ):
         self._stdout_q: list[str] = list(script_lines)
         self._stderr_q: list[str] = list(stderr_lines)
@@ -72,6 +75,12 @@ class FakePopen:
         self._returncode = startup_rc
         self.pid = 12345
         self.cmd = cmd
+        # PR #162 round 2 (C3): exercise the ProcessLookupError race that
+        # the real ``Popen`` exposes when the child has already been
+        # reaped between ``poll()`` and ``terminate()`` / ``kill()``.
+        self._terminate_raises = terminate_raises
+        self._kill_raises = kill_raises
+        self._wait_raises = wait_raises
 
         self.stdout = _BlockingLines(self._stdout_q, self._stdout_event, lambda: self._stdout_done)
         self.stderr = _BlockingLines(self._stderr_q, self._stderr_event, lambda: self._stderr_done)
@@ -80,7 +89,8 @@ class FakePopen:
         return self._returncode
 
     def terminate(self):
-        # Close both streams so reader threads can exit their for-loop.
+        if self._terminate_raises is not None:
+            raise self._terminate_raises
         self._stdout_done = True
         self._stderr_done = True
         self._stdout_event.set()
@@ -89,9 +99,18 @@ class FakePopen:
             self._returncode = 0
 
     def kill(self):
-        self.terminate()
+        if self._kill_raises is not None:
+            raise self._kill_raises
+        self._stdout_done = True
+        self._stderr_done = True
+        self._stdout_event.set()
+        self._stderr_event.set()
+        if self._returncode is None:
+            self._returncode = 0
 
     def wait(self, timeout=None):
+        if self._wait_raises is not None:
+            raise self._wait_raises
         return self._returncode if self._returncode is not None else 0
 
     def feed_stdout(self, line: str) -> None:
@@ -508,6 +527,186 @@ class TestLifecycle:
         # raised; the runner must keep going on user-callback errors.
         assert len(events) == 2
         assert seen == ["HEARTBEAT", "HEARTBEAT"]
+
+
+# ---------------------------------------------------------------------------
+# PR #162 round 2 (C3): ``stop()`` honours its "never re-raises" docstring.
+# ---------------------------------------------------------------------------
+
+
+class TestStopNeverReRaises:
+    """Pin the ``finally``-block-safe contract.
+
+    Pre-fix, ``BpftraceRunner.stop()`` would propagate
+    ``ProcessLookupError`` from ``Popen.terminate()`` / ``Popen.kill()``
+    on a race where the bpftrace child had already been reaped (e.g.
+    sudo's bpftrace exits the moment the traced PID dies). That broke
+    distributed cleanup in ``fsdp_trainer.py`` because
+    ``dist.destroy_process_group()`` would never run on the failing
+    rank, leaking the rendezvous backend and hanging every other rank.
+    """
+
+    def _start_runner(self, fake_kwargs):
+        captured: dict = {}
+
+        def factory(*args, **kwargs):
+            popen_only = {
+                k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")
+            }
+            captured["popen"] = FakePopen(args[0], **popen_only, **fake_kwargs)
+            return captured["popen"]
+
+        runner = _make_runner()
+        ctx = _patch_popen(factory)
+        ctx.__enter__()
+        runner.start()
+        return runner, captured["popen"], ctx
+
+    def test_stop_swallows_terminate_process_lookup_error(self, caplog):
+        runner, _fake, ctx = self._start_runner(
+            {
+                "script_lines": [],
+                "terminate_raises": ProcessLookupError(3, "No such process"),
+            }
+        )
+        try:
+            import logging
+
+            with caplog.at_level(logging.DEBUG, logger="aorta.ebpf.runner"):
+                events = runner.stop()
+        finally:
+            ctx.__exit__(None, None, None)
+        # No exception propagated, return type is still the events list.
+        assert isinstance(events, list)
+        assert runner.is_running is False
+
+    def test_stop_swallows_kill_process_lookup_error(self):
+        # ``terminate()`` succeeds, but ``wait()`` times out so the code
+        # path falls through to ``kill()``, which races. Pre-fix this
+        # would re-raise ``ProcessLookupError`` from ``stop()``.
+        import subprocess as _sp
+
+        runner, _fake, ctx = self._start_runner(
+            {
+                "script_lines": [],
+                "wait_raises": _sp.TimeoutExpired(cmd="bpftrace", timeout=0.1),
+                "kill_raises": ProcessLookupError(3, "No such process"),
+            }
+        )
+        try:
+            events = runner.stop()
+        finally:
+            ctx.__exit__(None, None, None)
+        assert isinstance(events, list)
+
+    def test_stop_short_circuits_on_already_exited(self):
+        # If the child already exited (poll() returns an rc), we must
+        # not even attempt to terminate -- doing so was the original
+        # source of the ProcessLookupError race.
+        captured: dict = {}
+
+        def factory(*args, **kwargs):
+            popen_only = {
+                k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "text", "bufsize")
+            }
+            captured["popen"] = FakePopen(
+                args[0],
+                **popen_only,
+                script_lines=["1 HEARTBEAT alive\n"],
+            )
+            return captured["popen"]
+
+        runner = _make_runner()
+        with _patch_popen(factory):
+            runner.start()
+            # Simulate child exit between start() and stop().
+            captured["popen"]._returncode = 0
+            captured["popen"]._stdout_done = True
+            captured["popen"]._stderr_done = True
+            captured["popen"]._stdout_event.set()
+            captured["popen"]._stderr_event.set()
+            # Make terminate() blow up to prove we never call it.
+            captured["popen"]._terminate_raises = AssertionError(
+                "terminate() must not be called after poll() reports exit"
+            )
+            captured["popen"]._kill_raises = AssertionError(
+                "kill() must not be called after poll() reports exit"
+            )
+            events = runner.stop()
+        assert isinstance(events, list)
+
+    def test_stop_swallows_unexpected_exception(self, caplog):
+        # Defensive: any unexpected exception type must still be
+        # logged-and-swallowed, not propagated. The docstring promises
+        # this without qualifying on exception class.
+        runner, _fake, ctx = self._start_runner(
+            {
+                "script_lines": [],
+                "terminate_raises": OSError(1, "Operation not permitted"),
+            }
+        )
+        try:
+            import logging
+
+            with caplog.at_level(logging.ERROR, logger="aorta.ebpf.runner"):
+                events = runner.stop()
+        finally:
+            ctx.__exit__(None, None, None)
+        assert isinstance(events, list)
+
+
+# ---------------------------------------------------------------------------
+# PR #162 round 2 (C4): explicit ``bpftrace_path`` is validated up-front.
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitBpftracePathValidation:
+    """``BpftraceConfig.bpftrace_path`` must point at a real file.
+
+    Pre-fix, a typo or stale absolute path would surface as a generic
+    ``FileNotFoundError`` from ``subprocess.Popen`` deep inside
+    ``start()`` -- callers (CLI, trainer) could not distinguish that
+    from "binary missing entirely on PATH" without parsing the
+    ``errno``. We now raise ``BpftraceUnavailableError`` synchronously
+    from ``_build_command()`` with a self-explanatory message.
+    """
+
+    def test_explicit_path_to_missing_file_raises_unavailable(self, tmp_path: Path):
+        cfg = BpftraceConfig(
+            target_pid=1,
+            use_sudo=False,
+            bpftrace_path=str(tmp_path / "definitely-not-here"),
+        )
+        runner = BpftraceRunner(cfg)
+        with pytest.raises(BpftraceUnavailableError) as excinfo:
+            runner._build_command()
+        msg = str(excinfo.value)
+        assert "definitely-not-here" in msg
+        assert "bpftrace_path" in msg
+
+    def test_explicit_path_to_directory_raises_unavailable(self, tmp_path: Path):
+        # Pointing at a directory was the same shape of bug; the
+        # validation must use ``is_file()``, not just ``exists()``.
+        cfg = BpftraceConfig(
+            target_pid=1,
+            use_sudo=False,
+            bpftrace_path=str(tmp_path),
+        )
+        runner = BpftraceRunner(cfg)
+        with pytest.raises(BpftraceUnavailableError):
+            runner._build_command()
+
+    def test_explicit_path_to_existing_file_is_accepted(self, tmp_path: Path):
+        binary = tmp_path / "fake_bpftrace"
+        binary.touch()
+        cfg = BpftraceConfig(
+            target_pid=1,
+            use_sudo=False,
+            bpftrace_path=str(binary),
+        )
+        runner = BpftraceRunner(cfg)
+        cmd = runner._build_command()
+        assert cmd[0] == str(binary)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/profiling/test_fsdp_trainer_kernel_profiler_lifecycle.py
+++ b/tests/profiling/test_fsdp_trainer_kernel_profiler_lifecycle.py
@@ -1,0 +1,143 @@
+"""Structural test for the FSDP trainer's kernel-profiler lifecycle.
+
+Cannot exercise ``aorta.training.fsdp_trainer.main`` end-to-end in this
+venv (no torch / no rendezvous), so this test asserts the structural
+property directly via AST inspection: ``kernel_profiler.start()`` must
+live inside the same ``try`` block whose ``finally`` calls
+``dist.destroy_process_group()``. Pre-fix (Copilot review on PR #162)
+``start()`` was *outside* that block, so a profiler-startup raise
+(``skip_if_unavailable=False`` and bpftrace missing, or the new
+``BpftraceRunner._await_startup`` permission failure) would leak the
+process group and hang the rendezvous on every other rank.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_TRAINER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "aorta"
+    / "training"
+    / "fsdp_trainer.py"
+)
+
+
+def _find_main_function(tree: ast.AST) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            return node
+    raise AssertionError("fsdp_trainer.main() not found")
+
+
+def _is_attr_call(node: ast.AST, target_attr: str) -> bool:
+    """Return True if ``node`` is an ``ast.Expr`` wrapping ``X.target_attr(...)``."""
+    if not isinstance(node, ast.Expr):
+        return False
+    call = node.value
+    if not isinstance(call, ast.Call):
+        return False
+    func = call.func
+    return isinstance(func, ast.Attribute) and func.attr == target_attr
+
+
+def _is_dist_destroy_call(node: ast.AST) -> bool:
+    """``dist.destroy_process_group()`` -- the cleanup we care about."""
+    if not isinstance(node, ast.Expr):
+        return False
+    call = node.value
+    if not isinstance(call, ast.Call):
+        return False
+    func = call.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "destroy_process_group"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "dist"
+    )
+
+
+def _walk_calls(nodes: list[ast.AST], attr: str) -> list[ast.Call]:
+    """Collect all ``X.attr(...)`` calls anywhere under ``nodes``."""
+    found: list[ast.Call] = []
+    for stmt in nodes:
+        for sub in ast.walk(stmt):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == attr
+            ):
+                found.append(sub)
+    return found
+
+
+@pytest.fixture(scope="module")
+def main_fn() -> ast.FunctionDef:
+    tree = ast.parse(_TRAINER_PATH.read_text())
+    return _find_main_function(tree)
+
+
+class TestKernelProfilerStartIsInsideCleanupTry:
+    """Pin the start-in-try invariant after Copilot review on PR #162."""
+
+    def test_kernel_profiler_start_lives_inside_a_try_with_dist_destroy_in_finally(
+        self, main_fn: ast.FunctionDef
+    ):
+        cleanup_try_blocks: list[ast.Try] = []
+        for node in ast.walk(main_fn):
+            if not isinstance(node, ast.Try):
+                continue
+            # Look for `dist.destroy_process_group()` anywhere in finalbody.
+            if any(_is_dist_destroy_call(stmt) for stmt in node.finalbody):
+                cleanup_try_blocks.append(node)
+
+        assert len(cleanup_try_blocks) == 1, (
+            f"expected exactly one try/finally that tears down the process "
+            f"group; found {len(cleanup_try_blocks)}"
+        )
+        cleanup_try = cleanup_try_blocks[0]
+
+        starts = _walk_calls(cleanup_try.body, "start")
+        # Filter to ``kernel_profiler.start(...)`` specifically.
+        kernel_starts = [
+            call
+            for call in starts
+            if isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "kernel_profiler"
+        ]
+        assert kernel_starts, (
+            "kernel_profiler.start() must be inside the same try-block whose "
+            "finally calls dist.destroy_process_group(); pre-fix it was outside, "
+            "so a start-time failure (bpftrace missing under "
+            "skip_if_unavailable=False, or the new _await_startup permission "
+            "raise) would leak the process group on every other rank"
+        )
+
+    def test_kernel_profiler_stop_remains_in_finally(self, main_fn: ast.FunctionDef):
+        cleanup_try_blocks = [
+            node
+            for node in ast.walk(main_fn)
+            if isinstance(node, ast.Try)
+            and any(_is_dist_destroy_call(stmt) for stmt in node.finalbody)
+        ]
+        assert cleanup_try_blocks, "no cleanup try/finally found"
+        cleanup_try = cleanup_try_blocks[0]
+
+        # ``kernel_profiler.stop()`` should be part of the finally block.
+        stops = _walk_calls(cleanup_try.finalbody, "stop")
+        kernel_stops = [
+            call
+            for call in stops
+            if isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "kernel_profiler"
+        ]
+        assert kernel_stops, (
+            "kernel_profiler.stop() must run from the cleanup finally so "
+            "bpftrace is reaped on training crash"
+        )

--- a/tests/profiling/test_fsdp_trainer_kernel_profiler_lifecycle.py
+++ b/tests/profiling/test_fsdp_trainer_kernel_profiler_lifecycle.py
@@ -14,16 +14,13 @@ process group and hang the rendezvous on every other rank.
 from __future__ import annotations
 
 import ast
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
 
 _TRAINER_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "src"
-    / "aorta"
-    / "training"
-    / "fsdp_trainer.py"
+    Path(__file__).resolve().parents[2] / "src" / "aorta" / "training" / "fsdp_trainer.py"
 )
 
 
@@ -61,7 +58,7 @@ def _is_dist_destroy_call(node: ast.AST) -> bool:
     )
 
 
-def _walk_calls(nodes: list[ast.AST], attr: str) -> list[ast.Call]:
+def _walk_calls(nodes: Sequence[ast.AST], attr: str) -> list[ast.Call]:
     """Collect all ``X.attr(...)`` calls anywhere under ``nodes``."""
     found: list[ast.Call] = []
     for stmt in nodes:
@@ -141,3 +138,81 @@ class TestKernelProfilerStartIsInsideCleanupTry:
             "kernel_profiler.stop() must run from the cleanup finally so "
             "bpftrace is reaped on training crash"
         )
+
+
+class TestKernelProfilerStopIsGuardedInFinally:
+    """PR #162 round 2 (C2): defense-in-depth around ``stop()``.
+
+    Even though ``BpftraceRunner.stop()`` now honours its
+    "never re-raises" contract, the trainer must still wrap
+    ``kernel_profiler.stop()`` in a ``try``/``except`` *inside*
+    the cleanup ``finally``. Otherwise a future regression in the
+    runner -- or a third-party kernel-trace backend wired in via the
+    same interface -- would propagate out of the ``finally`` block
+    and prevent ``dist.destroy_process_group()`` from running, leaking
+    the rendezvous backend on every other rank. Belt-and-braces.
+    """
+
+    def test_kernel_profiler_stop_is_wrapped_in_try_inside_finally(self, main_fn: ast.FunctionDef):
+        cleanup_try_blocks = [
+            node
+            for node in ast.walk(main_fn)
+            if isinstance(node, ast.Try)
+            and any(_is_dist_destroy_call(stmt) for stmt in node.finalbody)
+        ]
+        assert cleanup_try_blocks, "no cleanup try/finally found"
+        cleanup_try = cleanup_try_blocks[0]
+
+        # Walk the finally body looking for an inner Try whose body
+        # contains ``kernel_profiler.stop()``. We cannot assert the
+        # outer ``Try`` is the wrapper because ``main_fn`` already has
+        # an outer ``try/finally``; we want to find a *nested* one
+        # specifically for the stop() call.
+        nested_try_wraps_stop = False
+        for stmt in cleanup_try.finalbody:
+            for sub in ast.walk(stmt):
+                if not isinstance(sub, ast.Try):
+                    continue
+                # A try inside the cleanup finally that has at least
+                # one ``except`` and whose body contains
+                # kernel_profiler.stop() is exactly the shape we want.
+                if not sub.handlers:
+                    continue
+                stops_in_body = _walk_calls(sub.body, "stop")
+                if any(
+                    isinstance(call.func, ast.Attribute)
+                    and isinstance(call.func.value, ast.Name)
+                    and call.func.value.id == "kernel_profiler"
+                    for call in stops_in_body
+                ):
+                    nested_try_wraps_stop = True
+                    break
+            if nested_try_wraps_stop:
+                break
+
+        assert nested_try_wraps_stop, (
+            "kernel_profiler.stop() in the cleanup finally must be guarded "
+            "by an inner try/except so dist.destroy_process_group() always "
+            "runs even if stop() raises (Copilot review on PR #162 round 2)"
+        )
+
+    def test_dist_destroy_process_group_runs_after_stop_guard(self, main_fn: ast.FunctionDef):
+        # ``dist.destroy_process_group()`` must remain in the cleanup
+        # finalbody, *after* the stop() guard, so that even a thrown
+        # stop() does not bypass it. This is implicitly true if the
+        # AST has dist.destroy_process_group in the finalbody (which is
+        # already enforced by the previous test), but double-check the
+        # statement-level ordering.
+        cleanup_try_blocks = [
+            node
+            for node in ast.walk(main_fn)
+            if isinstance(node, ast.Try)
+            and any(_is_dist_destroy_call(stmt) for stmt in node.finalbody)
+        ]
+        cleanup_try = cleanup_try_blocks[0]
+
+        destroy_indices: list[int] = []
+        for idx, stmt in enumerate(cleanup_try.finalbody):
+            if _is_dist_destroy_call(stmt):
+                destroy_indices.append(idx)
+        assert destroy_indices, "dist.destroy_process_group() not in finalbody"

--- a/tests/profiling/test_kernel_profiler.py
+++ b/tests/profiling/test_kernel_profiler.py
@@ -1,0 +1,248 @@
+"""Tests for ``aorta.profiling.kernel_profiler.KernelTraceProfiler``.
+
+The profiler is loaded directly via ``importlib.util`` to bypass
+``aorta.profiling.__init__``'s torch-dependent ``StreamProfiler`` import,
+keeping the tests usable in venvs without PyTorch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from aorta.ebpf import KernelEvent, KernelEventType
+
+_PROF_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "aorta" / "profiling" / "kernel_profiler.py"
+)
+_spec = importlib.util.spec_from_file_location("kernel_profiler", _PROF_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _mod
+_spec.loader.exec_module(_mod)
+
+KernelTraceConfig = _mod.KernelTraceConfig
+KernelTraceProfiler = _mod.KernelTraceProfiler
+
+
+def _make_event(event_type: KernelEventType, **payload) -> KernelEvent:
+    return KernelEvent(
+        timestamp_ns=0,
+        event_type=event_type,
+        payload=dict(payload),
+        raw_line="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# enabled=False is a true no-op
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledProfilerIsNoop:
+    def test_start_does_nothing_when_disabled(self):
+        profiler = KernelTraceProfiler(KernelTraceConfig(enabled=False))
+        profiler.start()
+        assert profiler.enabled is False
+
+    def test_iteration_methods_no_op_when_disabled(self):
+        profiler = KernelTraceProfiler(KernelTraceConfig(enabled=False))
+        profiler.start()
+        profiler.start_iteration(0)
+        # end_iteration must return None and never crash, even with no
+        # paired start_iteration on the disabled path.
+        assert profiler.end_iteration() is None
+
+    def test_stop_returns_empty_list_when_disabled(self):
+        profiler = KernelTraceProfiler(KernelTraceConfig(enabled=False))
+        profiler.start()
+        assert profiler.stop() == []
+
+
+# ---------------------------------------------------------------------------
+# skip_if_unavailable: bpftrace missing should silently disable, not crash
+# ---------------------------------------------------------------------------
+
+
+class TestUnavailableHandling:
+    def test_skip_if_unavailable_disables_silently(self, monkeypatch):
+        # Simulate a host without bpftrace by stubbing
+        # BpftraceRunner.is_bpftrace_available -> False.
+        from aorta.ebpf import runner as runner_mod
+
+        monkeypatch.setattr(
+            runner_mod.BpftraceRunner, "is_bpftrace_available", staticmethod(lambda *a, **kw: False)
+        )
+        profiler = KernelTraceProfiler(
+            KernelTraceConfig(enabled=True, skip_if_unavailable=True, target_pid=os.getpid())
+        )
+        # Should not raise; profiler.enabled becomes False because the
+        # runner never started.
+        profiler.start()
+        assert profiler.enabled is False
+        # end_iteration on the disabled path returns None, not a record.
+        assert profiler.end_iteration() is None
+
+    def test_skip_if_unavailable_false_raises(self, monkeypatch):
+        from aorta.ebpf import runner as runner_mod
+
+        monkeypatch.setattr(
+            runner_mod.BpftraceRunner, "is_bpftrace_available", staticmethod(lambda *a, **kw: False)
+        )
+        profiler = KernelTraceProfiler(
+            KernelTraceConfig(enabled=True, skip_if_unavailable=False, target_pid=os.getpid())
+        )
+        with pytest.raises(RuntimeError, match="bpftrace binary not available"):
+            profiler.start()
+
+
+# ---------------------------------------------------------------------------
+# Per-iteration bucketing (with a fake runner injected)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunner:
+    """Stand-in for ``BpftraceRunner`` controlled from the test."""
+
+    def __init__(self):
+        self._queue: list[KernelEvent] = []
+        self.start_called = False
+        self.stop_called = False
+
+    def queue(self, *events: KernelEvent) -> None:
+        self._queue.extend(events)
+
+    def start(self) -> None:
+        self.start_called = True
+
+    def stop(self):
+        self.stop_called = True
+        events, self._queue = self._queue, []
+        return events
+
+    def drain_events(self):
+        events, self._queue = self._queue, []
+        return events
+
+
+@pytest.fixture
+def injected_profiler(monkeypatch):
+    """Yield a profiler whose runner is a controllable ``_FakeRunner``."""
+    fake = _FakeRunner()
+
+    # Inject the fake by patching BpftraceRunner construction *and*
+    # availability check within the kernel_profiler module's import scope.
+    monkeypatch.setattr(_mod, "BpftraceRunner", MagicMock(return_value=fake))
+    # `is_bpftrace_available` is called as a staticmethod on the original
+    # class; patch it on the MagicMock too.
+    _mod.BpftraceRunner.is_bpftrace_available = staticmethod(lambda *a, **kw: True)
+
+    profiler = KernelTraceProfiler(
+        KernelTraceConfig(enabled=True, skip_if_unavailable=False, target_pid=os.getpid())
+    )
+    profiler.start()
+    yield profiler, fake
+    profiler.stop()
+
+
+class TestIterationBucketing:
+    def test_summary_counts_per_iteration(self, injected_profiler):
+        profiler, fake = injected_profiler
+
+        profiler.start_iteration(0)
+        fake.queue(
+            _make_event(KernelEventType.KFD_EVICT, pid=1),
+            _make_event(KernelEventType.KFD_EVICT, pid=2),
+            _make_event(KernelEventType.SVM_EVICT, pid=3),
+            _make_event(KernelEventType.BO_MOVE, size=4096),
+        )
+        record = profiler.end_iteration()
+        assert record is not None
+        assert record["index"] == 0
+        assert record["summary"]["kfd_evict"] == 2
+        assert record["summary"]["svm_evict"] == 1
+        assert record["summary"]["bo_move"] == 1
+        # No raw events kept by default.
+        assert "events" not in record
+        assert record["event_count"] == 4
+
+    def test_tick_events_aggregate_into_pte_and_unmap_counters(self, injected_profiler):
+        profiler, fake = injected_profiler
+
+        profiler.start_iteration(7)
+        fake.queue(
+            _make_event(KernelEventType.TICK, unmaps=2, ptes=10),
+            _make_event(KernelEventType.TICK, unmaps=3, ptes=20),
+            _make_event(KernelEventType.VM_UNMAP_TICK, unmap_count=4, pte_count=40),
+        )
+        record = profiler.end_iteration()
+        assert record is not None
+        assert record["summary"]["pte_updates"] == 70
+        assert record["summary"]["vm_unmaps"] == 9
+
+    def test_keep_raw_events_serialises_event_list(self, monkeypatch):
+        fake = _FakeRunner()
+        monkeypatch.setattr(_mod, "BpftraceRunner", MagicMock(return_value=fake))
+        _mod.BpftraceRunner.is_bpftrace_available = staticmethod(lambda *a, **kw: True)
+
+        profiler = KernelTraceProfiler(
+            KernelTraceConfig(
+                enabled=True,
+                skip_if_unavailable=False,
+                target_pid=os.getpid(),
+                keep_raw_events=True,
+            )
+        )
+        profiler.start()
+        try:
+            profiler.start_iteration(0)
+            fake.queue(_make_event(KernelEventType.HEARTBEAT))
+            record = profiler.end_iteration()
+        finally:
+            profiler.stop()
+
+        assert record is not None
+        assert record["events"], "keep_raw_events=True must serialise events list"
+        assert record["events"][0]["event_type"] == "HEARTBEAT"
+
+    def test_double_start_iteration_raises(self, injected_profiler):
+        profiler, _ = injected_profiler
+        profiler.start_iteration(0)
+        with pytest.raises(RuntimeError, match="not finalised"):
+            profiler.start_iteration(1)
+
+    def test_pre_iteration_events_are_drained_not_attributed(self, injected_profiler):
+        # If the profiler started and bpftrace queued events before
+        # start_iteration(0), those events must NOT be charged to step 0.
+        profiler, fake = injected_profiler
+
+        # Pre-iteration noise
+        fake.queue(_make_event(KernelEventType.KFD_EVICT, pid=99))
+
+        profiler.start_iteration(0)
+        # No new events for this iteration
+        record = profiler.end_iteration()
+        assert record is not None
+        assert record["summary"]["kfd_evict"] == 0, (
+            "events queued before start_iteration must be drained, not credited to the iteration"
+        )
+
+
+class TestStopFlushesEvents:
+    def test_stop_returns_remaining_runner_events(self, monkeypatch):
+        fake = _FakeRunner()
+        monkeypatch.setattr(_mod, "BpftraceRunner", MagicMock(return_value=fake))
+        _mod.BpftraceRunner.is_bpftrace_available = staticmethod(lambda *a, **kw: True)
+
+        profiler = KernelTraceProfiler(
+            KernelTraceConfig(enabled=True, skip_if_unavailable=False, target_pid=os.getpid())
+        )
+        profiler.start()
+        fake.queue(_make_event(KernelEventType.HEARTBEAT))
+        leftover = profiler.stop()
+        assert len(leftover) == 1
+        assert profiler.all_events()[-1].event_type is KernelEventType.HEARTBEAT

--- a/tests/report/test_kernel_correlator.py
+++ b/tests/report/test_kernel_correlator.py
@@ -37,6 +37,8 @@ _ensure_pkg("aorta.report.analysis", _REPO_SRC / "aorta" / "report" / "analysis"
 
 def _load(name: str, relpath: str):
     spec = importlib.util.spec_from_file_location(name, _REPO_SRC / relpath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {name} from {relpath}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     spec.loader.exec_module(module)
@@ -244,3 +246,150 @@ class TestIterFindingsTable:
         assert row["global_step"] == 1
         assert row["lookback_iterations"] == 1
         assert row["kernel_bo_move"] == 7  # 2 + 5
+
+
+# ---------------------------------------------------------------------------
+# PR #162 round 2 (C1): explicit JSON ``null`` values must not crash
+# ``_payload_to_record`` with ``int(None)`` / ``float(None)`` TypeError.
+# Older / partial trainer schemas (rank crashed mid-iteration, custom
+# integrations) can emit explicit nulls instead of omitting the key.
+# ---------------------------------------------------------------------------
+
+
+class TestNullSafePayloadCoercion:
+    def test_null_event_count_is_treated_as_fallback_length(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        # Note: ``event_count`` is *explicitly null*, not omitted, so
+        # ``dict.get("event_count", default)`` returns None rather than
+        # the default. Pre-fix this raised ``TypeError: int() argument
+        # must be a string... not 'NoneType'``.
+        path.write_text(
+            json.dumps(
+                {
+                    "rank": 0,
+                    "global_step": 0,
+                    "epoch": 0,
+                    "step": 0,
+                    "loss": 1.0,
+                    "profile": {"overlap": {"overlap_ms": {}, "per_stream_ms": {}}},
+                    "kernel_trace": {
+                        "summary": {"kfd_evict": 1},
+                        "event_count": None,
+                        "events": [
+                            {"type": "kfd_evict"},
+                            {"type": "kfd_evict"},
+                        ],
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        records = KernelEventCorrelator().load_metrics(path)
+        assert len(records) == 1
+        # Fallback should derive from len(events) when event_count is null.
+        assert records[0].kernel_event_count == 2
+
+    def test_null_event_count_without_events_array_defaults_to_zero(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "rank": 0,
+                    "global_step": 0,
+                    "epoch": 0,
+                    "step": 0,
+                    "loss": 1.0,
+                    "profile": {"overlap": {"overlap_ms": {}, "per_stream_ms": {}}},
+                    "kernel_trace": {
+                        "summary": {},
+                        "event_count": None,
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        records = KernelEventCorrelator().load_metrics(path)
+        assert len(records) == 1
+        assert records[0].kernel_event_count == 0
+
+    def test_null_summary_value_defaults_to_zero(self, tmp_path: Path):
+        # A single null inside ``summary`` (e.g. partially-finalised
+        # iteration) must not poison the whole row -- we accept the row
+        # with that single counter coerced to zero.
+        path = tmp_path / "rank_0_metrics.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "rank": 0,
+                    "global_step": 0,
+                    "epoch": 0,
+                    "step": 0,
+                    "loss": 1.0,
+                    "profile": {"overlap": {"overlap_ms": {}, "per_stream_ms": {}}},
+                    "kernel_trace": {
+                        "summary": {"kfd_evict": 4, "bo_move": None},
+                        "event_count": 4,
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        records = KernelEventCorrelator().load_metrics(path)
+        assert len(records) == 1
+        assert records[0].kernel_summary["kfd_evict"] == 4
+        assert records[0].kernel_summary["bo_move"] == 0
+
+    def test_null_top_level_int_fields_default_to_zero(self, tmp_path: Path):
+        # ``rank``, ``global_step``, ``epoch``, ``step`` are all coerced
+        # via the same helper; nulls must not crash.
+        path = tmp_path / "rank_0_metrics.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "rank": None,
+                    "global_step": None,
+                    "epoch": None,
+                    "step": None,
+                    "loss": None,
+                    "profile": {"overlap": {"overlap_ms": {"H2D": None}, "per_stream_ms": {}}},
+                    "kernel_trace": {"summary": {}, "event_count": 0},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        records = KernelEventCorrelator().load_metrics(path)
+        assert len(records) == 1
+        assert records[0].rank == 0
+        assert records[0].global_step == 0
+        assert records[0].epoch == 0
+        assert records[0].step == 0
+        assert math.isnan(records[0].loss)
+        assert records[0].overlap_ms["H2D"] == 0.0
+
+    def test_kernel_trace_block_completely_absent(self, tmp_path: Path):
+        # Pre-existing safety net -- no ``kernel_trace`` key at all
+        # (older logs from before the eBPF integration). The fallback
+        # path must still produce a usable record.
+        path = tmp_path / "rank_0_metrics.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "rank": 0,
+                    "global_step": 7,
+                    "epoch": 0,
+                    "step": 7,
+                    "loss": 1.0,
+                    "profile": {"overlap": {"overlap_ms": {}, "per_stream_ms": {}}},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        records = KernelEventCorrelator().load_metrics(path)
+        assert len(records) == 1
+        assert records[0].kernel_event_count == 0
+        assert records[0].kernel_summary == {}

--- a/tests/report/test_kernel_correlator.py
+++ b/tests/report/test_kernel_correlator.py
@@ -1,0 +1,246 @@
+"""Tests for ``aorta.report.analysis.kernel_correlator``.
+
+Loaded via ``importlib.util`` to dodge the heavy ``aorta.report``
+``__init__`` chain (openpyxl/pandas/matplotlib are not in the test venv).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+import types
+from pathlib import Path
+
+_REPO_SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def _ensure_pkg(name: str, path: Path) -> None:
+    """Pre-register a parent package as an empty namespace module.
+
+    Required so that ``from ..analysis.kernel_correlator import ...``
+    relative imports inside ``kernel_report`` resolve when we direct-load
+    the leaf module.
+    """
+    if name in sys.modules:
+        return
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+
+
+_ensure_pkg("aorta", _REPO_SRC / "aorta")
+_ensure_pkg("aorta.report", _REPO_SRC / "aorta" / "report")
+_ensure_pkg("aorta.report.analysis", _REPO_SRC / "aorta" / "report" / "analysis")
+
+
+def _load(name: str, relpath: str):
+    spec = importlib.util.spec_from_file_location(name, _REPO_SRC / relpath)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_kc = _load(
+    "aorta.report.analysis.kernel_correlator",
+    "aorta/report/analysis/kernel_correlator.py",
+)
+KernelEventCorrelator = _kc.KernelEventCorrelator
+IterationRecord = _kc.IterationRecord
+iter_findings_table = _kc.iter_findings_table
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path: Path, payloads: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for payload in payloads:
+            fh.write(json.dumps(payload) + "\n")
+
+
+def _payload(
+    *,
+    rank: int,
+    global_step: int,
+    loss: float,
+    kernel_summary: dict[str, int] | None = None,
+    event_count: int = 0,
+) -> dict:
+    return {
+        "rank": rank,
+        "global_step": global_step,
+        "epoch": 0,
+        "step": global_step,
+        "loss": loss,
+        "profile": {"overlap": {"overlap_ms": {}, "per_stream_ms": {}}},
+        "kernel_trace": {
+            "summary": kernel_summary or {},
+            "event_count": event_count,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# JSONL parsing
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMetrics:
+    def test_parses_well_formed_lines(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _payload(rank=0, global_step=0, loss=1.5, kernel_summary={"kfd_evict": 1}),
+                _payload(rank=0, global_step=1, loss=1.4, kernel_summary={"bo_move": 2}),
+            ],
+        )
+        records = KernelEventCorrelator().load_metrics(path)
+        assert len(records) == 2
+        assert records[0].rank == 0
+        assert records[0].kernel_summary["kfd_evict"] == 1
+        assert records[1].kernel_summary["bo_move"] == 2
+
+    def test_skips_blank_and_malformed_lines(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        path.write_text(
+            json.dumps(_payload(rank=0, global_step=0, loss=1.0))
+            + "\n"
+            + "\n"
+            + "{not json}\n"
+            + json.dumps(_payload(rank=0, global_step=1, loss=2.0))
+            + "\n",
+            encoding="utf-8",
+        )
+        records = KernelEventCorrelator().load_metrics(path)
+        assert len(records) == 2
+
+    def test_loss_nan_is_recognised(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        # Write NaN as a JSON `null` (most loggers) and as the string
+        # "NaN" both end up as float('nan').
+        path.write_text(
+            json.dumps({**_payload(rank=0, global_step=0, loss=1.0), "loss": None})
+            + "\n"
+            + json.dumps({**_payload(rank=0, global_step=1, loss=1.0), "loss": "NaN"})
+            + "\n",
+            encoding="utf-8",
+        )
+        records = KernelEventCorrelator().load_metrics(path)
+        assert all(math.isnan(r.loss) for r in records)
+
+
+class TestLoadMetricsGlobOrders:
+    def test_files_concatenated_and_sorted_by_step_then_rank(self, tmp_path: Path):
+        _write_jsonl(
+            tmp_path / "rank_0_metrics.jsonl",
+            [_payload(rank=0, global_step=1, loss=1.0), _payload(rank=0, global_step=0, loss=1.0)],
+        )
+        _write_jsonl(
+            tmp_path / "rank_1_metrics.jsonl",
+            [_payload(rank=1, global_step=0, loss=1.0)],
+        )
+        records = KernelEventCorrelator().load_metrics_glob(tmp_path)
+        assert [(r.global_step, r.rank) for r in records] == [(0, 0), (0, 1), (1, 0)]
+
+
+# ---------------------------------------------------------------------------
+# NaN findings + lookback
+# ---------------------------------------------------------------------------
+
+
+class TestFindFailures:
+    def test_finds_each_nan_iteration(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        # Two NaN rows on rank 0, separated by a healthy row.
+        records = [
+            _payload(rank=0, global_step=0, loss=1.0),
+            _payload(rank=0, global_step=1, loss=float("nan")),
+            _payload(rank=0, global_step=2, loss=1.5),
+            _payload(rank=0, global_step=3, loss=float("nan")),
+        ]
+        _write_jsonl(path, records)
+        loaded = KernelEventCorrelator().load_metrics(path)
+        findings = KernelEventCorrelator().find_failures(loaded)
+        assert [f.target.global_step for f in findings] == [1, 3]
+
+    def test_lookback_window_respects_configured_size(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        rows = [
+            _payload(
+                rank=0,
+                global_step=i,
+                loss=1.0 if i < 5 else float("nan"),
+                kernel_summary={"kfd_evict": i},
+            )
+            for i in range(6)
+        ]
+        _write_jsonl(path, rows)
+        loaded = KernelEventCorrelator().load_metrics(path)
+        findings = KernelEventCorrelator(lookback_iterations=3).find_failures(loaded)
+        assert len(findings) == 1
+        # Lookback window should include steps 2, 3, 4 (the 3 preceding
+        # the NaN at step 5).
+        steps = [r.global_step for r in findings[0].preceding_window]
+        assert steps == [2, 3, 4]
+
+    def test_kernel_event_total_sums_window_plus_target(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        rows = [
+            _payload(rank=0, global_step=0, loss=1.0, kernel_summary={"bo_move": 5}),
+            _payload(rank=0, global_step=1, loss=1.0, kernel_summary={"bo_move": 7}),
+            _payload(
+                rank=0,
+                global_step=2,
+                loss=float("nan"),
+                kernel_summary={"bo_move": 3, "kfd_evict": 1},
+            ),
+        ]
+        _write_jsonl(path, rows)
+        loaded = KernelEventCorrelator().load_metrics(path)
+        findings = KernelEventCorrelator(lookback_iterations=2).find_failures(loaded)
+        assert len(findings) == 1
+        total = findings[0].kernel_event_total
+        assert total["bo_move"] == 15
+        assert total["kfd_evict"] == 1
+
+
+class TestSummarise:
+    def test_summary_counts_iterations_and_nans(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        rows = [
+            _payload(rank=0, global_step=0, loss=1.0, kernel_summary={"kfd_evict": 2}),
+            _payload(rank=0, global_step=1, loss=float("nan")),
+            _payload(rank=1, global_step=0, loss=1.0),
+        ]
+        _write_jsonl(path, rows)
+        loaded = KernelEventCorrelator().load_metrics(path)
+        summary = KernelEventCorrelator().summarise(loaded)
+        assert summary["total_iterations"] == 3
+        assert summary["nan_iterations"] == 1
+        assert summary["kernel_event_totals"]["kfd_evict"] == 2
+        assert summary["ranks"] == [0, 1]
+
+
+class TestIterFindingsTable:
+    def test_flatten_findings_into_dict_rows(self, tmp_path: Path):
+        path = tmp_path / "rank_0_metrics.jsonl"
+        rows = [
+            _payload(rank=0, global_step=0, loss=1.0, kernel_summary={"bo_move": 2}),
+            _payload(rank=0, global_step=1, loss=float("nan"), kernel_summary={"bo_move": 5}),
+        ]
+        _write_jsonl(path, rows)
+        loaded = KernelEventCorrelator().load_metrics(path)
+        findings = KernelEventCorrelator().find_failures(loaded)
+        table = list(iter_findings_table(findings))
+        assert len(table) == 1
+        row = table[0]
+        assert row["rank"] == 0
+        assert row["global_step"] == 1
+        assert row["lookback_iterations"] == 1
+        assert row["kernel_bo_move"] == 7  # 2 + 5

--- a/tests/report/test_kernel_report.py
+++ b/tests/report/test_kernel_report.py
@@ -153,7 +153,7 @@ class TestGenerateKernelReport:
         # Source line is rendered escaped.
         assert str(metrics) in html
 
-    def test_no_findings_writes_empty_csv_with_header_only(self, tmp_path: Path):
+    def test_no_findings_writes_header_matching_with_findings_path(self, tmp_path: Path):
         metrics = tmp_path / "metrics"
         metrics.mkdir()
         _write(
@@ -162,10 +162,54 @@ class TestGenerateKernelReport:
         )
         out = tmp_path / "report"
         artifacts = generate_kernel_report(metrics, out)
-        # No NaN -> findings CSV is the placeholder header line.
-        assert artifacts["findings_csv"].read_text().strip() == "rank,global_step,loss"
-        # And HTML reports "No NaN iterations detected".
+        # The empty-findings CSV must carry the same static-column
+        # prefix that ``iter_findings_table`` always emits, so a
+        # downstream tool can count on these columns being present
+        # regardless of whether NaNs were detected. Pre-fix this row
+        # said only "rank,global_step,loss" -- inconsistent with the
+        # populated path -- and Copilot flagged it on PR #162.
+        assert artifacts["findings_csv"].read_text().strip() == (
+            "rank,global_step,loss,lookback_iterations"
+        )
         assert "No NaN iterations detected" in artifacts["html_report"].read_text()
+
+
+class TestCsvColumnOrderIsStable:
+    """B3: column order is documented contract.
+
+    Pre-fix the populated path used ``sorted(...)`` on every key in
+    every row, which mixed static and dynamic columns alphabetically
+    (``global_step, kernel_bo_move, kernel_kfd_evict, lookback_iterations,
+    loss, rank``). Post-fix the order is fixed: static prefix in source
+    order, then sorted ``kernel_*`` columns.
+    """
+
+    def test_static_columns_come_first_in_documented_order(self, tmp_path: Path):
+        metrics = tmp_path / "metrics"
+        metrics.mkdir()
+        _write(
+            metrics / "rank_0_metrics.jsonl",
+            [
+                _payload(rank=0, global_step=0, loss=1.0, kernel_summary={"bo_move": 1}),
+                _payload(
+                    rank=0,
+                    global_step=1,
+                    loss=float("nan"),
+                    kernel_summary={"bo_move": 2, "kfd_evict": 1},
+                ),
+            ],
+        )
+        out = tmp_path / "report"
+        artifacts = generate_kernel_report(metrics, out)
+        header = artifacts["findings_csv"].read_text().splitlines()[0].split(",")
+        assert header[:4] == ["rank", "global_step", "loss", "lookback_iterations"]
+        # Dynamic kernel columns are sorted alphabetically and only
+        # appear after the static prefix.
+        dynamic = header[4:]
+        assert dynamic == sorted(dynamic)
+        assert all(name.startswith("kernel_") for name in dynamic)
+        assert "kernel_bo_move" in dynamic
+        assert "kernel_kfd_evict" in dynamic
 
     def test_creates_output_dir_if_missing(self, tmp_path: Path):
         metrics = tmp_path / "metrics"

--- a/tests/report/test_kernel_report.py
+++ b/tests/report/test_kernel_report.py
@@ -1,0 +1,180 @@
+"""Tests for ``aorta.report.generators.kernel_report.generate_kernel_report``."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+_REPO_SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def _ensure_pkg(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+
+
+_ensure_pkg("aorta", _REPO_SRC / "aorta")
+_ensure_pkg("aorta.report", _REPO_SRC / "aorta" / "report")
+_ensure_pkg("aorta.report.analysis", _REPO_SRC / "aorta" / "report" / "analysis")
+_ensure_pkg("aorta.report.generators", _REPO_SRC / "aorta" / "report" / "generators")
+
+
+def _load(name: str, relpath: str):
+    spec = importlib.util.spec_from_file_location(name, _REPO_SRC / relpath)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load the correlator first so kernel_report's relative import resolves.
+_load(
+    "aorta.report.analysis.kernel_correlator",
+    "aorta/report/analysis/kernel_correlator.py",
+)
+_kr = _load(
+    "aorta.report.generators.kernel_report",
+    "aorta/report/generators/kernel_report.py",
+)
+generate_kernel_report = _kr.generate_kernel_report
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _payload(
+    *,
+    rank: int,
+    global_step: int,
+    loss: float,
+    kernel_summary: dict[str, int] | None = None,
+    event_count: int = 0,
+) -> dict:
+    return {
+        "rank": rank,
+        "global_step": global_step,
+        "epoch": 0,
+        "step": global_step,
+        "loss": loss,
+        "profile": {"overlap": {"overlap_ms": {}, "per_stream_ms": {}}},
+        "kernel_trace": {
+            "summary": kernel_summary or {},
+            "event_count": event_count,
+        },
+    }
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# generate_kernel_report end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateKernelReport:
+    def test_writes_summary_csv_and_html(self, tmp_path: Path):
+        metrics = tmp_path / "metrics"
+        metrics.mkdir()
+        _write(
+            metrics / "rank_0_metrics.jsonl",
+            [
+                _payload(rank=0, global_step=0, loss=1.0, kernel_summary={"bo_move": 1}),
+                _payload(rank=0, global_step=1, loss=float("nan"), kernel_summary={"bo_move": 2}),
+            ],
+        )
+        out = tmp_path / "report"
+        artifacts = generate_kernel_report(metrics, out, lookback_iterations=2)
+
+        assert set(artifacts) == {"summary_json", "findings_csv", "html_report"}
+        # All three artifacts exist and are non-empty.
+        for path in artifacts.values():
+            assert path.exists()
+            assert path.stat().st_size > 0
+
+        # Summary JSON shape.
+        summary = json.loads(artifacts["summary_json"].read_text())
+        assert summary["summary"]["total_iterations"] == 2
+        assert summary["summary"]["nan_iterations"] == 1
+        assert len(summary["findings"]) == 1
+
+    def test_csv_findings_has_dynamic_kernel_columns(self, tmp_path: Path):
+        metrics = tmp_path / "metrics"
+        metrics.mkdir()
+        _write(
+            metrics / "rank_0_metrics.jsonl",
+            [
+                _payload(rank=0, global_step=0, loss=1.0, kernel_summary={"kfd_evict": 1}),
+                _payload(
+                    rank=0,
+                    global_step=1,
+                    loss=float("nan"),
+                    kernel_summary={"kfd_evict": 2, "bo_move": 3},
+                ),
+            ],
+        )
+        out = tmp_path / "report"
+        artifacts = generate_kernel_report(metrics, out)
+
+        rows = list(csv.DictReader(artifacts["findings_csv"].open()))
+        assert len(rows) == 1
+        # Dynamic column names use a ``kernel_`` prefix per
+        # iter_findings_table; the totals must reflect window+target.
+        assert rows[0]["kernel_kfd_evict"] == "3"
+        assert rows[0]["kernel_bo_move"] == "3"
+
+    def test_html_marks_nan_loss(self, tmp_path: Path):
+        metrics = tmp_path / "metrics"
+        metrics.mkdir()
+        _write(
+            metrics / "rank_0_metrics.jsonl",
+            [
+                _payload(rank=0, global_step=0, loss=1.0),
+                _payload(rank=0, global_step=1, loss=float("nan")),
+            ],
+        )
+        out = tmp_path / "report"
+        artifacts = generate_kernel_report(metrics, out)
+        html = artifacts["html_report"].read_text()
+        # The NaN row gets the .nan CSS class for visual emphasis.
+        assert "class='nan'" in html
+        # Source line is rendered escaped.
+        assert str(metrics) in html
+
+    def test_no_findings_writes_empty_csv_with_header_only(self, tmp_path: Path):
+        metrics = tmp_path / "metrics"
+        metrics.mkdir()
+        _write(
+            metrics / "rank_0_metrics.jsonl",
+            [_payload(rank=0, global_step=0, loss=1.0)],
+        )
+        out = tmp_path / "report"
+        artifacts = generate_kernel_report(metrics, out)
+        # No NaN -> findings CSV is the placeholder header line.
+        assert artifacts["findings_csv"].read_text().strip() == "rank,global_step,loss"
+        # And HTML reports "No NaN iterations detected".
+        assert "No NaN iterations detected" in artifacts["html_report"].read_text()
+
+    def test_creates_output_dir_if_missing(self, tmp_path: Path):
+        metrics = tmp_path / "metrics"
+        metrics.mkdir()
+        _write(
+            metrics / "rank_0_metrics.jsonl",
+            [_payload(rank=0, global_step=0, loss=1.0)],
+        )
+        out = tmp_path / "deeply" / "nested" / "report"
+        artifacts = generate_kernel_report(metrics, out)
+        assert out.is_dir()
+        assert all(path.parent == out for path in artifacts.values())

--- a/tests/report/test_kernel_report_dependency_free.py
+++ b/tests/report/test_kernel_report_dependency_free.py
@@ -1,0 +1,90 @@
+"""Regression test for the kernel-trace report's dependency-free promise.
+
+Pre-fix (Copilot review on PR #162) every entry into the kernel-trace
+path went through ``aorta.report.__init__`` -> ``aorta.report.cli``,
+which in turn imports the comparison subpackage and ultimately
+``pandas`` / ``openpyxl`` / ``matplotlib``. That defeated the whole
+selling point of ``aorta-report generate kernel-trace`` running on the
+base install.
+
+This test pins the contract that importing
+``aorta.report.generators.kernel_report.generate_kernel_report`` and
+``aorta.report.analysis.kernel_correlator.KernelEventCorrelator``
+(plus the package-level re-exports) does *not* drag in any of those
+heavy modules. Any new eager import in the chain will fail this test
+loudly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+_HEAVY_MODULES = ("pandas", "openpyxl", "matplotlib", "seaborn", "numpy")
+
+
+def _run_in_clean_subprocess(import_block: str) -> set[str]:
+    """Execute ``import_block`` in a fresh interpreter and return any
+    heavy modules that ended up loaded."""
+    script = textwrap.dedent(
+        f"""
+        import sys
+        {import_block}
+        loaded = sorted(
+            m for m in sys.modules
+            if any(m == h or m.startswith(h + ".") for h in {_HEAVY_MODULES!r})
+        )
+        for name in loaded:
+            print(name)
+        """
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+class TestKernelReportImportIsDependencyFree:
+    def test_leaf_module_import_does_not_load_pandas_openpyxl_matplotlib(self):
+        loaded = _run_in_clean_subprocess(
+            "from aorta.report.generators.kernel_report import generate_kernel_report"
+        )
+        assert loaded == set(), (
+            f"importing the leaf module pulled in heavy deps: {sorted(loaded)}; "
+            "the dependency-free promise of the kernel-trace path is broken"
+        )
+
+    def test_generators_package_level_import_stays_lazy(self):
+        loaded = _run_in_clean_subprocess(
+            "from aorta.report.generators import generate_kernel_report"
+        )
+        assert loaded == set(), (
+            f"package-level kernel-trace import dragged in {sorted(loaded)}; "
+            "aorta.report.generators.__init__ must not eagerly load the heavy "
+            "html/excel/plot generators just to expose generate_kernel_report"
+        )
+
+    def test_analysis_package_level_correlator_import_stays_lazy(self):
+        loaded = _run_in_clean_subprocess(
+            "from aorta.report.analysis import KernelEventCorrelator"
+        )
+        assert loaded == set(), (
+            f"package-level KernelEventCorrelator import dragged in {sorted(loaded)}; "
+            "aorta.report.analysis.__init__ must not eagerly load the analyse_* "
+            "modules just to expose KernelEventCorrelator"
+        )
+
+    def test_aorta_report_top_level_does_not_eagerly_load_cli_chain(self):
+        # Just importing the top-level package used to load the CLI
+        # dispatch chain (comparison.combine -> pandas). Verify the
+        # __getattr__ shim defers that until ``cli`` / ``main`` is
+        # actually requested.
+        loaded = _run_in_clean_subprocess("import aorta.report")
+        assert loaded == set(), (
+            f"`import aorta.report` loaded {sorted(loaded)} eagerly; the "
+            "package __init__ must keep the CLI imports lazy via __getattr__"
+        )


### PR DESCRIPTION
## Summary

Adds a first-class `aorta.ebpf` package that exposes the `ebpfaultline`
bpftrace tracing toolkit as a reusable Python API, and wires it into the
FSDP trainer + report generator so kernel-level GPU/KFD events can be
correlated with NaN iterations alongside the existing `StreamProfiler`
data.

* **`aorta/ebpf/`** -- subprocess wrapper around `bpftrace` (`runner.py`),
  regex-based stdout parser (`parser.py`), typed `KernelEvent` records
  (`events.py`), and the five vendored `.bt` scripts under `scripts/`
  with `PROVENANCE.md` documenting upstream + Heisenberg trade-offs per
  variant.
* **`aorta/profiling/kernel_profiler.py`** -- `KernelTraceProfiler` peer
  of `StreamProfiler`. Same `start_iteration` / `end_iteration` lifecycle,
  same JSONL output schema, designed to run side-by-side. `enabled=False`
  makes every method a real no-op so it's cheap to wire in behind a flag.
* **`aorta/training/fsdp_trainer.py`** -- new `--enable-kernel-trace` /
  `--kernel-trace-variant` flags, YAML `kernel_tracing.*` config, and a
  per-iteration `kernel_trace` field appended to the existing rank
  metrics. `kernel_profiler.stop()` is inside `finally:` so bpftrace is
  reaped on training crash.
* **`aorta/report/analysis/kernel_correlator.py`** -- joins
  `rank_*_metrics.jsonl` with the new `kernel_trace` field, finds each
  NaN iteration, and attaches a configurable look-back window of
  preceding kernel events.
* **`aorta/report/generators/kernel_report.py`** + new `aorta-report
  generate kernel-trace` subcommand -- JSON summary + CSV findings +
  dependency-free HTML, runnable on the base install (no matplotlib /
  pandas needed).

## Design choices worth flagging up-front

1. **Subprocess, not in-process eBPF.** The runner spawns
   `sudo bpftrace <script.bt> <pid>` rather than loading bytecode via
   `bcc` / `libbpf`. Matches the upstream `ebpfaultline` operational
   model and keeps the `aorta` base wheel free of a heavy Python eBPF
   binding.
2. **`TP_ONLY` is the default variant.** Tracepoints only, no kprobes.
   `PROVENANCE.md` documents why: kprobes can serialise the kernel path
   enough to suppress the very GPU memory races we're trying to catch.
3. **`kernel-trace` is its own `aorta-report generate` subcommand.** It
   only needs JSONL (no `.pt.trace.json` files), so it has a different
   input shape and a smaller dep surface than the `html` / `excel`
   subcommands. Folding it in would have leaked the lighter footprint.
4. **`use_sudo=True` is the default.** bpftrace usually needs CAP_BPF
   or root; making sudo opt-in would silently fail on stock hosts.
   Override via `BpftraceConfig(use_sudo=False)` for already-privileged
   workloads (root containers, etc.).
5. **Per-iteration record schema** matches `StreamProfiler` -- written
   under a top-level `kernel_trace` key so the existing JSONL consumers
   are untouched.

## Pre-PR hardening pass (commit `7bc1d6d`)

Applied four runner-level fixes before opening the PR so reviewers do
not have to triage them:

* **C1+C4: `start()` enforces `BpftraceConfig.startup_timeout_sec`** and
  raises `RuntimeError` with bpftrace's own stderr text when the
  subprocess exits during the startup window (binary missing, sudo
  prompt swallowed, "ERROR: Don't have permission to run BPF program").
  Healthy startups short-circuit on the first stdout line so they do
  not block for the full timeout.
* **C2: dedicated stderr drain thread.** Previously `stderr=PIPE` was
  never read, so a chatty bpftrace could fill the ~64 KiB OS pipe
  buffer and silently stall stdout. The new daemon thread drains
  stderr into `_stderr_lines`; `stderr_text()` exposes the buffer for
  diagnostics.
* **C3: reader-thread death surfaces.** Captured exception is stored
  on `_reader_exception`; `is_running` returns False when the reader
  exited; `stop()` logs the captured exception so a `finally:
  runner.stop()` caller learns about silent reader failures.
* **C5+C6: 73 new tests** under `tests/ebpf/`, `tests/profiling/`, and
  `tests/report/` covering every parser pattern (incl. ordering), the
  runner subprocess lifecycle (with a `FakePopen` stand-in so tests
  need no real `bpftrace` binary), the `KernelTraceProfiler` bucketing
  contract, the `KernelEventCorrelator` JSONL parsing, and the
  end-to-end `generate_kernel_report` artifact bundle.

The profiling / report tests use the `importlib.util` direct-load
pattern already established by `tests/test_gpu_control.py` to dodge
torch-/openpyxl-/matplotlib-dependent `__init__` chains, keeping them
runnable in venvs without those heavy deps.

## Verification

* `ruff check` + `ruff format --check` clean on every touched path.
* `mypy src/aorta/ebpf/runner.py` clean.
* `pre-commit run --files <touched>` passes.
* `pytest --ignore=tests/hw_queue_eval` -- 120 passed (47 pre-existing
  + 73 new); the `hw_queue_eval` ignore matches the established
  baseline on this venv (no torch installed).

## Test plan

- [ ] `aorta-report generate kernel-trace -i <run-dir> -o <out>` on a
      run captured with `--enable-kernel-trace` produces non-empty
      `kernel_trace_summary.json`, `kernel_trace_findings.csv`, and
      `kernel_trace_report.html`.
- [ ] Training without `--enable-kernel-trace` is byte-equivalent to
      `main` for `rank_*_metrics.jsonl` (no `kernel_trace` key leaks
      through).
- [ ] `KernelTraceProfiler` with `enabled=False` adds zero subprocess
      activity (verify via `strace -f -e execve` smoke).
- [ ] On a host without bpftrace, `--enable-kernel-trace` (default
      `--skip-if-unavailable=true`) logs a warning and otherwise
      behaves like the un-flagged path.
- [ ] On a host where bpftrace exists but lacks CAP_BPF, the new
      `start()` raises with bpftrace's permission-denied stderr line
      visible in the message rather than failing silently.