### PR TITLE
run: thread resolved Environment into workload config

### DIFF
--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -246,6 +246,28 @@ def _run_single_trial(
     if request.steps is not None:
         config["steps"] = request.steps
 
+    # Thread the resolved Environment descriptor into the workload's
+    # config under a reserved underscore-prefixed key.  Workloads that
+    # can isolate themselves (e.g., the recom_repro wrapper invoking
+    # ``docker run`` instead of ``python``) read this to pick the
+    # right image / venv; workloads that don't ignore the key.
+    #
+    # This is the dispatcher's way of telling the workload *which*
+    # environment was selected for this cell -- the ``--environment``
+    # flag and the ``environment:`` axis in a triage recipe both flow
+    # through here.  Triage runs vary this per-cell, so emitting it
+    # on every trial keeps cells independently runnable.
+    #
+    # The underscore prefix signals "platform-supplied; not a user
+    # override" and matches the same convention ``TrialResult`` uses
+    # for ``execution_env``.
+    config["_aorta_environment"] = {
+        "name": env_descriptor.name,
+        "docker": env_descriptor.docker,
+        "venv": env_descriptor.venv,
+        "source_package": env_descriptor.source_package,
+    }
+
     # Snapshot the env BEFORE applying mitigation / extra_env so the
     # ``finally`` block can restore both the dispatcher's overlay and
     # any workload-side mutations introduced by ``setup()`` / ``run()``.

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -150,26 +150,40 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
             "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
         )
 
-    # 4. Discover workload
+    # 4. Reject reserved ``_aorta_*`` keys in ``config_overrides``.
+    #    The dispatcher writes platform-supplied values (currently
+    #    ``_aorta_environment``) into ``config`` after merging
+    #    ``config_overrides``, so a caller-supplied ``_aorta_*`` key
+    #    would be silently clobbered.  Failing loudly here surfaces
+    #    typos and prevents callers from depending on a slot that
+    #    isn't actually theirs.
+    reserved_keys = sorted(k for k in request.config_overrides if k.startswith("_aorta_"))
+    if reserved_keys:
+        raise ValueError(
+            f"config_overrides keys {reserved_keys} use the reserved "
+            "'_aorta_' prefix (platform-supplied; not a user override)."
+        )
+
+    # 5. Discover workload
     workload_cls = get_workload_class(request.workload)
 
-    # 5. Validate launch mode BEFORE setup()
+    # 6. Validate launch mode BEFORE setup()
     validate_launch_mode(workload_cls)
 
-    # 6. Resolve environment.  Forward ``sidecar_files`` so any
+    # 7. Resolve environment.  Forward ``sidecar_files`` so any
     #    operator-supplied JSON sidecars (B3.1) are merged with
     #    built-ins and entry-point plugins.
     sidecar_files = list(request.sidecar_files) or None
     env_descriptor = get_environment(request.environment, extra_files=sidecar_files)
 
-    # 7. Resolve and union mitigations.  ``aorta.registry.get_mitigation``
+    # 8. Resolve and union mitigations.  ``aorta.registry.get_mitigation``
     #    returns a defensive ``dict[str, str]`` per-call, so later
     #    mitigations naturally win over earlier ones in the union.
     mitigation_env: dict[str, str] = {}
     for name in request.mitigations:
         mitigation_env.update(get_mitigation(name, extra_files=sidecar_files))
 
-    # 8. Determine if we should write (rank 0 only for distributed).
+    # 9. Determine if we should write (rank 0 only for distributed).
     #    Only rank 0 needs the output directory; creating it on every
     #    rank causes shared-FS contention and weakens the rank-0-only
     #    write guarantee.  Parse RANK defensively -- a misconfigured
@@ -188,7 +202,7 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     if should_write:
         results_dir.mkdir(parents=True, exist_ok=True)
 
-    # 9. Run trials
+    # 10. Run trials
     results: list[TrialResult] = []
     for trial_idx in range(request.trials):
         result = _run_single_trial(
@@ -260,13 +274,10 @@ def _run_single_trial(
     #
     # The underscore prefix signals "platform-supplied; not a user
     # override" and matches the same convention ``TrialResult`` uses
-    # for ``execution_env``.
-    config["_aorta_environment"] = {
-        "name": env_descriptor.name,
-        "docker": env_descriptor.docker,
-        "venv": env_descriptor.venv,
-        "source_package": env_descriptor.source_package,
-    }
+    # for ``execution_env``.  ``run_trials`` rejects ``_aorta_*`` keys
+    # in ``config_overrides`` so this assignment can't silently clobber
+    # a caller-supplied value.
+    config["_aorta_environment"] = asdict(env_descriptor)
 
     # Snapshot the env BEFORE applying mitigation / extra_env so the
     # ``finally`` block can restore both the dispatcher's overlay and
@@ -357,13 +368,10 @@ def _run_single_trial(
     # ``aorta.registry.Environment`` shape (no ``kind`` / ``rocm`` --
     # those were stub-isms; ROCm version now lives inside
     # ``env_snapshot.rocm`` and the runtime kind in
-    # ``env_snapshot.runtime_context.type``).
-    execution_env = {
-        "name": env_descriptor.name,
-        "docker": env_descriptor.docker,
-        "venv": env_descriptor.venv,
-        "source_package": env_descriptor.source_package,
-    }
+    # ``env_snapshot.runtime_context.type``).  Same shape as
+    # ``config["_aorta_environment"]`` above; sharing ``asdict`` keeps
+    # the two in lockstep if ``Environment`` ever grows a field.
+    execution_env = asdict(env_descriptor)
 
     # Build TrialResult
     trial_result = TrialResult(

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -180,6 +180,22 @@ class TestRunTrials:
             with pytest.raises(ValueError, match="Invalid extra_env keys"):
                 run_trials(req)
 
+    def test_rejects_reserved_aorta_prefix_in_config_overrides(self, tmp_path):
+        """``_aorta_*`` keys are reserved for platform-supplied values
+        (currently ``_aorta_environment``).  A caller passing one in
+        ``config_overrides`` would be silently clobbered by the
+        dispatcher; failing loudly surfaces typos and prevents callers
+        from depending on a slot that isn't theirs.
+        """
+        req = RunRequest(
+            workload="anything",
+            trials=1,
+            config_overrides={"_aorta_environment": "hijack"},
+            results_dir=tmp_path,
+        )
+        with pytest.raises(ValueError, match=r"reserved '_aorta_' prefix"):
+            run_trials(req)
+
     def test_cleanup_error_is_logged_not_swallowed(self, tmp_path, caplog):
         """A failing ``cleanup()`` is logged so leaked resources are visible."""
         import logging
@@ -767,6 +783,67 @@ class TestConfigOverrides:
         assert env_block["docker"] is None
         assert env_block["venv"] is None
         assert env_block["source_package"] == "aorta"
+
+    def test_non_none_docker_env_round_trips_to_both_sites(self, tmp_path):
+        """Built-in ``local`` env has ``docker=venv=None``, so the other
+        env tests don't exercise the non-``None`` branch of the
+        ``asdict(env_descriptor)`` serialization at the two call sites
+        (``config["_aorta_environment"]`` and ``TrialResult.execution_env``).
+        A regression that drops a field from either dict would slip
+        through.  Pin all four fields at both sites with a docker-set env.
+        """
+        from aorta.registry import Environment
+
+        captured_config: dict = {}
+
+        class EnvCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def __init__(self, config):
+                super().__init__(config)
+                captured_config.update(config)
+
+            def setup(self):
+                pass
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        env = Environment(
+            name="docker-test",
+            docker="img@sha256:deadbeef",
+            venv=None,
+            source_package="test",
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "envcapture"
+        mock_ep.load.return_value = EnvCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with patch("aorta.run.dispatcher.get_environment", return_value=env):
+                req = RunRequest(
+                    workload="envcapture",
+                    trials=1,
+                    environment="docker-test",
+                    results_dir=tmp_path,
+                )
+                results = run_trials(req)
+
+        expected = {
+            "name": "docker-test",
+            "docker": "img@sha256:deadbeef",
+            "venv": None,
+            "source_package": "test",
+        }
+        assert captured_config["_aorta_environment"] == expected
+        assert results[0].execution_env == expected
 
 
 class TestEnvironmentRestoration:

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -707,6 +707,67 @@ class TestConfigOverrides:
         assert captured_config.get("batch_size") == 32
         assert captured_config.get("lr") == 0.001
 
+    def test_resolved_environment_threaded_into_workload_config(self, tmp_path):
+        """The dispatcher threads the resolved ``Environment`` descriptor
+        into ``config["_aorta_environment"]`` so workloads that can
+        isolate themselves (e.g., a wrapper that invokes ``docker run``
+        instead of ``python``) know *which* environment was selected for
+        this cell.
+
+        ``aorta triage`` varies the environment axis across cells; the
+        in-process dispatcher API has no other way to communicate that
+        per-cell selection to the workload (the platform deliberately
+        does not pull or run docker images itself).
+        """
+        captured_config = {}
+
+        class EnvCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def __init__(self, config):
+                super().__init__(config)
+                captured_config.update(config)
+
+            def setup(self):
+                pass
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "envcapture"
+        mock_ep.load.return_value = EnvCapturingWorkload
+
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        # Built-in ``local`` env has docker=None, venv=None -- pick that
+        # to keep the test free of registry / sidecar setup.
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="envcapture",
+                trials=1,
+                environment="local",
+                results_dir=tmp_path,
+            )
+            run_trials(req)
+
+        env_block = captured_config.get("_aorta_environment")
+        assert env_block is not None, (
+            "dispatcher must thread the resolved Environment descriptor into "
+            "config['_aorta_environment']; otherwise workloads cannot tell "
+            "which environment was selected for the cell."
+        )
+        assert env_block["name"] == "local"
+        # Built-in ``local`` has no docker / venv.
+        assert env_block["docker"] is None
+        assert env_block["venv"] is None
+        assert env_block["source_package"] == "aorta"
+
 
 class TestEnvironmentRestoration:
     """Tests for environment variable restoration after trials."""


### PR DESCRIPTION
## Why

The B1 dispatcher records the selected `Environment` in `TrialResult.execution_env` (for the per-trial JSON) but never hands it to the workload itself. That's fine for workloads that run unconditionally on whatever Python invoked them, but it leaves workloads that *can* isolate themselves -- e.g. a wrapper that invokes `docker run` instead of host `python` -- with no way to know *which* environment was selected for the cell.

`aorta triage` varies the environment axis per-cell, so without this plumbing the per-cell environment selection has no path to the workload, and matrices like the Shampoo NaN triage (aorta-internal#14) silently degenerate to a single host environment with no `nan-repro` vs `fixed` signal.

## What

In `run.dispatcher._run_single_trial`, thread the resolved `Environment` descriptor into `config["_aorta_environment"]`:

```python
config["_aorta_environment"] = {
    "name": env_descriptor.name,
    "docker": env_descriptor.docker,
    "venv": env_descriptor.venv,
    "source_package": env_descriptor.source_package,
}
```

Workloads that don't care ignore the key. Workloads that want docker isolation read it and switch their argv accordingly. The underscore prefix signals \"platform-supplied; not a user override\" -- same convention `execution_env` uses in `TrialResult`.

## Why not a separate kwarg on `Workload.__init__`

That's the obvious alternative, but it's a breaking change to the public ABC's documented `__init__(self, config)` contract. Every existing plugin / test using the 1-arg signature would need to opt in. Plumbing through `config` is non-breaking: existing workloads simply ignore the key.

## Test surface

* New: `TestWorkloadConfig.test_resolved_environment_threaded_into_workload_config` asserts an entry-point-discovered workload sees the descriptor in its `config` dict. Built-in `local` (docker=None, venv=None) is used to keep the test free of registry / sidecar setup.
* Existing dispatcher / registry / triage suites stay green: **320 passed** (was 319; +1 new).

## Consumer

This PR is the platform half of fixing the docker-aware execution gap called out in [aorta-internal#14](https://github.com/ROCm/aorta-internal/issues/14). The workload-side half lives in aorta-internal -- it reads `config["_aorta_environment"]["docker"]` and either invokes `docker run --device=/dev/kfd ... image python script.py` or falls back to host python.

Refs: aorta-internal#14

Made with [Cursor](https://cursor.com)