### PR TITLE
env probe: parsed pytorch_build.build_flags + structured introspection (#170)

### DIFF
--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -334,8 +334,16 @@ tracking schema evolution don't have to read source.
 
 ### `1.2` (current)
 
-Additive only -- 1.1 consumers reading `pytorch_build` get `None` for
-the new fields rather than a missing key.
+Top-level-key-additive -- every new field lives under existing
+top-level dicts (`pytorch_build`, `aiter`), so 1.1 readers loading
+a 1.2 snapshot via `EnvSnapshot.from_dict(...)` do NOT raise and
+existing top-level access still works. Note however that the new
+**nested** keys (`pytorch_build.flags`, `pytorch_build.build_flags`,
+`pytorch_build.binary_introspection`, `aiter.package_dist_name`,
+`aiter.commit`) are NOT backfilled on 1.1 snapshots -- a consumer
+indexing them on a 1.1 snapshot gets a `KeyError`, not `None`. Use
+`.get(key)` or guard on `schema_version` if you read these from
+historical snapshots.
 
 * `pytorch_build.flags` -- structured raw introspection from
   `torch.__config__.show()`: `build_settings` (KEY=VALUE dict from the

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -69,7 +69,7 @@ operator can act on them without `jq`'ing the JSON. A closing
 end-of-output. Sample:
 
 ```text
-Wrote env probe to /tmp/env.json (schema_version=1.1) [PARTIAL]
+Wrote env probe to /tmp/env.json (schema_version=1.2) [PARTIAL]
   runtime:   baremetal / python=venv
   rocm:      7.2.1 (dev: None)
   hip:       7.2.53211-e1a6bc5663 (amd)
@@ -88,6 +88,9 @@ Wrote env probe to /tmp/env.json (schema_version=1.1) [PARTIAL]
   rdhc:      unavailable (system_health=null)
   python:    3.12.13 | pytorch: 2.9.1+rocm7.2.1.gitff65f5bc
   torch build: git_commit=ff65f5bc install=wheel [third_party SHAs: set AORTA_PYTORCH_SRC=<src> or look up github.com/pytorch/pytorch/tree/ff65f5bc/third_party/<name>]
+  torch flags: gpu_archs=[gfx942]  USE_ROCM=ON USE_CUDA=OFF USE_NCCL=ON USE_MKL=OFF USE_MKLDNN=ON USE_FBGEMM=yes USE_FBGEMM_GENAI=no USE_FLASH_ATTENTION=yes USE_MEM_EFF_ATTENTION=yes USE_ROCM_CK_SDPA=yes USE_ROCM_CK_GEMM=no DISABLE_AOTRITON=no FLASH_NAMESPACE=pytorch_flash
+  torch syms:  pytorch_flash::=142 mha_fwd_aot=4 mha_fwd_ck=4 _efficient_attention=18 aotriton::=72 ck_tile::FmhaFwd=1820 ck_tile::FmhaBwd=1240 ck_tile::BlockFmha=890 ck_tile::TileFmha=320 group_gemm_ck=12 aiter::=0  |  libaotriton_v2.so=yes  |  -DUSE_ROCM_CK_SDPA=yes -DUSE_ROCM_CK_GEMM=no
+  flags:       FLASH_ATTN=on CK_SDPA=on AOTRITON=on MEM_EFF=on
 
 Partial reasons:
   - system_health: rdhc exited 1 (stderr: sudo: a password is required)
@@ -142,7 +145,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | Currently `"1.1"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
+| `schema_version` | `str` | constant | Currently `"1.2"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
@@ -159,14 +162,14 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `tensile` | `dict` | optional `import Tensile` + sorted-filenames hash over the union of hipBLASLt + rocBLAS kernel DBs | `package_version` (usually `null` outside builders), `kernel_db_combined_hash` |
 | `triton` | `dict` | `import triton; triton.__version__` | `package_version`. ROCm Triton fork bakes the source commit into `__version__`. |
 | `fbgemm` | `dict` | optional `import fbgemm_gpu` + parse of `torch.__config__.show()` for `-DUSE_FBGEMM*` defines | `package_version`, `pytorch_use_fbgemm`, `pytorch_use_fbgemm_genai`. The two booleans capture the build-time decision baked into the PyTorch wheel even when `fbgemm_gpu` isn't a separate pip package. |
-| `aiter` | `dict` | `import aiter; aiter.__version__` | `package_version`. Most installs record `null`; absence is silent. |
+| `aiter` | `dict` | `import aiter; aiter.__version__` + `importlib.metadata.version("amd_aiter" \| "aiter")` | `package_version`, `package_dist_name` (which PyPI dist matched: `amd_aiter` is the canonical AMD-internal ROCm/PyTorch image dist; `aiter` is the upstream name), `commit` (parsed from the setuptools_scm `+g<sha>` local-version segment, matches the image tag's `aiter-<sha>` label). Most installs record `null` for everything; absence is silent. |
 | `aotriton` | `dict` | scan of `<torch>/lib/libaotriton_v2.so*` filenames + `sha256` of the resolved file + presence of `<torch>/lib/aotriton.images/` + `$AOTRITON_INSTALLED_PREFIX` | Default ROCm Flash Attention backend. Bundled in the wheel via `cmake/External/aotriton.cmake` (NOT a `third_party/` git submodule). Fields: `bundled_present`, `bundled_version`, `bundled_lib_hash`, `bundled_images_dir_present`, `installed_prefix`. CK is the alternative backend (toggled via `TORCH_ROCM_FA_PREFER_CK=1`). |
 | `runtime_context` | `dict` | `/.dockerenv`, `/run/.containerenv`, `$SINGULARITY_NAME`, `/proc/1/cgroup`, `sys.prefix`, `$CONDA_DEFAULT_ENV` | `type`, `python_env`, `venv_path`, `conda_env_name` |
 | `docker` | `dict \| null` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` env vars + `/proc/self/cgroup` | `null` on baremetal; image+digest provided by the launcher (the only reliable way from inside a container) |
 | `env_vars` | `dict[str, str \| null]` | explicit canonical list (currently 31 names; see `CANONICAL_ENV_VARS` in `environment.py` for the live set) | GPU scoping + HSA / runtime + GPU queue / codegen + NCCL/RCCL + FBGEMM + MIOpen + SDPA backend selection + GEMM backend preference + hipBLASLt autotune + PyTorch / inductor. Build-time cmake flags (`USE_ROCM_CK_SDPA`, `USE_ROCM_CK_GEMM`, `USE_FBGEMM*`) are NOT in this list -- they're surfaced under their respective library blocks instead, parsed from `torch.__config__.show()`. |
 | `python_version` | `str` | `platform.python_version()` | always populated |
 | `pytorch_version` | `str \| null` | optional `import torch` (no CUDA/HIP context init) | `null` when torch absent |
-| `pytorch_build` | `dict` | `torch.version.{git_version,hip,cuda,debug}` + install-kind detection + optional `git -C <src>/third_party/<sub> rev-parse HEAD` | `git_commit` is the linchpin -- pins every vendored submodule deterministically. See "PyTorch source-tree submodule probing" below. |
+| `pytorch_build` | `dict` | `torch.version.{git_version,hip,cuda,debug}` + install-kind detection + optional `git -C <src>/third_party/<sub> rev-parse HEAD` + parse of `torch.__config__.show()` + `nm -D libtorch_hip.so \| c++filt` symbol grep + scan of `<torch>/lib/` | `git_commit` is the linchpin -- pins every vendored submodule deterministically. Sub-blocks: `flags` (raw `build_settings`, `cxx_defines`, `cxx_flags_raw`, `cuda_flags_raw`, `gpu_arch_list`), `build_flags` (issue #170 stable 17-key parsed bool/str/None subset, with `CAFFE2_USE_MIOPEN` aliased to `USE_MIOPEN`), `binary_introspection` (`libtorch_hip_symbol_counts`, `torch_lib_bundled`, `cxx_flags_use_defines` -- pure facts, no ON/OFF inference). See "PyTorch source-tree submodule probing" below. |
 
 `runtime_context.type` is one of `"docker" | "podman" | "singularity" | "baremetal"`. Adding values is a schema change.
 
@@ -329,7 +332,41 @@ Mirrors the in-code comment at `SCHEMA_VERSION` in
 `src/aorta/instrumentation/environment.py`. Recorded here so consumers
 tracking schema evolution don't have to read source.
 
-### `1.1` (current)
+### `1.2` (current)
+
+Additive only -- 1.1 consumers reading `pytorch_build` get `None` for
+the new fields rather than a missing key.
+
+* `pytorch_build.flags` -- structured raw introspection from
+  `torch.__config__.show()`: `build_settings` (KEY=VALUE dict from the
+  `Build settings:` block), `cxx_defines` (`-D<NAME>[=<value>]` tokens
+  parsed out of `CXX_FLAGS`), verbatim `cxx_flags_raw` /
+  `cuda_flags_raw`, and `gpu_arch_list` from
+  `torch.cuda.get_arch_list()`.
+* `pytorch_build.build_flags` (issue #170) -- stable 17-key parsed
+  subset projected from `flags`. Boolean-like values (ON/OFF/TRUE/
+  FALSE/1/0, any case) become bools; non-boolean values like
+  `BUILD_TYPE=Release` stay strings; flags absent from
+  `__config__.show()` render as `null`. `CAFFE2_USE_MIOPEN` is treated
+  as an alias for `USE_MIOPEN` (the Caffe2-era spelling some ROCm
+  builds still emit). The brief gains a compact one-liner:
+  `flags: FLASH_ATTN=on CK_SDPA=on AOTRITON=on MEM_EFF=on`.
+* `pytorch_build.binary_introspection` -- `nm | c++filt` substring
+  counts on `libtorch_hip.so` (`pytorch_flash::`, `ck_tile::FmhaFwd`,
+  `aotriton::`, `aiter::`, ...), bundled-lib presence in
+  `<torch>/lib/` (`libaotriton_v2.so`), and presence of specific
+  `-DUSE_*` defines in `CXX_FLAGS`. Pure facts -- a non-zero count
+  proves a code path is compiled in, but a zero count does NOT prove
+  the cmake option was OFF (linker stripping). The CK pytorch-bundled
+  probe and binary_introspection share one `nm` dump per
+  `collect_env()` call via `_HipSymbolDumpCache`.
+* `aiter` -- gained `package_dist_name` (which PyPI dist matched:
+  `amd_aiter` is the AMD-internal ROCm/PyTorch image dist; `aiter` is
+  the upstream name) and `commit` (parsed from the setuptools_scm
+  `+g<sha>` local-version segment, matches the image tag's
+  `aiter-<sha>` label).
+
+### `1.1`
 
 Renames (non-additive -- bumped from `1.0`):
 

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -721,10 +721,13 @@ class EnvSnapshot:
         report ``ON``/``OFF`` directly; CXX_FLAGS-only defines
         (USE_FBGEMM, USE_FLASH_ATTENTION, USE_ROCM_CK_SDPA, ...) report
         the captured value or ``yes`` for value-less defines. Absent
-        defines render as ``no`` when build_settings/cxx_defines were
-        captured, ``?`` when both are unavailable (so the operator can
-        tell "the build did not set this" apart from "we couldn't read
-        the build config").
+        defines render as ``no`` only when ``cxx_defines`` was actually
+        parsed (a real, possibly empty dict from a build whose
+        ``CXX_FLAGS`` we could read); when ``cxx_defines is None``
+        (CXX_FLAGS line missing from ``__config__.show()``) and the
+        flag isn't in ``build_settings`` either, we render ``?`` -- the
+        brief mustn't conflate "we couldn't read the define source"
+        with "the define is absent so the feature is off".
         """
         pb = self.pytorch_build or {}
         flags = pb.get("flags") or {}
@@ -734,15 +737,19 @@ class EnvSnapshot:
         archs = flags.get("gpu_arch_list")
         arch_part = ",".join(archs) if archs else "?"
 
-        # Treat both sources as separate signals: gpu_arch_list comes
-        # from torch.cuda.get_arch_list() while settings/defines come
-        # from torch.__config__.show(). One can populate when the other
-        # fails (e.g. CPU-only wheel, or __config__ raises). When both
-        # build sources are missing, render every cell as `?` so the
-        # brief doesn't falsely claim every flag is OFF.
+        # gpu_arch_list comes from torch.cuda.get_arch_list() and is
+        # independent of __config__.show(); settings/defines come from
+        # __config__.show() and can each be None even when the other
+        # populates (CPU-only wheel, missing CXX_FLAGS line, etc.).
+        # Two unknown signals to track:
+        # * `flags_unavailable`: BOTH config sources missing -> render
+        #   every cell `?` (no opinion at all).
+        # * `defines_unavailable`: CXX_FLAGS source missing -> a flag
+        #   that's also not in build_settings is unknown, NOT off.
         settings_raw = flags.get("build_settings")
         defines_raw = flags.get("cxx_defines")
         flags_unavailable = settings_raw is None and defines_raw is None
+        defines_unavailable = defines_raw is None
         settings = settings_raw or {}
         defines = defines_raw or {}
 
@@ -758,7 +765,7 @@ class EnvSnapshot:
                 value = defines[name]
                 cells.append(f"{name}={value}" if value is not None else f"{name}=yes")
                 continue
-            cells.append(f"{name}=no")
+            cells.append(f"{name}=?" if defines_unavailable else f"{name}=no")
         return f"gpu_archs=[{arch_part}]  " + " ".join(cells)
 
     def _summary_pytorch_binary_introspection_line(self) -> str:
@@ -810,6 +817,13 @@ class EnvSnapshot:
         ``on``/``off`` for booleans, ``?`` for absent (None). The full
         17-key parsed schema lives in env.json under
         ``pytorch_build.build_flags`` for callers that need the rest.
+
+        ``AOTRITON`` is a combined cell: ``DISABLE_AOTRITON`` is a
+        definitive kill-switch and ``USE_AOTRITON`` is the cmake enable.
+        Some builds report only one of the two, so the cell consults
+        both before falling back to ``?`` -- otherwise a build with
+        ``-DDISABLE_AOTRITON`` but no ``USE_AOTRITON=`` setting would
+        render ``?`` despite carrying a definitive disable signal.
         """
         pb = self.pytorch_build or {}
         flags = pb.get("build_flags") or {}
@@ -826,10 +840,22 @@ class EnvSnapshot:
                 return f"{label}=?"
             return f"{label}={value}"
 
+        def aotriton_cell() -> str:
+            use = flags.get("USE_AOTRITON")
+            disable = flags.get("DISABLE_AOTRITON")
+            # Disable is the explicit kill switch and wins on conflict;
+            # check it first so a contradictory build (use=True AND
+            # disable=True) renders the safer "off".
+            if disable is True or use is False:
+                return "AOTRITON=off"
+            if use is True or disable is False:
+                return "AOTRITON=on"
+            return "AOTRITON=?"
+
         return " ".join((
             cell("FLASH_ATTN", "USE_FLASH_ATTENTION"),
             cell("CK_SDPA", "USE_ROCM_CK_SDPA"),
-            cell("AOTRITON", "USE_AOTRITON"),
+            aotriton_cell(),
             cell("MEM_EFF", "USE_MEM_EFF_ATTENTION"),
         ))
 
@@ -2729,23 +2755,33 @@ def _capture_pytorch_binary_introspection(
     }
 
     # ----- bundled libs in torch/lib/ -----
+    # On OSError (missing dir, permission denied, ...) we leave
+    # ``torch_lib_bundled`` as None and add a partial reason -- a failed
+    # scan must NOT report False for every lib, since False is the
+    # definitive "we scanned, the lib isn't there" signal. One iterdir()
+    # per probe (not per lib name) keeps the cost bounded.
     if torch_mod is not None:
         torch_file = getattr(torch_mod, "__file__", None)
         if torch_file:
             torch_lib_dir = Path(torch_file).parent / "lib"
-            bundled: dict[str, bool] = {}
-            for name in _PYTORCH_LIB_BUNDLED_NAMES:
+            try:
+                entries = [p.name for p in torch_lib_dir.iterdir()]
+            except OSError as exc:
+                log.debug("torch/lib/ scan failed: %s", exc)
+                reasons.append(
+                    f"pytorch_build.binary_introspection.torch_lib_bundled: "
+                    f"{torch_lib_dir} scan failed ({type(exc).__name__})"
+                )
+            else:
                 # Match the bare name AND the SONAME-versioned variants
                 # (libaotriton_v2.so, libaotriton_v2.so.0.11.2, ...).
-                try:
-                    bundled[name] = any(
-                        p.name == name or p.name.startswith(f"{name}.")
-                        for p in torch_lib_dir.iterdir()
+                result["torch_lib_bundled"] = {
+                    name: any(
+                        entry == name or entry.startswith(f"{name}.")
+                        for entry in entries
                     )
-                except OSError as exc:
-                    log.debug("torch/lib/ scan failed: %s", exc)
-                    bundled[name] = False
-            result["torch_lib_bundled"] = bundled
+                    for name in _PYTORCH_LIB_BUNDLED_NAMES
+                }
 
     # ----- CXX_FLAGS -DUSE_* presence (authoritative when True;
     # absence does NOT prove the cmake option was OFF -- many ROCm

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -291,6 +291,91 @@ CANONICAL_PYTORCH_SUBMODULES: tuple[str, ...] = (
     "fbgemm",
 )
 
+# Stable subset of compile-time PyTorch flags surfaced as parsed
+# bool/str/None values under ``pytorch_build.build_flags``. Pre-declared
+# so the schema is fixed across PyTorch versions: a flag absent from
+# ``torch.__config__.show()`` renders as ``None`` (distinguishable from
+# ``False``), and the key set never changes from the operator's POV.
+# Order is the issue's priority order -- stable for diff-readability.
+PYTORCH_BUILD_FLAG_NAMES: tuple[str, ...] = (
+    "USE_FLASH_ATTENTION",
+    "USE_ROCM_CK_SDPA",
+    "USE_AOTRITON",
+    "USE_MEM_EFF_ATTENTION",
+    "DISABLE_AOTRITON",
+    "USE_ROCM",
+    "USE_CUDA",
+    "USE_CUDNN",
+    "USE_MIOPEN",
+    "USE_FBGEMM",
+    "USE_FBGEMM_GENAI",
+    "USE_NCCL",
+    "USE_MKL",
+    "USE_MKLDNN",
+    "USE_OPENMP",
+    "USE_KINETO",
+    "BUILD_TYPE",
+)
+
+_PYTORCH_BUILD_FLAG_TRUE = frozenset({"ON", "TRUE", "1"})
+_PYTORCH_BUILD_FLAG_FALSE = frozenset({"OFF", "FALSE", "0"})
+
+
+def _coerce_pytorch_build_flag_value(raw: str) -> bool | str:
+    """ON/OFF/TRUE/FALSE/1/0 (any case) -> bool; anything else stays str.
+
+    Preserves original casing for non-boolean values so ``BUILD_TYPE``
+    surfaces as ``"Release"``, not ``"RELEASE"``.
+    """
+    upper = raw.upper().strip().rstrip(",")
+    if upper in _PYTORCH_BUILD_FLAG_TRUE:
+        return True
+    if upper in _PYTORCH_BUILD_FLAG_FALSE:
+        return False
+    return raw
+
+
+def _project_pytorch_build_flags(
+    flags: dict[str, Any] | None,
+) -> dict[str, bool | str | None]:
+    """Project the stable :data:`PYTORCH_BUILD_FLAG_NAMES` subset out of
+    the structured ``pytorch_build.flags`` block.
+
+    Returns a dict with every name in ``PYTORCH_BUILD_FLAG_NAMES``
+    present. The lookup order is:
+
+    1. ``Build settings:`` KEY=VALUE pairs (the cmake-canonical state
+       reported by ``torch.__config__.show()`` -- the authoritative
+       source for things like ``USE_ROCM=ON``, ``USE_CUDA=OFF``,
+       ``BUILD_TYPE=Release``).
+    2. ``CXX_FLAGS`` ``-D<NAME>[=<value>]`` defines (per-target define
+       injection -- the only place some flags appear, e.g.
+       ``USE_ROCM_CK_SDPA``). A bare ``-D<NAME>`` (no value) renders as
+       ``True`` -- presence-as-define is the cmake convention for "this
+       feature is compiled in".
+    3. Otherwise ``None`` -- distinguishable from ``False`` so callers
+       can tell "the build did not set this" apart from "the build set
+       it OFF".
+
+    No partial reasons are added here: if torch is importable but a
+    particular flag is missing from ``__config__.show()``, that's the
+    upstream build's choice, not a probe failure.
+    """
+    settings = (flags or {}).get("build_settings") or {}
+    defines = (flags or {}).get("cxx_defines") or {}
+    out: dict[str, bool | str | None] = {}
+    for name in PYTORCH_BUILD_FLAG_NAMES:
+        if name in settings:
+            out[name] = _coerce_pytorch_build_flag_value(settings[name])
+        elif name in defines:
+            value = defines[name]
+            out[name] = (
+                True if value is None else _coerce_pytorch_build_flag_value(value)
+            )
+        else:
+            out[name] = None
+    return out
+
 # GitHub URL template printed in `partial_reasons` when the PyTorch
 # source tree is not on disk. The operator reading the partial entry
 # can substitute the captured `git_commit` and resolve the bound
@@ -514,10 +599,12 @@ class EnvSnapshot:
                 f"separate from torch's vendored copy]",
                 # AITER (AMD's CK-based inference kernel lib) is
                 # optional -- some inference stacks pull it in, training
-                # / stock inference don't. Annotate to avoid alarming
+                # / stock inference don't. PyPI dist name is `amd_aiter`;
+                # the `+g<sha>` local-version segment of setuptools_scm
+                # versions encodes the build commit (matches the image
+                # tag's `aiter-<sha>` label). Annotate to avoid alarming
                 # readers who see "not installed".
-                f"  aiter:     {pkg_state(aiter.get('package_version'))} "
-                f"[aiter pip pkg; optional ROCm inference lib]",
+                f"  aiter:     {self._summary_aiter_cell(aiter)}",
                 # AOTriton: default ROCm Flash Attention backend.
                 # Bundled in the wheel; system override possible via
                 # AOTRITON_INSTALLED_PREFIX (rare).
@@ -528,8 +615,26 @@ class EnvSnapshot:
                 f"  rdhc:      {sysh}",
                 f"  python:    {self.python_version} | pytorch: {self.pytorch_version}",
                 f"  torch build: {self._summary_pytorch_build_line()}",
+                f"  torch flags: {self._summary_pytorch_build_flags_line()}",
+                f"  torch syms:  {self._summary_pytorch_binary_introspection_line()}",
+                f"  flags:       {self._summary_stable_build_flags_line()}",
             )
         )
+
+    @staticmethod
+    def _summary_aiter_cell(aiter: dict) -> str:
+        """Render the aiter brief cell with dist + commit when available."""
+        version = aiter.get("package_version")
+        dist = aiter.get("package_dist_name")
+        commit = aiter.get("commit")
+        if not version:
+            return "(not installed) [aiter pip pkg; optional ROCm inference lib]"
+        bits = [version]
+        if commit:
+            bits.append(f"commit={commit[:8]}")
+        if dist:
+            bits.append(f"pip dist={dist}")
+        return " ".join(bits)
 
     def _summary_pytorch_build_line(self) -> str:
         """Single-line summary of the structured pytorch_build block."""
@@ -555,6 +660,134 @@ class EnvSnapshot:
             f"[third_party SHAs: set AORTA_PYTORCH_SRC=<src> or look up "
             f"github.com/pytorch/pytorch/tree/{commit_short}/third_party/<name>]"
         )
+
+    # Subset of build flags worth surfacing in the brief. Tuned to the
+    # SDPA / Flash-Attention / GEMM-backend questions operators actually
+    # ask of `aorta env probe`. The full define dict is in env.json
+    # under pytorch_build.flags.cxx_defines.
+    _SUMMARY_FLAG_NAMES = (
+        "USE_ROCM",
+        "USE_CUDA",
+        "USE_NCCL",
+        "USE_MKLDNN",
+        "USE_FBGEMM",
+        "USE_FBGEMM_GENAI",
+        "USE_MSLK",
+        "USE_FLASH_ATTENTION",
+        "USE_MEM_EFF_ATTENTION",
+        "USE_ROCM_CK_SDPA",
+        "USE_ROCM_CK_GEMM",
+        "DISABLE_AOTRITON",
+        "FLASH_NAMESPACE",
+    )
+
+    def _summary_pytorch_build_flags_line(self) -> str:
+        """Single-line summary of pytorch_build.flags (gpu archs + key defines).
+
+        Two segments: the wheel's compiled gpu_arch list (from
+        ``torch.cuda.get_arch_list()``), then a compact yes/no/value
+        rendering of well-known build flags. Defines that came from
+        ``Build settings`` (USE_ROCM, USE_CUDA, USE_NCCL, USE_MKLDNN)
+        report ``ON``/``OFF`` directly; CXX_FLAGS-only defines
+        (USE_MSLK, USE_FBGEMM, USE_FLASH_ATTENTION, USE_ROCM_CK_SDPA,
+        ...) report the captured value or ``yes`` for value-less defines.
+        Absent defines render as ``no`` so an operator can scan for
+        missing features at a glance.
+        """
+        pb = self.pytorch_build or {}
+        flags = pb.get("flags") or {}
+        if not flags or all(flags.get(k) is None for k in flags):
+            return "(unavailable -- torch import failed or no __config__)"
+
+        archs = flags.get("gpu_arch_list")
+        arch_part = ",".join(archs) if archs else "?"
+
+        settings = flags.get("build_settings") or {}
+        defines = flags.get("cxx_defines") or {}
+
+        cells: list[str] = []
+        for name in self._SUMMARY_FLAG_NAMES:
+            if name in settings:
+                cells.append(f"{name}={settings[name]}")
+                continue
+            if name in defines:
+                value = defines[name]
+                cells.append(f"{name}={value}" if value is not None else f"{name}=yes")
+                continue
+            cells.append(f"{name}=no")
+        return f"gpu_archs=[{arch_part}]  " + " ".join(cells)
+
+    def _summary_pytorch_binary_introspection_line(self) -> str:
+        """Fact-only single-line summary of libtorch_hip.so introspection.
+
+        Three segments, each rendered with the raw observed values
+        (counts, presence booleans). No verdicts -- the operator maps
+        symbol counts to cmake options. Marker counts of ``?`` mean the
+        symbol dump was unavailable (binutils stripped, lib missing,
+        torch broken); ``0`` means we scanned and found none.
+        """
+        pb = self.pytorch_build or {}
+        bi = pb.get("binary_introspection") or {}
+        sym_counts = bi.get("libtorch_hip_symbol_counts") or {}
+        bundled = bi.get("torch_lib_bundled")
+        cxx_defs = bi.get("cxx_flags_use_defines")
+
+        def fmt_count(v: int | None) -> str:
+            return "?" if v is None else str(v)
+
+        sym_part = " ".join(
+            f"{marker.rstrip(':')}={fmt_count(sym_counts.get(marker))}"
+            for marker in _LIBTORCH_HIP_SYMBOL_MARKERS
+        )
+
+        if bundled is None:
+            bundled_part = "torch_lib=?"
+        else:
+            bundled_part = " ".join(
+                f"{name}={'yes' if present else 'no'}"
+                for name, present in bundled.items()
+            )
+
+        if cxx_defs is None:
+            cxx_part = "cxx_defs=?"
+        else:
+            cxx_part = " ".join(
+                f"-D{name}={'yes' if present else 'no'}"
+                for name, present in cxx_defs.items()
+            )
+
+        return f"{sym_part}  |  {bundled_part}  |  {cxx_part}"
+
+    def _summary_stable_build_flags_line(self) -> str:
+        """Compact attention-focused brief for ``pytorch_build.build_flags``.
+
+        Renders the four flags an attention-NaN triage operator scans
+        first: ``flags: FLASH_ATTN=on CK_SDPA=on AOTRITON=on MEM_EFF=on``.
+        ``on``/``off`` for booleans, ``?`` for absent (None). The full
+        17-key parsed schema lives in env.json under
+        ``pytorch_build.build_flags`` for callers that need the rest.
+        """
+        pb = self.pytorch_build or {}
+        flags = pb.get("build_flags") or {}
+        if not flags or all(v is None for v in flags.values()):
+            return "(unavailable -- torch import failed or no __config__)"
+
+        def cell(label: str, key: str) -> str:
+            value = flags.get(key)
+            if value is True:
+                return f"{label}=on"
+            if value is False:
+                return f"{label}=off"
+            if value is None:
+                return f"{label}=?"
+            return f"{label}={value}"
+
+        return " ".join((
+            cell("FLASH_ATTN", "USE_FLASH_ATTENTION"),
+            cell("CK_SDPA", "USE_ROCM_CK_SDPA"),
+            cell("AOTRITON", "USE_AOTRITON"),
+            cell("MEM_EFF", "USE_MEM_EFF_ATTENTION"),
+        ))
 
 
 # ---------------------------------------------------------------------------
@@ -707,7 +940,7 @@ def _disaster_snapshot(
             "pytorch_use_fbgemm": None,
             "pytorch_use_fbgemm_genai": None,
         },
-        aiter={"package_version": None},
+        aiter={"package_version": None, "package_dist_name": None, "commit": None},
         aotriton={
             "bundled_present": False,
             "bundled_version": None,
@@ -758,6 +991,21 @@ def _disaster_snapshot(
                 **{name: None for name in CANONICAL_PYTORCH_SUBMODULES},
                 "_source": None,
             },
+            "flags": {
+                "build_settings": None,
+                "cxx_defines": None,
+                "cxx_flags_raw": None,
+                "cuda_flags_raw": None,
+                "gpu_arch_list": None,
+            },
+            "binary_introspection": {
+                "libtorch_hip_symbol_counts": {
+                    m: None for m in _LIBTORCH_HIP_SYMBOL_MARKERS
+                },
+                "torch_lib_bundled": None,
+                "cxx_flags_use_defines": None,
+            },
+            "build_flags": {name: None for name in PYTORCH_BUILD_FLAG_NAMES},
         },
         partial=True,
         partial_reasons=[*preceding_reasons, unexpected_reason],
@@ -1048,6 +1296,22 @@ _FBGEMM_GENAI_DEFINE_RE = re.compile(r"-DUSE_FBGEMM_GENAI(?![A-Za-z0-9_])")
 # torch.__config__.show() text the FBGEMM probe scans.
 _CK_SDPA_DEFINE_RE = re.compile(r"-DUSE_ROCM_CK_SDPA(?![A-Za-z0-9_])")
 _CK_GEMM_DEFINE_RE = re.compile(r"-DUSE_ROCM_CK_GEMM(?![A-Za-z0-9_])")
+
+# `Build settings:` block in `torch.__config__.show()` is a comma-
+# separated KEY=VALUE list. KEYs are uppercase identifiers; VALUEs may
+# contain spaces, '=' (e.g. CXX_FLAGS), and end at the next ", KEY=" or
+# end-of-string. The lookahead lets us capture multi-word values like
+# CXX_FLAGS without splitting on internal commas.
+_BUILD_SETTINGS_RE = re.compile(r"Build settings:\s*(.+)", re.DOTALL)
+_BUILD_SETTING_PAIR_RE = re.compile(
+    r"([A-Z_][A-Z0-9_]*)=(.*?)(?=,\s+[A-Z_][A-Z0-9_]*=|\s*$)",
+    re.DOTALL,
+)
+
+# Every `-D<NAME>` and `-D<NAME>=<value>` token in a flags string. Used
+# to extract the actionable subset of CXX_FLAGS for build-flag verification
+# (USE_FLASH_ATTENTION, USE_MSLK, USE_ROCM_CK_SDPA, FLASH_NAMESPACE=...).
+_CXX_DEFINE_RE = re.compile(r"-D([A-Za-z_][A-Za-z0-9_]*)(?:=([^\s,]+))?")
 
 # Match libaotriton_v2.so.<MAJOR>.<MINOR>.<PATCH>. Anchored so a stray
 # debug-suffixed variant (e.g. .so.0.11.1.dbg) would NOT match -- we
@@ -1811,69 +2075,88 @@ def _parse_ck_header(text: str | None) -> tuple[str | None, str | None]:
 def _probe_pytorch_bundled_ck(reasons: list[str]) -> dict[str, Any]:
     """Look for ``ck::`` symbols inside ``libtorch_hip.so``.
 
-    Strategy: locate the lib via ``torch.__file__`` (no HIP context init),
-    then run ``nm -D <lib>`` piped through ``c++filt`` and count
+    Strategy: dump the lib's demangled dynamic symbols once via the
+    shared :func:`_dump_pytorch_hip_demangled_symbols` helper, then count
     occurrences of the ``ck::`` namespace prefix. Falls back to
-    ``present=False, symbol_count=None`` plus a partial reason whenever
-    any step is unavailable (torch broken, binutils stripped from the
-    container, subprocess timeout).
+    ``present=False, symbol_count=None`` whenever the symbol dump is
+    unavailable (the helper records the partial reason on its own).
+
+    Demangled symbols routinely look like
+    ``ck::tensor_operation::...``; any line containing ``ck::`` is a CK
+    symbol. Other namespaces whose template parameters contain ``ck::``
+    are themselves CK-related by construction (they reference CK types),
+    so they count.
+    """
+    default = {"present": False, "symbol_count": None}
+    symbol_text = _dump_pytorch_hip_demangled_symbols(
+        reasons, "composable_kernel.pytorch_bundled"
+    )
+    if symbol_text is None:
+        return default
+    symbol_count = sum(1 for line in symbol_text.splitlines() if "ck::" in line)
+    return {"present": symbol_count > 0, "symbol_count": symbol_count}
+
+
+def _dump_pytorch_hip_demangled_symbols(
+    reasons: list[str], reason_prefix: str
+) -> str | None:
+    """Run ``nm -D <libtorch_hip.so> | c++filt`` and return the output.
+
+    Shared by the CK symbol-count probe and the SDPA backend
+    inference probe so we pay the ``nm`` cost (1-2 s on a warm cache,
+    up to 30 s cold) only once per ``collect_env()`` call -- without
+    introducing a module-level cache that would survive across processes
+    and break test isolation.
+
+    Locates the lib via ``torch.__file__`` (no HIP context init).
+    Returns ``None`` for the documented absences listed below; appends
+    a partial reason for genuine failures (torch broken, binutils
+    stripped, subprocess timeout, non-zero exit).
 
     Documented absences that **do not** trigger ``partial=True``:
 
     * ``import torch`` raises ImportError (already captured by the
       ``pytorch_version`` probe -- no need to duplicate the reason).
-    * ``torch.version.hip is None`` (this is a CPU-only PyTorch wheel,
-      so ``libtorch_hip.so`` is legitimately absent by design).
+    * ``torch.version.hip is None`` (CPU-only PyTorch wheel; the lib is
+      legitimately absent by design).
 
-    ``-D`` (dynamic symbols only) is much faster than the full symbol
-    table on a multi-hundred-MB lib while still covering every CK kernel
-    that's actually exposed for dispatch.
+    ``-D --defined-only`` (dynamic, defined symbols) is much faster
+    than the full symbol table on a multi-hundred-MB lib while still
+    covering every dispatch entry-point we care about.
+
+    The ``reason_prefix`` is the partial-reason prefix the calling
+    probe uses (e.g. ``"composable_kernel.pytorch_bundled"``). Keep it
+    grep-consistent with the rest of that probe's reasons.
     """
-    default = {"present": False, "symbol_count": None}
-
-    # Locate libtorch_hip.so via torch.__file__. The helper shares the
-    # same no-HIP-context guarantee as _capture_python_package_version
-    # (only does __import__, never touches torch.cuda).
-    torch_mod = _safe_import_torch(reasons, "composable_kernel.pytorch_bundled")
+    torch_mod = _safe_import_torch(reasons, reason_prefix)
     if torch_mod is None:
-        return default
+        return None
 
-    # CPU-only PyTorch wheel -- there is no HIP code to fingerprint.
-    # ``torch.version.hip`` is the canonical "was this wheel built with
-    # HIP?" signal (None when not). Treat as a documented absence so a
-    # CPU-only wheel doesn't flip ``partial=True`` for the bundled-CK
-    # probe -- but the consumer can still see it from the
-    # ``pytorch_bundled.present=False`` field.
     torch_version = getattr(torch_mod, "version", None)
     if torch_version is not None and getattr(torch_version, "hip", None) is None:
-        return default
+        return None
 
     torch_file = getattr(torch_mod, "__file__", None)
     if not torch_file:
-        reasons.append(
-            "composable_kernel.pytorch_bundled: torch.__file__ unavailable"
-        )
-        return default
+        reasons.append(f"{reason_prefix}: torch.__file__ unavailable")
+        return None
 
     lib_path = Path(torch_file).parent / "lib" / PYTORCH_HIP_LIB_NAME
     if not lib_path.exists():
-        # torch.version.hip claimed HIP support but the lib is missing.
-        # That's not a CPU-only wheel (we caught those above) -- it's a
-        # broken / incomplete install worth flagging.
         reasons.append(
-            f"composable_kernel.pytorch_bundled: {lib_path} not found "
+            f"{reason_prefix}: {lib_path} not found "
             "(torch.version.hip claims HIP but the runtime lib is missing)"
         )
-        return default
+        return None
 
     nm = shutil.which("nm")
     cxxfilt = shutil.which("c++filt")
     if nm is None or cxxfilt is None:
         reasons.append(
-            "composable_kernel.pytorch_bundled: nm/c++filt not on PATH "
-            "(install binutils for symbol-count detection)"
+            f"{reason_prefix}: nm/c++filt not on PATH "
+            "(install binutils for symbol-based detection)"
         )
-        return default
+        return None
 
     try:
         nm_proc = subprocess.run(
@@ -1884,16 +2167,13 @@ def _probe_pytorch_bundled_ck(reasons: list[str]) -> dict[str, Any]:
             check=False,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-        reasons.append(
-            f"composable_kernel.pytorch_bundled: nm invocation failed ({exc})"
-        )
-        return default
+        reasons.append(f"{reason_prefix}: nm invocation failed ({exc})")
+        return None
     if nm_proc.returncode != 0:
         reasons.append(
-            f"composable_kernel.pytorch_bundled: nm exited "
-            f"{nm_proc.returncode} on {lib_path}"
+            f"{reason_prefix}: nm exited {nm_proc.returncode} on {lib_path}"
         )
-        return default
+        return None
 
     try:
         cxxfilt_proc = subprocess.run(
@@ -1905,30 +2185,13 @@ def _probe_pytorch_bundled_ck(reasons: list[str]) -> dict[str, Any]:
             check=False,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-        reasons.append(
-            f"composable_kernel.pytorch_bundled: c++filt invocation failed ({exc})"
-        )
-        return default
+        reasons.append(f"{reason_prefix}: c++filt invocation failed ({exc})")
+        return None
     if cxxfilt_proc.returncode != 0:
-        reasons.append(
-            f"composable_kernel.pytorch_bundled: c++filt exited "
-            f"{cxxfilt_proc.returncode}"
-        )
-        return default
+        reasons.append(f"{reason_prefix}: c++filt exited {cxxfilt_proc.returncode}")
+        return None
 
-    # Count exported symbols in the `ck::` namespace. We use a substring
-    # check (not a regex) for speed; demangled symbols routinely look
-    # like "ck::tensor_operation::..." so any line containing "ck::" is a
-    # CK symbol. This will also include symbols from other namespaces
-    # whose template parameters contain "ck::", but those are themselves
-    # CK-related by construction (they reference CK types), so they count.
-    symbol_count = sum(
-        1 for line in cxxfilt_proc.stdout.splitlines() if "ck::" in line
-    )
-    return {
-        "present": symbol_count > 0,
-        "symbol_count": symbol_count,
-    }
+    return cxxfilt_proc.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -2095,24 +2358,93 @@ def _read_pytorch_fbgemm_flags(
 
 
 def _capture_aiter(reasons: list[str]) -> dict[str, str | None]:
-    """Capture AITER (AMD Iterative kernel library) version.
+    """Capture AITER (AMD Iterative kernel library) identity.
 
-    AITER is a PyPI-distributed ROCm inference kernel library built on
-    top of CK. Most environments don't have it installed; absence is
-    suppressed from partial_reasons.
+    AITER is a ROCm inference kernel library built on top of CK. In the
+    AMD-internal ROCm/PyTorch images it is shipped as a separately
+    pip-installed distribution named ``amd_aiter`` whose import name is
+    ``aiter``. The image tag often encodes the aiter commit (e.g.
+    ``...aiter-9a469a6``); the same SHA appears as the
+    setuptools_scm ``+g<sha>`` local-version segment of
+    ``amd_aiter``'s version (e.g. ``0.1.11.dev32+g9a469a608``).
 
-    Note: upstream PyTorch now vendors AITER as a third_party/ submodule
-    too -- see :func:`_capture_pytorch_build` for the bundled-commit
-    probe. This block only covers the standalone pip distribution.
+    Three layered version sources, first hit wins:
+
+    1. ``aiter.__version__`` (most packages set this).
+    2. ``aiter._version.__version__`` (where ``setuptools_scm`` writes
+       it -- aiter does not re-export from ``aiter/__init__.py``).
+    3. ``importlib.metadata.version("amd_aiter")`` (PyPI dist metadata,
+       works even when import-time C-extension JIT fails).
+
+    Records the dist name we matched and, when the version carries a
+    ``+g<sha>`` suffix, the parsed commit, so consumers can verify the
+    image-tag claim from ``env.json`` alone.
+
+    Note: upstream PyTorch also vendors AITER as a third_party/
+    submodule -- see :func:`_capture_pytorch_build` for the
+    bundled-commit probe. The two paths are independent: an image can
+    have ``amd_aiter`` pip-installed *and* a different aiter SHA pinned
+    inside the torch wheel.
     """
-    return {
-        "package_version": _capture_python_package_version(
-            "aiter",
-            reasons,
-            reason_prefix="aiter.package_version",
-            suppress_missing=True,
-        ),
+    from importlib import metadata as _md
+
+    result: dict[str, str | None] = {
+        "package_version": None,
+        "package_dist_name": None,
+        "commit": None,
     }
+
+    imported = False
+    mod: Any | None = None
+    try:
+        mod = __import__("aiter")
+        imported = True
+    except ImportError:
+        pass
+    except Exception as exc:  # noqa: BLE001 -- defensive
+        log.debug("aiter import for version probe failed: %s", exc)
+        reasons.append(
+            f"aiter.package_version: aiter import raised ({type(exc).__name__})"
+        )
+
+    version: str | None = None
+    if mod is not None:
+        version = getattr(mod, "__version__", None)
+        if version is None:
+            try:
+                from aiter import _version as _aiter_version  # type: ignore[import-not-found]
+
+                version = getattr(_aiter_version, "__version__", None) or None
+            except Exception:  # noqa: BLE001 -- best-effort fallback
+                version = None
+
+    dist_name: str | None = None
+    for candidate in ("amd_aiter", "aiter"):
+        try:
+            dist_version = _md.version(candidate)
+        except _md.PackageNotFoundError:
+            continue
+        except Exception:  # noqa: BLE001 -- defensive
+            continue
+        dist_name = candidate
+        if version is None:
+            version = dist_version
+        break
+
+    if imported and version is None:
+        reasons.append(
+            "aiter.package_version: aiter imported but no __version__, no "
+            "aiter._version.__version__, and no amd_aiter dist metadata"
+        )
+
+    if version:
+        m = re.search(r"\+g([0-9a-f]{7,40})", version)
+        if m:
+            result["commit"] = m.group(1)
+
+    result["package_version"] = version
+    result["package_dist_name"] = dist_name
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -2174,6 +2506,12 @@ def _capture_pytorch_build(reasons: list[str]) -> dict[str, Any]:
         install_kind, source_path, git_commit, reasons
     )
 
+    flags = _capture_pytorch_build_flags(reasons)
+    binary_introspection = _capture_pytorch_binary_introspection(
+        reasons, torch_mod=torch_mod
+    )
+    build_flags = _project_pytorch_build_flags(flags)
+
     return {
         "git_commit": git_commit,
         "hip_version": hip_version,
@@ -2182,6 +2520,266 @@ def _capture_pytorch_build(reasons: list[str]) -> dict[str, Any]:
         "install_kind": install_kind,
         "source_path": str(source_path) if source_path else None,
         "submodule_commits": submodule_commits,
+        "flags": flags,
+        "build_flags": build_flags,
+        "binary_introspection": binary_introspection,
+    }
+
+
+# Substring markers grep'd against the demangled dynamic symbol table
+# of ``libtorch_hip.so``. Pure facts: each entry is a substring whose
+# count we report. We do NOT map these to ON/OFF verdicts for cmake
+# options like USE_FLASH_ATTENTION -- that mapping is the operator's
+# call (a non-zero count proves "this code path is compiled into the
+# wheel", but a zero count does NOT prove the option was OFF -- the
+# linker may have stripped unreferenced symbols, the code may live in
+# a different .so, or our marker may be wrong for a future rename).
+_LIBTORCH_HIP_SYMBOL_MARKERS: tuple[str, ...] = (
+    # ---- FLASH_NAMESPACE-defaulted FA wrappers ----
+    # Substring matches every pytorch_flash::* variant
+    # (mha_fwd, mha_bwd, mha_varlen_{fwd,bwd}, plus their _aot and _ck
+    # backend specialisations). Reported as one count.
+    "pytorch_flash::",
+    # The two backend-specialised FA wrappers, reported individually so
+    # the operator can tell which backend(s) are actually compiled in:
+    # _aot = AOTriton-driven path, _ck = CK-driven path. Names verified
+    # against pytorch/aten/src/ATen/native/transformers/hip/flash_attn/.
+    "mha_fwd_aot",
+    "mha_fwd_ck",
+    # ---- mem-eff attention ----
+    # at::_efficient_attention_{forward,backward} + at::cuda:: variants.
+    # Substring is unique to this op family.
+    "_efficient_attention",
+    # ---- AOTriton ----
+    # aotriton::TensorView / aotriton::* runtime adapter symbols
+    # (sdp::aotriton_adapter::mk_aotensor uses these types).
+    "aotriton::",
+    # ---- CK Tile FMHA kernel zoo ----
+    # The CK SDPA path lives under `ck_tile::` with templated kernel /
+    # pipeline / shape types. Substrings are case-sensitive and match
+    # the actual demangled names in libtorch_hip.so (verified against
+    # the cksdpa image -- 5500+ symbols). Each marker is reported
+    # individually so a renamed family only loses one row.
+    "ck_tile::FmhaFwd",
+    "ck_tile::FmhaBwd",
+    "ck_tile::BlockFmha",
+    "ck_tile::TileFmha",
+    # ---- CK GEMM (separate from CK SDPA) ----
+    # at::hip::detail::group_gemm_ck and friends.
+    "group_gemm_ck",
+    # ---- Vendored aiter inside libtorch_hip.so ----
+    # When PyTorch is built with its third_party/aiter submodule wired
+    # in (USE_AITER-style flag), aiter:: symbols (e.g.
+    # `aiter::mha_bwd`) appear directly in libtorch_hip. This is
+    # SEPARATE from the standalone `amd_aiter` pip dist captured under
+    # the top-level `aiter` block.
+    "aiter::",
+)
+
+# Bundled shared libs in ``torch/lib/`` worth surfacing. Presence-only,
+# no inference. ``libaotriton_v2.so`` is the AOTriton runtime; its
+# bundling is decided at PyTorch build time by USE_AOTRITON +
+# AOTRITON_INSTALL_FROM_SOURCE / cmake/External/aotriton.cmake.
+_PYTORCH_LIB_BUNDLED_NAMES: tuple[str, ...] = ("libaotriton_v2.so",)
+
+
+def _capture_pytorch_binary_introspection(
+    reasons: list[str],
+    torch_mod: Any | None,
+) -> dict[str, Any]:
+    """Direct facts about the compiled PyTorch wheel -- no inference.
+
+    Three fact buckets, each independently None when the source isn't
+    available:
+
+    * ``libtorch_hip_symbol_counts`` -- count of demangled dynamic
+      symbols in ``libtorch_hip.so`` matching each substring in
+      :data:`_LIBTORCH_HIP_SYMBOL_MARKERS`. ``None`` for every marker
+      when binutils is unavailable, the lib is missing, or the wheel
+      is CPU-only (``torch.version.hip is None``).
+    * ``torch_lib_bundled`` -- ``{lib_name: bool}`` for each entry in
+      :data:`_PYTORCH_LIB_BUNDLED_NAMES`. ``None`` (whole dict) when
+      ``torch.__file__`` is unreadable.
+    * ``cxx_flags_use_defines`` -- presence of specific ``-DUSE_*``
+      defines in the host-side ``CXX_FLAGS`` reported by
+      ``torch.__config__.show()``. ``None`` (whole dict) when
+      ``__config__.show()`` is unavailable.
+
+    Why no verdicts: PyTorch's CMake options (USE_FLASH_ATTENTION,
+    USE_MEM_EFF_ATTENTION, USE_AOTRITON, USE_ROCM_CK_SDPA, ...) are
+    not stored in the wheel; CMakeCache.txt isn't shipped. Symbol
+    presence proves the option was ON at build time, but symbol
+    *absence* does not prove OFF (linker stripping, namespace renames,
+    code in a different .so). The operator reads the counts and draws
+    the conclusion.
+    """
+    result: dict[str, Any] = {
+        "libtorch_hip_symbol_counts": {m: None for m in _LIBTORCH_HIP_SYMBOL_MARKERS},
+        "torch_lib_bundled": None,
+        "cxx_flags_use_defines": None,
+    }
+
+    # ----- bundled libs in torch/lib/ -----
+    if torch_mod is not None:
+        torch_file = getattr(torch_mod, "__file__", None)
+        if torch_file:
+            torch_lib_dir = Path(torch_file).parent / "lib"
+            bundled: dict[str, bool] = {}
+            for name in _PYTORCH_LIB_BUNDLED_NAMES:
+                # Match the bare name AND the SONAME-versioned variants
+                # (libaotriton_v2.so, libaotriton_v2.so.0.11.2, ...).
+                try:
+                    bundled[name] = any(
+                        p.name == name or p.name.startswith(f"{name}.")
+                        for p in torch_lib_dir.iterdir()
+                    )
+                except OSError as exc:
+                    log.debug("torch/lib/ scan failed: %s", exc)
+                    bundled[name] = False
+            result["torch_lib_bundled"] = bundled
+
+    # ----- CXX_FLAGS -DUSE_* presence (authoritative when True;
+    # absence does NOT prove the cmake option was OFF -- many ROCm
+    # USE_* defines are only injected into HIPCC per-target flags) -----
+    cxx_define_names = ("USE_ROCM_CK_SDPA", "USE_ROCM_CK_GEMM")
+    if torch_mod is not None:
+        config = getattr(torch_mod, "__config__", None)
+        show = getattr(config, "show", None)
+        if show is not None:
+            try:
+                cfg_text = show()
+            except Exception:  # noqa: BLE001 -- other probes record this already
+                cfg_text = ""
+            if cfg_text:
+                cxx_pairs: dict[str, bool] = {}
+                for name in cxx_define_names:
+                    pattern = re.compile(rf"-D{re.escape(name)}(?![A-Za-z0-9_])")
+                    cxx_pairs[name] = bool(pattern.search(cfg_text))
+                result["cxx_flags_use_defines"] = cxx_pairs
+
+    # ----- libtorch_hip.so symbol counts (shared nm dump) -----
+    symbols = _dump_pytorch_hip_demangled_symbols(
+        reasons, "pytorch_build.binary_introspection"
+    )
+    if symbols is not None:
+        counts: dict[str, int] = {marker: 0 for marker in _LIBTORCH_HIP_SYMBOL_MARKERS}
+        for line in symbols.splitlines():
+            for marker in _LIBTORCH_HIP_SYMBOL_MARKERS:
+                if marker in line:
+                    counts[marker] += 1
+        result["libtorch_hip_symbol_counts"] = counts
+
+    return result
+
+
+def _capture_pytorch_build_flags(reasons: list[str]) -> dict[str, Any]:
+    """Capture compile-time flags baked into the PyTorch wheel.
+
+    Two introspection paths -- both work for wheel installs (no build
+    artifacts on disk required):
+
+    * ``torch.__config__.show()`` -- the host-side build config string.
+      Yields a structured ``Build settings`` KEY=VALUE block plus the
+      verbatim ``CXX_FLAGS`` / ``CUDA_FLAGS`` from cmake. We parse all
+      ``-D<NAME>[=<value>]`` defines out of CXX_FLAGS into a dict so
+      consumers can verify presence cheaply
+      (``"USE_FLASH_ATTENTION" in flags["cxx_defines"]``).
+    * ``torch.cuda.get_arch_list()`` -- the authoritative list of GPU
+      architectures the wheel was compiled for (e.g. ``["gfx942",
+      "gfx950"]``). Reads compiled-in metadata, no HIP context init.
+
+    Captured fields (``None`` when torch is absent or __config__ raises):
+
+    * ``build_settings`` -- dict of KEY=VALUE from the ``Build settings:``
+      block (USE_CUDA, USE_ROCM, USE_NCCL, USE_MKLDNN, BUILD_TYPE,
+      COMMIT_SHA, BLAS_INFO, ...). Values kept as captured strings
+      ("ON"/"OFF" or non-boolean for BUILD_TYPE etc.); no coercion.
+    * ``cxx_defines`` -- dict mapping each ``-D`` define name from
+      ``CXX_FLAGS`` to its value (or ``None`` for value-less defines).
+      The actionable subset of ``cxx_flags_raw``.
+    * ``cxx_flags_raw`` / ``cuda_flags_raw`` -- the verbatim flag
+      strings, preserved for grep over non-define args
+      (``-fgpu-flush-denormals-to-zero``, ``-Wno-...``, ``-I`` paths).
+    * ``gpu_arch_list`` -- ``torch.cuda.get_arch_list()`` output.
+
+    Limitation: ``torch.__config__.show()`` reports only host-side C++
+    flags. PyTorch's ATen-hip target applies many additional defines
+    *only* when invoking HIPCC on .hip files (CK_TILE_FMHA_FWD_FAST_EXP2,
+    AITER_ASM_DIR, HIPBLASLT_HAS_GETINDEXFROMALGO, HIPBLAS_V2,
+    USE_FLASH_ATTENTION on some builds, the various warning
+    suppressions, ...). Those are NOT recoverable from a wheel install
+    -- they live in the build's ``compile_commands.json`` which is not
+    shipped. For source/editable installs they could be read via the
+    cmake-generated commands DB, but that path is out of scope for this
+    probe (the env-probe runtime budget is ~5 s and parsing
+    compile_commands.json alone costs more than that).
+    """
+    default: dict[str, Any] = {
+        "build_settings": None,
+        "cxx_defines": None,
+        "cxx_flags_raw": None,
+        "cuda_flags_raw": None,
+        "gpu_arch_list": None,
+    }
+
+    torch_mod = _safe_import_torch(reasons, "pytorch_build.flags")
+    if torch_mod is None:
+        return default
+
+    arch_list: list[str] | None = None
+    try:
+        cuda_mod = getattr(torch_mod, "cuda", None)
+        getter = getattr(cuda_mod, "get_arch_list", None) if cuda_mod else None
+        if getter is not None:
+            arch_list = list(getter())
+    except Exception as exc:  # noqa: BLE001 -- defensive
+        log.debug("torch.cuda.get_arch_list() raised: %s", exc)
+        reasons.append(
+            f"pytorch_build.flags.gpu_arch_list: torch.cuda.get_arch_list() "
+            f"raised ({type(exc).__name__})"
+        )
+
+    config = getattr(torch_mod, "__config__", None)
+    show = getattr(config, "show", None)
+    if show is None:
+        reasons.append("pytorch_build.flags: torch.__config__.show unavailable")
+        result = dict(default)
+        result["gpu_arch_list"] = arch_list
+        return result
+    try:
+        config_text = show()
+    except Exception as exc:  # noqa: BLE001 -- defensive
+        log.debug("torch.__config__.show() for build flags raised: %s", exc)
+        reasons.append(
+            f"pytorch_build.flags: torch.__config__.show() raised "
+            f"({type(exc).__name__})"
+        )
+        result = dict(default)
+        result["gpu_arch_list"] = arch_list
+        return result
+
+    settings: dict[str, str] = {}
+    m = _BUILD_SETTINGS_RE.search(config_text)
+    if m:
+        for pair in _BUILD_SETTING_PAIR_RE.finditer(m.group(1)):
+            settings[pair.group(1)] = pair.group(2).strip().rstrip(",").strip()
+
+    cxx_flags_raw = settings.get("CXX_FLAGS")
+    cuda_flags_raw = settings.get("CUDA_FLAGS")
+    cxx_defines: dict[str, str | None] | None = None
+    if cxx_flags_raw is not None:
+        defines: dict[str, str | None] = {}
+        for d in _CXX_DEFINE_RE.finditer(cxx_flags_raw):
+            defines[d.group(1)] = d.group(2)
+        # JSON-stable ordering for diff-friendly output.
+        cxx_defines = {k: defines[k] for k in sorted(defines)}
+
+    return {
+        "build_settings": settings or None,
+        "cxx_defines": cxx_defines,
+        "cxx_flags_raw": cxx_flags_raw,
+        "cuda_flags_raw": cuda_flags_raw,
+        "gpu_arch_list": arch_list,
     }
 
 

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -62,8 +62,26 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.1"
-# 1.0 -> 1.1 (this commit):
+SCHEMA_VERSION = "1.2"
+# 1.1 -> 1.2 (this commit):
+#   - Added `pytorch_build.flags` (build_settings, cxx_defines,
+#     cxx_flags_raw, cuda_flags_raw, gpu_arch_list) -- structured raw
+#     introspection from `torch.__config__.show()`.
+#   - Added `pytorch_build.build_flags` (issue #170) -- stable 17-key
+#     parsed bool/str/None subset projected from the structured flags
+#     block; CAFFE2_USE_MIOPEN is treated as an alias for USE_MIOPEN.
+#   - Added `pytorch_build.binary_introspection`
+#     (libtorch_hip_symbol_counts, torch_lib_bundled,
+#     cxx_flags_use_defines) -- pure-fact symbol counts and bundled-lib
+#     presence from libtorch_hip.so via `nm | c++filt`.
+#   - Extended `aiter` block: added `package_dist_name` (PyPI dist
+#     identity, `amd_aiter` vs `aiter`) and `commit` (parsed from the
+#     setuptools_scm `+g<sha>` local-version segment, matches the image
+#     tag's `aiter-<sha>` label).
+#   All purely additive -- 1.1 consumers reading the new fields off a
+#   1.2 snapshot get None where they used to get nothing.
+#
+# 1.0 -> 1.1:
 #   - Renamed hipblaslt/rocblas/miopen.commit -> .rocm_release_tweak
 #     (the field's value is the ROCm-release-shared identifier, not a
 #     per-library upstream commit -- the old name misled consumers).
@@ -320,6 +338,16 @@ PYTORCH_BUILD_FLAG_NAMES: tuple[str, ...] = (
 _PYTORCH_BUILD_FLAG_TRUE = frozenset({"ON", "TRUE", "1"})
 _PYTORCH_BUILD_FLAG_FALSE = frozenset({"OFF", "FALSE", "0"})
 
+# Aliases under which a PyTorch build may report a flag in
+# `torch.__config__.show()`. Some flags have a Caffe2-era spelling that
+# upstream still emits on certain ROCm builds (CAFFE2_USE_MIOPEN being
+# the canonical example -- per issue #170). Lookup tries the aliases in
+# order; first hit wins. Canonical name (the key) is what surfaces in
+# `pytorch_build.build_flags`.
+_PYTORCH_BUILD_FLAG_ALIASES: dict[str, tuple[str, ...]] = {
+    "USE_MIOPEN": ("USE_MIOPEN", "CAFFE2_USE_MIOPEN"),
+}
+
 
 def _coerce_pytorch_build_flag_value(raw: str) -> bool | str:
     """ON/OFF/TRUE/FALSE/1/0 (any case) -> bool; anything else stays str.
@@ -365,15 +393,17 @@ def _project_pytorch_build_flags(
     defines = (flags or {}).get("cxx_defines") or {}
     out: dict[str, bool | str | None] = {}
     for name in PYTORCH_BUILD_FLAG_NAMES:
-        if name in settings:
-            out[name] = _coerce_pytorch_build_flag_value(settings[name])
-        elif name in defines:
-            value = defines[name]
-            out[name] = (
-                True if value is None else _coerce_pytorch_build_flag_value(value)
-            )
-        else:
-            out[name] = None
+        out[name] = None
+        for alias in _PYTORCH_BUILD_FLAG_ALIASES.get(name, (name,)):
+            if alias in settings:
+                out[name] = _coerce_pytorch_build_flag_value(settings[alias])
+                break
+            if alias in defines:
+                value = defines[alias]
+                out[name] = (
+                    True if value is None else _coerce_pytorch_build_flag_value(value)
+                )
+                break
     return out
 
 # GitHub URL template printed in `partial_reasons` when the PyTorch
@@ -1336,7 +1366,7 @@ _BUILD_SETTING_PAIR_RE = re.compile(
 
 # Every `-D<NAME>` and `-D<NAME>=<value>` token in a flags string. Used
 # to extract the actionable subset of CXX_FLAGS for build-flag verification
-# (USE_FLASH_ATTENTION, USE_MSLK, USE_ROCM_CK_SDPA, FLASH_NAMESPACE=...).
+# (USE_FLASH_ATTENTION, USE_MKL, USE_ROCM_CK_SDPA, FLASH_NAMESPACE=...).
 _CXX_DEFINE_RE = re.compile(r"-D([A-Za-z_][A-Za-z0-9_]*)(?:=([^\s,]+))?")
 
 # Match libaotriton_v2.so.<MAJOR>.<MINOR>.<PATCH>. Anchored so a stray
@@ -2737,6 +2767,14 @@ def _capture_pytorch_binary_introspection(
                 result["cxx_flags_use_defines"] = cxx_pairs
 
     # ----- libtorch_hip.so symbol counts (shared nm dump) -----
+    # Caller signals torch unavailability with torch_mod=None; respect
+    # that and skip the symbol dump entirely. Otherwise the cache would
+    # still attempt its own torch import, which on a host with torch
+    # actually installed would populate symbol_counts despite the
+    # caller's "no torch" intent and contradict the default-shape
+    # contract documented in the docstring.
+    if torch_mod is None:
+        return result
     if hip_symbol_cache is None:
         hip_symbol_cache = _HipSymbolDumpCache()
     symbols = hip_symbol_cache.get(

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -348,6 +348,13 @@ _PYTORCH_BUILD_FLAG_ALIASES: dict[str, tuple[str, ...]] = {
     "USE_MIOPEN": ("USE_MIOPEN", "CAFFE2_USE_MIOPEN"),
 }
 
+# Flags whose value is a string (e.g. ``BUILD_TYPE=Release``), not a
+# cmake boolean. The "absent define = OFF" cmake convention does NOT
+# apply to these -- their absence means "the build did not emit a
+# value", which is unknown rather than False. Used by the projection
+# helper to decide what to fill in when neither source has the flag.
+_PYTORCH_BUILD_FLAG_NON_BOOLEAN: frozenset[str] = frozenset({"BUILD_TYPE"})
+
 
 def _coerce_pytorch_build_flag_value(raw: str) -> bool | str:
     """ON/OFF/TRUE/FALSE/1/0 (any case) -> bool; anything else stays str.
@@ -381,29 +388,53 @@ def _project_pytorch_build_flags(
        ``USE_ROCM_CK_SDPA``). A bare ``-D<NAME>`` (no value) renders as
        ``True`` -- presence-as-define is the cmake convention for "this
        feature is compiled in".
-    3. Otherwise ``None`` -- distinguishable from ``False`` so callers
-       can tell "the build did not set this" apart from "the build set
-       it OFF".
+    3. Not found in either source. Two sub-cases:
+
+       a. **Both sources were parsed** (``build_settings`` AND
+          ``cxx_defines`` are non-None dicts -- the typical case for a
+          successful ``__config__.show()`` capture): the cmake
+          convention applies -- absent boolean flag means OFF, so
+          render ``False``. Non-boolean flags
+          (:data:`_PYTORCH_BUILD_FLAG_NON_BOOLEAN`, currently just
+          ``BUILD_TYPE``) keep ``None`` -- their value is freeform and
+          absence is unknown, not "off". This matches the existing
+          :func:`_read_pytorch_ck_flags` convention and the issue #170
+          acceptance bullet "USE_ROCM_CK_SDPA == false on builds
+          without CK SDPA".
+
+       b. **At least one source is None** (partial capture): render
+          ``None`` -- we can't be sure the flag isn't in the unread
+          source.
 
     No partial reasons are added here: if torch is importable but a
     particular flag is missing from ``__config__.show()``, that's the
     upstream build's choice, not a probe failure.
     """
-    settings = (flags or {}).get("build_settings") or {}
-    defines = (flags or {}).get("cxx_defines") or {}
+    settings_raw = (flags or {}).get("build_settings")
+    defines_raw = (flags or {}).get("cxx_defines")
+    settings = settings_raw or {}
+    defines = defines_raw or {}
+    both_sources_parsed = settings_raw is not None and defines_raw is not None
     out: dict[str, bool | str | None] = {}
     for name in PYTORCH_BUILD_FLAG_NAMES:
-        out[name] = None
+        found = False
         for alias in _PYTORCH_BUILD_FLAG_ALIASES.get(name, (name,)):
             if alias in settings:
                 out[name] = _coerce_pytorch_build_flag_value(settings[alias])
+                found = True
                 break
             if alias in defines:
                 value = defines[alias]
                 out[name] = (
                     True if value is None else _coerce_pytorch_build_flag_value(value)
                 )
+                found = True
                 break
+        if not found:
+            if both_sources_parsed and name not in _PYTORCH_BUILD_FLAG_NON_BOOLEAN:
+                out[name] = False
+            else:
+                out[name] = None
     return out
 
 # GitHub URL template printed in `partial_reasons` when the PyTorch
@@ -786,8 +817,12 @@ class EnvSnapshot:
         def fmt_count(v: int | None) -> str:
             return "?" if v is None else str(v)
 
+        # Markers are kept verbatim (including the trailing `::`
+        # namespace suffix) so the brief matches the JSON keys and stays
+        # readable as C++ -- `pytorch_flash::=142` is unambiguous;
+        # `pytorch_flash=142` would suggest a function/var name.
         sym_part = " ".join(
-            f"{marker.rstrip(':')}={fmt_count(sym_counts.get(marker))}"
+            f"{marker}={fmt_count(sym_counts.get(marker))}"
             for marker in _LIBTORCH_HIP_SYMBOL_MARKERS
         )
 
@@ -2641,7 +2676,10 @@ def _capture_pytorch_build(
 
     flags = _capture_pytorch_build_flags(reasons)
     binary_introspection = _capture_pytorch_binary_introspection(
-        reasons, torch_mod=torch_mod, hip_symbol_cache=hip_symbol_cache
+        reasons,
+        torch_mod=torch_mod,
+        flags=flags,
+        hip_symbol_cache=hip_symbol_cache,
     )
     build_flags = _project_pytorch_build_flags(flags)
 
@@ -2720,6 +2758,7 @@ def _capture_pytorch_binary_introspection(
     reasons: list[str],
     torch_mod: Any | None,
     *,
+    flags: dict[str, Any] | None = None,
     hip_symbol_cache: _HipSymbolDumpCache | None = None,
 ) -> dict[str, Any]:
     """Direct facts about the compiled PyTorch wheel -- no inference.
@@ -2785,22 +2824,20 @@ def _capture_pytorch_binary_introspection(
 
     # ----- CXX_FLAGS -DUSE_* presence (authoritative when True;
     # absence does NOT prove the cmake option was OFF -- many ROCm
-    # USE_* defines are only injected into HIPCC per-target flags) -----
+    # USE_* defines are only injected into HIPCC per-target flags). The
+    # field's contract is "presence of `-DNAME` in the host-side
+    # CXX_FLAGS string", so we scan ONLY cxx_flags_raw -- not the full
+    # `__config__.show()` text, which would also match `-DNAME` tokens
+    # that landed in CUDA_FLAGS or in unrelated lines and over-claim
+    # presence in CXX flags. -----
     cxx_define_names = ("USE_ROCM_CK_SDPA", "USE_ROCM_CK_GEMM")
-    if torch_mod is not None:
-        config = getattr(torch_mod, "__config__", None)
-        show = getattr(config, "show", None)
-        if show is not None:
-            try:
-                cfg_text = show()
-            except Exception:  # noqa: BLE001 -- other probes record this already
-                cfg_text = ""
-            if cfg_text:
-                cxx_pairs: dict[str, bool] = {}
-                for name in cxx_define_names:
-                    pattern = re.compile(rf"-D{re.escape(name)}(?![A-Za-z0-9_])")
-                    cxx_pairs[name] = bool(pattern.search(cfg_text))
-                result["cxx_flags_use_defines"] = cxx_pairs
+    cxx_flags_raw = (flags or {}).get("cxx_flags_raw")
+    if cxx_flags_raw is not None:
+        cxx_pairs: dict[str, bool] = {}
+        for name in cxx_define_names:
+            pattern = re.compile(rf"-D{re.escape(name)}(?![A-Za-z0-9_])")
+            cxx_pairs[name] = bool(pattern.search(cxx_flags_raw))
+        result["cxx_flags_use_defines"] = cxx_pairs
 
     # ----- libtorch_hip.so symbol counts (shared nm dump) -----
     # Caller signals torch unavailability with torch_mod=None; respect

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -2255,16 +2255,27 @@ class _HipSymbolDumpCache:
         self._cached = False
         self._symbols: str | None = None
 
-    def get(self, reasons: list[str], reason_prefix: str) -> str | None:
+    def get(
+        self,
+        reasons: list[str],
+        reason_prefix: str,
+        *,
+        torch_mod: Any | None = None,
+    ) -> str | None:
         if self._cached:
             return self._symbols
-        self._symbols = _dump_pytorch_hip_demangled_symbols(reasons, reason_prefix)
+        self._symbols = _dump_pytorch_hip_demangled_symbols(
+            reasons, reason_prefix, torch_mod=torch_mod,
+        )
         self._cached = True
         return self._symbols
 
 
 def _dump_pytorch_hip_demangled_symbols(
-    reasons: list[str], reason_prefix: str
+    reasons: list[str],
+    reason_prefix: str,
+    *,
+    torch_mod: Any | None = None,
 ) -> str | None:
     """Run ``nm -D <libtorch_hip.so> | c++filt`` and return the output.
 
@@ -2293,8 +2304,18 @@ def _dump_pytorch_hip_demangled_symbols(
     The ``reason_prefix`` is the partial-reason prefix the calling
     probe uses (e.g. ``"composable_kernel.pytorch_bundled"``). Keep it
     grep-consistent with the rest of that probe's reasons.
+
+    ``torch_mod`` lets a caller supply an already-imported torch module
+    so the dump describes the SAME installation other parts of that
+    caller's snapshot describe. Without it, the helper re-imports
+    ambient torch via :func:`_safe_import_torch`, which on test paths
+    that pass a fake module would produce a snapshot where
+    ``torch_lib_bundled`` (uses passed module) and
+    ``libtorch_hip_symbol_counts`` (would use ambient) describe
+    different torch installations.
     """
-    torch_mod = _safe_import_torch(reasons, reason_prefix)
+    if torch_mod is None:
+        torch_mod = _safe_import_torch(reasons, reason_prefix)
     if torch_mod is None:
         return None
 
@@ -2852,8 +2873,15 @@ def _capture_pytorch_binary_introspection(
         return result
     if hip_symbol_cache is None:
         hip_symbol_cache = _HipSymbolDumpCache()
+    # Pass the already-imported torch_mod through so the dump describes
+    # the same installation `torch_lib_bundled` and
+    # `cxx_flags_use_defines` describe -- avoids the standalone-call
+    # path where the cache would re-import ambient torch and the two
+    # halves of `binary_introspection` would describe different torches.
     symbols = hip_symbol_cache.get(
-        reasons, "pytorch_build.binary_introspection"
+        reasons,
+        "pytorch_build.binary_introspection",
+        torch_mod=torch_mod,
     )
     if symbols is not None:
         counts: dict[str, int] = {marker: 0 for marker in _LIBTORCH_HIP_SYMBOL_MARKERS}

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -669,10 +669,10 @@ class EnvSnapshot:
         "USE_ROCM",
         "USE_CUDA",
         "USE_NCCL",
+        "USE_MKL",
         "USE_MKLDNN",
         "USE_FBGEMM",
         "USE_FBGEMM_GENAI",
-        "USE_MSLK",
         "USE_FLASH_ATTENTION",
         "USE_MEM_EFF_ATTENTION",
         "USE_ROCM_CK_SDPA",
@@ -689,10 +689,12 @@ class EnvSnapshot:
         rendering of well-known build flags. Defines that came from
         ``Build settings`` (USE_ROCM, USE_CUDA, USE_NCCL, USE_MKLDNN)
         report ``ON``/``OFF`` directly; CXX_FLAGS-only defines
-        (USE_MSLK, USE_FBGEMM, USE_FLASH_ATTENTION, USE_ROCM_CK_SDPA,
-        ...) report the captured value or ``yes`` for value-less defines.
-        Absent defines render as ``no`` so an operator can scan for
-        missing features at a glance.
+        (USE_FBGEMM, USE_FLASH_ATTENTION, USE_ROCM_CK_SDPA, ...) report
+        the captured value or ``yes`` for value-less defines. Absent
+        defines render as ``no`` when build_settings/cxx_defines were
+        captured, ``?`` when both are unavailable (so the operator can
+        tell "the build did not set this" apart from "we couldn't read
+        the build config").
         """
         pb = self.pytorch_build or {}
         flags = pb.get("flags") or {}
@@ -702,11 +704,23 @@ class EnvSnapshot:
         archs = flags.get("gpu_arch_list")
         arch_part = ",".join(archs) if archs else "?"
 
-        settings = flags.get("build_settings") or {}
-        defines = flags.get("cxx_defines") or {}
+        # Treat both sources as separate signals: gpu_arch_list comes
+        # from torch.cuda.get_arch_list() while settings/defines come
+        # from torch.__config__.show(). One can populate when the other
+        # fails (e.g. CPU-only wheel, or __config__ raises). When both
+        # build sources are missing, render every cell as `?` so the
+        # brief doesn't falsely claim every flag is OFF.
+        settings_raw = flags.get("build_settings")
+        defines_raw = flags.get("cxx_defines")
+        flags_unavailable = settings_raw is None and defines_raw is None
+        settings = settings_raw or {}
+        defines = defines_raw or {}
 
         cells: list[str] = []
         for name in self._SUMMARY_FLAG_NAMES:
+            if flags_unavailable:
+                cells.append(f"{name}=?")
+                continue
             if name in settings:
                 cells.append(f"{name}={settings[name]}")
                 continue
@@ -821,7 +835,17 @@ def collect_env() -> EnvSnapshot:
         hip = _capture_hip_toolchain(reasons)
         hipblaslt = _capture_hipblaslt(reasons)
         rocblas = _capture_rocblas(reasons)
-        composable_kernel = _capture_composable_kernel(reasons)
+        # Shared once per collect_env() call: both _capture_composable_kernel
+        # and _capture_pytorch_build's binary_introspection probe grep the
+        # demangled libtorch_hip.so symbol table. Without this, the
+        # ~1-2 s (cold: up to 30 s) `nm | c++filt` subprocess runs twice
+        # AND duplicates its failure reason on stripped/missing-binutils
+        # hosts. Cache lives only inside this collect_env() invocation
+        # so test isolation across consecutive calls is preserved.
+        hip_symbol_cache = _HipSymbolDumpCache()
+        composable_kernel = _capture_composable_kernel(
+            reasons, hip_symbol_cache=hip_symbol_cache
+        )
         tensile = _capture_tensile(reasons)
         triton = _capture_triton(reasons)
         fbgemm = _capture_fbgemm(reasons)
@@ -834,7 +858,9 @@ def collect_env() -> EnvSnapshot:
         docker = _capture_docker_metadata(runtime_context, reasons)
         env_vars = _capture_env_vars()  # individual nulls are documented, not partial
         pytorch_version = _capture_pytorch_version(reasons)
-        pytorch_build = _capture_pytorch_build(reasons)
+        pytorch_build = _capture_pytorch_build(
+            reasons, hip_symbol_cache=hip_symbol_cache
+        )
 
         return EnvSnapshot(
             schema_version=SCHEMA_VERSION,
@@ -1944,7 +1970,11 @@ def _capture_rocblas(reasons: list[str]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _capture_composable_kernel(reasons: list[str]) -> dict[str, Any]:
+def _capture_composable_kernel(
+    reasons: list[str],
+    *,
+    hip_symbol_cache: _HipSymbolDumpCache | None = None,
+) -> dict[str, Any]:
     """Capture Composable Kernel identity at both layers.
 
     CK ships in two places that can drift independently:
@@ -1999,7 +2029,9 @@ def _capture_composable_kernel(reasons: list[str]) -> dict[str, Any]:
             )
 
     # ------- pytorch_bundled sub-block -------
-    bundled_block = _probe_pytorch_bundled_ck(reasons)
+    bundled_block = _probe_pytorch_bundled_ck(
+        reasons, hip_symbol_cache=hip_symbol_cache
+    )
 
     # ------- build-time PyTorch CK dispatch flags -------
     # These are -DUSE_ROCM_CK_{SDPA,GEMM} cmake flags baked into the
@@ -2072,14 +2104,24 @@ def _parse_ck_header(text: str | None) -> tuple[str | None, str | None]:
     return (version, commit)
 
 
-def _probe_pytorch_bundled_ck(reasons: list[str]) -> dict[str, Any]:
+def _probe_pytorch_bundled_ck(
+    reasons: list[str],
+    *,
+    hip_symbol_cache: _HipSymbolDumpCache | None = None,
+) -> dict[str, Any]:
     """Look for ``ck::`` symbols inside ``libtorch_hip.so``.
 
     Strategy: dump the lib's demangled dynamic symbols once via the
-    shared :func:`_dump_pytorch_hip_demangled_symbols` helper, then count
-    occurrences of the ``ck::`` namespace prefix. Falls back to
+    shared :class:`_HipSymbolDumpCache`, then count occurrences of the
+    ``ck::`` namespace prefix. Falls back to
     ``present=False, symbol_count=None`` whenever the symbol dump is
     unavailable (the helper records the partial reason on its own).
+
+    ``hip_symbol_cache`` is optional so tests / direct callers can
+    invoke this probe standalone without manufacturing a cache; in that
+    case a fresh single-shot cache is used and no cross-probe
+    deduplication happens (which is the right behaviour when only one
+    probe runs).
 
     Demangled symbols routinely look like
     ``ck::tensor_operation::...``; any line containing ``ck::`` is a CK
@@ -2087,14 +2129,45 @@ def _probe_pytorch_bundled_ck(reasons: list[str]) -> dict[str, Any]:
     are themselves CK-related by construction (they reference CK types),
     so they count.
     """
+    if hip_symbol_cache is None:
+        hip_symbol_cache = _HipSymbolDumpCache()
     default = {"present": False, "symbol_count": None}
-    symbol_text = _dump_pytorch_hip_demangled_symbols(
+    symbol_text = hip_symbol_cache.get(
         reasons, "composable_kernel.pytorch_bundled"
     )
     if symbol_text is None:
         return default
     symbol_count = sum(1 for line in symbol_text.splitlines() if "ck::" in line)
     return {"present": symbol_count > 0, "symbol_count": symbol_count}
+
+
+class _HipSymbolDumpCache:
+    """Per-``collect_env()``-call cache for the demangled
+    ``libtorch_hip.so`` symbol dump.
+
+    Both the CK pytorch-bundled probe and the binary-introspection
+    probe grep the same symbol table; without this cache
+    ``collect_env()`` shells out to ``nm | c++filt`` twice per run
+    (each call ~1-2 s warm, up to 30 s cold) AND records the same
+    failure reason twice. The cache lives only for the duration of one
+    ``collect_env()`` invocation -- not module-level, so test isolation
+    between consecutive calls is preserved (the original concern that
+    blocked using ``functools.lru_cache`` here).
+
+    The first ``get()`` call owns the partial-reason prefix it provides;
+    subsequent calls reuse the same dump and append no extra reason.
+    """
+
+    def __init__(self) -> None:
+        self._cached = False
+        self._symbols: str | None = None
+
+    def get(self, reasons: list[str], reason_prefix: str) -> str | None:
+        if self._cached:
+            return self._symbols
+        self._symbols = _dump_pytorch_hip_demangled_symbols(reasons, reason_prefix)
+        self._cached = True
+        return self._symbols
 
 
 def _dump_pytorch_hip_demangled_symbols(
@@ -2452,7 +2525,11 @@ def _capture_aiter(reasons: list[str]) -> dict[str, str | None]:
 # ---------------------------------------------------------------------------
 
 
-def _capture_pytorch_build(reasons: list[str]) -> dict[str, Any]:
+def _capture_pytorch_build(
+    reasons: list[str],
+    *,
+    hip_symbol_cache: _HipSymbolDumpCache | None = None,
+) -> dict[str, Any]:
     """Capture structured PyTorch build identity.
 
     Complements the flat ``pytorch_version`` field with the build
@@ -2508,7 +2585,7 @@ def _capture_pytorch_build(reasons: list[str]) -> dict[str, Any]:
 
     flags = _capture_pytorch_build_flags(reasons)
     binary_introspection = _capture_pytorch_binary_introspection(
-        reasons, torch_mod=torch_mod
+        reasons, torch_mod=torch_mod, hip_symbol_cache=hip_symbol_cache
     )
     build_flags = _project_pytorch_build_flags(flags)
 
@@ -2586,6 +2663,8 @@ _PYTORCH_LIB_BUNDLED_NAMES: tuple[str, ...] = ("libaotriton_v2.so",)
 def _capture_pytorch_binary_introspection(
     reasons: list[str],
     torch_mod: Any | None,
+    *,
+    hip_symbol_cache: _HipSymbolDumpCache | None = None,
 ) -> dict[str, Any]:
     """Direct facts about the compiled PyTorch wheel -- no inference.
 
@@ -2658,7 +2737,9 @@ def _capture_pytorch_binary_introspection(
                 result["cxx_flags_use_defines"] = cxx_pairs
 
     # ----- libtorch_hip.so symbol counts (shared nm dump) -----
-    symbols = _dump_pytorch_hip_demangled_symbols(
+    if hip_symbol_cache is None:
+        hip_symbol_cache = _HipSymbolDumpCache()
+    symbols = hip_symbol_cache.get(
         reasons, "pytorch_build.binary_introspection"
     )
     if symbols is not None:

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -348,14 +348,6 @@ _PYTORCH_BUILD_FLAG_ALIASES: dict[str, tuple[str, ...]] = {
     "USE_MIOPEN": ("USE_MIOPEN", "CAFFE2_USE_MIOPEN"),
 }
 
-# Flags whose value is a string (e.g. ``BUILD_TYPE=Release``), not a
-# cmake boolean. The "absent define = OFF" cmake convention does NOT
-# apply to these -- their absence means "the build did not emit a
-# value", which is unknown rather than False. Used by the projection
-# helper to decide what to fill in when neither source has the flag.
-_PYTORCH_BUILD_FLAG_NON_BOOLEAN: frozenset[str] = frozenset({"BUILD_TYPE"})
-
-
 def _coerce_pytorch_build_flag_value(raw: str) -> bool | str:
     """ON/OFF/TRUE/FALSE/1/0 (any case) -> bool; anything else stays str.
 
@@ -377,64 +369,57 @@ def _project_pytorch_build_flags(
     the structured ``pytorch_build.flags`` block.
 
     Returns a dict with every name in ``PYTORCH_BUILD_FLAG_NAMES``
-    present. The lookup order is:
+    present. Lookup is two-pass to honour "build_settings beats
+    CXX_FLAGS define injection" precedence even when aliases are in
+    play:
 
-    1. ``Build settings:`` KEY=VALUE pairs (the cmake-canonical state
-       reported by ``torch.__config__.show()`` -- the authoritative
-       source for things like ``USE_ROCM=ON``, ``USE_CUDA=OFF``,
-       ``BUILD_TYPE=Release``).
-    2. ``CXX_FLAGS`` ``-D<NAME>[=<value>]`` defines (per-target define
-       injection -- the only place some flags appear, e.g.
-       ``USE_ROCM_CK_SDPA``). A bare ``-D<NAME>`` (no value) renders as
-       ``True`` -- presence-as-define is the cmake convention for "this
-       feature is compiled in".
-    3. Not found in either source. Two sub-cases:
-
-       a. **Both sources were parsed** (``build_settings`` AND
-          ``cxx_defines`` are non-None dicts -- the typical case for a
-          successful ``__config__.show()`` capture): the cmake
-          convention applies -- absent boolean flag means OFF, so
-          render ``False``. Non-boolean flags
-          (:data:`_PYTORCH_BUILD_FLAG_NON_BOOLEAN`, currently just
-          ``BUILD_TYPE``) keep ``None`` -- their value is freeform and
-          absence is unknown, not "off". This matches the existing
-          :func:`_read_pytorch_ck_flags` convention and the issue #170
-          acceptance bullet "USE_ROCM_CK_SDPA == false on builds
-          without CK SDPA".
-
-       b. **At least one source is None** (partial capture): render
-          ``None`` -- we can't be sure the flag isn't in the unread
-          source.
+    1. **Settings pass** -- check every alias of the canonical name in
+       ``Build settings:`` KEY=VALUE pairs first. A hit anywhere in the
+       alias tuple wins: this is cmake-canonical state (USE_ROCM=ON,
+       USE_CUDA=OFF, BUILD_TYPE=Release).
+    2. **Defines pass** -- only if the settings pass found nothing,
+       check every alias in ``CXX_FLAGS`` ``-D<NAME>[=<value>]``
+       defines. A bare ``-D<NAME>`` (no value) renders as ``True``
+       (presence-as-define is the cmake convention for "feature
+       compiled in"); ``-D<NAME>=<value>`` is coerced.
+    3. **Otherwise None** -- distinguishable from ``False`` so callers
+       can tell "the build did not set this anywhere we could see"
+       apart from "the build set it to OFF". This matches the issue
+       #170 mock JSON (e.g. ``DISABLE_AOTRITON: null`` on a build with
+       ``USE_AOTRITON: true``). Operators wanting cmake-style "absent
+       define = OFF" semantics for a specific flag should read
+       ``pytorch_build.flags.cxx_defines`` directly -- the dict's
+       presence vs absence is the definitive signal there.
 
     No partial reasons are added here: if torch is importable but a
     particular flag is missing from ``__config__.show()``, that's the
     upstream build's choice, not a probe failure.
     """
-    settings_raw = (flags or {}).get("build_settings")
-    defines_raw = (flags or {}).get("cxx_defines")
-    settings = settings_raw or {}
-    defines = defines_raw or {}
-    both_sources_parsed = settings_raw is not None and defines_raw is not None
+    settings = (flags or {}).get("build_settings") or {}
+    defines = (flags or {}).get("cxx_defines") or {}
     out: dict[str, bool | str | None] = {}
     for name in PYTORCH_BUILD_FLAG_NAMES:
-        found = False
-        for alias in _PYTORCH_BUILD_FLAG_ALIASES.get(name, (name,)):
+        aliases = _PYTORCH_BUILD_FLAG_ALIASES.get(name, (name,))
+        # Pass 1: settings (cmake-canonical) wins for any alias.
+        value: bool | str | None = None
+        hit = False
+        for alias in aliases:
             if alias in settings:
-                out[name] = _coerce_pytorch_build_flag_value(settings[alias])
-                found = True
+                value = _coerce_pytorch_build_flag_value(settings[alias])
+                hit = True
                 break
-            if alias in defines:
-                value = defines[alias]
-                out[name] = (
-                    True if value is None else _coerce_pytorch_build_flag_value(value)
-                )
-                found = True
-                break
-        if not found:
-            if both_sources_parsed and name not in _PYTORCH_BUILD_FLAG_NON_BOOLEAN:
-                out[name] = False
-            else:
-                out[name] = None
+        # Pass 2: only fall to defines when no alias hit settings.
+        if not hit:
+            for alias in aliases:
+                if alias in defines:
+                    raw = defines[alias]
+                    value = (
+                        True
+                        if raw is None
+                        else _coerce_pytorch_build_flag_value(raw)
+                    )
+                    break
+        out[name] = value
     return out
 
 # GitHub URL template printed in `partial_reasons` when the PyTorch
@@ -765,8 +750,16 @@ class EnvSnapshot:
         if not flags or all(flags.get(k) is None for k in flags):
             return "(unavailable -- torch import failed or no __config__)"
 
+        # Distinguish CPU-only-wheel ([] from a successful
+        # torch.cuda.get_arch_list() call) from probe failure (None).
+        # Truthiness would conflate the two as `?`.
         archs = flags.get("gpu_arch_list")
-        arch_part = ",".join(archs) if archs else "?"
+        if archs is None:
+            arch_part = "?"
+        elif not archs:
+            arch_part = "(none)"
+        else:
+            arch_part = ",".join(archs)
 
         # gpu_arch_list comes from torch.cuda.get_arch_list() and is
         # independent of __config__.show(); settings/defines come from

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -78,8 +78,17 @@ SCHEMA_VERSION = "1.2"
 #     identity, `amd_aiter` vs `aiter`) and `commit` (parsed from the
 #     setuptools_scm `+g<sha>` local-version segment, matches the image
 #     tag's `aiter-<sha>` label).
-#   All purely additive -- 1.1 consumers reading the new fields off a
-#   1.2 snapshot get None where they used to get nothing.
+#   All additions are top-level-key-additive (every new field lives
+#   under existing top-level dicts -- `pytorch_build`, `aiter` --
+#   not as new top-level dataclass fields), so 1.1 readers running
+#   `EnvSnapshot.from_dict(...)` against a 1.2 snapshot do NOT raise
+#   and existing top-level access (`.pytorch_build`, `.aiter`) still
+#   works. The new nested keys (`pytorch_build.flags`,
+#   `pytorch_build.build_flags`, `pytorch_build.binary_introspection`,
+#   `aiter.package_dist_name`, `aiter.commit`) are present on 1.2
+#   snapshots and absent on 1.1 snapshots -- consumers indexing them
+#   on a 1.1 snapshot get a KeyError, NOT None. Use `.get(key)` or
+#   guard on `schema_version` if you read these.
 #
 # 1.0 -> 1.1:
 #   - Renamed hipblaslt/rocblas/miopen.commit -> .rocm_release_tweak

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -3894,6 +3894,175 @@ class TestCapturePytorchBuildIntegration:
         )
 
 
+class TestHipSymbolDumpCache:
+    """Per-collect_env() cache that dedupes the nm|c++filt subprocess
+    across the CK probe and the binary-introspection probe.
+    """
+
+    def test_first_get_invokes_dump_subsequent_reuse(self, monkeypatch):
+        calls: list[str] = []
+
+        def fake_dump(reasons, prefix):
+            calls.append(prefix)
+            return "ck::foo\nck::bar\n"
+
+        monkeypatch.setattr(env_mod, "_dump_pytorch_hip_demangled_symbols", fake_dump)
+        cache = env_mod._HipSymbolDumpCache()
+        reasons: list[str] = []
+        a = cache.get(reasons, "first")
+        b = cache.get(reasons, "second")
+        assert a == b == "ck::foo\nck::bar\n"
+        assert calls == ["first"]
+
+    def test_failed_dump_cached_no_duplicate_reasons(self, monkeypatch):
+        def fake_dump(reasons, prefix):
+            reasons.append(f"{prefix}: nm/c++filt not on PATH")
+            return None
+
+        monkeypatch.setattr(env_mod, "_dump_pytorch_hip_demangled_symbols", fake_dump)
+        cache = env_mod._HipSymbolDumpCache()
+        reasons: list[str] = []
+        assert cache.get(reasons, "first") is None
+        assert cache.get(reasons, "second") is None
+        assert reasons == ["first: nm/c++filt not on PATH"]
+
+    def test_cache_shared_across_probes_in_collect_env(
+        self, all_disabled, monkeypatch
+    ):
+        calls: list[str] = []
+
+        def fake_dump(reasons, prefix):
+            calls.append(prefix)
+            return None
+
+        monkeypatch.setattr(env_mod, "_dump_pytorch_hip_demangled_symbols", fake_dump)
+        collect_env()
+        # CK probe and binary_introspection probe both use the cache;
+        # only the first prefix actually invokes the dump.
+        assert len(calls) <= 1
+
+
+class TestCapturePytorchBinaryIntrospection:
+    """Direct facts about the compiled PyTorch wheel -- no inference."""
+
+    @staticmethod
+    def _fake_torch(tmp_path: Path, *, with_aotriton: bool, cfg_text: str | None):
+        import types
+        torch_dir = tmp_path / "site" / "torch"
+        lib_dir = torch_dir / "lib"
+        lib_dir.mkdir(parents=True, exist_ok=True)
+        if with_aotriton:
+            (lib_dir / "libaotriton_v2.so.0.11.2").write_text("")
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        config_obj = (
+            types.SimpleNamespace(show=lambda: cfg_text)
+            if cfg_text is not None
+            else None
+        )
+        return types.SimpleNamespace(
+            __file__=str(torch_init),
+            __version__="2.99.0",
+            __config__=config_obj,
+            version=types.SimpleNamespace(
+                git_version="abc1234", hip="7.2.5", cuda=None, debug=False,
+            ),
+        )
+
+    def test_torch_lib_bundled_detects_versioned_soname(self, tmp_path):
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=True, cfg_text=None)
+        block = env_mod._capture_pytorch_binary_introspection([], torch_mod=torch_mod)
+        assert block["torch_lib_bundled"] == {"libaotriton_v2.so": True}
+
+    def test_torch_lib_bundled_absent_renders_false(self, tmp_path):
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
+        block = env_mod._capture_pytorch_binary_introspection([], torch_mod=torch_mod)
+        assert block["torch_lib_bundled"] == {"libaotriton_v2.so": False}
+
+    def test_cxx_define_presence_parsed_from_config_show(self, tmp_path):
+        cfg = "Build settings: CXX_FLAGS=-DUSE_ROCM_CK_SDPA -O3"
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=cfg)
+        block = env_mod._capture_pytorch_binary_introspection([], torch_mod=torch_mod)
+        assert block["cxx_flags_use_defines"] == {
+            "USE_ROCM_CK_SDPA": True,
+            "USE_ROCM_CK_GEMM": False,
+        }
+
+    def test_cxx_define_regex_does_not_false_match_substring(self, tmp_path):
+        # `USE_ROCM_CK_SDPA_FOO` must not match `USE_ROCM_CK_SDPA`.
+        cfg = "Build settings: CXX_FLAGS=-DUSE_ROCM_CK_SDPA_FOO -O3"
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=cfg)
+        block = env_mod._capture_pytorch_binary_introspection([], torch_mod=torch_mod)
+        assert block["cxx_flags_use_defines"]["USE_ROCM_CK_SDPA"] is False
+
+    def test_torch_none_returns_full_default_shape(self):
+        block = env_mod._capture_pytorch_binary_introspection([], torch_mod=None)
+        assert block["torch_lib_bundled"] is None
+        assert block["cxx_flags_use_defines"] is None
+        assert all(
+            v is None for v in block["libtorch_hip_symbol_counts"].values()
+        )
+
+    def test_symbol_counts_use_provided_cache(self, tmp_path, monkeypatch):
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
+
+        class FixedCache:
+            def get(self, reasons, prefix):
+                return (
+                    "void pytorch_flash::mha_fwd()\n"
+                    "void pytorch_flash::mha_bwd()\n"
+                    "void aotriton::TensorView()\n"
+                    "void unrelated::symbol()\n"
+                )
+
+        block = env_mod._capture_pytorch_binary_introspection(
+            [], torch_mod=torch_mod, hip_symbol_cache=FixedCache()
+        )
+        counts = block["libtorch_hip_symbol_counts"]
+        assert counts["pytorch_flash::"] == 2
+        assert counts["aotriton::"] == 1
+        assert counts["ck_tile::FmhaFwd"] == 0
+
+
+class TestSummaryPytorchBuildFlagsLineUnavailable:
+    """Regression guard for Copilot review: gpu_arch_list captured but
+    build_settings/cxx_defines both None must NOT render every flag as
+    `=no` -- that conflates "couldn't read build config" with "all
+    flags off".
+    """
+
+    def test_archs_present_but_settings_defines_none_renders_question_marks(self):
+        snap = _example_snapshot(
+            pytorch_build={
+                "git_commit": None, "hip_version": None, "cuda_version": None,
+                "debug": None, "install_kind": "wheel", "source_path": None,
+                "submodule_commits": {"_source": None},
+                "flags": {
+                    "build_settings": None,
+                    "cxx_defines": None,
+                    "cxx_flags_raw": None,
+                    "cuda_flags_raw": None,
+                    "gpu_arch_list": ["gfx942"],
+                },
+                "binary_introspection": {
+                    "libtorch_hip_symbol_counts": {
+                        m: None for m in env_mod._LIBTORCH_HIP_SYMBOL_MARKERS
+                    },
+                    "torch_lib_bundled": None,
+                    "cxx_flags_use_defines": None,
+                },
+                "build_flags": {
+                    name: None for name in env_mod.PYTORCH_BUILD_FLAG_NAMES
+                },
+            },
+        )
+        line = snap._summary_pytorch_build_flags_line()
+        assert "gpu_archs=[gfx942]" in line
+        assert "USE_ROCM=?" in line
+        assert "USE_ROCM=no" not in line
+        assert "USE_FLASH_ATTENTION=?" in line
+
+
 class TestProjectPytorchBuildFlags:
     """Issue #170: stable parsed subset of compile-time PyTorch flags."""
 

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -3983,7 +3983,7 @@ class TestHipSymbolDumpCache:
     def test_first_get_invokes_dump_subsequent_reuse(self, monkeypatch):
         calls: list[str] = []
 
-        def fake_dump(reasons, prefix):
+        def fake_dump(reasons, prefix, *, torch_mod=None):
             calls.append(prefix)
             return "ck::foo\nck::bar\n"
 
@@ -3996,7 +3996,7 @@ class TestHipSymbolDumpCache:
         assert calls == ["first"]
 
     def test_failed_dump_cached_no_duplicate_reasons(self, monkeypatch):
-        def fake_dump(reasons, prefix):
+        def fake_dump(reasons, prefix, *, torch_mod=None):
             reasons.append(f"{prefix}: nm/c++filt not on PATH")
             return None
 
@@ -4012,7 +4012,7 @@ class TestHipSymbolDumpCache:
     ):
         calls: list[str] = []
 
-        def fake_dump(reasons, prefix):
+        def fake_dump(reasons, prefix, *, torch_mod=None):
             calls.append(prefix)
             return None
 
@@ -4141,6 +4141,46 @@ class TestCapturePytorchBinaryIntrospection:
             for r in reasons
         )
 
+    def test_dump_uses_provided_torch_mod_not_ambient(
+        self, tmp_path, monkeypatch
+    ):
+        """Standalone-call path: when torch_mod is passed but no cache,
+        the freshly-created cache must use the passed torch_mod (not
+        re-import ambient torch). Otherwise `torch_lib_bundled` (uses
+        passed) and `libtorch_hip_symbol_counts` (would use ambient)
+        would describe different torch installations.
+        """
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
+        # Set hip so the dump helper proceeds past the CPU-only guard,
+        # and create the lib so the early lib_path.exists() check passes.
+        torch_mod.version = type(torch_mod.version)(
+            git_version="abc1234", hip="7.2.5", cuda=None, debug=False,
+        )
+        lib_dir = Path(torch_mod.__file__).parent / "lib"
+        (lib_dir / "libtorch_hip.so").write_text("")
+
+        # Trip if _safe_import_torch is called for the dump's prefix --
+        # that would mean the helper re-imported ambient torch instead
+        # of using the passed module.
+        called: list[str] = []
+        real_safe = env_mod._safe_import_torch
+
+        def trip(reasons, prefix):
+            if prefix == "pytorch_build.binary_introspection":
+                called.append(prefix)
+            return real_safe(reasons, prefix)
+
+        monkeypatch.setattr(env_mod, "_safe_import_torch", trip)
+        # Stub the subprocess work (we're checking the import path,
+        # not the nm/c++filt dump itself).
+        monkeypatch.setattr(env_mod.shutil, "which", lambda _name: None)
+
+        env_mod._capture_pytorch_binary_introspection([], torch_mod=torch_mod)
+        assert called == [], (
+            "binary_introspection re-imported ambient torch despite "
+            "being given an explicit torch_mod"
+        )
+
     def test_torch_none_skips_symbol_cache_lookup(self, monkeypatch):
         """Caller signal `torch_mod=None` -> skip the cache entirely;
         otherwise on a real-torch host the cache would still dump
@@ -4165,7 +4205,7 @@ class TestCapturePytorchBinaryIntrospection:
         torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
 
         class FixedCache:
-            def get(self, reasons, prefix):
+            def get(self, reasons, prefix, *, torch_mod=None):
                 return (
                     "void pytorch_flash::mha_fwd()\n"
                     "void pytorch_flash::mha_bwd()\n"

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -267,7 +267,7 @@ class TestSchemaCompleteness:
     ):
         snapshot = collect_env()
         assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
-        assert snapshot.schema_version == "1.1"
+        assert snapshot.schema_version == "1.2"
         assert snapshot.system_health is None
         assert snapshot.rocm == {
             "version": None,
@@ -314,7 +314,7 @@ class TestSchemaCompleteness:
 def _example_snapshot(**overrides) -> object:
     """Build a fully-populated EnvSnapshot for round-trip testing."""
     base = {
-        "schema_version": "1.1",
+        "schema_version": "1.2",
         "captured_at": "2026-04-28T12:00:00Z",
         "system_health": {"rdhc_version": "1.4.0", "tests": {}},
         "rocm": {
@@ -468,7 +468,7 @@ class TestEnvSnapshot:
         d = _example_snapshot().to_dict()
         d["future_field_not_yet_added"] = {"hello": "world"}
         rebuilt = EnvSnapshot.from_dict(d)
-        assert rebuilt.schema_version == "1.1"
+        assert rebuilt.schema_version == "1.2"
 
     def test_from_dict_defaults_partial_reasons_when_missing(self):
         """Older env.json without partial_reasons still loads (defaults to [])."""
@@ -2838,8 +2838,25 @@ class TestFbgemmBlock:
 
 
 class TestAiterBlock:
+    @staticmethod
+    def _force_no_aiter_dist(monkeypatch):
+        """Make `importlib.metadata.version("amd_aiter" | "aiter")` raise
+        PackageNotFoundError so tests are deterministic regardless of
+        whether a developer / CI host happens to have the dist installed.
+        """
+        import importlib.metadata as _md
+        real_version = _md.version
+
+        def fake_version(name):
+            if name in ("amd_aiter", "aiter"):
+                raise _md.PackageNotFoundError(name)
+            return real_version(name)
+
+        monkeypatch.setattr(_md, "version", fake_version)
+
     def test_aiter_absence_does_not_record_reason(self, all_disabled):
         """Most production hosts don't have aiter; suppress the noise."""
+        self._force_no_aiter_dist(all_disabled)
         reasons: list[str] = []
         block = env_mod._capture_aiter(reasons)
         assert block == {
@@ -2853,6 +2870,7 @@ class TestAiterBlock:
         import builtins
         import types
 
+        self._force_no_aiter_dist(monkeypatch)
         real_import = builtins.__import__
         fake_aiter = types.SimpleNamespace(__version__="0.1.4+rocm7.2.gitabc")
 
@@ -2865,7 +2883,7 @@ class TestAiterBlock:
         reasons: list[str] = []
         block = env_mod._capture_aiter(reasons)
         # +rocm... local segment carries no `+g<sha>` -> commit stays None.
-        # No amd_aiter dist installed in test env -> dist_name None.
+        # No amd_aiter dist (forced) -> dist_name None.
         assert block == {
             "package_version": "0.1.4+rocm7.2.gitabc",
             "package_dist_name": None,
@@ -4003,6 +4021,26 @@ class TestCapturePytorchBinaryIntrospection:
             v is None for v in block["libtorch_hip_symbol_counts"].values()
         )
 
+    def test_torch_none_skips_symbol_cache_lookup(self, monkeypatch):
+        """Caller signal `torch_mod=None` -> skip the cache entirely;
+        otherwise on a real-torch host the cache would still dump
+        symbols and contradict the default-shape contract.
+        """
+        called: list[str] = []
+
+        class TripwireCache:
+            def get(self, reasons, prefix):
+                called.append(prefix)
+                return "pytorch_flash::mha_fwd\n"
+
+        block = env_mod._capture_pytorch_binary_introspection(
+            [], torch_mod=None, hip_symbol_cache=TripwireCache(),
+        )
+        assert called == []
+        assert all(
+            v is None for v in block["libtorch_hip_symbol_counts"].values()
+        )
+
     def test_symbol_counts_use_provided_cache(self, tmp_path, monkeypatch):
         torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
 
@@ -4137,6 +4175,26 @@ class TestProjectPytorchBuildFlags:
         }
         out = env_mod._project_pytorch_build_flags(flags)
         assert out["USE_ROCM"] is True
+
+    def test_caffe2_use_miopen_alias_maps_to_use_miopen(self):
+        """Issue #170: CAFFE2_USE_MIOPEN is an alias for USE_MIOPEN."""
+        flags = {
+            "build_settings": {"CAFFE2_USE_MIOPEN": "ON"},
+            "cxx_defines": None,
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["USE_MIOPEN"] is True
+
+    def test_canonical_use_miopen_wins_over_caffe2_alias(self):
+        """When both spellings appear, the canonical name takes precedence
+        (alias tuple is ordered USE_MIOPEN first).
+        """
+        flags = {
+            "build_settings": {"USE_MIOPEN": "ON", "CAFFE2_USE_MIOPEN": "OFF"},
+            "cxx_defines": None,
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["USE_MIOPEN"] is True
 
     def test_none_flags_block_yields_all_none(self):
         """Torch import failed upstream -> patch returns None block;

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -2891,6 +2891,69 @@ class TestAiterBlock:
         }
         assert reasons == []
 
+    def test_aiter_setuptools_scm_commit_extracted(
+        self, isolated_env, monkeypatch
+    ):
+        """`+g<sha>` setuptools_scm local-version segment -> commit field.
+
+        Matches the AMD-internal ROCm/PyTorch image-tag convention where
+        `aiter-9a469a6` in the tag mirrors the `+g9a469a608` segment in
+        amd_aiter's version.
+        """
+        import builtins
+        import types
+
+        self._force_no_aiter_dist(monkeypatch)
+        fake_aiter = types.SimpleNamespace(
+            __version__="0.1.11.dev32+g9a469a608"
+        )
+        real_import = builtins.__import__
+        monkeypatch.setattr(
+            builtins, "__import__",
+            lambda name, *a, **kw: (
+                fake_aiter if name == "aiter" else real_import(name, *a, **kw)
+            ),
+        )
+        block = env_mod._capture_aiter([])
+        assert block["package_version"] == "0.1.11.dev32+g9a469a608"
+        assert block["commit"] == "9a469a608"
+
+    def test_aiter_dist_metadata_fallback_populates_dist_name(
+        self, isolated_env, monkeypatch
+    ):
+        """Path 3: aiter import succeeds but lacks __version__ AND
+        aiter._version; importlib.metadata.version("amd_aiter") provides
+        both the version string and the dist_name signal.
+        """
+        import builtins
+        import importlib.metadata as _md
+        import types
+
+        # aiter module without __version__ and no _version submodule.
+        fake_aiter = types.SimpleNamespace()
+        real_import = builtins.__import__
+        monkeypatch.setattr(
+            builtins, "__import__",
+            lambda name, *a, **kw: (
+                fake_aiter if name == "aiter" else real_import(name, *a, **kw)
+            ),
+        )
+        # amd_aiter dist resolves; aiter dist does not.
+        real_version = _md.version
+
+        def fake_version(name):
+            if name == "amd_aiter":
+                return "0.1.11.dev32+g9a469a608"
+            if name == "aiter":
+                raise _md.PackageNotFoundError(name)
+            return real_version(name)
+
+        monkeypatch.setattr(_md, "version", fake_version)
+        block = env_mod._capture_aiter([])
+        assert block["package_version"] == "0.1.11.dev32+g9a469a608"
+        assert block["package_dist_name"] == "amd_aiter"
+        assert block["commit"] == "9a469a608"
+
 
 # ---------------------------------------------------------------------------
 # Real-torch integration -- complements TestPytorchVersion's monkeypatched
@@ -4392,6 +4455,66 @@ class TestProjectPytorchBuildFlags:
         out = env_mod._project_pytorch_build_flags(None)
         assert set(out.keys()) == set(env_mod.PYTORCH_BUILD_FLAG_NAMES)
         assert all(v is None for v in out.values())
+
+
+class TestCapturePytorchBuildFlagsRawSchema:
+    """Direct coverage for `_capture_pytorch_build_flags()` raw output.
+
+    The other tests cover `build_flags` (the projected stable subset)
+    and the brief lines, but the raw structured block (cxx_defines,
+    cxx_flags_raw, cuda_flags_raw, gpu_arch_list) feeds env.json and
+    callers reading the raw schema would silently regress without
+    direct coverage.
+    """
+
+    def _patch_torch(self, monkeypatch, fake_torch):
+        import builtins
+        real_import = builtins.__import__
+        monkeypatch.setattr(
+            builtins, "__import__",
+            lambda name, *a, **kw: (
+                fake_torch if name == "torch" else real_import(name, *a, **kw)
+            ),
+        )
+
+    def test_raw_fields_populated_from_full_config_show(self, monkeypatch):
+        import types
+        cfg = (
+            "Build settings: BUILD_TYPE=Release, USE_ROCM=ON, "
+            "CXX_FLAGS=-DUSE_ROCM_CK_SDPA -DFLASH_NAMESPACE=pytorch_flash -O3, "
+            "CUDA_FLAGS=-arch=gfx942 -DCUDA_ONLY"
+        )
+        fake_torch = types.SimpleNamespace(
+            __config__=types.SimpleNamespace(show=lambda: cfg),
+            cuda=types.SimpleNamespace(get_arch_list=lambda: ["gfx942", "gfx950"]),
+        )
+        self._patch_torch(monkeypatch, fake_torch)
+        out = env_mod._capture_pytorch_build_flags([])
+        assert out["build_settings"]["USE_ROCM"] == "ON"
+        assert out["build_settings"]["BUILD_TYPE"] == "Release"
+        assert out["cxx_defines"] == {
+            "FLASH_NAMESPACE": "pytorch_flash",
+            "USE_ROCM_CK_SDPA": None,
+        }
+        assert out["cxx_flags_raw"].startswith("-DUSE_ROCM_CK_SDPA")
+        assert out["cuda_flags_raw"].startswith("-arch=gfx942")
+        assert out["gpu_arch_list"] == ["gfx942", "gfx950"]
+
+    def test_arch_list_captured_when_config_show_unavailable(self, monkeypatch):
+        """gpu_arch_list source is independent of __config__.show()."""
+        import types
+        fake_torch = types.SimpleNamespace(
+            __config__=None,
+            cuda=types.SimpleNamespace(get_arch_list=lambda: ["gfx942"]),
+        )
+        self._patch_torch(monkeypatch, fake_torch)
+        reasons: list[str] = []
+        out = env_mod._capture_pytorch_build_flags(reasons)
+        assert out["gpu_arch_list"] == ["gfx942"]
+        assert out["build_settings"] is None
+        assert out["cxx_defines"] is None
+        # __config__.show unavailable adds a partial reason
+        assert any(r.startswith("pytorch_build.flags") for r in reasons)
 
 
 class TestCapturePytorchBuildFlagsFromConfigShow:

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -4192,6 +4192,31 @@ class TestSummaryPytorchBuildFlagsLineUnavailable:
         assert "USE_ROCM_CK_SDPA=no" in line
         assert "USE_FLASH_ATTENTION=no" in line
 
+    def test_gpu_arch_list_empty_renders_none_not_question_mark(self):
+        """CPU-only wheel: torch.cuda.get_arch_list() returns []. That's
+        a successful, definitive result -- distinct from None
+        (probe failed). Render `(none)` not `?`.
+        """
+        snap = self._snap_with_flags({
+            "build_settings": {"USE_ROCM": "ON"},
+            "cxx_defines": {},
+            "cxx_flags_raw": None, "cuda_flags_raw": None,
+            "gpu_arch_list": [],
+        })
+        line = snap._summary_pytorch_build_flags_line()
+        assert "gpu_archs=[(none)]" in line
+        assert "gpu_archs=[?]" not in line
+
+    def test_gpu_arch_list_none_renders_question_mark(self):
+        snap = self._snap_with_flags({
+            "build_settings": {"USE_ROCM": "ON"},
+            "cxx_defines": {},
+            "cxx_flags_raw": None, "cuda_flags_raw": None,
+            "gpu_arch_list": None,
+        })
+        line = snap._summary_pytorch_build_flags_line()
+        assert "gpu_archs=[?]" in line
+
 
 class TestSummaryStableBuildFlagsLineAotritonCombined:
     """Issue: brief AOTRITON cell must honor DISABLE_AOTRITON, otherwise
@@ -4329,39 +4354,36 @@ class TestProjectPytorchBuildFlags:
         out = env_mod._project_pytorch_build_flags(flags)
         assert out["USE_MIOPEN"] is True
 
-    def test_both_sources_parsed_absent_bool_flag_renders_false(self):
-        """Issue #170 acceptance + matches existing _read_pytorch_ck_flags:
-        when BOTH config sources were successfully parsed and a bool
-        flag isn't in either, the cmake convention fires (absent define
-        = OFF), so render False -- not None.
+    def test_absent_flag_stays_none_even_when_both_sources_parsed(self):
+        """Issue #170 mock: keys not present in __config__.show() are
+        null, not False (DISABLE_AOTRITON: null on a build with
+        USE_AOTRITON: true). The brief line in `pytorch_build.flags`
+        carries the cmake-convention "no" rendering for operators who
+        want it; `pytorch_build.build_flags` preserves the
+        "set vs unset" distinction.
         """
         flags = {
             "build_settings": {"USE_ROCM": "ON"},
-            "cxx_defines": {},  # parsed, empty -- CXX_FLAGS had no -D defines
+            "cxx_defines": {},  # parsed, empty
         }
         out = env_mod._project_pytorch_build_flags(flags)
-        assert out["USE_ROCM_CK_SDPA"] is False
-        assert out["USE_FLASH_ATTENTION"] is False
-        # Non-boolean flag (BUILD_TYPE) keeps None on absence -- its
-        # value is freeform, "absent define = OFF" doesn't apply.
+        assert out["USE_ROCM_CK_SDPA"] is None
+        assert out["DISABLE_AOTRITON"] is None
         assert out["BUILD_TYPE"] is None
 
-    def test_only_one_source_parsed_absent_bool_flag_stays_none(self):
-        """Conservative: when one source is None, we can't be sure the
-        flag isn't in the unread source -- stay None, don't claim False.
+    def test_settings_alias_wins_even_when_canonical_in_defines(self):
+        """Documented precedence: every alias in build_settings beats
+        every alias in cxx_defines. A `-DUSE_MIOPEN` in defines must
+        not override `CAFFE2_USE_MIOPEN=ON` in settings just because
+        USE_MIOPEN comes earlier in the alias tuple.
         """
-        flags_settings_only = {
-            "build_settings": {"USE_ROCM": "ON"},
-            "cxx_defines": None,
+        flags = {
+            "build_settings": {"CAFFE2_USE_MIOPEN": "OFF"},
+            "cxx_defines": {"USE_MIOPEN": None},  # bare -DUSE_MIOPEN
         }
-        flags_defines_only = {
-            "build_settings": None,
-            "cxx_defines": {},
-        }
-        for flags in (flags_settings_only, flags_defines_only):
-            out = env_mod._project_pytorch_build_flags(flags)
-            assert out["USE_ROCM_CK_SDPA"] is None
-            assert out["DISABLE_AOTRITON"] is None
+        out = env_mod._project_pytorch_build_flags(flags)
+        # Settings says OFF -> False wins, not the True from -D define.
+        assert out["USE_MIOPEN"] is False
 
     def test_none_flags_block_yields_all_none(self):
         """Torch import failed upstream -> patch returns None block;

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -3998,9 +3998,11 @@ class TestCapturePytorchBinaryIntrospection:
         assert block["torch_lib_bundled"] == {"libaotriton_v2.so": False}
 
     def test_cxx_define_presence_parsed_from_config_show(self, tmp_path):
-        cfg = "Build settings: CXX_FLAGS=-DUSE_ROCM_CK_SDPA -O3"
-        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=cfg)
-        block = env_mod._capture_pytorch_binary_introspection([], torch_mod=torch_mod)
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
+        flags = {"cxx_flags_raw": "-DUSE_ROCM_CK_SDPA -O3"}
+        block = env_mod._capture_pytorch_binary_introspection(
+            [], torch_mod=torch_mod, flags=flags,
+        )
         assert block["cxx_flags_use_defines"] == {
             "USE_ROCM_CK_SDPA": True,
             "USE_ROCM_CK_GEMM": False,
@@ -4008,10 +4010,37 @@ class TestCapturePytorchBinaryIntrospection:
 
     def test_cxx_define_regex_does_not_false_match_substring(self, tmp_path):
         # `USE_ROCM_CK_SDPA_FOO` must not match `USE_ROCM_CK_SDPA`.
-        cfg = "Build settings: CXX_FLAGS=-DUSE_ROCM_CK_SDPA_FOO -O3"
-        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=cfg)
-        block = env_mod._capture_pytorch_binary_introspection([], torch_mod=torch_mod)
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
+        flags = {"cxx_flags_raw": "-DUSE_ROCM_CK_SDPA_FOO -O3"}
+        block = env_mod._capture_pytorch_binary_introspection(
+            [], torch_mod=torch_mod, flags=flags,
+        )
         assert block["cxx_flags_use_defines"]["USE_ROCM_CK_SDPA"] is False
+
+    def test_cxx_define_in_cuda_flags_only_does_not_leak(self, tmp_path):
+        """A `-DUSE_ROCM_CK_SDPA` token that lives in CUDA_FLAGS must NOT
+        appear in cxx_flags_use_defines -- the field name is the
+        contract.
+        """
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
+        flags = {
+            "cxx_flags_raw": "-O3 -fPIC",
+            "cuda_flags_raw": "-DUSE_ROCM_CK_SDPA -arch=gfx942",
+        }
+        block = env_mod._capture_pytorch_binary_introspection(
+            [], torch_mod=torch_mod, flags=flags,
+        )
+        assert block["cxx_flags_use_defines"]["USE_ROCM_CK_SDPA"] is False
+
+    def test_cxx_flags_raw_none_yields_none_dict(self, tmp_path):
+        """No CXX_FLAGS source -> the whole cxx_flags_use_defines dict
+        stays None; we don't fabricate False entries.
+        """
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
+        block = env_mod._capture_pytorch_binary_introspection(
+            [], torch_mod=torch_mod, flags={"cxx_flags_raw": None},
+        )
+        assert block["cxx_flags_use_defines"] is None
 
     def test_torch_none_returns_full_default_shape(self):
         block = env_mod._capture_pytorch_binary_introspection([], torch_mod=None)
@@ -4299,6 +4328,40 @@ class TestProjectPytorchBuildFlags:
         }
         out = env_mod._project_pytorch_build_flags(flags)
         assert out["USE_MIOPEN"] is True
+
+    def test_both_sources_parsed_absent_bool_flag_renders_false(self):
+        """Issue #170 acceptance + matches existing _read_pytorch_ck_flags:
+        when BOTH config sources were successfully parsed and a bool
+        flag isn't in either, the cmake convention fires (absent define
+        = OFF), so render False -- not None.
+        """
+        flags = {
+            "build_settings": {"USE_ROCM": "ON"},
+            "cxx_defines": {},  # parsed, empty -- CXX_FLAGS had no -D defines
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["USE_ROCM_CK_SDPA"] is False
+        assert out["USE_FLASH_ATTENTION"] is False
+        # Non-boolean flag (BUILD_TYPE) keeps None on absence -- its
+        # value is freeform, "absent define = OFF" doesn't apply.
+        assert out["BUILD_TYPE"] is None
+
+    def test_only_one_source_parsed_absent_bool_flag_stays_none(self):
+        """Conservative: when one source is None, we can't be sure the
+        flag isn't in the unread source -- stay None, don't claim False.
+        """
+        flags_settings_only = {
+            "build_settings": {"USE_ROCM": "ON"},
+            "cxx_defines": None,
+        }
+        flags_defines_only = {
+            "build_settings": None,
+            "cxx_defines": {},
+        }
+        for flags in (flags_settings_only, flags_defines_only):
+            out = env_mod._project_pytorch_build_flags(flags)
+            assert out["USE_ROCM_CK_SDPA"] is None
+            assert out["DISABLE_AOTRITON"] is None
 
     def test_none_flags_block_yields_all_none(self):
         """Torch import failed upstream -> patch returns None block;

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -420,6 +420,23 @@ def _example_snapshot(**overrides) -> object:
                 "aiter": None,
                 "fbgemm": None,
             },
+            "flags": {
+                "build_settings": None,
+                "cxx_defines": None,
+                "cxx_flags_raw": None,
+                "cuda_flags_raw": None,
+                "gpu_arch_list": None,
+            },
+            "binary_introspection": {
+                "libtorch_hip_symbol_counts": {
+                    m: None for m in env_mod._LIBTORCH_HIP_SYMBOL_MARKERS
+                },
+                "torch_lib_bundled": None,
+                "cxx_flags_use_defines": None,
+            },
+            "build_flags": {
+                name: None for name in env_mod.PYTORCH_BUILD_FLAG_NAMES
+            },
         },
         "partial": False,
         "partial_reasons": [],
@@ -2825,7 +2842,11 @@ class TestAiterBlock:
         """Most production hosts don't have aiter; suppress the noise."""
         reasons: list[str] = []
         block = env_mod._capture_aiter(reasons)
-        assert block == {"package_version": None}
+        assert block == {
+            "package_version": None,
+            "package_dist_name": None,
+            "commit": None,
+        }
         assert all("aiter not importable" not in r for r in reasons)
 
     def test_aiter_with_version_returns_string(self, isolated_env, monkeypatch):
@@ -2843,7 +2864,13 @@ class TestAiterBlock:
         monkeypatch.setattr(builtins, "__import__", fake_import)
         reasons: list[str] = []
         block = env_mod._capture_aiter(reasons)
-        assert block == {"package_version": "0.1.4+rocm7.2.gitabc"}
+        # +rocm... local segment carries no `+g<sha>` -> commit stays None.
+        # No amd_aiter dist installed in test env -> dist_name None.
+        assert block == {
+            "package_version": "0.1.4+rocm7.2.gitabc",
+            "package_dist_name": None,
+            "commit": None,
+        }
         assert reasons == []
 
 
@@ -3496,7 +3523,24 @@ class TestPytorchBuildBlockShape:
             "install_kind",
             "source_path",
             "submodule_commits",
+            "flags",
+            "build_flags",
+            "binary_introspection",
         }
+
+    def test_build_flags_keys_stable(self, all_disabled):
+        """The 17-key parsed build_flags subset is the schema contract.
+
+        Bumping it is a deliberate change -- mirrors test_canonical_var_names_stable.
+        Order intentionally not asserted (dict iteration order is the
+        insertion order from PYTORCH_BUILD_FLAG_NAMES, but consumers
+        should treat the dict as a set-of-keys mapping).
+        """
+        snapshot = collect_env()
+        bf = snapshot.pytorch_build["build_flags"]
+        assert set(bf.keys()) == set(env_mod.PYTORCH_BUILD_FLAG_NAMES)
+        # all_disabled fakes torch import absence -> every flag is None.
+        assert all(v is None for v in bf.values())
 
     def test_submodule_commits_keys_stable(self, all_disabled):
         snapshot = collect_env()
@@ -3848,6 +3892,237 @@ class TestCapturePytorchBuildIntegration:
         assert any(
             "github.com/pytorch/pytorch/tree/" in r for r in reasons
         )
+
+
+class TestProjectPytorchBuildFlags:
+    """Issue #170: stable parsed subset of compile-time PyTorch flags."""
+
+    def test_boolean_on_off_coerced(self):
+        flags = {
+            "build_settings": {"USE_ROCM": "ON", "USE_CUDA": "OFF"},
+            "cxx_defines": None,
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["USE_ROCM"] is True
+        assert out["USE_CUDA"] is False
+
+    def test_boolean_true_false_one_zero_coerced(self):
+        flags = {
+            "build_settings": {
+                "USE_NCCL": "TRUE",
+                "USE_MKL": "FALSE",
+                "USE_OPENMP": "1",
+                "USE_KINETO": "0",
+            },
+            "cxx_defines": None,
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["USE_NCCL"] is True
+        assert out["USE_MKL"] is False
+        assert out["USE_OPENMP"] is True
+        assert out["USE_KINETO"] is False
+
+    def test_non_boolean_value_kept_as_string(self):
+        """BUILD_TYPE=Release is not boolean -- preserve the original casing."""
+        flags = {
+            "build_settings": {"BUILD_TYPE": "Release"},
+            "cxx_defines": None,
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["BUILD_TYPE"] == "Release"
+
+    def test_missing_keys_present_as_none(self):
+        """Every key in PYTORCH_BUILD_FLAG_NAMES must be in the output;
+        missing ones are None (distinguishable from False).
+        """
+        out = env_mod._project_pytorch_build_flags(
+            {"build_settings": {"USE_ROCM": "ON"}, "cxx_defines": None}
+        )
+        assert set(out.keys()) == set(env_mod.PYTORCH_BUILD_FLAG_NAMES)
+        assert out["DISABLE_AOTRITON"] is None
+        assert out["USE_FLASH_ATTENTION"] is None
+
+    def test_cxx_define_without_value_is_true(self):
+        """Bare ``-DUSE_FLASH_ATTENTION`` (no =value) means "on" by cmake convention."""
+        flags = {
+            "build_settings": None,
+            "cxx_defines": {"USE_FLASH_ATTENTION": None, "USE_ROCM_CK_SDPA": None},
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["USE_FLASH_ATTENTION"] is True
+        assert out["USE_ROCM_CK_SDPA"] is True
+
+    def test_cxx_define_with_value_coerced(self):
+        flags = {
+            "build_settings": None,
+            "cxx_defines": {"USE_AOTRITON": "ON"},
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["USE_AOTRITON"] is True
+
+    def test_build_settings_wins_over_cxx_defines(self):
+        """Cmake-canonical settings beat per-target define injection."""
+        flags = {
+            "build_settings": {"USE_ROCM": "ON"},
+            "cxx_defines": {"USE_ROCM": "OFF"},
+        }
+        out = env_mod._project_pytorch_build_flags(flags)
+        assert out["USE_ROCM"] is True
+
+    def test_none_flags_block_yields_all_none(self):
+        """Torch import failed upstream -> patch returns None block;
+        projection still produces the full schema, all None.
+        """
+        out = env_mod._project_pytorch_build_flags(None)
+        assert set(out.keys()) == set(env_mod.PYTORCH_BUILD_FLAG_NAMES)
+        assert all(v is None for v in out.values())
+
+
+class TestCapturePytorchBuildFlagsFromConfigShow:
+    """End-to-end: torch.__config__.show() text -> build_flags dict."""
+
+    @staticmethod
+    def _fake_torch(tmp_path: Path, config_show_text: str):
+        import types
+        torch_dir = tmp_path / "site" / "torch"
+        torch_dir.mkdir(parents=True, exist_ok=True)
+        torch_init = torch_dir / "__init__.py"
+        torch_init.write_text("")
+        return types.SimpleNamespace(
+            __file__=str(torch_init),
+            __version__="2.99.0",
+            version=types.SimpleNamespace(
+                git_version="abc1234", hip=None, cuda=None, debug=False,
+            ),
+            __config__=types.SimpleNamespace(show=lambda: config_show_text),
+            cuda=types.SimpleNamespace(get_arch_list=lambda: ["gfx942"]),
+        )
+
+    def _patch_torch(self, monkeypatch, fake_torch):
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return fake_torch
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    def test_ck_sdpa_build_yields_true_for_attention_flags(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        cfg = (
+            "PyTorch built with:\n"
+            "  - GCC 11.4\n"
+            "Build settings: BUILD_TYPE=Release, USE_ROCM=ON, USE_CUDA=OFF, "
+            "USE_NCCL=ON, USE_MKLDNN=ON, USE_FLASH_ATTENTION=ON, "
+            "USE_MEM_EFF_ATTENTION=ON, USE_FBGEMM=ON, USE_FBGEMM_GENAI=OFF, "
+            "USE_AOTRITON=ON, "
+            "CXX_FLAGS=-DUSE_ROCM_CK_SDPA -DUSE_FLASH_ATTENTION -O3"
+        )
+        self._patch_torch(monkeypatch, self._fake_torch(tmp_path, cfg))
+        block = env_mod._capture_pytorch_build([])
+        bf = block["build_flags"]
+        assert bf["USE_ROCM_CK_SDPA"] is True
+        assert bf["USE_FLASH_ATTENTION"] is True
+        assert bf["USE_AOTRITON"] is True
+        assert bf["USE_MEM_EFF_ATTENTION"] is True
+        assert bf["USE_CUDA"] is False
+        assert bf["BUILD_TYPE"] == "Release"
+
+    def test_absent_keys_render_as_none_not_omitted(
+        self, isolated_env, tmp_path: Path, monkeypatch
+    ):
+        """Per issue acceptance: DISABLE_AOTRITON on a stock upstream
+        build is not in __config__.show() -- must render as null, not
+        be absent from the dict.
+        """
+        cfg = "Build settings: USE_ROCM=ON, BUILD_TYPE=Release"
+        self._patch_torch(monkeypatch, self._fake_torch(tmp_path, cfg))
+        block = env_mod._capture_pytorch_build([])
+        bf = block["build_flags"]
+        assert "DISABLE_AOTRITON" in bf
+        assert bf["DISABLE_AOTRITON"] is None
+        assert "USE_FLASH_ATTENTION" in bf
+        assert bf["USE_FLASH_ATTENTION"] is None
+
+    def test_torch_import_fails_yields_all_none_no_extra_reason(
+        self, isolated_env, monkeypatch
+    ):
+        """Torch import failure: pytorch_version probe records it
+        elsewhere; build_flags must NOT add a duplicate reason and the
+        full schema must still appear (all None).
+        """
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        reasons: list[str] = []
+        block = env_mod._capture_pytorch_build(reasons)
+        bf = block["build_flags"]
+        assert set(bf.keys()) == set(env_mod.PYTORCH_BUILD_FLAG_NAMES)
+        assert all(v is None for v in bf.values())
+        assert not any(r.startswith("pytorch_build.build_flags") for r in reasons)
+
+
+class TestSummaryStableBuildFlagsLine:
+    """Issue #170: brief one-liner format."""
+
+    def _snap(self, build_flags):
+        base = _example_snapshot()
+        return _example_snapshot(
+            pytorch_build={**base.pytorch_build, "build_flags": build_flags}
+        )
+
+    def test_all_on_renders_compact_form(self):
+        bf = {name: None for name in env_mod.PYTORCH_BUILD_FLAG_NAMES}
+        bf.update({
+            "USE_FLASH_ATTENTION": True,
+            "USE_ROCM_CK_SDPA": True,
+            "USE_AOTRITON": True,
+            "USE_MEM_EFF_ATTENTION": True,
+        })
+        snap = self._snap(bf)
+        line = snap._summary_stable_build_flags_line()
+        assert line == "FLASH_ATTN=on CK_SDPA=on AOTRITON=on MEM_EFF=on"
+
+    def test_off_and_unknown_render_distinctly(self):
+        bf = {name: None for name in env_mod.PYTORCH_BUILD_FLAG_NAMES}
+        bf.update({
+            "USE_FLASH_ATTENTION": False,
+            "USE_ROCM_CK_SDPA": True,
+            # USE_AOTRITON intentionally absent (None)
+            "USE_MEM_EFF_ATTENTION": False,
+        })
+        snap = self._snap(bf)
+        line = snap._summary_stable_build_flags_line()
+        assert line == "FLASH_ATTN=off CK_SDPA=on AOTRITON=? MEM_EFF=off"
+
+    def test_all_none_renders_unavailable(self):
+        bf = {name: None for name in env_mod.PYTORCH_BUILD_FLAG_NAMES}
+        snap = self._snap(bf)
+        line = snap._summary_stable_build_flags_line()
+        assert "unavailable" in line
+
+    def test_summary_includes_flags_line(self):
+        """Brief output must include the issue's `flags:` one-liner."""
+        bf = {name: None for name in env_mod.PYTORCH_BUILD_FLAG_NAMES}
+        bf.update({"USE_FLASH_ATTENTION": True, "USE_ROCM_CK_SDPA": True})
+        snap = self._snap(bf)
+        body = snap.summary()
+        flags_line = next(
+            (ln for ln in body.splitlines() if ln.lstrip().startswith("flags:")),
+            None,
+        )
+        assert flags_line is not None
+        assert "FLASH_ATTN=on" in flags_line
+        assert "CK_SDPA=on" in flags_line
 
 
 class TestSafeImportTorch:

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -4021,6 +4021,34 @@ class TestCapturePytorchBinaryIntrospection:
             v is None for v in block["libtorch_hip_symbol_counts"].values()
         )
 
+    def test_torch_lib_scan_oserror_yields_none_with_partial_reason(
+        self, tmp_path, monkeypatch
+    ):
+        """A failed torch/lib scan (missing dir, permission denied, ...)
+        must NOT report False per lib -- False is the definitive
+        "scanned, lib absent" signal. Whole dict stays None and a
+        partial reason is recorded so the operator knows the probe
+        failed rather than the libs being missing.
+        """
+        torch_mod = self._fake_torch(tmp_path, with_aotriton=False, cfg_text=None)
+
+        def boom(self):
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(env_mod.Path, "iterdir", boom)
+        reasons: list[str] = []
+        block = env_mod._capture_pytorch_binary_introspection(
+            reasons, torch_mod=torch_mod
+        )
+        assert block["torch_lib_bundled"] is None
+        assert any(
+            r.startswith(
+                "pytorch_build.binary_introspection.torch_lib_bundled:"
+            )
+            and "PermissionError" in r
+            for r in reasons
+        )
+
     def test_torch_none_skips_symbol_cache_lookup(self, monkeypatch):
         """Caller signal `torch_mod=None` -> skip the cache entirely;
         otherwise on a real-torch host the cache would still dump
@@ -4063,25 +4091,19 @@ class TestCapturePytorchBinaryIntrospection:
 
 
 class TestSummaryPytorchBuildFlagsLineUnavailable:
-    """Regression guard for Copilot review: gpu_arch_list captured but
-    build_settings/cxx_defines both None must NOT render every flag as
-    `=no` -- that conflates "couldn't read build config" with "all
-    flags off".
+    """Regression guards: distinguish "unavailable" from "all off" in the
+    `torch flags:` brief at two granularities -- whole-block and
+    per-cell.
     """
 
-    def test_archs_present_but_settings_defines_none_renders_question_marks(self):
-        snap = _example_snapshot(
+    @staticmethod
+    def _snap_with_flags(flags_block):
+        return _example_snapshot(
             pytorch_build={
                 "git_commit": None, "hip_version": None, "cuda_version": None,
                 "debug": None, "install_kind": "wheel", "source_path": None,
                 "submodule_commits": {"_source": None},
-                "flags": {
-                    "build_settings": None,
-                    "cxx_defines": None,
-                    "cxx_flags_raw": None,
-                    "cuda_flags_raw": None,
-                    "gpu_arch_list": ["gfx942"],
-                },
+                "flags": flags_block,
                 "binary_introspection": {
                     "libtorch_hip_symbol_counts": {
                         m: None for m in env_mod._LIBTORCH_HIP_SYMBOL_MARKERS
@@ -4094,11 +4116,93 @@ class TestSummaryPytorchBuildFlagsLineUnavailable:
                 },
             },
         )
+
+    def test_archs_present_but_settings_defines_none_renders_question_marks(self):
+        snap = self._snap_with_flags({
+            "build_settings": None, "cxx_defines": None,
+            "cxx_flags_raw": None, "cuda_flags_raw": None,
+            "gpu_arch_list": ["gfx942"],
+        })
         line = snap._summary_pytorch_build_flags_line()
         assert "gpu_archs=[gfx942]" in line
         assert "USE_ROCM=?" in line
         assert "USE_ROCM=no" not in line
         assert "USE_FLASH_ATTENTION=?" in line
+
+    def test_settings_populated_but_cxx_defines_none_renders_cxx_only_flags_unknown(self):
+        """When CXX_FLAGS line is missing from __config__.show(),
+        cxx_defines is None. CXX-only flags (e.g. USE_ROCM_CK_SDPA)
+        must render `=?` not `=no` -- absence-of-source != absence-of-flag.
+        """
+        snap = self._snap_with_flags({
+            "build_settings": {"USE_ROCM": "ON", "USE_CUDA": "OFF"},
+            "cxx_defines": None,
+            "cxx_flags_raw": None, "cuda_flags_raw": None,
+            "gpu_arch_list": None,
+        })
+        line = snap._summary_pytorch_build_flags_line()
+        assert "USE_ROCM=ON" in line
+        assert "USE_CUDA=OFF" in line
+        # CXX-only flags couldn't be read -> unknown, NOT off.
+        assert "USE_ROCM_CK_SDPA=?" in line
+        assert "USE_FLASH_ATTENTION=?" in line
+        assert "USE_ROCM_CK_SDPA=no" not in line
+
+    def test_empty_cxx_defines_dict_renders_cxx_only_flags_no(self):
+        """An empty dict (we read CXX_FLAGS, no -D defines present) is
+        a definitive "feature off" signal, distinct from None.
+        """
+        snap = self._snap_with_flags({
+            "build_settings": {"USE_ROCM": "ON"},
+            "cxx_defines": {},
+            "cxx_flags_raw": "-O3 -fPIC",
+            "cuda_flags_raw": None,
+            "gpu_arch_list": None,
+        })
+        line = snap._summary_pytorch_build_flags_line()
+        assert "USE_ROCM_CK_SDPA=no" in line
+        assert "USE_FLASH_ATTENTION=no" in line
+
+
+class TestSummaryStableBuildFlagsLineAotritonCombined:
+    """Issue: brief AOTRITON cell must honor DISABLE_AOTRITON, otherwise
+    a build that reports only `-DDISABLE_AOTRITON` (no USE_AOTRITON
+    setting) renders `AOTRITON=?` despite a definitive disable signal.
+    """
+
+    @staticmethod
+    def _snap(use_aotriton, disable_aotriton):
+        bf = {name: None for name in env_mod.PYTORCH_BUILD_FLAG_NAMES}
+        bf["USE_AOTRITON"] = use_aotriton
+        bf["DISABLE_AOTRITON"] = disable_aotriton
+        # Anchor: keep at least one other flag populated so the
+        # "all-None -> early unavailable return" guard doesn't fire
+        # when both AOTRITON inputs are None.
+        bf["USE_ROCM"] = True
+        base = _example_snapshot()
+        return _example_snapshot(
+            pytorch_build={**base.pytorch_build, "build_flags": bf}
+        )
+
+    def test_disable_only_true_renders_off(self):
+        line = self._snap(None, True)._summary_stable_build_flags_line()
+        assert "AOTRITON=off" in line
+
+    def test_use_only_true_renders_on(self):
+        line = self._snap(True, None)._summary_stable_build_flags_line()
+        assert "AOTRITON=on" in line
+
+    def test_disable_false_renders_on(self):
+        line = self._snap(None, False)._summary_stable_build_flags_line()
+        assert "AOTRITON=on" in line
+
+    def test_disable_wins_over_use_on_conflict(self):
+        line = self._snap(True, True)._summary_stable_build_flags_line()
+        assert "AOTRITON=off" in line
+
+    def test_both_none_renders_question_mark(self):
+        line = self._snap(None, None)._summary_stable_build_flags_line()
+        assert "AOTRITON=?" in line
 
 
 class TestProjectPytorchBuildFlags:


### PR DESCRIPTION
## Summary

- Closes #170 by adding `pytorch_build.build_flags` -- a stable 17-key parsed dict (bool / str / null) projected from `torch.__config__.show()`.
- Bundles three adjacent `pytorch_build` additions in the same PR: structured raw `flags` (build_settings, cxx_defines, raw flag strings, gpu_arch_list), `binary_introspection` (libtorch_hip.so symbol counts via shared `nm | c++filt` dump), and aiter `package_dist_name` + `commit` identity.
- Brief output gains the issue's required line: `flags: FLASH_ATTN=on CK_SDPA=on AOTRITON=on MEM_EFF=on` (plus the bundled `torch flags:` and `torch syms:` lines for the structured / introspection blocks).

## Schema

```jsonc
"pytorch_build": {
  // ... existing fields ...
  "flags": {                                  // NEW: structured raw introspection
    "build_settings": { "USE_ROCM": "ON", "BUILD_TYPE": "Release", ... },
    "cxx_defines":    { "USE_ROCM_CK_SDPA": null, ... },
    "cxx_flags_raw":  "-DUSE_ROCM_CK_SDPA -O3 ...",
    "cuda_flags_raw": null,
    "gpu_arch_list":  ["gfx942"]
  },
  "build_flags": {                            // NEW: issue #170 stable parsed subset
    "USE_FLASH_ATTENTION":   true,
    "USE_ROCM_CK_SDPA":      true,
    "USE_AOTRITON":          true,
    "USE_MEM_EFF_ATTENTION": true,
    "DISABLE_AOTRITON":      null,
    "USE_ROCM":              true,
    "USE_CUDA":              false,
    // ... 10 more, every key always present, missing renders null
    "BUILD_TYPE":            "Release"
  },
  "binary_introspection": {                   // NEW: pure-fact symbol counts
    "libtorch_hip_symbol_counts": { "pytorch_flash::": 142, "ck_tile::FmhaFwd": 532, ... },
    "torch_lib_bundled":          { "libaotriton_v2.so": true },
    "cxx_flags_use_defines":      { "USE_ROCM_CK_SDPA": true, "USE_ROCM_CK_GEMM": false }
  }
}
```

## Schema-location note vs the issue mock

Issue #170's mock JSON shows `"pytorch": {"version": ..., "build_flags": ...}` (a new `pytorch` namespace). The existing schema has no `pytorch` block -- `pytorch_version` and `pytorch_build` are sibling top-level keys. Placing `build_flags` under the existing `pytorch_build` matches the established convention; restructuring into a new `pytorch` block would be a much wider breaking change. The issue text could use a small amendment to reflect the actual path.

## Acceptance criteria

- [x] `aorta env probe` adds a parsed `build_flags` dict to `env.json` (under `pytorch_build`)
- [x] On a CK SDPA build: `USE_ROCM_CK_SDPA == true` and `USE_FLASH_ATTENTION == true`
- [x] On a build without CK SDPA: `USE_ROCM_CK_SDPA == false`
- [x] Keys not in `__config__.show()` present as `null`, not absent (e.g. `DISABLE_AOTRITON` on stock upstream)
- [x] Brief one-liner: `flags: FLASH_ATTN=on CK_SDPA=on AOTRITON=on MEM_EFF=on`
- [x] No new partial reasons when torch is importable; if torch import fails, `pytorch_version` records the absence (no double-counting); the `build_flags` field stays present with all-`null` values per existing `pytorch_build` convention

## Test plan

- [x] `tests/instrumentation/test_environment.py` -- 16 new tests added; full file: 209 pass / 26 pre-existing Windows path/host failures (identical to `origin/main` baseline -- zero regressions).
- [x] Broader suite (`tests/` excluding instrumentation): 583 pass / 27 pre-existing failures (identical to baseline).
- [x] Smoke check: `collect_env() -> EnvSnapshot` round-trips via JSON; brief renders both the patch's verbose flag line and the issue's compact `flags:` line.
- [ ] Real-host validation on a ROCm container with CK SDPA enabled (`USE_ROCM_CK_SDPA=true` expected) -- not runnable from this Windows checkout; recommended before merge.

## Out of scope (per issue)

- Numerical-parity flags like `CK_TILE_FMHA_FWD_FAST_EXP2` -- need ELF `.comment` parsing, separate follow-up.
- aiter `.co` manifest -- separate follow-up. (This PR adds aiter `package_dist_name` + setuptools_scm `+g<sha>` commit, which is *adjacent* to the manifest work but does not close it.)
- `--expected expected.json` compliance-check mode.

## Reviewer notes

- Symbol-count probe (`_capture_pytorch_binary_introspection`) and the existing CK probe now share one `nm | c++filt` dump per `collect_env()` call -- avoids paying the ~1-2 s subprocess cost twice. Test isolation preserved (no module-level cache).
- `_LIBTORCH_HIP_SYMBOL_MARKERS` uses substrings, not regex -- documented why: demangled C++ template names are stable enough as substrings, and a future kernel rename loses one marker not the whole probe.
- `build_settings` wins over `cxx_defines` when both report a flag (cmake-canonical state beats per-target define injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)