### PR TITLE
triage/save_logs: inject _aorta_log_prefix (full path) instead of bare basename

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -100,11 +100,13 @@ cells:
   that spawn subprocesses (e.g. `recom_repro` invoking `docker run`)
   don't have their subprocess output captured automatically. Those
   wrappers can opt in by reading the platform-supplied
-  `_aorta_save_logs` / `_aorta_log_basename` config keys the dispatcher
+  `_aorta_save_logs` / `_aorta_log_prefix` config keys the dispatcher
   injects, and writing their own capture to a sibling path derived from
-  the basename (e.g. `<basename>.subprocess.stdout.log`). The
-  dispatcher already holds the `<basename>.{stdout,stderr}.log` paths
-  open, so wrappers must NOT write to them directly.
+  the prefix (e.g. `<prefix>.subprocess.stdout.log`). The prefix is an
+  absolute path-with-stem (e.g. `<results_dir>/trial_d0_m0_t0`), so
+  wrappers don't need to know `results_dir`. The dispatcher already
+  holds the `<prefix>.{stdout,stderr}.log` paths open, so wrappers must
+  NOT write to them directly.
 - **`workload_config`** -- optional `dict[str, Any]`, allowed at both
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -103,10 +103,13 @@ cells:
   `_aorta_save_logs` / `_aorta_log_prefix` config keys the dispatcher
   injects, and writing their own capture to a sibling path derived from
   the prefix (e.g. `<prefix>.subprocess.stdout.log`). The prefix is an
-  absolute path-with-stem (e.g. `<results_dir>/trial_d0_m0_t0`), so
-  wrappers don't need to know `results_dir`. The dispatcher already
-  holds the `<prefix>.{stdout,stderr}.log` paths open, so wrappers must
-  NOT write to them directly.
+  absolute path-with-stem rooted in the per-workload results
+  subdirectory (e.g. `<results_dir>/<workload>/trial_d0_m0_t0`,
+  anchored via `Path.absolute()` so a relative `results_dir` still
+  yields a usable prefix), so wrappers don't need to know
+  `results_dir`. The dispatcher already holds the
+  `<prefix>.{stdout,stderr}.log` paths open, so wrappers must NOT
+  write to them directly.
 - **`workload_config`** -- optional `dict[str, Any]`, allowed at both
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -85,13 +85,13 @@ class RunRequest:
             ``contextlib.redirect_*`` only catches Python-level writes;
             subprocesses are not captured. Wrappers that own a
             subprocess can opt in by reading the platform-supplied
-            ``_aorta_save_logs`` / ``_aorta_log_basename`` config keys
-            this dispatcher injects; the basename is the trial filename
-            stem (e.g. ``trial_d0_m0_t0``) and the wrapper derives a
-            non-colliding sibling path such as
-            ``<basename>.subprocess.{stdout,stderr}.log`` -- the
+            ``_aorta_save_logs`` / ``_aorta_log_prefix`` config keys
+            this dispatcher injects; the prefix is an absolute
+            path-with-stem (e.g. ``<results_dir>/trial_d0_m0_t0``) and
+            the wrapper derives a non-colliding sibling path such as
+            ``<prefix>.subprocess.{stdout,stderr}.log`` -- the
             dispatcher already holds open the
-            ``<basename>.{stdout,stderr}.log`` paths and double-writing
+            ``<prefix>.{stdout,stderr}.log`` paths and double-writing
             them would race.
 
             The ``redirect_*`` rebinding is process-wide. Today no
@@ -368,12 +368,13 @@ def _run_single_trial(
     # ``save_logs`` opens per-trial log files and redirects
     # ``sys.stdout`` / ``sys.stderr`` for the duration of
     # ``setup()`` + ``run()`` + ``cleanup()``. The reserved
-    # ``_aorta_save_logs`` / ``_aorta_log_basename`` config keys let
+    # ``_aorta_save_logs`` / ``_aorta_log_prefix`` config keys let
     # subprocess-based wrappers (whose child output ``redirect_stdout``
     # doesn't catch) opt in and write their own capture to a sibling
-    # path derived from the basename -- the dispatcher already holds
-    # open the ``<basename>.{stdout,stderr}.log`` paths so wrappers
-    # must NOT write to them directly.
+    # path derived from the prefix -- the dispatcher already holds
+    # open the ``<prefix>.{stdout,stderr}.log`` paths so wrappers
+    # must NOT write to them directly. The prefix is an absolute
+    # path-with-stem so wrappers don't need to know ``results_dir``.
     #
     # ``encoding="utf-8", errors="backslashreplace"`` is deliberate:
     # the platform default encoding is locale-dependent (cp1252 on
@@ -435,7 +436,10 @@ def _run_single_trial(
             )
         else:
             config["_aorta_save_logs"] = True
-            config["_aorta_log_basename"] = log_basename
+            # Absolute path-with-stem: wrappers compose sibling files as
+            # f"{prefix}.subprocess.{stdout,stderr}.log" without needing
+            # to know ``results_dir``.
+            config["_aorta_log_prefix"] = str(results_dir / log_basename)
 
     with contextlib.ExitStack() as log_stack:
         if stdout_fh is not None and stderr_fh is not None:

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -87,8 +87,11 @@ class RunRequest:
             subprocess can opt in by reading the platform-supplied
             ``_aorta_save_logs`` / ``_aorta_log_prefix`` config keys
             this dispatcher injects; the prefix is an absolute
-            path-with-stem (e.g. ``<results_dir>/trial_d0_m0_t0``) and
-            the wrapper derives a non-colliding sibling path such as
+            path-with-stem rooted in the per-workload results
+            subdirectory (e.g. ``<results_dir>/<workload>/trial_d0_m0_t0``,
+            anchored via ``Path.absolute()`` so a relative
+            ``RunRequest.results_dir`` still yields a usable prefix)
+            and the wrapper derives a non-colliding sibling path such as
             ``<prefix>.subprocess.{stdout,stderr}.log`` -- the
             dispatcher already holds open the
             ``<prefix>.{stdout,stderr}.log`` paths and double-writing
@@ -438,8 +441,15 @@ def _run_single_trial(
             config["_aorta_save_logs"] = True
             # Absolute path-with-stem: wrappers compose sibling files as
             # f"{prefix}.subprocess.{stdout,stderr}.log" without needing
-            # to know ``results_dir``.
-            config["_aorta_log_prefix"] = str(results_dir / log_basename)
+            # to know ``results_dir``. ``.absolute()`` (not ``.resolve()``)
+            # because we only need to anchor relative inputs against cwd
+            # -- a default ``RunRequest(results_dir=Path("results"))``
+            # would otherwise leak a relative prefix to wrappers whose
+            # subprocesses run with a different cwd (docker bind mounts,
+            # torchrun-launched workers). ``.resolve()`` would also walk
+            # symlinks and touch the filesystem, which is unnecessary
+            # here and surprising on Windows.
+            config["_aorta_log_prefix"] = str((results_dir / log_basename).absolute())
 
     with contextlib.ExitStack() as log_stack:
         if stdout_fh is not None and stderr_fh is not None:

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -208,13 +208,15 @@ class Recipe:
             process's TTY). Workloads that spawn subprocesses don't have
             their subprocess output captured by ``redirect_*``; those
             wrappers can opt in by reading the platform-supplied
-            ``_aorta_save_logs`` / ``_aorta_log_basename`` config keys
+            ``_aorta_save_logs`` / ``_aorta_log_prefix`` config keys
             the dispatcher injects and writing their own capture to a
-            sibling path derived from the basename (e.g.
-            ``<basename>.subprocess.stdout.log``). Both file capture and
-            key injection are **rank-0 only** -- matches the trial-JSON
-            write guarantee. Wrappers running on non-rank-0 won't see
-            the keys and should treat capture as off there.
+            sibling path derived from the prefix (e.g.
+            ``<prefix>.subprocess.stdout.log``). The prefix is an
+            absolute path-with-stem so wrappers don't need to know
+            ``results_dir``. Both file capture and key injection are
+            **rank-0 only** -- matches the trial-JSON write guarantee.
+            Wrappers running on non-rank-0 won't see the keys and
+            should treat capture as off there.
     """
 
     schema_version: int

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -1119,8 +1119,28 @@ class TestSaveLogs:
         assert cfg["_aorta_save_logs"] is True
         # Absolute path-with-stem so wrappers can build sibling files
         # (``<prefix>.subprocess.{stdout,stderr}.log``) without needing
-        # to know ``results_dir``.
-        assert cfg["_aorta_log_prefix"] == str(cell_dir / "trial_d0_m0_t0")
+        # to know ``results_dir``. ``tmp_path`` is already absolute, so
+        # the dispatcher's ``.absolute()`` call is a no-op here -- but
+        # the relative-input path is covered by
+        # ``test_on_injects_absolute_prefix_even_with_relative_results_dir``.
+        assert cfg["_aorta_log_prefix"] == str((cell_dir / "trial_d0_m0_t0").absolute())
+        assert Path(cfg["_aorta_log_prefix"]).is_absolute()
+
+    def test_on_injects_absolute_prefix_even_with_relative_results_dir(self, tmp_path, monkeypatch):
+        """Default ``RunRequest(results_dir=Path("results"))`` is relative;
+        wrappers whose subprocesses run with a different cwd (docker bind
+        mounts, torchrun-launched workers) would otherwise be unable to
+        locate the sibling-log directory. Pin that the dispatcher
+        anchors the prefix against cwd before injection."""
+        monkeypatch.chdir(tmp_path)
+        mock_ep = MagicMock(name="noisy")
+        mock_ep.name = "noisy"
+        mock_ep.load.return_value = NoisyWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            run_trials(RunRequest(workload="noisy", trials=1, save_logs=True))
+        assert Path(NoisyWorkload.seen_config["_aorta_log_prefix"]).is_absolute()
 
     def test_on_non_rank_zero_writes_no_log_files(self, tmp_path):
         with patch.dict(os.environ, {"RANK": "1"}):

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -1114,10 +1114,13 @@ class TestSaveLogs:
         assert (cell_dir / "trial_d0_m0_t0.stderr.log").read_text().strip() == "STDERR-FROM-WORKLOAD"
 
     def test_on_injects_aorta_log_keys_for_subprocess_wrappers(self, tmp_path):
-        self._run(tmp_path, save_logs=True)
+        cell_dir = self._run(tmp_path, save_logs=True)
         cfg = NoisyWorkload.seen_config
         assert cfg["_aorta_save_logs"] is True
-        assert cfg["_aorta_log_basename"] == "trial_d0_m0_t0"
+        # Absolute path-with-stem so wrappers can build sibling files
+        # (``<prefix>.subprocess.{stdout,stderr}.log``) without needing
+        # to know ``results_dir``.
+        assert cfg["_aorta_log_prefix"] == str(cell_dir / "trial_d0_m0_t0")
 
     def test_on_non_rank_zero_writes_no_log_files(self, tmp_path):
         with patch.dict(os.environ, {"RANK": "1"}):
@@ -1174,4 +1177,4 @@ class TestSaveLogs:
         assert not (tmp_path / "noisy" / "trial_d0_m0_t0.stdout.log").exists()
         assert "AORTA_LEAK_PROBE" not in os.environ, "env overlay leaked when log-open failed"
         assert "_aorta_save_logs" not in NoisyWorkload.seen_config
-        assert "_aorta_log_basename" not in NoisyWorkload.seen_config
+        assert "_aorta_log_prefix" not in NoisyWorkload.seen_config


### PR DESCRIPTION
## Summary

Renames the dispatcher-injected reserved config key
``_aorta_log_basename`` -> ``_aorta_log_prefix`` and changes its value
from a bare filename stem to an absolute path-with-stem.

- **Before:** ``config[\"_aorta_log_basename\"] = \"trial_d0_m0_t0\"``
- **After:**  ``config[\"_aorta_log_prefix\"]   = str(results_dir / \"trial_d0_m0_t0\")``

## Why

The reserved-key contract added in #185 was meant to let
subprocess-based wrappers (most importantly ``recom_repro``, which
shells out to ``docker run``) write their captured child stdout/stderr
to a *sibling* path next to the dispatcher-owned
``<basename>.{stdout,stderr}.log`` files.

But the dispatcher does not ``chdir`` into ``results_dir`` before
calling the workload, and #185 injected only the bare filename stem --
giving wrappers no reliable way to learn the directory. The documented
"sibling path" semantics were unimplementable in practice.

Switching to a single absolute-path key fixes that with the smallest
possible change to the contract: one key, fully self-describing, no
need for a second ``_aorta_log_dir`` companion.

## Breaking change scope

The key was first shipped in #185 (merged 2026-05-19, prior to any
tagged release). No third-party workloads consume the old name; the
in-flight aorta-internal recom_repro wrapper PR is the only known
consumer and is built directly on this new key.

## Test plan

- [x] ``pytest tests/run/test_dispatcher.py::TestSaveLogs`` (all 6 pass)
  - ``test_on_injects_aorta_log_keys_for_subprocess_wrappers`` now
    asserts ``cfg[\"_aorta_log_prefix\"] == str(cell_dir / \"trial_d0_m0_t0\")``
  - ``test_log_open_failure_degrades_gracefully_and_restores_env`` now
    asserts the renamed key is absent on the degraded path
- [ ] Downstream: aorta-internal PR (recom_repro wrapper) consumes
  ``_aorta_log_prefix`` and writes
  ``<prefix>.subprocess.{stdout,stderr}.log``

Docs updated: ``recipes/README.md``, ``run_trials.save_logs`` and
``Recipe.save_logs`` docstrings.