### PR TITLE
triage: recipe-level workload_config for arbitrary workload kwargs (B2.2)

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -88,6 +88,32 @@ cells:
   mitigation bundle, so it can override a registered mitigation's env var
   for one-off experiments without polluting the registry. Recorded in
   `matrix.json` for audit.
+- **`workload_config`** -- optional `dict[str, Any]`, allowed at both
+  recipe scope (top level) and per cell. Forwarded to the workload
+  constructor through the dispatcher's `Request.config_overrides`. Use
+  this for workload-specific knobs that aren't env vars -- e.g.
+  `shampoo_api: old` on the `recom_repro` workload to select the V2
+  Meta-internal SHAMPOO entry script. Cell-scope merges over recipe-scope
+  on a per-key basis (cell wins on collision; non-collision keys union),
+  so a recipe can set a workload-wide default and opt one cell out.
+  Reserved keys: `"steps"` (first-class field; would be silently
+  overwritten by the dispatcher) and any `_aorta_*` prefix
+  (platform-supplied) are rejected at load time. Example:
+
+  ```yaml
+  workload: recom_repro
+  workload_config:
+    shampoo_api: new          # recipe default
+  cells:
+    - name: v3-baseline
+      mitigations: [none]
+      environment: nan-repro-v3
+    - name: v2-baseline
+      mitigations: [none]
+      environment: nan-repro-v2-image
+      workload_config:
+        shampoo_api: old      # cell override
+  ```
 
 Every validation error reports a path like `cells[2].mitigations` so the
 failure is localisable without reading the loader source.

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -465,6 +465,12 @@ def write_resolved_recipe(
             cell_doc["trials"] = cell.trials
         if cell.steps is not None:
             cell_doc["steps"] = cell.steps
+        if cell.workload_config:
+            # Emit cell-scope workload_config verbatim. The runner merges
+            # recipe-scope under cell-scope at execution time; the resolved
+            # YAML preserves both scopes (recipe-scope key below) so a
+            # round-trip load+run produces the same effective config.
+            cell_doc["workload_config"] = dict(cell.workload_config)
         resolved_cells.append(cell_doc)
 
     doc: dict[str, Any] = {
@@ -475,6 +481,11 @@ def write_resolved_recipe(
     }
     if recipe.ticket is not None:
         doc["ticket"] = recipe.ticket
+    if recipe.workload_config:
+        # Recipe-scope workload_config -- emitted only when non-empty so
+        # recipes that never used the field round-trip to byte-equivalent
+        # YAML. Cell-scope values are written per cell above.
+        doc["workload_config"] = dict(recipe.workload_config)
     doc["confound"] = {
         "threshold": recipe.confound.threshold,
         "baseline_cell": recipe.confound.baseline_cell,

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -37,11 +37,36 @@ from aorta.registry import (
 SCHEMA_VERSION = 1
 
 _VALID_TOP_LEVEL = frozenset(
-    {"schema_version", "ticket", "workload", "trials", "steps", "confound", "cells"}
+    {
+        "schema_version",
+        "ticket",
+        "workload",
+        "trials",
+        "steps",
+        "confound",
+        "cells",
+        "workload_config",
+    }
 )
 _VALID_CONFOUND_KEYS = frozenset({"threshold", "baseline_cell"})
-_VALID_CELL_KEYS = frozenset({"name", "mitigations", "environment", "extra_env", "trials", "steps"})
+_VALID_CELL_KEYS = frozenset(
+    {"name", "mitigations", "environment", "extra_env", "trials", "steps", "workload_config"}
+)
 _VALID_INLINE_ENV_KEYS = frozenset({"docker"})
+
+# Keys that workload_config (recipe- or cell-scope) is NOT allowed to set.
+# - "steps" is a first-class recipe/cell field; the dispatcher writes
+#   ``config["steps"] = request.steps`` AFTER spreading config_overrides
+#   (src/aorta/run/dispatcher.py), so a workload_config["steps"] would be
+#   silently clobbered. Reject at load time so the recipe author finds out
+#   immediately instead of debugging a step count that mysteriously ignores
+#   their override.
+# - The ``_aorta_*`` prefix is reserved for platform-supplied keys
+#   (currently ``_aorta_environment``); the dispatcher already rejects them
+#   at runtime. Mirror the rejection at recipe-load time so the failure
+#   surfaces before any trial runs.
+_RESERVED_WORKLOAD_CONFIG_KEYS = frozenset({"steps"})
+_RESERVED_WORKLOAD_CONFIG_PREFIX = "_aorta_"
 
 # Cell names become directory components under cells/<name>/ in the run output
 # tree.  Reject characters that would let a recipe escape its own cells/
@@ -108,6 +133,13 @@ class Cell:
             disagreements are flagged as errors.
         trials: Optional per-cell override of the recipe-level ``trials``.
         steps: Optional per-cell override of the recipe-level ``steps``.
+        workload_config: Arbitrary ``dict[str, Any]`` forwarded to the
+            workload constructor via ``Request.config_overrides``. Merged
+            over the recipe-level ``workload_config`` (cell wins on key
+            collision). Keys must be strings; ``"steps"`` and any
+            ``_aorta_*`` key are rejected at load time -- ``steps`` is a
+            first-class field the dispatcher would silently overwrite, and
+            ``_aorta_*`` is reserved for platform-supplied keys.
     """
 
     name: str
@@ -116,6 +148,7 @@ class Cell:
     extra_env: dict[str, str] = field(default_factory=dict)
     trials: int | None = None
     steps: int | None = None
+    workload_config: dict[str, Any] = field(default_factory=dict)
 
     def effective_trials(self, recipe_trials: int) -> int:
         return self.trials if self.trials is not None else recipe_trials
@@ -160,6 +193,12 @@ class Recipe:
             flag-mode). Surfaced in ``matrix.md``.
         source_sha256: SHA-256 of the source file text (None for flag-mode).
             Surfaced in ``matrix.md`` for reproducibility.
+        workload_config: Recipe-scope ``dict[str, Any]`` applied to every
+            cell as the base ``Request.config_overrides``. Per-cell
+            ``Cell.workload_config`` merges over this on a per-key basis
+            (cell wins on collision; non-collision keys union). Empty dict
+            when the recipe omits the field -- behaviourally identical to
+            today's recipes.
     """
 
     schema_version: int
@@ -173,6 +212,7 @@ class Recipe:
     sidecar_files: tuple[Path, ...] = ()
     source_path: Path | None = None
     source_sha256: str | None = None
+    workload_config: dict[str, Any] = field(default_factory=dict)
 
 
 def inline_env_name(docker_ref: str) -> str:
@@ -272,6 +312,46 @@ def _parse_environment(path_hint: str, raw: Any, inline_envs: dict[str, InlineEn
     return auto_name
 
 
+def _parse_workload_config(path_hint: str, raw: Any) -> dict[str, Any]:
+    """Validate and copy a ``workload_config`` mapping.
+
+    Returns an empty dict when ``raw`` is None / missing so the caller can
+    just call ``_parse_workload_config(hint, data.get("workload_config"))``
+    without branching. The returned dict is a shallow copy -- values are
+    forwarded as-is to the workload constructor (``dict[str, Any]``),
+    keys MUST be strings, and the reserved set in
+    :data:`_RESERVED_WORKLOAD_CONFIG_KEYS` / the ``_aorta_`` prefix is
+    rejected at load time (see their docstring for the rationale).
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RecipeSchemaError(
+            f"{path_hint}.workload_config: must be a mapping, got {type(raw).__name__}"
+        )
+    out: dict[str, Any] = {}
+    for k, v in raw.items():
+        if not isinstance(k, str):
+            raise RecipeSchemaError(
+                f"{path_hint}.workload_config: keys must be strings, "
+                f"got {type(k).__name__} ({k!r})"
+            )
+        if k in _RESERVED_WORKLOAD_CONFIG_KEYS:
+            raise RecipeSchemaError(
+                f"{path_hint}.workload_config: key {k!r} is reserved -- "
+                "it is a first-class recipe/cell field and would be silently "
+                "overwritten by the dispatcher. Set it at the recipe/cell scope instead."
+            )
+        if k.startswith(_RESERVED_WORKLOAD_CONFIG_PREFIX):
+            raise RecipeSchemaError(
+                f"{path_hint}.workload_config: key {k!r} uses the reserved "
+                f"{_RESERVED_WORKLOAD_CONFIG_PREFIX!r} prefix "
+                "(platform-supplied; not a user override)."
+            )
+        out[k] = v
+    return out
+
+
 def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
     path_hint = f"cells[{idx}]"
     if not isinstance(raw, dict):
@@ -328,6 +408,8 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
     if steps is not None and (not isinstance(steps, int) or isinstance(steps, bool) or steps < 1):
         raise RecipeSchemaError(f"{path_hint}.steps: must be a positive int, got {steps!r}")
 
+    workload_config = _parse_workload_config(path_hint, raw.get("workload_config"))
+
     return Cell(
         name=name,
         mitigations=tuple(mitigations),
@@ -335,6 +417,7 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
         extra_env=extra_env,
         trials=trials,
         steps=steps,
+        workload_config=workload_config,
     )
 
 
@@ -550,6 +633,7 @@ def _build_recipe(
         )
 
     confound = _parse_confound("recipe", data.get("confound"))
+    workload_config = _parse_workload_config("recipe", data.get("workload_config"))
 
     raw_cells = data["cells"]
     if not isinstance(raw_cells, list) or not raw_cells:
@@ -583,6 +667,7 @@ def _build_recipe(
         sidecar_files=tuple(sidecar_files) if sidecar_files else (),
         source_path=source_path,
         source_sha256=source_sha256,
+        workload_config=workload_config,
     )
 
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -554,6 +554,13 @@ def _run_one_cell(
 
     resolved_env_vars = _resolve_cell_env_vars(cell.mitigations, cell.extra_env, sidecar_files)
 
+    # Recipe-scope workload_config is the base; cell-scope merges over it so
+    # the cell wins on key collision and non-collision keys union. Empty
+    # dicts on both sides collapse to ``{}``, which RunRequest.__post_init__
+    # deep-copies and the dispatcher spreads into ``config`` -- so omitting
+    # workload_config from the recipe stays byte-equivalent to today.
+    merged_workload_config = {**recipe.workload_config, **cell.workload_config}
+
     request = RunRequest(
         workload=recipe.workload,
         trials=cell.effective_trials(recipe.trials),
@@ -561,6 +568,7 @@ def _run_one_cell(
         mitigations=tuple(cell.mitigations),
         extra_env=dict(cell.extra_env),
         steps=cell.effective_steps(recipe.steps),
+        config_overrides=merged_workload_config,
         results_dir=cell_dir,
         sidecar_files=sidecar_files,
     )
@@ -604,14 +612,25 @@ def _preflight_validate(recipe: Recipe) -> None:
 def _print_dry_run(recipe: Recipe) -> None:
     """Write the resolved cell list to stdout without touching the filesystem."""
     click.echo(f"Dry run: {recipe.workload} / ticket={recipe.ticket or '(none)'}")
+    if recipe.workload_config:
+        click.echo(f"Recipe workload_config: {recipe.workload_config}")
     click.echo(f"Cells ({len(recipe.cells)}):")
     for cell in recipe.cells:
+        # Mirror the runner's merge so the dry-run shows the EFFECTIVE config
+        # the workload would be constructed with -- cell-scope wins on key
+        # collision, non-collision keys union with recipe-scope.
+        effective_workload_config = {**recipe.workload_config, **cell.workload_config}
         click.echo(
             f"  - {cell.name}: mitigations={list(cell.mitigations)} "
             f"environment={cell.environment} "
             f"trials={cell.effective_trials(recipe.trials)} "
             f"steps={cell.effective_steps(recipe.steps)}"
             + (f" extra_env={cell.extra_env}" if cell.extra_env else "")
+            + (
+                f" workload_config={effective_workload_config}"
+                if effective_workload_config
+                else ""
+            )
         )
     if recipe.inline_environments:
         click.echo("Inline docker environments:")

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -384,6 +384,37 @@ def test_resolved_recipe_inline_envs_emit_docker_shorthand(
     assert reloaded.cells[0].environment == r.cells[0].environment
 
 
+def test_resolved_recipe_round_trips_workload_config(
+    tmp_path, patched_env, patched_run_trials
+):
+    """B2.2: workload_config at recipe + cell scope must survive load -> run -> reload."""
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe, load_recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(
+            Cell(name="a", mitigations=("none",), environment="local"),
+            Cell(
+                name="b",
+                mitigations=("none",),
+                environment="local",
+                workload_config={"shampoo_api": "old"},
+            ),
+        ),
+        ticket="WC-RT",
+        confound=ConfoundCfg(baseline_cell="a"),
+        workload_config={"shampoo_api": "new", "warmup": 5},
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    reloaded = load_recipe(run_dir / "recipe.resolved.yaml")
+    assert reloaded.workload_config == {"shampoo_api": "new", "warmup": 5}
+    assert reloaded.cells[0].workload_config == {}
+    assert reloaded.cells[1].workload_config == {"shampoo_api": "old"}
+
+
 def test_matrix_json_records_resolved_environment_per_cell(
     tmp_path, patched_env, patched_run_trials
 ):

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -383,6 +383,64 @@ def test_extra_env_must_be_strings(tmp_path):
         load_recipe(_write_yaml(tmp_path, text))
 
 
+# ---- workload_config ------------------------------------------------------
+
+
+def test_workload_config_defaults_empty(tmp_path):
+    r = load_recipe(_write_yaml(tmp_path, _MINIMAL_YAML))
+    assert r.workload_config == {}
+    assert r.cells[0].workload_config == {}
+
+
+def test_workload_config_recipe_scope(tmp_path):
+    text = _MINIMAL_YAML + "workload_config:\n  shampoo_api: new\n  batch_size: 32\n"
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.workload_config == {"shampoo_api": "new", "batch_size": 32}
+
+
+def test_workload_config_cell_scope(tmp_path):
+    text = _MINIMAL_YAML.replace(
+        "    environment: local\n",
+        "    environment: local\n    workload_config:\n      shampoo_api: old\n",
+    )
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.cells[0].workload_config == {"shampoo_api": "old"}
+
+
+def test_workload_config_must_be_mapping(tmp_path):
+    text = _MINIMAL_YAML + "workload_config: not-a-dict\n"
+    with pytest.raises(RecipeSchemaError, match="workload_config"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_workload_config_rejects_non_string_keys(tmp_path):
+    # YAML int key triggers the str-key validator.
+    text = _MINIMAL_YAML + "workload_config:\n  1: foo\n"
+    with pytest.raises(RecipeSchemaError, match="keys must be strings"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_workload_config_rejects_reserved_steps_key(tmp_path):
+    text = _MINIMAL_YAML + "workload_config:\n  steps: 9999\n"
+    with pytest.raises(RecipeSchemaError, match="reserved"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_workload_config_rejects_aorta_prefix(tmp_path):
+    text = _MINIMAL_YAML + "workload_config:\n  _aorta_environment: x\n"
+    with pytest.raises(RecipeSchemaError, match="reserved"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_workload_config_cell_scope_validation_path(tmp_path):
+    text = _MINIMAL_YAML.replace(
+        "    environment: local\n",
+        "    environment: local\n    workload_config:\n      steps: 1\n",
+    )
+    with pytest.raises(RecipeSchemaError, match=r"cells\[0\].workload_config"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
 # ---- Flag-mode builder ----------------------------------------------------
 
 

--- a/tests/triage/test_runner_b1_api.py
+++ b/tests/triage/test_runner_b1_api.py
@@ -164,6 +164,78 @@ def test_cell_overrides_flow_through_effective_values(tmp_path, patched_env, pat
     assert (reqs[1].trials, reqs[1].steps) == (7, 999)
 
 
+def test_workload_config_recipe_scope_reaches_dispatcher(
+    tmp_path, patched_env, patched_run_trials
+):
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(Cell(name="a", mitigations=("none",), environment="local"),),
+        ticket="WC-1",
+        confound=ConfoundCfg(baseline_cell="a"),
+        workload_config={"shampoo_api": "new"},
+    )
+    runner.run_recipe(r, output_dir=tmp_path)
+    req: RunRequest = patched_run_trials.call_args_list[0].args[0]
+    assert req.config_overrides == {"shampoo_api": "new"}
+
+
+def test_workload_config_cell_overrides_recipe_and_merges(
+    tmp_path, patched_env, patched_run_trials
+):
+    """Cell-scope wins on key collision; non-collision keys union (B2.2)."""
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(
+            Cell(name="a", mitigations=("none",), environment="local"),
+            Cell(
+                name="b",
+                mitigations=("none",),
+                environment="local",
+                workload_config={"shampoo_api": "old", "batch_size": 64},
+            ),
+        ),
+        ticket="WC-2",
+        confound=ConfoundCfg(baseline_cell="a"),
+        workload_config={"shampoo_api": "new", "warmup": 5},
+    )
+    runner.run_recipe(r, output_dir=tmp_path)
+    reqs = [c.args[0] for c in patched_run_trials.call_args_list]
+    assert reqs[0].config_overrides == {"shampoo_api": "new", "warmup": 5}
+    # Cell b: shampoo_api collides -> cell wins ('old'); warmup carries through
+    # from recipe; batch_size unions in from cell.
+    assert reqs[1].config_overrides == {
+        "shampoo_api": "old",
+        "warmup": 5,
+        "batch_size": 64,
+    }
+
+
+def test_workload_config_absent_yields_empty_overrides(
+    tmp_path, patched_env, patched_run_trials
+):
+    """Recipes without workload_config behave byte-equivalent to today."""
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none",
+        environment_axis="local",
+        trials=1,
+        steps=10,
+    )
+    runner.run_recipe(r, output_dir=tmp_path)
+    req: RunRequest = patched_run_trials.call_args_list[0].args[0]
+    assert req.config_overrides == {}
+
+
 def test_inline_docker_sidecar_written_and_passed_to_run_trials(
     tmp_path, patched_env, patched_run_trials
 ):


### PR DESCRIPTION
## Summary
- Add `workload_config: dict[str, Any]` at recipe scope and per cell. Cell-scope merges over recipe-scope on key collision (cell wins); non-collision keys union.
- Runner merges both scopes into `RunRequest.config_overrides`, so workload-specific knobs (e.g. `recom_repro`'s `shampoo_api: old`) are reachable from a recipe — no more direct-in-Python construction to opt one cell into the V2 SHAMPOO entry script.
- Reserved keys `"steps"` (first-class field; dispatcher would silently overwrite) and the `_aorta_*` prefix (platform-supplied) are rejected at load time.
- `workload_config` surfaces in dry-run output and round-trips through `recipe.resolved.yaml`.

The dispatcher's `Request.config_overrides → workload_cls(config)` plumbing was already in place (`src/aorta/run/dispatcher.py:287`); this PR just surfaces the missing field in the recipe loader.

## Files
- `src/aorta/triage/recipe.py` — `workload_config` on `Cell` + `Recipe`; `_parse_workload_config` validator.
- `src/aorta/triage/runner.py` — `_run_one_cell` merges + plumbs; dry-run prints effective config per cell.
- `src/aorta/triage/output.py` — `write_resolved_recipe` emits `workload_config` at both scopes (only when non-empty, so today's recipes round-trip byte-equivalent).
- `tests/triage/test_recipe.py` — 8 new tests (defaults, both scopes, non-mapping, non-str keys, reserved-key rejections, cell-scope error path).
- `tests/triage/test_runner_b1_api.py` — 3 new tests (recipe-scope reaches dispatcher, cell-overrides-recipe merge, absent → `{}`).
- `tests/triage/test_output_layout.py` — 1 new test (full round-trip preserves both scopes).
- `recipes/README.md` — schema-rules bullet with `recom_repro` example.

## Out of scope
- `--config-override KEY=VAL` CLI flag for `aorta triage run` (recipe-level coverage is enough per B2.2 spec; deferrable).
- `build_recipe_from_flags` plumbing (no flag-mode handle for it).
- Schema-version bump (additive optional field; schema_version=1 recipes stay valid).

## Test plan
- [x] `pytest tests/triage/ -q` → 235 passed (12 new).
- [ ] Smoke-test: load a recipe with both scopes, confirm cell-scope wins on collision in `--dry-run` output.
- [ ] Confirm `aorta-internal/recipes/SHAMPOO-NAN-2026-042-v2.yaml` can opt a cell into `shampoo_api: old` without touching Python (downstream task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)