### PR TITLE
bundle: aorta bundle command + manifest + redactor protocol (closes #196)

### DIFF
--- a/docs/probe-188/bundle.md
+++ b/docs/probe-188/bundle.md
@@ -33,8 +33,8 @@ streamed through the redactor and copied into the staging tree.
 |-----------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------|
 | `--ticket TICKET`     | inferred from `<run-dir>` basename           | Cross-check against the probe artifact tree; required when the basename is `_no_ticket_`.       |
 | `--review`            | off                                          | Print the manifest summary and pause for `[y/N]` confirmation before writing the tarball.       |
-| `--output PATH`       | `./<ticket>-<UTC-timestamp>.tar.gz`          | Where to write the bundle tarball.                                                              |
-| `--redaction-from F`  | `<run-dir>/recipe.resolved.yaml` (optional)  | Recipe to read the `redaction:` block from. Phase 3 of #188 wires the actual scrubbers in.      |
+| `--output PATH`       | `./<ticket>-<UTC-timestamp>.tar.gz`          | Where to write the bundle tarball. An *existing* directory drops the default filename inside it; any other PATH is used verbatim as the tarball filename. |
+| `--redaction-from F`  | (none today)                                 | Recipe to read the `redaction:` block from. Phase 3 of #188 wires the actual scrubbers in and will add the auto-fallback to `<run-dir>/recipe.resolved.yaml`. Today an explicit path is required to log a redaction-from line at all; without it the bundle runs through the `IdentityRedactor`. |
 
 ### Ticket resolution
 
@@ -152,9 +152,10 @@ of the run directory).
 | `NoTicketError`        | basename is `_no_ticket_` and `--ticket` was not passed.                |
 | `EmptyRunDirError`     | `<run-dir>` exists but contains no `trial_*/result.json` artifacts.     |
 | `BundleAbortedError`   | `--review` was passed and the operator answered `n`.                    |
+| `BundleIOError`        | An `OSError` (permissions, ENOSPC, etc.) escaped staging or tarball writing. The original exception is preserved on `.cause`. |
 
-All four bridge to `click.ClickException` in the CLI handler so
-operators see a clean error message instead of a Python traceback.
+All bridge to `click.ClickException` in the CLI handler so operators
+see a clean error message instead of a Python traceback.
 
 ## What this command does NOT do (issue #196 out-of-scope)
 

--- a/docs/probe-188/bundle.md
+++ b/docs/probe-188/bundle.md
@@ -1,0 +1,167 @@
+# `aorta bundle` — design + reference (issue #196)
+
+> Tracking issue: [`ROCm/aorta#196`](https://github.com/ROCm/aorta/issues/196).
+> This command is the prerequisite for `aorta probe` Phase 3 (issue #188).
+
+`aorta bundle` packages a probe run directory into a single
+shareable tarball, applying recipe-specified redaction along the way.
+It does **not** ship its own scrubbers; that work lives in
+`aorta.probe.redaction` (Phase 3 of #188). Until Phase 3 lands the
+bundle command runs with the built-in `IdentityRedactor` — every
+file is copied byte-for-byte and the per-file redaction counts in
+the manifest are zero.
+
+## CLI
+
+```
+aorta bundle <run-dir>
+    [--ticket TICKET]
+    [--review]
+    [--output BUNDLE_PATH]
+    [--redaction-from RECIPE]
+```
+
+`<run-dir>` is the per-ticket leaf written by `aorta probe`'s
+`flat_resume` layout (`<probe-output>/<safe_slug(ticket)>/`). The
+command does not look inside the cell directories beyond what the
+redactor consumes — every file under `<run-dir>` (recursively) is
+streamed through the redactor and copied into the staging tree.
+
+### Flag reference
+
+| Flag                  | Default                                      | Purpose                                                                                         |
+|-----------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `--ticket TICKET`     | inferred from `<run-dir>` basename           | Cross-check against the probe artifact tree; required when the basename is `_no_ticket_`.       |
+| `--review`            | off                                          | Print the manifest summary and pause for `[y/N]` confirmation before writing the tarball.       |
+| `--output PATH`       | `./<ticket>-<UTC-timestamp>.tar.gz`          | Where to write the bundle tarball.                                                              |
+| `--redaction-from F`  | `<run-dir>/recipe.resolved.yaml` (optional)  | Recipe to read the `redaction:` block from. Phase 3 of #188 wires the actual scrubbers in.      |
+
+### Ticket resolution
+
+`aorta bundle` refuses to write a bundle that has no real ticket.
+That guarantee comes in two halves:
+
+1. If `<run-dir>` basename is `_no_ticket_`, the command exits
+   non-zero with a `ClickException` pointing at
+   `aorta probe --ticket TICKET ...`. This matches the rubric §3.B
+   FR 3.1 contract for #188 Phase 3.
+2. If `--ticket TICKET` is passed and the basename does not match
+   `safe_slug(TICKET)`, the command **proceeds** but logs a
+   warning. Operators legitimately move probe artifact trees
+   between machines (e.g. NFS handoff) and the basename is the
+   strict source of truth only when the operator did not override
+   it.
+
+If neither condition triggers a refusal, the resolved ticket is the
+`--ticket` value (if passed) or the basename (otherwise). The
+resolved value lands in the manifest's `ticket` field.
+
+## Output layout
+
+```
+<bundle-name>.tar.gz
+└── <bundle-name>/
+    ├── manifest.json
+    ├── recipe.resolved.yaml      # copied if present in source
+    ├── matrix.md                 # copied if present in source
+    ├── matrix.json               # copied if present in source
+    ├── host_env.json             # copied if present in source
+    └── <cell>/
+        └── trial_<n>/
+            ├── stdout.log
+            ├── stderr.log
+            ├── result.json
+            └── probe.env         # only when env_passthrough_mode == 'file'
+```
+
+`<bundle-name>` defaults to `<ticket>-<UTC-timestamp>` and is also
+the tarball's top-level directory. The manifest lives at
+`bundle/manifest.json` so a downstream consumer can extract a single
+file (`tar -xzOf <bundle> <bundle-name>/manifest.json`) without
+unpacking the whole tree.
+
+## Manifest schema
+
+```json
+{
+  "schema_version": 1,
+  "ticket": "TICKET-1234",
+  "created_at": "2026-05-25T10:00:00Z",
+  "aorta_version": "0.2.0",
+  "source_run_dir": "/abs/path/to/probe_results/TICKET-1234",
+  "redaction_applied": false,
+  "redactor_kind": "identity",
+  "files": [
+    {
+      "path": "none-none/trial_0/stdout.log",
+      "env_keys_removed": 0,
+      "paths_rewritten": 0,
+      "ips_rewritten": 0,
+      "bytes_in": 12345,
+      "bytes_out": 12345
+    }
+  ]
+}
+```
+
+* `path` is **relative to `<bundle-name>/`** (matches the path the
+  reader gets after `tar -xzf ...`). Forward slashes regardless of
+  host OS.
+* `redaction_applied` is `false` while the only redactor is
+  `IdentityRedactor` (the default until #188 Phase 3 ships).
+* `redactor_kind` is a stable string identifier the redactor
+  reports (currently `"identity"`; #188 Phase 3 will register e.g.
+  `"probe.v1"`).
+
+## Redactor contract
+
+`aorta.bundle.redactor.Redactor` is an `ABC` with one method:
+
+```python
+def scrub_file(self, src: Path, dst: Path) -> RedactionCounts: ...
+```
+
+* `src` is a regular file inside the source `<run-dir>`.
+* `dst` is the destination path in the staging tree (parent dirs
+  pre-created).
+* `RedactionCounts` is a frozen dataclass with the three documented
+  counters (`env_keys_removed`, `paths_rewritten`, `ips_rewritten`)
+  plus `bytes_in` / `bytes_out`.
+
+The default `IdentityRedactor` calls `shutil.copyfile(src, dst)`
+and returns zeros. `aorta.probe.redaction` (Phase 3 of #188) will
+ship a `RedactingRedactor` that the bundle CLI can pick up via the
+`--redaction-from` flag once that module lands. **`aorta bundle`
+does not own the scrubbers** — the issue #196 contract is
+explicit on this.
+
+## Originals are never modified
+
+Every file in `<run-dir>` is read, never written. The staging tree
+is built under a `tempfile.TemporaryDirectory`; the tarball is
+written to `--output` and the staging tree is cleaned up. The
+existing `aorta probe` `flat_resume` lockfile is left alone — the
+bundle command does not acquire it (bundle is a read-only consumer
+of the run directory).
+
+## Errors (operator-visible)
+
+| Class                  | Trigger                                                                |
+|------------------------|------------------------------------------------------------------------|
+| `RunDirNotFoundError`  | `<run-dir>` does not exist or is not a directory.                       |
+| `NoTicketError`        | basename is `_no_ticket_` and `--ticket` was not passed.                |
+| `EmptyRunDirError`     | `<run-dir>` exists but contains no `trial_*/result.json` artifacts.     |
+| `BundleAbortedError`   | `--review` was passed and the operator answered `n`.                    |
+
+All four bridge to `click.ClickException` in the CLI handler so
+operators see a clean error message instead of a Python traceback.
+
+## What this command does NOT do (issue #196 out-of-scope)
+
+* Network upload of bundles.
+* Bundle decryption / unpacking utilities.
+* Auto-detection of secrets beyond what the recipe's `redaction:`
+  block specifies — Phase 3 of #188 owns that policy.
+* Implementing `aorta.probe.redaction` itself. Until that module
+  lands, the redactor is the no-op `IdentityRedactor` and the
+  manifest's per-file counts are zero.

--- a/docs/probe-188/bundle.md
+++ b/docs/probe-188/bundle.md
@@ -122,8 +122,14 @@ def scrub_file(self, src: Path, dst: Path) -> RedactionCounts: ...
 ```
 
 * `src` is a regular file inside the source `<run-dir>`.
-* `dst` is the destination path in the staging tree (parent dirs
-  pre-created).
+* `dst` is the destination path in the staging tree. **The
+  implementation creates `dst.parent` itself** -- the bundle
+  writer only creates the top-level bundle root, not the
+  per-file parent dirs. `IdentityRedactor.scrub_file` calls
+  `dst.parent.mkdir(parents=True, exist_ok=True)` before copying;
+  Phase 3's `RedactingRedactor` must do the same. (Earlier
+  revisions of this doc said the parent was pre-created;
+  that was wrong -- see PR #199.)
 * `RedactionCounts` is a frozen dataclass with the three documented
   counters (`env_keys_removed`, `paths_rewritten`, `ips_rewritten`)
   plus `bytes_in` / `bytes_out`.

--- a/docs/probe-188/bundle.md
+++ b/docs/probe-188/bundle.md
@@ -88,7 +88,7 @@ unpacking the whole tree.
   "ticket": "TICKET-1234",
   "created_at": "2026-05-25T10:00:00Z",
   "aorta_version": "0.2.0",
-  "source_run_dir": "/abs/path/to/probe_results/TICKET-1234",
+  "source_run_dir": "TICKET-1234",
   "redaction_applied": false,
   "redactor_kind": "identity",
   "files": [
@@ -112,6 +112,21 @@ unpacking the whole tree.
 * `redactor_kind` is a stable string identifier the redactor
   reports (currently `"identity"`; #188 Phase 3 will register e.g.
   `"probe.v1"`).
+* `source_run_dir` records **only the leaf directory name** (the
+  per-ticket segment), never the operator's absolute path. A bundle
+  is a shareable artifact, so the full path is deliberately withheld
+  to avoid leaking workstation usernames, mount points, or customer
+  directory names off the source machine.
+
+## Trust boundary: symlinks
+
+`aorta bundle` walks the run dir and includes regular files only.
+A symlink (or a symlinked parent component) whose resolved target
+lands **outside** the run dir is refused with `UnsafeSymlinkError`
+rather than dereferenced — otherwise a link such as
+`cell/trial_0/leak -> ../../secret.txt` would pull unrelated local
+bytes into a "shareable" tarball and break the trust boundary.
+Symlinks whose target stays inside the run dir are still followed.
 
 ## Redactor contract
 

--- a/docs/probe-188/bundle.md
+++ b/docs/probe-188/bundle.md
@@ -33,7 +33,7 @@ streamed through the redactor and copied into the staging tree.
 |-----------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------|
 | `--ticket TICKET`     | inferred from `<run-dir>` basename           | Cross-check against the probe artifact tree; required when the basename is `_no_ticket_`.       |
 | `--review`            | off                                          | Print the manifest summary and pause for `[y/N]` confirmation before writing the tarball.       |
-| `--output PATH`       | `./<ticket>-<UTC-timestamp>.tar.gz`          | Where to write the bundle tarball. An *existing* directory drops the default filename inside it; any other PATH is used verbatim as the tarball filename. |
+| `--output PATH`       | `./<safe_slug(ticket)>-<UTC-timestamp>.tar.gz` | Where to write the bundle tarball. An *existing* directory drops the default filename inside it; any other PATH is used verbatim as the tarball filename. The ticket is slugified for filesystem safety (spaces/slashes → `_`). |
 | `--redaction-from F`  | (none today)                                 | Recipe to read the `redaction:` block from. Phase 3 of #188 wires the actual scrubbers in and will add the auto-fallback to `<run-dir>/recipe.resolved.yaml`. Today an explicit path is required to log a redaction-from line at all; without it the bundle runs through the `IdentityRedactor`. |
 
 ### Ticket resolution
@@ -74,8 +74,9 @@ resolved value lands in the manifest's `ticket` field.
             └── probe.env         # only when env_passthrough_mode == 'file'
 ```
 
-`<bundle-name>` defaults to `<ticket>-<UTC-timestamp>` and is also
-the tarball's top-level directory. The manifest lives at
+`<bundle-name>` defaults to `<safe_slug(ticket)>-<UTC-timestamp>`
+(the ticket is slugified for filesystem safety, so spaces/slashes
+become `_`) and is also the tarball's top-level directory. The manifest lives at
 `bundle/manifest.json` so a downstream consumer can extract a single
 file (`tar -xzOf <bundle> <bundle-name>/manifest.json`) without
 unpacking the whole tree.

--- a/src/aorta/bundle/__init__.py
+++ b/src/aorta/bundle/__init__.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from aorta.bundle.errors import (
     BundleAbortedError,
     BundleError,
+    BundleIOError,
     EmptyRunDirError,
     NoTicketError,
     RunDirNotFoundError,
@@ -47,6 +48,7 @@ __all__ = [
     "MANIFEST_SCHEMA_VERSION",
     "BundleAbortedError",
     "BundleError",
+    "BundleIOError",
     "EmptyRunDirError",
     "FileRecord",
     "IdentityRedactor",

--- a/src/aorta/bundle/__init__.py
+++ b/src/aorta/bundle/__init__.py
@@ -1,0 +1,60 @@
+"""``aorta.bundle`` -- shareable artifact bundler for ``aorta probe`` runs.
+
+Public surface (issue #196):
+
+* :func:`bundle_run_dir` -- programmatic entry point. Stages a probe
+  run directory through the configured :class:`Redactor`, writes a
+  ``manifest.json``, and packs everything into a single ``.tar.gz``.
+  Returns the absolute path of the bundle.
+* :class:`Manifest`, :class:`FileRecord` -- typed view of the
+  ``manifest.json`` shape so downstream tooling does not have to
+  re-derive it.
+* :class:`Redactor`, :class:`IdentityRedactor`, :class:`RedactionCounts`
+  -- the redactor contract. ``aorta probe`` Phase 3 (issue #188) ships
+  a real implementation; until then bundles use the
+  :class:`IdentityRedactor` (no scrubbing, zero counts).
+* :class:`BundleError` and its subclasses -- typed exceptions the CLI
+  layer maps to ``click.ClickException``.
+* :data:`MANIFEST_SCHEMA_VERSION`, :data:`MANIFEST_FILENAME` --
+  constants other modules can reference without duplicating the
+  literals.
+
+The CLI lives in :mod:`aorta.cli.bundle` and is a thin Click shim
+around :func:`bundle_run_dir` (mirrors the ``aorta probe`` /
+``aorta run`` discipline).
+"""
+
+from __future__ import annotations
+
+from aorta.bundle.errors import (
+    BundleAbortedError,
+    BundleError,
+    EmptyRunDirError,
+    NoTicketError,
+    RunDirNotFoundError,
+)
+from aorta.bundle.manifest import (
+    MANIFEST_FILENAME,
+    MANIFEST_SCHEMA_VERSION,
+    FileRecord,
+    Manifest,
+)
+from aorta.bundle.redactor import IdentityRedactor, RedactionCounts, Redactor
+from aorta.bundle.writer import bundle_run_dir, resolve_ticket
+
+__all__ = [
+    "MANIFEST_FILENAME",
+    "MANIFEST_SCHEMA_VERSION",
+    "BundleAbortedError",
+    "BundleError",
+    "EmptyRunDirError",
+    "FileRecord",
+    "IdentityRedactor",
+    "Manifest",
+    "NoTicketError",
+    "RedactionCounts",
+    "Redactor",
+    "RunDirNotFoundError",
+    "bundle_run_dir",
+    "resolve_ticket",
+]

--- a/src/aorta/bundle/__init__.py
+++ b/src/aorta/bundle/__init__.py
@@ -33,6 +33,7 @@ from aorta.bundle.errors import (
     EmptyRunDirError,
     NoTicketError,
     RunDirNotFoundError,
+    UnsafeSymlinkError,
 )
 from aorta.bundle.manifest import (
     MANIFEST_FILENAME,
@@ -57,6 +58,7 @@ __all__ = [
     "RedactionCounts",
     "Redactor",
     "RunDirNotFoundError",
+    "UnsafeSymlinkError",
     "bundle_run_dir",
     "resolve_ticket",
 ]

--- a/src/aorta/bundle/_slug.py
+++ b/src/aorta/bundle/_slug.py
@@ -1,0 +1,45 @@
+"""Filesystem-safe slug helper -- stdlib-only copy for ``aorta.bundle``.
+
+Deliberately duplicated from :func:`aorta.triage.output.safe_slug` (and
+its ``NO_TICKET_SLUG`` constant) so that importing ``aorta.bundle`` does
+NOT transitively pull in PyYAML and the whole ``aorta.triage`` /
+``aorta.registry`` stack at import time. Issue #196 acceptance
+criterion 7 pins the bundle package to stdlib + ``click`` only;
+``aorta.triage.output`` imports ``yaml`` (PR #199 review).
+
+Keep this behaviourally in sync with the canonical
+``aorta.triage.output.safe_slug``. ``tests/bundle/test_no_new_deps.py``
+asserts byte-for-byte parity between the two implementations so this
+copy cannot silently drift (e.g. if triage tightens the slug regex for
+a path-traversal fix).
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Basename a run dir carries when ``aorta probe`` ran without a ticket.
+NO_TICKET_SLUG = "_no_ticket_"
+
+# Replace anything that isn't ``[A-Za-z0-9_.-]`` with ``_`` so a ticket
+# never creates surprise subdirectories.
+_SAFE_RE = re.compile(r"[^A-Za-z0-9_.\-]")
+# ``.`` / ``..`` survive the character scrub but are still path-meaningful;
+# keep them out so a ticket like ``..`` cannot escape the output tree.
+_RESERVED_SLUGS = frozenset({".", ".."})
+
+
+def safe_slug(value: str) -> str:
+    """Turn a ticket / name into a safe directory component.
+
+    Replaces anything outside ``[A-Za-z0-9_.-]`` with ``_`` and rewrites
+    the reserved ``.`` / ``..`` components (and empty input) to ``_`` so
+    the result can never refer to the current or parent directory.
+    """
+    cleaned = _SAFE_RE.sub("_", value)
+    if not cleaned or cleaned in _RESERVED_SLUGS:
+        return "_"
+    return cleaned
+
+
+__all__ = ["NO_TICKET_SLUG", "safe_slug"]

--- a/src/aorta/bundle/errors.py
+++ b/src/aorta/bundle/errors.py
@@ -78,9 +78,11 @@ class EmptyRunDirError(BundleError):
 class BundleAbortedError(BundleError):
     """Raised when ``--review`` was passed and the operator answered ``n``.
 
-    Carries the manifest summary that was shown so a CLI test can
-    assert the operator was given the documented context before the
-    abort.
+    Carries the source ``run_dir`` so the CLI can render a "no
+    tarball was written; run dir untouched" message. The rendered
+    review summary is printed to ``stdout`` by the review callback
+    BEFORE the prompt -- it is not stored on the exception (CLI tests
+    assert against captured stdout, not against this class).
     """
 
     def __init__(self, run_dir: Path) -> None:
@@ -88,4 +90,29 @@ class BundleAbortedError(BundleError):
         super().__init__(
             f"aorta bundle: review-pause aborted by operator (run dir "
             f"{run_dir}). No tarball was written."
+        )
+
+
+class BundleIOError(BundleError):
+    """Raised when a filesystem error escapes the staging / tarball pipeline.
+
+    Wraps ``OSError`` from the redactor's ``scrub_file`` (and the
+    underlying ``shutil.copyfile``), from ``tarfile.add`` /
+    ``tarfile.open``, and from manifest writes so the CLI shim
+    surfaces a clean ``ClickException`` instead of a Python
+    traceback. The ``Redactor`` ABC docstring documents this wrap;
+    the writer is the place that performs it.
+
+    Carries the ``run_dir`` and the original ``OSError`` so a future
+    test or ops tool can grade whether the failure was a permissions
+    problem (``PermissionError``), out of disk (``ENOSPC``), or
+    something else without parsing the rendered message.
+    """
+
+    def __init__(self, run_dir: Path, cause: OSError) -> None:
+        self.run_dir = run_dir
+        self.cause = cause
+        super().__init__(
+            f"aorta bundle: filesystem error while bundling {run_dir}: "
+            f"{type(cause).__name__}: {cause}. No tarball was written."
         )

--- a/src/aorta/bundle/errors.py
+++ b/src/aorta/bundle/errors.py
@@ -75,6 +75,35 @@ class EmptyRunDirError(BundleError):
         )
 
 
+class UnsafeSymlinkError(BundleError):
+    """Raised when a file under ``<run-dir>`` resolves outside the tree.
+
+    ``aorta bundle`` produces a *shareable* artifact, so it must not
+    silently pull bytes from outside the run dir. A symlink (or a
+    symlinked parent component) whose resolved target escapes
+    ``run_dir`` would dereference into an unrelated local file or a
+    mounted-share path and bundle its contents -- breaking the trust
+    boundary for the command. We refuse such entries instead of
+    following them. In-tree symlinks (target stays inside
+    ``run_dir``) are still followed.
+
+    Carries the offending ``path`` and its resolved ``target`` so the
+    CLI shim can name both in the operator-visible message and tests
+    can assert on the fields.
+    """
+
+    def __init__(self, run_dir: Path, path: Path, target: Path) -> None:
+        self.run_dir = run_dir
+        self.path = path
+        self.target = target
+        super().__init__(
+            f"aorta bundle: refusing to follow symlink {path} -> {target}: "
+            f"its target is outside the run dir {run_dir}. Bundles must "
+            "stay within the source tree to remain shareable. Remove the "
+            "symlink or copy the real file into the run dir before bundling."
+        )
+
+
 class BundleAbortedError(BundleError):
     """Raised when ``--review`` was passed and the operator answered ``n``.
 

--- a/src/aorta/bundle/errors.py
+++ b/src/aorta/bundle/errors.py
@@ -107,7 +107,7 @@ class UnsafeSymlinkError(BundleError):
 class BundleAbortedError(BundleError):
     """Raised when ``--review`` was passed and the operator answered ``n``.
 
-    Carries the source ``run_dir`` so the CLI can render a "no
+    Carries the source ``run_dir`` so the CLI can render a "no new
     tarball was written; run dir untouched" message. The rendered
     review summary is printed to ``stdout`` by the review callback
     BEFORE the prompt -- it is not stored on the exception (CLI tests
@@ -118,7 +118,8 @@ class BundleAbortedError(BundleError):
         self.run_dir = run_dir
         super().__init__(
             f"aorta bundle: review-pause aborted by operator (run dir "
-            f"{run_dir}). No tarball was written."
+            f"{run_dir}). No new tarball was written; any existing file "
+            "at the output path was left untouched."
         )
 
 
@@ -143,5 +144,7 @@ class BundleIOError(BundleError):
         self.cause = cause
         super().__init__(
             f"aorta bundle: filesystem error while bundling {run_dir}: "
-            f"{type(cause).__name__}: {cause}. No tarball was written."
+            f"{type(cause).__name__}: {cause}. No new tarball was written; "
+            "any existing file at the output path was left untouched (the "
+            "atomic write only replaces it on success)."
         )

--- a/src/aorta/bundle/errors.py
+++ b/src/aorta/bundle/errors.py
@@ -1,0 +1,91 @@
+"""Typed exceptions for ``aorta bundle`` (issue #196).
+
+Kept in their own module so :mod:`aorta.bundle.writer`,
+:mod:`aorta.bundle.cli`, and downstream Phase 3 (#188) integration
+code can import them without pulling in the writer/tarball
+machinery. Each subclass carries the operator-visible context
+(path, ticket, etc.) so the CLI shim can render a useful
+``ClickException`` message without re-deriving it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class BundleError(Exception):
+    """Base class for every error :mod:`aorta.bundle` raises.
+
+    Catching :class:`BundleError` in the CLI shim covers all the
+    documented failure modes (no ticket, missing run dir, empty run
+    dir, operator-aborted review). Concrete subclasses each carry
+    the structured context the message was rendered from so test
+    assertions can match on the field rather than on substring
+    soup.
+    """
+
+
+class RunDirNotFoundError(BundleError):
+    """Raised when ``<run-dir>`` does not exist or is not a directory."""
+
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+        super().__init__(
+            f"aorta bundle: run dir {run_dir} does not exist or is not "
+            "a directory. Pass the per-ticket leaf produced by 'aorta "
+            "probe' (e.g. <probe-output>/<ticket>/)."
+        )
+
+
+class NoTicketError(BundleError):
+    """Raised when the run dir resolves to ``_no_ticket_`` and no ``--ticket`` was passed.
+
+    Mirrors rubric §3.B FR 3.1 for issue #188 Phase 3: a bundle with
+    no ticket has nowhere to land downstream, so refuse early
+    instead of writing a ``_no_ticket_-<timestamp>.tar.gz`` that
+    nobody can route.
+    """
+
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+        super().__init__(
+            f"aorta bundle: run dir {run_dir} resolves to '_no_ticket_'. "
+            "Pass --ticket TICKET (or re-run 'aorta probe' with "
+            "--ticket TICKET so the source tree carries one). Bundles "
+            "without a real ticket have no routing target downstream."
+        )
+
+
+class EmptyRunDirError(BundleError):
+    """Raised when the run dir has no ``trial_*/result.json`` artifacts.
+
+    A directory with `aorta probe` shape but zero completed trials
+    is almost always operator error -- pointing at the wrong path,
+    forgetting the ``--ticket`` segment, or running before any cell
+    finished. Refuse before writing an empty tarball.
+    """
+
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+        super().__init__(
+            f"aorta bundle: run dir {run_dir} contains no "
+            "'trial_*/result.json' artifacts. Did you forget to "
+            "include the per-ticket segment, or run before any "
+            "probe trial finished?"
+        )
+
+
+class BundleAbortedError(BundleError):
+    """Raised when ``--review`` was passed and the operator answered ``n``.
+
+    Carries the manifest summary that was shown so a CLI test can
+    assert the operator was given the documented context before the
+    abort.
+    """
+
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+        super().__init__(
+            f"aorta bundle: review-pause aborted by operator (run dir "
+            f"{run_dir}). No tarball was written."
+        )

--- a/src/aorta/bundle/manifest.py
+++ b/src/aorta/bundle/manifest.py
@@ -5,7 +5,9 @@ bundle and is the single authoritative record of:
 
 * what was redacted (per-file counts),
 * what was bundled (relative paths inside the tarball),
-* who wrote the bundle (aorta version, redactor kind, source run dir).
+* who wrote the bundle (aorta version, redactor kind, and the source
+  run dir's leaf name only -- never its absolute path, which would
+  leak operator/customer path details off the source machine).
 
 Schema is versioned via :data:`MANIFEST_SCHEMA_VERSION`. Phase 3 of
 issue #188 will not need a bump -- it only fills in the existing
@@ -88,6 +90,14 @@ class Manifest:
     ticket: str
     created_at: str
     aorta_version: str
+    #: Provenance ONLY: the leaf directory name of the source run dir
+    #: (its basename), never the absolute path. A bundle is a
+    #: shareable artifact, so recording ``/home/<user>/<customer>/...``
+    #: would leak workstation usernames, mount points, and customer
+    #: directory names off the source machine (PR #199 security
+    #: review). The leaf name is the per-ticket segment, which is
+    #: already non-sensitive (it equals ``ticket`` in normal probe
+    #: output).
     source_run_dir: str
     redaction_applied: bool
     redactor_kind: str
@@ -124,7 +134,9 @@ class Manifest:
             ticket=ticket,
             created_at=now.strftime("%Y-%m-%dT%H:%M:%SZ"),
             aorta_version=aorta_version,
-            source_run_dir=str(source_run_dir.resolve()),
+            # Basename only -- NEVER the absolute path. See the
+            # ``source_run_dir`` field docstring for the rationale.
+            source_run_dir=source_run_dir.name,
             redaction_applied=applied,
             redactor_kind=redactor_kind,
             files=tuple(files),

--- a/src/aorta/bundle/manifest.py
+++ b/src/aorta/bundle/manifest.py
@@ -31,6 +31,24 @@ MANIFEST_FILENAME = "manifest.json"
 MANIFEST_SCHEMA_VERSION = 1
 
 
+def _to_utc(now: _dt.datetime) -> _dt.datetime:
+    """Normalise an arbitrary datetime to UTC.
+
+    Bundle artifacts ALWAYS label timestamps as UTC ("Z" suffix in
+    manifests; no suffix but UTC-convention in filenames). Callers
+    (tests, future Phase 3 hooks) may inject a naive or
+    non-UTC-aware ``now`` -- we treat a naive datetime as already
+    being in UTC (matches ``datetime.now(timezone.utc)``'s shape
+    once tz is stripped) and convert any aware datetime to UTC
+    before formatting. The alternative (silently slapping ``Z`` on
+    a local-time naive datetime) is the bug Copilot caught on PR
+    #199.
+    """
+    if now.tzinfo is None:
+        return now.replace(tzinfo=_dt.timezone.utc)
+    return now.astimezone(_dt.timezone.utc)
+
+
 @dataclass(frozen=True)
 class FileRecord:
     """One row of ``manifest.json::files``.
@@ -88,12 +106,18 @@ class Manifest:
         """Build a :class:`Manifest` and derive ``redaction_applied``.
 
         ``now`` is optional so tests can pin a deterministic
-        timestamp; default uses ``datetime.now(timezone.utc)``. The
-        timestamp is rendered in ISO-8601 with the ``Z`` suffix so
-        downstream tools can parse it with ``datetime.fromisoformat``
-        (Python 3.11+) or any standard ISO-8601 parser.
+        timestamp; default uses ``datetime.now(timezone.utc)``. A
+        non-UTC or naive ``now`` is normalised by :func:`_to_utc`
+        before formatting so the ``Z`` suffix in the on-disk
+        ``created_at`` always reflects the real UTC clock (not
+        the caller's local time silently labelled UTC).
+
+        The timestamp is rendered in ISO-8601 with the ``Z`` suffix
+        so downstream tools can parse it with
+        ``datetime.fromisoformat`` (Python 3.11+) or any standard
+        ISO-8601 parser.
         """
-        now = now or _dt.datetime.now(_dt.timezone.utc)
+        now = _to_utc(now or _dt.datetime.now(_dt.timezone.utc))
         applied = any(f.env_keys_removed or f.paths_rewritten or f.ips_rewritten for f in files)
         return cls(
             schema_version=MANIFEST_SCHEMA_VERSION,

--- a/src/aorta/bundle/manifest.py
+++ b/src/aorta/bundle/manifest.py
@@ -1,0 +1,170 @@
+"""Manifest dataclasses + JSON shape for ``aorta bundle`` (issue #196).
+
+The manifest lives at ``<bundle-name>/manifest.json`` inside every
+bundle and is the single authoritative record of:
+
+* what was redacted (per-file counts),
+* what was bundled (relative paths inside the tarball),
+* who wrote the bundle (aorta version, redactor kind, source run dir).
+
+Schema is versioned via :data:`MANIFEST_SCHEMA_VERSION`. Phase 3 of
+issue #188 will not need a bump -- it only fills in the existing
+``RedactionCounts`` fields with non-zero values.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+#: Filename used inside both the staging tree and the tarball.
+MANIFEST_FILENAME = "manifest.json"
+
+#: Bumped only on a non-additive change. Adding fields with
+#: documented defaults does NOT bump this. The reader in
+#: :func:`Manifest.from_json` rejects schema versions it does not
+#: understand; current readers are inside
+#: ``tests/bundle/test_writer.py`` only, but a downstream tool that
+#: parses the manifest can pin the same constant.
+MANIFEST_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    """One row of ``manifest.json::files``.
+
+    ``path`` is relative to the bundle's top-level directory (which
+    is also the tarball's top-level entry). Forward slashes
+    regardless of host OS so a manifest written on Windows is
+    readable on Linux without normalisation.
+    """
+
+    path: str
+    env_keys_removed: int = 0
+    paths_rewritten: int = 0
+    ips_rewritten: int = 0
+    bytes_in: int = 0
+    bytes_out: int = 0
+
+    def to_dict(self) -> dict[str, int | str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """``manifest.json`` shape -- see ``docs/probe-188/bundle.md``.
+
+    ``redaction_applied`` is the boolean roll-up of the per-file
+    counts (it's ``True`` iff at least one ``FileRecord`` carries a
+    non-zero env / path / ip count). Recorded explicitly so a
+    consumer does not have to scan every record to know whether
+    scrubbers ran -- the field is the index, not the source of
+    truth. The actual roll-up is computed in :meth:`from_files`
+    so callers cannot accidentally mark a bundle as "redaction
+    applied" while submitting zero-count records.
+    """
+
+    schema_version: int
+    ticket: str
+    created_at: str
+    aorta_version: str
+    source_run_dir: str
+    redaction_applied: bool
+    redactor_kind: str
+    files: tuple[FileRecord, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_files(
+        cls,
+        ticket: str,
+        source_run_dir: Path,
+        redactor_kind: str,
+        aorta_version: str,
+        files: list[FileRecord],
+        now: _dt.datetime | None = None,
+    ) -> Manifest:
+        """Build a :class:`Manifest` and derive ``redaction_applied``.
+
+        ``now`` is optional so tests can pin a deterministic
+        timestamp; default uses ``datetime.now(timezone.utc)``. The
+        timestamp is rendered in ISO-8601 with the ``Z`` suffix so
+        downstream tools can parse it with ``datetime.fromisoformat``
+        (Python 3.11+) or any standard ISO-8601 parser.
+        """
+        now = now or _dt.datetime.now(_dt.timezone.utc)
+        applied = any(f.env_keys_removed or f.paths_rewritten or f.ips_rewritten for f in files)
+        return cls(
+            schema_version=MANIFEST_SCHEMA_VERSION,
+            ticket=ticket,
+            created_at=now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            aorta_version=aorta_version,
+            source_run_dir=str(source_run_dir.resolve()),
+            redaction_applied=applied,
+            redactor_kind=redactor_kind,
+            files=tuple(files),
+        )
+
+    def to_json(self) -> str:
+        doc: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "ticket": self.ticket,
+            "created_at": self.created_at,
+            "aorta_version": self.aorta_version,
+            "source_run_dir": self.source_run_dir,
+            "redaction_applied": self.redaction_applied,
+            "redactor_kind": self.redactor_kind,
+            "files": [f.to_dict() for f in self.files],
+        }
+        return json.dumps(doc, indent=2, sort_keys=False)
+
+    @classmethod
+    def from_json(cls, raw: str) -> Manifest:
+        """Round-trip the manifest from its on-disk JSON form.
+
+        Used by tests + downstream tooling. Rejects unknown schema
+        versions up front so a future bump cannot be silently mis-read.
+        """
+        doc = json.loads(raw)
+        version = doc.get("schema_version")
+        if version != MANIFEST_SCHEMA_VERSION:
+            raise ValueError(
+                f"manifest.json: unsupported schema_version {version!r}; "
+                f"this build understands version {MANIFEST_SCHEMA_VERSION}"
+            )
+        files = tuple(
+            FileRecord(
+                path=str(f["path"]),
+                env_keys_removed=int(f.get("env_keys_removed", 0)),
+                paths_rewritten=int(f.get("paths_rewritten", 0)),
+                ips_rewritten=int(f.get("ips_rewritten", 0)),
+                bytes_in=int(f.get("bytes_in", 0)),
+                bytes_out=int(f.get("bytes_out", 0)),
+            )
+            for f in doc.get("files", [])
+        )
+        return cls(
+            schema_version=version,
+            ticket=str(doc["ticket"]),
+            created_at=str(doc["created_at"]),
+            aorta_version=str(doc["aorta_version"]),
+            source_run_dir=str(doc["source_run_dir"]),
+            redaction_applied=bool(doc.get("redaction_applied", False)),
+            redactor_kind=str(doc.get("redactor_kind", "identity")),
+            files=files,
+        )
+
+    def total_bytes_in(self) -> int:
+        return sum(f.bytes_in for f in self.files)
+
+    def total_bytes_out(self) -> int:
+        return sum(f.bytes_out for f in self.files)
+
+
+__all__ = [
+    "MANIFEST_FILENAME",
+    "MANIFEST_SCHEMA_VERSION",
+    "FileRecord",
+    "Manifest",
+]

--- a/src/aorta/bundle/redactor.py
+++ b/src/aorta/bundle/redactor.py
@@ -102,14 +102,17 @@ class IdentityRedactor(Redactor):
     ``manifest.json`` written under this redactor reports
     ``redaction_applied: false`` and ``redactor_kind: "identity"``.
 
-    ``shutil.copyfile`` (vs ``copy`` / ``copy2``) is deliberate:
-    we want bytes-only fidelity. Mode bits are recreated on the
-    bundle side from the staging tree; we do not inherit ``probe.env``'s
-    ``0600`` mode here because the bundle is the redacted
-    deliverable -- the secret-bearing original stays in
-    ``<run-dir>``. Phase 3 of #188 explicitly scrubs the env file
-    before bundling, so even when its mode bits did transfer, the
-    contents would be redacted.
+    Copy semantics: ``shutil.copyfile`` (vs ``copy`` / ``copy2``)
+    moves bytes only, then ``shutil.copymode`` carries the source's
+    permission bits onto the staged copy. Preserving the mode is a
+    defense-in-depth requirement, not a nicety: ``aorta probe``
+    creates ``probe.env`` at ``0600`` (owner-only), and a plain
+    ``copyfile`` would land it at the process umask default
+    (typically ``0644``) -- *widening* a secret-bearing file as it
+    enters a shareable bundle. We never want the bundle copy to be
+    less restrictive than the original (PR #199 review). We do not
+    use ``copy2`` because timestamps/xattrs are not part of the
+    bundle contract -- only the access mode matters here.
     """
 
     kind = "identity"
@@ -117,6 +120,9 @@ class IdentityRedactor(Redactor):
     def scrub_file(self, src: Path, dst: Path) -> RedactionCounts:
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(src, dst)
+        # Carry the source mode so a 0600 probe.env is not widened to
+        # the umask default inside the shareable bundle.
+        shutil.copymode(src, dst)
         size = dst.stat().st_size
         return RedactionCounts(bytes_in=size, bytes_out=size)
 

--- a/src/aorta/bundle/redactor.py
+++ b/src/aorta/bundle/redactor.py
@@ -1,0 +1,128 @@
+"""Redactor protocol + identity (no-op) implementation for ``aorta bundle``.
+
+The bundle CLI does NOT own the scrubbers. Per issue #196 and the
+``aorta probe`` Phase 3 rubric (#188), the actual env-key glob,
+path, and IP scrubbers live in ``aorta.probe.redaction`` (Phase 3
+of #188). Until that module lands, every bundle uses the
+:class:`IdentityRedactor` here -- a no-op that copies bytes
+through and reports zero counts.
+
+The :class:`Redactor` ABC is the public hand-off point. Phase 3 of
+#188 will register a ``RedactingRedactor`` that the CLI loads via
+``--redaction-from <recipe>``; everything else in the bundle
+pipeline (staging, manifest, tarballing) is redactor-agnostic.
+
+The contract is intentionally small (one method, one return type)
+so a future ``redaction_v2`` implementation does not require a
+breaking change to the bundle module.
+"""
+
+from __future__ import annotations
+
+import shutil
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RedactionCounts:
+    """Per-file scrubber output -- accumulated into the manifest.
+
+    Values are non-negative ``int``. The default-constructed
+    instance is the "identity" outcome (no scrubbing applied) and
+    is what :class:`IdentityRedactor` returns. Issue #196 documents
+    these three counters as the manifest's per-file shape; Phase 3
+    of #188 fills them in with real scrubber output.
+
+    ``bytes_in`` / ``bytes_out`` are NOT documented in the issue
+    body but are needed to make the manifest self-describing
+    (the bytes-in / bytes-out columns in the issue example come
+    from these). We keep them on the same dataclass because every
+    redactor knows them as a side effect of the copy and recording
+    them elsewhere would force a separate ``stat()`` on every file.
+    """
+
+    env_keys_removed: int = 0
+    paths_rewritten: int = 0
+    ips_rewritten: int = 0
+    bytes_in: int = 0
+    bytes_out: int = 0
+
+
+class Redactor(ABC):
+    """Strategy for copying a single file with optional scrubbing.
+
+    Implementations:
+
+    * :class:`IdentityRedactor` -- the default. Used when no
+      ``redaction:`` block is present in the source recipe (which
+      is every probe recipe in Phase 1/2 of #188 -- the recipe
+      loader rejects ``redaction:`` until Phase 3 of #188 lands).
+    * ``aorta.probe.redaction.RedactingRedactor`` (Phase 3 of #188,
+      not yet shipped) -- applies env-key / path / IP scrubbers
+      configured from the recipe's ``redaction:`` block.
+
+    The :attr:`kind` string is recorded in the manifest so a
+    downstream consumer can tell at a glance which redactor wrote
+    the bundle. Stable identifiers; see the manifest schema in
+    ``docs/probe-188/bundle.md``.
+    """
+
+    #: Stable string identifier recorded under ``manifest.json::redactor_kind``.
+    kind: str = "abstract"
+
+    @abstractmethod
+    def scrub_file(self, src: Path, dst: Path) -> RedactionCounts:
+        """Copy ``src`` to ``dst`` (creating parent dirs as needed).
+
+        Returns the per-file count summary. Implementations MUST:
+
+        * Read from ``src`` only -- never modify the source tree
+          (issue #196 acceptance criterion 5: "originals
+          untouched"). The bundle pipeline tests this directly.
+        * Create the destination's parent directory if missing.
+        * Return :class:`RedactionCounts` with ``bytes_in`` /
+          ``bytes_out`` populated.
+
+        Raises:
+            OSError: forwarded from the underlying copy. The bundle
+                writer wraps these into a single
+                ``BundleError``-shaped failure rather than letting
+                the operator see a raw stack trace.
+        """
+
+
+class IdentityRedactor(Redactor):
+    """No-op redactor: ``shutil.copyfile`` plus zero counts.
+
+    Used by every ``aorta bundle`` invocation today (issue #196).
+    Will be replaced by a Phase-3-of-#188 redactor when the
+    ``--redaction-from <recipe>`` flag is wired through. The
+    ``manifest.json`` written under this redactor reports
+    ``redaction_applied: false`` and ``redactor_kind: "identity"``.
+
+    ``shutil.copyfile`` (vs ``copy`` / ``copy2``) is deliberate:
+    we want bytes-only fidelity. Mode bits are recreated on the
+    bundle side from the staging tree; we do not inherit ``probe.env``'s
+    ``0600`` mode here because the bundle is the redacted
+    deliverable -- the secret-bearing original stays in
+    ``<run-dir>``. Phase 3 of #188 explicitly scrubs the env file
+    before bundling, so even when its mode bits did transfer, the
+    contents would be redacted.
+    """
+
+    kind = "identity"
+
+    def scrub_file(self, src: Path, dst: Path) -> RedactionCounts:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dst)
+        size = dst.stat().st_size
+        return RedactionCounts(bytes_in=size, bytes_out=size)
+
+
+__all__ = [
+    "IdentityRedactor",
+    "RedactionCounts",
+    "Redactor",
+]

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -42,6 +42,7 @@ from aorta.bundle.errors import (
     EmptyRunDirError,
     NoTicketError,
     RunDirNotFoundError,
+    UnsafeSymlinkError,
 )
 from aorta.bundle.manifest import MANIFEST_FILENAME, FileRecord, Manifest, _to_utc
 from aorta.bundle.redactor import IdentityRedactor, Redactor
@@ -178,12 +179,14 @@ def _iter_source_files(run_dir: Path) -> list[Path]:
       cryptographic equality across machines they should hash the
       manifest, not the tarball.
 
-    Symlinks are followed via ``Path.is_file`` semantics; an
-    operator who symlinks an external directory into their probe
-    output gets that directory bundled. We document this behaviour
-    in ``docs/probe-188/bundle.md`` rather than try to detect-and-
-    block it (the legitimate use case -- symlinking a shared
-    ``host_env.json`` -- is a feature).
+    Symlinks are followed via ``Path.is_file`` semantics ONLY when
+    their resolved target stays inside ``run_dir``. A symlink (or a
+    symlinked parent component) whose target escapes the tree raises
+    :class:`UnsafeSymlinkError`: ``aorta bundle`` ships a shareable
+    artifact, so it must not dereference a link pointing at an
+    unrelated local file or a mounted-share path and pull those bytes
+    in (the trust-boundary hole flagged in PR #199 review). In-tree
+    symlinks are still followed so legitimate intra-run links work.
 
     Skips (TOP-LEVEL ONLY; a nested file with the same basename in a
     cell / trial directory is a legitimate artifact and IS bundled):
@@ -200,10 +203,18 @@ def _iter_source_files(run_dir: Path) -> list[Path]:
     bundler-style output) gets those files bundled normally.
     """
     skipped_rel_paths = frozenset({".aorta-probe.lock", MANIFEST_FILENAME})
+    root = run_dir.resolve()
     files: list[Path] = []
     for path in run_dir.rglob("*"):
         if not path.is_file():
             continue
+        # Resolve the full path (dereferences symlinks at any
+        # component) and refuse anything that lands outside the run
+        # dir. A regular file always resolves within ``root``; only a
+        # symlink escaping the tree trips this guard.
+        resolved = path.resolve()
+        if resolved != root and root not in resolved.parents:
+            raise UnsafeSymlinkError(run_dir=run_dir, path=path, target=resolved)
         rel = path.relative_to(run_dir).as_posix()
         if rel in skipped_rel_paths:
             continue
@@ -323,10 +334,13 @@ def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
             for path in bundle_root.rglob("*"):
                 if path.is_file():
                     rel_paths.append(path.relative_to(bundle_root))
-            # Sort with manifest.json last so ``tar -tzf`` reads it as
-            # the trailer (matches the docstring contract).
+            # Sort with the TOP-LEVEL manifest.json last so ``tar -tzf``
+            # reads it as the trailer (matches the docstring contract).
+            # Key on the relative POSIX path, not the basename: a nested
+            # ``*/manifest.json`` artifact must stay in alphabetical
+            # position, only ``./manifest.json`` is the trailer.
             rel_paths.sort(
-                key=lambda p: (p.name == MANIFEST_FILENAME, p.as_posix()),
+                key=lambda p: (p.as_posix() == MANIFEST_FILENAME, p.as_posix()),
             )
             for rel in rel_paths:
                 tar.add(str(bundle_root / rel), arcname=f"{bundle_name}/{rel.as_posix()}")

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -36,6 +36,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
+from aorta.bundle._slug import NO_TICKET_SLUG, safe_slug
 from aorta.bundle.errors import (
     BundleAbortedError,
     BundleIOError,
@@ -46,7 +47,6 @@ from aorta.bundle.errors import (
 )
 from aorta.bundle.manifest import MANIFEST_FILENAME, FileRecord, Manifest, _to_utc
 from aorta.bundle.redactor import IdentityRedactor, Redactor
-from aorta.triage.output import NO_TICKET_SLUG, safe_slug
 
 log = logging.getLogger(__name__)
 
@@ -172,12 +172,14 @@ def _iter_source_files(run_dir: Path) -> list[Path]:
       manifests modulo the timestamp / source path fields.
     * Tarball entry order is reproducible at the entry-list level
       (``tar -tzf <bundle>`` lists files in the same order
-      everywhere). Note that the resulting tarball **bytes** are
-      NOT bit-identical across hosts: ``tarfile`` and ``gzip`` embed
-      mtime / uid / gid / gzip-header timestamp by default, and the
-      writer does not normalise them. If a downstream consumer needs
-      cryptographic equality across machines they should hash the
-      manifest, not the tarball.
+      everywhere). :func:`_scrub_tarinfo` additionally zeroes
+      uid/gid, clears uname/gname, and pins mtime in the tar headers
+      so the archive neither leaks the operator's workstation
+      identity nor varies on those fields. The resulting **bytes**
+      are still NOT bit-identical across hosts -- the outer gzip
+      wrapper embeds its own header timestamp that ``tarfile`` does
+      not expose -- so a consumer needing cryptographic equality
+      should hash the manifest, not the tarball.
 
     Symlinks are followed via ``Path.is_file`` semantics ONLY when
     their resolved target stays inside ``run_dir``. A symlink (or a
@@ -284,6 +286,28 @@ def stage_run_dir(
     return manifest
 
 
+def _scrub_tarinfo(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Normalise ownership + mtime in tar headers for a shareable bundle.
+
+    ``tarfile.add`` copies the staging file's uid/gid and -- because the
+    files were just written by this process -- the operator's user/group
+    names into the archive headers. A bundle is meant to be shared, so
+    those headers would leak workstation identity (and make the archive
+    non-reproducible). We zero uid/gid, clear uname/gname, and pin mtime
+    to the epoch.
+
+    The file MODE is left untouched on purpose: :class:`IdentityRedactor`
+    preserves a ``0600`` ``probe.env`` (PR #199 review) and the tarball
+    must carry that restrictive bit through to extraction.
+    """
+    tarinfo.uid = 0
+    tarinfo.gid = 0
+    tarinfo.uname = ""
+    tarinfo.gname = ""
+    tarinfo.mtime = 0
+    return tarinfo
+
+
 def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
     """Pack ``<staging_dir>/<bundle_name>/`` into ``output.tar.gz``.
 
@@ -310,9 +334,11 @@ def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
     Tarball entries are added in the order :func:`_iter_source_files`
     produced (alphabetical on relative POSIX path), with the manifest
     last so consumers running ``tar -tzf`` see the data first and
-    the index trailer last. ``tarfile.add`` is used directly with
-    a deterministic ``arcname`` so the tarball never carries the
-    operator's ``--output`` parent path.
+    the index trailer last. ``tarfile.add`` is used with a
+    deterministic ``arcname`` (so the tarball never carries the
+    operator's ``--output`` parent path) and a ``filter=``
+    (:func:`_scrub_tarinfo`) that strips ownership/identity metadata
+    from the headers while preserving file modes.
     """
     output = output.absolute()
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -343,7 +369,11 @@ def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
                 key=lambda p: (p.as_posix() == MANIFEST_FILENAME, p.as_posix()),
             )
             for rel in rel_paths:
-                tar.add(str(bundle_root / rel), arcname=f"{bundle_name}/{rel.as_posix()}")
+                tar.add(
+                    str(bundle_root / rel),
+                    arcname=f"{bundle_name}/{rel.as_posix()}",
+                    filter=_scrub_tarinfo,
+                )
         os.replace(partial, output)
     except BaseException:
         # Includes OSError (ENOSPC, EACCES, ...), KeyboardInterrupt,

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -1,0 +1,379 @@
+"""Bundle staging, manifest, and tarball writer for ``aorta bundle``.
+
+Three layers, each independently testable:
+
+1. :func:`resolve_ticket` -- pure function that maps ``(run_dir,
+   --ticket)`` to the bundle ticket. Refuses ``_no_ticket_``.
+2. :func:`stage_run_dir` -- copies every file under ``run_dir``
+   through the redactor into a staging tree under
+   ``<staging>/<bundle_name>/``, producing a :class:`Manifest`.
+3. :func:`write_tarball` -- packs ``<staging>/<bundle_name>/`` into
+   ``<output>.tar.gz`` (gzip-compressed, deterministic top-level
+   directory).
+
+:func:`bundle_run_dir` is the CLI's single entry point; it stitches
+the three layers together with a ``TemporaryDirectory`` for
+staging and an optional ``review_callback`` so the CLI can surface
+the manifest before the tarball is written. The callback design
+keeps the writer free of Click imports -- the CLI shim wires
+:func:`click.confirm` in via the callback.
+
+The redactor is :class:`IdentityRedactor` until Phase 3 of issue
+#188 ships ``aorta.probe.redaction``. The function signature is
+ready for the swap (``redactor=`` keyword) so #188 can wire its
+implementation in without re-shaping any contract here.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import tarfile
+import tempfile
+from collections.abc import Callable
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+from aorta.bundle.errors import (
+    BundleAbortedError,
+    EmptyRunDirError,
+    NoTicketError,
+    RunDirNotFoundError,
+)
+from aorta.bundle.manifest import MANIFEST_FILENAME, FileRecord, Manifest
+from aorta.bundle.redactor import IdentityRedactor, Redactor
+from aorta.triage.output import NO_TICKET_SLUG, safe_slug
+
+log = logging.getLogger(__name__)
+
+#: Glob the writer uses to confirm a run dir actually came from
+#: ``aorta probe`` (i.e. has at least one completed trial). The
+#: pattern matches the artifact-tree contract documented at
+#: ``docs/probe-188/usage.md`` (cell/trial_N/result.json).
+_TRIAL_RESULT_GLOB = "*/trial_*/result.json"
+
+
+def _aorta_version() -> str:
+    """Return the installed ``aorta`` package version (best-effort)."""
+    try:
+        return _pkg_version("aorta")
+    except PackageNotFoundError:
+        return "unknown"
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+def _bundle_timestamp(now: _dt.datetime | None = None) -> str:
+    """Filesystem-safe UTC timestamp for the bundle's directory + filename.
+
+    ISO-8601 with colons replaced by dashes (Windows-friendly), to
+    millisecond precision (``%f`` truncated to ms) so two bundles
+    written in quick succession do not collide on the same name.
+    """
+    now = now or _dt.datetime.now(_dt.timezone.utc)
+    return now.strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def resolve_ticket(run_dir: Path, ticket_flag: str | None) -> str:
+    """Resolve the bundle's ticket per ``docs/probe-188/bundle.md``.
+
+    Order of precedence:
+
+    1. ``--ticket TICKET`` flag, if non-empty. The ticket is
+       cross-checked against the basename of ``run_dir``; a
+       mismatch is logged at WARNING level but does not refuse.
+       Operators move artifact trees between machines (e.g. NFS
+       handoff) and the basename is not authoritative when the
+       operator overrides it.
+    2. ``run_dir`` basename, if not ``_no_ticket_``.
+    3. Otherwise, raise :class:`NoTicketError` -- the issue #196
+       acceptance criterion 2 ("refuses without --ticket").
+
+    Whitespace-only ``ticket_flag`` is treated as missing so
+    ``--ticket ""`` does not silently produce an unsluggable
+    bundle. The resolved value is returned verbatim (NOT slugged):
+    the manifest records the operator-supplied ticket, while
+    :func:`safe_slug` is applied separately for filesystem
+    components.
+    """
+    basename = run_dir.name
+    if ticket_flag is not None and ticket_flag.strip():
+        ticket = ticket_flag.strip()
+        if basename != safe_slug(ticket) and basename != NO_TICKET_SLUG:
+            log.warning(
+                "aorta bundle: --ticket %r does not match run-dir "
+                "basename %r; proceeding with the flag value (operator "
+                "override). The manifest will record %r.",
+                ticket,
+                basename,
+                ticket,
+            )
+        if basename == NO_TICKET_SLUG:
+            log.warning(
+                "aorta bundle: run dir basename is '%s' but --ticket %r "
+                "was passed; using the flag value. Re-run 'aorta probe' "
+                "with --ticket %r so the source tree carries one too.",
+                NO_TICKET_SLUG,
+                ticket,
+                ticket,
+            )
+        return ticket
+    if basename == NO_TICKET_SLUG:
+        raise NoTicketError(run_dir=run_dir)
+    return basename
+
+
+def _validate_run_dir(run_dir: Path) -> None:
+    """Reject non-existent paths, non-directories, and empty trees.
+
+    The writer treats an existing directory with at least one
+    ``trial_*/result.json`` artifact as a valid probe run dir. The
+    ``_TRIAL_RESULT_GLOB`` matches the documented per-cell layout
+    in ``docs/probe-188/usage.md``; legitimate probe outputs always
+    have at least one such file (the dispatcher writes
+    ``result.json`` even on the exec-failed and timed-out paths --
+    see ``src/aorta/workloads/_subprocess.py::run`` for the
+    artifact-tree contract).
+    """
+    if not run_dir.exists() or not run_dir.is_dir():
+        raise RunDirNotFoundError(run_dir=run_dir)
+    if not any(run_dir.glob(_TRIAL_RESULT_GLOB)):
+        raise EmptyRunDirError(run_dir=run_dir)
+
+
+def _iter_source_files(run_dir: Path) -> list[Path]:
+    """Walk ``run_dir`` and return every regular file in deterministic order.
+
+    Order is sorted alphabetic on the relative POSIX path. That
+    matters for two reasons:
+
+    * Manifests round-trip byte-equivalently across hosts (no
+      ``os.walk`` insertion-order surprises).
+    * Tarball entry order is reproducible, which makes
+      ``sha256(<bundle>.tar.gz)`` comparisons across machines
+      meaningful when nothing else changed.
+
+    Symlinks are followed via ``Path.is_file`` semantics; an
+    operator who symlinks an external directory into their probe
+    output gets that directory bundled. We document this behaviour
+    in ``docs/probe-188/bundle.md`` rather than try to detect-and-
+    block it (the legitimate use case -- symlinking a shared
+    ``host_env.json`` -- is a feature).
+
+    Skips:
+
+    * The ``flat_resume`` lockfile (``.aorta-probe.lock``) -- it is
+      a transient runtime artifact, not a deliverable.
+    * ``manifest.json`` left over from a prior bundle invocation
+      that wrote into the source tree (defensive; the writer never
+      does this today, but a downstream copy could).
+    """
+    skipped_basenames = frozenset({".aorta-probe.lock", MANIFEST_FILENAME})
+    files: list[Path] = []
+    for path in run_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.name in skipped_basenames:
+            continue
+        files.append(path)
+    files.sort(key=lambda p: p.relative_to(run_dir).as_posix())
+    return files
+
+
+def stage_run_dir(
+    run_dir: Path,
+    staging_dir: Path,
+    bundle_name: str,
+    *,
+    redactor: Redactor,
+    ticket: str,
+    aorta_version: str,
+    now: _dt.datetime | None = None,
+) -> Manifest:
+    """Copy every file under ``run_dir`` through ``redactor`` into staging.
+
+    Lays out the staging tree as
+    ``<staging_dir>/<bundle_name>/<rel-path>/...`` so the tarball's
+    top-level entry is ``<bundle_name>/`` (matching the layout
+    documented in ``docs/probe-188/bundle.md``). Builds a
+    :class:`Manifest` from the per-file :class:`RedactionCounts`
+    and writes it to ``<staging_dir>/<bundle_name>/manifest.json``.
+
+    Returns the in-memory manifest so the caller can show it under
+    ``--review`` without re-reading from disk.
+    """
+    bundle_root = staging_dir / bundle_name
+    bundle_root.mkdir(parents=True, exist_ok=False)
+
+    records: list[FileRecord] = []
+    for src in _iter_source_files(run_dir):
+        rel = src.relative_to(run_dir)
+        dst = bundle_root / rel
+        counts = redactor.scrub_file(src, dst)
+        records.append(
+            FileRecord(
+                path=rel.as_posix(),
+                env_keys_removed=counts.env_keys_removed,
+                paths_rewritten=counts.paths_rewritten,
+                ips_rewritten=counts.ips_rewritten,
+                bytes_in=counts.bytes_in,
+                bytes_out=counts.bytes_out,
+            )
+        )
+
+    manifest = Manifest.from_files(
+        ticket=ticket,
+        source_run_dir=run_dir,
+        redactor_kind=redactor.kind,
+        aorta_version=aorta_version,
+        files=records,
+        now=now,
+    )
+    (bundle_root / MANIFEST_FILENAME).write_text(manifest.to_json(), encoding="utf-8")
+    return manifest
+
+
+def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
+    """Pack ``<staging_dir>/<bundle_name>/`` into ``output.tar.gz``.
+
+    Returns the absolute path of the written tarball. ``output`` is
+    used as-is (no automatic ``.tar.gz`` suffix injection); the CLI
+    layer is responsible for picking the final filename per the
+    documented ``--output`` default. ``output.parent`` is created
+    with ``exist_ok=True`` so a fresh checkout's ``./<ticket>...``
+    default just works.
+
+    Tarball entries are added in the order :func:`_iter_source_files`
+    produced (alphabetical on relative POSIX path), with the manifest
+    last so consumers running ``tar -tzf`` see the data first and
+    the index trailer last. ``tarfile.add`` is used directly with
+    a deterministic ``arcname`` so the tarball never carries the
+    operator's ``--output`` parent path.
+    """
+    output = output.absolute()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    bundle_root = staging_dir / bundle_name
+
+    with tarfile.open(output, "w:gz") as tar:
+        # Walk the staged tree (NOT the source tree) so the
+        # manifest written by stage_run_dir is included.
+        rel_paths: list[Path] = []
+        for path in bundle_root.rglob("*"):
+            if path.is_file():
+                rel_paths.append(path.relative_to(bundle_root))
+        # Sort with manifest.json last so ``tar -tzf`` reads it as
+        # the trailer (matches the docstring contract).
+        rel_paths.sort(
+            key=lambda p: (p.name == MANIFEST_FILENAME, p.as_posix()),
+        )
+        for rel in rel_paths:
+            tar.add(str(bundle_root / rel), arcname=f"{bundle_name}/{rel.as_posix()}")
+    return output
+
+
+def _default_output_path(bundle_name: str, output: Path | None) -> Path:
+    """Resolve ``--output`` per the documented default.
+
+    Issue #196's documented default is ``<ticket>-<timestamp>.tar.gz``
+    in CWD. When ``output`` is ``None`` we apply that. When the
+    operator passes a directory (``--output ./bundles``) we drop
+    the default filename inside it. When they pass a file we use
+    it verbatim, regardless of suffix -- ``aorta`` does not police
+    the ``.tar.gz`` extension because operators sometimes have
+    pipeline reasons for a non-default name.
+    """
+    if output is None:
+        return Path.cwd() / f"{bundle_name}.tar.gz"
+    if output.is_dir():
+        return output / f"{bundle_name}.tar.gz"
+    return output
+
+
+def bundle_run_dir(
+    run_dir: Path,
+    *,
+    ticket: str | None = None,
+    output: Path | None = None,
+    redaction_from: Path | None = None,
+    redactor: Redactor | None = None,
+    review_callback: Callable[[Manifest], bool] | None = None,
+    now: _dt.datetime | None = None,
+) -> Path:
+    """End-to-end bundle write. CLI layer's only entry point.
+
+    Validates the run dir, resolves the ticket, stages every file
+    through the redactor into a temporary tree, writes the
+    manifest, optionally pauses for ``review_callback`` (which the
+    CLI wires to ``click.confirm``), and writes the tarball.
+
+    Args:
+        run_dir: ``<probe-output>/<ticket>/`` produced by
+            ``aorta probe``.
+        ticket: Optional override; otherwise inferred from
+            ``run_dir`` basename. ``_no_ticket_`` raises
+            :class:`NoTicketError` when no override is supplied.
+        output: Where to write the tarball; defaults to
+            ``./<bundle-name>.tar.gz``.
+        redaction_from: Recipe path to load the ``redaction:``
+            block from. Until Phase 3 of issue #188 ships
+            ``aorta.probe.redaction``, the parameter is recorded in
+            log output but NOT consumed -- the redactor stays
+            :class:`IdentityRedactor`. The function signature is
+            ready for #188 to wire the real loader in.
+        redactor: Override the default :class:`IdentityRedactor`
+            (test injection point + Phase 3 of #188 hand-off
+            point).
+        review_callback: Called with the staged :class:`Manifest`
+            right before the tarball is written. Return ``True``
+            to proceed, ``False`` to abort. Aborting raises
+            :class:`BundleAbortedError`. ``None`` (default) skips
+            the pause -- ``aorta bundle`` without ``--review`` is
+            silent.
+        now: Optional clock injection point for deterministic
+            tests.
+
+    Returns the absolute path of the written tarball.
+    """
+    run_dir = run_dir.resolve()
+    _validate_run_dir(run_dir)
+    resolved_ticket = resolve_ticket(run_dir, ticket)
+
+    if redaction_from is not None:
+        # Phase 3 of #188 will read the recipe's ``redaction:`` block
+        # here and instantiate ``aorta.probe.redaction.RedactingRedactor``.
+        # Until then we honor the flag's existence (operator can wire
+        # it through pipelines today) but log that the scrubbers are
+        # not yet active.
+        log.info(
+            "aorta bundle: --redaction-from %s ignored: "
+            "aorta.probe.redaction is gated on issue #188 Phase 3 "
+            "and the bundle will be written with the IdentityRedactor.",
+            redaction_from,
+        )
+
+    effective_redactor = redactor if redactor is not None else IdentityRedactor()
+    bundle_name = f"{safe_slug(resolved_ticket)}-{_bundle_timestamp(now)}"
+
+    with tempfile.TemporaryDirectory(prefix="aorta-bundle-") as staging_str:
+        staging = Path(staging_str)
+        manifest = stage_run_dir(
+            run_dir,
+            staging,
+            bundle_name,
+            redactor=effective_redactor,
+            ticket=resolved_ticket,
+            aorta_version=_aorta_version(),
+            now=now,
+        )
+        if review_callback is not None and not review_callback(manifest):
+            raise BundleAbortedError(run_dir=run_dir)
+        return write_tarball(staging, bundle_name, _default_output_path(bundle_name, output))
+
+
+__all__ = [
+    "bundle_run_dir",
+    "resolve_ticket",
+    "stage_run_dir",
+    "write_tarball",
+]

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -362,8 +362,10 @@ def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
 def _default_output_path(bundle_name: str, output: Path | None) -> Path:
     """Resolve ``--output`` per the documented default.
 
-    Issue #196's documented default is ``<ticket>-<timestamp>.tar.gz``
-    in CWD. When ``output`` is ``None`` we apply that. When the
+    Issue #196's documented default is
+    ``<safe_slug(ticket)>-<timestamp>.tar.gz`` in CWD (``bundle_name``
+    is already slugified by the caller). When ``output`` is ``None``
+    we apply that. When the
     operator passes a directory (``--output ./bundles``) we drop
     the default filename inside it. When they pass a file we use
     it verbatim, regardless of suffix -- ``aorta`` does not police

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -288,9 +288,9 @@ def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
     * The tarball is written to a sibling ``<output>.partial`` first
       and renamed onto the final path with ``os.replace`` only after
       the gzip footer is flushed. Mid-write failures (``ENOSPC``,
-      tarfile / gzip raising, a network FS dropping out) leave the
-      partial behind for cleanup but never produce a half-written
-      ``output``.
+      tarfile / gzip raising, a network FS dropping out) are cleaned up
+      by unlinking ``<output>.partial`` (best-effort) and never produce a
+      half-written ``output``.
     * If ``output`` already exists from a prior run, an in-flight
       failure leaves the OLD content intact -- ``os.replace`` only
       overwrites on success. The ``.partial`` sibling is unlinked

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 from aorta.bundle.errors import (
     BundleAbortedError,
+    BundleIOError,
     EmptyRunDirError,
     NoTicketError,
     RunDirNotFoundError,
@@ -68,11 +69,19 @@ def _bundle_timestamp(now: _dt.datetime | None = None) -> str:
     """Filesystem-safe UTC timestamp for the bundle's directory + filename.
 
     ISO-8601 with colons replaced by dashes (Windows-friendly), to
-    millisecond precision (``%f`` truncated to ms) so two bundles
-    written in quick succession do not collide on the same name.
+    millisecond precision so two bundles written in quick succession
+    (e.g. back-to-back CI invocations) do not collide on the same
+    name -- a collision would also fail the staging
+    ``mkdir(exist_ok=False)`` and abort the second run, so this is
+    a correctness concern, not just a cosmetic one.
+
+    The format is ``%Y-%m-%dT%H-%M-%S-<ms>`` with ``<ms>`` zero-padded
+    to three digits (``microsecond // 1000``). Plain ``%f`` would give
+    six digits, which is more entropy than we need and clutters the
+    filename.
     """
     now = now or _dt.datetime.now(_dt.timezone.utc)
-    return now.strftime("%Y-%m-%dT%H-%M-%S")
+    return f"{now.strftime('%Y-%m-%dT%H-%M-%S')}-{now.microsecond // 1000:03d}"
 
 
 def resolve_ticket(run_dir: Path, ticket_flag: str | None) -> str:
@@ -146,13 +155,20 @@ def _iter_source_files(run_dir: Path) -> list[Path]:
     """Walk ``run_dir`` and return every regular file in deterministic order.
 
     Order is sorted alphabetic on the relative POSIX path. That
-    matters for two reasons:
+    matters because:
 
     * Manifests round-trip byte-equivalently across hosts (no
-      ``os.walk`` insertion-order surprises).
-    * Tarball entry order is reproducible, which makes
-      ``sha256(<bundle>.tar.gz)`` comparisons across machines
-      meaningful when nothing else changed.
+      ``os.walk`` insertion-order surprises) -- two bundles of the
+      same source tree on different hosts produce identical
+      manifests modulo the timestamp / source path fields.
+    * Tarball entry order is reproducible at the entry-list level
+      (``tar -tzf <bundle>`` lists files in the same order
+      everywhere). Note that the resulting tarball **bytes** are
+      NOT bit-identical across hosts: ``tarfile`` and ``gzip`` embed
+      mtime / uid / gid / gzip-header timestamp by default, and the
+      writer does not normalise them. If a downstream consumer needs
+      cryptographic equality across machines they should hash the
+      manifest, not the tarball.
 
     Symlinks are followed via ``Path.is_file`` semantics; an
     operator who symlinks an external directory into their probe
@@ -320,7 +336,10 @@ def bundle_run_dir(
             ``aorta.probe.redaction``, the parameter is recorded in
             log output but NOT consumed -- the redactor stays
             :class:`IdentityRedactor`. The function signature is
-            ready for #188 to wire the real loader in.
+            ready for #188 to wire the real loader in; that loader
+            will own the ``<run-dir>/recipe.resolved.yaml`` fallback
+            when it ships (today there is no fallback -- explicit
+            paths only).
         redactor: Override the default :class:`IdentityRedactor`
             (test injection point + Phase 3 of #188 hand-off
             point).
@@ -357,18 +376,29 @@ def bundle_run_dir(
 
     with tempfile.TemporaryDirectory(prefix="aorta-bundle-") as staging_str:
         staging = Path(staging_str)
-        manifest = stage_run_dir(
-            run_dir,
-            staging,
-            bundle_name,
-            redactor=effective_redactor,
-            ticket=resolved_ticket,
-            aorta_version=_aorta_version(),
-            now=now,
-        )
+        try:
+            manifest = stage_run_dir(
+                run_dir,
+                staging,
+                bundle_name,
+                redactor=effective_redactor,
+                ticket=resolved_ticket,
+                aorta_version=_aorta_version(),
+                now=now,
+            )
+        except OSError as exc:
+            # Filesystem failure during staging (redactor scrub_file,
+            # shutil.copyfile, or manifest write). The Redactor ABC
+            # docstring promises BundleError-shaped failures here,
+            # so wrap before letting Click see it. The original
+            # OSError is preserved on .cause for ops tooling.
+            raise BundleIOError(run_dir=run_dir, cause=exc) from exc
         if review_callback is not None and not review_callback(manifest):
             raise BundleAbortedError(run_dir=run_dir)
-        return write_tarball(staging, bundle_name, _default_output_path(bundle_name, output))
+        try:
+            return write_tarball(staging, bundle_name, _default_output_path(bundle_name, output))
+        except OSError as exc:
+            raise BundleIOError(run_dir=run_dir, cause=exc) from exc
 
 
 __all__ = [

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import logging
+import os
 import tarfile
 import tempfile
 from collections.abc import Callable
@@ -42,7 +43,7 @@ from aorta.bundle.errors import (
     NoTicketError,
     RunDirNotFoundError,
 )
-from aorta.bundle.manifest import MANIFEST_FILENAME, FileRecord, Manifest
+from aorta.bundle.manifest import MANIFEST_FILENAME, FileRecord, Manifest, _to_utc
 from aorta.bundle.redactor import IdentityRedactor, Redactor
 from aorta.triage.output import NO_TICKET_SLUG, safe_slug
 
@@ -79,8 +80,15 @@ def _bundle_timestamp(now: _dt.datetime | None = None) -> str:
     to three digits (``microsecond // 1000``). Plain ``%f`` would give
     six digits, which is more entropy than we need and clutters the
     filename.
+
+    A naive or non-UTC ``now`` is normalised through
+    :func:`aorta.bundle.manifest._to_utc` so the embedded clock
+    matches the ``Z`` convention in the manifest's ``created_at``.
+    Test injection of a deterministic naive datetime previously
+    rendered the caller's local clock as UTC silently -- the same
+    trap Copilot caught on the manifest path.
     """
-    now = now or _dt.datetime.now(_dt.timezone.utc)
+    now = _to_utc(now or _dt.datetime.now(_dt.timezone.utc))
     return f"{now.strftime('%Y-%m-%dT%H-%M-%S')}-{now.microsecond // 1000:03d}"
 
 
@@ -177,20 +185,27 @@ def _iter_source_files(run_dir: Path) -> list[Path]:
     block it (the legitimate use case -- symlinking a shared
     ``host_env.json`` -- is a feature).
 
-    Skips:
+    Skips (TOP-LEVEL ONLY; a nested file with the same basename in a
+    cell / trial directory is a legitimate artifact and IS bundled):
 
-    * The ``flat_resume`` lockfile (``.aorta-probe.lock``) -- it is
+    * The ``flat_resume`` lockfile (``./.aorta-probe.lock``) -- it is
       a transient runtime artifact, not a deliverable.
-    * ``manifest.json`` left over from a prior bundle invocation
+    * ``./manifest.json`` left over from a prior bundle invocation
       that wrote into the source tree (defensive; the writer never
       does this today, but a downstream copy could).
+
+    The skip set is matched against the file's relative POSIX path,
+    not its basename -- a workload that emits ``cell/trial_0/manifest.json``
+    or ``cell/.aorta-probe.lock`` (e.g. a script that wraps its own
+    bundler-style output) gets those files bundled normally.
     """
-    skipped_basenames = frozenset({".aorta-probe.lock", MANIFEST_FILENAME})
+    skipped_rel_paths = frozenset({".aorta-probe.lock", MANIFEST_FILENAME})
     files: list[Path] = []
     for path in run_dir.rglob("*"):
         if not path.is_file():
             continue
-        if path.name in skipped_basenames:
+        rel = path.relative_to(run_dir).as_posix()
+        if rel in skipped_rel_paths:
             continue
         files.append(path)
     files.sort(key=lambda p: p.relative_to(run_dir).as_posix())
@@ -215,6 +230,14 @@ def stage_run_dir(
     documented in ``docs/probe-188/bundle.md``). Builds a
     :class:`Manifest` from the per-file :class:`RedactionCounts`
     and writes it to ``<staging_dir>/<bundle_name>/manifest.json``.
+
+    Parent-dir responsibility: this function creates ONLY the
+    bundle root (``<staging_dir>/<bundle_name>/``). The per-file
+    ``dst.parent`` directories are created by the redactor's
+    ``scrub_file`` implementation (see the :class:`Redactor` ABC
+    docstring -- "Create the destination's parent directory if
+    missing."). The split keeps the staging contract local to the
+    redactor and avoids two layers of ``mkdir(exist_ok=True)``.
 
     Returns the in-memory manifest so the caller can show it under
     ``--review`` without re-reading from disk.
@@ -260,6 +283,19 @@ def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
     with ``exist_ok=True`` so a fresh checkout's ``./<ticket>...``
     default just works.
 
+    Atomicity:
+
+    * The tarball is written to a sibling ``<output>.partial`` first
+      and renamed onto the final path with ``os.replace`` only after
+      the gzip footer is flushed. Mid-write failures (``ENOSPC``,
+      tarfile / gzip raising, a network FS dropping out) leave the
+      partial behind for cleanup but never produce a half-written
+      ``output``.
+    * If ``output`` already exists from a prior run, an in-flight
+      failure leaves the OLD content intact -- ``os.replace`` only
+      overwrites on success. The ``.partial`` sibling is unlinked
+      either way so a retry does not race against a stale temp file.
+
     Tarball entries are added in the order :func:`_iter_source_files`
     produced (alphabetical on relative POSIX path), with the manifest
     last so consumers running ``tar -tzf`` see the data first and
@@ -270,21 +306,42 @@ def write_tarball(staging_dir: Path, bundle_name: str, output: Path) -> Path:
     output = output.absolute()
     output.parent.mkdir(parents=True, exist_ok=True)
     bundle_root = staging_dir / bundle_name
+    partial = output.with_name(output.name + ".partial")
 
-    with tarfile.open(output, "w:gz") as tar:
-        # Walk the staged tree (NOT the source tree) so the
-        # manifest written by stage_run_dir is included.
-        rel_paths: list[Path] = []
-        for path in bundle_root.rglob("*"):
-            if path.is_file():
-                rel_paths.append(path.relative_to(bundle_root))
-        # Sort with manifest.json last so ``tar -tzf`` reads it as
-        # the trailer (matches the docstring contract).
-        rel_paths.sort(
-            key=lambda p: (p.name == MANIFEST_FILENAME, p.as_posix()),
-        )
-        for rel in rel_paths:
-            tar.add(str(bundle_root / rel), arcname=f"{bundle_name}/{rel.as_posix()}")
+    # Defensive: a stale .partial from a crashed previous run would
+    # otherwise survive into the new try and confuse the os.replace
+    # path (or, worse, get atomic-replaced into place if the next
+    # write somehow succeeded against it).
+    if partial.exists():
+        partial.unlink()
+
+    try:
+        with tarfile.open(partial, "w:gz") as tar:
+            # Walk the staged tree (NOT the source tree) so the
+            # manifest written by stage_run_dir is included.
+            rel_paths: list[Path] = []
+            for path in bundle_root.rglob("*"):
+                if path.is_file():
+                    rel_paths.append(path.relative_to(bundle_root))
+            # Sort with manifest.json last so ``tar -tzf`` reads it as
+            # the trailer (matches the docstring contract).
+            rel_paths.sort(
+                key=lambda p: (p.name == MANIFEST_FILENAME, p.as_posix()),
+            )
+            for rel in rel_paths:
+                tar.add(str(bundle_root / rel), arcname=f"{bundle_name}/{rel.as_posix()}")
+        os.replace(partial, output)
+    except BaseException:
+        # Includes OSError (ENOSPC, EACCES, ...), KeyboardInterrupt,
+        # and anything tarfile raises. The bundle_run_dir caller
+        # wraps OSError into BundleIOError; here we just make sure
+        # neither the partial nor a corrupted final file survives.
+        if partial.exists():
+            try:
+                partial.unlink()
+            except OSError:  # pragma: no cover - best-effort cleanup
+                pass
+        raise
     return output
 
 

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -2,7 +2,7 @@
 
 import click
 
-from aorta.cli import env, environments, mitigations, probe, run, triage
+from aorta.cli import bundle, env, environments, mitigations, probe, run, triage
 
 
 @click.group()
@@ -11,6 +11,7 @@ def main() -> None:
     """AORTA - GPU debugging platform for ROCm."""
 
 
+main.add_command(bundle.bundle)
 main.add_command(env.env)
 main.add_command(environments.environments)
 main.add_command(mitigations.mitigations)

--- a/src/aorta/cli/bundle.py
+++ b/src/aorta/cli/bundle.py
@@ -93,8 +93,13 @@ def _render_review_summary(manifest: Manifest) -> str:
     default=None,
     help=(
         "Where to write the tarball. Default: '<ticket>-<UTC-timestamp>.tar.gz' "
-        "in the current directory. A directory value drops the default "
-        "filename inside it."
+        "in the current directory. If PATH is an EXISTING directory the "
+        "default filename is dropped inside it; otherwise PATH is "
+        "treated verbatim as the tarball filename (the parent is "
+        "created if missing). 'aorta bundle ./bundles' will write a "
+        "file literally named 'bundles' unless that directory already "
+        "exists -- create it first with mkdir if you want directory "
+        "semantics."
     ),
 )
 @click.option(
@@ -103,11 +108,13 @@ def _render_review_summary(manifest: Manifest) -> str:
     default=None,
     help=(
         "Recipe whose 'redaction:' block governs scrubber behaviour. "
-        "Falls back to '<run-dir>/recipe.resolved.yaml' if present. "
         "NOTE: until 'aorta probe' Phase 3 (issue #188) ships "
         "'aorta.probe.redaction', this flag is logged but not yet "
         "consumed -- bundles run with the IdentityRedactor (no "
-        "scrubbing, zero per-file counts)."
+        "scrubbing, zero per-file counts). Phase 3 will also add "
+        "the auto-fallback to '<run-dir>/recipe.resolved.yaml' "
+        "when this flag is omitted; today an explicit path is "
+        "required to log a redaction-from line at all."
     ),
 )
 def bundle(

--- a/src/aorta/cli/bundle.py
+++ b/src/aorta/cli/bundle.py
@@ -92,8 +92,10 @@ def _render_review_summary(manifest: Manifest) -> str:
     type=click.Path(file_okay=True, dir_okay=True, path_type=Path),
     default=None,
     help=(
-        "Where to write the tarball. Default: '<ticket>-<UTC-timestamp>.tar.gz' "
-        "in the current directory. If PATH is an EXISTING directory the "
+        "Where to write the tarball. Default: "
+        "'<safe-slug(ticket)>-<UTC-timestamp>.tar.gz' in the current "
+        "directory (the ticket is slugified for filesystem safety, so "
+        "spaces/slashes become underscores). If PATH is an EXISTING directory the "
         "default filename is dropped inside it; otherwise PATH is "
         "treated verbatim as the tarball filename (the parent is "
         "created if missing). 'aorta bundle ./bundles' will write a "
@@ -160,8 +162,10 @@ def _prompt_review(manifest: Manifest) -> bool:
 
     ``click.confirm(default=False)`` matches the issue #196
     contract -- a bare press of ``Enter`` (or any non-``y`` answer)
-    aborts. Test inject ``CliRunner(input="y\\n")`` /
-    ``input="n\\n"``.
+    aborts. Tests inject the answer through the invoke call, e.g.
+    ``runner.invoke(cli, [...], input="y\\n")`` /
+    ``input="n\\n"`` (the ``input=`` kwarg belongs to ``invoke``,
+    not the ``CliRunner`` constructor).
     """
     click.echo(_render_review_summary(manifest))
     click.echo("")

--- a/src/aorta/cli/bundle.py
+++ b/src/aorta/cli/bundle.py
@@ -1,0 +1,164 @@
+"""``aorta bundle`` -- thin Click shim around :func:`aorta.bundle.bundle_run_dir`.
+
+Mirrors the discipline tested in ``tests/run/test_cli_parsing.py`` and
+``tests/probe/test_cli_parsing.py``: this handler does no
+orchestration. It validates inputs, builds a ``review_callback``
+when ``--review`` is set, calls :func:`bundle_run_dir`, and maps
+:class:`aorta.bundle.errors.BundleError` subclasses to a
+:class:`click.ClickException`. The acceptance criteria from issue
+#196 are split between the writer (the actual bundling) and this
+shim (CLI surface, exit codes, ``--review`` interactive pause).
+
+The handler is intentionally short -- under the same ~60-line
+ceiling the ``aorta probe`` handler keeps -- so reviewers can
+audit it without scrolling.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from aorta.bundle import (
+    BundleAbortedError,
+    BundleError,
+    Manifest,
+    bundle_run_dir,
+)
+
+
+def _render_review_summary(manifest: Manifest) -> str:
+    """Build the ``--review`` summary text shown right before the prompt.
+
+    Renders a short header (ticket, source dir, redactor, totals) plus
+    a per-file-count table. Per-file rows are truncated to the first
+    ten files when there are more than twelve total -- the manifest
+    JSON is always written to disk for full inspection, the
+    review pause is just an "is this what you meant?" sanity
+    check. The truncated-rows note tells the operator how to see the
+    rest if they need to.
+    """
+    lines: list[str] = []
+    lines.append("aorta bundle: review pause")
+    lines.append(f"  ticket            : {manifest.ticket}")
+    lines.append(f"  source run dir    : {manifest.source_run_dir}")
+    lines.append(f"  redactor          : {manifest.redactor_kind}")
+    lines.append(f"  redaction applied : {manifest.redaction_applied}")
+    lines.append(f"  files             : {len(manifest.files)}")
+    lines.append(f"  total bytes in    : {manifest.total_bytes_in()}")
+    lines.append(f"  total bytes out   : {manifest.total_bytes_out()}")
+    lines.append("")
+    lines.append("  per-file counts (env / paths / ips, bytes_in -> bytes_out):")
+    rows = manifest.files
+    truncated = len(rows) > 12
+    shown = rows[:10] if truncated else rows
+    for f in shown:
+        lines.append(
+            f"    {f.path}: "
+            f"{f.env_keys_removed}/{f.paths_rewritten}/{f.ips_rewritten} "
+            f"({f.bytes_in} -> {f.bytes_out})"
+        )
+    if truncated:
+        lines.append(f"    ... ({len(rows) - 10} more; full set in manifest.json)")
+    return "\n".join(lines)
+
+
+@click.command(name="bundle")
+@click.argument(
+    "run_dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+)
+@click.option(
+    "--ticket",
+    default=None,
+    help=(
+        "Bundle ticket. When omitted, inferred from the basename of "
+        "<run-dir>. Required when the basename is '_no_ticket_' "
+        "(otherwise the bundle has no routing target downstream)."
+    ),
+)
+@click.option(
+    "--review",
+    is_flag=True,
+    help=(
+        "Print the manifest summary and pause for [y/N] confirmation "
+        "before writing the tarball. Answering 'n' aborts the bundle "
+        "with exit 1 and writes nothing."
+    ),
+)
+@click.option(
+    "--output",
+    type=click.Path(file_okay=True, dir_okay=True, path_type=Path),
+    default=None,
+    help=(
+        "Where to write the tarball. Default: '<ticket>-<UTC-timestamp>.tar.gz' "
+        "in the current directory. A directory value drops the default "
+        "filename inside it."
+    ),
+)
+@click.option(
+    "--redaction-from",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Recipe whose 'redaction:' block governs scrubber behaviour. "
+        "Falls back to '<run-dir>/recipe.resolved.yaml' if present. "
+        "NOTE: until 'aorta probe' Phase 3 (issue #188) ships "
+        "'aorta.probe.redaction', this flag is logged but not yet "
+        "consumed -- bundles run with the IdentityRedactor (no "
+        "scrubbing, zero per-file counts)."
+    ),
+)
+def bundle(
+    run_dir: Path,
+    ticket: str | None,
+    review: bool,
+    output: Path | None,
+    redaction_from: Path | None,
+) -> None:
+    """Package an ``aorta probe`` run directory into a redacted tarball.
+
+    Issue tracker: https://github.com/ROCm/aorta/issues/196 .
+    Design + manifest schema: ``docs/probe-188/bundle.md``.
+    """
+    review_callback = (lambda manifest: _prompt_review(manifest)) if review else None
+    try:
+        path = bundle_run_dir(
+            run_dir,
+            ticket=ticket,
+            output=output,
+            redaction_from=redaction_from,
+            review_callback=review_callback,
+        )
+    except BundleAbortedError as exc:
+        # Operator answered 'n' at the review pause. Distinct from
+        # other BundleErrors because we want exit 1 (per issue #196
+        # acceptance criterion 3) without a "ClickException" prefix
+        # cluttering the abort message.
+        click.echo(str(exc), err=True)
+        raise click.exceptions.Exit(1) from exc
+    except BundleError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Wrote bundle to {path}")
+
+
+def _prompt_review(manifest: Manifest) -> bool:
+    """Show the manifest summary and prompt for ``[y/N]``.
+
+    Used as the ``review_callback`` argument to :func:`bundle_run_dir`
+    when ``--review`` is set. Returning ``False`` makes the writer
+    raise :class:`BundleAbortedError`, which the CLI handler maps
+    to ``Exit(1)``.
+
+    ``click.confirm(default=False)`` matches the issue #196
+    contract -- a bare press of ``Enter`` (or any non-``y`` answer)
+    aborts. Test inject ``CliRunner(input="y\\n")`` /
+    ``input="n\\n"``.
+    """
+    click.echo(_render_review_summary(manifest))
+    click.echo("")
+    return click.confirm("Write the bundle?", default=False)
+
+
+__all__ = ["bundle"]

--- a/tests/bundle/__init__.py
+++ b/tests/bundle/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``aorta bundle`` (issue #196)."""

--- a/tests/bundle/conftest.py
+++ b/tests/bundle/conftest.py
@@ -1,0 +1,114 @@
+"""Shared fixtures for ``aorta bundle`` tests.
+
+The bundle command operates on the per-ticket leaf of an ``aorta probe``
+run dir (``<probe-output>/<ticket>/<cell>/trial_<n>/...``). Building
+that tree by invoking ``aorta probe`` from every test would couple
+bundle tests to probe behaviour (and slow the suite down). Instead
+we synthesise a tree on disk that matches the documented artifact
+shape -- the bundle pipeline does not care HOW the tree was
+produced as long as it has ``trial_*/result.json`` entries.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _write_trial(
+    cell_dir: Path,
+    trial_idx: int,
+    *,
+    stdout: str = "hello\n",
+    stderr: str = "",
+    verdict: str = "pass",
+    exit_code: int = 0,
+    probe_env: str | None = None,
+) -> None:
+    trial = cell_dir / f"trial_{trial_idx}"
+    trial.mkdir(parents=True, exist_ok=False)
+    (trial / "stdout.log").write_text(stdout, encoding="utf-8")
+    (trial / "stderr.log").write_text(stderr, encoding="utf-8")
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "verdict": verdict,
+                "exit_code": exit_code,
+                "walltime_sec": 0.1,
+                "argv": ["bash", "-c", "echo hello"],
+                "cell_name": cell_dir.name,
+                "trial_index": trial_idx,
+                "env_passthrough_mode": "inherit",
+                "timed_out": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    if probe_env is not None:
+        (trial / "probe.env").write_text(probe_env, encoding="utf-8")
+
+
+@pytest.fixture
+def synthetic_run_dir(tmp_path: Path) -> Path:
+    """A 2-cell probe-run leaf with 1 trial per cell + matrix metadata.
+
+    Mirrors what ``aorta probe --ticket TKT-1 --output ./out -- bash``
+    leaves under ``./out/TKT-1/``. Includes ``matrix.json`` and a
+    minimal ``recipe.resolved.yaml`` so tests can exercise the
+    "extra files are bundled too" path.
+    """
+    ticket = "TKT-1"
+    run_dir = tmp_path / "probe-out" / ticket
+    run_dir.mkdir(parents=True)
+
+    _write_trial(run_dir / "none-none", 0)
+    _write_trial(
+        run_dir / "tf32_off-none",
+        0,
+        stdout="loss=0.5\n",
+        verdict="fail",
+        exit_code=1,
+    )
+
+    (run_dir / "matrix.md").write_text(
+        "# Triage Matrix - _subprocess\n\n| Cell | Failures |\n",
+        encoding="utf-8",
+    )
+    (run_dir / "matrix.json").write_text(
+        json.dumps({"schema_version": 1, "ticket": ticket}, indent=2),
+        encoding="utf-8",
+    )
+    (run_dir / "recipe.resolved.yaml").write_text(
+        "schema_version: 1\nmode: probe\n",
+        encoding="utf-8",
+    )
+    (run_dir / "host_env.json").write_text("{}\n", encoding="utf-8")
+    return run_dir
+
+
+@pytest.fixture
+def no_ticket_run_dir(tmp_path: Path) -> Path:
+    """A probe-run leaf whose basename is ``_no_ticket_``.
+
+    Used to exercise the issue #196 acceptance criterion 2: bundle
+    must refuse without --ticket when the source tree carries none.
+    """
+    run_dir = tmp_path / "probe-out" / "_no_ticket_"
+    run_dir.mkdir(parents=True)
+    _write_trial(run_dir / "none-none", 0)
+    return run_dir
+
+
+@pytest.fixture
+def empty_run_dir(tmp_path: Path) -> Path:
+    """An existing directory with no ``trial_*/result.json`` artifacts.
+
+    Bundle command should refuse this with ``EmptyRunDirError``.
+    """
+    run_dir = tmp_path / "probe-out" / "TKT-EMPTY"
+    run_dir.mkdir(parents=True)
+    (run_dir / "matrix.md").write_text("placeholder\n", encoding="utf-8")
+    return run_dir

--- a/tests/bundle/test_cli.py
+++ b/tests/bundle/test_cli.py
@@ -1,0 +1,142 @@
+"""CLI tests for ``aorta bundle`` (issue #196).
+
+These are the acceptance-criteria-1-through-3 tests from issue
+#196: `--help` lists the flags, `<dir>` without `--ticket` (when
+basename is `_no_ticket_`) exits non-zero, and `--review` pauses
+for confirmation.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from aorta.bundle.manifest import MANIFEST_FILENAME
+from aorta.cli.bundle import bundle
+
+
+def test_help_lists_documented_flags():
+    """Acceptance criterion 1: ``aorta bundle --help`` lists the flags."""
+    runner = CliRunner()
+    result = runner.invoke(bundle, ["--help"])
+    assert result.exit_code == 0, result.output
+    for flag in ("--ticket", "--review", "--output", "--redaction-from"):
+        assert flag in result.output, f"--help missing {flag!r}: {result.output!r}"
+    # And the positional argument is documented.
+    assert "RUN_DIR" in result.output.upper() or "<RUN_DIR>" in result.output.upper()
+
+
+def test_refuses_no_ticket_basename(no_ticket_run_dir):
+    """Acceptance criterion 2: refuses without --ticket when source has none."""
+    runner = CliRunner()
+    result = runner.invoke(bundle, [str(no_ticket_run_dir)])
+    assert result.exit_code != 0
+    assert "_no_ticket_" in result.output or "no_ticket" in result.output
+    assert "--ticket" in result.output
+
+
+def test_runs_with_ticket_flag_against_no_ticket_source(no_ticket_run_dir, tmp_path):
+    out = tmp_path / "out.tar.gz"
+    runner = CliRunner()
+    result = runner.invoke(
+        bundle,
+        [str(no_ticket_run_dir), "--ticket", "OVERRIDE-1", "--output", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.is_file()
+
+
+def test_runs_against_synthetic_run_dir(synthetic_run_dir, tmp_path):
+    out = tmp_path / "out.tar.gz"
+    runner = CliRunner()
+    result = runner.invoke(bundle, [str(synthetic_run_dir), "--output", str(out)])
+    assert result.exit_code == 0, result.output
+    assert out.is_file()
+    # Final stdout line tells the operator where the bundle landed.
+    assert str(out.resolve()) in result.output
+
+
+def test_review_y_proceeds(synthetic_run_dir, tmp_path):
+    """Acceptance criterion 3a: --review with 'y' produces the tarball."""
+    out = tmp_path / "out.tar.gz"
+    runner = CliRunner()
+    result = runner.invoke(
+        bundle,
+        [str(synthetic_run_dir), "--review", "--output", str(out)],
+        input="y\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert out.is_file()
+    # The review summary actually surfaced before the prompt.
+    assert "review pause" in result.output
+    assert "ticket" in result.output
+    assert "TKT-1" in result.output
+
+
+def test_review_n_aborts_cleanly(synthetic_run_dir, tmp_path):
+    """Acceptance criterion 3b: --review with 'n' aborts with exit 1, no tarball."""
+    out = tmp_path / "out.tar.gz"
+    runner = CliRunner()
+    result = runner.invoke(
+        bundle,
+        [str(synthetic_run_dir), "--review", "--output", str(out)],
+        input="n\n",
+    )
+    assert result.exit_code == 1, result.output
+    assert "aborted" in result.output.lower()
+    assert not out.exists()
+
+
+def test_review_default_no_aborts(synthetic_run_dir, tmp_path):
+    """Pressing Enter at the [y/N] prompt aborts (default=False)."""
+    out = tmp_path / "out.tar.gz"
+    runner = CliRunner()
+    result = runner.invoke(
+        bundle,
+        [str(synthetic_run_dir), "--review", "--output", str(out)],
+        input="\n",
+    )
+    assert result.exit_code == 1, result.output
+    assert not out.exists()
+
+
+def test_cli_run_dir_missing_returns_click_usage_error(tmp_path):
+    """Click rejects nonexistent <run-dir> at parse time (exit 2)."""
+    runner = CliRunner()
+    result = runner.invoke(bundle, [str(tmp_path / "no-such-dir")])
+    assert result.exit_code != 0
+
+
+def test_cli_empty_run_dir_returns_friendly_error(empty_run_dir):
+    runner = CliRunner()
+    result = runner.invoke(bundle, [str(empty_run_dir)])
+    assert result.exit_code != 0
+    assert "no 'trial_*/result.json' artifacts" in result.output
+
+
+def test_cli_emits_top_level_bundle_in_tar(synthetic_run_dir, tmp_path):
+    """Sanity: the tar's top-level directory name embeds the ticket."""
+    out = tmp_path / "out.tar.gz"
+    runner = CliRunner()
+    result = runner.invoke(bundle, [str(synthetic_run_dir), "--output", str(out)])
+    assert result.exit_code == 0, result.output
+    with tarfile.open(out, "r:gz") as tar:
+        names = tar.getnames()
+    top_levels = {Path(n).parts[0] for n in names}
+    assert len(top_levels) == 1
+    only = next(iter(top_levels))
+    assert only.startswith("TKT-1-")
+    # manifest.json sits directly under the top-level dir.
+    assert f"{only}/{MANIFEST_FILENAME}" in names
+
+
+def test_cli_registered_as_subcommand_on_main_group():
+    """``aorta`` group exposes the bundle subcommand."""
+    from aorta.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["bundle", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "Package an" in result.output  # docstring's first sentence

--- a/tests/bundle/test_manifest.py
+++ b/tests/bundle/test_manifest.py
@@ -97,6 +97,47 @@ def test_manifest_rejects_unknown_schema_version():
         Manifest.from_json(raw)
 
 
+def test_manifest_from_files_normalises_naive_now_as_utc(tmp_path):
+    """A naive datetime injection is treated as already-UTC --
+    NOT silently stamped with the local clock + 'Z' suffix.
+
+    Before this fix, a test pinning ``datetime(2026, 6, 1, 7, 0, 0)``
+    on a +05:30 machine would land in the on-disk manifest as
+    ``2026-06-01T07:00:00Z`` while operators read it as UTC -- a
+    silent ~5h skew per Copilot's PR #199 review.
+    """
+    naive = _dt.datetime(2026, 6, 1, 7, 0, 0)
+    m = Manifest.from_files(
+        ticket="T",
+        source_run_dir=tmp_path,
+        redactor_kind="identity",
+        aorta_version="x",
+        files=[],
+        now=naive,
+    )
+    assert m.created_at == "2026-06-01T07:00:00Z"
+
+
+def test_manifest_from_files_normalises_non_utc_now_to_utc(tmp_path):
+    """An aware datetime in +05:30 is converted to UTC before the
+    'Z' suffix is applied -- so the on-disk timestamp matches what
+    ``datetime.now(timezone.utc)`` would have produced at that
+    wall-clock instant.
+    """
+    ist = _dt.timezone(_dt.timedelta(hours=5, minutes=30))
+    local = _dt.datetime(2026, 6, 1, 12, 30, 0, tzinfo=ist)
+    # 12:30 IST == 07:00 UTC
+    m = Manifest.from_files(
+        ticket="T",
+        source_run_dir=tmp_path,
+        redactor_kind="identity",
+        aorta_version="x",
+        files=[],
+        now=local,
+    )
+    assert m.created_at == "2026-06-01T07:00:00Z"
+
+
 def test_manifest_total_bytes_helpers():
     files = [
         FileRecord(path="a", bytes_in=10, bytes_out=8),

--- a/tests/bundle/test_manifest.py
+++ b/tests/bundle/test_manifest.py
@@ -1,0 +1,113 @@
+"""Manifest schema / round-trip tests (issue #196)."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+
+import pytest
+
+from aorta.bundle.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    FileRecord,
+    Manifest,
+)
+
+
+def _sample_files() -> list[FileRecord]:
+    return [
+        FileRecord(path="none-none/trial_0/stdout.log", bytes_in=6, bytes_out=6),
+        FileRecord(path="none-none/trial_0/stderr.log", bytes_in=0, bytes_out=0),
+    ]
+
+
+def test_manifest_from_files_records_documented_shape(tmp_path):
+    """Acceptance criterion 4: manifest in the documented shape."""
+    pinned = _dt.datetime(2026, 5, 25, 10, 0, 0, tzinfo=_dt.timezone.utc)
+    m = Manifest.from_files(
+        ticket="TKT-1",
+        source_run_dir=tmp_path,
+        redactor_kind="identity",
+        aorta_version="0.2.0",
+        files=_sample_files(),
+        now=pinned,
+    )
+    doc = json.loads(m.to_json())
+    assert doc["schema_version"] == MANIFEST_SCHEMA_VERSION
+    assert doc["ticket"] == "TKT-1"
+    assert doc["created_at"] == "2026-05-25T10:00:00Z"
+    assert doc["aorta_version"] == "0.2.0"
+    assert doc["redactor_kind"] == "identity"
+    assert doc["redaction_applied"] is False
+    assert isinstance(doc["files"], list) and len(doc["files"]) == 2
+    first = doc["files"][0]
+    for key in (
+        "path",
+        "env_keys_removed",
+        "paths_rewritten",
+        "ips_rewritten",
+        "bytes_in",
+        "bytes_out",
+    ):
+        assert key in first, f"missing {key} in file record"
+
+
+def test_manifest_redaction_applied_rollup_true_when_any_count_nonzero(tmp_path):
+    files = [
+        FileRecord(path="a", bytes_in=1, bytes_out=1),
+        FileRecord(path="b", env_keys_removed=2, bytes_in=10, bytes_out=8),
+    ]
+    m = Manifest.from_files(
+        ticket="T",
+        source_run_dir=tmp_path,
+        redactor_kind="probe.v1",
+        aorta_version="x",
+        files=files,
+    )
+    assert m.redaction_applied is True
+
+
+def test_manifest_round_trip_via_json(tmp_path):
+    m = Manifest.from_files(
+        ticket="TKT-2",
+        source_run_dir=tmp_path,
+        redactor_kind="identity",
+        aorta_version="0.2.0",
+        files=_sample_files(),
+        now=_dt.datetime(2026, 1, 1, tzinfo=_dt.timezone.utc),
+    )
+    reparsed = Manifest.from_json(m.to_json())
+    assert reparsed == m
+
+
+def test_manifest_rejects_unknown_schema_version():
+    raw = json.dumps(
+        {
+            "schema_version": 99,
+            "ticket": "X",
+            "created_at": "2026",
+            "aorta_version": "x",
+            "source_run_dir": "/",
+            "redaction_applied": False,
+            "redactor_kind": "identity",
+            "files": [],
+        }
+    )
+    with pytest.raises(ValueError, match="unsupported schema_version"):
+        Manifest.from_json(raw)
+
+
+def test_manifest_total_bytes_helpers():
+    files = [
+        FileRecord(path="a", bytes_in=10, bytes_out=8),
+        FileRecord(path="b", bytes_in=20, bytes_out=18),
+    ]
+    m = Manifest.from_files(
+        ticket="T",
+        source_run_dir=files[0].path and (__import__("pathlib").Path(".")),
+        redactor_kind="identity",
+        aorta_version="x",
+        files=files,
+    )
+    assert m.total_bytes_in() == 30
+    assert m.total_bytes_out() == 26

--- a/tests/bundle/test_manifest.py
+++ b/tests/bundle/test_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+from pathlib import Path
 
 import pytest
 
@@ -145,7 +146,7 @@ def test_manifest_total_bytes_helpers():
     ]
     m = Manifest.from_files(
         ticket="T",
-        source_run_dir=files[0].path and (__import__("pathlib").Path(".")),
+        source_run_dir=Path("."),
         redactor_kind="identity",
         aorta_version="x",
         files=files,

--- a/tests/bundle/test_no_new_deps.py
+++ b/tests/bundle/test_no_new_deps.py
@@ -46,6 +46,12 @@ def _imports(path: Path) -> list[str]:
             for alias in node.names:
                 names.append(alias.name)
         elif isinstance(node, ast.ImportFrom) and node.module:
+            # Relative imports (``from .errors import ...``, level > 0)
+            # are internal by definition -- ``node.module`` is a bare
+            # sibling name with no package prefix, so recording it would
+            # mis-flag it as a third-party top-level import. Skip them.
+            if node.level > 0:
+                continue
             names.append(node.module)
     return names
 

--- a/tests/bundle/test_no_new_deps.py
+++ b/tests/bundle/test_no_new_deps.py
@@ -1,0 +1,101 @@
+"""Dependency / discipline tests: keep ``aorta bundle`` stdlib-only.
+
+Issue #196 acceptance criterion 7: no new top-level dependencies
+(uses stdlib ``tarfile`` + ``json``). The rubric for #188 has the
+matching "no new third-party dependencies" guardrail. We pin that
+here at the import level so a future drive-by ``import requests``
+in the bundle module surfaces as a unit-test failure rather than
+landing silently.
+
+We also pin two design invariants that the rubric forbids:
+
+* No ``runner`` / ``dispatcher`` filename under ``src/aorta/bundle/``
+  (the engine-reuse gate -- bundle is a writer, not a runner).
+* No ``subprocess`` import inside ``src/aorta/bundle/`` (the
+  command operates purely on filesystem artifacts; spawning
+  children is out of scope and would dodge the redactor).
+"""
+
+from __future__ import annotations
+
+import ast
+import pkgutil
+from pathlib import Path
+
+import aorta.bundle as _bundle_pkg
+
+# Anything outside this set on a `from ... import ...` line in any
+# bundle module is a new third-party dependency by definition.
+# stdlib packages don't need to be enumerated -- isort's `known_first_party`
+# already separates them, but we want a positive allowlist so an
+# accidental top-level vendor package gets flagged here too.
+_ALLOWED_THIRD_PARTY = frozenset({"click"})
+_AORTA_INTERNAL_PREFIX = "aorta."
+
+
+def _bundle_source_files() -> list[Path]:
+    pkg_dir = Path(_bundle_pkg.__file__).parent
+    return [p for p in pkg_dir.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.append(node.module)
+    return names
+
+
+def test_no_third_party_imports_beyond_click():
+    """Acceptance criterion 7: stdlib + click only.
+
+    Walks every ``.py`` under ``src/aorta/bundle/`` and asserts the
+    top-level module of every import is either stdlib or
+    ``aorta.*`` or in the small allowlist.
+    """
+    stdlib = set(getattr(__import__("sys"), "stdlib_module_names", set()))
+    for path in _bundle_source_files():
+        for name in _imports(path):
+            top = name.split(".", 1)[0]
+            if top in stdlib:
+                continue
+            if name.startswith(_AORTA_INTERNAL_PREFIX) or name == "aorta":
+                continue
+            assert top in _ALLOWED_THIRD_PARTY, (
+                f"{path}: new third-party import {name!r}; the bundle "
+                "module is stdlib + click only by issue #196 acceptance."
+            )
+
+
+def test_no_subprocess_import_in_bundle():
+    """Bundle is a filesystem-only writer; no children should be spawned."""
+    for path in _bundle_source_files():
+        for name in _imports(path):
+            assert name != "subprocess", (
+                f"{path}: 'subprocess' import not allowed in aorta.bundle "
+                "(filesystem-only writer; spawning children would dodge "
+                "the redactor)."
+            )
+
+
+def test_no_runner_or_dispatcher_filename_under_bundle():
+    """Engine-reuse gate from the #188 rubric §X.4 applied to bundle.
+
+    Bundle is not a runner; never let a future refactor smuggle a
+    runner under its package name.
+    """
+    pkg_dir = Path(_bundle_pkg.__file__).parent
+    for path in pkg_dir.rglob("*.py"):
+        stem = path.stem.lower()
+        assert "runner" not in stem, f"{path}: 'runner' is reserved for engine code"
+        assert "dispatcher" not in stem, f"{path}: 'dispatcher' is reserved for engine code"
+
+
+def test_bundle_submodules_collected():
+    """Sanity: the package actually exposes the four submodules."""
+    submodules = {m.name for m in pkgutil.iter_modules(_bundle_pkg.__path__)}
+    assert {"errors", "manifest", "redactor", "writer"} <= submodules

--- a/tests/bundle/test_no_new_deps.py
+++ b/tests/bundle/test_no_new_deps.py
@@ -77,6 +77,53 @@ def test_no_third_party_imports_beyond_click():
             )
 
 
+def test_bundle_only_imports_its_own_aorta_subpackage():
+    """The bundle package must not import sibling ``aorta`` packages.
+
+    ``aorta.triage.output`` (the old home of ``safe_slug``) imports
+    PyYAML and the registry stack, so a ``from aorta.triage... import``
+    silently busts the stdlib+click import budget (PR #199 review).
+    Only ``aorta.bundle.*`` internal imports are allowed.
+    """
+    for path in _bundle_source_files():
+        for name in _imports(path):
+            if name == "aorta" or name.startswith(_AORTA_INTERNAL_PREFIX):
+                assert name.startswith("aorta.bundle"), (
+                    f"{path}: cross-package import {name!r}; aorta.bundle must "
+                    "depend only on its own subpackage to stay stdlib+click "
+                    "(no transitive PyYAML via aorta.triage)."
+                )
+
+
+def test_bundle_safe_slug_matches_triage_canonical():
+    """The inlined ``aorta.bundle._slug`` copy must stay byte-for-byte
+    equivalent to the canonical ``aorta.triage.output.safe_slug`` so the
+    decoupling (PR #199) cannot silently drift -- e.g. if triage tightens
+    the slug regex for a path-traversal fix, this test fails until the
+    bundle copy is updated too.
+    """
+    from aorta.bundle._slug import NO_TICKET_SLUG as BUNDLE_NO_TICKET
+    from aorta.bundle._slug import safe_slug as bundle_slug
+    from aorta.triage.output import NO_TICKET_SLUG as TRIAGE_NO_TICKET
+    from aorta.triage.output import safe_slug as triage_slug
+
+    assert BUNDLE_NO_TICKET == TRIAGE_NO_TICKET
+    samples = [
+        "PROJ-123",
+        "TKT 1",
+        "a/b/c",
+        "..",
+        ".",
+        "",
+        "weird:name*x",
+        "a.b-c_d",
+        "../../etc/passwd",
+        "with space and / slash",
+    ]
+    for s in samples:
+        assert bundle_slug(s) == triage_slug(s), f"slug drift on {s!r}"
+
+
 def test_no_subprocess_import_in_bundle():
     """Bundle is a filesystem-only writer; no children should be spawned."""
     for path in _bundle_source_files():

--- a/tests/bundle/test_writer.py
+++ b/tests/bundle/test_writer.py
@@ -1,0 +1,366 @@
+"""Writer / staging / tarball tests for ``aorta bundle`` (issue #196)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from aorta.bundle import (
+    EmptyRunDirError,
+    IdentityRedactor,
+    Manifest,
+    NoTicketError,
+    RedactionCounts,
+    Redactor,
+    RunDirNotFoundError,
+    bundle_run_dir,
+    resolve_ticket,
+)
+from aorta.bundle.manifest import MANIFEST_FILENAME
+from aorta.bundle.writer import stage_run_dir, write_tarball
+
+# --- resolve_ticket --------------------------------------------------------
+
+
+def test_resolve_ticket_uses_flag_when_provided(tmp_path):
+    run_dir = tmp_path / "TKT-XYZ"
+    run_dir.mkdir()
+    assert resolve_ticket(run_dir, "OVERRIDE-1") == "OVERRIDE-1"
+
+
+def test_resolve_ticket_infers_from_basename(tmp_path):
+    run_dir = tmp_path / "TKT-1"
+    run_dir.mkdir()
+    assert resolve_ticket(run_dir, None) == "TKT-1"
+
+
+def test_resolve_ticket_strips_whitespace_then_falls_back(tmp_path):
+    run_dir = tmp_path / "TKT-2"
+    run_dir.mkdir()
+    assert resolve_ticket(run_dir, "   ") == "TKT-2"
+
+
+def test_resolve_ticket_refuses_no_ticket_slug(tmp_path):
+    run_dir = tmp_path / "_no_ticket_"
+    run_dir.mkdir()
+    with pytest.raises(NoTicketError) as exc:
+        resolve_ticket(run_dir, None)
+    assert exc.value.run_dir == run_dir
+
+
+def test_resolve_ticket_no_ticket_slug_with_flag_override_uses_flag(tmp_path, caplog):
+    run_dir = tmp_path / "_no_ticket_"
+    run_dir.mkdir()
+    with caplog.at_level("WARNING"):
+        out = resolve_ticket(run_dir, "RESCUED-1")
+    assert out == "RESCUED-1"
+    assert any("_no_ticket_" in r.message for r in caplog.records)
+
+
+def test_resolve_ticket_mismatched_flag_warns_but_proceeds(tmp_path, caplog):
+    run_dir = tmp_path / "TKT-1"
+    run_dir.mkdir()
+    with caplog.at_level("WARNING"):
+        out = resolve_ticket(run_dir, "TKT-2")
+    assert out == "TKT-2"
+    assert any("does not match run-dir" in r.message for r in caplog.records)
+
+
+# --- _validate_run_dir / bundle_run_dir error path -------------------------
+
+
+def test_bundle_run_dir_missing_path_raises(tmp_path):
+    missing = tmp_path / "no-such-dir"
+    with pytest.raises(RunDirNotFoundError):
+        bundle_run_dir(missing)
+
+
+def test_bundle_run_dir_file_path_raises(tmp_path):
+    f = tmp_path / "not-a-dir"
+    f.write_text("nope")
+    with pytest.raises(RunDirNotFoundError):
+        bundle_run_dir(f)
+
+
+def test_bundle_run_dir_empty_tree_raises(empty_run_dir):
+    with pytest.raises(EmptyRunDirError) as exc:
+        bundle_run_dir(empty_run_dir)
+    assert exc.value.run_dir == empty_run_dir.resolve()
+
+
+def test_bundle_run_dir_no_ticket_basename_raises(no_ticket_run_dir):
+    with pytest.raises(NoTicketError):
+        bundle_run_dir(no_ticket_run_dir)
+
+
+def test_bundle_run_dir_no_ticket_basename_with_flag_succeeds(no_ticket_run_dir, tmp_path):
+    out = tmp_path / "bundle.tar.gz"
+    written = bundle_run_dir(no_ticket_run_dir, ticket="RESCUED-1", output=out)
+    assert written == out.resolve()
+    assert written.is_file()
+
+
+# --- happy path: stage_run_dir / write_tarball ----------------------------
+
+
+def test_stage_run_dir_copies_every_file_and_writes_manifest(synthetic_run_dir, tmp_path):
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    manifest = stage_run_dir(
+        synthetic_run_dir,
+        staging,
+        "TKT-1-bundle",
+        redactor=IdentityRedactor(),
+        ticket="TKT-1",
+        aorta_version="0.2.0",
+    )
+    bundle_root = staging / "TKT-1-bundle"
+    assert (bundle_root / MANIFEST_FILENAME).is_file()
+    for f in manifest.files:
+        assert (bundle_root / f.path).is_file()
+    # Identity redactor: every count is 0 and bytes_in == bytes_out.
+    for f in manifest.files:
+        assert f.env_keys_removed == 0
+        assert f.paths_rewritten == 0
+        assert f.ips_rewritten == 0
+        assert f.bytes_in == f.bytes_out
+
+
+def test_stage_run_dir_manifest_excludes_itself_and_lockfile(synthetic_run_dir, tmp_path):
+    """Defensive: pre-existing manifest.json + lockfile in the source
+    are not re-bundled. Otherwise re-bundling an extracted bundle
+    would double-count and a stale lockfile would survive."""
+    (synthetic_run_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    (synthetic_run_dir / ".aorta-probe.lock").write_text("{}", encoding="utf-8")
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    manifest = stage_run_dir(
+        synthetic_run_dir,
+        staging,
+        "TKT-1-bundle",
+        redactor=IdentityRedactor(),
+        ticket="TKT-1",
+        aorta_version="0.2.0",
+    )
+    paths = {f.path for f in manifest.files}
+    assert "manifest.json" not in paths
+    assert ".aorta-probe.lock" not in paths
+
+
+def test_write_tarball_round_trip(synthetic_run_dir, tmp_path):
+    """Acceptance criterion 6: happy-path tarball round-trip."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    manifest = stage_run_dir(
+        synthetic_run_dir,
+        staging,
+        "TKT-1-bundle",
+        redactor=IdentityRedactor(),
+        ticket="TKT-1",
+        aorta_version="0.2.0",
+    )
+    out = tmp_path / "TKT-1.tar.gz"
+    written = write_tarball(staging, "TKT-1-bundle", out)
+    assert written == out.absolute()
+    assert written.is_file()
+
+    with tempfile.TemporaryDirectory() as extract_root:
+        extract = Path(extract_root)
+        with tarfile.open(written, "r:gz") as tar:
+            tar.extractall(extract)  # noqa: S202 - test fixture, controlled input
+        # Every file recorded in the manifest is present in the extracted
+        # tree under the bundle-root directory.
+        bundle_root = extract / "TKT-1-bundle"
+        assert (bundle_root / MANIFEST_FILENAME).is_file()
+        for f in manifest.files:
+            assert (bundle_root / f.path).is_file()
+        # Manifest is the tarball trailer.
+        with tarfile.open(written, "r:gz") as tar:
+            names = tar.getnames()
+        assert names[-1] == f"TKT-1-bundle/{MANIFEST_FILENAME}"
+
+
+# --- originals untouched (acceptance criterion 5) -------------------------
+
+
+def _snapshot_tree(root: Path) -> dict[str, bytes]:
+    out: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            out[str(path.relative_to(root))] = path.read_bytes()
+    return out
+
+
+def test_bundle_run_dir_does_not_modify_source(synthetic_run_dir, tmp_path):
+    """Acceptance criterion 5: originals untouched.
+
+    Snapshot every file's bytes before and after bundling; the
+    tree must be byte-identical.
+    """
+    before = _snapshot_tree(synthetic_run_dir)
+    out = tmp_path / "out.tar.gz"
+    bundle_run_dir(synthetic_run_dir, output=out)
+    after = _snapshot_tree(synthetic_run_dir)
+    assert before == after
+
+
+def test_bundle_run_dir_default_output_in_cwd(synthetic_run_dir, tmp_path, monkeypatch):
+    """Default ``--output`` lands a ``<ticket>-<ts>.tar.gz`` in CWD."""
+    monkeypatch.chdir(tmp_path)
+    out = bundle_run_dir(synthetic_run_dir)
+    assert out.parent == tmp_path.resolve()
+    assert out.name.startswith("TKT-1-")
+    assert out.suffix == ".gz"
+    assert out.is_file()
+
+
+def test_bundle_run_dir_output_directory_drops_default_filename(synthetic_run_dir, tmp_path):
+    target = tmp_path / "bundles"
+    target.mkdir()
+    out = bundle_run_dir(synthetic_run_dir, output=target)
+    assert out.parent == target.resolve()
+    assert out.name.startswith("TKT-1-")
+
+
+# --- redactor injection point --------------------------------------------
+
+
+class _RecordingRedactor(Redactor):
+    """Sentinel redactor: records every (src, dst) pair the writer
+    calls scrub_file with so we can assert the writer routes
+    EVERY source file through the redactor.
+
+    Also lets us prove the redactor's per-file count return is
+    plumbed into the manifest verbatim (so when Phase 3 of #188's
+    real RedactingRedactor lands, its counts will land in the
+    manifest unchanged).
+    """
+
+    kind = "recording"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Path, Path]] = []
+
+    def scrub_file(self, src: Path, dst: Path) -> RedactionCounts:
+        self.calls.append((src, dst))
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dst)
+        size = dst.stat().st_size
+        return RedactionCounts(
+            env_keys_removed=1,
+            paths_rewritten=2,
+            ips_rewritten=3,
+            bytes_in=size,
+            bytes_out=size,
+        )
+
+
+def test_bundle_run_dir_routes_every_source_file_through_redactor(synthetic_run_dir, tmp_path):
+    redactor = _RecordingRedactor()
+    out = bundle_run_dir(synthetic_run_dir, output=tmp_path / "out.tar.gz", redactor=redactor)
+    assert out.is_file()
+    # Every file in the source tree (minus skipped basenames) was scrubbed.
+    bundled_sources = {src for src, _ in redactor.calls}
+    expected = {
+        p
+        for p in synthetic_run_dir.rglob("*")
+        if p.is_file() and p.name not in {".aorta-probe.lock", "manifest.json"}
+    }
+    assert bundled_sources == expected
+
+
+def test_bundle_run_dir_propagates_redactor_counts_into_manifest(synthetic_run_dir, tmp_path):
+    """Phase 3 of #188 contract: per-file counts surfaced verbatim."""
+    out = tmp_path / "out.tar.gz"
+    bundle_run_dir(synthetic_run_dir, output=out, redactor=_RecordingRedactor())
+    with tarfile.open(out, "r:gz") as tar:
+        names = tar.getnames()
+        manifest_member = [n for n in names if n.endswith(MANIFEST_FILENAME)][0]
+        extracted = tar.extractfile(manifest_member)
+        assert extracted is not None
+        manifest = Manifest.from_json(extracted.read().decode("utf-8"))
+    assert manifest.redaction_applied is True
+    assert manifest.redactor_kind == "recording"
+    for f in manifest.files:
+        assert f.env_keys_removed == 1
+        assert f.paths_rewritten == 2
+        assert f.ips_rewritten == 3
+
+
+# --- review callback ------------------------------------------------------
+
+
+def test_bundle_run_dir_review_yes_proceeds(synthetic_run_dir, tmp_path):
+    seen: list[Manifest] = []
+
+    def confirm(manifest):
+        seen.append(manifest)
+        return True
+
+    out = tmp_path / "out.tar.gz"
+    written = bundle_run_dir(synthetic_run_dir, output=out, review_callback=confirm)
+    assert written.is_file()
+    assert len(seen) == 1
+    assert seen[0].ticket == "TKT-1"
+
+
+def test_bundle_run_dir_review_no_aborts_with_typed_error(synthetic_run_dir, tmp_path):
+    from aorta.bundle import BundleAbortedError
+
+    out = tmp_path / "out.tar.gz"
+    with pytest.raises(BundleAbortedError):
+        bundle_run_dir(synthetic_run_dir, output=out, review_callback=lambda m: False)
+    assert not out.exists()
+
+
+# --- redaction-from flag is honoured but no-op until #188 Phase 3 ---------
+
+
+def test_bundle_run_dir_redaction_from_logged_when_present(synthetic_run_dir, tmp_path, caplog):
+    """Acceptance: --redaction-from is wired through (not yet consumed)."""
+    recipe = synthetic_run_dir / "recipe.resolved.yaml"  # already created by fixture
+    out = tmp_path / "out.tar.gz"
+    with caplog.at_level("INFO", logger="aorta.bundle.writer"):
+        bundle_run_dir(synthetic_run_dir, output=out, redaction_from=recipe)
+    assert any(
+        "aorta.probe.redaction is gated on issue #188 Phase 3" in r.message for r in caplog.records
+    )
+
+
+# --- bundle name + timestamp -----------------------------------------------
+
+
+def test_bundle_name_uses_safe_slug_of_ticket(synthetic_run_dir, tmp_path):
+    """Tickets with slashes / spaces are slugged for the filename."""
+    out = bundle_run_dir(synthetic_run_dir, ticket="TKT/with spaces", output=tmp_path)
+    # safe_slug rewrites '/' and ' ' to '_'.
+    assert out.name.startswith("TKT_with_spaces-")
+    # The manifest still records the ORIGINAL ticket (un-slugged).
+    with tarfile.open(out, "r:gz") as tar:
+        member = next(n for n in tar.getnames() if n.endswith(MANIFEST_FILENAME))
+        manifest = Manifest.from_json(tar.extractfile(member).read().decode("utf-8"))
+    assert manifest.ticket == "TKT/with spaces"
+
+
+def test_bundle_run_dir_result_json_round_trip(synthetic_run_dir, tmp_path):
+    """The bundle's stdout.log / result.json files match the source bytes
+    when running with the IdentityRedactor (no scrubbing).
+    """
+    out = tmp_path / "out.tar.gz"
+    bundle_run_dir(synthetic_run_dir, output=out)
+    with tempfile.TemporaryDirectory() as extract_root:
+        extract = Path(extract_root)
+        with tarfile.open(out, "r:gz") as tar:
+            tar.extractall(extract)  # noqa: S202 - controlled fixture
+        bundle_root = next(p for p in extract.iterdir() if p.is_dir())
+        for rel in ("none-none/trial_0/stdout.log", "none-none/trial_0/result.json"):
+            assert (bundle_root / rel).read_bytes() == (synthetic_run_dir / rel).read_bytes()
+        # result.json is still parseable.
+        doc = json.loads((bundle_root / "none-none/trial_0/result.json").read_text())
+        assert doc["verdict"] == "pass"

--- a/tests/bundle/test_writer.py
+++ b/tests/bundle/test_writer.py
@@ -503,10 +503,11 @@ def test_iter_source_files_keeps_nested_manifest_and_lockfile_lookalikes(
 
 
 def test_write_tarball_failure_leaves_no_partial(synthetic_run_dir, tmp_path, monkeypatch):
-    """If tarfile / gzip raises mid-write (ENOSPC, EIO, ...) the
-    final ``output`` path must NOT exist -- BundleIOError's message
-    claims 'No tarball was written' and the writer has to honour
-    that.
+    """If tarfile / gzip raises mid-write (ENOSPC, EIO, ...) and the
+    final ``output`` path did not pre-exist, it must NOT exist after
+    the failure -- BundleIOError's message promises 'no new tarball
+    was written' and the writer has to honour that (here there is no
+    prior file at the path, so nothing should appear).
 
     The partial sibling (``<output>.partial``) is also cleaned up so
     a retry does not race against stale temp data.
@@ -560,12 +561,17 @@ def test_write_tarball_failure_preserves_prior_output(synthetic_run_dir, tmp_pat
 
     monkeypatch.setattr(writer_mod.tarfile, "open", _exploding_open)
 
-    with pytest.raises(BundleIOError):
+    with pytest.raises(BundleIOError) as exc:
         bundle_run_dir(synthetic_run_dir, output=out)
     # Prior file untouched.
     assert out.read_bytes() == sentinel
     # No .partial left behind.
     assert not out.with_name(out.name + ".partial").exists()
+    # The message must NOT claim the path is empty -- it says no NEW
+    # tarball was written and the existing file was left untouched
+    # (Copilot PR #199 review).
+    assert "no new tarball was written" in str(exc.value).lower()
+    assert "left untouched" in str(exc.value).lower()
 
 
 def test_write_tarball_cleans_stale_partial_before_writing(synthetic_run_dir, tmp_path):

--- a/tests/bundle/test_writer.py
+++ b/tests/bundle/test_writer.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from aorta.bundle import (
+    BundleIOError,
     EmptyRunDirError,
     IdentityRedactor,
     Manifest,
@@ -22,7 +23,7 @@ from aorta.bundle import (
     resolve_ticket,
 )
 from aorta.bundle.manifest import MANIFEST_FILENAME
-from aorta.bundle.writer import stage_run_dir, write_tarball
+from aorta.bundle.writer import _bundle_timestamp, stage_run_dir, write_tarball
 
 # --- resolve_ticket --------------------------------------------------------
 
@@ -364,3 +365,87 @@ def test_bundle_run_dir_result_json_round_trip(synthetic_run_dir, tmp_path):
         # result.json is still parseable.
         doc = json.loads((bundle_root / "none-none/trial_0/result.json").read_text())
         assert doc["verdict"] == "pass"
+
+
+# --- bundle name carries millisecond precision (review fix) ----------------
+
+
+def test_bundle_timestamp_has_millisecond_resolution():
+    """Two timestamps in the same second but different ms produce
+    distinct strings -- otherwise back-to-back ``aorta bundle`` runs
+    would collide on the staging mkdir(exist_ok=False) and fail.
+
+    Pure-function test against ``_bundle_timestamp`` so we don't
+    have to race the wall clock.
+    """
+    import datetime as dt
+
+    base = dt.datetime(2026, 6, 1, 7, 0, 0, 123_000, tzinfo=dt.timezone.utc)
+    twin = base.replace(microsecond=456_000)
+    a = _bundle_timestamp(base)
+    b = _bundle_timestamp(twin)
+    assert a == "2026-06-01T07-00-00-123"
+    assert b == "2026-06-01T07-00-00-456"
+    assert a != b
+
+
+def test_bundle_name_includes_milliseconds(synthetic_run_dir, tmp_path):
+    """End-to-end: the bundle filename includes the ms suffix, so
+    back-to-back invocations don't clobber each other or fail the
+    staging mkdir.
+    """
+    import datetime as dt
+
+    fixed = dt.datetime(2026, 6, 1, 7, 0, 0, 789_000, tzinfo=dt.timezone.utc)
+    out = bundle_run_dir(synthetic_run_dir, output=tmp_path, now=fixed)
+    assert out.name == "TKT-1-2026-06-01T07-00-00-789.tar.gz"
+
+
+# --- OSError wrapping (review fix) -----------------------------------------
+
+
+class _RaisingRedactor(Redactor):
+    """Redactor whose scrub_file raises OSError on the first call.
+
+    Models the operator-visible failure modes documented on
+    :class:`Redactor` (permissions, ENOSPC, transient FS errors).
+    """
+
+    kind = "raising"
+
+    def __init__(self, exc: OSError) -> None:
+        self.exc = exc
+
+    def scrub_file(self, src: Path, dst: Path) -> RedactionCounts:
+        raise self.exc
+
+
+def test_bundle_run_dir_wraps_oserror_from_redactor_into_bundle_io_error(
+    synthetic_run_dir, tmp_path
+):
+    """The Redactor ABC docstring promises BundleError-shaped failures.
+
+    Without the writer wrap, a permission denied (or ENOSPC) on a
+    single file would escape as a raw OSError and bypass the CLI's
+    BundleError -> ClickException mapping, leaving the operator with
+    a Python traceback. The wrap below is what makes that promise
+    real.
+    """
+    boom = PermissionError(13, "Permission denied", "stdout.log")
+    with pytest.raises(BundleIOError) as exc:
+        bundle_run_dir(
+            synthetic_run_dir,
+            output=tmp_path / "out.tar.gz",
+            redactor=_RaisingRedactor(boom),
+        )
+    # The original OSError is preserved on .cause so ops tooling can
+    # grade the failure (PermissionError vs ENOSPC vs ...) without
+    # parsing the message.
+    assert exc.value.cause is boom
+    assert exc.value.run_dir == synthetic_run_dir.resolve()
+    # And the message includes the original error so the CLI surface
+    # is not "filesystem error: <empty>".
+    assert "Permission denied" in str(exc.value)
+    # No tarball was written despite the half-staged tree -- the
+    # TemporaryDirectory cleans up.
+    assert not (tmp_path / "out.tar.gz").exists()

--- a/tests/bundle/test_writer.py
+++ b/tests/bundle/test_writer.py
@@ -654,6 +654,34 @@ def test_bundle_follows_in_tree_symlink(synthetic_run_dir, tmp_path):
     assert any(n.endswith("/none-none/trial_0/stdout_alias.log") for n in names)
 
 
+def test_identity_redactor_preserves_restrictive_mode(synthetic_run_dir, tmp_path):
+    """A 0600 source file (e.g. ``probe.env``) must NOT be widened to
+    the umask default when copied into the bundle staging tree
+    (Copilot PR #199 review). ``IdentityRedactor`` carries the source
+    mode via ``shutil.copymode`` so the bundle copy is never less
+    restrictive than the original.
+    """
+    import stat
+
+    secret = synthetic_run_dir / "none-none" / "trial_0" / "probe.env"
+    secret.write_text("AWS_SECRET=shhh\n", encoding="utf-8")
+    secret.chmod(0o600)
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    stage_run_dir(
+        synthetic_run_dir,
+        staging,
+        "TKT-1-bundle",
+        redactor=IdentityRedactor(),
+        ticket="TKT-1",
+        aorta_version="0.2.0",
+    )
+    staged = staging / "TKT-1-bundle" / "none-none" / "trial_0" / "probe.env"
+    assert staged.is_file()
+    assert stat.S_IMODE(staged.stat().st_mode) == 0o600
+
+
 def test_manifest_does_not_leak_absolute_source_path(synthetic_run_dir, tmp_path):
     """The extracted manifest must not carry the operator's absolute
     source path (Sonbol PR #199 review): that would leak workstation

--- a/tests/bundle/test_writer.py
+++ b/tests/bundle/test_writer.py
@@ -688,6 +688,33 @@ def test_identity_redactor_preserves_restrictive_mode(synthetic_run_dir, tmp_pat
     assert stat.S_IMODE(staged.stat().st_mode) == 0o600
 
 
+def test_tarball_headers_scrub_owner_identity(synthetic_run_dir, tmp_path):
+    """Tar headers must not leak the operator's uid/gid/uname/gname and
+    must pin mtime (Copilot PR #199 review): a shareable bundle should
+    not carry workstation identity. File MODE is still preserved through
+    the filter so a 0600 probe.env stays restrictive.
+    """
+    import stat
+
+    secret = synthetic_run_dir / "none-none" / "trial_0" / "probe.env"
+    secret.write_text("AWS_SECRET=shhh\n", encoding="utf-8")
+    secret.chmod(0o600)
+
+    out = tmp_path / "out.tar.gz"
+    bundle_run_dir(synthetic_run_dir, output=out)
+    with tarfile.open(out, "r:gz") as tar:
+        members = tar.getmembers()
+    assert members
+    for m in members:
+        assert m.uid == 0, f"{m.name}: uid leaked"
+        assert m.gid == 0, f"{m.name}: gid leaked"
+        assert m.uname == "", f"{m.name}: uname leaked"
+        assert m.gname == "", f"{m.name}: gname leaked"
+        assert m.mtime == 0, f"{m.name}: mtime not pinned"
+    env_member = next(m for m in members if m.name.endswith("/none-none/trial_0/probe.env"))
+    assert stat.S_IMODE(env_member.mode) == 0o600
+
+
 def test_manifest_does_not_leak_absolute_source_path(synthetic_run_dir, tmp_path):
     """The extracted manifest must not carry the operator's absolute
     source path (Sonbol PR #199 review): that would leak workstation

--- a/tests/bundle/test_writer.py
+++ b/tests/bundle/test_writer.py
@@ -19,6 +19,7 @@ from aorta.bundle import (
     RedactionCounts,
     Redactor,
     RunDirNotFoundError,
+    UnsafeSymlinkError,
     bundle_run_dir,
     resolve_ticket,
 )
@@ -476,7 +477,8 @@ def test_iter_source_files_keeps_nested_manifest_and_lockfile_lookalikes(
     out = tmp_path / "out.tar.gz"
     bundle_run_dir(synthetic_run_dir, output=out)
     with tarfile.open(out, "r:gz") as tar:
-        names = set(tar.getnames())
+        ordered_names = [n for n in tar.getnames() if n]
+    names = set(ordered_names)
     # Derive bundle_root from a file that lives ONLY at the top level
     # (host_env.json) so we don't accidentally pick a deeper match.
     bundle_root = next(n for n in names if n.endswith("/host_env.json"))[: -len("/host_env.json")]
@@ -488,6 +490,13 @@ def test_iter_source_files_keeps_nested_manifest_and_lockfile_lookalikes(
     # only ./manifest.json in the archive, written by stage_run_dir.)
     assert sum(1 for n in names if n == f"{bundle_root}/manifest.json") == 1
     assert f"{bundle_root}/.aorta-probe.lock" not in names
+    # Ordering contract (Sonbol PR #199 review): the TOP-LEVEL
+    # manifest.json is the tarball trailer even when a nested
+    # ``*/manifest.json`` exists. The sort keys on the relative POSIX
+    # path, so the nested manifest must NOT be the final member.
+    file_entries = [n for n in ordered_names if n != bundle_root]
+    assert file_entries[-1] == f"{bundle_root}/manifest.json"
+    assert file_entries[-1] != f"{bundle_root}/none-none/trial_0/manifest.json"
 
 
 # --- atomic tarball write (review fix) -------------------------------------
@@ -602,3 +611,64 @@ def test_bundle_timestamp_normalises_non_utc_now_to_utc():
     # 12:30 IST == 07:00 UTC
     out = _bundle_timestamp(local)
     assert out == "2026-06-01T07-00-00-500"
+
+
+# --- trust boundary: symlinks + manifest path leak (Sonbol review) ---------
+
+
+def test_bundle_refuses_symlink_escaping_run_dir(synthetic_run_dir, tmp_path):
+    """A symlink under the run dir whose target is OUTSIDE the tree
+    must not be dereferenced into the bundle (Sonbol PR #199 review).
+
+    ``aorta bundle`` ships a shareable artifact, so following
+    ``run_dir/cell/trial_0/link -> ../../secret.txt`` would pull an
+    unrelated local file's bytes across the trust boundary. The
+    writer refuses with :class:`UnsafeSymlinkError`.
+    """
+    secret = tmp_path / "secret.txt"
+    secret.write_text("CUSTOMER_PRIVATE_KEY=hunter2\n", encoding="utf-8")
+    link = synthetic_run_dir / "none-none" / "trial_0" / "leak"
+    link.symlink_to(secret)
+
+    out = tmp_path / "out.tar.gz"
+    with pytest.raises(UnsafeSymlinkError) as exc:
+        bundle_run_dir(synthetic_run_dir, output=out)
+    assert exc.value.target == secret.resolve()
+    assert exc.value.path.name == "leak"
+    # Nothing was written.
+    assert not out.exists()
+
+
+def test_bundle_follows_in_tree_symlink(synthetic_run_dir, tmp_path):
+    """A symlink whose target stays INSIDE the run dir is still
+    followed -- the guard only refuses escapes, not all symlinks.
+    """
+    target = synthetic_run_dir / "none-none" / "trial_0" / "stdout.log"
+    link = synthetic_run_dir / "none-none" / "trial_0" / "stdout_alias.log"
+    link.symlink_to(target)
+
+    out = tmp_path / "out.tar.gz"
+    written = bundle_run_dir(synthetic_run_dir, output=out)
+    with tarfile.open(written, "r:gz") as tar:
+        names = set(tar.getnames())
+    assert any(n.endswith("/none-none/trial_0/stdout_alias.log") for n in names)
+
+
+def test_manifest_does_not_leak_absolute_source_path(synthetic_run_dir, tmp_path):
+    """The extracted manifest must not carry the operator's absolute
+    source path (Sonbol PR #199 review): that would leak workstation
+    usernames, mount points, or customer directory names off the
+    source machine. Only the run dir's leaf name is recorded.
+    """
+    out = tmp_path / "out.tar.gz"
+    bundle_run_dir(synthetic_run_dir, output=out)
+    with tarfile.open(out, "r:gz") as tar:
+        manifest_member = next(n for n in tar.getnames() if n.endswith(f"/{MANIFEST_FILENAME}"))
+        raw = tar.extractfile(manifest_member).read().decode("utf-8")
+    manifest = Manifest.from_json(raw)
+    # Only the leaf name -- never the absolute path or any parent.
+    assert manifest.source_run_dir == synthetic_run_dir.name
+    abs_source = str(synthetic_run_dir.resolve())
+    assert abs_source not in raw
+    assert str(tmp_path) not in raw
+    assert "/" not in manifest.source_run_dir

--- a/tests/bundle/test_writer.py
+++ b/tests/bundle/test_writer.py
@@ -449,3 +449,156 @@ def test_bundle_run_dir_wraps_oserror_from_redactor_into_bundle_io_error(
     # No tarball was written despite the half-staged tree -- the
     # TemporaryDirectory cleans up.
     assert not (tmp_path / "out.tar.gz").exists()
+
+
+# --- skip-filter is top-level only (review fix) ----------------------------
+
+
+def test_iter_source_files_keeps_nested_manifest_and_lockfile_lookalikes(
+    synthetic_run_dir, tmp_path
+):
+    """Per docstring: only ``./manifest.json`` and ``./.aorta-probe.lock``
+    are dropped. A workload that writes those same basenames inside a
+    cell / trial directory is emitting legitimate artifacts and must
+    have them bundled.
+
+    Before PR #199 round 2, ``_iter_source_files`` matched basenames
+    anywhere in the tree, silently dropping nested artifacts.
+    """
+    nested_manifest = synthetic_run_dir / "none-none" / "trial_0" / "manifest.json"
+    nested_lockfile = synthetic_run_dir / "tf32_off-none" / "trial_0" / ".aorta-probe.lock"
+    nested_manifest.write_text('{"workload": "ok"}', encoding="utf-8")
+    nested_lockfile.write_text("nested lock\n", encoding="utf-8")
+    # Top-level versions of both should still be dropped.
+    (synthetic_run_dir / "manifest.json").write_text("stale\n", encoding="utf-8")
+    (synthetic_run_dir / ".aorta-probe.lock").write_text("stale\n", encoding="utf-8")
+
+    out = tmp_path / "out.tar.gz"
+    bundle_run_dir(synthetic_run_dir, output=out)
+    with tarfile.open(out, "r:gz") as tar:
+        names = set(tar.getnames())
+    # Derive bundle_root from a file that lives ONLY at the top level
+    # (host_env.json) so we don't accidentally pick a deeper match.
+    bundle_root = next(n for n in names if n.endswith("/host_env.json"))[: -len("/host_env.json")]
+    # Nested look-alikes survived the filter.
+    assert f"{bundle_root}/none-none/trial_0/manifest.json" in names
+    assert f"{bundle_root}/tf32_off-none/trial_0/.aorta-probe.lock" in names
+    # Top-level stale ones did NOT.
+    # (The OWN manifest.json the bundle writes at top-level is the
+    # only ./manifest.json in the archive, written by stage_run_dir.)
+    assert sum(1 for n in names if n == f"{bundle_root}/manifest.json") == 1
+    assert f"{bundle_root}/.aorta-probe.lock" not in names
+
+
+# --- atomic tarball write (review fix) -------------------------------------
+
+
+def test_write_tarball_failure_leaves_no_partial(synthetic_run_dir, tmp_path, monkeypatch):
+    """If tarfile / gzip raises mid-write (ENOSPC, EIO, ...) the
+    final ``output`` path must NOT exist -- BundleIOError's message
+    claims 'No tarball was written' and the writer has to honour
+    that.
+
+    The partial sibling (``<output>.partial``) is also cleaned up so
+    a retry does not race against stale temp data.
+    """
+    import aorta.bundle.writer as writer_mod
+
+    real_open = tarfile.open
+
+    def _raising_open(*args, **kwargs):
+        tar = real_open(*args, **kwargs)
+        original_add = tar.add
+        call_count = {"n": 0}
+
+        def boom_after_one_add(*a, **kw):
+            call_count["n"] += 1
+            if call_count["n"] >= 2:
+                raise OSError(28, "No space left on device")  # ENOSPC
+            return original_add(*a, **kw)
+
+        tar.add = boom_after_one_add
+        return tar
+
+    monkeypatch.setattr(writer_mod.tarfile, "open", _raising_open)
+
+    out = tmp_path / "out.tar.gz"
+    with pytest.raises(BundleIOError) as exc:
+        bundle_run_dir(synthetic_run_dir, output=out)
+    assert "No space left on device" in str(exc.value)
+    # The promise: neither the final file nor the partial survives.
+    assert not out.exists(), "Atomic write violated -- partial tarball at final path"
+    assert not out.with_name(out.name + ".partial").exists(), ".partial sibling leaked on failure"
+
+
+def test_write_tarball_failure_preserves_prior_output(synthetic_run_dir, tmp_path, monkeypatch):
+    """The atomicity guarantee is strongest when ``output`` already
+    exists from a prior run: a mid-write failure must NOT corrupt
+    or remove the prior copy.
+
+    Pre-populates ``output`` with a sentinel, forces the new write
+    to fail, then re-reads the file and asserts the sentinel is
+    intact.
+    """
+    import aorta.bundle.writer as writer_mod
+
+    out = tmp_path / "out.tar.gz"
+    sentinel = b"PRIOR-BUNDLE-DO-NOT-DELETE"
+    out.write_bytes(sentinel)
+
+    def _exploding_open(*args, **kwargs):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(writer_mod.tarfile, "open", _exploding_open)
+
+    with pytest.raises(BundleIOError):
+        bundle_run_dir(synthetic_run_dir, output=out)
+    # Prior file untouched.
+    assert out.read_bytes() == sentinel
+    # No .partial left behind.
+    assert not out.with_name(out.name + ".partial").exists()
+
+
+def test_write_tarball_cleans_stale_partial_before_writing(synthetic_run_dir, tmp_path):
+    """A leftover ``.partial`` from a previous crashed run must not
+    survive into the next successful write -- ``write_tarball``
+    proactively unlinks it before opening the new gzip stream.
+    """
+    out = tmp_path / "out.tar.gz"
+    stale = out.with_name(out.name + ".partial")
+    stale.write_bytes(b"stale partial bytes")
+    # Should succeed and leave only the final tarball; no .partial.
+    written = bundle_run_dir(synthetic_run_dir, output=out)
+    assert written == out.resolve()
+    assert out.is_file()
+    assert not stale.exists()
+
+
+# --- UTC normalisation (review fix) ----------------------------------------
+
+
+def test_bundle_timestamp_normalises_naive_now_as_utc():
+    """A naive datetime is treated as already-UTC (matching
+    ``datetime.now(timezone.utc)``'s shape) instead of being
+    silently mislabelled.
+    """
+    import datetime as dt
+
+    naive = dt.datetime(2026, 6, 1, 7, 0, 0, 250_000)  # no tzinfo
+    out = _bundle_timestamp(naive)
+    # The naive wall-clock 07:00:00.250 is taken at face value.
+    assert out == "2026-06-01T07-00-00-250"
+
+
+def test_bundle_timestamp_normalises_non_utc_now_to_utc():
+    """An aware datetime in +05:30 is converted to UTC before
+    formatting, so the embedded clock matches the ``Z`` convention
+    in the manifest.
+    """
+    import datetime as dt
+
+    ist = dt.timezone(dt.timedelta(hours=5, minutes=30))
+    local = dt.datetime(2026, 6, 1, 12, 30, 0, 500_000, tzinfo=ist)
+    # 12:30 IST == 07:00 UTC
+    out = _bundle_timestamp(local)
+    assert out == "2026-06-01T07-00-00-500"


### PR DESCRIPTION
## Summary

Adds the standalone `aorta bundle` command per issue #196: takes an
`aorta probe` run directory (`<probe-output>/<ticket>/`), applies
recipe-specified redaction, and writes a single shareable
`<ticket>-<UTC-timestamp>.tar.gz` plus a JSON manifest recording
per-file redaction counts. **Closes #196.**

This PR ships the **command, the manifest, and the redactor protocol**
— it does NOT ship the actual scrubbers. Per issue #196:

> Redaction implementation lives in `aorta probe` Phase 3 (PR will
> follow #194 series) as `src/aorta/probe/redaction.py`. `aorta bundle`
> consumes that module — it does not own the scrubbers.

So bundles run today with the default `IdentityRedactor` (bytes-only
copy, zero counts in the manifest). When the `aorta probe` Phase 3 PR
ships `RedactingRedactor`, no bundle-side change is needed — the
`bundle_run_dir(..., redactor=...)` injection point already accepts it.

## Why this PR exists

Issue #188 ([`aorta probe`](https://github.com/ROCm/aorta/issues/188))
Phase 3 is explicitly **gated on `aorta bundle` landing first**
(rubric §3.A finding F5: "the implementation of `aorta bundle`
itself — that's a separate ticket; this PR consumes its public
API"). Landing the command standalone unblocks the #188 Phase 3 PR
and gives the redactor a real consumer the day it ships.

## What's in the PR

**`src/aorta/bundle/`** (4 modules, stdlib-only):
- `errors.py` — `BundleError` + 4 typed subclasses (`RunDirNotFoundError`, `NoTicketError`, `EmptyRunDirError`, `BundleAbortedError`).
- `manifest.py` — `Manifest` + `FileRecord` dataclasses, JSON round-trip, schema-version gated.
- `redactor.py` — `Redactor` ABC, `IdentityRedactor` default, `RedactionCounts` dataclass.
- `writer.py` — `resolve_ticket`, `stage_run_dir`, `write_tarball`, `bundle_run_dir`.

**`src/aorta/cli/bundle.py`** — Thin Click shim (~60-line handler body, matching the `aorta probe` / `aorta run` discipline). Registered on the `aorta` main group.

**`tests/bundle/`** (44 tests, all green):
- `test_cli.py` — `--help`, no-ticket refusal, `--review y/n`, end-to-end through `CliRunner`.
- `test_writer.py` — `resolve_ticket` precedence rules, validation errors, redactor injection, byte-snapshot \"originals untouched\" assertion, tarball round-trip.
- `test_manifest.py` — schema round-trip, redaction-applied roll-up logic.
- `test_no_new_deps.py` — AST-walks every bundle source file and asserts the only third-party import is `click`.

**`docs/probe-188/bundle.md`** — CLI shape, ticket inference rules, manifest schema, redactor handoff contract for #188 Phase 3.

## Issue #196 acceptance criteria — coverage

| Criterion | Test |
|---|---|
| `aorta bundle --help` lists the documented flags | `test_help_lists_documented_flags` |
| `<dir>` without `--ticket` exits non-zero | `test_refuses_no_ticket_basename` |
| `--review` with `y` produces tarball; `n` aborts | `test_review_y_proceeds`, `test_review_n_aborts_cleanly` |
| Manifest records per-file redaction counts | `test_manifest_from_files_records_documented_shape`, `test_bundle_run_dir_propagates_redactor_counts_into_manifest` |
| Originals untouched | `test_bundle_run_dir_does_not_modify_source` (byte-snapshot diff) |
| Tests in `tests/bundle/` + happy-path tarball round-trip | `test_write_tarball_round_trip` |
| No new top-level dependencies | `test_no_third_party_imports_beyond_click` |

## Test plan

- [x] `pytest tests/bundle/` — 44/44 pass against fresh `main` base.
- [x] `pytest tests/probe/` — 83/83 pass (Phase 1; unaffected).
- [x] `pytest tests/triage/` — 258/258 pass (unaffected).
- [x] `ruff check`, `black --check`, `isort --check`, `mypy` — all clean on new files.
- [x] End-to-end smoke: `aorta probe ... ; aorta bundle <ticket-dir>` produces a valid tarball with manifest; `--review` + `n` aborts cleanly and writes nothing.
- [ ] Reviewer: spot-check the redactor handoff contract in `docs/probe-188/bundle.md` and confirm the `Redactor` ABC shape is acceptable for #188 Phase 3 to implement against.

## Branch strategy

This PR is based directly on `main` — **no dependency on the #188 Phase 2 PR (#197)** even though the work was originally scoped for that base. Verified: the bundle module's only `aorta.*` import outside its own package is `aorta.triage.output.{NO_TICKET_SLUG, safe_slug}`, both shipped in Phase 1. The two PRs (#197 and this one) can land in any order.

## Out of scope (per issue #196)

- Network upload of bundles.
- Bundle decryption / unpacking utilities.
- Auto-detection of secrets beyond what the recipe's `redaction:` block specifies (the redactor's responsibility, not bundle's).
- The actual env-key / path / IP scrubbers — Phase 3 of #188.

## References

- Closes: #196
- Unblocks: #188 Phase 3
- Rubric: `docs/plans/aorta-probe-188-rubric.md` §3 (Phase 3 scope; finding F5 gates this work)

Made with [Cursor](https://cursor.com)