### PR TITLE
triage: diffs-only Config column in matrix.md + persist workload_config

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -161,6 +161,11 @@ failure is localisable without reading the loader source.
 - `resolved_env_vars` -- the env-var bundle as actually applied (mitigation
   union + `extra_env`).
 - `resolved_environment` -- the resolved `Environment` descriptor.
+- `workload_config` -- the merged per-cell `workload_config` dict (recipe
+  scope union cell scope, cell wins on collision). Empty `{}` when neither
+  scope sets it. `matrix.md` surfaces keys whose value varies across cells
+  in a `Config` column (diffs only; the column is hidden when no cell has
+  workload_config or when every cell agrees on every key).
 - `trial_paths` -- per-trial JSON paths, sorted by trial index (NOT
   lexicographically, so `trial_2.json` precedes `trial_10.json`).
 

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -120,6 +120,14 @@ class CellStats:
     cell value for matrix.md's "Iters" column (e.g. ``"0/50"``,
     ``"199..200/200"``, ``"?/?"`` if trials disagreed on the configured
     count, or ``"—"`` when the workload didn't track iterations).
+
+    ``workload_config`` is the per-cell ``Request.config_overrides`` dict
+    (the merge of ``recipe.workload_config`` and ``cell.workload_config``,
+    cell wins on collision). Persisted in matrix.json so the report
+    renderer can surface workload-knob differences (e.g.
+    ``shampoo_api=old``) in the matrix.md ``Config`` column. Empty dict
+    when the recipe omits the field for every cell -- behaviourally
+    identical to the pre-B2.2 schema.
     """
 
     name: str
@@ -149,6 +157,7 @@ class CellStats:
     executed_iter_max: int | None = None
     configured_iters: int | None = None
     iters_display: str = "—"
+    workload_config: dict[str, Any] = field(default_factory=dict)
 
     @property
     def failure_rate(self) -> float:
@@ -457,6 +466,7 @@ def aggregate_cell(
     effective_steps: int,
     trial_paths: list[str] | None = None,
     error: str | None = None,
+    workload_config: dict[str, Any] | None = None,
 ) -> CellStats:
     """Aggregate a list of TrialResult-shaped objects into a :class:`CellStats`.
 
@@ -479,10 +489,16 @@ def aggregate_cell(
             files; recorded in matrix.json.
         error: Cell-level error message; when set, the cell is marked as an
             error row and all numeric aggregates are forced to zero / 0.0.
+        workload_config: Per-cell merged ``workload_config`` dict (recipe
+            scope union cell scope, cell wins on collision). Persisted on
+            the returned :class:`CellStats` so matrix.md and matrix.json
+            can surface workload-knob differences across cells. ``None``
+            and ``{}`` both collapse to an empty dict on the result.
 
     Returns:
         :class:`CellStats` populated from the trials.
     """
+    workload_config = dict(workload_config or {})
     if error is not None:
         return CellStats(
             name=name,
@@ -512,6 +528,7 @@ def aggregate_cell(
             executed_iter_max=None,
             configured_iters=None,
             iters_display="—",
+            workload_config=workload_config,
         )
 
     trial_count = len(trials)
@@ -595,6 +612,7 @@ def aggregate_cell(
         executed_iter_max=exec_max,
         configured_iters=configured_iters,
         iters_display=iters_display,
+        workload_config=workload_config,
     )
 
 

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -159,6 +159,42 @@ def _format_confound(tag: ConfoundTag) -> str:
     return str(tag)
 
 
+_CONFIG_KEY_ABSENT = object()
+
+
+def _varying_workload_config_keys(cell_stats: list[CellStats]) -> list[str]:
+    """Sorted keys whose effective value differs across cells.
+
+    "Effective value" includes absence -- a cell that omits a key is
+    distinct from one that sets it. ``repr`` is used for the equality
+    comparison so unhashable values (e.g. dict, list) don't blow up the
+    set construction. Returns ``[]`` when no cell has workload_config or
+    when every cell agrees on every key.
+    """
+    all_keys: set[str] = set()
+    for c in cell_stats:
+        all_keys.update(c.workload_config.keys())
+    if not all_keys:
+        return []
+    return sorted(
+        k
+        for k in all_keys
+        if len({repr(c.workload_config.get(k, _CONFIG_KEY_ABSENT)) for c in cell_stats}) > 1
+    )
+
+
+def _format_workload_config(cell: CellStats, varying_keys: list[str]) -> str:
+    """Render only the varying-key subset of one cell's workload_config.
+
+    Keys omitted from the cell render nothing (no ``key=—`` noise). When
+    the cell has none of the varying keys at all, render ``"—"`` so the
+    column stays width-aligned. ``str(value)`` keeps scalar values
+    unquoted (``shampoo_api=old`` rather than ``shampoo_api='old'``).
+    """
+    parts = [f"{k}={cell.workload_config[k]}" for k in varying_keys if k in cell.workload_config]
+    return ", ".join(parts) if parts else "—"
+
+
 def _render_failure_hints(cell_stats: list[CellStats]) -> list[str]:
     """Build the ``## Failure hints`` section for matrix.md.
 
@@ -233,13 +269,22 @@ def write_matrix_md(
     # contradiction itself is exactly what an operator needs to see --
     # hiding the column would silently swallow it.
     show_iters = any(c.iters_display != "—" for c in cell_stats)
+    # Config column surfaces per-cell workload_config keys whose values
+    # vary across cells -- e.g. ``shampoo_api=old`` when one cell flips
+    # the optimizer API and others don't. Hidden entirely when no cell
+    # has workload_config, or when every cell agrees on every key.
+    # ``Confound`` stays unchanged: this column carries the disambiguation,
+    # not a new confound tag.
+    varying_config_keys = _varying_workload_config_keys(cell_stats)
+    show_config = bool(varying_config_keys)
     header_cells: list[str] = [
         "Cell",
         "Mitigations",
         "Environment",
-        "Failure rate",
-        "Failures",
     ]
+    if show_config:
+        header_cells.append("Config")
+    header_cells.extend(["Failure rate", "Failures"])
     if show_iters:
         header_cells.append("Iters")
     header_cells.extend(["Mean step (ms)", "Confound"])
@@ -251,9 +296,10 @@ def write_matrix_md(
             cell.name,
             _format_mitigations(cell.mitigations),
             cell.environment,
-            _format_failure_rate(cell),
-            _format_failures(cell),
         ]
+        if show_config:
+            row.append(_format_workload_config(cell, varying_config_keys))
+        row.extend([_format_failure_rate(cell), _format_failures(cell)])
         if show_iters:
             row.append(cell.iters_display)
         row.extend([_format_step_ms(cell), _format_confound(tag)])
@@ -323,6 +369,17 @@ def write_matrix_md(
             "on the configured count (defensive; should not happen under a single recipe). "
             "`—` = workload didn't track iterations. The column is hidden entirely "
             "when no cell in the matrix populates the new field."
+        )
+    if show_config:
+        lines.append(
+            "- `Config` -- per-cell `workload_config` keys whose value differs across "
+            "cells (rendered `key=value, key2=value2`). Only varying keys appear, so "
+            "a key set identically by every cell stays hidden. `—` means the cell "
+            "has none of the varying keys. Confound classification is unchanged; this "
+            "column carries the disambiguation when two otherwise-identical rows "
+            "behave differently because of a workload knob (e.g. `shampoo_api=old` "
+            "selecting the V1 SHAMPOO entry script). The column is hidden entirely "
+            "when no cell sets `workload_config`, or when every cell agrees on every key."
         )
     lines.append(
         "- `Failures` is `failed_count / trial_count` (e.g. `3 / 8` = three failed out "

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -168,8 +168,14 @@ def _varying_workload_config_keys(cell_stats: list[CellStats]) -> list[str]:
     "Effective value" includes absence -- a cell that omits a key is
     distinct from one that sets it. ``repr`` is used for the equality
     comparison so unhashable values (e.g. dict, list) don't blow up the
-    set construction. Returns ``[]`` when no cell has workload_config or
-    when every cell agrees on every key.
+    set construction, and ``sort_keys=True`` keeps the canonical form
+    stable across insertion-order differences -- ``{a:1,b:2}`` and
+    ``{b:2,a:1}`` are semantically equal but ``repr``-different in
+    Python 3.7+, which would otherwise flag spurious "varying" keys
+    from programmatically-generated recipes. ``default=repr`` falls
+    back for the absent-key sentinel and any non-JSON values.
+    Returns ``[]`` when no cell has workload_config or when every cell
+    agrees on every key.
     """
     all_keys: set[str] = set()
     for c in cell_stats:
@@ -179,8 +185,18 @@ def _varying_workload_config_keys(cell_stats: list[CellStats]) -> list[str]:
     return sorted(
         k
         for k in all_keys
-        if len({repr(c.workload_config.get(k, _CONFIG_KEY_ABSENT)) for c in cell_stats}) > 1
+        if len({_canon(c.workload_config.get(k, _CONFIG_KEY_ABSENT)) for c in cell_stats}) > 1
     )
+
+
+def _canon(value: Any) -> str:
+    """Stable canonical form for cross-cell value comparison."""
+    return json.dumps(value, sort_keys=True, default=repr)
+
+
+def _escape_md_cell(s: str) -> str:
+    """Escape characters that would break a markdown table row."""
+    return s.replace("\\", "\\\\").replace("|", "\\|").replace("\n", "<br>")
 
 
 def _format_workload_config(cell: CellStats, varying_keys: list[str]) -> str:
@@ -190,8 +206,15 @@ def _format_workload_config(cell: CellStats, varying_keys: list[str]) -> str:
     the cell has none of the varying keys at all, render ``"—"`` so the
     column stays width-aligned. ``str(value)`` keeps scalar values
     unquoted (``shampoo_api=old`` rather than ``shampoo_api='old'``).
+    Values are passed through ``_escape_md_cell`` so a ``|`` or newline
+    in a workload_config value (workload_config is not schema-validated)
+    can't break the markdown table layout.
     """
-    parts = [f"{k}={cell.workload_config[k]}" for k in varying_keys if k in cell.workload_config]
+    parts = [
+        f"{k}={_escape_md_cell(str(cell.workload_config[k]))}"
+        for k in varying_keys
+        if k in cell.workload_config
+    ]
     return ", ".join(parts) if parts else "—"
 
 

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -190,8 +190,19 @@ def _varying_workload_config_keys(cell_stats: list[CellStats]) -> list[str]:
 
 
 def _canon(value: Any) -> str:
-    """Stable canonical form for cross-cell value comparison."""
-    return json.dumps(value, sort_keys=True, default=repr)
+    """Stable canonical form for cross-cell value comparison.
+
+    ``json.dumps`` can still raise even with ``default=repr``: circular
+    references are detected before the ``default`` callback runs, and a
+    user-defined ``__repr__`` could itself raise from inside ``default``.
+    Fall back to bare ``repr`` so a pathological workload_config value
+    can never crash matrix rendering -- Python's ``repr`` handles
+    circular structures natively (prints ``[[...]]``).
+    """
+    try:
+        return json.dumps(value, sort_keys=True, default=repr)
+    except (ValueError, TypeError):
+        return repr(value)
 
 
 def _escape_md_cell(s: str) -> str:

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -798,6 +798,10 @@ def run_recipe(
                 suffix,
             )
 
+        # Mirror _run_one_cell's merge so CellStats.workload_config records
+        # what the dispatcher actually constructed the workload with. Cell-
+        # scope wins on collision; non-collision keys union with recipe-
+        # scope. Stays {} when neither scope sets workload_config.
         stats = aggregate_cell(
             name=cell.name,
             mitigations=tuple(cell.mitigations),
@@ -808,6 +812,7 @@ def run_recipe(
             effective_steps=cell.effective_steps(recipe.steps),
             trial_paths=trial_paths,
             error=error,
+            workload_config={**recipe.workload_config, **cell.workload_config},
         )
         cell_stats.append(stats)
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -799,9 +799,14 @@ def run_recipe(
             )
 
         # Mirror _run_one_cell's merge so CellStats.workload_config records
-        # what the dispatcher actually constructed the workload with. Cell-
-        # scope wins on collision; non-collision keys union with recipe-
-        # scope. Stays {} when neither scope sets workload_config.
+        # the effective user-supplied ``config_overrides`` for the cell
+        # (recipe-scope + cell-scope workload_config merged; cell wins on
+        # collision; non-collision keys union). NOT the full runtime config
+        # the dispatcher constructs -- the dispatcher additionally injects
+        # ``steps`` and ``_aorta_*`` keys (e.g. ``_aorta_environment``,
+        # ``_aorta_save_logs``) which are runtime/platform-supplied and
+        # deliberately not surfaced in the matrix. Stays {} when neither
+        # scope sets workload_config.
         stats = aggregate_cell(
             name=cell.name,
             mitigations=tuple(cell.mitigations),

--- a/tests/triage/test_matrix.py
+++ b/tests/triage/test_matrix.py
@@ -731,3 +731,18 @@ def test_error_cell_outcome_counts_empty_and_iters_display_dash():
     assert stats.outcome_counts == {}
     assert stats.iters_display == "—"
     assert stats.configured_iters is None
+
+
+def test_workload_config_defaults_to_empty_dict():
+    assert _default_call(trials=[_trial()]).workload_config == {}
+
+
+def test_workload_config_persisted_on_cellstats():
+    stats = _default_call(trials=[_trial()], workload_config={"shampoo_api": "old"})
+    assert stats.workload_config == {"shampoo_api": "old"}
+
+
+def test_workload_config_persisted_on_error_cell():
+    stats = _default_call(trials=[_trial()], error="docker pull failed",
+                          workload_config={"shampoo_api": "old"})
+    assert stats.workload_config == {"shampoo_api": "old"}

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -415,6 +415,104 @@ def test_resolved_recipe_round_trips_workload_config(
     assert reloaded.cells[1].workload_config == {"shampoo_api": "old"}
 
 
+# ---- Config column (diffs-only workload_config) --------------------------
+#
+# The column surfaces per-cell workload_config keys whose value varies
+# across cells. Hidden when no cell sets workload_config OR when every
+# cell agrees. Confound classification unchanged: this column is the
+# disambiguation when two otherwise-identical rows differ only on a
+# workload knob (e.g. `shampoo_api=old` selecting the V1 SHAMPOO entry).
+
+
+def _cell(name: str, *, workload_config: dict | None = None):
+    """One-line Cell builder for Config-column tests."""
+    from aorta.triage.recipe import Cell
+
+    return Cell(
+        name=name,
+        mitigations=("none",),
+        environment="local",
+        workload_config=workload_config or {},
+    )
+
+
+def _recipe_with_cells(*cells, recipe_workload_config: dict | None = None):
+    from aorta.triage.recipe import ConfoundCfg, Recipe
+
+    return Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=tuple(cells),
+        ticket="CFG",
+        confound=ConfoundCfg(baseline_cell=cells[0].name),
+        workload_config=recipe_workload_config or {},
+    )
+
+
+def test_matrix_md_config_column_hidden_when_no_workload_config(
+    tmp_path, patched_env, patched_run_trials
+):
+    r = _recipe_with_cells(_cell("a"), _cell("b"))
+    md = (runner.run_recipe(r, output_dir=tmp_path) / "matrix.md").read_text(encoding="utf-8")
+    assert "| Config " not in md
+
+
+def test_matrix_md_config_column_hidden_when_all_cells_share_config(
+    tmp_path, patched_env, patched_run_trials
+):
+    r = _recipe_with_cells(_cell("a"), _cell("b"),
+                           recipe_workload_config={"shampoo_api": "new"})
+    md = (runner.run_recipe(r, output_dir=tmp_path) / "matrix.md").read_text(encoding="utf-8")
+    assert "| Config " not in md
+
+
+def test_matrix_md_config_column_shows_only_varying_keys(
+    tmp_path, patched_env, patched_run_trials
+):
+    """One cell flips shampoo_api -> Config column appears; only that key is rendered."""
+    r = _recipe_with_cells(
+        _cell("a"),
+        _cell("b", workload_config={"shampoo_api": "old"}),
+        recipe_workload_config={"warmup": 5},  # shared key: NOT rendered
+    )
+    md = (runner.run_recipe(r, output_dir=tmp_path) / "matrix.md").read_text(encoding="utf-8")
+    assert "| Config " in md
+    assert "shampoo_api=old" in md
+    assert "warmup=5" not in md  # shared across cells -> hidden
+    assert "- `Config` --" in md  # legend bullet present
+
+
+def test_matrix_md_config_column_renders_dash_for_cell_with_no_varying_keys(
+    tmp_path, patched_env, patched_run_trials
+):
+    r = _recipe_with_cells(
+        _cell("a"),
+        _cell("b", workload_config={"shampoo_api": "old"}),
+    )
+    md = (runner.run_recipe(r, output_dir=tmp_path) / "matrix.md").read_text(encoding="utf-8")
+    # Cell "a" has no workload_config; under Config column it must show "—".
+    a_row = next(line for line in md.splitlines() if line.startswith("| a "))
+    assert "| — " in a_row
+
+
+def test_matrix_json_records_workload_config_per_cell(
+    tmp_path, patched_env, patched_run_trials
+):
+    """Persisted on CellStats so downstream consumers can re-render the column."""
+    r = _recipe_with_cells(
+        _cell("a"),
+        _cell("b", workload_config={"shampoo_api": "old"}),
+        recipe_workload_config={"warmup": 5},
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    doc = json.loads((run_dir / "matrix.json").read_text())
+    by_name = {c["name"]: c for c in doc["cells"]}
+    assert by_name["a"]["workload_config"] == {"warmup": 5}
+    assert by_name["b"]["workload_config"] == {"warmup": 5, "shampoo_api": "old"}
+
+
 def test_matrix_json_records_resolved_environment_per_cell(
     tmp_path, patched_env, patched_run_trials
 ):


### PR DESCRIPTION
## Summary

- Add a **diffs-only `Config` column** to `matrix.md` that surfaces per-cell `workload_config` keys whose value varies across cells (e.g. `shampoo_api=old`). Hidden when no cell sets `workload_config` or when every cell agrees on every key — existing recipes stay byte-identical.
- Persist the merged `workload_config` on `CellStats` (and therefore in `matrix.json`) so downstream re-renderers don't have to re-read the recipe.
- **Confound classification stays unchanged.** This column carries the disambiguation; no new confound tag, no change to existing tags.

## Why

Today the renderer hides every per-cell `workload_config`. Two cells whose only meaningful axis is `shampoo_api=old` vs `new` look indistinguishable in `matrix.md`: same `Mitigations`, same `Environment`, same `(none)` confound — and one passes while the other crashes, with no visible reason. The 2026-05-19 v2-smoke run is exactly this: `baseline-nan-repro` and `baseline-v2api-nan-repro` differ only in `workload_config`, but the table showed them as carbon copies. The Config column makes that disambiguation visible.

## Example

Before (today):

| Cell | Mitigations | Environment | Failure rate | ... | Confound |
|---|---|---|---|---|---|
| baseline-nan-repro | none | nan-repro | 100% | ... | did_not_run |
| baseline-v2api-nan-repro | none | nan-repro | 0% | ... | n/a |

After (this PR):

| Cell | Mitigations | Environment | Config | Failure rate | ... | Confound |
|---|---|---|---|---|---|---|
| baseline-nan-repro | none | nan-repro | — | 100% | ... | did_not_run |
| baseline-v2api-nan-repro | none | nan-repro | shampoo_api=old | 0% | ... | n/a |

(The actual recipe still has the bad cell name; that's a separate follow-up tracked in workspace `tasks/active/demo__prep-prs.md`. The point is that the table no longer hides the only axis that matters.)

## Files

| File | What |
|---|---|
| `src/aorta/triage/matrix.py` | `CellStats.workload_config: dict[str, Any] = field(default_factory=dict)`; `aggregate_cell` takes an optional `workload_config=` kwarg and threads it onto both success and error returns. `None` / `{}` both collapse to `{}` |
| `src/aorta/triage/runner.py` | Pass the merged `{**recipe.workload_config, **cell.workload_config}` (cell wins on collision — same rule the dispatcher already uses for `Request.config_overrides`) into the `aggregate_cell` call at line 801 |
| `src/aorta/triage/output.py` | New `_varying_workload_config_keys()` helper (uses `repr` for value comparison so unhashable values don't break set construction); new `_format_workload_config()` helper (renders only the varying-key subset for a cell, `—` if cell has none of the varying keys); `write_matrix_md` inserts the column between `Environment` and `Failure rate` when keys vary; new Notes legend bullet |
| `recipes/README.md` | Document `workload_config` in the matrix.json per-cell shape; reference the new matrix.md `Config` column |
| `tests/triage/test_matrix.py` | 3 small tests pinning the new field |
| `tests/triage/test_output_layout.py` | 5 tests covering the column rendering rules + matrix.json persistence. Helper `_cell` / `_recipe_with_cells` builders keep each test body to ~6 lines |

## Tests

- `pytest tests/triage/ tests/run/` — 353/353 passing locally.
- Coverage: column hidden when no cell has `workload_config`, hidden when all cells share identical config, shown when cells differ, only varying keys rendered (shared keys hidden), cells with none of the varying keys render `—`, matrix.json persists the merged dict per cell.
- One drive-by fix: my new dash-rendering test caught that the existing tests' `.read_text()` calls decode `matrix.md` as `cp1252` on Windows and silently turn UTF-8 em-dash into `â€”`. New tests use `.read_text(encoding=\"utf-8\")`. Worth a follow-up to sweep the older tests for the same issue, but out of scope here.

## Follow-ups (not in this PR)

- aorta-internal: rename the misleading `baseline-v2api-nan-repro` cell in `recipes/SHAMPOO-NAN-2026-042-v2-smoke.yaml` (it's V1 now post-aorta-internal#39). Bundled into the demo-prep tracker.
- aorta public: PR-1 (`save_logs`) is in-flight (#185); PR-3b (wrapper save_logs opt-in) blocks on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)