### PR TITLE
probe: built-in 5-tier classifier + sandboxed custom_patterns (#188 phase 2)

### DIFF
--- a/docs/probe-188/classifier.md
+++ b/docs/probe-188/classifier.md
@@ -96,12 +96,15 @@ Version: `BUILTIN_PATTERN_VERSION = "1"` (exposed by
 | `tier4:collective_timeout` | Torch distributed watchdog timeout | `Watchdog caught collective operation timeout` |
 | `tier4:nan_signature` | Training-loss NaN signature | `loss is NaN` |
 
-Each pattern ships a sibling fixture log under
-`tests/probe/fixtures/tier4_logs/<id>.log`. Adding a new pattern
-requires:
+Each pattern ships a sibling fixture log at
+`tests/probe/fixtures/tier4_logs/<detector-suffix>.txt` -- `.txt`
+rather than `.log` so the project's `.gitignore` `*.log` rule never
+silently swallows a new fixture, and the basename is the detector ID
+with the `tier4:` prefix stripped (e.g. `cuda_error.txt` for
+`tier4:cuda_error`). Adding a new pattern requires:
 
 1. Add to `_BUILTIN_PATTERNS` in `tier4_patterns.py`.
-2. Add fixture under `tests/probe/fixtures/tier4_logs/`.
+2. Add fixture under `tests/probe/fixtures/tier4_logs/<suffix>.txt`.
 3. Bump `BUILTIN_PATTERN_VERSION`.
 4. Update this document.
 

--- a/docs/probe-188/classifier.md
+++ b/docs/probe-188/classifier.md
@@ -138,7 +138,12 @@ with the `tier4:` prefix stripped (e.g. `cuda_error.txt` for
 
 Catastrophic-backtracking mitigation: every Tier 4 `re.search` runs
 against a **10 MiB-capped window** (`MAX_LOG_BYTES`). Logs longer
-than the cap are scanned in successive non-overlapping windows.
+than the cap are scanned in successive windows that overlap by
+**4 KiB** (`_WINDOW_OVERLAP_BYTES`, capped at half the window) so
+matches straddling a window seam — typically the multi-line shape
+of `Traceback (most recent call last):` plus its body — still
+fire. The same overlapping-window scheme is used by Tier 5
+(`tier5_custom._iter_windows`).
 
 ## Tier 5 — Custom Patterns
 

--- a/docs/probe-188/classifier.md
+++ b/docs/probe-188/classifier.md
@@ -29,13 +29,27 @@ Encounter order: timeout > signal > exit_nonzero, then coredump
 appended regardless. The verdict resolver preserves this order in
 `failure_detectors_fired`.
 
+**Coredump caveat.** The dispatcher does **not** force
+`cwd=<trial_dir>` on the workload's `Popen` -- the user's `--`
+command often references files by relative path and a forced cwd
+would silently break the repro. With the kernel-default
+`core_pattern` (`core`/`core.<pid>` next to the process's cwd), core
+files therefore land in `aorta probe`'s invocation cwd, **not** the
+trial dir, and `tier1:coredump` will not fire on a real segfault.
+To wire coredump detection, set
+`/proc/sys/kernel/core_pattern` to an absolute template that
+interpolates the trial dir (e.g.
+`/path/to/run/core.%e.%p` and a sidecar collector), or set
+`ulimit -c unlimited` and have the workload write its own core
+artifact into `$AORTA_PROBE_TRIAL_DIR`.
+
 ## Tier 2 — Hang Monitor
 
 Source: `src/aorta/probe/classifier/tier2_hang.py`.
 
 | ID | Fires when |
 |---|---|
-| `tier2:hang` | Two-of-three predicate (stdout silent for `hang_window_sec`, GPU idle per `amd-smi`, `/proc/<pid>/io` rchar+wchar delta = 0) AND elapsed > `hang_grace_period_at_start` |
+| `tier2:hang` | Two-of-three predicate (stdout silent for `hang_window_sec`, GPU idle per `amd-smi monitor` GFX% < 5, `/proc/<pid>/io` rchar+wchar delta = 0) AND elapsed > `hang_grace_period_at_start`. The GPU-idle leg gracefully degrades to "always False" when `amd-smi` is missing/unparseable, so the predicate collapses to 2-of-2 (stdout + IO) on hosts without ROCm telemetry. |
 
 Defaults (overridable per recipe top-level key in `mode: probe`):
 
@@ -74,10 +88,24 @@ The single-warning rule is enforced by the per-invocation
 `Tier3State` instance — the runner owns one and threads it into each
 trial.
 
-`AORTA_PROBE_AMDSMI_FAKE=vram=<MiB>,throttle=<n>` is a test-only
-shim that bypasses the real `amd-smi` invocation; unit tests in
-`tests/probe/classifier/test_tier3.py` use it to exercise the diff
-logic without a GPU.
+**Live amd-smi polling.** `poll_amd_smi` runs
+`amd-smi monitor --csv --gfx --vram-usage` and parses the documented
+CSV columns: `VRAM_USED` (summed across GPUs) and `GFX%` (max across
+GPUs). The CSV path is preferred over `amd-smi metric --json`
+because the column layout is stable across ROCm 6.x / 7.x; the JSON
+shape has been observed to differ between point releases (e.g.
+socket-vs-partition layouts on MI300). `thermal_throttle_count` is
+NOT computed in the live path -- `monitor` only exposes current %
+time in throttle, not a cumulative counter -- so
+`tier3:thermal_throttle` fires only via the fake-shim test path
+today. A future enhancement can plumb a per-trial throttle counter
+through `amd-smi metric --violation --json`.
+
+`AORTA_PROBE_AMDSMI_FAKE=vram=<MiB>,throttle=<n>[,util=<pct>]` is a
+test-only shim that bypasses the real `amd-smi` invocation; unit
+tests in `tests/probe/classifier/test_tier3.py` use it to exercise
+the diff logic and the GPU-idle leg of the Tier 2 two-of-three
+predicate without a GPU.
 
 ## Tier 4 — Built-in Pattern Library
 

--- a/docs/probe-188/classifier.md
+++ b/docs/probe-188/classifier.md
@@ -1,0 +1,194 @@
+# `aorta probe` — Five-Tier Classifier Reference (Issue #188, Phase 2)
+
+This document is the **stable detector-ID reference** for the
+`aorta probe` Phase 2 classifier. Each `result.json::failure_detectors_fired`
+or `warn_detectors_fired` entry is a string from one of the tiers below.
+Built-in (`tier1:` / `tier2:` / `tier3:` / `tier4:`) and custom
+(`custom:<id>`) detectors are listed as peers in every consumer
+(matrix.md, matrix.json, `aorta bundle`).
+
+The classifier is invoked from `SubprocessWorkload.run()` post-exit; see
+`src/aorta/probe/classifier/__init__.py` for the entry point.
+
+---
+
+## Tier 1 — Process Detectors
+
+Source: `src/aorta/probe/classifier/tier1_process.py`.
+
+| ID | Fires when |
+|---|---|
+| `tier1:exit_nonzero` | `proc.returncode != 0` and no signal fired |
+| `tier1:sigsegv` | `returncode == -signal.SIGSEGV` |
+| `tier1:sigabrt` | `returncode == -signal.SIGABRT` |
+| `tier1:sigbus` | `returncode == -signal.SIGBUS` |
+| `tier1:timeout` | `Popen.wait(timeout=recipe.timeout_per_trial)` raised `TimeoutExpired` |
+| `tier1:coredump` | Any `core.*` (or bare `core`) file exists directly under `<trial_dir>/` post-exit |
+
+Encounter order: timeout > signal > exit_nonzero, then coredump
+appended regardless. The verdict resolver preserves this order in
+`failure_detectors_fired`.
+
+## Tier 2 — Hang Monitor
+
+Source: `src/aorta/probe/classifier/tier2_hang.py`.
+
+| ID | Fires when |
+|---|---|
+| `tier2:hang` | Two-of-three predicate (stdout silent for `hang_window_sec`, GPU idle per `amd-smi`, `/proc/<pid>/io` rchar+wchar delta = 0) AND elapsed > `hang_grace_period_at_start` |
+
+Defaults (overridable per recipe top-level key in `mode: probe`):
+
+- `hang_window_sec`: 30 seconds
+- `hang_grace_period_at_start`: 60 seconds
+
+A `HangMonitor` thread runs alongside `proc.wait()`, polling at most
+every 5 seconds. The first time the predicate trips, the monitor flips
+its `hang_detected` flag. The workload reads the flag post-exit.
+
+## Tier 3 — Kernel + GPU Detectors
+
+Source: `src/aorta/probe/classifier/tier3_kernel.py`.
+
+`dmesg` scan IDs:
+
+| ID | Regex anchor |
+|---|---|
+| `tier3:amdgpu_reset` | `amdgpu: GPU reset` |
+| `tier3:sdma_timeout` | `SDMA semaphore timeout \| SDMA hang` |
+| `tier3:vm_l2_fault` | `VM_L2_PROTECTION_FAULT` |
+| `tier3:xgmi_link_error` | `XGMI.*(?:error\|fail\|link down)` |
+| `tier3:pcie_aer_fatal` | `AER:?\s+Fatal` |
+
+`amd-smi` snapshot diff IDs:
+
+| ID | Fires when |
+|---|---|
+| `tier3:vram_growth` | `vram_used_mib(post) - vram_used_mib(pre) >= 256 MiB` |
+| `tier3:thermal_throttle` | `thermal_throttle_count(post) > thermal_throttle_count(pre)` |
+
+**Fail-soft**: missing `dmesg` / `amd-smi` binaries log
+`tier3 disabled: <reason>` exactly **once per `aorta probe`
+invocation** (FR 2.11) and the classifier continues with Tiers 1+2+4.
+The single-warning rule is enforced by the per-invocation
+`Tier3State` instance — the runner owns one and threads it into each
+trial.
+
+`AORTA_PROBE_AMDSMI_FAKE=vram=<MiB>,throttle=<n>` is a test-only
+shim that bypasses the real `amd-smi` invocation; unit tests in
+`tests/probe/classifier/test_tier3.py` use it to exercise the diff
+logic without a GPU.
+
+## Tier 4 — Built-in Pattern Library
+
+Source: `src/aorta/probe/classifier/tier4_patterns.py`.
+
+Version: `BUILTIN_PATTERN_VERSION = "1"` (exposed by
+`aorta probe --list-patterns --version`).
+
+| ID | Description | Sample |
+|---|---|---|
+| `tier4:python_traceback` | Python traceback header line | `Traceback (most recent call last):` |
+| `tier4:hip_error` | HIP error code | `hipError_OutOfMemory` |
+| `tier4:cuda_error` | CUDA error code | `cudaErrorIllegalAddress` |
+| `tier4:rocm_error` | ROCm error-code marker | `Error code: 1` |
+| `tier4:nccl_rccl_error` | NCCL/RCCL collective error | `NCCL error: ...` |
+| `tier4:collective_timeout` | Torch distributed watchdog timeout | `Watchdog caught collective operation timeout` |
+| `tier4:nan_signature` | Training-loss NaN signature | `loss is NaN` |
+
+Each pattern ships a sibling fixture log under
+`tests/probe/fixtures/tier4_logs/<id>.log`. Adding a new pattern
+requires:
+
+1. Add to `_BUILTIN_PATTERNS` in `tier4_patterns.py`.
+2. Add fixture under `tests/probe/fixtures/tier4_logs/`.
+3. Bump `BUILTIN_PATTERN_VERSION`.
+4. Update this document.
+
+Catastrophic-backtracking mitigation: every Tier 4 `re.search` runs
+against a **10 MiB-capped window** (`MAX_LOG_BYTES`). Logs longer
+than the cap are scanned in successive non-overlapping windows.
+
+## Tier 5 — Custom Patterns
+
+Source: `src/aorta/probe/classifier/tier5_custom.py`.
+
+Detector IDs are `custom:<id>` where `<id>` is the recipe-declared
+pattern ID. Compile-validated at recipe load. Optional `condition`
+fields are sandbox-validated at recipe load via
+`aorta.probe.sandbox.validate_and_compile` — see
+[sandbox.md](sandbox.md).
+
+`on_match` semantics:
+
+| Value | Effect |
+|---|---|
+| `fail` | Contributes to `failure_detectors_fired`. Default. |
+| `warn` | Contributes to `warn_detectors_fired`. Does **not** change verdict. |
+| `info` | Populates `capture{}` only. |
+
+`required_for_pass: true` (only valid with `on_match: fail`): if the
+pattern does **not** fire, the verdict resolver injects
+`meta:missing_pass_signal` and `verdict = "fail"`.
+
+## Meta Detectors
+
+| ID | Source |
+|---|---|
+| `meta:missing_pass_signal` | Verdict resolver (`src/aorta/probe/classifier/verdict.py`). Synthesised when a `required_for_pass` pattern did not fire. |
+
+## Verdict Precedence
+
+Implemented in `src/aorta/probe/classifier/verdict.py::resolve`.
+
+1. Any Tier 1–4 detector OR any `on_match: fail` custom pattern
+   fires → `verdict = "fail"`.
+2. `failure_detectors_fired` lists ALL fired in encounter order:
+   T1 → T2 → T3 → T4 → custom-fail → `meta:missing_pass_signal`.
+3. A `required_for_pass: true` pattern that did NOT fire adds
+   `meta:missing_pass_signal` to `failure_detectors_fired` and flips
+   the verdict to `fail`.
+4. Otherwise → `verdict = "pass"`.
+
+`on_match: warn` contributes only to `warn_detectors_fired`;
+`on_match: info` only to `capture`. Neither changes the verdict.
+
+## `result.json` Shape
+
+```jsonc
+{
+  "verdict": "pass" | "fail",
+  "exit_code": int,
+  "walltime_sec": float,
+  "peak_vram_mib": int | null,
+  "argv": [string, ...],
+  "cell_name": string,
+  "trial_index": int,
+  "failure_detectors_fired": [string, ...],
+  "warn_detectors_fired": [string, ...],
+  "capture": {string: (string | float | int)},
+  "tier_durations_ms": {"tier1": float, "tier2": float, "tier3": float, "tier4": float, "tier5": float},
+
+  // Phase 1 keys still present (subset of Phase 2 shape):
+  "env_passthrough_mode": "inherit" | "file",
+  "timed_out": bool
+}
+```
+
+## Ownership
+
+Per Open Question #1 + #5 in the rubric, the AORTA team
+(`@mycpuorg` per `CODEOWNERS`) owns the Tier 4 pattern library.
+Every version bump requires:
+
+- Update to `_BUILTIN_PATTERNS` in `tier4_patterns.py`.
+- New fixture log under `tests/probe/fixtures/tier4_logs/`.
+- Bump of `BUILTIN_PATTERN_VERSION`.
+- This document updated.
+- A security-reviewer sign-off (sandbox-touching changes only).
+
+## See Also
+
+- [sandbox.md](sandbox.md) — `condition` expression whitelist.
+- [usage.md](usage.md) — CLI walkthrough + `--list-patterns` flag.
+- `tests/probe/classifier/` — unit tests for every tier.

--- a/docs/probe-188/sandbox.md
+++ b/docs/probe-188/sandbox.md
@@ -191,8 +191,12 @@ To bound catastrophic backtracking on operator-supplied regex at
 runtime — without swapping the regex engine — every per-trial
 regex scan runs against a **10 MiB-capped window**
 (`MAX_LOG_BYTES = 10 * 1024 * 1024`). Logs longer than the cap are
-scanned in successive non-overlapping windows. The same rule applies
-to the Tier 4 built-in scanner.
+scanned in successive windows that overlap by **4 KiB**
+(`_WINDOW_OVERLAP_BYTES`, capped at half the window so each step
+still advances) so a multi-line match straddling a seam — a
+Python traceback header at the end of one window with its body at
+the start of the next — still fires. The same rule applies to the
+Tier 4 built-in scanner.
 
 ---
 

--- a/docs/probe-188/sandbox.md
+++ b/docs/probe-188/sandbox.md
@@ -24,8 +24,12 @@ For every `custom_patterns[*]` entry with a `match.condition`:
    - Walks the AST and rejects every node, name, attribute, subscript,
      and call target outside the whitelist (see below).
    - Rejects integer literals whose magnitude is `>= 10^9`
-     (`MAX_INT_CONSTANT`) — prevents `2 ** 1000000000`-shaped resource
-     exhaustion at eval time.
+     (`MAX_INT_CONSTANT`) — prevents bare resource-exhaustion
+     literals like `exit_code == 1000000000` from ever reaching
+     `eval`. Exponentiation (`**`) is rejected one layer up because
+     it is not in the AST allow-list; the magnitude cap is no
+     longer the only defence against `2 ** capture['n']`-style
+     attacks where the exponent comes from non-literal text.
    - Returns a compiled `CodeType` cached on the `CompiledPattern`.
 2. At **trial post-exit**, if the pattern's regex matched, the runner
    calls `evaluate(code, capture=..., exit_code=..., walltime_sec=...,
@@ -63,10 +67,17 @@ ast.Expression, ast.BoolOp, ast.BinOp, ast.UnaryOp, ast.Compare,
 ast.Call, ast.Subscript, ast.Name, ast.Constant, ast.IfExp,
 ast.And, ast.Or, ast.Not, ast.Eq, ast.NotEq, ast.Lt, ast.LtE,
 ast.Gt, ast.GtE, ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod,
-ast.FloorDiv, ast.Pow, ast.USub, ast.UAdd, ast.Load,
+ast.FloorDiv, ast.USub, ast.UAdd, ast.Load,
 ```
 
 Plus `ast.Attribute` ONLY when it spells `math.isnan` or `math.isinf`.
+
+`ast.Pow` (`**`) is deliberately omitted. The integer-literal
+magnitude cap only restricts literal constants; with `Pow` allowed,
+an expression like `2 ** int(capture['exp'])` could allocate a huge
+Python int from regex-capture text at eval time. Legitimate
+`condition:` expressions are boolean checks (`exit_code == 137`,
+`walltime_sec > 60`) and never need exponentiation.
 
 ## Allowed Names
 
@@ -125,7 +136,7 @@ type(capture)
 getattr(capture, 'pop')('eval_loss')
 capture['x'].__class__
 math.__loader__.load_module('os')
-2 ** 1000000000  # rejected by the 256-char length cap
+2 ** 1000000000  # rejected because ast.Pow is not in the allow-list
 ```
 
 Each line covers a distinct exploit class:
@@ -139,7 +150,13 @@ Each line covers a distinct exploit class:
 - Function literals (`lambda`).
 - Comprehensions (`ListComp`, `DictComp`).
 - Forbidden builtins (`type`, `getattr`).
-- Resource-exhaustion integer literals.
+- Resource-exhaustion exponentiation (`**`) — rejected at the AST
+  level rather than relying on the integer-literal magnitude cap,
+  because the exponent can be derived from non-literal expressions
+  like `int(capture['exp'])` that the magnitude cap does not see.
+- Resource-exhaustion integer literals
+  (`exit_code == 1000000000`-style) — rejected by
+  `MAX_INT_CONSTANT = 10**9`.
 
 ---
 

--- a/docs/probe-188/sandbox.md
+++ b/docs/probe-188/sandbox.md
@@ -1,0 +1,221 @@
+# `condition:` Sandbox — Whitelist + Worked Examples (Issue #188, Phase 2)
+
+The `condition:` field on a `custom_patterns[*].match` block lets a
+probe-mode recipe author write a boolean expression evaluated **after**
+the regex matches a per-trial log line. It is the only place where
+user-supplied YAML drives arbitrary computation against trial-time
+data, so the security posture is **default-deny at parse time**.
+
+Source: `src/aorta/probe/sandbox.py`. Tests:
+`tests/probe/test_sandbox.py`. Hostile-input corpus:
+`tests/probe/fixtures/conditions/hostile.txt`.
+
+---
+
+## What Goes Through the Sandbox
+
+For every `custom_patterns[*]` entry with a `match.condition`:
+
+1. At **recipe load**, `validate_and_compile(condition_text)`:
+   - Strips the expression.
+   - Rejects empty / non-string input.
+   - Rejects expressions longer than **256 characters** (`MAX_EXPR_LEN`).
+   - `ast.parse(text, mode="eval")` (any parse error → `SandboxError`).
+   - Walks the AST and rejects every node, name, attribute, subscript,
+     and call target outside the whitelist (see below).
+   - Rejects integer literals whose magnitude is `>= 10^9`
+     (`MAX_INT_CONSTANT`) — prevents `2 ** 1000000000`-shaped resource
+     exhaustion at eval time.
+   - Returns a compiled `CodeType` cached on the `CompiledPattern`.
+2. At **trial post-exit**, if the pattern's regex matched, the runner
+   calls `evaluate(code, capture=..., exit_code=..., walltime_sec=...,
+   peak_vram_mib=...)`:
+   - Globals are `{"__builtins__": {}, "math": math, "float": float,
+     "int": int, "len": len}`.
+   - Locals are the four documented variables (see "Variables in
+     scope" below).
+   - Result is coerced to `bool`. Any runtime exception is treated as
+     "did not fire" (the trial verdict is not aborted by a hostile
+     condition that survived the parse-time walker — defence in
+     depth).
+
+Rejections are reported with the offending AST node type and source
+line so the recipe author can find the bad expression without
+counting yaml indents. The exception is `SandboxError`, which
+subclasses `RecipeSchemaError` so the existing CLI / recipe-loader
+error path catches it without code changes.
+
+---
+
+## Variables in Scope (Read-Only)
+
+| Name | Type | Source |
+|---|---|---|
+| `capture` | `dict[str, str]` | Named regex captures from the matched pattern. Indexed only as `capture['name']`. |
+| `exit_code` | `int` | The trial's process exit code (negative when signalled, e.g. `-11` for SIGSEGV). |
+| `walltime_sec` | `float` | Wall-clock seconds from `Popen.start()` to `wait()` return. |
+| `peak_vram_mib` | `int` (0 if unavailable) | Per-trial peak VRAM from `amd-smi`. Bound to **0** when the actual value is None so `peak_vram_mib > 100` does not blow up mid-eval. |
+
+## Allowed AST Nodes
+
+```python
+ast.Expression, ast.BoolOp, ast.BinOp, ast.UnaryOp, ast.Compare,
+ast.Call, ast.Subscript, ast.Name, ast.Constant, ast.IfExp,
+ast.And, ast.Or, ast.Not, ast.Eq, ast.NotEq, ast.Lt, ast.LtE,
+ast.Gt, ast.GtE, ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod,
+ast.FloorDiv, ast.Pow, ast.USub, ast.UAdd, ast.Load,
+```
+
+Plus `ast.Attribute` ONLY when it spells `math.isnan` or `math.isinf`.
+
+## Allowed Names
+
+```python
+{"capture", "exit_code", "walltime_sec", "peak_vram_mib",
+ "math", "float", "int", "len"}
+```
+
+## Allowed Calls
+
+`float`, `int`, `len`, `math.isnan`, `math.isinf`. Anything else — including
+`getattr`, `hasattr`, `type`, `isinstance`, `capture.update(...)`,
+`open(...)`, `__import__(...)` — is rejected at parse time.
+
+`capture[...]` subscript is permitted; `foo[...]` for any other name
+is rejected.
+
+---
+
+## Worked Examples — Allowed
+
+```yaml
+# Trial failed when loss exploded.
+condition: "math.isnan(float(capture['loss']))"
+
+# Slow iteration only counts on a real GPU host.
+condition: "walltime_sec > 60 and peak_vram_mib > 0"
+
+# Exit code 137 (OOM-kill) only when the user log mentions oom.
+condition: "exit_code == 137 and 'oom' in capture['msg']"
+# NOTE: the above uses ``in`` on a string -- works because ast.Compare
+# with ast.In is a planned future addition. Today, prefer:
+condition: "exit_code == 137 and len(capture['msg']) > 0"
+
+# Specific value check (Tier-3 OOM-killer signature).
+condition: "int(capture['code']) == 137"
+```
+
+## Worked Examples — Rejected
+
+Every entry below is in `tests/probe/fixtures/conditions/hostile.txt`
+and is parametrised in `tests/probe/test_sandbox.py::test_hostile_inputs_rejected`:
+
+```python
+__import__('os').system('rm -rf /')
+(0).__class__.__bases__[0].__subclasses__()
+().__class__.__mro__[-1]
+open('/etc/passwd').read()
+exec("import os; os.system('id')")
+eval("1+1")
+lambda x: x
+[x for x in range(10)]
+{k: v for k, v in capture.items()}
+capture.update({'pwn': '1'})
+type(capture)
+getattr(capture, 'pop')('eval_loss')
+capture['x'].__class__
+math.__loader__.load_module('os')
+2 ** 1000000000  # rejected by the 256-char length cap
+```
+
+Each line covers a distinct exploit class:
+
+- Import / system-call gadgets (`__import__`, `exec`, `eval`).
+- Object-graph walks (`__class__`, `__bases__`, `__subclasses__`,
+  `__mro__`).
+- Attribute-walking on whitelisted names (`capture.update`,
+  `getattr(capture, 'pop')`, `math.__loader__`).
+- Filesystem access (`open(...)`).
+- Function literals (`lambda`).
+- Comprehensions (`ListComp`, `DictComp`).
+- Forbidden builtins (`type`, `getattr`).
+- Resource-exhaustion integer literals.
+
+---
+
+## Regex DoS Hardening (§2.E.5)
+
+The sandbox doc covers `condition:` validation; the recipe loader
+separately compile-validates every `custom_patterns[*].match.regex`
+via `re.compile(regex)` at load (FR 2.6) so a bad pattern surfaces
+immediately.
+
+To bound catastrophic backtracking on operator-supplied regex at
+runtime — without swapping the regex engine — every per-trial
+regex scan runs against a **10 MiB-capped window**
+(`MAX_LOG_BYTES = 10 * 1024 * 1024`). Logs longer than the cap are
+scanned in successive non-overlapping windows. The same rule applies
+to the Tier 4 built-in scanner.
+
+---
+
+## Defence-in-Depth Layers
+
+The sandbox is intentionally layered so a single regression cannot
+unlock arbitrary code execution:
+
+1. **Parse-time AST whitelist** (`validate_and_compile`). The
+   walker is ~80 lines and entirely auditable.
+2. **Empty `__builtins__`** at eval. Even if the walker were to
+   regress, `__import__` is unreachable.
+3. **No module references in scope** besides `math`. Attribute
+   access on `math` is parse-time-restricted to `isnan` / `isinf`.
+4. **Length cap before parse**, integer-magnitude cap during walk.
+5. **Runtime exception → did-not-fire**, not classifier abort.
+   Hostile conditions that survive (they shouldn't) cannot poison
+   the verdict for an entire run.
+
+The hostile-input corpus
+(`tests/probe/fixtures/conditions/hostile.txt`) is the regression
+suite for layer #1; the rest of the layers have their own dedicated
+tests (`test_empty_builtins_neutralises_eval`,
+`test_math_module_is_only_globals_module`,
+`test_int_constant_at_cap_rejected`).
+
+---
+
+## Why Not RestrictedPython?
+
+A third-party Python sandbox library (`RestrictedPython`,
+`pysandbox`, etc.) was considered and rejected:
+
+- **Heavier dependency surface**. Each library is itself a security
+  artifact requiring its own review cadence; rolling our own
+  ~80-line walker is auditable in a single review pass.
+- **More permissive default whitelist**. `RestrictedPython` allows
+  loops, list comprehensions, and explicit re-exports that this
+  use case has no need for.
+- **Phase-2 do-not-do list (§2.H)** explicitly forbids third-party
+  sandbox libraries.
+
+If a future need arises that genuinely requires a larger surface
+(generators, list comprehensions, multi-argument calls), the right
+move is to revisit the rubric and the security-reviewer sign-off
+together — not to silently broaden this walker.
+
+---
+
+## Security-Reviewer Sign-off
+
+Per Open Question #1 in the rubric, Phase 2 PR merge is **blocked**
+on a security-reviewer's approval of this sandbox. The reviewer
+should read:
+
+1. This document.
+2. `src/aorta/probe/sandbox.py` end-to-end.
+3. `tests/probe/test_sandbox.py` end-to-end.
+4. `tests/probe/fixtures/conditions/hostile.txt` (parametrised
+   rejection corpus).
+
+The same reviewer should also approve Phase 3's redaction module
+when it lands.

--- a/docs/probe-188/sandbox.md
+++ b/docs/probe-188/sandbox.md
@@ -26,10 +26,14 @@ For every `custom_patterns[*]` entry with a `match.condition`:
    - Rejects integer literals whose magnitude is `>= 10^9`
      (`MAX_INT_CONSTANT`) — prevents bare resource-exhaustion
      literals like `exit_code == 1000000000` from ever reaching
-     `eval`. Exponentiation (`**`) is rejected one layer up because
-     it is not in the AST allow-list; the magnitude cap is no
-     longer the only defence against `2 ** capture['n']`-style
-     attacks where the exponent comes from non-literal text.
+     `eval`. Three resource-exhaustion operators (`**`, `*`, `%`)
+     are also rejected one layer up because they are not in the
+     AST allow-list, closing the variants that operate on
+     non-literal operands: `2 ** capture['n']` (huge int),
+     `'a' * 999999998` (huge string), `'%999999998s' % capture['x']`
+     (huge printf buffer). The magnitude cap and the operator
+     allow-list together cover both the literal and the
+     name-derived attack shapes.
    - Returns a compiled `CodeType` cached on the `CompiledPattern`.
 2. At **trial post-exit**, if the pattern's regex matched, the runner
    calls `evaluate(code, capture=..., exit_code=..., walltime_sec=...,
@@ -66,18 +70,23 @@ error path catches it without code changes.
 ast.Expression, ast.BoolOp, ast.BinOp, ast.UnaryOp, ast.Compare,
 ast.Call, ast.Subscript, ast.Name, ast.Constant, ast.IfExp,
 ast.And, ast.Or, ast.Not, ast.Eq, ast.NotEq, ast.Lt, ast.LtE,
-ast.Gt, ast.GtE, ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod,
+ast.Gt, ast.GtE, ast.Add, ast.Sub, ast.Div,
 ast.FloorDiv, ast.USub, ast.UAdd, ast.Load,
 ```
 
 Plus `ast.Attribute` ONLY when it spells `math.isnan` or `math.isinf`.
 
-`ast.Pow` (`**`) is deliberately omitted. The integer-literal
-magnitude cap only restricts literal constants; with `Pow` allowed,
-an expression like `2 ** int(capture['exp'])` could allocate a huge
-Python int from regex-capture text at eval time. Legitimate
+`ast.Pow` (`**`), `ast.Mult` (`*`), and `ast.Mod` (`%`) are
+deliberately omitted. The integer-literal magnitude cap only
+restricts *literal* constants, and Python's `*` / `%` / `**`
+operators all overload on non-numeric operands (strings repeat,
+tuples repeat, printf-formatting allocates), so the walker can't
+distinguish "numeric arithmetic" from "resource-exhaustion bomb"
+at parse time without knowing the operand types. The simplest
+correct defence is to forbid all three operators. Legitimate
 `condition:` expressions are boolean checks (`exit_code == 137`,
-`walltime_sec > 60`) and never need exponentiation.
+`walltime_sec > 60`, `peak_vram_mib > 100`) and never need
+exponentiation, multiplication, or modulo.
 
 ## Allowed Names
 
@@ -106,15 +115,23 @@ condition: "math.isnan(float(capture['loss']))"
 # Slow iteration only counts on a real GPU host.
 condition: "walltime_sec > 60 and peak_vram_mib > 0"
 
-# Exit code 137 (OOM-kill) only when the user log mentions oom.
-condition: "exit_code == 137 and 'oom' in capture['msg']"
-# NOTE: the above uses ``in`` on a string -- works because ast.Compare
-# with ast.In is a planned future addition. Today, prefer:
+# Exit code 137 (OOM-kill) plus a non-empty captured message
+# (we can't substring-search the message today; ``ast.In`` is
+# rejected by the walker, so use a presence check instead).
 condition: "exit_code == 137 and len(capture['msg']) > 0"
 
 # Specific value check (Tier-3 OOM-killer signature).
 condition: "int(capture['code']) == 137"
 ```
+
+> **`in` is currently rejected.** `ast.Compare` with the `ast.In`
+> operator is **not** in the allow-list today, so a condition like
+> `'oom' in capture['msg']` raises `SandboxError` at recipe-load
+> time. If you need substring matching, do it in the
+> `custom_patterns[*].match.regex` field (where it belongs) and
+> use `condition:` for the boolean glue. Membership-test support
+> is tracked as a planned future addition; until then the
+> "Rejected" section below pins the current behaviour.
 
 ## Worked Examples — Rejected
 
@@ -137,6 +154,9 @@ getattr(capture, 'pop')('eval_loss')
 capture['x'].__class__
 math.__loader__.load_module('os')
 2 ** 1000000000  # rejected because ast.Pow is not in the allow-list
+'a' * 999999998  # rejected because ast.Mult is not in the allow-list (string repeat -> ~1 GiB alloc)
+'%999999998s' % capture['x']  # rejected because ast.Mod is not in the allow-list (printf-style formatting -> same billion-byte buffer)
+'oom' in capture['msg']  # rejected because ast.In is not in the allow-list (no membership tests today; use the regex for substring matching)
 ```
 
 Each line covers a distinct exploit class:

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -194,8 +194,8 @@ forward-compatible:
 `peak_vram_mib` is a coarse high-water mark sampled from two
 `amd-smi` snapshots (pre- and post-Popen). It may be `null` when
 `amd-smi` is missing or unparseable -- Tier-5 sandbox conditions
-that reference it bind `null -> 0` so they stay deterministic
-(see `aorta.probe.sandbox.build_sandbox_env`).
+that reference it bind `null -> 0` inside `aorta.probe.sandbox.evaluate`
+so they stay deterministic.
 
 The verdict comes from `aorta.probe.classifier`:
 

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -1,9 +1,14 @@
-# `aorta probe` — Phase 1 Usage Walkthrough (issue #188)
+# `aorta probe` — Usage Walkthrough (issue #188, Phases 1+2)
 
-> Tier 1 only: verdict is `exit_code == 0 ? "pass" : "fail"`. No
-> pattern-matching, hang detection, dmesg scraping, sandboxing, or
-> bundling in this phase — see §2 / §3 of the rubric for what is
-> coming next.
+> **Phase 1 (Tier 1 only)**: verdict is `exit_code == 0 ? "pass" : "fail"`.
+> **Phase 2 (this walkthrough)**: five-tier classifier (`tier1:` process,
+> `tier2:` hang, `tier3:` kernel + GPU, `tier4:` built-in pattern library,
+> `custom:` user patterns), plus a sandboxed `condition:` evaluator for
+> custom patterns and a `--list-patterns` flag. No bundling /
+> redaction in this phase — see §3 of the rubric.
+>
+> See [classifier.md](classifier.md) for the full detector-ID reference
+> and [sandbox.md](sandbox.md) for the `condition` whitelist.
 
 `aorta probe` runs an **opaque user launch command** across the
 cartesian product of a **mitigation axis × diagnostic axis**, in an
@@ -68,8 +73,22 @@ timeout_per_trial: 1800           # seconds; null = no timeout
 env_passthrough_mode: inherit     # 'inherit' | 'file' — overridden by --env-passthrough-mode when that flag is passed
 ```
 
-Phase 2/3 keys (`custom_patterns`, `condition`, `redaction`) are
-**rejected at load time** with a "deferred to Phase 2/3" error message.
+Phase 2 keys accepted in `mode: probe` recipes (rubric §2.C):
+
+```yaml
+hang_window_sec: 30                # how long each hang signal must hold
+hang_grace_period_at_start: 60     # wait before Tier 2 fires
+custom_patterns:                   # Tier 5 user-defined patterns
+  - id: oom_killer
+    match:
+      regex: "out of memory \\(oom_kill"
+      condition: "exit_code == 137"   # optional; sandboxed at load
+    on_match: fail                    # 'fail' | 'warn' | 'info'
+    required_for_pass: false          # only valid with on_match: fail
+```
+
+Phase 3 keys (`redaction`, top-level `condition`) are still **rejected
+at load time** with a "deferred to Phase 3" error message.
 
 **Registered mitigation / diagnostic names.** The built-in registry
 (see `src/aorta/registry/mitigations.py`) currently ships only `none`,
@@ -139,31 +158,59 @@ of the three built-ins above) when copy-pasting this template.
 * Any flag not in the table above must come from the recipe; the CLI is
   intentionally **thin** (see `tests/probe/test_cli_parsing.py`).
 
-## 6. What the verdict means in Phase 1
+## 6. What the verdict means in Phase 2
+
+A Phase-2 `result.json` looks like (Phase 1 keys are a subset):
 
 Phase-1 `result.json` shape (exact keys written by
 `SubprocessWorkload.run()`):
 
 ```json
 {
-  "verdict": "pass",
-  "exit_code": 0,
+  "verdict": "fail",
+  "exit_code": 137,
   "walltime_sec": 12.345,
+  "peak_vram_mib": null,
   "argv": ["python3", "my_repro.py", "--steps", "100"],
   "cell_name": "none-none",
   "trial_index": 0,
+  "failure_detectors_fired": ["tier1:exit_nonzero", "tier4:hip_error"],
+  "warn_detectors_fired": ["custom:slow_iter"],
+  "capture": {"loss": "nan"},
+  "tier_durations_ms": {"tier1": 0.4, "tier2": 0.1, "tier3": 12.1, "tier4": 1.8, "tier5": 0.3},
   "env_passthrough_mode": "inherit",
   "timed_out": false
 }
 ```
 
-`verdict` is **exactly** `exit_code == 0 and not timed_out ? "pass" : "fail"`.
-Pattern matching, hang detection, and per-step time analysis are
-deferred to Phase 2 — Phase 2 extends this document by ADDING keys
-(never by removing), so any tool reading the Phase-1 keys above keeps
-working when Phase 2 ships.
+The verdict comes from `aorta.probe.classifier`:
 
-## 7. Shared engine guarantee
+1. Any `tier1:*` / `tier2:*` / `tier3:*` / `tier4:*` detector fires
+   OR any `custom_patterns[*]` with `on_match: fail` fires →
+   `verdict = "fail"`.
+2. `required_for_pass: true` patterns that don't fire add
+   `meta:missing_pass_signal` and flip the verdict.
+3. Otherwise → `verdict = "pass"`.
+
+Full ordering rules + per-tier detector IDs:
+[classifier.md](classifier.md). `condition:` expression whitelist:
+[sandbox.md](sandbox.md).
+
+## 7. `--list-patterns` (Phase 2 deviation)
+
+The rubric's `aorta probe list-patterns` subcommand is implemented as
+a **flag** on the existing `aorta probe` command:
+
+```bash
+aorta probe --list-patterns          # full Tier 4 catalogue (one entry per pattern)
+aorta probe --list-patterns --version  # 'aorta probe pattern library v1 (aorta <pkg>)'
+```
+
+This deviation preserves the Phase-1 CLI surface byte-equivalently —
+`aorta probe -- <argv>` still works without a subcommand prefix. The
+flag short-circuits before recipe loading.
+
+## 8. Shared engine guarantee
 
 `aorta probe` and `aorta triage run` both reach
 `aorta.triage.runner.run_recipe` — there is no parallel runner. The

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -160,17 +160,17 @@ of the three built-ins above) when copy-pasting this template.
 
 ## 6. What the verdict means in Phase 2
 
-A Phase-2 `result.json` looks like (Phase 1 keys are a subset):
-
-Phase-1 `result.json` shape (exact keys written by
-`SubprocessWorkload.run()`):
+Phase-2 `result.json` shape (exact keys written by
+`SubprocessWorkload.run()`). The Phase-1 subset is annotated inline
+so downstream tooling that only parsed the Phase-1 fields stays
+forward-compatible:
 
 ```json
 {
   "verdict": "fail",
   "exit_code": 137,
   "walltime_sec": 12.345,
-  "peak_vram_mib": null,
+  "peak_vram_mib": 71234,
   "argv": ["python3", "my_repro.py", "--steps", "100"],
   "cell_name": "none-none",
   "trial_index": 0,
@@ -182,6 +182,20 @@ Phase-1 `result.json` shape (exact keys written by
   "timed_out": false
 }
 ```
+
+* **Phase-1 keys** (back-compat guaranteed by the
+  `tests/probe/test_subprocess_workload.py` minimum-shape assertion):
+  `verdict`, `exit_code`, `walltime_sec`, `peak_vram_mib`, `argv`,
+  `cell_name`, `trial_index`, `env_passthrough_mode`, `timed_out`.
+* **Phase-2 additions** (new in this PR, never replaced or removed):
+  `failure_detectors_fired`, `warn_detectors_fired`, `capture`,
+  `tier_durations_ms`.
+
+`peak_vram_mib` is a coarse high-water mark sampled from two
+`amd-smi` snapshots (pre- and post-Popen). It may be `null` when
+`amd-smi` is missing or unparseable -- Tier-5 sandbox conditions
+that reference it bind `null -> 0` so they stay deterministic
+(see `aorta.probe.sandbox.build_sandbox_env`).
 
 The verdict comes from `aorta.probe.classifier`:
 

--- a/recipes/example-probe-smoke.yaml
+++ b/recipes/example-probe-smoke.yaml
@@ -1,6 +1,6 @@
 # Smoke-test recipe for `aorta probe` (issue #188).
 #
-# Tier-1, opaque user launch command:
+# Opaque user launch command:
 #
 #   aorta probe \
 #       --recipe recipes/example-probe-smoke.yaml \
@@ -9,8 +9,14 @@
 #       -- \
 #       bash -c 'echo hi'
 #
-# Verdict is exit-code only ("pass" if zero else "fail"). Per-cell stdout
-# and stderr land in `<output>/<ticket>/<cell>/trial_<n>/`.
+# Verdict comes from the Phase-2 five-tier classifier in
+# `aorta.probe.classifier`: a trial fails if any Tier 1-4 detector
+# (process exit, hang, dmesg/amd-smi, built-in pattern) fires OR any
+# `custom_patterns[*]` entry with `on_match: fail` matches; otherwise
+# it passes. Exit code is one input among several -- see
+# `docs/probe-188/classifier.md` for the full precedence rules.
+# Per-cell stdout and stderr land in
+# `<output>/<ticket>/<cell>/trial_<n>/`.
 #
 # Mitigation / diagnostic names below must resolve in the B3 registry.
 # The built-in registry (see src/aorta/registry/mitigations.py) ships
@@ -34,8 +40,11 @@ mitigation_axis:
 diagnostic_axis:
   - none
 
-# Phase-1 stubs -- parsed and validated, but currently ignored by the
-# Tier-1 verdict path. Will become live in Phase 2 (classifier).
+# Reserved for a future phase -- both keys are parsed and validated by
+# the recipe-builder (so a typo surfaces immediately) but neither is
+# consumed by the Phase-2 classifier. `step_time_regex` will feed a
+# per-step time analysis in a later phase; `collect_paths` will feed
+# `aorta bundle` (#196) in Phase 3. Leave as below for now.
 step_time_regex: null
 collect_paths: []
 timeout_per_trial: 1800

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -18,6 +18,17 @@ orchestration). The CLI's whole job is:
 The shared-engine test in ``tests/probe/test_shared_engine.py`` mocks
 ``run_recipe`` and invokes both ``aorta probe`` and ``aorta triage
 run`` -- both must reach the mock.
+
+Phase 2 adds two short-circuit flags:
+
+* ``--list-patterns`` -- print the built-in Tier-4 pattern catalogue
+  and exit 0 without loading any recipe. This is the rubric's
+  ``aorta probe list-patterns`` subcommand expressed as a flag so the
+  Phase 1 CLI surface (``aorta probe -- <argv>``) stays
+  byte-equivalent. See the PR description for the rationale.
+* ``--version`` (paired with ``--list-patterns``) -- print
+  ``aorta probe pattern library v<N> (aorta <pkg-version>)`` and
+  exit.
 """
 
 from __future__ import annotations
@@ -27,6 +38,10 @@ from pathlib import Path
 
 import click
 
+from aorta.probe.classifier.tier4_patterns import (
+    BUILTIN_PATTERN_VERSION,
+    all_patterns,
+)
 from aorta.probe.cli_helpers import (
     ProbeUsageError,
     help_token_in_option_zone,
@@ -45,6 +60,47 @@ from aorta.triage.recipe import (
     load_recipe,
 )
 from aorta.triage.runner import run_recipe
+
+
+def _aorta_package_version() -> str:
+    """Return the installed ``aorta`` package version (best-effort).
+
+    ``importlib.metadata.version`` is the supported API; falls back
+    to ``"unknown"`` only when the package metadata is missing
+    (editable install on a Python that doesn't expose dist-info,
+    very rare).
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("aorta")
+    except PackageNotFoundError:
+        return "unknown"
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+def _print_list_patterns(show_version: bool) -> None:
+    """Render the Tier-4 catalogue or the version banner (rubric FR 2.5).
+
+    Plain stdout writes (no JSON) so the output is greppable from a
+    shell. Each pattern emits a stable three-line entry: ID,
+    description, sample regex match line.
+    """
+    if show_version:
+        click.echo(
+            f"aorta probe pattern library v{BUILTIN_PATTERN_VERSION} "
+            f"(aorta {_aorta_package_version()})"
+        )
+        return
+    click.echo(f"aorta probe built-in pattern library (v{BUILTIN_PATTERN_VERSION})")
+    click.echo("")
+    for pattern in all_patterns():
+        click.echo(f"  {pattern.detector_id}")
+        click.echo(f"      description: {pattern.description}")
+        click.echo(f"      regex     : {pattern.regex.pattern}")
+        click.echo(f"      sample    : {pattern.sample}")
+        click.echo("")
 
 
 def _reject_flag_shaped_callback(
@@ -72,18 +128,25 @@ class _ProbeCommand(click.Command):
     Implemented as a ``parse_args`` override so the check sees the same
     argv that Click sees -- whether that's ``sys.argv[1:]`` from the real
     entry point or the ``args=[...]`` list from ``CliRunner.invoke`` in
-    tests. ``--help``/``-h`` short-circuits the check, but ONLY when the
-    help token sits in the aorta-option zone (before the user-command
-    boundary). A naive ``"--help" in args`` bypass is wrong because
-    ``aorta probe --recipe r --output o echo --help`` would silently
-    skip the separator check -- ``--help`` is the user-command's flag
-    there, not aorta's. See :func:`help_token_in_option_zone` for the
-    scoping rule.
+    tests. ``--help``/``-h`` and ``--list-patterns`` short-circuit the
+    check, but ONLY when the bypass token sits in the aorta-option
+    zone (before the user-command boundary). A naive ``"--help" in
+    args`` bypass is wrong because ``aorta probe --recipe r --output o
+    echo --help`` would silently skip the separator check -- ``--help``
+    is the user-command's flag there, not aorta's. See
+    :func:`help_token_in_option_zone` for the scoping rule.
+
+    ``--list-patterns`` is grouped with the help bypass because it
+    also prints info and exits without consuming a user command --
+    the rubric's ``aorta probe list-patterns`` shape, expressed as
+    a flag to preserve the Phase 1 CLI byte-equivalently.
     """
+
+    _BYPASS_TOKENS: frozenset[str] = frozenset({"--help", "-h", "--list-patterns"})
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         if not ctx.resilient_parsing and not help_token_in_option_zone(
-            args, self._value_taking_option_tokens()
+            args, self._value_taking_option_tokens(), self._BYPASS_TOKENS
         ):
             try:
                 require_double_dash_separator(args)
@@ -118,9 +181,28 @@ class _ProbeCommand(click.Command):
     context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
 )
 @click.option(
+    "--list-patterns",
+    "list_patterns",
+    is_flag=True,
+    help=(
+        "Print the built-in Tier-4 pattern catalogue and exit. "
+        "Combines with --version to print the pattern-library version "
+        "and the aorta package version."
+    ),
+)
+@click.option(
+    "--version",
+    "show_version",
+    is_flag=True,
+    help=(
+        "With --list-patterns: print 'aorta probe pattern library "
+        "v<N> (aorta <pkg-version>)' and exit. Ignored without --list-patterns."
+    ),
+)
+@click.option(
     "--recipe",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
-    required=True,
+    required=False,
     callback=_reject_flag_shaped_callback,
     help="Path to a 'mode: probe' YAML or JSON recipe file.",
 )
@@ -170,7 +252,9 @@ class _ProbeCommand(click.Command):
 )
 @click.argument("argv", nargs=-1, type=click.UNPROCESSED)
 def probe(
-    recipe: Path,
+    list_patterns: bool,
+    show_version: bool,
+    recipe: Path | None,
     output: Path,
     ticket: str | None,
     dry_run: bool,
@@ -184,7 +268,16 @@ def probe(
     command. Aorta never parses them; the only "boundary" is the
     optional ``probe.env`` file written under ``--env-passthrough-mode file``.
     """
+    if list_patterns:
+        _print_list_patterns(show_version=show_version)
+        return
+
     configure_verbose_logging(verbose)
+    if recipe is None:
+        raise click.UsageError(
+            "Missing option '--recipe'. Pass --recipe <path>, or run "
+            "with --list-patterns to print the built-in pattern catalogue."
+        )
     try:
         # ``--env-passthrough-mode`` defaults to None so the handler can
         # distinguish "user passed the flag" from "user omitted it". Per

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -328,9 +328,7 @@ def probe(
                 "set 'mode: probe' at the recipe top level"
             )
         r = apply_recipe_overrides(r, ticket=ticket, cli_passthrough_mode=cli_passthrough_mode)
-    except ProbeUsageError as exc:
-        raise click.ClickException(str(exc)) from exc
-    except (RecipeSchemaError, RecipeCellError, RegistryError) as exc:
+    except (ProbeUsageError, RecipeSchemaError, RecipeCellError, RegistryError) as exc:
         raise click.ClickException(str(exc)) from exc
 
     try:

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -169,9 +169,7 @@ class _ProbeCommand(click.Command):
     the more helpful "use --list-patterns" hint.
     """
 
-    _BYPASS_TOKENS: frozenset[str] = frozenset(
-        {"--help", "-h", "--list-patterns", "--version"}
-    )
+    _BYPASS_TOKENS: frozenset[str] = frozenset({"--help", "-h", "--list-patterns", "--version"})
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         if not ctx.resilient_parsing and not help_token_in_option_zone(

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -33,7 +33,6 @@ Phase 2 adds two short-circuit flags:
 
 from __future__ import annotations
 
-import dataclasses
 from pathlib import Path
 
 import click
@@ -44,6 +43,7 @@ from aorta.probe.classifier.tier4_patterns import (
 )
 from aorta.probe.cli_helpers import (
     ProbeUsageError,
+    apply_recipe_overrides,
     help_token_in_option_zone,
     parse_env_passthrough_mode,
     reject_flag_shaped_value,
@@ -225,7 +225,9 @@ class _ProbeCommand(click.Command):
     is_flag=True,
     help=(
         "With --list-patterns: print 'aorta probe pattern library "
-        "v<N> (aorta <pkg-version>)' and exit. Ignored without --list-patterns."
+        "v<N> (aorta <pkg-version>)' and exit. Rejected with a usage "
+        "error when passed without --list-patterns (see "
+        "_reject_bare_version_flag for the rationale)."
     ),
 )
 @click.option(
@@ -313,11 +315,8 @@ def probe(
         )
     try:
         # ``--env-passthrough-mode`` defaults to None so the handler can
-        # distinguish "user passed the flag" from "user omitted it". Per
-        # FR 1.10 the CLI wins only when present; otherwise the recipe's
-        # ``env_passthrough_mode:`` (set by the probe-mode recipe-builder,
-        # defaulting to "inherit") stays in effect. Validate the value
-        # only when the user actually supplied it.
+        # distinguish "user passed the flag" from "user omitted it"; per
+        # FR 1.10 the CLI wins only when present (see apply_recipe_overrides).
         cli_passthrough_mode = (
             parse_env_passthrough_mode(env_passthrough_mode)
             if env_passthrough_mode is not None
@@ -325,21 +324,12 @@ def probe(
         )
         clean_argv = validate_trailing_argv(argv)
         r = load_recipe(recipe)
-        probe_extras = r.probe_extras
-        if probe_extras is None:
+        if r.probe_extras is None:
             raise ProbeUsageError(
                 f"recipe {recipe} is not a probe-mode recipe; "
                 "set 'mode: probe' at the recipe top level"
             )
-        if ticket is not None:
-            r = dataclasses.replace(r, ticket=ticket)
-        if cli_passthrough_mode is not None:
-            r = dataclasses.replace(
-                r,
-                probe_extras=dataclasses.replace(
-                    probe_extras, env_passthrough_mode=cli_passthrough_mode
-                ),
-            )
+        r = apply_recipe_overrides(r, ticket=ticket, cli_passthrough_mode=cli_passthrough_mode)
     except ProbeUsageError as exc:
         raise click.ClickException(str(exc)) from exc
     except (RecipeSchemaError, RecipeCellError, RegistryError) as exc:

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -103,6 +103,26 @@ def _print_list_patterns(show_version: bool) -> None:
         click.echo("")
 
 
+def _reject_bare_version_flag() -> None:
+    """Raise a targeted ``click.UsageError`` for bare ``--version``.
+
+    The flag is documented as meaningful only when paired with
+    ``--list-patterns`` (it prints the built-in pattern-library
+    version next to the aorta package version). Without
+    ``--list-patterns`` it has no semantics; silently falling
+    through to the ``--recipe`` check would surface a confusing
+    "Missing option '--recipe'" error, suggesting the operator
+    needs a recipe just to see a version string. Reject up-front
+    with a targeted usage message that names the intended pairing.
+    """
+    raise click.UsageError(
+        "--version is only meaningful with --list-patterns. "
+        "Run 'aorta probe --list-patterns --version' to print the "
+        "pattern-library and package versions, or drop --version "
+        "to run a probe trial."
+    )
+
+
 def _reject_flag_shaped_callback(
     ctx: click.Context, param: click.Parameter, value: object
 ) -> object:
@@ -140,9 +160,18 @@ class _ProbeCommand(click.Command):
     also prints info and exits without consuming a user command --
     the rubric's ``aorta probe list-patterns`` shape, expressed as
     a flag to preserve the Phase 1 CLI byte-equivalently.
+
+    ``--version`` similarly short-circuits: it is documented as only
+    meaningful when paired with ``--list-patterns``, and the body
+    rejects ``--version`` alone with a targeted usage message. Without
+    this short-circuit, ``aorta probe --version`` would die at the
+    ``--`` separator check first and the operator would never see
+    the more helpful "use --list-patterns" hint.
     """
 
-    _BYPASS_TOKENS: frozenset[str] = frozenset({"--help", "-h", "--list-patterns"})
+    _BYPASS_TOKENS: frozenset[str] = frozenset(
+        {"--help", "-h", "--list-patterns", "--version"}
+    )
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         if not ctx.resilient_parsing and not help_token_in_option_zone(
@@ -271,6 +300,10 @@ def probe(
     if list_patterns:
         _print_list_patterns(show_version=show_version)
         return
+    if show_version:
+        # ``--version`` is only meaningful with ``--list-patterns``;
+        # see :func:`_reject_bare_version_flag` for the rationale.
+        _reject_bare_version_flag()
 
     configure_verbose_logging(verbose)
     if recipe is None:

--- a/src/aorta/probe/__init__.py
+++ b/src/aorta/probe/__init__.py
@@ -1,6 +1,6 @@
 """``aorta probe`` -- wrap-and-collect command for opaque user launch commands.
 
-Phase 1 (issue #188) ships an MVP that:
+Phase 1 (issue #188) shipped the MVP:
 
 * loads a ``mode: probe`` recipe;
 * synthesises cells from ``mitigation_axis x diagnostic_axis``;
@@ -12,9 +12,15 @@ Phase 1 (issue #188) ships an MVP that:
 * re-running with the same ``--output`` skips cells whose
   ``result.json`` is valid and carries a non-empty ``verdict``.
 
-Phase 2 (built-in 5-tier classifier + sandboxed ``custom_patterns``) and
+Phase 2 has shipped on top of Phase 1: the five-tier classifier lives
+in :mod:`aorta.probe.classifier` and the AST-whitelisted ``condition``
+evaluator in :mod:`aorta.probe.sandbox`. ``custom_patterns`` are
+compiled at recipe-load time and resolved post-exit by the workload;
+detector IDs land in ``result.json::failure_detectors_fired`` /
+``warn_detectors_fired``.
+
 Phase 3 (``aorta bundle`` integration + redaction + handout templates)
-are tracked separately and are NOT implemented in this module.
+is tracked separately (issue #196) and is NOT yet implemented.
 """
 
 from aorta.probe.recipe_builder import (

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -87,7 +87,11 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
 
     Tier 3 is fail-soft on missing binaries; passing a None
     ``tier3_state`` skips Tier 3 entirely (rubric §2.B FR 2.3 +
-    FR 2.11). Tier 5 is skipped when ``custom_patterns`` is empty.
+    FR 2.11). Tier 5 is always invoked so its measured duration
+    appears in ``tier_durations_ms``; with an empty
+    ``custom_patterns`` tuple the call returns an empty
+    :class:`~aorta.probe.classifier.tier5_custom.CustomScanResult`
+    in microseconds.
     """
     import time
 

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -1,0 +1,150 @@
+"""Five-tier classifier for ``aorta probe`` (issue #188 Phase 2).
+
+Single entry point :func:`classify_trial` consumed by
+:class:`aorta.workloads._subprocess.SubprocessWorkload.run` post-exit.
+The tiers are individually importable for unit tests and the
+``aorta probe --list-patterns`` subcommand.
+
+The classifier intentionally lives OUTSIDE the workload module so
+the workload stays small and testable: the workload owns the
+subprocess; the classifier owns the verdict. Cross-tier ordering
+(``failure_detectors_fired`` reflects Tier 1 → Tier 2 → Tier 3 →
+Tier 4 → Tier 5) lives in :mod:`aorta.probe.classifier.verdict`.
+
+This package is the only module in :mod:`aorta.probe` whose name
+contains "classifier"; per the rubric's engine-reuse gate, no
+file under :mod:`aorta.probe` may include "runner" or "dispatcher"
+in its name (the shared-engine test enforces this — the classifier
+hangs off ``SubprocessWorkload.run()`` post-exit, never replaces
+the dispatcher).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from aorta.probe.classifier import (
+    tier1_process,
+    tier3_kernel,
+    tier4_patterns,
+    tier5_custom,
+)
+from aorta.probe.classifier.tier1_process import Tier1Context
+from aorta.probe.classifier.tier2_hang import DETECTOR_HANG
+from aorta.probe.classifier.tier3_kernel import AmdSmiSnapshot, Tier3State
+from aorta.probe.classifier.tier5_custom import CompiledPattern
+from aorta.probe.classifier.verdict import Verdict, VerdictInputs, resolve
+
+
+@dataclass(frozen=True)
+class TrialContext:
+    """Inputs to :func:`classify_trial`.
+
+    ``hang_detected`` is the post-monitor flag captured by
+    :class:`aorta.probe.classifier.tier2_hang.HangMonitor`. Pure
+    bool so the workload doesn't have to hold a live ``HangMonitor``
+    reference after stopping it.
+
+    ``tier3_state`` carries the "tier3 disabled" warning latch so
+    the classifier can scan dmesg / amd-smi without double-logging
+    across cells/trials (rubric §2.B FR 2.11). The runner owns
+    one instance per ``aorta probe`` invocation.
+
+    ``amd_smi_pre`` / ``amd_smi_post`` are the snapshots polled
+    before and after the trial; either being None disables Tier 3
+    GPU counters (fail-soft per FR 2.3).
+    """
+
+    exit_code: int
+    timed_out: bool
+    walltime_sec: float
+    trial_dir: Path
+    log_text: str
+    custom_patterns: tuple[CompiledPattern, ...] = ()
+    hang_detected: bool = False
+    peak_vram_mib: int | None = None
+    dmesg_text: str | None = None
+    tier3_state: Tier3State | None = None
+    amd_smi_pre: AmdSmiSnapshot | None = None
+    amd_smi_post: AmdSmiSnapshot | None = None
+
+
+def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
+    """Run all five tiers and resolve the trial's verdict.
+
+    Returns ``(verdict, tier_durations_ms)`` where the second value
+    is the wall-clock time spent in each tier (logged to
+    ``result.json::tier_durations_ms`` for budget audits).
+
+    Tier 3 is fail-soft on missing binaries; passing a None
+    ``tier3_state`` skips Tier 3 entirely (rubric §2.B FR 2.3 +
+    FR 2.11). Tier 5 is skipped when ``custom_patterns`` is empty.
+    """
+    import time
+
+    tier_durations_ms: dict[str, float] = {}
+
+    t0 = time.perf_counter()
+    tier1 = tier1_process.detect(
+        Tier1Context(
+            exit_code=ctx.exit_code,
+            timed_out=ctx.timed_out,
+            trial_dir=ctx.trial_dir,
+        )
+    )
+    tier_durations_ms["tier1"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    tier2 = [DETECTOR_HANG] if ctx.hang_detected else []
+    tier_durations_ms["tier2"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    tier3: list[str] = []
+    if ctx.tier3_state is not None:
+        if ctx.dmesg_text is not None:
+            tier3.extend(tier3_kernel.scan_dmesg_text(ctx.dmesg_text))
+        if ctx.amd_smi_pre is not None and ctx.amd_smi_post is not None:
+            tier3.extend(
+                tier3_kernel.scan_amd_smi(ctx.tier3_state, ctx.amd_smi_pre, ctx.amd_smi_post)
+            )
+    tier_durations_ms["tier3"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    tier4 = tier4_patterns.scan(ctx.log_text)
+    tier_durations_ms["tier4"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    custom_result = tier5_custom.scan(
+        ctx.log_text,
+        ctx.custom_patterns,
+        exit_code=ctx.exit_code,
+        walltime_sec=ctx.walltime_sec,
+        peak_vram_mib=ctx.peak_vram_mib,
+    )
+    tier_durations_ms["tier5"] = (time.perf_counter() - t0) * 1000.0
+
+    verdict = resolve(
+        VerdictInputs(
+            tier1=tier1,
+            tier2=tier2,
+            tier3=tier3,
+            tier4=tier4,
+            custom_result=custom_result,
+            custom_required_patterns=ctx.custom_patterns,
+        )
+    )
+    return verdict, tier_durations_ms
+
+
+__all__ = [
+    "TrialContext",
+    "Verdict",
+    "VerdictInputs",
+    "classify_trial",
+    "resolve",
+    "tier1_process",
+    "tier3_kernel",
+    "tier4_patterns",
+    "tier5_custom",
+]

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -68,6 +68,14 @@ class TrialContext:
     tier3_state: Tier3State | None = None
     amd_smi_pre: AmdSmiSnapshot | None = None
     amd_smi_post: AmdSmiSnapshot | None = None
+    # Tier 3 detector IDs the caller has already collected (e.g. the
+    # workload pre-invoked ``scan_dmesg`` with a known ``--since``
+    # window and prefers not to round-trip through ``dmesg_text``).
+    # Merged with the in-classifier scan results; empty tuple is the
+    # legacy-equivalent no-op. Distinct from ``dmesg_text`` so callers
+    # can supply IDs without the source text and the classifier can
+    # supply the source text without the IDs -- the two paths union.
+    tier3_extra: tuple[str, ...] = ()
 
 
 def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
@@ -102,7 +110,15 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
     t0 = time.perf_counter()
     tier3: list[str] = []
     if ctx.tier3_state is not None:
-        if ctx.dmesg_text is not None:
+        # Caller-pre-collected IDs come first so the call order in
+        # ``failure_detectors_fired`` matches the chronological order
+        # of detection (workload polls dmesg before classify_trial
+        # runs; in-classifier scans run after).
+        tier3.extend(ctx.tier3_extra)
+        if ctx.dmesg_text:
+            # Only call scan_dmesg_text when there's actual content --
+            # an empty string is the workload's "no new dmesg lines"
+            # signal and shouldn't redundantly re-run the regex set.
             tier3.extend(tier3_kernel.scan_dmesg_text(ctx.dmesg_text))
         if ctx.amd_smi_pre is not None and ctx.amd_smi_post is not None:
             tier3.extend(

--- a/src/aorta/probe/classifier/tier1_process.py
+++ b/src/aorta/probe/classifier/tier1_process.py
@@ -13,8 +13,14 @@ exited:
   ``Popen.wait(timeout=...)`` raising ``TimeoutExpired`` after
   ``recipe.timeout_per_trial`` seconds.
 * ``tier1:coredump`` -- any file matching ``core.*`` exists in the
-  trial directory post-exit (covers the default kernel pattern
-  ``core.<pid>`` and the ``core_pattern`` template variants).
+  trial directory post-exit. This only fires when ``/proc/sys/
+  kernel/core_pattern`` writes into the trial dir; the dispatcher
+  does NOT chdir the workload (the user's ``--`` command often uses
+  relative paths and a forced ``cwd`` would silently break it), so
+  with the typical relative-path ``core`` / ``core.<pid>`` pattern
+  the core file lands in ``aorta probe``'s invocation cwd, not the
+  trial dir. Operators who care about coredump detection set an
+  absolute ``core_pattern`` that templates the trial dir in.
 
 The classifier consumes a small :class:`Tier1Context` value and
 returns an ordered list of detector IDs (in encounter order — the
@@ -59,10 +65,16 @@ class Tier1Context:
     """Inputs for :func:`detect`.
 
     ``trial_dir`` is the per-trial output directory; the coredump
-    scan looks for ``core.*`` in this dir only (NOT recursive — the
-    kernel's default pattern writes alongside the running process,
-    which the dispatcher sets to the trial dir via ``cwd``-less
-    Popen, so ``core.*`` lands one level deep at most).
+    scan looks for ``core.*`` in this dir only (NOT recursive). The
+    dispatcher does NOT pass ``cwd=trial_dir`` to ``Popen`` -- the
+    user's ``--`` command is allowed to depend on the launcher's
+    cwd, so forcing a new one would break repros that reference
+    files by relative path. As a result the detector only sees core
+    files when ``/proc/sys/kernel/core_pattern`` is configured to
+    write into the trial dir (e.g. an absolute template that
+    interpolates the trial path). With the kernel default
+    (``core`` next to the process cwd) the detector stays silent
+    even on a real segfault.
 
     ``timed_out`` flips the verdict to ``tier1:timeout`` and
     suppresses the ``exit_nonzero`` detector (a process killed by
@@ -104,12 +116,14 @@ def detect(ctx: Tier1Context) -> list[str]:
 def _has_coredump(trial_dir: Path) -> bool:
     """Return True iff a ``core.*`` file exists directly under ``trial_dir``.
 
-    Non-recursive. The Linux kernel writes core files alongside the
-    process's working directory; nested subdirectories would mean
-    the workload itself launched a child that crashed (which Tier 1
-    cannot reason about). ``trial_dir.glob`` returns an iterator;
-    short-circuit on the first match to avoid scanning the whole
-    directory for large trials.
+    Non-recursive. Tier 1 cannot reason about cores from grandchild
+    processes; nested subdirectories would also create false
+    positives if the workload itself touches a ``core/`` dir. The
+    detector relies on the operator's ``core_pattern`` writing into
+    the trial dir -- see :class:`Tier1Context` for why the
+    dispatcher does not chdir the workload. ``trial_dir.glob``
+    returns an iterator; short-circuit on the first match to avoid
+    scanning the whole directory for large trials.
     """
     if not trial_dir.is_dir():
         return False

--- a/src/aorta/probe/classifier/tier1_process.py
+++ b/src/aorta/probe/classifier/tier1_process.py
@@ -1,0 +1,145 @@
+"""Tier 1 process-level failure detectors for ``aorta probe`` (issue #188).
+
+Tier 1 is the only tier that does not need to inspect logs or system
+state — every signal is derived from how the subprocess itself
+exited:
+
+* ``tier1:exit_nonzero`` -- ``proc.returncode != 0`` and no signal
+  fired. Standalone ``exit 1``.
+* ``tier1:sigsegv`` -- ``returncode == -signal.SIGSEGV``.
+* ``tier1:sigabrt`` -- ``returncode == -signal.SIGABRT``.
+* ``tier1:sigbus``  -- ``returncode == -signal.SIGBUS``.
+* ``tier1:timeout`` -- the workload was killed via
+  ``Popen.wait(timeout=...)`` raising ``TimeoutExpired`` after
+  ``recipe.timeout_per_trial`` seconds.
+* ``tier1:coredump`` -- any file matching ``core.*`` exists in the
+  trial directory post-exit (covers the default kernel pattern
+  ``core.<pid>`` and the ``core_pattern`` template variants).
+
+The classifier consumes a small :class:`Tier1Context` value and
+returns an ordered list of detector IDs (in encounter order — the
+verdict resolver in :mod:`aorta.probe.classifier.verdict` cares
+about order because ``failure_detectors_fired`` is required to
+preserve it). Tier 1 is fully unit-testable without spawning a real
+subprocess: construct a ``Tier1Context`` with the desired exit code
+and trial directory and call :func:`detect`.
+"""
+
+from __future__ import annotations
+
+import signal
+from dataclasses import dataclass
+from pathlib import Path
+
+# Detector IDs — exported so Tier 4 / 5 cross-references and the
+# verdict resolver name them without typos. ID strings are stable
+# (part of the public ``result.json`` contract); changing one is a
+# breaking change for downstream tooling that parses
+# ``failure_detectors_fired``.
+DETECTOR_EXIT_NONZERO = "tier1:exit_nonzero"
+DETECTOR_SIGSEGV = "tier1:sigsegv"
+DETECTOR_SIGABRT = "tier1:sigabrt"
+DETECTOR_SIGBUS = "tier1:sigbus"
+DETECTOR_TIMEOUT = "tier1:timeout"
+DETECTOR_COREDUMP = "tier1:coredump"
+
+# Map ``returncode`` (negative when the process died via signal) to
+# the corresponding detector ID. ``signal`` constants are platform-
+# dependent on the surface but stable on Linux (the only platform
+# aorta probe ships against today).
+_SIGNAL_DETECTORS: dict[int, str] = {
+    -int(signal.SIGSEGV): DETECTOR_SIGSEGV,
+    -int(signal.SIGABRT): DETECTOR_SIGABRT,
+    -int(signal.SIGBUS): DETECTOR_SIGBUS,
+}
+
+
+@dataclass(frozen=True)
+class Tier1Context:
+    """Inputs for :func:`detect`.
+
+    ``trial_dir`` is the per-trial output directory; the coredump
+    scan looks for ``core.*`` in this dir only (NOT recursive — the
+    kernel's default pattern writes alongside the running process,
+    which the dispatcher sets to the trial dir via ``cwd``-less
+    Popen, so ``core.*`` lands one level deep at most).
+
+    ``timed_out`` flips the verdict to ``tier1:timeout`` and
+    suppresses the ``exit_nonzero`` detector (a process killed by
+    ``proc.kill()`` after a timeout always exits with a non-zero
+    code; we want the more informative detector ID to fire alone).
+    """
+
+    exit_code: int
+    timed_out: bool
+    trial_dir: Path
+
+
+def detect(ctx: Tier1Context) -> list[str]:
+    """Return the ordered list of Tier 1 detector IDs that fired.
+
+    Encounter order is fixed to match how a human reading
+    ``result.json`` expects to scan the failure list: most specific
+    cause first (timeout > signal > exit_nonzero), then ancillary
+    artifacts (coredump) regardless of the primary cause.
+
+    Returns ``[]`` when ``exit_code == 0`` and no timeout/coredump
+    fired (the trial's Tier 1 status is "pass — exit zero").
+    """
+    fired: list[str] = []
+
+    if ctx.timed_out:
+        fired.append(DETECTOR_TIMEOUT)
+    elif ctx.exit_code in _SIGNAL_DETECTORS:
+        fired.append(_SIGNAL_DETECTORS[ctx.exit_code])
+    elif ctx.exit_code != 0:
+        fired.append(DETECTOR_EXIT_NONZERO)
+
+    if _has_coredump(ctx.trial_dir):
+        fired.append(DETECTOR_COREDUMP)
+
+    return fired
+
+
+def _has_coredump(trial_dir: Path) -> bool:
+    """Return True iff a ``core.*`` file exists directly under ``trial_dir``.
+
+    Non-recursive. The Linux kernel writes core files alongside the
+    process's working directory; nested subdirectories would mean
+    the workload itself launched a child that crashed (which Tier 1
+    cannot reason about). ``trial_dir.glob`` returns an iterator;
+    short-circuit on the first match to avoid scanning the whole
+    directory for large trials.
+    """
+    if not trial_dir.is_dir():
+        return False
+    for _ in trial_dir.glob("core.*"):
+        return True
+    # Also tolerate the bare ``core`` filename (the default kernel
+    # ``core_pattern`` on some distros writes ``core`` with no PID
+    # suffix). Cheap second check; keeps the detector accurate
+    # across distros.
+    return (trial_dir / "core").is_file()
+
+
+ALL_DETECTOR_IDS = (
+    DETECTOR_TIMEOUT,
+    DETECTOR_SIGSEGV,
+    DETECTOR_SIGABRT,
+    DETECTOR_SIGBUS,
+    DETECTOR_EXIT_NONZERO,
+    DETECTOR_COREDUMP,
+)
+
+
+__all__ = [
+    "ALL_DETECTOR_IDS",
+    "DETECTOR_COREDUMP",
+    "DETECTOR_EXIT_NONZERO",
+    "DETECTOR_SIGABRT",
+    "DETECTOR_SIGBUS",
+    "DETECTOR_SIGSEGV",
+    "DETECTOR_TIMEOUT",
+    "Tier1Context",
+    "detect",
+]

--- a/src/aorta/probe/classifier/tier2_hang.py
+++ b/src/aorta/probe/classifier/tier2_hang.py
@@ -170,13 +170,24 @@ class HangMonitor:
             if current_mtime != last_stdout_mtime:
                 last_stdout_mtime = current_mtime
                 last_stdout_seen_at = now
+
+            # ``_io_total`` returns None when /proc/<pid>/io can't be
+            # read. "Unknown" must NOT vote io_idle=True -- if we
+            # treated None as a value, two consecutive Nones would
+            # look like a stable I/O counter and the io_idle window
+            # would tick over on its own. Skip the staleness check on
+            # missing-source iterations and bind io_idle=False so the
+            # detector can never fire from the I/O leg alone.
             current_io = self._io_total()
-            if current_io != last_io_total:
-                last_io_total = current_io
-                last_io_seen_at = now
+            if current_io is None:
+                io_idle = False
+            else:
+                if current_io != last_io_total:
+                    last_io_total = current_io
+                    last_io_seen_at = now
+                io_idle = (now - last_io_seen_at) >= self.hang_window_sec
 
             stdout_silent = (now - last_stdout_seen_at) >= self.hang_window_sec
-            io_idle = (now - last_io_seen_at) >= self.hang_window_sec
             gpu_idle = bool(self.gpu_idle_probe()) if self.gpu_idle_probe else False
 
             signals = HangSignals(
@@ -213,14 +224,19 @@ class HangMonitor:
         except OSError:
             return 0.0
 
-    def _io_total(self) -> int:
+    def _io_total(self) -> int | None:
         """``rchar + wchar`` from ``/proc/<pid>/io``.
 
-        Returns ``0`` when the file is unreadable (process already
-        exited, permission denied). The monitor degrades to "io
-        idle unknown" in that case, which contributes False to the
-        two-of-three (so a single missing-signal source can't fire
-        the detector alone).
+        Returns ``None`` when the file is unreadable (process already
+        exited, permission denied, ``ptrace_scope`` restricted, NFS
+        with no proc visibility). The monitor's ``_run`` loop treats
+        ``None`` as "I/O availability unknown" and contributes
+        ``io_idle=False`` to the predicate -- without this distinction,
+        an unreadable ``/proc/<pid>/io`` would look like a permanently
+        stable I/O counter (``current == last`` because both are
+        ``0``) and could flip ``io_idle=True`` after
+        ``hang_window_sec``, false-firing ``tier2:hang`` on hosts where
+        I/O telemetry simply isn't readable.
         """
         try:
             with open(f"/proc/{self.pid}/io", encoding="utf-8") as fh:
@@ -232,7 +248,7 @@ class HangMonitor:
                         wchar = int(line.split(":", 1)[1].strip())
                 return rchar + wchar
         except (FileNotFoundError, PermissionError, OSError, ValueError):
-            return 0
+            return None
 
 
 def read_proc_io_total(pid: int) -> int | None:

--- a/src/aorta/probe/classifier/tier2_hang.py
+++ b/src/aorta/probe/classifier/tier2_hang.py
@@ -37,6 +37,7 @@ the workload reads it post-exit to decide whether to add
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
@@ -44,10 +45,29 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+log = logging.getLogger(__name__)
+
 DETECTOR_HANG = "tier2:hang"
 
 DEFAULT_HANG_WINDOW_SEC = 30.0
 DEFAULT_HANG_GRACE_SEC = 60.0
+
+# Upper-bound on how long :attr:`HangMonitor.gpu_idle_probe` can
+# block. Mirrors the live ``amd-smi monitor`` subprocess timeout in
+# :mod:`aorta.probe.classifier.tier3_kernel` (10s) plus a 1s
+# buffer. Used by :meth:`HangMonitor.stop` to size the thread-join
+# budget so a poll currently blocked inside ``amd-smi`` is given
+# time to return before teardown -- if ``stop()`` returned early,
+# the poll thread would race the *next* trial's monitor for
+# ``Tier3State`` reads (cross-trial state corruption). Per Sonbol's
+# PR #197 review.
+#
+# Hard-coded rather than imported from tier3 so the tier2 module
+# keeps no compile-time dependency on tier3 (the monitor takes
+# ``gpu_idle_probe`` as a callable specifically so the two tiers
+# stay decoupled). If the amd-smi timeout grows materially in
+# tier3, raise this constant in lockstep.
+GPU_IDLE_PROBE_MAX_BLOCK_SEC = 11.0
 
 
 @dataclass(frozen=True)
@@ -143,11 +163,35 @@ class HangMonitor:
         self._thread.start()
 
     def stop(self) -> None:
-        """Signal the thread to exit and join with a small timeout."""
+        """Signal the thread to exit and join, with a budget that covers the slowest probe.
+
+        The join budget must outlast the longest in-flight call the
+        monitor thread can be inside when ``stop()`` runs. The
+        ``gpu_idle_probe`` closure typically wraps
+        ``tier3_kernel.poll_amd_smi``, whose subprocess timeout is
+        ~10s; a naive ``join(timeout=poll_interval + 1)`` (=6s)
+        returns *before* a stuck amd-smi call gives up, leaving an
+        orphan thread that lives into the next trial and races for
+        ``Tier3State`` reads. Take the max of the two budgets; log
+        a warning if the thread is still alive after that (it
+        means a probe wedged past its own timeout — rare, but the
+        caller deserves a breadcrumb in the run log).
+        Per Sonbol's PR #197 review.
+        """
         self._stop.set()
-        if self._thread is not None:
-            self._thread.join(timeout=self.poll_interval_sec + 1.0)
-            self._thread = None
+        if self._thread is None:
+            return
+        join_budget = max(self.poll_interval_sec + 1.0, GPU_IDLE_PROBE_MAX_BLOCK_SEC)
+        self._thread.join(timeout=join_budget)
+        if self._thread.is_alive():
+            log.warning(
+                "HangMonitor.stop(): poll thread for pid=%d still alive after "
+                "%.1fs join budget; continuing teardown (next trial may see "
+                "stale tier-3 state).",
+                self.pid,
+                join_budget,
+            )
+        self._thread = None
 
     def _run(self) -> None:
         """Polling loop. Exits when ``_stop`` is set or hang is detected.

--- a/src/aorta/probe/classifier/tier2_hang.py
+++ b/src/aorta/probe/classifier/tier2_hang.py
@@ -1,0 +1,275 @@
+"""Tier 2 hang detector for ``aorta probe`` (issue #188).
+
+Fires :data:`DETECTOR_HANG` (``tier2:hang``) when **at least two of
+three** in-flight signals agree, AND only after the trial's grace
+period has elapsed:
+
+* ``stdout_silent`` -- no stdout writes for ``hang_window_sec``.
+* ``gpu_idle`` -- ``amd-smi`` reports zero activity for the window.
+* ``io_idle`` -- ``/proc/<pid>/io``'s ``rchar+wchar`` is unchanged
+  for the window.
+
+Both knobs come from the recipe (``hang_window_sec`` defaults to
+30, ``hang_grace_period_at_start`` to 60 — chosen to be longer than
+typical PyTorch import + dataloader warm-up). Recipes pin them via
+the new ``hang_window_sec`` and ``hang_grace_period_at_start``
+top-level keys (accepted only in ``mode: probe`` recipes).
+
+The detector is split into two surfaces:
+
+* :func:`evaluate_predicate` -- pure, takes a :class:`HangSignals`
+  snapshot and returns ``True`` iff two-of-three agree AND the
+  grace window has elapsed. Unit-testable without a process.
+* :class:`HangMonitor` -- a polling loop runnable in a background
+  thread; consumes the subprocess's PID, the trial's stdout path,
+  and an amd-smi shim, and calls ``evaluate_predicate`` once per
+  poll. The first ``True`` evaluation flags the trial as hung
+  (the workload itself decides whether to kill the process — the
+  workload owns process lifecycle).
+
+The ``aorta probe`` SubprocessWorkload runs the monitor in a
+background thread alongside the synchronous ``proc.wait(...)``
+call. The monitor's sole side-effect is to flip the
+:attr:`HangMonitor.hang_detected` flag once the predicate trips;
+the workload reads it post-exit to decide whether to add
+``tier2:hang`` to ``failure_detectors_fired``.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DETECTOR_HANG = "tier2:hang"
+
+DEFAULT_HANG_WINDOW_SEC = 30.0
+DEFAULT_HANG_GRACE_SEC = 60.0
+
+
+@dataclass(frozen=True)
+class HangSignals:
+    """One sample of the three two-of-three signals.
+
+    ``elapsed_sec`` is the time since trial start; the predicate
+    short-circuits to ``False`` when ``elapsed_sec < grace_period``
+    so the early phase of the trial (PyTorch import, dataloader
+    setup) can be silent without flagging.
+    """
+
+    stdout_silent: bool
+    gpu_idle: bool
+    io_idle: bool
+    elapsed_sec: float
+
+
+def evaluate_predicate(
+    signals: HangSignals,
+    *,
+    grace_period_sec: float = DEFAULT_HANG_GRACE_SEC,
+) -> bool:
+    """Return True iff the trial looks hung per the two-of-three rule.
+
+    Returns ``False`` while ``elapsed_sec < grace_period_sec`` no
+    matter how many signals agree — the grace window deliberately
+    suppresses every false-positive during workload startup.
+
+    The "two of three" choice (rather than "all three") is a
+    deliberate trade-off: a workload that is hung but periodically
+    flushes a heartbeat to stderr (stdout silent + GPU idle + IO
+    non-idle because of the heartbeat) would not trip a strict
+    "all three" rule, and the AORTA team has seen that pattern in
+    NCCL collective hangs. Two-of-three trips it; if false
+    positives become a problem in practice the recipe can raise
+    ``hang_window_sec``.
+    """
+    if signals.elapsed_sec < grace_period_sec:
+        return False
+    agreeing = sum((signals.stdout_silent, signals.gpu_idle, signals.io_idle))
+    return agreeing >= 2
+
+
+@dataclass
+class HangMonitor:
+    """Polls the three signals in a background thread.
+
+    Attributes:
+        pid: PID of the user subprocess (read /proc/<pid>/io).
+        stdout_path: Trial stdout log; mtime advances when the
+            child writes.
+        hang_window_sec: How long each signal must hold to count.
+        hang_grace_period_at_start: How long to wait before
+            firing at all (rubric default 60s).
+        poll_interval_sec: How often the monitor wakes. Small
+            enough to catch a hang within a window; large enough
+            to keep monitoring overhead negligible.
+        gpu_idle_probe: A callable returning the current GPU
+            "idle" boolean — typically a closure over
+            :func:`aorta.probe.classifier.tier3_kernel.poll_amd_smi`
+            results. ``None`` (default) is treated as "GPU idle
+            unknown" → contributes False to the two-of-three.
+        hang_detected: Flips to True the first time
+            :func:`evaluate_predicate` returns True. The workload
+            reads this after ``proc.wait()`` to decide whether
+            ``tier2:hang`` belongs in ``failure_detectors_fired``.
+    """
+
+    pid: int
+    stdout_path: Path
+    hang_window_sec: float = DEFAULT_HANG_WINDOW_SEC
+    hang_grace_period_at_start: float = DEFAULT_HANG_GRACE_SEC
+    poll_interval_sec: float = 5.0
+    gpu_idle_probe: Callable[[], bool] | None = None
+
+    _stop: threading.Event = field(default_factory=threading.Event)
+    _thread: threading.Thread | None = None
+    hang_detected: bool = False
+    started_at: float = 0.0
+
+    def start(self) -> None:
+        """Spawn the polling thread. Idempotent."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self.started_at = time.monotonic()
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"aorta-probe-hang-monitor-{self.pid}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the thread to exit and join with a small timeout."""
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.poll_interval_sec + 1.0)
+            self._thread = None
+
+    def _run(self) -> None:
+        """Polling loop. Exits when ``_stop`` is set or hang is detected.
+
+        The loop computes the three signals each iteration and
+        feeds them to :func:`evaluate_predicate`. The first True
+        flips ``hang_detected`` and exits; the workload reads the
+        flag once ``proc.wait()`` returns.
+        """
+        last_stdout_mtime = self._stdout_mtime()
+        last_io_total = self._io_total()
+        last_stdout_seen_at = time.monotonic()
+        last_io_seen_at = time.monotonic()
+
+        while not self._stop.is_set():
+            now = time.monotonic()
+            elapsed = now - self.started_at
+
+            current_mtime = self._stdout_mtime()
+            if current_mtime != last_stdout_mtime:
+                last_stdout_mtime = current_mtime
+                last_stdout_seen_at = now
+            current_io = self._io_total()
+            if current_io != last_io_total:
+                last_io_total = current_io
+                last_io_seen_at = now
+
+            stdout_silent = (now - last_stdout_seen_at) >= self.hang_window_sec
+            io_idle = (now - last_io_seen_at) >= self.hang_window_sec
+            gpu_idle = bool(self.gpu_idle_probe()) if self.gpu_idle_probe else False
+
+            signals = HangSignals(
+                stdout_silent=stdout_silent,
+                gpu_idle=gpu_idle,
+                io_idle=io_idle,
+                elapsed_sec=elapsed,
+            )
+            if evaluate_predicate(
+                signals,
+                grace_period_sec=self.hang_grace_period_at_start,
+            ):
+                self.hang_detected = True
+                return
+
+            # Sleep with the stop event so a quick stop() during a
+            # poll wakes the thread immediately rather than waiting
+            # for the full poll_interval_sec.
+            if self._stop.wait(self.poll_interval_sec):
+                return
+
+    def _stdout_mtime(self) -> float:
+        """Last-modified timestamp of the trial's stdout log.
+
+        Returns ``0.0`` when the file does not yet exist — the
+        workload may not have opened it before the monitor first
+        polled. ``0.0`` is a safe initial value because a real
+        mtime will always differ from it on the next poll.
+        """
+        try:
+            return self.stdout_path.stat().st_mtime
+        except FileNotFoundError:
+            return 0.0
+        except OSError:
+            return 0.0
+
+    def _io_total(self) -> int:
+        """``rchar + wchar`` from ``/proc/<pid>/io``.
+
+        Returns ``0`` when the file is unreadable (process already
+        exited, permission denied). The monitor degrades to "io
+        idle unknown" in that case, which contributes False to the
+        two-of-three (so a single missing-signal source can't fire
+        the detector alone).
+        """
+        try:
+            with open(f"/proc/{self.pid}/io", encoding="utf-8") as fh:
+                rchar = wchar = 0
+                for line in fh:
+                    if line.startswith("rchar:"):
+                        rchar = int(line.split(":", 1)[1].strip())
+                    elif line.startswith("wchar:"):
+                        wchar = int(line.split(":", 1)[1].strip())
+                return rchar + wchar
+        except (FileNotFoundError, PermissionError, OSError, ValueError):
+            return 0
+
+
+def read_proc_io_total(pid: int) -> int | None:
+    """Convenience for tests: read ``rchar+wchar`` for ``pid``.
+
+    Returns ``None`` when ``/proc/<pid>/io`` is unreadable so the
+    caller can distinguish "0 bytes done" from "no information".
+    """
+    try:
+        with open(f"/proc/{pid}/io", encoding="utf-8") as fh:
+            rchar = wchar = 0
+            for line in fh:
+                if line.startswith("rchar:"):
+                    rchar = int(line.split(":", 1)[1].strip())
+                elif line.startswith("wchar:"):
+                    wchar = int(line.split(":", 1)[1].strip())
+            return rchar + wchar
+    except (FileNotFoundError, PermissionError, OSError, ValueError):
+        return None
+
+
+# Re-export so tests can ``from aorta.probe.classifier.tier2_hang
+# import _ALL_DETECTOR_IDS`` (parity with other tiers).
+ALL_DETECTOR_IDS = (DETECTOR_HANG,)
+
+
+__all__ = [
+    "ALL_DETECTOR_IDS",
+    "DEFAULT_HANG_GRACE_SEC",
+    "DEFAULT_HANG_WINDOW_SEC",
+    "DETECTOR_HANG",
+    "HangMonitor",
+    "HangSignals",
+    "evaluate_predicate",
+    "read_proc_io_total",
+]
+# Keep ``os`` imported -- read_proc_io_total opens via path and the
+# linter would otherwise flag the unused stdlib import while we keep
+# the option open for switching to ``os.read``-based I/O.
+_ = os.path

--- a/src/aorta/probe/classifier/tier3_kernel.py
+++ b/src/aorta/probe/classifier/tier3_kernel.py
@@ -1,0 +1,358 @@
+"""Tier 3 kernel / GPU detectors via ``dmesg`` and ``amd-smi`` shims.
+
+Two complementary signal sources:
+
+* ``dmesg --since=<probe_start>`` -- kernel ring buffer entries
+  emitted by the amdgpu / kfd drivers between trial start and trial
+  end. Detector IDs cover the failure modes the AORTA team has seen
+  enough times to bake into the platform:
+
+  - ``tier3:amdgpu_reset`` -- "amdgpu: GPU reset" lines
+  - ``tier3:sdma_timeout`` -- "SDMA semaphore timeout" / "SDMA hang"
+  - ``tier3:vm_l2_fault`` -- "VM_L2_PROTECTION_FAULT" lines
+  - ``tier3:xgmi_link_error`` -- "XGMI" link-error lines
+  - ``tier3:pcie_aer_fatal`` -- "AER" fatal PCIe errors
+
+* ``amd-smi`` -- counters polled twice (pre/post-trial) and diffed:
+
+  - ``tier3:vram_growth`` -- VRAM used delta exceeds the trial's
+    starting VRAM by more than :data:`VRAM_GROWTH_THRESHOLD_MIB`.
+    Catches leaks the workload's own ``peak_vram_mib`` doesn't
+    reveal because the workload exited cleanly but left the VRAM
+    allocated under another process.
+  - ``tier3:thermal_throttle`` -- thermal throttling counter
+    incremented during the trial.
+
+Both signal sources are **fail-soft**: a missing binary (``dmesg``,
+``amd-smi`` not on ``PATH``), a non-zero exit status, an unparseable
+line — every error path logs a single ``tier3 disabled: <reason>``
+warning the first time it fires per ``aorta probe`` invocation and
+otherwise returns no fired detectors. Tiers 1 + 2 + 4 continue;
+operators see a clear "tier 3 unavailable" signal in the runner
+log instead of a sea of per-trial failures (rubric §2.B FR 2.11).
+
+The Tier 3 detector functions are intentionally pure given their
+inputs (a captured ``dmesg`` text blob and an ``amd-smi`` snapshot
+pair) so they're unit-testable without a real GPU / kernel
+(rubric §2.B FR 2.13). The *invocation* code calls
+``shutil.which`` and subprocess-runs the shim, but that wrapper is
+covered by the missing-binary test which exercises the fail-soft
+branch.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+# Detector IDs (stable contract, see Tier 1 / Tier 4 docstrings).
+DETECTOR_AMDGPU_RESET = "tier3:amdgpu_reset"
+DETECTOR_SDMA_TIMEOUT = "tier3:sdma_timeout"
+DETECTOR_VM_L2_FAULT = "tier3:vm_l2_fault"
+DETECTOR_XGMI_LINK_ERROR = "tier3:xgmi_link_error"
+DETECTOR_PCIE_AER_FATAL = "tier3:pcie_aer_fatal"
+DETECTOR_VRAM_GROWTH = "tier3:vram_growth"
+DETECTOR_THERMAL_THROTTLE = "tier3:thermal_throttle"
+
+# VRAM growth that crosses this threshold (MiB) between pre- and
+# post-trial polls fires :data:`DETECTOR_VRAM_GROWTH`. Chosen well
+# above the noise floor on a multi-tenant host where unrelated
+# processes can move VRAM by a few MiB during the trial.
+VRAM_GROWTH_THRESHOLD_MIB = 256
+
+# Cap on the amount of dmesg text we scan per trial. Same rationale
+# as :data:`aorta.probe.sandbox.MAX_LOG_BYTES`: a runaway dmesg
+# producing > 10MiB of output in one trial would point at a kernel
+# log loop, not the trial; scanning more than this is wasted work.
+MAX_DMESG_BYTES = 10 * 1024 * 1024
+
+# Compiled patterns. Module-level so the cost is paid once per
+# process. ``MULTILINE`` so ``^`` / ``$`` match per line.
+_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        DETECTOR_AMDGPU_RESET,
+        re.compile(r"amdgpu: GPU reset", re.MULTILINE | re.IGNORECASE),
+    ),
+    (
+        DETECTOR_SDMA_TIMEOUT,
+        re.compile(r"SDMA semaphore timeout|SDMA hang", re.MULTILINE | re.IGNORECASE),
+    ),
+    (
+        DETECTOR_VM_L2_FAULT,
+        re.compile(r"VM_L2_PROTECTION_FAULT", re.MULTILINE),
+    ),
+    (
+        DETECTOR_XGMI_LINK_ERROR,
+        # 'XGMI' lines that carry 'error' / 'link' / 'failed' --
+        # narrow enough to avoid a healthy 'XGMI initialized'
+        # message firing the detector.
+        re.compile(r"XGMI.*(?:error|fail|link down)", re.MULTILINE | re.IGNORECASE),
+    ),
+    (
+        DETECTOR_PCIE_AER_FATAL,
+        re.compile(r"AER:?\s+Fatal", re.MULTILINE),
+    ),
+)
+
+
+@dataclass
+class Tier3State:
+    """Per-``aorta probe`` invocation state for Tier 3.
+
+    Tracks the "tier3 disabled" warning so it's emitted at most
+    once even when scanning N cells x M trials (rubric §2.B FR
+    2.11). Pass the SAME instance into every call to
+    :func:`scan_dmesg` / :func:`scan_amd_smi` over the course of
+    one ``aorta probe`` run.
+    """
+
+    dmesg_disabled_logged: bool = False
+    amdsmi_disabled_logged: bool = False
+    # Disabled reasons captured for ``result.json::capture`` if the
+    # workload wants to surface them — not currently consumed but
+    # recorded so a future audit can reconstruct what was skipped.
+    disabled_reasons: list[str] = field(default_factory=list)
+
+
+def scan_dmesg_text(text: str) -> list[str]:
+    """Scan an already-captured ``dmesg`` text blob for tier-3 patterns.
+
+    Pure: no subprocess, no FS. The :func:`scan_dmesg` wrapper does
+    the subprocess and threads its output through here. Exposed
+    separately so the patterns can be unit-tested against canned
+    text fixtures (rubric §2.B FR 2.13).
+    """
+    if not text:
+        return []
+    if len(text) > MAX_DMESG_BYTES:
+        text = text[:MAX_DMESG_BYTES]
+    fired: list[str] = []
+    for detector_id, pattern in _PATTERNS:
+        if pattern.search(text):
+            fired.append(detector_id)
+    return fired
+
+
+def scan_dmesg(
+    state: Tier3State,
+    since_seconds: float | None = None,
+) -> list[str]:
+    """Invoke ``dmesg`` and return the fired tier-3 kernel detectors.
+
+    Fail-soft on every error path. Returns ``[]`` when:
+
+    * ``dmesg`` is not on ``PATH``.
+    * ``dmesg`` exits non-zero (permission denied is the common
+      case in unprivileged containers; ``CAP_SYSLOG`` is required
+      on recent kernels).
+    * The subprocess raises (timeout, ``OSError``).
+
+    On the first failure for a given invocation, a single warning
+    is logged via the module logger; subsequent calls during the
+    same invocation are silent. The ``state`` object carries the
+    "already logged" bit across calls.
+    """
+    binary = shutil.which("dmesg")
+    if binary is None:
+        _log_disabled_once(state, "dmesg", "dmesg not on PATH")
+        return []
+
+    # ``--since=<n>seconds`` is the standard idiom on util-linux
+    # dmesg. We pass ``--no-pager`` for portability across systems
+    # where the operator's PAGER is set.
+    argv: list[str] = [binary, "--no-pager"]
+    if since_seconds is not None and since_seconds > 0:
+        # 'X seconds ago' is the human shape util-linux accepts.
+        argv.extend(["--since", f"{int(since_seconds)} seconds ago"])
+
+    try:
+        completed = subprocess.run(  # noqa: S603 -- audited argv list
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10.0,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _log_disabled_once(state, "dmesg", f"{type(exc).__name__}: {exc}")
+        return []
+    if completed.returncode != 0:
+        # Common case: 'dmesg: read kernel buffer failed: Operation
+        # not permitted'. Logged once; tiers 1+2+4 continue.
+        reason = (completed.stderr or completed.stdout or "non-zero exit").strip()
+        _log_disabled_once(state, "dmesg", f"non-zero exit: {reason!r}")
+        return []
+    return scan_dmesg_text(completed.stdout)
+
+
+@dataclass(frozen=True)
+class AmdSmiSnapshot:
+    """Minimum fields a Tier 3 amd-smi poll surfaces.
+
+    ``vram_used_mib`` is the cumulative used VRAM across every GPU
+    visible to ``amd-smi``; we don't try to attribute usage per
+    process (a much harder problem). ``thermal_throttle_count`` is
+    the all-GPU sum of the ``thermal_throttle_count`` counter
+    amd-smi exposes via ``static`` queries on recent ROCm builds.
+
+    Frozen so callers can keep two snapshots side-by-side (pre /
+    post) without one mutating the other.
+    """
+
+    vram_used_mib: int
+    thermal_throttle_count: int
+
+
+def scan_amd_smi(
+    state: Tier3State,
+    pre: AmdSmiSnapshot | None,
+    post: AmdSmiSnapshot | None,
+) -> list[str]:
+    """Diff two amd-smi snapshots and return the fired Tier 3 detectors.
+
+    Either snapshot being ``None`` means the polling step failed —
+    fail-soft: log once, return ``[]``. When both are present,
+    fire :data:`DETECTOR_VRAM_GROWTH` if the delta crosses
+    :data:`VRAM_GROWTH_THRESHOLD_MIB` and
+    :data:`DETECTOR_THERMAL_THROTTLE` if the throttle counter went
+    up during the trial.
+    """
+    if pre is None or post is None:
+        _log_disabled_once(
+            state,
+            "amd-smi",
+            "amd-smi not on PATH or polling failed (see runner log)",
+        )
+        return []
+    fired: list[str] = []
+    if post.vram_used_mib - pre.vram_used_mib >= VRAM_GROWTH_THRESHOLD_MIB:
+        fired.append(DETECTOR_VRAM_GROWTH)
+    if post.thermal_throttle_count > pre.thermal_throttle_count:
+        fired.append(DETECTOR_THERMAL_THROTTLE)
+    return fired
+
+
+def poll_amd_smi(state: Tier3State) -> AmdSmiSnapshot | None:
+    """Single ``amd-smi`` poll. Returns ``None`` when unavailable.
+
+    Reads ``amd-smi static -t product`` and ``amd-smi metric``
+    (subset). The exact arg shape varies across ROCm releases; we
+    invoke a small, stable subset and parse the human-readable
+    output defensively — any parse failure returns ``None`` and
+    counts as "amd-smi disabled" for the rest of the invocation.
+
+    Tests stub this via the ``AORTA_PROBE_AMDSMI_FAKE`` env var: if
+    set to ``vram=<int>,throttle=<int>`` the value is parsed and
+    returned without spawning a subprocess. Allows the unit suite
+    to exercise the diff logic in :func:`scan_amd_smi` without a
+    real GPU.
+    """
+    import os
+
+    fake = os.environ.get("AORTA_PROBE_AMDSMI_FAKE")
+    if fake is not None:
+        return _parse_fake_snapshot(fake, state)
+
+    binary = shutil.which("amd-smi")
+    if binary is None:
+        _log_disabled_once(state, "amd-smi", "amd-smi not on PATH")
+        return None
+    # Real polling is deferred -- the rubric's Tier 3 scoring path
+    # is exercised through the fake-shim env var in the unit
+    # suite; the production path requires a ROCm host the CI
+    # doesn't have. The function returns None (fail-soft) when
+    # the env var is unset and the runner gracefully skips Tier 3
+    # GPU counters with the standard "tier3 disabled" warning.
+    _log_disabled_once(
+        state,
+        "amd-smi",
+        "amd-smi present but live polling not implemented; "
+        "set AORTA_PROBE_AMDSMI_FAKE=vram=<MiB>,throttle=<n> for tests",
+    )
+    return None
+
+
+def _parse_fake_snapshot(spec: str, state: Tier3State) -> AmdSmiSnapshot | None:
+    """Parse ``AORTA_PROBE_AMDSMI_FAKE=vram=N,throttle=M`` for tests.
+
+    Returns ``None`` on parse failure (treats it as 'amd-smi not
+    available'). The test-only env var is intentionally simple so
+    a unit test can wire ``vram=100,throttle=0`` for the pre-poll
+    and ``vram=600,throttle=1`` for the post-poll, and assert
+    ``scan_amd_smi`` fires both detectors.
+    """
+    try:
+        parts = dict(item.split("=") for item in spec.split(","))
+        return AmdSmiSnapshot(
+            vram_used_mib=int(parts.get("vram", "0")),
+            thermal_throttle_count=int(parts.get("throttle", "0")),
+        )
+    except (ValueError, KeyError, AttributeError):
+        _log_disabled_once(state, "amd-smi", f"unparseable fake spec: {spec!r}")
+        return None
+
+
+def _log_disabled_once(state: Tier3State, source: str, reason: str) -> None:
+    """Emit a single ``tier3 disabled:`` warning per source per invocation.
+
+    Per the rubric (FR 2.11): the warning is logged at most once
+    for the whole ``aorta probe`` invocation regardless of how
+    many cells / trials hit the same failure. Subsequent calls
+    silently update the captured reasons list for audit.
+    """
+    state.disabled_reasons.append(f"{source}: {reason}")
+    flag_attr = f"{source.replace('-', '')}_disabled_logged"
+    # ``source`` is one of 'dmesg', 'amd-smi'; map to the
+    # corresponding flag attribute. ``amd-smi`` collapses to
+    # ``amdsmi_disabled_logged`` after the strip.
+    if source == "dmesg":
+        if state.dmesg_disabled_logged:
+            return
+        state.dmesg_disabled_logged = True
+    elif source == "amd-smi":
+        if state.amdsmi_disabled_logged:
+            return
+        state.amdsmi_disabled_logged = True
+    else:  # pragma: no cover - guards future renames
+        log.warning("tier3 disabled (%s): %s", source, reason)
+        return
+    log.warning("tier3 disabled (%s): %s", source, reason)
+    # Reference the helper attribute name to silence "unused" linters
+    # when the dead branch is removed in future refactors.
+    _ = flag_attr
+
+
+ALL_DETECTOR_IDS = (
+    DETECTOR_AMDGPU_RESET,
+    DETECTOR_SDMA_TIMEOUT,
+    DETECTOR_VM_L2_FAULT,
+    DETECTOR_XGMI_LINK_ERROR,
+    DETECTOR_PCIE_AER_FATAL,
+    DETECTOR_VRAM_GROWTH,
+    DETECTOR_THERMAL_THROTTLE,
+)
+
+
+__all__ = [
+    "ALL_DETECTOR_IDS",
+    "DETECTOR_AMDGPU_RESET",
+    "DETECTOR_PCIE_AER_FATAL",
+    "DETECTOR_SDMA_TIMEOUT",
+    "DETECTOR_THERMAL_THROTTLE",
+    "DETECTOR_VM_L2_FAULT",
+    "DETECTOR_VRAM_GROWTH",
+    "DETECTOR_XGMI_LINK_ERROR",
+    "MAX_DMESG_BYTES",
+    "VRAM_GROWTH_THRESHOLD_MIB",
+    "AmdSmiSnapshot",
+    "Tier3State",
+    "poll_amd_smi",
+    "scan_amd_smi",
+    "scan_dmesg",
+    "scan_dmesg_text",
+]

--- a/src/aorta/probe/classifier/tier3_kernel.py
+++ b/src/aorta/probe/classifier/tier3_kernel.py
@@ -132,7 +132,13 @@ def scan_dmesg_text(text: str) -> list[str]:
     if not text:
         return []
     if len(text) > MAX_DMESG_BYTES:
-        text = text[:MAX_DMESG_BYTES]
+        # Keep the *tail*, not the head. The XGMI / HBM / MMU
+        # kernel signatures Tier 3 looks for are almost always
+        # emitted in the seconds before the trial ends -- i.e. at
+        # the end of the dmesg ring. The previous head-slice
+        # discarded exactly those lines on long-running trials
+        # where the ring filled up. Per Sonbol's PR #197 review.
+        text = text[-MAX_DMESG_BYTES:]
     fired: list[str] = []
     for detector_id, pattern in _PATTERNS:
         if pattern.search(text):

--- a/src/aorta/probe/classifier/tier3_kernel.py
+++ b/src/aorta/probe/classifier/tier3_kernel.py
@@ -42,6 +42,8 @@ branch.
 
 from __future__ import annotations
 
+import csv
+import io
 import logging
 import re
 import shutil
@@ -197,8 +199,16 @@ class AmdSmiSnapshot:
     ``vram_used_mib`` is the cumulative used VRAM across every GPU
     visible to ``amd-smi``; we don't try to attribute usage per
     process (a much harder problem). ``thermal_throttle_count`` is
-    the all-GPU sum of the ``thermal_throttle_count`` counter
-    amd-smi exposes via ``static`` queries on recent ROCm builds.
+    the all-GPU sum of the throttle counter -- in live polling we
+    can't compute a true monotonic counter from
+    ``amd-smi monitor`` alone (the CLI surfaces current % time in
+    violation, not a cumulative count) so the live path leaves it
+    at ``0``; the fake-shim env var keeps the diff-based
+    ``DETECTOR_THERMAL_THROTTLE`` test path working as before.
+    ``gpu_utilization_pct`` is the across-GPU max ``GFX%`` value
+    (``None`` when amd-smi doesn't expose it or the column isn't
+    in the CSV header). The hang monitor uses this as the third
+    "GPU idle" leg of the two-of-three Tier 2 predicate.
 
     Frozen so callers can keep two snapshots side-by-side (pre /
     post) without one mutating the other.
@@ -206,6 +216,21 @@ class AmdSmiSnapshot:
 
     vram_used_mib: int
     thermal_throttle_count: int
+    gpu_utilization_pct: int | None = None
+
+
+# GPU is considered idle if the max-GPU ``GFX%`` from
+# ``amd-smi monitor`` is below this threshold. A running GPU
+# workload typically pegs activity at 80-100%; a hung kernel sits at
+# 0-2% (the residual is amd-smi's own polling). 5% is well below any
+# real compute and well above the noise floor.
+GPU_IDLE_UTILIZATION_THRESHOLD_PCT = 5
+
+
+# Subprocess timeout for amd-smi monitor in the live polling path.
+# Longer than dmesg's because monitor enumerates every GPU; an
+# unresponsive driver shouldn't block the hang monitor forever.
+_AMD_SMI_TIMEOUT_SEC = 10.0
 
 
 def scan_amd_smi(
@@ -240,17 +265,32 @@ def scan_amd_smi(
 def poll_amd_smi(state: Tier3State) -> AmdSmiSnapshot | None:
     """Single ``amd-smi`` poll. Returns ``None`` when unavailable.
 
-    Reads ``amd-smi static -t product`` and ``amd-smi metric``
-    (subset). The exact arg shape varies across ROCm releases; we
-    invoke a small, stable subset and parse the human-readable
-    output defensively — any parse failure returns ``None`` and
-    counts as "amd-smi disabled" for the rest of the invocation.
+    Live path: runs ``amd-smi monitor --csv --gfx --vram-usage``
+    and parses the (stable, documented) CSV output. ``monitor`` is
+    used in preference to ``metric --json`` because the column
+    layout is documented and stable across ROCm 6.x / 7.x while
+    the ``metric --json`` shape has been observed to differ
+    between point releases (e.g. socket-vs-partition layouts on
+    MI300). The CSV path covers the two columns we actually need
+    (VRAM_USED, GFX%); ``thermal_throttle_count`` is left at 0
+    because ``monitor`` only exposes current % time in violation,
+    not a cumulative counter -- the diff-based
+    ``DETECTOR_THERMAL_THROTTLE`` continues to fire through the
+    fake-shim env var path for tests.
 
-    Tests stub this via the ``AORTA_PROBE_AMDSMI_FAKE`` env var: if
-    set to ``vram=<int>,throttle=<int>`` the value is parsed and
-    returned without spawning a subprocess. Allows the unit suite
-    to exercise the diff logic in :func:`scan_amd_smi` without a
-    real GPU.
+    Test stub: ``AORTA_PROBE_AMDSMI_FAKE`` env var. When set to
+    ``vram=<int>,throttle=<int>`` (optionally ``,util=<int>``)
+    the value is parsed and returned without spawning a
+    subprocess. Allows the unit suite to exercise the diff logic
+    in :func:`scan_amd_smi` and the gpu-idle leg of
+    :func:`tier2_hang.evaluate_predicate` without a real GPU.
+
+    Any error in the live path (missing binary, non-zero exit,
+    unparseable header, timeout) returns ``None`` and counts as
+    "amd-smi disabled" via :func:`_log_disabled_once` for the
+    rest of the invocation -- the runner sees a single
+    ``tier3 disabled (amd-smi): <reason>`` warning and Tiers
+    1+2+4 continue (rubric §2.B FR 2.11).
     """
     import os
 
@@ -262,39 +302,193 @@ def poll_amd_smi(state: Tier3State) -> AmdSmiSnapshot | None:
     if binary is None:
         _log_disabled_once(state, "amd-smi", "amd-smi not on PATH")
         return None
-    # Real polling is deferred -- the rubric's Tier 3 scoring path
-    # is exercised through the fake-shim env var in the unit
-    # suite; the production path requires a ROCm host the CI
-    # doesn't have. The function returns None (fail-soft) when
-    # the env var is unset and the runner gracefully skips Tier 3
-    # GPU counters with the standard "tier3 disabled" warning.
-    _log_disabled_once(
-        state,
-        "amd-smi",
-        "amd-smi present but live polling not implemented; "
-        "set AORTA_PROBE_AMDSMI_FAKE=vram=<MiB>,throttle=<n> for tests",
+    return _poll_amd_smi_live(binary, state)
+
+
+def _poll_amd_smi_live(binary: str, state: Tier3State) -> AmdSmiSnapshot | None:
+    """Run ``amd-smi monitor --csv --gfx --vram-usage`` and parse the result.
+
+    Split out from :func:`poll_amd_smi` so the test suite can shim
+    the binary path via PATH (same pattern as the dmesg shim
+    test). Any subprocess failure or parse failure logs a single
+    ``tier3 disabled (amd-smi): ...`` warning and returns
+    ``None``.
+    """
+    argv = [binary, "monitor", "--csv", "--gfx", "--vram-usage"]
+    try:
+        completed = subprocess.run(  # noqa: S603 -- audited argv list
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_AMD_SMI_TIMEOUT_SEC,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _log_disabled_once(state, "amd-smi", f"{type(exc).__name__}: {exc}")
+        return None
+    if completed.returncode != 0:
+        reason = (completed.stderr or completed.stdout or "non-zero exit").strip()
+        _log_disabled_once(state, "amd-smi", f"non-zero exit: {reason!r}")
+        return None
+    snapshot = _parse_amd_smi_monitor_csv(completed.stdout)
+    if snapshot is None:
+        _log_disabled_once(
+            state,
+            "amd-smi",
+            f"unrecognised monitor CSV output: {completed.stdout[:200]!r}",
+        )
+    return snapshot
+
+
+# Recognised column-header aliases. Kept here so the parser can
+# absorb minor CSV header churn between ROCm releases without
+# editing the function body. All comparisons are uppercased and
+# stripped of whitespace.
+_VRAM_USED_HEADERS = frozenset({"VRAM_USED"})
+_GFX_HEADERS = frozenset({"GFX%", "GFX_ACTIVITY", "GFX"})
+
+
+def _parse_amd_smi_monitor_csv(payload: str) -> AmdSmiSnapshot | None:
+    """Parse the CSV from ``amd-smi monitor --csv --gfx --vram-usage``.
+
+    Sums ``VRAM_USED`` across rows (one row per GPU) and takes the
+    max of ``GFX%`` (the "idle" probe wants the busiest GPU; if any
+    GPU is doing real work the workload isn't hung GPU-wise).
+    ``N/A`` cells contribute nothing. Returns ``None`` when the
+    payload is empty / missing a recognised header so the caller
+    can log a single disabled warning.
+
+    Pure function (no logging, no subprocess) so unit tests can
+    exercise the parser directly with deterministic input.
+    """
+    reader = csv.reader(io.StringIO(payload))
+    try:
+        header = next(reader)
+    except StopIteration:
+        return None
+    normalised = [cell.strip().upper() for cell in header]
+    vram_idx = next((i for i, h in enumerate(normalised) if h in _VRAM_USED_HEADERS), None)
+    gfx_idx = next((i for i, h in enumerate(normalised) if h in _GFX_HEADERS), None)
+    if vram_idx is None and gfx_idx is None:
+        return None
+
+    vram_total_mib = 0
+    util_max: int | None = None
+    for row in reader:
+        if not row:
+            continue
+        if vram_idx is not None and vram_idx < len(row):
+            mib = _parse_mib(row[vram_idx])
+            if mib is not None:
+                vram_total_mib += mib
+        if gfx_idx is not None and gfx_idx < len(row):
+            pct = _parse_pct(row[gfx_idx])
+            if pct is not None:
+                util_max = pct if util_max is None else max(util_max, pct)
+    return AmdSmiSnapshot(
+        vram_used_mib=vram_total_mib,
+        thermal_throttle_count=0,
+        gpu_utilization_pct=util_max,
     )
-    return None
+
+
+# Permissive numeric-with-unit parsers. amd-smi cells look like
+# ``14 MB``, ``96432 MB``, ``0 %``, ``N/A`` -- the regex accepts an
+# optional unit suffix, ``MB``/``MiB``/``GB``/``GiB`` (case
+# insensitive), and a trailing ``%`` for percentages. Any
+# non-match returns ``None`` so the caller can skip the cell.
+_MIB_VALUE_RE = re.compile(r"^\s*(\d+)\s*(MB|MIB|GB|GIB)?\s*$", re.IGNORECASE)
+_PCT_VALUE_RE = re.compile(r"^\s*(\d+)\s*%?\s*$")
+
+
+def _parse_mib(cell: str) -> int | None:
+    """Parse a memory cell like ``'14 MB'``, returning MiB-or-None.
+
+    ``N/A`` / empty / unrecognised returns ``None``. ``GB`` /
+    ``GiB`` values are scaled by 1024; ``MB`` / ``MiB`` (the common
+    case) pass through unchanged because at the precision amd-smi
+    reports the two are interchangeable for hang-detection
+    purposes.
+    """
+    text = cell.strip()
+    if not text or text.upper() == "N/A":
+        return None
+    m = _MIB_VALUE_RE.match(text)
+    if m is None:
+        return None
+    value = int(m.group(1))
+    unit = (m.group(2) or "MB").upper()
+    if unit in ("GB", "GIB"):
+        return value * 1024
+    return value
+
+
+def _parse_pct(cell: str) -> int | None:
+    """Parse a percentage cell like ``'42 %'``, returning the integer.
+
+    ``N/A`` / empty / unrecognised returns ``None``.
+    """
+    text = cell.strip()
+    if not text or text.upper() == "N/A":
+        return None
+    m = _PCT_VALUE_RE.match(text)
+    if m is None:
+        return None
+    return int(m.group(1))
 
 
 def _parse_fake_snapshot(spec: str, state: Tier3State) -> AmdSmiSnapshot | None:
-    """Parse ``AORTA_PROBE_AMDSMI_FAKE=vram=N,throttle=M`` for tests.
+    """Parse ``AORTA_PROBE_AMDSMI_FAKE=vram=N,throttle=M[,util=U]`` for tests.
 
     Returns ``None`` on parse failure (treats it as 'amd-smi not
     available'). The test-only env var is intentionally simple so
     a unit test can wire ``vram=100,throttle=0`` for the pre-poll
     and ``vram=600,throttle=1`` for the post-poll, and assert
-    ``scan_amd_smi`` fires both detectors.
+    ``scan_amd_smi`` fires both detectors. The optional ``util``
+    field feeds the GPU-idle leg of :func:`tier2_hang.evaluate_predicate`
+    in tests that exercise the two-of-three predicate.
     """
     try:
         parts = dict(item.split("=") for item in spec.split(","))
+        util_raw = parts.get("util")
+        util = int(util_raw) if util_raw is not None else None
         return AmdSmiSnapshot(
             vram_used_mib=int(parts.get("vram", "0")),
             thermal_throttle_count=int(parts.get("throttle", "0")),
+            gpu_utilization_pct=util,
         )
     except (ValueError, KeyError, AttributeError):
         _log_disabled_once(state, "amd-smi", f"unparseable fake spec: {spec!r}")
         return None
+
+
+def gpu_idle_probe_from_state(state: Tier3State) -> "callable[[], bool]":  # noqa: UP037
+    """Return a zero-arg closure that polls amd-smi and returns "GPU idle?".
+
+    Intended to be wired into :class:`tier2_hang.HangMonitor`'s
+    ``gpu_idle_probe`` constructor argument. The closure returns
+    ``True`` iff the live amd-smi poll surfaces a max-GPU
+    ``GFX%`` below :data:`GPU_IDLE_UTILIZATION_THRESHOLD_PCT`.
+    Any None (binary missing, parse fail, utilization column
+    absent) yields ``False`` so the GPU leg can never single-
+    handedly trip the two-of-three predicate when telemetry is
+    unavailable -- consistent with the I/O leg's
+    ``current_io is None -> io_idle=False`` rule in
+    :class:`HangMonitor._run`.
+
+    Each call spawns one amd-smi subprocess; the HangMonitor polls
+    at ``poll_interval_sec`` (default 5s) so we expect ~12 calls
+    per minute under default settings, well within the budget for
+    a hang-monitoring background thread.
+    """
+
+    def _probe() -> bool:
+        snap = poll_amd_smi(state)
+        if snap is None or snap.gpu_utilization_pct is None:
+            return False
+        return snap.gpu_utilization_pct < GPU_IDLE_UTILIZATION_THRESHOLD_PCT
+
+    return _probe
 
 
 def _log_disabled_once(state: Tier3State, source: str, reason: str) -> None:
@@ -340,6 +534,7 @@ ALL_DETECTOR_IDS = (
 
 __all__ = [
     "ALL_DETECTOR_IDS",
+    "AmdSmiSnapshot",
     "DETECTOR_AMDGPU_RESET",
     "DETECTOR_PCIE_AER_FATAL",
     "DETECTOR_SDMA_TIMEOUT",
@@ -347,10 +542,11 @@ __all__ = [
     "DETECTOR_VM_L2_FAULT",
     "DETECTOR_VRAM_GROWTH",
     "DETECTOR_XGMI_LINK_ERROR",
+    "GPU_IDLE_UTILIZATION_THRESHOLD_PCT",
     "MAX_DMESG_BYTES",
-    "VRAM_GROWTH_THRESHOLD_MIB",
-    "AmdSmiSnapshot",
     "Tier3State",
+    "VRAM_GROWTH_THRESHOLD_MIB",
+    "gpu_idle_probe_from_state",
     "poll_amd_smi",
     "scan_amd_smi",
     "scan_dmesg",

--- a/src/aorta/probe/classifier/tier4_patterns.py
+++ b/src/aorta/probe/classifier/tier4_patterns.py
@@ -25,10 +25,13 @@ corresponding ID fires.
 The detectors run AGAINST a 10-MiB-capped window of the trial's
 stdout/stderr concatenation (see :data:`MAX_LOG_BYTES` in
 :mod:`aorta.probe.sandbox`). A log larger than the cap is scanned
-in successive windows so a single ``re.search`` never touches more
-than the cap at once — the only defence against catastrophic
-backtracking that does not require swapping the regex engine
-(rubric §X.2 R2).
+in successive windows that **overlap** by
+:data:`_WINDOW_OVERLAP_BYTES` (see :func:`_iter_windows`) so a
+multi-line match straddling a seam still fires; each
+``re.search`` invocation still touches at most ``MAX_LOG_BYTES``
+of input, preserving the catastrophic-backtracking bound that's
+the only defence against operator-supplied regex without
+swapping the regex engine (rubric §X.2 R2).
 """
 
 from __future__ import annotations
@@ -148,11 +151,16 @@ def scan(log_text: str) -> list[str]:
     Each pattern runs at most once over the input; patterns are
     independent (an HIP error and a Python traceback in the same
     log fire both detectors). The scanner enforces the
-    :data:`MAX_LOG_BYTES` per-scan window cap: logs longer than the
-    cap are split into sequential non-overlapping windows and each
-    pattern runs against each window. This bounds catastrophic
-    backtracking on operator-supplied logs without changing the
-    regex engine (rubric §X.2 R2).
+    :data:`MAX_LOG_BYTES` per-scan window cap: logs longer than
+    the cap are split into successive windows that **overlap by
+    :data:`_WINDOW_OVERLAP_BYTES`** so a multi-line match
+    straddling a seam still fires (see :func:`_iter_windows`).
+    Each pattern runs against each window. This bounds
+    catastrophic backtracking on operator-supplied logs without
+    changing the regex engine (rubric §X.2 R2). Per Copilot's PR
+    #197 review — the doc previously claimed "non-overlapping",
+    which has been wrong since the Sonbol-round straddling-match
+    fix.
 
     Returns the IDs in catalogue order — Tier 4 is internally
     deterministic, but ``failure_detectors_fired`` overall preserves

--- a/src/aorta/probe/classifier/tier4_patterns.py
+++ b/src/aorta/probe/classifier/tier4_patterns.py
@@ -172,23 +172,45 @@ def scan(log_text: str) -> list[str]:
     return fired
 
 
+# Overlap between adjacent windows in :func:`_iter_windows`. Sized to
+# comfortably exceed the longest match the Tier 4 catalogue can
+# produce -- the widest built-in pattern today matches a Python
+# traceback header plus a few continuation lines (a few hundred
+# bytes), so 4 KiB is ~10x safety margin. If a future pattern needs
+# more, raise this constant; the cost is bounded ``re.search``
+# re-work on the overlap region, never a missed match.
+_WINDOW_OVERLAP_BYTES = 4096
+
+
 def _iter_windows(text: str, window: int):
-    """Yield non-overlapping ``window``-sized slices of ``text``.
+    """Yield ``window``-sized slices of ``text`` with a small overlap.
 
     Used to bound each ``re.search`` invocation's worst-case input
-    size. A pattern whose match straddles a window boundary may
-    miss in that scan; for the Tier 4 catalogue this is acceptable
-    because every pattern matches a single short line (a Python
-    traceback header, an HIP error code) that fits comfortably
-    inside a 10MiB window. If a pattern is ever added whose match
-    can be longer than the window, this helper should switch to
-    overlapping windows of (window, window + overlap).
+    size. The previous shape sliced ``text`` into back-to-back
+    non-overlapping chunks; a pattern whose match straddled a
+    chunk boundary (``Traceback (most recent call last):`` ending
+    one window with the body starting the next) was silently
+    missed -- the very class of multi-line failure signature the
+    Tier 4 detectors are meant to catch on the long-log path.
+    Overlap by :data:`_WINDOW_OVERLAP_BYTES` (capped at half the
+    window so each step still advances by at least ``window // 2``,
+    avoiding an infinite loop when a test or future caller sets a
+    pathologically small window). Cost is at most one extra
+    overlap-sized scan per seam, bounded by ``2 * len(text) /
+    window``. Per Sonbol's PR #197 review.
     """
     if len(text) <= window:
         yield text
         return
-    for start in range(0, len(text), window):
-        yield text[start : start + window]
+    # Cap overlap so step >= window // 2 -- guarantees forward progress.
+    overlap = min(_WINDOW_OVERLAP_BYTES, max(window // 2, 0))
+    start = 0
+    while start < len(text):
+        end = min(start + window, len(text))
+        yield text[start:end]
+        if end == len(text):
+            return
+        start = end - overlap
 
 
 __all__ = [

--- a/src/aorta/probe/classifier/tier4_patterns.py
+++ b/src/aorta/probe/classifier/tier4_patterns.py
@@ -1,0 +1,203 @@
+"""Tier 4 built-in pattern library for ``aorta probe`` (issue #188).
+
+A small, versioned set of regex patterns covering the failure modes
+the AORTA team has seen often enough to bake into the platform.
+Every pattern has a stable detector ID (the value persisted in
+``result.json::failure_detectors_fired``); the regexes themselves
+may evolve between versions, but the IDs are part of the public
+contract.
+
+Version bump policy (rubric §X.1 row 5):
+
+* Adding a pattern: increment :data:`BUILTIN_PATTERN_VERSION`.
+* Renaming a pattern's regex (refining recall): increment.
+* Removing a pattern: increment, and document the rename of any
+  downstream user reading the old ID.
+
+Each pattern ships a sibling fixture log under
+``tests/probe/fixtures/tier4_logs/<id>.log``; the parametrised
+Tier 4 test reads each fixture and asserts the corresponding ID
+fires.
+
+The detectors run AGAINST a 10-MiB-capped window of the trial's
+stdout/stderr concatenation (see :data:`MAX_LOG_BYTES` in
+:mod:`aorta.probe.sandbox`). A log larger than the cap is scanned
+in successive windows so a single ``re.search`` never touches more
+than the cap at once — the only defence against catastrophic
+backtracking that does not require swapping the regex engine
+(rubric §X.2 R2).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from aorta.probe.sandbox import MAX_LOG_BYTES
+
+# Version string surfaced by ``aorta probe --list-patterns --version``.
+# Bumped per the policy above; consumers MAY pin to a known version
+# in their CI to detect platform-side pattern changes that would
+# alter ``failure_detectors_fired`` for already-archived runs.
+BUILTIN_PATTERN_VERSION = "1"
+
+# Detector IDs. The prefix is uniformly ``tier4:`` so a reader of
+# ``failure_detectors_fired`` can route by prefix (``tier1:`` for
+# process-level, ``tier2:`` for hang, ``tier3:`` for kernel,
+# ``tier4:`` for built-in patterns, ``custom:<id>`` for
+# user-provided patterns from the recipe's ``custom_patterns:``).
+DETECTOR_PYTHON_TRACEBACK = "tier4:python_traceback"
+DETECTOR_HIP_ERROR = "tier4:hip_error"
+DETECTOR_CUDA_ERROR = "tier4:cuda_error"
+DETECTOR_ROCM_ERROR = "tier4:rocm_error"
+DETECTOR_NCCL_RCCL_ERROR = "tier4:nccl_rccl_error"
+DETECTOR_COLLECTIVE_TIMEOUT = "tier4:collective_timeout"
+DETECTOR_NAN_SIGNATURE = "tier4:nan_signature"
+
+
+@dataclass(frozen=True)
+class BuiltinPattern:
+    """One entry in the Tier 4 catalogue.
+
+    ``regex`` is a pre-compiled :class:`re.Pattern` so the scanner
+    does not re-compile per trial; ``sample`` is a one-line example
+    of a log fragment that would match (shown by
+    ``aorta probe --list-patterns`` so an operator can recognise
+    the shape without reading the regex).
+    """
+
+    detector_id: str
+    description: str
+    regex: re.Pattern[str]
+    sample: str
+
+
+# Pattern order is the order ``aorta probe --list-patterns`` prints
+# (rubric §2.B FR 2.5). It is also the order :func:`scan` walks, but
+# every match contributes to ``fired`` independently so order is
+# UI-only — the returned list reflects the patterns that matched, in
+# this catalogue order. The verdict resolver further preserves the
+# encounter order it sees, but Tier 4 firing order is deterministic
+# because the catalogue is fixed.
+_BUILTIN_PATTERNS: tuple[BuiltinPattern, ...] = (
+    BuiltinPattern(
+        detector_id=DETECTOR_PYTHON_TRACEBACK,
+        description="Python traceback ('Traceback (most recent call last):')",
+        # MULTILINE so '^' matches at the start of each line; DOTALL
+        # NOT set so '.' does not gobble across the traceback frames.
+        regex=re.compile(
+            r"^Traceback \(most recent call last\):",
+            re.MULTILINE,
+        ),
+        sample="Traceback (most recent call last):",
+    ),
+    BuiltinPattern(
+        detector_id=DETECTOR_HIP_ERROR,
+        description="HIP error code (hipError_* or HIP error: ...)",
+        # Both shapes seen in the wild: the enum-style identifier
+        # printed by ROCm/HIP and the prose 'HIP error:' prefix.
+        regex=re.compile(r"hipError_[A-Za-z0-9_]+|HIP error:"),
+        sample="hipError_OutOfMemory",
+    ),
+    BuiltinPattern(
+        detector_id=DETECTOR_CUDA_ERROR,
+        description="CUDA error code (cudaError_* or CUDA error: ...)",
+        regex=re.compile(r"cudaError[A-Za-z0-9_]*|CUDA error:"),
+        sample="cudaErrorIllegalAddress",
+    ),
+    BuiltinPattern(
+        detector_id=DETECTOR_ROCM_ERROR,
+        description="ROCm error code marker ('Error code: <n>')",
+        regex=re.compile(r"Error code: \d+"),
+        sample="Error code: 1",
+    ),
+    BuiltinPattern(
+        detector_id=DETECTOR_NCCL_RCCL_ERROR,
+        description="NCCL or RCCL collective error",
+        regex=re.compile(r"NCCL error|RCCL ERROR"),
+        sample="NCCL error: unhandled system error",
+    ),
+    BuiltinPattern(
+        detector_id=DETECTOR_COLLECTIVE_TIMEOUT,
+        description="Torch distributed watchdog collective-operation timeout",
+        regex=re.compile(r"Watchdog caught collective operation timeout"),
+        sample="Watchdog caught collective operation timeout: WorkNCCL ...",
+    ),
+    BuiltinPattern(
+        detector_id=DETECTOR_NAN_SIGNATURE,
+        description="Training-loss NaN signature",
+        # Case-insensitive 'loss is NaN' / 'loss=nan' / bare 'loss
+        # NaN'. Common shapes across PyTorch, TF, JAX trainers.
+        regex=re.compile(r"loss(?: is)? NaN|loss=nan", re.IGNORECASE),
+        sample="loss is NaN",
+    ),
+)
+
+
+def all_patterns() -> tuple[BuiltinPattern, ...]:
+    """Return the immutable Tier 4 pattern catalogue."""
+    return _BUILTIN_PATTERNS
+
+
+def scan(log_text: str) -> list[str]:
+    """Return Tier 4 detector IDs that fired against ``log_text``.
+
+    Each pattern runs at most once over the input; patterns are
+    independent (an HIP error and a Python traceback in the same
+    log fire both detectors). The scanner enforces the
+    :data:`MAX_LOG_BYTES` per-scan window cap: logs longer than the
+    cap are split into sequential non-overlapping windows and each
+    pattern runs against each window. This bounds catastrophic
+    backtracking on operator-supplied logs without changing the
+    regex engine (rubric §X.2 R2).
+
+    Returns the IDs in catalogue order — Tier 4 is internally
+    deterministic, but ``failure_detectors_fired`` overall preserves
+    encounter order via the verdict resolver.
+    """
+    if not log_text:
+        return []
+    fired: list[str] = []
+    for window in _iter_windows(log_text, MAX_LOG_BYTES):
+        for pattern in _BUILTIN_PATTERNS:
+            if pattern.detector_id in fired:
+                continue
+            if pattern.regex.search(window):
+                fired.append(pattern.detector_id)
+        if len(fired) == len(_BUILTIN_PATTERNS):
+            break
+    return fired
+
+
+def _iter_windows(text: str, window: int):
+    """Yield non-overlapping ``window``-sized slices of ``text``.
+
+    Used to bound each ``re.search`` invocation's worst-case input
+    size. A pattern whose match straddles a window boundary may
+    miss in that scan; for the Tier 4 catalogue this is acceptable
+    because every pattern matches a single short line (a Python
+    traceback header, an HIP error code) that fits comfortably
+    inside a 10MiB window. If a pattern is ever added whose match
+    can be longer than the window, this helper should switch to
+    overlapping windows of (window, window + overlap).
+    """
+    if len(text) <= window:
+        yield text
+        return
+    for start in range(0, len(text), window):
+        yield text[start : start + window]
+
+
+__all__ = [
+    "BUILTIN_PATTERN_VERSION",
+    "BuiltinPattern",
+    "DETECTOR_COLLECTIVE_TIMEOUT",
+    "DETECTOR_CUDA_ERROR",
+    "DETECTOR_HIP_ERROR",
+    "DETECTOR_NAN_SIGNATURE",
+    "DETECTOR_NCCL_RCCL_ERROR",
+    "DETECTOR_PYTHON_TRACEBACK",
+    "DETECTOR_ROCM_ERROR",
+    "all_patterns",
+    "scan",
+]

--- a/src/aorta/probe/classifier/tier4_patterns.py
+++ b/src/aorta/probe/classifier/tier4_patterns.py
@@ -15,9 +15,12 @@ Version bump policy (rubric §X.1 row 5):
   downstream user reading the old ID.
 
 Each pattern ships a sibling fixture log under
-``tests/probe/fixtures/tier4_logs/<id>.log``; the parametrised
-Tier 4 test reads each fixture and asserts the corresponding ID
-fires.
+``tests/probe/fixtures/tier4_logs/<detector-suffix>.txt`` (``.txt``
+keeps the fixtures out of the project's ``.gitignore`` ``*.log``
+rule; the basename is the detector ID with the ``tier4:`` prefix
+stripped, e.g. ``cuda_error.txt`` for ``tier4:cuda_error``). The
+parametrised Tier 4 test reads each fixture and asserts the
+corresponding ID fires.
 
 The detectors run AGAINST a 10-MiB-capped window of the trial's
 stdout/stderr concatenation (see :data:`MAX_LOG_BYTES` in

--- a/src/aorta/probe/classifier/tier5_custom.py
+++ b/src/aorta/probe/classifier/tier5_custom.py
@@ -196,11 +196,18 @@ def _validate_one(
     if condition_raw is not None:
         try:
             condition_code = validate_and_compile(condition_raw)
-        except SandboxError:
-            # Re-raise so the rubric-mandated subclass identity is
-            # preserved (RecipeSchemaError catch-clauses still
-            # catch it because SandboxError subclasses it).
-            raise
+        except SandboxError as exc:
+            # Wrap with the recipe path so a multi-entry recipe makes
+            # the bad entry findable without counting list positions.
+            # ``SandboxError`` subclasses ``RecipeSchemaError`` per the
+            # rubric, so callers that catch the parent type still
+            # catch the wrapped instance; the wrapped message keeps
+            # the original sandbox detail (forbidden node, magnitude
+            # cap, ...) intact at the end so no diagnostic is lost.
+            # Per Copilot's PR #197 review.
+            raise SandboxError(
+                f"{path}.match.condition: {exc}"
+            ) from exc
         condition_source = condition_raw
 
     on_match_raw = entry.get("on_match", "fail")

--- a/src/aorta/probe/classifier/tier5_custom.py
+++ b/src/aorta/probe/classifier/tier5_custom.py
@@ -316,16 +316,40 @@ def scan(
     return result
 
 
+# Same overlap rationale as Tier 4 (see
+# :data:`aorta.probe.classifier.tier4_patterns._WINDOW_OVERLAP_BYTES`).
+# Operator-supplied ``custom_patterns`` may legitimately match a
+# multi-line region (a stack frame, a JSON payload); 4 KiB of
+# overlap covers every plausible single-match width without
+# meaningfully inflating scan cost.
+_WINDOW_OVERLAP_BYTES = 4096
+
+
 def _iter_windows(text: str, window: int):
-    """Same window-chunked scanner as Tier 4. Kept separate so a
-    future change to the Tier 4 window strategy doesn't have to
-    move in lock-step with the custom-pattern runner.
+    """Window-chunked scanner. Same shape as Tier 4 with an overlap.
+
+    Kept separate from the Tier 4 helper so a future change to the
+    Tier 4 window strategy doesn't have to move in lock-step with
+    the custom-pattern runner. The overlap closes the same
+    straddling-match gap that Tier 4 had: a custom pattern whose
+    match crosses a 10 MiB seam was silently missed by the
+    non-overlapping shape. Overlap is capped at half the window so
+    each step still advances by at least ``window // 2`` --
+    mirrors the Tier 4 helper's loop-safety guard. Per Sonbol's PR
+    #197 review (sweep from the Tier 4 fix to the parallel Tier 5
+    helper).
     """
     if len(text) <= window:
         yield text
         return
-    for start in range(0, len(text), window):
-        yield text[start : start + window]
+    overlap = min(_WINDOW_OVERLAP_BYTES, max(window // 2, 0))
+    start = 0
+    while start < len(text):
+        end = min(start + window, len(text))
+        yield text[start:end]
+        if end == len(text):
+            return
+        start = end - overlap
 
 
 __all__ = [

--- a/src/aorta/probe/classifier/tier5_custom.py
+++ b/src/aorta/probe/classifier/tier5_custom.py
@@ -1,0 +1,337 @@
+"""Tier 5 user ``custom_patterns`` runner for ``aorta probe`` (issue #188).
+
+Consumes the ``custom_patterns:`` block on a probe-mode recipe and
+fires detectors per-trial. Each pattern has:
+
+* ``id`` -- stable detector ID (the value persisted into
+  ``failure_detectors_fired`` / ``warn_detectors_fired``). The
+  ID is namespaced under ``custom:`` so a reader of
+  ``result.json`` can route by prefix.
+* ``match.regex`` -- compile-validated at recipe load
+  (:func:`validate_custom_patterns`). Named groups (``(?P<name>...)``)
+  contribute to the trial's ``capture`` dict when the pattern
+  matches.
+* ``match.condition`` (optional) -- a sandboxed expression
+  evaluated AFTER the regex matches. Must validate via
+  :func:`aorta.probe.sandbox.validate_and_compile` at load time.
+  When present, the detector fires only if BOTH the regex matched
+  AND the condition evaluated to True.
+* ``on_match`` -- ``"fail"`` (contributes to
+  ``failure_detectors_fired``), ``"warn"`` (contributes to
+  ``warn_detectors_fired``), or ``"info"`` (only populates
+  ``capture``).
+* ``required_for_pass`` (optional bool, default False) -- when
+  True and the pattern does NOT fire, the verdict resolver
+  injects ``meta:missing_pass_signal`` into
+  ``failure_detectors_fired`` (rubric §2.B FR 2.8.c).
+
+The runner is purely text-driven so it's testable without a real
+subprocess: pass a log string and a list of ``CompiledPattern``s
+and assert the returned :class:`CustomScanResult`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from types import CodeType
+from typing import Literal
+
+from aorta.probe.sandbox import MAX_LOG_BYTES, SandboxError, evaluate, validate_and_compile
+from aorta.triage.recipe import RecipeSchemaError
+
+OnMatch = Literal["fail", "warn", "info"]
+_VALID_ON_MATCH: frozenset[str] = frozenset({"fail", "warn", "info"})
+
+# Per-pattern key bank. ``required_for_pass`` is allowed only when
+# ``on_match == "fail"`` (a warn/info pattern can't be required for
+# pass — it doesn't change the verdict). Validated at load time.
+_VALID_PATTERN_KEYS = frozenset({"id", "match", "on_match", "required_for_pass"})
+_VALID_MATCH_KEYS = frozenset({"regex", "condition"})
+
+
+@dataclass(frozen=True)
+class CompiledPattern:
+    """A custom_patterns entry, pre-compiled and pre-validated.
+
+    Produced by :func:`validate_custom_patterns` from the parsed
+    recipe dict. The recipe loader hands a tuple of these onto
+    :attr:`aorta.probe.recipe_builder.ProbeExtras.custom_patterns`
+    so the SubprocessWorkload doesn't re-compile per-trial.
+
+    Attributes:
+        detector_id: The ``custom:<id>`` string surfaced in
+            ``failure_detectors_fired`` / ``warn_detectors_fired``.
+        regex: Compiled :class:`re.Pattern`.
+        condition_code: Pre-compiled sandbox CodeType, or None if
+            no ``condition`` was supplied.
+        condition_source: The raw condition string (useful for
+            error messages and ``aorta probe --list-patterns``).
+        on_match: ``"fail"`` / ``"warn"`` / ``"info"``.
+        required_for_pass: When True and the pattern doesn't fire,
+            the verdict resolver injects ``meta:missing_pass_signal``.
+    """
+
+    detector_id: str
+    regex: re.Pattern[str]
+    condition_code: CodeType | None
+    condition_source: str | None
+    on_match: OnMatch
+    required_for_pass: bool = False
+
+
+@dataclass
+class CustomScanResult:
+    """Outcome of scanning one trial's log against ``custom_patterns``.
+
+    The verdict resolver assembles the final
+    ``failure_detectors_fired`` / ``warn_detectors_fired`` /
+    ``capture`` from this struct plus Tier 1–4 detector lists,
+    so the per-tier outputs stay decoupled.
+
+    ``fired_required_ids`` is the subset of fired detectors that
+    came from a pattern with ``required_for_pass=True``; the
+    resolver checks ``required_for_pass`` patterns that did NOT
+    fire and synthesises ``meta:missing_pass_signal`` accordingly.
+    """
+
+    fail_detectors: list[str] = field(default_factory=list)
+    warn_detectors: list[str] = field(default_factory=list)
+    capture: dict[str, str | float | int] = field(default_factory=dict)
+    fired_required_ids: set[str] = field(default_factory=set)
+
+
+def validate_custom_patterns(raw: object) -> tuple[CompiledPattern, ...]:
+    """Parse, compile, and sandbox-validate the ``custom_patterns:`` block.
+
+    Returns an empty tuple when ``raw`` is None / missing so the
+    caller can ``validate_custom_patterns(data.get("custom_patterns"))``
+    without branching. Raises :class:`RecipeSchemaError` (or its
+    :class:`SandboxError` subclass) on the first invalid entry —
+    fail-fast on recipe load.
+
+    Validation rules:
+
+    * ``raw`` must be a non-empty list of mappings.
+    * Each entry has a non-empty string ``id`` and a ``match``
+      mapping with a compile-valid ``regex``.
+    * ``match.condition`` (if present) sandbox-validates.
+    * ``on_match`` ∈ {fail, warn, info}; default is ``fail`` when
+      absent (matches the rubric's "any pattern that fires is a
+      failure unless explicitly opted out").
+    * ``required_for_pass`` ∈ {True, False}; only meaningful with
+      ``on_match == "fail"``. Rejected with a clear error when
+      paired with warn/info because the user almost certainly
+      didn't mean it.
+    * Unknown keys at either level reject with the allowed set.
+    """
+    if raw is None:
+        return ()
+    if not isinstance(raw, list) or not raw:
+        raise RecipeSchemaError(f"recipe.custom_patterns: must be a non-empty list, got {raw!r}")
+    compiled: list[CompiledPattern] = []
+    seen_ids: set[str] = set()
+    for idx, entry in enumerate(raw):
+        compiled.append(_validate_one(idx, entry, seen_ids))
+    return tuple(compiled)
+
+
+def _validate_one(
+    idx: int,
+    entry: object,
+    seen_ids: set[str],
+) -> CompiledPattern:
+    """Validate one ``custom_patterns[idx]`` entry.
+
+    Per-entry errors carry the ``custom_patterns[idx]`` path hint
+    so the operator can find the offending entry without counting
+    mapping keys. Schema-error first, then regex-error, then
+    sandbox-error (the order recipe authors are most likely to hit
+    in the wild).
+    """
+    path = f"recipe.custom_patterns[{idx}]"
+    if not isinstance(entry, dict):
+        raise RecipeSchemaError(f"{path}: must be a mapping, got {type(entry).__name__}")
+    unknown = set(entry) - _VALID_PATTERN_KEYS
+    if unknown:
+        raise RecipeSchemaError(
+            f"{path}: unknown keys {sorted(unknown)}; allowed: {sorted(_VALID_PATTERN_KEYS)}"
+        )
+
+    raw_id = entry.get("id")
+    if not isinstance(raw_id, str) or not raw_id:
+        raise RecipeSchemaError(f"{path}.id: must be a non-empty string")
+    if raw_id in seen_ids:
+        raise RecipeSchemaError(
+            f"{path}.id: duplicate id {raw_id!r} (custom-pattern ids must be unique within a recipe)"
+        )
+    seen_ids.add(raw_id)
+    detector_id = f"custom:{raw_id}"
+
+    match_raw = entry.get("match")
+    if not isinstance(match_raw, dict):
+        raise RecipeSchemaError(
+            f"{path}.match: must be a mapping with 'regex' (and optional 'condition'), "
+            f"got {type(match_raw).__name__}"
+        )
+    match_unknown = set(match_raw) - _VALID_MATCH_KEYS
+    if match_unknown:
+        raise RecipeSchemaError(
+            f"{path}.match: unknown keys {sorted(match_unknown)}; "
+            f"allowed: {sorted(_VALID_MATCH_KEYS)}"
+        )
+    regex_raw = match_raw.get("regex")
+    if not isinstance(regex_raw, str) or not regex_raw:
+        raise RecipeSchemaError(f"{path}.match.regex: must be a non-empty string")
+    try:
+        compiled_regex = re.compile(regex_raw)
+    except re.error as exc:
+        raise RecipeSchemaError(
+            f"{path}.match.regex: invalid regex ({exc}): {regex_raw!r}"
+        ) from exc
+
+    condition_raw = match_raw.get("condition")
+    condition_code: CodeType | None = None
+    condition_source: str | None = None
+    if condition_raw is not None:
+        try:
+            condition_code = validate_and_compile(condition_raw)
+        except SandboxError:
+            # Re-raise so the rubric-mandated subclass identity is
+            # preserved (RecipeSchemaError catch-clauses still
+            # catch it because SandboxError subclasses it).
+            raise
+        condition_source = condition_raw
+
+    on_match_raw = entry.get("on_match", "fail")
+    if on_match_raw not in _VALID_ON_MATCH:
+        raise RecipeSchemaError(
+            f"{path}.on_match: must be one of {sorted(_VALID_ON_MATCH)}, got {on_match_raw!r}"
+        )
+
+    required = entry.get("required_for_pass", False)
+    if not isinstance(required, bool):
+        raise RecipeSchemaError(
+            f"{path}.required_for_pass: must be a boolean, got {type(required).__name__}"
+        )
+    if required and on_match_raw != "fail":
+        raise RecipeSchemaError(
+            f"{path}.required_for_pass: only meaningful with on_match='fail' "
+            f"(got on_match={on_match_raw!r}); a warn/info pattern cannot be required for pass"
+        )
+
+    return CompiledPattern(
+        detector_id=detector_id,
+        regex=compiled_regex,
+        condition_code=condition_code,
+        condition_source=condition_source,
+        on_match=on_match_raw,
+        required_for_pass=required,
+    )
+
+
+def scan(
+    log_text: str,
+    patterns: tuple[CompiledPattern, ...],
+    *,
+    exit_code: int,
+    walltime_sec: float,
+    peak_vram_mib: int | None,
+) -> CustomScanResult:
+    """Apply every ``CompiledPattern`` to ``log_text`` and return the result.
+
+    Each pattern runs at most once. Named regex capture groups
+    populate :attr:`CustomScanResult.capture` for every fired
+    pattern; later-fired patterns whose capture group names
+    collide overwrite earlier values (recipe authors should choose
+    unique names).
+
+    The ``condition`` sandbox is invoked only when the regex
+    matches, and only with the four documented variables. A regex
+    miss skips the sandbox entirely — that's the rubric's FR 2.12
+    "no eval reach for rejected input" guarantee at runtime, in
+    addition to the parse-time enforcement.
+
+    The scanner enforces :data:`MAX_LOG_BYTES` via window-chunked
+    scanning so a 100MiB log cannot blow up the runner.
+    """
+    result = CustomScanResult()
+    if not patterns:
+        return result
+    if not log_text:
+        log_text = ""
+
+    # First-window-match wins per pattern; once a pattern has
+    # fired, skip it on subsequent windows. This keeps the result
+    # ordered by encounter (which is what the verdict resolver
+    # expects for ``failure_detectors_fired`` order) and bounds
+    # total work to O(patterns * windows).
+    fired_ids: set[str] = set()
+    for window in _iter_windows(log_text, MAX_LOG_BYTES):
+        for pattern in patterns:
+            if pattern.detector_id in fired_ids:
+                continue
+            match = pattern.regex.search(window)
+            if match is None:
+                continue
+            named_capture = {k: v for k, v in match.groupdict().items() if v is not None}
+            if pattern.condition_code is not None:
+                try:
+                    fired = evaluate(
+                        pattern.condition_code,
+                        capture=named_capture,
+                        exit_code=exit_code,
+                        walltime_sec=walltime_sec,
+                        peak_vram_mib=peak_vram_mib,
+                    )
+                except Exception:
+                    # A condition that raises at eval is treated as
+                    # "did not fire" rather than aborting the
+                    # classifier — the alternative (re-raising)
+                    # would let a single misbehaving condition
+                    # break the verdict for an entire run. The
+                    # parse-time sandbox already rejects everything
+                    # we can statically detect; runtime errors are
+                    # operator misconfiguration we degrade past.
+                    fired = False
+            else:
+                fired = True
+            if not fired:
+                continue
+            fired_ids.add(pattern.detector_id)
+            # capture is populated regardless of on_match: even
+            # ``info`` patterns are useful precisely for surfacing
+            # numbers into the trial's capture dict.
+            result.capture.update(named_capture)
+            if pattern.on_match == "fail":
+                result.fail_detectors.append(pattern.detector_id)
+                if pattern.required_for_pass:
+                    result.fired_required_ids.add(pattern.detector_id)
+            elif pattern.on_match == "warn":
+                result.warn_detectors.append(pattern.detector_id)
+            # ``info`` matches are silent w.r.t. detector lists —
+            # capture-only.
+        if len(fired_ids) == len(patterns):
+            break
+    return result
+
+
+def _iter_windows(text: str, window: int):
+    """Same window-chunked scanner as Tier 4. Kept separate so a
+    future change to the Tier 4 window strategy doesn't have to
+    move in lock-step with the custom-pattern runner.
+    """
+    if len(text) <= window:
+        yield text
+        return
+    for start in range(0, len(text), window):
+        yield text[start : start + window]
+
+
+__all__ = [
+    "CompiledPattern",
+    "CustomScanResult",
+    "OnMatch",
+    "scan",
+    "validate_custom_patterns",
+]

--- a/src/aorta/probe/classifier/verdict.py
+++ b/src/aorta/probe/classifier/verdict.py
@@ -6,10 +6,16 @@ Combines the per-tier detector outputs into the final
 (a) Any Tier 1–4 detector fires OR any ``custom_patterns[*]``
     with ``on_match: fail`` fires → ``verdict = "fail"``.
 
-(b) ``result.json::failure_detectors_fired`` lists ALL fired in
-    encounter order (Tier 1 first, then Tier 3 / Tier 4 / Tier 5
-    failures in that order; Tier 2 fires from the in-flight
-    monitor at the position the workload returns it).
+(b) ``result.json::failure_detectors_fired`` lists ALL fired in a
+    fixed encounter order: Tier 1, Tier 2, Tier 3, Tier 4, then
+    Tier 5 (``custom_patterns`` failures). The order is set by
+    :func:`resolve` (and the :class:`VerdictInputs` field order it
+    iterates), independent of when each tier physically fires
+    relative to the workload exit. The in-flight Tier 2 hang monitor
+    contributes its detector IDs to ``inputs.tier2`` before
+    :func:`resolve` is called, so even though the predicate fires
+    mid-run, the IDs always land between Tier 1 and Tier 3 in the
+    serialised list.
 
 (c) Any ``custom_patterns[*]`` with ``required_for_pass: true``
     AND none of them fired → add ``meta:missing_pass_signal`` to

--- a/src/aorta/probe/classifier/verdict.py
+++ b/src/aorta/probe/classifier/verdict.py
@@ -1,0 +1,122 @@
+"""Verdict precedence resolver for ``aorta probe`` Phase 2 (issue #188).
+
+Combines the per-tier detector outputs into the final
+``result.json`` shape. The rules (rubric §2.B FR 2.8) are:
+
+(a) Any Tier 1–4 detector fires OR any ``custom_patterns[*]``
+    with ``on_match: fail`` fires → ``verdict = "fail"``.
+
+(b) ``result.json::failure_detectors_fired`` lists ALL fired in
+    encounter order (Tier 1 first, then Tier 3 / Tier 4 / Tier 5
+    failures in that order; Tier 2 fires from the in-flight
+    monitor at the position the workload returns it).
+
+(c) Any ``custom_patterns[*]`` with ``required_for_pass: true``
+    AND none of them fired → add ``meta:missing_pass_signal`` to
+    ``failure_detectors_fired`` AND ``verdict = "fail"``.
+
+(d) Otherwise → ``verdict = "pass"``.
+
+``on_match: warn`` populates ``warn_detectors_fired`` only.
+``on_match: info`` populates ``capture`` only.
+
+The resolver consumes :class:`VerdictInputs` (a plain bundle of
+per-tier outputs) and returns :class:`Verdict`. Both are
+dataclasses so the call site stays declarative and unit tests can
+build inputs in one line.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from aorta.probe.classifier.tier5_custom import CompiledPattern, CustomScanResult
+
+# Synthesised detector ID for "the recipe asked for one required
+# pattern to fire and none did". The ``meta:`` prefix marks it as
+# coming from the verdict resolver, not from any tier directly.
+DETECTOR_MISSING_PASS_SIGNAL = "meta:missing_pass_signal"
+
+
+@dataclass
+class VerdictInputs:
+    """Per-tier outputs the resolver merges.
+
+    Order MATTERS for ``failure_detectors_fired``: the resolver
+    walks the lists in the order they appear on this struct
+    (tier1, tier2, tier3, tier4, custom-fail, meta) and appends in
+    that order so the final list is reproducible across runs
+    given the same inputs.
+
+    ``custom_required_patterns`` is the list of ``CompiledPattern``
+    objects with ``required_for_pass=True``, regardless of whether
+    they fired. The resolver compares against
+    ``custom_result.fired_required_ids`` to decide whether to
+    inject :data:`DETECTOR_MISSING_PASS_SIGNAL`.
+    """
+
+    tier1: list[str] = field(default_factory=list)
+    tier2: list[str] = field(default_factory=list)
+    tier3: list[str] = field(default_factory=list)
+    tier4: list[str] = field(default_factory=list)
+    custom_result: CustomScanResult = field(default_factory=CustomScanResult)
+    custom_required_patterns: tuple[CompiledPattern, ...] = ()
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Final resolution: ``verdict``, fired-detector lists, capture.
+
+    Each list is freshly constructed (not a reference to a
+    caller's mutable list) so a downstream consumer can mutate the
+    result without affecting cached classifier state.
+    """
+
+    verdict: str  # "pass" | "fail"
+    failure_detectors_fired: list[str]
+    warn_detectors_fired: list[str]
+    capture: dict[str, str | float | int]
+
+
+def resolve(inputs: VerdictInputs) -> Verdict:
+    """Apply the precedence rules and return the trial's verdict.
+
+    Pure: no FS / subprocess. Suited to table-driven parametrised
+    testing (rubric §2.B FR 2.8 — verdict precedence is a hard
+    gate).
+    """
+    failures: list[str] = []
+    failures.extend(inputs.tier1)
+    failures.extend(inputs.tier2)
+    failures.extend(inputs.tier3)
+    failures.extend(inputs.tier4)
+    failures.extend(inputs.custom_result.fail_detectors)
+
+    # required_for_pass: every pattern in the recipe whose flag is
+    # True must have fired. If at least one didn't, synthesise
+    # ``meta:missing_pass_signal`` so the trial fails with a
+    # clear, namespaced reason. The check considers ONLY patterns
+    # whose .required_for_pass is True; non-required patterns
+    # have no effect here.
+    required_ids = {p.detector_id for p in inputs.custom_required_patterns if p.required_for_pass}
+    if required_ids and not (required_ids <= inputs.custom_result.fired_required_ids):
+        failures.append(DETECTOR_MISSING_PASS_SIGNAL)
+
+    warns = list(inputs.custom_result.warn_detectors)
+    capture = dict(inputs.custom_result.capture)
+
+    verdict = "fail" if failures else "pass"
+    return Verdict(
+        verdict=verdict,
+        failure_detectors_fired=failures,
+        warn_detectors_fired=warns,
+        capture=capture,
+    )
+
+
+__all__ = [
+    "DETECTOR_MISSING_PASS_SIGNAL",
+    "Verdict",
+    "VerdictInputs",
+    "resolve",
+]

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -8,8 +8,12 @@ no subprocess.
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Sequence
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from aorta.triage.recipe import Recipe
 
 VALID_ENV_PASSTHROUGH_MODES: tuple[Literal["inherit", "file"], ...] = ("inherit", "file")
 
@@ -174,6 +178,40 @@ def validate_trailing_argv(argv: tuple[str, ...]) -> tuple[str, ...]:
     return argv
 
 
+def apply_recipe_overrides(
+    recipe: Recipe,
+    *,
+    ticket: str | None,
+    cli_passthrough_mode: Literal["inherit", "file"] | None,
+) -> Recipe:
+    """Layer CLI flags on top of a loaded probe-mode ``Recipe``.
+
+    Two overlays today:
+
+    * ``--ticket`` -- when set, replaces ``recipe.ticket``;
+    * ``--env-passthrough-mode`` -- when set (i.e. the user actually
+      passed the flag), replaces ``recipe.probe_extras.env_passthrough_mode``.
+
+    The caller must verify ``recipe.probe_extras is not None`` before
+    invoking this helper (probe-mode discriminator is the CLI's
+    responsibility). Living in ``aorta.probe.cli_helpers`` so the
+    Click handler stays a thin shim per FR 1.15 (handler ≤ 60 lines,
+    enforced by ``tests/probe/test_cli_parsing.py::test_handler_is_thin_shim``).
+    """
+    probe_extras = recipe.probe_extras
+    assert probe_extras is not None, "apply_recipe_overrides: not a probe-mode recipe"
+    if ticket is not None:
+        recipe = dataclasses.replace(recipe, ticket=ticket)
+    if cli_passthrough_mode is not None:
+        recipe = dataclasses.replace(
+            recipe,
+            probe_extras=dataclasses.replace(
+                probe_extras, env_passthrough_mode=cli_passthrough_mode
+            ),
+        )
+    return recipe
+
+
 def format_dry_run_line(
     cell_name: str,
     env: dict[str, str],
@@ -192,6 +230,7 @@ def format_dry_run_line(
 __all__ = [
     "VALID_ENV_PASSTHROUGH_MODES",
     "ProbeUsageError",
+    "apply_recipe_overrides",
     "format_dry_run_line",
     "help_token_in_option_zone",
     "parse_env_passthrough_mode",

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -50,12 +50,19 @@ def reject_flag_shaped_value(option_name: str, value: str | None) -> None:
         )
 
 
-def help_token_in_option_zone(args: Sequence[str], value_taking_options: frozenset[str]) -> bool:
-    """True iff ``--help`` / ``-h`` appears in the aorta-option zone.
+_DEFAULT_BYPASS_TOKENS: frozenset[str] = frozenset({"--help", "-h"})
+
+
+def help_token_in_option_zone(
+    args: Sequence[str],
+    value_taking_options: frozenset[str],
+    bypass_tokens: frozenset[str] = _DEFAULT_BYPASS_TOKENS,
+) -> bool:
+    """True iff a bypass token (default ``--help``/``-h``) appears in the aorta-option zone.
 
     The "aorta-option zone" is the prefix of ``args`` that comes BEFORE
     either the explicit ``--`` separator or the first non-option
-    positional argument (the user-command executable). Help tokens
+    positional argument (the user-command executable). Bypass tokens
     appearing AFTER the user command (``aorta probe --recipe r -- echo
     --help`` or ``aorta probe --recipe r echo --help`` with
     ``allow_interspersed_args=False``) are part of the user command and
@@ -67,8 +74,13 @@ def help_token_in_option_zone(args: Sequence[str], value_taking_options: frozens
     ``params``). ``--opt=value`` is consumed as a single token. Flag
     options (``-v``, ``--dry-run``) are single tokens. The first token
     that doesn't start with ``-`` (and isn't an option value) marks
-    the user-command boundary; ``--help`` at or after that boundary is
-    user-command content.
+    the user-command boundary; a bypass token at or after that boundary
+    is user-command content.
+
+    ``bypass_tokens`` defaults to ``{"--help", "-h"}`` for callers that
+    only need the help short-circuit. Phase 2 callers pass an extended
+    set to also include ``--list-patterns`` (a flag that prints the
+    Tier-4 catalogue and exits without consuming a user command).
 
     Defends against the bot-flagged misparse where ``aorta probe
     --recipe r --output o echo --help`` would silently skip the
@@ -77,7 +89,7 @@ def help_token_in_option_zone(args: Sequence[str], value_taking_options: frozens
     i = 0
     while i < len(args):
         token = args[i]
-        if token in ("--help", "-h"):
+        if token in bypass_tokens:
             return True
         if token == "--":
             return False

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -58,9 +58,9 @@ class ProbeExtras:
     Carried as a typed sidecar (rather than smuggled into
     ``workload_config``) so the runner can read them without
     re-parsing the YAML and so the triage code path stays untouched.
-    Phase 2 will extend this with classifier knobs (``hang_window_sec``,
-    ``hang_grace_period_at_start``, ``custom_patterns``); Phase 3 adds
-    the ``redaction`` block. Phase 1 ships just the four fields below.
+    Phase 2 added the classifier knobs (``hang_window_sec``,
+    ``hang_grace_period_at_start``, ``custom_patterns``) -- see the
+    fields below. Phase 3 will add the ``redaction`` block.
 
     Attributes:
         step_time_regex: Optional regex string; Phase 1 keeps this on

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -213,18 +213,35 @@ def _validate_env_passthrough_mode(raw: Any) -> Literal["inherit", "file"]:
     return "file" if raw == "file" else "inherit"
 
 
-def _validate_positive_seconds(path_hint: str, raw: Any, *, default: float) -> float:
+def _validate_positive_seconds(
+    path_hint: str,
+    raw: Any,
+    *,
+    default: float,
+    allow_zero: bool = False,
+) -> float:
     """Validate a positive-seconds Phase-2 knob (hang_window_sec, etc.).
 
     Returns ``default`` when ``raw`` is None / missing; otherwise
     coerces to ``float`` after rejecting bools (which would pass
     ``isinstance(int)`` checks) and non-positive numbers.
+
+    ``allow_zero`` flips the lower bound from strict (``> 0``) to
+    inclusive (``>= 0``). Used for ``hang_grace_period_at_start``,
+    which the runtime predicate explicitly supports as "no grace
+    period -- a hang can be detected immediately after the window
+    elapses" (useful for short-running repros where 60s of grace
+    swallows the trial). ``hang_window_sec`` keeps the strict bound
+    because a zero window would re-trip the predicate on every poll.
     """
     if raw is None:
         return float(default)
     if isinstance(raw, bool) or not isinstance(raw, (int, float)):
         raise RecipeSchemaError(f"{path_hint}: must be a number, got {type(raw).__name__}")
-    if raw <= 0:
+    if allow_zero:
+        if raw < 0:
+            raise RecipeSchemaError(f"{path_hint}: must be >= 0 when set, got {raw}")
+    elif raw <= 0:
         raise RecipeSchemaError(f"{path_hint}: must be > 0 when set, got {raw}")
     return float(raw)
 
@@ -279,6 +296,7 @@ def build_probe_recipe_from_dict(
         "recipe.hang_grace_period_at_start",
         data.get("hang_grace_period_at_start"),
         default=DEFAULT_HANG_GRACE_SEC,
+        allow_zero=True,
     )
 
     # confound block is permitted (already in _PROBE_TOP_LEVEL) but

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -17,6 +17,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from aorta.probe.classifier.tier2_hang import (
+    DEFAULT_HANG_GRACE_SEC,
+    DEFAULT_HANG_WINDOW_SEC,
+)
+from aorta.probe.classifier.tier5_custom import (
+    CompiledPattern,
+    validate_custom_patterns,
+)
 from aorta.registry import get_mitigation
 from aorta.registry.errors import UnknownMitigationError
 from aorta.triage.recipe import (
@@ -95,6 +103,15 @@ class ProbeExtras:
     # only. ``dict`` rather than ``frozendict`` to keep the dataclass
     # JSON-serialisable for matrix.json.
     cell_envs: dict[str, dict[str, str]] = field(default_factory=dict)
+    # Phase 2 additions (issue #188): compiled custom_patterns +
+    # hang knobs threaded onto the recipe so the runner can attach
+    # them to each cell's ``RunRequest.probe_extras`` without
+    # re-parsing the YAML. ``custom_patterns`` is empty by default
+    # so probe recipes that don't set the block round-trip exactly
+    # as Phase 1 produced them.
+    custom_patterns: tuple[CompiledPattern, ...] = ()
+    hang_window_sec: float = DEFAULT_HANG_WINDOW_SEC
+    hang_grace_period_at_start: float = DEFAULT_HANG_GRACE_SEC
 
 
 def _ensure_str_list(path_hint: str, raw: Any, *, allow_empty: bool = False) -> list[str]:
@@ -196,6 +213,22 @@ def _validate_env_passthrough_mode(raw: Any) -> Literal["inherit", "file"]:
     return "file" if raw == "file" else "inherit"
 
 
+def _validate_positive_seconds(path_hint: str, raw: Any, *, default: float) -> float:
+    """Validate a positive-seconds Phase-2 knob (hang_window_sec, etc.).
+
+    Returns ``default`` when ``raw`` is None / missing; otherwise
+    coerces to ``float`` after rejecting bools (which would pass
+    ``isinstance(int)`` checks) and non-positive numbers.
+    """
+    if raw is None:
+        return float(default)
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise RecipeSchemaError(f"{path_hint}: must be a number, got {type(raw).__name__}")
+    if raw <= 0:
+        raise RecipeSchemaError(f"{path_hint}: must be > 0 when set, got {raw}")
+    return float(raw)
+
+
 def build_probe_recipe_from_dict(
     data: dict,
     sidecar_files: tuple[Path, ...] | None,
@@ -236,6 +269,17 @@ def build_probe_recipe_from_dict(
     collect_paths = _validate_collect_paths(data.get("collect_paths"))
     timeout_per_trial = _validate_timeout_per_trial(data.get("timeout_per_trial"))
     env_passthrough_mode = _validate_env_passthrough_mode(data.get("env_passthrough_mode"))
+    custom_patterns = validate_custom_patterns(data.get("custom_patterns"))
+    hang_window_sec = _validate_positive_seconds(
+        "recipe.hang_window_sec",
+        data.get("hang_window_sec"),
+        default=DEFAULT_HANG_WINDOW_SEC,
+    )
+    hang_grace_period_at_start = _validate_positive_seconds(
+        "recipe.hang_grace_period_at_start",
+        data.get("hang_grace_period_at_start"),
+        default=DEFAULT_HANG_GRACE_SEC,
+    )
 
     # confound block is permitted (already in _PROBE_TOP_LEVEL) but
     # not meaningful for Tier-1-only Phase 1 -- pass it through with
@@ -355,6 +399,9 @@ def build_probe_recipe_from_dict(
         mitigation_axis=tuple(mitigation_axis),
         diagnostic_axis=tuple(diagnostic_axis),
         cell_envs=cell_envs,
+        custom_patterns=custom_patterns,
+        hang_window_sec=hang_window_sec,
+        hang_grace_period_at_start=hang_grace_period_at_start,
     )
 
     return Recipe(

--- a/src/aorta/probe/sandbox.py
+++ b/src/aorta/probe/sandbox.py
@@ -54,20 +54,32 @@ MAX_LOG_BYTES = 10 * 1024 * 1024  # 10 MiB
 # parser could be coerced into.
 MAX_EXPR_LEN = 256
 
-# Magnitude cap on integer literals. Catches the
-# ``2 ** 1000000000``-shaped resource-exhaustion input in the rubric's
-# hostile-input corpus (§2.E.4): every operand is a whitelisted
-# ``Constant`` and ``Pow`` is in :data:`_ALLOWED_NODES`, so the only
-# defense against ``2 ** <huge>`` is to refuse the huge literal at
-# parse time. ``10**9`` is comfortably above every legitimate value a
-# ``condition`` would name (exit codes, walltime in seconds, VRAM in
-# MiB, log-line counts) and orders of magnitude below the size that
-# turns ``int.__pow__`` into a memory bomb.
+# Magnitude cap on integer literals. Catches OOM-bait constants like
+# ``exit_code == 1000000000`` from ever reaching ``eval`` -- a literal
+# that survives parse-time validation can still be evaluated, and there
+# is no runtime numeric guard once the expression is compiled. ``10**9``
+# is comfortably above every legitimate value a ``condition`` would
+# name (exit codes, walltime in seconds, VRAM in MiB, log-line counts)
+# and orders of magnitude below the size that turns ``int.__mul__``
+# into a memory bomb.
+#
+# Exponentiation (``**``) is NOT in the allow-list (see
+# :data:`_ALLOWED_NODES`) so the magnitude cap is no longer the last
+# line of defence against ``2 ** capture['n']``-style attacks: any Pow
+# expression rejects at parse time before either operand is considered.
 MAX_INT_CONSTANT = 10**9
 
 # AST node types that the walker accepts. Anything else (Lambda,
 # ListComp, DictComp, SetComp, GeneratorExp, FormattedValue,
 # JoinedStr, ClassDef, FunctionDef, Import, ...) rejects.
+#
+# ``ast.Pow`` is deliberately EXCLUDED. The :data:`MAX_INT_CONSTANT`
+# magnitude cap only restricts literal constants -- it cannot stop
+# ``2 ** int(capture['exp'])`` from allocating a giant Python int from
+# untrusted regex-capture text. Legitimate ``condition`` expressions
+# are simple boolean checks (``exit_code == 137``,
+# ``walltime_sec > 60``); none of them need exponentiation, so dropping
+# ``**`` entirely is a free safety win.
 _ALLOWED_NODES = frozenset(
     {
         ast.Expression,
@@ -95,7 +107,6 @@ _ALLOWED_NODES = frozenset(
         ast.Div,
         ast.Mod,
         ast.FloorDiv,
-        ast.Pow,
         ast.USub,
         ast.UAdd,
         ast.Load,
@@ -242,18 +253,21 @@ def _check_node(node: ast.AST) -> None:
 
     if isinstance(node, ast.Constant):
         # ``int`` and ``float`` constants are subject to a magnitude
-        # cap so ``2 ** 1000000000`` (and similar resource-exhaustion
-        # inputs in the hostile-input corpus, §2.E.4) refuses at
-        # parse time before ``eval`` can produce a memory-bombing
-        # integer. ``str``/``bool``/``None`` constants pass through.
+        # cap so a literal like ``exit_code == 1000000000`` (and
+        # similar resource-exhaustion inputs in the hostile-input
+        # corpus, §2.E.4) refuses at parse time before ``eval`` can
+        # construct a large arbitrary-precision integer at compile
+        # time. ``str``/``bool``/``None`` constants pass through.
+        # ``**`` is no longer in the allow-list (see
+        # :data:`_ALLOWED_NODES`), so Pow-based ints from non-literal
+        # exponents are stopped one layer up.
         constant_value = node.value
         if isinstance(constant_value, bool):
             return
         if isinstance(constant_value, int) and abs(constant_value) >= MAX_INT_CONSTANT:
             raise SandboxError(
                 f"condition: integer constant magnitude {abs(constant_value)} >= "
-                f"{MAX_INT_CONSTANT} (rejected to prevent resource exhaustion "
-                "from operators like ``**``)"
+                f"{MAX_INT_CONSTANT} (rejected to prevent resource exhaustion)"
             )
         return
 

--- a/src/aorta/probe/sandbox.py
+++ b/src/aorta/probe/sandbox.py
@@ -35,10 +35,25 @@ from __future__ import annotations
 
 import ast
 import math
+import sys
 from types import CodeType
 from typing import Any
 
 from aorta.triage.recipe import RecipeSchemaError
+
+# CPython 3.11+ caps ``int()``-from-string parsing at 4300 digits by
+# default (`PEP 651 / GH-95778`) to defend against the O(n^2) digit
+# parser. 3.10 does not. The sandbox allows ``int()`` calls (it's a
+# legitimate move on a numeric regex capture), and ``capture[...]``
+# can return a multi-megabyte string when a hostile pattern matches
+# a huge log window — so ``int(capture['x'])`` would burn the CPU
+# for minutes on 3.10. Apply the same 4300-digit cap explicitly at
+# import time so the sandbox has matching behavior across the
+# project's supported Python versions (pyproject ``requires-python
+# = ">=3.10"``). No-op on 3.11+ where the same cap is already the
+# default. Per Sonbol's PR #197 review.
+if hasattr(sys, "set_int_max_str_digits"):
+    sys.set_int_max_str_digits(4300)
 
 # Hard cap on per-trial log bytes scanned for regex matches. Hardens
 # against catastrophic backtracking on operator-supplied regex without
@@ -247,11 +262,29 @@ def _check_node(node: ast.AST) -> None:
 
     if isinstance(node, ast.Subscript):
         # ``capture[...]`` only. ``foo[0]`` rejects because the
-        # subscripted name must be ``capture``; the index expression
-        # is itself walked, so ``capture[exit_code]`` would still be
-        # subject to the ``Name`` check on ``exit_code``.
+        # subscripted name must be ``capture``.
         if not (isinstance(node.value, ast.Name) and node.value.id == "capture"):
             raise SandboxError("condition: subscript only allowed on capture[...]")
+        # The slice must be a *string literal* — anything else (a
+        # ``Name`` like ``capture[exit_code]``, a slice like
+        # ``capture['x':]``, a tuple/star/call) gets through the
+        # whitelist of nested node types because ``ast.walk``
+        # validates them in isolation, but lands as a runtime
+        # ``KeyError`` / ``TypeError`` on eval. The Tier-5 runner
+        # then swallows that with ``except Exception: fired =
+        # False`` (tier5_custom.py post-eval), so a typoed recipe
+        # ships to prod and the detector silently never fires.
+        # Closing this at parse time means the sandbox contract
+        # ("you can only look up named string keys in capture") is
+        # actually enforced, and the recipe author gets a
+        # ``SandboxError`` at recipe-load time naming the bad index
+        # rather than a silent no-fire. Per Sonbol's PR #197
+        # review.
+        if not (isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str)):
+            raise SandboxError(
+                f"condition: capture[...] index must be a string literal, "
+                f"got {ast.unparse(node.slice)!r}"
+            )
         return
 
     if isinstance(node, ast.Call):

--- a/src/aorta/probe/sandbox.py
+++ b/src/aorta/probe/sandbox.py
@@ -63,23 +63,42 @@ MAX_EXPR_LEN = 256
 # and orders of magnitude below the size that turns ``int.__mul__``
 # into a memory bomb.
 #
-# Exponentiation (``**``) is NOT in the allow-list (see
-# :data:`_ALLOWED_NODES`) so the magnitude cap is no longer the last
-# line of defence against ``2 ** capture['n']``-style attacks: any Pow
-# expression rejects at parse time before either operand is considered.
+# The resource-exhaustion operators (``**``, ``*``, ``%``) are also
+# NOT in the allow-list (see :data:`_ALLOWED_NODES`), so the
+# magnitude cap is not the last line of defence against
+# ``2 ** capture['n']``, ``'a' * 999999998``, or
+# ``'%999999998s' % capture['x']``-style attacks: those expressions
+# reject at parse time before either operand is considered.
 MAX_INT_CONSTANT = 10**9
 
 # AST node types that the walker accepts. Anything else (Lambda,
 # ListComp, DictComp, SetComp, GeneratorExp, FormattedValue,
 # JoinedStr, ClassDef, FunctionDef, Import, ...) rejects.
 #
-# ``ast.Pow`` is deliberately EXCLUDED. The :data:`MAX_INT_CONSTANT`
-# magnitude cap only restricts literal constants -- it cannot stop
-# ``2 ** int(capture['exp'])`` from allocating a giant Python int from
-# untrusted regex-capture text. Legitimate ``condition`` expressions
-# are simple boolean checks (``exit_code == 137``,
-# ``walltime_sec > 60``); none of them need exponentiation, so dropping
-# ``**`` entirely is a free safety win.
+# ``ast.Pow``, ``ast.Mult``, and ``ast.Mod`` are deliberately EXCLUDED:
+#
+# * ``Pow`` -- :data:`MAX_INT_CONSTANT` only restricts literal
+#   constants. ``2 ** int(capture['exp'])`` would still allocate a
+#   giant Python int from untrusted regex-capture text. Dropping
+#   ``**`` closes that path at parse time before either operand is
+#   considered.
+# * ``Mult`` -- Python's ``*`` operator overloads on strings and
+#   tuples (``'a' * 999999998`` allocates a ~1 GiB string). The
+#   integer-literal cap is at 10**9 (just below the
+#   string-repetition pressure point), but a literal like
+#   ``999999998`` slips under the cap and detonates at eval time;
+#   the walker can't distinguish "numeric multiply" from "string
+#   repeat" because operand types are only known at runtime. The
+#   simplest correct defence is to forbid ``*`` entirely.
+# * ``Mod`` -- Python's ``%`` overloads on strings as printf-style
+#   formatting (``'%999999998s' % capture['x']`` allocates the same
+#   billion-byte buffer). Same reasoning: no walk-time type
+#   discrimination, drop the operator.
+#
+# Legitimate ``condition`` expressions are simple boolean checks
+# (``exit_code == 137``, ``walltime_sec > 60``, ``peak_vram_mib > 100``);
+# none of them need ``**``, ``*``, or ``%``, so dropping all three
+# is a free safety win.
 _ALLOWED_NODES = frozenset(
     {
         ast.Expression,
@@ -103,9 +122,7 @@ _ALLOWED_NODES = frozenset(
         ast.GtE,
         ast.Add,
         ast.Sub,
-        ast.Mult,
         ast.Div,
-        ast.Mod,
         ast.FloorDiv,
         ast.USub,
         ast.UAdd,

--- a/src/aorta/probe/sandbox.py
+++ b/src/aorta/probe/sandbox.py
@@ -59,7 +59,11 @@ if hasattr(sys, "set_int_max_str_digits"):
 # against catastrophic backtracking on operator-supplied regex without
 # requiring a different regex engine (Phase 2 explicitly forbids the
 # ``regex`` / ``re2`` swap). Per-scan window; logs larger than this
-# are scanned in successive ``MAX_LOG_BYTES``-sized chunks.
+# are scanned in successive windows that overlap by a small
+# ``_WINDOW_OVERLAP_BYTES`` slice (defined in
+# :mod:`aorta.probe.classifier.tier4_patterns` /
+# :mod:`aorta.probe.classifier.tier5_custom`) so a match straddling
+# the seam still fires.
 MAX_LOG_BYTES = 10 * 1024 * 1024  # 10 MiB
 
 # Per-expression character cap (post-strip). Prevents an attacker from

--- a/src/aorta/probe/sandbox.py
+++ b/src/aorta/probe/sandbox.py
@@ -1,0 +1,319 @@
+"""``condition:`` expression sandbox for ``custom_patterns`` (issue #188 Phase 2).
+
+The ``condition`` field on a ``custom_patterns[*].match`` block lets a
+recipe author write a small boolean expression that is evaluated AFTER
+the regex matches a per-trial log line. The expression has access to a
+fixed set of variables (the named regex captures, the trial's exit
+code, walltime, and peak VRAM) and a fixed set of callables (``float``,
+``int``, ``len``, ``math.isnan``, ``math.isinf``). It is the only place
+where user-supplied YAML can drive arbitrary computation against
+trial-time data, so the security posture is **default-deny at
+parse time**:
+
+1. ``validate_and_compile`` walks the parsed AST and rejects anything
+   that is not in the explicit allow-list (``_ALLOWED_NODES``,
+   ``_ALLOWED_NAMES``, ``_ALLOWED_CALLS``).
+2. ``eval`` is invoked with ``__builtins__={}`` so even if a hostile
+   expression slipped past the whitelist it cannot reach the import
+   machinery.
+3. Expressions longer than :data:`MAX_EXPR_LEN` characters (after
+   stripping) are rejected before ``ast.parse`` to prevent resource
+   exhaustion at compile time.
+
+The whitelist is intentionally small (~80 lines of walker code). A
+third-party sandbox library (e.g. ``RestrictedPython``) was considered
+and rejected: heavyweight dep, more permissive defaults than the issue
+demands, and an auditable hand-rolled walker is the response a security
+reviewer can sign off on by reading.
+
+See :mod:`docs/probe-188/sandbox.md` for the worked-example corpus and
+``tests/probe/fixtures/conditions/hostile.txt`` for the parameterised
+rejection suite (`tests/probe/test_sandbox.py::test_hostile_inputs_rejected`).
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+from types import CodeType
+from typing import Any
+
+from aorta.triage.recipe import RecipeSchemaError
+
+# Hard cap on per-trial log bytes scanned for regex matches. Hardens
+# against catastrophic backtracking on operator-supplied regex without
+# requiring a different regex engine (Phase 2 explicitly forbids the
+# ``regex`` / ``re2`` swap). Per-scan window; logs larger than this
+# are scanned in successive ``MAX_LOG_BYTES``-sized chunks.
+MAX_LOG_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+# Per-expression character cap (post-strip). Prevents an attacker from
+# burning ``ast.parse`` time on a multi-MB expression. 256 chars is
+# enough for every legitimate ``condition`` (a half-dozen comparisons
+# at most) and well under any pathological-backtracking input the
+# parser could be coerced into.
+MAX_EXPR_LEN = 256
+
+# Magnitude cap on integer literals. Catches the
+# ``2 ** 1000000000``-shaped resource-exhaustion input in the rubric's
+# hostile-input corpus (§2.E.4): every operand is a whitelisted
+# ``Constant`` and ``Pow`` is in :data:`_ALLOWED_NODES`, so the only
+# defense against ``2 ** <huge>`` is to refuse the huge literal at
+# parse time. ``10**9`` is comfortably above every legitimate value a
+# ``condition`` would name (exit codes, walltime in seconds, VRAM in
+# MiB, log-line counts) and orders of magnitude below the size that
+# turns ``int.__pow__`` into a memory bomb.
+MAX_INT_CONSTANT = 10**9
+
+# AST node types that the walker accepts. Anything else (Lambda,
+# ListComp, DictComp, SetComp, GeneratorExp, FormattedValue,
+# JoinedStr, ClassDef, FunctionDef, Import, ...) rejects.
+_ALLOWED_NODES = frozenset(
+    {
+        ast.Expression,
+        ast.BoolOp,
+        ast.BinOp,
+        ast.UnaryOp,
+        ast.Compare,
+        ast.Call,
+        ast.Subscript,
+        ast.Name,
+        ast.Constant,
+        ast.IfExp,
+        ast.And,
+        ast.Or,
+        ast.Not,
+        ast.Eq,
+        ast.NotEq,
+        ast.Lt,
+        ast.LtE,
+        ast.Gt,
+        ast.GtE,
+        ast.Add,
+        ast.Sub,
+        ast.Mult,
+        ast.Div,
+        ast.Mod,
+        ast.FloorDiv,
+        ast.Pow,
+        ast.USub,
+        ast.UAdd,
+        ast.Load,
+    }
+)
+
+# The four trial-time variables plus the ``math`` module reference
+# plus the names of every callable in :data:`_ALLOWED_CALLS` (bare
+# ``Name`` lookups for ``float`` / ``int`` / ``len`` arrive at the
+# walker before the ``Call`` check fires; allowing them here lets the
+# walker pass them so the per-Call whitelist still gets to decide).
+# Any other ``Name`` lookup (``os``, ``__import__``, ``True`` is fine
+# because it parses as ``Constant``, ``capture.items`` is fine because
+# that's an attribute walk -- rejected separately).
+_ALLOWED_NAMES = frozenset(
+    {
+        "capture",
+        "exit_code",
+        "walltime_sec",
+        "peak_vram_mib",
+        "math",
+        "float",
+        "int",
+        "len",
+    }
+)
+
+# Callables a condition may invoke. ``ast.unparse`` of the call's
+# ``func`` must be exactly one of these strings. ``getattr``,
+# ``hasattr``, ``type``, ``isinstance``, ``len`` on a non-capture
+# value, etc., all fail this check.
+_ALLOWED_CALLS = frozenset({"float", "int", "len", "math.isnan", "math.isinf"})
+
+
+class SandboxError(RecipeSchemaError):
+    """Raised when a ``condition`` expression fails sandbox validation.
+
+    Subclasses :class:`RecipeSchemaError` so the existing recipe-loader
+    error path (CLI handler catches ``RecipeSchemaError``, surfaces as
+    a ``ClickException``) catches it without code changes. The
+    distinct subclass lets tests / callers assert "this rejection
+    came from the sandbox" specifically.
+    """
+
+
+def validate_and_compile(expr: str) -> CodeType:
+    """Parse, whitelist-validate, and compile a ``condition`` expression.
+
+    Returns a :class:`CodeType` object ready for
+    ``eval(code, globals, locals)`` with ``__builtins__={}`` and
+    ``math`` in ``globals`` (see :func:`evaluate`).
+
+    Raises :class:`SandboxError` if any of the following hold:
+
+    * The expression is empty or longer than :data:`MAX_EXPR_LEN`
+      characters after ``str.strip()``.
+    * ``ast.parse(expr, mode="eval")`` raises ``SyntaxError``.
+    * The AST contains a node type not in :data:`_ALLOWED_NODES`,
+      an :class:`ast.Attribute` access that isn't ``math.isnan`` or
+      ``math.isinf``, a :class:`ast.Name` lookup outside
+      :data:`_ALLOWED_NAMES`, a :class:`ast.Subscript` against
+      anything other than ``capture[...]``, or a :class:`ast.Call`
+      whose target isn't in :data:`_ALLOWED_CALLS`.
+
+    The check is at PARSE TIME — a hostile expression that walks the
+    object graph or imports something can never reach :func:`evaluate`.
+    """
+    if not isinstance(expr, str):
+        raise SandboxError(f"condition: must be a string, got {type(expr).__name__}")
+    stripped = expr.strip()
+    if not stripped:
+        raise SandboxError("condition: expression must be non-empty")
+    if len(stripped) > MAX_EXPR_LEN:
+        raise SandboxError(
+            f"condition: expression length {len(stripped)} exceeds the "
+            f"{MAX_EXPR_LEN}-character cap (rejected before ast.parse to "
+            "bound parse-time work)"
+        )
+
+    try:
+        tree = ast.parse(stripped, mode="eval")
+    except SyntaxError as exc:
+        raise SandboxError(
+            f"condition: syntax error: {exc.msg} (line {exc.lineno}, col {exc.offset})"
+        ) from exc
+
+    for node in ast.walk(tree):
+        _check_node(node)
+
+    return compile(tree, "<condition>", "eval")
+
+
+def _check_node(node: ast.AST) -> None:
+    """Whitelist-check a single AST node.
+
+    Split out so the per-node logic stays small enough to audit. The
+    rules deliberately mirror the rubric §2.E.3 sketch with one
+    addition: a ``Compare`` node's comparator chain is implicitly
+    valid because each comparator is itself walked by ``ast.walk``,
+    which means the per-node check runs against each one too. The
+    same applies to ``BoolOp`` operands and ``BinOp`` left/right.
+    """
+    if isinstance(node, ast.Attribute):
+        # The only attribute access we allow is ``math.<isnan|isinf>``.
+        # Everything else (``capture.update``, ``(0).__class__``,
+        # ``math.__loader__``) rejects.
+        value = node.value
+        if not (
+            isinstance(value, ast.Name) and value.id == "math" and node.attr in ("isnan", "isinf")
+        ):
+            raise SandboxError(f"condition: forbidden attribute access: {ast.unparse(node)}")
+        return
+
+    if type(node) not in _ALLOWED_NODES:
+        raise SandboxError(f"condition: forbidden AST node: {type(node).__name__}")
+
+    if isinstance(node, ast.Name):
+        if node.id not in _ALLOWED_NAMES:
+            raise SandboxError(f"condition: forbidden name: {node.id}")
+        return
+
+    if isinstance(node, ast.Subscript):
+        # ``capture[...]`` only. ``foo[0]`` rejects because the
+        # subscripted name must be ``capture``; the index expression
+        # is itself walked, so ``capture[exit_code]`` would still be
+        # subject to the ``Name`` check on ``exit_code``.
+        if not (isinstance(node.value, ast.Name) and node.value.id == "capture"):
+            raise SandboxError("condition: subscript only allowed on capture[...]")
+        return
+
+    if isinstance(node, ast.Call):
+        # The full dotted path for the call's target. ``ast.unparse``
+        # handles attribute chains (`math.isnan`) and bare names
+        # (`float`) uniformly. The whitelist is exact-match.
+        try:
+            target = ast.unparse(node.func)
+        except (AttributeError, ValueError) as exc:
+            raise SandboxError(
+                f"condition: forbidden call target: {type(node.func).__name__}"
+            ) from exc
+        if target not in _ALLOWED_CALLS:
+            raise SandboxError(f"condition: forbidden call: {target}")
+        return
+
+    if isinstance(node, ast.Constant):
+        # ``int`` and ``float`` constants are subject to a magnitude
+        # cap so ``2 ** 1000000000`` (and similar resource-exhaustion
+        # inputs in the hostile-input corpus, §2.E.4) refuses at
+        # parse time before ``eval`` can produce a memory-bombing
+        # integer. ``str``/``bool``/``None`` constants pass through.
+        constant_value = node.value
+        if isinstance(constant_value, bool):
+            return
+        if isinstance(constant_value, int) and abs(constant_value) >= MAX_INT_CONSTANT:
+            raise SandboxError(
+                f"condition: integer constant magnitude {abs(constant_value)} >= "
+                f"{MAX_INT_CONSTANT} (rejected to prevent resource exhaustion "
+                "from operators like ``**``)"
+            )
+        return
+
+
+def evaluate(
+    code: CodeType,
+    *,
+    capture: dict[str, str],
+    exit_code: int,
+    walltime_sec: float,
+    peak_vram_mib: int | None,
+) -> bool:
+    """Run a sandbox-compiled ``condition`` against trial-time data.
+
+    ``peak_vram_mib`` is bound to ``0`` when the actual value is
+    ``None`` so a condition that references it (``peak_vram_mib >
+    100``) does not blow up with a ``TypeError`` mid-eval. Documented
+    in rubric §2.E.1 — ``int | None`` at the source, ``int`` at
+    eval time.
+
+    ``__builtins__`` is set to ``{}`` so even a hostile expression
+    that slipped past :func:`validate_and_compile` (it shouldn't —
+    every callable goes through the whitelist) cannot reach
+    ``__import__``. ``math`` is the only module in scope; the
+    whitelist already restricts attribute access to ``math.isnan`` /
+    ``math.isinf`` so the broader module surface is unreachable.
+
+    Returns the result coerced to ``bool``. A non-boolean expression
+    (``capture['x']`` returning a string) follows Python's usual
+    truthiness rules — the recipe author can be more strict by
+    wrapping with ``len(...)`` or comparing explicitly.
+    """
+    if peak_vram_mib is None:
+        peak_vram_mib = 0
+    # ``__builtins__={}`` neutralises ``__import__``; the whitelisted
+    # callables (``float``, ``int``, ``len``) are explicitly seeded
+    # into ``globals`` so they resolve without re-enabling the
+    # builtins namespace. ``math`` is the only module reference in
+    # scope; attribute access is parse-time-restricted to
+    # ``math.isnan`` / ``math.isinf`` (see :func:`validate_and_compile`).
+    globals_dict: dict[str, Any] = {
+        "__builtins__": {},
+        "math": math,
+        "float": float,
+        "int": int,
+        "len": len,
+    }
+    locals_dict: dict[str, Any] = {
+        "capture": capture,
+        "exit_code": exit_code,
+        "walltime_sec": walltime_sec,
+        "peak_vram_mib": peak_vram_mib,
+    }
+    return bool(eval(code, globals_dict, locals_dict))  # noqa: S307 -- sandboxed
+
+
+__all__ = [
+    "MAX_EXPR_LEN",
+    "MAX_LOG_BYTES",
+    "SandboxError",
+    "evaluate",
+    "validate_and_compile",
+]

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -594,18 +594,12 @@ def _run_single_trial(
     stdout_fh: Any = None
     stderr_fh: Any = None
     if request.save_logs and should_write:
-        log_basename = (
-            f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
-        )
+        log_basename = f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
         candidate_stdout = results_dir / f"{log_basename}.stdout.log"
         candidate_stderr = results_dir / f"{log_basename}.stderr.log"
         try:
-            stdout_fh = open(
-                candidate_stdout, "w", encoding="utf-8", errors="backslashreplace"
-            )
-            stderr_fh = open(
-                candidate_stderr, "w", encoding="utf-8", errors="backslashreplace"
-            )
+            stdout_fh = open(candidate_stdout, "w", encoding="utf-8", errors="backslashreplace")
+            stderr_fh = open(candidate_stderr, "w", encoding="utf-8", errors="backslashreplace")
         except OSError as exc:
             if stdout_fh is not None:
                 stdout_fh.close()
@@ -763,10 +757,68 @@ def _run_single_trial(
         output_path = results_dir / (
             f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}.json"
         )
+        serialized = trial_result.to_dict()
+        # ``_aorta_probe_extras.custom_patterns`` is a tuple of
+        # :class:`aorta.probe.classifier.tier5_custom.CompiledPattern`
+        # objects carrying a compiled ``re.Pattern`` and a
+        # ``CodeType`` -- neither is JSON-serializable, so leaving
+        # the tuple untouched would crash this ``json.dump`` for
+        # every probe-mode trial that configured custom patterns
+        # (#197 round-7 review). Sanitize down to a JSON-safe
+        # summary list (detector id, regex source, on_match,
+        # required_for_pass, condition source) so the on-disk
+        # ``TrialResult.config`` still tells operators which
+        # patterns the workload ran against; the compiled forms
+        # were only ever needed by ``SubprocessWorkload.run()``,
+        # which has already consumed them by the time we get here.
+        _sanitize_probe_extras_for_json(serialized.get("config"))
         with open(output_path, "w") as f:
-            json.dump(trial_result.to_dict(), f, indent=2)
+            json.dump(serialized, f, indent=2)
 
     return trial_result
+
+
+def _sanitize_probe_extras_for_json(config: Any) -> None:
+    """Replace ``_aorta_probe_extras.custom_patterns`` with a JSON-safe summary.
+
+    Mutates ``config`` in place. ``trial_result.to_dict()`` returns a
+    deep copy so mutation is local to the about-to-be-written dict
+    and does not affect the live :class:`TrialResult`.
+
+    Non-probe-mode trials (no ``_aorta_probe_extras`` key) and
+    probe-mode trials with no ``custom_patterns`` are no-ops.
+    Custom-pattern entries that are already JSON-safe (plain dicts,
+    e.g. from a future :func:`from_dict` round-trip) pass through
+    unchanged.
+    """
+    if not isinstance(config, dict):
+        return
+    extras = config.get("_aorta_probe_extras")
+    if not isinstance(extras, dict):
+        return
+    patterns = extras.get("custom_patterns")
+    if not patterns:
+        return
+    summarized: list[dict[str, Any]] = []
+    for p in patterns:
+        if isinstance(p, dict):
+            # Already JSON-safe (round-trip from disk); pass through.
+            summarized.append(p)
+            continue
+        # ``CompiledPattern`` (or any duck-type with the same field
+        # names). Surface the public attributes the operator cares
+        # about on inspection; skip the compiled regex / CodeType
+        # which are runtime-only.
+        summarized.append(
+            {
+                "detector_id": getattr(p, "detector_id", None),
+                "regex": getattr(getattr(p, "regex", None), "pattern", None),
+                "on_match": getattr(p, "on_match", None),
+                "required_for_pass": getattr(p, "required_for_pass", False),
+                "condition_source": getattr(p, "condition_source", None),
+            }
+        )
+    extras["custom_patterns"] = summarized
 
 
 __all__ = ["RunRequest", "run_trials"]

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -772,7 +772,11 @@ def _run_single_trial(
         # were only ever needed by ``SubprocessWorkload.run()``,
         # which has already consumed them by the time we get here.
         _sanitize_probe_extras_for_json(serialized.get("config"))
-        with open(output_path, "w") as f:
+        # ``encoding="utf-8"`` matches the stdout/stderr opens at L601-602
+        # and the rest of the codebase's text-artifact writes -- avoids
+        # platform-default-encoding surprises on Windows / containers
+        # without a configured locale. Per Copilot's PR #197 review.
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(serialized, f, indent=2)
 
     return trial_result

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -644,30 +644,35 @@ def _aggregate_top_detector_ids(
 ) -> tuple[str | None, str | None]:
     """Pick the highest-frequency detector ID from a cell's probe trials.
 
-    Reads ``failure_detectors_fired`` / ``warn_detectors_fired``
-    from each trial's ``result.json`` (the Phase-2 probe artifact
-    layout). Triage-mode trials never set these keys; the function
-    returns ``(None, None)`` and the matrix.md renderer hides the
-    columns.
+    Reads ``failure_detectors_fired`` / ``warn_detectors_fired`` from
+    each :class:`~aorta.run.TrialResult`'s **in-memory** ``trial.result``
+    payload, NOT from disk. Two source shapes are accepted (both live
+    on ``trial.result``):
 
-    Two source orders, in priority:
+    1. ``result["metrics"]["failure_detectors_fired"]`` — the channel
+       :class:`~aorta.workloads._subprocess.SubprocessWorkload` writes
+       into when it returns a :class:`WorkloadResult`. The dispatcher
+       serialises ``WorkloadResult`` into ``trial.result``, so this is
+       the live-run path.
+    2. ``result["failure_detectors_fired"]`` — a flat fallback some
+       test trials populate directly. Accepting both keeps the
+       presentation layer test-friendly.
 
-    1. **In-memory** -- ``trial.result`` already carries the
-       per-trial WorkloadResult.metrics with the Phase-2 detector
-       lists (the SubprocessWorkload populates them in
-       ``metrics``). Cheapest path, no FS.
-    2. **On-disk fallback** -- when in-memory data isn't present
-       (e.g. resumed runs that load ``trial_*.json`` from a prior
-       invocation), the trial_paths entries point to the
-       dispatcher-written per-trial JSON; we'd need to walk to the
-       sibling probe-mode ``result.json`` to find the fired
-       detectors, which is too invasive for what's a presentation
-       layer. Phase 2 defers that fallback — the in-memory path
-       covers the live-run case (rubric §2.B FR 2.10).
+    Triage-mode trials never set these keys; the function returns
+    ``(None, None)`` and the matrix.md renderer hides the columns.
+
+    **No on-disk fallback.** ``trial_paths`` is accepted for symmetry
+    with the matrix-builder call sites but explicitly discarded
+    here — see :func:`_collect_trial_paths` / resume hydration in
+    ``runner.py`` for the disk-walk path; both already load the
+    per-trial JSON back into ``trial.result`` so the in-memory shape
+    above remains correct on resumed runs. Reading ``result.json``
+    again from this presentation helper would duplicate that work and
+    couple the matrix renderer to the probe artifact layout.
 
     "Highest frequency" is fire-count across the cell's trials, NOT
-    earliest-fired. Ties resolve by encounter order so the result
-    is stable across runs.
+    earliest-fired. Ties resolve by encounter order so the result is
+    stable across runs.
     """
     del trial_paths  # see docstring; on-disk fallback deferred
     fail_counter: Counter[str] = Counter()

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -692,16 +692,30 @@ def _aggregate_top_detector_ids(
         #   - Some test trials populate ``result`` directly. Accept
         #     either shape.
         metrics = result.get("metrics") if isinstance(result.get("metrics"), dict) else {}
+        # Dedup within a SINGLE trial across the two source shapes
+        # above. Production ``SubprocessWorkload`` writes to
+        # ``metrics`` only, but the docstring above explicitly
+        # invites the flat ``result`` shape from test fixtures —
+        # any trial that populates both would double-count the
+        # detector and skew ``top_failure_detector_id`` /
+        # ``top_warn_detector_id``. The seen-sets are reset per
+        # trial so cross-trial fire counts (the docstring's
+        # "fire-count across the cell's trials") are unchanged.
+        # Per Sonbol's PR #197 review.
+        seen_fail_this_trial: set[str] = set()
+        seen_warn_this_trial: set[str] = set()
         for source in (metrics, result):
             for entry in source.get("failure_detectors_fired", []) or []:
-                if not isinstance(entry, str):
+                if not isinstance(entry, str) or entry in seen_fail_this_trial:
                     continue
+                seen_fail_this_trial.add(entry)
                 if entry not in fail_counter:
                     fail_order.append(entry)
                 fail_counter[entry] += 1
             for entry in source.get("warn_detectors_fired", []) or []:
-                if not isinstance(entry, str):
+                if not isinstance(entry, str) or entry in seen_warn_this_trial:
                     continue
+                seen_warn_this_trial.add(entry)
                 if entry not in warn_counter:
                     warn_order.append(entry)
                 warn_counter[entry] += 1

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -165,6 +165,14 @@ class CellStats:
     configured_iters: int | None = None
     iters_display: str = "—"
     workload_config: dict[str, Any] = field(default_factory=dict)
+    # Phase 2 (issue #188): the highest-frequency Tier 4 / custom
+    # detector IDs across the cell's trials. ``None`` when no trial
+    # in the cell fired anything (or when ``result.json`` doesn't
+    # have the Phase-2 keys, e.g. triage-mode cells). The matrix.md
+    # renderer hides the ``Top failure`` / ``Top warn`` columns when
+    # NO cell carries data — so triage-mode runs stay byte-equivalent.
+    top_failure_detector_id: str | None = None
+    top_warn_detector_id: str | None = None
 
     @property
     def failure_rate(self) -> float:
@@ -536,6 +544,8 @@ def aggregate_cell(
             configured_iters=None,
             iters_display="—",
             workload_config=workload_config,
+            top_failure_detector_id=None,
+            top_warn_detector_id=None,
         )
 
     trial_count = len(trials)
@@ -579,6 +589,7 @@ def aggregate_cell(
 
     cell_source = _reduce_step_time_sources(trial_sources)
     exec_min, exec_max, configured_iters, iters_display = _aggregate_iter_counts(trials)
+    top_failure_id, top_warn_id = _aggregate_top_detector_ids(trials, trial_paths or [])
 
     if all_step_times:
         mean_step = float(statistics.fmean(all_step_times))
@@ -622,7 +633,91 @@ def aggregate_cell(
         configured_iters=configured_iters,
         iters_display=iters_display,
         workload_config=workload_config,
+        top_failure_detector_id=top_failure_id,
+        top_warn_detector_id=top_warn_id,
     )
+
+
+def _aggregate_top_detector_ids(
+    trials: list[Any],
+    trial_paths: list[str],
+) -> tuple[str | None, str | None]:
+    """Pick the highest-frequency detector ID from a cell's probe trials.
+
+    Reads ``failure_detectors_fired`` / ``warn_detectors_fired``
+    from each trial's ``result.json`` (the Phase-2 probe artifact
+    layout). Triage-mode trials never set these keys; the function
+    returns ``(None, None)`` and the matrix.md renderer hides the
+    columns.
+
+    Two source orders, in priority:
+
+    1. **In-memory** -- ``trial.result`` already carries the
+       per-trial WorkloadResult.metrics with the Phase-2 detector
+       lists (the SubprocessWorkload populates them in
+       ``metrics``). Cheapest path, no FS.
+    2. **On-disk fallback** -- when in-memory data isn't present
+       (e.g. resumed runs that load ``trial_*.json`` from a prior
+       invocation), the trial_paths entries point to the
+       dispatcher-written per-trial JSON; we'd need to walk to the
+       sibling probe-mode ``result.json`` to find the fired
+       detectors, which is too invasive for what's a presentation
+       layer. Phase 2 defers that fallback — the in-memory path
+       covers the live-run case (rubric §2.B FR 2.10).
+
+    "Highest frequency" is fire-count across the cell's trials, NOT
+    earliest-fired. Ties resolve by encounter order so the result
+    is stable across runs.
+    """
+    del trial_paths  # see docstring; on-disk fallback deferred
+    fail_counter: Counter[str] = Counter()
+    warn_counter: Counter[str] = Counter()
+    fail_order: list[str] = []
+    warn_order: list[str] = []
+    for trial in trials:
+        result = getattr(trial, "result", None)
+        if not isinstance(result, dict):
+            continue
+        # Two source shapes:
+        #   - SubprocessWorkload.run() routes the detector lists
+        #     through WorkloadResult.metrics. The dispatcher then
+        #     serialises WorkloadResult-as-dict into trial.result,
+        #     so result["metrics"]["failure_detectors_fired"] is
+        #     the in-memory channel.
+        #   - Some test trials populate ``result`` directly. Accept
+        #     either shape.
+        metrics = result.get("metrics") if isinstance(result.get("metrics"), dict) else {}
+        for source in (metrics, result):
+            for entry in source.get("failure_detectors_fired", []) or []:
+                if not isinstance(entry, str):
+                    continue
+                if entry not in fail_counter:
+                    fail_order.append(entry)
+                fail_counter[entry] += 1
+            for entry in source.get("warn_detectors_fired", []) or []:
+                if not isinstance(entry, str):
+                    continue
+                if entry not in warn_counter:
+                    warn_order.append(entry)
+                warn_counter[entry] += 1
+
+    top_fail = _pick_top(fail_counter, fail_order)
+    top_warn = _pick_top(warn_counter, warn_order)
+    return top_fail, top_warn
+
+
+def _pick_top(counter: Counter[str], order: list[str]) -> str | None:
+    """Return the most-fired detector ID, ties broken by encounter order."""
+    if not counter:
+        return None
+    best: str | None = None
+    best_count = -1
+    for detector_id in order:
+        count = counter[detector_id]
+        if count > best_count:
+            best = detector_id
+            best_count = count
+    return best
 
 
 __all__ = [

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -570,6 +570,13 @@ def write_matrix_md(
     # not a new confound tag.
     varying_config_keys = _varying_workload_config_keys(cell_stats)
     show_config = bool(varying_config_keys)
+    # Phase 2 (issue #188): Top failure / Top warn columns appear
+    # immediately after Failures when at least one cell in the
+    # matrix populates the corresponding field. Triage-mode runs
+    # never set them, so the columns stay hidden and the legacy
+    # matrix.md layout is byte-equivalent.
+    show_top_failure = any(c.top_failure_detector_id for c in cell_stats)
+    show_top_warn = any(c.top_warn_detector_id for c in cell_stats)
     header_cells: list[str] = [
         "Cell",
         "Mitigations",
@@ -578,6 +585,10 @@ def write_matrix_md(
     if show_config:
         header_cells.append("Config")
     header_cells.extend(["Failure rate", "Failures"])
+    if show_top_failure:
+        header_cells.append("Top failure")
+    if show_top_warn:
+        header_cells.append("Top warn")
     if show_iters:
         header_cells.append("Iters")
     header_cells.extend(["Mean step (ms)", "Confound"])
@@ -593,6 +604,10 @@ def write_matrix_md(
         if show_config:
             row.append(_format_workload_config(cell, varying_config_keys))
         row.extend([_format_failure_rate(cell), _format_failures(cell)])
+        if show_top_failure:
+            row.append(cell.top_failure_detector_id or "—")
+        if show_top_warn:
+            row.append(cell.top_warn_detector_id or "—")
         if show_iters:
             row.append(cell.iters_display)
         row.extend([_format_step_ms(cell), _format_confound(tag)])
@@ -662,6 +677,13 @@ def write_matrix_md(
             "on the configured count (defensive; should not happen under a single recipe). "
             "`—` = workload didn't track iterations. The column is hidden entirely "
             "when no cell in the matrix populates the new field."
+        )
+    if show_top_failure or show_top_warn:
+        lines.append(
+            "- `Top failure` / `Top warn` -- the most-frequently fired detector ID "
+            "(probe-mode Phase 2; issue #188) across the cell's trials. Built-in "
+            "(`tier1:`, `tier2:`, `tier3:`, `tier4:`) and user (`custom:`) IDs "
+            "are listed as peers. The columns are hidden in triage-mode runs."
         )
     if show_config:
         lines.append(

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -68,17 +68,28 @@ _PROBE_TOP_LEVEL = frozenset(
         "timeout_per_trial",
         "env_passthrough_mode",
         "confound",
+        # Phase 2 additions (issue #188): custom_patterns runs after
+        # the built-in classifier, hang knobs tune the Tier 2 monitor.
+        # Accepted only in mode: probe (the triage-mode check below
+        # rejects them when mode != "probe"); a top-level ``condition``
+        # key OUTSIDE a custom_patterns[*] entry is still Phase 3 and
+        # rejected via _PHASE_3_KEYS.
+        "custom_patterns",
+        "hang_window_sec",
+        "hang_grace_period_at_start",
     }
 )
-# Phase 2/3 keys -- intercepted at load time BEFORE the unknown-keys
-# rejection so the operator sees a clear "deferred to Phase 2/3"
-# pointer (see FR 1.19) instead of a generic "unknown key" message.
-# Without the explicit interception a Phase 1 recipe that copy-pasted
-# a future-tense ``custom_patterns:`` block from the design doc would
-# silently fall into the generic-unknown path and the operator would
-# have no signal that the key WILL be valid once Phase 2 ships.
-_PHASE_2_KEYS = frozenset({"custom_patterns", "condition"})
-_PHASE_3_KEYS = frozenset({"redaction"})
+# Phase 3 keys -- intercepted at load time BEFORE the unknown-keys
+# rejection so the operator sees a clear "deferred to Phase 3"
+# pointer instead of a generic "unknown key" message. Phase 2 keys
+# (custom_patterns, hang knobs) are now in _PROBE_TOP_LEVEL and
+# parsed normally when mode == "probe".
+#
+# A top-level ``condition:`` (outside a ``custom_patterns[*].match.condition``)
+# is reserved for a future Phase 3-style "fail-the-trial-by-condition"
+# block; rejected here so a typo'd indent of a custom_patterns
+# condition can't fall through to a silent no-op.
+_PHASE_3_KEYS = frozenset({"redaction", "condition"})
 # Union of valid keys -- used for the unknown-key rejection. Phase 2/3
 # keys are NOT in this set; they take a special-cased path so the
 # error message identifies the phase, not just "you misspelled it".
@@ -482,31 +493,24 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
 
 
 def _reject_phase_2_3_keys(data: dict) -> None:
-    """Intercept Phase 2/3 keys with a "deferred to phase N" pointer.
+    """Intercept Phase 3 keys with a "deferred to phase N" pointer.
 
-    Phase 1 (issue #188) intentionally ships only Tier 1 exit-code
-    verdicts; ``custom_patterns`` and ``condition`` need the sandbox
-    (Phase 2) and ``redaction`` needs the bundle integration (Phase 3).
-    Without this interception, a copy-pasted-from-the-design-doc
-    recipe carrying any of those keys would silently fall into the
-    generic "unknown top-level key" path and the operator would have
-    no signal that the key WILL be valid once the later phases ship.
+    Phase 2 (issue #188) accepts ``custom_patterns`` /
+    ``hang_window_sec`` / ``hang_grace_period_at_start`` in
+    ``mode: probe`` recipes (validated downstream); ``redaction``
+    and a top-level ``condition`` are deferred to Phase 3. Without
+    this interception, a copy-pasted-from-the-design-doc recipe
+    carrying ``redaction:`` would silently fall into the generic
+    "unknown top-level key" path and the operator would have no
+    signal that the key WILL be valid once Phase 3 ships.
     """
-    phase2 = set(data) & _PHASE_2_KEYS
-    if phase2:
-        raise RecipeSchemaError(
-            f"recipe: keys {sorted(phase2)} are deferred to Phase 2 "
-            "(built-in classifier + sandboxed custom_patterns); see "
-            "docs/plans/aorta-probe-188-rubric.md §PHASE 2. Remove these "
-            "keys from your Phase 1 probe recipe."
-        )
     phase3 = set(data) & _PHASE_3_KEYS
     if phase3:
         raise RecipeSchemaError(
             f"recipe: keys {sorted(phase3)} are deferred to Phase 3 "
             "(bundle integration + redaction + handout templates); see "
             "docs/plans/aorta-probe-188-rubric.md §PHASE 3. Remove these "
-            "keys from your Phase 1 probe recipe."
+            "keys from your recipe."
         )
 
 
@@ -523,9 +527,7 @@ def _validate_top_level(data: Any) -> None:
 
     mode = data.get("mode", "triage")
     if mode not in ("triage", "probe"):
-        raise RecipeSchemaError(
-            f"recipe.mode: must be 'triage' or 'probe', got {mode!r}"
-        )
+        raise RecipeSchemaError(f"recipe.mode: must be 'triage' or 'probe', got {mode!r}")
 
     unknown = set(data) - _VALID_TOP_LEVEL
     if unknown:
@@ -560,9 +562,7 @@ def _validate_top_level(data: Any) -> None:
             )
         for required in ("schema_version", "trials", "mitigation_axis", "diagnostic_axis"):
             if required not in data:
-                raise RecipeSchemaError(
-                    f"recipe (mode: probe): missing required key '{required}'"
-                )
+                raise RecipeSchemaError(f"recipe (mode: probe): missing required key '{required}'")
 
     version = data["schema_version"]
     if not isinstance(version, int) or isinstance(version, bool):

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -90,9 +90,12 @@ _PROBE_TOP_LEVEL = frozenset(
 # block; rejected here so a typo'd indent of a custom_patterns
 # condition can't fall through to a silent no-op.
 _PHASE_3_KEYS = frozenset({"redaction", "condition"})
-# Union of valid keys -- used for the unknown-key rejection. Phase 2/3
-# keys are NOT in this set; they take a special-cased path so the
-# error message identifies the phase, not just "you misspelled it".
+# Union of valid keys -- used for the unknown-key rejection. Phase 2 keys
+# (``custom_patterns``, ``hang_window_sec``, ``hang_grace_period_at_start``)
+# ARE included via ``_PROBE_TOP_LEVEL`` and parsed normally when
+# ``mode == "probe"``. Only Phase 3 keys (``_PHASE_3_KEYS``) are kept
+# OUT of this set; they are intercepted earlier so the operator sees
+# a "deferred to Phase 3" pointer instead of a generic "unknown key".
 _VALID_TOP_LEVEL = _TRIAGE_TOP_LEVEL | _PROBE_TOP_LEVEL | {"mode"}
 _VALID_CONFOUND_KEYS = frozenset({"threshold", "baseline_cell"})
 _VALID_CELL_KEYS = frozenset(

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -495,17 +495,21 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
     )
 
 
-def _reject_phase_2_3_keys(data: dict) -> None:
+def _reject_phase_3_keys(data: dict) -> None:
     """Intercept Phase 3 keys with a "deferred to phase N" pointer.
 
-    Phase 2 (issue #188) accepts ``custom_patterns`` /
-    ``hang_window_sec`` / ``hang_grace_period_at_start`` in
-    ``mode: probe`` recipes (validated downstream); ``redaction``
-    and a top-level ``condition`` are deferred to Phase 3. Without
-    this interception, a copy-pasted-from-the-design-doc recipe
+    Phase 2 keys (``custom_patterns`` / ``hang_window_sec`` /
+    ``hang_grace_period_at_start``) are NOT intercepted here — they
+    are valid in ``mode: probe`` recipes and parsed downstream. Only
+    Phase 3 keys (``redaction``, top-level ``condition``) hit this
+    rejection. Without it, a copy-pasted-from-the-design-doc recipe
     carrying ``redaction:`` would silently fall into the generic
     "unknown top-level key" path and the operator would have no
     signal that the key WILL be valid once Phase 3 ships.
+
+    Renamed from ``_reject_phase_2_3_keys`` in PR #197 after Phase 2
+    keys became valid (Copilot review): keeping the old name would
+    have mis-suggested that Phase 2 keys are still trapped here.
     """
     phase3 = set(data) & _PHASE_3_KEYS
     if phase3:
@@ -521,12 +525,15 @@ def _validate_top_level(data: Any) -> None:
     if not isinstance(data, dict):
         raise RecipeSchemaError(f"recipe top-level must be a mapping, got {type(data).__name__}")
 
-    # Phase 2/3 keys are intercepted BEFORE either the unknown-key or
-    # the per-mode required-key checks. A recipe with both a Phase 2
-    # key AND a typo'd top-level key should surface the Phase 2 error
-    # first because that's the one the operator can act on without
-    # changing their intent.
-    _reject_phase_2_3_keys(data)
+    # Phase 3 keys are intercepted BEFORE either the unknown-key or
+    # the per-mode required-key checks so the operator sees a
+    # "deferred to Phase 3" pointer instead of a generic
+    # "unknown top-level key" error. Phase 2 keys
+    # (``custom_patterns``, ``hang_window_sec``,
+    # ``hang_grace_period_at_start``) are NOT intercepted here; they
+    # live in ``_PROBE_TOP_LEVEL`` and parse normally when
+    # ``mode == "probe"``.
+    _reject_phase_3_keys(data)
 
     mode = data.get("mode", "triage")
     if mode not in ("triage", "probe"):

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -751,6 +751,15 @@ def _run_one_cell(
             "cell_env_vars": dict(resolved_env_vars),
             "step_time_regex": probe_extras.step_time_regex,
             "collect_paths": list(probe_extras.collect_paths),
+            # Phase 2 (issue #188): pre-compiled custom_patterns and
+            # hang knobs forwarded to SubprocessWorkload. The
+            # compiled CompiledPattern objects ride as a tuple --
+            # ``RunRequest.__post_init__`` deep-copies the dict but
+            # the tuple of frozen dataclasses is immutable so the
+            # deep copy is a no-op cost-wise.
+            "custom_patterns": tuple(probe_extras.custom_patterns),
+            "hang_window_sec": probe_extras.hang_window_sec,
+            "hang_grace_period_at_start": probe_extras.hang_grace_period_at_start,
         }
 
     # save_logs is forced True for probe-mode cells because

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -754,9 +754,12 @@ def _run_one_cell(
             # Phase 2 (issue #188): pre-compiled custom_patterns and
             # hang knobs forwarded to SubprocessWorkload. The
             # compiled CompiledPattern objects ride as a tuple --
-            # ``RunRequest.__post_init__`` deep-copies the dict but
-            # the tuple of frozen dataclasses is immutable so the
-            # deep copy is a no-op cost-wise.
+            # ``RunRequest.__post_init__`` deep-copies the dict
+            # (and therefore traverses this tuple), but the
+            # CompiledPattern fields are all treated as immutable
+            # post-compile (re.Pattern, CodeType, str, bool) so the
+            # traversal is benign: nothing the dispatcher hands to
+            # the workload can be mutated from outside RunRequest.
             "custom_patterns": tuple(probe_extras.custom_patterns),
             "hang_window_sec": probe_extras.hang_window_sec,
             "hang_grace_period_at_start": probe_extras.hang_grace_period_at_start,

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -44,6 +44,13 @@ import time
 from pathlib import Path
 from typing import Any
 
+from aorta.probe.classifier import TrialContext, classify_trial
+from aorta.probe.classifier.tier2_hang import (
+    DEFAULT_HANG_GRACE_SEC,
+    DEFAULT_HANG_WINDOW_SEC,
+    HangMonitor,
+)
+from aorta.probe.classifier.tier3_kernel import Tier3State
 from aorta.workloads._base import Workload, WorkloadResult
 
 # Config key the dispatcher uses to deliver the opaque user argv. The
@@ -153,7 +160,18 @@ class SubprocessWorkload(Workload):
         self._trial_dir.mkdir(parents=True, exist_ok=True)
 
     def run(self) -> WorkloadResult:
-        """Fork the user command and write the Tier-1 ``result.json``."""
+        """Fork the user command and write the Phase-2 ``result.json``.
+
+        Phase 2 hangs the five-tier classifier off this method
+        post-exit. The Tier 1 verdict (Phase 1 contract) is a
+        subset of the Phase 2 verdict — a trial that exits 0 with
+        no Tier 2/3/4/5 detector firing still resolves to
+        ``verdict = "pass"``, matching Phase 1 byte-for-byte. The
+        Phase 1 minimum-shape test in
+        ``tests/probe/test_subprocess_workload.py`` continues to
+        pass without modification because Phase 2 only ADDS keys
+        to ``result.json``.
+        """
         if self._argv is None or self._trial_dir is None or self._trial_index is None:
             raise RuntimeError("SubprocessWorkload.run() called before setup()")
 
@@ -166,6 +184,11 @@ class SubprocessWorkload(Workload):
         probe_extras = self.config.get(CONFIG_KEY_PROBE_EXTRAS) or {}
         env_mode = probe_extras.get("env_passthrough_mode", "inherit")
         timeout = probe_extras.get("timeout_per_trial")
+        custom_patterns = tuple(probe_extras.get("custom_patterns") or ())
+        hang_window_sec = float(probe_extras.get("hang_window_sec") or DEFAULT_HANG_WINDOW_SEC)
+        hang_grace_sec = float(
+            probe_extras.get("hang_grace_period_at_start") or DEFAULT_HANG_GRACE_SEC
+        )
 
         # ``inherit`` mode: the dispatcher has already stamped the
         # cell's mitigation + diagnostic env vars onto os.environ in
@@ -242,6 +265,7 @@ class SubprocessWorkload(Workload):
         # below for the propagation into ``main_work_started`` /
         # ``executed_iterations``.
         launched = False
+        hang_monitor: HangMonitor | None = None
         try:
             with open(stdout_path, "wb") as out_fh, open(stderr_path, "wb") as err_fh:
                 proc = subprocess.Popen(
@@ -251,6 +275,13 @@ class SubprocessWorkload(Workload):
                     env=child_env,
                 )
                 launched = True
+                hang_monitor = HangMonitor(
+                    pid=proc.pid,
+                    stdout_path=stdout_path,
+                    hang_window_sec=hang_window_sec,
+                    hang_grace_period_at_start=hang_grace_sec,
+                )
+                hang_monitor.start()
                 try:
                     exit_code = proc.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
@@ -276,6 +307,9 @@ class SubprocessWorkload(Workload):
                     except ProcessLookupError:
                         pass
                     exit_code = -1
+                finally:
+                    if hang_monitor is not None:
+                        hang_monitor.stop()
         except (FileNotFoundError, PermissionError, OSError) as exc:
             # Exec-time ``Popen`` failures all become Tier-1 fails with
             # the artifact tree intact (stderr.log + result.json). The
@@ -311,15 +345,49 @@ class SubprocessWorkload(Workload):
                 pass
         walltime_sec = time.perf_counter() - t0
 
-        verdict = "pass" if exit_code == 0 and not timed_out else "fail"
+        # Tier 2-5 classifier post-exit. Reads the captured logs
+        # back from disk -- the file handles above are closed by
+        # the ``with`` block. Errors here MUST NOT propagate (the
+        # workload already succeeded or failed; classifier crashes
+        # are bugs, not trial outcomes).
+        log_text = _read_log_text(stdout_path, stderr_path)
+        hang_detected = bool(hang_monitor and hang_monitor.hang_detected)
+
+        verdict_obj, tier_durations_ms = classify_trial(
+            TrialContext(
+                exit_code=exit_code,
+                timed_out=timed_out,
+                walltime_sec=walltime_sec,
+                trial_dir=trial_dir,
+                log_text=log_text,
+                custom_patterns=custom_patterns,
+                hang_detected=hang_detected,
+                peak_vram_mib=None,
+                # Tier 3 dmesg/amd-smi disabled when no runner-level
+                # state is plumbed through; the runner can pass one
+                # in via probe_extras in a future enhancement.
+                tier3_state=Tier3State(),
+            )
+        )
 
         result_doc: dict[str, Any] = {
-            "verdict": verdict,
+            "verdict": verdict_obj.verdict,
             "exit_code": exit_code,
             "walltime_sec": walltime_sec,
+            "peak_vram_mib": None,
             "argv": list(argv),
             "cell_name": probe_extras.get("cell_name", "_unknown_"),
             "trial_index": self._trial_index,
+            "failure_detectors_fired": list(verdict_obj.failure_detectors_fired),
+            "warn_detectors_fired": list(verdict_obj.warn_detectors_fired),
+            "capture": dict(verdict_obj.capture),
+            "tier_durations_ms": dict(tier_durations_ms),
+            # Phase 1 keys preserved for back-compat with any
+            # downstream tool that already parses them. The Phase 1
+            # minimum-shape test in tests/probe/test_subprocess_workload.py
+            # asserts these continue to exist; the Phase 2 shape
+            # extends the doc by ADDING keys, never by removing
+            # them (rubric §2.B FR 2.9).
             "env_passthrough_mode": env_mode,
             "timed_out": timed_out,
         }
@@ -338,12 +406,13 @@ class SubprocessWorkload(Workload):
         # ``result.json`` is still written either way -- the artifact
         # contract from PR #194 round 4 is independent of the
         # matrix-side semantic.
+        passed = verdict_obj.verdict == "pass"
         return WorkloadResult(
-            passed=(verdict == "pass"),
-            failure_count=0 if verdict == "pass" else 1,
+            passed=passed,
+            failure_count=0 if passed else 1,
             failure_details=(
                 []
-                if verdict == "pass"
+                if passed
                 else [
                     {
                         "exit_code": exit_code,
@@ -351,6 +420,7 @@ class SubprocessWorkload(Workload):
                         "type": (
                             "subprocess_nonzero_exit" if launched else "subprocess_exec_failed"
                         ),
+                        "failure_detectors_fired": list(verdict_obj.failure_detectors_fired),
                     }
                 ]
             ),
@@ -359,9 +429,11 @@ class SubprocessWorkload(Workload):
             configured_iterations=1,
             elapsed_sec=walltime_sec,
             metrics={
-                "verdict": verdict,
+                "verdict": verdict_obj.verdict,
                 "exit_code": exit_code,
                 "result_json_path": str(result_path),
+                "failure_detectors_fired": list(verdict_obj.failure_detectors_fired),
+                "warn_detectors_fired": list(verdict_obj.warn_detectors_fired),
             },
         )
 
@@ -498,6 +570,30 @@ def _validate_env_file_entries(env: dict[str, str]) -> None:
                 "probe.env uses bare KEY=VALUE format and cannot "
                 "encode multi-line values"
             )
+
+
+def _read_log_text(stdout_path: Path, stderr_path: Path) -> str:
+    """Read stdout + stderr back as a single text blob for the classifier.
+
+    Reads are bounded to twice
+    :data:`aorta.probe.sandbox.MAX_LOG_BYTES` so a runaway log
+    can't OOM the classifier; the per-tier scanners further bound
+    individual ``re.search`` invocations. Errors decoded with
+    ``backslashreplace`` so a binary blob doesn't blow up the
+    text channel.
+    """
+    from aorta.probe.sandbox import MAX_LOG_BYTES
+
+    parts: list[str] = []
+    for path in (stdout_path, stderr_path):
+        try:
+            data = path.read_bytes()[:MAX_LOG_BYTES]
+            parts.append(data.decode("utf-8", errors="backslashreplace"))
+        except FileNotFoundError:
+            parts.append("")
+        except OSError:
+            parts.append("")
+    return "\n".join(parts)
 
 
 def _write_env_file(path: Path, env: dict[str, str]) -> None:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -28,9 +28,14 @@ Per-trial output layout (Phase 1):
 * ``<cell_dir>/trial_<N>/probe.env`` -- only when
   ``env_passthrough_mode == "file"`` (chmod 0600).
 
-Verdict rule (Phase 1, Tier 1 only): ``exit_code == 0`` -> pass, else
-fail. Pattern matching, hang detection, dmesg scanning, and the
-``custom_patterns`` runner are deferred to Phase 2.
+Verdict (Phase 2): the five-tier classifier in
+:mod:`aorta.probe.classifier` runs post-exit. A trial whose process
+exit is non-zero, timed out, hung, hit a dmesg / amd-smi signal, hit
+a built-in Tier-4 pattern, or hit a user ``custom_patterns`` entry
+with ``on_match: fail`` resolves to ``"fail"``; otherwise ``"pass"``.
+Phase 1's exit-code-only rule remains a strict subset (``exit_code
+== 0 and no detector fires`` -> pass), so any tooling that read the
+Phase-1 minimum shape keeps working.
 """
 
 from __future__ import annotations
@@ -118,8 +123,10 @@ class SubprocessWorkload(Workload):
        under ``_subprocess/`` -- and serves as the "I-ran" marker for
        triage-mode tooling; the probe-mode ``result.json`` is the one
        resume / classifier code consults.
-    3. Verdict is Tier 1 only in Phase 1: ``exit_code == 0`` -> pass.
-       The full classifier and the sandbox land in Phase 2.
+    3. Verdict is the union of Tier 1-5 detectors (Phase 2). Phase 1's
+       ``exit_code == 0 -> pass`` rule is a strict subset: a trial
+       that exits zero AND fires no other tier still resolves to
+       ``"pass"``. See :mod:`aorta.probe.classifier`.
     """
 
     launch_mode = "single_process"
@@ -211,9 +218,17 @@ class SubprocessWorkload(Workload):
         env_mode = probe_extras.get("env_passthrough_mode", "inherit")
         timeout = probe_extras.get("timeout_per_trial")
         custom_patterns = tuple(probe_extras.get("custom_patterns") or ())
-        hang_window_sec = float(probe_extras.get("hang_window_sec") or DEFAULT_HANG_WINDOW_SEC)
-        hang_grace_sec = float(
-            probe_extras.get("hang_grace_period_at_start") or DEFAULT_HANG_GRACE_SEC
+        # ``... or DEFAULT`` collapses a recipe-configured ``0.0`` (a
+        # legitimate "disable grace" / "disable window" value validated
+        # by the recipe-builder) into the default. Use explicit ``is
+        # None`` so an opt-in zero survives the runtime extraction.
+        _hang_window_raw = probe_extras.get("hang_window_sec")
+        hang_window_sec = (
+            DEFAULT_HANG_WINDOW_SEC if _hang_window_raw is None else float(_hang_window_raw)
+        )
+        _hang_grace_raw = probe_extras.get("hang_grace_period_at_start")
+        hang_grace_sec = (
+            DEFAULT_HANG_GRACE_SEC if _hang_grace_raw is None else float(_hang_grace_raw)
         )
 
         # ``inherit`` mode: the dispatcher has already stamped the

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -45,6 +45,8 @@ from pathlib import Path
 from typing import Any
 
 from aorta.probe.classifier import TrialContext, classify_trial
+from aorta.probe.classifier.tier1_process import Tier1Context
+from aorta.probe.classifier.tier1_process import detect as tier1_detect
 from aorta.probe.classifier.tier2_hang import (
     DEFAULT_HANG_GRACE_SEC,
     DEFAULT_HANG_WINDOW_SEC,
@@ -56,6 +58,7 @@ from aorta.probe.classifier.tier3_kernel import (
     poll_amd_smi,
     scan_dmesg,
 )
+from aorta.probe.classifier.verdict import Verdict
 from aorta.workloads._base import Workload, WorkloadResult
 
 # Process-wide Tier 3 state. Shared across every SubprocessWorkload
@@ -418,23 +421,42 @@ class SubprocessWorkload(Workload):
             fired_kernel_ids = []
             dmesg_text = None
 
-        verdict_obj, tier_durations_ms = classify_trial(
-            TrialContext(
+        # Classifier crash containment (rubric §2.B FR 2.11 fail-soft
+        # policy applied to the classifier itself). The trial has
+        # already run end-to-end -- we have its exit_code,
+        # walltime_sec, captured logs, and Tier 1 inputs all in hand.
+        # If a tier classifier raises (regex catastrophe, schema
+        # surprise from a future refactor, anything), we MUST still
+        # write a ``result.json`` so the trial doesn't silently
+        # disappear from the matrix. Fall back to a Tier-1-only
+        # verdict derived from the same Tier 1 inputs, record the
+        # classifier exception under ``capture['classifier_error']``
+        # for the operator, and continue.
+        try:
+            verdict_obj, tier_durations_ms = classify_trial(
+                TrialContext(
+                    exit_code=exit_code,
+                    timed_out=timed_out,
+                    walltime_sec=walltime_sec,
+                    trial_dir=trial_dir,
+                    log_text=log_text,
+                    custom_patterns=custom_patterns,
+                    hang_detected=hang_detected,
+                    peak_vram_mib=None,
+                    dmesg_text=dmesg_text,
+                    amd_smi_pre=amd_smi_pre,
+                    amd_smi_post=amd_smi_post,
+                    tier3_extra=tuple(fired_kernel_ids),
+                    tier3_state=_TIER3_STATE,
+                )
+            )
+        except Exception as classifier_exc:  # noqa: BLE001 -- classifier crash containment
+            verdict_obj, tier_durations_ms = _tier1_only_fallback_verdict(
                 exit_code=exit_code,
                 timed_out=timed_out,
-                walltime_sec=walltime_sec,
                 trial_dir=trial_dir,
-                log_text=log_text,
-                custom_patterns=custom_patterns,
-                hang_detected=hang_detected,
-                peak_vram_mib=None,
-                dmesg_text=dmesg_text,
-                amd_smi_pre=amd_smi_pre,
-                amd_smi_post=amd_smi_post,
-                tier3_extra=tuple(fired_kernel_ids),
-                tier3_state=_TIER3_STATE,
+                classifier_exc=classifier_exc,
             )
-        )
 
         result_doc: dict[str, Any] = {
             "verdict": verdict_obj.verdict,
@@ -660,6 +682,60 @@ def _read_log_text(stdout_path: Path, stderr_path: Path) -> str:
         except OSError:
             parts.append("")
     return "\n".join(parts)
+
+
+def _tier1_only_fallback_verdict(
+    *,
+    exit_code: int,
+    timed_out: bool,
+    trial_dir: Path,
+    classifier_exc: BaseException,
+) -> tuple[Verdict, dict[str, float]]:
+    """Build a deterministic verdict when :func:`classify_trial` raises.
+
+    Tier 1 alone is enough to give the trial a sensible verdict: it
+    is the only tier that's a pure function of the subprocess exit
+    state and the trial dir, so it can't itself crash on regex /
+    capture / dmesg edge cases. We re-run :func:`tier1_detect`
+    here (cheap, no FS work beyond a glob in ``trial_dir``) and
+    encode the original classifier exception under
+    ``capture['classifier_error']`` so operators see WHY the full
+    classifier was bypassed instead of a silent Tier-1-only
+    result. ``tier_durations_ms`` records the fallback in
+    ``capture`` rather than the per-tier breakdown -- the other
+    four tiers genuinely did not run.
+
+    Verdict rule: any Tier 1 detector fires -> ``fail``; else
+    ``pass``. Matches the existing Phase-1 fallback shape so
+    downstream tooling that already parses ``failure_detectors_fired``
+    keeps working.
+    """
+    fired = tier1_detect(
+        Tier1Context(
+            exit_code=exit_code,
+            timed_out=timed_out,
+            trial_dir=trial_dir,
+        )
+    )
+    verdict_str = "fail" if fired else "pass"
+    capture: dict[str, str | float | int] = {
+        "classifier_error": f"{type(classifier_exc).__name__}: {classifier_exc}",
+    }
+    verdict = Verdict(
+        verdict=verdict_str,
+        failure_detectors_fired=list(fired),
+        warn_detectors_fired=[],
+        capture=capture,
+    )
+    # Per-tier durations: Tier 1 ran, everything else was skipped.
+    tier_durations_ms = {
+        "tier1": 0.0,
+        "tier2": 0.0,
+        "tier3": 0.0,
+        "tier4": 0.0,
+        "tier5": 0.0,
+    }
+    return verdict, tier_durations_ms
 
 
 def _write_env_file(path: Path, env: dict[str, str]) -> None:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -50,8 +50,30 @@ from aorta.probe.classifier.tier2_hang import (
     DEFAULT_HANG_WINDOW_SEC,
     HangMonitor,
 )
-from aorta.probe.classifier.tier3_kernel import Tier3State
+from aorta.probe.classifier.tier3_kernel import (
+    Tier3State,
+    poll_amd_smi,
+    scan_dmesg,
+)
 from aorta.workloads._base import Workload, WorkloadResult
+
+# Process-wide Tier 3 state. Shared across every SubprocessWorkload
+# instance the dispatcher constructs over one ``aorta probe`` invocation
+# so the rubric's "tier3 disabled: <reason>" warning is logged at most
+# ONCE per invocation (FR 2.11), regardless of how many cells x trials
+# the matrix produces. ``Tier3State`` is mutable and the dispatcher's
+# deep-copy semantics for ``probe_extras`` would defeat that guarantee
+# if we tried to plumb it through the config dict -- a module-level
+# singleton is the smallest correct alternative and lives only for the
+# lifetime of the ``aorta probe`` process (probe-mode is single-process
+# by design; the rubric forbids subprocess-launched workloads).
+_TIER3_STATE = Tier3State()
+
+# Pad added to the dmesg ``--since`` window to cover the small wall-
+# clock drift between ``time.perf_counter`` and the kernel's monotonic
+# clock and to catch messages logged a few seconds after the child
+# crashed (e.g. amdgpu reset messages often arrive on the next tick).
+_DMESG_SINCE_PAD_SEC = 5.0
 
 # Config key the dispatcher uses to deliver the opaque user argv. The
 # leading ``_aorta_`` prefix is reserved by the dispatcher and rejected
@@ -252,6 +274,13 @@ class SubprocessWorkload(Workload):
             # contents.
             env_file_path.unlink(missing_ok=True)
 
+        # Tier 3 pre-snapshot. Fail-soft: returns None when ``amd-smi``
+        # is missing or polling fails; ``scan_amd_smi`` then accepts
+        # ``None`` and contributes nothing without aborting the trial.
+        # The shared ``_TIER3_STATE`` ensures the "amd-smi disabled"
+        # log fires at most once across the full probe invocation.
+        amd_smi_pre = poll_amd_smi(_TIER3_STATE)
+
         t0 = time.perf_counter()
         exit_code: int
         timed_out = False
@@ -353,6 +382,30 @@ class SubprocessWorkload(Workload):
         log_text = _read_log_text(stdout_path, stderr_path)
         hang_detected = bool(hang_monitor and hang_monitor.hang_detected)
 
+        # Tier 3 post-snapshot + dmesg scan. ``since_seconds`` covers
+        # the trial walltime plus a small pad so kernel messages
+        # logged shortly after the child crashed (amdgpu reset etc.)
+        # still land in the window. Both helpers are fail-soft and
+        # share ``_TIER3_STATE`` with the pre-snapshot above so the
+        # one-warning-per-invocation contract holds.
+        amd_smi_post = poll_amd_smi(_TIER3_STATE)
+        dmesg_text: str | None
+        try:
+            fired_kernel_ids = scan_dmesg(
+                _TIER3_STATE,
+                since_seconds=walltime_sec + _DMESG_SINCE_PAD_SEC,
+            )
+            # ``scan_dmesg`` returns the fired detector IDs directly;
+            # rebuild a synthetic text blob so the classifier's
+            # ``scan_dmesg_text`` second pass is a no-op (it would
+            # otherwise re-scan ``None`` and emit []). The empty
+            # string here keeps Tier 3's text path inert; the
+            # already-fired IDs are surfaced via ``tier3_extra``.
+            dmesg_text = "" if fired_kernel_ids else None
+        except Exception:
+            fired_kernel_ids = []
+            dmesg_text = None
+
         verdict_obj, tier_durations_ms = classify_trial(
             TrialContext(
                 exit_code=exit_code,
@@ -363,10 +416,11 @@ class SubprocessWorkload(Workload):
                 custom_patterns=custom_patterns,
                 hang_detected=hang_detected,
                 peak_vram_mib=None,
-                # Tier 3 dmesg/amd-smi disabled when no runner-level
-                # state is plumbed through; the runner can pass one
-                # in via probe_extras in a future enhancement.
-                tier3_state=Tier3State(),
+                dmesg_text=dmesg_text,
+                amd_smi_pre=amd_smi_pre,
+                amd_smi_post=amd_smi_post,
+                tier3_extra=tuple(fired_kernel_ids),
+                tier3_state=_TIER3_STATE,
             )
         )
 

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -412,6 +412,21 @@ class SubprocessWorkload(Workload):
         log_text = _read_log_text(stdout_path, stderr_path)
         hang_detected = bool(hang_monitor and hang_monitor.hang_detected)
 
+        # Best-effort ``peak_vram_mib`` from the Tier-3 amd-smi
+        # snapshots. We only have two samples (pre + post Popen) so
+        # this is a coarse high-water-mark, not a true peak -- a
+        # short-lived spike in the middle of the trial is invisible
+        # to a 2-point sampler. We surface it anyway because the
+        # alternative is leaving the field permanently ``None`` and
+        # rendering Tier-5 sandbox conditions like
+        # ``peak_vram_mib > 70000`` unusable on real hosts, which is
+        # the bot-flagged gap. Both snapshots are fail-soft (either
+        # can be ``None`` when amd-smi is missing / unparseable) --
+        # if neither is available we fall back to ``None`` and the
+        # sandbox's existing ``peak_vram_mib is None -> 0`` shim in
+        # :func:`aorta.probe.sandbox.build_sandbox_env` keeps
+        # conditions deterministic.
+
         # Tier 3 post-snapshot + dmesg scan. ``since_seconds`` covers
         # the trial walltime plus a small pad so kernel messages
         # logged shortly after the child crashed (amdgpu reset etc.)
@@ -436,6 +451,16 @@ class SubprocessWorkload(Workload):
             fired_kernel_ids = []
             dmesg_text = None
 
+        peak_vram_mib: int | None
+        if amd_smi_pre is not None and amd_smi_post is not None:
+            peak_vram_mib = max(amd_smi_pre.vram_used_mib, amd_smi_post.vram_used_mib)
+        elif amd_smi_pre is not None:
+            peak_vram_mib = amd_smi_pre.vram_used_mib
+        elif amd_smi_post is not None:
+            peak_vram_mib = amd_smi_post.vram_used_mib
+        else:
+            peak_vram_mib = None
+
         # Classifier crash containment (rubric §2.B FR 2.11 fail-soft
         # policy applied to the classifier itself). The trial has
         # already run end-to-end -- we have its exit_code,
@@ -457,7 +482,7 @@ class SubprocessWorkload(Workload):
                     log_text=log_text,
                     custom_patterns=custom_patterns,
                     hang_detected=hang_detected,
-                    peak_vram_mib=None,
+                    peak_vram_mib=peak_vram_mib,
                     dmesg_text=dmesg_text,
                     amd_smi_pre=amd_smi_pre,
                     amd_smi_post=amd_smi_post,
@@ -477,7 +502,7 @@ class SubprocessWorkload(Workload):
             "verdict": verdict_obj.verdict,
             "exit_code": exit_code,
             "walltime_sec": walltime_sec,
-            "peak_vram_mib": None,
+            "peak_vram_mib": peak_vram_mib,
             "argv": list(argv),
             "cell_name": probe_extras.get("cell_name", "_unknown_"),
             "trial_index": self._trial_index,
@@ -678,12 +703,22 @@ def _validate_env_file_entries(env: dict[str, str]) -> None:
 def _read_log_text(stdout_path: Path, stderr_path: Path) -> str:
     """Read stdout + stderr back as a single text blob for the classifier.
 
-    Reads are bounded to twice
-    :data:`aorta.probe.sandbox.MAX_LOG_BYTES` so a runaway log
-    can't OOM the classifier; the per-tier scanners further bound
-    individual ``re.search`` invocations. Errors decoded with
-    ``backslashreplace`` so a binary blob doesn't blow up the
-    text channel.
+    Reads are bounded to :data:`aorta.probe.sandbox.MAX_LOG_BYTES`
+    per stream as a hard regex-DoS cap; the per-tier scanners further
+    bound individual ``re.search`` invocations.
+
+    Errors decoded with ``errors="replace"`` (U+FFFD per invalid
+    byte, 1:1 byte→char) rather than ``backslashreplace`` (up to
+    4 chars per invalid byte for ``\\xff`` etc.). The cheaper
+    expansion matters because ``MAX_LOG_BYTES`` is meant to be the
+    upper bound on the regex-input length; with
+    ``backslashreplace`` a binary-heavy stdout could quadruple the
+    decoded string and let a runaway log inflate regex CPU/memory
+    past the documented cap. The replacement char loses the
+    underlying byte value but the classifier scanners don't depend
+    on the exact byte -- they pattern-match on textual error
+    messages, where invalid UTF-8 is noise that just needs a
+    placeholder so the surrounding text stays in line.
     """
     from aorta.probe.sandbox import MAX_LOG_BYTES
 
@@ -691,7 +726,7 @@ def _read_log_text(stdout_path: Path, stderr_path: Path) -> str:
     for path in (stdout_path, stderr_path):
         try:
             data = path.read_bytes()[:MAX_LOG_BYTES]
-            parts.append(data.decode("utf-8", errors="backslashreplace"))
+            parts.append(data.decode("utf-8", errors="replace"))
         except FileNotFoundError:
             parts.append("")
         except OSError:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -52,6 +52,7 @@ from aorta.probe.classifier.tier2_hang import (
 )
 from aorta.probe.classifier.tier3_kernel import (
     Tier3State,
+    gpu_idle_probe_from_state,
     poll_amd_smi,
     scan_dmesg,
 )
@@ -304,11 +305,22 @@ class SubprocessWorkload(Workload):
                     env=child_env,
                 )
                 launched = True
+                # Wire the third leg of the two-of-three Tier 2
+                # predicate. The closure spawns one ``amd-smi monitor``
+                # call per HangMonitor poll (~12/min at the default 5s
+                # poll cadence) and returns True iff the busiest GPU
+                # reports < GPU_IDLE_UTILIZATION_THRESHOLD_PCT. When
+                # amd-smi is missing or unparseable the closure returns
+                # False, so the predicate gracefully degrades to the
+                # 2-of-2 ``stdout_silent`` + ``io_idle`` shape that the
+                # round-1 wiring was already covering (rubric §2.B FR
+                # 2.11 fail-soft policy).
                 hang_monitor = HangMonitor(
                     pid=proc.pid,
                     stdout_path=stdout_path,
                     hang_window_sec=hang_window_sec,
                     hang_grace_period_at_start=hang_grace_sec,
+                    gpu_idle_probe=gpu_idle_probe_from_state(_TIER3_STATE),
                 )
                 hang_monitor.start()
                 try:

--- a/tests/probe/classifier/test_tier1.py
+++ b/tests/probe/classifier/test_tier1.py
@@ -1,0 +1,101 @@
+"""Tests for Tier 1 process-level detectors (FR 2.1).
+
+Each detector is exercised against a synthetic command (no GPU, no
+kernel state) so the suite runs under ``pytest -m "not gpu and not
+rocm"`` on any Linux host.
+"""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from aorta.probe.classifier import tier1_process
+from aorta.probe.classifier.tier1_process import Tier1Context
+
+
+def _ctx(tmp_path: Path, exit_code: int, *, timed_out: bool = False) -> Tier1Context:
+    return Tier1Context(exit_code=exit_code, timed_out=timed_out, trial_dir=tmp_path)
+
+
+def test_pass_no_detectors(tmp_path):
+    """Exit 0 + no timeout + no coredump fires nothing."""
+    assert tier1_process.detect(_ctx(tmp_path, 0)) == []
+
+
+def test_exit_nonzero_fires(tmp_path):
+    """Non-zero exit fires ``tier1:exit_nonzero`` (and only it)."""
+    assert tier1_process.detect(_ctx(tmp_path, 1)) == [tier1_process.DETECTOR_EXIT_NONZERO]
+
+
+def test_timeout_fires_alone(tmp_path):
+    """A timed-out trial fires ``tier1:timeout``, suppressing ``exit_nonzero``."""
+    detectors = tier1_process.detect(_ctx(tmp_path, -1, timed_out=True))
+    assert tier1_process.DETECTOR_TIMEOUT in detectors
+    assert tier1_process.DETECTOR_EXIT_NONZERO not in detectors
+
+
+@pytest.mark.parametrize(
+    "sig,detector",
+    [
+        (signal.SIGSEGV, tier1_process.DETECTOR_SIGSEGV),
+        (signal.SIGABRT, tier1_process.DETECTOR_SIGABRT),
+        (signal.SIGBUS, tier1_process.DETECTOR_SIGBUS),
+    ],
+)
+def test_signal_detectors(tmp_path, sig, detector):
+    """``returncode == -SIG`` fires the corresponding ``tier1:*`` detector."""
+    detectors = tier1_process.detect(_ctx(tmp_path, -int(sig)))
+    assert detector in detectors
+    # Signal classification suppresses the ``exit_nonzero`` detector
+    # (per rubric FR 2.1: most-specific cause wins).
+    assert tier1_process.DETECTOR_EXIT_NONZERO not in detectors
+
+
+def test_coredump_fires(tmp_path):
+    """Any ``core.*`` file in the trial dir flags the trial."""
+    (tmp_path / "core.12345").write_bytes(b"")
+    detectors = tier1_process.detect(_ctx(tmp_path, 1))
+    assert tier1_process.DETECTOR_COREDUMP in detectors
+
+
+def test_bare_core_filename_also_fires(tmp_path):
+    """Distros with ``core_pattern = core`` produce a bare ``core``."""
+    (tmp_path / "core").write_bytes(b"")
+    detectors = tier1_process.detect(_ctx(tmp_path, 1))
+    assert tier1_process.DETECTOR_COREDUMP in detectors
+
+
+def test_no_coredump_when_missing(tmp_path):
+    """Missing trial dir falls through cleanly (no FS-error explosion)."""
+    detectors = tier1_process.detect(
+        Tier1Context(exit_code=0, timed_out=False, trial_dir=tmp_path / "does-not-exist")
+    )
+    assert detectors == []
+
+
+# ---- Synthetic-subprocess integration: real signals & exit codes --------
+
+
+def test_synthetic_exit_nonzero(tmp_path):
+    """``exit 1`` from bash flows through Tier 1 cleanly."""
+    proc = subprocess.run(  # noqa: S607 -- audited test invocation
+        ["bash", "-c", "exit 1"], check=False
+    )
+    detectors = tier1_process.detect(_ctx(tmp_path, proc.returncode))
+    assert detectors == [tier1_process.DETECTOR_EXIT_NONZERO]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="signal semantics linux-only")
+def test_synthetic_sigsegv(tmp_path):
+    """A bash sub-shell self-kill produces ``returncode == -SIGSEGV``."""
+    proc = subprocess.run(  # noqa: S607 -- audited test invocation
+        ["bash", "-c", "kill -SEGV $$"], check=False
+    )
+    assert proc.returncode == -int(signal.SIGSEGV)
+    detectors = tier1_process.detect(_ctx(tmp_path, proc.returncode))
+    assert tier1_process.DETECTOR_SIGSEGV in detectors

--- a/tests/probe/classifier/test_tier2.py
+++ b/tests/probe/classifier/test_tier2.py
@@ -150,3 +150,85 @@ def test_io_total_returns_none_for_unreadable_pid():
     """
     mon = HangMonitor(pid=-1, stdout_path=Path("/dev/null"))
     assert mon._io_total() is None
+
+
+def test_stop_join_budget_outlasts_slow_gpu_probe(tmp_path: Path, caplog):
+    """Regression for PR #197 review (Sonbol): ``stop()`` must wait long
+    enough for a ``gpu_idle_probe`` blocked inside ``amd-smi`` (10s
+    subprocess timeout) to return -- otherwise the join returns
+    early, the orphan thread keeps running, and it races the *next*
+    trial's monitor for ``Tier3State`` reads.
+
+    The join budget is ``max(poll_interval + 1,
+    GPU_IDLE_PROBE_MAX_BLOCK_SEC)``; this test pins
+    ``GPU_IDLE_PROBE_MAX_BLOCK_SEC`` to a small value so the test is
+    fast, makes the probe sleep for a slice under that budget, and
+    asserts the thread is gone after ``stop()`` returns.
+    """
+    monkey_budget = 0.3
+    stdout = tmp_path / "stdout.log"
+    stdout.write_text("hi\n", encoding="utf-8")
+
+    def slow_probe() -> bool:
+        time.sleep(0.2)
+        return False
+
+    mon = HangMonitor(
+        pid=1,
+        stdout_path=stdout,
+        hang_window_sec=10.0,
+        hang_grace_period_at_start=10.0,
+        poll_interval_sec=0.01,
+        gpu_idle_probe=slow_probe,
+    )
+
+    import logging
+    from unittest.mock import patch
+
+    with patch.object(tier2_hang, "GPU_IDLE_PROBE_MAX_BLOCK_SEC", monkey_budget):
+        mon.start()
+        time.sleep(0.05)
+        with caplog.at_level(logging.WARNING, logger="aorta.probe.classifier.tier2_hang"):
+            mon.stop()
+
+    assert mon._thread is None, "stop() must clear the thread handle after join"
+    # The slow probe (0.2s) completes inside the 0.3s budget so no
+    # warning fires.
+    assert not any("still alive" in rec.getMessage() for rec in caplog.records)
+
+
+def test_stop_warns_when_probe_outlasts_budget(tmp_path: Path, caplog):
+    """If the probe outlasts even the generous join budget (an
+    amd-smi call wedged past its own subprocess timeout), the
+    monitor logs a warning so the operator has a breadcrumb in
+    the run log instead of a silent cross-trial state leak.
+    Per Sonbol's PR #197 review.
+    """
+    stdout = tmp_path / "stdout.log"
+    stdout.write_text("hi\n", encoding="utf-8")
+
+    def wedged_probe() -> bool:
+        time.sleep(2.0)
+        return False
+
+    mon = HangMonitor(
+        pid=1,
+        stdout_path=stdout,
+        hang_window_sec=10.0,
+        hang_grace_period_at_start=10.0,
+        poll_interval_sec=0.01,
+        gpu_idle_probe=wedged_probe,
+    )
+
+    import logging
+    from unittest.mock import patch
+
+    with patch.object(tier2_hang, "GPU_IDLE_PROBE_MAX_BLOCK_SEC", 0.1):
+        mon.start()
+        time.sleep(0.05)
+        with caplog.at_level(logging.WARNING, logger="aorta.probe.classifier.tier2_hang"):
+            mon.stop()
+
+    warnings = [rec for rec in caplog.records if "still alive" in rec.getMessage()]
+    assert warnings, "expected a 'still alive' warning when probe outlasts join budget"
+    assert mon._thread is None, "stop() still clears the thread handle"

--- a/tests/probe/classifier/test_tier2.py
+++ b/tests/probe/classifier/test_tier2.py
@@ -1,0 +1,110 @@
+"""Tests for Tier 2 hang detector (FR 2.2).
+
+The predicate is pure (operates on a :class:`HangSignals` snapshot)
+so it's tested directly. ``HangMonitor`` is exercised through its
+public ``hang_detected`` flag with synthetic stdout / IO probes —
+no real subprocess hang required.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from aorta.probe.classifier import tier2_hang
+from aorta.probe.classifier.tier2_hang import (
+    DEFAULT_HANG_GRACE_SEC,
+    DEFAULT_HANG_WINDOW_SEC,
+    HangMonitor,
+    HangSignals,
+    evaluate_predicate,
+)
+
+
+def _sig(stdout: bool, gpu: bool, io: bool, *, elapsed: float = 120.0) -> HangSignals:
+    return HangSignals(
+        stdout_silent=stdout,
+        gpu_idle=gpu,
+        io_idle=io,
+        elapsed_sec=elapsed,
+    )
+
+
+def test_two_of_three_required():
+    """Single-signal never fires; two-of-three trips it."""
+    assert not evaluate_predicate(_sig(True, False, False))
+    assert not evaluate_predicate(_sig(False, True, False))
+    assert not evaluate_predicate(_sig(False, False, True))
+    assert evaluate_predicate(_sig(True, True, False))
+    assert evaluate_predicate(_sig(True, False, True))
+    assert evaluate_predicate(_sig(False, True, True))
+    assert evaluate_predicate(_sig(True, True, True))
+
+
+def test_grace_window_suppresses_early_detection():
+    """During ``hang_grace_period_at_start``, all-three signals don't fire."""
+    early = HangSignals(stdout_silent=True, gpu_idle=True, io_idle=True, elapsed_sec=10.0)
+    assert not evaluate_predicate(early, grace_period_sec=60.0)
+
+
+def test_grace_window_default_is_60s():
+    """Default grace period matches the rubric's stated default."""
+    assert DEFAULT_HANG_GRACE_SEC == 60.0
+    assert DEFAULT_HANG_WINDOW_SEC == 30.0
+
+
+def test_grace_boundary_fires_at_or_above():
+    """At exactly the grace boundary, two-of-three trips immediately."""
+    boundary = HangSignals(
+        stdout_silent=True,
+        gpu_idle=True,
+        io_idle=False,
+        elapsed_sec=DEFAULT_HANG_GRACE_SEC,
+    )
+    assert evaluate_predicate(boundary)
+
+
+# ---- HangMonitor integration (no real hang, just signal plumbing) -------
+
+
+def test_monitor_starts_and_stops_cleanly(tmp_path: Path):
+    """``HangMonitor`` start/stop round-trips even without a subprocess."""
+    stdout = tmp_path / "stdout.log"
+    stdout.write_text("hello\n", encoding="utf-8")
+    # PID 1 always exists; the monitor will read /proc/1/io and either
+    # get a value or fail-soft to 0 on hosts that don't expose it.
+    mon = HangMonitor(
+        pid=1,
+        stdout_path=stdout,
+        hang_window_sec=0.05,
+        hang_grace_period_at_start=0.0,
+        poll_interval_sec=0.01,
+    )
+    mon.start()
+    time.sleep(0.05)
+    mon.stop()
+    # No assertion on hang_detected -- depends on whether /proc/1/io
+    # was readable and how the test scheduler interleaved; this test
+    # is purely about clean start/stop.
+
+
+def test_monitor_no_hang_during_grace(tmp_path: Path):
+    """The monitor's ``hang_detected`` stays False while inside grace."""
+    stdout = tmp_path / "stdout.log"
+    stdout.write_text("hello\n", encoding="utf-8")
+    mon = HangMonitor(
+        pid=1,
+        stdout_path=stdout,
+        hang_window_sec=0.05,
+        hang_grace_period_at_start=10.0,  # well above the test window
+        poll_interval_sec=0.01,
+    )
+    mon.start()
+    time.sleep(0.05)
+    mon.stop()
+    assert mon.hang_detected is False
+
+
+def test_module_detector_id():
+    """Detector ID is the rubric-mandated ``tier2:hang``."""
+    assert tier2_hang.DETECTOR_HANG == "tier2:hang"

--- a/tests/probe/classifier/test_tier2.py
+++ b/tests/probe/classifier/test_tier2.py
@@ -108,3 +108,45 @@ def test_monitor_no_hang_during_grace(tmp_path: Path):
 def test_module_detector_id():
     """Detector ID is the rubric-mandated ``tier2:hang``."""
     assert tier2_hang.DETECTOR_HANG == "tier2:hang"
+
+
+def test_monitor_cannot_fire_when_io_source_is_missing(tmp_path: Path, monkeypatch):
+    """Regression for PR #197 review: an unreadable ``/proc/<pid>/io`` used
+    to look like a stable I/O counter (``_io_total`` returned 0 on the
+    error path), which would flip ``io_idle=True`` after ``hang_window_sec``
+    on hosts with ptrace_scope/permission restrictions. The monitor must
+    treat "I/O availability unknown" as ``io_idle=False`` so the detector
+    cannot fire from the I/O leg alone.
+    """
+    stdout = tmp_path / "stdout.log"
+    stdout.write_text("hello\n", encoding="utf-8")
+    mon = HangMonitor(
+        pid=1,
+        stdout_path=stdout,
+        hang_window_sec=0.01,
+        hang_grace_period_at_start=0.0,
+        poll_interval_sec=0.01,
+    )
+    monkeypatch.setattr(mon, "_io_total", lambda: None)
+    monkeypatch.setattr(mon, "_stdout_mtime", lambda: stdout.stat().st_mtime)
+    mon.start()
+    time.sleep(0.1)
+    mon.stop()
+    assert mon.hang_detected is False, (
+        "tier2 fired with the I/O source unreadable; the only signals that "
+        "could have voted True are stdout_silent (gpu_idle defaults to "
+        "False), so two-of-three is impossible -- the unavailability of "
+        "I/O is being misread as a stable counter"
+    )
+
+
+def test_io_total_returns_none_for_unreadable_pid():
+    """``_io_total`` distinguishes ``0 bytes done`` from ``unreadable``.
+
+    PID ``-1`` cannot exist (kernel reserves negative PIDs as TIDs for
+    threads, never as process IDs the user can spawn), so
+    ``/proc/-1/io`` is guaranteed absent and the helper must return
+    None rather than 0.
+    """
+    mon = HangMonitor(pid=-1, stdout_path=Path("/dev/null"))
+    assert mon._io_total() is None

--- a/tests/probe/classifier/test_tier3.py
+++ b/tests/probe/classifier/test_tier3.py
@@ -10,7 +10,10 @@ import pytest
 from aorta.probe.classifier import tier3_kernel
 from aorta.probe.classifier.tier3_kernel import (
     AmdSmiSnapshot,
+    GPU_IDLE_UTILIZATION_THRESHOLD_PCT,
     Tier3State,
+    _parse_amd_smi_monitor_csv,
+    gpu_idle_probe_from_state,
     poll_amd_smi,
     scan_amd_smi,
     scan_dmesg,
@@ -146,3 +149,152 @@ def test_scan_dmesg_via_shim(monkeypatch, tmp_path):
     state = Tier3State()
     fired = scan_dmesg(state)
     assert tier3_kernel.DETECTOR_AMDGPU_RESET in fired
+
+
+# ---- Live amd-smi CSV parsing (PR #197 round-2 review) -------------------
+
+
+def test_parse_amd_smi_monitor_csv_typical_shape():
+    """The documented ``amd-smi monitor --csv --gfx --vram-usage``
+    output: a single header row + one row per GPU. The parser
+    sums VRAM_USED across GPUs and takes the max GFX%.
+    """
+    payload = (
+        "GPU,GFX%,VRAM_USED\n"
+        "0,5 %,14 MB\n"
+        "1,87 %,1024 MB\n"
+        "2,0 %,14 MB\n"
+    )
+    snap = _parse_amd_smi_monitor_csv(payload)
+    assert snap is not None
+    assert snap.vram_used_mib == 14 + 1024 + 14
+    assert snap.gpu_utilization_pct == 87  # max across GPUs
+    assert snap.thermal_throttle_count == 0  # live path leaves this at 0
+
+
+def test_parse_amd_smi_monitor_csv_handles_units_and_na():
+    """N/A cells contribute nothing; GB scales by 1024."""
+    payload = (
+        "GPU,GFX%,VRAM_USED\n"
+        "0,N/A,4 GB\n"   # 4 * 1024 MiB
+        "1,42 %,N/A\n"   # contributes util only
+    )
+    snap = _parse_amd_smi_monitor_csv(payload)
+    assert snap is not None
+    assert snap.vram_used_mib == 4 * 1024
+    assert snap.gpu_utilization_pct == 42
+
+
+def test_parse_amd_smi_monitor_csv_unknown_header_returns_none():
+    """Unknown header (e.g. an older ROCm shipping different column
+    names) returns None so the caller logs a single ``tier3
+    disabled`` warning and the live path stays fail-soft."""
+    payload = "FOO,BAR\n1,2\n"
+    assert _parse_amd_smi_monitor_csv(payload) is None
+
+
+def test_parse_amd_smi_monitor_csv_empty_returns_none():
+    """An empty payload returns None (no header to inspect)."""
+    assert _parse_amd_smi_monitor_csv("") is None
+
+
+def test_poll_amd_smi_via_shim(monkeypatch, tmp_path):
+    """End-to-end shim test: a fake ``amd-smi`` on PATH emits the
+    monitor CSV the parser expects and ``poll_amd_smi`` returns a
+    populated snapshot. Mirrors :func:`test_scan_dmesg_via_shim`
+    for the new live polling path (PR #197 round-2 review on
+    `tier3_kernel.py:277`).
+    """
+    monkeypatch.delenv("AORTA_PROBE_AMDSMI_FAKE", raising=False)
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    shim = shim_dir / "amd-smi"
+    shim.write_text(
+        "#!/bin/sh\n"
+        "cat <<'EOF'\n"
+        "GPU,GFX%,VRAM_USED\n"
+        "0,12 %,256 MB\n"
+        "1,80 %,512 MB\n"
+        "EOF\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    state = Tier3State()
+    snap = poll_amd_smi(state)
+    assert snap is not None
+    assert snap.vram_used_mib == 256 + 512
+    assert snap.gpu_utilization_pct == 80
+
+
+def test_poll_amd_smi_shim_failure_logs_once(monkeypatch, tmp_path, caplog):
+    """A shim that exits non-zero -> ``poll_amd_smi`` returns None and
+    logs a single ``tier3 disabled (amd-smi)`` warning (FR 2.11).
+    """
+    monkeypatch.delenv("AORTA_PROBE_AMDSMI_FAKE", raising=False)
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    shim = shim_dir / "amd-smi"
+    shim.write_text("#!/bin/sh\necho 'boom' >&2\nexit 1\n", encoding="utf-8")
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    state = Tier3State()
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            assert poll_amd_smi(state) is None
+    disabled = [
+        r for r in caplog.records
+        if "tier3 disabled" in r.getMessage() and "amd-smi" in r.getMessage()
+    ]
+    assert len(disabled) == 1
+
+
+# ---- gpu_idle_probe_from_state (PR #197 round-2 review) ------------------
+
+
+def test_gpu_idle_probe_idle_when_utilization_below_threshold(monkeypatch):
+    """``gpu_idle_probe_from_state`` returns True when amd-smi reports
+    a max-GPU utilization strictly below
+    :data:`GPU_IDLE_UTILIZATION_THRESHOLD_PCT`. Wires the third leg
+    of the two-of-three Tier 2 hang predicate.
+    """
+    idle_pct = max(0, GPU_IDLE_UTILIZATION_THRESHOLD_PCT - 1)
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", f"vram=100,throttle=0,util={idle_pct}")
+    state = Tier3State()
+    probe = gpu_idle_probe_from_state(state)
+    assert probe() is True
+
+
+def test_gpu_idle_probe_not_idle_when_utilization_at_or_above_threshold(monkeypatch):
+    """Equal to the threshold is NOT idle (strict less-than)."""
+    monkeypatch.setenv(
+        "AORTA_PROBE_AMDSMI_FAKE",
+        f"vram=100,throttle=0,util={GPU_IDLE_UTILIZATION_THRESHOLD_PCT}",
+    )
+    state = Tier3State()
+    assert gpu_idle_probe_from_state(state)() is False
+
+
+def test_gpu_idle_probe_returns_false_when_amd_smi_unavailable(monkeypatch):
+    """No amd-smi on PATH, no fake env var -> probe returns False so
+    the GPU leg can never single-handedly trip the two-of-three
+    predicate (parity with the I/O leg's None-handling).
+    """
+    monkeypatch.delenv("AORTA_PROBE_AMDSMI_FAKE", raising=False)
+    monkeypatch.setenv("PATH", "/nonexistent-dir-that-does-not-exist")
+    state = Tier3State()
+    assert gpu_idle_probe_from_state(state)() is False
+
+
+def test_gpu_idle_probe_returns_false_when_utilization_column_missing(monkeypatch):
+    """Live snapshot with no ``gpu_utilization_pct`` (e.g. CSV had
+    only VRAM_USED) -> probe returns False, NOT True.
+    """
+    monkeypatch.delenv("AORTA_PROBE_AMDSMI_FAKE", raising=False)
+    state = Tier3State()
+
+    def fake_poll(_state):
+        return AmdSmiSnapshot(vram_used_mib=100, thermal_throttle_count=0)
+
+    monkeypatch.setattr(tier3_kernel, "poll_amd_smi", fake_poll)
+    assert gpu_idle_probe_from_state(state)() is False

--- a/tests/probe/classifier/test_tier3.py
+++ b/tests/probe/classifier/test_tier3.py
@@ -1,0 +1,148 @@
+"""Tests for Tier 3 dmesg / amd-smi detectors (FR 2.3, 2.11)."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from aorta.probe.classifier import tier3_kernel
+from aorta.probe.classifier.tier3_kernel import (
+    AmdSmiSnapshot,
+    Tier3State,
+    poll_amd_smi,
+    scan_amd_smi,
+    scan_dmesg,
+    scan_dmesg_text,
+)
+
+# ---- Pure text-scan path -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,detector",
+    [
+        ("amdgpu: GPU reset failed\nfoo", tier3_kernel.DETECTOR_AMDGPU_RESET),
+        ("SDMA semaphore timeout", tier3_kernel.DETECTOR_SDMA_TIMEOUT),
+        ("SDMA hang detected on engine 0", tier3_kernel.DETECTOR_SDMA_TIMEOUT),
+        ("VM_L2_PROTECTION_FAULT_STATUS: ...", tier3_kernel.DETECTOR_VM_L2_FAULT),
+        ("XGMI link down detected", tier3_kernel.DETECTOR_XGMI_LINK_ERROR),
+        ("AER: Fatal error received", tier3_kernel.DETECTOR_PCIE_AER_FATAL),
+    ],
+)
+def test_scan_dmesg_text_patterns(text, detector):
+    fired = scan_dmesg_text(text)
+    assert detector in fired
+
+
+def test_scan_dmesg_text_no_match():
+    assert scan_dmesg_text("nothing relevant here\nall green") == []
+
+
+def test_scan_dmesg_text_empty():
+    assert scan_dmesg_text("") == []
+
+
+def test_xgmi_healthy_does_not_fire():
+    """A healthy XGMI line ('XGMI initialized') stays silent."""
+    assert scan_dmesg_text("XGMI initialized successfully") == []
+
+
+# ---- Fail-soft missing-binary path (FR 2.11) -----------------------------
+
+
+def test_dmesg_missing_logs_once(monkeypatch, caplog):
+    """``dmesg`` missing -> single ``tier3 disabled:`` warning per invocation."""
+    monkeypatch.setenv("PATH", "/nonexistent-dir-that-does-not-exist")
+    state = Tier3State()
+    with caplog.at_level(logging.WARNING):
+        scan_dmesg(state)
+        scan_dmesg(state)
+        scan_dmesg(state)
+    disabled_warnings = [
+        record
+        for record in caplog.records
+        if "tier3 disabled" in record.getMessage() and "dmesg" in record.getMessage()
+    ]
+    assert len(disabled_warnings) == 1
+
+
+def test_amdsmi_missing_logs_once(monkeypatch, caplog):
+    """Same one-warning rule for ``amd-smi`` (FR 2.11 + R3)."""
+    monkeypatch.setenv("PATH", "/nonexistent-dir-that-does-not-exist")
+    monkeypatch.delenv("AORTA_PROBE_AMDSMI_FAKE", raising=False)
+    state = Tier3State()
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            poll_amd_smi(state)
+    disabled_warnings = [
+        record
+        for record in caplog.records
+        if "tier3 disabled" in record.getMessage() and "amd-smi" in record.getMessage()
+    ]
+    assert len(disabled_warnings) == 1
+
+
+# ---- amd-smi diff logic via fake-shim env var ----------------------------
+
+
+def test_amdsmi_fake_env_var_vram_growth(monkeypatch):
+    """Fake-shim diff above VRAM threshold fires ``tier3:vram_growth``."""
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=100,throttle=0")
+    state = Tier3State()
+    pre = poll_amd_smi(state)
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=500,throttle=0")
+    post = poll_amd_smi(state)
+    fired = scan_amd_smi(state, pre, post)
+    assert tier3_kernel.DETECTOR_VRAM_GROWTH in fired
+
+
+def test_amdsmi_fake_env_var_thermal_throttle(monkeypatch):
+    """Throttle counter incremented -> ``tier3:thermal_throttle`` fires."""
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=100,throttle=0")
+    state = Tier3State()
+    pre = poll_amd_smi(state)
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=100,throttle=5")
+    post = poll_amd_smi(state)
+    fired = scan_amd_smi(state, pre, post)
+    assert tier3_kernel.DETECTOR_THERMAL_THROTTLE in fired
+
+
+def test_amdsmi_below_threshold_does_not_fire(monkeypatch):
+    """VRAM delta under the threshold stays silent (noise floor)."""
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=100,throttle=0")
+    state = Tier3State()
+    pre = poll_amd_smi(state)
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=110,throttle=0")
+    post = poll_amd_smi(state)
+    fired = scan_amd_smi(state, pre, post)
+    assert tier3_kernel.DETECTOR_VRAM_GROWTH not in fired
+    assert tier3_kernel.DETECTOR_THERMAL_THROTTLE not in fired
+
+
+def test_amdsmi_missing_snapshot_returns_no_detectors():
+    """None snapshot -> fail-soft (no fired detectors)."""
+    state = Tier3State()
+    pre = AmdSmiSnapshot(vram_used_mib=100, thermal_throttle_count=0)
+    assert scan_amd_smi(state, pre, None) == []
+    assert scan_amd_smi(state, None, pre) == []
+
+
+# ---- dmesg shim via PATH (FR 2.3 happy path) -----------------------------
+
+
+def test_scan_dmesg_via_shim(monkeypatch, tmp_path):
+    """A fake ``dmesg`` script on PATH emits canned content the scanner sees."""
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    shim = shim_dir / "dmesg"
+    shim.write_text(
+        "#!/bin/sh\necho 'amdgpu: GPU reset triggered'\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    state = Tier3State()
+    fired = scan_dmesg(state)
+    assert tier3_kernel.DETECTOR_AMDGPU_RESET in fired

--- a/tests/probe/classifier/test_tier3.py
+++ b/tests/probe/classifier/test_tier3.py
@@ -9,8 +9,8 @@ import pytest
 
 from aorta.probe.classifier import tier3_kernel
 from aorta.probe.classifier.tier3_kernel import (
-    AmdSmiSnapshot,
     GPU_IDLE_UTILIZATION_THRESHOLD_PCT,
+    AmdSmiSnapshot,
     Tier3State,
     _parse_amd_smi_monitor_csv,
     gpu_idle_probe_from_state,
@@ -45,6 +45,31 @@ def test_scan_dmesg_text_no_match():
 
 def test_scan_dmesg_text_empty():
     assert scan_dmesg_text("") == []
+
+
+def test_scan_dmesg_text_truncates_to_tail_not_head(monkeypatch):
+    """Regression for PR #197 review (Sonbol): the dmesg truncation
+    must keep the tail, not the head.
+
+    XGMI / HBM / MMU kernel signatures are almost always emitted
+    in the seconds before a failing trial ends -- i.e. at the
+    end of the dmesg ring. The previous head-slice (``text[:MAX]``)
+    discarded exactly those lines on long-running trials.
+
+    Verified by planting an XGMI error at the *tail* of an oversized
+    blob and confirming the detector fires.
+    """
+    monkeypatch.setattr(tier3_kernel, "MAX_DMESG_BYTES", 100)
+    head_noise = "boot: amdgpu probe ok\n" * 20  # well past 100 bytes
+    tail_signature = "XGMI link down detected on dev 1\n"
+    blob = head_noise + tail_signature
+    assert len(blob) > 100, "fixture must exceed cap to force truncation"
+
+    fired = scan_dmesg_text(blob)
+    assert tier3_kernel.DETECTOR_XGMI_LINK_ERROR in fired, (
+        "tail-side signature must survive truncation; the previous "
+        "head-slice would have discarded it"
+    )
 
 
 def test_xgmi_healthy_does_not_fire():

--- a/tests/probe/classifier/test_tier4.py
+++ b/tests/probe/classifier/test_tier4.py
@@ -23,13 +23,13 @@ FIXTURES = Path(__file__).parent.parent / "fixtures" / "tier4_logs"
 @pytest.mark.parametrize(
     "fixture_name,detector_id",
     [
-        ("python_traceback.log", tier4_patterns.DETECTOR_PYTHON_TRACEBACK),
-        ("hip_error.log", tier4_patterns.DETECTOR_HIP_ERROR),
-        ("cuda_error.log", tier4_patterns.DETECTOR_CUDA_ERROR),
-        ("rocm_error.log", tier4_patterns.DETECTOR_ROCM_ERROR),
-        ("nccl_rccl_error.log", tier4_patterns.DETECTOR_NCCL_RCCL_ERROR),
-        ("collective_timeout.log", tier4_patterns.DETECTOR_COLLECTIVE_TIMEOUT),
-        ("nan_signature.log", tier4_patterns.DETECTOR_NAN_SIGNATURE),
+        ("python_traceback.txt", tier4_patterns.DETECTOR_PYTHON_TRACEBACK),
+        ("hip_error.txt", tier4_patterns.DETECTOR_HIP_ERROR),
+        ("cuda_error.txt", tier4_patterns.DETECTOR_CUDA_ERROR),
+        ("rocm_error.txt", tier4_patterns.DETECTOR_ROCM_ERROR),
+        ("nccl_rccl_error.txt", tier4_patterns.DETECTOR_NCCL_RCCL_ERROR),
+        ("collective_timeout.txt", tier4_patterns.DETECTOR_COLLECTIVE_TIMEOUT),
+        ("nan_signature.txt", tier4_patterns.DETECTOR_NAN_SIGNATURE),
     ],
 )
 def test_each_fixture_fires_its_detector(fixture_name, detector_id):

--- a/tests/probe/classifier/test_tier4.py
+++ b/tests/probe/classifier/test_tier4.py
@@ -71,3 +71,48 @@ def test_catalogue_entries_have_compiled_regex():
         assert isinstance(pattern.regex, re.Pattern)
         assert pattern.detector_id.startswith("tier4:")
         assert pattern.sample  # non-empty sample line
+
+
+def test_window_overlap_catches_straddling_match(monkeypatch):
+    """Regression for PR #197 review (Sonbol): a pattern whose match
+    straddles a window boundary must still fire.
+
+    The previous ``_iter_windows`` shape sliced ``text`` into
+    back-to-back non-overlapping chunks; a multi-line failure
+    signature (Python traceback header on one window, body on the
+    next) was silently missed on the >10 MiB long-log path -- the
+    very class of input Tier 4 is meant to catch. The fix adds
+    ``_WINDOW_OVERLAP_BYTES`` of carry-over between adjacent
+    windows.
+
+    Verified by shrinking the window to a small size and planting
+    a traceback that crosses the seam.
+    """
+    monkeypatch.setattr(tier4_patterns, "MAX_LOG_BYTES", 100)
+
+    # Pattern is anchored at line start (``^Traceback ...`` with
+    # re.MULTILINE), so the fixture wraps the traceback in newlines.
+    # Lay out the seam so the traceback header straddles the
+    # window-1 / window-2 boundary (window=100, no overlap would
+    # split "Traceback..." in half across two windows).
+    pad_left = ("x" * 79) + "\n"  # forces the next char to be at column 0
+    pad_right = "\n" + ("y" * 79)
+    straddling = (
+        pad_left
+        + "Traceback (most recent call last):\n"
+        + "  File 'x.py', line 1\n"
+        + "RuntimeError: boom"
+        + pad_right
+    )
+    assert len(straddling) > 100, "fixture must exceed MAX_LOG_BYTES to force chunking"
+    # Sanity: the traceback header crosses byte 100 (window seam).
+    header_start = straddling.index("Traceback")
+    assert header_start < 100 < header_start + len("Traceback (most recent call last):"), (
+        "fixture must place the header *across* the seam to exercise the overlap"
+    )
+
+    fired = scan(straddling)
+    assert tier4_patterns.DETECTOR_PYTHON_TRACEBACK in fired, (
+        "straddling traceback must fire across the chunk seam; "
+        "non-overlapping windows would silently miss it"
+    )

--- a/tests/probe/classifier/test_tier4.py
+++ b/tests/probe/classifier/test_tier4.py
@@ -1,0 +1,73 @@
+"""Tests for Tier 4 built-in pattern library (FR 2.4).
+
+Each fixture under ``tests/probe/fixtures/tier4_logs/`` holds a log
+sample that should fire exactly one Tier-4 detector.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aorta.probe.classifier import tier4_patterns
+from aorta.probe.classifier.tier4_patterns import (
+    BUILTIN_PATTERN_VERSION,
+    all_patterns,
+    scan,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "tier4_logs"
+
+
+@pytest.mark.parametrize(
+    "fixture_name,detector_id",
+    [
+        ("python_traceback.log", tier4_patterns.DETECTOR_PYTHON_TRACEBACK),
+        ("hip_error.log", tier4_patterns.DETECTOR_HIP_ERROR),
+        ("cuda_error.log", tier4_patterns.DETECTOR_CUDA_ERROR),
+        ("rocm_error.log", tier4_patterns.DETECTOR_ROCM_ERROR),
+        ("nccl_rccl_error.log", tier4_patterns.DETECTOR_NCCL_RCCL_ERROR),
+        ("collective_timeout.log", tier4_patterns.DETECTOR_COLLECTIVE_TIMEOUT),
+        ("nan_signature.log", tier4_patterns.DETECTOR_NAN_SIGNATURE),
+    ],
+)
+def test_each_fixture_fires_its_detector(fixture_name, detector_id):
+    text = (FIXTURES / fixture_name).read_text(encoding="utf-8")
+    fired = scan(text)
+    assert detector_id in fired, f"expected {detector_id} for fixture {fixture_name}; got {fired}"
+
+
+def test_empty_log_fires_nothing():
+    assert scan("") == []
+
+
+def test_unrelated_log_fires_nothing():
+    assert scan("everything is fine\nstep 100/100 done") == []
+
+
+def test_multiple_patterns_in_one_log():
+    """A log with both a traceback and an HIP error fires both detectors."""
+    text = (
+        "Traceback (most recent call last):\n"
+        "  File 'x.py'\n"
+        "RuntimeError: hipError_OutOfMemory\n"
+    )
+    fired = scan(text)
+    assert tier4_patterns.DETECTOR_PYTHON_TRACEBACK in fired
+    assert tier4_patterns.DETECTOR_HIP_ERROR in fired
+
+
+def test_builtin_pattern_version_is_string_one():
+    """The version starts at '1' for the Phase-2 PR (rubric §X.1)."""
+    assert BUILTIN_PATTERN_VERSION == "1"
+
+
+def test_catalogue_entries_have_compiled_regex():
+    """Every entry exposes a pre-compiled regex (cost paid once)."""
+    import re
+
+    for pattern in all_patterns():
+        assert isinstance(pattern.regex, re.Pattern)
+        assert pattern.detector_id.startswith("tier4:")
+        assert pattern.sample  # non-empty sample line

--- a/tests/probe/classifier/test_tier5.py
+++ b/tests/probe/classifier/test_tier5.py
@@ -162,6 +162,39 @@ def test_window_cap_does_not_explode_on_huge_log():
     assert isinstance(result, CustomScanResult)
 
 
+def test_window_overlap_catches_straddling_match(monkeypatch):
+    """Regression for PR #197 review (Sonbol, sweep from Tier 4 to
+    Tier 5): a custom_patterns match that straddles a window
+    boundary must still fire.
+
+    Operator-supplied custom patterns can legitimately match
+    multi-line regions (stack frames, JSON payloads); the
+    previous non-overlapping ``_iter_windows`` silently dropped
+    those when the match seam fell on a chunk boundary. The fix
+    mirrors Tier 4's overlap, defended below by shrinking the
+    window and planting a match that crosses it.
+    """
+    from aorta.probe.classifier import tier5_custom
+
+    monkeypatch.setattr(tier5_custom, "MAX_LOG_BYTES", 100)
+
+    pad_left = "x" * 80
+    pad_right = "y" * 80
+    straddling = pad_left + "FATAL: payload boundary kaboom" + pad_right
+    pattern = _make(raw_id="straddle", regex=r"FATAL: payload boundary kaboom")
+    result = tier5_custom.scan(
+        straddling,
+        (pattern,),
+        exit_code=1,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert "custom:straddle" in result.fail_detectors, (
+        "straddling match must fire across the chunk seam; "
+        "non-overlapping windows would silently miss it"
+    )
+
+
 def test_empty_patterns_returns_empty_result():
     result = scan(
         "anything",

--- a/tests/probe/classifier/test_tier5.py
+++ b/tests/probe/classifier/test_tier5.py
@@ -274,6 +274,37 @@ def test_validate_rejects_hostile_condition():
         validate_custom_patterns(raw)
 
 
+def test_sandbox_error_carries_recipe_path():
+    """Regression for PR #197 review (Copilot): when a hostile
+    ``condition`` survives parse, the raised ``SandboxError`` must
+    name the offending ``custom_patterns[i]`` entry so a multi-entry
+    recipe makes the bad entry findable without manual list-position
+    counting. The wrapping preserves the original sandbox detail at
+    the end of the message so no diagnostic is lost.
+    """
+    raw = [
+        {"id": "ok", "match": {"regex": "ok"}},
+        {"id": "ok2", "match": {"regex": "ok2"}},
+        {
+            "id": "bad",
+            "match": {
+                "regex": "fatal",
+                "condition": "__import__('os').system('id')",
+            },
+        },
+    ]
+    with pytest.raises(SandboxError) as exc_info:
+        validate_custom_patterns(raw)
+    msg = str(exc_info.value)
+    assert "recipe.custom_patterns[2].match.condition" in msg, (
+        f"SandboxError must carry the recipe path; got: {msg!r}"
+    )
+    # The original sandbox detail (`forbidden`) survives the wrap.
+    assert "forbidden" in msg.lower() or "__import__" in msg, (
+        f"wrapped SandboxError dropped the original sandbox detail; got: {msg!r}"
+    )
+
+
 def test_validate_rejects_unknown_top_keys():
     raw = [{"id": "p", "match": {"regex": "x"}, "bogus": True}]
     with pytest.raises(RecipeSchemaError, match="unknown keys"):

--- a/tests/probe/classifier/test_tier5.py
+++ b/tests/probe/classifier/test_tier5.py
@@ -1,0 +1,281 @@
+"""Tests for Tier 5 ``custom_patterns`` runner (FR 2.5, 2.6, 2.7)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from aorta.probe.classifier.tier5_custom import (
+    CompiledPattern,
+    CustomScanResult,
+    scan,
+    validate_custom_patterns,
+)
+from aorta.probe.sandbox import SandboxError, validate_and_compile
+from aorta.triage.recipe import RecipeSchemaError
+
+
+def _make(
+    *,
+    raw_id: str,
+    regex: str,
+    on_match: str = "fail",
+    condition: str | None = None,
+    required_for_pass: bool = False,
+) -> CompiledPattern:
+    compiled_condition = validate_and_compile(condition) if condition else None
+    return CompiledPattern(
+        detector_id=f"custom:{raw_id}",
+        regex=re.compile(regex),
+        condition_code=compiled_condition,
+        condition_source=condition,
+        on_match=on_match,  # type: ignore[arg-type]
+        required_for_pass=required_for_pass,
+    )
+
+
+# ---- scan() behaviour -----------------------------------------------------
+
+
+def test_simple_match_fires_fail_detector():
+    pattern = _make(raw_id="oom_killer", regex=r"oom_killer triggered")
+    result = scan(
+        "step 1\noom_killer triggered\nstep 2\n",
+        (pattern,),
+        exit_code=137,
+        walltime_sec=12.0,
+        peak_vram_mib=None,
+    )
+    assert result.fail_detectors == ["custom:oom_killer"]
+    assert result.warn_detectors == []
+
+
+def test_warn_match_does_not_fail():
+    pattern = _make(raw_id="slow_iter", regex=r"slow iteration", on_match="warn")
+    result = scan(
+        "slow iteration detected\n",
+        (pattern,),
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert result.fail_detectors == []
+    assert result.warn_detectors == ["custom:slow_iter"]
+
+
+def test_info_only_pattern_populates_capture():
+    pattern = _make(
+        raw_id="bw",
+        regex=r"effective bandwidth: (?P<bw>[0-9]+) GB/s",
+        on_match="info",
+    )
+    result = scan(
+        "effective bandwidth: 240 GB/s\n",
+        (pattern,),
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert result.fail_detectors == []
+    assert result.warn_detectors == []
+    assert result.capture.get("bw") == "240"
+
+
+def test_condition_gates_match():
+    """The condition must be true for the detector to fire."""
+    pattern = _make(
+        raw_id="oom_under_8gb",
+        regex=r"out of memory",
+        condition="peak_vram_mib < 8000",
+    )
+    result_low = scan(
+        "out of memory\n",
+        (pattern,),
+        exit_code=1,
+        walltime_sec=1.0,
+        peak_vram_mib=4000,
+    )
+    assert result_low.fail_detectors == ["custom:oom_under_8gb"]
+    result_high = scan(
+        "out of memory\n",
+        (pattern,),
+        exit_code=1,
+        walltime_sec=1.0,
+        peak_vram_mib=64000,
+    )
+    assert result_high.fail_detectors == []
+
+
+def test_required_for_pass_tracked():
+    pattern = _make(
+        raw_id="benchmark_ok",
+        regex=r"benchmark passed",
+        on_match="fail",  # only fail patterns may be required_for_pass
+        required_for_pass=True,
+    )
+    result_hit = scan(
+        "benchmark passed\n",
+        (pattern,),
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert "custom:benchmark_ok" in result_hit.fired_required_ids
+    result_miss = scan(
+        "other output\n",
+        (pattern,),
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert result_miss.fired_required_ids == set()
+
+
+def test_no_match_no_capture():
+    pattern = _make(
+        raw_id="bw",
+        regex=r"effective bandwidth: (?P<bw>[0-9]+) GB/s",
+    )
+    result = scan(
+        "totally unrelated log\n",
+        (pattern,),
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert result.fail_detectors == []
+    assert result.capture == {}
+
+
+def test_window_cap_does_not_explode_on_huge_log():
+    """A 12 MiB log scans cleanly without OOM."""
+    big = ("xx\n" * (2 * 1024 * 1024)) + "FATAL: kaboom\n"
+    pattern = _make(raw_id="kaboom", regex=r"FATAL: kaboom")
+    result = scan(
+        big,
+        (pattern,),
+        exit_code=1,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert isinstance(result, CustomScanResult)
+
+
+def test_empty_patterns_returns_empty_result():
+    result = scan(
+        "anything",
+        (),
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert result.fail_detectors == []
+    assert result.warn_detectors == []
+    assert result.capture == {}
+
+
+def test_empty_log_returns_empty_result():
+    pattern = _make(raw_id="x", regex=r"x")
+    result = scan(
+        "",
+        (pattern,),
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert result.fail_detectors == []
+
+
+# ---- validate_custom_patterns() at recipe load -----------------------------
+
+
+def test_validate_accepts_simple_recipe():
+    raw = [
+        {
+            "id": "oom",
+            "match": {"regex": "out of memory"},
+            "on_match": "fail",
+        }
+    ]
+    compiled = validate_custom_patterns(raw)
+    assert len(compiled) == 1
+    assert compiled[0].detector_id == "custom:oom"
+
+
+def test_validate_none_returns_empty_tuple():
+    assert validate_custom_patterns(None) == ()
+
+
+def test_validate_rejects_empty_list():
+    with pytest.raises(RecipeSchemaError, match="non-empty"):
+        validate_custom_patterns([])
+
+
+def test_validate_rejects_duplicate_ids():
+    raw = [
+        {"id": "x", "match": {"regex": "a"}},
+        {"id": "x", "match": {"regex": "b"}},
+    ]
+    with pytest.raises(RecipeSchemaError, match="duplicate id"):
+        validate_custom_patterns(raw)
+
+
+def test_validate_rejects_invalid_regex():
+    raw = [{"id": "broken", "match": {"regex": "(unclosed"}}]
+    with pytest.raises(RecipeSchemaError, match="invalid regex"):
+        validate_custom_patterns(raw)
+
+
+def test_validate_rejects_hostile_condition():
+    raw = [
+        {
+            "id": "p",
+            "match": {
+                "regex": "fatal",
+                "condition": "__import__('os').system('id')",
+            },
+        }
+    ]
+    with pytest.raises(SandboxError):
+        validate_custom_patterns(raw)
+
+
+def test_validate_rejects_unknown_top_keys():
+    raw = [{"id": "p", "match": {"regex": "x"}, "bogus": True}]
+    with pytest.raises(RecipeSchemaError, match="unknown keys"):
+        validate_custom_patterns(raw)
+
+
+def test_validate_rejects_invalid_on_match():
+    raw = [{"id": "p", "match": {"regex": "x"}, "on_match": "explode"}]
+    with pytest.raises(RecipeSchemaError, match="on_match"):
+        validate_custom_patterns(raw)
+
+
+def test_validate_rejects_required_for_pass_on_warn():
+    raw = [
+        {
+            "id": "p",
+            "match": {"regex": "x"},
+            "on_match": "warn",
+            "required_for_pass": True,
+        }
+    ]
+    with pytest.raises(RecipeSchemaError, match="required_for_pass"):
+        validate_custom_patterns(raw)
+
+
+def test_validate_accepts_condition_at_load_time():
+    raw = [
+        {
+            "id": "vram_check",
+            "match": {
+                "regex": "vram=(?P<used>[0-9]+)",
+                "condition": "int(capture['used']) > 1000",
+            },
+        }
+    ]
+    compiled = validate_custom_patterns(raw)
+    assert compiled[0].condition_code is not None
+    assert compiled[0].condition_source == "int(capture['used']) > 1000"

--- a/tests/probe/classifier/test_verdict.py
+++ b/tests/probe/classifier/test_verdict.py
@@ -1,0 +1,156 @@
+"""Tests for the verdict-precedence resolver (FR 2.8)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from aorta.probe.classifier.tier5_custom import CompiledPattern, CustomScanResult
+from aorta.probe.classifier.verdict import (
+    DETECTOR_MISSING_PASS_SIGNAL,
+    VerdictInputs,
+    resolve,
+)
+
+
+def _required_pattern(raw_id: str) -> CompiledPattern:
+    return CompiledPattern(
+        detector_id=f"custom:{raw_id}",
+        regex=re.compile("x"),
+        condition_code=None,
+        condition_source=None,
+        on_match="fail",
+        required_for_pass=True,
+    )
+
+
+def _inputs(**kw) -> VerdictInputs:
+    base = {
+        "tier1": [],
+        "tier2": [],
+        "tier3": [],
+        "tier4": [],
+        "custom_result": CustomScanResult(),
+        "custom_required_patterns": (),
+    }
+    base.update(kw)
+    return VerdictInputs(**base)
+
+
+def test_pass_when_nothing_fired():
+    verdict = resolve(_inputs())
+    assert verdict.verdict == "pass"
+    assert verdict.failure_detectors_fired == []
+    assert verdict.warn_detectors_fired == []
+
+
+def test_tier1_fail_alone_is_enough():
+    verdict = resolve(_inputs(tier1=["tier1:sigsegv"]))
+    assert verdict.verdict == "fail"
+    assert verdict.failure_detectors_fired == ["tier1:sigsegv"]
+
+
+@pytest.mark.parametrize(
+    "kw,expected",
+    [
+        ({"tier1": ["tier1:exit_nonzero"]}, "tier1:exit_nonzero"),
+        ({"tier2": ["tier2:hang"]}, "tier2:hang"),
+        ({"tier3": ["tier3:amdgpu_reset"]}, "tier3:amdgpu_reset"),
+        ({"tier4": ["tier4:hip_error"]}, "tier4:hip_error"),
+    ],
+)
+def test_any_tier_failure_is_a_fail(kw, expected):
+    verdict = resolve(_inputs(**kw))
+    assert verdict.verdict == "fail"
+    assert expected in verdict.failure_detectors_fired
+
+
+def test_custom_fail_pattern_is_a_fail():
+    custom = CustomScanResult(fail_detectors=["custom:my_pattern"])
+    verdict = resolve(_inputs(custom_result=custom))
+    assert verdict.verdict == "fail"
+    assert "custom:my_pattern" in verdict.failure_detectors_fired
+
+
+def test_warn_alone_is_pass():
+    custom = CustomScanResult(warn_detectors=["custom:slow_iter"])
+    verdict = resolve(_inputs(custom_result=custom))
+    assert verdict.verdict == "pass"
+    assert verdict.failure_detectors_fired == []
+    assert verdict.warn_detectors_fired == ["custom:slow_iter"]
+
+
+def test_info_match_populates_capture_only():
+    """Info-only patterns populate ``capture`` but never the verdict lists."""
+    custom = CustomScanResult(capture={"bw": "240"})
+    verdict = resolve(_inputs(custom_result=custom))
+    assert verdict.verdict == "pass"
+    assert verdict.capture == {"bw": "240"}
+
+
+def test_encounter_order_preserved_across_tiers():
+    """All tiers contribute in T1->T2->T3->T4->custom-fail order."""
+    custom = CustomScanResult(fail_detectors=["custom:p"])
+    verdict = resolve(
+        _inputs(
+            tier1=["tier1:exit_nonzero"],
+            tier2=["tier2:hang"],
+            tier3=["tier3:amdgpu_reset"],
+            tier4=["tier4:hip_error", "tier4:nan_signature"],
+            custom_result=custom,
+        )
+    )
+    assert verdict.failure_detectors_fired == [
+        "tier1:exit_nonzero",
+        "tier2:hang",
+        "tier3:amdgpu_reset",
+        "tier4:hip_error",
+        "tier4:nan_signature",
+        "custom:p",
+    ]
+
+
+def test_required_for_pass_missing_marks_fail():
+    """``required_for_pass`` not fired -> ``meta:missing_pass_signal``."""
+    required = _required_pattern("benchmark_ok")
+    custom = CustomScanResult()  # nothing fired
+    verdict = resolve(
+        _inputs(
+            custom_result=custom,
+            custom_required_patterns=(required,),
+        )
+    )
+    assert verdict.verdict == "fail"
+    assert DETECTOR_MISSING_PASS_SIGNAL in verdict.failure_detectors_fired
+
+
+def test_required_for_pass_satisfied_no_meta():
+    """When every required pattern fired, ``meta:missing_pass_signal`` is NOT injected."""
+    required = _required_pattern("benchmark_ok")
+    custom = CustomScanResult(
+        fail_detectors=["custom:benchmark_ok"],
+        fired_required_ids={"custom:benchmark_ok"},
+    )
+    verdict = resolve(
+        _inputs(
+            custom_result=custom,
+            custom_required_patterns=(required,),
+        )
+    )
+    assert DETECTOR_MISSING_PASS_SIGNAL not in verdict.failure_detectors_fired
+
+
+def test_required_for_pass_no_required_patterns_no_meta():
+    """When the recipe declares no required patterns, meta detector is never injected."""
+    verdict = resolve(_inputs())
+    assert DETECTOR_MISSING_PASS_SIGNAL not in verdict.failure_detectors_fired
+
+
+def test_returned_lists_are_fresh_copies():
+    """Caller mutating verdict.failure_detectors_fired should not poison resolver state."""
+    verdict = resolve(_inputs(tier1=["tier1:exit_nonzero"]))
+    verdict.failure_detectors_fired.append("mutated")
+    # The second resolve must NOT see "mutated"; the resolver builds a new list each call.
+    verdict2 = resolve(_inputs(tier1=["tier1:exit_nonzero"]))
+    assert "mutated" not in verdict2.failure_detectors_fired

--- a/tests/probe/classifier/test_verdict.py
+++ b/tests/probe/classifier/test_verdict.py
@@ -25,8 +25,8 @@ def _required_pattern(raw_id: str) -> CompiledPattern:
     )
 
 
-def _inputs(**kw) -> VerdictInputs:
-    base = {
+def _inputs(**kw: object) -> VerdictInputs:
+    base: dict[str, object] = {
         "tier1": [],
         "tier2": [],
         "tier3": [],
@@ -35,7 +35,7 @@ def _inputs(**kw) -> VerdictInputs:
         "custom_required_patterns": (),
     }
     base.update(kw)
-    return VerdictInputs(**base)
+    return VerdictInputs(**base)  # type: ignore[arg-type]
 
 
 def test_pass_when_nothing_fired():

--- a/tests/probe/fixtures/conditions/hostile.txt
+++ b/tests/probe/fixtures/conditions/hostile.txt
@@ -17,3 +17,6 @@ math.__loader__.load_module('os')
 '%999999998s' % capture['x']  # forbidden-node: ast.Mod is no longer in the allow-list (printf-style %s would allocate the same billion-byte buffer)
 capture['x'] * 999999998  # forbidden-node: ast.Mult; the multiplier dodges the integer-literal cap because it's named
 'oom' in capture['msg']  # forbidden-node: ast.In is not in the allow-list (the docs explicitly point users at the regex field for substring matching)
+capture[exit_code]  # capture[...] index must be a string literal -- a Name index would land as KeyError at eval time (capture is dict[str, str]) and tier5 swallows the exception silently
+capture[0]  # capture[...] index must be a string literal -- a numeric index would land as KeyError at eval time and tier5 swallows the exception silently
+capture['x':]  # capture[...] index must be a string literal -- a slice would land as TypeError at eval time and tier5 swallows the exception silently

--- a/tests/probe/fixtures/conditions/hostile.txt
+++ b/tests/probe/fixtures/conditions/hostile.txt
@@ -1,0 +1,15 @@
+__import__('os').system('rm -rf /')
+(0).__class__.__bases__[0].__subclasses__()
+().__class__.__mro__[-1]
+open('/etc/passwd').read()
+exec("import os; os.system('id')")
+eval("1+1")
+lambda x: x
+[x for x in range(10)]
+{k: v for k, v in capture.items()}
+capture.update({'pwn': '1'})
+type(capture)
+getattr(capture, 'pop')('eval_loss')
+capture['x'].__class__
+math.__loader__.load_module('os')
+2 ** 1000000000  # length-restricted: reject expressions > 256 chars

--- a/tests/probe/fixtures/conditions/hostile.txt
+++ b/tests/probe/fixtures/conditions/hostile.txt
@@ -13,3 +13,7 @@ getattr(capture, 'pop')('eval_loss')
 capture['x'].__class__
 math.__loader__.load_module('os')
 2 ** 1000000000  # forbidden-node: ast.Pow is no longer in the allow-list (would otherwise build a huge int via int.__pow__)
+'a' * 999999998  # forbidden-node: ast.Mult is no longer in the allow-list (string repetition would allocate ~1 GiB without crossing MAX_INT_CONSTANT)
+'%999999998s' % capture['x']  # forbidden-node: ast.Mod is no longer in the allow-list (printf-style %s would allocate the same billion-byte buffer)
+capture['x'] * 999999998  # forbidden-node: ast.Mult; the multiplier dodges the integer-literal cap because it's named
+'oom' in capture['msg']  # forbidden-node: ast.In is not in the allow-list (the docs explicitly point users at the regex field for substring matching)

--- a/tests/probe/fixtures/conditions/hostile.txt
+++ b/tests/probe/fixtures/conditions/hostile.txt
@@ -12,4 +12,4 @@ type(capture)
 getattr(capture, 'pop')('eval_loss')
 capture['x'].__class__
 math.__loader__.load_module('os')
-2 ** 1000000000  # length-restricted: reject expressions > 256 chars
+2 ** 1000000000  # forbidden-node: ast.Pow is no longer in the allow-list (would otherwise build a huge int via int.__pow__)

--- a/tests/probe/fixtures/tier4_logs/collective_timeout.txt
+++ b/tests/probe/fixtures/tier4_logs/collective_timeout.txt
@@ -1,0 +1,2 @@
+[rank3]: Watchdog caught collective operation timeout: WorkNCCL(SeqNum=42)
+[rank3]: terminating worker

--- a/tests/probe/fixtures/tier4_logs/cuda_error.txt
+++ b/tests/probe/fixtures/tier4_logs/cuda_error.txt
@@ -1,0 +1,3 @@
+opening tensor
+operator returned cudaErrorIllegalAddress at kernel.cu:120
+aborting

--- a/tests/probe/fixtures/tier4_logs/hip_error.txt
+++ b/tests/probe/fixtures/tier4_logs/hip_error.txt
@@ -1,0 +1,3 @@
+starting trial
+HIP runtime call failed with hipError_OutOfMemory (status=2)
+exit 1

--- a/tests/probe/fixtures/tier4_logs/nan_signature.txt
+++ b/tests/probe/fixtures/tier4_logs/nan_signature.txt
@@ -1,0 +1,3 @@
+step=99 lr=0.001
+step=100 loss is NaN; aborting
+checkpoint discarded

--- a/tests/probe/fixtures/tier4_logs/nccl_rccl_error.txt
+++ b/tests/probe/fixtures/tier4_logs/nccl_rccl_error.txt
@@ -1,0 +1,3 @@
+[rank0]: starting collective
+[rank0]: NCCL error: unhandled system error (run with NCCL_DEBUG=INFO)
+[rank0]: shutting down

--- a/tests/probe/fixtures/tier4_logs/python_traceback.txt
+++ b/tests/probe/fixtures/tier4_logs/python_traceback.txt
@@ -1,0 +1,7 @@
+Some preamble line.
+Traceback (most recent call last):
+  File "train.py", line 42, in <module>
+    main()
+  File "train.py", line 31, in main
+    model.train()
+RuntimeError: CUDA out of memory

--- a/tests/probe/fixtures/tier4_logs/rocm_error.txt
+++ b/tests/probe/fixtures/tier4_logs/rocm_error.txt
@@ -1,0 +1,3 @@
+device init complete
+hsa-runtime: failed to allocate Error code: 1
+shutdown

--- a/tests/probe/test_end_to_end.py
+++ b/tests/probe/test_end_to_end.py
@@ -48,6 +48,63 @@ def test_smoke_passes(tmp_path):
     assert "hi" in stdout
 
 
+def test_custom_patterns_recipe_does_not_break_dispatcher_json(tmp_path):
+    """Regression for PR #197 round-7 review: a probe-mode recipe with
+    ``custom_patterns`` used to crash the dispatcher's per-trial
+    JSON write because ``probe_extras_payload['custom_patterns']``
+    held :class:`CompiledPattern` objects (compiled ``re.Pattern`` +
+    ``CodeType``), neither of which is JSON-serializable. The
+    dispatcher now sanitizes the tuple down to a JSON-safe summary
+    list before ``json.dump``; this test pins the contract by
+    running a real probe through ``CliRunner`` with
+    ``custom_patterns`` present and asserting the dispatcher's
+    ``trial_d*_m*_t*.json`` is both written and round-trippable.
+    """
+    output = tmp_path / "out"
+    runner = CliRunner()
+    result = runner.invoke(
+        probe,
+        [
+            "--recipe",
+            str(FIXTURES / "probe_with_phase_2_keys.yaml"),
+            "--output",
+            str(output),
+            "--ticket",
+            "CUSTOM-PATTERNS-1",
+            "--",
+            "bash",
+            "-c",
+            "echo hi; exit 0",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    cell_dir = output / "CUSTOM-PATTERNS-1" / "none-none"
+    # The dispatcher per-trial JSONs live under the workload
+    # subdirectory (``_subprocess`` for ``aorta probe``); the
+    # cell-root ``trial_<n>/`` holds the SubprocessWorkload's own
+    # ``result.json``.
+    dispatcher_jsons = list((cell_dir / "_subprocess").glob("trial_d*_m*_t*.json"))
+    assert dispatcher_jsons, (
+        "dispatcher per-trial JSON was not written -- probe-mode + "
+        "custom_patterns regressed the dispatcher's JSON-serialization "
+        "path"
+    )
+    # Round-trip the dispatcher JSON: if any field still carries a
+    # CompiledPattern / re.Pattern, ``json.loads`` would never have
+    # gotten here, but the explicit reload + sanity check makes the
+    # regression obvious in failure output.
+    doc = json.loads(dispatcher_jsons[0].read_text(encoding="utf-8"))
+    summarized = doc["config"]["_aorta_probe_extras"]["custom_patterns"]
+    assert isinstance(summarized, list) and summarized, (
+        f"_aorta_probe_extras.custom_patterns should be a non-empty "
+        f"list of summary dicts after sanitization; got {summarized!r}"
+    )
+    entry = summarized[0]
+    assert entry["detector_id"] == "custom:hip_oom"
+    assert entry["regex"] == "hipErrorOutOfMemory"
+    assert entry["on_match"] == "fail"
+
+
 def test_no_ticket_routed_to_no_ticket_slug(tmp_path):
     """FR 1.14 -- omitted --ticket routes to '_no_ticket_/' under output."""
     # The fixture has a ticket; override it to None by writing a fresh recipe.

--- a/tests/probe/test_list_patterns.py
+++ b/tests/probe/test_list_patterns.py
@@ -21,6 +21,24 @@ def test_list_patterns_exits_zero():
     assert result.exit_code == 0, result.output
 
 
+def test_version_without_list_patterns_is_rejected_with_targeted_message():
+    """Regression for PR #197 round-3 review: ``--version`` is
+    documented as meaningful only when paired with
+    ``--list-patterns``. Used to silently fall through to the
+    ``--recipe`` check, producing a confusing "Missing option
+    '--recipe'" error. Now we reject up-front with a targeted
+    usage message so the operator sees the intended pairing.
+    """
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--version"])
+    assert result.exit_code != 0
+    # click.UsageError formats messages on stderr-equivalent; in
+    # CliRunner that lands in ``output`` by default.
+    assert "--version is only meaningful with --list-patterns" in result.output
+    # Confirm we did NOT fall through to the recipe complaint.
+    assert "Missing option '--recipe'" not in result.output
+
+
 def test_list_patterns_prints_every_detector_id():
     """Every Tier 4 detector ID is in the output (rubric §2.B FR 2.5)."""
     runner = CliRunner()

--- a/tests/probe/test_list_patterns.py
+++ b/tests/probe/test_list_patterns.py
@@ -1,0 +1,72 @@
+"""Tests for ``aorta probe --list-patterns`` flag (FR 2.5).
+
+The CLI deviation from the rubric: ``--list-patterns`` is a flag on the
+``aorta probe`` command (not a ``list-patterns`` subcommand) so the
+Phase-1 ``aorta probe -- <argv>`` invocation surface stays byte-equivalent.
+See the PR description for the rationale.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from aorta.cli.probe import probe
+from aorta.probe.classifier import tier4_patterns
+from aorta.probe.classifier.tier4_patterns import BUILTIN_PATTERN_VERSION
+
+
+def test_list_patterns_exits_zero():
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--list-patterns"])
+    assert result.exit_code == 0, result.output
+
+
+def test_list_patterns_prints_every_detector_id():
+    """Every Tier 4 detector ID is in the output (rubric §2.B FR 2.5)."""
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--list-patterns"])
+    assert result.exit_code == 0
+    for pattern in tier4_patterns.all_patterns():
+        assert pattern.detector_id in result.output
+
+
+def test_list_patterns_prints_sample_regex():
+    """Each entry includes its sample regex so an operator can grep visually."""
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--list-patterns"])
+    for pattern in tier4_patterns.all_patterns():
+        assert pattern.regex.pattern in result.output
+
+
+def test_list_patterns_version_flag_prints_version_banner():
+    """`--list-patterns --version` prints the rubric-specified version line."""
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--list-patterns", "--version"])
+    assert result.exit_code == 0
+    expected_fragment = f"aorta probe pattern library v{BUILTIN_PATTERN_VERSION}"
+    assert expected_fragment in result.output
+    assert "aorta " in result.output  # contains the aorta package version too
+
+
+def test_list_patterns_short_circuits_recipe_load():
+    """Without --recipe, --list-patterns must still exit 0 (no recipe required)."""
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--list-patterns"])
+    assert result.exit_code == 0
+
+
+def test_list_patterns_no_double_dash_required():
+    """The Phase 1 require-double-dash check is short-circuited for --list-patterns."""
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--list-patterns"])
+    assert result.exit_code == 0
+    assert "double-dash" not in result.output.lower()
+
+
+def test_list_patterns_does_not_write_to_disk(tmp_path, monkeypatch):
+    """A `--list-patterns` invocation MUST NOT touch the filesystem."""
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(probe, ["--list-patterns"])
+    assert result.exit_code == 0
+    assert list(tmp_path.iterdir()) == []

--- a/tests/probe/test_recipe.py
+++ b/tests/probe/test_recipe.py
@@ -128,23 +128,41 @@ diagnostic_axis: [none]
 # ---- FR 1.19 (Phase 2/3 rejection with pointer) --------------------------
 
 
-def test_phase_2_3_keys_rejected_with_pointer(tmp_path):
-    """Phase 2 keys raise with a 'deferred to Phase 2' pointer to the rubric."""
+def test_custom_patterns_accepted_in_probe_mode(tmp_path):
+    """Phase 2: ``custom_patterns`` loads in probe-mode (rubric §2.C)."""
     text = (
         _PROBE_MINIMAL
         + """\
 custom_patterns:
   - id: hip_oom
     match:
-      regex: "hipErrorOutOfMemory"
+      regex: "hipError_OutOfMemory"
 """
     )
-    with pytest.raises(RecipeSchemaError) as exc:
+    recipe = load_recipe(_write_yaml(tmp_path, text))
+    assert recipe.probe_extras is not None
+    assert len(recipe.probe_extras.custom_patterns) == 1
+    assert recipe.probe_extras.custom_patterns[0].detector_id == "custom:hip_oom"
+
+
+def test_custom_patterns_rejected_in_triage_mode(tmp_path):
+    """``custom_patterns`` is probe-mode-only; triage-mode rejects it."""
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 1
+cells:
+  - name: c
+    mitigations: [none]
+    environment: local
+custom_patterns:
+  - id: hip_oom
+    match:
+      regex: "hipError_OutOfMemory"
+"""
+    with pytest.raises(RecipeSchemaError, match="probe-mode only"):
         load_recipe(_write_yaml(tmp_path, text))
-    msg = str(exc.value)
-    assert "Phase 2" in msg
-    assert "custom_patterns" in msg
-    assert "aorta-probe-188-rubric.md" in msg
 
 
 def test_phase_3_keys_rejected_with_pointer(tmp_path):
@@ -162,7 +180,8 @@ redaction:
     assert "redaction" in msg
 
 
-def test_condition_key_rejected_with_pointer(tmp_path):
+def test_top_level_condition_rejected_as_phase_3(tmp_path):
+    """Top-level ``condition:`` (outside custom_patterns[*].match) is Phase 3."""
     text = (
         _PROBE_MINIMAL
         + """\
@@ -170,7 +189,7 @@ condition:
   - "exit_code != 0"
 """
     )
-    with pytest.raises(RecipeSchemaError, match="Phase 2"):
+    with pytest.raises(RecipeSchemaError, match="Phase 3"):
         load_recipe(_write_yaml(tmp_path, text))
 
 
@@ -301,6 +320,8 @@ def test_minimal_fixture_loads():
     assert len(r.cells) == 1
 
 
-def test_phase_2_fixture_rejected():
-    with pytest.raises(RecipeSchemaError, match="Phase 2"):
-        load_recipe(FIXTURES / "probe_with_phase_2_keys.yaml")
+def test_phase_2_fixture_loads_in_probe_mode():
+    """Phase 2: ``custom_patterns`` recipe loads cleanly (rubric §2.B FR 2.6)."""
+    recipe = load_recipe(FIXTURES / "probe_with_phase_2_keys.yaml")
+    assert recipe.probe_extras is not None
+    assert len(recipe.probe_extras.custom_patterns) == 1

--- a/tests/probe/test_recipe.py
+++ b/tests/probe/test_recipe.py
@@ -325,3 +325,74 @@ def test_phase_2_fixture_loads_in_probe_mode():
     recipe = load_recipe(FIXTURES / "probe_with_phase_2_keys.yaml")
     assert recipe.probe_extras is not None
     assert len(recipe.probe_extras.custom_patterns) == 1
+
+
+def test_hang_grace_period_zero_is_accepted(tmp_path):
+    """Regression for PR #197 review: ``hang_grace_period_at_start: 0`` is
+    a documented runtime value -- ``HangMonitor`` / ``evaluate_predicate``
+    treat it as "no grace, fire as soon as the window elapses", useful
+    for short-running repros where 60s of grace swallows the trial.
+    The recipe validator used to reject it via the strict ``> 0`` check.
+    ``hang_window_sec`` keeps the strict bound because a zero window
+    would re-trip the predicate on every poll.
+    """
+    recipe_path = tmp_path / "probe_zero_grace.yaml"
+    recipe_path.write_text(
+        """\
+schema_version: 1
+mode: probe
+ticket: ZERO-GRACE
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+hang_grace_period_at_start: 0
+""",
+        encoding="utf-8",
+    )
+    recipe = load_recipe(recipe_path)
+    assert recipe.probe_extras is not None
+    assert recipe.probe_extras.hang_grace_period_at_start == 0.0
+
+
+def test_hang_window_sec_zero_still_rejected(tmp_path):
+    """``hang_window_sec: 0`` stays rejected -- a zero window would
+    re-trip the predicate on every poll. Keeps the strict ``> 0`` bound
+    asymmetric with grace (which DOES allow 0).
+    """
+    recipe_path = tmp_path / "probe_zero_window.yaml"
+    recipe_path.write_text(
+        """\
+schema_version: 1
+mode: probe
+ticket: ZERO-WINDOW
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+hang_window_sec: 0
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(RecipeSchemaError, match="hang_window_sec.*> 0"):
+        load_recipe(recipe_path)
+
+
+def test_hang_grace_period_negative_is_rejected(tmp_path):
+    """Even with ``allow_zero=True`` the validator still rejects
+    negative values -- the predicate would silently ignore a negative
+    grace period (clamped by ``elapsed > grace_period_sec``).
+    """
+    recipe_path = tmp_path / "probe_negative_grace.yaml"
+    recipe_path.write_text(
+        """\
+schema_version: 1
+mode: probe
+ticket: NEG-GRACE
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+hang_grace_period_at_start: -1
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(RecipeSchemaError, match="hang_grace_period_at_start.*>= 0"):
+        load_recipe(recipe_path)

--- a/tests/probe/test_sandbox.py
+++ b/tests/probe/test_sandbox.py
@@ -1,0 +1,241 @@
+"""Tests for :mod:`aorta.probe.sandbox` — the ``condition:`` evaluator.
+
+Covers Phase 2 FR 2.7 (hostile-input corpus rejection at recipe load)
+and FR 2.12 (parse-time enforcement — a hostile input never reaches
+``eval``).
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aorta.probe.sandbox import (
+    MAX_EXPR_LEN,
+    MAX_INT_CONSTANT,
+    SandboxError,
+    evaluate,
+    validate_and_compile,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "conditions"
+
+
+def _hostile_lines() -> list[str]:
+    """Read the hostile-input corpus, returning one expression per line."""
+    text = (FIXTURES / "hostile.txt").read_text(encoding="utf-8")
+    return [line.rstrip("\n") for line in text.splitlines() if line.strip()]
+
+
+@pytest.mark.parametrize("expr", _hostile_lines())
+def test_hostile_inputs_rejected(expr: str) -> None:
+    """Every entry in ``hostile.txt`` MUST be rejected by the sandbox."""
+    with pytest.raises(SandboxError):
+        validate_and_compile(expr)
+
+
+def test_no_eval_reach_for_rejected_input() -> None:
+    """FR 2.12: a hostile expression never reaches ``builtins.eval``.
+
+    Patches Python's ``eval`` and asserts the patched callable is
+    never invoked when ``validate_and_compile`` rejects the input.
+    The patch covers the *module-global* ``eval`` symbol; the
+    sandbox's own ``compile``/``eval`` would route through it if
+    enforcement leaked past parse time.
+    """
+    with patch("aorta.probe.sandbox.eval") as eval_mock:
+        for expr in _hostile_lines():
+            with pytest.raises(SandboxError):
+                validate_and_compile(expr)
+    assert eval_mock.call_count == 0
+
+
+def test_length_cap_rejects_at_parse_time() -> None:
+    """A 257+ char expression rejects before ``ast.parse`` can run."""
+    long_expr = "1" + (" + 1" * 70)
+    assert len(long_expr) > MAX_EXPR_LEN
+    with pytest.raises(SandboxError, match="exceeds"):
+        validate_and_compile(long_expr)
+
+
+def test_empty_expression_rejected() -> None:
+    with pytest.raises(SandboxError, match="non-empty"):
+        validate_and_compile("")
+    with pytest.raises(SandboxError, match="non-empty"):
+        validate_and_compile("   ")
+
+
+def test_non_string_input_rejected() -> None:
+    with pytest.raises(SandboxError, match="must be a string"):
+        validate_and_compile(42)  # type: ignore[arg-type]
+
+
+def test_syntax_error_rejected() -> None:
+    with pytest.raises(SandboxError, match="syntax error"):
+        validate_and_compile("capture[")
+
+
+# ---- Happy path -----------------------------------------------------------
+
+
+def test_allows_named_capture_lookup() -> None:
+    code = validate_and_compile("capture['loss'] == 'nan'")
+    assert evaluate(
+        code,
+        capture={"loss": "nan"},
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert not evaluate(
+        code,
+        capture={"loss": "fine"},
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+
+
+def test_allows_float_int_len() -> None:
+    code = validate_and_compile("int(capture['count']) > 10 and len(capture) > 0")
+    assert evaluate(
+        code,
+        capture={"count": "42", "other": "v"},
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+
+
+def test_allows_math_isnan_isinf() -> None:
+    code = validate_and_compile("math.isnan(float(capture['loss']))")
+    assert evaluate(
+        code,
+        capture={"loss": "nan"},
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    assert not evaluate(
+        code,
+        capture={"loss": "1.0"},
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+
+
+def test_allows_exit_code_walltime_peak_vram() -> None:
+    code = validate_and_compile("exit_code != 0 and walltime_sec > 1.0 and peak_vram_mib > 100")
+    assert evaluate(
+        code,
+        capture={},
+        exit_code=137,
+        walltime_sec=12.5,
+        peak_vram_mib=512,
+    )
+
+
+def test_peak_vram_none_binds_to_zero() -> None:
+    """FR §2.E.1: peak_vram_mib bound to 0 when actual is None.
+
+    The expression compares ``peak_vram_mib > 0`` — must not blow up
+    on None and must evaluate to False (because the bound value is 0).
+    """
+    code = validate_and_compile("peak_vram_mib > 0")
+    assert not evaluate(
+        code,
+        capture={},
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+
+
+def test_ifexp_and_boolop_allowed() -> None:
+    code = validate_and_compile("(1 if exit_code != 0 else 0) or (walltime_sec > 0)")
+    assert evaluate(
+        code,
+        capture={},
+        exit_code=1,
+        walltime_sec=0.0,
+        peak_vram_mib=None,
+    )
+
+
+def test_int_constant_below_cap_allowed() -> None:
+    code = validate_and_compile(f"exit_code == {MAX_INT_CONSTANT - 1}")
+    assert not evaluate(
+        code,
+        capture={},
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+
+
+def test_int_constant_at_cap_rejected() -> None:
+    with pytest.raises(SandboxError, match="integer constant magnitude"):
+        validate_and_compile(f"2 ** {MAX_INT_CONSTANT}")
+
+
+def test_empty_builtins_neutralises_eval() -> None:
+    """Defence-in-depth: even if ``eval`` were reached, ``__builtins__={}``
+    means ``__import__`` is unreachable.
+
+    Constructed by manually compiling an expression that LOOKS like an
+    import and asserting that running it via the sandbox's
+    ``evaluate`` fails with NameError (because ``__import__`` is not
+    in the empty builtins). Demonstrates the belt-and-suspenders
+    layer even if the AST walker were to regress.
+    """
+    code = compile("__import__('os')", "<test>", "eval")
+    with pytest.raises(NameError):
+        evaluate(
+            code,
+            capture={},
+            exit_code=0,
+            walltime_sec=1.0,
+            peak_vram_mib=None,
+        )
+
+
+def test_math_module_is_only_globals_module() -> None:
+    """``os`` is not in the eval globals — name lookup fails."""
+    code = compile("os.getenv('PATH')", "<test>", "eval")
+    with pytest.raises(NameError):
+        evaluate(
+            code,
+            capture={},
+            exit_code=0,
+            walltime_sec=1.0,
+            peak_vram_mib=None,
+        )
+
+
+def test_math_is_only_safe_attrs() -> None:
+    """Sanity: ``math.isnan`` works post-compile; ``math.pi`` is not
+    in the whitelist so ``validate_and_compile`` rejects it.
+    """
+    with pytest.raises(SandboxError, match="forbidden attribute"):
+        validate_and_compile("math.pi")
+    # And isnan/isinf are unambiguously allowed.
+    code = validate_and_compile("math.isinf(float(capture['x']))")
+    assert evaluate(
+        code,
+        capture={"x": "inf"},
+        exit_code=0,
+        walltime_sec=1.0,
+        peak_vram_mib=None,
+    )
+    # NB: math.inf is also accessible at eval because ``math`` is a
+    # real module reference in globals; the whitelist runs at parse,
+    # so the only way to NAME math.<attr> in a condition is through
+    # the AST walker, which rejects everything but isnan/isinf.
+    _ = math.inf  # silence "unused import" lints
+
+
+__all__: list[str] = []

--- a/tests/probe/test_sandbox.py
+++ b/tests/probe/test_sandbox.py
@@ -178,8 +178,24 @@ def test_int_constant_below_cap_allowed() -> None:
 
 
 def test_int_constant_at_cap_rejected() -> None:
+    # ``**`` is no longer in the allow-list -- exercise the magnitude
+    # cap via a comparison literal instead, which is the realistic
+    # shape an operator would write.
     with pytest.raises(SandboxError, match="integer constant magnitude"):
-        validate_and_compile(f"2 ** {MAX_INT_CONSTANT}")
+        validate_and_compile(f"exit_code == {MAX_INT_CONSTANT}")
+
+
+def test_pow_operator_rejected() -> None:
+    """Regression for PR #197 review: dropping ``ast.Pow`` from the
+    allow-list closes the ``2 ** int(capture['exp'])`` resource-
+    exhaustion path -- the magnitude cap only restricts literal
+    constants, so an exponent derived from regex-capture text would
+    otherwise let an attacker allocate an enormous Python int at
+    eval time.
+    """
+    for hostile in ("2 ** 31", "10 ** int(capture['exp'])", "2 ** exit_code"):
+        with pytest.raises(SandboxError, match="forbidden AST node"):
+            validate_and_compile(hostile)
 
 
 def test_empty_builtins_neutralises_eval() -> None:

--- a/tests/probe/test_sandbox.py
+++ b/tests/probe/test_sandbox.py
@@ -234,6 +234,56 @@ def test_mod_operator_rejected_for_printf_format() -> None:
             validate_and_compile(hostile)
 
 
+def test_subscript_index_must_be_string_literal() -> None:
+    """Regression for PR #197 review (Sonbol): the Subscript rule
+    only checks that the *base* is ``capture`` -- without an index
+    check, ``capture[exit_code]`` (Name), ``capture[0]`` (numeric
+    Constant), and ``capture['x':]`` (slice) all parse cleanly and
+    only blow up at eval time. The Tier 5 runner then swallows
+    those eval-time exceptions silently with
+    ``except Exception: fired = False``, so a typoed recipe ships
+    to prod and the detector never fires. Closing the check at
+    parse time means recipe authors get a ``SandboxError`` at
+    load time naming the bad index.
+    """
+    for hostile, expected_marker in (
+        ("capture[exit_code]", "exit_code"),
+        ("capture[0]", "0"),
+        ("capture['x':]", "'x'"),
+    ):
+        with pytest.raises(SandboxError, match="must be a string literal"):
+            validate_and_compile(hostile)
+        # Sanity: the error message names the bad index so the
+        # operator can fix it without reading the sandbox source.
+        with pytest.raises(SandboxError) as exc_info:
+            validate_and_compile(hostile)
+        assert expected_marker in str(exc_info.value)
+
+
+def test_int_from_string_digit_cap_active() -> None:
+    """Regression for PR #197 review (Sonbol): Python 3.10 has no
+    default cap on ``int()``-from-string parsing, so a hostile
+    regex capture returning a multi-megabyte string would let
+    ``int(capture['x'])`` burn CPU for minutes via the O(n^2)
+    digit parser. The sandbox module sets
+    ``sys.set_int_max_str_digits(4300)`` at import time to apply
+    the CPython 3.11+ default cap explicitly on 3.10.
+
+    Verified by attempting to parse a 5000-char digit string at
+    eval time -- the cap raises ``ValueError`` synchronously
+    rather than hanging.
+    """
+    code = validate_and_compile("int(capture['x']) > 0")
+    with pytest.raises(ValueError, match="(?i)exceeds the limit"):
+        evaluate(
+            code,
+            capture={"x": "0" * 5000},
+            exit_code=0,
+            walltime_sec=1.0,
+            peak_vram_mib=None,
+        )
+
+
 def test_empty_builtins_neutralises_eval() -> None:
     """Defence-in-depth: even if ``eval`` were reached, ``__builtins__={}``
     means ``__import__`` is unreachable.

--- a/tests/probe/test_sandbox.py
+++ b/tests/probe/test_sandbox.py
@@ -198,6 +198,42 @@ def test_pow_operator_rejected() -> None:
             validate_and_compile(hostile)
 
 
+def test_mult_operator_rejected_for_string_repeat() -> None:
+    """Regression for PR #197 round-3 review: dropping ``ast.Mult``
+    from the allow-list closes the string-repetition path
+    (``'a' * 999999998`` allocates a ~1 GiB string without ever
+    crossing :data:`MAX_INT_CONSTANT`). The walker can't tell at
+    parse time whether ``*`` is a numeric multiply or a string /
+    tuple repeat, so the simplest correct defence is to forbid the
+    operator. Same reasoning as Pow.
+    """
+    for hostile in (
+        "'a' * 999999998",
+        "capture['x'] * 999999998",
+        "exit_code * 2",
+        "(1,) * 999999998",
+    ):
+        with pytest.raises(SandboxError, match="forbidden AST node"):
+            validate_and_compile(hostile)
+
+
+def test_mod_operator_rejected_for_printf_format() -> None:
+    """Regression for PR #197 round-3 review: dropping ``ast.Mod``
+    closes the printf-style string-formatting path
+    (``'%999999998s' % capture['x']`` allocates the same billion-
+    byte buffer as string-repeat). The walker can't discriminate
+    numeric modulo from string formatting at parse time, so the
+    operator goes entirely.
+    """
+    for hostile in (
+        "'%999999998s' % capture['x']",
+        "exit_code % 2",
+        "'%s' % capture['code']",
+    ):
+        with pytest.raises(SandboxError, match="forbidden AST node"):
+            validate_and_compile(hostile)
+
+
 def test_empty_builtins_neutralises_eval() -> None:
     """Defence-in-depth: even if ``eval`` were reached, ``__builtins__={}``
     means ``__import__`` is unreachable.

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -490,3 +490,104 @@ def test_classifier_crash_on_passing_trial_falls_back_to_pass(tmp_path, monkeypa
     assert doc["failure_detectors_fired"] == []
     assert "classifier_error" in doc["capture"]
     assert result.passed is True
+
+
+def test_peak_vram_mib_threaded_from_amd_smi_snapshots(tmp_path, monkeypatch):
+    """Regression for PR #197 round-6 review:
+    ``peak_vram_mib`` was hard-coded to ``None`` both in the
+    ``TrialContext`` handed to ``classify_trial`` and in the emitted
+    ``result.json``, which made Tier-5 sandbox conditions like
+    ``peak_vram_mib > 70000`` permanently unreachable on real hosts.
+
+    With the fix, the workload computes a coarse high-water mark
+    from the two amd-smi snapshots it already collects
+    (pre-Popen + post-Popen) and threads the value into BOTH the
+    classifier context and ``result.json``.
+    """
+    from aorta.probe.classifier.tier3_kernel import AmdSmiSnapshot
+    from aorta.workloads import _subprocess as workload_mod
+
+    pre = AmdSmiSnapshot(vram_used_mib=4000, thermal_throttle_count=0)
+    post = AmdSmiSnapshot(vram_used_mib=71234, thermal_throttle_count=0)
+
+    calls = {"n": 0}
+
+    def _two_snapshots(_state):
+        calls["n"] += 1
+        return pre if calls["n"] == 1 else post
+
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", _two_snapshots)
+
+    seen_ctx_peak: dict[str, int | None] = {}
+    real_classify = workload_mod.classify_trial
+
+    def _spy_classify(ctx):
+        seen_ctx_peak["value"] = ctx.peak_vram_mib
+        return real_classify(ctx)
+
+    monkeypatch.setattr(workload_mod, "classify_trial", _spy_classify)
+
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    wl.run()
+
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["peak_vram_mib"] == 71234, (
+        "peak_vram_mib in result.json should be max(pre.vram, post.vram); "
+        f"got {doc['peak_vram_mib']!r}"
+    )
+    assert seen_ctx_peak["value"] == 71234, (
+        "TrialContext.peak_vram_mib should match the result.json value so "
+        "Tier-5 sandbox conditions and the emitted doc agree"
+    )
+
+
+def test_peak_vram_mib_none_when_amd_smi_unavailable(tmp_path, monkeypatch):
+    """Both snapshots returning ``None`` -> ``peak_vram_mib`` stays
+    ``None`` (the sandbox's ``None -> 0`` shim then keeps Tier-5
+    conditions deterministic).
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", lambda _state: None)
+
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    wl.run()
+
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["peak_vram_mib"] is None
+
+
+def test_read_log_text_uses_replace_not_backslashreplace(tmp_path):
+    """Regression for PR #197 round-6 review: ``_read_log_text`` used
+    ``errors="backslashreplace"`` which expands each invalid byte
+    into up to four characters (``\\\\xff``). For a binary-heavy log,
+    that inflates the decoded string past ``MAX_LOG_BYTES``,
+    defeating the documented regex-DoS cap.
+
+    The fix decodes with ``errors="replace"`` so each invalid byte
+    becomes a single U+FFFD replacement char, holding the 1:1
+    byte->char invariant.
+    """
+    from aorta.probe.sandbox import MAX_LOG_BYTES
+    from aorta.workloads._subprocess import _read_log_text
+
+    # A blob of pure invalid bytes the size of the cap. ``replace``
+    # gives len == MAX_LOG_BYTES; ``backslashreplace`` would give
+    # 4 * MAX_LOG_BYTES.
+    binary = b"\xff" * MAX_LOG_BYTES
+    stdout_path = tmp_path / "stdout.log"
+    stderr_path = tmp_path / "stderr.log"
+    stdout_path.write_bytes(binary)
+    stderr_path.write_bytes(b"")
+
+    text = _read_log_text(stdout_path, stderr_path)
+    # Allow a small overhead for the ``\n`` joiner and the empty
+    # stderr piece; the load-bearing assertion is the 4x cap.
+    assert len(text) <= MAX_LOG_BYTES + 8, (
+        f"decoded log length {len(text)} exceeds the MAX_LOG_BYTES "
+        f"({MAX_LOG_BYTES}) cap -- the decode path is back on "
+        "backslashreplace and a binary-heavy log can quadruple the "
+        "regex-input size, defeating the cap."
+    )

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -394,6 +394,47 @@ def test_tier3_actually_runs_per_trial(tmp_path, monkeypatch):
     )
 
 
+def test_hang_grace_zero_survives_runtime_extraction(tmp_path, monkeypatch):
+    """Regression for PR #197 review: ``probe_extras["hang_grace_period_at_start"]
+    == 0.0`` is a validated "no grace, fire as soon as the window
+    elapses" value (see ``test_hang_grace_period_zero_is_accepted``
+    in ``test_recipe.py``). The runtime extraction used to
+    short-circuit through ``... or DEFAULT_HANG_GRACE_SEC``, which
+    treats ``0.0`` as falsy and silently substitutes the default,
+    defeating the entire knob.
+
+    Pin the behavior by intercepting ``HangMonitor.__init__`` and
+    asserting it observed the configured ``0.0`` exactly.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    captured: dict[str, float] = {}
+    real_hang_monitor = workload_mod.HangMonitor
+
+    class _SpyHangMonitor(real_hang_monitor):  # type: ignore[misc, valid-type]
+        def __init__(self, *args, **kwargs):
+            captured["hang_grace_period_at_start"] = kwargs["hang_grace_period_at_start"]
+            captured["hang_window_sec"] = kwargs["hang_window_sec"]
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(workload_mod, "HangMonitor", _SpyHangMonitor)
+
+    wl = _make_workload(
+        tmp_path,
+        ["true"],
+        hang_grace_period_at_start=0.0,
+        hang_window_sec=30.0,
+    )
+    wl.setup()
+    wl.run()
+    assert captured["hang_grace_period_at_start"] == 0.0, (
+        "Configured hang_grace_period_at_start=0.0 was silently clobbered to "
+        f"{captured['hang_grace_period_at_start']!r} -- the `or DEFAULT` falsy "
+        "shortcut is back. Use an explicit `is None` check at the extraction."
+    )
+    assert captured["hang_window_sec"] == 30.0
+
+
 def test_classifier_crash_still_writes_result_json(tmp_path, monkeypatch):
     """Regression for PR #197 round-3 review: if ``classify_trial``
     raises (regex catastrophe, future refactor edge case, etc.),

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -346,3 +346,49 @@ def test_phase_1_shape_still_present_in_phase_2_doc(tmp_path):
     doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
     for key in ("verdict", "exit_code", "walltime_sec", "argv", "cell_name", "trial_index"):
         assert key in doc
+
+
+def test_tier3_actually_runs_per_trial(tmp_path, monkeypatch):
+    """Regression for PR #197 review: Tier 3 used to be unreachable because
+    SubprocessWorkload constructed a fresh Tier3State per trial and hard-
+    coded ``dmesg_text=None`` + ``amd_smi_*=None``. Now the workload
+    invokes ``poll_amd_smi`` and ``scan_dmesg`` through the module-level
+    shared state, so a fake amd-smi snapshot is enough to make Tier 3
+    surface its detector ID end-to-end.
+    """
+    from aorta.probe.classifier.tier3_kernel import DETECTOR_VRAM_GROWTH
+    from aorta.workloads import _subprocess as workload_mod
+
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=0,throttle=0")
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    pre_calls: dict[str, int] = {"n": 0}
+
+    real_poll = workload_mod.poll_amd_smi
+
+    def _toggle_snapshot(state):
+        # First call (pre) returns the env-supplied snapshot; the
+        # second call (post) returns a snapshot with VRAM jumped past
+        # the rubric's growth threshold so scan_amd_smi will fire.
+        from aorta.probe.classifier.tier3_kernel import (
+            VRAM_GROWTH_THRESHOLD_MIB,
+            AmdSmiSnapshot,
+        )
+
+        pre_calls["n"] += 1
+        if pre_calls["n"] == 1:
+            return real_poll(state)
+        return AmdSmiSnapshot(
+            vram_used_mib=VRAM_GROWTH_THRESHOLD_MIB + 1,
+            thermal_throttle_count=0,
+        )
+
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", _toggle_snapshot)
+    wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    fired = set(doc["failure_detectors_fired"]) | set(doc["warn_detectors_fired"])
+    assert DETECTOR_VRAM_GROWTH in fired, (
+        "Tier 3 vram-growth detector did not fire even though the workload "
+        "supplied pre/post snapshots crossing the growth threshold; the "
+        "SubprocessWorkload Tier-3 wiring is silently disabled"
+    )

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -296,3 +296,53 @@ def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
     assert doc["timed_out"] is True
     assert doc["exit_code"] == -1
     assert result.passed is False
+
+
+# ---- FR 2.9 (Phase 2 result.json shape) ----------------------------------
+
+
+def test_result_json_phase_2_shape(tmp_path):
+    """Phase 2 ``result.json`` carries the rubric §2.B FR 2.9 fields.
+
+    The Phase 1 minimum shape is a subset; both shapes coexist (the
+    Phase 1 test above continues to pass). Phase 2 adds:
+
+    * ``failure_detectors_fired: list[str]``
+    * ``warn_detectors_fired: list[str]``
+    * ``capture: dict``
+    * ``tier_durations_ms: dict``
+    * ``peak_vram_mib: int | null``
+    """
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    # Phase 2 keys present on every trial.
+    assert isinstance(doc["failure_detectors_fired"], list)
+    assert isinstance(doc["warn_detectors_fired"], list)
+    assert isinstance(doc["capture"], dict)
+    assert isinstance(doc["tier_durations_ms"], dict)
+    # peak_vram_mib is int | null (null in env-less smoke runs).
+    assert doc["peak_vram_mib"] is None or isinstance(doc["peak_vram_mib"], int)
+    # tier_durations_ms records each tier's wall-clock contribution.
+    for tier_key in ("tier1", "tier2", "tier3", "tier4", "tier5"):
+        assert tier_key in doc["tier_durations_ms"]
+
+
+def test_phase_2_failure_path_lists_tier1_detector(tmp_path):
+    """A non-zero exit fires ``tier1:exit_nonzero`` in failure_detectors_fired."""
+    wl = _make_workload(tmp_path, ["false"])
+    wl.setup()
+    wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert "tier1:exit_nonzero" in doc["failure_detectors_fired"]
+
+
+def test_phase_1_shape_still_present_in_phase_2_doc(tmp_path):
+    """Phase 1's minimum-shape keys remain (rubric §2.B FR 2.9 'subset' clause)."""
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    for key in ("verdict", "exit_code", "walltime_sec", "argv", "cell_name", "trial_index"):
+        assert key in doc

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -392,3 +392,60 @@ def test_tier3_actually_runs_per_trial(tmp_path, monkeypatch):
         "supplied pre/post snapshots crossing the growth threshold; the "
         "SubprocessWorkload Tier-3 wiring is silently disabled"
     )
+
+
+def test_classifier_crash_still_writes_result_json(tmp_path, monkeypatch):
+    """Regression for PR #197 round-3 review: if ``classify_trial``
+    raises (regex catastrophe, future refactor edge case, etc.),
+    the workload MUST still write a ``result.json`` so the trial
+    doesn't silently disappear from the matrix. Falls back to a
+    Tier-1-only verdict derived from the captured exit code, and
+    records the classifier exception under
+    ``capture['classifier_error']`` so the operator sees the
+    cause.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    boom = RuntimeError("synthetic classifier crash for PR #197 review")
+
+    def _exploding_classify(_ctx):
+        raise boom
+
+    monkeypatch.setattr(workload_mod, "classify_trial", _exploding_classify)
+
+    # Use ``false`` so Tier 1 fallback fires ``tier1:exit_nonzero``.
+    wl = _make_workload(tmp_path, ["false"])
+    wl.setup()
+    result = wl.run()
+
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert "tier1:exit_nonzero" in doc["failure_detectors_fired"]
+    assert "classifier_error" in doc["capture"]
+    assert "synthetic classifier crash" in doc["capture"]["classifier_error"]
+    # The workload result still reports the failure (not a hang) so
+    # the dispatcher records a failed trial deterministically.
+    assert result.passed is False
+
+
+def test_classifier_crash_on_passing_trial_falls_back_to_pass(tmp_path, monkeypatch):
+    """A ``true`` exit + classifier crash -> Tier-1-only verdict is
+    ``pass`` (no Tier 1 detector fires for exit_code=0), but the
+    classifier_error still gets recorded so the operator knows the
+    full classifier didn't run.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    def _exploding_classify(_ctx):
+        raise ValueError("simulated tier-4 regex catastrophe")
+
+    monkeypatch.setattr(workload_mod, "classify_trial", _exploding_classify)
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    result = wl.run()
+
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "pass"
+    assert doc["failure_detectors_fired"] == []
+    assert "classifier_error" in doc["capture"]
+    assert result.passed is True

--- a/tests/triage/test_matrix_top_columns.py
+++ b/tests/triage/test_matrix_top_columns.py
@@ -251,3 +251,91 @@ def test_aggregator_returns_none_when_no_detectors_fired():
     )
     assert stats.top_failure_detector_id is None
     assert stats.top_warn_detector_id is None
+
+
+def test_aggregator_dedups_when_both_sources_mirror_detector():
+    """Regression for PR #197 review (Sonbol): when a trial populates
+    both ``result["metrics"]["failure_detectors_fired"]`` and the
+    flat ``result["failure_detectors_fired"]`` (a shape the
+    docstring explicitly invites for test trials), the previous
+    aggregator double-counted the detector and could misrank
+    ``top_failure_detector_id``.
+
+    Construct one trial that mirrors ``tier4:hip_error`` into both
+    sources and a second trial that only fires ``tier4:nan_signature``.
+    Without the dedup, hip_error's count would be 2 (one from
+    metrics, one from result) vs nan_signature's 1, and the top
+    would be hip_error. With the dedup, hip_error counts as 1
+    (per trial) and ties nan_signature, with hip_error winning on
+    encounter order. We assert the per-source dedup specifically
+    by making the contest decisive: two trials each mirror
+    hip_error into both sources, and two trials each fire
+    nan_signature only into metrics. Without dedup hip=4 vs
+    nan=2; with dedup hip=2 vs nan=2 and encounter-order
+    resolves to hip_error -- so we instead set up the case where
+    the bug would have picked the wrong winner.
+    """
+    def mirrored_trial(detector_id: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            exit_status="failed",
+            wall_clock_sec=1.0,
+            result={
+                "failure_detectors_fired": [detector_id],
+                "metrics": {
+                    "failure_detectors_fired": [detector_id],
+                },
+            },
+        )
+
+    trials = [
+        mirrored_trial("tier4:hip_error"),
+        _trial_with_detectors(failures=["tier4:nan_signature"]),
+        _trial_with_detectors(failures=["tier4:nan_signature"]),
+    ]
+    stats = aggregate_cell(
+        name="c",
+        mitigations=("none",),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=trials,
+        effective_steps=1,
+    )
+    # With dedup: hip_error fires once (1 trial), nan_signature fires
+    # twice (2 trials). Winner: nan_signature.
+    # Without dedup: hip_error fires twice (mirrored across sources),
+    # nan_signature fires twice, tie resolves to hip_error (first
+    # encountered) -- the wrong answer.
+    assert stats.top_failure_detector_id == "tier4:nan_signature", (
+        "double-count bug: hip_error was mirrored across both sources "
+        "in one trial and outranked nan_signature (which legitimately "
+        "fired in two trials)"
+    )
+
+
+def test_aggregator_dedups_warn_detectors_same_class():
+    """Same dedup applies to warn_detectors_fired (proactive sweep)."""
+    mirror = SimpleNamespace(
+        exit_status="ok",
+        wall_clock_sec=1.0,
+        result={
+            "warn_detectors_fired": ["tier3:vram_growth"],
+            "metrics": {
+                "warn_detectors_fired": ["tier3:vram_growth"],
+            },
+        },
+    )
+    just_other = _trial_with_detectors(warns=["tier3:thermal_throttle"])
+    stats = aggregate_cell(
+        name="c",
+        mitigations=("none",),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=[mirror, just_other, just_other],
+        effective_steps=1,
+    )
+    assert stats.top_warn_detector_id == "tier3:thermal_throttle", (
+        "warn-side double-count: vram_growth mirrored across sources "
+        "in one trial outranked thermal_throttle (two distinct trials)"
+    )

--- a/tests/triage/test_matrix_top_columns.py
+++ b/tests/triage/test_matrix_top_columns.py
@@ -1,0 +1,251 @@
+"""Tests for the Phase-2 ``Top failure`` / ``Top warn`` columns in matrix.md (FR 2.10).
+
+These tests live under ``tests/triage/`` because the renderer is
+:func:`aorta.triage.output.write_matrix_md` (mode-agnostic). The
+columns appear ONLY when a cell populates the new
+:attr:`aorta.triage.matrix.CellStats.top_failure_detector_id` /
+``top_warn_detector_id`` fields — so triage-mode runs (which never set
+them) render byte-equivalently to Phase 1.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from aorta.triage.matrix import CellStats, aggregate_cell
+from aorta.triage.output import write_matrix_md
+from aorta.triage.recipe import Recipe, build_recipe_from_flags
+
+
+def _minimal_recipe() -> Recipe:
+    """A no-op triage-mode recipe; the renderer only reads workload/ticket/etc."""
+    return build_recipe_from_flags(
+        workload="echo",
+        mitigation_axis="none",
+        environment_axis="local",
+        trials=1,
+        steps=1,
+    )
+
+
+def _stats(
+    name: str,
+    *,
+    top_failure: str | None = None,
+    top_warn: str | None = None,
+    trials: int = 1,
+    failed: int = 0,
+) -> CellStats:
+    return CellStats(
+        name=name,
+        mitigations=("none",),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=trials,
+        passed_count=trials - failed,
+        failed_count=failed,
+        mean_step_time_ms=10.0,
+        std_step_time_ms=0.0,
+        min_step_time_ms=10.0,
+        max_step_time_ms=10.0,
+        p50_step_time_ms=10.0,
+        p90_step_time_ms=10.0,
+        p99_step_time_ms=10.0,
+        mean_wall_clock_sec=1.0,
+        step_time_source="per_step",
+        top_failure_detector_id=top_failure,
+        top_warn_detector_id=top_warn,
+    )
+
+
+def test_columns_hidden_when_no_cell_populates_detectors(tmp_path: Path):
+    """Triage-mode default: no cell sets the detector fields -> no columns."""
+    recipe = _minimal_recipe()
+    stats = [_stats("none-local")]
+    out = tmp_path / "matrix.md"
+    write_matrix_md(
+        out,
+        recipe,
+        stats,
+        baseline=stats[0],
+        confound_tags={"none-local": ("(baseline)", None)},
+        warnings=[],
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    text = out.read_text(encoding="utf-8")
+    # When NO cell carries detector data, neither the header nor the
+    # legend should mention Top failure / Top warn (rubric §2.B FR 2.10).
+    assert "Top failure" not in text
+    assert "Top warn" not in text
+
+
+def test_top_failure_column_visible_when_a_cell_has_detector(tmp_path: Path):
+    """A single cell with a top_failure_detector_id surfaces the column."""
+    recipe = _minimal_recipe()
+    stats = [_stats("c", top_failure="tier4:hip_error", failed=1)]
+    out = tmp_path / "matrix.md"
+    write_matrix_md(
+        out,
+        recipe,
+        stats,
+        baseline=stats[0],
+        confound_tags={"c": ("(baseline)", None)},
+        warnings=[],
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    text = out.read_text(encoding="utf-8")
+    assert "Top failure" in text
+    assert "tier4:hip_error" in text
+    # The HEADER row should not contain a 'Top warn' column when no cell
+    # populates a warn detector. The legend mentions both column names
+    # together; we check the table separators row to disambiguate.
+    header_line = next(line for line in text.splitlines() if line.startswith("| Cell"))
+    assert "Top warn" not in header_line
+
+
+def test_top_warn_column_visible_when_a_cell_has_warn(tmp_path: Path):
+    recipe = _minimal_recipe()
+    stats = [_stats("c", top_warn="custom:slow_iter")]
+    out = tmp_path / "matrix.md"
+    write_matrix_md(
+        out,
+        recipe,
+        stats,
+        baseline=stats[0],
+        confound_tags={"c": ("(baseline)", None)},
+        warnings=[],
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    text = out.read_text(encoding="utf-8")
+    header_line = next(line for line in text.splitlines() if line.startswith("| Cell"))
+    assert "Top warn" in header_line
+    assert "custom:slow_iter" in text
+
+
+def test_both_columns_present_when_both_kinds_fire(tmp_path: Path):
+    recipe = _minimal_recipe()
+    stats = [
+        _stats(
+            "c",
+            top_failure="tier4:python_traceback",
+            top_warn="custom:slow_iter",
+            failed=1,
+        )
+    ]
+    out = tmp_path / "matrix.md"
+    write_matrix_md(
+        out,
+        recipe,
+        stats,
+        baseline=stats[0],
+        confound_tags={"c": ("(baseline)", None)},
+        warnings=[],
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    text = out.read_text(encoding="utf-8")
+    header_line = next(line for line in text.splitlines() if line.startswith("| Cell"))
+    assert "Top failure" in header_line
+    assert "Top warn" in header_line
+    assert "tier4:python_traceback" in text
+    assert "custom:slow_iter" in text
+
+
+def test_empty_cells_render_em_dash_in_visible_columns(tmp_path: Path):
+    """Cells without a top_failure_detector_id render '—' when the column shows."""
+    recipe = _minimal_recipe()
+    stats = [
+        _stats("a", top_failure="tier4:hip_error", failed=1),
+        _stats("b"),
+    ]
+    out = tmp_path / "matrix.md"
+    write_matrix_md(
+        out,
+        recipe,
+        stats,
+        baseline=stats[0],
+        confound_tags={"a": ("(baseline)", None), "b": ("-", 1.0)},
+        warnings=[],
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    text = out.read_text(encoding="utf-8")
+    header_line = next(line for line in text.splitlines() if line.startswith("| Cell"))
+    assert "Top failure" in header_line
+    # ``b``'s row should contain an em-dash placeholder in the Top failure column.
+    b_line = next(line for line in text.splitlines() if "| b " in line)
+    assert "—" in b_line
+
+
+# ---- aggregate_cell() picks the highest-frequency detector ID ----------
+
+
+def _trial_with_detectors(
+    *, failures: list[str] = None, warns: list[str] = None
+) -> SimpleNamespace:
+    """A minimal trial-shaped object matching what the aggregator reads."""
+    return SimpleNamespace(
+        exit_status="ok",
+        wall_clock_sec=1.0,
+        result={
+            "passed": True,
+            "step_times_ms": [100.0],
+            "metrics": {
+                "failure_detectors_fired": list(failures or []),
+                "warn_detectors_fired": list(warns or []),
+            },
+        },
+    )
+
+
+def test_aggregator_picks_most_frequent_detector():
+    """Across trials, the detector ID fired the most wins (FR 2.10)."""
+    trials = [
+        _trial_with_detectors(failures=["tier4:hip_error"]),
+        _trial_with_detectors(failures=["tier4:hip_error"]),
+        _trial_with_detectors(failures=["tier4:nan_signature"]),
+    ]
+    stats = aggregate_cell(
+        name="c",
+        mitigations=("none",),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=trials,
+        effective_steps=1,
+    )
+    assert stats.top_failure_detector_id == "tier4:hip_error"
+
+
+def test_aggregator_ties_resolve_by_encounter_order():
+    """A tie picks the first-encountered detector ID (rubric §2.10)."""
+    trials = [
+        _trial_with_detectors(failures=["tier4:nan_signature"]),
+        _trial_with_detectors(failures=["tier4:hip_error"]),
+    ]
+    stats = aggregate_cell(
+        name="c",
+        mitigations=("none",),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=trials,
+        effective_steps=1,
+    )
+    assert stats.top_failure_detector_id == "tier4:nan_signature"
+
+
+def test_aggregator_returns_none_when_no_detectors_fired():
+    """No detectors -> ``None`` (matrix.md hides the column)."""
+    trials = [_trial_with_detectors()]
+    stats = aggregate_cell(
+        name="c",
+        mitigations=("none",),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=trials,
+        effective_steps=1,
+    )
+    assert stats.top_failure_detector_id is None
+    assert stats.top_warn_detector_id is None

--- a/tests/triage/test_matrix_top_columns.py
+++ b/tests/triage/test_matrix_top_columns.py
@@ -181,7 +181,9 @@ def test_empty_cells_render_em_dash_in_visible_columns(tmp_path: Path):
 
 
 def _trial_with_detectors(
-    *, failures: list[str] = None, warns: list[str] = None
+    *,
+    failures: list[str] | None = None,
+    warns: list[str] | None = None,
 ) -> SimpleNamespace:
     """A minimal trial-shaped object matching what the aggregator reads."""
     return SimpleNamespace(


### PR DESCRIPTION
## Summary

Lands Phase 2 of \`aorta probe\` (issue #188): a 5-tier failure classifier wired into every probe trial, plus a hardened sandboxed evaluator for user-supplied \`custom_patterns\`. Result: \`aorta probe\` now produces structured pass/fail verdicts with named detector IDs, not just exit codes.

This PR is stacked on Phase 1 (#194). **Base = \`users/vivekag/aorta-probe-188-phase-1\` for now; will retarget to \`main\` automatically when #194 merges.** The diff stays Phase-2-only either way.

## Pipeline status

| Phase | PR | Status | Scope |
|---|---|---|---|
| 1 | #194 | Open, awaits @oyazdanb F1/F3/F6 ack | MVP CLI + recipe schema + engine reuse |
| **2 (this PR)** | this | Open, awaits security reviewer (Open Q #1) | 5-tier classifier + sandbox + \`--list-patterns\` |
| 3 | not yet | Blocked on #196 (\`aorta bundle\`) | Redaction + handout templates |

## What's in this PR

### Classifier (\`src/aorta/probe/classifier/\`)

| Tier | Module | Detector IDs |
|---|---|---|
| 1 | \`tier1_process.py\` | \`tier1:exit_nonzero\`, \`tier1:sigsegv\`, \`tier1:sigabrt\`, \`tier1:sigbus\`, \`tier1:timeout\`, \`tier1:coredump\` |
| 2 | \`tier2_hang.py\` | \`tier2:hang\` (two-of-three predicate: stdout silent, GPU idle, \`/proc/<pid>/io\` quiet; respects \`hang_grace_period_at_start\`) |
| 3 | \`tier3_kernel.py\` | \`tier3:amdgpu_reset\`, \`tier3:sdma_timeout\`, \`tier3:vm_l2_fault\`, \`tier3:xgmi_link_error\`, \`tier3:pcie_aer_fatal\`, \`tier3:vram_growth\`, \`tier3:thermal_throttle\` |
| 4 | \`tier4_patterns.py\` | \`tier4:python_traceback\`, \`tier4:hip_error\`, \`tier4:cuda_error\`, \`tier4:rocm_error\`, \`tier4:nccl_rccl_error\`, \`tier4:collective_timeout\`, \`tier4:nan_signature\` |
| 5 | \`tier5_custom.py\` | user-defined IDs from \`custom_patterns[*].id\` |
| meta | \`verdict.py\` | \`meta:missing_pass_signal\` (when \`required_for_pass: true\` and none fired) |

Tiers 3+ fail-soft: missing \`dmesg\` / \`amd-smi\` is logged once per invocation and the rest of the classifier continues. Tier 4 scan is capped at 10 MiB per regex window to defeat regex-DoS.

### Sandbox (\`src/aorta/probe/sandbox.py\`)

Hand-rolled AST-walk whitelist per rubric §2.E, ~80 lines (no third-party sandbox library). At parse time it rejects everything except:

- 9 AST node types
- 4 variables in scope: \`capture: dict[str, str]\`, \`exit_code: int\`, \`walltime_sec: float\`, \`peak_vram_mib: int\` (bound to \`0\` when None)
- 5 callables: \`float\`, \`int\`, \`len\`, \`math.isnan\`, \`math.isinf\`
- Subscript only on \`capture[...]\`
- Attribute access only for \`math.isnan\` / \`math.isinf\`

Eval runs with \`__builtins__={}\` and \`{"math": math}\` as the only globals. Expression length capped at 256 chars after stripping. Integer-literal magnitude cap defeats \`2**1000000000\`-style exhaustion.

**15-line hostile-input corpus** at \`tests/probe/fixtures/conditions/hostile.txt\` (verbatim from rubric §2.E.4) is exercised by \`tests/probe/test_sandbox.py::test_hostile_inputs_rejected\`. Local smoke: 15/15 rejected at parse time, none reach eval.

### Result.json shape (extended)

Phase 1 fields preserved; Phase 2 adds:

\`\`\`json
{
  "verdict": "pass" | "fail",
  "failure_detectors_fired": ["tier1:exit_nonzero", "tier4:python_traceback"],
  "warn_detectors_fired": [],
  "capture": {},
  "tier_durations_ms": {"tier1": 0.24, "tier2": 0.003, "tier3": 0.003, "tier4": 0.05, "tier5": 0.02},
  "peak_vram_mib": null
}
\`\`\`

Verdict precedence (rubric FR 2.8, exactly): any Tier 1–4 OR any \`custom_patterns[*]\` with \`on_match: fail\` → fail; \`required_for_pass: true\` with no match → fail + \`meta:missing_pass_signal\`; \`warn\` → \`warn_detectors_fired\` only; \`info\` → \`capture\` only.

### \`matrix.md\` columns

\`Top failure\` and \`Top warn\` columns appear immediately after \`Failures\` **only when** at least one cell has data. Triage-mode runs are byte-equivalent.

### CLI deviation from rubric § 2.A — `--list-patterns` is a flag, not a subcommand

Per rubric §2.A the suggestion was \`aorta probe list-patterns\`. Converting \`aorta probe\` from \`click.Command\` to \`click.Group\` would break the existing \`aorta probe -- <argv>\` invocation that Phase 1 ships and that Phase 1 tests pin. Instead, **\`aorta probe --list-patterns\` is a flag** that short-circuits before recipe loading, so the Phase 1 CLI surface stays byte-equivalent. \`--list-patterns --version\` prints \`aorta probe pattern library v1 (aorta 0.2.0)\`. Reviewers expecting a subcommand: this is intentional, documented in \`docs/probe-188/usage.md\` and \`docs/probe-188/classifier.md\`.

## Hard-gate self-check (rubric §X.3)

| FR | Description | Status |
|---|---|---|
| 2.1 | Tier 1 fires on exit/SIGSEGV/timeout/coredump synthetic commands | ✅ |
| 2.7 | Sandbox rejects every line of \`hostile.txt\` at recipe load | ✅ 15/15 |
| 2.8 | Verdict precedence table green (table-driven) | ✅ |
| 2.9 | \`result.json\` shape conforms; Phase 1 minimum-shape test unchanged | ✅ |
| 2.12 | Sandbox parse-time enforcement (hostile input never reaches eval) | ✅ |
| Engine-reuse | \`test_shared_engine\` still green; no new \`*runner*\` / \`*dispatcher*\` under \`src/aorta/probe/\` | ✅ |

**Hard gate §X.3 #5 — security reviewer sign-off — is DEFERRED to PR-open process.** This PR cannot merge until a named security reviewer signs off on \`src/aorta/probe/sandbox.py\` and the \`hostile.txt\` corpus. See [issue #188 comment](https://github.com/ROCm/aorta/issues/188#issuecomment-4536013651) where I asked @oyazdanb to name the reviewer.

## Test plan

\`\`\`bash
# Unit + integration
pytest tests/probe tests/triage tests/run
# Result: 556 passed in 63s

# Sandbox red-team
python3 -c "from aorta.probe.sandbox import validate_and_compile; \\
            [validate_and_compile(l) for l in open('tests/probe/fixtures/conditions/hostile.txt').read().splitlines() if l.strip() and not l.startswith('#')]"
# Result: 15/15 SandboxError raised

# Lint / format
ruff check src/aorta/probe src/aorta/cli/probe.py src/aorta/workloads/_subprocess.py tests/probe
black --check src/aorta/probe src/aorta/cli/probe.py src/aorta/workloads/_subprocess.py tests/probe

# Build
buck2 build //:aorta_lib //:aorta  # BUILD SUCCEEDED

# End-to-end with a deliberate Python traceback
D=\$(mktemp -d)
aorta probe --recipe recipes/example-probe-smoke.yaml --output "\$D" --ticket P2-SMOKE \\
  -- bash -c 'echo "Traceback (most recent call last):"; echo RuntimeError; exit 1'
# Verdict: fail. failure_detectors_fired: ["tier1:exit_nonzero", "tier4:python_traceback"]
\`\`\`

## Out-of-scope guardrails

- Zero files touched under \`src/aorta/{ebpf,hw_queue_eval,profiling,race,report,training}\`, \`notebooks/\`, \`experiments/\`, \`analysis/\`, \`misc/\`
- No \`subprocess\` import under \`src/aorta/triage/\` (preserves #151 grep-test)
- No new top-level dependencies in \`pyproject.toml\` or \`requirements.txt\`
- No third-party sandbox library (\`RestrictedPython\`, \`pysandbox\`, etc.) — hand-rolled walker only
- No third-party regex engine swap — stdlib \`re\` with length-capped windows
- \`redaction:\` recipe block + \`aorta bundle\` integration explicitly deferred to Phase 3

## Late-stage finding fixed in this PR — fixture extension

Initial implementation wrote Tier 4 fixtures as \`tests/probe/fixtures/tier4_logs/*.log\`. The repo's \`.gitignore\` rule \`*.log\` silently swallowed them — tests passed locally because the files were in the working tree, but CI would have failed since git never tracked them. Commit \`b43beba\` renames \`.log\` → \`.txt\` and updates the parametrize block. Cleaner than \`git add -f\` against \`.gitignore\`.

## Findings worth surfacing for review (not blockers)

1. **\`amd-smi\` JSON schema varies across ROCm 6.0 / 6.1 / 6.2.** Tier 3 parses defensively (per-key try/except). If a reviewer wants to harden further, that's a follow-up.
2. **\`/proc/<pid>/io\` requires \`kernel.yama.ptrace_scope = 0\`** to be readable across uids. Tier 2 treats \`PermissionError\` as "I/O signal unavailable" and falls back to the other two of three. Site admins on ptrace_scope ≥ 1 get slightly degraded hang detection — documented in \`docs/probe-188/classifier.md\`.
3. **\`BUILTIN_PATTERN_VERSION\` is module-level and bumped manually.** No automation links it to the actual pattern set. If/when Tier 4 evolves, a reviewer needs to remember to bump. Adding a \`test_pattern_version.py\` is a clean follow-up but not in this PR.

## Related

- Parent issue: #188
- Phase 1: #194 (must merge before this PR retargets to \`main\`)
- Missing B3 mitigations follow-up: #195
- \`aorta bundle\` design (Phase 3 dependency): #196
- Rubric: \`docs/plans/aorta-probe-188-rubric.md\` §2

cc @oyazdanb — please name the security reviewer per issue #188 comment so the merge gate can clear.

Made with [Cursor](https://cursor.com)