### PR TITLE
probe: MVP — aorta probe command + recipe schema + engine reuse (#188 phase 1)

### DIFF
--- a/docs/plans/aorta-probe-188-rubric.md
+++ b/docs/plans/aorta-probe-188-rubric.md
@@ -1,0 +1,630 @@
+---
+title: "aorta probe — feature rubric for ROCm/aorta#188"
+issue: https://github.com/ROCm/aorta/issues/188
+branch: users/vivekag/aorta-probe-188
+base_commit: b79da71
+base_pr: "#187 (build: make the AORTA CLI Buck2-buildable + audit deps -> cquery)"
+implementer: amd-vivekag
+author_of_issue: oyazdanb
+planner: feature-rubric-planner v1 (codebase-anchored)
+planner_run_date: 2026-05-25
+---
+
+# `aorta probe` — Implementation Rubric (Issue #188)
+
+> Wrap-and-collect command for opaque user launch commands. Three sequential phases, each a separate PR off `main`.
+
+---
+
+## 0. Findings That May Revise the Issue
+
+Read before scoring. These are gaps / contradictions between the issue text and the current codebase that the implementer (or issue author) must resolve in writing before merge of the Phase 1 PR.
+
+### F1 — Output-tree layout conflicts with `run_recipe`'s contract
+
+The issue specifies `Y/<ticket>/<cell>/trial_<n>/{stdout.log, stderr.log, result.json}` and "re-running with same `--output` skips completed cells". The current `aorta.triage.runner.run_recipe` calls `aorta.triage.output.resolve_run_dir(...)` (`src/aorta/triage/output.py:85-124`), which **always creates a fresh, timestamped, non-overwriteable leaf**: `<output_dir>/<ticket>/<workload>/<timestamp>[-N]/`, and explodes per-cell artifacts under `cells/<safe_slug(cell.name)>/<workload>/trial_<N>.json`. That layout (a) has no resume affordance and (b) names a `<workload>` and `<timestamp>` segment the issue's layout elides.
+
+Two conformant resolutions:
+
+1. **(Recommended)** Extend `resolve_run_dir` with a `layout: Literal["timestamped", "flat_resume"]` selector that probe-mode passes as `"flat_resume"`. In `flat_resume`, the leaf is `<output_dir>/<safe_slug(ticket)>/` (idempotent `mkdir(exist_ok=True)`), per-cell artifacts live at `<run_dir>/<safe_slug(cell.name)>/trial_<n>/`, and `SubprocessWorkload` writes its own `stdout.log` / `stderr.log` / `result.json` inside each `trial_<n>/`. This keeps `run_recipe` as the single matrix engine.
+2. Fork the output writer entirely for probe-mode. **Rejected.** Violates the issue's "MUST call the same `run_recipe`" rule by introducing parallel I/O layer divergence.
+
+→ Phase 1 must include a `layout=` parameter on `resolve_run_dir` and `run_recipe`, defaulting to `"timestamped"` so `aorta triage run` behaviour is byte-equivalent.
+
+### F2 — Recipe schema explicitly forbids the probe-mode keys today
+
+`src/aorta/triage/recipe.py:39-51` defines `_VALID_TOP_LEVEL` as a closed frozenset that **rejects** every probe-mode key in the issue (`mode`, `mitigation_axis`, `diagnostic_axis`, `step_time_regex`, `collect_paths`, `redaction`, `custom_patterns`). Loading the example probe-mode recipe from the issue today raises `RecipeSchemaError`. Phase 1 must extend `_VALID_TOP_LEVEL` and the parser to accept these keys when `mode == "probe"`, and reject them when `mode == "triage"` (default). It must also relax three triage-mode required keys (`workload`, `cells`, `steps`) to optional when `mode == "probe"` because probe-mode synthesises cells from `mitigation_axis × diagnostic_axis` and fixes `workload` internally to a reserved name.
+
+### F3 — No `SubprocessWorkload` exists, and the `_aorta_` prefix is closed to user input
+
+The issue mandates `SubprocessWorkload` in `aorta/workloads/_subprocess.py`, taking `argv` from `setup()`. `src/aorta/run/dispatcher.py:193` explicitly rejects any `config_overrides` key starting with `_aorta_` ("platform-supplied; not a user override"). Therefore argv cannot be smuggled in via `config_overrides`. The clean fix: add a typed field `subprocess_argv: tuple[str, ...] | None = None` to `RunRequest` (`src/aorta/run/dispatcher.py:39-122`), and have the dispatcher inject it as `config["_aorta_subprocess_argv"]` after merging `config_overrides` (same pattern as `config["_aorta_environment"]` at `dispatcher.py:346`). `SubprocessWorkload.setup()` reads the reserved key.
+
+### F4 — `_subprocess` is not registered as an entry-point workload
+
+`pyproject.toml:42-48` shows `[project.entry-points."aorta.workloads"]` is commented out. `aorta.run.discovery.get_workload_class` (`src/aorta/run/discovery.py:65-87`) raises `ValueError` for any name not found via `importlib.metadata.entry_points`. Phase 1 must register the workload:
+
+```toml
+[project.entry-points."aorta.workloads"]
+_subprocess = "aorta.workloads._subprocess:SubprocessWorkload"
+```
+
+`_subprocess` is leading-underscored so it cannot collide with user-facing workload names and so it is visibly platform-internal in `aorta triage list-workloads` (when that command lands).
+
+### F5 — `aorta bundle` truly does not exist
+
+`gh pr list --state all --search 'bundle'` returns only unrelated PRs. No `src/aorta/cli/bundle.py`, no `src/aorta/bundle/` module, no design doc beyond an empty `docs/probe-188/` directory. **Phase 3 is genuinely blocked on a separate ticket landing `aorta bundle`.** Phase 1 + 2 must ship standalone without Phase 3 dependencies. The rubric reflects this by gating every Phase 3 criterion on the upstream bundle PR.
+
+### F6 — `--env-passthrough-mode {inherit, file}` and the no-parse invariant collide
+
+The issue says "everything after `--` is forwarded byte-for-byte; aorta never parses it" AND "the one real boundary is `docker run`, addressed with a two-mode passthrough (inherit | file)". These two together imply:
+
+- `inherit` mode: aorta sets per-cell env vars in its own process and `exec`s the user's argv. Works for `torchrun`, `bash`, `python`, `buck2 run`. For `docker run`, **the user is responsible** for `-e KEY` lines in their own argv — aorta does not inject them.
+- `file` mode: aorta writes a `KEY=VALUE\n` file at `${AORTA_ARTIFACT_DIR}/probe.env` and exports `AORTA_ENV_FILE=<path>` into the child process so the user can reference it themselves in their argv (`docker run --env-file $AORTA_ENV_FILE ...`).
+
+This reading is the only one consistent with the no-parse invariant. The implementer should propose it in writing in the Phase 1 PR description and get the issue author to confirm before merge.
+
+### F7 — `mitigation_axis` and `diagnostic_axis` resolve through B3 today; no schema change to the registry needed
+
+`tf32_off`, `hsa_no_scratch_reclaim`, `fa_prefer_ck`, `hip_launch_blocking`, `none` — every name in the issue's example axes looks like a B3 `Mitigation`. The probe-mode recipe-builder can synthesise cells with `mitigations=(mitigation_axis_value, diagnostic_axis_value)`, name them `<m>-<d>`, and rely on the existing `_validate_no_mitigation_collisions` check (`src/aorta/triage/recipe.py:531-572`) to catch overlapping env-var keys between the two axes. The only registry-side work is **verifying that every name in the issue's example axes is registered** (Phase 1 docs deliverable).
+
+---
+
+## 1. Branching and PR Convention
+
+The base branch `users/vivekag/aorta-probe-188` (currently at `b79da71`) is the **integration branch**. Each phase ships as its own PR off `main`, **not** stacked off the integration branch, so reviewers see one self-contained diff per phase and one phase can land independently of later phases stalling.
+
+| Phase | Branch | PR Title |
+|---|---|---|
+| 1 | `users/vivekag/aorta-probe-188-phase-1` | `probe: MVP — aorta probe command + recipe schema + engine reuse (#188 phase 1)` |
+| 2 | `users/vivekag/aorta-probe-188-phase-2` | `probe: built-in 5-tier classifier + sandboxed custom_patterns (#188 phase 2)` |
+| 3 | `users/vivekag/aorta-probe-188-phase-3` | `probe: bundle integration + redaction + handout templates (#188 phase 3)` |
+
+Each PR body references issue #188 and the prior phase PR (so the dependency chain is auditable in the GitHub UI).
+
+---
+
+# PHASE 1 — MVP
+
+**Goal.** Ship `aorta probe` as a CLI command that loads a probe-mode recipe, synthesises mitigation × diagnostic cells, and runs them through `aorta.triage.runner.run_recipe` (no parallel runner). Per-trial artifacts land in `Y/<ticket>/<cell>/trial_<n>/{stdout.log, stderr.log, result.json}`. Re-runs with the same `--output` skip completed cells.
+
+## 1.A Scope
+
+**In:**
+- New CLI subcommand `aorta probe` with all flags from the issue (`--recipe`, `--output`, `--ticket`, `--dry-run`, `--env-passthrough-mode`, trailing `--` argv).
+- Recipe schema extension: `mode: probe` discriminator; new probe-mode keys (`mitigation_axis`, `diagnostic_axis`, `step_time_regex`, `collect_paths`, optional `confound`, `timeout_per_trial`). Strict unknown-key rejection retained.
+- `SubprocessWorkload` (`src/aorta/workloads/_subprocess.py`) — invoked via the existing dispatcher, takes `argv` from a new `RunRequest.subprocess_argv` field.
+- `RunRequest.subprocess_argv` field; dispatcher injection of `_aorta_subprocess_argv` into workload config (mirrors `_aorta_environment`).
+- `aorta.triage.runner.run_recipe` extended with `layout: Literal["timestamped", "flat_resume"]` (default `"timestamped"`); `aorta.triage.output.resolve_run_dir` honours it.
+- Probe-mode resume: existing `<cell>/trial_<n>/result.json` (well-formed JSON with non-empty `verdict` field) marks the trial complete and skipped.
+- `--dry-run`: prints each cell's planned env + argv with no execution.
+- Shared-engine unit test asserting `aorta probe` and `aorta triage run` both reach `run_recipe`.
+
+**Out (Phase 1):**
+- Any failure-tier classification beyond exit code (Tier 1 only, no patterns).
+- `custom_patterns`, `redaction`, `condition` sandbox.
+- `aorta bundle` integration.
+- `aorta probe list-patterns`.
+- `py-spy` integration.
+- Hang detection (Tier 2), GPU/kernel detection (Tier 3), pattern library (Tier 4).
+- Recipe templates for torchrun / buck2 (Phase 3 deliverable).
+- Generic `--collect-path` glob/copy semantics beyond `${AORTA_ARTIFACT_DIR}/{stdout,stderr}.log` (Phase 2 wires the rest).
+
+**Assumptions:**
+- Every name in the issue's example axes is already registered in B3 (verify per F7).
+- Resolution F1 (extend `resolve_run_dir`) is accepted by the issue author.
+- Resolution F6 (env-file handoff) is accepted by the issue author.
+
+## 1.B Functional Requirements (Weighted)
+
+| # | Requirement | Weight | Verification |
+|---|---|---|---|
+| 1.1 | `aorta probe --help` exits 0 and shows `--recipe`, `--output`, `--ticket`, `--dry-run`, `--env-passthrough-mode` flags, plus the trailing-argv usage line. | 3 | Unit test `tests/probe/test_cli_parsing.py::test_help_lists_documented_flags` (Click `--help` invocation). |
+| 1.2 | `aorta probe --recipe X --dry-run -- echo hi` exits 0, prints one line per (mitigation × diagnostic) cell with the planned env-var bundle and the literal argv `['echo', 'hi']`, and writes nothing to disk. | 5 | Unit test `tests/probe/test_dry_run.py` (capture stdout, snapshot-compare cell list, assert `tmp_path` empty post-run). |
+| 1.3 | `aorta probe --recipe X --output Y --ticket T -- bash -c 'echo hi; exit 0'` runs every cell × trial, writes `Y/<safe_slug(T)>/<safe_slug(cell)>/trial_<n>/{stdout.log,stderr.log,result.json}`, exits 0. | 5 | Integration test `tests/probe/test_end_to_end.py::test_smoke_passes` with `tmp_path` as output. |
+| 1.4 | Re-invoking the same command with the same `--output` and `--ticket` does NOT re-execute cells whose `result.json` exists, is valid JSON, and contains a non-empty `verdict` key. Partial / truncated `result.json` (empty file, syntactically invalid, missing `verdict`) IS re-executed. | 5 | Unit tests `tests/probe/test_resume.py::test_skips_completed_cell` and `::test_reruns_truncated_result_json` (write half a `{`, verify next invocation re-runs). |
+| 1.5 | `aorta probe` and `aorta triage run` both reach `aorta.triage.runner.run_recipe` with a validated `Recipe`. Verified by a unit test that monkeypatches `run_recipe` to a `MagicMock` and invokes both CLIs. | 5 | Unit test `tests/probe/test_shared_engine.py::test_probe_and_triage_share_run_recipe` (mock pattern mirrors `tests/triage/test_runner_b1_api.py`). |
+| 1.6 | Recipe loader rejects unknown top-level keys with `RecipeSchemaError` listing the unknown keys and the allowed set. Probe-mode keys (`mode`, `mitigation_axis`, `diagnostic_axis`, `step_time_regex`, `collect_paths`, `timeout_per_trial`) are rejected when `mode != "probe"` or absent. | 4 | Unit tests `tests/probe/test_recipe.py::test_rejects_unknown_top_level`, `::test_rejects_probe_keys_in_triage_mode`. |
+| 1.7 | Probe-mode recipe loader synthesises cells as the cartesian product of `mitigation_axis × diagnostic_axis`, naming each `<m>-<d>`. Cell-name collisions (axis values that slug-collide) are rejected at load time. | 4 | Unit test `tests/probe/test_recipe.py::test_cell_synthesis_and_collision`. |
+| 1.8 | `mitigation_axis` and `diagnostic_axis` items resolve through `aorta.registry.get_mitigation` at load time; unknown names raise `UnknownMitigationError` with the name. | 4 | Unit test `tests/probe/test_recipe.py::test_axis_unknown_name_rejected`. |
+| 1.9 | `--env-passthrough-mode inherit` (default): the dispatcher sets per-cell mitigation + diagnostic env vars in `os.environ` before invoking the workload's `run()`; `SubprocessWorkload.run()` `exec`s the user argv via `subprocess.Popen(..., env=os.environ.copy())`. No `--env-file` is written. | 4 | Unit test `tests/probe/test_env_passthrough.py::test_inherit_mode_does_not_write_env_file` (monkeypatch `subprocess.Popen` with a recording fake, assert no extra file under `tmp_path`). |
+| 1.10 | `--env-passthrough-mode file`: in addition to setting env vars in-process, write `<trial_dir>/probe.env` with `KEY=VALUE\n` lines (POSIX env-file format) and export `AORTA_ENV_FILE=<absolute path>` into the child process env. **Never modifies the user's argv.** File mode is `chmod 0600` at write time (defence against R5 leakage). | 4 | Unit test `tests/probe/test_env_passthrough.py::test_file_mode_writes_env_file_and_exports_pointer` AND `::test_env_file_is_0600`. |
+| 1.11 | `RunRequest.subprocess_argv: tuple[str, ...] \| None = None` is the only legal channel for passing argv to `SubprocessWorkload`. Setting `config_overrides["_aorta_subprocess_argv"]` is rejected by the existing reserved-prefix check (`dispatcher.py:193`). The dispatcher copies `request.subprocess_argv` into `config["_aorta_subprocess_argv"]` after `config_overrides` is merged. | 4 | Unit tests `tests/run/test_dispatcher.py::test_subprocess_argv_injected_into_config` and `::test_user_supplied_aorta_subprocess_argv_rejected`. |
+| 1.12 | `SubprocessWorkload.run()` populates a per-trial `result.json` containing at minimum: `verdict: "pass" \| "fail"`, `exit_code: int`, `walltime_sec: float`, `argv: list[str]`, `cell_name: str`, `trial_index: int`. Tier-1 verdict logic: `exit_code == 0` → pass, else → fail. | 4 | Unit test `tests/probe/test_subprocess_workload.py::test_pass_and_fail_minimum_result_shape`. |
+| 1.13 | `aorta.triage.output.resolve_run_dir(layout="flat_resume")` creates `<output_dir>/<safe_slug(ticket)>/` (or `<output_dir>/_no_ticket_/` when `ticket` is `None`) with `mkdir(parents=True, exist_ok=True)`, no timestamp suffix, no `<workload>` segment. Default `layout="timestamped"` preserves today's behaviour byte-equivalently. | 5 | Unit tests `tests/triage/test_output_layout.py::test_flat_resume_layout` AND existing `test_resolve_run_dir_*` tests continue to pass unchanged. |
+| 1.14 | When `--ticket` is omitted, the output directory uses `_no_ticket_` (existing constant `NO_TICKET_SLUG` from `aorta.triage.output`); Phase 3 will tighten this for `aorta bundle`, but Phase 1 accepts both. | 2 | Unit test `tests/probe/test_end_to_end.py::test_no_ticket_routed_to_no_ticket_slug`. |
+| 1.15 | The Click handler in `src/aorta/cli/probe.py` is a thin shim (≤ 60 lines body, matches the `aorta run` discipline tested at `tests/run/test_cli_parsing.py::TestCliHandlerIsThinShell`). All orchestration lives in `aorta.probe.cli_helpers` or `aorta.triage.runner.run_recipe`. | 3 | Unit test `tests/probe/test_cli_parsing.py::test_handler_is_thin_shim`. |
+| 1.16 | Recipe `schema_version: 1` is preserved (per open-question recommendation #4). Probe-mode is differentiated by `mode: probe`. A `mode: triage` recipe is byte-equivalent to today's recipes (back-compat: omitting `mode` defaults to `"triage"`). | 3 | Unit test `tests/probe/test_recipe.py::test_mode_defaults_to_triage_and_existing_recipes_load`. |
+| 1.17 | Probe-mode entries in `aorta.workloads` entry-point group: `_subprocess = "aorta.workloads._subprocess:SubprocessWorkload"` is registered in `pyproject.toml` and resolves via `get_workload_class("_subprocess")`. | 3 | Unit test `tests/probe/test_subprocess_workload.py::test_resolved_via_entry_point`. |
+| 1.18 | `aorta probe` exits non-zero (Click `ClickException`) when the recipe is invalid, when no axis items resolve, when `--env-passthrough-mode` is invalid, or when the trailing argv is empty (`--` followed by nothing). | 3 | Unit tests `tests/probe/test_cli_parsing.py::test_invalid_recipe_nonzero_exit`, `::test_empty_argv_nonzero_exit`. |
+| 1.19 | Probe-mode rejects `condition`, `custom_patterns`, `redaction` keys at load time with a "deferred to Phase 2/3" error message that points to the phase. (Prevents users writing recipes that will silently no-op until later phases.) | 2 | Unit test `tests/probe/test_recipe.py::test_phase_2_3_keys_rejected_with_pointer`. |
+| 1.20 | `tests/probe/` contains an `__init__.py` and is collected by `pytest` per the existing `[tool.pytest.ini_options]` (`testpaths = ["tests"]`). | 1 | `pytest tests/probe` discovers ≥ 1 test. |
+|   | **Total weight** | **77** |  |
+
+## 1.C File-by-File Deliverables
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `src/aorta/cli/probe.py` | Thin Click shim. Parses CLI, builds probe-mode `Recipe`, calls `run_recipe(..., layout="flat_resume")`. |
+| `src/aorta/probe/__init__.py` | Package marker for probe helpers. |
+| `src/aorta/probe/cli_helpers.py` | Pure parsers: `parse_env_passthrough_mode`, `split_argv_at_double_dash` (Click's own `--` handling is enough; helper is for the dry-run formatter). |
+| `src/aorta/probe/recipe_builder.py` | `build_probe_recipe_from_dict(data, sidecar_files=None) -> Recipe`. Synthesises cells from `mitigation_axis × diagnostic_axis`, sets `workload="_subprocess"`, threads `step_time_regex` / `collect_paths` / `timeout_per_trial` onto a typed `ProbeExtras` block attached to the `Recipe` (via `workload_config`). |
+| `src/aorta/probe/resume.py` | `is_trial_complete(trial_dir: Path) -> bool` — checks for valid `result.json` with non-empty `verdict`. Called from the runner per-cell. |
+| `src/aorta/workloads/_subprocess.py` | `SubprocessWorkload(Workload)`. `setup()` reads `config["_aorta_subprocess_argv"]`; `run()` `subprocess.Popen`s, captures stdout/stderr to files in the trial dir, writes `result.json` with Tier-1 verdict. |
+| `tests/probe/__init__.py` | Package marker. |
+| `tests/probe/test_cli_parsing.py` | Click `--help`, invalid inputs, thin-shim assertion. |
+| `tests/probe/test_dry_run.py` | `--dry-run` semantics. |
+| `tests/probe/test_recipe.py` | Schema validation: probe-mode keys, axis-name resolution, cell synthesis, Phase-2/3 key rejection. |
+| `tests/probe/test_subprocess_workload.py` | `SubprocessWorkload` unit tests (entry-point resolution, result.json shape, signal-as-fail). |
+| `tests/probe/test_env_passthrough.py` | `inherit` vs `file` mode (no docker daemon needed; assert side effects on `os.environ` and `tmp_path`). |
+| `tests/probe/test_resume.py` | Resume semantics: completed → skip, truncated → re-run. |
+| `tests/probe/test_shared_engine.py` | Mocks `aorta.triage.runner.run_recipe`, invokes both `aorta probe` and `aorta triage run`, asserts both reach the same call site. |
+| `tests/probe/test_end_to_end.py` | End-to-end smoke: synthetic axis values that resolve to no-op mitigations, real subprocess (`bash -c 'echo hi'`), assert artifact tree. |
+| `tests/probe/fixtures/probe_minimal.yaml` | A 2-cell probe-mode recipe with `none` on both axes (minimum valid). |
+| `tests/probe/fixtures/probe_with_phase_2_keys.yaml` | Has `custom_patterns:` block to assert Phase 1 rejection with pointer. |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `src/aorta/cli/__init__.py` | Add `from aorta.cli import probe` and `main.add_command(probe.probe)`. |
+| `src/aorta/triage/recipe.py` | Extend `_VALID_TOP_LEVEL` with probe-mode keys + `mode`. Branch `_build_recipe` on `data.get("mode", "triage")`. New helper `_build_probe_recipe(data, sidecar_files)` lives in `aorta.probe.recipe_builder` and is called from here. `Recipe` gains an optional `probe_extras: ProbeExtras \| None = None` frozen-dataclass field for `step_time_regex`, `collect_paths`, `timeout_per_trial`, `env_passthrough_mode` (set on the Recipe so the runner sees it without re-parsing). |
+| `src/aorta/triage/output.py` | `resolve_run_dir(..., layout: Literal["timestamped", "flat_resume"] = "timestamped") -> Path`. `flat_resume` branch produces `<output_dir>/<safe_slug(ticket)>/` with `mkdir(parents=True, exist_ok=True)`. |
+| `src/aorta/triage/runner.py` | `run_recipe(..., layout="timestamped", resume_existing=False)`. When `layout="flat_resume"`, per-cell artifacts land at `<run_dir>/<safe_slug(cell.name)>/trial_<n>/` (matching the dispatcher's `_aorta_log_prefix` writes). When `resume_existing=True`, `_run_one_cell` consults `aorta.probe.resume.is_trial_complete` before invoking `run_trials` for each trial; completed trials are loaded from disk and reported as skipped in the per-cell log line. |
+| `src/aorta/run/dispatcher.py` | Add `subprocess_argv: tuple[str, ...] \| None = None` to `RunRequest`. After `config_overrides` is merged (line ~320), if `request.subprocess_argv is not None`, `config["_aorta_subprocess_argv"] = list(request.subprocess_argv)`. (`_aorta_*` prefix block at line 193 already prevents user-side injection of the same key.) |
+| `pyproject.toml` | Uncomment and populate `[project.entry-points."aorta.workloads"]` with `_subprocess = "aorta.workloads._subprocess:SubprocessWorkload"`. |
+| `BUCK` | No change required — top-level glob `src/aorta/**/*.py` already picks up new files. **Verify** with `buck2 build //:aorta_lib` post-change. |
+| `recipes/README.md` | Add a section documenting probe-mode recipe shape and the `mode:` discriminator. |
+| `recipes/example-probe-smoke.yaml` | New minimal probe-mode recipe ('echo hi'-friendly). Phase 3 ships the full handout templates; Phase 1 ships one smoke. |
+| `README.md` | New "Probe-mode" subsection under the CLI overview, linking the recipe README and `docs/probe-188/usage.md`. |
+| `docs/probe-188/usage.md` | New: command-line walkthrough including `--dry-run`, the two env-passthrough modes (with the F6 design rationale documented), the resume model, and the artifact tree. |
+
+## 1.D Test Plan
+
+- **Unit tests:** every row in §1.B with a `tests/probe/...` reference, plus the dispatcher additions in `tests/run/test_dispatcher.py` and the output-layout test in `tests/triage/test_output_layout.py`.
+- **Integration test:** `tests/probe/test_end_to_end.py` invokes the real `aorta probe` Click command via `CliRunner`, with `tmp_path` as `--output`, a 2-cell recipe whose axes both contain `none`, and the trailing argv `['bash', '-c', 'echo hi']`. Asserts:
+  - exit 0;
+  - `<tmp_path>/<ticket>/<cell>/trial_0/{stdout.log,stderr.log,result.json}` exist for both cells;
+  - `result.json::verdict == "pass"`.
+- **Regression gates touched:** `tests/triage/test_runner_b1_api.py` (must still pass — runner contract unchanged for triage-mode), `tests/triage/test_recipe.py` (existing triage recipes still load), `tests/triage/test_output_layout.py` (default layout still timestamped).
+- **Manual verification:** on a workstation with `aorta` installed editable, run:
+  ```
+  aorta probe --recipe recipes/example-probe-smoke.yaml --output /tmp/probe-188 --ticket SMOKE-1 -- bash -c 'echo hello'
+  ```
+  Verify the artifact tree manually; re-invoke and verify the second run is a no-op (look for "skipped" log lines).
+
+## 1.E Documentation Deliverables
+
+- `README.md` — new "Probe-mode" subsection.
+- `docs/probe-188/usage.md` — full walkthrough (replaces the currently empty directory).
+- `recipes/README.md` — probe-mode schema reference.
+- `aorta probe --help` and `aorta probe --recipe <X> --help` Click strings.
+
+## 1.F CI / Lint / Build Gates
+
+| Gate | Command | Notes |
+|---|---|---|
+| Pytest | `pytest tests/` | New `tests/probe/` must collect and pass. |
+| ruff | `ruff check src/aorta tests/probe` | Per `pyproject.toml:[tool.ruff]` — `E, F, W, I, N, UP, B, C4`. |
+| black | `black --check src/aorta/cli/probe.py src/aorta/probe/ src/aorta/workloads/_subprocess.py tests/probe/` | Per `pyproject.toml:[tool.black]`. |
+| isort | `isort --check src/aorta tests/probe` | Per `pyproject.toml:[tool.isort]`. |
+| mypy | `mypy src/aorta/cli/probe.py src/aorta/probe src/aorta/workloads/_subprocess.py` | Per `pyproject.toml:[tool.mypy]`. |
+| Pre-commit | `pre-commit run --all-files` | Three current hooks (trailing-whitespace, end-of-file-fixer, check-yaml). |
+| Buck2 build | `buck2 build //:aorta_lib && buck2 build //:aorta` | The top-level `BUCK` globs `src/aorta/**/*.py`; verify new files do not introduce a missing third-party dep beyond `click`/`pyyaml`. **`subprocess` is stdlib — no BUCK dep change expected.** |
+
+## 1.G Definition of Done (Phase 1)
+
+- [ ] All 20 functional requirements in §1.B pass their named tests.
+- [ ] `pytest`, `ruff`, `black`, `isort`, `mypy`, `pre-commit`, and both `buck2 build` targets succeed locally and in CI.
+- [ ] No file under `src/aorta/triage/runner.py` or `src/aorta/triage/recipe.py` regressed against `tests/triage/`.
+- [ ] `aorta probe --help` shows the documented flag set; `aorta triage run --help` is unchanged.
+- [ ] `README.md`, `recipes/README.md`, `docs/probe-188/usage.md` updated.
+- [ ] PR description quotes Findings F1, F3, F6 from this rubric and gets explicit `oyazdanb` approval on each before merge.
+- [ ] PR title is `probe: MVP — aorta probe command + recipe schema + engine reuse (#188 phase 1)`.
+- [ ] No new top-level dependencies in `pyproject.toml` or `requirements.txt`.
+- [ ] `git diff main...HEAD` touches **zero files** under `src/aorta/ebpf/`, `src/aorta/hw_queue_eval/`, `src/aorta/profiling/`, `src/aorta/race/`, `src/aorta/report/`, `src/aorta/training/`, `notebooks/`, `experiments/`, `analysis/`, `misc/` (out-of-scope guardrail).
+- [ ] No `subprocess.run` / `subprocess.Popen` import under `src/aorta/triage/` (preserves the #151 grep-test rule asserted by `tests/triage/test_runner_b1_api.py`).
+
+## 1.H Do-Not-Do List (Phase 1)
+
+- Do **not** add Tier 2–5 failure detection. `result.json::verdict` is set by Tier 1 only (exit code 0/non-zero).
+- Do **not** implement `custom_patterns`, `condition`, or the sandbox. Recipes carrying these keys are rejected at load time with a "deferred to Phase 2" message (#1.B row 1.19).
+- Do **not** ship `aorta probe list-patterns` or `aorta probe attach*` (out-of-scope per the issue).
+- Do **not** add `py-spy`, `amd-smi`, or dmesg integration.
+- Do **not** modify `aorta triage run`'s CLI surface or default behaviour. Every existing recipe must load and run byte-equivalently.
+- Do **not** invent a parallel runner. Every cell goes through `aorta.triage.runner.run_recipe` (the shared-engine test enforces this).
+- Do **not** rewrite the `<workload>` segment in the timestamped layout — only the `flat_resume` branch elides it.
+- Do **not** redact anything (Phase 3 owns redaction).
+
+---
+
+# PHASE 2 — Built-in Five-Tier Classifier + `custom_patterns`
+
+**Goal.** Make `SubprocessWorkload.run()` (and a per-trial post-process hook) populate `verdict`, `failure_detectors_fired[]`, `capture{}` based on the full 5-tier classifier. Land the sandboxed `condition` evaluator. Render `top failure` / `top warn` columns in `matrix.md`.
+
+## 2.A Scope
+
+**In:**
+- New module `src/aorta/probe/classifier/` with one submodule per tier:
+  - `tier1_process.py` — exit code, signal, timeout, coredump.
+  - `tier2_hang.py` — stdout-silent + GPU-idle + /proc/<pid>/io two-of-three predicate, with `hang_grace_period_at_start` from the recipe.
+  - `tier3_kernel.py` — `dmesg --since=<probe_start>` scan for amdgpu reset / SDMA timeout / VM_L2 fault / XGMI / PCIe AER; `amd-smi` VRAM growth and thermal-throttle counters. Fail-soft: missing `dmesg` permission / missing `amd-smi` binary → log once per run, continue with Tiers 1+2+4.
+  - `tier4_patterns.py` — built-in pattern library (Python tracebacks, HIP/CUDA/ROCm errors, NCCL/RCCL errors, collective timeouts, NaN signatures). Versioned: module-level `BUILTIN_PATTERN_VERSION = "1"`.
+  - `tier5_custom.py` — user `custom_patterns` runner.
+- New module `src/aorta/probe/sandbox.py` — the `condition` evaluator (AST-walk whitelist, see §2.E for the exact rule set).
+- `aorta probe list-patterns` subcommand: prints every built-in pattern ID, source, sample regex.
+- `aorta probe list-patterns --version` prints `BUILTIN_PATTERN_VERSION` and the `aorta` package version on separate lines.
+- `result.json` extended with `verdict`, `failure_detectors_fired: list[str]`, `capture: dict[str, str | float | int]`, `tier_durations_ms: dict[str, float]`.
+- `matrix.md` gains `Top failure` and `Top warn` columns (detector IDs, with built-in and custom listed as peers).
+- Recipe-load validation: every `custom_patterns[*].match.regex` is compile-validated; every `custom_patterns[*].match.condition` is sandbox-validated.
+
+**Out (Phase 2):**
+- `aorta bundle`.
+- Redaction (Phase 3).
+- Recipe templates (Phase 3).
+- Network upload.
+
+## 2.B Functional Requirements (Weighted)
+
+| # | Requirement | Weight | Verification |
+|---|---|---|---|
+| 2.1 | Tier 1 fires for `exit_code != 0`, SIGSEGV (`-signal.SIGSEGV`), SIGABRT, SIGBUS, timeout (`Popen.communicate(timeout=...)` `TimeoutExpired` after `recipe.timeout_per_trial`), and the presence of a `core.*` file in the trial dir post-exit. Detector IDs: `tier1:exit_nonzero`, `tier1:sigsegv`, `tier1:sigabrt`, `tier1:sigbus`, `tier1:timeout`, `tier1:coredump`. | 5 | `tests/probe/classifier/test_tier1.py` covers each, with parameterised synthetic commands (`exit 1`, `bash -c 'kill -SEGV $$'`, etc.). |
+| 2.2 | Tier 2 hang detector fires only when at least two of (stdout silent for `hang_window_sec`, GPU idle per `amd-smi`, `/proc/<pid>/io` rchar+wchar delta = 0) hold simultaneously, AND only after `hang_grace_period_at_start` (default 60s) has elapsed since trial start. Detector ID: `tier2:hang`. | 5 | `tests/probe/classifier/test_tier2.py` with a fake `amd-smi` shim (env var `AORTA_PROBE_AMDSMI_FAKE=idle`) and a synthetic child writing to stdout periodically. Includes a regression test asserting hang does NOT fire during grace. |
+| 2.3 | Tier 3 dmesg detector fires for each documented amdgpu signature. When `dmesg` is missing/permission-denied, the runner logs `tier3 disabled: <reason>` exactly once for the whole `aorta probe` invocation and continues with 1+2+4 (no per-trial spam, no failure). Detector IDs: `tier3:amdgpu_reset`, `tier3:sdma_timeout`, `tier3:vm_l2_fault`, `tier3:xgmi_link_error`, `tier3:pcie_aer_fatal`, `tier3:vram_growth`, `tier3:thermal_throttle`. | 5 | `tests/probe/classifier/test_tier3.py` with a fake `dmesg` script on `PATH` (via `monkeypatch.setenv("PATH", ...)`) and a missing-`dmesg` test asserting the single warning and continued operation. |
+| 2.4 | Tier 4 built-in library fires for: Python traceback (`^Traceback \(most recent call last\):` followed by an exception line), HIP error (`hipError_*`), CUDA error (`cudaError_*`), ROCm error (`Error code: \d+`), NCCL/RCCL error (`NCCL error|RCCL ERROR`), collective timeout (`Watchdog caught collective operation timeout`), NaN signature (`loss(?: is)? NaN|loss=nan`). Detector IDs prefixed `tier4:`. | 5 | `tests/probe/classifier/test_tier4.py` — one parameterised test per pattern, with a fixture file under `tests/probe/fixtures/tier4_logs/<id>.log`. |
+| 2.5 | `aorta probe list-patterns` exits 0 and prints every Tier 4 detector ID + sample regex. `--version` prints `aorta probe pattern library v1 (aorta 0.2.0)` exactly. | 3 | `tests/probe/test_list_patterns.py`. |
+| 2.6 | `custom_patterns[*].match.regex` is compile-validated at recipe load. Invalid regex → `RecipeSchemaError` with the pattern `id` and the `re.error` message. | 4 | `tests/probe/test_recipe.py::test_invalid_custom_regex_rejected`. |
+| 2.7 | `custom_patterns[*].match.condition` is sandbox-validated at recipe load (§2.E). Whitelist violations → `RecipeSchemaError` listing the rejected AST node type and source line. | 5 | `tests/probe/test_sandbox.py::test_hostile_inputs_rejected` parameterised over the corpus in §2.E.4. |
+| 2.8 | Verdict precedence is exactly: (a) any Tier 1–4 detector fires OR any `custom_patterns[*]` with `on_match: fail` fires → trial fails, `result.json::verdict == "fail"`; (b) `result.json::failure_detectors_fired` lists ALL that fired in encounter order (not just the first); (c) if any `custom_patterns[*]` has `required_for_pass: true` and none of them fired → `verdict == "fail"` and detector ID `meta:missing_pass_signal` appears in `failure_detectors_fired`; (d) otherwise → `verdict == "pass"`. `on_match: warn` populates a separate `warn_detectors_fired: list[str]` and does NOT change `verdict`; `on_match: info` only populates `capture`. | 5 | `tests/probe/classifier/test_verdict_precedence.py` — table-driven parameterised test covering each branch and the `required_for_pass` case. |
+| 2.9 | `result.json` shape (post-Phase-2): `{"verdict": "pass"\|"fail", "exit_code": int, "walltime_sec": float, "peak_vram_mib": int\|null, "argv": list[str], "cell_name": str, "trial_index": int, "failure_detectors_fired": list[str], "warn_detectors_fired": list[str], "capture": dict[str, str\|float\|int], "tier_durations_ms": dict[str, float]}`. | 4 | `tests/probe/test_subprocess_workload.py::test_result_json_phase_2_shape` with a JSON schema (jsonschema dep optional — hand-rolled key/type assertion is acceptable). |
+| 2.10 | `matrix.md` gains `Top failure` and `Top warn` columns immediately after `Failures`. Each shows the detector ID with the highest fire count across the cell's trials. Built-in (`tier4:*`) and custom IDs are listed as peers (no namespace prefix discrimination beyond their own ID prefix). Hidden when no cell has a non-empty `failure_detectors_fired` / `warn_detectors_fired`. | 3 | `tests/triage/test_output_layout.py::test_matrix_md_top_failure_warn_columns`. |
+| 2.11 | When `dmesg` is unavailable, the `tier3 disabled` log line appears at most once per `aorta probe` invocation (not per cell, not per trial). | 2 | `tests/probe/classifier/test_tier3.py::test_dmesg_missing_log_once`. |
+| 2.12 | The sandbox evaluator runs the `condition` only when the regex matches, and only with the variables documented in §2.E.1. The expression is `compile(..., mode="eval")` then `eval(code, restricted_globals, restricted_locals)`. Whitelist enforcement is at parse time (AST walk), not at eval time, so a hostile input cannot reach eval. | 5 | `tests/probe/test_sandbox.py::test_no_eval_reach_for_rejected_input`. |
+| 2.13 | All Tier 2–4 detectors are unit-testable without a real GPU or real `dmesg`. Test fixtures use shim scripts (`tests/probe/fixtures/bin/dmesg`, `tests/probe/fixtures/bin/amd-smi`) prepended to `PATH` via `monkeypatch.setenv`. | 3 | Reviewer checklist item: every Phase 2 test runs under `pytest -m "not gpu and not rocm"` (existing markers in `pyproject.toml`). |
+| 2.14 | Phase 1 contract (resume, dry-run, shared-engine) is unchanged. Re-running an already-completed cell still skips it; `--dry-run` still prints cells without executing. | 2 | Re-run `tests/probe/test_resume.py`, `test_dry_run.py`, `test_shared_engine.py` — must all pass with no source change. |
+|   | **Total weight** | **56** |  |
+
+## 2.C File-by-File Deliverables
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `src/aorta/probe/classifier/__init__.py` | Re-export `classify_trial(...)`. |
+| `src/aorta/probe/classifier/tier1_process.py` | Exit/signal/timeout/coredump. |
+| `src/aorta/probe/classifier/tier2_hang.py` | Two-of-three hang predicate with grace window. |
+| `src/aorta/probe/classifier/tier3_kernel.py` | dmesg + amd-smi scanning. |
+| `src/aorta/probe/classifier/tier4_patterns.py` | Built-in pattern library + `BUILTIN_PATTERN_VERSION`. |
+| `src/aorta/probe/classifier/tier5_custom.py` | User custom_patterns runner. |
+| `src/aorta/probe/classifier/verdict.py` | Precedence resolver (§2.B row 2.8). |
+| `src/aorta/probe/sandbox.py` | AST-whitelist `condition` evaluator. |
+| `src/aorta/cli/probe.py` (modified) | Add `list-patterns` subcommand to the existing `aorta probe` group. |
+| `tests/probe/classifier/__init__.py` | Package marker. |
+| `tests/probe/classifier/test_tier1.py` | Per-detector tests. |
+| `tests/probe/classifier/test_tier2.py` | Hang predicate + grace. |
+| `tests/probe/classifier/test_tier3.py` | dmesg/amd-smi shim tests, missing-binary path. |
+| `tests/probe/classifier/test_tier4.py` | Pattern fixture tests. |
+| `tests/probe/classifier/test_verdict_precedence.py` | Table-driven precedence cases. |
+| `tests/probe/test_sandbox.py` | Sandbox happy-path + hostile-input fixture corpus (§2.E.4). |
+| `tests/probe/test_list_patterns.py` | `list-patterns` subcommand. |
+| `tests/probe/fixtures/tier4_logs/*.log` | One per built-in pattern. |
+| `tests/probe/fixtures/bin/{dmesg,amd-smi}` | Test shims (executable bash scripts emitting fixture content). |
+| `tests/probe/fixtures/custom_patterns_hostile.yaml` | A recipe with one `condition` per hostile-input class for the sandbox test. |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `src/aorta/workloads/_subprocess.py` | `run()` invokes `classify_trial` post-exit and populates the Phase-2 `result.json` shape. |
+| `src/aorta/triage/output.py` | `write_matrix_md` adds `Top failure` / `Top warn` columns gated on any cell having data. |
+| `src/aorta/triage/matrix.py` | `CellStats` gains `top_failure_detector_id: str \| None` and `top_warn_detector_id: str \| None`; aggregation reads `result.json` for these. |
+| `src/aorta/probe/recipe_builder.py` | Hand `custom_patterns` block through to the validator + the `ProbeExtras` attached to `Recipe`. |
+| `src/aorta/triage/recipe.py` | Accept `custom_patterns`, `condition`, `hang_grace_period_at_start`, `hang_window_sec` keys when `mode == "probe"`. |
+| `docs/probe-188/usage.md` | Section on the 5-tier classifier, the `condition` sandbox whitelist, and `list-patterns`. |
+| `docs/probe-188/classifier.md` | New: detector ID reference. |
+
+## 2.D Documentation Deliverables
+
+- `docs/probe-188/classifier.md` — full detector ID reference.
+- `docs/probe-188/sandbox.md` — `condition` whitelist + worked examples + the rejected-AST-types corpus.
+- `docs/probe-188/usage.md` updated with `list-patterns` and the `custom_patterns` example.
+- `aorta probe list-patterns --help` Click string.
+
+## 2.E `condition` Sandbox Specification (P0 security gate)
+
+### 2.E.1 — Variables in scope (read-only)
+
+| Name | Type | Source |
+|---|---|---|
+| `capture` | `dict[str, str]` | Named capture groups from the matched regex. Indexed only with `capture['name']`. |
+| `exit_code` | `int` | From Tier 1. |
+| `walltime_sec` | `float` | From Tier 1. |
+| `peak_vram_mib` | `int \| None` | From `amd-smi` post-exit (None if unavailable). Condition expressions that reference it when None MUST not blow up — `peak_vram_mib` is bound to `0` when actual is None to keep arithmetic total. |
+
+### 2.E.2 — Callable whitelist
+
+`float`, `int`, `len`, `math.isnan`, `math.isinf`. **Nothing else.** `math` is the only allowed module, and only its two named functions. No `getattr`, no `hasattr`, no `type`, no `isinstance`.
+
+### 2.E.3 — Implementation (recommended)
+
+```python
+import ast
+
+_ALLOWED_NODES = {
+    ast.Expression, ast.BoolOp, ast.BinOp, ast.UnaryOp, ast.Compare,
+    ast.Call, ast.Subscript, ast.Name, ast.Constant, ast.IfExp,
+    ast.And, ast.Or, ast.Not, ast.Eq, ast.NotEq, ast.Lt, ast.LtE,
+    ast.Gt, ast.GtE, ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod,
+    ast.FloorDiv, ast.Pow, ast.USub, ast.UAdd, ast.Load,
+}
+_ALLOWED_NAMES = {"capture", "exit_code", "walltime_sec", "peak_vram_mib", "math"}
+_ALLOWED_CALLS = {"float", "int", "len", "math.isnan", "math.isinf"}
+
+def validate_and_compile(expr: str) -> CodeType:
+    tree = ast.parse(expr, mode="eval")
+    for node in ast.walk(tree):
+        if type(node) not in _ALLOWED_NODES and not isinstance(node, ast.Attribute):
+            raise SandboxError(f"forbidden AST node: {type(node).__name__}")
+        if isinstance(node, ast.Attribute):
+            # Only math.isnan / math.isinf attribute access is allowed.
+            if not (isinstance(node.value, ast.Name) and node.value.id == "math"
+                    and node.attr in {"isnan", "isinf"}):
+                raise SandboxError(f"forbidden attribute access: {ast.unparse(node)}")
+        if isinstance(node, ast.Name) and node.id not in _ALLOWED_NAMES:
+            raise SandboxError(f"forbidden name: {node.id}")
+        if isinstance(node, ast.Subscript):
+            # capture[...] only; reject e.g. foo[0].
+            if not (isinstance(node.value, ast.Name) and node.value.id == "capture"):
+                raise SandboxError("subscript only allowed on capture[...]")
+        if isinstance(node, ast.Call):
+            name = ast.unparse(node.func)
+            if name not in _ALLOWED_CALLS:
+                raise SandboxError(f"forbidden call: {name}")
+    return compile(tree, "<condition>", "eval")
+```
+
+Eval is `eval(code, {"__builtins__": {}, "math": math}, {"capture": ..., "exit_code": ..., "walltime_sec": ..., "peak_vram_mib": ...})`. Empty `__builtins__` neutralises `__import__`.
+
+**Alternative considered:** `RestrictedPython`. Rejected — heavyweight dep, large attack surface, more permissive than the issue's whitelist by default. The hand-rolled walker is ~80 lines and entirely auditable.
+
+### 2.E.4 — Hostile-input corpus (test fixture)
+
+The Phase 2 PR ships `tests/probe/fixtures/conditions/hostile.txt`, one expression per line, all of which MUST be rejected at recipe load:
+
+```
+__import__('os').system('rm -rf /')
+(0).__class__.__bases__[0].__subclasses__()
+().__class__.__mro__[-1]
+open('/etc/passwd').read()
+exec("import os; os.system('id')")
+eval("1+1")
+lambda x: x
+[x for x in range(10)]
+{k: v for k, v in capture.items()}
+capture.update({'pwn': '1'})
+type(capture)
+getattr(capture, 'pop')('eval_loss')
+capture['x'].__class__
+math.__loader__.load_module('os')
+2 ** 1000000000  # length-restricted: reject expressions > 256 chars
+```
+
+Each line is a parameterised test case in `tests/probe/test_sandbox.py::test_hostile_inputs_rejected`. The expression length cap (256 chars, after stripping) is rubric-required and prevents resource exhaustion at `ast.parse` time.
+
+### 2.E.5 — Regex DoS hardening
+
+The Phase-1 compile-validation (#1.B 1.6) and Phase-2 regex validation (#2.B 2.6) must run `re.compile(pattern)` once at load. Phase 2 must additionally **cap each per-trial regex run** with `re.search(..., string[:MAX_LOG_BYTES])` where `MAX_LOG_BYTES = 10 * 1024 * 1024` (10 MiB) — stdout/stderr larger than this are scanned in 10MiB windows. This is the only mitigation for catastrophic backtracking that doesn't require swapping the regex engine; document it in `docs/probe-188/sandbox.md`.
+
+## 2.F CI / Lint / Build Gates
+
+Same as Phase 1 plus:
+
+- `pytest tests/probe/classifier/ tests/probe/test_sandbox.py tests/probe/test_list_patterns.py` — must all pass.
+- `mypy src/aorta/probe/classifier src/aorta/probe/sandbox.py`.
+- No new third-party dependencies (Tier 3 `dmesg`/`amd-smi` are detect-and-skip per open question #3 recommendation).
+
+## 2.G Definition of Done (Phase 2)
+
+- [ ] All 14 functional requirements in §2.B pass.
+- [ ] Sandbox hostile-input corpus is committed and all entries are rejected.
+- [ ] Phase 1 regression gates pass unchanged.
+- [ ] `aorta probe list-patterns` and `--version` work.
+- [ ] PR title: `probe: built-in 5-tier classifier + sandboxed custom_patterns (#188 phase 2)`.
+- [ ] PR description quotes the §2.E sandbox spec and gets a security-reviewer approval (Open Question #1 — must be resolved before merge of Phase 2, not just Phase 3).
+- [ ] `docs/probe-188/classifier.md` and `docs/probe-188/sandbox.md` published.
+
+## 2.H Do-Not-Do List (Phase 2)
+
+- Do **not** ship `aorta bundle` or `redaction:` semantics.
+- Do **not** make `dmesg` or `amd-smi` a hard dependency; both detect-and-skip.
+- Do **not** swap the regex engine for `regex` or `re2` — keep `re` and use length-capped windows.
+- Do **not** introduce a Python sandbox library (`RestrictedPython`, `pysandbox`, etc.). Hand-rolled AST walker only.
+- Do **not** capture trial environment variables yet (Phase 3 redaction owns that to prevent secret leakage).
+- Do **not** alter the `aorta triage run` matrix.md format for non-probe cells (the new columns are gated on probe-mode data presence).
+
+---
+
+# PHASE 3 — `aorta bundle` + Redaction + Handout Templates
+
+**Goal.** Land redaction (P0 security gate), integrate the (separately-built) `aorta bundle` command, and ship generic recipe templates. **Gated on `aorta bundle` upstream PR landing.**
+
+## 3.A Scope
+
+**In:**
+- New module `src/aorta/probe/redaction.py` — env-key glob scrubbing, path rewriting, IPv4/IPv6 rewriting; emits a per-file count manifest.
+- Integration with `aorta bundle <output-dir>/<ticket>/`: bundle reads the recipe's `redaction:` block, applies it to every file in the trial tree before bundling, refuses without `--ticket`, supports `--review` interactive confirmation.
+- `recipes/probe-template-torchrun.yaml`, `recipes/probe-template-buck2.yaml`, `recipes/probe-template-bash.yaml` — generic handout templates.
+- `docs/probe-188/redaction.md`, `docs/probe-188/handout-templates.md`.
+
+**Out:**
+- Network upload (issue-out-of-scope).
+- Auto-discovering the launch command (issue-out-of-scope).
+- The implementation of `aorta bundle` itself — that's a separate ticket; this PR consumes its public API.
+
+## 3.B Functional Requirements (Weighted)
+
+| # | Requirement | Weight | Verification |
+|---|---|---|---|
+| 3.1 | `aorta bundle <output-dir>/<ticket>/` is called without `--ticket` (or `<ticket>` resolves to `_no_ticket_`) → exits non-zero with a `ClickException` pointing to the `--ticket` flag in `aorta probe`. | 4 | `tests/probe/test_bundle_integration.py::test_refuses_no_ticket`. |
+| 3.2 | `aorta bundle --review <dir>` prints the manifest (cell list, per-file redaction counts, total size, redaction summary) and pauses for `[y/N]` confirmation; `n` aborts with exit 1, `y` proceeds. | 3 | `tests/probe/test_bundle_integration.py::test_review_pause_and_confirm` using `CliRunner(input="y\n")` / `input="n\n"`. |
+| 3.3 | `scrub_env_keys: ["AWS_*", "*_TOKEN"]` removes matching keys from every captured-env block (per-trial `result.json::env`, host-env snapshot, per-environment snapshots) using `fnmatch.fnmatchcase`. Match is case-sensitive (env vars are case-sensitive on Linux). | 5 | `tests/probe/test_redaction.py::test_env_key_glob` with fixture env blocks. |
+| 3.4 | `scrub_paths: true` rewrites every absolute filesystem path (regex `/(?:[A-Za-z0-9_.\-]+/)+[A-Za-z0-9_.\-]+`) found in `stdout.log`, `stderr.log`, and any string value in `result.json::capture` to `<PATH:N>` where `N` is the per-bundle deduplication index. A mapping from `<PATH:N>` → original path is NOT written (the whole point is to not leak the path). | 5 | `tests/probe/test_redaction.py::test_path_rewrite` with a fixture log containing 3 unique paths and 5 occurrences. |
+| 3.5 | `scrub_ip_addresses: true` rewrites IPv4 (`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`) and IPv6 (RFC-5952-shape regex from `ipaddress`-grade validators) to `<IPV4:N>` / `<IPV6:N>`. | 4 | `tests/probe/test_redaction.py::test_ip_rewrite` with a fixture log mixing v4 and v6. |
+| 3.6 | The bundle manifest (`bundle/manifest.json`) records, per scrubbed file: `{"path": str, "env_keys_removed": int, "paths_rewritten": int, "ips_rewritten": int, "bytes_in": int, "bytes_out": int}`. | 4 | `tests/probe/test_bundle_integration.py::test_manifest_records_per_file_counts`. |
+| 3.7 | `recipes/probe-template-torchrun.yaml`, `recipes/probe-template-buck2.yaml`, `recipes/probe-template-bash.yaml` all pass `aorta probe --recipe <template> --dry-run -- echo hi` with exit 0. | 3 | `tests/probe/test_handout_templates.py` — parameterised over the three templates. |
+| 3.8 | Phase 1 + Phase 2 contracts are unchanged. Specifically: `aorta probe` without a `redaction:` block is byte-equivalent to Phase 2 behaviour; `aorta bundle` is a separate command, not implicit in `aorta probe`. | 3 | All Phase 1/2 tests still pass. |
+| 3.9 | Redaction is **applied to a copy**, not in-place. The bundle directory contains scrubbed copies; the original `<output-dir>/<ticket>/` is untouched. | 4 | `tests/probe/test_bundle_integration.py::test_originals_untouched`. |
+| 3.10 | A hostile log designed to inflate path regex backtracking (e.g. 100kB of `/` characters) is processed in < 5 seconds for a 10MiB file (regex-DoS guard from §2.E.5 applies here too). | 3 | `tests/probe/test_redaction.py::test_redaction_dos_bound` with `pytest-timeout` marker. |
+|   | **Total weight** | **38** |  |
+
+## 3.C File-by-File Deliverables
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `src/aorta/probe/redaction.py` | All three scrubbers; per-file count return type. |
+| `src/aorta/probe/bundle_hook.py` | Adapter between `aorta.probe.redaction` and `aorta.bundle` (the latter is a separate ticket). |
+| `recipes/probe-template-torchrun.yaml` | torchrun-shaped probe recipe. |
+| `recipes/probe-template-buck2.yaml` | `buck2 run`-shaped probe recipe. |
+| `recipes/probe-template-bash.yaml` | Generic `bash launch.sh`-shaped probe recipe. |
+| `tests/probe/test_redaction.py` | Three scrubbers + DoS bound. |
+| `tests/probe/test_bundle_integration.py` | End-to-end bundle invocation with `--ticket`, `--review`, manifest check. |
+| `tests/probe/test_handout_templates.py` | Each template `--dry-run`s. |
+| `tests/probe/fixtures/redaction_input.log` | Fixture log with paths, IPs, env-var values. |
+| `docs/probe-188/redaction.md` | Glob/path/IP rewrite semantics, security-reviewer sign-off note. |
+| `docs/probe-188/handout-templates.md` | Per-template walkthrough. |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `src/aorta/triage/recipe.py` | Accept `redaction:` block when `mode == "probe"`, with strict key validation (`scrub_env_keys: list[str]`, `scrub_paths: bool`, `scrub_ip_addresses: bool`). |
+| `src/aorta/probe/recipe_builder.py` | Thread `redaction:` onto `ProbeExtras`. |
+| `docs/probe-188/usage.md` | Add a "redaction + bundle" section. |
+| `README.md` | Cross-link to `aorta bundle` once that PR has landed. |
+
+## 3.D Documentation Deliverables
+
+- `docs/probe-188/redaction.md` — exhaustive scrubber reference, security-review sign-off appended at the bottom.
+- `docs/probe-188/handout-templates.md` — when to use each template.
+- `recipes/README.md` — probe-template section.
+
+## 3.E Definition of Done (Phase 3)
+
+- [ ] All 10 functional requirements in §3.B pass.
+- [ ] `aorta bundle` upstream PR has landed (Phase 3 cannot merge before).
+- [ ] Security-reviewer approval recorded in the PR description (Open Question #1).
+- [ ] Bundle manifest format documented in `docs/probe-188/redaction.md` and matches the implementation byte-for-byte.
+- [ ] Phase 1 + 2 regression suite passes unchanged.
+- [ ] PR title: `probe: bundle integration + redaction + handout templates (#188 phase 3)`.
+
+## 3.F Do-Not-Do List (Phase 3)
+
+- Do **not** reimplement `aorta bundle` in this PR. Consume the public API only.
+- Do **not** make redaction the default; it activates only when `redaction:` appears in the recipe.
+- Do **not** alter `aorta probe`'s exit semantics — `aorta bundle` is a separate user step.
+- Do **not** ship network-upload functionality.
+- Do **not** auto-detect "secret-looking" env vars; the glob list is recipe-authoritative.
+
+---
+
+# Cross-Phase Items
+
+## X.1 Open Question Resolutions (with Phase Mapping)
+
+| # | Open Question | Recommendation | Blocks |
+|---|---|---|---|
+| 1 | Security-review owner for redaction | **Block Phase 2 merge** on `oyazdanb` naming a security reviewer in the issue (the sandbox is in Phase 2; redaction is in Phase 3 but the sandbox is also a security artifact). Same reviewer ideally signs off on both. | Phase 2 + Phase 3 |
+| 2 | `aorta bundle` status | Land Phase 1 and Phase 2 independently. Phase 3 cannot start without the bundle PR. Implementer files a follow-up issue `aorta bundle: scope + contract` at Phase 1 PR merge time so the team can prioritise. | Phase 3 only |
+| 3 | `py-spy` dep model | **Vendor-detect-and-skip** (issue's own recommendation). `tier2_hang.py` calls `shutil.which("py-spy")` once per run; if absent, hang detection still fires but does not attach a stack dump. No `pyproject.toml` change. | Phase 2 |
+| 4 | Recipe `schema_version` | **Keep `1`, differentiate by `mode:`** (issue's own recommendation). Implemented per F2 and FR 1.16. | Phase 1 |
+| 5 | Tier 4 pattern library ownership | **Recommend** the AORTA team (specifically the issue's CODEOWNERS, currently `@mycpuorg`) owns version bumps; new patterns require a PR that bumps `BUILTIN_PATTERN_VERSION`, adds a fixture log under `tests/probe/fixtures/tier4_logs/`, and updates `docs/probe-188/classifier.md`. **Phase 2 PR codifies this in `docs/probe-188/classifier.md::ownership`.** | Phase 2 (process doc); does not block code merge |
+
+## X.2 Risk Register
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | **Engine drift** — Phase 2 needs new per-trial output shape; tempting to add a probe-only runner. | Phase 1 FR 1.5 (`tests/probe/test_shared_engine.py`) and a code-review checklist item explicitly forbidding any new file under `src/aorta/probe/` whose name contains `runner` or `dispatcher`. CI gate: `tests/probe/test_shared_engine.py` is in the required-pass set on every probe-touching PR. |
+| R2 | **Regex DoS in `custom_patterns`** — user supplies `^(a+)+$` against a 100MB log. | Compile-validation at load (rejects unparseable regex); per-scan window cap (10MiB per `re.search`); per-trial wall-clock timeout from the recipe; documented in `docs/probe-188/sandbox.md`. |
+| R3 | **dmesg / amd-smi permission denied** — Tier 3 needs root or `CAP_SYSLOG`; common in container deployments. | Detect-and-skip (Phase 2 FR 2.3 + 2.11); single warning per invocation; Tiers 1+2+4 continue. Documented in `docs/probe-188/classifier.md`. |
+| R4 | **Sandbox bypass** — a clever `condition` reaches `__import__` or attribute walking. | AST-walk whitelist (§2.E.3) rejects at parse time; empty `__builtins__` at eval time as defence-in-depth; hostile-input corpus (§2.E.4) is the regression suite; security-reviewer sign-off required for Phase 2 merge (Open Question #1). |
+| R5 | **Env-passthrough leaking secrets** — `--env-passthrough-mode file` writes `KEY=VALUE\n` lines to disk, including the user's `*_TOKEN` env vars. | Phase 1 documents the hazard in `docs/probe-188/usage.md`; the `<trial_dir>/probe.env` file is `chmod 0600` at write time (FR 1.10); Phase 3 redaction strips matching keys from the bundle. |
+
+## X.3 Scoring
+
+Per-phase pass thresholds, with explicit hard-gate vs soft-criterion separation.
+
+### Phase 1 (total 77 points)
+
+- **Hard gates (45 pts; ALL must pass)**: FR 1.1, 1.3, 1.4, 1.5, 1.6, 1.9, 1.10, 1.11, 1.12, 1.13. A miss on any of these is a blocking failure.
+- **Quality criteria (32 pts)**: every other FR row.
+- **Threshold to merge: ≥ 70 / 77 AND every hard gate passes AND every item in §1.G Definition of Done is checked.**
+- **Below 70 but every hard gate passes:** PR can land with explicit follow-up issues filed for each missing FR; reviewer sign-off required.
+- **Any hard-gate failure:** blocking; no waiver.
+
+### Phase 2 (total 56 points)
+
+- **Hard gates (28 pts; ALL must pass)**: FR 2.1, 2.7, 2.8, 2.9, 2.12. Plus the security-reviewer sign-off (Open Question #1) is a binary blocker.
+- **Quality criteria (28 pts)**: every other FR row.
+- **Threshold to merge: ≥ 50 / 56 AND every hard gate passes AND security sign-off recorded.**
+
+### Phase 3 (total 38 points)
+
+- **Hard gates (22 pts; ALL must pass)**: FR 3.1, 3.3, 3.4, 3.5, 3.6, 3.9. Plus `aorta bundle` upstream PR landed.
+- **Quality criteria (16 pts)**: every other FR row.
+- **Threshold to merge: ≥ 34 / 38 AND every hard gate passes AND `aorta bundle` is on `main`.**
+
+### Failure-class definitions
+
+- **Blocking failure (`fail:blocker`):** any hard gate, any sandbox/redaction security check, any documented security-reviewer requirement.
+- **Material failure (`fail:material`):** any quality-criterion miss totalling > 10% of the phase's quality points.
+- **Nit (`nit`):** lint/style/doc-wording miss with no functional effect; reviewer may waive in the PR thread.
+
+## X.4 Code-Review Checklist (paste into PR description, per phase)
+
+- [ ] No new file under `src/aorta/probe/` whose name contains `runner` or `dispatcher` (engine-reuse gate, all phases).
+- [ ] No new `subprocess` import under `src/aorta/triage/` (preserves #151 grep-test).
+- [ ] Every recipe-schema addition is reflected in `_VALID_TOP_LEVEL` / `_VALID_CELL_KEYS` AND has a unit test asserting unknown-key rejection.
+- [ ] Every reserved `_aorta_*` key the dispatcher injects is documented in the `RunRequest` docstring.
+- [ ] Every new third-party dependency is justified (Phase 2 + 3 expect NONE).
+- [ ] Phase 2: hostile-input corpus is fully red on a deliberately-buggy sandbox (mutation test).
+- [ ] Phase 3: bundle redaction is verified against a fixture log with secrets the test asserts are absent from the bundled output.
+
+---
+
+# Files Read to Anchor This Rubric
+
+Every file path cited in the rubric was read or grep'd; the audit list:
+
+| Path | Read for |
+|---|---|
+| `src/aorta/cli/__init__.py` | CLI entry-point registration pattern. |
+| `src/aorta/cli/triage.py` | `aorta triage run` shape, exception-bridging convention, `ClickException` discipline. |
+| `src/aorta/cli/run.py` | `aorta run` "thin-shell" handler contract (anchor for FR 1.15). |
+| `src/aorta/triage/runner.py` | `run_recipe` signature, output-dir layout, per-cell exception handling, dry-run early-return, preflight validation, `_aorta_log_prefix` semantics. |
+| `src/aorta/triage/recipe.py` | `_VALID_TOP_LEVEL`, `_RESERVED_WORKLOAD_CONFIG_PREFIX`, `_build_recipe`, `Recipe` dataclass, `_validate_no_mitigation_collisions`. |
+| `src/aorta/triage/output.py` | `resolve_run_dir`, `safe_slug`, `NO_TICKET_SLUG`, `write_matrix_md` table-builder. |
+| `src/aorta/workloads/__init__.py` | Workload package shape. |
+| `src/aorta/workloads/_base.py` | `Workload` ABC, `WorkloadResult`, lifecycle, `launch_mode`. |
+| `src/aorta/run/dispatcher.py` | `RunRequest` dataclass, `_aorta_*` reserved-prefix rejection (line 193), `_aorta_environment` / `_aorta_save_logs` / `_aorta_log_prefix` injection pattern (line 346, 441, 452), `save_logs` per-trial stdout/stderr capture. |
+| `src/aorta/run/discovery.py` | Workload discovery via `aorta.workloads` entry-point group. |
+| `src/aorta/run/results.py` | `TrialResult` shape (anchor for the probe-mode `result.json` divergence note). |
+| `src/aorta/run/collectors.py` | `KNOWN_RECIPES` (collector recipe validation). |
+| `src/aorta/registry/__init__.py` | Public registry API. |
+| `src/aorta/registry/types.py` | `Mitigation`, `Environment` dataclasses. |
+| `src/aorta/instrumentation/environment.py` (header) | A1 env-probe contract (fail-soft, schema 1.1+). |
+| `tests/triage/test_runner_b1_api.py` (header) | Existing mock-`run_trials` pattern that probe-mode's shared-engine test mirrors. |
+| `tests/run/test_cli_parsing.py` (header) | Thin-shell-handler test pattern (anchor for FR 1.15). |
+| `tests/conftest.py` | Shared fixtures (none relevant to probe). |
+| `recipes/example-fsdp-smoke.yaml` | Existing recipe shape (triage-mode) for back-compat assertion. |
+| `pyproject.toml` | Project metadata, optional-deps, `[project.entry-points."aorta.workloads"]` (commented out), `[project.scripts] aorta=aorta.cli:main`, lint/format config. |
+| `.pre-commit-config.yaml` | Active hooks (trailing-whitespace, end-of-file-fixer, check-yaml). |
+| `BUCK` | Top-level `python_library` + `python_binary` definitions; `src/aorta/**/*.py` glob (confirms no per-file BUCK changes needed for new modules). |
+| `CODEOWNERS` | `@mycpuorg` reviewer routing (only one owner; sandbox/redaction PRs need an additional explicit security reviewer per Open Question #1). |
+| `docs/probe-188/` | Empty directory confirms no prior probe scaffolding. |
+| `gh issue view 188 --repo ROCm/aorta` | Live issue text (matches the summary in the prompt; no drift). |
+| `gh pr list --state all --search 'probe'` | No prior probe scaffolding PR. |
+| `gh pr list --state all --search 'bundle'` | Confirms no `aorta bundle` PR — Phase 3 blocker is real (F5). |
+| `git status` / `git log -1` | Branch `users/vivekag/aorta-probe-188` at `b79da71`. |

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -35,17 +35,19 @@ probe_results/
       trial_0/
         stdout.log
         stderr.log
-        result.json               # {verdict, exit_code, duration_s, ...}
+        result.json               # see §6 for the actual field set
         probe.env                 # only with --env-passthrough-mode file
     tf32_off-none/
       trial_0/
         ...
 ```
 
-Re-running the **same command** is a no-op for completed trials: each
-trial is "complete" iff its `result.json` parses and has a non-empty
-`verdict` field. Truncated, missing, or malformed `result.json` files
-trigger a re-run of just that trial.
+Re-running the **same command** is a no-op for already-complete cells.
+A *cell* is "complete" iff every `trial_<n>/result.json` parses and has
+a non-empty `verdict` field; in that case the runner skips the cell
+entirely and re-uses the existing artifacts. If any trial under a cell
+is missing or truncated, the runner re-runs the whole cell (per-trial
+resume is tracked as a Phase 2+ enhancement).
 
 ## 2. Recipe shape (Phase 1)
 
@@ -93,10 +95,15 @@ Phase 2/3 keys (`custom_patterns`, `condition`, `redaction`) are
 * `<output>/<ticket>/` is created with `mkdir(exist_ok=True)` — no
   timestamp segment, no workload segment, so re-invocations land in the
   same directory.
-* Before each cell runs, the runner checks every `trial_<n>/result.json`
-  under that cell. If `trials` complete trials are already on disk, the
-  cell is skipped entirely. Otherwise it picks up at the next missing
-  index.
+* Before each cell runs, the runner counts how many `trial_<n>/result.json`
+  files under the cell already parse and carry a non-empty `verdict`. If
+  that count reaches the cell's `trials` setting, the cell is skipped
+  entirely and the existing per-trial JSONs are surfaced into matrix.json
+  unchanged. If even one trial is missing or malformed, the **whole cell**
+  re-runs from `trial_0` -- per-trial resume is a Phase 2+ enhancement
+  (the per-trial coordinate would have to round-trip through the dispatcher
+  and the dispatcher currently writes its own `trial_<N>.json` set
+  unconditionally).
 
 ## 5. CLI / recipe interaction
 
@@ -110,25 +117,27 @@ Phase 2/3 keys (`custom_patterns`, `condition`, `redaction`) are
 
 ## 6. What the verdict means in Phase 1
 
+Phase-1 `result.json` shape (exact keys written by
+`SubprocessWorkload.run()`):
+
 ```json
 {
-  "schema_version": 1,
   "verdict": "pass",
   "exit_code": 0,
-  "duration_s": 12.345,
-  "started_at": "2026-05-25T13:01:02Z",
-  "finished_at": "2026-05-25T13:01:14Z",
+  "walltime_sec": 12.345,
   "argv": ["python3", "my_repro.py", "--steps", "100"],
-  "mitigation": "none",
-  "diagnostic": "none",
+  "cell_name": "none-none",
+  "trial_index": 0,
   "env_passthrough_mode": "inherit",
-  "env_file": null
+  "timed_out": false
 }
 ```
 
-`verdict` is **exactly** `exit_code == 0 ? "pass" : "fail"`. Pattern
-matching, hang detection, and per-step time analysis are deferred to
-Phase 2.
+`verdict` is **exactly** `exit_code == 0 and not timed_out ? "pass" : "fail"`.
+Pattern matching, hang detection, and per-step time analysis are
+deferred to Phase 2 — Phase 2 extends this document by ADDING keys
+(never by removing), so any tool reading the Phase-1 keys above keeps
+working when Phase 2 ships.
 
 ## 7. Shared engine guarantee
 

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -1,0 +1,138 @@
+# `aorta probe` — Phase 1 Usage Walkthrough (issue #188)
+
+> Tier 1 only: verdict is `exit_code == 0 ? "pass" : "fail"`. No
+> pattern-matching, hang detection, dmesg scraping, sandboxing, or
+> bundling in this phase — see §2 / §3 of the rubric for what is
+> coming next.
+
+`aorta probe` runs an **opaque user launch command** across the
+cartesian product of a **mitigation axis × diagnostic axis**, in an
+**idempotent / resumable** output tree. It is the bring-your-own-script
+equivalent of `aorta triage run`: aorta does not parse the user's argv,
+it just executes it once per `(mitigation, diagnostic)` cell × `trials`
+trials and records the exit code.
+
+## 1. Quick start
+
+```bash
+aorta probe \
+    --recipe my_probe.yaml \
+    --output ./probe_results \
+    --ticket ROCM-1234 \
+    -- \
+    python3 my_repro.py --steps 100
+```
+
+Artifact tree (the documented Phase-1 layout):
+
+```
+probe_results/
+  ROCM-1234/                      # safe_slug(ticket)
+    recipe.resolved.yaml          # one snapshot of the recipe
+    host_env.json                 # one host-env capture
+    matrix.md / matrix.json
+    none-none/                    # safe_slug(cell.name)
+      trial_0/
+        stdout.log
+        stderr.log
+        result.json               # {verdict, exit_code, duration_s, ...}
+        probe.env                 # only with --env-passthrough-mode file
+    tf32_off-none/
+      trial_0/
+        ...
+```
+
+Re-running the **same command** is a no-op for completed trials: each
+trial is "complete" iff its `result.json` parses and has a non-empty
+`verdict` field. Truncated, missing, or malformed `result.json` files
+trigger a re-run of just that trial.
+
+## 2. Recipe shape (Phase 1)
+
+```yaml
+schema_version: 1
+mode: probe                       # discriminator — required for probe-mode
+ticket: ROCM-1234                 # optional; --ticket on CLI overrides
+trials: 3                         # >= 1
+mitigation_axis:
+  - none
+  - tf32_off
+diagnostic_axis:
+  - none
+  - hsa_no_scratch_reclaim        # only if registered in the B3 registry
+step_time_regex: null             # phase-1 stub; ignored (rubric §F8)
+collect_paths: []                 # phase-1 stub; ignored
+timeout_per_trial: 1800           # seconds; null = no timeout
+env_passthrough_mode: inherit     # 'inherit' | 'file' — CLI flag overrides
+```
+
+Phase 2/3 keys (`custom_patterns`, `condition`, `redaction`) are
+**rejected at load time** with a "deferred to Phase 2/3" error message.
+
+## 3. Env-passthrough modes (`--env-passthrough-mode`)
+
+`inherit` (default)
+:   Each cell's mitigations are applied to `os.environ` for the duration
+    of the trial, and the child `subprocess.Popen` inherits via
+    `env=os.environ.copy()`. No env file is written.
+
+`file`
+:   Same as above, **plus** aorta writes `<trial_dir>/probe.env`
+    (POSIX `KEY=VALUE\n`, one var per line) at `chmod 0600` and exports
+    `AORTA_ENV_FILE=<absolute path>` into the child's environment. The
+    user's argv is **never modified** — pick this mode if your launch
+    command needs to forward the env file by hand
+    (`docker run --env-file "$AORTA_ENV_FILE" ...`,
+    `srun --export ALL,${AORTA_ENV_FILE_VARS} ...`, etc.).
+
+## 4. Resume semantics
+
+`aorta probe` always passes `layout="flat_resume"` and
+`resume_existing=True` to `aorta.triage.runner.run_recipe`. That means:
+
+* `<output>/<ticket>/` is created with `mkdir(exist_ok=True)` — no
+  timestamp segment, no workload segment, so re-invocations land in the
+  same directory.
+* Before each cell runs, the runner checks every `trial_<n>/result.json`
+  under that cell. If `trials` complete trials are already on disk, the
+  cell is skipped entirely. Otherwise it picks up at the next missing
+  index.
+
+## 5. CLI / recipe interaction
+
+* `--ticket` overrides the recipe's `ticket` field.
+* `--env-passthrough-mode` overrides the recipe's `env_passthrough_mode`
+  field.
+* `--dry-run` validates the recipe, prints the planned cell list +
+  argv, and exits without writing to disk.
+* Any flag not in the table above must come from the recipe; the CLI is
+  intentionally **thin** (see `tests/probe/test_cli_parsing.py`).
+
+## 6. What the verdict means in Phase 1
+
+```json
+{
+  "schema_version": 1,
+  "verdict": "pass",
+  "exit_code": 0,
+  "duration_s": 12.345,
+  "started_at": "2026-05-25T13:01:02Z",
+  "finished_at": "2026-05-25T13:01:14Z",
+  "argv": ["python3", "my_repro.py", "--steps", "100"],
+  "mitigation": "none",
+  "diagnostic": "none",
+  "env_passthrough_mode": "inherit",
+  "env_file": null
+}
+```
+
+`verdict` is **exactly** `exit_code == 0 ? "pass" : "fail"`. Pattern
+matching, hang detection, and per-step time analysis are deferred to
+Phase 2.
+
+## 7. Shared engine guarantee
+
+`aorta probe` and `aorta triage run` both reach
+`aorta.triage.runner.run_recipe` — there is no parallel runner. The
+shared-engine contract is pinned by
+`tests/probe/test_shared_engine.py`.

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -81,11 +81,20 @@ Phase 2/3 keys (`custom_patterns`, `condition`, `redaction`) are
 `file`
 :   Same as above, **plus** aorta writes `<trial_dir>/probe.env`
     (POSIX `KEY=VALUE\n`, one var per line) at `chmod 0600` and exports
-    `AORTA_ENV_FILE=<absolute path>` into the child's environment. The
-    user's argv is **never modified** — pick this mode if your launch
-    command needs to forward the env file by hand
-    (`docker run --env-file "$AORTA_ENV_FILE" ...`,
-    `srun --export ALL,${AORTA_ENV_FILE_VARS} ...`, etc.).
+    `AORTA_ENV_FILE=<absolute path>` into the child's environment.
+    `AORTA_ENV_FILE` is the only variable aorta exports for this mode;
+    the user's argv is **never modified**. Pick this mode if your
+    launch command needs to forward the env file by hand:
+
+    * `docker run --env-file "$AORTA_ENV_FILE" ...` — Docker reads the
+      file directly.
+    * `srun --export=ALL,AORTA_ENV_FILE bash -c 'set -a; . "$AORTA_ENV_FILE"; set +a; exec my_repro ...'`
+      — Slurm forwards `AORTA_ENV_FILE` to the remote step, which then
+      sources the file into the launched shell.
+
+    Earlier drafts of this doc referenced `AORTA_ENV_FILE_VARS`; that
+    variable is **not** exported and never was — use `AORTA_ENV_FILE`
+    (a path to the env file) as shown above.
 
 ## 4. Resume semantics
 

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -54,22 +54,32 @@ resume is tracked as a Phase 2+ enhancement).
 ```yaml
 schema_version: 1
 mode: probe                       # discriminator — required for probe-mode
-ticket: ROCM-1234                 # optional; --ticket on CLI overrides
+ticket: ROCM-1234                 # optional; overridden by --ticket when that flag is passed
 trials: 3                         # >= 1
 mitigation_axis:
   - none
   - tf32_off
 diagnostic_axis:
   - none
-  - hsa_no_scratch_reclaim        # only if registered in the B3 registry
+  - xnack                         # built-in (see note below on registered names)
 step_time_regex: null             # phase-1 stub; ignored (rubric §F8)
 collect_paths: []                 # phase-1 stub; ignored
 timeout_per_trial: 1800           # seconds; null = no timeout
-env_passthrough_mode: inherit     # 'inherit' | 'file' — CLI flag overrides
+env_passthrough_mode: inherit     # 'inherit' | 'file' — overridden by --env-passthrough-mode when that flag is passed
 ```
 
 Phase 2/3 keys (`custom_patterns`, `condition`, `redaction`) are
 **rejected at load time** with a "deferred to Phase 2/3" error message.
+
+**Registered mitigation / diagnostic names.** The built-in registry
+(see `src/aorta/registry/mitigations.py`) currently ships only `none`,
+`tf32_off`, and `xnack`. Any other name (e.g. `hsa_no_scratch_reclaim`,
+`fa_prefer_ck`, `hip_launch_blocking`) must come from an
+`aorta.mitigations` entry-point plugin or a `--mitigations-file`
+sidecar JSON, otherwise the recipe fails to load with
+`UnknownMitigationError`. Issue #195 tracks expanding the built-in
+set; until that lands, swap any unregistered name for `none` (or one
+of the three built-ins above) when copy-pasting this template.
 
 ## 3. Env-passthrough modes (`--env-passthrough-mode`)
 
@@ -116,9 +126,14 @@ Phase 2/3 keys (`custom_patterns`, `condition`, `redaction`) are
 
 ## 5. CLI / recipe interaction
 
-* `--ticket` overrides the recipe's `ticket` field.
-* `--env-passthrough-mode` overrides the recipe's `env_passthrough_mode`
-  field.
+* `--ticket` overrides the recipe's `ticket` field when present. If the
+  flag is omitted, the recipe value is used (falling back to
+  `_no_ticket_` if the recipe also omits it, per
+  `aorta.triage.output.NO_TICKET_SLUG`).
+* `--env-passthrough-mode` overrides the recipe's
+  `env_passthrough_mode` field when present. If the flag is omitted,
+  the recipe value is used (falling back to `inherit` if the recipe
+  also omits it).
 * `--dry-run` validates the recipe, prints the planned cell list +
   argv, and exits without writing to disk.
 * Any flag not in the table above must come from the recipe; the CLI is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,15 @@ aorta = "aorta.cli:main"
 # Public workloads (when they land) register here; private workloads
 # register from downstream packages' pyproject.toml under the same group.
 #
-# No public workloads are wired up yet -- the prior `fsdp` entry pointed at
-# `aorta.workloads.fsdp:FsdpWorkload`, which was never created, so `aorta run`
-# would log a noisy "Failed to load workload 'fsdp'" warning on every
-# invocation. Removed until a real public workload lands.
-# [project.entry-points."aorta.workloads"]
+# ``_subprocess`` is platform-internal: it wraps an opaque user launch
+# command for ``aorta probe`` (issue #188). The leading underscore both
+# (a) prevents collision with user-facing workload names and (b) marks
+# the entry as visibly platform-internal in ``aorta triage list-workloads``
+# when that command lands. Direct ``aorta run --workload _subprocess``
+# invocations fail at ``SubprocessWorkload.setup()`` because the
+# reserved argv config key is only injected by ``aorta probe``.
+[project.entry-points."aorta.workloads"]
+_subprocess = "aorta.workloads._subprocess:SubprocessWorkload"
 
 [project.optional-dependencies]
 # For analysis/visualization scripts

--- a/recipes/example-probe-smoke.yaml
+++ b/recipes/example-probe-smoke.yaml
@@ -12,9 +12,13 @@
 # Verdict is exit-code only ("pass" if zero else "fail"). Per-cell stdout
 # and stderr land in `<output>/<ticket>/<cell>/trial_<n>/`.
 #
-# Mitigation / diagnostic names below must resolve in the B3 registry --
-# only `none`, `tf32_off`, `xnack`, and `hsa_no_scratch_reclaim` are
-# guaranteed in the current public build. Swap in `none` for any name
+# Mitigation / diagnostic names below must resolve in the B3 registry.
+# The built-in registry (see src/aorta/registry/mitigations.py) ships
+# only `none`, `tf32_off`, and `xnack`; any other name (e.g.
+# `hsa_no_scratch_reclaim`, `fa_prefer_ck`, `hip_launch_blocking`) must
+# come from an `aorta.mitigations` entry-point plugin or a
+# `--mitigations-file` sidecar. Issue #195 tracks adding the rubric's
+# other example axes to the built-in set. Swap in `none` for any name
 # you have not registered locally.
 schema_version: 1
 mode: probe

--- a/recipes/example-probe-smoke.yaml
+++ b/recipes/example-probe-smoke.yaml
@@ -1,0 +1,42 @@
+# Smoke-test recipe for `aorta probe` (issue #188).
+#
+# Tier-1, opaque user launch command:
+#
+#   aorta probe \
+#       --recipe recipes/example-probe-smoke.yaml \
+#       --output ./probe_results \
+#       --ticket PROBE-188 \
+#       -- \
+#       bash -c 'echo hi'
+#
+# Verdict is exit-code only ("pass" if zero else "fail"). Per-cell stdout
+# and stderr land in `<output>/<ticket>/<cell>/trial_<n>/`.
+#
+# Mitigation / diagnostic names below must resolve in the B3 registry --
+# only `none`, `tf32_off`, `xnack`, and `hsa_no_scratch_reclaim` are
+# guaranteed in the current public build. Swap in `none` for any name
+# you have not registered locally.
+schema_version: 1
+mode: probe
+
+ticket: PROBE-188-SMOKE
+
+trials: 2
+
+mitigation_axis:
+  - none
+  - tf32_off
+
+diagnostic_axis:
+  - none
+
+# Phase-1 stubs -- parsed and validated, but currently ignored by the
+# Tier-1 verdict path. Will become live in Phase 2 (classifier).
+step_time_regex: null
+collect_paths: []
+timeout_per_trial: 1800
+
+# 'inherit' = stamp mitigations on os.environ in-process; child Popen
+# inherits via env=os.environ.copy(). Switch to 'file' for an extra
+# chmod-0600 probe.env file + AORTA_ENV_FILE exported into the child.
+env_passthrough_mode: inherit

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -2,7 +2,7 @@
 
 import click
 
-from aorta.cli import env, environments, mitigations, run, triage
+from aorta.cli import env, environments, mitigations, probe, run, triage
 
 
 @click.group()
@@ -14,6 +14,7 @@ def main() -> None:
 main.add_command(env.env)
 main.add_command(environments.environments)
 main.add_command(mitigations.mitigations)
+main.add_command(probe.probe)
 main.add_command(run.run)
 main.add_command(triage.triage)
 

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -29,6 +29,7 @@ import click
 
 from aorta.probe.cli_helpers import (
     ProbeUsageError,
+    help_token_in_option_zone,
     parse_env_passthrough_mode,
     reject_flag_shaped_value,
     require_double_dash_separator,
@@ -70,17 +71,44 @@ class _ProbeCommand(click.Command):
     Implemented as a ``parse_args`` override so the check sees the same
     argv that Click sees -- whether that's ``sys.argv[1:]`` from the real
     entry point or the ``args=[...]`` list from ``CliRunner.invoke`` in
-    tests. ``--help`` short-circuits via ``ctx.resilient_parsing`` so the
-    help text still renders without requiring ``--``.
+    tests. ``--help``/``-h`` short-circuits the check, but ONLY when the
+    help token sits in the aorta-option zone (before the user-command
+    boundary). A naive ``"--help" in args`` bypass is wrong because
+    ``aorta probe --recipe r --output o echo --help`` would silently
+    skip the separator check -- ``--help`` is the user-command's flag
+    there, not aorta's. See :func:`help_token_in_option_zone` for the
+    scoping rule.
     """
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        if not ctx.resilient_parsing and "--help" not in args and "-h" not in args:
+        if not ctx.resilient_parsing and not help_token_in_option_zone(
+            args, self._value_taking_option_tokens()
+        ):
             try:
                 require_double_dash_separator(args)
             except ProbeUsageError as exc:
                 raise click.UsageError(str(exc), ctx=ctx) from exc
         return super().parse_args(ctx, args)
+
+    def _value_taking_option_tokens(self) -> frozenset[str]:
+        """Long-form option tokens (``--recipe`` etc.) that consume a value.
+
+        Derived from the Click command's own ``params`` so adding a new
+        option that takes a value (without ``is_flag``/``count``) won't
+        silently re-open the bot-flagged misparse. Boolean flags and
+        ``count`` options are excluded -- they don't consume the next
+        token.
+        """
+        tokens: set[str] = set()
+        for param in self.params:
+            if not isinstance(param, click.Option):
+                continue
+            if param.is_flag or param.count:
+                continue
+            for opt in param.opts:
+                if opt.startswith("--"):
+                    tokens.add(opt)
+        return frozenset(tokens)
 
 
 @click.command(

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -6,7 +6,10 @@ orchestration). The CLI's whole job is:
 1. Validate the trailing argv and the env-passthrough mode.
 2. Load the recipe (must be ``mode: probe``).
 3. Override ``recipe.probe_extras.env_passthrough_mode`` from the CLI
-   flag (the flag wins when present, per FR 1.10).
+   flag **only when the user actually passed it** (FR 1.10: the flag
+   wins when present, otherwise the recipe's ``env_passthrough_mode:``
+   takes effect; if neither is set the recipe-builder default
+   ``"inherit"`` applies).
 4. Call :func:`aorta.triage.runner.run_recipe` with the probe-mode
    knobs (``layout="flat_resume"``, ``resume_existing=True``,
    ``subprocess_argv=...``).
@@ -117,15 +120,17 @@ class _ProbeCommand(click.Command):
 @click.option(
     "--env-passthrough-mode",
     type=click.Choice(["inherit", "file"]),
-    default="inherit",
-    show_default=True,
+    default=None,
     help=(
         "How per-cell env vars reach the user command: 'inherit' stamps "
         "them on os.environ in-process (the child Popen inherits); 'file' "
         "additionally writes a chmod-0600 probe.env file in the trial dir "
         "and exports AORTA_ENV_FILE for the user's argv to reference "
         "(e.g. 'docker run --env-file $AORTA_ENV_FILE ...'). "
-        "Aorta never modifies the user's argv."
+        "Aorta never modifies the user's argv. "
+        "When omitted, the recipe's 'env_passthrough_mode:' value is used "
+        "(falling back to 'inherit' if the recipe also omits it). When "
+        "present, this flag overrides the recipe."
     ),
 )
 @click.option(
@@ -140,7 +145,7 @@ def probe(
     output: Path,
     ticket: str | None,
     dry_run: bool,
-    env_passthrough_mode: str,
+    env_passthrough_mode: str | None,
     verbose: int,
     argv: tuple[str, ...],
 ) -> None:
@@ -152,7 +157,17 @@ def probe(
     """
     configure_verbose_logging(verbose)
     try:
-        passthrough_mode = parse_env_passthrough_mode(env_passthrough_mode)
+        # ``--env-passthrough-mode`` defaults to None so the handler can
+        # distinguish "user passed the flag" from "user omitted it". Per
+        # FR 1.10 the CLI wins only when present; otherwise the recipe's
+        # ``env_passthrough_mode:`` (set by the probe-mode recipe-builder,
+        # defaulting to "inherit") stays in effect. Validate the value
+        # only when the user actually supplied it.
+        cli_passthrough_mode = (
+            parse_env_passthrough_mode(env_passthrough_mode)
+            if env_passthrough_mode is not None
+            else None
+        )
         clean_argv = validate_trailing_argv(argv)
         r = load_recipe(recipe)
         probe_extras = r.probe_extras
@@ -163,10 +178,13 @@ def probe(
             )
         if ticket is not None:
             r = dataclasses.replace(r, ticket=ticket)
-        r = dataclasses.replace(
-            r,
-            probe_extras=dataclasses.replace(probe_extras, env_passthrough_mode=passthrough_mode),
-        )
+        if cli_passthrough_mode is not None:
+            r = dataclasses.replace(
+                r,
+                probe_extras=dataclasses.replace(
+                    probe_extras, env_passthrough_mode=cli_passthrough_mode
+                ),
+            )
     except ProbeUsageError as exc:
         raise click.ClickException(str(exc)) from exc
     except (RecipeSchemaError, RecipeCellError, RegistryError) as exc:

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -38,6 +38,7 @@ from aorta.probe.cli_helpers import (
 from aorta.probe.recipe_builder import ProbeExtras
 from aorta.registry import RegistryError
 from aorta.run.cli_helpers import configure_verbose_logging
+from aorta.triage.output import RunDirLockedError
 from aorta.triage.recipe import (
     RecipeCellError,
     RecipeSchemaError,
@@ -227,6 +228,12 @@ def probe(
             resume_existing=True,
             subprocess_argv=clean_argv,
         )
+    except RunDirLockedError as exc:
+        # Friendlier surface than a stack trace: the exception message
+        # already names the holder host/PID and the lockfile path to
+        # remove. Wrap into ClickException so click exits 1 with the
+        # operator-visible message rather than a Python traceback.
+        raise click.ClickException(str(exc)) from exc
     except (RegistryError, RecipeCellError, RecipeSchemaError) as exc:
         raise click.ClickException(str(exc)) from exc
     if not dry_run:

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -1,0 +1,148 @@
+"""``aorta probe`` -- wrap-and-collect command for opaque user launch commands.
+
+Thin Click shim per the rubric (FR 1.15: handler body <= 60 lines, no
+orchestration). The CLI's whole job is:
+
+1. Validate the trailing argv and the env-passthrough mode.
+2. Load the recipe (must be ``mode: probe``).
+3. Override ``recipe.probe_extras.env_passthrough_mode`` from the CLI
+   flag (the flag wins when present, per FR 1.10).
+4. Call :func:`aorta.triage.runner.run_recipe` with the probe-mode
+   knobs (``layout="flat_resume"``, ``resume_existing=True``,
+   ``subprocess_argv=...``).
+5. Map runner exceptions to ``ClickException``.
+
+The shared-engine test in ``tests/probe/test_shared_engine.py`` mocks
+``run_recipe`` and invokes both ``aorta probe`` and ``aorta triage
+run`` -- both must reach the mock.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import click
+
+from aorta.probe.cli_helpers import (
+    ProbeUsageError,
+    parse_env_passthrough_mode,
+    validate_trailing_argv,
+)
+from aorta.probe.recipe_builder import ProbeExtras
+from aorta.registry import RegistryError
+from aorta.run.cli_helpers import configure_verbose_logging
+from aorta.triage.recipe import (
+    RecipeCellError,
+    RecipeSchemaError,
+    load_recipe,
+)
+from aorta.triage.runner import run_recipe
+
+
+@click.command(
+    name="probe",
+    context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
+)
+@click.option(
+    "--recipe",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to a 'mode: probe' YAML or JSON recipe file.",
+)
+@click.option(
+    "--output",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path("probe_results"),
+    show_default=True,
+    help="Top-level output directory; <output>/<ticket>/<cell>/trial_<n>/ artifacts land here.",
+)
+@click.option(
+    "--ticket",
+    default=None,
+    help=(
+        "Ticket ID for output-dir grouping. When omitted, output is grouped "
+        "under '_no_ticket_/'. Required for 'aorta bundle' downstream (Phase 3)."
+    ),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Validate the recipe and print the planned cell list + argv without executing.",
+)
+@click.option(
+    "--env-passthrough-mode",
+    type=click.Choice(["inherit", "file"]),
+    default="inherit",
+    show_default=True,
+    help=(
+        "How per-cell env vars reach the user command: 'inherit' stamps "
+        "them on os.environ in-process (the child Popen inherits); 'file' "
+        "additionally writes a chmod-0600 probe.env file in the trial dir "
+        "and exports AORTA_ENV_FILE for the user's argv to reference "
+        "(e.g. 'docker run --env-file $AORTA_ENV_FILE ...'). "
+        "Aorta never modifies the user's argv."
+    ),
+)
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Stream per-cell progress to stderr. -v = INFO, -vv = DEBUG.",
+)
+@click.argument("argv", nargs=-1, type=click.UNPROCESSED)
+def probe(
+    recipe: Path,
+    output: Path,
+    ticket: str | None,
+    dry_run: bool,
+    env_passthrough_mode: str,
+    verbose: int,
+    argv: tuple[str, ...],
+) -> None:
+    """Run an opaque user launch command across a mitigation x diagnostic matrix.
+
+    All arguments after ``--`` are forwarded byte-for-byte to the user
+    command. Aorta never parses them; the only "boundary" is the
+    optional ``probe.env`` file written under ``--env-passthrough-mode file``.
+    """
+    configure_verbose_logging(verbose)
+    try:
+        passthrough_mode = parse_env_passthrough_mode(env_passthrough_mode)
+        clean_argv = validate_trailing_argv(argv)
+        r = load_recipe(recipe)
+        probe_extras = r.probe_extras
+        if probe_extras is None:
+            raise ProbeUsageError(
+                f"recipe {recipe} is not a probe-mode recipe; "
+                "set 'mode: probe' at the recipe top level"
+            )
+        if ticket is not None:
+            r = dataclasses.replace(r, ticket=ticket)
+        r = dataclasses.replace(
+            r,
+            probe_extras=dataclasses.replace(
+                probe_extras, env_passthrough_mode=passthrough_mode
+            ),
+        )
+    except ProbeUsageError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except (RecipeSchemaError, RecipeCellError, RegistryError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    try:
+        run_dir = run_recipe(
+            r,
+            output_dir=output,
+            dry_run=dry_run,
+            layout="flat_resume",
+            resume_existing=True,
+            subprocess_argv=clean_argv,
+        )
+    except (RegistryError, RecipeCellError, RecipeSchemaError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not dry_run:
+        click.echo(f"Wrote probe artifacts to {run_dir}")
+
+
+__all__ = ["probe", "ProbeExtras"]

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -27,6 +27,8 @@ import click
 from aorta.probe.cli_helpers import (
     ProbeUsageError,
     parse_env_passthrough_mode,
+    reject_flag_shaped_value,
+    require_double_dash_separator,
     validate_trailing_argv,
 )
 from aorta.probe.recipe_builder import ProbeExtras
@@ -40,14 +42,54 @@ from aorta.triage.recipe import (
 from aorta.triage.runner import run_recipe
 
 
+def _reject_flag_shaped_callback(
+    ctx: click.Context, param: click.Parameter, value: object
+) -> object:
+    """Click callback wiring :func:`reject_flag_shaped_value` onto string options.
+
+    Translates :class:`ProbeUsageError` into :class:`click.BadParameter`
+    so the standard Click usage rendering kicks in (with the option name
+    + usage hint).
+    """
+    if value is None or not isinstance(value, (str, Path)):
+        return value
+    option_name = f"--{param.name.replace('_', '-')}" if param.name else "<option>"
+    try:
+        reject_flag_shaped_value(option_name, str(value))
+    except ProbeUsageError as exc:
+        raise click.BadParameter(str(exc), ctx=ctx, param=param) from exc
+    return value
+
+
+class _ProbeCommand(click.Command):
+    """``probe`` command that requires an explicit ``--`` separator in raw argv.
+
+    Implemented as a ``parse_args`` override so the check sees the same
+    argv that Click sees -- whether that's ``sys.argv[1:]`` from the real
+    entry point or the ``args=[...]`` list from ``CliRunner.invoke`` in
+    tests. ``--help`` short-circuits via ``ctx.resilient_parsing`` so the
+    help text still renders without requiring ``--``.
+    """
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if not ctx.resilient_parsing and "--help" not in args and "-h" not in args:
+            try:
+                require_double_dash_separator(args)
+            except ProbeUsageError as exc:
+                raise click.UsageError(str(exc), ctx=ctx) from exc
+        return super().parse_args(ctx, args)
+
+
 @click.command(
     name="probe",
+    cls=_ProbeCommand,
     context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
 )
 @click.option(
     "--recipe",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=True,
+    callback=_reject_flag_shaped_callback,
     help="Path to a 'mode: probe' YAML or JSON recipe file.",
 )
 @click.option(
@@ -55,11 +97,13 @@ from aorta.triage.runner import run_recipe
     type=click.Path(file_okay=False, path_type=Path),
     default=Path("probe_results"),
     show_default=True,
+    callback=_reject_flag_shaped_callback,
     help="Top-level output directory; <output>/<ticket>/<cell>/trial_<n>/ artifacts land here.",
 )
 @click.option(
     "--ticket",
     default=None,
+    callback=_reject_flag_shaped_callback,
     help=(
         "Ticket ID for output-dir grouping. When omitted, output is grouped "
         "under '_no_ticket_/'. Required for 'aorta bundle' downstream (Phase 3)."
@@ -121,9 +165,7 @@ def probe(
             r = dataclasses.replace(r, ticket=ticket)
         r = dataclasses.replace(
             r,
-            probe_extras=dataclasses.replace(
-                probe_extras, env_passthrough_mode=passthrough_mode
-            ),
+            probe_extras=dataclasses.replace(probe_extras, env_passthrough_mode=passthrough_mode),
         )
     except ProbeUsageError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/aorta/probe/__init__.py
+++ b/src/aorta/probe/__init__.py
@@ -1,0 +1,30 @@
+"""``aorta probe`` -- wrap-and-collect command for opaque user launch commands.
+
+Phase 1 (issue #188) ships an MVP that:
+
+* loads a ``mode: probe`` recipe;
+* synthesises cells from ``mitigation_axis x diagnostic_axis``;
+* runs every cell through :func:`aorta.triage.runner.run_recipe`
+  (NO parallel runner -- the shared-engine test in
+  ``tests/probe/test_shared_engine.py`` enforces this);
+* writes per-trial artifacts under
+  ``<output>/<safe_slug(ticket)>/<safe_slug(cell)>/trial_<n>/``;
+* re-running with the same ``--output`` skips cells whose
+  ``result.json`` is valid and carries a non-empty ``verdict``.
+
+Phase 2 (built-in 5-tier classifier + sandboxed ``custom_patterns``) and
+Phase 3 (``aorta bundle`` integration + redaction + handout templates)
+are tracked separately and are NOT implemented in this module.
+"""
+
+from aorta.probe.recipe_builder import (
+    ProbeExtras,
+    build_probe_recipe_from_dict,
+)
+from aorta.probe.resume import is_trial_complete
+
+__all__ = [
+    "ProbeExtras",
+    "build_probe_recipe_from_dict",
+    "is_trial_complete",
+]

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -50,6 +50,51 @@ def reject_flag_shaped_value(option_name: str, value: str | None) -> None:
         )
 
 
+def help_token_in_option_zone(args: Sequence[str], value_taking_options: frozenset[str]) -> bool:
+    """True iff ``--help`` / ``-h`` appears in the aorta-option zone.
+
+    The "aorta-option zone" is the prefix of ``args`` that comes BEFORE
+    either the explicit ``--`` separator or the first non-option
+    positional argument (the user-command executable). Help tokens
+    appearing AFTER the user command (``aorta probe --recipe r -- echo
+    --help`` or ``aorta probe --recipe r echo --help`` with
+    ``allow_interspersed_args=False``) are part of the user command and
+    MUST NOT short-circuit the mandatory ``--`` separator check.
+
+    Walks the token list left-to-right and consumes
+    ``--opt value`` pairs for options that take a value (passed as
+    ``value_taking_options``, derived from the Click command's
+    ``params``). ``--opt=value`` is consumed as a single token. Flag
+    options (``-v``, ``--dry-run``) are single tokens. The first token
+    that doesn't start with ``-`` (and isn't an option value) marks
+    the user-command boundary; ``--help`` at or after that boundary is
+    user-command content.
+
+    Defends against the bot-flagged misparse where ``aorta probe
+    --recipe r --output o echo --help`` would silently skip the
+    separator check.
+    """
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token in ("--help", "-h"):
+            return True
+        if token == "--":
+            return False
+        if token.startswith("--"):
+            opt = token.split("=", 1)[0]
+            if "=" in token or opt not in value_taking_options:
+                i += 1
+                continue
+            i += 2  # consume the value as well
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        return False  # first user-command positional
+    return False
+
+
 def require_double_dash_separator(raw_argv: Sequence[str]) -> None:
     """Require an explicit ``--`` separator in the raw process argv.
 
@@ -136,6 +181,7 @@ __all__ = [
     "VALID_ENV_PASSTHROUGH_MODES",
     "ProbeUsageError",
     "format_dry_run_line",
+    "help_token_in_option_zone",
     "parse_env_passthrough_mode",
     "reject_flag_shaped_value",
     "require_double_dash_separator",

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -8,6 +8,7 @@ no subprocess.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Literal
 
 VALID_ENV_PASSTHROUGH_MODES: tuple[Literal["inherit", "file"], ...] = ("inherit", "file")
@@ -21,6 +22,54 @@ class ProbeUsageError(ValueError):
     consumers -- don't need to depend on Click to catch it. The Click
     handler bridges this into a ``ClickException`` at the CLI boundary.
     """
+
+
+def reject_flag_shaped_value(option_name: str, value: str | None) -> None:
+    """Reject option values that look like another flag.
+
+    Defends against the classic ``--output $TMPDIR --ticket X`` bug where
+    ``$TMPDIR`` is unset: the shell collapses two spaces into one, Click
+    sees ``--output --ticket`` and silently accepts ``--ticket`` as the
+    *value* of ``--output``. The user's run then writes to a directory
+    literally named ``--ticket`` and ``--ticket X`` is lost. ``X`` and
+    everything after gets swept into the trailing argv.
+
+    Only the leading ``--`` is treated as suspicious. A single ``-foo`` or
+    a path that genuinely starts with ``-`` (rare but legal) is allowed
+    through; the user can quote or use ``./-foo`` to disambiguate if
+    needed. The leading-``--`` check covers ~all real-world recurrences
+    of the bug without false-positive risk on legitimate paths.
+    """
+    if value is None:
+        return
+    if value.startswith("--"):
+        raise ProbeUsageError(
+            f"{option_name}: value {value!r} looks like another flag. "
+            "Did you forget to set the variable or to quote the value? "
+            f"(common cause: '{option_name} $VAR ...' where $VAR is unset)"
+        )
+
+
+def require_double_dash_separator(raw_argv: Sequence[str]) -> None:
+    """Require an explicit ``--`` separator in the raw process argv.
+
+    Without ``--``, Click cheerfully sweeps any leftover positional
+    arguments into the trailing-argv list, masking flag-misparse bugs
+    (e.g. a stray ``SMOKE-1`` becoming the user-command executable name).
+    Requiring ``--`` makes the boundary explicit: aorta options on the
+    left, opaque user command on the right.
+
+    ``raw_argv`` is the full process argv (``sys.argv[1:]`` or the equivalent
+    for a tested CLI invocation). The check passes as long as ``--`` appears
+    somewhere; the trailing-argv emptiness check is a separate concern
+    handled by :func:`validate_trailing_argv`.
+    """
+    if "--" not in raw_argv:
+        raise ProbeUsageError(
+            "missing '--' separator. The user command must come after a "
+            "literal '--' so aorta knows where its own flags end. "
+            "Usage: aorta probe [options] -- <command> [args...]"
+        )
 
 
 def parse_env_passthrough_mode(value: str) -> Literal["inherit", "file"]:
@@ -42,17 +91,28 @@ def parse_env_passthrough_mode(value: str) -> Literal["inherit", "file"]:
 
 
 def validate_trailing_argv(argv: tuple[str, ...]) -> tuple[str, ...]:
-    """Reject an empty trailing-argv list.
+    """Reject an empty / clearly-misparsed trailing-argv list.
 
     ``aorta probe -- <argv>`` is the only legal channel for the user
     command; ``aorta probe`` without a trailing ``--`` (or with ``--``
     followed by nothing) is a usage error. The "no parsing" invariant
     means we don't otherwise inspect ``argv`` -- it's forwarded
     byte-for-byte to :class:`SubprocessWorkload`.
+
+    A second guard rejects ``argv[0]`` that starts with ``-``: a real user
+    command's executable name is essentially never dash-prefixed, but a
+    leaked aorta option (e.g. ``-v`` smuggled past Click) is. Catching
+    this here turns a 127 exit-code "fail" trial into a clear usage error.
     """
     if not argv:
         raise ProbeUsageError(
             "no trailing argv supplied. Usage: aorta probe [options] -- <command> [args...]"
+        )
+    if argv[0].startswith("-"):
+        raise ProbeUsageError(
+            f"user command starts with {argv[0]!r}, which looks like a flag. "
+            "Place all aorta options before '--' and the user command after. "
+            "Usage: aorta probe [options] -- <command> [args...]"
         )
     return argv
 
@@ -77,5 +137,7 @@ __all__ = [
     "ProbeUsageError",
     "format_dry_run_line",
     "parse_env_passthrough_mode",
+    "reject_flag_shaped_value",
+    "require_double_dash_separator",
     "validate_trailing_argv",
 ]

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -1,0 +1,81 @@
+"""Pure helpers for the ``aorta probe`` CLI.
+
+Kept out of :mod:`aorta.cli.probe` so the Click handler stays a thin shim
+(see FR 1.15 -- handler body is bounded at 60 lines so it can't silently
+grow business logic). Every function here is pure: no FS, no env mutation,
+no subprocess.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+VALID_ENV_PASSTHROUGH_MODES: tuple[Literal["inherit", "file"], ...] = ("inherit", "file")
+
+
+class ProbeUsageError(ValueError):
+    """User-input error that the CLI should surface as ``ClickException``.
+
+    Kept as a plain ``ValueError`` subclass (not a ``click.ClickException``)
+    so non-CLI callers -- tests, the recipe-builder, future programmatic
+    consumers -- don't need to depend on Click to catch it. The Click
+    handler bridges this into a ``ClickException`` at the CLI boundary.
+    """
+
+
+def parse_env_passthrough_mode(value: str) -> Literal["inherit", "file"]:
+    """Validate the ``--env-passthrough-mode`` value.
+
+    Both modes share the same in-process env-var application (the
+    dispatcher sets per-cell mitigation + diagnostic env vars on
+    ``os.environ`` before the workload's ``run()``); ``file`` mode
+    additionally drops a ``probe.env`` file in the trial dir and exports
+    ``AORTA_ENV_FILE`` to point at it. See ``docs/probe-188/usage.md``
+    §"Env-passthrough modes" for the F6 rationale.
+    """
+    if value not in VALID_ENV_PASSTHROUGH_MODES:
+        raise ProbeUsageError(
+            f"--env-passthrough-mode: must be one of "
+            f"{list(VALID_ENV_PASSTHROUGH_MODES)}, got {value!r}"
+        )
+    return value  # type: ignore[return-value]
+
+
+def validate_trailing_argv(argv: tuple[str, ...]) -> tuple[str, ...]:
+    """Reject an empty trailing-argv list.
+
+    ``aorta probe -- <argv>`` is the only legal channel for the user
+    command; ``aorta probe`` without a trailing ``--`` (or with ``--``
+    followed by nothing) is a usage error. The "no parsing" invariant
+    means we don't otherwise inspect ``argv`` -- it's forwarded
+    byte-for-byte to :class:`SubprocessWorkload`.
+    """
+    if not argv:
+        raise ProbeUsageError(
+            "no trailing argv supplied. Usage: aorta probe [options] -- <command> [args...]"
+        )
+    return argv
+
+
+def format_dry_run_line(
+    cell_name: str,
+    env: dict[str, str],
+    argv: tuple[str, ...],
+) -> str:
+    """Render one cell's dry-run line.
+
+    Stable key order (sorted) so snapshot-style tests are deterministic
+    across runs. Kept in the helper module so the dry-run formatter can
+    be unit-tested without invoking the CLI.
+    """
+    env_part = " ".join(f"{k}={v}" for k, v in sorted(env.items())) or "(no env)"
+    return f"  {cell_name}: env=[{env_part}] argv={list(argv)}"
+
+
+__all__ = [
+    "VALID_ENV_PASSTHROUGH_MODES",
+    "ProbeUsageError",
+    "format_dry_run_line",
+    "parse_env_passthrough_mode",
+    "validate_trailing_argv",
+]

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -65,9 +65,18 @@ class ProbeExtras:
         timeout_per_trial: Wall-clock cap per trial in seconds; None
             means no cap. Passed verbatim to ``SubprocessWorkload``.
         env_passthrough_mode: ``"inherit"`` (default) or ``"file"``.
-            Carried here so a recipe can pin the mode (the CLI flag
-            wins when present); ``aorta probe`` sets this from the
-            CLI flag unconditionally in Phase 1.
+            Carried here so a recipe can pin the mode. Precedence: the
+            CLI flag ``--env-passthrough-mode`` wins ONLY when the
+            user actually passes it; otherwise the recipe's
+            ``env_passthrough_mode:`` value (this field) is honored,
+            and if neither is set the recipe-builder default
+            ``"inherit"`` applies. The CLI handler in
+            ``aorta.cli.probe.probe`` distinguishes "user omitted the
+            flag" from "user passed the flag" by defaulting the
+            Click option to ``None`` and only overlaying when not
+            ``None``; see
+            ``tests/probe/test_cli_parsing.py::test_env_passthrough_mode_precedence_*``
+            for the pinned contract.
         mitigation_axis: The mitigation-axis names that produced the
             cells, preserved for audit + the dry-run formatter.
         diagnostic_axis: Same, for the diagnostic axis.

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 from aorta.registry import get_mitigation
 from aorta.registry.errors import UnknownMitigationError
 from aorta.triage.recipe import (
+    _VALID_CONFOUND_KEYS,
     SCHEMA_VERSION,
     Cell,
     ConfoundCfg,
@@ -236,6 +237,20 @@ def build_probe_recipe_from_dict(
         raise RecipeSchemaError(
             f"recipe.confound: must be a mapping, got {type(confound_raw).__name__}"
         )
+    if confound_raw is not None:
+        # Mirror the triage-mode loader's strict-schema contract
+        # (:func:`aorta.triage.recipe._parse_confound`): reject typo'd
+        # keys like ``baseline_cel`` up-front instead of silently
+        # ignoring them and using the auto-discovered baseline. Sharing
+        # ``_VALID_CONFOUND_KEYS`` with the triage parser means a new
+        # confound key added there is automatically rejected here too
+        # until probe explicitly opts in.
+        unknown = set(confound_raw) - _VALID_CONFOUND_KEYS
+        if unknown:
+            raise RecipeSchemaError(
+                f"recipe.confound: unknown keys {sorted(unknown)}; "
+                f"allowed: {sorted(_VALID_CONFOUND_KEYS)}"
+            )
 
     # Synthesise the cartesian product of the two axes. Cell-name
     # collisions (two distinct (m, d) pairs that slug-collapse to the

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -1,0 +1,364 @@
+"""Probe-mode recipe builder (issue #188 Phase 1).
+
+Parses a ``mode: probe`` recipe dict into a :class:`aorta.triage.recipe.Recipe`
+whose ``cells`` are the cartesian product of
+``mitigation_axis x diagnostic_axis``, with ``workload`` fixed to the
+reserved internal name ``_subprocess`` and ``probe_extras`` populated for
+the runner to honour layout / resume / env-passthrough semantics.
+
+This module is the SINGLE place that knows how a probe-mode recipe shape
+maps to the existing Recipe / Cell shape; the rest of the platform stays
+mode-agnostic (the runner just iterates ``recipe.cells``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from aorta.registry import get_mitigation
+from aorta.registry.errors import UnknownMitigationError
+from aorta.triage.recipe import (
+    SCHEMA_VERSION,
+    Cell,
+    ConfoundCfg,
+    Recipe,
+    RecipeCellError,
+    RecipeSchemaError,
+)
+
+# Fixed workload name for probe-mode cells. Leading underscore is
+# deliberate: it cannot collide with a user-facing workload (B1's
+# discovery doesn't reserve the prefix but no public workload uses
+# it) and it surfaces as "platform-internal" when ``aorta triage
+# list-workloads`` lands. Registered in pyproject.toml under
+# ``[project.entry-points."aorta.workloads"]``.
+SUBPROCESS_WORKLOAD_NAME = "_subprocess"
+
+# Default for ``timeout_per_trial`` when the recipe omits it. None means
+# no timeout -- the subprocess runs until exit. Wired through to
+# SubprocessWorkload via ProbeExtras; the dispatcher does not look at it.
+DEFAULT_TIMEOUT_PER_TRIAL: float | None = None
+
+
+@dataclass(frozen=True)
+class ProbeExtras:
+    """Probe-mode-only knobs attached to :class:`Recipe.probe_extras`.
+
+    Carried as a typed sidecar (rather than smuggled into
+    ``workload_config``) so the runner can read them without
+    re-parsing the YAML and so the triage code path stays untouched.
+    Phase 2 will extend this with classifier knobs (``hang_window_sec``,
+    ``hang_grace_period_at_start``, ``custom_patterns``); Phase 3 adds
+    the ``redaction`` block. Phase 1 ships just the four fields below.
+
+    Attributes:
+        step_time_regex: Optional regex string; Phase 1 keeps this on
+            the recipe for forward-compat only -- the Phase 2
+            classifier consumes it. Validated as compileable at load
+            time so a typo surfaces immediately.
+        collect_paths: List of glob patterns. Phase 1 always collects
+            ``stdout.log`` / ``stderr.log`` / ``result.json``; the
+            generic collector lands in Phase 2.
+        timeout_per_trial: Wall-clock cap per trial in seconds; None
+            means no cap. Passed verbatim to ``SubprocessWorkload``.
+        env_passthrough_mode: ``"inherit"`` (default) or ``"file"``.
+            Carried here so a recipe can pin the mode (the CLI flag
+            wins when present); ``aorta probe`` sets this from the
+            CLI flag unconditionally in Phase 1.
+        mitigation_axis: The mitigation-axis names that produced the
+            cells, preserved for audit + the dry-run formatter.
+        diagnostic_axis: Same, for the diagnostic axis.
+    """
+
+    step_time_regex: str | None = None
+    collect_paths: tuple[str, ...] = ()
+    timeout_per_trial: float | None = DEFAULT_TIMEOUT_PER_TRIAL
+    env_passthrough_mode: Literal["inherit", "file"] = "inherit"
+    mitigation_axis: tuple[str, ...] = ()
+    diagnostic_axis: tuple[str, ...] = ()
+    # Env vars the mitigation_axis + diagnostic_axis stamps resolve
+    # to, keyed by cell name. The dispatcher applies them via the
+    # existing ``mitigations=`` channel on RunRequest, so this field
+    # exists for the dry-run formatter and Phase 2 / 3 inspection
+    # only. ``dict`` rather than ``frozendict`` to keep the dataclass
+    # JSON-serialisable for matrix.json.
+    cell_envs: dict[str, dict[str, str]] = field(default_factory=dict)
+
+
+def _ensure_str_list(path_hint: str, raw: Any, *, allow_empty: bool = False) -> list[str]:
+    if not isinstance(raw, list) or not all(isinstance(x, str) for x in raw):
+        raise RecipeSchemaError(
+            f"{path_hint}: must be a list[str], got {type(raw).__name__} ({raw!r})"
+        )
+    if not raw and not allow_empty:
+        raise RecipeSchemaError(f"{path_hint}: must be a non-empty list")
+    return list(raw)
+
+
+def _validate_axis_names(
+    path_hint: str,
+    axis: list[str],
+    sidecar_files: tuple[Path, ...] | None,
+) -> None:
+    """Resolve every axis name through the mitigations registry.
+
+    Probe-mode treats both axes as mitigation names: ``none`` is the
+    no-op baseline, ``tf32_off`` flips ``DISABLE_TF32`` etc. Unknown
+    names bubble up as :class:`aorta.registry.errors.UnknownMitigationError`
+    at load time rather than mid-run.
+    """
+    extra = list(sidecar_files) if sidecar_files else None
+    for name in axis:
+        try:
+            get_mitigation(name, extra_files=extra)
+        except UnknownMitigationError as exc:
+            raise UnknownMitigationError(f"{path_hint}: {exc}") from exc
+
+
+def _safe_cell_segment(name: str) -> str:
+    """Slug an axis-value into a cell-name path segment.
+
+    Cell names ride through the existing ``_validate_cell_name`` regex
+    (``^[A-Za-z0-9_][A-Za-z0-9_.\\-]*$``) so the resulting
+    ``<mitigation>-<diagnostic>`` string can be used as a path
+    component without an extra slugging layer. Most B3 mitigation
+    names already conform; we light-weight scrub anything that
+    doesn't.
+    """
+    import re
+
+    cleaned = re.sub(r"[^A-Za-z0-9_.\-]", "_", name)
+    if not cleaned or cleaned[0] in {".", "-"}:
+        cleaned = "_" + cleaned
+    return cleaned
+
+
+def _validate_collect_paths(raw: Any) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list) or not all(isinstance(x, str) for x in raw):
+        raise RecipeSchemaError(
+            f"recipe.collect_paths: must be a list[str], got {type(raw).__name__}"
+        )
+    return tuple(raw)
+
+
+def _validate_step_time_regex(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise RecipeSchemaError(
+            f"recipe.step_time_regex: must be a string, got {type(raw).__name__}"
+        )
+    # Phase-1 hardening: compile-validate the regex at load time so a
+    # typo surfaces immediately rather than at first match (Phase 2's
+    # classifier is the actual consumer).
+    import re
+
+    try:
+        re.compile(raw)
+    except re.error as exc:
+        raise RecipeSchemaError(f"recipe.step_time_regex: invalid regex ({exc}): {raw!r}") from exc
+    return raw
+
+
+def _validate_timeout_per_trial(raw: Any) -> float | None:
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise RecipeSchemaError(
+            f"recipe.timeout_per_trial: must be a number or null, got {type(raw).__name__}"
+        )
+    if raw <= 0:
+        raise RecipeSchemaError(f"recipe.timeout_per_trial: must be > 0 when set, got {raw}")
+    return float(raw)
+
+
+def _validate_env_passthrough_mode(raw: Any) -> Literal["inherit", "file"]:
+    if raw is None:
+        return "inherit"
+    if raw not in ("inherit", "file"):
+        raise RecipeSchemaError(
+            f"recipe.env_passthrough_mode: must be 'inherit' or 'file', got {raw!r}"
+        )
+    return "file" if raw == "file" else "inherit"
+
+
+def build_probe_recipe_from_dict(
+    data: dict,
+    sidecar_files: tuple[Path, ...] | None,
+    source_path: Path | None = None,
+    source_sha256: str | None = None,
+) -> Recipe:
+    """Build a probe-mode :class:`Recipe` from a parsed YAML/JSON dict.
+
+    Called from :func:`aorta.triage.recipe._build_recipe` when
+    ``data["mode"] == "probe"``. The caller has already run
+    :func:`aorta.triage.recipe._validate_top_level`, so the dict is
+    known to be schema-valid at the outer layer (mode set, required
+    probe-mode keys present, no triage-mode-only keys, no Phase 2/3
+    keys).
+
+    Synthesises cells as ``<mitigation>-<diagnostic>`` and pre-computes
+    each cell's resolved env-var bundle on the returned
+    :class:`ProbeExtras` so the dry-run formatter doesn't need to call
+    back into the registry.
+    """
+    trials_raw = data["trials"]
+    if isinstance(trials_raw, bool) or not isinstance(trials_raw, int) or trials_raw < 1:
+        raise RecipeSchemaError(f"recipe.trials: must be a positive int, got {trials_raw!r}")
+
+    ticket = data.get("ticket")
+    if ticket is not None and not isinstance(ticket, str):
+        raise RecipeSchemaError(
+            f"recipe.ticket: must be a string or absent, got {type(ticket).__name__}"
+        )
+
+    mitigation_axis = _ensure_str_list("recipe.mitigation_axis", data["mitigation_axis"])
+    diagnostic_axis = _ensure_str_list("recipe.diagnostic_axis", data["diagnostic_axis"])
+
+    _validate_axis_names("recipe.mitigation_axis", mitigation_axis, sidecar_files)
+    _validate_axis_names("recipe.diagnostic_axis", diagnostic_axis, sidecar_files)
+
+    step_time_regex = _validate_step_time_regex(data.get("step_time_regex"))
+    collect_paths = _validate_collect_paths(data.get("collect_paths"))
+    timeout_per_trial = _validate_timeout_per_trial(data.get("timeout_per_trial"))
+    env_passthrough_mode = _validate_env_passthrough_mode(data.get("env_passthrough_mode"))
+
+    # confound block is permitted (already in _PROBE_TOP_LEVEL) but
+    # not meaningful for Tier-1-only Phase 1 -- pass it through with
+    # an explicit default so the runner's existing baseline-resolution
+    # code keeps working.
+    confound_raw = data.get("confound")
+    if confound_raw is not None and not isinstance(confound_raw, dict):
+        raise RecipeSchemaError(
+            f"recipe.confound: must be a mapping, got {type(confound_raw).__name__}"
+        )
+
+    # Synthesise the cartesian product of the two axes. Cell-name
+    # collisions (two distinct (m, d) pairs that slug-collapse to the
+    # same name) are rejected up-front so the per-trial directory
+    # layout never silently overwrites a sibling.
+    cells: list[Cell] = []
+    seen_cell_names: dict[str, tuple[str, str]] = {}
+    extra = list(sidecar_files) if sidecar_files else None
+    cell_envs: dict[str, dict[str, str]] = {}
+    for m in mitigation_axis:
+        m_env = get_mitigation(m, extra_files=extra)
+        for d in diagnostic_axis:
+            d_env = get_mitigation(d, extra_files=extra)
+            cell_name = f"{_safe_cell_segment(m)}-{_safe_cell_segment(d)}"
+            if cell_name in seen_cell_names:
+                prior = seen_cell_names[cell_name]
+                raise RecipeCellError(
+                    f"probe-mode cell synthesis: ({m!r}, {d!r}) and "
+                    f"({prior[0]!r}, {prior[1]!r}) both slug to {cell_name!r}; "
+                    "rename one of the axis values"
+                )
+            seen_cell_names[cell_name] = (m, d)
+
+            # Resolved env bundle for the cell, for the dry-run formatter
+            # and matrix.json audit. The dispatcher computes the same
+            # bundle internally from ``mitigations=(m, d)``; we capture
+            # it here so the cell-collision check on overlapping keys
+            # surfaces at recipe-load time rather than mid-run.
+            merged_env: dict[str, str] = {}
+            for key, val in m_env.items():
+                merged_env[key] = val
+            for key, val in d_env.items():
+                prior_val = merged_env.get(key)
+                if prior_val is not None and prior_val != val:
+                    raise RecipeCellError(
+                        f"probe-mode cell {cell_name!r}: mitigation axis "
+                        f"{m!r} sets {key}={prior_val!r}, diagnostic axis "
+                        f"{d!r} sets {key}={val!r}. Pick a non-overlapping "
+                        "pair or split the conflicting axis."
+                    )
+                merged_env[key] = val
+            cell_envs[cell_name] = merged_env
+
+            # Construct the Cell. ``mitigations`` carries BOTH axes so
+            # the dispatcher unions them itself (the same code path B2
+            # already exercises for stacked-mitigation cells); we don't
+            # smuggle the merged env via ``extra_env`` because that
+            # would lose the per-axis provenance the matrix wants.
+            cells.append(
+                Cell(
+                    name=cell_name,
+                    mitigations=(m, d),
+                    environment="local",
+                )
+            )
+
+    # Probe-mode bypasses the speed-confound classifier (Phase 1 is
+    # Tier-1 only), but ``run_recipe`` unconditionally resolves a
+    # baseline cell -- so we set one here so the existing resolver
+    # (which expects either an explicit name, a ``baseline-*`` cell, or
+    # a ``mitigations == ['none']`` cell) doesn't trip on probe-mode
+    # cell names like ``none-none`` / ``tf32_off-none`` whose
+    # mitigation tuples have length 2. Prefer a cell whose both axes
+    # are ``none`` (the canonical no-op baseline); fall back to the
+    # first cell so a recipe without a none-none pair still resolves.
+    none_none_name: str | None = None
+    for cell in cells:
+        if all(m == "none" for m in cell.mitigations):
+            none_none_name = cell.name
+            break
+    default_baseline = none_none_name if none_none_name is not None else cells[0].name
+
+    confound = ConfoundCfg(baseline_cell=default_baseline)
+    if confound_raw is not None:
+        # Honor an explicit threshold if the operator set one (cheap
+        # forward-compat for Phase 2 step-time-regex aggregation).
+        threshold = confound_raw.get("threshold", confound.threshold)
+        if isinstance(threshold, bool) or not isinstance(threshold, (int, float)) or threshold <= 0:
+            raise RecipeSchemaError(f"recipe.confound.threshold: must be > 0, got {threshold!r}")
+        explicit_baseline = confound_raw.get("baseline_cell", default_baseline)
+        if explicit_baseline is not None and not isinstance(explicit_baseline, str):
+            raise RecipeSchemaError(
+                f"recipe.confound.baseline_cell: must be a string, got "
+                f"{type(explicit_baseline).__name__}"
+            )
+        confound = ConfoundCfg(threshold=float(threshold), baseline_cell=explicit_baseline)
+
+    probe_extras = ProbeExtras(
+        step_time_regex=step_time_regex,
+        collect_paths=collect_paths,
+        timeout_per_trial=timeout_per_trial,
+        env_passthrough_mode=env_passthrough_mode,
+        mitigation_axis=tuple(mitigation_axis),
+        diagnostic_axis=tuple(diagnostic_axis),
+        cell_envs=cell_envs,
+    )
+
+    return Recipe(
+        schema_version=SCHEMA_VERSION,
+        workload=SUBPROCESS_WORKLOAD_NAME,
+        trials=trials_raw,
+        # ``steps`` is required by the triage-mode dataclass; probe
+        # mode doesn't use it (subprocess workloads don't iterate),
+        # so we pass 1 as a non-meaningful placeholder. The runner
+        # threads it through but ``SubprocessWorkload.run()`` ignores
+        # the value.
+        steps=1,
+        cells=tuple(cells),
+        ticket=ticket,
+        confound=confound,
+        inline_environments=(),
+        sidecar_files=tuple(sidecar_files) if sidecar_files else (),
+        source_path=source_path,
+        source_sha256=source_sha256,
+        workload_config={},
+        save_logs=False,
+        probe_extras=probe_extras,
+    )
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT_PER_TRIAL",
+    "SUBPROCESS_WORKLOAD_NAME",
+    "ProbeExtras",
+    "build_probe_recipe_from_dict",
+]

--- a/src/aorta/probe/resume.py
+++ b/src/aorta/probe/resume.py
@@ -1,0 +1,56 @@
+"""Resume helper for ``aorta probe`` (issue #188 Phase 1).
+
+A trial is considered "complete" iff its ``trial_<n>/result.json`` exists,
+parses as JSON, and carries a non-empty ``verdict`` field. Anything else --
+missing file, empty file, syntactically invalid JSON, JSON without
+``verdict``, or ``verdict == ""`` -- is treated as incomplete so the runner
+re-executes the trial.
+
+This module is deliberately tiny and pure (no FS writes, no env mutation)
+so the runner can call it per trial without performance concern. The
+contract is fixed by FR 1.4 in ``docs/plans/aorta-probe-188-rubric.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def is_trial_complete(trial_dir: Path) -> bool:
+    """Return True iff the trial directory carries a valid completion marker.
+
+    A trial completes when ``trial_dir/result.json`` exists, parses as
+    JSON, and contains a non-empty ``verdict`` field. Partial or
+    truncated writes (zero-byte file, half a ``{``, missing
+    ``verdict``, blank ``verdict``) are treated as incomplete so the
+    runner re-executes the trial -- the rubric's "completed -> skip,
+    truncated -> re-run" contract.
+
+    Any unexpected error (PermissionError, UnicodeDecodeError, etc.)
+    is treated as "incomplete" rather than re-raised: the failure
+    surfaces when the re-execution itself fails, but the resume helper
+    never crashes the whole probe run.
+    """
+    result_path = trial_dir / "result.json"
+    if not result_path.is_file():
+        return False
+    try:
+        text = result_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if not text.strip():
+        return False
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    verdict = parsed.get("verdict")
+    if not isinstance(verdict, str) or not verdict:
+        return False
+    return True
+
+
+__all__ = ["is_trial_complete"]

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -153,6 +153,29 @@ class RunRequest:
             different capture mechanism -- this mirrors the same
             single-caller assumption the env-restore block on this
             function relies on.
+        subprocess_argv: Opaque ``argv`` forwarded byte-for-byte to a
+            subprocess-shaped workload. The dispatcher injects this
+            tuple into the workload config as the reserved
+            ``_aorta_subprocess_argv`` key after ``config_overrides``
+            is merged, so user-supplied ``config_overrides`` cannot
+            collide (the reserved-prefix rejection at the top of
+            ``run_trials`` enforces this). Only consumed today by
+            :class:`aorta.workloads._subprocess.SubprocessWorkload`,
+            which ``aorta probe`` wires up; other workloads ignore
+            the key. ``None`` (the default) leaves the key unset so
+            existing single-process workloads round-trip exactly as
+            before. Carrying ``argv`` here -- rather than letting it
+            leak into ``config_overrides`` -- preserves the "no
+            user-supplied ``_aorta_*`` keys" invariant and makes the
+            data-flow visible in the dataclass surface.
+        probe_extras: Opaque probe-mode metadata bundle injected into
+            the workload config as the reserved ``_aorta_probe_extras``
+            key, post-``config_overrides`` merge. Consumed only by
+            :class:`aorta.workloads._subprocess.SubprocessWorkload`
+            (Phase 1) to know its cell name, the requested
+            ``env_passthrough_mode``, the per-trial timeout, and the
+            resolved cell env-var bundle. ``None`` (default) leaves
+            the key unset so non-probe workloads see no change.
     """
 
     workload: str
@@ -223,6 +246,8 @@ class RunRequest:
     dataset_index: int = 0
     mitigation_index: int = 0
     save_logs: bool = False
+    subprocess_argv: tuple[str, ...] | None = None
+    probe_extras: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         # Defensively deep-copy mutable dict fields.  ``frozen=True``
@@ -230,6 +255,13 @@ class RunRequest:
         # ``object.__setattr__`` to install the copies.
         for field_name in ("extra_env", "config_overrides"):
             object.__setattr__(self, field_name, copy.deepcopy(getattr(self, field_name)))
+        # ``probe_extras`` is the same pattern as the two dict fields
+        # above -- frozen blocks attribute reassignment but does not
+        # stop the caller from mutating the nested dict. Deep-copy on
+        # construction so an in-flight request can never be mutated
+        # out from under the dispatcher. ``None`` short-circuits.
+        if self.probe_extras is not None:
+            object.__setattr__(self, "probe_extras", copy.deepcopy(self.probe_extras))
 
 
 def run_trials(request: RunRequest) -> list[TrialResult]:
@@ -476,6 +508,31 @@ def _run_single_trial(
     # in ``config_overrides`` so this assignment can't silently clobber
     # a caller-supplied value.
     config["_aorta_environment"] = asdict(env_descriptor)
+
+    # Subprocess-shaped workloads (currently SubprocessWorkload, wired
+    # by ``aorta probe``) receive their opaque user argv via a typed
+    # ``RunRequest.subprocess_argv`` field rather than via
+    # ``config_overrides`` -- the ``_aorta_*`` prefix is reserved and
+    # the dispatcher rejects user-supplied keys carrying it.  Inject
+    # AFTER the ``config_overrides`` spread so the same reserved-key
+    # rejection at the top of ``run_trials`` continues to guard the
+    # slot from accidental smuggling, then convert to a list so the
+    # JSON-serialised ``TrialResult.config`` is round-trippable
+    # (tuples are not JSON types).  When ``subprocess_argv`` is None
+    # (every existing caller pre-#188), the key stays absent and
+    # ``SubprocessWorkload.setup()`` raises a clear error if it ends
+    # up running without one.
+    if request.subprocess_argv is not None:
+        config["_aorta_subprocess_argv"] = list(request.subprocess_argv)
+
+    # ``probe_extras`` follows the same pattern: a typed RunRequest
+    # field is the only legal channel; the dispatcher copies it into
+    # the reserved ``_aorta_probe_extras`` slot post-merge.
+    # ``SubprocessWorkload`` reads cell name / env-passthrough mode /
+    # timeout / cell-env-bundle from this dict; non-probe workloads
+    # ignore it.
+    if request.probe_extras is not None:
+        config["_aorta_probe_extras"] = dict(request.probe_extras)
 
     # Snapshot the env BEFORE applying mitigation / extra_env so the
     # ``finally`` block can restore both the dispatcher's overlay and

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -119,6 +119,17 @@ def resolve_run_dir(
       this branch but kept on the signature so callers don't need to
       know which layout they're invoking.
     """
+    # ``layout`` is a typed Literal but the type guard only fires under
+    # mypy --strict; a caller passing ``layout="flatresume"`` (typo)
+    # would otherwise silently land in the timestamped branch. Reject
+    # unknown values at runtime so probe-mode callers can't
+    # accidentally get the wrong output tree.
+    if layout not in ("timestamped", "flat_resume"):
+        raise ValueError(
+            f"resolve_run_dir: layout must be 'timestamped' or 'flat_resume', "
+            f"got {layout!r}"
+        )
+
     ticket_slug = safe_slug(recipe.ticket) if recipe.ticket else NO_TICKET_SLUG
 
     if layout == "flat_resume":

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -37,7 +37,7 @@ import re
 from collections.abc import Iterable
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 
@@ -86,22 +86,53 @@ def resolve_run_dir(
     output_dir: Path,
     recipe: Recipe,
     timestamp: str | None = None,
+    layout: Literal["timestamped", "flat_resume"] = "timestamped",
 ) -> Path:
-    """Return ``<output-dir>/<ticket>/<workload>/<timestamp>[-N]/``.
+    """Return the per-run output directory for the given layout.
 
-    Creates parents as needed. **Never overwrites an existing directory.**
-    The base candidate is ``<timestamp>``; if that already exists (two runs
-    in the same wall-clock second for the same ``(ticket, workload)`` --
-    common in CI loops or concurrent jobs), a numeric suffix ``-2``, ``-3``,
-    ... is appended until ``mkdir(exist_ok=False)`` succeeds. The race
-    between two parallel processes is resolved by ``mkdir`` itself: only one
-    can win for a given suffix, the loser bumps and retries.
+    Two layouts are supported:
 
-    The base directory ``<output_dir>/<ticket>/<workload>/`` IS created with
-    ``exist_ok=True`` -- it's a shared parent across runs and the
-    "no-overwrite" guarantee only applies to the per-run leaf.
+    * ``"timestamped"`` (default) -- preserves ``aorta triage run``
+      behaviour byte-equivalently. Returns
+      ``<output-dir>/<ticket>/<workload>/<timestamp>[-N]/``. Creates
+      parents as needed and **never overwrites an existing directory**:
+      the base candidate is ``<timestamp>``; if that already exists
+      (two runs in the same wall-clock second for the same
+      ``(ticket, workload)`` -- common in CI loops or concurrent
+      jobs), a numeric suffix ``-2``, ``-3``, ... is appended until
+      ``mkdir(exist_ok=False)`` succeeds. The race between two
+      parallel processes is resolved by ``mkdir`` itself: only one
+      can win for a given suffix, the loser bumps and retries. The
+      base directory ``<output_dir>/<ticket>/<workload>/`` IS created
+      with ``exist_ok=True`` -- it's a shared parent across runs and
+      the "no-overwrite" guarantee only applies to the per-run leaf.
+
+    * ``"flat_resume"`` -- the layout ``aorta probe`` (issue #188)
+      passes. Returns ``<output-dir>/<safe_slug(ticket)>/`` (or
+      ``<output-dir>/_no_ticket_/`` when ``ticket`` is ``None``) with
+      ``mkdir(parents=True, exist_ok=True)``. NO timestamp segment, NO
+      ``<workload>`` segment -- those would defeat the resume model
+      (re-running the same probe with the same ``--output`` and
+      ``--ticket`` must land in the same directory so per-cell
+      ``trial_<n>/result.json`` files can be detected as
+      "already complete"). The ``timestamp`` argument is ignored in
+      this branch but kept on the signature so callers don't need to
+      know which layout they're invoking.
     """
     ticket_slug = safe_slug(recipe.ticket) if recipe.ticket else NO_TICKET_SLUG
+
+    if layout == "flat_resume":
+        # Idempotent: the same (output_dir, ticket) tuple always yields
+        # the same leaf so re-runs can detect already-complete trials
+        # via ``aorta.probe.resume.is_trial_complete``. No timestamp
+        # segment because that would force a fresh leaf on every
+        # invocation -- which is exactly what ``aorta triage run``'s
+        # "timestamped" layout does and exactly what probe-mode is
+        # explicitly opting out of.
+        run_dir = Path(output_dir) / ticket_slug
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return run_dir
+
     workload_slug = safe_slug(recipe.workload)
     ts = timestamp or format_timestamp()
     parent = Path(output_dir) / ticket_slug / workload_slug

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -31,10 +31,15 @@ Sibling files / directories (written by :mod:`aorta.triage.runner`):
 
 from __future__ import annotations
 
+import contextlib
 import datetime as _dt
+import errno
 import json
+import logging
+import os
 import re
-from collections.abc import Iterable
+import socket
+from collections.abc import Iterable, Iterator
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Literal
@@ -46,7 +51,14 @@ from aorta.triage.confound import CONFOUND_DID_NOT_RUN, ConfoundTag
 from aorta.triage.matrix import CellStats
 from aorta.triage.recipe import Recipe
 
+log = logging.getLogger(__name__)
+
 NO_TICKET_SLUG = "_no_ticket_"
+
+# ``flat_resume`` lockfile name. Lives at ``<run_dir>/.aorta-probe.lock``; the
+# leading dot keeps it out of casual ``ls`` output and matches the convention
+# used by other resume-state files in the run dir.
+FLAT_RESUME_LOCKFILE = ".aorta-probe.lock"
 
 # Filesystem-safe slug: replace anything that isn't [A-Za-z0-9_.-] with '_'.
 # Ticket IDs like "PROJ-123" pass through unchanged; spaces, slashes, ':'
@@ -164,6 +176,211 @@ def resolve_run_dir(
         f"resolve_run_dir: exhausted 10000 suffixes for {parent / ts!r}; "
         "something is wedged upstream (clock not advancing? runaway loop?)"
     )
+
+
+class RunDirLockedError(RuntimeError):
+    """Raised when a ``flat_resume`` run dir is already locked by another writer.
+
+    Carries the parsed lock-holder identity so the CLI layer can render a
+    targeted operator message (host, PID, start time) rather than a generic
+    "something is wrong" stack trace.
+    """
+
+    def __init__(
+        self,
+        run_dir: Path,
+        holder_host: str,
+        holder_pid: int | None,
+        holder_started_at: str | None,
+        reason: str,
+    ) -> None:
+        self.run_dir = run_dir
+        self.holder_host = holder_host
+        self.holder_pid = holder_pid
+        self.holder_started_at = holder_started_at
+        self.reason = reason
+        super().__init__(
+            f"flat_resume run dir {run_dir} is locked: {reason} "
+            f"(holder host={holder_host!r} pid={holder_pid} "
+            f"started_at={holder_started_at!r}). If the holder is no longer "
+            f"running, remove {run_dir / FLAT_RESUME_LOCKFILE} and retry."
+        )
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort liveness probe for a same-host PID.
+
+    ``os.kill(pid, 0)`` is the standard Unix idiom: it doesn't actually
+    signal the process, just performs the permission/existence check. We
+    treat ``EPERM`` (process exists but is owned by another user) as alive
+    too -- that's still a live process that could be mid-write.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we can't signal it (different uid).
+        return True
+    except OSError:
+        # Defensive: any other errno -> assume alive to avoid stomping.
+        return True
+    return True
+
+
+@contextlib.contextmanager
+def acquire_flat_resume_lock(run_dir: Path) -> Iterator[None]:
+    """Advisory PID+host lockfile for the ``flat_resume`` run directory.
+
+    ``flat_resume`` reuses a stable ``<output>/<ticket>/`` leaf across
+    invocations (intentional, so per-trial ``result.json`` files can be
+    detected as already-complete). That same property means two concurrent
+    ``aorta probe`` invocations against the same ``--output`` /
+    ``--ticket`` would race on ``matrix.json``, ``matrix.md``, and per-cell
+    artifacts.
+
+    On entry we ``O_CREAT|O_EXCL`` a small JSON file holding our PID, host,
+    and start timestamp. If the file already exists we read it and decide:
+
+    * Same host **and** ``os.kill(pid, 0)`` succeeds -> raise
+      :class:`RunDirLockedError`. The other writer is genuinely live;
+      stomping their tree would corrupt both runs.
+    * Same host **and** PID is dead -> stale lock from a crashed prior
+      run. Log a warning, overwrite, and proceed (this is the recovery
+      path -- it's the whole reason ``flat_resume`` exists).
+    * Different host -> we have no way to verify liveness across hosts.
+      Fail closed: raise :class:`RunDirLockedError` and ask the operator
+      to remove the lockfile explicitly. (Shared NFS with concurrent
+      multi-host writers is the worst case; rather than guess we surface
+      the situation.)
+    * Lockfile present but unparseable -> treat as stale (a partial write
+      from a crashed prior run); warn + overwrite. The alternative is to
+      wedge resume indefinitely on a corrupt lock file.
+
+    On context exit the lockfile is best-effort removed; failure to
+    remove (e.g. the run dir was deleted under us) does not raise so the
+    caller's own exit path isn't masked.
+
+    Limitations (deliberately documented rather than papered over):
+
+    * Advisory only -- a non-aorta writer (or an aorta version predating
+      this lock) into the same tree is undetected.
+    * Same-host liveness is checked via PID; PID reuse on busy hosts
+      with very long-running operator sessions is theoretically possible
+      but unlikely within a probe sweep's lifetime.
+    * Cross-host NFS semantics for ``O_EXCL`` are
+      filesystem-implementation-dependent. We don't rely on the
+      atomicity of the cross-host case; the same-host PID check is the
+      load-bearing guarantee. Operators running concurrent multi-host
+      probes against the same tree should not (Phase-1 scope).
+    """
+    lock_path = run_dir / FLAT_RESUME_LOCKFILE
+    payload = {
+        "pid": os.getpid(),
+        "host": socket.gethostname(),
+        "started_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+    serialised = json.dumps(payload, indent=2).encode("utf-8")
+
+    while True:
+        try:
+            fd = os.open(
+                str(lock_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError:
+            # Existing lock: inspect the holder and decide stale-vs-live.
+            holder_host: str = "<unknown>"
+            holder_pid: int | None = None
+            holder_started_at: str | None = None
+            try:
+                holder_raw = lock_path.read_text(encoding="utf-8")
+                holder = json.loads(holder_raw)
+                holder_host = str(holder.get("host", "<unknown>"))
+                pid_raw = holder.get("pid")
+                holder_pid = int(pid_raw) if pid_raw is not None else None
+                started_raw = holder.get("started_at")
+                holder_started_at = str(started_raw) if started_raw is not None else None
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                # Corrupt or unreadable lock: treat as stale.
+                log.warning(
+                    "flat_resume lock at %s is unreadable (%s); "
+                    "treating as stale and taking over",
+                    lock_path,
+                    exc,
+                )
+                try:
+                    lock_path.unlink()
+                except OSError:
+                    pass
+                continue
+
+            our_host = socket.gethostname()
+            if holder_host == our_host:
+                if holder_pid is not None and _pid_alive(holder_pid):
+                    # ``raise ... from None``: the originating
+                    # ``FileExistsError`` from ``os.open`` is an expected
+                    # signal, not an error; chaining it would mislead the
+                    # operator into thinking something failed at the FS
+                    # layer when the real cause is "another process owns
+                    # this dir".
+                    raise RunDirLockedError(
+                        run_dir=run_dir,
+                        holder_host=holder_host,
+                        holder_pid=holder_pid,
+                        holder_started_at=holder_started_at,
+                        reason="another aorta probe process on this host "
+                        "is still running",
+                    ) from None
+                log.warning(
+                    "flat_resume lock at %s is stale (holder pid=%s on this "
+                    "host is no longer running, started_at=%s); taking over",
+                    lock_path,
+                    holder_pid,
+                    holder_started_at,
+                )
+                try:
+                    lock_path.unlink()
+                except OSError:
+                    pass
+                continue
+
+            # See the same-host live branch above for the ``from None``
+            # rationale.
+            raise RunDirLockedError(
+                run_dir=run_dir,
+                holder_host=holder_host,
+                holder_pid=holder_pid,
+                holder_started_at=holder_started_at,
+                reason=(
+                    "lock was created on a different host; cross-host "
+                    "liveness cannot be verified automatically"
+                ),
+            ) from None
+        except OSError as exc:
+            # Anything other than EEXIST (which FileExistsError covers)
+            # is a genuine open() failure -- don't pretend we hold the
+            # lock.
+            raise RuntimeError(
+                f"acquire_flat_resume_lock: could not create {lock_path} "
+                f"(errno={errno.errorcode.get(exc.errno, exc.errno)}): {exc}"
+            ) from exc
+        else:
+            break
+
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(serialised)
+        yield
+    finally:
+        try:
+            lock_path.unlink()
+        except OSError:
+            # Best-effort: the dir may have been removed under us, or a
+            # concurrent process raced us to cleanup. Either way, not
+            # crashing here keeps the caller's exit path intact.
+            pass
 
 
 def _format_mitigations(mitigations: Iterable[str]) -> str:

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -36,7 +36,13 @@ from aorta.registry import (
 
 SCHEMA_VERSION = 1
 
-_VALID_TOP_LEVEL = frozenset(
+# Top-level keys accepted by the recipe loader regardless of ``mode``.
+# Two banks: triage-mode keys (the historical set, also accepted in
+# probe-mode as a strict subset where they overlap) and probe-mode keys
+# (issue #188) which are ONLY accepted when ``mode == "probe"``. The
+# loader uses the union for unknown-key rejection and re-checks the
+# subset per mode below.
+_TRIAGE_TOP_LEVEL = frozenset(
     {
         "schema_version",
         "ticket",
@@ -49,6 +55,34 @@ _VALID_TOP_LEVEL = frozenset(
         "save_logs",
     }
 )
+_PROBE_TOP_LEVEL = frozenset(
+    {
+        "schema_version",
+        "ticket",
+        "mode",
+        "trials",
+        "mitigation_axis",
+        "diagnostic_axis",
+        "step_time_regex",
+        "collect_paths",
+        "timeout_per_trial",
+        "env_passthrough_mode",
+        "confound",
+    }
+)
+# Phase 2/3 keys -- intercepted at load time BEFORE the unknown-keys
+# rejection so the operator sees a clear "deferred to Phase 2/3"
+# pointer (see FR 1.19) instead of a generic "unknown key" message.
+# Without the explicit interception a Phase 1 recipe that copy-pasted
+# a future-tense ``custom_patterns:`` block from the design doc would
+# silently fall into the generic-unknown path and the operator would
+# have no signal that the key WILL be valid once Phase 2 ships.
+_PHASE_2_KEYS = frozenset({"custom_patterns", "condition"})
+_PHASE_3_KEYS = frozenset({"redaction"})
+# Union of valid keys -- used for the unknown-key rejection. Phase 2/3
+# keys are NOT in this set; they take a special-cased path so the
+# error message identifies the phase, not just "you misspelled it".
+_VALID_TOP_LEVEL = _TRIAGE_TOP_LEVEL | _PROBE_TOP_LEVEL | {"mode"}
 _VALID_CONFOUND_KEYS = frozenset({"threshold", "baseline_cell"})
 _VALID_CELL_KEYS = frozenset(
     {"name", "mitigations", "environment", "extra_env", "trials", "steps", "workload_config"}
@@ -232,6 +266,13 @@ class Recipe:
     source_sha256: str | None = None
     workload_config: dict[str, Any] = field(default_factory=dict)
     save_logs: bool = False
+    # Probe-mode (issue #188) extras attached to the recipe so the
+    # runner can branch on layout / resume / env-passthrough without
+    # re-parsing the YAML. ``None`` for every triage-mode recipe;
+    # populated only by :func:`aorta.probe.recipe_builder.build_probe_recipe_from_dict`.
+    # Typed as ``Any`` to keep this module's import graph cycle-free --
+    # the actual dataclass is :class:`aorta.probe.recipe_builder.ProbeExtras`.
+    probe_extras: Any | None = None
 
 
 def inline_env_name(docker_ref: str) -> str:
@@ -440,17 +481,89 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
     )
 
 
+def _reject_phase_2_3_keys(data: dict) -> None:
+    """Intercept Phase 2/3 keys with a "deferred to phase N" pointer.
+
+    Phase 1 (issue #188) intentionally ships only Tier 1 exit-code
+    verdicts; ``custom_patterns`` and ``condition`` need the sandbox
+    (Phase 2) and ``redaction`` needs the bundle integration (Phase 3).
+    Without this interception, a copy-pasted-from-the-design-doc
+    recipe carrying any of those keys would silently fall into the
+    generic "unknown top-level key" path and the operator would have
+    no signal that the key WILL be valid once the later phases ship.
+    """
+    phase2 = set(data) & _PHASE_2_KEYS
+    if phase2:
+        raise RecipeSchemaError(
+            f"recipe: keys {sorted(phase2)} are deferred to Phase 2 "
+            "(built-in classifier + sandboxed custom_patterns); see "
+            "docs/plans/aorta-probe-188-rubric.md §PHASE 2. Remove these "
+            "keys from your Phase 1 probe recipe."
+        )
+    phase3 = set(data) & _PHASE_3_KEYS
+    if phase3:
+        raise RecipeSchemaError(
+            f"recipe: keys {sorted(phase3)} are deferred to Phase 3 "
+            "(bundle integration + redaction + handout templates); see "
+            "docs/plans/aorta-probe-188-rubric.md §PHASE 3. Remove these "
+            "keys from your Phase 1 probe recipe."
+        )
+
+
 def _validate_top_level(data: Any) -> None:
     if not isinstance(data, dict):
         raise RecipeSchemaError(f"recipe top-level must be a mapping, got {type(data).__name__}")
-    for required in ("schema_version", "workload", "trials", "steps", "cells"):
-        if required not in data:
-            raise RecipeSchemaError(f"recipe: missing required key '{required}'")
+
+    # Phase 2/3 keys are intercepted BEFORE either the unknown-key or
+    # the per-mode required-key checks. A recipe with both a Phase 2
+    # key AND a typo'd top-level key should surface the Phase 2 error
+    # first because that's the one the operator can act on without
+    # changing their intent.
+    _reject_phase_2_3_keys(data)
+
+    mode = data.get("mode", "triage")
+    if mode not in ("triage", "probe"):
+        raise RecipeSchemaError(
+            f"recipe.mode: must be 'triage' or 'probe', got {mode!r}"
+        )
+
     unknown = set(data) - _VALID_TOP_LEVEL
     if unknown:
         raise RecipeSchemaError(
             f"recipe: unknown top-level keys {sorted(unknown)}; allowed: {sorted(_VALID_TOP_LEVEL)}"
         )
+
+    # Per-mode bank check: each mode has its own subset of valid keys.
+    # Probe-mode keys (mitigation_axis, diagnostic_axis, step_time_regex,
+    # collect_paths, timeout_per_trial, env_passthrough_mode) only make
+    # sense when ``mode == 'probe'`` -- in triage mode they would be
+    # silently ignored, which is exactly the silent-no-op footgun the
+    # strict-unknown-key policy is supposed to forbid.
+    if mode == "triage":
+        misplaced = set(data) & (_PROBE_TOP_LEVEL - _TRIAGE_TOP_LEVEL - {"mode"})
+        if misplaced:
+            raise RecipeSchemaError(
+                f"recipe: keys {sorted(misplaced)} are probe-mode only; "
+                "set 'mode: probe' at the recipe top level or remove these keys"
+            )
+        for required in ("schema_version", "workload", "trials", "steps", "cells"):
+            if required not in data:
+                raise RecipeSchemaError(f"recipe: missing required key '{required}'")
+    else:  # mode == "probe"
+        misplaced = set(data) & (_TRIAGE_TOP_LEVEL - _PROBE_TOP_LEVEL - {"mode"})
+        if misplaced:
+            raise RecipeSchemaError(
+                f"recipe: keys {sorted(misplaced)} are triage-mode only and "
+                "are not valid in a 'mode: probe' recipe (probe-mode synthesises "
+                "cells from mitigation_axis x diagnostic_axis and fixes the "
+                "workload internally). Remove these keys."
+            )
+        for required in ("schema_version", "trials", "mitigation_axis", "diagnostic_axis"):
+            if required not in data:
+                raise RecipeSchemaError(
+                    f"recipe (mode: probe): missing required key '{required}'"
+                )
+
     version = data["schema_version"]
     if not isinstance(version, int) or isinstance(version, bool):
         raise RecipeSchemaError(
@@ -631,6 +744,21 @@ def _build_recipe(
     source_sha256: str | None,
 ) -> Recipe:
     _validate_top_level(data)
+
+    # Probe-mode recipes go through a separate builder so the
+    # triage-mode path here stays byte-equivalent to today's loader.
+    # The import is local because aorta.probe.recipe_builder imports
+    # back into aorta.triage.recipe for Recipe / Cell / ConfoundCfg --
+    # a top-level import would be a cycle.
+    if data.get("mode", "triage") == "probe":
+        from aorta.probe.recipe_builder import build_probe_recipe_from_dict
+
+        return build_probe_recipe_from_dict(
+            data,
+            sidecar_files=sidecar_files,
+            source_path=source_path,
+            source_sha256=source_sha256,
+        )
 
     workload = data["workload"]
     _ensure_type("recipe", workload, str, "workload")

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -365,6 +365,27 @@ def _collect_trial_paths(results_dir: Path) -> list[str]:
     return [str(p) for p in found]
 
 
+def _extract_trial_indices(trial_paths: list[str]) -> set[int]:
+    """Return the integer trial indices encoded in dispatcher / legacy filenames.
+
+    Mirrors the regex pair from :func:`_collect_trial_paths` so the
+    resume short-circuit can verify the on-disk index set matches the
+    current recipe's ``range(effective_trials)`` (catches the
+    ``_t0 missing, _t2 stale`` edge case where the count check alone
+    would pass with the wrong indices). Files whose stems don't parse
+    are silently ignored -- they're already shoved to the end of the
+    sorted list by ``_collect_trial_paths`` and never carry an index
+    that could overlap with a real trial.
+    """
+    indices: set[int] = set()
+    for raw in trial_paths:
+        stem = Path(raw).stem
+        m = _DISPATCHER_TRIAL_RE.match(stem) or _LEGACY_TRIAL_RE.match(stem)
+        if m is not None:
+            indices.add(int(m.group(1)))
+    return indices
+
+
 def _hydrate_trials_from_paths(trial_paths: list[str]) -> list[TrialResult]:
     """Load dispatcher-written ``trial_*.json`` files into TrialResult objects.
 
@@ -643,20 +664,36 @@ def _run_one_cell(
         if completed >= effective_trials:
             trial_paths = _collect_trial_paths(cell_dir)
             hydrated = _hydrate_trials_from_paths(trial_paths)
-            if len(hydrated) >= effective_trials:
+            # Validate the EXACT trial-index set, not just the count. A
+            # `len(hydrated) >= effective_trials` check alone admits the
+            # pathological case where a prior run wrote dispatcher
+            # JSONs ``_t1, _t2`` (e.g. ``_t0`` was hand-deleted or
+            # corrupted) while ``trial_0/result.json`` is intact: the
+            # probe per-trial dirs and the dispatcher JSONs are TWO
+            # different artifact streams that ``is_trial_complete``
+            # and ``_collect_trial_paths`` walk separately. If the
+            # index set isn't exactly ``{0..effective_trials-1}``, the
+            # hydrated bodies carry the wrong ``trial_index`` for the
+            # current recipe and the matrix would aggregate the wrong
+            # set. Fall back to a full re-run -- correctness wins over
+            # the resume-skip optimisation in this edge case.
+            required_indices = set(range(effective_trials))
+            collected_indices = _extract_trial_indices(trial_paths)
+            indices_match = required_indices.issubset(collected_indices)
+            if len(hydrated) >= effective_trials and indices_match:
                 # Slice to the CURRENT recipe's effective_trials. A user
                 # who re-runs with ``trials: 1`` after a previous
                 # ``trials: 3`` left a directory with three completed
                 # trial dirs on disk; without the slice, matrix.md
                 # would aggregate the stale extra trials instead of
-                # the requested one. Truncating both ``hydrated`` and
-                # ``trial_paths`` to ``effective_trials`` keeps the
-                # resume short-circuit's output consistent with what
-                # a fresh run would have produced. (Stale on-disk
-                # trial_<n>/ directories with n >= effective_trials
-                # are left in place so manual inspection of the prior
-                # run is still possible; downstream aggregation only
-                # sees the indices it asked for.)
+                # the requested one. ``_collect_trial_paths`` already
+                # sorts by trial index, so the first ``effective_trials``
+                # entries are exactly the indices we just validated.
+                # Stale on-disk ``trial_<n>/`` directories with
+                # ``n >= effective_trials`` are left in place so manual
+                # inspection of the prior run is still possible;
+                # downstream aggregation only sees the indices it
+                # asked for.
                 hydrated = hydrated[:effective_trials]
                 trial_paths = trial_paths[:effective_trials]
                 log.info(
@@ -665,14 +702,26 @@ def _run_one_cell(
                     effective_trials,
                 )
                 return hydrated, None, resolved_env_vars, trial_paths
-            log.info(
-                "cell %r: result.json marks %d trial(s) complete but only %d "
-                "dispatcher JSON(s) hydrated; re-running the cell so matrix "
-                "counts stay consistent",
-                cell.name,
-                completed,
-                len(hydrated),
-            )
+            if not indices_match:
+                missing = sorted(required_indices - collected_indices)
+                log.info(
+                    "cell %r: result.json marks %d trial(s) complete but "
+                    "dispatcher JSONs miss indices %s (collected %s); "
+                    "re-running the cell so matrix counts stay consistent",
+                    cell.name,
+                    completed,
+                    missing,
+                    sorted(collected_indices),
+                )
+            else:
+                log.info(
+                    "cell %r: result.json marks %d trial(s) complete but only %d "
+                    "dispatcher JSON(s) hydrated; re-running the cell so matrix "
+                    "counts stay consistent",
+                    cell.name,
+                    completed,
+                    len(hydrated),
+                )
 
     # Recipe-scope workload_config is the base; cell-scope merges over it so
     # the cell wins on key collision and non-collision keys union. Empty

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 import time
 from pathlib import Path
@@ -323,32 +324,40 @@ def _cells_dir(run_dir: Path) -> Path:
     return d
 
 
-def _collect_trial_paths(results_dir: Path) -> list[str]:
-    """Return the trial_*.json paths B1 wrote, sorted by trial index.
+_DISPATCHER_TRIAL_RE = re.compile(r"^trial_d\d+_m\d+_t(\d+)$")
+_LEGACY_TRIAL_RE = re.compile(r"^trial_(\d+)$")
 
-    B1's dispatcher writes to ``<results_dir>/<workload>/trial_<N>.json``
-    (the dispatcher appends the workload subdir; that's a B1 contract B2
-    currently honours without surgery). We glob the workload subdir so the
-    matrix.json ``trial_paths`` field matches reality on disk.
+
+def _collect_trial_paths(results_dir: Path) -> list[str]:
+    """Return the per-trial JSON paths the dispatcher wrote, sorted by trial index.
+
+    The dispatcher writes to
+    ``<results_dir>/<workload>/trial_d<dataset>_m<mitigation>_t<trial>.json``
+    (the dispatcher appends the workload subdir; that's a B1 contract
+    B2 currently honours without surgery). Older fixtures and tests
+    use the simpler ``trial_<N>.json`` shape; both are supported here
+    so this helper is the single sorting authority across the matrix /
+    resume code paths.
 
     Sort by the integer ``N`` extracted from the filename, NOT
-    lexicographically -- a lex sort would put ``trial_10.json`` before
-    ``trial_2.json`` and the recorded order would diverge from execution
-    order once a cell has 10+ trials. Files whose names don't parse as
-    ``trial_<int>.json`` sort last (alphabetically), which keeps any future
-    sibling artifacts visible without breaking the contract for the common
+    lexicographically -- a lex sort would put ``..._t10.json`` before
+    ``..._t2.json`` and the recorded order would diverge from
+    execution order once a cell has 10+ trials. This silently broke
+    the resume short-circuit's hydration order for any
+    trials >= 10 because ``_hydrate_trials_from_paths`` walks the
+    list in order. Files whose names don't parse under either regex
+    sort last (alphabetically), which keeps any future sibling
+    artifacts visible without breaking the contract for the common
     case.
     """
     if not results_dir.exists():
         return []
 
     def _key(path: Path) -> tuple[int, str]:
-        stem = path.stem  # "trial_3"
-        if stem.startswith("trial_"):
-            try:
-                return (int(stem[len("trial_") :]), "")
-            except ValueError:
-                pass
+        stem = path.stem
+        m = _DISPATCHER_TRIAL_RE.match(stem) or _LEGACY_TRIAL_RE.match(stem)
+        if m is not None:
+            return (int(m.group(1)), "")
         # Sentinel: push non-conforming names after every trial_N entry.
         return (10**12, str(path))
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -33,6 +33,7 @@ import logging
 import re
 import shutil
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
@@ -367,55 +368,70 @@ def _collect_trial_paths(results_dir: Path) -> list[str]:
     return [str(p) for p in found]
 
 
-def _extract_trial_indices(trial_paths: list[str]) -> set[int]:
-    """Return the integer trial indices encoded in dispatcher / legacy filenames.
+@dataclass(frozen=True)
+class _HydratedTrial:
+    """One successfully hydrated dispatcher JSON, keyed by parsed trial index.
 
-    Mirrors the regex pair from :func:`_collect_trial_paths` so the
-    resume short-circuit can verify the on-disk index set matches the
-    current recipe's ``range(effective_trials)`` (catches the
-    ``_t0 missing, _t2 stale`` edge case where the count check alone
-    would pass with the wrong indices). Files whose stems don't parse
-    are silently ignored -- they're already shoved to the end of the
-    sorted list by ``_collect_trial_paths`` and never carry an index
-    that could overlap with a real trial.
+    Carries the dispatcher's source path alongside the body so the
+    resume short-circuit can return ``trial_paths`` aligned with
+    ``hydrated`` (same index -> same position in both lists) without
+    re-walking the directory.
     """
-    indices: set[int] = set()
-    for raw in trial_paths:
-        stem = Path(raw).stem
-        m = _DISPATCHER_TRIAL_RE.match(stem) or _LEGACY_TRIAL_RE.match(stem)
-        if m is not None:
-            indices.add(int(m.group(1)))
-    return indices
+
+    index: int
+    path: str
+    trial: TrialResult
 
 
-def _hydrate_trials_from_paths(trial_paths: list[str]) -> list[TrialResult]:
-    """Load dispatcher-written ``trial_*.json`` files into TrialResult objects.
+def _hydrate_trials_by_index(trial_paths: list[str]) -> dict[int, _HydratedTrial]:
+    """Hydrate dispatcher ``trial_*.json`` files into an index-keyed map.
 
-    Used by the ``aorta probe`` resume short-circuit so
-    :func:`aorta.triage.matrix.aggregate_cell` receives the real trial
-    bodies on a skipped-but-complete cell. Returning ``[]`` would force
-    matrix.md to record ``trials=0/passed=0`` for the cell -- inconsistent
-    with what actually ran.
+    Each entry appears in the returned dict iff ALL THREE of:
 
-    Files that fail to parse, miss required keys, or otherwise violate
-    the :class:`TrialResult` schema are SKIPPED (logged at WARNING). The
-    caller compares the returned length against ``effective_trials`` and
-    falls back to a full re-run on a short list, so a single corrupted
-    dispatcher JSON cannot misrepresent the cell.
+    1. The filename's trial-index suffix parses under the dispatcher
+       regex (``trial_d<d>_m<m>_t<idx>``) or the legacy
+       ``trial_<idx>`` shape.
+    2. ``Path.read_text`` + ``json.loads`` succeed.
+    3. :meth:`TrialResult.from_dict` accepts the body.
+
+    Any failure at steps 2 or 3 logs at WARNING and the entry is
+    silently dropped -- the caller's
+    ``required_indices.issubset(hydrated_by_index.keys())`` check
+    then catches the missing index and falls back to a full re-run.
+
+    Index-keyed (rather than the previous "list + side-channel index
+    set" shape) so a corrupted required ``_t0.json`` co-existing with
+    a stale extra ``_t<N>.json`` cannot pass the resume validation.
+    The previous implementation validated indices via the *filename
+    set* (from :func:`_collect_trial_paths`) while hydration silently
+    skipped the unreadable required file; the count check then passed
+    on the stale extra and the slice returned the wrong trial bodies.
+    The fix lives in the key set of this dict: a body that does not
+    hydrate cannot be in the keys, so the subset check is the load-
+    bearing invariant rather than the filename walk.
     """
-    hydrated: list[TrialResult] = []
+    by_index: dict[int, _HydratedTrial] = {}
     for raw in trial_paths:
         path = Path(raw)
+        m = _DISPATCHER_TRIAL_RE.match(path.stem) or _LEGACY_TRIAL_RE.match(path.stem)
+        if m is None:
+            # Filename doesn't parse; ignored just as
+            # ``_collect_trial_paths`` already shoves these to the
+            # end of the sorted list.
+            continue
+        index = int(m.group(1))
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             log.warning("resume: unreadable trial JSON %s (%s)", path, exc)
             continue
         try:
-            hydrated.append(TrialResult.from_dict(data))
+            trial = TrialResult.from_dict(data)
         except (KeyError, TypeError, ValueError) as exc:
             log.warning("resume: trial JSON %s violates schema (%s)", path, exc)
-    return hydrated
+            continue
+        by_index[index] = _HydratedTrial(index=index, path=raw, trial=trial)
+    return by_index
 
 
 def _trial_passed_for_log(trial: Any) -> bool:
@@ -665,65 +681,54 @@ def _run_one_cell(
         )
         if completed >= effective_trials:
             trial_paths = _collect_trial_paths(cell_dir)
-            hydrated = _hydrate_trials_from_paths(trial_paths)
-            # Validate the EXACT trial-index set, not just the count. A
-            # `len(hydrated) >= effective_trials` check alone admits the
-            # pathological case where a prior run wrote dispatcher
-            # JSONs ``_t1, _t2`` (e.g. ``_t0`` was hand-deleted or
-            # corrupted) while ``trial_0/result.json`` is intact: the
-            # probe per-trial dirs and the dispatcher JSONs are TWO
-            # different artifact streams that ``is_trial_complete``
-            # and ``_collect_trial_paths`` walk separately. If the
-            # index set isn't exactly ``{0..effective_trials-1}``, the
-            # hydrated bodies carry the wrong ``trial_index`` for the
-            # current recipe and the matrix would aggregate the wrong
-            # set. Fall back to a full re-run -- correctness wins over
-            # the resume-skip optimisation in this edge case.
+            # Hydrate into an index-keyed map. The key set is the
+            # load-bearing invariant for the resume short-circuit: a
+            # dispatcher JSON that fails to read or schema-validate
+            # is absent from the keys, so a corrupted required
+            # ``_t0.json`` co-existing with a stale extra
+            # ``_t<N>.json`` (where N >= effective_trials) is caught
+            # by the subset check below -- the previous
+            # filename-set-based validation would have admitted it.
+            # See ``_hydrate_trials_by_index`` for the failure modes
+            # silently dropped on the floor.
+            hydrated_by_index = _hydrate_trials_by_index(trial_paths)
             required_indices = set(range(effective_trials))
-            collected_indices = _extract_trial_indices(trial_paths)
-            indices_match = required_indices.issubset(collected_indices)
-            if len(hydrated) >= effective_trials and indices_match:
-                # Slice to the CURRENT recipe's effective_trials. A user
-                # who re-runs with ``trials: 1`` after a previous
-                # ``trials: 3`` left a directory with three completed
-                # trial dirs on disk; without the slice, matrix.md
-                # would aggregate the stale extra trials instead of
-                # the requested one. ``_collect_trial_paths`` already
-                # sorts by trial index, so the first ``effective_trials``
-                # entries are exactly the indices we just validated.
-                # Stale on-disk ``trial_<n>/`` directories with
-                # ``n >= effective_trials`` are left in place so manual
-                # inspection of the prior run is still possible;
-                # downstream aggregation only sees the indices it
-                # asked for.
-                hydrated = hydrated[:effective_trials]
-                trial_paths = trial_paths[:effective_trials]
+            if required_indices.issubset(hydrated_by_index.keys()):
+                # Build the canonical (hydrated, trial_paths) pair from
+                # the dict so positions line up by index: position i
+                # carries the body and path for trial i. ``aggregate_cell``
+                # records the path list in matrix.json::cells[*].trial_paths
+                # in the same order as the trial bodies, so misalignment
+                # here would silently scramble downstream cross-references.
+                # Stale on-disk extras with index >= effective_trials are
+                # dropped here (not deleted) so manual inspection of the
+                # prior run is still possible; downstream aggregation
+                # only sees what the current recipe asked for.
+                hydrated = [hydrated_by_index[i].trial for i in range(effective_trials)]
+                trial_paths = [hydrated_by_index[i].path for i in range(effective_trials)]
                 log.info(
                     "cell %r: all %d trial(s) already complete -- skipping per resume mode",
                     cell.name,
                     effective_trials,
                 )
                 return hydrated, None, resolved_env_vars, trial_paths
-            if not indices_match:
-                missing = sorted(required_indices - collected_indices)
-                log.info(
-                    "cell %r: result.json marks %d trial(s) complete but "
-                    "dispatcher JSONs miss indices %s (collected %s); "
-                    "re-running the cell so matrix counts stay consistent",
-                    cell.name,
-                    completed,
-                    missing,
-                    sorted(collected_indices),
-                )
-            else:
-                log.info(
-                    "cell %r: result.json marks %d trial(s) complete but only %d "
-                    "dispatcher JSON(s) hydrated; re-running the cell so matrix "
-                    "counts stay consistent",
-                    cell.name,
-                    completed,
-                    len(hydrated),
-                )
+            # Subset check failed -> at least one required index is missing.
+            # The single-branch log subsumes the previous two-branch shape
+            # (separate "indices missing" vs "count short" cases): with the
+            # index-keyed map, an index that didn't hydrate IS by definition
+            # both a missing index and a missing body, so distinguishing the
+            # two on the operator side adds no diagnostic value.
+            missing = sorted(required_indices - hydrated_by_index.keys())
+            log.info(
+                "cell %r: result.json marks %d trial(s) complete but "
+                "successful hydration is missing trial indices %s "
+                "(hydrated %s); re-running the cell so matrix counts "
+                "stay consistent",
+                cell.name,
+                completed,
+                missing,
+                sorted(hydrated_by_index.keys()),
+            )
 
     # Recipe-scope workload_config is the base; cell-scope merges over it so
     # the cell wins on key collision and non-collision keys union. Empty

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -32,7 +32,7 @@ import logging
 import shutil
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import click
 
@@ -539,6 +539,10 @@ def _run_one_cell(
     recipe: Recipe,
     run_dir: Path,
     sidecar_files: tuple[Path, ...],
+    *,
+    layout: Literal["timestamped", "flat_resume"] = "timestamped",
+    resume_existing: bool = False,
+    subprocess_argv: tuple[str, ...] | None = None,
 ) -> tuple[list[TrialResult], str | None, dict[str, str], list[str]]:
     """Execute a single cell through B1 and return (trials, error, env_vars, trial_paths).
 
@@ -548,11 +552,55 @@ def _run_one_cell(
     errored without bringing down the whole matrix. The full traceback is
     logged at WARNING so operators can diagnose, but the returned ``error``
     string stays short -- it's the text shown in matrix.md.
+
+    ``layout`` / ``resume_existing`` / ``subprocess_argv`` activate the
+    ``aorta probe`` (issue #188) code paths:
+
+    * ``layout="flat_resume"`` puts the cell artifacts at
+      ``<run_dir>/<safe_slug(cell.name)>/`` (NO ``cells/`` segment) so
+      the artifact tree matches the rubric's
+      ``<output>/<ticket>/<cell>/trial_<n>/...`` layout exactly.
+    * ``resume_existing=True`` consults
+      :func:`aorta.probe.resume.is_trial_complete` for every trial
+      directory under the cell BEFORE invoking the dispatcher. When
+      every trial is complete, the dispatcher call is skipped and the
+      trial JSONs the dispatcher had written previously are surfaced
+      as the cell's trials.
+    * ``subprocess_argv`` (not None) flips the request to
+      ``save_logs=True`` and routes the opaque user argv to the
+      reserved ``_aorta_subprocess_argv`` slot -- the only legal
+      channel for delivering argv to :class:`SubprocessWorkload`.
     """
-    cell_dir = _cells_dir(run_dir) / safe_slug(cell.name)
+    if layout == "flat_resume":
+        cell_dir = run_dir / safe_slug(cell.name)
+    else:
+        cell_dir = _cells_dir(run_dir) / safe_slug(cell.name)
     cell_dir.mkdir(parents=True, exist_ok=True)
 
     resolved_env_vars = _resolve_cell_env_vars(cell.mitigations, cell.extra_env, sidecar_files)
+    effective_trials = cell.effective_trials(recipe.trials)
+
+    # Resume short-circuit: if every trial directory under this cell
+    # carries a valid result.json + non-empty verdict, the cell is
+    # already done. Surface its existing dispatcher-written JSONs as
+    # the cell's trials (so matrix.json continues to record them) and
+    # skip the dispatcher call entirely.
+    if resume_existing and layout == "flat_resume":
+        from aorta.probe.resume import is_trial_complete
+
+        completed = sum(
+            1
+            for i in range(effective_trials)
+            if is_trial_complete(cell_dir / f"trial_{i}")
+        )
+        if completed >= effective_trials:
+            log.info(
+                "cell %r: all %d trial(s) already complete -- skipping per resume mode",
+                cell.name,
+                effective_trials,
+            )
+            trial_paths = _collect_trial_paths(cell_dir)
+            return [], None, resolved_env_vars, trial_paths
 
     # Recipe-scope workload_config is the base; cell-scope merges over it so
     # the cell wins on key collision and non-collision keys union. Empty
@@ -561,9 +609,31 @@ def _run_one_cell(
     # workload_config from the recipe stays byte-equivalent to today.
     merged_workload_config = {**recipe.workload_config, **cell.workload_config}
 
+    # Probe-mode extras delivered to ``SubprocessWorkload`` via the
+    # typed ``RunRequest.probe_extras`` field. The runner is the only
+    # producer of this dict; ``SubprocessWorkload`` reads it from the
+    # ``_aorta_probe_extras`` slot the dispatcher injects.
+    probe_extras_payload: dict[str, Any] | None = None
+    probe_extras = recipe.probe_extras
+    if subprocess_argv is not None and probe_extras is not None:
+        probe_extras_payload = {
+            "cell_name": cell.name,
+            "env_passthrough_mode": probe_extras.env_passthrough_mode,
+            "timeout_per_trial": probe_extras.timeout_per_trial,
+            "cell_env_vars": dict(resolved_env_vars),
+            "step_time_regex": probe_extras.step_time_regex,
+            "collect_paths": list(probe_extras.collect_paths),
+        }
+
+    # save_logs is forced True for probe-mode cells because
+    # SubprocessWorkload reads ``_aorta_log_prefix`` to derive its
+    # per-trial directory; the dispatcher only injects that key when
+    # save_logs=True.
+    save_logs = recipe.save_logs or (subprocess_argv is not None)
+
     request = RunRequest(
         workload=recipe.workload,
-        trials=cell.effective_trials(recipe.trials),
+        trials=effective_trials,
         environment=cell.environment,
         mitigations=tuple(cell.mitigations),
         extra_env=dict(cell.extra_env),
@@ -571,7 +641,9 @@ def _run_one_cell(
         config_overrides=merged_workload_config,
         results_dir=cell_dir,
         sidecar_files=sidecar_files,
-        save_logs=recipe.save_logs,
+        save_logs=save_logs,
+        subprocess_argv=subprocess_argv,
+        probe_extras=probe_extras_payload,
     )
 
     try:
@@ -610,8 +682,39 @@ def _preflight_validate(recipe: Recipe) -> None:
     resolve_baseline(recipe.cells, recipe.confound.baseline_cell)
 
 
-def _print_dry_run(recipe: Recipe) -> None:
-    """Write the resolved cell list to stdout without touching the filesystem."""
+def _print_dry_run(
+    recipe: Recipe,
+    subprocess_argv: tuple[str, ...] | None = None,
+) -> None:
+    """Write the resolved cell list to stdout without touching the filesystem.
+
+    For probe-mode (``recipe.probe_extras is not None``), each line shows
+    the cell's planned env-var bundle and the literal trailing argv -- the
+    rubric's FR 1.2 contract. Triage-mode dry-run shows the existing
+    cell summary (mitigations / environment / trials / steps) for back-compat.
+    """
+    if recipe.probe_extras is not None:
+        # Probe-mode dry-run: cell name, resolved env bundle, literal argv.
+        # No FS writes, no execution -- matches FR 1.2 byte-for-byte.
+        argv_display = list(subprocess_argv) if subprocess_argv is not None else []
+        click.echo(
+            f"Dry run (probe): ticket={recipe.ticket or '(none)'} "
+            f"cells={len(recipe.cells)} trials/cell={recipe.trials}"
+        )
+        click.echo(f"Argv (forwarded byte-for-byte): {argv_display}")
+        click.echo(
+            f"Env-passthrough mode: {recipe.probe_extras.env_passthrough_mode}"
+        )
+        for cell in recipe.cells:
+            env_bundle = recipe.probe_extras.cell_envs.get(cell.name, {})
+            env_str = (
+                " ".join(f"{k}={v}" for k, v in sorted(env_bundle.items())) or "(no env)"
+            )
+            click.echo(
+                f"  {cell.name}: env=[{env_str}] argv={argv_display}"
+            )
+        return
+
     click.echo(f"Dry run: {recipe.workload} / ticket={recipe.ticket or '(none)'}")
     if recipe.workload_config:
         click.echo(f"Recipe workload_config: {recipe.workload_config}")
@@ -647,6 +750,10 @@ def run_recipe(
     dry_run: bool = False,
     extra_sidecar_files: tuple[Path, ...] = (),
     timestamp: str | None = None,
+    *,
+    layout: Literal["timestamped", "flat_resume"] = "timestamped",
+    resume_existing: bool = False,
+    subprocess_argv: tuple[str, ...] | None = None,
 ) -> Path:
     """Execute a recipe and write matrix.md / matrix.json / recipe.resolved.yaml.
 
@@ -668,9 +775,22 @@ def run_recipe(
             callers that build a ``Recipe`` directly (tests, in-process
             embedders) and want to add sidecars at execute time.
         timestamp: Override for the run-dir timestamp component (test hook).
+        layout: Output-tree layout (issue #188). ``"timestamped"`` (default)
+            preserves byte-equivalence with ``aorta triage run``;
+            ``"flat_resume"`` produces ``<output_dir>/<ticket>/`` (no
+            timestamp, no ``<workload>`` segment) for ``aorta probe``'s
+            resume semantics.
+        resume_existing: When True (probe-mode only), per-cell
+            invocations consult :func:`aorta.probe.resume.is_trial_complete`
+            and skip cells whose every trial is already complete.
+        subprocess_argv: Opaque argv forwarded byte-for-byte to every
+            cell's :class:`SubprocessWorkload` via the typed
+            ``RunRequest.subprocess_argv`` field. Required for probe-mode;
+            ignored in triage-mode.
 
     Returns:
-        The run directory path (``<output-dir>/<ticket>/<workload>/<timestamp>``).
+        The run directory path (``<output-dir>/<ticket>/<workload>/<timestamp>``
+        for triage-mode, ``<output-dir>/<ticket>/`` for probe-mode).
     """
     # Preflight first, BEFORE the dry-run early-return: dry-run is documented
     # as "validation without execution", so it must reject everything the
@@ -679,11 +799,11 @@ def run_recipe(
     _preflight_validate(recipe)
 
     if dry_run:
-        _print_dry_run(recipe)
+        _print_dry_run(recipe, subprocess_argv=subprocess_argv)
         return Path(".")
 
     ts = timestamp or format_timestamp()
-    run_dir = resolve_run_dir(output_dir, recipe, timestamp=ts)
+    run_dir = resolve_run_dir(output_dir, recipe, timestamp=ts, layout=layout)
 
     # Operator sidecars come from two places: ones the Recipe was built
     # against (``recipe.sidecar_files``, populated by ``load_recipe`` /
@@ -765,7 +885,13 @@ def run_recipe(
         )
         cell_t0 = time.perf_counter()
         trials, error, resolved_env_vars, trial_paths = _run_one_cell(
-            cell, recipe, run_dir, sidecar_files
+            cell,
+            recipe,
+            run_dir,
+            sidecar_files,
+            layout=layout,
+            resume_existing=resume_existing,
+            subprocess_argv=subprocess_argv,
         )
         cell_elapsed = time.perf_counter() - cell_t0
         if error is not None:

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -356,6 +356,36 @@ def _collect_trial_paths(results_dir: Path) -> list[str]:
     return [str(p) for p in found]
 
 
+def _hydrate_trials_from_paths(trial_paths: list[str]) -> list[TrialResult]:
+    """Load dispatcher-written ``trial_*.json`` files into TrialResult objects.
+
+    Used by the ``aorta probe`` resume short-circuit so
+    :func:`aorta.triage.matrix.aggregate_cell` receives the real trial
+    bodies on a skipped-but-complete cell. Returning ``[]`` would force
+    matrix.md to record ``trials=0/passed=0`` for the cell -- inconsistent
+    with what actually ran.
+
+    Files that fail to parse, miss required keys, or otherwise violate
+    the :class:`TrialResult` schema are SKIPPED (logged at WARNING). The
+    caller compares the returned length against ``effective_trials`` and
+    falls back to a full re-run on a short list, so a single corrupted
+    dispatcher JSON cannot misrepresent the cell.
+    """
+    hydrated: list[TrialResult] = []
+    for raw in trial_paths:
+        path = Path(raw)
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning("resume: unreadable trial JSON %s (%s)", path, exc)
+            continue
+        try:
+            hydrated.append(TrialResult.from_dict(data))
+        except (KeyError, TypeError, ValueError) as exc:
+            log.warning("resume: trial JSON %s violates schema (%s)", path, exc)
+    return hydrated
+
+
 def _trial_passed_for_log(trial: Any) -> bool:
     """Mirror of ``aorta.triage.matrix._trial_passed`` for the per-cell
     log line.
@@ -582,9 +612,19 @@ def _run_one_cell(
 
     # Resume short-circuit: if every trial directory under this cell
     # carries a valid result.json + non-empty verdict, the cell is
-    # already done. Surface its existing dispatcher-written JSONs as
-    # the cell's trials (so matrix.json continues to record them) and
-    # skip the dispatcher call entirely.
+    # already done. Hydrate the dispatcher's per-trial JSONs into
+    # ``TrialResult`` objects so ``aggregate_cell`` sees the real
+    # trial bodies (counts, timings, exit_status). Returning ``[]``
+    # here would make matrix.md report ``trials=0/passed=0`` for a
+    # skipped-but-complete cell -- the resume contract is "no extra
+    # work, identical artifacts".
+    #
+    # Fall through to a full re-run when hydration cannot reconstruct
+    # the full trial set (dispatcher JSON missing because the prior
+    # run was killed between writing the probe ``result.json`` and
+    # the dispatcher's ``trial_<N>.json``; or schema drift). Re-running
+    # a complete cell is wasteful but preserves matrix correctness;
+    # silently returning [] would not.
     if resume_existing and layout == "flat_resume":
         from aorta.probe.resume import is_trial_complete
 
@@ -594,13 +634,23 @@ def _run_one_cell(
             if is_trial_complete(cell_dir / f"trial_{i}")
         )
         if completed >= effective_trials:
-            log.info(
-                "cell %r: all %d trial(s) already complete -- skipping per resume mode",
-                cell.name,
-                effective_trials,
-            )
             trial_paths = _collect_trial_paths(cell_dir)
-            return [], None, resolved_env_vars, trial_paths
+            hydrated = _hydrate_trials_from_paths(trial_paths)
+            if len(hydrated) >= effective_trials:
+                log.info(
+                    "cell %r: all %d trial(s) already complete -- skipping per resume mode",
+                    cell.name,
+                    effective_trials,
+                )
+                return hydrated, None, resolved_env_vars, trial_paths
+            log.info(
+                "cell %r: result.json marks %d trial(s) complete but only %d "
+                "dispatcher JSON(s) hydrated; re-running the cell so matrix "
+                "counts stay consistent",
+                cell.name,
+                completed,
+                len(hydrated),
+            )
 
     # Recipe-scope workload_config is the base; cell-scope merges over it so
     # the cell wins on key collision and non-collision keys union. Empty

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -27,6 +27,7 @@ Per the acceptance criteria in issue #151, this module MUST NOT use
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import re
@@ -55,6 +56,7 @@ from aorta.triage.matrix import (
     aggregate_cell,
 )
 from aorta.triage.output import (
+    acquire_flat_resume_lock,
     format_timestamp,
     resolve_run_dir,
     safe_slug,
@@ -916,6 +918,47 @@ def run_recipe(
     ts = timestamp or format_timestamp()
     run_dir = resolve_run_dir(output_dir, recipe, timestamp=ts, layout=layout)
 
+    # ``flat_resume`` reuses a stable ``<output>/<ticket>/`` directory across
+    # invocations so resume can detect per-trial ``result.json`` files as
+    # already complete. That same property means two concurrent ``aorta
+    # probe`` invocations against the same ``--output``/``--ticket`` would
+    # race on ``matrix.json``, ``matrix.md``, and per-cell artifacts. Take
+    # an advisory PID+host lock for the duration of the matrix run; the
+    # ``"timestamped"`` layout (``aorta triage run``) is unaffected because
+    # ``resolve_run_dir`` already gives each invocation a fresh leaf via the
+    # ``-N`` suffix loop. ``ExitStack`` keeps the lock optional without
+    # forcing a re-indent of the entire matrix loop.
+    with contextlib.ExitStack() as stack:
+        if layout == "flat_resume":
+            stack.enter_context(acquire_flat_resume_lock(run_dir))
+        return _run_recipe_locked(
+            recipe=recipe,
+            extra_sidecar_files=extra_sidecar_files,
+            ts=ts,
+            run_dir=run_dir,
+            layout=layout,
+            resume_existing=resume_existing,
+            subprocess_argv=subprocess_argv,
+        )
+
+
+def _run_recipe_locked(
+    *,
+    recipe: Recipe,
+    extra_sidecar_files: tuple[Path, ...],
+    ts: str,
+    run_dir: Path,
+    layout: Literal["timestamped", "flat_resume"],
+    resume_existing: bool,
+    subprocess_argv: tuple[str, ...] | None,
+) -> Path:
+    """Body of :func:`run_recipe` after the flat_resume lock is held.
+
+    Extracted so the lock-acquisition is a single
+    ``contextlib.ExitStack`` block at the top of :func:`run_recipe` and
+    the matrix-loop body doesn't need to be re-indented inside a ``with``.
+    Not part of the public API -- callers go through :func:`run_recipe`.
+    """
     # Operator sidecars come from two places: ones the Recipe was built
     # against (``recipe.sidecar_files``, populated by ``load_recipe`` /
     # ``build_recipe_from_flags``) and ones the caller hands in directly at

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -638,14 +638,27 @@ def _run_one_cell(
         from aorta.probe.resume import is_trial_complete
 
         completed = sum(
-            1
-            for i in range(effective_trials)
-            if is_trial_complete(cell_dir / f"trial_{i}")
+            1 for i in range(effective_trials) if is_trial_complete(cell_dir / f"trial_{i}")
         )
         if completed >= effective_trials:
             trial_paths = _collect_trial_paths(cell_dir)
             hydrated = _hydrate_trials_from_paths(trial_paths)
             if len(hydrated) >= effective_trials:
+                # Slice to the CURRENT recipe's effective_trials. A user
+                # who re-runs with ``trials: 1`` after a previous
+                # ``trials: 3`` left a directory with three completed
+                # trial dirs on disk; without the slice, matrix.md
+                # would aggregate the stale extra trials instead of
+                # the requested one. Truncating both ``hydrated`` and
+                # ``trial_paths`` to ``effective_trials`` keeps the
+                # resume short-circuit's output consistent with what
+                # a fresh run would have produced. (Stale on-disk
+                # trial_<n>/ directories with n >= effective_trials
+                # are left in place so manual inspection of the prior
+                # run is still possible; downstream aggregation only
+                # sees the indices it asked for.)
+                hydrated = hydrated[:effective_trials]
+                trial_paths = trial_paths[:effective_trials]
                 log.info(
                     "cell %r: all %d trial(s) already complete -- skipping per resume mode",
                     cell.name,
@@ -761,17 +774,11 @@ def _print_dry_run(
             f"cells={len(recipe.cells)} trials/cell={recipe.trials}"
         )
         click.echo(f"Argv (forwarded byte-for-byte): {argv_display}")
-        click.echo(
-            f"Env-passthrough mode: {recipe.probe_extras.env_passthrough_mode}"
-        )
+        click.echo(f"Env-passthrough mode: {recipe.probe_extras.env_passthrough_mode}")
         for cell in recipe.cells:
             env_bundle = recipe.probe_extras.cell_envs.get(cell.name, {})
-            env_str = (
-                " ".join(f"{k}={v}" for k, v in sorted(env_bundle.items())) or "(no env)"
-            )
-            click.echo(
-                f"  {cell.name}: env=[{env_str}] argv={argv_display}"
-            )
+            env_str = " ".join(f"{k}={v}" for k, v in sorted(env_bundle.items())) or "(no env)"
+            click.echo(f"  {cell.name}: env=[{env_str}] argv={argv_display}")
         return
 
     click.echo(f"Dry run: {recipe.workload} / ticket={recipe.ticket or '(none)'}")
@@ -789,11 +796,7 @@ def _print_dry_run(
             f"trials={cell.effective_trials(recipe.trials)} "
             f"steps={cell.effective_steps(recipe.steps)}"
             + (f" extra_env={cell.extra_env}" if cell.extra_env else "")
-            + (
-                f" workload_config={effective_workload_config}"
-                if effective_workload_config
-                else ""
-            )
+            + (f" workload_config={effective_workload_config}" if effective_workload_config else "")
         )
     if recipe.inline_environments:
         click.echo("Inline docker environments:")
@@ -1043,9 +1046,7 @@ def run_recipe(
     if recipe.confound.baseline_cell is not None:
         baseline_cell = resolve_baseline(recipe.cells, recipe.confound.baseline_cell)
         if baseline_cell.name in disqualified_names:
-            baseline_stats_ref = next(
-                c for c in cell_stats if c.name == baseline_cell.name
-            )
+            baseline_stats_ref = next(c for c in cell_stats if c.name == baseline_cell.name)
             msg = (
                 f"explicit baseline_cell {baseline_cell.name!r} produced only "
                 f"did_not_run trials "
@@ -1061,17 +1062,13 @@ def run_recipe(
             incomplete_reason = msg
     else:
         try:
-            baseline_cell = resolve_baseline(
-                recipe.cells, None, skip_names=disqualified_names
-            )
+            baseline_cell = resolve_baseline(recipe.cells, None, skip_names=disqualified_names)
         except RecipeCellError:
             # Every candidate was disqualified -- fall back to the original
             # auto-resolution (without the skip set) so matrix.json still
             # records WHO would have been the baseline, then warn loudly.
             baseline_cell = resolve_baseline(recipe.cells, None)
-            baseline_stats_ref = next(
-                c for c in cell_stats if c.name == baseline_cell.name
-            )
+            baseline_stats_ref = next(c for c in cell_stats if c.name == baseline_cell.name)
             msg = (
                 f"Auto-baseline {baseline_cell.name!r} had "
                 f"{baseline_stats_ref.outcome_counts.get(OUTCOME_DID_NOT_RUN, 0)}/"

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -210,6 +210,7 @@ class SubprocessWorkload(Workload):
                     exc=exc,
                     result_path=result_path,
                     stderr_path=stderr_path,
+                    env_file_path=env_file_path,
                     argv=argv,
                     probe_extras=probe_extras,
                     env_mode=env_mode,
@@ -370,6 +371,7 @@ class SubprocessWorkload(Workload):
         exc: ValueError,
         result_path: Path,
         stderr_path: Path,
+        env_file_path: Path,
         argv: tuple[str, ...],
         probe_extras: dict[str, Any],
         env_mode: str,
@@ -382,7 +384,16 @@ class SubprocessWorkload(Workload):
         ``is_trial_complete`` predicate keys off a missing ``result.json``
         and re-runs the same broken cell on every subsequent
         ``aorta probe`` invocation.
+
+        Also unlinks ``probe.env`` (best-effort) before writing the fail
+        result so the trial directory cannot leave behind a misleading
+        artifact: ``_write_env_file`` is now validation-first
+        (atomic-on-failure), but a stale probe.env from a PRIOR run of
+        the same ``trial_<n>/`` directory (resume + flat_resume reuse
+        the same dir) would otherwise survive the validation rejection
+        and contradict ``result.json::failure_type==env_file_validation_failed``.
         """
+        env_file_path.unlink(missing_ok=True)
         try:
             stderr_path.write_text(f"{exc}\n", encoding="utf-8")
         except OSError:
@@ -452,54 +463,73 @@ class SubprocessWorkload(Workload):
         return {str(k): str(v) for k, v in bundle.items()}
 
 
+def _validate_env_file_entries(env: dict[str, str]) -> None:
+    """Reject hostile/malformed env keys+values without touching the filesystem.
+
+    Two row-injection vectors that the sidecar-mitigation loader does
+    NOT catch (it only enforces ``isinstance(key, str)``):
+
+    * ``\\n``, ``\\r`` or ``=`` in a *key* would let a hostile sidecar
+      inject extra ``KEY=VALUE`` rows or rebind a later key.
+    * ``\\n``/``\\r`` in a *value* would corrupt the bare-KEY=VALUE
+      file shape; a downstream reader would silently see a truncated
+      value.
+
+    Run a full-map validation pass BEFORE the caller opens / truncates
+    ``probe.env`` so a rejection on row 5 does not leave rows 1..4 on
+    disk (per the round-6 review on ``_write_env_file``: a partial
+    file is "valid-looking but incomplete" -- worse than no file at
+    all, because downstream tools cannot tell the difference between
+    "the cell ran with these vars" and "the cell rejected the
+    bundle but only after writing these four").
+    """
+    for key in sorted(env):
+        if "\n" in key or "\r" in key or "=" in key:
+            raise ValueError(
+                f"env key {key!r} contains a newline, carriage "
+                "return, or '=' character; probe.env uses bare "
+                "KEY=VALUE format and rejects these to prevent "
+                "row-injection via a hostile mitigation sidecar"
+            )
+        value = env[key]
+        if "\n" in value or "\r" in value:
+            raise ValueError(
+                f"env value for {key!r} contains a newline; "
+                "probe.env uses bare KEY=VALUE format and cannot "
+                "encode multi-line values"
+            )
+
+
 def _write_env_file(path: Path, env: dict[str, str]) -> None:
     """Write a POSIX KEY=VALUE\\n env file at ``chmod 0600``.
 
-    The 0600 mode is set BEFORE writing the values via ``open(... 0o600)``
-    on platforms that honour ``os.O_CREAT`` mode bits, and chmod'd
-    after as a belt-and-suspenders for filesystems that ignore the
-    open-mode (NFS without root squash, some FUSE backends).
+    Atomic with respect to validation failure: ``_validate_env_file_entries``
+    runs the full key/value check BEFORE we ``os.open(..., O_TRUNC)``, so
+    a hostile or malformed bundle either produces a complete + correct
+    file or leaves the path untouched. The previous interleaved shape
+    (open-truncate first, validate per-row while writing) could leave a
+    partial probe.env from rows 1..N-1 when row N was rejected. That
+    file looked legitimate (0600, KEY=VALUE shape) but contained only
+    a subset of the cell's bundle -- exactly the misleading artifact
+    the round-6 review flagged.
+
+    The 0600 mode is set via ``os.O_CREAT`` mode bits on platforms
+    that honour them, and chmod'd after as a belt-and-suspenders for
+    filesystems that ignore the open-mode (NFS without root squash,
+    some FUSE backends).
 
     Per R5 in the rubric, the env file is the leakage surface for
     secrets in ``file`` mode; Phase 3 redaction scrubs these from the
     bundle, but Phase 1 ships the 0600 guard as the only mitigation.
     """
+    _validate_env_file_entries(env)
+
     fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             for key in sorted(env):
-                # POSIX env-file shape: bare KEY=VALUE\n, no quoting.
-                # Sidecar mitigations only enforce that keys are
-                # strings, NOT that they are single-line and
-                # ``=``-free, so a hostile mitigation file could try
-                # to inject extra KEY=VALUE rows via ``\n`` or
-                # ``\r`` in a key, or smuggle a second ``=`` to
-                # rebind a later key. Reject all three explicitly
-                # (newline/CR/equals) so the file shape stays one
-                # KEY=VALUE per row and a downstream reader cannot
-                # be coerced into seeing a different binding than
-                # what the mitigation actually wrote.
-                if "\n" in key or "\r" in key or "=" in key:
-                    raise ValueError(
-                        f"env key {key!r} contains a newline, carriage "
-                        "return, or '=' character; probe.env uses bare "
-                        "KEY=VALUE format and rejects these to prevent "
-                        "row-injection via a hostile mitigation sidecar"
-                    )
-                # Reject newlines in values up-front for the same
-                # reason: a value with ``\n`` would corrupt the
-                # file shape and a downstream tool would silently
-                # read a truncated value.
-                value = env[key]
-                if "\n" in value or "\r" in value:
-                    raise ValueError(
-                        f"env value for {key!r} contains a newline; "
-                        "probe.env uses bare KEY=VALUE format and cannot "
-                        "encode multi-line values"
-                    )
-                fh.write(f"{key}={value}\n")
+                fh.write(f"{key}={env[key]}\n")
     finally:
-        # Re-assert 0600 in case the underlying FS dropped the open-mode.
         try:
             os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
         except OSError:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -232,11 +232,35 @@ class SubprocessWorkload(Workload):
                     except ProcessLookupError:
                         pass
                     exit_code = -1
-        except FileNotFoundError as exc:
-            # ``Popen`` raises FileNotFoundError when argv[0] doesn't
-            # resolve to an executable -- record as a Tier-1 fail with
-            # the error captured in stderr.log for diagnosis.
-            exit_code = 127
+        except (FileNotFoundError, PermissionError, OSError) as exc:
+            # Exec-time ``Popen`` failures all become Tier-1 fails with
+            # the artifact tree intact (stderr.log + result.json). The
+            # error families we capture:
+            #
+            # * ``FileNotFoundError`` (ENOENT, exit 127) -- argv[0]
+            #   doesn't resolve to a binary on $PATH;
+            # * ``PermissionError`` (EACCES, exit 126) -- argv[0]
+            #   exists but isn't executable (chmod missing the +x bit);
+            # * other ``OSError`` (e.g. ENOEXEC "Exec format error"
+            #   for a shebang-less script, ELOOP for a symlink loop) --
+            #   the operator gets the diagnostic via stderr.log but
+            #   the trial still occupies its slot in the matrix.
+            #
+            # Without this guard a non-executable user command would
+            # escape to the dispatcher as ``infrastructure_failed``,
+            # leaving the per-trial directory without a
+            # ``result.json`` and breaking the documented "every probe
+            # trial leaves an artifact" contract. ``FileNotFoundError``
+            # and ``PermissionError`` are ``OSError`` subclasses so the
+            # three-way tuple is logically a single OSError catch; we
+            # name the subclasses explicitly so the exit-code mapping
+            # below stays grep-able.
+            if isinstance(exc, FileNotFoundError):
+                exit_code = 127
+            elif isinstance(exc, PermissionError):
+                exit_code = 126
+            else:
+                exit_code = 1
             try:
                 stderr_path.write_text(f"{exc}\n", encoding="utf-8")
             except OSError:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -179,10 +179,22 @@ class SubprocessWorkload(Workload):
         # See F6 in the rubric for the no-parse-argv rationale.
         cell_env_snapshot = self._capture_cell_env(probe_extras)
         child_env = os.environ.copy()
+        env_file_path = trial_dir / "probe.env"
         if env_mode == "file":
-            env_file_path = trial_dir / "probe.env"
             _write_env_file(env_file_path, cell_env_snapshot)
             child_env["AORTA_ENV_FILE"] = str(env_file_path.absolute())
+        else:
+            # ``inherit`` mode: scrub any probe.env left over from a
+            # prior run that used ``file`` mode (resume scenarios under
+            # ``flat_resume`` re-use the same ``trial_<n>/`` directory
+            # when a previous attempt's ``result.json`` was truncated).
+            # Without this cleanup the on-disk artifacts would
+            # contradict the current invocation -- the operator would
+            # see a ``probe.env`` even though the child never had
+            # ``AORTA_ENV_FILE`` exported, which is at best confusing
+            # and at worst points downstream tooling at stale env
+            # contents.
+            env_file_path.unlink(missing_ok=True)
 
         t0 = time.perf_counter()
         exit_code: int

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -1,0 +1,302 @@
+"""Reserved platform-internal workload wrapping an opaque user subprocess.
+
+Wired into the ``aorta.workloads`` entry-point group as the leading-
+underscored name ``_subprocess`` so it cannot collide with any user-
+facing workload name. Consumed by ``aorta probe`` (issue #188) to wrap
+arbitrary launch commands -- ``bash launch.sh``, ``torchrun ...``,
+``buck2 run //path:target -- ...``, ``docker run ...`` -- without
+parsing or modifying the user's argv.
+
+The argv is delivered as a reserved config key, ``_aorta_subprocess_argv``,
+injected by :class:`aorta.run.dispatcher.RunRequest` after
+``config_overrides`` is merged. The reserved-prefix block at the top of
+``run_trials`` rejects any user-supplied ``_aorta_*`` key, so users
+cannot smuggle an argv via ``config_overrides`` -- the typed
+``RunRequest.subprocess_argv`` field is the only legal channel.
+
+Per-trial output layout (Phase 1):
+
+* ``<cell_dir>/trial_<N>/stdout.log`` -- captured stdout (utf-8,
+  backslashreplace on encode errors).
+* ``<cell_dir>/trial_<N>/stderr.log`` -- captured stderr.
+* ``<cell_dir>/trial_<N>/result.json`` -- Tier-1 verdict + metadata.
+* ``<cell_dir>/trial_<N>/probe.env`` -- only when
+  ``env_passthrough_mode == "file"`` (chmod 0600).
+
+Verdict rule (Phase 1, Tier 1 only): ``exit_code == 0`` -> pass, else
+fail. Pattern matching, hang detection, dmesg scanning, and the
+``custom_patterns`` runner are deferred to Phase 2.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from aorta.workloads._base import Workload, WorkloadResult
+
+# Config key the dispatcher uses to deliver the opaque user argv. The
+# leading ``_aorta_`` prefix is reserved by the dispatcher and rejected
+# in ``config_overrides`` -- the only legal producer is
+# :class:`aorta.run.dispatcher.RunRequest.subprocess_argv`.
+CONFIG_KEY_SUBPROCESS_ARGV = "_aorta_subprocess_argv"
+
+# Config keys the dispatcher injects when ``RunRequest.save_logs`` is
+# True. ``_aorta_log_prefix`` is the only reliable in-process channel
+# carrying the per-trial coordinate (the ``_t<N>`` suffix) and is what
+# this workload uses to compute its per-trial output directory.
+CONFIG_KEY_LOG_PREFIX = "_aorta_log_prefix"
+
+# Probe-extras-derived config keys. The runner attaches these to the
+# per-cell request config_overrides BEFORE the dispatcher's
+# reserved-prefix injection so the workload can pick them up.
+CONFIG_KEY_PROBE_EXTRAS = "_aorta_probe_extras"
+
+# Match the ``trial_d<d>_m<m>_t<idx>`` suffix the dispatcher uses for
+# ``_aorta_log_prefix``. Captured group is the trial index; we use it
+# to compute ``trial_<idx>/`` per the probe-mode artifact layout.
+_LOG_PREFIX_TRIAL_RE = re.compile(r"trial_d\d+_m\d+_t(\d+)$")
+
+
+class SubprocessWorkload(Workload):
+    """Workload that forks the user's opaque launch command.
+
+    Distinct from triage-mode workloads in three ways:
+
+    1. The "config" it cares about is delivered via reserved
+       ``_aorta_*`` keys (argv, log prefix, probe-extras) rather than
+       user ``config_overrides``. The class is platform-internal and
+       only ``aorta probe`` wires it up.
+    2. Per-trial artifacts land in the ``flat_resume`` layout
+       (``<cell_dir>/trial_<N>/...``) rather than the dispatcher's
+       default ``<results_dir>/<workload>/trial_d<d>_m<m>_t<n>.json``.
+       The dispatcher's per-trial JSON is still written -- as a sibling
+       under ``_subprocess/`` -- and serves as the "I-ran" marker for
+       triage-mode tooling; the probe-mode ``result.json`` is the one
+       resume / classifier code consults.
+    3. Verdict is Tier 1 only in Phase 1: ``exit_code == 0`` -> pass.
+       The full classifier and the sandbox land in Phase 2.
+    """
+
+    launch_mode = "single_process"
+    min_world_size = 1
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        super().__init__(config)
+        self._argv: tuple[str, ...] | None = None
+        self._trial_dir: Path | None = None
+        self._trial_index: int | None = None
+
+    def setup(self) -> None:
+        """Resolve argv + trial directory from the reserved config keys."""
+        argv = self.config.get(CONFIG_KEY_SUBPROCESS_ARGV)
+        if argv is None:
+            raise RuntimeError(
+                "SubprocessWorkload requires the platform-supplied "
+                f"{CONFIG_KEY_SUBPROCESS_ARGV!r} config key. This workload is "
+                "wired internally by 'aorta probe'; do not invoke it "
+                "directly via 'aorta run'."
+            )
+        if not isinstance(argv, list) or not argv:
+            raise RuntimeError(
+                f"{CONFIG_KEY_SUBPROCESS_ARGV} must be a non-empty list[str], "
+                f"got {type(argv).__name__} ({argv!r})"
+            )
+        if not all(isinstance(a, str) for a in argv):
+            raise RuntimeError(
+                f"{CONFIG_KEY_SUBPROCESS_ARGV} entries must be str, got "
+                f"{[type(a).__name__ for a in argv]}"
+            )
+        self._argv = tuple(argv)
+
+        log_prefix = self.config.get(CONFIG_KEY_LOG_PREFIX)
+        if not isinstance(log_prefix, str) or not log_prefix:
+            raise RuntimeError(
+                "SubprocessWorkload requires the platform-supplied "
+                f"{CONFIG_KEY_LOG_PREFIX!r} config key (the runner sets "
+                "save_logs=True for probe-mode cells; this is a runner bug "
+                "if it's missing)."
+            )
+        match = _LOG_PREFIX_TRIAL_RE.search(Path(log_prefix).name)
+        if match is None:
+            raise RuntimeError(
+                f"{CONFIG_KEY_LOG_PREFIX} {log_prefix!r} does not match the "
+                "documented 'trial_d<d>_m<m>_t<idx>' shape; cannot derive "
+                "per-trial directory."
+            )
+        self._trial_index = int(match.group(1))
+        # ``Path(log_prefix).parent`` is ``<results_dir>/<workload>/``
+        # (the dispatcher's per-workload subdir); the probe-mode cell
+        # dir is its parent. trial_<N>/ lives directly under the cell
+        # dir so the artifact tree matches the rubric's
+        # ``<cell>/trial_<n>/{stdout,stderr,result}`` layout.
+        cell_dir = Path(log_prefix).parent.parent
+        self._trial_dir = cell_dir / f"trial_{self._trial_index}"
+        self._trial_dir.mkdir(parents=True, exist_ok=True)
+
+    def run(self) -> WorkloadResult:
+        """Fork the user command and write the Tier-1 ``result.json``."""
+        if self._argv is None or self._trial_dir is None or self._trial_index is None:
+            raise RuntimeError("SubprocessWorkload.run() called before setup()")
+
+        argv = self._argv
+        trial_dir = self._trial_dir
+        stdout_path = trial_dir / "stdout.log"
+        stderr_path = trial_dir / "stderr.log"
+        result_path = trial_dir / "result.json"
+
+        probe_extras = self.config.get(CONFIG_KEY_PROBE_EXTRAS) or {}
+        env_mode = probe_extras.get("env_passthrough_mode", "inherit")
+        timeout = probe_extras.get("timeout_per_trial")
+
+        # ``inherit`` mode: the dispatcher has already stamped the
+        # cell's mitigation + diagnostic env vars onto os.environ in
+        # _run_single_trial's pre-run overlay (it restores them in the
+        # finally block after run()). We pass a snapshot to Popen so
+        # the child inherits exactly what the parent had at fork.
+        #
+        # ``file`` mode: ALSO write a 0600 KEY=VALUE\n env file in the
+        # trial dir and export AORTA_ENV_FILE so the user's argv can
+        # reference it (``docker run --env-file $AORTA_ENV_FILE ...``).
+        # See F6 in the rubric for the no-parse-argv rationale.
+        cell_env_snapshot = self._capture_cell_env(probe_extras)
+        child_env = os.environ.copy()
+        if env_mode == "file":
+            env_file_path = trial_dir / "probe.env"
+            _write_env_file(env_file_path, cell_env_snapshot)
+            child_env["AORTA_ENV_FILE"] = str(env_file_path.absolute())
+
+        t0 = time.perf_counter()
+        exit_code: int
+        timed_out = False
+        try:
+            with open(stdout_path, "wb") as out_fh, open(stderr_path, "wb") as err_fh:
+                proc = subprocess.Popen(
+                    list(argv),
+                    stdout=out_fh,
+                    stderr=err_fh,
+                    env=child_env,
+                )
+                try:
+                    exit_code = proc.wait(timeout=timeout)
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                    proc.kill()
+                    proc.wait()
+                    exit_code = -1
+        except FileNotFoundError as exc:
+            # ``Popen`` raises FileNotFoundError when argv[0] doesn't
+            # resolve to an executable -- record as a Tier-1 fail with
+            # the error captured in stderr.log for diagnosis.
+            exit_code = 127
+            try:
+                stderr_path.write_text(f"{exc}\n", encoding="utf-8")
+            except OSError:
+                pass
+        walltime_sec = time.perf_counter() - t0
+
+        verdict = "pass" if exit_code == 0 and not timed_out else "fail"
+
+        result_doc: dict[str, Any] = {
+            "verdict": verdict,
+            "exit_code": exit_code,
+            "walltime_sec": walltime_sec,
+            "argv": list(argv),
+            "cell_name": probe_extras.get("cell_name", "_unknown_"),
+            "trial_index": self._trial_index,
+            "env_passthrough_mode": env_mode,
+            "timed_out": timed_out,
+        }
+        result_path.write_text(
+            json.dumps(result_doc, indent=2, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        return WorkloadResult(
+            passed=(verdict == "pass"),
+            failure_count=0 if verdict == "pass" else 1,
+            failure_details=(
+                []
+                if verdict == "pass"
+                else [
+                    {
+                        "exit_code": exit_code,
+                        "timed_out": timed_out,
+                        "type": "subprocess_nonzero_exit",
+                    }
+                ]
+            ),
+            main_work_started=True,
+            executed_iterations=1,
+            configured_iterations=1,
+            elapsed_sec=walltime_sec,
+            metrics={
+                "verdict": verdict,
+                "exit_code": exit_code,
+                "result_json_path": str(result_path),
+            },
+        )
+
+    def _capture_cell_env(self, probe_extras: dict[str, Any]) -> dict[str, str]:
+        """Compute the cell's mitigation+diagnostic env-var bundle.
+
+        Phase 1 takes the bundle from the probe_extras dict the runner
+        attaches per-cell -- the dispatcher has already stamped these
+        on os.environ for ``inherit`` mode, but ``file`` mode needs
+        the raw bundle to write into ``probe.env`` (without scooping
+        unrelated host env vars).
+        """
+        bundle = probe_extras.get("cell_env_vars") or {}
+        if not isinstance(bundle, dict):
+            return {}
+        return {str(k): str(v) for k, v in bundle.items()}
+
+
+def _write_env_file(path: Path, env: dict[str, str]) -> None:
+    """Write a POSIX KEY=VALUE\\n env file at ``chmod 0600``.
+
+    The 0600 mode is set BEFORE writing the values via ``open(... 0o600)``
+    on platforms that honour ``os.O_CREAT`` mode bits, and chmod'd
+    after as a belt-and-suspenders for filesystems that ignore the
+    open-mode (NFS without root squash, some FUSE backends).
+
+    Per R5 in the rubric, the env file is the leakage surface for
+    secrets in ``file`` mode; Phase 3 redaction scrubs these from the
+    bundle, but Phase 1 ships the 0600 guard as the only mitigation.
+    """
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            for key in sorted(env):
+                # POSIX env-file shape: bare KEY=VALUE\n, no quoting.
+                # Reject newlines in values up-front -- they would
+                # corrupt the file shape and a downstream tool would
+                # silently read a truncated value.
+                value = env[key]
+                if "\n" in value or "\r" in value:
+                    raise ValueError(
+                        f"env value for {key!r} contains a newline; "
+                        "probe.env uses bare KEY=VALUE format and cannot "
+                        "encode multi-line values"
+                    )
+                fh.write(f"{key}={value}\n")
+    finally:
+        # Re-assert 0600 in case the underlying FS dropped the open-mode.
+        try:
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+
+
+__all__ = [
+    "CONFIG_KEY_LOG_PREFIX",
+    "CONFIG_KEY_PROBE_EXTRAS",
+    "CONFIG_KEY_SUBPROCESS_ARGV",
+    "SubprocessWorkload",
+]

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -16,9 +16,14 @@ cannot smuggle an argv via ``config_overrides`` -- the typed
 
 Per-trial output layout (Phase 1):
 
-* ``<cell_dir>/trial_<N>/stdout.log`` -- captured stdout (utf-8,
-  backslashreplace on encode errors).
-* ``<cell_dir>/trial_<N>/stderr.log`` -- captured stderr.
+* ``<cell_dir>/trial_<N>/stdout.log`` -- captured stdout written as
+  RAW BYTES (the file handle is opened in binary ``"wb"`` mode so the
+  child process's output lands on disk byte-for-byte; no decode,
+  encoding-error handling, or line buffering is performed in the
+  parent). Downstream readers should treat the file as bytes and
+  decode lazily.
+* ``<cell_dir>/trial_<N>/stderr.log`` -- captured stderr, same raw-
+  bytes contract as stdout.log.
 * ``<cell_dir>/trial_<N>/result.json`` -- Tier-1 verdict + metadata.
 * ``<cell_dir>/trial_<N>/probe.env`` -- only when
   ``env_passthrough_mode == "file"`` (chmod 0600).
@@ -119,9 +124,16 @@ class SubprocessWorkload(Workload):
         if not isinstance(log_prefix, str) or not log_prefix:
             raise RuntimeError(
                 "SubprocessWorkload requires the platform-supplied "
-                f"{CONFIG_KEY_LOG_PREFIX!r} config key (the runner sets "
-                "save_logs=True for probe-mode cells; this is a runner bug "
-                "if it's missing)."
+                f"{CONFIG_KEY_LOG_PREFIX!r} config key. The dispatcher "
+                "only injects it on the rank-0 ('should_write') path when "
+                "save_logs=True. The most likely root causes are: (1) "
+                "the workload was invoked under a launcher with RANK!=0 "
+                "(probe-mode is single-rank by design; multi-rank wrapping "
+                "is not supported in Phase 1), (2) the runner forgot to "
+                "set save_logs=True (this is a runner bug if the cell is "
+                "probe-mode), or (3) the workload was invoked outside "
+                "'aorta probe' altogether (not supported -- this workload "
+                "is platform-internal)."
             )
         match = _LOG_PREFIX_TRIAL_RE.search(Path(log_prefix).name)
         if match is None:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -199,6 +199,16 @@ class SubprocessWorkload(Workload):
         t0 = time.perf_counter()
         exit_code: int
         timed_out = False
+        # ``launched`` distinguishes "subprocess ran (maybe poorly)"
+        # from "subprocess never started" (exec-time Popen failure --
+        # ENOENT / EACCES / ENOEXEC). The artifact-tree contract from
+        # PR #194 round 4 still applies (``result.json`` is written
+        # either way), but the matrix outcome classifier needs the
+        # signal to avoid counting a command-not-found as a completed
+        # 1/1 trial. See the ``return WorkloadResult(...)`` block
+        # below for the propagation into ``main_work_started`` /
+        # ``executed_iterations``.
+        launched = False
         try:
             with open(stdout_path, "wb") as out_fh, open(stderr_path, "wb") as err_fh:
                 proc = subprocess.Popen(
@@ -207,6 +217,7 @@ class SubprocessWorkload(Workload):
                     stderr=err_fh,
                     env=child_env,
                 )
+                launched = True
                 try:
                     exit_code = proc.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
@@ -284,6 +295,16 @@ class SubprocessWorkload(Workload):
             encoding="utf-8",
         )
 
+        # ``main_work_started`` / ``executed_iterations`` mirror
+        # whether ``Popen`` actually launched a child. A normal
+        # non-zero child exit is still ``launched=True`` (the
+        # subprocess ran and exited); exec-time ``Popen`` failures
+        # (ENOENT / EACCES / ENOEXEC) leave both fields at 0/False so
+        # the matrix outcome classifier doesn't conflate a
+        # command-not-found with a completed 1/1 trial. The
+        # ``result.json`` is still written either way -- the artifact
+        # contract from PR #194 round 4 is independent of the
+        # matrix-side semantic.
         return WorkloadResult(
             passed=(verdict == "pass"),
             failure_count=0 if verdict == "pass" else 1,
@@ -294,12 +315,14 @@ class SubprocessWorkload(Workload):
                     {
                         "exit_code": exit_code,
                         "timed_out": timed_out,
-                        "type": "subprocess_nonzero_exit",
+                        "type": (
+                            "subprocess_nonzero_exit" if launched else "subprocess_exec_failed"
+                        ),
                     }
                 ]
             ),
-            main_work_started=True,
-            executed_iterations=1,
+            main_work_started=launched,
+            executed_iterations=1 if launched else 0,
             configured_iterations=1,
             elapsed_sec=walltime_sec,
             metrics={

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -199,8 +199,26 @@ class SubprocessWorkload(Workload):
                     exit_code = proc.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
                     timed_out = True
-                    proc.kill()
-                    proc.wait()
+                    # Race-safe shutdown: the child can exit between
+                    # the ``wait()`` timeout and our ``kill()`` (e.g.
+                    # the workload finished while the kernel was
+                    # delivering the SIGALRM the timeout uses), which
+                    # makes ``Popen.kill()`` raise
+                    # ``ProcessLookupError`` (ESRCH) on Linux. Swallow
+                    # that one specific case so the trial deterministically
+                    # records ``timed_out=True`` and ``exit_code=-1``
+                    # rather than crashing the workload and leaving the
+                    # trial with no ``result.json``. Any other OSError
+                    # from kill() (EPERM etc.) re-raises so we don't
+                    # silently swallow a genuine bug.
+                    try:
+                        proc.kill()
+                    except ProcessLookupError:
+                        pass
+                    try:
+                        proc.wait()
+                    except ProcessLookupError:
+                        pass
                     exit_code = -1
         except FileNotFoundError as exc:
             # ``Popen`` raises FileNotFoundError when argv[0] doesn't
@@ -287,9 +305,27 @@ def _write_env_file(path: Path, env: dict[str, str]) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             for key in sorted(env):
                 # POSIX env-file shape: bare KEY=VALUE\n, no quoting.
-                # Reject newlines in values up-front -- they would
-                # corrupt the file shape and a downstream tool would
-                # silently read a truncated value.
+                # Sidecar mitigations only enforce that keys are
+                # strings, NOT that they are single-line and
+                # ``=``-free, so a hostile mitigation file could try
+                # to inject extra KEY=VALUE rows via ``\n`` or
+                # ``\r`` in a key, or smuggle a second ``=`` to
+                # rebind a later key. Reject all three explicitly
+                # (newline/CR/equals) so the file shape stays one
+                # KEY=VALUE per row and a downstream reader cannot
+                # be coerced into seeing a different binding than
+                # what the mitigation actually wrote.
+                if "\n" in key or "\r" in key or "=" in key:
+                    raise ValueError(
+                        f"env key {key!r} contains a newline, carriage "
+                        "return, or '=' character; probe.env uses bare "
+                        "KEY=VALUE format and rejects these to prevent "
+                        "row-injection via a hostile mitigation sidecar"
+                    )
+                # Reject newlines in values up-front for the same
+                # reason: a value with ``\n`` would corrupt the
+                # file shape and a downstream tool would silently
+                # read a truncated value.
                 value = env[key]
                 if "\n" in value or "\r" in value:
                     raise ValueError(

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -181,7 +181,39 @@ class SubprocessWorkload(Workload):
         child_env = os.environ.copy()
         env_file_path = trial_dir / "probe.env"
         if env_mode == "file":
-            _write_env_file(env_file_path, cell_env_snapshot)
+            try:
+                _write_env_file(env_file_path, cell_env_snapshot)
+            except ValueError as exc:
+                # ``_write_env_file`` rejects hostile/malformed mitigation
+                # keys/values (newlines, '=' in key, etc.) by raising
+                # ``ValueError``. Without this handler the exception would
+                # escape ``run()`` and the dispatcher would record an
+                # ``infrastructure_failed`` TrialResult -- but with NO
+                # per-trial ``result.json``. That breaks two contracts at
+                # once:
+                #
+                # 1. The artifact-tree contract (every probe trial leaves
+                #    ``trial_<n>/result.json``).
+                # 2. ``flat_resume``: ``is_trial_complete`` keys off the
+                #    presence of ``result.json``, so a missing file makes
+                #    every subsequent ``aorta probe`` invocation re-run
+                #    the same broken cell forever.
+                #
+                # Treat it like the exec-time ``Popen`` failures below
+                # (FileNotFoundError, PermissionError): synthesize a
+                # Tier-1 ``fail`` ``result.json``, write the error message
+                # to ``stderr.log``, and return a ``WorkloadResult`` with
+                # ``launched=False`` / ``main_work_started=False`` so the
+                # matrix classifier doesn't conflate this with a real
+                # subprocess that exited non-zero.
+                return self._write_env_file_failure_result(
+                    exc=exc,
+                    result_path=result_path,
+                    stderr_path=stderr_path,
+                    argv=argv,
+                    probe_extras=probe_extras,
+                    env_mode=env_mode,
+                )
             child_env["AORTA_ENV_FILE"] = str(env_file_path.absolute())
         else:
             # ``inherit`` mode: scrub any probe.env left over from a
@@ -328,6 +360,79 @@ class SubprocessWorkload(Workload):
             metrics={
                 "verdict": verdict,
                 "exit_code": exit_code,
+                "result_json_path": str(result_path),
+            },
+        )
+
+    def _write_env_file_failure_result(
+        self,
+        *,
+        exc: ValueError,
+        result_path: Path,
+        stderr_path: Path,
+        argv: tuple[str, ...],
+        probe_extras: dict[str, Any],
+        env_mode: str,
+    ) -> WorkloadResult:
+        """Persist a Tier-1 ``fail`` artifact when probe.env validation rejects.
+
+        Mirrors the exec-failed bookkeeping in :meth:`run` so the per-trial
+        directory always contains both ``stderr.log`` (with the validation
+        error message) and ``result.json``. Without this, ``flat_resume``'s
+        ``is_trial_complete`` predicate keys off a missing ``result.json``
+        and re-runs the same broken cell on every subsequent
+        ``aorta probe`` invocation.
+        """
+        try:
+            stderr_path.write_text(f"{exc}\n", encoding="utf-8")
+        except OSError:
+            pass
+        result_doc: dict[str, Any] = {
+            "verdict": "fail",
+            # Exit-code 2 mirrors the ``_setup_validation`` convention used
+            # elsewhere in the codebase for "config rejected before
+            # subprocess could start" -- distinct from 126/127 which we
+            # reserve for chmod/PATH problems on argv[0].
+            "exit_code": 2,
+            # Walltime is 0 because the subprocess never launched; we
+            # spent only the env-file-validation pass which is bounded
+            # to a few hundred microseconds. Reporting 0.0 keeps the
+            # matrix's step-time aggregates from being polluted by a
+            # cell that never produced step times.
+            "walltime_sec": 0.0,
+            "argv": list(argv),
+            "cell_name": probe_extras.get("cell_name", "_unknown_"),
+            "trial_index": self._trial_index,
+            "env_passthrough_mode": env_mode,
+            "timed_out": False,
+            "failure_type": "env_file_validation_failed",
+            "error_message": str(exc),
+        }
+        result_path.write_text(
+            json.dumps(result_doc, indent=2, sort_keys=False),
+            encoding="utf-8",
+        )
+        return WorkloadResult(
+            passed=False,
+            failure_count=1,
+            failure_details=[
+                {
+                    "exit_code": 2,
+                    "timed_out": False,
+                    "type": "env_file_validation_failed",
+                }
+            ],
+            # ``launched`` / ``main_work_started`` mirror the Popen-exec-
+            # failed branch in :meth:`run`: the subprocess never started,
+            # so neither flag flips. This keeps the matrix outcome
+            # classifier from counting this as a completed 1/1 trial.
+            main_work_started=False,
+            executed_iterations=0,
+            configured_iterations=1,
+            elapsed_sec=0.0,
+            metrics={
+                "verdict": "fail",
+                "exit_code": 2,
                 "result_json_path": str(result_path),
             },
         )

--- a/tests/probe/fixtures/probe_minimal.yaml
+++ b/tests/probe/fixtures/probe_minimal.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+mode: probe
+ticket: PROBE-188-SMOKE
+trials: 1
+mitigation_axis:
+  - none
+diagnostic_axis:
+  - none

--- a/tests/probe/fixtures/probe_two_cell.yaml
+++ b/tests/probe/fixtures/probe_two_cell.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+mode: probe
+ticket: PROBE-188-TWO
+trials: 1
+mitigation_axis:
+  - none
+  - tf32_off
+diagnostic_axis:
+  - none

--- a/tests/probe/fixtures/probe_with_phase_2_keys.yaml
+++ b/tests/probe/fixtures/probe_with_phase_2_keys.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis:
+  - none
+diagnostic_axis:
+  - none
+custom_patterns:
+  - id: hip_oom
+    match:
+      regex: "hipErrorOutOfMemory"

--- a/tests/probe/test_cli_parsing.py
+++ b/tests/probe/test_cli_parsing.py
@@ -1,0 +1,136 @@
+"""CLI parsing tests for ``aorta probe`` (issue #188 Phase 1).
+
+Covers FR 1.1 (documented flags appear in --help), FR 1.15 (handler is a
+thin shim), and FR 1.18 (invalid recipe / empty argv exit non-zero).
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from aorta.cli.probe import probe
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---- FR 1.1 (documented flags) -------------------------------------------
+
+
+def test_help_lists_documented_flags():
+    """`aorta probe --help` shows the rubric-documented flag set."""
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--help"])
+    assert result.exit_code == 0
+    out = result.output
+    for flag in ("--recipe", "--output", "--ticket", "--dry-run", "--env-passthrough-mode"):
+        assert flag in out, f"missing flag {flag} in --help output"
+    # Trailing-argv usage line:
+    assert "ARGV" in out or "argv" in out
+
+
+# ---- FR 1.15 (thin-shim handler) -----------------------------------------
+
+
+def test_handler_is_thin_shim():
+    """The handler body is bounded so orchestration can't drift in.
+
+    Mirrors ``tests/run/test_cli_parsing.py::TestCliHandlerIsThinShell``.
+    Rubric pins the cap at <= 60 lines.
+    """
+    fn = probe.callback
+    source = inspect.getsource(fn)
+    tree = ast.parse(source)
+    func_def = tree.body[0]
+    assert isinstance(func_def, ast.FunctionDef)
+    body_start = func_def.body[0].lineno
+    body_end = func_def.end_lineno
+    assert body_end is not None
+    body_lines = body_end - body_start + 1
+    assert body_lines <= 60, (
+        f"Click handler body has grown to {body_lines} lines -- "
+        "move logic into aorta.probe.cli_helpers / aorta.probe.recipe_builder."
+    )
+
+
+def test_no_per_trial_loop_in_handler():
+    """The handler must not contain a ``for ... in range(...)`` loop."""
+    fn = probe.callback
+    source = inspect.getsource(fn)
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.For):
+            if (
+                isinstance(node.iter, ast.Call)
+                and isinstance(node.iter.func, ast.Name)
+                and node.iter.func.id == "range"
+            ):
+                raise AssertionError("Click handler contains a `for ... in range(...)` loop")
+
+
+# ---- FR 1.18 (invalid inputs exit non-zero) ------------------------------
+
+
+def test_empty_argv_nonzero_exit(tmp_path):
+    """`aorta probe --recipe X --` with nothing after `--` exits non-zero."""
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        ["--recipe", str(FIXTURES / "probe_minimal.yaml"), "--output", str(tmp_path), "--"],
+    )
+    assert result.exit_code != 0
+    assert "no trailing argv" in result.output.lower() or "no trailing argv" in str(
+        result.exception
+    )
+
+
+def test_invalid_recipe_nonzero_exit(tmp_path):
+    """`aorta probe --recipe <bogus_path>` exits non-zero with a ClickException."""
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        ["--recipe", str(tmp_path / "nonexistent.yaml"), "--", "echo", "hi"],
+    )
+    assert result.exit_code != 0
+
+
+def test_triage_mode_recipe_rejected(tmp_path):
+    """A non-probe-mode recipe surfaces a ClickException."""
+    recipe_path = tmp_path / "triage.yaml"
+    recipe_path.write_text(
+        "schema_version: 1\n"
+        "workload: fsdp\n"
+        "trials: 1\n"
+        "steps: 1\n"
+        "cells:\n"
+        "  - name: c\n"
+        "    mitigations: [none]\n"
+        "    environment: local\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--recipe", str(recipe_path), "--", "echo", "hi"])
+    assert result.exit_code != 0
+    assert "probe-mode" in result.output.lower()
+
+
+def test_invalid_env_passthrough_mode():
+    """Click's Choice validator rejects bogus modes pre-handler."""
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--env-passthrough-mode",
+            "bogus",
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "bogus" in result.output or "Invalid value" in result.output

--- a/tests/probe/test_cli_parsing.py
+++ b/tests/probe/test_cli_parsing.py
@@ -134,3 +134,122 @@ def test_invalid_env_passthrough_mode():
     )
     assert result.exit_code != 0
     assert "bogus" in result.output or "Invalid value" in result.output
+
+
+# ---- FR 1.18 defensive parsing (post-bug-report from real-world misuse) --
+
+
+def test_flag_shaped_value_for_output_rejected(tmp_path):
+    """``--output --ticket X`` (i.e. $TMPDIR unset) is refused, not silently accepted.
+
+    Real-world bug: shell expands ``--output $TMPDIR --ticket SMOKE-1``
+    to ``--output --ticket SMOKE-1`` when TMPDIR is unset. Click would
+    otherwise pass ``--ticket`` as the value of ``--output``, silently
+    creating a directory literally named ``--ticket`` and dropping the
+    real ``--ticket`` flag entirely.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--output",
+            "--ticket",
+            "SMOKE-1",
+            "--",
+            "bash",
+            "-c",
+            "echo hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "looks like another flag" in result.output
+
+
+def test_flag_shaped_value_for_recipe_rejected():
+    """``--recipe --ticket X`` is refused (either by exists= or our callback).
+
+    For ``--recipe``, Click's ``Path(exists=True)`` validator fires before
+    the post-conversion callback, so the user sees "File '--ticket' does
+    not exist" -- which is also a clear, non-zero-exit error pointing
+    them at the misparse. Either message is acceptable; the contract is
+    that the bug isn't silently accepted.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        ["--recipe", "--ticket", "X", "--", "echo", "hi"],
+    )
+    assert result.exit_code != 0
+    assert "looks like another flag" in result.output or "does not exist" in result.output
+
+
+def test_flag_shaped_value_for_ticket_rejected(tmp_path):
+    """``--ticket --output X`` (transposed flags) is refused."""
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--ticket",
+            "--output",
+            str(tmp_path),
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "looks like another flag" in result.output
+
+
+def test_missing_double_dash_separator_rejected(tmp_path):
+    """Without ``--`` in raw argv, the CLI refuses to silently sweep positionals.
+
+    Real-world bug: a stray positional (e.g. ``SMOKE-1``) before any
+    ``--`` got swept into the user command argv as the executable name,
+    producing an exit-127 "fail" trial that was actually a CLI misparse.
+    The double-dash separator is mandatory.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--output",
+            str(tmp_path),
+            "SMOKE-1",
+            "bash",
+            "-c",
+            "echo hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "missing '--' separator" in result.output
+
+
+def test_user_command_starting_with_dash_rejected(tmp_path):
+    """A user command whose first token starts with ``-`` is refused.
+
+    Catches the residual case where ``--`` was present but a leftover
+    aorta-shaped flag (e.g. ``-v``) still leaked into ``argv[0]``.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--output",
+            str(tmp_path),
+            "--",
+            "-v",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "looks like a flag" in result.output

--- a/tests/probe/test_cli_parsing.py
+++ b/tests/probe/test_cli_parsing.py
@@ -366,3 +366,67 @@ def test_cli_env_passthrough_mode_file_overrides_no_recipe_key(monkeypatch, tmp_
     )
     assert recipe_arg.probe_extras is not None
     assert recipe_arg.probe_extras.env_passthrough_mode == "file"
+
+
+# ---- PR #194 round-3 review: --help bypass must be option-zone-scoped ------
+
+
+def test_user_command_help_does_not_bypass_separator(tmp_path):
+    """A ``--help`` token AFTER the user command must NOT bypass the
+    mandatory ``--`` separator.
+
+    Regression for PR #194 review: ``aorta probe --recipe r --output o
+    echo --help`` previously short-circuited the separator check
+    because ``"--help" in args`` is True -- but here ``--help`` is the
+    user command's flag, not aorta's. The fix scopes the bypass to
+    help tokens that sit in the aorta-option zone (before the
+    user-command boundary). See
+    :func:`aorta.probe.cli_helpers.help_token_in_option_zone`.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--output",
+            str(tmp_path),
+            "echo",
+            "--help",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "missing '--' separator" in result.output
+
+
+def test_aorta_help_still_works(tmp_path):
+    """``aorta probe --help`` (no user command, --help before any
+    positional) still renders help. Pins the upper bound of the
+    scoped bypass: real help invocations are not regressed.
+    """
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--help"])
+    assert result.exit_code == 0
+    assert "ARGV" in result.output or "argv" in result.output
+
+
+def test_aorta_help_after_value_taking_option_still_works(tmp_path):
+    """``aorta probe --recipe r --help`` -- the help token follows
+    ``--recipe`` (a value-taking option that consumes ``r``) but stays
+    in the option zone because no user-command positional has been
+    seen yet. Must still render help, not raise the separator error.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--help",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "ARGV" in result.output or "argv" in result.output
+
+
+# ---- PR #194 round-3 review: exec-time errors land as Tier-1 fails ----

--- a/tests/probe/test_cli_parsing.py
+++ b/tests/probe/test_cli_parsing.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import ast
 import inspect
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from click.testing import CliRunner
 
+import aorta.cli.probe as probe_cli
 from aorta.cli.probe import probe
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -253,3 +255,114 @@ def test_user_command_starting_with_dash_rejected(tmp_path):
     )
     assert result.exit_code != 0
     assert "looks like a flag" in result.output
+
+
+# ---- FR 1.10 (CLI flag precedence over recipe env_passthrough_mode) ------
+
+
+def _invoke_probe_capturing_recipe(monkeypatch, tmp_path, *, recipe_text, cli_extra):
+    """Run ``aorta probe`` against an in-memory recipe and return the
+    :class:`Recipe` the CLI handed to ``run_recipe``.
+
+    Both modules bind ``run_recipe`` at import time so patching only the
+    runner module would miss the CLI binding -- patch ``aorta.cli.probe``
+    directly. Mirrors the pattern in ``tests/probe/test_shared_engine.py``.
+    """
+    mock = MagicMock(return_value=tmp_path / "run-dir")
+    monkeypatch.setattr(probe_cli, "run_recipe", mock)
+    recipe_path = tmp_path / "r.yaml"
+    recipe_path.write_text(recipe_text, encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe_path),
+            "--output",
+            str(tmp_path / "out"),
+            *cli_extra,
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock.assert_called_once()
+    args, kwargs = mock.call_args
+    recipe_arg = args[0] if args else kwargs["recipe"]
+    return recipe_arg
+
+
+_RECIPE_WITH_FILE_MODE = (
+    "schema_version: 1\n"
+    "mode: probe\n"
+    "ticket: PROBE-188-PRECEDENCE\n"
+    "trials: 1\n"
+    "mitigation_axis: [none]\n"
+    "diagnostic_axis: [none]\n"
+    "env_passthrough_mode: file\n"
+)
+
+_RECIPE_NO_MODE = (
+    "schema_version: 1\n"
+    "mode: probe\n"
+    "ticket: PROBE-188-PRECEDENCE\n"
+    "trials: 1\n"
+    "mitigation_axis: [none]\n"
+    "diagnostic_axis: [none]\n"
+)
+
+
+def test_recipe_env_passthrough_mode_honored_when_cli_omits_flag(monkeypatch, tmp_path):
+    """Recipe says ``env_passthrough_mode: file`` and CLI omits the flag -> ``file`` wins.
+
+    Regression for PR #194 review: the Click option used to default to
+    ``"inherit"`` and unconditionally overwrite ``recipe.probe_extras
+    .env_passthrough_mode``, making the recipe key impossible to honour
+    when the user didn't pass the flag. Default is now ``None`` and the
+    handler only overrides when the user actually supplied the flag.
+    """
+    recipe_arg = _invoke_probe_capturing_recipe(
+        monkeypatch,
+        tmp_path,
+        recipe_text=_RECIPE_WITH_FILE_MODE,
+        cli_extra=[],
+    )
+    assert recipe_arg.probe_extras is not None
+    assert recipe_arg.probe_extras.env_passthrough_mode == "file"
+
+
+def test_cli_env_passthrough_mode_overrides_recipe(monkeypatch, tmp_path):
+    """Recipe says ``file`` and CLI says ``inherit`` -> CLI wins (FR 1.10)."""
+    recipe_arg = _invoke_probe_capturing_recipe(
+        monkeypatch,
+        tmp_path,
+        recipe_text=_RECIPE_WITH_FILE_MODE,
+        cli_extra=["--env-passthrough-mode", "inherit"],
+    )
+    assert recipe_arg.probe_extras is not None
+    assert recipe_arg.probe_extras.env_passthrough_mode == "inherit"
+
+
+def test_default_passthrough_mode_when_neither_set(monkeypatch, tmp_path):
+    """Neither CLI nor recipe sets the mode -> recipe-builder default ``"inherit"``."""
+    recipe_arg = _invoke_probe_capturing_recipe(
+        monkeypatch,
+        tmp_path,
+        recipe_text=_RECIPE_NO_MODE,
+        cli_extra=[],
+    )
+    assert recipe_arg.probe_extras is not None
+    assert recipe_arg.probe_extras.env_passthrough_mode == "inherit"
+
+
+def test_cli_env_passthrough_mode_file_overrides_no_recipe_key(monkeypatch, tmp_path):
+    """Recipe omits the key, CLI says ``file`` -> ``file`` wins."""
+    recipe_arg = _invoke_probe_capturing_recipe(
+        monkeypatch,
+        tmp_path,
+        recipe_text=_RECIPE_NO_MODE,
+        cli_extra=["--env-passthrough-mode", "file"],
+    )
+    assert recipe_arg.probe_extras is not None
+    assert recipe_arg.probe_extras.env_passthrough_mode == "file"

--- a/tests/probe/test_dry_run.py
+++ b/tests/probe/test_dry_run.py
@@ -1,0 +1,61 @@
+"""Dry-run semantics for ``aorta probe`` (issue #188 Phase 1 FR 1.2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from aorta.cli.probe import probe
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_dry_run_prints_cells_and_argv(tmp_path):
+    """`aorta probe --dry-run -- echo hi` prints one line per cell + argv."""
+    output = tmp_path / "out"
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_two_cell.yaml"),
+            "--output",
+            str(output),
+            "--dry-run",
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # Both cells listed with their literal argv:
+    assert "none-none" in out
+    assert "tf32_off-none" in out
+    assert "['echo', 'hi']" in out
+    # Env-passthrough mode is shown:
+    assert "inherit" in out.lower() or "inherit" in out
+    # tf32_off sets DISABLE_TF32=1 -- the cell's env bundle must surface.
+    assert "DISABLE_TF32" in out
+
+
+def test_dry_run_does_not_write_disk(tmp_path):
+    """Dry-run must not create the output directory."""
+    output = tmp_path / "nope"
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--output",
+            str(output),
+            "--dry-run",
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0
+    assert not output.exists(), f"dry-run created {output}; expected no FS writes"

--- a/tests/probe/test_end_to_end.py
+++ b/tests/probe/test_end_to_end.py
@@ -1,0 +1,79 @@
+"""End-to-end smoke for ``aorta probe`` (issue #188 FR 1.3, 1.14).
+
+Invokes the real ``aorta probe`` Click command via :class:`CliRunner`,
+runs a 1-cell recipe with ``bash -c 'echo hi'`` as the user command,
+and asserts the artifact tree matches the rubric.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from aorta.cli.probe import probe
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_smoke_passes(tmp_path):
+    """FR 1.3 -- full smoke with the documented artifact tree."""
+    output = tmp_path / "out"
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--output",
+            str(output),
+            "--ticket",
+            "SMOKE-1",
+            "--",
+            "bash",
+            "-c",
+            "echo hi; exit 0",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    cell_dir = output / "SMOKE-1" / "none-none"
+    trial = cell_dir / "trial_0"
+    for artifact in ("stdout.log", "stderr.log", "result.json"):
+        assert (trial / artifact).is_file(), f"missing {artifact} in {trial}"
+    doc = json.loads((trial / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "pass"
+    assert doc["exit_code"] == 0
+    stdout = (trial / "stdout.log").read_text(encoding="utf-8")
+    assert "hi" in stdout
+
+
+def test_no_ticket_routed_to_no_ticket_slug(tmp_path):
+    """FR 1.14 -- omitted --ticket routes to '_no_ticket_/' under output."""
+    # The fixture has a ticket; override it to None by writing a fresh recipe.
+    recipe = tmp_path / "no_ticket.yaml"
+    recipe.write_text(
+        "schema_version: 1\n"
+        "mode: probe\n"
+        "trials: 1\n"
+        "mitigation_axis: [none]\n"
+        "diagnostic_axis: [none]\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "out"
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe),
+            "--output",
+            str(output),
+            "--",
+            "bash",
+            "-c",
+            "echo hi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (output / "_no_ticket_" / "none-none" / "trial_0" / "result.json").is_file()

--- a/tests/probe/test_env_passthrough.py
+++ b/tests/probe/test_env_passthrough.py
@@ -103,6 +103,81 @@ def test_env_file_is_0600(tmp_path):
     assert perms == 0o600, f"expected 0600, got 0o{perms:o}"
 
 
+def test_env_file_validation_failure_does_not_leave_partial_file(tmp_path):
+    """Validation rejection must NOT leave a partial probe.env on disk.
+
+    Regression for PR #194 round 6 (Copilot): the previous shape
+    ``os.open(..., O_TRUNC) -> for-loop with mid-stream raise`` would
+    write rows 0..k-1 to disk and then raise on row k. The caller
+    recorded ``env_file_validation_failed`` in result.json, but a
+    partial probe.env was already on disk -- a 0600 KEY=VALUE file
+    that looked legitimate but contained only a subset of the
+    cell's bundle. Operators inspecting the trial directory would
+    see a probe.env that contradicts result.json's failure_type.
+
+    The fix is two-pronged and this test pins both: validate-first
+    in ``_write_env_file`` (atomic-on-rejection) AND a defensive
+    unlink in the caller's failure path (so a *prior* run's stale
+    probe.env from the same trial directory cannot survive either).
+    """
+    wl = _make_workload(
+        tmp_path,
+        argv=["true"],
+        env_mode="file",
+        # Sorted iteration: AAA, BBB, ZZZ_BAD (the bad key). If
+        # validation were per-row-during-write, AAA + BBB would
+        # land on disk before the ZZZ raise.
+        cell_env_vars={
+            "AAA_GOOD": "first",
+            "BBB_GOOD": "second",
+            "ZZZ_BAD\nKEY": "value",
+        },
+    )
+    wl.setup()
+    wl.run()
+    trial_dir = tmp_path / "trial_0"
+    env_path = trial_dir / "probe.env"
+    assert not env_path.exists(), (
+        "probe.env must not exist after env-file validation failure; "
+        f"found contents: {env_path.read_text() if env_path.exists() else '(absent)'}"
+    )
+    # Sanity: the failure was still recorded.
+    import json
+
+    doc = json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
+    assert doc["failure_type"] == "env_file_validation_failed"
+
+
+def test_env_file_validation_failure_scrubs_stale_prior_file(tmp_path):
+    """A stale probe.env from a previous run must be cleaned up on rejection.
+
+    Resume + flat_resume reuse the same ``trial_<n>/`` directory across
+    invocations. If a previous run wrote a valid probe.env and the
+    current run's bundle fails validation, the on-disk artifact
+    must agree with result.json -- a stale leftover would contradict
+    ``failure_type=env_file_validation_failed``.
+    """
+    trial_dir = tmp_path / "trial_0"
+    trial_dir.mkdir(parents=True, exist_ok=True)
+    stale_path = trial_dir / "probe.env"
+    stale_path.write_text("STALE=from_prior_run\n", encoding="utf-8")
+    stale_path.chmod(0o600)
+
+    wl = _make_workload(
+        tmp_path,
+        argv=["true"],
+        env_mode="file",
+        cell_env_vars={"BAD\nKEY": "value"},
+    )
+    wl.setup()
+    wl.run()
+
+    assert not stale_path.exists(), (
+        "stale probe.env from a prior run was not scrubbed after the "
+        "current run's env-file validation failure"
+    )
+
+
 def test_env_file_rejects_newline_in_value(tmp_path):
     """Newline in env value -> Tier-1 fail artifact (not unhandled raise).
 

--- a/tests/probe/test_env_passthrough.py
+++ b/tests/probe/test_env_passthrough.py
@@ -104,7 +104,19 @@ def test_env_file_is_0600(tmp_path):
 
 
 def test_env_file_rejects_newline_in_value(tmp_path):
-    """Newline in env value would corrupt the KEY=VALUE shape -- reject up-front."""
+    """Newline in env value -> Tier-1 fail artifact (not unhandled raise).
+
+    Previous contract (pre-PR-#194-review): ``_write_env_file`` raised
+    ``ValueError`` and the exception escaped ``run()``. That broke the
+    "every probe trial leaves an artifact" contract: the dispatcher
+    recorded an ``infrastructure_failed`` TrialResult but no per-trial
+    ``result.json`` was on disk, which made ``flat_resume``'s
+    ``is_trial_complete`` predicate re-run the broken cell on every
+    subsequent ``aorta probe`` invocation. The new contract synthesises
+    a ``result.json`` (verdict=fail, ``failure_type=env_file_validation_failed``)
+    so resume sees the cell as complete and the operator gets a
+    grep-able cause in the artifact tree.
+    """
     wl = _make_workload(
         tmp_path,
         argv=["true"],
@@ -112,8 +124,34 @@ def test_env_file_rejects_newline_in_value(tmp_path):
         cell_env_vars={"MULTILINE": "line1\nline2"},
     )
     wl.setup()
-    with pytest.raises(ValueError, match="newline"):
-        wl.run()
+    result = wl.run()
+
+    trial_dir = tmp_path / "trial_0"
+    result_path = trial_dir / "result.json"
+    assert result_path.is_file(), (
+        "env-file validation failure must still leave result.json -- "
+        "otherwise flat_resume re-runs the cell forever"
+    )
+    import json
+
+    doc = json.loads(result_path.read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["failure_type"] == "env_file_validation_failed"
+    assert "newline" in doc["error_message"]
+    assert doc["env_passthrough_mode"] == "file"
+    assert doc["trial_index"] == 0
+    # ``stderr.log`` carries the same diagnostic so operators inspecting
+    # the trial without parsing JSON still see the cause.
+    stderr_text = (trial_dir / "stderr.log").read_text(encoding="utf-8")
+    assert "newline" in stderr_text
+
+    # WorkloadResult must reflect "never launched" so the matrix
+    # outcome classifier doesn't conflate this with a completed
+    # 1/1 trial (the same invariant the Popen-exec-failed branch
+    # already maintains).
+    assert result.passed is False
+    assert result.main_work_started is False
+    assert result.executed_iterations == 0
 
 
 @pytest.mark.parametrize(
@@ -126,12 +164,19 @@ def test_env_file_rejects_newline_in_value(tmp_path):
     ],
 )
 def test_env_file_rejects_unsafe_chars_in_key(tmp_path, bad_key):
-    """Regression for PR #194 review: hostile mitigation sidecars
-    could smuggle ``\\n``, ``\\r``, or ``=`` into env *keys* to
-    inject extra KEY=VALUE rows or rebind a later key. The
-    sidecar loader only enforces ``isinstance(key, str)``, so the
-    env-file writer is the right place to catch this -- it is the
-    layer that owns the on-disk KEY=VALUE row shape.
+    """Hostile sidecar keys -> Tier-1 fail artifact.
+
+    Original regression (PR #194 round 4): hostile mitigation sidecars
+    could smuggle ``\\n``, ``\\r``, or ``=`` into env *keys* to inject
+    extra KEY=VALUE rows or rebind a later key. The sidecar loader
+    only enforces ``isinstance(key, str)``, so the env-file writer is
+    the right place to catch this -- it is the layer that owns the
+    on-disk KEY=VALUE row shape.
+
+    Pre-fix behaviour was a raw ``ValueError`` escape; post-fix the
+    rejection is recorded as ``verdict=fail`` /
+    ``failure_type=env_file_validation_failed`` in ``result.json`` so
+    flat_resume can move past the broken cell.
     """
     wl = _make_workload(
         tmp_path,
@@ -140,8 +185,17 @@ def test_env_file_rejects_unsafe_chars_in_key(tmp_path, bad_key):
         cell_env_vars={bad_key: "safe-value"},
     )
     wl.setup()
-    with pytest.raises(ValueError, match="env key"):
-        wl.run()
+    result = wl.run()
+
+    trial_dir = tmp_path / "trial_0"
+    import json
+
+    doc = json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["failure_type"] == "env_file_validation_failed"
+    assert "env key" in doc["error_message"]
+    assert result.passed is False
+    assert result.main_work_started is False
 
 
 def test_inherit_mode_passes_env_to_child(tmp_path, monkeypatch):

--- a/tests/probe/test_env_passthrough.py
+++ b/tests/probe/test_env_passthrough.py
@@ -119,10 +119,10 @@ def test_env_file_rejects_newline_in_value(tmp_path):
 @pytest.mark.parametrize(
     "bad_key",
     [
-        "FOO\nBAR",       # newline in key
-        "FOO\rBAR",       # carriage return in key
-        "FOO=BAR",        # embedded '=' would rebind a later key
-        "X\n=injected",   # newline-then-equals row-injection attempt
+        "FOO\nBAR",  # newline in key
+        "FOO\rBAR",  # carriage return in key
+        "FOO=BAR",  # embedded '=' would rebind a later key
+        "X\n=injected",  # newline-then-equals row-injection attempt
     ],
 )
 def test_env_file_rejects_unsafe_chars_in_key(tmp_path, bad_key):
@@ -162,3 +162,58 @@ def test_inherit_mode_passes_env_to_child(tmp_path, monkeypatch):
     wl.run()
     stdout = (tmp_path / "trial_0" / "stdout.log").read_text(encoding="utf-8")
     assert "from_inherit" in stdout
+
+
+def test_inherit_mode_scrubs_stale_probe_env(tmp_path):
+    """A leftover ``probe.env`` from a prior ``file``-mode attempt is removed.
+
+    Regression for PR #194 review: in ``flat_resume`` runs the trial
+    directory is re-used when a prior attempt's ``result.json`` was
+    truncated. If the prior attempt ran in ``env_passthrough_mode=file``
+    it wrote a ``probe.env``; if the resumed attempt is in ``inherit``
+    mode the file would otherwise remain on disk, contradicting the
+    on-the-wire behaviour (no ``AORTA_ENV_FILE`` exported in the child).
+    """
+    workload_subdir = tmp_path / "_subprocess"
+    workload_subdir.mkdir(parents=True, exist_ok=True)
+    # Pre-create the trial dir + a stale probe.env from a "previous"
+    # file-mode run, then invoke the workload in inherit mode.
+    trial_dir = tmp_path / "trial_0"
+    trial_dir.mkdir()
+    stale = trial_dir / "probe.env"
+    stale.write_text("STALE_KEY=stale_value\n", encoding="utf-8")
+    assert stale.is_file()
+
+    wl = _make_workload(
+        tmp_path,
+        argv=["true"],
+        env_mode="inherit",
+        cell_env_vars={"DISABLE_TF32": "1"},
+    )
+    wl.setup()
+    wl.run()
+
+    assert not stale.exists(), "inherit mode must scrub a stale probe.env"
+    # Child must not have seen AORTA_ENV_FILE either; verify by
+    # re-running with a probe that echoes the var to stdout.
+    wl2 = _make_workload(
+        tmp_path,
+        argv=["sh", "-c", "echo AORTA_ENV_FILE=${AORTA_ENV_FILE:-unset}"],
+        env_mode="inherit",
+    )
+    wl2.setup()
+    wl2.run()
+    stdout = (trial_dir / "stdout.log").read_text(encoding="utf-8")
+    assert "AORTA_ENV_FILE=unset" in stdout
+
+
+def test_inherit_mode_with_no_prior_probe_env_is_a_noop(tmp_path):
+    """Scrubbing logic must not raise when there's no stale file to remove."""
+    wl = _make_workload(
+        tmp_path,
+        argv=["true"],
+        env_mode="inherit",
+    )
+    wl.setup()
+    wl.run()
+    assert not (tmp_path / "trial_0" / "probe.env").exists()

--- a/tests/probe/test_env_passthrough.py
+++ b/tests/probe/test_env_passthrough.py
@@ -1,0 +1,136 @@
+"""Env-passthrough mode tests for ``aorta probe`` (FR 1.9 / 1.10)."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from aorta.workloads._subprocess import (
+    CONFIG_KEY_LOG_PREFIX,
+    CONFIG_KEY_PROBE_EXTRAS,
+    CONFIG_KEY_SUBPROCESS_ARGV,
+    SubprocessWorkload,
+)
+
+
+def _make_workload(
+    tmp_path: Path,
+    argv: list[str],
+    env_mode: str,
+    cell_env_vars: dict[str, str] | None = None,
+) -> SubprocessWorkload:
+    workload_subdir = tmp_path / "_subprocess"
+    workload_subdir.mkdir(parents=True, exist_ok=True)
+    prefix = workload_subdir / "trial_d0_m0_t0"
+    cfg = {
+        CONFIG_KEY_SUBPROCESS_ARGV: argv,
+        CONFIG_KEY_LOG_PREFIX: str(prefix),
+        CONFIG_KEY_PROBE_EXTRAS: {
+            "cell_name": "test-cell",
+            "env_passthrough_mode": env_mode,
+            "timeout_per_trial": None,
+            "cell_env_vars": dict(cell_env_vars or {}),
+        },
+    }
+    return SubprocessWorkload(cfg)
+
+
+# ---- FR 1.9 (inherit mode does NOT write env file) -----------------------
+
+
+def test_inherit_mode_does_not_write_env_file(tmp_path):
+    """`inherit` mode runs the subprocess without dropping a probe.env."""
+    wl = _make_workload(
+        tmp_path,
+        argv=["sh", "-c", "echo hi"],
+        env_mode="inherit",
+        cell_env_vars={"DISABLE_TF32": "1"},
+    )
+    wl.setup()
+    wl.run()
+    trial_dir = tmp_path / "trial_0"
+    assert (trial_dir / "stdout.log").is_file()
+    assert (trial_dir / "result.json").is_file()
+    assert not (trial_dir / "probe.env").exists(), "inherit mode must NOT write probe.env"
+
+
+# ---- FR 1.10 (file mode writes env file + exports AORTA_ENV_FILE) --------
+
+
+def test_file_mode_writes_env_file_and_exports_pointer(tmp_path):
+    """`file` mode writes probe.env (chmod 0600) and exports AORTA_ENV_FILE."""
+    wl = _make_workload(
+        tmp_path,
+        argv=[
+            "sh",
+            "-c",
+            'test -f "$AORTA_ENV_FILE" && cat "$AORTA_ENV_FILE"',
+        ],
+        env_mode="file",
+        cell_env_vars={"DISABLE_TF32": "1", "HSA_XNACK": "1"},
+    )
+    wl.setup()
+    wl.run()
+    trial_dir = tmp_path / "trial_0"
+    env_path = trial_dir / "probe.env"
+    assert env_path.is_file(), "file mode must write probe.env"
+    text = env_path.read_text(encoding="utf-8")
+    # Sorted keys (deterministic) -> DISABLE_TF32 first, HSA_XNACK second.
+    assert "DISABLE_TF32=1" in text
+    assert "HSA_XNACK=1" in text
+    # The subprocess saw AORTA_ENV_FILE and was able to cat it.
+    stdout = (trial_dir / "stdout.log").read_text(encoding="utf-8")
+    assert "DISABLE_TF32=1" in stdout
+    assert "HSA_XNACK=1" in stdout
+
+
+def test_env_file_is_0600(tmp_path):
+    """probe.env must be chmod 0600 to keep secrets off the public read bit."""
+    wl = _make_workload(
+        tmp_path,
+        argv=["true"],
+        env_mode="file",
+        cell_env_vars={"SECRET_TOKEN": "supersecret"},
+    )
+    wl.setup()
+    wl.run()
+    env_path = tmp_path / "trial_0" / "probe.env"
+    assert env_path.is_file()
+    mode = env_path.stat().st_mode
+    perms = stat.S_IMODE(mode)
+    assert perms == 0o600, f"expected 0600, got 0o{perms:o}"
+
+
+def test_env_file_rejects_newline_in_value(tmp_path):
+    """Newline in env value would corrupt the KEY=VALUE shape -- reject up-front."""
+    wl = _make_workload(
+        tmp_path,
+        argv=["true"],
+        env_mode="file",
+        cell_env_vars={"MULTILINE": "line1\nline2"},
+    )
+    wl.setup()
+    with pytest.raises(ValueError, match="newline"):
+        wl.run()
+
+
+def test_inherit_mode_passes_env_to_child(tmp_path, monkeypatch):
+    """`inherit` mode's Popen env=os.environ.copy() snapshot includes our key.
+
+    The runner stamps the cell's env vars on ``os.environ`` before
+    calling ``run()``; the workload's Popen uses ``env=os.environ.copy()``
+    so the child sees those keys. Simulate the runner overlay by
+    setting the var via monkeypatch.
+    """
+    monkeypatch.setenv("PROBE_TEST_VAR", "from_inherit")
+    wl = _make_workload(
+        tmp_path,
+        argv=["sh", "-c", "echo $PROBE_TEST_VAR"],
+        env_mode="inherit",
+    )
+    wl.setup()
+    wl.run()
+    stdout = (tmp_path / "trial_0" / "stdout.log").read_text(encoding="utf-8")
+    assert "from_inherit" in stdout

--- a/tests/probe/test_env_passthrough.py
+++ b/tests/probe/test_env_passthrough.py
@@ -116,6 +116,34 @@ def test_env_file_rejects_newline_in_value(tmp_path):
         wl.run()
 
 
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        "FOO\nBAR",       # newline in key
+        "FOO\rBAR",       # carriage return in key
+        "FOO=BAR",        # embedded '=' would rebind a later key
+        "X\n=injected",   # newline-then-equals row-injection attempt
+    ],
+)
+def test_env_file_rejects_unsafe_chars_in_key(tmp_path, bad_key):
+    """Regression for PR #194 review: hostile mitigation sidecars
+    could smuggle ``\\n``, ``\\r``, or ``=`` into env *keys* to
+    inject extra KEY=VALUE rows or rebind a later key. The
+    sidecar loader only enforces ``isinstance(key, str)``, so the
+    env-file writer is the right place to catch this -- it is the
+    layer that owns the on-disk KEY=VALUE row shape.
+    """
+    wl = _make_workload(
+        tmp_path,
+        argv=["true"],
+        env_mode="file",
+        cell_env_vars={bad_key: "safe-value"},
+    )
+    wl.setup()
+    with pytest.raises(ValueError, match="env key"):
+        wl.run()
+
+
 def test_inherit_mode_passes_env_to_child(tmp_path, monkeypatch):
     """`inherit` mode's Popen env=os.environ.copy() snapshot includes our key.
 

--- a/tests/probe/test_recipe.py
+++ b/tests/probe/test_recipe.py
@@ -1,0 +1,277 @@
+"""Tests for the probe-mode recipe loader (issue #188 Phase 1).
+
+The probe-mode loader lives in :mod:`aorta.probe.recipe_builder` and is
+dispatched from :func:`aorta.triage.recipe._build_recipe` when
+``data["mode"] == "probe"``. These tests pin the rubric's FR 1.6-1.8,
+1.16, and 1.19 contracts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aorta.probe.recipe_builder import (
+    SUBPROCESS_WORKLOAD_NAME,
+    ProbeExtras,
+    build_probe_recipe_from_dict,
+)
+from aorta.registry.errors import UnknownMitigationError
+from aorta.triage.recipe import (
+    Recipe,
+    RecipeCellError,
+    RecipeSchemaError,
+    load_recipe,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _write_yaml(tmp_path: Path, text: str, name: str = "r.yaml") -> Path:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+_PROBE_MINIMAL = """\
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+"""
+
+_PROBE_TWO_CELL = """\
+schema_version: 1
+mode: probe
+trials: 2
+mitigation_axis: [none, tf32_off]
+diagnostic_axis: [none]
+"""
+
+
+# ---- FR 1.16 (back-compat) -----------------------------------------------
+
+
+def test_mode_defaults_to_triage_and_existing_recipes_load(tmp_path):
+    """Existing triage-mode recipes (no 'mode:' key) load byte-equivalently."""
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+"""
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.workload == "fsdp"
+    assert r.probe_extras is None  # triage-mode never populates this
+    assert len(r.cells) == 1
+
+
+# ---- FR 1.6 (unknown / misplaced keys) -----------------------------------
+
+
+def test_rejects_unknown_top_level(tmp_path):
+    text = _PROBE_MINIMAL + "garbage: 42\n"
+    with pytest.raises(RecipeSchemaError, match="unknown top-level keys"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_rejects_probe_keys_in_triage_mode(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+mitigation_axis: [none]
+diagnostic_axis: [none]
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+"""
+    with pytest.raises(RecipeSchemaError, match="probe-mode only"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_rejects_triage_keys_in_probe_mode(tmp_path):
+    text = (
+        _PROBE_MINIMAL
+        + """\
+workload: fsdp
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+"""
+    )
+    with pytest.raises(RecipeSchemaError, match="triage-mode only"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_rejects_invalid_mode_value(tmp_path):
+    text = """\
+schema_version: 1
+mode: bogus
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+"""
+    with pytest.raises(RecipeSchemaError, match=r"mode.*'triage' or 'probe'"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+# ---- FR 1.19 (Phase 2/3 rejection with pointer) --------------------------
+
+
+def test_phase_2_3_keys_rejected_with_pointer(tmp_path):
+    """Phase 2 keys raise with a 'deferred to Phase 2' pointer to the rubric."""
+    text = (
+        _PROBE_MINIMAL
+        + """\
+custom_patterns:
+  - id: hip_oom
+    match:
+      regex: "hipErrorOutOfMemory"
+"""
+    )
+    with pytest.raises(RecipeSchemaError) as exc:
+        load_recipe(_write_yaml(tmp_path, text))
+    msg = str(exc.value)
+    assert "Phase 2" in msg
+    assert "custom_patterns" in msg
+    assert "aorta-probe-188-rubric.md" in msg
+
+
+def test_phase_3_keys_rejected_with_pointer(tmp_path):
+    text = (
+        _PROBE_MINIMAL
+        + """\
+redaction:
+  scrub_env_keys: ["AWS_*"]
+"""
+    )
+    with pytest.raises(RecipeSchemaError) as exc:
+        load_recipe(_write_yaml(tmp_path, text))
+    msg = str(exc.value)
+    assert "Phase 3" in msg
+    assert "redaction" in msg
+
+
+def test_condition_key_rejected_with_pointer(tmp_path):
+    text = (
+        _PROBE_MINIMAL
+        + """\
+condition:
+  - "exit_code != 0"
+"""
+    )
+    with pytest.raises(RecipeSchemaError, match="Phase 2"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+# ---- FR 1.7 (cell synthesis and collision) -------------------------------
+
+
+def test_cell_synthesis_and_collision(tmp_path):
+    """Cells are synthesised as cartesian product; slug-collisions rejected."""
+    r = load_recipe(_write_yaml(tmp_path, _PROBE_TWO_CELL))
+    assert isinstance(r, Recipe)
+    cell_names = sorted(c.name for c in r.cells)
+    assert cell_names == ["none-none", "tf32_off-none"]
+    # Mitigations carry BOTH axes -- the dispatcher unions the env bundles.
+    for cell in r.cells:
+        assert len(cell.mitigations) == 2
+    # Workload pinned to the platform-internal name.
+    assert r.workload == SUBPROCESS_WORKLOAD_NAME
+    # probe_extras populated with the axes for the dry-run formatter.
+    assert isinstance(r.probe_extras, ProbeExtras)
+    assert r.probe_extras.mitigation_axis == ("none", "tf32_off")
+    assert r.probe_extras.diagnostic_axis == ("none",)
+
+
+def test_cell_name_collision_rejected(tmp_path):
+    """Axis values that slug to the same cell name are rejected at load."""
+    # ``foo-bar`` and ``foo`` paired with ``bar`` would both slug to
+    # "foo-bar" if the cell-name builder didn't reject. Use synthetic
+    # collisions via a mock registry to avoid registry coupling.
+    from unittest.mock import patch
+
+    with patch("aorta.probe.recipe_builder.get_mitigation", return_value={}):
+        with pytest.raises(RecipeCellError, match="slug to"):
+            build_probe_recipe_from_dict(
+                {
+                    "schema_version": 1,
+                    "mode": "probe",
+                    "trials": 1,
+                    # Two pairs slug to the same name:
+                    "mitigation_axis": ["a-b", "a"],
+                    "diagnostic_axis": ["c", "b-c"],
+                },
+                sidecar_files=None,
+            )
+
+
+# ---- FR 1.8 (axis name resolution) ---------------------------------------
+
+
+def test_axis_unknown_name_rejected(tmp_path):
+    text = """\
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis: [no_such_mitigation]
+diagnostic_axis: [none]
+"""
+    with pytest.raises(UnknownMitigationError):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+# ---- Validation -----------------------------------------------------------
+
+
+def test_missing_required_probe_keys(tmp_path):
+    text = """\
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis: [none]
+"""
+    with pytest.raises(RecipeSchemaError, match="missing required key 'diagnostic_axis'"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_step_time_regex_compile_validated(tmp_path):
+    text = _PROBE_MINIMAL + "step_time_regex: '(unclosed group'\n"
+    with pytest.raises(RecipeSchemaError, match="invalid regex"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_env_passthrough_mode_validated(tmp_path):
+    text = _PROBE_MINIMAL + "env_passthrough_mode: bogus\n"
+    with pytest.raises(RecipeSchemaError, match="inherit.*file"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_timeout_per_trial_must_be_positive(tmp_path):
+    text = _PROBE_MINIMAL + "timeout_per_trial: 0\n"
+    with pytest.raises(RecipeSchemaError, match="must be > 0"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+# ---- Fixture loads -------------------------------------------------------
+
+
+def test_minimal_fixture_loads():
+    r = load_recipe(FIXTURES / "probe_minimal.yaml")
+    assert r.workload == SUBPROCESS_WORKLOAD_NAME
+    assert len(r.cells) == 1
+
+
+def test_phase_2_fixture_rejected():
+    with pytest.raises(RecipeSchemaError, match="Phase 2"):
+        load_recipe(FIXTURES / "probe_with_phase_2_keys.yaml")

--- a/tests/probe/test_recipe.py
+++ b/tests/probe/test_recipe.py
@@ -263,6 +263,35 @@ def test_timeout_per_trial_must_be_positive(tmp_path):
         load_recipe(_write_yaml(tmp_path, text))
 
 
+# ---- PR #194 round-3 review: probe confound rejects unknown keys ---------
+
+
+def test_probe_confound_unknown_key_rejected(tmp_path):
+    """Probe-mode ``confound`` must reject typo'd keys like ``baseline_cel``.
+
+    Regression for PR #194 review: the probe-mode parser previously
+    used ``confound_raw.get("baseline_cell", default)`` which silently
+    ignored typo'd keys, leaving the auto-derived baseline in place
+    and weakening the loader's strict-schema contract that the
+    triage-mode parser (:func:`aorta.triage.recipe._parse_confound`)
+    enforces. Both parsers now share ``_VALID_CONFOUND_KEYS`` so a new
+    confound key has to be opted into both code paths explicitly.
+    """
+    text = _PROBE_MINIMAL + "confound:\n  baseline_cel: none-none\n"
+    with pytest.raises(RecipeSchemaError, match="unknown keys.*baseline_cel"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_probe_confound_known_keys_still_accepted(tmp_path):
+    """Verify the strict-schema check doesn't reject the legitimate
+    ``threshold`` / ``baseline_cell`` keys (upper bound on the fix).
+    """
+    text = _PROBE_MINIMAL + "confound:\n  threshold: 1.5\n  baseline_cell: none-none\n"
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.confound.threshold == 1.5
+    assert r.confound.baseline_cell == "none-none"
+
+
 # ---- Fixture loads -------------------------------------------------------
 
 

--- a/tests/probe/test_resume.py
+++ b/tests/probe/test_resume.py
@@ -228,6 +228,112 @@ def test_resume_with_reduced_trial_count_slices_to_current_recipe(tmp_path):
     )
 
 
+def test_resume_falls_back_when_trial_indices_dont_cover_current_recipe(tmp_path):
+    """Resume must verify the EXACT trial-index set, not just the count.
+
+    Regression for PR #194 round-5 review: the previous
+    ``len(hydrated) >= effective_trials`` check admitted a
+    pathological state where the dispatcher JSONs on disk are
+    ``..._t1, _t2`` (e.g. ``_t0`` was hand-deleted or corrupted by a
+    crashed previous run) while ``trial_0/result.json`` is intact.
+    The count would pass with the wrong index set, and matrix.md
+    would aggregate trials carrying the wrong ``trial_index``.
+
+    The fix walks the collected paths' filenames and requires the
+    integer trial-index set to be a superset of
+    ``range(effective_trials)``. We pin the behaviour by simulating
+    the pathological state -- ``trial_0/result.json`` complete on
+    disk, but the dispatcher JSON for ``_t0`` deleted while ``_t1``
+    remains. The resume short-circuit must fall back to a full
+    re-run, which overwrites the artifacts with a fresh
+    ``_t0`` / ``_t1`` pair.
+    """
+    output = tmp_path / "out"
+
+    # First run with trials: 2 so we get a clean two-trial baseline
+    # with dispatcher JSONs ``_t0`` and ``_t1`` on disk.
+    recipe = tmp_path / "trials_2.yaml"
+    recipe.write_text(
+        "schema_version: 1\n"
+        "mode: probe\n"
+        "ticket: RESUME-INDEX\n"
+        "trials: 2\n"
+        "mitigation_axis: [none]\n"
+        "diagnostic_axis: [none]\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    rc1 = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe),
+            "--output",
+            str(output),
+            "--ticket",
+            "RESUME-INDEX",
+            "--",
+            "sh",
+            "-c",
+            "exit 0",
+        ],
+    ).exit_code
+    assert rc1 == 0
+    cell_dir = output / "RESUME-INDEX" / "none-none"
+    # Probe per-trial dirs land directly under cell_dir.
+    assert (cell_dir / "trial_0" / "result.json").is_file()
+    assert (cell_dir / "trial_1" / "result.json").is_file()
+
+    # Find the dispatcher JSONs (workload subdir under cell_dir).
+    dispatcher_jsons = sorted(cell_dir.rglob("trial_d*_m*_t*.json"))
+    assert len(dispatcher_jsons) == 2, (
+        f"first run should have produced exactly 2 dispatcher JSONs, "
+        f"got {[p.name for p in dispatcher_jsons]}"
+    )
+    # Delete the ``_t0`` dispatcher JSON to simulate corruption; keep
+    # the matching probe ``trial_0/result.json`` intact so
+    # ``is_trial_complete`` still returns True for index 0.
+    t0_dispatcher = next(p for p in dispatcher_jsons if p.stem.endswith("_t0"))
+    t0_dispatcher.unlink()
+    # Add a STALE ``_t2`` JSON copied from ``_t1`` so the count check
+    # alone would still pass (2 dispatcher JSONs on disk).
+    t1_dispatcher = next(p for p in dispatcher_jsons if p.stem.endswith("_t1"))
+    stale_t2 = t1_dispatcher.with_name(t1_dispatcher.stem[:-2] + "t2.json")
+    stale_t2.write_text(t1_dispatcher.read_text(encoding="utf-8"), encoding="utf-8")
+
+    # Re-run with the same recipe (trials: 2). The buggy code would
+    # short-circuit on ``len(hydrated)==2`` with indices {1, 2}; the
+    # fix should detect the missing index 0 and re-run the cell.
+    rc2 = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe),
+            "--output",
+            str(output),
+            "--ticket",
+            "RESUME-INDEX",
+            "--",
+            "sh",
+            "-c",
+            "exit 0",
+        ],
+    ).exit_code
+    assert rc2 == 0
+
+    # After the re-run the dispatcher JSON for ``_t0`` must exist again
+    # AND the matrix must report exactly 2 trials (not 3 -- the stale
+    # ``_t2`` must not leak into the aggregation; the dispatcher
+    # rewrites the workload subdir on a re-run).
+    matrix_doc = json.loads((output / "RESUME-INDEX" / "matrix.json").read_text(encoding="utf-8"))
+    cells = {c["name"]: c for c in matrix_doc["cells"]}
+    assert cells["none-none"]["trials"] == 2, (
+        f"matrix reported {cells['none-none']['trials']} trials; expected 2 "
+        "(resume short-circuit should have fallen back to a full re-run "
+        "because the dispatcher index set didn't cover range(2))"
+    )
+
+
 def test_reruns_truncated_result_json(tmp_path):
     """Half a `{` in result.json -> trial is re-executed."""
     output = tmp_path / "out"

--- a/tests/probe/test_resume.py
+++ b/tests/probe/test_resume.py
@@ -1,0 +1,134 @@
+"""Resume semantics tests for ``aorta probe`` (issue #188 FR 1.4)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from aorta.cli.probe import probe
+from aorta.probe.resume import is_trial_complete
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---- Pure resume-helper unit tests ---------------------------------------
+
+
+def test_is_trial_complete_missing(tmp_path):
+    """No result.json -> incomplete."""
+    assert is_trial_complete(tmp_path) is False
+
+
+def test_is_trial_complete_empty_file(tmp_path):
+    (tmp_path / "result.json").write_text("", encoding="utf-8")
+    assert is_trial_complete(tmp_path) is False
+
+
+def test_is_trial_complete_invalid_json(tmp_path):
+    (tmp_path / "result.json").write_text("{not json", encoding="utf-8")
+    assert is_trial_complete(tmp_path) is False
+
+
+def test_is_trial_complete_missing_verdict(tmp_path):
+    (tmp_path / "result.json").write_text(json.dumps({"exit_code": 0}), encoding="utf-8")
+    assert is_trial_complete(tmp_path) is False
+
+
+def test_is_trial_complete_blank_verdict(tmp_path):
+    (tmp_path / "result.json").write_text(json.dumps({"verdict": ""}), encoding="utf-8")
+    assert is_trial_complete(tmp_path) is False
+
+
+def test_is_trial_complete_pass(tmp_path):
+    (tmp_path / "result.json").write_text(
+        json.dumps({"verdict": "pass", "exit_code": 0}), encoding="utf-8"
+    )
+    assert is_trial_complete(tmp_path) is True
+
+
+def test_is_trial_complete_fail_still_counts(tmp_path):
+    """A failed trial is still 'complete' -- the operator can decide to re-run."""
+    (tmp_path / "result.json").write_text(
+        json.dumps({"verdict": "fail", "exit_code": 1}), encoding="utf-8"
+    )
+    assert is_trial_complete(tmp_path) is True
+
+
+# ---- End-to-end resume via the CLI ---------------------------------------
+
+
+def _invoke_probe(output: Path, recipe: Path) -> int:
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe),
+            "--output",
+            str(output),
+            "--ticket",
+            "RESUME-1",
+            "--",
+            "sh",
+            "-c",
+            "echo run-marker; exit 0",
+        ],
+    )
+    if result.exit_code != 0:
+        print(result.output)
+        if result.exception:
+            import traceback
+
+            traceback.print_exception(
+                type(result.exception), result.exception, result.exception.__traceback__
+            )
+    return result.exit_code
+
+
+def test_skips_completed_cell(tmp_path):
+    """Second invocation does NOT re-run a completed cell."""
+    output = tmp_path / "out"
+    rc1 = _invoke_probe(output, FIXTURES / "probe_minimal.yaml")
+    assert rc1 == 0
+    cell_dir = output / "RESUME-1" / "none-none"
+    trial0 = cell_dir / "trial_0"
+    result_path = trial0 / "result.json"
+    assert result_path.is_file()
+    first_mtime = result_path.stat().st_mtime
+    stdout_first = (trial0 / "stdout.log").read_text(encoding="utf-8")
+    assert "run-marker" in stdout_first
+
+    # Second invocation: same output dir / ticket -> cell is already done,
+    # the runner must skip it. result.json must be byte-equivalent (same
+    # mtime) because the trial was not re-executed.
+    rc2 = _invoke_probe(output, FIXTURES / "probe_minimal.yaml")
+    assert rc2 == 0
+    second_mtime = result_path.stat().st_mtime
+    assert second_mtime == first_mtime, (
+        f"result.json mtime changed ({first_mtime} -> {second_mtime}); "
+        "cell was re-executed when it should have been skipped"
+    )
+
+
+def test_reruns_truncated_result_json(tmp_path):
+    """Half a `{` in result.json -> trial is re-executed."""
+    output = tmp_path / "out"
+    rc1 = _invoke_probe(output, FIXTURES / "probe_minimal.yaml")
+    assert rc1 == 0
+    trial0 = output / "RESUME-1" / "none-none" / "trial_0"
+    result_path = trial0 / "result.json"
+
+    # Truncate to half a JSON object.
+    result_path.write_text("{", encoding="utf-8")
+    first_mtime = result_path.stat().st_mtime
+
+    rc2 = _invoke_probe(output, FIXTURES / "probe_minimal.yaml")
+    assert rc2 == 0
+    # The trial was re-run; result.json was overwritten with a valid doc.
+    doc = json.loads(result_path.read_text(encoding="utf-8"))
+    assert doc["verdict"] == "pass"
+    second_mtime = result_path.stat().st_mtime
+    # mtime should change since we overwrote the truncated file.
+    assert second_mtime >= first_mtime

--- a/tests/probe/test_resume.py
+++ b/tests/probe/test_resume.py
@@ -143,6 +143,91 @@ def test_skipped_cell_records_real_counts_in_matrix(tmp_path):
     assert second_cells["none-none"]["failed_count"] == 0
 
 
+def test_resume_with_reduced_trial_count_slices_to_current_recipe(tmp_path):
+    """When the resumed directory has MORE completed trials than the
+    current recipe asks for, the short-circuit must slice the
+    hydrated list (and trial paths) down to ``effective_trials``.
+
+    Regression for PR #194 review: a user who re-ran with ``trials: 1``
+    after a previous ``trials: 3`` left a directory with three
+    completed trial dirs on disk. Without the slice, ``aggregate_cell``
+    saw all three and matrix.md reported the stale extra trials. We
+    only assert the count is correct here; the stale dirs on disk are
+    left in place so the operator can still inspect prior runs.
+    """
+    output = tmp_path / "out"
+
+    # First run with trials: 3.
+    recipe_3 = tmp_path / "trials_3.yaml"
+    recipe_3.write_text(
+        "schema_version: 1\n"
+        "mode: probe\n"
+        "ticket: RESUME-SLICE\n"
+        "trials: 3\n"
+        "mitigation_axis: [none]\n"
+        "diagnostic_axis: [none]\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    rc1 = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe_3),
+            "--output",
+            str(output),
+            "--ticket",
+            "RESUME-SLICE",
+            "--",
+            "sh",
+            "-c",
+            "exit 0",
+        ],
+    ).exit_code
+    assert rc1 == 0
+    cell_dir = output / "RESUME-SLICE" / "none-none"
+    # Three trial dirs landed.
+    assert (cell_dir / "trial_0" / "result.json").is_file()
+    assert (cell_dir / "trial_1" / "result.json").is_file()
+    assert (cell_dir / "trial_2" / "result.json").is_file()
+
+    # Re-run with the SAME output/ticket but trials: 1.
+    recipe_1 = tmp_path / "trials_1.yaml"
+    recipe_1.write_text(
+        "schema_version: 1\n"
+        "mode: probe\n"
+        "ticket: RESUME-SLICE\n"
+        "trials: 1\n"
+        "mitigation_axis: [none]\n"
+        "diagnostic_axis: [none]\n",
+        encoding="utf-8",
+    )
+    rc2 = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe_1),
+            "--output",
+            str(output),
+            "--ticket",
+            "RESUME-SLICE",
+            "--",
+            "sh",
+            "-c",
+            "exit 0",
+        ],
+    ).exit_code
+    assert rc2 == 0
+
+    matrix_doc = json.loads((output / "RESUME-SLICE" / "matrix.json").read_text(encoding="utf-8"))
+    cells = {c["name"]: c for c in matrix_doc["cells"]}
+    assert cells["none-none"]["trials"] == 1, (
+        f"matrix reported {cells['none-none']['trials']} trials; expected 1 "
+        "(the resume short-circuit returned stale extra trials instead of "
+        "slicing to the current recipe's effective_trials)"
+    )
+
+
 def test_reruns_truncated_result_json(tmp_path):
     """Half a `{` in result.json -> trial is re-executed."""
     output = tmp_path / "out"

--- a/tests/probe/test_resume.py
+++ b/tests/probe/test_resume.py
@@ -334,6 +334,126 @@ def test_resume_falls_back_when_trial_indices_dont_cover_current_recipe(tmp_path
     )
 
 
+def test_resume_falls_back_when_required_trial_json_is_corrupt(tmp_path):
+    """Corrupted (unreadable) required ``_t0.json`` + stale extra ``_t2.json``
+    must trigger a full re-run, not silently re-map stale bodies to wrong indices.
+
+    Regression for PR #194 round 6 (Copilot): the previous index-set
+    validation walked ``_collect_trial_paths`` (filename set) while
+    ``_hydrate_trials_from_paths`` silently skipped unreadable files.
+    A corrupt-but-present ``_t0.json`` therefore appeared in the
+    filename set (passing the subset check) but NOT in the hydrated
+    list. A stale extra ``_t2.json`` (from a prior trials=3 run) kept
+    ``len(hydrated) >= effective_trials`` true. The slice
+    ``hydrated[:2]`` then returned data from ``_t1`` and ``_t2``
+    labelled as trials 0 and 1 -- a silent body-vs-index scramble in
+    matrix.json.
+
+    Distinct from the existing
+    ``test_resume_falls_back_when_trial_indices_dont_cover_current_recipe``
+    test (which deletes ``_t0.json``, so the filename set already
+    misses index 0). The fix moves the validation to be keyed on
+    *successful hydration*, so a corrupt-but-present file is treated
+    the same as a missing one.
+    """
+    output = tmp_path / "out"
+
+    recipe = tmp_path / "trials_2.yaml"
+    recipe.write_text(
+        "schema_version: 1\n"
+        "mode: probe\n"
+        "ticket: RESUME-CORRUPT\n"
+        "trials: 2\n"
+        "mitigation_axis: [none]\n"
+        "diagnostic_axis: [none]\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    rc1 = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe),
+            "--output",
+            str(output),
+            "--ticket",
+            "RESUME-CORRUPT",
+            "--",
+            "sh",
+            "-c",
+            "exit 0",
+        ],
+    ).exit_code
+    assert rc1 == 0
+    cell_dir = output / "RESUME-CORRUPT" / "none-none"
+
+    dispatcher_jsons = sorted(cell_dir.rglob("trial_d*_m*_t*.json"))
+    assert len(dispatcher_jsons) == 2
+
+    # Corrupt the ``_t0`` dispatcher JSON in place (file still exists,
+    # so the filename set still contains index 0; but its JSON is
+    # unparseable so hydration must skip it). Keep the matching
+    # ``trial_0/result.json`` intact so ``is_trial_complete`` still
+    # returns True for index 0 -> the resume code path executes the
+    # short-circuit check.
+    t0_dispatcher = next(p for p in dispatcher_jsons if p.stem.endswith("_t0"))
+    t0_dispatcher.write_text("{not valid json", encoding="utf-8")
+
+    # Add a STALE ``_t2`` JSON copied from ``_t1`` so the body count
+    # alone would still pass for trials=2 (3 dispatcher JSONs on disk
+    # but only _t1 + _t2 hydrate successfully -> len(hydrated)=2 >=
+    # effective_trials=2).
+    t1_dispatcher = next(p for p in dispatcher_jsons if p.stem.endswith("_t1"))
+    stale_t2 = t1_dispatcher.with_name(t1_dispatcher.stem[:-2] + "t2.json")
+    stale_t2.write_text(t1_dispatcher.read_text(encoding="utf-8"), encoding="utf-8")
+
+    rc2 = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe),
+            "--output",
+            str(output),
+            "--ticket",
+            "RESUME-CORRUPT",
+            "--",
+            "sh",
+            "-c",
+            "exit 0",
+        ],
+    ).exit_code
+    assert rc2 == 0
+
+    # After the re-run: ``_t0.json`` must be parseable again (the
+    # dispatcher rewrote the workload subdir) AND matrix.json must
+    # report exactly 2 trials -- not 3 (stale extras leaked into the
+    # aggregation) and not the buggy "indices 1 and 2 labelled as 0
+    # and 1" outcome.
+    rewritten = sorted(cell_dir.rglob("trial_d*_m*_t*.json"))
+    parseable = []
+    for p in rewritten:
+        try:
+            json.loads(p.read_text(encoding="utf-8"))
+            parseable.append(p)
+        except json.JSONDecodeError:
+            pass
+    assert len(parseable) >= 2, (
+        "after the re-run at least _t0 and _t1 must parse; got parseable="
+        f"{[p.name for p in parseable]}"
+    )
+
+    matrix_doc = json.loads(
+        (output / "RESUME-CORRUPT" / "matrix.json").read_text(encoding="utf-8")
+    )
+    cells = {c["name"]: c for c in matrix_doc["cells"]}
+    assert cells["none-none"]["trials"] == 2, (
+        f"matrix reported {cells['none-none']['trials']} trials; expected 2 "
+        "(resume short-circuit should have fallen back to a full re-run "
+        "because hydration could not produce a TrialResult for required "
+        "index 0)"
+    )
+
+
 def test_reruns_truncated_result_json(tmp_path):
     """Half a `{` in result.json -> trial is re-executed."""
     output = tmp_path / "out"

--- a/tests/probe/test_resume.py
+++ b/tests/probe/test_resume.py
@@ -112,6 +112,37 @@ def test_skips_completed_cell(tmp_path):
     )
 
 
+def test_skipped_cell_records_real_counts_in_matrix(tmp_path):
+    """Resume short-circuit must surface real trial counts in matrix.json.
+
+    Regression for PR #194 review: the short-circuit previously returned
+    ``trials=[]`` which made ``aggregate_cell`` record
+    ``trials=0/passed=0/failed=0`` for a skipped-but-complete cell -- a
+    silently incorrect matrix on every resumed run. The runner must
+    hydrate the dispatcher's per-trial JSONs into TrialResult objects so
+    the matrix reflects what actually ran.
+    """
+    output = tmp_path / "out"
+    rc1 = _invoke_probe(output, FIXTURES / "probe_minimal.yaml")
+    assert rc1 == 0
+    matrix_path = output / "RESUME-1" / "matrix.json"
+    first_doc = json.loads(matrix_path.read_text(encoding="utf-8"))
+    first_cells = {c["name"]: c for c in first_doc["cells"]}
+    assert first_cells["none-none"]["trials"] == 1
+    assert first_cells["none-none"]["passed_count"] == 1
+
+    rc2 = _invoke_probe(output, FIXTURES / "probe_minimal.yaml")
+    assert rc2 == 0
+    second_doc = json.loads(matrix_path.read_text(encoding="utf-8"))
+    second_cells = {c["name"]: c for c in second_doc["cells"]}
+    assert second_cells["none-none"]["trials"] == 1, (
+        "resumed cell reported trials=0; the short-circuit returned an empty "
+        "trials list to aggregate_cell instead of hydrating dispatcher JSONs"
+    )
+    assert second_cells["none-none"]["passed_count"] == 1
+    assert second_cells["none-none"]["failed_count"] == 0
+
+
 def test_reruns_truncated_result_json(tmp_path):
     """Half a `{` in result.json -> trial is re-executed."""
     output = tmp_path / "out"

--- a/tests/probe/test_shared_engine.py
+++ b/tests/probe/test_shared_engine.py
@@ -1,0 +1,131 @@
+"""Shared-engine contract: both CLIs reach :func:`aorta.triage.runner.run_recipe`.
+
+This test is FR 1.5 in the rubric -- it pins the "no parallel runner"
+guarantee that issue #188 names as P0. Mirrors the mock-``run_trials``
+pattern from ``tests/triage/test_runner_b1_api.py`` but at one level up:
+we mock ``run_recipe`` itself and assert both ``aorta probe`` and
+``aorta triage run`` reach it with a validated :class:`Recipe`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+import aorta.cli.probe as probe_cli
+import aorta.cli.triage as triage_cli
+from aorta.cli.probe import probe
+from aorta.cli.triage import triage
+from aorta.triage.recipe import Recipe
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def mock_run_recipe(monkeypatch):
+    """Replace ``run_recipe`` in BOTH CLI modules with a single Mock.
+
+    The probe and triage Click handlers each ``from aorta.triage.runner
+    import run_recipe``, so the symbol is bound in each module's
+    namespace; patching only ``aorta.triage.runner.run_recipe`` would
+    miss them. Patching both binding sites gives us a single shared
+    Mock either CLI must end up calling.
+    """
+    mock = MagicMock(return_value=Path("/tmp/mock-run-dir"))
+    monkeypatch.setattr(probe_cli, "run_recipe", mock)
+    monkeypatch.setattr(triage_cli, "run_recipe", mock)
+    return mock
+
+
+def test_probe_reaches_run_recipe(mock_run_recipe, tmp_path):
+    """`aorta probe` calls run_recipe with a validated probe-mode Recipe."""
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--output",
+            str(tmp_path / "out"),
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_run_recipe.assert_called_once()
+    # First positional arg is the validated Recipe; keyword args carry
+    # layout=flat_resume + resume_existing=True + subprocess_argv.
+    args, kwargs = mock_run_recipe.call_args
+    recipe_arg = args[0] if args else kwargs.get("recipe")
+    assert isinstance(recipe_arg, Recipe)
+    assert recipe_arg.probe_extras is not None
+    assert kwargs.get("layout") == "flat_resume"
+    assert kwargs.get("resume_existing") is True
+    assert kwargs.get("subprocess_argv") == ("echo", "hi")
+
+
+def test_triage_reaches_run_recipe(mock_run_recipe, tmp_path):
+    """`aorta triage run --recipe ...` reaches the same run_recipe."""
+    triage_recipe = tmp_path / "triage.yaml"
+    triage_recipe.write_text(
+        "schema_version: 1\n"
+        "workload: fsdp\n"
+        "trials: 1\n"
+        "steps: 1\n"
+        "cells:\n"
+        "  - name: baseline-local\n"
+        "    mitigations: [none]\n"
+        "    environment: local\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        triage,
+        ["run", "--recipe", str(triage_recipe), "--output-dir", str(tmp_path / "out")],
+    )
+    assert result.exit_code == 0, result.output
+    mock_run_recipe.assert_called_once()
+    args, kwargs = mock_run_recipe.call_args
+    recipe_arg = args[0] if args else kwargs.get("recipe")
+    assert isinstance(recipe_arg, Recipe)
+    assert recipe_arg.probe_extras is None  # triage-mode never sets this.
+
+
+def test_probe_and_triage_share_run_recipe(mock_run_recipe, tmp_path):
+    """Both CLIs together: the SAME mocked run_recipe is reached twice."""
+    triage_recipe = tmp_path / "triage.yaml"
+    triage_recipe.write_text(
+        "schema_version: 1\n"
+        "workload: fsdp\n"
+        "trials: 1\n"
+        "steps: 1\n"
+        "cells:\n"
+        "  - name: baseline-local\n"
+        "    mitigations: [none]\n"
+        "    environment: local\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    r1 = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_minimal.yaml"),
+            "--output",
+            str(tmp_path / "p"),
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert r1.exit_code == 0, r1.output
+    r2 = runner.invoke(
+        triage,
+        ["run", "--recipe", str(triage_recipe), "--output-dir", str(tmp_path / "t")],
+    )
+    assert r2.exit_code == 0, r2.output
+    assert mock_run_recipe.call_count == 2

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -132,6 +132,70 @@ def test_missing_executable_yields_fail(tmp_path):
     assert result.passed is False
 
 
+def test_non_executable_script_yields_fail(tmp_path):
+    """A user command pointing at a file without the +x bit must land
+    as a Tier-1 fail (exit_code=126), NOT escape to the dispatcher as
+    ``infrastructure_failed``.
+
+    Regression for PR #194 review: previously only ``FileNotFoundError``
+    was caught. ``PermissionError`` (EACCES, raised by ``Popen`` when
+    argv[0] exists but isn't executable) escaped the handler, leaving
+    the per-trial directory without a ``result.json`` and breaking
+    the documented "every probe trial leaves an artifact" contract.
+    """
+    script = tmp_path / "no_exec_bit.sh"
+    script.write_text("#!/bin/bash\necho hi\n", encoding="utf-8")
+    script.chmod(0o644)  # readable, but NOT executable
+    wl = _make_workload(tmp_path, [str(script)])
+    wl.setup()
+    result = wl.run()
+    result_path = tmp_path / "trial_0" / "result.json"
+    assert result_path.exists(), (
+        "result.json missing: PermissionError escaped instead of being "
+        "captured as a Tier-1 fail (regression of PR #194 review fix)"
+    )
+    doc = json.loads(result_path.read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["exit_code"] == 126
+    assert result.passed is False
+    # stderr.log should carry the diagnostic so the operator knows
+    # which exec-time error fired.
+    stderr_text = (tmp_path / "trial_0" / "stderr.log").read_text(encoding="utf-8")
+    assert "Permission" in stderr_text or "permitted" in stderr_text.lower()
+
+
+def test_popen_oserror_yields_fail(tmp_path, monkeypatch):
+    """A generic ``OSError`` from ``Popen`` (e.g. ENOEXEC "Exec format
+    error" for a shebang-less script) also lands as a Tier-1 fail
+    with the artifact tree intact, rather than escaping to the
+    dispatcher.
+
+    Regression for PR #194 review: only ``FileNotFoundError`` and
+    ``PermissionError`` were named explicitly in the previous handler;
+    other ``OSError`` subclasses (ENOEXEC, ELOOP, ...) leaked through.
+    """
+    import subprocess as _subprocess
+
+    def _raises_oserror(*args, **kwargs):
+        raise OSError(8, "Exec format error")
+
+    monkeypatch.setattr(_subprocess, "Popen", _raises_oserror)
+    wl = _make_workload(tmp_path, ["/some/path/with/bad/format"])
+    wl.setup()
+    result = wl.run()
+    result_path = tmp_path / "trial_0" / "result.json"
+    assert result_path.exists(), (
+        "result.json missing: bare OSError escaped instead of being " "captured as a Tier-1 fail"
+    )
+    doc = json.loads(result_path.read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    # Exit code falls back to 1 for non-{FileNotFound,Permission} OSError.
+    assert doc["exit_code"] == 1
+    assert result.passed is False
+    stderr_text = (tmp_path / "trial_0" / "stderr.log").read_text(encoding="utf-8")
+    assert "Exec format error" in stderr_text
+
+
 def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
     """Regression for PR #194 review: ``proc.kill()`` after a
     ``TimeoutExpired`` must not propagate ``ProcessLookupError``
@@ -152,9 +216,9 @@ def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
 
     class _RacingPopen:
         def __init__(self, *args, **kwargs):
-            self._real = real_popen(["true"], **{
-                k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "env")
-            })
+            self._real = real_popen(
+                ["true"], **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "env")}
+            )
             self.pid = self._real.pid
             self._wait_calls = 0
 

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -132,6 +132,56 @@ def test_missing_executable_yields_fail(tmp_path):
     assert result.passed is False
 
 
+def test_exec_time_failure_flags_main_work_not_started(tmp_path):
+    """Exec-time ``Popen`` failures must report
+    ``main_work_started=False`` / ``executed_iterations=0`` so the
+    matrix outcome classifier doesn't conflate a command-not-found
+    with a completed 1/1 trial.
+
+    Regression for PR #194 round-5 review: the workload used to
+    hard-code ``main_work_started=True`` / ``executed_iterations=1``
+    even on the ``FileNotFoundError`` / ``PermissionError`` /
+    ``OSError`` exec-time-failure branch. The ``result.json`` is
+    still written (artifact contract from PR #194 round 4) but the
+    WorkloadResult now reflects "we never actually ran the child".
+    """
+    wl = _make_workload(tmp_path, ["definitely-not-a-real-binary-9d8f7s6"])
+    wl.setup()
+    result = wl.run()
+    # Artifact tree intact (round-4 contract).
+    assert (tmp_path / "trial_0" / "result.json").is_file()
+    # Round-5 contract: matrix-side semantics reflect the exec-time failure.
+    assert result.main_work_started is False, (
+        "main_work_started=True for an exec-time failure misrepresents "
+        "command-not-found as a completed trial"
+    )
+    assert result.executed_iterations == 0, (
+        "executed_iterations=1 for an exec-time failure misrepresents "
+        "command-not-found as a completed iteration"
+    )
+    assert result.failure_count == 1
+    assert result.failure_details[0]["type"] == "subprocess_exec_failed", (
+        "failure_details should distinguish exec-time failure from a "
+        "normal subprocess non-zero exit"
+    )
+
+
+def test_successful_trial_flags_main_work_started(tmp_path):
+    """Normal subprocess exits (zero OR non-zero) keep
+    ``main_work_started=True`` -- the child actually ran. Pins the
+    upper bound of the launched-flag change: the matrix outcome
+    classifier still sees a normal 1/1 trial when the user command
+    just exits with a non-zero status.
+    """
+    wl = _make_workload(tmp_path, ["false"])  # exits 1
+    wl.setup()
+    result = wl.run()
+    assert result.main_work_started is True
+    assert result.executed_iterations == 1
+    assert result.failure_count == 1
+    assert result.failure_details[0]["type"] == "subprocess_nonzero_exit"
+
+
 def test_non_executable_script_yields_fail(tmp_path):
     """A user command pointing at a file without the +x bit must land
     as a Tier-1 fail (exit_code=126), NOT escape to the dispatcher as

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -130,3 +130,55 @@ def test_missing_executable_yields_fail(tmp_path):
     assert doc["verdict"] == "fail"
     assert doc["exit_code"] == 127
     assert result.passed is False
+
+
+def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
+    """Regression for PR #194 review: ``proc.kill()`` after a
+    ``TimeoutExpired`` must not propagate ``ProcessLookupError``
+    when the child happens to exit between the timeout firing and
+    the kill landing. The workload should record a deterministic
+    timed-out trial with ``exit_code=-1`` and a ``result.json``
+    on disk -- crashing here would mean a trial silently disappears
+    from the matrix.
+
+    We simulate the race by monkeypatching ``Popen`` so ``wait()``
+    raises ``TimeoutExpired`` and ``kill()``/``wait()`` raise
+    ``ProcessLookupError`` (matching the Linux ESRCH behaviour
+    when the child has already exited).
+    """
+    import subprocess as _subprocess
+
+    real_popen = _subprocess.Popen
+
+    class _RacingPopen:
+        def __init__(self, *args, **kwargs):
+            self._real = real_popen(["true"], **{
+                k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "env")
+            })
+            self.pid = self._real.pid
+            self._wait_calls = 0
+
+        def wait(self, timeout=None):
+            self._wait_calls += 1
+            if self._wait_calls == 1:
+                # First ``proc.wait(timeout=...)`` -- pretend the
+                # child is still running so the timeout branch fires.
+                raise _subprocess.TimeoutExpired(cmd="true", timeout=timeout)
+            # Second ``proc.wait()`` after kill() -- child is gone.
+            raise ProcessLookupError(3, "No such process")
+
+        def kill(self):
+            raise ProcessLookupError(3, "No such process")
+
+    monkeypatch.setattr(_subprocess, "Popen", _RacingPopen)
+
+    wl = _make_workload(tmp_path, ["true"], timeout_per_trial=0.01)
+    wl.setup()
+    # The crash this test is pinning: previously the unguarded
+    # proc.kill() would propagate ProcessLookupError out of run().
+    result = wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["timed_out"] is True
+    assert doc["exit_code"] == -1
+    assert result.passed is False

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -1,0 +1,132 @@
+"""Unit tests for :class:`aorta.workloads._subprocess.SubprocessWorkload`.
+
+Covers FR 1.11 (entry-point resolution), FR 1.12 (per-trial result.json
+shape), and the Tier-1 verdict rule.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aorta.run.discovery import get_workload_class
+from aorta.workloads._subprocess import (
+    CONFIG_KEY_LOG_PREFIX,
+    CONFIG_KEY_PROBE_EXTRAS,
+    CONFIG_KEY_SUBPROCESS_ARGV,
+    SubprocessWorkload,
+)
+
+# ---- FR 1.17 (entry-point resolution) ------------------------------------
+
+
+def test_resolved_via_entry_point():
+    """``get_workload_class('_subprocess')`` returns SubprocessWorkload."""
+    cls = get_workload_class("_subprocess")
+    assert cls is SubprocessWorkload
+
+
+# ---- Setup() guards ------------------------------------------------------
+
+
+def test_setup_requires_subprocess_argv():
+    """Direct invocation without the reserved argv key raises."""
+    workload = SubprocessWorkload({})
+    with pytest.raises(RuntimeError, match=CONFIG_KEY_SUBPROCESS_ARGV):
+        workload.setup()
+
+
+def test_setup_requires_log_prefix(tmp_path):
+    """Missing ``_aorta_log_prefix`` raises -- the runner must set save_logs=True."""
+    workload = SubprocessWorkload({CONFIG_KEY_SUBPROCESS_ARGV: ["echo", "hi"]})
+    with pytest.raises(RuntimeError, match=CONFIG_KEY_LOG_PREFIX):
+        workload.setup()
+
+
+def test_setup_rejects_non_list_argv(tmp_path):
+    workload = SubprocessWorkload(
+        {
+            CONFIG_KEY_SUBPROCESS_ARGV: "echo hi",
+            CONFIG_KEY_LOG_PREFIX: str(tmp_path / "trial_d0_m0_t0"),
+        }
+    )
+    with pytest.raises(RuntimeError, match="non-empty list"):
+        workload.setup()
+
+
+# ---- FR 1.12 (result.json shape + Tier 1 verdict) ------------------------
+
+
+def _make_workload(tmp_path: Path, argv: list[str], **extras):
+    """Build a SubprocessWorkload with a synthetic log_prefix that decodes to trial 0.
+
+    The runner sets ``_aorta_log_prefix`` to ``<cell_dir>/<workload>/trial_d0_m0_t<N>``
+    and SubprocessWorkload derives ``<cell_dir>/trial_<N>/`` from it
+    (Path(prefix).parent.parent is the cell dir, the trial idx comes from
+    the _t<N> suffix). The synthetic prefix mirrors that shape so the
+    test exercises the real path-decoding.
+    """
+    workload_subdir = tmp_path / "_subprocess"
+    workload_subdir.mkdir(parents=True, exist_ok=True)
+    prefix = workload_subdir / "trial_d0_m0_t0"
+    cfg = {
+        CONFIG_KEY_SUBPROCESS_ARGV: argv,
+        CONFIG_KEY_LOG_PREFIX: str(prefix),
+        CONFIG_KEY_PROBE_EXTRAS: {
+            "cell_name": "none-none",
+            "env_passthrough_mode": "inherit",
+            "timeout_per_trial": None,
+            "cell_env_vars": {},
+            **extras,
+        },
+    }
+    return SubprocessWorkload(cfg)
+
+
+def test_pass_minimum_result_shape(tmp_path):
+    """Successful exit_code=0 yields verdict=pass + rubric-mandated fields."""
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    result = wl.run()
+    trial_dir = tmp_path / "trial_0"
+    result_path = trial_dir / "result.json"
+    assert result_path.is_file()
+    doc = json.loads(result_path.read_text(encoding="utf-8"))
+    # FR 1.12: minimum shape.
+    for key in ("verdict", "exit_code", "walltime_sec", "argv", "cell_name", "trial_index"):
+        assert key in doc, f"missing required key {key} in result.json"
+    assert doc["verdict"] == "pass"
+    assert doc["exit_code"] == 0
+    assert doc["argv"] == ["true"]
+    assert doc["cell_name"] == "none-none"
+    assert doc["trial_index"] == 0
+    assert isinstance(doc["walltime_sec"], (int, float))
+    # stdout.log and stderr.log written.
+    assert (trial_dir / "stdout.log").is_file()
+    assert (trial_dir / "stderr.log").is_file()
+    # WorkloadResult round-trip:
+    assert result.passed is True
+
+
+def test_fail_minimum_result_shape(tmp_path):
+    """Non-zero exit yields verdict=fail."""
+    wl = _make_workload(tmp_path, ["false"])
+    wl.setup()
+    result = wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["exit_code"] != 0
+    assert result.passed is False
+
+
+def test_missing_executable_yields_fail(tmp_path):
+    """argv[0] not found surfaces as a Tier-1 fail with exit_code=127."""
+    wl = _make_workload(tmp_path, ["definitely-not-a-real-binary-9d8f7s6"])
+    wl.setup()
+    result = wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["exit_code"] == 127
+    assert result.passed is False

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -222,6 +222,136 @@ class TestRunTrials:
         with pytest.raises(ValueError, match=r"reserved '_aorta_' prefix"):
             run_trials(req)
 
+    def test_user_supplied_aorta_subprocess_argv_rejected(self, tmp_path):
+        """``RunRequest.subprocess_argv`` is the only legal channel.
+
+        Per issue #188 FR 1.11: users must not be able to smuggle argv
+        via ``config_overrides`` -- the reserved-prefix guard at the
+        top of ``run_trials`` blocks ``_aorta_subprocess_argv`` exactly
+        like every other ``_aorta_*`` key.
+        """
+        req = RunRequest(
+            workload="anything",
+            trials=1,
+            config_overrides={"_aorta_subprocess_argv": ["echo", "pwn"]},
+            results_dir=tmp_path,
+        )
+        with pytest.raises(ValueError, match=r"reserved '_aorta_' prefix"):
+            run_trials(req)
+
+    def test_subprocess_argv_injected_into_config(self, tmp_path):
+        """``RunRequest.subprocess_argv`` lands at ``config['_aorta_subprocess_argv']``.
+
+        Verifies the dispatcher injects the typed field AFTER
+        ``config_overrides`` is merged (per issue #188 FR 1.11), so a
+        user-supplied ``config_overrides`` cannot clobber the slot.
+        """
+        captured_config: dict = {}
+
+        class ConfigCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_config.update(self.config)
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "argv_capturing"
+        mock_ep.load.return_value = ConfigCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="argv_capturing",
+                trials=1,
+                results_dir=tmp_path,
+                subprocess_argv=("echo", "hi"),
+            )
+            run_trials(req)
+        assert captured_config["_aorta_subprocess_argv"] == ["echo", "hi"]
+
+    def test_subprocess_argv_absent_when_none(self, tmp_path):
+        """No ``_aorta_subprocess_argv`` key when ``RunRequest.subprocess_argv`` is None.
+
+        Otherwise every existing workload's ``config`` would gain a
+        spurious ``None`` slot and the JSON-serialised trial result
+        would diverge from today's shape.
+        """
+        captured_config: dict = {}
+
+        class ConfigCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_config.update(self.config)
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "noargv"
+        mock_ep.load.return_value = ConfigCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(workload="noargv", trials=1, results_dir=tmp_path)
+            run_trials(req)
+        assert "_aorta_subprocess_argv" not in captured_config
+
+    def test_probe_extras_injected_into_config(self, tmp_path):
+        """``RunRequest.probe_extras`` lands at ``config['_aorta_probe_extras']``.
+
+        The probe-mode runner builds this dict per cell so
+        ``SubprocessWorkload`` can pick up cell name / env-passthrough
+        mode / timeout / cell-env-bundle without parsing the recipe
+        itself.
+        """
+        captured_config: dict = {}
+
+        class ConfigCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_config.update(self.config)
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "extras_capturing"
+        mock_ep.load.return_value = ConfigCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="extras_capturing",
+                trials=1,
+                results_dir=tmp_path,
+                probe_extras={"cell_name": "none-none", "timeout_per_trial": None},
+            )
+            run_trials(req)
+        assert captured_config["_aorta_probe_extras"] == {
+            "cell_name": "none-none",
+            "timeout_per_trial": None,
+        }
+
     def test_cleanup_error_is_logged_not_swallowed(self, tmp_path, caplog):
         """A failing ``cleanup()`` is logged so leaked resources are visible."""
         import logging

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -787,6 +788,55 @@ def test_collect_trial_paths_sorts_numerically_not_lexicographically(tmp_path):
     paths = runner._collect_trial_paths(cell_dir)
     indices = [int(p.rsplit("trial_", 1)[1].rsplit(".", 1)[0]) for p in paths]
     assert indices == [0, 1, 2, 3, 9, 10, 11, 100]
+
+
+def test_collect_trial_paths_sorts_dispatcher_naming_by_trial_index(tmp_path):
+    """Regression for PR #194 review: dispatcher writes
+    ``trial_d<dataset>_m<mitigation>_t<trial>.json`` and the sort key
+    must extract ``<trial>`` so ``..._t10.json`` doesn't lex-sort
+    before ``..._t2.json``. Previously the helper only matched
+    ``trial_<N>.json`` and fell into the alphabetical sentinel branch
+    for dispatcher-shape files, mis-ordering hydration for any
+    cell with >= 10 trials.
+    """
+    cell_dir = tmp_path / "cell"
+    work_dir = cell_dir / "_subprocess"
+    work_dir.mkdir(parents=True)
+    for i in [0, 1, 2, 3, 9, 10, 11, 100]:
+        (work_dir / f"trial_d0_m0_t{i}.json").write_text("{}")
+
+    paths = runner._collect_trial_paths(cell_dir)
+
+    def _t_index(p: str) -> int:
+        # 'trial_d0_m0_t10' -> '10'
+        return int(p.rsplit("_t", 1)[1].rsplit(".", 1)[0])
+
+    indices = [_t_index(p) for p in paths]
+    assert indices == [0, 1, 2, 3, 9, 10, 11, 100]
+
+
+def test_collect_trial_paths_mixed_naming_keeps_each_shape_natural_sorted(tmp_path):
+    """A directory that contains BOTH legacy ``trial_<N>.json`` and
+    dispatcher ``trial_d<d>_m<m>_t<N>.json`` files should sort by the
+    integer trial index across both, so resume-hydration order matches
+    execution order regardless of how the file was written.
+    """
+    cell_dir = tmp_path / "cell"
+    work_dir = cell_dir / "_subprocess"
+    work_dir.mkdir(parents=True)
+    (work_dir / "trial_d0_m0_t10.json").write_text("{}")
+    (work_dir / "trial_2.json").write_text("{}")
+    (work_dir / "trial_d0_m0_t1.json").write_text("{}")
+    (work_dir / "trial_11.json").write_text("{}")
+
+    paths = runner._collect_trial_paths(cell_dir)
+    # By integer trial index: 1, 2, 10, 11.
+    assert [Path(p).stem for p in paths] == [
+        "trial_d0_m0_t1",
+        "trial_2",
+        "trial_d0_m0_t10",
+        "trial_11",
+    ]
 
 
 # ---- Class B: --mitigations-file (sidecar) lifecycle ---------------------

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -175,6 +175,44 @@ def test_resolve_run_dir_without_ticket_routes_to_no_ticket(tmp_path):
     assert run_dir.parts[-3] == NO_TICKET_SLUG
 
 
+# ---- layout="flat_resume" (issue #188 FR 1.13) ---------------------------
+
+
+def test_flat_resume_layout(tmp_path):
+    """`layout="flat_resume"` returns <output>/<ticket>/ (no timestamp, no workload)."""
+    r = _simple_recipe(ticket="PROBE-1")
+    run_dir = resolve_run_dir(tmp_path, r, layout="flat_resume")
+    assert run_dir == tmp_path / "PROBE-1"
+    assert run_dir.is_dir()
+
+
+def test_flat_resume_layout_is_idempotent(tmp_path):
+    """Re-invoking with the same args returns the same path (resume model)."""
+    r = _simple_recipe(ticket="PROBE-1")
+    a = resolve_run_dir(tmp_path, r, layout="flat_resume")
+    b = resolve_run_dir(tmp_path, r, layout="flat_resume")
+    assert a == b
+
+
+def test_flat_resume_layout_no_ticket(tmp_path):
+    r = _simple_recipe(ticket=None)
+    run_dir = resolve_run_dir(tmp_path, r, layout="flat_resume")
+    assert run_dir == tmp_path / NO_TICKET_SLUG
+
+
+def test_default_layout_is_byte_equivalent_to_timestamped(tmp_path):
+    """Existing callers see no behaviour change -- the default is 'timestamped'."""
+    r = _simple_recipe(ticket="PROJ-1")
+    a = resolve_run_dir(tmp_path, r, timestamp="2026-01-01T00-00-00")
+    # Same call with explicit layout="timestamped" produces a sibling
+    # timestamped dir (a -2 suffix appended because parent path matches).
+    assert a == tmp_path / "PROJ-1" / "fsdp" / "2026-01-01T00-00-00"
+    b = resolve_run_dir(
+        tmp_path, r, timestamp="2026-01-01T00-00-00", layout="timestamped"
+    )
+    assert b == tmp_path / "PROJ-1" / "fsdp" / "2026-01-01T00-00-00-2"
+
+
 # ---- End-to-end via run_recipe -------------------------------------------
 
 

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -200,6 +200,19 @@ def test_flat_resume_layout_no_ticket(tmp_path):
     assert run_dir == tmp_path / NO_TICKET_SLUG
 
 
+def test_resolve_run_dir_rejects_unknown_layout(tmp_path):
+    """Regression for PR #194 review: an unknown ``layout`` value used
+    to silently land in the timestamped branch (the type guard fires only
+    under mypy --strict). The runtime check must reject misspellings so
+    probe-mode callers cannot accidentally produce a timestamped tree.
+    """
+    r = _simple_recipe(ticket="PROJ-1")
+    with pytest.raises(ValueError, match="layout must be"):
+        resolve_run_dir(tmp_path, r, layout="flatresume")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="layout must be"):
+        resolve_run_dir(tmp_path, r, layout="")  # type: ignore[arg-type]
+
+
 def test_default_layout_is_byte_equivalent_to_timestamped(tmp_path):
     """Existing callers see no behaviour change -- the default is 'timestamped'."""
     r = _simple_recipe(ticket="PROJ-1")

--- a/tests/triage/test_run_dir_lock.py
+++ b/tests/triage/test_run_dir_lock.py
@@ -1,0 +1,203 @@
+"""Tests for the ``flat_resume`` run-dir lock helper (PR #194 follow-up).
+
+These cover the same-host live-PID rejection, same-host stale-PID takeover,
+cross-host fail-closed semantics, and the corrupt-lock recovery path.
+The matching reviewer comment is on
+``src/aorta/triage/output.py::resolve_run_dir`` (PRRT_kwDOP5TFPc6E08d0).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from aorta.triage.output import (
+    FLAT_RESUME_LOCKFILE,
+    RunDirLockedError,
+    acquire_flat_resume_lock,
+)
+
+# ---- Same-host, lock unheld ---------------------------------------------
+
+
+def test_acquires_when_lock_absent(tmp_path: Path) -> None:
+    """No existing lock -> context entered successfully, lockfile created."""
+    with acquire_flat_resume_lock(tmp_path):
+        lock_path = tmp_path / FLAT_RESUME_LOCKFILE
+        assert lock_path.is_file(), "lock file must exist inside the context"
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
+        assert payload["pid"] == os.getpid()
+        assert payload["host"] == socket.gethostname()
+        assert "started_at" in payload
+    # On exit the lockfile is cleaned up.
+    assert not (tmp_path / FLAT_RESUME_LOCKFILE).exists()
+
+
+def test_releases_on_exception(tmp_path: Path) -> None:
+    """Exception inside the context still cleans up the lockfile."""
+    with pytest.raises(RuntimeError, match="boom"):
+        with acquire_flat_resume_lock(tmp_path):
+            raise RuntimeError("boom")
+    assert not (tmp_path / FLAT_RESUME_LOCKFILE).exists()
+
+
+def test_reentry_after_clean_release(tmp_path: Path) -> None:
+    """Two sequential acquisitions succeed: the resume happy path."""
+    with acquire_flat_resume_lock(tmp_path):
+        pass
+    with acquire_flat_resume_lock(tmp_path):
+        pass
+
+
+# ---- Same-host, live holder (the bug Copilot called out) ---------------
+
+
+def test_rejects_when_same_host_live_pid(tmp_path: Path) -> None:
+    """A second writer hitting the same run dir must fail fast, not stomp.
+
+    The reviewer's concern: ``mkdir(exist_ok=True)`` made flat_resume
+    silently race two concurrent ``aorta probe`` invocations. The lock
+    converts that into a clean ``RunDirLockedError`` with the holder's
+    PID + host in the message.
+    """
+    with acquire_flat_resume_lock(tmp_path):
+        with pytest.raises(RunDirLockedError) as exc_info:
+            with acquire_flat_resume_lock(tmp_path):
+                pytest.fail("inner acquisition must not enter the body")
+    err = exc_info.value
+    assert err.holder_host == socket.gethostname()
+    assert err.holder_pid == os.getpid()
+    assert "still running" in str(err)
+
+
+# ---- Same-host, stale lock from a crashed prior run --------------------
+
+
+def _spawn_quickly_dying_child() -> int:
+    """Return the PID of a process that has already exited.
+
+    We can't use the current PID for the "dead" check (it's alive by
+    definition). Spawning + waiting on a child gives us a PID that is
+    guaranteed to be reaped (``Popen.wait`` reaps it) before we use it
+    in the lock file.
+    """
+    proc = subprocess.Popen([sys.executable, "-c", "import sys; sys.exit(0)"])
+    proc.wait()
+    return proc.pid
+
+
+def test_takes_over_stale_same_host_lock(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Same host + dead holder PID -> warn + overwrite, do not raise.
+
+    This is the documented recovery path: ``flat_resume`` exists for the
+    "previous run crashed, re-run to fill the gaps" workflow. A
+    fail-closed semantic here would defeat the whole resume model.
+    """
+    dead_pid = _spawn_quickly_dying_child()
+    lock_path = tmp_path / FLAT_RESUME_LOCKFILE
+    lock_path.write_text(
+        json.dumps(
+            {
+                "pid": dead_pid,
+                "host": socket.gethostname(),
+                "started_at": "2026-01-01T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING", logger="aorta.triage.output"):
+        with acquire_flat_resume_lock(tmp_path):
+            payload = json.loads(lock_path.read_text(encoding="utf-8"))
+            assert payload["pid"] == os.getpid(), (
+                "stale lock must have been overwritten with our identity"
+            )
+
+    assert any("stale" in record.message for record in caplog.records), (
+        "stale-lock takeover must emit an operator-visible warning"
+    )
+
+
+# ---- Cross-host (NFS / shared FS): fail closed -------------------------
+
+
+def test_rejects_cross_host_lock(tmp_path: Path) -> None:
+    """Different host in the lockfile -> raise.
+
+    Cross-host PID-liveness is not verifiable in Phase 1. Failing closed
+    surfaces the situation to the operator rather than silently stomping
+    a peer's in-flight run on a shared filesystem.
+    """
+    lock_path = tmp_path / FLAT_RESUME_LOCKFILE
+    lock_path.write_text(
+        json.dumps(
+            {
+                "pid": 99999,
+                "host": "other-host.example.invalid",
+                "started_at": "2026-01-01T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RunDirLockedError) as exc_info:
+        with acquire_flat_resume_lock(tmp_path):
+            pytest.fail("cross-host lock must block entry")
+    err = exc_info.value
+    assert err.holder_host == "other-host.example.invalid"
+    assert "different host" in str(err)
+
+
+# ---- Corrupt lockfile recovery ----------------------------------------
+
+
+def test_recovers_from_corrupt_lockfile(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unparseable lockfile -> warn + take over (rather than wedge resume)."""
+    lock_path = tmp_path / FLAT_RESUME_LOCKFILE
+    lock_path.write_text("this is not json {", encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="aorta.triage.output"):
+        with acquire_flat_resume_lock(tmp_path):
+            payload = json.loads(lock_path.read_text(encoding="utf-8"))
+            assert payload["pid"] == os.getpid()
+
+    assert any("unreadable" in record.message for record in caplog.records)
+
+
+# ---- Composition smoke: helper works on a resolve_run_dir leaf ---------
+
+
+def test_composes_with_resolve_run_dir(tmp_path: Path) -> None:
+    """Smoke: the helper accepts a freshly resolved flat_resume run dir.
+
+    ``resolve_run_dir(layout='flat_resume')`` is the only call-site in
+    ``run_recipe`` -- this asserts the directory it produces is a valid
+    target for the lock (no hidden permission / path-type surprises).
+    """
+    from aorta.triage.output import resolve_run_dir
+    from aorta.triage.recipe import Recipe
+
+    recipe = Recipe(
+        schema_version=1,
+        workload="noop",
+        trials=1,
+        steps=1,
+        cells=(),
+        ticket="PROBE-LOCK-TEST",
+    )
+    run_dir = resolve_run_dir(tmp_path, recipe, layout="flat_resume")
+    assert run_dir.is_dir()
+
+    with acquire_flat_resume_lock(run_dir):
+        assert (run_dir / FLAT_RESUME_LOCKFILE).is_file()
+    assert not (run_dir / FLAT_RESUME_LOCKFILE).exists()


### PR DESCRIPTION
## Summary

Lands Phase 1 of `aorta probe` (closes part of #188): a wrap-and-collect CLI that runs an opaque user launch command across a mitigation × diagnostic matrix, with all artifacts captured per-cell + per-trial. Re-runs with the same `--output` skip completed cells. **Tier-1 verdict only** (exit code) — pattern matching, sandboxed `custom_patterns`, redaction, and `aorta bundle` integration are deferred to Phase 2 / Phase 3 per the rubric in `docs/plans/aorta-probe-188-rubric.md`.

This is one of three sequential PRs:

| Phase | Branch | Scope |
|---|---|---|
| **1 (this PR)** | `users/vivekag/aorta-probe-188-phase-1` | MVP CLI + recipe schema + engine reuse |
| 2 (next) | `users/vivekag/aorta-probe-188-phase-2` | 5-tier classifier + sandboxed `custom_patterns` |
| 3 (gated on `aorta bundle`) | `users/vivekag/aorta-probe-188-phase-3` | Redaction + handout templates |

Each phase ships as its own PR off `main`, not stacked, so reviewers see one self-contained diff per phase.

## What's in this PR

- New CLI subcommand `aorta probe` (`src/aorta/cli/probe.py`) — thin Click shim (≤60 line handler body, asserted by test).
- New probe package `src/aorta/probe/` with `cli_helpers`, `recipe_builder`, `resume`.
- New workload `src/aorta/workloads/_subprocess.py` (registered via `aorta.workloads` entry-point as `_subprocess`).
- Recipe schema extension in `src/aorta/triage/recipe.py`: `mode: probe` discriminator, probe-mode keys (`mitigation_axis`, `diagnostic_axis`, `step_time_regex`, `collect_paths`, `timeout_per_trial`, `env_passthrough_mode`). Existing `mode: triage` recipes load byte-equivalently.
- `aorta.triage.runner.run_recipe` and `aorta.triage.output.resolve_run_dir` extended with `layout: Literal["timestamped", "flat_resume"]` (default `"timestamped"` is byte-equivalent to today). Probe-mode uses `flat_resume` for idempotent resume.
- `RunRequest.subprocess_argv` field (typed channel for opaque argv → `SubprocessWorkload`).
- Late defensive fix (commit `28d5ed3`) for three real-world CLI-misparse classes hit during smoke testing — see "Late-stage finding" below.
- 57 new tests in `tests/probe/` + dispatcher and output-layout regression tests.
- New docs: `docs/probe-188/usage.md`, `recipes/example-probe-smoke.yaml`, and the planning rubric at `docs/plans/aorta-probe-188-rubric.md` (committed as the first commit so reviewers see the success criteria the code is measured against).

## Findings against the issue text — needs author confirmation before merge

Per the rubric's Definition of Done (§1.G), three findings I made against the issue text need explicit ack from @oyazdanb before merge. Each is resolved in code per the rubric's recommendation; flagging here for traceability.

### F1 — output-tree layout

The issue specifies `Y/<ticket>/<cell>/trial_<n>/{stdout.log,stderr.log,result.json}` and "re-running with same `--output` skips completed cells". The existing `aorta.triage.output.resolve_run_dir` always creates a fresh timestamped leaf and has no resume affordance.

**Resolution shipped:** extended `resolve_run_dir` (and `run_recipe`) with `layout: Literal["timestamped", "flat_resume"] = "timestamped"`. Default behaviour is byte-equivalent (verified by existing `tests/triage/test_output_layout.py` passing unchanged); probe-mode passes `flat_resume` which produces `<output_dir>/<safe_slug(ticket)>/` with `mkdir(exist_ok=True)` and per-cell artifacts at `<run_dir>/<safe_slug(cell.name)>/trial_<n>/`. **@oyazdanb please confirm this matches your intent.**

### F3 — argv injection channel

The issue mandates `SubprocessWorkload.setup()` reads `argv`. The dispatcher's `_aorta_*` reserved-prefix rejection (line ~193 of `dispatcher.py`) explicitly blocks any user-supplied `_aorta_subprocess_argv` in `config_overrides`, so argv cannot be smuggled that way.

**Resolution shipped:** added a typed `subprocess_argv: tuple[str, ...] | None = None` field to `RunRequest`. The dispatcher copies it into `config["_aorta_subprocess_argv"]` **after** `config_overrides` is merged, mirroring the existing `_aorta_environment` injection pattern. User attempts to smuggle the reserved key via `config_overrides` are still rejected (test: `tests/run/test_dispatcher.py::test_user_supplied_aorta_subprocess_argv_rejected`). **@oyazdanb please confirm this is the right injection channel.**

### F6 — `--env-passthrough-mode {inherit, file}` semantics

The issue says (a) "everything after `--` is forwarded byte-for-byte; aorta never parses it" AND (b) "the docker boundary uses a two-mode passthrough (inherit | file)". Reading both literally:

- **`inherit`** (default): aorta sets per-cell env vars in `os.environ`, child `Popen` inherits via `env=os.environ.copy()`. For `docker run`, the user is responsible for `-e KEY` lines in their own argv.
- **`file`**: as above, plus aorta writes `<trial_dir>/probe.env` (POSIX `KEY=VALUE\n` format, `chmod 0600`) and exports `AORTA_ENV_FILE=<absolute path>` into the child env. The user references it themselves in their own argv (`docker run --env-file $AORTA_ENV_FILE ...`). **Aorta never modifies the user's argv.**

**Resolution shipped:** the above. **@oyazdanb please confirm this reading is correct** — it's the only one consistent with the "no parse" invariant, but if you intended automatic `-e KEY` injection (which would break the invariant), this needs a follow-up design discussion.

## Other findings worth surfacing

- **F7 / missing B3 mitigations.** `hsa_no_scratch_reclaim`, `fa_prefer_ck`, `hip_launch_blocking` from the issue's example axes are not registered in the public B3 build. The smoke recipe and end-to-end test use only `none` and `tf32_off` (both resolve). Follow-up issue filed to register the missing axes (see #TBD-followup linked from this PR).
- **Artifact-tree duplication (reviewer judgment requested).** The dispatcher's existing `save_logs` mechanism writes `<cell>/_subprocess/trial_d<dx>_m<mx>_t<tx>.{stdout,stderr,json}` *in addition to* the new probe-style `<cell>/trial_<n>/{stdout.log,stderr.log,result.json}`. Both trees co-exist on disk. Functionally correct (the probe-style tree is the source of truth for resume and Phase-3 bundling), but the duplication is noisy. Happy to either: (a) suppress `save_logs` for probe-mode in this PR, (b) leave it for a follow-up so this PR stays minimal, or (c) document the convention. Currently option (b).
- **Pre-existing repo debt** (not in this diff): mypy warnings in `src/aorta/triage/output.py:379-380`, ~1,324 ruff warnings repo-wide, `pytest.ini` shadowing `pyproject.toml` test config. Flagging for hygiene, not blocking.

## Late-stage finding — three silent CLI-misparse classes (commit `28d5ed3`)

Smoke-testing surfaced three real-world misuse patterns that all silently succeeded with garbage output:

1. `--output \$UNSET --ticket X`: shell collapses the empty `\$UNSET`, Click accepts `--ticket` as the *value* of `--output`. Artifacts went to a directory literally named `--ticket` and the real `--ticket X` was dropped.
2. Missing `--` separator: positional args leak into the user-command argv.
3. `-- -v echo hi`: residual flag leaks into `argv[0]`, child runs `-v echo hi`, exits 127, trial recorded as a "fail" that was actually a CLI parse accident.

Commit `28d5ed3` adds three defenses (Click callback on string options, `parse_args` override demanding `--`, `argv[0]` dash-guard), all routed through the existing `ProbeUsageError` → `ClickException` bridge. 5 new parameterised tests in `test_cli_parsing.py`. Happy path and `--help` unaffected.

## Hard-gate self-check (rubric §X.3)

All 10 hard gates pass:

| FR | Description | Status |
|---|---|---|
| 1.1 | `--help` shows documented flags | ✅ |
| 1.3 | End-to-end smoke writes the documented tree, exit 0 | ✅ |
| 1.4 | Resume: complete → skip, truncated → re-run | ✅ |
| 1.5 | Both CLIs reach `run_recipe` (shared engine) | ✅ |
| 1.6 | Unknown / probe-in-triage keys rejected | ✅ |
| 1.9 | `inherit` mode does not write env file | ✅ |
| 1.10 | `file` mode writes 0600 `probe.env` + exports `AORTA_ENV_FILE` | ✅ |
| 1.11 | `subprocess_argv` is the only channel; reserved key rejected | ✅ |
| 1.12 | `result.json` minimum shape | ✅ |
| 1.13 | `flat_resume` works; `timestamped` byte-equivalent | ✅ |

Phase 2 / Phase 3 keys (`custom_patterns`, `condition`, `redaction`) are **rejected at recipe load** with a "deferred to Phase {2,3}" pointer (FR 1.19) — recipes that carry them today won't silently no-op when those phases land.

## Test plan

```bash
# Unit + integration
pytest tests/probe tests/triage tests/run
# Result: 427 passed in 73s

# Lint / format / types on touched files
ruff check src/aorta/cli/probe.py src/aorta/probe src/aorta/workloads/_subprocess.py tests/probe
black --check src/aorta/cli/probe.py src/aorta/probe src/aorta/workloads/_subprocess.py tests/probe
isort --check src/aorta/cli/probe.py src/aorta/probe src/aorta/workloads/_subprocess.py tests/probe
mypy src/aorta/cli/probe.py src/aorta/probe src/aorta/workloads/_subprocess.py

# Build
buck2 build //:aorta_lib //:aorta  # BUILD SUCCEEDED

# Manual smoke
D=\$(mktemp -d)
aorta probe --recipe recipes/example-probe-smoke.yaml --output "\$D" --ticket SMOKE-1 -- bash -c 'echo hi; exit 0'
# -> "Wrote probe artifacts to \$D/SMOKE-1"
find "\$D" -name result.json -exec head -3 {} \;
# -> "verdict": "pass" for every trial

# Resume check
aorta probe --recipe recipes/example-probe-smoke.yaml --output "\$D" --ticket SMOKE-1 -- bash -c 'echo SHOULD_NOT_RUN; exit 1'
# -> stdout.log still contains "hi"; second invocation was a no-op
```

## Out-of-scope guardrails

`git diff main...HEAD` touches **zero** files under `src/aorta/{ebpf,hw_queue_eval,profiling,race,report,training}`, `notebooks/`, `experiments/`, `analysis/`, `misc/`. No `subprocess` import under `src/aorta/triage/` (preserves the #151 grep-test rule). No new top-level dependencies in `pyproject.toml` or `requirements.txt`.

## Definition of Done checklist (rubric §1.G)

- [x] All 20 functional requirements pass their named tests
- [x] `pytest`, `ruff`, `black`, `isort`, `mypy`, `pre-commit`, and `buck2 build` succeed
- [x] No regression in `tests/triage/` (196 passed) or `tests/run/` (174 passed)
- [x] `aorta probe --help` shows the documented flag set; `aorta triage run --help` unchanged
- [x] `recipes/README.md` already covers triage-mode; new probe-mode walkthrough in `docs/probe-188/usage.md`
- [ ] **@oyazdanb confirmation on F1, F3, F6** (this PR description)
- [x] PR title matches rubric convention
- [x] No new top-level dependencies
- [x] Out-of-scope guardrails clean
- [x] No `subprocess` import under `src/aorta/triage/`

cc @oyazdanb for the F1/F3/F6 ack and overall design review.

Made with [Cursor](https://cursor.com)