### PR TITLE
triage__exit-status: add workload_setup_failed bucket

### DIFF
--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -479,8 +479,14 @@ def _run_single_trial(
                 workload_result = WorkloadResult(
                     passed=False,
                     failure_count=1,
-                    failure_details=[{"error": str(e), "type": type(e).__name__,
-                                      "phase": "setup"}],
+                    failure_details=[
+                        {
+                            "error": str(e),
+                            "type": type(e).__name__,
+                            "phase": "setup",
+                        }
+                    ],
+                    main_work_started=False,
                 )
             else:
                 workload_result = workload.run()

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -463,11 +463,29 @@ def _run_single_trial(
             # contract -- third-party plugins are free to name their first
             # parameter something other than ``config``.
             workload = workload_cls(config)
-            workload.setup()
-            workload_result = workload.run()
-
-            if not workload_result.passed:
-                exit_status = "workload_failed"
+            # setup() is split into its own try so a setup-time exception
+            # gets the "workload_setup_failed" bucket instead of being
+            # lumped under "infrastructure_failed". The distinction
+            # matters: a row of all-setup-failures means the workload
+            # never got off the ground (missing dep, broken probe), not
+            # that the measurement under test failed -- matrix.md readers
+            # need to see those differently. Construction failures and
+            # run()-time exceptions still flow to the outer except as
+            # infrastructure_failed (unchanged).
+            try:
+                workload.setup()
+            except Exception as e:
+                exit_status = "workload_setup_failed"
+                workload_result = WorkloadResult(
+                    passed=False,
+                    failure_count=1,
+                    failure_details=[{"error": str(e), "type": type(e).__name__,
+                                      "phase": "setup"}],
+                )
+            else:
+                workload_result = workload.run()
+                if not workload_result.passed:
+                    exit_status = "workload_failed"
 
         except Exception as e:
             exit_status = "infrastructure_failed"

--- a/src/aorta/run/results.py
+++ b/src/aorta/run/results.py
@@ -49,11 +49,30 @@ class TrialResult:
             ``partial`` / ``partial_reasons``, etc.).
         result: WorkloadResult serialized to dict.
         wall_clock_sec: Total wall clock time for the trial.
-        exit_status: Outcome of the trial execution.  ``"timeout"`` is
-            deliberately NOT in the literal: B1 ships no ``--timeout``
-            flag and no watchdog, so no code path can produce it.
-            Re-add the value in the same commit that adds a producer
-            (e.g. when a ``--timeout`` watchdog lands).
+        exit_status: Outcome of the trial execution.  Values:
+
+            * ``"ok"`` -- workload ran and reported ``passed=True``.
+            * ``"workload_failed"`` -- workload ran and reported
+              ``passed=False`` from ``run()`` (e.g. NaN detected,
+              assertion fired mid-loop).
+            * ``"workload_setup_failed"`` -- ``workload.setup()`` raised
+              before the workload's main work could begin (e.g. missing
+              dependency at import time, broken env probe). Distinct
+              from ``infrastructure_failed`` so a setup-time crash
+              can't masquerade as a 100 % failure rate of the
+              measurement under test -- a row of all-setup-failures
+              means the workload never got off the ground, not that
+              the bug reproduces every trial.
+            * ``"infrastructure_failed"`` -- the dispatcher caught an
+              exception that wasn't attributable to ``setup()``: the
+              workload class itself failed to construct
+              (``workload_cls(config)`` raised), or ``run()`` raised
+              after ``setup()`` returned cleanly.
+
+            ``"timeout"`` is deliberately NOT in the literal: B1 ships
+            no ``--timeout`` flag and no watchdog, so no code path can
+            produce it.  Re-add the value in the same commit that adds
+            a producer (e.g. when a ``--timeout`` watchdog lands).
     """
 
     trial_id: str
@@ -64,7 +83,9 @@ class TrialResult:
     env: dict[str, Any]
     result: dict[str, Any]
     wall_clock_sec: float
-    exit_status: Literal["ok", "workload_failed", "infrastructure_failed"]
+    exit_status: Literal[
+        "ok", "workload_failed", "workload_setup_failed", "infrastructure_failed"
+    ]
     schema_version: str = "0.1"
 
     def __post_init__(self) -> None:

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -32,7 +32,10 @@ The aggregator does NOT inspect *why* a trial failed (NaN vs corruption vs
 divergence vs infrastructure crash); that's :class:`WorkloadResult` /
 ``exit_status`` territory and is preserved separately via the
 ``exit_status_counts`` histogram so callers can distinguish e.g.
-``workload_failed`` from ``infrastructure_failed`` when triaging.
+``workload_failed`` (run() returned passed=False) from
+``workload_setup_failed`` (setup() raised, never reached the
+measurement) from ``infrastructure_failed`` (construction or run()
+itself raised) when triaging.
 """
 
 from __future__ import annotations
@@ -82,9 +85,13 @@ class CellStats:
     consumer without forcing them to recompute.
 
     ``exit_status_counts`` is a histogram keyed by ``TrialResult.exit_status``
-    (``"ok"``, ``"workload_failed"``, ``"infrastructure_failed"``, ...). It
-    lets matrix.json consumers distinguish failure modes that ``failure_rate``
-    alone collapses into a single number.
+    (``"ok"``, ``"workload_failed"``, ``"workload_setup_failed"``,
+    ``"infrastructure_failed"``, ...). It lets matrix.json consumers
+    distinguish failure modes that ``failure_rate`` alone collapses
+    into a single number. ``workload_setup_failed`` specifically calls
+    out trials where ``workload.setup()`` raised, so a row of all-setup-
+    failures can't be misread as "the bug reproduces 100 %" -- the
+    workload never got far enough to test the bug.
 
     ``step_time_source`` records which branch of the fallback ladder
     populated ``step_times_ms`` -- ``"per_step"``, ``"elapsed_per_iter"``,
@@ -557,10 +564,12 @@ def aggregate_cell(
         wall_clocks.append(float(wall))
         # Histogram by raw exit_status so callers can distinguish e.g.
         # "workload_failed" (the workload's run() returned a failed
-        # WorkloadResult) from "infrastructure_failed" (B1's dispatcher
-        # caught an exception around setup/run/cleanup and synthesised a
-        # passed=False WorkloadResult so the cell still has a row).
-        # ``aorta.run.dispatcher`` populates a WorkloadResult in either
+        # WorkloadResult), "workload_setup_failed" (setup() raised --
+        # the workload never reached the measurement), and
+        # "infrastructure_failed" (B1's dispatcher caught an exception
+        # around construction or run() and synthesised a passed=False
+        # WorkloadResult so the cell still has a row).
+        # ``aorta.run.dispatcher`` populates a WorkloadResult in every
         # case; the distinction is purely the exit_status value.
         # Falling back to "unknown" keeps the histogram total == trial_count
         # even for stand-in trial objects that omit the attribute.

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -420,8 +420,11 @@ def write_matrix_md(
         "of eight). `Failure rate` is the same data as a percentage and counts every "
         "trial whose `exit_status != ok` or whose `WorkloadResult.passed` is False; "
         "neither is NaN-specific. Use `matrix.json::cells[*].exit_status_counts` to "
-        "break failures down by mode (`workload_failed` vs `infrastructure_failed` "
-        "vs `unknown`, etc.)."
+        "break failures down by mode: `workload_failed` (run() reported "
+        "passed=False), `workload_setup_failed` (setup() raised, so the "
+        "workload never reached the measurement -- a 100% setup-fail row is "
+        "NOT a 100% reproduction), `infrastructure_failed` (construction or "
+        "run() itself raised), `unknown`, etc."
     )
     lines.append(
         "- Only `mean step (ms)` is shown here. Per-cell `std`, `min`, `max`, "

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -411,6 +411,7 @@ class TestRunTrials:
         assert details[0]["type"] == "ImportError"
         assert details[0]["phase"] == "setup"
         assert "missing dependency" in details[0]["error"]
+        assert results[0].result["main_work_started"] is False
 
     def test_one_failing_trial_doesnt_stop_others(self, tmp_path):
         """One trial failing doesn't prevent other trials from running."""

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -72,6 +72,25 @@ class CrashingWorkload(Workload):
         pass
 
 
+class SetupCrashingWorkload(Workload):
+    """Mock workload whose setup() raises (e.g. missing dependency at import)."""
+
+    launch_mode = "single_process"
+    min_world_size = 1
+
+    def setup(self) -> None:
+        raise ImportError("simulated missing dependency in setup()")
+
+    def run(self) -> WorkloadResult:
+        # Should never be reached; assert just in case so a regression where
+        # the dispatcher swallows setup() failures and proceeds to run()
+        # surfaces loudly instead of silently passing the test.
+        raise AssertionError("run() must not be called when setup() raised")
+
+    def cleanup(self) -> None:
+        pass
+
+
 class TestRunRequest:
     """Tests for RunRequest dataclass."""
 
@@ -359,6 +378,39 @@ class TestRunTrials:
         assert len(results) == 1
         assert results[0].exit_status == "infrastructure_failed"
         assert "RuntimeError" in str(results[0].result["failure_details"])
+
+    def test_setup_crashing_workload_sets_workload_setup_failed(self, tmp_path):
+        """setup() exception gets its own bucket, not infrastructure_failed.
+
+        A row of all-setup-failures must read as "workload never got off
+        the ground", not "100% reproduction of the bug under test" -- so
+        the dispatcher splits the setup() try-block out and attributes
+        its exception to workload_setup_failed. The failure_details
+        record carries a ``phase: "setup"`` marker so trial_*.json is
+        self-describing.
+        """
+        mock_ep = MagicMock()
+        mock_ep.name = "setup_crashing"
+        mock_ep.load.return_value = SetupCrashingWorkload
+
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="setup_crashing",
+                trials=1,
+                results_dir=tmp_path,
+            )
+            results = run_trials(req)
+
+        assert len(results) == 1
+        assert results[0].exit_status == "workload_setup_failed"
+        details = results[0].result["failure_details"]
+        assert len(details) == 1
+        assert details[0]["type"] == "ImportError"
+        assert details[0]["phase"] == "setup"
+        assert "missing dependency" in details[0]["error"]
 
     def test_one_failing_trial_doesnt_stop_others(self, tmp_path):
         """One trial failing doesn't prevent other trials from running."""

--- a/tests/run/test_results.py
+++ b/tests/run/test_results.py
@@ -139,7 +139,12 @@ class TestTrialResult:
         it.  Re-add it (and this test entry) in the same commit that
         adds a producer.
         """
-        for status in ["ok", "workload_failed", "infrastructure_failed"]:
+        for status in [
+            "ok",
+            "workload_failed",
+            "workload_setup_failed",
+            "infrastructure_failed",
+        ]:
             result = TrialResult(
                 trial_id="test",
                 workload="test",

--- a/tests/triage/test_matrix.py
+++ b/tests/triage/test_matrix.py
@@ -197,12 +197,14 @@ def test_min_max_p90_step_times_populated():
 
 def test_exit_status_histogram_distinguishes_failure_modes():
     """Pin the new exit_status_counts field. Failure rate alone is generic;
-    callers triaging a cell need to tell workload_failed from infrastructure_failed.
+    callers triaging a cell need to tell workload_failed from
+    workload_setup_failed from infrastructure_failed.
     """
     trials = [
         _trial(passed=True, exit_status="ok"),
         _trial(passed=True, exit_status="ok"),
         _trial(passed=False, exit_status="workload_failed"),
+        _trial(passed=False, exit_status="workload_setup_failed"),
         _trial(passed=False, exit_status="infrastructure_failed"),
         _trial(passed=False, exit_status="infrastructure_failed"),
     ]
@@ -210,12 +212,13 @@ def test_exit_status_histogram_distinguishes_failure_modes():
     assert stats.exit_status_counts == {
         "ok": 2,
         "workload_failed": 1,
+        "workload_setup_failed": 1,
         "infrastructure_failed": 2,
     }
     # Histogram total must equal trial count, by construction.
     assert sum(stats.exit_status_counts.values()) == stats.trials
-    # And the failure_rate is consistent with the histogram (3 of 5 not "ok").
-    assert abs(stats.failure_rate - 0.6) < 1e-9
+    # And the failure_rate is consistent with the histogram (4 of 6 not "ok").
+    assert abs(stats.failure_rate - (4.0 / 6.0)) < 1e-9
 
 
 def test_failure_rate_docstring_is_general_not_nan_specific():


### PR DESCRIPTION
## Summary

Adds a `workload_setup_failed` value to `TrialResult.exit_status` so a row of all-setup-failures (missing dep, broken import, broken env probe) can't be misread as a 100% NaN reproduction.

The 2026-05-13 SHAMPOO-NAN smoke run lost a half-day to this exact confusion: every `nan-repro` trial died on a `distributed_shampoo.shampoo_types` ImportError before training started, but the matrix surface read as "the bug reproduces every trial."

## What changes

- `src/aorta/run/dispatcher.py` -- `workload.setup()` is now wrapped in its own `try/except`; an exception there classifies as `workload_setup_failed`. Construction failures and `run()` exceptions still classify as `infrastructure_failed` (unchanged). The new bucket's `failure_details` record includes `"phase": "setup"` so `trial_*.json` is self-describing.
- `src/aorta/run/results.py` -- adds `"workload_setup_failed"` to the `exit_status` `Literal` and rewrites the docstring to enumerate all four values.
- `src/aorta/triage/matrix.py` -- docstring + inline-comment updates listing the new bucket. No logic change; the existing `status_counter[trial.exit_status]` already carries new values through to `exit_status_counts`.
- `src/aorta/triage/output.py` -- Failures-column legend lists the new bucket with the explicit warning that "100% setup-fail row is NOT a 100% reproduction."

## What this PR deliberately does NOT do

**No second inference path in the dispatcher.** The matrix layer already has `_looks_like_did_not_run` (from issue #173) which infers setup-failure from observable signals on the WorkloadResult (empty `step_times_ms` + `elapsed_sec == 0` + non-ok `exit_status`) and surfaces it as the `did_not_run` Confound-column tag. That path continues to handle wrappers like `recom_repro` that catch their own subprocess crashes and return `passed=False`. Duplicating that inference in the dispatcher would split the rule across two layers; this PR keeps the dispatcher's classification purely on what its own try-blocks tell it directly.

The accompanying quickstart-doc update in `aorta-internal` points operators at both channels (new bucket + existing `did_not_run` tag).

## Test plan

- [x] `pytest tests/run/test_dispatcher.py -v` -- 36/36 pass including the new `test_setup_crashing_workload_sets_workload_setup_failed`
- [x] `pytest tests/triage/ tests/run/` -- 362/362 pass; no regression in the matrix/output/runner suites
- [x] Existing `test_failing_workload_sets_exit_status` (run returns passed=False) and `test_crashing_workload_sets_exit_status` (run raises) still pass unchanged -- confirms the no-inference contract
- [ ] Reviewer spot-check: setup-time crash in a real workload now appears as `workload_setup_failed` in `matrix.json::cells[*].exit_status_counts`

## Companion change

`aorta-internal` quickstart doc gains a bullet covering both `workload_setup_failed` (this PR) and the existing `did_not_run` Confound-column tag as "fix-the-wrapper-not-the-matrix" signals. Filed in parallel; safe to merge in either order (the bullet only describes existing surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)