### PR TITLE
cli: add --verbose / -v flag to `aorta run` and `aorta triage run`

### DIFF
--- a/src/aorta/cli/run.py
+++ b/src/aorta/cli/run.py
@@ -24,6 +24,7 @@ import click
 
 from aorta.registry import RegistryError
 from aorta.run.cli_helpers import (
+    configure_verbose_logging,
     parse_csv,
     parse_extra_env,
     parse_mitigations,
@@ -68,6 +69,17 @@ from aorta.run.dispatcher import RunRequest, run_trials
 @click.option(
     "--extra-env", default="", help="Comma-separated KEY=VAL pairs (applied after mitigations)."
 )
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help=(
+        "Stream per-trial progress to stderr. -v = INFO (trial start/finish, "
+        "timings); -vv = DEBUG (also workload-internal logs). Default is "
+        "silent: only the final pass/fail summary prints. Useful for long "
+        "trials where there's otherwise no signal that anything is happening."
+    ),
+)
 def run(
     workload: str,
     trials: int,
@@ -78,6 +90,7 @@ def run(
     results_dir: Path,
     collect: str,
     extra_env: str,
+    verbose: int,
 ) -> None:
     """Run a workload across N trials with optional mitigations.
 
@@ -86,6 +99,7 @@ def run(
     orchestration logic lives here -- see ``aorta.run.dispatcher``
     and ``aorta.run.cli_helpers``.
     """
+    configure_verbose_logging(verbose)
     try:
         req = RunRequest(
             workload=workload,

--- a/src/aorta/cli/run.py
+++ b/src/aorta/cli/run.py
@@ -74,10 +74,12 @@ from aorta.run.dispatcher import RunRequest, run_trials
     "--verbose",
     count=True,
     help=(
-        "Stream per-trial progress to stderr. -v = INFO (trial start/finish, "
-        "timings); -vv = DEBUG (also workload-internal logs). Default is "
-        "silent: only the final pass/fail summary prints. Useful for long "
-        "trials where there's otherwise no signal that anything is happening."
+        "Stream per-trial progress (rank 0 only) to stderr. -v = INFO "
+        "(trial start/finish, timings, exit_status); -vv = DEBUG "
+        "(aorta-internal debug logs). Scope is the aorta.* logger "
+        "hierarchy; workload code in sibling packages "
+        "(aorta_internal.workloads.*, etc.) is unaffected. Default is "
+        "silent: only the final pass/fail summary prints."
     ),
 )
 def run(

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -23,6 +23,7 @@ from aorta.registry import (
     load_environments,
     load_mitigations,
 )
+from aorta.run.cli_helpers import configure_verbose_logging
 from aorta.triage.recipe import (
     RecipeCellError,
     RecipeSchemaError,
@@ -142,6 +143,19 @@ def triage() -> None:
         "envs with the same name-collision rules (B3.1)."
     ),
 )
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help=(
+        "Stream per-cell progress to stderr while the matrix runs. "
+        "-v = INFO (cell start/finish, timings, baseline). "
+        "-vv = DEBUG (also workload-internal logs). Default is silent: "
+        "only the final 'Wrote matrix to ...' line prints. Useful for "
+        "long matrix runs (~6h for SHAMPOO-NAN-2026-042-v2) where "
+        "you'd otherwise have no signal that anything is happening."
+    ),
+)
 def triage_run(
     recipe: Path | None,
     dry_run: bool,
@@ -156,8 +170,10 @@ def triage_run(
     confound_threshold: float | None,
     output_dir: Path,
     mitigation_files: tuple[Path, ...],
+    verbose: int,
 ) -> None:
     """Run the triage matrix: sweep mitigations x environments x trials, write matrix.md + matrix.json."""
+    configure_verbose_logging(verbose)
     # Defence-in-depth: Click's ``Choice(["matrix"])`` already enforces this,
     # but the CLI advertises ``--mode optimize`` as a future P1 addition (per
     # D11) and the dispatch site for that branch does not exist yet. Assert

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -149,11 +149,14 @@ def triage() -> None:
     count=True,
     help=(
         "Stream per-cell progress to stderr while the matrix runs. "
-        "-v = INFO (cell start/finish, timings, baseline). "
-        "-vv = DEBUG (also workload-internal logs). Default is silent: "
-        "only the final 'Wrote matrix to ...' line prints. Useful for "
-        "long matrix runs (~6h for SHAMPOO-NAN-2026-042-v2) where "
-        "you'd otherwise have no signal that anything is happening."
+        "-v = INFO (matrix preamble, per-cell start/finish, timings, "
+        "trials passed). -vv = DEBUG (aorta-internal debug logs). "
+        "Scope is the aorta.* logger hierarchy; workload code in "
+        "sibling packages (aorta_internal.workloads.*, etc.) is "
+        "unaffected. Default is silent: only the final 'Wrote matrix "
+        "to ...' line prints. Useful for long matrix runs (~6h for "
+        "SHAMPOO-NAN-2026-042-v2) where you'd otherwise have no "
+        "signal that anything is happening."
     ),
 )
 def triage_run(

--- a/src/aorta/run/cli_helpers.py
+++ b/src/aorta/run/cli_helpers.py
@@ -37,25 +37,42 @@ def configure_verbose_logging(verbose_count: int) -> None:
     nothing until the final ``Wrote matrix to ...`` line, leaving
     operators with no signal that anything is happening.
 
+    Scope: only the ``aorta.*`` logger hierarchy. Workloads registered
+    via the ``aorta.workloads`` entry-point group from sibling packages
+    (e.g. ``aorta_internal.workloads.recom_repro``) live OUTSIDE that
+    hierarchy, so their logging is unaffected -- a separate handler
+    on those packages' loggers (or the root logger) would be needed.
+
     ``verbose_count`` follows Click's ``count=True`` convention:
 
-    * ``0``: no-op (default; preserves backwards-compatible silence).
+    * ``0``: tear-down / no-op. If a prior call in the same process
+      installed verbosity, this removes it (handler + level reset);
+      otherwise nothing happens.
     * ``1`` (``-v``): INFO -- per-trial / per-cell progress.
-    * ``>=2`` (``-vv``): DEBUG -- also workload-internal logs.
+    * ``>=2`` (``-vv``): DEBUG -- aorta-internal debug logs.
 
     Output goes to **stderr** so stdout stays clean for the existing
     ``click.echo`` lines (final pass/fail summary, "to rerun" hint, etc.)
     that callers may pipe into a parser.
 
-    Idempotent: invoking twice on the same process (tests use
-    ``CliRunner.invoke`` repeatedly) does not stack handlers.
+    Symmetric and idempotent: ``configure_verbose_logging(N)`` followed
+    by ``configure_verbose_logging(0)`` returns the logger to its
+    original NOTSET state. CliRunner-based tests can invoke commands
+    with and without ``-v`` in any order without leaking state.
     """
-    if verbose_count <= 0:
-        return
-    level = logging.DEBUG if verbose_count >= 2 else logging.INFO
     aorta_logger = logging.getLogger("aorta")
-    # Mark the handler so re-invocation under CliRunner doesn't pile up
-    # duplicates across tests / nested CLI invocations in the same process.
+
+    if verbose_count <= 0:
+        # Tear down any handler we previously installed; reset level so
+        # subsequent invocations in the same process truly start silent.
+        for h in [h for h in aorta_logger.handlers if getattr(h, "_aorta_verbose", False)]:
+            aorta_logger.removeHandler(h)
+        aorta_logger.setLevel(logging.NOTSET)
+        return
+
+    level = logging.DEBUG if verbose_count >= 2 else logging.INFO
+    # Don't stack duplicate handlers under repeated invocation (CliRunner,
+    # programmatic callers calling the helper twice with -v).
     if not any(getattr(h, "_aorta_verbose", False) for h in aorta_logger.handlers):
         handler = logging.StreamHandler(sys.stderr)
         handler.setFormatter(logging.Formatter("[%(asctime)s] %(message)s", datefmt="%H:%M:%S"))
@@ -149,6 +166,7 @@ def summarize_results(results: Iterable[TrialResult]) -> RunSummary:
 
 __all__ = [
     "RunSummary",
+    "configure_verbose_logging",
     "parse_csv",
     "parse_extra_env",
     "parse_mitigations",

--- a/src/aorta/run/cli_helpers.py
+++ b/src/aorta/run/cli_helpers.py
@@ -20,10 +20,48 @@ Validation that the library API needs to enforce regardless of caller
 this module still get checked.
 """
 
+import logging
+import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 
 from aorta.run.results import TrialResult
+
+
+def configure_verbose_logging(verbose_count: int) -> None:
+    """Wire a stderr StreamHandler onto the ``aorta`` logger when -v is set.
+
+    Both ``aorta run`` and ``aorta triage run`` are silent by default --
+    the ``aorta.*`` loggers exist but have no handlers, so INFO-level
+    progress calls are dropped. Without this, a long matrix run prints
+    nothing until the final ``Wrote matrix to ...`` line, leaving
+    operators with no signal that anything is happening.
+
+    ``verbose_count`` follows Click's ``count=True`` convention:
+
+    * ``0``: no-op (default; preserves backwards-compatible silence).
+    * ``1`` (``-v``): INFO -- per-trial / per-cell progress.
+    * ``>=2`` (``-vv``): DEBUG -- also workload-internal logs.
+
+    Output goes to **stderr** so stdout stays clean for the existing
+    ``click.echo`` lines (final pass/fail summary, "to rerun" hint, etc.)
+    that callers may pipe into a parser.
+
+    Idempotent: invoking twice on the same process (tests use
+    ``CliRunner.invoke`` repeatedly) does not stack handlers.
+    """
+    if verbose_count <= 0:
+        return
+    level = logging.DEBUG if verbose_count >= 2 else logging.INFO
+    aorta_logger = logging.getLogger("aorta")
+    # Mark the handler so re-invocation under CliRunner doesn't pile up
+    # duplicates across tests / nested CLI invocations in the same process.
+    if not any(getattr(h, "_aorta_verbose", False) for h in aorta_logger.handlers):
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("[%(asctime)s] %(message)s", datefmt="%H:%M:%S"))
+        handler._aorta_verbose = True  # type: ignore[attr-defined]
+        aorta_logger.addHandler(handler)
+    aorta_logger.setLevel(level)
 
 
 def parse_csv(value: str) -> tuple[str, ...]:

--- a/src/aorta/run/cli_helpers.py
+++ b/src/aorta/run/cli_helpers.py
@@ -46,38 +46,62 @@ def configure_verbose_logging(verbose_count: int) -> None:
     ``verbose_count`` follows Click's ``count=True`` convention:
 
     * ``0``: tear-down / no-op. If a prior call in the same process
-      installed verbosity, this removes it (handler + level reset);
-      otherwise nothing happens.
+      installed verbosity, the marked handler is removed and the logger's
+      ``level`` and ``propagate`` are restored to the values observed at
+      install time (NOT unconditionally reset to NOTSET / True). An
+      embedding application that had configured ``aorta`` itself before
+      invoking the CLI gets its state back. If no prior install exists,
+      the call is a true no-op.
     * ``1`` (``-v``): INFO -- per-trial / per-cell progress.
     * ``>=2`` (``-vv``): DEBUG -- aorta-internal debug logs.
 
     Output goes to **stderr** so stdout stays clean for the existing
     ``click.echo`` lines (final pass/fail summary, "to rerun" hint, etc.)
-    that callers may pipe into a parser.
+    that callers may pipe into a parser. ``aorta_logger.propagate`` is
+    set to ``False`` while verbose is active so a configured root logger
+    (e.g. via ``logging.basicConfig()`` in an embedding app) does not
+    also emit each record -- otherwise every progress line would print
+    twice. Restored on teardown.
 
     Symmetric and idempotent: ``configure_verbose_logging(N)`` followed
-    by ``configure_verbose_logging(0)`` returns the logger to its
-    original NOTSET state. CliRunner-based tests can invoke commands
-    with and without ``-v`` in any order without leaking state.
+    by ``configure_verbose_logging(0)`` returns the logger to its exact
+    original state. CliRunner-based tests can invoke commands with and
+    without ``-v`` in any order without leaking state.
     """
     aorta_logger = logging.getLogger("aorta")
 
     if verbose_count <= 0:
-        # Tear down any handler we previously installed; reset level so
-        # subsequent invocations in the same process truly start silent.
+        # Tear down any handler we previously installed and restore the
+        # exact (level, propagate) we observed at install time. Embedding
+        # applications that had configured the aorta logger themselves
+        # (e.g. ``logging.getLogger("aorta").setLevel(WARNING)``) get
+        # their state back instead of an unconditional NOTSET reset.
         for h in [h for h in aorta_logger.handlers if getattr(h, "_aorta_verbose", False)]:
+            aorta_logger.setLevel(getattr(h, "_aorta_prior_level", logging.NOTSET))
+            aorta_logger.propagate = getattr(h, "_aorta_prior_propagate", True)
             aorta_logger.removeHandler(h)
-        aorta_logger.setLevel(logging.NOTSET)
         return
 
     level = logging.DEBUG if verbose_count >= 2 else logging.INFO
-    # Don't stack duplicate handlers under repeated invocation (CliRunner,
-    # programmatic callers calling the helper twice with -v).
-    if not any(getattr(h, "_aorta_verbose", False) for h in aorta_logger.handlers):
+    existing = next(
+        (h for h in aorta_logger.handlers if getattr(h, "_aorta_verbose", False)),
+        None,
+    )
+    if existing is None:
         handler = logging.StreamHandler(sys.stderr)
         handler.setFormatter(logging.Formatter("[%(asctime)s] %(message)s", datefmt="%H:%M:%S"))
+        # Snapshot prior (level, propagate) so teardown can restore exactly
+        # what the embedding app configured. Capture BEFORE we mutate, and
+        # store on the handler so the restore path is self-contained.
         handler._aorta_verbose = True  # type: ignore[attr-defined]
+        handler._aorta_prior_level = aorta_logger.level  # type: ignore[attr-defined]
+        handler._aorta_prior_propagate = aorta_logger.propagate  # type: ignore[attr-defined]
         aorta_logger.addHandler(handler)
+        # Disable propagation so a configured root logger (e.g. via
+        # ``logging.basicConfig()`` in an embedding app) does not also
+        # emit the same record -- otherwise -v would print every progress
+        # line twice. Restored on teardown.
+        aorta_logger.propagate = False
     aorta_logger.setLevel(level)
 
 

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -203,17 +203,23 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
         results_dir.mkdir(parents=True, exist_ok=True)
 
     # 10. Run trials
-    logger.info(
-        "run_trials: workload=%s environment=%s mitigations=%s trials=%d steps=%s",
-        request.workload,
-        request.environment,
-        list(request.mitigations) or ["(none)"],
-        request.trials,
-        request.steps if request.steps is not None else "(workload default)",
-    )
+    # Gate progress logs on rank 0 -- the same predicate that gates JSON
+    # writes -- so a torchrun-launched workload doesn't emit duplicate
+    # "trial K/N starting" lines from every rank under -v. Non-rank-0
+    # processes still execute the trial; they just don't narrate it.
+    if should_write:
+        logger.info(
+            "run_trials: workload=%s environment=%s mitigations=%s trials=%d steps=%s",
+            request.workload,
+            request.environment,
+            list(request.mitigations) or ["(none)"],
+            request.trials,
+            request.steps if request.steps is not None else "(workload default)",
+        )
     results: list[TrialResult] = []
     for trial_idx in range(request.trials):
-        logger.info("trial %d/%d: starting", trial_idx + 1, request.trials)
+        if should_write:
+            logger.info("trial %d/%d: starting", trial_idx + 1, request.trials)
         trial_t0 = time.perf_counter()
         result = _run_single_trial(
             trial_idx=trial_idx,
@@ -224,17 +230,18 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
             results_dir=results_dir,
             should_write=should_write,
         )
-        # ``TrialResult.result`` is the WorkloadResult-as-dict; .get() so
-        # workloads that omit ``passed`` still classify cleanly.
-        passed = bool(result.result.get("passed"))
-        logger.info(
-            "trial %d/%d: %s in %.1fs (exit_status=%s)",
-            trial_idx + 1,
-            request.trials,
-            "passed" if passed else "FAILED",
-            time.perf_counter() - trial_t0,
-            result.exit_status,
-        )
+        if should_write:
+            # ``TrialResult.result`` is the WorkloadResult-as-dict; .get() so
+            # workloads that omit ``passed`` still classify cleanly.
+            passed = bool(result.result.get("passed"))
+            logger.info(
+                "trial %d/%d: %s in %.1fs (exit_status=%s)",
+                trial_idx + 1,
+                request.trials,
+                "passed" if passed else "FAILED",
+                time.perf_counter() - trial_t0,
+                result.exit_status,
+            )
         results.append(result)
 
     return results

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -203,8 +203,18 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
         results_dir.mkdir(parents=True, exist_ok=True)
 
     # 10. Run trials
+    logger.info(
+        "run_trials: workload=%s environment=%s mitigations=%s trials=%d steps=%s",
+        request.workload,
+        request.environment,
+        list(request.mitigations) or ["(none)"],
+        request.trials,
+        request.steps if request.steps is not None else "(workload default)",
+    )
     results: list[TrialResult] = []
     for trial_idx in range(request.trials):
+        logger.info("trial %d/%d: starting", trial_idx + 1, request.trials)
+        trial_t0 = time.perf_counter()
         result = _run_single_trial(
             trial_idx=trial_idx,
             workload_cls=workload_cls,
@@ -213,6 +223,17 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
             mitigation_env=mitigation_env,
             results_dir=results_dir,
             should_write=should_write,
+        )
+        # ``TrialResult.result`` is the WorkloadResult-as-dict; .get() so
+        # workloads that omit ``passed`` still classify cleanly.
+        passed = bool(result.result.get("passed"))
+        logger.info(
+            "trial %d/%d: %s in %.1fs (exit_status=%s)",
+            trial_idx + 1,
+            request.trials,
+            "passed" if passed else "FAILED",
+            time.perf_counter() - trial_t0,
+            result.exit_status,
         )
         results.append(result)
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+import time
 from pathlib import Path
 from typing import Any
 
@@ -499,7 +500,17 @@ def run_recipe(
     # same errors). No need to re-check here.
 
     cell_stats: list[CellStats] = []
-    for cell in recipe.cells:
+    total_cells = len(recipe.cells)
+    log.info(
+        "matrix run started: workload=%s ticket=%s cells=%d trials/cell=%d steps/trial=%d output=%s",
+        recipe.workload,
+        recipe.ticket or "(none)",
+        total_cells,
+        recipe.trials,
+        recipe.steps,
+        run_dir,
+    )
+    for cell_idx, cell in enumerate(recipe.cells, start=1):
         if cell.environment not in seen_envs:
             env_json_path = env_dir / safe_slug(cell.environment) / "env.json"
             if _is_isolated_environment(
@@ -520,9 +531,43 @@ def run_recipe(
                 )
             seen_envs.add(cell.environment)
 
+        log.info(
+            "cell %d/%d: %s (mitigations=%s environment=%s) -- starting %d trial(s)",
+            cell_idx,
+            total_cells,
+            cell.name,
+            list(cell.mitigations) or ["(none)"],
+            cell.environment,
+            cell.effective_trials(recipe.trials),
+        )
+        cell_t0 = time.perf_counter()
         trials, error, resolved_env_vars, trial_paths = _run_one_cell(
             cell, recipe, run_dir, sidecar_files
         )
+        cell_elapsed = time.perf_counter() - cell_t0
+        if error is not None:
+            log.info(
+                "cell %d/%d: %s -- ERROR (%s) in %.1fs",
+                cell_idx,
+                total_cells,
+                cell.name,
+                error,
+                cell_elapsed,
+            )
+        else:
+            # ``TrialResult.result`` is the WorkloadResult-serialised-to-dict
+            # (see ``aorta/run/results.py`` schema); use ``.get`` so a future
+            # workload that omits the key from its dict still classifies cleanly.
+            passed = sum(1 for t in trials if t.result.get("passed"))
+            log.info(
+                "cell %d/%d: %s -- done in %.1fs [%d/%d trials passed]",
+                cell_idx,
+                total_cells,
+                cell.name,
+                cell_elapsed,
+                passed,
+                len(trials),
+            )
 
         stats = aggregate_cell(
             name=cell.name,


### PR DESCRIPTION
## Why

Both `aorta run` and `aorta triage run` are silent for the entire run by default. A 6-hour `SHAMPOO-NAN-2026-042-v2` production matrix on the MI350 prints nothing until the final `Wrote matrix to <path>` line — operators have no signal whether the run is healthy, blocked on a docker pull, or mid-cell.

## What

A count-style `-v / --verbose` flag on **both** commands, sharing one helper so the wiring is symmetric.

| Command | `-v` (INFO) | `-vv` (DEBUG) |
|---|---|---|
| `aorta run` | per-trial start/finish lines | also workload-internal logs |
| `aorta triage run` | matrix start + per-cell start/finish lines | also workload-internal logs |

Sample `aorta triage run -v` output:
```
[14:02:11] matrix run started: workload=recom_repro ticket=SHAMPOO-NAN-2026-042 cells=12 trials/cell=2 steps/trial=50 output=./aorta_smoke/SHAMPOO-NAN-2026-042/recom_repro/...
[14:02:11] cell 1/12: baseline-nan-repro (mitigations=['none'] environment=nan-repro) -- starting 2 trial(s)
[14:02:11] trial 1/2: starting
[14:03:15] trial 1/2: passed in 64.1s (exit_status=ok)
[14:03:15] trial 2/2: starting
[14:04:21] trial 2/2: FAILED in 65.8s (exit_status=workload_failed)
[14:04:21] cell 1/12: baseline-nan-repro -- done in 130.0s [1/2 trials passed]
[14:04:21] cell 2/12: baseline-fixed (mitigations=['none'] environment=fixed) -- starting 2 trial(s)
...
```

## Implementation

5 files, one new helper, two new CLI options, six log-call sites.

- `src/aorta/run/cli_helpers.py` — adds `configure_verbose_logging(count)`. Installs a stderr `StreamHandler` on the `"aorta"` logger and sets the level. Idempotent (CliRunner-based tests can re-invoke without piling up handlers).
- `src/aorta/cli/run.py` — new `-v / --verbose` Click option; calls the helper.
- `src/aorta/cli/triage.py` — same.
- `src/aorta/run/dispatcher.py` — INFO log calls in the `run_trials` trial loop: matrix-config preamble, per-trial start, per-trial finish (with timing + `exit_status`).
- `src/aorta/triage/runner.py` — INFO log calls in the `run_recipe` cell loop: matrix preamble, per-cell start, per-cell finish (with timing + pass count).

## Wiring verification

Both submodule loggers use `logging.getLogger(__name__)`:
- `aorta.run.dispatcher` (in `dispatcher.py`)
- `aorta.triage.runner` (in `runner.py`)

These are children of the `"aorta"` logger, so the handler the helper installs receives their records via Python's default `propagate=True`.

## Compatibility

- **stdout stays clean.** All verbose output is on stderr; the existing `click.echo` lines (final pass/fail summary in `run`, `Wrote matrix to ...` and `to rerun: ...` in `triage`) are unchanged. Callers piping stdout into a parser are unaffected.
- **No behaviour change without `-v`.** `configure_verbose_logging(0)` is a no-op. Log calls go to a logger with no handlers (existing behaviour) and records are silently dropped.
- **No new dependencies.**

## Tests

Existing tests are unaffected (no `-v` → no log output → no assertion changes). Adding a CliRunner test that invokes `--verbose -v` and asserts a substring of the matrix-start log line lands in `result.output` would be the natural follow-up but isn't required to make this safe to merge.

## Unblocks

[`aorta-internal#14`](https://github.com/ROCm/aorta-internal/issues/14) — SHAMPOO-NAN-2026-042 smoke + production runs on `cv350-rck-g03-c06-18`. Operator was running the smoke matrix and had no way to see progress.