### PR TITLE
A1.2b: env probe: schema 1.3 — Buck-aware library introspection

### DIFF
--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -69,7 +69,7 @@ operator can act on them without `jq`'ing the JSON. A closing
 end-of-output. Sample:
 
 ```text
-Wrote env probe to /tmp/env.json (schema_version=1.3) [PARTIAL]
+Wrote env probe to /tmp/env.json (schema_version=1.4) [PARTIAL]
   runtime:   baremetal / python=venv
   rocm:      7.2.1 (dev: None)
   hip:       7.2.53211-e1a6bc5663 (amd)
@@ -145,7 +145,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | Currently `"1.3"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
+| `schema_version` | `str` | constant | Currently `"1.4"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
@@ -171,6 +171,8 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `pytorch_version` | `str \| null` | optional `import torch` (no CUDA/HIP context init) | `null` when torch absent |
 | `pytorch_build` | `dict` | `torch.version.{git_version,hip,cuda,debug}` + install-kind detection + optional `git -C <src>/third_party/<sub> rev-parse HEAD` + parse of `torch.__config__.show()` + `nm -D libtorch_hip.so \| c++filt` symbol grep + scan of `<torch>/lib/` | `git_commit` is the linchpin -- pins every vendored submodule deterministically. Sub-blocks: `flags` (raw `build_settings`, `cxx_defines`, `cxx_flags_raw`, `cuda_flags_raw`, `gpu_arch_list`), `build_flags` (issue #170 stable 17-key parsed bool/str/None subset, with `CAFFE2_USE_MIOPEN` aliased to `USE_MIOPEN`), `binary_introspection` (`libtorch_hip_symbol_counts`, `torch_lib_bundled`, `cxx_flags_use_defines` -- pure facts, no ON/OFF inference). See "PyTorch source-tree submodule probing" below. |
 | `build_system` | `dict` | `buck2 --version` + `buck2 root` + `hg id -i` / `git rev-parse HEAD` | Always present. `{"kind": "buck2", "buck2_version": str, "repo_root": str, "revision": str \| null}` when buck2 is on PATH AND we are demonstrably inside a Buck checkout (both `buck2 --version` and `buck2 root` succeed); `buck2_version` and `repo_root` are guaranteed populated, only `revision` may be `null`. `{"kind": "none"}` in every other case, including the dominant "buck2 is installed but cwd is not inside a Buck checkout" scenario. Added in schema 1.3 for issue #163 (A1.2a) so consumers can branch on Buck2 vs. system-package environments. See "Running inside a Buck environment" below. |
+| `library_introspection` | `list[dict]` | `buck2 audit dependencies <target> --transitive --json` (only when `--buck-target` is supplied) | Always present. Empty `[]` outside Buck mode. In Buck mode, one entry per matched library: `{"name", "source": "buck", "revision", "target"}`. The matched library set lives in `KNOWN_LIBRARY_PATTERNS` in `src/aorta/instrumentation/buck_introspect.py`. Added in schema 1.4 for issue #163 (A1.2b). |
+| `library_introspection_alternates` | `list[dict]` | synthesised from A1's per-library blocks when a Buck match overlaps | Always present. Empty `[]` outside Buck mode and when no Buck-matched library is also captured by A1. Each entry mirrors the unified shape with `source: "package"` and pulls `revision` / `package_version` / `lib_hash` from the matching A1 block (e.g. `hipblaslt`). Added in schema 1.4 for issue #163 (A1.2b). |
 
 `runtime_context.type` is one of `"docker" | "podman" | "singularity" | "baremetal"`. Adding values is a schema change.
 
@@ -333,7 +335,32 @@ Mirrors the in-code comment at `SCHEMA_VERSION` in
 `src/aorta/instrumentation/environment.py`. Recorded here so consumers
 tracking schema evolution don't have to read source.
 
-### `1.3` (current)
+### `1.4` (current)
+
+Additive change (issue #163, A1.2b):
+
+* New top-level `library_introspection` (list[dict], default `[]`)
+  and `library_introspection_alternates` (list[dict], default `[]`).
+  Both always present. Populated only when `collect_env(buck_target=...)`
+  is invoked (or `aorta env probe --buck-target ...`); each transitive
+  dep label of the Buck target that matches one of the patterns in
+  `KNOWN_LIBRARY_PATTERNS` (see `src/aorta/instrumentation/buck_introspect.py`)
+  yields one entry of shape `{"name", "source": "buck", "revision",
+  "target"}`. When a library matched via Buck is also captured by
+  A1's existing per-library blocks (`hipblaslt`, `rocblas`, `miopen`,
+  `rccl`), the A1-side identifiers are synthesised into a parallel
+  entry placed in `library_introspection_alternates` so consumers can
+  compare the buck label vs. the system-package version/lib_hash.
+  Outside Buck mode both lists stay empty; A1's existing per-library
+  top-level blocks remain authoritative.
+
+Schema 1.4 is forward- and backward-compatible: an env.json produced
+by 1.4 contains every 1.3 key unchanged. Loading a 1.1 / 1.2 / 1.3
+env.json into the 1.4 `EnvSnapshot.from_dict()` succeeds because all
+new fields default to empty (lists or `{"kind": "none"}` per their
+type).
+
+### `1.3`
 
 Additive change (issue #163, A1.2a):
 
@@ -683,11 +710,11 @@ Short version: edit `CANONICAL_ENV_VARS`, update
 
 As of schema 1.3 (issue #163, A1.2a), the env probe detects whether
 it's running inside a [Buck2](https://buck2.build/) build environment
-and records the result in the top-level `build_system` block. This is
-the metadata signal -- A1.2b will add Buck-aware library introspection
-(`--buck-target`) and A1.2c will add a recipe emitter (`aorta env
-recipe --format buck env.json`); both will extend this section when
-they land.
+and records the result in the top-level `build_system` block. As of
+schema 1.4 (issue #163, A1.2b), it can additionally introspect a
+target's transitive deps to populate the `library_introspection`
+list. A1.2c will add a recipe emitter (`aorta env recipe --format
+buck env.json`).
 
 Quick check:
 
@@ -718,6 +745,41 @@ therefore reports `{"kind": "none"}`, and the revision lookup never
 runs against an unrelated working directory. If only the revision
 lookup fails (no VCS at the Buck root), the dict is still populated
 with `revision: null`.
+
+### Buck-aware library introspection (`--buck-target`)
+
+```bash
+# Outside Buck mode the two introspection lists stay empty.
+aorta env probe -o /tmp/env.json
+jq '.library_introspection' /tmp/env.json              # -> []
+jq '.library_introspection_alternates' /tmp/env.json   # -> []
+
+# Inside a Buck checkout, point the probe at a top-level target. We
+# wrap `buck2 audit dependencies <target> --transitive --json` and
+# match each transitive dep label against KNOWN_LIBRARY_PATTERNS.
+aorta env probe --buck-target //myproj:training_main -o /tmp/env.json
+jq '.library_introspection' /tmp/env.json
+# -> [
+#   {"name":"hipblaslt","source":"buck","revision":"<repo-sha>","target":"//.../hipblaslt_lib"},
+#   {"name":"rccl","source":"buck","revision":"<repo-sha>","target":"//.../rccl_lib"},
+#   {"name":"pytorch","source":"buck","revision":"<repo-sha>","target":"//pytorch:torch"},
+#   ...
+# ]
+
+# When a Buck-matched library is also captured by an A1 per-library
+# block (hipblaslt, rocblas, miopen, rccl), an alternate entry is
+# synthesised from the A1 block so consumers can compare the buck
+# label against the system-package version/lib_hash:
+jq '.library_introspection_alternates[] | select(.name=="hipblaslt")' /tmp/env.json
+# -> {"name":"hipblaslt","source":"package","revision":"...","package_version":"...","lib_hash":"..."}
+```
+
+`--buck-timeout` (default 10 s) caps the audit subprocess. A timeout,
+non-zero exit, or unparseable JSON degrades gracefully: both lists are
+returned empty and the failure is recorded in `partial_reasons`. The
+match patterns currently cover `hipblaslt`, `rccl`, `pytorch`, and
+`rocm` runtime; new libraries are added by appending to
+`KNOWN_LIBRARY_PATTERNS` in `src/aorta/instrumentation/buck_introspect.py`.
 
 ## Testing the probe locally
 

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -39,7 +39,27 @@ def env() -> None:
     is_flag=True,
     help="After the brief, also print the full snapshot JSON to stdout.",
 )
-def probe(output: Path, verbose: bool) -> None:
+@click.option(
+    "--buck-target",
+    type=str,
+    default=None,
+    help=(
+        "Buck2 label to introspect for library identity (issue #163, "
+        "A1.2b). When given, the snapshot's library_introspection list "
+        "is populated from `buck2 audit dependencies <label> --transitive "
+        "--json`. Ignored if buck2 isn't on PATH."
+    ),
+)
+@click.option(
+    "--buck-timeout",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Per-call timeout (seconds) for `buck2 audit dependencies`.",
+)
+def probe(
+    output: Path, verbose: bool, buck_target: str | None, buck_timeout: int
+) -> None:
     """Capture trial-environment state to env.json (issue #147)."""
     from aorta.instrumentation.environment import collect_env
 
@@ -55,7 +75,7 @@ def probe(output: Path, verbose: bool) -> None:
             f"Failed to create parent directory for {output}: {exc}"
         ) from exc
 
-    snapshot = collect_env()
+    snapshot = collect_env(buck_target=buck_target, buck_timeout=buck_timeout)
 
     # NOTE: deliberately not passing ``default=str`` -- the snapshot is
     # supposed to be JSON-native (str/int/bool/None/list/dict). If a

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -10,6 +10,7 @@ will live here too.
 | --- | --- | --- |
 | [`environment`](environment.py) | ROCm + ML stack version snapshot + container/python env detection. See block list below. | `collect_env() -> EnvSnapshot` |
 | [`build_system`](build_system.py) | Detects Buck2 build environments (issue #163, A1.2a). Wrapped by `collect_env()` and surfaced as the `build_system` field of `EnvSnapshot`. | `detect_build_system() -> dict` |
+| [`buck_introspect`](buck_introspect.py) | Buck-aware library introspection via `buck2 audit dependencies <target> --transitive --json` (issue #163, A1.2b). Triggered by `collect_env(buck_target=...)` (or `aorta env probe --buck-target ...`); populates the `library_introspection` and `library_introspection_alternates` fields of `EnvSnapshot`. | `introspect_libraries_via_buck(target, repo_revision, ...) -> (entries, reasons)` |
 
 **`environment` blocks** (every snapshot includes all of these; missing
 values become `None` plus a `partial_reasons` line):
@@ -33,6 +34,13 @@ values become `None` plus a `partial_reasons` line):
 * Build system: `build_system` (always present; `{"kind": "buck2",
   ...}` when Buck2 is on PATH and functional, `{"kind": "none"}`
   otherwise). Populated by `aorta.instrumentation.build_system.detect_build_system()`.
+* Library introspection (Buck mode only): `library_introspection` and
+  `library_introspection_alternates` (always present; both `[]`
+  outside Buck mode). Populated only when `collect_env(buck_target=...)`
+  is invoked (or `aorta env probe --buck-target ...`); see
+  [`buck_introspect.py`](buck_introspect.py) for the matched library
+  set. Outside Buck mode the existing per-library blocks
+  (`hipblaslt`, `rocblas`, `miopen`, `rccl`, ...) remain authoritative.
 
 ## env probe quick reference
 
@@ -69,6 +77,11 @@ aorta env probe
 
 # Custom path; parent dirs are created if missing
 aorta env probe -o runs/exp1/env.json
+
+# Buck mode: also runs `buck2 audit dependencies <target> --transitive
+# --json` and populates library_introspection. The default
+# `--buck-timeout` is 10 s.
+aorta env probe --buck-target //myproj:training_main
 ```
 
 After the run, `cat env.json` reveals the same dict that
@@ -135,7 +148,8 @@ tensile           triton            fbgemm          aiter
 aotriton          gpu_arch          host
 runtime_context   docker            env_vars
 python_version    pytorch_version   pytorch_build
-build_system
+build_system      library_introspection
+library_introspection_alternates
 ```
 
 For the per-version field history (renames, env-var additions /

--- a/src/aorta/instrumentation/buck_introspect.py
+++ b/src/aorta/instrumentation/buck_introspect.py
@@ -1,0 +1,188 @@
+"""Buck-aware library introspection for ``aorta env probe`` (issue #163, A1.2b).
+
+A1's existing per-library blocks (``hipblaslt``, ``rocblas``,
+``miopen``, ``rccl``, ...) work by reading headers, hashing libraries
+on disk, and parsing pkg-config / Docker image digests. Inside a
+Buck2 monorepo none of those signals exist -- libraries are Buck
+*targets*, not files at well-known FHS paths.
+
+This module wraps ``buck2 audit dependencies <target> --transitive
+--json`` and matches each transitive dep label against a small
+known-pattern list (hipblaslt, pytorch, rccl, rocm). For matches it
+returns one ``library_introspection`` entry per library with
+``source: "buck"`` plus the Buck-specific ``target`` field. A1's
+existing per-library blocks remain populated independently; the
+caller (``collect_env``) merges by name with Buck winning ties.
+
+Per aorta's external-tool policy: subprocess wrapper around the
+open-source ``buck2`` binary; no Buck rules / macros / libraries
+vendored.
+
+Per the env-probe never-raises contract: every subprocess call is
+guarded; timeouts and OS errors degrade silently. Callers receive a
+``(entries, reasons)`` tuple -- one human-readable string per
+documented failure goes into ``reasons`` so the snapshot's
+``partial_reasons`` field surfaces it for the operator.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+import subprocess
+
+log = logging.getLogger(__name__)
+
+# Library identifier -> regex patterns matched against the string form
+# of `buck2 audit dependencies` labels. Order doesn't matter; any
+# match wins. Patterns are anchored loosely so internal project-
+# specific prefixes (e.g. //third-party/rocm:hipblaslt vs
+# //rocm:hipblaslt-lib) match.
+#
+# To add a new library, append a new key + patterns. No other code
+# changes are needed; the merge logic in environment.py handles
+# arbitrary library names. Document the addition in the PR.
+KNOWN_LIBRARY_PATTERNS: dict[str, list[re.Pattern]] = {
+    "hipblaslt": [
+        re.compile(r":hipblaslt(_lib|-lib)?$"),
+        re.compile(r"^hipblaslt-"),  # cell-name prefix
+    ],
+    "pytorch": [
+        re.compile(r":(py)?torch$"),
+        re.compile(r":torch_(cuda|hip|rocm)$"),
+    ],
+    "rccl": [
+        re.compile(r":rccl(_lib|-lib)?$"),
+    ],
+    "rocm": [
+        re.compile(r":(hip|rocm)_runtime$"),  # libamdhip64 / librocm-runtime
+    ],
+}
+
+
+def introspect_libraries_via_buck(
+    target: str,
+    repo_revision: str | None,
+    timeout: int = 10,
+    cwd: str | None = None,
+) -> tuple[list[dict], list[str]]:
+    """Run ``buck2 audit dependencies`` and return matched library entries.
+
+    Returns ``(entries, reasons)``:
+
+    * ``entries`` -- one dict per matched library, in the unified
+      ``library_introspection`` shape: ``{name, source: "buck",
+      revision, target}``. Empty when no matches or when the audit
+      fails. ``revision`` is set to ``repo_revision`` (the build-system-
+      wide revision captured by ``detect_build_system``); per-target
+      revisions can be derived from a follow-up ``buck2 audit
+      providers`` call but are out of scope for A1.2b.
+    * ``reasons`` -- one human-readable string per documented failure
+      (buck2 absent, target not found, audit timeout, JSON parse
+      error). Suitable for appending to ``partial_reasons``. Empty on
+      a clean audit run -- including the case where the audit
+      succeeded but matched nothing (an empty match set is not a
+      failure).
+
+    Never raises. Callers get a fully-shaped tuple even on failure.
+
+    The function does NOT validate ``target`` syntax; an invalid label
+    will surface as a ``buck2 audit`` non-zero exit captured in
+    ``reasons``.
+    """
+    buck2 = shutil.which("buck2")
+    if buck2 is None:
+        # Defensive: collect_env() only calls this when build_system.kind
+        # == "buck2", which already implies buck2 is on PATH. If that
+        # invariant is violated we still degrade cleanly.
+        return [], [
+            f"library_introspection: buck2 not on PATH; "
+            f"--buck-target {target} ignored"
+        ]
+
+    cmd = [buck2, "audit", "dependencies", target, "--transitive", "--json"]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return [], [
+            f"library_introspection: buck2 audit dependencies {target} "
+            f"timed out after {timeout}s (raise --buck-timeout if needed)"
+        ]
+    except (FileNotFoundError, OSError) as exc:
+        return [], [
+            f"library_introspection: buck2 audit dependencies {target} "
+            f"failed to launch ({exc})"
+        ]
+
+    if result.returncode != 0:
+        # Common cause: target not found, or buck2 misconfiguration.
+        # Surface the stderr (truncated) so the operator can debug
+        # without re-running by hand.
+        stderr = (result.stderr or "").strip()[:300]
+        return [], [
+            f"library_introspection: buck2 audit dependencies {target} "
+            f"exited {result.returncode} (stderr: {stderr or '(empty)'})"
+        ]
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return [], [
+            f"library_introspection: buck2 audit dependencies {target} "
+            f"returned non-JSON output ({exc})"
+        ]
+
+    # `buck2 audit dependencies --json` returns a dict mapping the
+    # queried target(s) to a list of dep labels. Flatten across all
+    # queried targets (we pass exactly one, but the shape is generic).
+    dep_labels: list[str] = []
+    if isinstance(payload, dict):
+        for v in payload.values():
+            if isinstance(v, list):
+                dep_labels.extend(str(x) for x in v)
+    else:
+        return [], [
+            f"library_introspection: buck2 audit dependencies {target} "
+            f"returned unexpected JSON shape ({type(payload).__name__})"
+        ]
+
+    entries: list[dict] = []
+    seen_names: set[str] = set()
+    for label in dep_labels:
+        match = _match_library(label)
+        if match is None:
+            continue
+        if match in seen_names:
+            # Duplicate match: keep the first label (deterministic by
+            # `buck2 audit dependencies` alphabetical ordering). The
+            # second-match label would be lost; record nothing.
+            continue
+        seen_names.add(match)
+        entries.append(
+            {
+                "name": match,
+                "source": "buck",
+                "revision": repo_revision,
+                "target": label,
+            }
+        )
+
+    return entries, []
+
+
+def _match_library(label: str) -> str | None:
+    """Return the library name a Buck target label resolves to, or None."""
+    for name, patterns in KNOWN_LIBRARY_PATTERNS.items():
+        for pat in patterns:
+            if pat.search(label):
+                return name
+    return None

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -62,8 +62,23 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.3"
-# 1.2 -> 1.3 (this commit, issue #163 / A1.2a):
+SCHEMA_VERSION = "1.4"
+# 1.3 -> 1.4 (this commit, issue #163 / A1.2b):
+#   - Added top-level `library_introspection` (list[dict], default `[]`)
+#     and `library_introspection_alternates` (list[dict], default `[]`).
+#     Both always present. Populated only when collect_env() is called
+#     with `buck_target=...` AND buck2 is functional; in that mode each
+#     transitive dep label matched against
+#     buck_introspect.KNOWN_LIBRARY_PATTERNS yields an entry of the
+#     form ``{"name", "source": "buck", "revision", "target"}``. When
+#     a library matched via Buck is also captured by A1's existing
+#     per-library blocks (hipblaslt, rocblas, ...), the A1-side
+#     identifiers are synthesised into a parallel entry placed in
+#     `library_introspection_alternates`. Outside buck mode both lists
+#     are empty; A1's existing per-library top-level blocks remain
+#     unchanged and authoritative.
+#
+# 1.2 -> 1.3 (issue #163 / A1.2a):
 #   - Added top-level `build_system` block (always present). Populated
 #     by aorta.instrumentation.build_system.detect_build_system(); the
 #     value is `{"kind": "buck2", "buck2_version": str, "repo_root":
@@ -539,19 +554,34 @@ class EnvSnapshot:
     partial_reasons: list[str] = field(default_factory=list)
     # build_system: A1.2a (issue #163). Always present; ``{"kind": "none"}``
     # when buck2 isn't on PATH. Populated by detect_build_system() in
-    # collect_env() / _disaster_snapshot(). Kept as the last field
-    # with a ``default_factory`` so existing direct callers --
-    # internal triage test fixtures, downstream tools that pin to an
-    # older schema, etc. -- can still construct an ``EnvSnapshot(...)``
-    # without supplying this 1.3 addition. Mirrors the
-    # ``partial_reasons`` pattern: additive schema fields don't break
-    # constructors. The serialised JSON-key order is now ...
-    # pytorch_build, partial, partial_reasons, build_system; the
-    # schema is order-insensitive (consumers parse by key) so this
-    # is purely a serialisation cosmetic.
+    # collect_env() / _disaster_snapshot(). Kept with a ``default_factory``
+    # so existing direct callers -- internal triage test fixtures,
+    # downstream tools that pin to an older schema, etc. -- can still
+    # construct an ``EnvSnapshot(...)`` without supplying this 1.3
+    # addition. Mirrors the ``partial_reasons`` pattern: additive schema
+    # fields don't break constructors. The serialised JSON-key order is
+    # ... pytorch_build, partial, partial_reasons, build_system,
+    # library_introspection, library_introspection_alternates; the
+    # schema is order-insensitive (consumers parse by key) so this is
+    # purely a serialisation cosmetic.
     build_system: dict = field(
         default_factory=lambda: {"kind": "none"}
     )
+    # library_introspection: A1.2b (issue #163). Always present. Empty
+    # list outside buck mode. In buck mode, one entry per matched
+    # transitive dep, shape ``{"name", "source": "buck", "revision",
+    # "target"}``. See `aorta.instrumentation.buck_introspect` for the
+    # match patterns and the `--buck-target` CLI flag for the entry
+    # point.
+    library_introspection: list[dict] = field(default_factory=list)
+    # library_introspection_alternates: A1.2b. Empty outside buck mode.
+    # In buck mode, holds the synthesised A1-block-derived alternate
+    # entry for each library that buck *also* matched -- so a consumer
+    # can compare the buck label/revision against the system-package
+    # version/lib_hash. Same name appearing in both lists is the
+    # by-design overlap; the primary entry (buck) wins for downstream
+    # identity comparisons.
+    library_introspection_alternates: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to the env.json shape. Round-trip pair with from_dict."""
@@ -563,12 +593,18 @@ class EnvSnapshot:
 
         Tolerates extra unknown keys (forward-compat) and back-fills
         defaults for additive top-level fields that older snapshots
-        predate, so a 1.3 reader can still load a 1.1 / 1.2 env.json:
+        predate, so a 1.4 reader can still load a 1.1 / 1.2 / 1.3
+        env.json:
 
         * ``partial_reasons`` -> ``[]`` (always optional).
         * ``build_system`` -> ``{"kind": "none"}`` (added in schema 1.3;
           equivalent to "we did not detect Buck2", which is the only
           honest answer when the producer did not even run the probe).
+        * ``library_introspection`` -> ``[]`` (added in schema 1.4;
+          empty list means "no buck-aware introspection was run").
+        * ``library_introspection_alternates`` -> ``[]`` (added in
+          schema 1.4; empty list means "nothing was dropped in the
+          Buck-vs-A1 merge").
 
         Strictly-required older fields (the schema-1.0/1.1 set) are NOT
         defaulted -- a missing ``rocm`` or ``hipblaslt`` key still
@@ -579,6 +615,8 @@ class EnvSnapshot:
         kwargs = {k: v for k, v in d.items() if k in known}
         kwargs.setdefault("partial_reasons", [])
         kwargs.setdefault("build_system", {"kind": "none"})
+        kwargs.setdefault("library_introspection", [])
+        kwargs.setdefault("library_introspection_alternates", [])
         return cls(**kwargs)
 
     def summary(self) -> str:
@@ -965,7 +1003,10 @@ class EnvSnapshot:
 # ---------------------------------------------------------------------------
 
 
-def collect_env() -> EnvSnapshot:
+def collect_env(
+    buck_target: str | None = None,
+    buck_timeout: int = 10,
+) -> EnvSnapshot:
     """Capture the current process environment as an :class:`EnvSnapshot`.
 
     NEVER raises. The promise is enforced two ways:
@@ -982,6 +1023,16 @@ def collect_env() -> EnvSnapshot:
 
     No GPU compute. No tensor allocations. The optional ``import torch``
     for the version probe does NOT initialise CUDA / HIP context.
+
+    Buck mode (``buck_target=...``) opts into the A1.2b path: the
+    function additionally runs ``buck2 audit dependencies <target>
+    --transitive --json``, matches transitive deps against
+    ``buck_introspect.KNOWN_LIBRARY_PATTERNS``, and populates
+    ``library_introspection`` (plus ``library_introspection_alternates``
+    when an A1 per-library block also captured the same name). Outside
+    buck mode both lists stay empty and the existing per-library
+    top-level blocks remain authoritative. ``buck_timeout`` caps the
+    audit subprocess (seconds; default 10).
     """
     reasons: list[str] = []
     try:
@@ -1019,6 +1070,22 @@ def collect_env() -> EnvSnapshot:
         )
         build_system = _detect_build_system_safe()
 
+        a1_blocks_by_lib = {
+            "hipblaslt": hipblaslt,
+            "rocblas": rocblas,
+            "miopen": miopen,
+            "rccl": rccl,
+        }
+        library_introspection, library_introspection_alternates = (
+            _run_buck_introspection_safe(
+                buck_target=buck_target,
+                buck_timeout=buck_timeout,
+                build_system=build_system,
+                a1_blocks_by_lib=a1_blocks_by_lib,
+                reasons=reasons,
+            )
+        )
+
         return EnvSnapshot(
             schema_version=SCHEMA_VERSION,
             captured_at=_utc_now_iso(),
@@ -1046,6 +1113,8 @@ def collect_env() -> EnvSnapshot:
             build_system=build_system,
             partial=bool(reasons),
             partial_reasons=reasons,
+            library_introspection=library_introspection,
+            library_introspection_alternates=library_introspection_alternates,
         )
     except Exception as exc:  # noqa: BLE001 -- this is the never-raises gate
         log.info("collect_env() hit unexpected exception", exc_info=True)
@@ -1194,6 +1263,8 @@ def _disaster_snapshot(
         build_system={"kind": "none"},
         partial=True,
         partial_reasons=[*preceding_reasons, unexpected_reason],
+        library_introspection=[],
+        library_introspection_alternates=[],
     )
 
 
@@ -1213,6 +1284,94 @@ def _detect_build_system_safe() -> dict:
     except Exception as exc:  # noqa: BLE001 -- never-raises gate
         log.info("build_system: detect_build_system raised (%s)", exc, exc_info=True)
         return {"kind": "none"}
+
+
+def _run_buck_introspection_safe(
+    buck_target: str | None,
+    buck_timeout: int,
+    build_system: dict,
+    a1_blocks_by_lib: dict[str, dict],
+    reasons: list[str],
+) -> tuple[list[dict], list[dict]]:
+    """Run the A1.2b buck-aware library introspection if requested.
+
+    Returns ``(library_introspection, library_introspection_alternates)``.
+    Both are ``[]`` when ``buck_target is None``. When a target is
+    supplied but ``build_system["kind"] != "buck2"``, we still attempt
+    the audit (so an operator can force-run from a non-Buck cwd) but
+    record a partial reason so the disconnect is visible.
+
+    Per the env-probe never-raises contract: any unexpected exception
+    is swallowed and surfaced via ``reasons``; both lists are returned
+    empty.
+    """
+    if buck_target is None:
+        return [], []
+    try:
+        from aorta.instrumentation.buck_introspect import (
+            introspect_libraries_via_buck,
+        )
+
+        repo_revision = build_system.get("revision") if isinstance(build_system, dict) else None
+        cwd = build_system.get("repo_root") if isinstance(build_system, dict) else None
+        if isinstance(build_system, dict) and build_system.get("kind") != "buck2":
+            reasons.append(
+                f"library_introspection: --buck-target {buck_target} supplied but "
+                f"build_system.kind={build_system.get('kind')!r}; running anyway"
+            )
+        entries, buck_reasons = introspect_libraries_via_buck(
+            target=buck_target,
+            repo_revision=repo_revision,
+            timeout=buck_timeout,
+            cwd=cwd,
+        )
+        reasons.extend(buck_reasons)
+        alternates = _synthesise_library_alternates(entries, a1_blocks_by_lib)
+        return entries, alternates
+    except Exception as exc:  # noqa: BLE001 -- never-raises gate
+        log.info(
+            "library_introspection: buck introspection raised (%s)", exc, exc_info=True
+        )
+        reasons.append(
+            f"library_introspection: buck introspection raised "
+            f"({type(exc).__name__}: {exc})"
+        )
+        return [], []
+
+
+def _synthesise_library_alternates(
+    buck_entries: list[dict], a1_blocks_by_lib: dict[str, dict]
+) -> list[dict]:
+    """Build the parallel A1-derived alternates list for buck matches.
+
+    For each buck entry whose library name has a matching A1 per-library
+    block, emit a single shape-aligned alternate entry pulling the
+    library's identifying fields out of the existing block. Libraries
+    A1 doesn't capture (e.g. ``pytorch``, ``rocm`` runtime) get no
+    alternate -- the buck entry is the only signal in that case.
+
+    The alternate's ``source`` is ``"package"`` for the rocm-release
+    kernel libs (which A1 captures via header + pkg-config + lib hash)
+    -- i.e. matches the existing per-library block's provenance.
+    """
+    alternates: list[dict] = []
+    for entry in buck_entries:
+        name = entry.get("name")
+        block = a1_blocks_by_lib.get(name) if name else None
+        if not block:
+            continue
+        alternates.append(
+            {
+                "name": name,
+                "source": "package",
+                "revision": block.get("rocm_release_tweak")
+                or block.get("version"),
+                "package_version": block.get("package_version")
+                or block.get("version"),
+                "lib_hash": block.get("lib_hash"),
+            }
+        )
+    return alternates
 
 
 def _utc_now_iso() -> str:

--- a/tests/fixtures/buck/audit_dependencies.json
+++ b/tests/fixtures/buck/audit_dependencies.json
@@ -1,0 +1,12 @@
+{
+  "//myproj:training_main": [
+    "//third-party/rocm:hipblaslt_lib",
+    "//third-party/rocm:rccl_lib",
+    "//third-party/rocm:hip_runtime",
+    "//third-party/pytorch:torch",
+    "//third-party/pytorch:torch_hip",
+    "//myproj/util:logging",
+    "//myproj/util:metrics",
+    "//some/other:unrelated_target"
+  ]
+}

--- a/tests/instrumentation/test_buck_introspect.py
+++ b/tests/instrumentation/test_buck_introspect.py
@@ -1,0 +1,394 @@
+"""Tests for ``aorta.instrumentation.buck_introspect`` (issue #163, A1.2b).
+
+Strategy mirrors ``test_build_system.py``: load the modules by file path
+so the test does not pull in torch via ``aorta.utils``. Every
+subprocess and ``shutil.which`` lookup is monkeypatched so tests run
+on any host -- with or without buck2.
+
+Coverage matrix (per the A1.2b acceptance criteria):
+
+* ``buck2`` absent -> empty entries, single ``reasons`` line.
+* Happy path: fixture JSON yields the expected library set with
+  ``source: "buck"`` and the passed-through repo revision.
+* Pattern matching: every documented label shape resolves to the
+  right library name; unrelated labels resolve to ``None``.
+* Failure modes: timeout, OSError, non-zero exit (with stderr
+  truncation), invalid JSON, unexpected JSON shape -- all surface as
+  ``reasons`` lines without raising.
+* ``collect_env()`` integration: buck kwargs wire through, alternates
+  are synthesised only for libraries A1 also captures, partial reasons
+  propagate, an unexpected exception in introspection is swallowed,
+  and the introspection lists round-trip via ``to_dict()`` /
+  ``from_dict()``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# -- Direct module load (mirrors test_build_system.py) -----------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module(rel_path: str, mod_name: str):
+    spec = importlib.util.spec_from_file_location(
+        mod_name, _REPO_ROOT / rel_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bi_mod = _load_module(
+    "src/aorta/instrumentation/buck_introspect.py",
+    "aorta.instrumentation.buck_introspect",
+)
+bs_mod = _load_module(
+    "src/aorta/instrumentation/build_system.py",
+    "aorta.instrumentation.build_system",
+)
+env_mod = _load_module(
+    "src/aorta/instrumentation/environment.py",
+    "aorta.instrumentation.environment",
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).parent.parent / "fixtures" / "buck" / "audit_dependencies.json"
+)
+
+
+def _make_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["buck2"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# ---------------------------------------------------------------------------
+# _match_library: pattern matching against the known library list
+# ---------------------------------------------------------------------------
+
+
+class TestMatchLibrary:
+    @pytest.mark.parametrize(
+        "label,expected",
+        [
+            ("//third-party/rocm:hipblaslt_lib", "hipblaslt"),
+            ("//third-party/rocm:hipblaslt-lib", "hipblaslt"),
+            ("//some/path:hipblaslt", "hipblaslt"),
+            ("hipblaslt-foo:lib", "hipblaslt"),
+            ("//third-party/rocm:rccl_lib", "rccl"),
+            ("//third-party/rocm:rccl-lib", "rccl"),
+            ("//third-party/pytorch:torch", "pytorch"),
+            ("//third-party/pytorch:pytorch", "pytorch"),
+            ("//third-party/pytorch:torch_hip", "pytorch"),
+            ("//third-party/pytorch:torch_cuda", "pytorch"),
+            ("//third-party/rocm:hip_runtime", "rocm"),
+            ("//third-party/rocm:rocm_runtime", "rocm"),
+            ("//myproj/util:logging", None),
+            ("//some/other:unrelated_target", None),
+            ("", None),
+        ],
+    )
+    def test_pattern_matching(self, label, expected):
+        assert bi_mod._match_library(label) == expected
+
+
+# ---------------------------------------------------------------------------
+# introspect_libraries_via_buck: subprocess wrapper end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestBuck2Absent:
+    def test_returns_empty_with_reason_when_buck2_missing(self, monkeypatch):
+        monkeypatch.setattr(bi_mod.shutil, "which", lambda _name: None)
+        entries, reasons = bi_mod.introspect_libraries_via_buck(
+            target="//foo:bar", repo_revision="rev"
+        )
+        assert entries == []
+        assert len(reasons) == 1
+        assert "buck2 not on PATH" in reasons[0]
+        assert "//foo:bar" in reasons[0]
+
+
+class TestBuck2HappyPath:
+    def test_fixture_yields_expected_library_set(self, monkeypatch):
+        monkeypatch.setattr(bi_mod.shutil, "which", lambda _name: "/usr/bin/buck2")
+        fixture = FIXTURE_PATH.read_text()
+        with patch.object(
+            bi_mod.subprocess, "run", return_value=_make_completed(stdout=fixture)
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//myproj:training_main", repo_revision="cafef00d"
+            )
+
+        assert reasons == []
+        names = sorted(e["name"] for e in entries)
+        assert names == ["hipblaslt", "pytorch", "rccl", "rocm"]
+        for entry in entries:
+            assert entry["source"] == "buck"
+            assert entry["revision"] == "cafef00d"
+            assert entry["target"].startswith("//")
+
+    def test_dedup_keeps_first_match_only(self, monkeypatch):
+        monkeypatch.setattr(bi_mod.shutil, "which", lambda _name: "/usr/bin/buck2")
+        payload = {
+            "//foo": [
+                "//a:hipblaslt_lib",
+                "//b:hipblaslt-lib",
+            ]
+        }
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(stdout=json.dumps(payload)),
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision=None
+            )
+        assert reasons == []
+        assert len(entries) == 1
+        assert entries[0]["target"] == "//a:hipblaslt_lib"
+
+    def test_revision_passes_through_when_none(self, monkeypatch):
+        monkeypatch.setattr(bi_mod.shutil, "which", lambda _name: "/usr/bin/buck2")
+        payload = {"//foo": ["//x:rccl_lib"]}
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(stdout=json.dumps(payload)),
+        ):
+            entries, _ = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision=None
+            )
+        assert entries[0]["revision"] is None
+
+    def test_empty_match_set_is_not_partial(self, monkeypatch):
+        monkeypatch.setattr(bi_mod.shutil, "which", lambda _name: "/usr/bin/buck2")
+        payload = {"//foo": ["//util:logging", "//util:metrics"]}
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(stdout=json.dumps(payload)),
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision="r"
+            )
+        assert entries == []
+        assert reasons == []  # success with no matches != failure
+
+
+class TestBuck2FailureModes:
+    def setup_method(self):
+        self._patch = patch.object(bi_mod.shutil, "which", lambda _name: "/usr/bin/buck2")
+        self._patch.start()
+
+    def teardown_method(self):
+        self._patch.stop()
+
+    def test_timeout_returns_reason(self):
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd="buck2", timeout=10),
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision="r", timeout=10
+            )
+        assert entries == []
+        assert any("timed out after 10s" in r for r in reasons)
+
+    def test_oserror_returns_reason(self):
+        with patch.object(
+            bi_mod.subprocess, "run", side_effect=OSError("permission denied")
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision="r"
+            )
+        assert entries == []
+        assert any("failed to launch" in r for r in reasons)
+
+    def test_nonzero_exit_includes_truncated_stderr(self):
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(
+                stdout="", stderr="target //foo not found", returncode=2
+            ),
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision="r"
+            )
+        assert entries == []
+        assert any("exited 2" in r and "target //foo not found" in r for r in reasons)
+
+    def test_nonzero_exit_with_empty_stderr_renders_placeholder(self):
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(stdout="", stderr="", returncode=1),
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision="r"
+            )
+        assert entries == []
+        assert any("(empty)" in r for r in reasons)
+
+    def test_invalid_json_returns_reason(self):
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(stdout="not-json"),
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision="r"
+            )
+        assert entries == []
+        assert any("non-JSON output" in r for r in reasons)
+
+    def test_unexpected_json_shape_returns_reason(self):
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(stdout=json.dumps(["//a", "//b"])),
+        ):
+            entries, reasons = bi_mod.introspect_libraries_via_buck(
+                target="//foo", repo_revision="r"
+            )
+        assert entries == []
+        assert any("unexpected JSON shape" in r for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# collect_env() integration: kwargs path + alternates synthesis + round trip
+# ---------------------------------------------------------------------------
+
+
+class TestCollectEnvIntegration:
+    """Integration uses the env_mod helper directly to avoid the
+    ~150-test all_disabled fixture machinery in test_environment.py.
+    The introspection function itself is patched, so we don't need to
+    fake any of A1's per-library probes -- we only validate the wiring.
+    """
+
+    def test_no_buck_target_yields_empty_lists(self):
+        snap = env_mod.collect_env()
+        assert snap.library_introspection == []
+        assert snap.library_introspection_alternates == []
+
+    def test_buck_target_populates_library_introspection(self, monkeypatch):
+        fake_entries = [
+            {
+                "name": "hipblaslt",
+                "source": "buck",
+                "revision": "cafef00d",
+                "target": "//rocm:hipblaslt_lib",
+            },
+            {
+                "name": "pytorch",
+                "source": "buck",
+                "revision": "cafef00d",
+                "target": "//pytorch:torch",
+            },
+        ]
+        monkeypatch.setattr(
+            bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, [])
+        )
+        snap = env_mod.collect_env(buck_target="//foo:bar")
+        assert snap.library_introspection == fake_entries
+
+    def test_alternates_synthesised_only_for_a1_overlap(self, monkeypatch):
+        fake_entries = [
+            {
+                "name": "hipblaslt",
+                "source": "buck",
+                "revision": "cafef00d",
+                "target": "//rocm:hipblaslt_lib",
+            },
+            {
+                "name": "pytorch",
+                "source": "buck",
+                "revision": "cafef00d",
+                "target": "//pytorch:torch",
+            },
+        ]
+        monkeypatch.setattr(
+            bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, [])
+        )
+        snap = env_mod.collect_env(buck_target="//foo:bar")
+        names = [a["name"] for a in snap.library_introspection_alternates]
+        # hipblaslt has an A1 block, pytorch does not => only one alt
+        assert names == ["hipblaslt"]
+        assert snap.library_introspection_alternates[0]["source"] == "package"
+
+    def test_buck_reasons_propagate_to_partial_reasons(self, monkeypatch):
+        monkeypatch.setattr(
+            bi_mod,
+            "introspect_libraries_via_buck",
+            lambda **_: ([], ["library_introspection: synthetic failure"]),
+        )
+        snap = env_mod.collect_env(buck_target="//foo:bar")
+        assert any(
+            "library_introspection: synthetic failure" in r
+            for r in snap.partial_reasons
+        )
+
+    def test_unexpected_exception_in_introspection_is_swallowed(self, monkeypatch):
+        def boom(**_kwargs):
+            raise RuntimeError("buck2 went sideways")
+
+        monkeypatch.setattr(bi_mod, "introspect_libraries_via_buck", boom)
+        snap = env_mod.collect_env(buck_target="//foo:bar")
+        assert snap.library_introspection == []
+        assert any(
+            "buck introspection raised" in r and "RuntimeError" in r
+            for r in snap.partial_reasons
+        )
+
+    def test_round_trip_preserves_introspection_lists(self, monkeypatch):
+        fake_entries = [
+            {
+                "name": "rccl",
+                "source": "buck",
+                "revision": "abc",
+                "target": "//rocm:rccl_lib",
+            }
+        ]
+        monkeypatch.setattr(
+            bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, [])
+        )
+        snap = env_mod.collect_env(buck_target="//foo:bar")
+        d = snap.to_dict()
+        assert d["library_introspection"] == fake_entries
+        rebuilt = env_mod.EnvSnapshot.from_dict(d)
+        assert rebuilt.library_introspection == fake_entries
+        assert (
+            rebuilt.library_introspection_alternates
+            == snap.library_introspection_alternates
+        )
+
+    def test_disconnect_buck_target_without_buck2_kind_records_reason(
+        self, monkeypatch
+    ):
+        # Force build_system to look non-buck so the reconciliation
+        # branch fires regardless of whether the host has buck2 installed.
+        monkeypatch.setattr(
+            env_mod, "_detect_build_system_safe", lambda: {"kind": "none"}
+        )
+        monkeypatch.setattr(
+            bi_mod, "introspect_libraries_via_buck", lambda **_: ([], [])
+        )
+        snap = env_mod.collect_env(buck_target="//foo:bar")
+        assert any(
+            "build_system.kind=" in r and "running anyway" in r
+            for r in snap.partial_reasons
+        )

--- a/tests/instrumentation/test_build_system.py
+++ b/tests/instrumentation/test_build_system.py
@@ -611,8 +611,13 @@ class TestSnapshotIntegration:
         rebuilt = env_mod.EnvSnapshot.from_dict(d)
         assert rebuilt.build_system == d["build_system"]
 
-    def test_schema_version_bumped_to_1_3(self):
-        assert env_mod.SCHEMA_VERSION == "1.3"
+    def test_schema_version_includes_build_system_bump(self):
+        # A1.2a bumped 1.2 -> 1.3 to add ``build_system``. Subsequent
+        # A1.2 phases keep bumping (A1.2b -> 1.4 with
+        # ``library_introspection``), so this assertion pins the floor
+        # rather than the exact value: ``build_system`` must be present
+        # in the current schema version's required key set.
+        assert tuple(int(p) for p in env_mod.SCHEMA_VERSION.split(".")) >= (1, 3)
 
     def test_from_dict_defaults_missing_build_system_to_none_kind(
         self, all_disabled

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -259,6 +259,8 @@ REQUIRED_TOP_KEYS = {
     "pytorch_version",
     "pytorch_build",
     "build_system",
+    "library_introspection",
+    "library_introspection_alternates",
 }
 
 
@@ -268,7 +270,7 @@ class TestSchemaCompleteness:
     ):
         snapshot = collect_env()
         assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
-        assert snapshot.schema_version == "1.3"
+        assert snapshot.schema_version == "1.4"
         assert snapshot.system_health is None
         assert snapshot.rocm == {
             "version": None,
@@ -315,7 +317,7 @@ class TestSchemaCompleteness:
 def _example_snapshot(**overrides) -> object:
     """Build a fully-populated EnvSnapshot for round-trip testing."""
     base = {
-        "schema_version": "1.3",
+        "schema_version": "1.4",
         "captured_at": "2026-04-28T12:00:00Z",
         "system_health": {"rdhc_version": "1.4.0", "tests": {}},
         "rocm": {
@@ -442,6 +444,8 @@ def _example_snapshot(**overrides) -> object:
         "build_system": {"kind": "none"},
         "partial": False,
         "partial_reasons": [],
+        "library_introspection": [],
+        "library_introspection_alternates": [],
     }
     base.update(overrides)
     return EnvSnapshot(**base)
@@ -470,7 +474,7 @@ class TestEnvSnapshot:
         d = _example_snapshot().to_dict()
         d["future_field_not_yet_added"] = {"hello": "world"}
         rebuilt = EnvSnapshot.from_dict(d)
-        assert rebuilt.schema_version == "1.3"
+        assert rebuilt.schema_version == "1.4"
 
     def test_from_dict_defaults_partial_reasons_when_missing(self):
         """Older env.json without partial_reasons still loads (defaults to [])."""
@@ -1041,8 +1045,8 @@ class TestCliIsThinWrapper:
         # `test_cli_does_no_probing_imports` below -- this one is a
         # soft canary against the file ballooning.
         line_count = sum(1 for _ in cli_path.read_text().splitlines())
-        assert line_count <= 120, (
-            f"cli/env.py is {line_count} lines; soft budget is 120. "
+        assert line_count <= 140, (
+            f"cli/env.py is {line_count} lines; soft budget is 140. "
             "If you need more, check that the new code is genuinely "
             "wiring/error-handling and not probing -- "
             "test_cli_does_no_probing_imports is the strict guard."


### PR DESCRIPTION
## Summary

`Refs #163` (A1.2b of the 3-PR effort to make `aorta env probe` first-class in Buck2 environments).

- New `aorta env probe --buck-target //label` flag (and matching `collect_env(buck_target=...)` kwarg). Wraps `buck2 audit dependencies <target> --transitive --json`, matches transitive dep labels against `KNOWN_LIBRARY_PATTERNS` (hipblaslt, rccl, pytorch, rocm), and populates two new always-present top-level fields: `library_introspection` (buck entries) and `library_introspection_alternates` (A1-block-derived entries for matched libraries A1 also captures).
- Schema 1.2 → 1.3, forward-compatible — both new fields default to `[]` so `EnvSnapshot.from_dict()` still loads older snapshots.
- Outside Buck mode both lists stay empty; existing per-library blocks (`hipblaslt`, `rocblas`, …) remain authoritative.
- Never-raises contract preserved: every documented buck failure (timeout, OSError, non-zero exit, invalid JSON, unexpected shape) surfaces as a `partial_reasons` line rather than an exception. Defence-in-depth wrapper in `environment.py` swallows even unexpected exceptions from the introspection module.

## Dependency

This PR is **stacked on top of #164** (A1.2a — `build_system` block). Base branch is set to `users/amd-vivekag/A1.2a-build-system`. Once #164 merges to `main`, this PR's base should be retargeted to `main`.

## Test plan

- [x] `pytest tests/instrumentation/ -q` → 268 passed, 3 skipped
- [x] New `tests/instrumentation/test_buck_introspect.py` (33 tests): pattern matching, buck2-absent path, happy path against `tests/fixtures/buck/audit_dependencies.json`, dedup, every documented failure mode, `collect_env()` integration (kwargs wiring, alternates synthesis, partial_reasons propagation, swallowed exceptions, JSON round-trip, build_system-kind disconnect)
- [x] CLI smoke: `aorta env probe --help` renders both new flags
- [x] Existing `test_environment.py` schema-completeness + `test_build_system.py` integration tests updated for 1.2 → 1.3 bump
- [ ] Manual end-to-end against a real Buck2 checkout (will run before un-drafting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)