### PR TITLE
env probe: address outstanding Copilot review comments from A1.2a/b/c

### DIFF
--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -94,6 +94,7 @@ end-of-output. Sample:
 ```text
 Wrote env probe to /tmp/env.json (schema_version=1.5) [PARTIAL]
   runtime:   baremetal / python=venv
+  build_sys: none
   rocm:      7.2.1 (dev: None)
   hip:       7.2.53211-e1a6bc5663 (amd)
   hipblaslt: 1.2.2 rocm_release_tweak=dabb6df2b9

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -78,15 +78,21 @@ def env() -> None:
         "Buck2 label to introspect for library identity (issue #163, "
         "A1.2b). When given, the snapshot's library_introspection list "
         "is populated from `buck2 audit dependencies <label> --transitive "
-        "--json`. Ignored if buck2 isn't on PATH."
+        "--json`. If buck2 isn't on PATH (or `buck2 audit` otherwise "
+        "fails), the library_introspection list stays empty and a "
+        "human-readable reason is recorded in `partial_reasons`."
     ),
 )
 @click.option(
     "--buck-timeout",
-    type=int,
+    # ``IntRange(min=1)`` rejects 0 / negative values at arg-parse time
+    # rather than letting them flow into ``subprocess.run(timeout=...)``
+    # where they raise ``ValueError`` and confuse the never-raises
+    # fallback path. Per Copilot review on PR #165.
+    type=click.IntRange(min=1),
     default=10,
     show_default=True,
-    help="Per-call timeout (seconds) for `buck2 audit dependencies`.",
+    help="Per-call timeout (seconds, must be >= 1) for `buck2 audit dependencies`.",
 )
 def probe(
     output: Path,
@@ -279,9 +285,14 @@ def recipe(env_json: Path, fmt: str) -> None:
       to a Buck-only world).
     """
     try:
-        env_dict = json.loads(env_json.read_text())
-    except (OSError, json.JSONDecodeError) as exc:
-        # Wrap both filesystem and JSON-parse errors as a single
+        # ``read_text()`` defaults to the platform encoding (usually
+        # UTF-8 on Linux). A snapshot written on a host with a stricter
+        # encoding (or a hand-edited file with stray bytes) can raise
+        # ``UnicodeDecodeError`` -- catch that alongside the obvious
+        # OSError/JSONDecodeError. Per Copilot review on PR #178.
+        env_dict = json.loads(env_json.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        # Wrap filesystem, decode, and JSON-parse errors as a single
         # Click error so the operator sees a clean one-liner instead
         # of a Python traceback.
         raise click.ClickException(

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -160,8 +160,18 @@ def probe(
     # supposed to be JSON-native (str/int/bool/None/list/dict). If a
     # non-serializable type sneaks in (e.g. a Path or datetime), we want
     # the failure to be loud rather than silently stringified.
+    #
+    # ``encoding="utf-8"`` is set explicitly to stay symmetric with the
+    # ``recipe`` reader (which also forces utf-8). Without it,
+    # ``write_text`` would use the platform default (e.g. cp1252 on
+    # some Windows locales / containers), which could produce a file
+    # that ``aorta env recipe`` later refuses to decode. Per Copilot
+    # round-1 review on PR #181.
     try:
-        output.write_text(json.dumps(snapshot_dict, indent=2))
+        output.write_text(
+            json.dumps(snapshot_dict, indent=2),
+            encoding="utf-8",
+        )
     except OSError as exc:
         raise click.ClickException(
             f"Failed to write env probe to {output}: {exc}"

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -8,7 +8,7 @@ will live here too.
 
 | Submodule | Purpose | Public API |
 | --- | --- | --- |
-| [`environment`](environment.py) | ROCm + ML stack version snapshot + container/python env detection. See block list below. | `collect_env() -> EnvSnapshot` |
+| [`environment`](environment.py) | ROCm + ML stack version snapshot + container/python env detection. See block list below. | `collect_env(buck_target: str \| None = None, buck_timeout: int = 10) -> EnvSnapshot` |
 | [`build_system`](build_system.py) | Detects Buck2 build environments (issue #163, A1.2a). Wrapped by `collect_env()` and surfaced as the `build_system` field of `EnvSnapshot`. | `detect_build_system() -> dict` |
 | [`buck_introspect`](buck_introspect.py) | Buck-aware library introspection via `buck2 audit dependencies <target> --transitive --json` (issue #163, A1.2b). Triggered by `collect_env(buck_target=...)` (or `aorta env probe --buck-target ...`); populates the `library_introspection` and `library_introspection_alternates` fields of `EnvSnapshot`. | `introspect_libraries_via_buck(target, repo_revision, ...) -> (entries, reasons)` |
 | [`recipes/buck`](recipes/buck.py) | BUCK file-fragment emitter for `aorta env recipe --format buck` (issue #163, A1.2c). Reads `build_system` + `library_introspection` from a captured env.json dict and emits one `prebuilt_cxx_library` per `source == "buck"` entry, prefixed with a loud "BEST-EFFORT, NOT EXACT" header. Pure text generation -- never invokes `buck2 build`, never vendors Buck rules. | `emit_buck_recipe(env: dict) -> str` |

--- a/src/aorta/instrumentation/recipes/buck.py
+++ b/src/aorta/instrumentation/recipes/buck.py
@@ -69,7 +69,24 @@ def emit_buck_recipe(env: dict[str, Any]) -> str:
     """
     out: list[str] = [RECIPE_HEADER]
 
-    build_system = env.get("build_system") or {"kind": "unknown"}
+    # Guard against env.json that carries a non-dict ``build_system``
+    # (hand-edited file, schema regression, future-version field with
+    # an unexpected shape). The emitter's "never raises" contract means
+    # we surface the violation as a recipe-visible warning rather than
+    # letting ``.get(...)`` raise AttributeError. Per Copilot review on
+    # PR #178.
+    raw_build_system = env.get("build_system")
+    if raw_build_system is None:
+        build_system: dict[str, Any] = {"kind": "unknown"}
+    elif isinstance(raw_build_system, dict):
+        build_system = raw_build_system
+    else:
+        out.append(
+            f"# warning: build_system has unexpected type "
+            f"{type(raw_build_system).__name__}; expected dict. "
+            f"Treating as kind=unknown."
+        )
+        build_system = {"kind": "unknown"}
     out.append(_build_system_comment(build_system))
 
     introspection = env.get("library_introspection") or []

--- a/tests/instrumentation/test_buck_recipe.py
+++ b/tests/instrumentation/test_buck_recipe.py
@@ -278,6 +278,32 @@ class TestEmptyAndDegradedShapes:
         assert out.startswith(RECIPE_HEADER)
         assert "prebuilt_cxx_library(" not in out
 
+    @pytest.mark.parametrize(
+        "bad_build_system",
+        ["string-not-dict", 42, ["list", "not", "dict"], True],
+        ids=["str", "int", "list", "bool"],
+    )
+    def test_non_dict_build_system_does_not_raise(self, bad_build_system):
+        """A hand-edited env.json that puts a non-dict in ``build_system``
+        must not blow up the emitter via ``.get("kind")`` on a non-dict.
+        Per Copilot review on PR #178: surface as a recipe-visible
+        warning + degrade to ``kind=unknown``. Regression guard for the
+        never-raises contract.
+        """
+        env = {
+            "build_system": bad_build_system,
+            "library_introspection": [],
+            "library_introspection_alternates": [],
+        }
+        out = emit_buck_recipe(env)
+        assert out.startswith(RECIPE_HEADER)
+        assert "warning" in out
+        assert "build_system" in out
+        assert "unexpected type" in out
+        # Degraded path produces the kind=unknown provenance line.
+        assert "kind=unknown" in out
+        assert "prebuilt_cxx_library(" not in out
+
 
 class TestAlternates:
     def test_alternates_render_as_comment_block_only(self):

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -1525,6 +1525,85 @@ class TestProbeBuckTimeoutValidation:
             assert result.exit_code == 0, result.output
 
 
+class TestProbeWritesUtf8:
+    """Per Copilot review on PR #181: `aorta env probe` must write
+    env.json with `encoding="utf-8"` so the symmetric
+    `aorta env recipe` reader (which forces utf-8) can always read it
+    back, regardless of the host's default encoding. Without this,
+    a non-UTF-8 default locale (e.g. cp1252) on the producing host
+    could silently produce a file that the consumer refuses to decode.
+    """
+
+    @staticmethod
+    def _cli_mod():
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        spec = importlib.util.spec_from_file_location(
+            "aorta.cli.env", cli_path,
+        )
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+        return cli_mod
+
+    def test_probe_passes_utf8_encoding_to_write_text(
+        self, all_disabled, tmp_path: Path,
+    ):
+        """Direct regression guard: patch ``Path.write_text`` and
+        assert ``encoding="utf-8"`` is in the call. This is the only
+        unambiguous way to assert the writer side of the round-trip
+        contract without manufacturing a non-UTF-8 host environment.
+        """
+        from click.testing import CliRunner
+
+        captured_kwargs: dict = {}
+        original_write_text = Path.write_text
+
+        def fake_write_text(self, *args, **kwargs):
+            # Capture the kwargs the CLI passed and then delegate to
+            # the real implementation so the file actually lands and
+            # the rest of the CLI path (echoes, summary, etc.) runs.
+            captured_kwargs.update(kwargs)
+            return original_write_text(self, *args, **kwargs)
+
+        cli_mod = self._cli_mod()
+        runner = CliRunner()
+        out = tmp_path / "env.json"
+        with patch.object(Path, "write_text", fake_write_text):
+            result = runner.invoke(cli_mod.env, ["probe", "-o", str(out)])
+
+        assert result.exit_code == 0, result.output
+        assert captured_kwargs.get("encoding") == "utf-8", (
+            f"probe must pass encoding='utf-8' to write_text; "
+            f"got kwargs={captured_kwargs}"
+        )
+
+    def test_probe_then_recipe_round_trip_succeeds(
+        self, all_disabled, tmp_path: Path,
+    ):
+        """End-to-end: write a snapshot with ``probe``, then read it
+        with ``recipe`` and confirm the recipe is emitted. This is the
+        operator-visible contract Copilot's comment was protecting.
+        """
+        from click.testing import CliRunner
+        cli_mod = self._cli_mod()
+        runner = CliRunner()
+        out = tmp_path / "env.json"
+
+        probe_result = runner.invoke(cli_mod.env, ["probe", "-o", str(out)])
+        assert probe_result.exit_code == 0, probe_result.output
+        assert out.exists()
+
+        # The file must be valid UTF-8.
+        decoded = out.read_text(encoding="utf-8")
+        assert "schema_version" in decoded
+
+        recipe_result = runner.invoke(
+            cli_mod.env, ["recipe", str(out), "--format", "buck"]
+        )
+        assert recipe_result.exit_code == 0, recipe_result.output
+        assert "BEST-EFFORT, NOT EXACT" in recipe_result.output
+
+
 # ---------------------------------------------------------------------------
 # RDHC wrapper
 # ---------------------------------------------------------------------------

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -1467,6 +1467,64 @@ class TestCliSummaryAndFieldFlags:
         assert payload["schema_version"] == env_mod.SCHEMA_VERSION
 
 
+class TestProbeBuckTimeoutValidation:
+    """Per Copilot review on PR #165: ``--buck-timeout`` must reject
+    values <= 0 at arg-parse time. ``subprocess.run(timeout=...)``
+    raises ``ValueError`` on a non-positive timeout, which would
+    short-circuit the buck audit into the never-raises fallback path
+    instead of failing loudly. Catching it in Click means the operator
+    sees the typo, not a silent "no introspection done".
+    """
+
+    @staticmethod
+    def _cli_mod():
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        spec = importlib.util.spec_from_file_location(
+            "aorta.cli.env", cli_path,
+        )
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+        return cli_mod
+
+    @pytest.mark.parametrize("bad_value", ["0", "-1", "-100"])
+    def test_buck_timeout_non_positive_rejected_by_click(
+        self, bad_value, all_disabled, tmp_path: Path,
+    ):
+        from click.testing import CliRunner
+        cli_mod = self._cli_mod()
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(
+                cli_mod.env,
+                ["probe", "--buck-timeout", bad_value, "--summary"],
+            )
+            assert result.exit_code != 0
+            # Click's IntRange formatting names the option and the
+            # offending value; assert on stable text.
+            lower = result.output.lower()
+            assert "buck-timeout" in lower
+            assert "invalid value" in lower or "not in the range" in lower
+            # No Python traceback should leak.
+            assert "Traceback" not in result.output
+
+    def test_buck_timeout_positive_value_accepted(
+        self, all_disabled, tmp_path: Path,
+    ):
+        """Sanity: any value >= 1 still parses (no regression on the
+        documented default of 10 or any other reasonable override).
+        """
+        from click.testing import CliRunner
+        cli_mod = self._cli_mod()
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(
+                cli_mod.env,
+                ["probe", "--buck-timeout", "5", "--summary"],
+            )
+            assert result.exit_code == 0, result.output
+
+
 # ---------------------------------------------------------------------------
 # RDHC wrapper
 # ---------------------------------------------------------------------------

--- a/tests/instrumentation/test_recipe_cli.py
+++ b/tests/instrumentation/test_recipe_cli.py
@@ -138,6 +138,21 @@ class TestInputValidation:
         assert "invalid value" in result.output.lower() or \
                "ninja" in result.output.lower()
 
+    def test_non_utf8_file_surfaces_as_click_error(self, runner, tmp_path):
+        """A file existing on disk but holding bytes that aren't valid
+        UTF-8 (snapshot copied from a stricter-locale host, or a
+        truncated transfer) must surface as a clean ClickException
+        rather than a ``UnicodeDecodeError`` traceback. Per Copilot
+        review on PR #178.
+        """
+        bad = tmp_path / "non-utf8.json"
+        # 0xff / 0xfe / 0xfd are invalid as a UTF-8 start byte sequence.
+        bad.write_bytes(b"\xff\xfe\xfd not utf-8")
+        result = runner.invoke(env, ["recipe", str(bad), "--format", "buck"])
+        assert result.exit_code != 0
+        assert "failed to read" in result.output.lower()
+        assert "Traceback" not in result.output
+
 
 class TestHelpSurface:
     def test_recipe_help_advertises_supported_formats(self, runner):


### PR DESCRIPTION
## Why

PRs #164 / #165 / #178 (issue #163, the full A1.2 env-probe-buck
pipeline) were merged with several Copilot-flagged real concerns
left unaddressed. This PR batches those follow-ups into one
review-able change so they can be fixed without skipping review
the way the original merges did.


## What

Six fixes + tests for each. All changes are docs / wiring /
input-validation -- no schema bump.

### From PR #164 round 3
- **docs/env-probe.md**: add the missing `build_sys:` line (right
  after `runtime:`) to the sample `aorta env probe` output. The
  doc now matches what `EnvSnapshot.summary()` actually prints.

### From PR #165
- **cli/env.py** `--buck-target` help: previous wording said
  "Ignored if buck2 isn't on PATH", which understated the
  behaviour. The buck-introspection path also records a
  human-readable reason in `partial_reasons`. Help text now spells
  this out.
- **cli/env.py** `--buck-timeout`: switched from `int` to
  `click.IntRange(min=1)`. A value of `0` or negative would have
  flowed into `subprocess.run(timeout=...)` and raised
  `ValueError`, silently short-circuiting buck introspection into
  the never-raises fallback instead of failing loudly. Click now
  rejects bad values at arg-parse time.
- **instrumentation/README.md**: updated the `collect_env()`
  signature row to include the new `buck_target` /
  `buck_timeout` kwargs added in A1.2b.

### From PR #178
- **recipes/buck.py**: guard `emit_buck_recipe()` against
  `env["build_system"]` not being a dict. A hand-edited env.json
  carrying a string / int / list / bool used to raise
  `AttributeError` on `.get("kind")`, violating the
  ``never raises`` contract. Non-dict is now surfaced as a
  recipe-visible `# warning: ...` comment and the kind degrades
  to `unknown`.
- **cli/env.py** `recipe` command: widened the exception handler
  to also catch `UnicodeDecodeError`. An env.json copied from a
  stricter-locale host (or a truncated transfer) used to leak a
  Python traceback; now surfaces as a clean ``ClickException``.
  Also pinned the read to `encoding="utf-8"` explicitly.

## Tests added

| File | Test | Covers |
| --- | --- | --- |
| `tests/instrumentation/test_buck_recipe.py` | `test_non_dict_build_system_does_not_raise[str,int,list,bool]` | parametrised, 4 sub-tests |
| `tests/instrumentation/test_recipe_cli.py` | `test_non_utf8_file_surfaces_as_click_error` | invalid UTF-8 bytes |
| `tests/instrumentation/test_environment.py::TestProbeBuckTimeoutValidation` | `non_positive_rejected_by_click[0,-1,-100]` + `positive_value_accepted` | 4 sub-tests |

Run results:

```
tests/instrumentation/test_buck_recipe.py        ........ 26 passed
tests/instrumentation/test_recipe_cli.py         ........ 10 passed
tests/instrumentation/TestProbeBuckTimeoutValidation  4 passed
```

Full `tests/instrumentation/` suite: **408 passed, 1 failed
(pre-existing `triton not importable` on this dev host -- unrelated
to this PR), 3 skipped**.

## Acceptance check

- [x] No schema bump (changes are docs + validation + wiring only).
- [x] `EnvSnapshot.summary()` brief lines match the docs sample.
- [x] `aorta env probe --buck-timeout 0` is rejected by Click
  with a clear "not in the range" message (no `ValueError`
  traceback).
- [x] `aorta env recipe` on a non-UTF-8 env.json produces a
  one-line ``ClickException`` (no traceback).
- [x] `aorta env recipe` on an env.json with non-dict
  `build_system` produces a recipe that still starts with the
  loud header and surfaces the malformed shape as a warning
  comment instead of crashing.
- [x] `cli/env.py` is 327 lines (soft budget 350, no probing logic
  added).

## Out of scope

- Skipping the lower-confidence Copilot nits (style preferences,
  duplicated literals that don't change behaviour) -- same policy
  as the prior rounds.
- No changes to the buck-introspection code path beyond the help-
  text wording.

Refs #163.

Made with [Cursor](https://cursor.com)