### PR TITLE
triage: require per-step instrumentation on both sides for confound ratios

### DIFF
--- a/src/aorta/triage/confound.py
+++ b/src/aorta/triage/confound.py
@@ -203,14 +203,20 @@ def classify(
         # without claiming the mitigation is trustworthy.
         return CONFOUND_NA, None
 
-    if cell.step_time_source != baseline.step_time_source:
-        # Mixing fidelity tiers (e.g. baseline ran a workload that emits
-        # per-step times, this cell ran one that only exposes wall-clock)
-        # produces a ratio between fundamentally different signals: the
-        # baseline's number is iteration time only, the cell's number folds
-        # setup / teardown. Refuse to label that comparison; matrix.json
-        # keeps both cells' ``step_time_source`` so reviewers can see why
-        # the row landed on n/a (issue #160 / Sonbol's review on PR #160).
+    if cell.step_time_source != "per_step" or baseline.step_time_source != "per_step":
+        # Only ``per_step`` is a real iteration-time signal. ``elapsed_per_iter``
+        # divides workload-reported elapsed by workload-reported iteration count
+        # (close, but folds any warm-up / shutdown the workload didn't separately
+        # account for). ``wall_clock_total`` divides the trial's whole wall clock
+        # by the configured step count (folds setup + teardown + crash time --
+        # the 2026-05-13 smoke matrix produced ``speed (+3500%)`` tags from
+        # ratios between two such wall-clock-derived numbers, none of which
+        # were iteration-time comparisons). Refuse the ratio whenever either
+        # side fell back. This is strictly stronger than the prior
+        # "sources must match" rule (issue #160 / Sonbol's review on PR #160):
+        # two ``wall_clock_total`` numbers also fail it. matrix.json keeps both
+        # cells' ``step_time_source`` so reviewers can see why the row landed
+        # on n/a.
         return CONFOUND_NA, None
 
     ratio = cell.mean_step_time_ms / baseline.mean_step_time_ms

--- a/src/aorta/triage/confound.py
+++ b/src/aorta/triage/confound.py
@@ -12,11 +12,16 @@ matrix.md captures exactly that distinction:
   causal conclusions.
 * ``no effect`` -- neither the failure rate nor the iteration time moved.
   The mitigation likely doesn't apply to this workload.
-* ``n/a`` -- the baseline cell errored or produced no usable timing data,
-  so no step-time ratio could be computed for *any* non-baseline cell.
-  Distinct from ``-`` (which advertises a trustworthy cell): re-using the
-  neutral tag here would mislead readers of matrix.md into trusting cells
-  that were never compared against anything.
+* ``n/a`` -- the cell could not be compared against the baseline. Fires
+  when (a) the baseline errored or produced no usable timing, (b) the
+  cell itself produced no usable timing, or (c) the cell or baseline
+  lacks per-step instrumentation (``step_time_source != "per_step"``);
+  fallback branches (``wall_clock_total``, ``elapsed_per_iter``) fold
+  setup / teardown / crash time into the per-iter number, so any
+  ratio against them would not be an iteration-time comparison.
+  Distinct from ``-`` (which advertises a trustworthy cell): re-using
+  the neutral tag here would mislead readers of matrix.md into trusting
+  cells that were never compared against anything.
 * ``error`` -- the whole cell failed. Row preserved so the matrix is
   complete; classification is skipped.
 
@@ -166,11 +171,15 @@ def classify(
     Returns:
         ``(tag, ratio)`` where ``tag`` is the matrix.md cell text and
         ``ratio`` is ``None`` for the baseline row or whenever a meaningful
-        ratio could not be computed (baseline errored, baseline has no
-        usable timing, the cell itself has no usable timing, or the cell
-        and baseline derived their step-time from different fallback
-        branches -- comparing per-step workload clocks against
-        wall-clock-divided-by-step-count would be apples to oranges).
+        ratio could not be computed: the baseline errored, the baseline
+        has no usable timing, the cell itself has no usable timing, or
+        either the cell or the baseline lacks per-step instrumentation
+        (``step_time_source != "per_step"``). The last clause is strictly
+        stronger than the prior "sources must differ" rule from PR #160:
+        two matching ``wall_clock_total`` numbers also fail it, because
+        ``wall_clock_total`` and ``elapsed_per_iter`` both fold setup /
+        teardown / crash time into the per-iter number and a ratio
+        between two such numbers is not an iteration-time comparison.
     """
     if cell.error is not None:
         return CONFOUND_ERROR, None

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -291,10 +291,10 @@ def write_matrix_md(
     lines.append(
         "  - `n/a` -- the cell could not be compared against the baseline. Possible "
         "reasons: the baseline errored, the baseline produced no usable timing, the "
-        "cell itself produced no usable timing, or the cell and baseline derived "
-        "their step-time from different fallback branches (e.g. `per_step` vs "
-        "`wall_clock_total`) so the ratio would mix fundamentally different "
-        "signals. Distinct from `-`: these cells are **unclassified**, not "
+        "cell itself produced no usable timing, or the cell or baseline lacks "
+        "per-step instrumentation (`step_time_source != per_step`) so the ratio "
+        "would be dominated by setup / teardown / crash time rather than per-step "
+        "cost. Distinct from `-`: these cells are **unclassified**, not "
         "trustworthy. Check `matrix.json::cells[*].step_time_source` to see which "
         "branch each row landed on."
     )

--- a/tests/triage/test_confound.py
+++ b/tests/triage/test_confound.py
@@ -200,27 +200,24 @@ def test_confound_na_is_distinct_from_neutral():
     assert CONFOUND_NEUTRAL == "-"
 
 
-# ---- step_time_source mismatch -------------------------------------------
+# ---- per-step instrumentation required (smoke-3) -------------------------
 #
-# Sonbol's review on PR #160 flagged that comparing a cell whose timing came
-# from per-step workload clocks against one whose timing came from
-# wall-clock-divided-by-step-count is an apples-to-oranges ratio: the latter
-# folds setup + teardown into the "step time". The classifier must refuse
-# such ratios with CONFOUND_NA so matrix.md doesn't claim a meaningful
-# comparison happened.
-
-
-def test_classify_returns_na_when_step_time_source_differs():
-    base = _stats("b", mean_step_time_ms=100.0, step_time_source="per_step", passed_count=0)
-    cell = _stats("c", mean_step_time_ms=120.0, step_time_source="wall_clock_total", passed_count=8)
-    tag, ratio = classify(cell, base, threshold=1.15)
-    assert tag == CONFOUND_NA
-    assert ratio is None
+# The 2026-05-13 smoke matrix produced ``speed (+3500%)`` tags from ratios
+# between two cells whose step times were ``wall_clock_total / configured_steps``
+# (the import-time wall-clock of a setup crash divided by a never-reached
+# step count). Those ratios are dominated by setup / teardown / crash time,
+# not per-step cost. Smoke-3's rule: confound classification requires
+# ``step_time_source == "per_step"`` on BOTH the cell and the baseline; any
+# fallback branch (``elapsed_per_iter`` or ``wall_clock_total``) on either
+# side collapses to ``CONFOUND_NA``. Strictly stronger than the older
+# "sources must match" rule from PR #160.
 
 
 def test_classify_returns_na_when_only_baseline_has_per_step():
-    """Asymmetric case: baseline measured cleanly, cell only has wall-clock.
-    The ratio would be (setup+steps)/steps, which is meaningless."""
+    """Baseline measured cleanly, cell fell back to elapsed_per_iter.
+    The fallback folds workload warm-up / shutdown into the per-iter number,
+    so the ratio is not a per-step comparison even though both sides have
+    *some* timing."""
     base = _stats("b", mean_step_time_ms=100.0, step_time_source="per_step")
     cell = _stats("c", mean_step_time_ms=110.0, step_time_source="elapsed_per_iter")
     tag, ratio = classify(cell, base, threshold=1.15)
@@ -228,13 +225,56 @@ def test_classify_returns_na_when_only_baseline_has_per_step():
     assert ratio is None
 
 
-def test_classify_computes_ratio_when_sources_match():
-    """Sanity check: matching sources still go through the normal classifier."""
-    base = _stats("b", mean_step_time_ms=400.0, step_time_source="wall_clock_total", passed_count=4)
-    slow = _stats(
+def test_classify_returns_na_when_only_cell_has_per_step():
+    """Symmetric: baseline fell back, cell measured cleanly. The baseline's
+    number folds setup time, so the ratio's denominator isn't iteration time."""
+    base = _stats("b", mean_step_time_ms=100.0, step_time_source="wall_clock_total")
+    cell = _stats("c", mean_step_time_ms=120.0, step_time_source="per_step")
+    tag, ratio = classify(cell, base, threshold=1.15)
+    assert tag == CONFOUND_NA
+    assert ratio is None
+
+
+def test_classify_returns_na_when_both_sources_are_wall_clock_total():
+    """The smoke-3 regression case: both sides fell back to wall-clock and the
+    old classifier (sources match) happily emitted a ``speed (+N%)`` tag.
+    Under the new rule, two wall-clock numbers can't anchor a per-step ratio
+    even when they agree on the fallback branch."""
+    base = _stats(
+        "b",
+        mean_step_time_ms=400.0,
+        step_time_source="wall_clock_total",
+        passed_count=4,
+    )
+    cell = _stats(
         "tf32-local",
         mean_step_time_ms=500.0,
         step_time_source="wall_clock_total",
+        passed_count=8,
+    )
+    tag, ratio = classify(cell, base, threshold=1.15)
+    assert tag == CONFOUND_NA
+    assert ratio is None
+
+
+def test_classify_returns_na_when_both_sources_are_elapsed_per_iter():
+    """Even the higher-fidelity fallback (elapsed/iterations from the workload's
+    own report) is excluded -- it still folds the workload's warm-up and any
+    untimed shutdown into the per-iter number."""
+    base = _stats("b", mean_step_time_ms=100.0, step_time_source="elapsed_per_iter")
+    cell = _stats("c", mean_step_time_ms=120.0, step_time_source="elapsed_per_iter")
+    tag, ratio = classify(cell, base, threshold=1.15)
+    assert tag == CONFOUND_NA
+    assert ratio is None
+
+
+def test_classify_computes_ratio_when_both_sources_are_per_step():
+    """Sanity check: per_step on both sides goes through the normal classifier."""
+    base = _stats("b", mean_step_time_ms=400.0, step_time_source="per_step", passed_count=4)
+    slow = _stats(
+        "tf32-local",
+        mean_step_time_ms=500.0,
+        step_time_source="per_step",
         passed_count=8,
     )
     tag, ratio = classify(slow, base, threshold=1.15)

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -485,6 +485,42 @@ def test_baseline_error_marks_other_cells_unclassified_not_neutral(
     assert "**unclassified**, not trustworthy" in md
 
 
+def test_wall_clock_only_cells_collapse_to_na_not_speed_confound(
+    tmp_path, patched_env, monkeypatch
+):
+    """smoke-3: ``wall_clock_total`` on both sides must NOT render as ``speed (+N%)``.
+
+    Reproduces the 2026-05-13 smoke matrix regression case: every cell has
+    ``step_time_source == "wall_clock_total"`` (workload completed but never
+    emitted per-step times, so the platform divided wall clock by configured
+    steps). Pre-smoke-3 the classifier matched the two sources and emitted a
+    bogus ``speed (+N%)`` tag whose numerator and denominator were both
+    wall-clock-derived. The fix collapses every non-baseline cell to ``n/a``
+    and updates the legend to name the new reason.
+    """
+    wall_only = _FakeTrial(
+        exit_status="ok",
+        wall_clock_sec=5.0,
+        result={"passed": True},  # no step_times_ms, no elapsed/total -> wall_clock_total
+    )
+    monkeypatch.setattr(runner, "run_trials", MagicMock(return_value=[wall_only, wall_only]))
+    r = _simple_recipe()
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+
+    doc = json.loads((run_dir / "matrix.json").read_text())
+    tf32 = next(c for c in doc["cells"] if c["name"] == "tf32_off-local")
+    assert tf32["step_time_source"] == "wall_clock_total"
+    assert tf32["confound"] == "n/a"
+    assert tf32["step_time_ratio"] is None
+
+    md = (run_dir / "matrix.md").read_text()
+    # Legend must name the new reason so an operator reading "n/a" can find
+    # the explanation without grepping source. Pin both halves so a future
+    # legend rewrite can't quietly drop the per-step requirement.
+    assert "lacks per-step instrumentation" in md
+    assert "`step_time_source != per_step`" in md
+
+
 # ---- Class D: matrix.json carries new aggregation fields -----------------
 
 


### PR DESCRIPTION
## Summary

- Replace the "sources must match" rule in `confound.classify()` with the strictly-stronger "both sides must be `per_step`" rule. `wall_clock_total` and `elapsed_per_iter` on either cell or baseline now collapse to `CONFOUND_NA`.
- Update the `n/a` legend in `matrix.md` to name the new reason (`step_time_source != per_step` ⇒ ratio dominated by setup / teardown / crash time).
- `matrix.json` continues to record `step_time_source` per cell so reviewers can see why a row landed on n/a.

## Motivation

The 2026-05-13 SHAMPOO smoke matrix (`docs/demos/2026-05-triage/2026-05-13T15-02-36/`) made the gap concrete: every `nan-repro` cell crashed during import, so every cell's `mean_step_time_ms` was a few seconds of import-time wall clock divided by the never-reached configured step count. The previous classifier (sources match → emit ratio) produced:

| Cell | Reported |
|---|---|
| `baseline-nan-repro` | mean step 96.9 ms (5 s import / 50 steps) |
| `baseline-fixed` | mean step 3543 ms (real run) |
| `tf32_off-fixed` | `speed (+3619%)` |
| `hip_blocking-nan-repro` | `speed (+16%)` |

Neither ratio was a real iteration-time comparison. Under this PR, both collapse to `n/a` and the legend points at `step_time_source` for the explanation.

This is the second triage-smoke follow-up; the first (`did_not_run` outcome + `Iters` column + baseline disqualification) landed in #175.

## Behavior change

- Before: `(per_step, per_step)` → ratio; `(wall_clock_total, wall_clock_total)` → ratio; `(per_step, wall_clock_total)` → `n/a`.
- After: only `(per_step, per_step)` produces a ratio. Any fallback on either side ⇒ `n/a` and `step_time_ratio: null` in `matrix.json`.

The old "sources differ" guard becomes redundant and is removed; the new rule subsumes it.

## Test plan

- [x] `tests/triage/test_confound.py` — new + updated cases pin the new contract: both `wall_clock_total` → `n/a`, both `elapsed_per_iter` → `n/a`, asymmetric directions → `n/a`, both `per_step` still computes the ratio.
- [x] `tests/triage/test_output_layout.py` — new `test_wall_clock_only_cells_collapse_to_na_not_speed_confound` end-to-end pin: `confound == "n/a"`, `step_time_ratio is None`, legend mentions `lacks per-step instrumentation` and `step_time_source != per_step`.
- [x] Full triage suite green (223/223).
- [ ] Replay the 2026-05-13 smoke artifacts through the updated renderer to confirm every cell with `step_time_source != per_step` renders `n/a` (manual smoke; not part of CI).

## Out of scope

- Top-level `matrix.json::warnings` entry when every cell lacks per-step instrumentation. Useful follow-up; left for a separate issue.
- Adding per-step instrumentation to `recom_repro` itself (workload-side change tracked separately).
- Removing the `wall_clock_total` fallback. It is still a useful diagnostic value to expose — just not for confound classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)