### PR TITLE
pyproject: drop dangling aorta.workloads.fsdp entry-point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,18 @@ dependencies = [
 [project.scripts]
 aorta = "aorta.cli:main"
 
-# Plugin discovery: workloads register here via aorta.workloads entry-point group.
-# Engineer task A2 adds the first one (fsdp). Private workloads
-# (meta_recom_repro, precision_swaitcnt_test) register from aorta-internal's
-# pyproject.toml under the same group, separate package.
-[project.entry-points."aorta.workloads"]
-fsdp = "aorta.workloads.fsdp:FsdpWorkload"
+# Plugin discovery: workloads register here via aorta.workloads entry-point
+# group once they actually exist. The first public one is tracked by
+# https://github.com/ROCm/aorta/issues/149 (A2: FSDP Workload) -- registering
+# it preemptively as `fsdp = "aorta.workloads.fsdp:FsdpWorkload"` breaks
+# `aorta run` / `aorta triage` for any user with a recipe that touches
+# discovery, because `discover_workloads()` tries to load every registered
+# entry and the unresolved module path raises `ModuleNotFoundError`. The
+# `aorta.workloads` table is intentionally empty until #149 lands.
+#
+# Private workloads (e.g. recom_repro from aorta-internal) register
+# against this same group from their own pyproject.toml, separate
+# package; they are unaffected by anything in this file.
 
 [project.optional-dependencies]
 # For analysis/visualization scripts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,17 @@ dependencies = [
 [project.scripts]
 aorta = "aorta.cli:main"
 
-# Plugin discovery: workloads register here via aorta.workloads entry-point
-# group once they actually exist. The first public one is tracked by
-# https://github.com/ROCm/aorta/issues/149 (A2: FSDP Workload) -- registering
-# it preemptively as `fsdp = "aorta.workloads.fsdp:FsdpWorkload"` breaks
-# `aorta run` / `aorta triage` for any user with a recipe that touches
-# discovery, because `discover_workloads()` tries to load every registered
-# entry and the unresolved module path raises `ModuleNotFoundError`. The
-# `aorta.workloads` table is intentionally empty until #149 lands.
+# Plugin discovery: workloads register here via the aorta.workloads
+# entry-point group once they actually exist. The first public one is
+# tracked by https://github.com/ROCm/aorta/issues/149 (A2: FSDP Workload)
+# -- registering it preemptively as
+# `fsdp = "aorta.workloads.fsdp:FsdpWorkload"` breaks `aorta run` /
+# `aorta triage` for any user with a recipe that touches discovery,
+# because `discover_workloads()` tries to load every registered entry
+# and the unresolved module path raises `ModuleNotFoundError`. No
+# in-tree workload entry-points are defined here until #149 lands;
+# the A2 PR re-adds a `[project.entry-points."aorta.workloads"]` table
+# together with the implementation.
 #
 # Private workloads (e.g. recom_repro from aorta-internal) register
 # against this same group from their own pyproject.toml, separate


### PR DESCRIPTION
## Summary

`pyproject.toml` registers a single workload entry-point:

```toml
[project.entry-points."aorta.workloads"]
fsdp = "aorta.workloads.fsdp:FsdpWorkload"
```

…but `src/aorta/workloads/fsdp.py` does **not** exist. The actual FSDP workload is still tracked by open issue [#149 "A2: FSDP Workload"](https://github.com/ROCm/aorta/issues/149) and hasn't been written yet — the entry-point was registered preemptively when the issue was filed.

Every `aorta` invocation that touches discovery (`aorta run`, `aorta triage run`, `aorta triage list-mitigations`, …) walks this group via `discover_workloads()` and calls `ep.load()` on each entry. The discovery layer correctly logs-and-continues on `ImportError`, but the WARNING-level traceback is dumped to stderr on every command:

```
::: Step 8/8: discovery + dry-run
Failed to load workload 'fsdp'
Traceback (most recent call last):
  File ".../aorta/run/discovery.py", line 35, in discover_workloads
    cls = ep.load()
  …
ModuleNotFoundError: No module named 'aorta.workloads.fsdp'
   [ok]   discover_workloads() -> ['recom_repro']
```

That's alarming noise for any user with an otherwise-clean recipe (e.g. the SHAMPOO-NAN-2026-042 matrix from [aorta-internal#14](https://github.com/ROCm/aorta-internal/issues/14)) and obscures real failures.

This was originally surfaced as **M1** in the [issue #148 acceptance-criteria audit](https://github.com/ROCm/aorta/issues/148).

## Change

- Remove the `[project.entry-points."aorta.workloads"]` table.
- Replace the comment with one that explains why the table is intentionally empty and points to #149 so the A2 author re-adds the entry in the natural place when the workload actually ships.

## Why drop, not stub?

Adding a stub `aorta/workloads/fsdp.py` that raises `NotImplementedError` would carry dead code and still surface in `discover_workloads()` (so `aorta run --workload fsdp` would *appear* available but blow up at instantiation — strictly worse UX than "fsdp is not yet registered"). The right semantics are: *the workload doesn't exist yet*; the entry-point comes back together with the implementation under #149.

## Verification

- `pytest tests/run/` → 107/107 pass.
- After `pip install -e .` of this branch, `importlib.metadata.entry_points().select(group='aorta.workloads')` returns only `recom_repro` (registered by `aorta-internal`'s own `pyproject.toml`, unaffected).
- `aorta triage list-mitigations` / `list-environments` / `run --dry-run` no longer emit the spurious `fsdp` traceback.

## Test plan

- [ ] CI green.
- [ ] No behavioral change beyond suppression of the `fsdp` load warning.
- [ ] Issue #149 reviewer remembers to re-register the entry-point as part of the A2 PR (the comment block in `pyproject.toml` calls this out).


Made with [Cursor](https://cursor.com)