### PR TITLE
A1.4: registry Environment -- buck_target field as docker/venv peer

### DIFF
--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -4,8 +4,9 @@ Two small registries that ship with aorta:
 
 - **Mitigations** (`name → env vars`) — process-level flags applied just before
   the workload subprocess launches. Examples: `tf32_off`, `xnack`.
-- **Environments** (`name → docker / venv recipe`) — baseline state of the
-  process or container the workload runs in. Examples: `local`, `default`.
+- **Environments** (`name → docker / venv / buck_target recipe`) — baseline
+  state of the process, container, or Buck-built binary the workload runs in.
+  Examples: `local`, `default`.
 
 Both follow the same shape: built-ins ship from this package; external
 contributions arrive via Python entry-points and are merged at runtime.
@@ -198,10 +199,51 @@ workloads via the `aorta.workloads` entry-point group.
 ## Adding an environment
 
 Same two paths, with `aorta.environments` as the entry-point group. Plugin
-payloads must use only the keys `docker` and `venv`; anything else (e.g.
-`rocm`) raises `RegistryError` at load time. ROCm version is implicit in
-the docker image digest or in the host the venv runs on — capture it from
-`aorta env probe` at runtime, not via static declaration.
+payloads must use only the keys `docker`, `venv`, or `buck_target`; anything
+else (e.g. `rocm`) raises `RegistryError` at load time. ROCm version is
+implicit in the docker image digest, the host the venv runs on, or the Buck
+checkout's captured revision — capture it from `aorta env probe` at runtime,
+not via static declaration.
+
+### Tier hints: how the workload consumes the resolved environment
+
+The dispatcher threads the resolved `Environment` dataclass into each
+workload's config under the reserved key `_aorta_environment`:
+
+```python
+config["_aorta_environment"] = {
+    "name": "...",
+    "docker": "...",         # or None
+    "venv": "...",           # or None
+    "buck_target": "...",    # or None
+    "source_package": "...",
+}
+```
+
+Workloads that can isolate themselves read this dict and branch their
+subprocess invocation accordingly. The platform itself launches no docker
+images, activates no venvs, and invokes no `buck2 run` — it threads the
+metadata; the wrapper decides. Today's `recom_repro` wrapper consumes
+`docker`; a Buck-aware wrapper consumes `buck_target` with the same
+pattern:
+
+```python
+# Inside a workload's run() method:
+env = self.config.get("_aorta_environment") or {}
+buck_target = env.get("buck_target")
+image = env.get("docker")
+
+if buck_target:
+    argv = ["buck2", "run", buck_target, "--", *script_args]
+elif image:
+    argv = ["docker", "run", ..., image, "python", ...]
+else:
+    argv = [sys.executable, str(entry)]
+```
+
+Adding a fourth tier later (e.g. Bazel) follows the same pattern: extend
+`Environment`, extend `_VALID_ENV_KEYS`, document the read pattern here.
+The dispatcher round-trips the field for free (`asdict(env_descriptor)`).
 
 ## Collisions
 

--- a/src/aorta/registry/environments.py
+++ b/src/aorta/registry/environments.py
@@ -1,13 +1,14 @@
 """Environments registry: built-ins + entry-point discovery + collision detection.
 
 Mirrors the mitigations registry. Plugin payloads are validated against
-`_VALID_ENV_KEYS` — only `docker` and `venv` are accepted. ROCm version is
-intentionally not a valid key (see `Environment` docstring).
+`_VALID_ENV_KEYS` — `docker`, `venv`, and `buck_target` are accepted. ROCm
+version is intentionally not a valid key (see `Environment` docstring).
 
 Plugin authors register one entry-point per environment in their `pyproject.toml`
 under the `aorta.environments` group. The entry-point name IS the environment
-name; the loaded object is the recipe (`dict[str, str | None]` with keys
-`docker` and/or `venv`). Mirrors the `aorta.workloads` extension-point pattern.
+name; the loaded object is the recipe (`dict[str, str | None]` with any of the
+keys `docker`, `venv`, `buck_target`). Mirrors the `aorta.workloads`
+extension-point pattern.
 """
 
 from importlib.metadata import entry_points
@@ -22,7 +23,9 @@ from aorta.registry.sidecar import check_sidecar_basenames, load_sidecar_environ
 from aorta.registry.types import Environment
 
 _GROUP = "aorta.environments"
-_VALID_ENV_KEYS = frozenset({"docker", "venv"})
+# `buck_target` joins `docker` / `venv` as a peer baseline-recipe key (#182).
+# Order in the frozenset is irrelevant; spelled this way for grep-ability.
+_VALID_ENV_KEYS = frozenset({"docker", "venv", "buck_target"})
 
 # Built-in environments. `local` and `default` are both "current process, no
 # overrides" — `default` is reserved as a site-configurable alias. Customer
@@ -56,6 +59,7 @@ def load_environments(
             name=name,
             docker=spec.get("docker"),
             venv=spec.get("venv"),
+            buck_target=spec.get("buck_target"),
             source_package="aorta",
         )
         for name, spec in BUILTIN_ENVIRONMENTS.items()
@@ -99,6 +103,7 @@ def load_environments(
             name=ep.name,
             docker=spec.get("docker"),
             venv=spec.get("venv"),
+            buck_target=spec.get("buck_target"),
             source_package=plugin_name,
         )
 

--- a/src/aorta/registry/sidecar.py
+++ b/src/aorta/registry/sidecar.py
@@ -20,7 +20,10 @@ from aorta.registry.types import Environment, Mitigation
 
 SCHEMA_VERSION = 1
 _VALID_TOP_LEVEL = frozenset({"version", "mitigations", "environments"})
-_VALID_ENV_KEYS = frozenset({"docker", "venv"})
+# Keep in sync with `aorta.registry.environments._VALID_ENV_KEYS`; the two
+# allow-lists are intentionally identical so sidecar payloads and entry-point
+# payloads accept the same schema. `buck_target` peers `docker` / `venv` per #182.
+_VALID_ENV_KEYS = frozenset({"docker", "venv", "buck_target"})
 
 
 def _source_tag(path: Path) -> str:
@@ -196,6 +199,7 @@ def load_sidecar_environments(path: Path) -> dict[str, Environment]:
             name=name,
             docker=spec.get("docker"),
             venv=spec.get("venv"),
+            buck_target=spec.get("buck_target"),
             source_package=src,
         )
     return out

--- a/src/aorta/registry/types.py
+++ b/src/aorta/registry/types.py
@@ -21,13 +21,22 @@ class Mitigation:
 class Environment:
     """A baseline process / container recipe for a workload run.
 
-    `docker` and `venv` are independent ways of describing the baseline; either,
-    both, or neither may be set (built-in `local` has neither — current process).
-    No `rocm` field: ROCm version is implicit in the docker image digest or in
-    the host the venv runs on; capture it from `aorta env probe` at runtime.
+    `docker`, `venv`, and `buck_target` are independent ways of describing the
+    baseline; any combination (or none) may be set — built-in `local` has none
+    (current process). No `rocm` field: ROCm version is implicit in the docker
+    image digest, the host the venv runs on, or the captured `revision` of the
+    Buck checkout; capture it from `aorta env probe` at runtime.
+
+    `buck_target` is a Buck2 target label (e.g. `"//workloads/recom_repro:recom_repro"`).
+    Interpreted by Buck-aware workload wrappers analogous to how `docker` is
+    interpreted by docker-aware wrappers: the platform threads the field; the
+    wrapper decides to shell out to `buck2 run <label>`. The platform itself
+    does not invoke Buck (mirrors the no-docker-launching-in-platform policy
+    documented in `aorta-internal#14`).
     """
 
     name: str
     docker: str | None = None
     venv: str | None = None
+    buck_target: str | None = None
     source_package: str = "aorta"

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -291,8 +291,13 @@ def _run_single_trial(
     # Thread the resolved Environment descriptor into the workload's
     # config under a reserved underscore-prefixed key.  Workloads that
     # can isolate themselves (e.g., the recom_repro wrapper invoking
-    # ``docker run`` instead of ``python``) read this to pick the
-    # right image / venv; workloads that don't ignore the key.
+    # ``docker run`` instead of ``python``, or a buck-aware wrapper
+    # invoking ``buck2 run <label>``) read this to pick the right
+    # image / venv / buck target; workloads that don't ignore the key.
+    # Recognized tier hints today: ``docker`` (image digest), ``venv``
+    # (path), ``buck_target`` (#182 -- Buck2 target label).  The platform
+    # itself launches none of these -- it threads metadata, the wrapper
+    # decides.
     #
     # This is the dispatcher's way of telling the workload *which*
     # environment was selected for this cell -- the ``--environment``

--- a/tests/registry/test_environments.py
+++ b/tests/registry/test_environments.py
@@ -25,6 +25,7 @@ def test_get_environment_returns_dataclass(fake_env_eps):
     assert isinstance(env, Environment)
     assert env.docker is None
     assert env.venv is None
+    assert env.buck_target is None
     assert env.source_package == "aorta"
 
 
@@ -82,4 +83,78 @@ def test_non_string_value_raises(fake_env_eps):
 def test_non_dict_payload_raises(fake_env_eps):
     fake_env_eps([("bad", "not-a-dict", "plugin_x")])
     with pytest.raises(RegistryError, match="plugin_x.*bad.*str"):
+        load_environments()
+
+
+# --- buck_target (#182) -----------------------------------------------------
+#
+# `buck_target` is the third baseline-recipe key, peering with `docker` and
+# `venv`. The loader treats it identically to the existing keys: pass-through
+# from the spec dict, no platform-side interpretation. These tests pin the
+# field's round-trip through both the dataclass and the plugin loader, and
+# confirm the field is also accepted alone (no docker, no venv) so a
+# Buck-native workload can declare a pure-Buck environment.
+
+
+def test_buck_target_field_round_trips_from_plugin(fake_env_eps):
+    fake_env_eps([
+        (
+            "recom-repro-buck",
+            {"buck_target": "//workloads/recom_repro:recom_repro"},
+            "fake_internal",
+        ),
+    ])
+    result = load_environments()
+    env = result["recom-repro-buck"]
+    assert env.buck_target == "//workloads/recom_repro:recom_repro"
+    assert env.docker is None
+    assert env.venv is None
+    assert env.source_package == "fake_internal"
+
+
+def test_buck_target_coexists_with_docker_for_buck_in_docker(fake_env_eps):
+    # The Buck-inside-Docker tier from #37 (regression-gate buck-tier) sets
+    # both keys -- platform must accept both without preferring one.
+    fake_env_eps([
+        (
+            "buck-in-docker",
+            {
+                "docker": "rocm/private@sha256:abc",
+                "buck_target": "//workloads/recom_repro:recom_repro",
+            },
+            "fake_internal",
+        ),
+    ])
+    env = load_environments()["buck-in-docker"]
+    assert env.docker == "rocm/private@sha256:abc"
+    assert env.buck_target == "//workloads/recom_repro:recom_repro"
+
+
+def test_environment_constructs_with_buck_target_only():
+    # Direct dataclass construction -- pure-Buck environments don't need a
+    # docker image or venv. Pins the field default and `asdict` shape so
+    # downstream consumers (dispatcher's `_aorta_environment` round-trip,
+    # `TrialResult.execution_env`) see the field.
+    from dataclasses import asdict
+
+    env = Environment(name="pure-buck", buck_target="//foo:bar")
+    assert env.buck_target == "//foo:bar"
+    assert env.docker is None
+    assert env.venv is None
+    assert asdict(env) == {
+        "name": "pure-buck",
+        "docker": None,
+        "venv": None,
+        "buck_target": "//foo:bar",
+        "source_package": "aorta",
+    }
+
+
+def test_buck_target_with_non_string_value_raises(fake_env_eps):
+    # Mirrors `test_non_string_value_raises` for docker -- the validator is
+    # a single allow-list and doesn't special-case keys, but pinning the
+    # behaviour for the new key guards against future per-key validators
+    # silently exempting it.
+    fake_env_eps([("bad", {"buck_target": 123}, "plugin_x")])
+    with pytest.raises(RegistryError, match="plugin_x.*bad.*non-string"):
         load_environments()

--- a/tests/registry/test_sidecar.py
+++ b/tests/registry/test_sidecar.py
@@ -148,6 +148,26 @@ def test_sidecar_environment_invalid_key(tmp_sidecar, fake_env_eps):
         load_environments(extra_files=[p])
 
 
+def test_sidecar_environment_with_buck_target_round_trips(
+    tmp_sidecar, fake_env_eps
+):
+    # #182: `buck_target` is a peer of `docker` / `venv` in the sidecar
+    # allow-list. Pin the round-trip so the sidecar payload and the
+    # plugin payload accept the same schema (the two `_VALID_ENV_KEYS`
+    # allow-lists are intentionally identical -- see sidecar.py).
+    fake_env_eps([])
+    p = tmp_sidecar({
+        "version": 1,
+        "environments": {
+            "buck-env": {"buck_target": "//workloads/recom_repro:recom_repro"},
+        },
+    })
+    envs = load_environments(extra_files=[p])
+    assert envs["buck-env"].buck_target == "//workloads/recom_repro:recom_repro"
+    assert envs["buck-env"].docker is None
+    assert envs["buck-env"].source_package == f"sidecar:{p.name}"
+
+
 # ---------- partial files (only one of mitigations / environments) ----------
 
 

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -785,12 +785,12 @@ class TestConfigOverrides:
         assert env_block["source_package"] == "aorta"
 
     def test_non_none_docker_env_round_trips_to_both_sites(self, tmp_path):
-        """Built-in ``local`` env has ``docker=venv=None``, so the other
-        env tests don't exercise the non-``None`` branch of the
+        """Built-in ``local`` env has ``docker=venv=buck_target=None``, so the
+        other env tests don't exercise the non-``None`` branch of the
         ``asdict(env_descriptor)`` serialization at the two call sites
         (``config["_aorta_environment"]`` and ``TrialResult.execution_env``).
         A regression that drops a field from either dict would slip
-        through.  Pin all four fields at both sites with a docker-set env.
+        through.  Pin all five fields at both sites with a docker-set env.
         """
         from aorta.registry import Environment
 
@@ -840,6 +840,72 @@ class TestConfigOverrides:
             "name": "docker-test",
             "docker": "img@sha256:deadbeef",
             "venv": None,
+            "buck_target": None,
+            "source_package": "test",
+        }
+        assert captured_config["_aorta_environment"] == expected
+        assert results[0].execution_env == expected
+
+    def test_non_none_buck_target_env_round_trips_to_both_sites(self, tmp_path):
+        """#182: peer of the docker-set round-trip test above, but for the
+        ``buck_target`` field. Pins that the dispatcher threads a Buck-tier
+        environment all the way through to ``config["_aorta_environment"]``
+        and ``TrialResult.execution_env`` without losing the field.
+
+        This is the contract aorta-internal#36 (recom_repro Buck pilot) and
+        aorta-internal#37 (regression-gate Buck tier) will rely on -- a
+        regression here breaks both downstream workstreams silently.
+        """
+        from aorta.registry import Environment
+
+        captured_config: dict = {}
+
+        class EnvCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def __init__(self, config):
+                super().__init__(config)
+                captured_config.update(config)
+
+            def setup(self):
+                pass
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        env = Environment(
+            name="buck-test",
+            docker=None,
+            venv=None,
+            buck_target="//workloads/recom_repro:recom_repro",
+            source_package="test",
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "envcapture"
+        mock_ep.load.return_value = EnvCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with patch("aorta.run.dispatcher.get_environment", return_value=env):
+                req = RunRequest(
+                    workload="envcapture",
+                    trials=1,
+                    environment="buck-test",
+                    results_dir=tmp_path,
+                )
+                results = run_trials(req)
+
+        expected = {
+            "name": "buck-test",
+            "docker": None,
+            "venv": None,
+            "buck_target": "//workloads/recom_repro:recom_repro",
             "source_package": "test",
         }
         assert captured_config["_aorta_environment"] == expected


### PR DESCRIPTION
## Why

Issue #182 (the platform half of the A1.4 Buck-tier arc). Today `aorta.registry.Environment` carries `docker` and `venv` as baseline-recipe keys; any workload that wants to opt into a docker tier reads `config["_aorta_environment"]["docker"]` in its wrapper and branches subprocess invocation. There is no peer key for Buck — so a Buck-using customer who wants their workload to run under `buck2 run //my:target` instead of `docker run …` has nowhere to declare it.

#163 (A1.2-env-probe-buck) added Buck-aware introspection to `aorta env probe` (PRs #164/#165/#178). This PR is the runtime-contract half: it teaches the `Environment` registry to *describe* a Buck-tier baseline so any workload — public or private — can adopt Buck-tier subprocess invocation by reading one config key, the same way today's workloads opt into Docker-tier.

This unblocks aorta-internal#36 (the `recom_repro` Buck pilot) and, transitively, aorta-internal#37 (regression-gate Buck tier as a peer of `image_digest`).

## What

Single field on a frozen dataclass + the two loaders that build it + the dispatcher comment + tests + docs. No logic change in the dispatcher itself — `asdict(env_descriptor)` already round-trips the whole dataclass, so the new field flows into both `config["_aorta_environment"]` and `TrialResult.execution_env` for free.

### Code changes

| File | Change |
|---|---|
| `src/aorta/registry/types.py` | Add `buck_target: str | None = None` to `Environment` between `venv` and `source_package`. Docstring documents the wrapper-interpreted semantics + the no-platform-side-Buck-launching policy (mirrors `aorta-internal#14` for docker). |
| `src/aorta/registry/environments.py` | Add `"buck_target"` to `_VALID_ENV_KEYS`; thread `spec.get("buck_target")` into both the builtin-construction and plugin-construction call sites. |
| `src/aorta/registry/sidecar.py` | Same treatment as the entry-point loader — the two `_VALID_ENV_KEYS` allow-lists are intentionally identical so sidecar payloads and plugin payloads accept the same schema. Comment cross-references the env-side allow-list. |
| `src/aorta/run/dispatcher.py` | Update the inline comment around the `config["_aorta_environment"] = asdict(env_descriptor)` site to list `buck_target` alongside `docker` / `venv` as a recognized tier hint. **No logic change.** |
| `src/aorta/registry/README.md` | Extend the "Adding an environment" section; add a new "Tier hints" subsection documenting the wrapper-side read pattern with a concrete `if buck_target / elif image / else` example, so workload authors have one place to look. |

### Tests added

| File | Test | Covers |
|---|---|---|
| `tests/registry/test_environments.py` | `test_buck_target_field_round_trips_from_plugin` | Plugin payload `{"buck_target": "//foo:bar"}` round-trips through the loader. |
| `tests/registry/test_environments.py` | `test_buck_target_coexists_with_docker_for_buck_in_docker` | Both keys can be set simultaneously (the Buck-inside-Docker tier from aorta-internal#37). |
| `tests/registry/test_environments.py` | `test_environment_constructs_with_buck_target_only` | Direct dataclass construction + `asdict()` shape pinned for downstream consumers. |
| `tests/registry/test_environments.py` | `test_buck_target_with_non_string_value_raises` | Validator parity with the existing `docker` non-string test. |
| `tests/registry/test_environments.py` | `test_get_environment_returns_dataclass` *(extended)* | Now asserts `buck_target is None` for the `local` builtin. |
| `tests/registry/test_sidecar.py` | `test_sidecar_environment_with_buck_target_round_trips` | Sidecar payload round-trips, source_package tagged as `sidecar:<basename>`. |
| `tests/run/test_dispatcher.py` | `test_non_none_buck_target_env_round_trips_to_both_sites` | Pins that `config["_aorta_environment"]` and `TrialResult.execution_env` both carry the field. Peer of the existing docker-set round-trip test. |
| `tests/run/test_dispatcher.py` | `test_non_none_docker_env_round_trips_to_both_sites` *(extended)* | `expected` dict now includes `"buck_target": None`; docstring updated from "four fields" to "five fields". |

Run results:

```
tests/registry/        50 passed
tests/run/            109 passed
                      ----------
                      159 passed in 3.08s
```

## Acceptance check (matches issue #182)

- [x] `Environment` accepts `buck_target` and `asdict()` includes it.
- [x] The registry loader accepts the new field with no behavior change to existing entries (existing built-ins `local` / `default` still construct fine; sidecar invalid-key test still rejects `rocm`).
- [x] `_aorta_environment` dict in a workload's `config` carries the field when set, defaults to `None` otherwise.
- [x] Workload-author docs include the new key with a concrete read pattern (registry README, new "Tier hints" subsection).
- [x] All existing dispatcher and registry tests continue to pass unchanged.

## Out of scope (deferred per issue body)

- **Launching Buck from the platform.** Same call as the existing docker policy — the platform threads metadata; the wrapper invokes the subprocess. No `buck2 run` invocation anywhere in platform-side code.
- **Shared `buck_run_argv()` helper.** Deferred until the `recom_repro` pilot is in review — if its `_build_argv` Buck branch proves to be cargo-cultable boilerplate, file a follow-up to extract.
- **`Environment` carrying captured Buck revision.** Revision pinning is a regression-gate concern (aorta-internal#37), not a runtime-env one.

## Conflict / compatibility note

PR #181 (env-probe Copilot-review follow-ups, currently open) touches `cli/env.py`, `recipes/buck.py`, `instrumentation/README.md`, `docs/env-probe.md`, and instrumentation test files — no overlap with the files this PR touches. Either merge order is safe.

Closes #182. Refs #163.
