### PR TITLE
B2.1: surface per-trial failure hints in matrix.md / matrix.json

### DIFF
--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -205,18 +205,30 @@ def _collect_trial_hints(trial: Any) -> list[str]:
 
 
 def _aggregate_failure_hints(trials: list[Any]) -> list[tuple[str, int]]:
-    """Deduplicate hints across a cell's trials, preserving first-seen order.
+    """Deduplicate hints across a cell's trials, counting *trials that emitted*.
 
-    Each trial may emit zero or more hints (one per ``failure_details``
-    entry that carries a ``hint``). A hint that appears N times across the
-    cell's trials shows up once with count N. Order is the order each
-    distinct hint string was first encountered while walking trials in
-    input order.
+    Each trial may produce zero or more hint strings (one per
+    ``failure_details`` entry that carries a ``hint``). The count is
+    the number of distinct *trials* that emitted a given hint, NOT the
+    number of total occurrences -- if a single trial emits the same
+    hint twice it counts as 1, not 2. This matches the matrix.md
+    rendering ``({count}/{cell.trials} trials)`` and keeps the count
+    bounded by ``len(trials)`` so the fraction is never impossible.
+
+    Order is the order each distinct hint string was first encountered
+    while walking trials in input order.
     """
     counts: Counter[str] = Counter()
     order: list[str] = []
     for trial in trials:
+        # Dedupe within the trial before counting -- one trial can
+        # legitimately have multiple ``failure_details`` entries (e.g.
+        # multi-phase workloads) and they may share a hint.
+        seen_in_trial: set[str] = set()
         for hint in _collect_trial_hints(trial):
+            if hint in seen_in_trial:
+                continue
+            seen_in_trial.add(hint)
             if hint not in counts:
                 order.append(hint)
             counts[hint] += 1

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -86,6 +86,14 @@ class CellStats:
     this field to refuse cell-vs-baseline ratios whose numerators and
     denominators were derived from incomparable signals (issue #160 /
     Sonbol's review on PR #160).
+
+    ``failure_hints`` is the deduplicated list of one-line ``hint`` strings
+    pulled from each trial's ``result["failure_details"][*]["hint"]``, paired
+    with how many trials in the cell emitted that exact hint. The aggregator
+    treats the hint as opaque text -- the workload owns the contract.
+    Trials with no ``failure_details`` or no ``hint`` key contribute nothing.
+    Order of appearance is preserved (first hint seen comes first) so the
+    matrix.md renderer is stable across runs with the same trial order.
     """
 
     name: str
@@ -109,6 +117,7 @@ class CellStats:
     trial_paths: list[str] = field(default_factory=list)
     error: str | None = None
     step_time_source: StepTimeSource = "missing"
+    failure_hints: list[tuple[str, int]] = field(default_factory=list)
 
     @property
     def failure_rate(self) -> float:
@@ -169,6 +178,49 @@ def _reduce_step_time_sources(sources: list[StepTimeSource]) -> StepTimeSource:
     if not contributing:
         return "missing"
     return max(contributing, key=lambda s: _SOURCE_RANK.get(s, 99))
+
+
+def _collect_trial_hints(trial: Any) -> list[str]:
+    """Return non-empty ``hint`` strings from a trial's ``failure_details``.
+
+    Only the explicit ``hint`` field is considered. Status / returncode /
+    stderr tails are deliberately ignored -- the renderer must not
+    paraphrase failure causes from logs, only surface the workload's own
+    one-line hint when it chose to provide one.
+    """
+    result = getattr(trial, "result", None)
+    if not isinstance(result, dict):
+        return []
+    details = result.get("failure_details")
+    if not isinstance(details, list):
+        return []
+    hints: list[str] = []
+    for entry in details:
+        if not isinstance(entry, dict):
+            continue
+        hint = entry.get("hint")
+        if isinstance(hint, str) and hint:
+            hints.append(hint)
+    return hints
+
+
+def _aggregate_failure_hints(trials: list[Any]) -> list[tuple[str, int]]:
+    """Deduplicate hints across a cell's trials, preserving first-seen order.
+
+    Each trial may emit zero or more hints (one per ``failure_details``
+    entry that carries a ``hint``). A hint that appears N times across the
+    cell's trials shows up once with count N. Order is the order each
+    distinct hint string was first encountered while walking trials in
+    input order.
+    """
+    counts: Counter[str] = Counter()
+    order: list[str] = []
+    for trial in trials:
+        for hint in _collect_trial_hints(trial):
+            if hint not in counts:
+                order.append(hint)
+            counts[hint] += 1
+    return [(hint, counts[hint]) for hint in order]
 
 
 def _trial_passed(trial: Any) -> bool:
@@ -257,6 +309,7 @@ def aggregate_cell(
             trial_paths=list(trial_paths or []),
             error=error,
             step_time_source="missing",
+            failure_hints=_aggregate_failure_hints(trials),
         )
 
     trial_count = len(trials)
@@ -318,6 +371,7 @@ def aggregate_cell(
         trial_paths=list(trial_paths or []),
         error=None,
         step_time_source=cell_source,
+        failure_hints=_aggregate_failure_hints(trials),
     )
 
 

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -159,6 +159,30 @@ def _format_confound(tag: ConfoundTag) -> str:
     return str(tag)
 
 
+def _render_failure_hints(cell_stats: list[CellStats]) -> list[str]:
+    """Build the ``## Failure hints`` section for matrix.md.
+
+    Returns an empty list when no cell carries a hint -- the caller
+    suppresses the section entirely in that case so the markdown does not
+    sprout an empty header for runs where every workload either passed or
+    failed without emitting an explanatory hint.
+
+    One bullet per ``(cell, hint)`` pair: a cell that emits two distinct
+    hints across its trials gets two bullets so each hint stays one line
+    and operators can scan-read. The ``(N/M trials)`` parenthetical reads
+    as "the hint fired in N of the cell's M trials" -- not the cell's
+    failure rate; trials can fail without emitting a hint.
+    """
+    if not any(cell.failure_hints for cell in cell_stats):
+        return []
+    lines = ["## Failure hints", ""]
+    for cell in cell_stats:
+        for hint, count in cell.failure_hints:
+            lines.append(f"- **{cell.name}** ({count}/{cell.trials} trials): {hint}")
+    lines.append("")
+    return lines
+
+
 def write_matrix_md(
     path: Path,
     recipe: Recipe,
@@ -234,6 +258,7 @@ def write_matrix_md(
         lines.append(_row(row))
 
     lines.append("")
+    lines.extend(_render_failure_hints(cell_stats))
     lines.append("## Notes")
     lines.append("")
     lines.append(

--- a/tests/triage/test_matrix.py
+++ b/tests/triage/test_matrix.py
@@ -14,6 +14,7 @@ def _trial(
     total_iterations: int | None = None,
     elapsed_sec: float | None = None,
     wall_clock_sec: float = 1.0,
+    failure_details: list[dict] | None = None,
 ):
     """Build a TrialResult-shaped stand-in. aggregate_cell uses duck typing."""
     result: dict = {"passed": passed}
@@ -23,6 +24,8 @@ def _trial(
         result["total_iterations"] = total_iterations
     if elapsed_sec is not None:
         result["elapsed_sec"] = elapsed_sec
+    if failure_details is not None:
+        result["failure_details"] = failure_details
     return SimpleNamespace(
         exit_status=exit_status,
         wall_clock_sec=wall_clock_sec,
@@ -289,3 +292,80 @@ def test_step_time_source_for_error_cell_is_missing():
     rather than a stale default that implies real timing exists."""
     stats = _default_call(trials=[], error="docker pull failed")
     assert stats.step_time_source == "missing"
+
+
+# ---- failure_hints aggregation -------------------------------------------
+#
+# Workloads that can't run (image / config mismatch, missing dependency)
+# emit an explanatory `hint` string in `failure_details[*].hint`. The
+# aggregator surfaces those at the cell level so matrix.md can show them
+# without a reader having to open per-trial JSON.
+
+
+def test_failure_hints_default_empty_when_no_hints():
+    trials = [_trial(passed=True), _trial(passed=False)]
+    stats = _default_call(trials=trials)
+    assert stats.failure_hints == []
+
+
+def test_failure_hints_collects_and_counts_duplicates():
+    hint = "shampoo import failed: try shampoo_api='old'"
+    trials = [
+        _trial(passed=False, failure_details=[{"status": "crash", "hint": hint}]),
+        _trial(passed=False, failure_details=[{"status": "crash", "hint": hint}]),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.failure_hints == [(hint, 2)]
+
+
+def test_failure_hints_preserve_first_seen_order_with_distinct_hints():
+    h1 = "first hint"
+    h2 = "second hint"
+    trials = [
+        _trial(passed=False, failure_details=[{"hint": h1}]),
+        _trial(passed=False, failure_details=[{"hint": h2}]),
+        _trial(passed=False, failure_details=[{"hint": h1}]),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.failure_hints == [(h1, 2), (h2, 1)]
+
+
+def test_failure_hints_skips_entries_without_hint_key():
+    """A trial that crashed but didn't emit a hint contributes nothing.
+
+    Pin: the aggregator must NOT invent a hint from status / stderr.
+    """
+    trials = [
+        _trial(passed=False, failure_details=[{"status": "crash", "returncode": 1}]),
+        _trial(passed=False, failure_details=[{"hint": "real hint"}]),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.failure_hints == [("real hint", 1)]
+
+
+def test_failure_hints_skips_none_and_empty_hint_values():
+    trials = [
+        _trial(passed=False, failure_details=[{"hint": None}]),
+        _trial(passed=False, failure_details=[{"hint": ""}]),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.failure_hints == []
+
+
+def test_failure_hints_handles_multiple_details_per_trial():
+    trials = [
+        _trial(
+            passed=False,
+            failure_details=[{"hint": "h1"}, {"hint": "h2"}],
+        ),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.failure_hints == [("h1", 1), ("h2", 1)]
+
+
+def test_failure_hints_for_error_cell_reflects_supplied_trials():
+    """Error cells short-circuit numeric aggregation but still expose hints
+    from any trials that did execute before the cell-level error fired."""
+    trials = [_trial(passed=False, failure_details=[{"hint": "boom"}])]
+    stats = _default_call(trials=trials, error="cell crashed")
+    assert stats.failure_hints == [("boom", 1)]

--- a/tests/triage/test_matrix.py
+++ b/tests/triage/test_matrix.py
@@ -363,6 +363,30 @@ def test_failure_hints_handles_multiple_details_per_trial():
     assert stats.failure_hints == [("h1", 1), ("h2", 1)]
 
 
+def test_failure_hints_dedupes_within_trial_so_count_is_bounded_by_trials():
+    """A single trial that emits the same hint in two failure_details entries
+    must contribute 1 to the count, not 2.
+
+    The rendered ``({count}/{cell.trials} trials)`` would otherwise be
+    nonsense (e.g. ``2/1 trials``) once a workload emits multiple
+    ``failure_details`` per trial. Pin the per-trial-presence semantic
+    so the fraction stays interpretable.
+    """
+    trials = [
+        _trial(
+            passed=False,
+            failure_details=[{"hint": "x"}, {"hint": "x"}],
+        ),
+        _trial(
+            passed=False,
+            failure_details=[{"hint": "x"}],
+        ),
+    ]
+    stats = _default_call(trials=trials)
+    # Two trials emitted the hint, even though it appears 3 times across details.
+    assert stats.failure_hints == [("x", 2)]
+
+
 def test_failure_hints_for_error_cell_reflects_supplied_trials():
     """Error cells short-circuit numeric aggregation but still expose hints
     from any trials that did execute before the cell-level error fired."""

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -804,6 +804,82 @@ def test_matrix_md_does_not_overpromise_reproducibility(tmp_path, patched_env, p
     assert "resolved_env_vars" in md
 
 
+# ---- Failure hints surfacing in matrix.md / matrix.json ------------------
+#
+# When a workload returns `failure_details[*].hint`, both outputs must
+# expose the hint at the cell level so a reader can tell "couldn't run"
+# apart from "ran and produced wrong numbers" without opening per-trial
+# JSON.
+
+
+def _fake_trial_with_hint(hint: str) -> _FakeTrial:
+    return _FakeTrial(
+        exit_status="workload_failed",
+        wall_clock_sec=1.0,
+        result={
+            "passed": False,
+            "failure_details": [{"status": "crash", "hint": hint}],
+        },
+    )
+
+
+def test_matrix_md_omits_failure_hints_section_when_no_hints(
+    tmp_path, patched_env, patched_run_trials
+):
+    """No cell carries a hint -> no header, not an empty `## Failure hints`."""
+    r = _simple_recipe(ticket="T-1")
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    md = (run_dir / "matrix.md").read_text()
+    assert "## Failure hints" not in md
+
+
+def test_matrix_md_renders_failure_hints_when_present(tmp_path, patched_env, monkeypatch):
+    """A cell whose trials emit a hint surfaces under `## Failure hints`."""
+    hint = "shampoo import failed: try shampoo_api='old'"
+    monkeypatch.setattr(
+        runner,
+        "run_trials",
+        MagicMock(return_value=[_fake_trial_with_hint(hint), _fake_trial_with_hint(hint)]),
+    )
+    r = _simple_recipe(ticket="T-1")
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    md = (run_dir / "matrix.md").read_text()
+    assert "## Failure hints" in md
+    # One bullet per (cell, hint); both cells share the stub so both fire.
+    assert f"**none-local** (2/2 trials): {hint}" in md
+    assert f"**tf32_off-local** (2/2 trials): {hint}" in md
+    # Section appears between the table and the Notes block.
+    assert md.index("## Failure hints") < md.index("## Notes")
+
+
+def test_matrix_json_records_failure_hints_per_cell(tmp_path, patched_env, monkeypatch):
+    """matrix.json::cells[*].failure_hints exposes the same data structurally."""
+    hint = "shampoo import failed"
+    monkeypatch.setattr(
+        runner,
+        "run_trials",
+        MagicMock(return_value=[_fake_trial_with_hint(hint), _fake_trial_with_hint(hint)]),
+    )
+    r = _simple_recipe(ticket="T-1")
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    doc = json.loads((run_dir / "matrix.json").read_text())
+    for cell in doc["cells"]:
+        # asdict turns tuples into lists; JSON consumers see [hint, count] pairs.
+        assert cell["failure_hints"] == [[hint, 2]]
+
+
+def test_matrix_json_failure_hints_empty_when_none_emitted(
+    tmp_path, patched_env, patched_run_trials
+):
+    """No hints -> field is present-and-empty, not omitted, so consumers
+    can rely on `cells[*].failure_hints` always being a list."""
+    r = _simple_recipe(ticket="T-1")
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    doc = json.loads((run_dir / "matrix.json").read_text())
+    for cell in doc["cells"]:
+        assert cell["failure_hints"] == []
+
+
 def test_isolated_env_check_honors_sidecar_files(
     tmp_path, patched_env, patched_run_trials, monkeypatch
 ):

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -864,7 +864,8 @@ def test_matrix_json_records_failure_hints_per_cell(tmp_path, patched_env, monke
     run_dir = runner.run_recipe(r, output_dir=tmp_path)
     doc = json.loads((run_dir / "matrix.json").read_text())
     for cell in doc["cells"]:
-        # asdict turns tuples into lists; JSON consumers see [hint, count] pairs.
+        # asdict preserves the tuple shape; json.dumps then serializes
+        # tuples as JSON arrays, so consumers see [hint, count] pairs.
         assert cell["failure_hints"] == [[hint, 2]]
 
 


### PR DESCRIPTION
Closes #171.

## Summary

- Surface workload-emitted `failure_details[*].hint` strings at the cell level in both `matrix.md` (new `## Failure hints` section, only rendered when at least one cell has a hint) and `matrix.json` (`cells[*].failure_hints` as `[[hint, count], ...]`).
- Lets a triage operator tell "the workload couldn't run" apart from "the workload ran and produced wrong numbers" without opening per-trial JSON. Concretely: the 2026-05 SHAMPOO triage on `recom_repro` had cells reading `Failure rate: 100% / Confound: no effect` whose actual cause was a SHAMPOO API/image mismatch — invisible in the markdown until now.
- Aggregator only reads the explicit `hint` field — no inference from status / returncode / stderr tails. Hint format is the workload's contract.

## Scope

- `CellStats` gains one new defaulted field (`failure_hints: list[tuple[str, int]]`); existing constructors are unchanged.
- One bullet per `(cell, hint)` pair so a cell with multiple distinct hints stays scannable.
- Section position: between the Reproduction Summary table and `## Notes`. Not added as a new column (would force every row to render `—` for the common no-hint case and lose table signal density).
- Confound classification untouched. The `recom_repro` workload itself is not modified — hint emission lives on the aorta-internal `users/oyazdanb/shampoo_old_api` branch and is referenced only.

## Test plan

- [x] `pytest tests/triage/` — 180/180 passing (29 in `test_matrix.py`, 38 in `test_output_layout.py`)
- [x] 7 new aggregation tests: empty default, dedupe + counts, first-seen order, ignores entries without `hint` key, ignores `None` / empty hint, multiple details per trial, error cells still surface hints
- [x] 4 new rendering tests: section absent when no hints, section rendered + ordered before `## Notes`, `matrix.json` field present-and-empty by default, present with `[[hint, count]]` when hints fire
- [x] Manual render check: spacing clean in both has-hints and no-hints cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
