### PR TITLE
pyproject: remove dead fsdp entry-point (silences spurious load failure on every CLI invocation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,15 @@ dependencies = [
 aorta = "aorta.cli:main"
 
 # Plugin discovery: workloads register here via aorta.workloads entry-point group.
-# Engineer task A2 adds the first one (fsdp). Private workloads
-# (meta_recom_repro, precision_swaitcnt_test) register from aorta-internal's
+# Public workloads (when they land) register here; private workloads
+# (recom_repro, precision_swaitcnt_test, etc.) register from aorta-internal's
 # pyproject.toml under the same group, separate package.
-[project.entry-points."aorta.workloads"]
-fsdp = "aorta.workloads.fsdp:FsdpWorkload"
+#
+# No public workloads are wired up yet -- the prior `fsdp` entry pointed at
+# `aorta.workloads.fsdp:FsdpWorkload`, which was never created, so `aorta run`
+# would log a noisy "Failed to load workload 'fsdp'" warning on every
+# invocation. Removed until a real public workload lands.
+# [project.entry-points."aorta.workloads"]
 
 [project.optional-dependencies]
 # For analysis/visualization scripts


### PR DESCRIPTION
## What

Comment out the dead `aorta.workloads` entry-point:

```toml
[project.entry-points."aorta.workloads"]
fsdp = "aorta.workloads.fsdp:FsdpWorkload"
```

The target module `aorta.workloads.fsdp` was never created — `src/aorta/workloads/` only ever contained `__init__.py` and `_base.py`. The entry-point line was added ahead of an implementation that didn't land.

## Symptom

Every invocation of `aorta run` / `aorta triage run` / `aorta triage list-mitigations` now logs:

```
Failed to load workload 'fsdp'
Traceback (most recent call last):
  File ".../aorta/src/aorta/run/discovery.py", line 35, in discover_workloads
    cls = ep.load()
  File ".../importlib/metadata/__init__.py", line 179, in load
    module = import_module(match.group('module'))
  ...
ModuleNotFoundError: No module named 'aorta.workloads.fsdp'
```

## Behavior change

**None at runtime.** `discovery.py:36-44` already wraps `ep.load()` in a `try/except` that logs the failure with `exc_info=True` and continues — other workloads (notably `recom_repro` from `aorta-internal`) discover normally, and `aorta triage run` matrices complete. This change just removes the noisy warning.

## Why it matters

Confirmed downstream confusion: a user running the SHAMPOO-NAN-2026-042 smoke matrix on an MI350 box ([aorta-internal#14](https://github.com/ROCm/aorta-internal/issues/14)) interpreted the traceback as a fatal error and reported the run as broken, even though `recom_repro` was being discovered fine and the matrix was running. The traceback is verbose under Python 3.13 in particular.

## Future-proofing

Left the section header commented out (rather than deleted) so the next public workload contribution has a placeholder to uncomment. Also rewrote the surrounding comment to explain the situation honestly: there are no public workloads yet; private ones register from sibling packages under the same group.

## Tests

No test impact — this is a `pyproject.toml` cleanup, not a code change. `discovery.py`'s try/except already covered this case; verifying that other workloads (`recom_repro`) still resolve is the test of record.