### PR TITLE
triage: add save_logs recipe field for per-trial stdout/stderr capture

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -97,8 +97,12 @@ cells:
   that spawn subprocesses (e.g. `recom_repro` invoking `docker run`)
   don't have their subprocess output captured automatically. Those
   wrappers can opt in by reading the platform-supplied
-  `_aorta_save_logs` / `_aorta_log_stdout` / `_aorta_log_stderr` config
-  keys the dispatcher injects when `save_logs=true`.
+  `_aorta_save_logs` / `_aorta_log_basename` config keys the dispatcher
+  injects when `save_logs=true`, and writing their own capture to a
+  sibling path derived from the basename (e.g.
+  `<basename>.subprocess.stdout.log`). The dispatcher already holds the
+  `<basename>.{stdout,stderr}.log` paths open, so wrappers must NOT
+  write to them directly.
 - **`workload_config`** -- optional `dict[str, Any]`, allowed at both
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -17,6 +17,7 @@ ticket: EXAMPLE-001                  # optional; drives output dir grouping
 workload: fsdp                       # required; resolved via aorta.workloads entry-point group
 trials: 8                            # required; per-cell trial count
 steps: 5000                          # required; per-cell step count
+save_logs: false                     # optional; when true, dispatcher writes per-trial stdout/stderr files
 
 confound:
   threshold: 1.15                    # default; > 1.15 -> "speed (+N%)" flag
@@ -88,13 +89,25 @@ cells:
   mitigation bundle, so it can override a registered mitigation's env var
   for one-off experiments without polluting the registry. Recorded in
   `matrix.json` for audit.
+- **`save_logs`** -- optional `bool`, default `false`. When `true`, the
+  dispatcher captures the workload's in-process `stdout` / `stderr`
+  writes into `trial_d{d}_m{m}_t{t}.{stdout,stderr}.log` files alongside
+  the trial JSON. Rank-0 only (matches the trial-JSON write guarantee).
+  `contextlib.redirect_*` only catches Python-level writes; workloads
+  that spawn subprocesses (e.g. `recom_repro` invoking `docker run`)
+  don't have their subprocess output captured automatically. Those
+  wrappers can opt in by reading the platform-supplied
+  `_aorta_save_logs` / `_aorta_log_stdout` / `_aorta_log_stderr` config
+  keys the dispatcher injects when `save_logs=true`.
 - **`workload_config`** -- optional `dict[str, Any]`, allowed at both
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use
   this for workload-specific knobs that aren't env vars -- e.g.
-  `shampoo_api: old` on the `recom_repro` workload to select the V2
-  Meta-internal SHAMPOO entry script. Cell-scope merges over recipe-scope
-  on a per-key basis (cell wins on collision; non-collision keys union),
+  `shampoo_api: old` on the `recom_repro` workload to select the V1
+  flat-kwarg SHAMPOO entry script (both `new` and `old` import from the
+  OSS `distributed_shampoo` package; they differ in constructor shape).
+  Cell-scope merges over recipe-scope on a per-key basis (cell wins on
+  collision; non-collision keys union),
   so a recipe can set a workload-wide default and opt one cell out.
   Reserved keys: `"steps"` (first-class field; would be silently
   overwritten by the dispatcher) and any `_aorta_*` prefix

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -92,17 +92,19 @@ cells:
 - **`save_logs`** -- optional `bool`, default `false`. When `true`, the
   dispatcher captures the workload's in-process `stdout` / `stderr`
   writes into `trial_d{d}_m{m}_t{t}.{stdout,stderr}.log` files alongside
-  the trial JSON. Rank-0 only (matches the trial-JSON write guarantee).
+  the trial JSON. Both the file capture and the reserved-key injection
+  described below are **rank-0 only** (matches the trial-JSON write
+  guarantee); wrappers running on non-rank-0 won't see the keys and
+  should treat capture as off there.
   `contextlib.redirect_*` only catches Python-level writes; workloads
   that spawn subprocesses (e.g. `recom_repro` invoking `docker run`)
   don't have their subprocess output captured automatically. Those
   wrappers can opt in by reading the platform-supplied
   `_aorta_save_logs` / `_aorta_log_basename` config keys the dispatcher
-  injects when `save_logs=true`, and writing their own capture to a
-  sibling path derived from the basename (e.g.
-  `<basename>.subprocess.stdout.log`). The dispatcher already holds the
-  `<basename>.{stdout,stderr}.log` paths open, so wrappers must NOT
-  write to them directly.
+  injects, and writing their own capture to a sibling path derived from
+  the basename (e.g. `<basename>.subprocess.stdout.log`). The
+  dispatcher already holds the `<basename>.{stdout,stderr}.log` paths
+  open, so wrappers must NOT write to them directly.
 - **`workload_config`** -- optional `dict[str, Any]`, allowed at both
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -379,25 +379,55 @@ def _run_single_trial(
     # Enabling a debug knob must never break an otherwise-healthy
     # trial; ``backslashreplace`` keeps the file lossless-enough for
     # grep without ever raising.
-    trial_log_stdout: Path | None = None
-    trial_log_stderr: Path | None = None
+    #
+    # The opens happen up-front in their own ``try/except OSError``
+    # for two reasons:
+    #   1. An opt-in debug knob must not crash the run -- if the disk
+    #      is full or the dir lost write permission, we warn and let
+    #      the trial proceed without capture.
+    #   2. We've already mutated ``os.environ`` above with the
+    #      mitigation / extra_env overlay. If an OSError escaped the
+    #      ``with log_stack:`` block below, the env-restore ``finally``
+    #      inside that block would never run and the mitigation vars
+    #      would leak into the caller's process -- corrupting
+    #      subsequent triage cells.
+    # The ``_aorta_*`` config keys are only injected on success so
+    # that wrappers can trust "if you see the keys, capture is on".
+    stdout_fh: Any = None
+    stderr_fh: Any = None
     if request.save_logs and should_write:
         log_basename = (
             f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
         )
-        trial_log_stdout = results_dir / f"{log_basename}.stdout.log"
-        trial_log_stderr = results_dir / f"{log_basename}.stderr.log"
-        config["_aorta_save_logs"] = True
-        config["_aorta_log_basename"] = log_basename
+        candidate_stdout = results_dir / f"{log_basename}.stdout.log"
+        candidate_stderr = results_dir / f"{log_basename}.stderr.log"
+        try:
+            stdout_fh = open(
+                candidate_stdout, "w", encoding="utf-8", errors="backslashreplace"
+            )
+            stderr_fh = open(
+                candidate_stderr, "w", encoding="utf-8", errors="backslashreplace"
+            )
+        except OSError as exc:
+            if stdout_fh is not None:
+                stdout_fh.close()
+                stdout_fh = None
+            logger.warning(
+                "save_logs=True but failed to open log files in %s "
+                "(%s: %s); trial '%s' will run without capture.",
+                results_dir,
+                type(exc).__name__,
+                exc,
+                trial_id,
+            )
+        else:
+            config["_aorta_save_logs"] = True
+            config["_aorta_log_basename"] = log_basename
 
     with contextlib.ExitStack() as log_stack:
-        if trial_log_stdout is not None and trial_log_stderr is not None:
-            stdout_fh = log_stack.enter_context(
-                open(trial_log_stdout, "w", encoding="utf-8", errors="backslashreplace")
-            )
-            stderr_fh = log_stack.enter_context(
-                open(trial_log_stderr, "w", encoding="utf-8", errors="backslashreplace")
-            )
+        if stdout_fh is not None and stderr_fh is not None:
+            log_stack.callback(stderr_fh.close)
+            log_stack.callback(stdout_fh.close)
             log_stack.enter_context(contextlib.redirect_stdout(stdout_fh))
             log_stack.enter_context(contextlib.redirect_stderr(stderr_fh))
 

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -412,6 +412,14 @@ def _run_single_trial(
             if stdout_fh is not None:
                 stdout_fh.close()
                 stdout_fh = None
+            # Best-effort cleanup so a 0-byte stub doesn't masquerade
+            # as the trial's captured output -- if stdout opened but
+            # stderr failed, the empty stdout.log is still on disk.
+            for path in (candidate_stdout, candidate_stderr):
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
             logger.warning(
                 "save_logs=True but failed to open log files in %s "
                 "(%s: %s); trial '%s' will run without capture.",

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -78,7 +78,10 @@ class RunRequest:
             ``stdout`` / ``stderr`` writes to per-trial files alongside
             the trial JSON (``trial_d{d}_m{m}_t{t}.{stdout,stderr}.log``).
             Default ``False`` preserves today's behaviour (no capture).
-            Rank-0 only -- matches the trial-JSON write guarantee.
+            Both file capture and the reserved-key injection described
+            below are **rank-0 only** -- matches the trial-JSON write
+            guarantee. Wrappers running on non-rank-0 won't see the
+            keys and should treat capture as off there.
             ``contextlib.redirect_*`` only catches Python-level writes;
             subprocesses are not captured. Wrappers that own a
             subprocess can opt in by reading the platform-supplied

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -82,8 +82,23 @@ class RunRequest:
             ``contextlib.redirect_*`` only catches Python-level writes;
             subprocesses are not captured. Wrappers that own a
             subprocess can opt in by reading the platform-supplied
-            ``_aorta_save_logs`` / ``_aorta_log_stdout`` /
-            ``_aorta_log_stderr`` config keys this dispatcher injects.
+            ``_aorta_save_logs`` / ``_aorta_log_basename`` config keys
+            this dispatcher injects; the basename is the trial filename
+            stem (e.g. ``trial_d0_m0_t0``) and the wrapper derives a
+            non-colliding sibling path such as
+            ``<basename>.subprocess.{stdout,stderr}.log`` -- the
+            dispatcher already holds open the
+            ``<basename>.{stdout,stderr}.log`` paths and double-writing
+            them would race.
+
+            The ``redirect_*`` rebinding is process-wide. Today no
+            caller invokes ``run_trials`` from multiple threads
+            concurrently (``aorta run`` is one cell, ``aorta triage``
+            iterates cells serially), so cross-thread crosstalk is
+            theoretical. If that ever changes, this knob would need a
+            different capture mechanism -- this mirrors the same
+            single-caller assumption the env-restore block on this
+            function relies on.
     """
 
     workload: str
@@ -345,10 +360,22 @@ def _run_single_trial(
     # ``save_logs`` opens per-trial log files and redirects
     # ``sys.stdout`` / ``sys.stderr`` for the duration of
     # ``setup()`` + ``run()`` + ``cleanup()``. The reserved
-    # ``_aorta_save_logs`` / ``_aorta_log_{stdout,stderr}`` config keys
-    # let subprocess-based wrappers (whose child output
-    # ``redirect_stdout`` doesn't catch) opt in and write their own
-    # capture to a non-colliding path.
+    # ``_aorta_save_logs`` / ``_aorta_log_basename`` config keys let
+    # subprocess-based wrappers (whose child output ``redirect_stdout``
+    # doesn't catch) opt in and write their own capture to a sibling
+    # path derived from the basename -- the dispatcher already holds
+    # open the ``<basename>.{stdout,stderr}.log`` paths so wrappers
+    # must NOT write to them directly.
+    #
+    # ``encoding="utf-8", errors="backslashreplace"`` is deliberate:
+    # the platform default encoding is locale-dependent (cp1252 on
+    # Windows, ASCII under ``LC_ALL=C``), and a workload printing a
+    # non-ASCII glyph would otherwise raise ``UnicodeEncodeError``
+    # inside ``print()`` -- which the trial's ``except Exception``
+    # would catch and flip the run to ``infrastructure_failed``.
+    # Enabling a debug knob must never break an otherwise-healthy
+    # trial; ``backslashreplace`` keeps the file lossless-enough for
+    # grep without ever raising.
     trial_log_stdout: Path | None = None
     trial_log_stderr: Path | None = None
     if request.save_logs and should_write:
@@ -358,13 +385,16 @@ def _run_single_trial(
         trial_log_stdout = results_dir / f"{log_basename}.stdout.log"
         trial_log_stderr = results_dir / f"{log_basename}.stderr.log"
         config["_aorta_save_logs"] = True
-        config["_aorta_log_stdout"] = str(trial_log_stdout)
-        config["_aorta_log_stderr"] = str(trial_log_stderr)
+        config["_aorta_log_basename"] = log_basename
 
     with contextlib.ExitStack() as log_stack:
         if trial_log_stdout is not None and trial_log_stderr is not None:
-            stdout_fh = log_stack.enter_context(open(trial_log_stdout, "w"))
-            stderr_fh = log_stack.enter_context(open(trial_log_stderr, "w"))
+            stdout_fh = log_stack.enter_context(
+                open(trial_log_stdout, "w", encoding="utf-8", errors="backslashreplace")
+            )
+            stderr_fh = log_stack.enter_context(
+                open(trial_log_stderr, "w", encoding="utf-8", errors="backslashreplace")
+            )
             log_stack.enter_context(contextlib.redirect_stdout(stdout_fh))
             log_stack.enter_context(contextlib.redirect_stderr(stderr_fh))
 

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -8,6 +8,7 @@ The dispatcher is the core of `aorta run`. It:
 5. Persists results as JSON (rank 0 only for distributed)
 """
 
+import contextlib
 import copy
 import json
 import logging
@@ -73,6 +74,16 @@ class RunRequest:
             rationale as ``dataset_index``).  ``aorta triage`` varies
             this across its mitigation axis; ``aorta run`` always emits
             ``m0``.
+        save_logs: When ``True``, capture the workload's in-process
+            ``stdout`` / ``stderr`` writes to per-trial files alongside
+            the trial JSON (``trial_d{d}_m{m}_t{t}.{stdout,stderr}.log``).
+            Default ``False`` preserves today's behaviour (no capture).
+            Rank-0 only -- matches the trial-JSON write guarantee.
+            ``contextlib.redirect_*`` only catches Python-level writes;
+            subprocesses are not captured. Wrappers that own a
+            subprocess can opt in by reading the platform-supplied
+            ``_aorta_save_logs`` / ``_aorta_log_stdout`` /
+            ``_aorta_log_stderr`` config keys this dispatcher injects.
     """
 
     workload: str
@@ -87,6 +98,7 @@ class RunRequest:
     sidecar_files: tuple[Path, ...] = field(default_factory=tuple)
     dataset_index: int = 0
     mitigation_index: int = 0
+    save_logs: bool = False
 
     def __post_init__(self) -> None:
         # Defensively deep-copy mutable dict fields.  ``frozen=True``
@@ -330,65 +342,91 @@ def _run_single_trial(
     workload_result: WorkloadResult
     workload: Workload | None = None
 
-    try:
-        # Construct positionally to match the documented Workload(config)
-        # contract -- third-party plugins are free to name their first
-        # parameter something other than ``config``.
-        workload = workload_cls(config)
-        workload.setup()
-        workload_result = workload.run()
-
-        if not workload_result.passed:
-            exit_status = "workload_failed"
-
-    except Exception as e:
-        exit_status = "infrastructure_failed"
-        # Create error WorkloadResult
-        workload_result = WorkloadResult(
-            passed=False,
-            failure_count=1,
-            failure_details=[{"error": str(e), "type": type(e).__name__}],
+    # ``save_logs`` opens per-trial log files and redirects
+    # ``sys.stdout`` / ``sys.stderr`` for the duration of
+    # ``setup()`` + ``run()`` + ``cleanup()``. The reserved
+    # ``_aorta_save_logs`` / ``_aorta_log_{stdout,stderr}`` config keys
+    # let subprocess-based wrappers (whose child output
+    # ``redirect_stdout`` doesn't catch) opt in and write their own
+    # capture to a non-colliding path.
+    trial_log_stdout: Path | None = None
+    trial_log_stderr: Path | None = None
+    if request.save_logs and should_write:
+        log_basename = (
+            f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
         )
+        trial_log_stdout = results_dir / f"{log_basename}.stdout.log"
+        trial_log_stderr = results_dir / f"{log_basename}.stderr.log"
+        config["_aorta_save_logs"] = True
+        config["_aorta_log_stdout"] = str(trial_log_stdout)
+        config["_aorta_log_stderr"] = str(trial_log_stderr)
 
-    finally:
-        # Always attempt cleanup if the workload was constructed, even
-        # when setup()/run() raised -- otherwise we leak GPU memory,
-        # process groups, file handles, etc.  Cleanup failures are not
-        # allowed to mask the original exception/exit_status.
-        if workload is not None:
-            try:
-                workload.cleanup()
-            except Exception as cleanup_exc:
-                # Log -- silently swallowing makes leaked GPU memory /
-                # process groups invisible to the operator.  Use
-                # ``exc_info=True`` so the original traceback survives.
-                logger.warning(
-                    "workload.cleanup() raised %s during trial '%s'; "
-                    "continuing so the original outcome is preserved.",
-                    type(cleanup_exc).__name__,
-                    trial_id,
-                    exc_info=True,
-                )
-        # Restore environment by diff against the pre-trial snapshot.
-        # We deliberately do NOT use ``os.environ.clear() +
-        # os.environ.update(snapshot)`` -- ``run_trials`` is a public
-        # library API and ``clear()`` would, for an instant, blank the
-        # entire environment for every other thread in the process.
-        # The diff approach has no such window: each key transitions
-        # at most once, directly to its target value.
-        current_keys = set(os.environ)
-        saved_keys = set(pre_trial_env)
-        for key in current_keys - saved_keys:
-            # Added during the trial (mitigation / extra_env / workload
-            # setup) -- remove.
-            del os.environ[key]
-        for key, value in pre_trial_env.items():
-            # Restore both the keys we overwrote and any workload-side
-            # mutations to pre-existing keys.  ``os.environ.get`` is
-            # cheap; this skip avoids a redundant write when the value
-            # is already correct.
-            if os.environ.get(key) != value:
-                os.environ[key] = value
+    with contextlib.ExitStack() as log_stack:
+        if trial_log_stdout is not None and trial_log_stderr is not None:
+            stdout_fh = log_stack.enter_context(open(trial_log_stdout, "w"))
+            stderr_fh = log_stack.enter_context(open(trial_log_stderr, "w"))
+            log_stack.enter_context(contextlib.redirect_stdout(stdout_fh))
+            log_stack.enter_context(contextlib.redirect_stderr(stderr_fh))
+
+        try:
+            # Construct positionally to match the documented Workload(config)
+            # contract -- third-party plugins are free to name their first
+            # parameter something other than ``config``.
+            workload = workload_cls(config)
+            workload.setup()
+            workload_result = workload.run()
+
+            if not workload_result.passed:
+                exit_status = "workload_failed"
+
+        except Exception as e:
+            exit_status = "infrastructure_failed"
+            # Create error WorkloadResult
+            workload_result = WorkloadResult(
+                passed=False,
+                failure_count=1,
+                failure_details=[{"error": str(e), "type": type(e).__name__}],
+            )
+
+        finally:
+            # Always attempt cleanup if the workload was constructed, even
+            # when setup()/run() raised -- otherwise we leak GPU memory,
+            # process groups, file handles, etc.  Cleanup failures are not
+            # allowed to mask the original exception/exit_status.
+            if workload is not None:
+                try:
+                    workload.cleanup()
+                except Exception as cleanup_exc:
+                    # Log -- silently swallowing makes leaked GPU memory /
+                    # process groups invisible to the operator.  Use
+                    # ``exc_info=True`` so the original traceback survives.
+                    logger.warning(
+                        "workload.cleanup() raised %s during trial '%s'; "
+                        "continuing so the original outcome is preserved.",
+                        type(cleanup_exc).__name__,
+                        trial_id,
+                        exc_info=True,
+                    )
+            # Restore environment by diff against the pre-trial snapshot.
+            # We deliberately do NOT use ``os.environ.clear() +
+            # os.environ.update(snapshot)`` -- ``run_trials`` is a public
+            # library API and ``clear()`` would, for an instant, blank the
+            # entire environment for every other thread in the process.
+            # The diff approach has no such window: each key transitions
+            # at most once, directly to its target value.
+            current_keys = set(os.environ)
+            saved_keys = set(pre_trial_env)
+            for key in current_keys - saved_keys:
+                # Added during the trial (mitigation / extra_env / workload
+                # setup) -- remove.
+                del os.environ[key]
+            for key, value in pre_trial_env.items():
+                # Restore both the keys we overwrote and any workload-side
+                # mutations to pre-existing keys.  ``os.environ.get`` is
+                # cheap; this skip avoids a redundant write when the value
+                # is already correct.
+                if os.environ.get(key) != value:
+                    os.environ[key] = value
 
     wall_clock = time.perf_counter() - start_time
 

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -46,6 +46,7 @@ _VALID_TOP_LEVEL = frozenset(
         "confound",
         "cells",
         "workload_config",
+        "save_logs",
     }
 )
 _VALID_CONFOUND_KEYS = frozenset({"threshold", "baseline_cell"})
@@ -199,6 +200,17 @@ class Recipe:
             (cell wins on collision; non-collision keys union). Empty dict
             when the recipe omits the field -- behaviourally identical to
             today's recipes.
+        save_logs: When ``True``, the dispatcher captures the workload's
+            in-process ``stdout`` / ``stderr`` writes (via
+            ``contextlib.redirect_*``) into per-trial files alongside the
+            trial JSON. Default ``False`` preserves today's behaviour
+            (writes go nowhere captured; they appear on the parent
+            process's TTY). Workloads that spawn subprocesses don't have
+            their subprocess output captured by ``redirect_*``; those
+            wrappers can opt in by reading the platform-supplied
+            ``_aorta_save_logs`` / ``_aorta_log_stdout`` /
+            ``_aorta_log_stderr`` config keys the dispatcher injects
+            when ``save_logs=True``.
     """
 
     schema_version: int
@@ -213,6 +225,7 @@ class Recipe:
     source_path: Path | None = None
     source_sha256: str | None = None
     workload_config: dict[str, Any] = field(default_factory=dict)
+    save_logs: bool = False
 
 
 def inline_env_name(docker_ref: str) -> str:
@@ -635,6 +648,12 @@ def _build_recipe(
     confound = _parse_confound("recipe", data.get("confound"))
     workload_config = _parse_workload_config("recipe", data.get("workload_config"))
 
+    raw_save_logs = data.get("save_logs", False)
+    if not isinstance(raw_save_logs, bool):
+        raise RecipeSchemaError(
+            f"recipe.save_logs: must be a boolean, got {type(raw_save_logs).__name__}"
+        )
+
     raw_cells = data["cells"]
     if not isinstance(raw_cells, list) or not raw_cells:
         raise RecipeSchemaError(f"recipe.cells: must be a non-empty list, got {raw_cells!r}")
@@ -668,6 +687,7 @@ def _build_recipe(
         source_path=source_path,
         source_sha256=source_sha256,
         workload_config=workload_config,
+        save_logs=raw_save_logs,
     )
 
 

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -204,14 +204,17 @@ class Recipe:
             in-process ``stdout`` / ``stderr`` writes (via
             ``contextlib.redirect_*``) into per-trial files alongside the
             trial JSON. Default ``False`` preserves today's behaviour
-            (writes go nowhere captured; they appear on the parent
+            (writes are not captured -- they appear on the parent
             process's TTY). Workloads that spawn subprocesses don't have
             their subprocess output captured by ``redirect_*``; those
             wrappers can opt in by reading the platform-supplied
             ``_aorta_save_logs`` / ``_aorta_log_basename`` config keys
-            the dispatcher injects when ``save_logs=True`` and writing
-            their own capture to a sibling path derived from the
-            basename (e.g. ``<basename>.subprocess.stdout.log``).
+            the dispatcher injects and writing their own capture to a
+            sibling path derived from the basename (e.g.
+            ``<basename>.subprocess.stdout.log``). Both file capture and
+            key injection are **rank-0 only** -- matches the trial-JSON
+            write guarantee. Wrappers running on non-rank-0 won't see
+            the keys and should treat capture as off there.
     """
 
     schema_version: int

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -208,9 +208,10 @@ class Recipe:
             process's TTY). Workloads that spawn subprocesses don't have
             their subprocess output captured by ``redirect_*``; those
             wrappers can opt in by reading the platform-supplied
-            ``_aorta_save_logs`` / ``_aorta_log_stdout`` /
-            ``_aorta_log_stderr`` config keys the dispatcher injects
-            when ``save_logs=True``.
+            ``_aorta_save_logs`` / ``_aorta_log_basename`` config keys
+            the dispatcher injects when ``save_logs=True`` and writing
+            their own capture to a sibling path derived from the
+            basename (e.g. ``<basename>.subprocess.stdout.log``).
     """
 
     schema_version: int

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -571,6 +571,7 @@ def _run_one_cell(
         config_overrides=merged_workload_config,
         results_dir=cell_dir,
         sidecar_files=sidecar_files,
+        save_logs=recipe.save_logs,
     )
 
     try:

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -1006,6 +1006,24 @@ class NoisyWorkload(Workload):
         pass
 
 
+class NoisyCrashingWorkload(Workload):
+    """Prints, then raises -- exercises ExitStack flush on exception."""
+
+    launch_mode = "single_process"
+    min_world_size = 1
+
+    def setup(self) -> None:
+        pass
+
+    def run(self) -> WorkloadResult:
+        print("BEFORE-CRASH-STDOUT")
+        print("BEFORE-CRASH-STDERR", file=sys.stderr)
+        raise RuntimeError("boom")
+
+    def cleanup(self) -> None:
+        pass
+
+
 class TestSaveLogs:
     """Per-trial stdout/stderr capture knob (default off)."""
 
@@ -1030,14 +1048,28 @@ class TestSaveLogs:
         assert (cell_dir / "trial_d0_m0_t0.stderr.log").read_text().strip() == "STDERR-FROM-WORKLOAD"
 
     def test_on_injects_aorta_log_keys_for_subprocess_wrappers(self, tmp_path):
-        cell_dir = self._run(tmp_path, save_logs=True)
+        self._run(tmp_path, save_logs=True)
         cfg = NoisyWorkload.seen_config
         assert cfg["_aorta_save_logs"] is True
-        assert cfg["_aorta_log_stdout"] == str(cell_dir / "trial_d0_m0_t0.stdout.log")
-        assert cfg["_aorta_log_stderr"] == str(cell_dir / "trial_d0_m0_t0.stderr.log")
+        assert cfg["_aorta_log_basename"] == "trial_d0_m0_t0"
 
     def test_on_non_rank_zero_writes_no_log_files(self, tmp_path):
         with patch.dict(os.environ, {"RANK": "1"}):
             cell_dir = self._run(tmp_path, save_logs=True)
         assert not (cell_dir / "trial_d0_m0_t0.stdout.log").exists()
         assert not (cell_dir / "trial_d0_m0_t0.stderr.log").exists()
+
+    def test_on_captures_output_even_when_workload_raises(self, tmp_path):
+        mock_ep = MagicMock(name="crasher")
+        mock_ep.name = "crasher"
+        mock_ep.load.return_value = NoisyCrashingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            results = run_trials(
+                RunRequest(workload="crasher", trials=1, results_dir=tmp_path, save_logs=True)
+            )
+        cell_dir = tmp_path / "crasher"
+        assert results[0].exit_status == "infrastructure_failed"
+        assert (cell_dir / "trial_d0_m0_t0.stdout.log").read_text().strip() == "BEFORE-CRASH-STDOUT"
+        assert (cell_dir / "trial_d0_m0_t0.stderr.log").read_text().strip() == "BEFORE-CRASH-STDERR"

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -1073,3 +1073,39 @@ class TestSaveLogs:
         assert results[0].exit_status == "infrastructure_failed"
         assert (cell_dir / "trial_d0_m0_t0.stdout.log").read_text().strip() == "BEFORE-CRASH-STDOUT"
         assert (cell_dir / "trial_d0_m0_t0.stderr.log").read_text().strip() == "BEFORE-CRASH-STDERR"
+
+    def test_log_open_failure_degrades_gracefully_and_restores_env(self, tmp_path):
+        """If log-file open() raises, the trial must still run, the env
+        overlay must still be restored (otherwise mitigation vars leak
+        across cells), and the _aorta_* keys must NOT be injected."""
+        real_open = open
+
+        def raising_open(path, *args, **kwargs):
+            if str(path).endswith((".stdout.log", ".stderr.log")):
+                raise PermissionError("simulated log-open failure")
+            return real_open(path, *args, **kwargs)
+
+        os.environ.pop("AORTA_LEAK_PROBE", None)
+        NoisyWorkload.seen_config = {}
+        mock_ep = MagicMock(name="noisy")
+        mock_ep.name = "noisy"
+        mock_ep.load.return_value = NoisyWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+        with patch("importlib.metadata.entry_points", return_value=mock_eps), patch(
+            "builtins.open", side_effect=raising_open
+        ):
+            results = run_trials(
+                RunRequest(
+                    workload="noisy",
+                    trials=1,
+                    results_dir=tmp_path,
+                    save_logs=True,
+                    extra_env={"AORTA_LEAK_PROBE": "leaked"},
+                )
+            )
+        assert results[0].exit_status == "ok"
+        assert not (tmp_path / "noisy" / "trial_d0_m0_t0.stdout.log").exists()
+        assert "AORTA_LEAK_PROBE" not in os.environ, "env overlay leaked when log-open failed"
+        assert "_aorta_save_logs" not in NoisyWorkload.seen_config
+        assert "_aorta_log_basename" not in NoisyWorkload.seen_config

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -982,3 +983,61 @@ class TestEnvironmentRestoration:
                 os.environ.pop("TEST_RESTORE_VAR", None)
             else:
                 os.environ["TEST_RESTORE_VAR"] = original_value
+
+
+class NoisyWorkload(Workload):
+    """Workload that writes a marker to stdout + stderr and records the
+    ``_aorta_log_*`` keys the dispatcher injected, for save_logs tests."""
+
+    launch_mode = "single_process"
+    min_world_size = 1
+    seen_config: dict = {}
+
+    def setup(self) -> None:
+        pass
+
+    def run(self) -> WorkloadResult:
+        NoisyWorkload.seen_config = dict(self.config)
+        print("STDOUT-FROM-WORKLOAD")
+        print("STDERR-FROM-WORKLOAD", file=sys.stderr)
+        return WorkloadResult(passed=True)
+
+    def cleanup(self) -> None:
+        pass
+
+
+class TestSaveLogs:
+    """Per-trial stdout/stderr capture knob (default off)."""
+
+    def _run(self, tmp_path, **kw) -> Path:
+        mock_ep = MagicMock(name="noisy")
+        mock_ep.name = "noisy"
+        mock_ep.load.return_value = NoisyWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            run_trials(RunRequest(workload="noisy", trials=1, results_dir=tmp_path, **kw))
+        return tmp_path / "noisy"
+
+    def test_default_off_writes_no_log_files(self, tmp_path):
+        cell_dir = self._run(tmp_path)
+        assert not (cell_dir / "trial_d0_m0_t0.stdout.log").exists()
+        assert not (cell_dir / "trial_d0_m0_t0.stderr.log").exists()
+
+    def test_on_captures_stdout_and_stderr(self, tmp_path):
+        cell_dir = self._run(tmp_path, save_logs=True)
+        assert (cell_dir / "trial_d0_m0_t0.stdout.log").read_text().strip() == "STDOUT-FROM-WORKLOAD"
+        assert (cell_dir / "trial_d0_m0_t0.stderr.log").read_text().strip() == "STDERR-FROM-WORKLOAD"
+
+    def test_on_injects_aorta_log_keys_for_subprocess_wrappers(self, tmp_path):
+        cell_dir = self._run(tmp_path, save_logs=True)
+        cfg = NoisyWorkload.seen_config
+        assert cfg["_aorta_save_logs"] is True
+        assert cfg["_aorta_log_stdout"] == str(cell_dir / "trial_d0_m0_t0.stdout.log")
+        assert cfg["_aorta_log_stderr"] == str(cell_dir / "trial_d0_m0_t0.stderr.log")
+
+    def test_on_non_rank_zero_writes_no_log_files(self, tmp_path):
+        with patch.dict(os.environ, {"RANK": "1"}):
+            cell_dir = self._run(tmp_path, save_logs=True)
+        assert not (cell_dir / "trial_d0_m0_t0.stdout.log").exists()
+        assert not (cell_dir / "trial_d0_m0_t0.stderr.log").exists()


### PR DESCRIPTION
## Summary

- New top-level recipe field **`save_logs: false`** (default off). When `true`, the dispatcher writes per-trial `trial_d{d}_m{m}_t{t}.{stdout,stderr}.log` files alongside the trial JSON in the cell directory.
- In-process capture via `contextlib.redirect_stdout/redirect_stderr` covers Python-level writes from `setup()`, `run()`, and `cleanup()`. Subprocess output is NOT captured automatically — see two-tier note below.
- Threads through the standard chain: `Recipe.save_logs` → `runner._run_one_cell` → `RunRequest.save_logs` → `_run_single_trial`. Rank-0 only (mirrors the existing trial-JSON write guarantee). Default off preserves byte-equivalent behaviour for every existing recipe.

## Why

The dispatcher discards workload stdout/stderr today. Debugging a cell that exits `workload_failed` or `infrastructure_failed` is painful unless the wrapper happened to stuff output tails into `WorkloadResult.failure_details` (only `recom_repro` does). For the demo prep, the user wants a uniform way to opt into log capture across all workloads.

## Two-tier capture (and why subprocess wrappers need the reserved keys)

`contextlib.redirect_stdout` rebinds `sys.stdout` for the calling Python process; it doesn't follow forked subprocesses or C extensions writing to file descriptor 1/2 directly. For `recom_repro` (which `subprocess.run`s the entry script), the dispatcher's redirect catches nothing useful.

So when `save_logs=True`, the dispatcher also injects two reserved config keys the wrapper can read (rank-0 only — matches the file-write rank guarantee):

- `_aorta_save_logs: True`
- `_aorta_log_basename: "trial_d{d}_m{m}_t{t}"` — the trial filename stem

The aorta-internal companion PR (PR-3b in workspace `tasks/active/demo-prep-prs.md`) will have the `recom_repro` wrapper check `_aorta_save_logs` and write its subprocess capture to a **sibling** path derived from the basename (e.g. `<basename>.subprocess.{stdout,stderr}.log`). The dispatcher already holds the `<basename>.{stdout,stderr}.log` paths open for the in-process redirect, so wrappers must NOT write to them directly — double-writers would race. The reserved-key convention matches the existing `_aorta_environment` plumbing.

The log files are opened with `encoding="utf-8", errors="backslashreplace"` so a workload printing non-ASCII (em-dash, ✓/✗, accented model name) can never raise `UnicodeEncodeError` under cp1252 (Windows default) or `LC_ALL=C` — an opt-in debug knob must not break the run it's meant to debug.

## Files

| File | What |
|---|---|
| `src/aorta/triage/recipe.py` | `Recipe.save_logs: bool = False` field + docstring + `_VALID_TOP_LEVEL` allowlist + bool validation in `_build_recipe` |
| `src/aorta/run/dispatcher.py` | `RunRequest.save_logs: bool = False`; wrap setup/run/cleanup in an `ExitStack` that opens the log files (utf-8 / backslashreplace) and installs the `redirect_*` context managers when the flag is set. **Env-restore stays inside `finally:`** (preserves `KeyboardInterrupt` / `SystemExit` semantics — most of the dispatcher.py line delta is just the re-indent of that block) |
| `src/aorta/triage/runner.py` | One-line: `save_logs=recipe.save_logs` in `RunRequest(...)` |
| `recipes/README.md` | New schema entry for `save_logs` + quick-reference example. **Also fixes a stale 'V2 Meta-internal SHAMPOO entry script' claim** in the existing `workload_config` example (broken by merged aorta-internal#39 — `shampoo_api: old` is V1-on-OSS now, both APIs import from the OSS package) |
| `tests/run/test_dispatcher.py` | New `TestSaveLogs` class, 5 focused tests via `NoisyWorkload` / `NoisyCrashingWorkload` fixtures |

## Tests

- `pytest tests/triage/ tests/run/` — 350/350 passing locally.
- The 5 new tests cover: default off → no files, on → both streams captured verbatim, on → reserved config keys (`_aorta_save_logs` + `_aorta_log_basename`) present and well-formed, on + non-rank-0 → no files, on + workload raises mid-trial → partial capture survives in the log files + trial reports `infrastructure_failed`.
- Pre-existing platform failures (`tests/instrumentation/test_environment.py` POSIX-path tests, `tests/report/test_kernel_report_dependency_free.py` import-isolation tests) are not touched by this PR — confirmed by running them against `main` with my changes stashed.

## Demo plan

```yaml
# example-recipe.yaml
schema_version: 1
workload: recom_repro
trials: 2
steps: 3
save_logs: true        # new
cells: [...]
```

After `aorta triage run --recipe example-recipe.yaml`:

```
cells/<cell>/<workload>/
  trial_d0_m0_t0.json
  trial_d0_m0_t0.stdout.log    # new (rank 0 only)
  trial_d0_m0_t0.stderr.log    # new
  ...
```

For `recom_repro`, the dispatcher's log files will be empty (subprocess writes don't land there) until PR-3b lands the wrapper-side opt-in. For pure in-process workloads (fsdp, hsdp), they fill immediately.

## Follow-ups

- aorta-internal: `recom_repro` wrapper reads `_aorta_save_logs` + `_aorta_log_basename` and writes its subprocess capture to a derived sibling path (tracked: workspace `tasks/active/demo-prep-prs.md` PR-3b).
- aorta public: matrix.md `Config` column (tracked: workspace PR-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)