### PR TITLE
probe: bundle integration + redaction + handout templates (#188 phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ AORTA generates comprehensive performance reports comparing ROCm versions across
 | [Configuration](docs/configuration.md) | FSDP tuning, RCCL variables, profiler settings |
 | [Profiling](docs/profiling.md) | Torch profiler, rocprofv3, overlap reports |
 | [Environment Probe](docs/env-probe.md) | Capture / diff / query a versioned environment snapshot; jq cookbook |
+| [`aorta probe`](docs/probe-188/usage.md) | Wrap-and-collect opaque launch commands; matrix + classifier |
+| [`aorta bundle`](docs/probe-188/bundle.md) | Package probe artifacts with recipe-driven redaction |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues |
 
 ## Repository Layout

--- a/docs/probe-188/bundle.md
+++ b/docs/probe-188/bundle.md
@@ -4,12 +4,10 @@
 > This command is the prerequisite for `aorta probe` Phase 3 (issue #188).
 
 `aorta bundle` packages a probe run directory into a single
-shareable tarball, applying recipe-specified redaction along the way.
-It does **not** ship its own scrubbers; that work lives in
-`aorta.probe.redaction` (Phase 3 of #188). Until Phase 3 lands the
-bundle command runs with the built-in `IdentityRedactor` — every
-file is copied byte-for-byte and the per-file redaction counts in
-the manifest are zero.
+shareable tarball, applying recipe-specified redaction via
+`aorta.probe.redaction.RedactingRedactor` when the recipe (or
+`<run-dir>/recipe.resolved.yaml`) includes a `redaction:` block.
+Otherwise the built-in `IdentityRedactor` copies bytes through.
 
 ## CLI
 
@@ -34,7 +32,7 @@ streamed through the redactor and copied into the staging tree.
 | `--ticket TICKET`     | inferred from `<run-dir>` basename           | Cross-check against the probe artifact tree; required when the basename is `_no_ticket_`.       |
 | `--review`            | off                                          | Print the manifest summary and pause for `[y/N]` confirmation before writing the tarball.       |
 | `--output PATH`       | `./<safe_slug(ticket)>-<UTC-timestamp>.tar.gz` | Where to write the bundle tarball. An *existing* directory drops the default filename inside it; any other PATH is used verbatim as the tarball filename. The ticket is slugified for filesystem safety (spaces/slashes → `_`). |
-| `--redaction-from F`  | (none today)                                 | Recipe to read the `redaction:` block from. Phase 3 of #188 wires the actual scrubbers in and will add the auto-fallback to `<run-dir>/recipe.resolved.yaml`. Today an explicit path is required to log a redaction-from line at all; without it the bundle runs through the `IdentityRedactor`. |
+| `--redaction-from F`  | auto: `<run-dir>/recipe.resolved.yaml`       | Recipe whose `redaction:` block governs scrubbers. Explicit path overrides the auto-fallback. Without a `redaction:` block, `IdentityRedactor` runs (no scrubbing). |
 
 ### Ticket resolution
 
@@ -108,11 +106,8 @@ unpacking the whole tree.
 * `path` is **relative to `<bundle-name>/`** (matches the path the
   reader gets after `tar -xzf ...`). Forward slashes regardless of
   host OS.
-* `redaction_applied` is `false` while the only redactor is
-  `IdentityRedactor` (the default until #188 Phase 3 ships).
-* `redactor_kind` is a stable string identifier the redactor
-  reports (currently `"identity"`; #188 Phase 3 will register e.g.
-  `"probe.v1"`).
+* `redaction_applied` is `true` when any file had non-zero env/path/ip counts.
+* `redactor_kind` is `"identity"` (no scrubbing) or `"probe.v1"` (Phase 3 redactor).
 * `source_run_dir` records **only the leaf directory name** (the
   per-ticket segment), never the operator's absolute path. A bundle
   is a shareable artifact, so the full path is deliberately withheld
@@ -151,11 +146,10 @@ def scrub_file(self, src: Path, dst: Path) -> RedactionCounts: ...
   plus `bytes_in` / `bytes_out`.
 
 The default `IdentityRedactor` calls `shutil.copyfile(src, dst)`
-and returns zeros. `aorta.probe.redaction` (Phase 3 of #188) will
-ship a `RedactingRedactor` that the bundle CLI can pick up via the
-`--redaction-from` flag once that module lands. **`aorta bundle`
-does not own the scrubbers** — the issue #196 contract is
-explicit on this.
+and returns zeros. `RedactingRedactor` in `aorta.probe.redaction`
+implements the scrubbers described in [`redaction.md`](redaction.md).
+**`aorta bundle` does not own the scrubber logic** — it only invokes
+the `Redactor` protocol.
 
 ## Originals are never modified
 
@@ -184,7 +178,6 @@ see a clean error message instead of a Python traceback.
 * Network upload of bundles.
 * Bundle decryption / unpacking utilities.
 * Auto-detection of secrets beyond what the recipe's `redaction:`
-  block specifies — Phase 3 of #188 owns that policy.
-* Implementing `aorta.probe.redaction` itself. Until that module
-  lands, the redactor is the no-op `IdentityRedactor` and the
-  manifest's per-file counts are zero.
+  block specifies — see [`redaction.md`](redaction.md).
+* Re-implementing scrubbers inside `aorta.bundle` (they live in
+  `aorta.probe.redaction`).

--- a/docs/probe-188/classifier.md
+++ b/docs/probe-188/classifier.md
@@ -205,6 +205,9 @@ Implemented in `src/aorta/probe/classifier/verdict.py::resolve`.
   "capture": {string: (string | float | int)},
   "tier_durations_ms": {"tier1": float, "tier2": float, "tier3": float, "tier4": float, "tier5": float},
 
+  // Phase 3: cell env bundle (scrubbed by aorta bundle redaction):
+  "env": {string: string},
+
   // Phase 1 keys still present (subset of Phase 2 shape):
   "env_passthrough_mode": "inherit" | "file",
   "timed_out": bool

--- a/docs/probe-188/handout-templates.md
+++ b/docs/probe-188/handout-templates.md
@@ -1,0 +1,55 @@
+# Probe handout templates
+
+Generic `mode: probe` recipes for customer-facing handouts. Each template ships
+with a `redaction:` block so `aorta bundle` can produce a shareable tarball
+without manual scrubbing.
+
+## When to use which template
+
+| Template | Customer launch pattern | Example trailing argv |
+|---|---|---|
+| [`probe-template-torchrun.yaml`](../../recipes/probe-template-torchrun.yaml) | PyTorch distributed / `torchrun` | `torchrun --nproc_per_node=8 train.py --config cfg.yaml` |
+| [`probe-template-buck2.yaml`](../../recipes/probe-template-buck2.yaml) | Buck2 monorepo targets | `buck2 run //models:train -- --steps 1000` |
+| [`probe-template-bash.yaml`](../../recipes/probe-template-bash.yaml) | Shell script / Makefile wrapper | `bash launch.sh --profile production` |
+
+All three templates use a 2×2 mitigation × diagnostic matrix (`none` /
+`tf32_off` × `none` / `xnack`), three trials, and a 30-minute
+`timeout_per_trial` (1800 seconds).
+
+## Workflow
+
+1. Copy or symlink the template; set `ticket:` to the customer's ticket id.
+2. Run probe (customer prepends `aorta probe`, keeps their argv after `--`):
+
+   ```bash
+   aorta probe --recipe recipes/probe-template-bash.yaml \
+       --output ./probe-out --ticket TICKET-1234 -- \
+       bash launch.sh
+   ```
+
+3. Dry-run first when validating the recipe on your side:
+
+   ```bash
+   aorta probe --recipe recipes/probe-template-bash.yaml --dry-run -- echo hi
+   ```
+
+4. After the matrix completes, bundle the ticket leaf:
+
+   ```bash
+   aorta bundle ./probe-out/TICKET-1234/ --review
+   ```
+
+   Redaction is loaded automatically from `./probe-out/TICKET-1234/recipe.resolved.yaml`
+   when that file contains a `redaction:` block (the runner writes it during
+   `aorta probe`).
+
+5. Share the resulting `<ticket>-<timestamp>.tar.gz` with AMD support.
+
+## Customising axes
+
+Replace `mitigation_axis` / `diagnostic_axis` entries with any names registered
+in `aorta.registry` (run `aorta mitigations list` on your host). The template
+defaults use only mitigations present in the public registry snapshot.
+
+See [`redaction.md`](redaction.md) for scrubber semantics and
+[`usage.md`](usage.md) for env-passthrough and artifact layout.

--- a/docs/probe-188/redaction.md
+++ b/docs/probe-188/redaction.md
@@ -1,0 +1,101 @@
+# Redaction engine (`aorta.probe.redaction`)
+
+> Issue [#188 Phase 3](https://github.com/ROCm/aorta/issues/188). Consumed by
+> [`aorta bundle`](bundle.md) via the `Redactor` ABC.
+
+The redaction engine scrubs probe artifacts **before** they land in a shareable
+bundle tarball. Scrubbing always operates on **copies** staged under a
+temporary directory; the original `<probe-output>/<ticket>/` tree is never
+modified.
+
+## Recipe block
+
+Probe-mode recipes may include:
+
+```yaml
+redaction:
+  scrub_env_keys: ["AWS_*", "GCP_*", "*_TOKEN", "*_KEY", "USER", "HOME"]
+  scrub_paths: true
+  scrub_ip_addresses: true
+```
+
+| Key | Type | Effect |
+|---|---|---|
+| `scrub_env_keys` | `list[str]` | Remove env keys matching any glob (case-sensitive `fnmatch`) |
+| `scrub_paths` | `bool` | Rewrite absolute POSIX paths to `<PATH:N>` |
+| `scrub_ip_addresses` | `bool` | Rewrite IPv4/IPv6 to `<IPV4:N>` / `<IPV6:N>` |
+
+Unknown keys under `redaction:` are rejected at recipe load time.
+
+## Where each scrubber runs
+
+| Artifact | Env keys | Paths | IPs |
+|---|---|---|---|
+| `result.json` (`env`, `argv`, `capture`, string leaves) | yes | yes | yes |
+| `probe.env` | yes | no | no |
+| `host_env.json` (`env` block) | yes | yes | yes |
+| `stdout.log`, `stderr.log`, `matrix.md`, `recipe.resolved.yaml`, other text | no | yes | yes |
+| Binary / unknown extensions | no | no | no (byte copy) |
+
+### `result.json::env`
+
+Phase 3 adds an `env: {}` block to every probe trial's `result.json` recording
+the cell's resolved mitigation + diagnostic env bundle. This is the canonical
+env snapshot for bundling — it is scrubbed with `scrub_env_keys` before the
+bundle is written.
+
+## Placeholder semantics
+
+* **Paths:** `/(?:[A-Za-z0-9_.\-]+/)+[A-Za-z0-9_.\-]+` → `<PATH:N>`. The index
+  `N` deduplicates within a single file (restarts per bundled file). **No reverse
+  mapping** from `<PATH:N>` back to the original path is written anywhere.
+* **IPv4:** validated with `ipaddress.ip_address` before rewrite → `<IPV4:N>`.
+* **IPv6:** coarse scan + `ipaddress` validation → `<IPV6:N>`.
+* IPv4 and IPv6 counters are summed into the manifest's `ips_rewritten` field.
+
+## DoS bound
+
+Text scrubbers process input in `MAX_LOG_BYTES` (10 MiB) windows — the same
+cap used by the Phase 2 classifier sandbox. A hostile log cannot force unbounded
+regex work per file.
+
+## Bundle integration
+
+`aorta bundle` resolves the recipe via:
+
+1. `--redaction-from <recipe>` when passed, else
+2. `<run-dir>/recipe.resolved.yaml` when present.
+
+When the resolved recipe has no `redaction:` block, `IdentityRedactor` copies
+bytes through (zero counts in `manifest.json`).
+
+When a block is present, `RedactingRedactor` (`redactor_kind: "probe.v1"`) runs
+and `manifest.json` records per-file counts:
+
+```json
+{
+  "path": "none-none/trial_0/stdout.log",
+  "env_keys_removed": 0,
+  "paths_rewritten": 3,
+  "ips_rewritten": 2,
+  "bytes_in": 12345,
+  "bytes_out": 12200
+}
+```
+
+See [`bundle.md`](bundle.md) for the full manifest schema.
+
+## Security review
+
+> **Sign-off block (Open Question #1 from issue #188):**
+>
+> Redaction semantics in this document MUST be reviewed by a security owner
+> outside the AORTA team before external customers run `aorta bundle` on
+> real probe artifacts. Recommended reviewer: issue author (`@oyazdanb`) or
+> their designated security delegate.
+>
+> Review checklist:
+> - [ ] Env-key glob list is recipe-authoritative (no auto-detect heuristics).
+> - [ ] Path/IP placeholders carry no reverse mapping.
+> - [ ] Original probe tree is never modified in place.
+> - [ ] `condition` sandbox (Phase 2) and redaction engine (Phase 3) reviewed together.

--- a/docs/probe-188/redaction.md
+++ b/docs/probe-188/redaction.md
@@ -50,7 +50,10 @@ bundle is written.
   `N` deduplicates within a single file (restarts per bundled file). **No reverse
   mapping** from `<PATH:N>` back to the original path is written anywhere.
 * **IPv4:** validated with `ipaddress.ip_address` before rewrite → `<IPV4:N>`.
-* **IPv6:** coarse scan + `ipaddress` validation → `<IPV6:N>`.
+* **IPv6:** bracketed literals (`[::1]`, `[2001:db8::1]`) and compressed
+  unbracketed forms (`::1`, `fe80::1`) are matched without relying on word
+  boundaries; each candidate is validated with `ipaddress` before rewrite →
+  `<IPV6:N>`.
 * IPv4 and IPv6 counters are summed into the manifest's `ips_rewritten` field.
 
 ## DoS bound

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -1,14 +1,12 @@
-# `aorta probe` — Usage Walkthrough (issue #188, Phases 1+2)
+# `aorta probe` — Usage Walkthrough (issue #188, Phases 1–3)
 
 > **Phase 1 (Tier 1 only)**: verdict is `exit_code == 0 ? "pass" : "fail"`.
-> **Phase 2 (this walkthrough)**: five-tier classifier (`tier1:` process,
-> `tier2:` hang, `tier3:` kernel + GPU, `tier4:` built-in pattern library,
-> `custom:` user patterns), plus a sandboxed `condition:` evaluator for
-> custom patterns and a `--list-patterns` flag. No bundling /
-> redaction in this phase — see §3 of the rubric.
+> **Phase 2**: five-tier classifier + `custom_patterns` + `--list-patterns`.
+> **Phase 3 (this section)**: `redaction:` recipe block, `aorta bundle`,
+> handout templates — see [redaction.md](redaction.md) and [bundle.md](bundle.md).
 >
-> See [classifier.md](classifier.md) for the full detector-ID reference
-> and [sandbox.md](sandbox.md) for the `condition` whitelist.
+> See [classifier.md](classifier.md) for detector IDs and [sandbox.md](sandbox.md)
+> for the `condition` whitelist.
 
 `aorta probe` runs an **opaque user launch command** across the
 cartesian product of a **mitigation axis × diagnostic axis**, in an
@@ -230,3 +228,37 @@ flag short-circuits before recipe loading.
 `aorta.triage.runner.run_recipe` — there is no parallel runner. The
 shared-engine contract is pinned by
 `tests/probe/test_shared_engine.py`.
+
+## 9. Redaction + bundle (Phase 3)
+
+After a probe run completes, package the ticket leaf for sharing:
+
+```bash
+aorta bundle ./probe_results/ROCM-1234/ --review
+```
+
+* Redaction policy comes from the recipe's `redaction:` block.
+* When `--redaction-from` is omitted, `aorta bundle` auto-loads
+  `./probe_results/ROCM-1234/recipe.resolved.yaml` when present.
+* Without a `redaction:` block, files are copied byte-for-byte
+  (`IdentityRedactor`, zero counts in `manifest.json`).
+
+### `result.json::env`
+
+Every trial's `result.json` includes an `env` object with the cell's
+resolved mitigation + diagnostic env bundle. The bundle scrubber removes
+keys matching `scrub_env_keys` from that block (and from `probe.env` /
+`host_env.json`).
+
+Example minimal `redaction:` block:
+
+```yaml
+redaction:
+  scrub_env_keys: ["AWS_*", "*_TOKEN", "USER", "HOME"]
+  scrub_paths: true
+  scrub_ip_addresses: true
+```
+
+Handout templates: [handout-templates.md](handout-templates.md).
+Scrubber reference: [redaction.md](redaction.md).
+Bundle CLI reference: [bundle.md](bundle.md).

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -254,3 +254,23 @@ axis, e.g. `--environment-axis local,image:rocm/pytorch:nightly`. Each
 comma-separated item is parsed independently; bare names go through the
 registry, `image:<ref>` maps to the same `{ docker: <ref> }` shorthand as
 recipe mode.
+
+## Probe handout templates (issue #188 Phase 3)
+
+Generic ``mode: probe`` recipes for customer handouts. Each template
+includes a ``redaction:`` block consumed by ``aorta bundle`` when
+packaging artifacts for sharing.
+
+| Template | Typical trailing argv |
+|---|---|
+| `probe-template-torchrun.yaml` | `torchrun --nproc_per_node=N train.py ...` |
+| `probe-template-buck2.yaml` | `buck2 run //path:target -- ...` |
+| `probe-template-bash.yaml` | `bash launch.sh ...` |
+
+Dry-run smoke:
+
+```
+aorta probe --recipe recipes/probe-template-bash.yaml --dry-run -- echo hi
+```
+
+See `docs/probe-188/handout-templates.md` for per-template walkthroughs.

--- a/recipes/probe-template-bash.yaml
+++ b/recipes/probe-template-bash.yaml
@@ -1,0 +1,26 @@
+# Generic probe handout template for bash / shell-script launches.
+# Usage:
+#   aorta probe --recipe recipes/probe-template-bash.yaml \
+#       --output ./probe-out --ticket TICKET-1234 -- \
+#       bash launch.sh --extra-args
+schema_version: 1
+mode: probe
+ticket: TICKET-1234
+trials: 3
+timeout_per_trial: 1800
+
+mitigation_axis: [none, tf32_off]
+diagnostic_axis: [none, xnack]
+
+collect_paths:
+  - ${AORTA_ARTIFACT_DIR}/stdout.log
+  - ${AORTA_ARTIFACT_DIR}/stderr.log
+
+confound:
+  threshold: 1.15
+  baseline_cell: none-none
+
+redaction:
+  scrub_env_keys: ["AWS_*", "GCP_*", "*_TOKEN", "*_KEY", "USER", "HOME"]
+  scrub_paths: true
+  scrub_ip_addresses: true

--- a/recipes/probe-template-buck2.yaml
+++ b/recipes/probe-template-buck2.yaml
@@ -1,0 +1,26 @@
+# Generic probe handout template for buck2 run-style launches.
+# Usage:
+#   aorta probe --recipe recipes/probe-template-buck2.yaml \
+#       --output ./probe-out --ticket TICKET-1234 -- \
+#       buck2 run //path/to:target -- --flag value
+schema_version: 1
+mode: probe
+ticket: TICKET-1234
+trials: 3
+timeout_per_trial: 1800
+
+mitigation_axis: [none, tf32_off]
+diagnostic_axis: [none, xnack]
+
+collect_paths:
+  - ${AORTA_ARTIFACT_DIR}/stdout.log
+  - ${AORTA_ARTIFACT_DIR}/stderr.log
+
+confound:
+  threshold: 1.15
+  baseline_cell: none-none
+
+redaction:
+  scrub_env_keys: ["AWS_*", "GCP_*", "*_TOKEN", "*_KEY", "USER", "HOME"]
+  scrub_paths: true
+  scrub_ip_addresses: true

--- a/recipes/probe-template-torchrun.yaml
+++ b/recipes/probe-template-torchrun.yaml
@@ -1,0 +1,26 @@
+# Generic probe handout template for torchrun-style launches.
+# Usage:
+#   aorta probe --recipe recipes/probe-template-torchrun.yaml \
+#       --output ./probe-out --ticket TICKET-1234 -- \
+#       torchrun --nproc_per_node=8 train.py --config configs/default.yaml
+schema_version: 1
+mode: probe
+ticket: TICKET-1234
+trials: 3
+timeout_per_trial: 1800
+
+mitigation_axis: [none, tf32_off]
+diagnostic_axis: [none, xnack]
+
+collect_paths:
+  - ${AORTA_ARTIFACT_DIR}/stdout.log
+  - ${AORTA_ARTIFACT_DIR}/stderr.log
+
+confound:
+  threshold: 1.15
+  baseline_cell: none-none
+
+redaction:
+  scrub_env_keys: ["AWS_*", "GCP_*", "*_TOKEN", "*_KEY", "USER", "HOME"]
+  scrub_paths: true
+  scrub_ip_addresses: true

--- a/src/aorta/bundle/errors.py
+++ b/src/aorta/bundle/errors.py
@@ -148,3 +148,30 @@ class BundleIOError(BundleError):
             "any existing file at the output path was left untouched (the "
             "atomic write only replaces it on success)."
         )
+
+
+class RedactionError(BundleError):
+    """Raised when a redactor cannot guarantee an artifact was scrubbed.
+
+    A :class:`~aorta.bundle.redactor.Redactor` that parses structured
+    artifacts (``result.json``, ``host_env.json``) must fail *closed*
+    when the artifact is corrupted/truncated: a raw
+    ``json.JSONDecodeError`` would otherwise escape staging as an
+    unhandled traceback, and -- worse -- partial parsing could let an
+    unredacted artifact through. Failing with a typed ``BundleError``
+    means the CLI shim renders a clean message and no bundle is written
+    when scrubbing cannot be guaranteed.
+
+    Carries the offending ``path`` and the underlying ``cause`` so the
+    operator can name the bad file and tests can assert on the fields
+    instead of substring-matching the rendered message.
+    """
+
+    def __init__(self, path: Path, cause: Exception) -> None:
+        self.path = path
+        self.cause = cause
+        super().__init__(
+            f"aorta bundle: cannot redact {path}: {type(cause).__name__}: "
+            f"{cause}. Refusing to write a bundle whose scrubbing is not "
+            "guaranteed -- fix or remove the corrupted artifact and re-run."
+        )

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -414,7 +414,6 @@ def bundle_run_dir(
     *,
     ticket: str | None = None,
     output: Path | None = None,
-    redaction_from: Path | None = None,
     redactor: Redactor | None = None,
     review_callback: Callable[[Manifest], bool] | None = None,
     now: _dt.datetime | None = None,
@@ -434,18 +433,11 @@ def bundle_run_dir(
             :class:`NoTicketError` when no override is supplied.
         output: Where to write the tarball; defaults to
             ``./<bundle-name>.tar.gz``.
-        redaction_from: Recipe path to load the ``redaction:``
-            block from. Until Phase 3 of issue #188 ships
-            ``aorta.probe.redaction``, the parameter is recorded in
-            log output but NOT consumed -- the redactor stays
-            :class:`IdentityRedactor`. The function signature is
-            ready for #188 to wire the real loader in; that loader
-            will own the ``<run-dir>/recipe.resolved.yaml`` fallback
-            when it ships (today there is no fallback -- explicit
-            paths only).
-        redactor: Override the default :class:`IdentityRedactor`
-            (test injection point + Phase 3 of #188 hand-off
-            point).
+        redactor: Redactor implementation. Defaults to
+            :class:`IdentityRedactor`. The CLI resolves a
+            :class:`~aorta.probe.redaction.RedactingRedactor` from
+            ``--redaction-from`` / ``recipe.resolved.yaml`` before
+            calling this function.
         review_callback: Called with the staged :class:`Manifest`
             right before the tarball is written. Return ``True``
             to proceed, ``False`` to abort. Aborting raises
@@ -460,19 +452,6 @@ def bundle_run_dir(
     run_dir = run_dir.resolve()
     _validate_run_dir(run_dir)
     resolved_ticket = resolve_ticket(run_dir, ticket)
-
-    if redaction_from is not None:
-        # Phase 3 of #188 will read the recipe's ``redaction:`` block
-        # here and instantiate ``aorta.probe.redaction.RedactingRedactor``.
-        # Until then we honor the flag's existence (operator can wire
-        # it through pipelines today) but log that the scrubbers are
-        # not yet active.
-        log.info(
-            "aorta bundle: --redaction-from %s ignored: "
-            "aorta.probe.redaction is gated on issue #188 Phase 3 "
-            "and the bundle will be written with the IdentityRedactor.",
-            redaction_from,
-        )
 
     effective_redactor = redactor if redactor is not None else IdentityRedactor()
     bundle_name = f"{safe_slug(resolved_ticket)}-{_bundle_timestamp(now)}"

--- a/src/aorta/cli/bundle.py
+++ b/src/aorta/cli/bundle.py
@@ -26,6 +26,7 @@ from aorta.bundle import (
     Manifest,
     bundle_run_dir,
 )
+from aorta.probe.bundle_hook import build_redactor_from_recipe
 
 
 def _render_review_summary(manifest: Manifest) -> str:
@@ -110,13 +111,9 @@ def _render_review_summary(manifest: Manifest) -> str:
     default=None,
     help=(
         "Recipe whose 'redaction:' block governs scrubber behaviour. "
-        "NOTE: until 'aorta probe' Phase 3 (issue #188) ships "
-        "'aorta.probe.redaction', this flag is logged but not yet "
-        "consumed -- bundles run with the IdentityRedactor (no "
-        "scrubbing, zero per-file counts). Phase 3 will also add "
-        "the auto-fallback to '<run-dir>/recipe.resolved.yaml' "
-        "when this flag is omitted; today an explicit path is "
-        "required to log a redaction-from line at all."
+        "When omitted, falls back to '<run-dir>/recipe.resolved.yaml' "
+        "when that file exists. If neither path yields a redaction: "
+        "block, the bundle runs with IdentityRedactor (no scrubbing)."
     ),
 )
 def bundle(
@@ -133,11 +130,12 @@ def bundle(
     """
     review_callback = (lambda manifest: _prompt_review(manifest)) if review else None
     try:
+        redactor = build_redactor_from_recipe(redaction_from, run_dir)
         path = bundle_run_dir(
             run_dir,
             ticket=ticket,
             output=output,
-            redaction_from=redaction_from,
+            redactor=redactor,
             review_callback=review_callback,
         )
     except BundleAbortedError as exc:

--- a/src/aorta/cli/bundle.py
+++ b/src/aorta/cli/bundle.py
@@ -27,6 +27,7 @@ from aorta.bundle import (
     bundle_run_dir,
 )
 from aorta.probe.bundle_hook import build_redactor_from_recipe
+from aorta.triage.recipe import RecipeCellError, RecipeSchemaError
 
 
 def _render_review_summary(manifest: Manifest) -> str:
@@ -145,6 +146,12 @@ def bundle(
         # cluttering the abort message.
         click.echo(str(exc), err=True)
         raise click.exceptions.Exit(1) from exc
+    except (RecipeSchemaError, RecipeCellError) as exc:
+        # build_redactor_from_recipe parses the recipe's redaction: block;
+        # a malformed block raises a recipe error (a ValueError, not a
+        # BundleError). Render it as a clean CLI error rather than letting
+        # it escape as a traceback.
+        raise click.ClickException(f"aorta bundle: {exc}") from exc
     except BundleError as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(f"Wrote bundle to {path}")

--- a/src/aorta/probe/__init__.py
+++ b/src/aorta/probe/__init__.py
@@ -12,25 +12,29 @@ Phase 1 (issue #188) shipped the MVP:
 * re-running with the same ``--output`` skips cells whose
   ``result.json`` is valid and carries a non-empty ``verdict``.
 
-Phase 2 has shipped on top of Phase 1: the five-tier classifier lives
-in :mod:`aorta.probe.classifier` and the AST-whitelisted ``condition``
-evaluator in :mod:`aorta.probe.sandbox`. ``custom_patterns`` are
-compiled at recipe-load time and resolved post-exit by the workload;
-detector IDs land in ``result.json::failure_detectors_fired`` /
-``warn_detectors_fired``.
+Phase 2: five-tier classifier in :mod:`aorta.probe.classifier` and the
+AST-whitelisted ``condition`` evaluator in :mod:`aorta.probe.sandbox`.
 
-Phase 3 (``aorta bundle`` integration + redaction + handout templates)
-is tracked separately (issue #196) and is NOT yet implemented.
+Phase 3: redaction scrubbers in :mod:`aorta.probe.redaction`, bundle
+integration via :mod:`aorta.probe.bundle_hook`, and handout templates
+under ``recipes/probe-template-*.yaml``.
 """
 
+from aorta.probe.bundle_hook import build_redactor_from_recipe, load_redaction_cfg
 from aorta.probe.recipe_builder import (
     ProbeExtras,
     build_probe_recipe_from_dict,
 )
+from aorta.probe.redaction import RedactingRedactor, RedactionCfg, parse_redaction
 from aorta.probe.resume import is_trial_complete
 
 __all__ = [
     "ProbeExtras",
+    "RedactionCfg",
+    "RedactingRedactor",
     "build_probe_recipe_from_dict",
+    "build_redactor_from_recipe",
     "is_trial_complete",
+    "load_redaction_cfg",
+    "parse_redaction",
 ]

--- a/src/aorta/probe/bundle_hook.py
+++ b/src/aorta/probe/bundle_hook.py
@@ -1,0 +1,74 @@
+"""Adapter between probe-mode recipes and ``aorta bundle`` (issue #188 Phase 3).
+
+Resolves the ``redaction:`` block from a probe recipe and constructs the
+:class:`~aorta.probe.redaction.RedactingRedactor` the bundle writer expects.
+When no ``redaction:`` block is present, returns
+:class:`~aorta.bundle.redactor.IdentityRedactor`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from aorta.bundle.redactor import IdentityRedactor, Redactor
+from aorta.probe.redaction import RedactingRedactor, RedactionCfg
+from aorta.triage.recipe import load_recipe
+
+log = logging.getLogger(__name__)
+
+_RECIPE_RESOLVED_NAME = "recipe.resolved.yaml"
+
+
+def load_redaction_cfg(recipe_path: Path) -> RedactionCfg | None:
+    """Load ``redaction:`` from a probe-mode recipe file."""
+    recipe = load_recipe(recipe_path)
+    if recipe.probe_extras is None or recipe.probe_extras.redaction is None:
+        return None
+    cfg: RedactionCfg = recipe.probe_extras.redaction
+    return cfg
+
+
+def build_redactor_from_recipe(
+    recipe_path: Path | None,
+    run_dir: Path,
+) -> Redactor:
+    """Resolve recipe path and return the appropriate :class:`Redactor`.
+
+    Precedence:
+
+    1. Explicit ``--redaction-from`` path when provided.
+    2. ``<run-dir>/recipe.resolved.yaml`` when present.
+    3. :class:`IdentityRedactor` when neither yields a ``redaction:`` block.
+    """
+    resolved_path: Path | None = None
+    if recipe_path is not None:
+        resolved_path = recipe_path
+    else:
+        fallback = run_dir / _RECIPE_RESOLVED_NAME
+        if fallback.is_file():
+            resolved_path = fallback
+            log.info(
+                "aorta bundle: using redaction recipe fallback %s",
+                fallback,
+            )
+
+    if resolved_path is None:
+        return IdentityRedactor()
+
+    cfg = load_redaction_cfg(resolved_path)
+    if cfg is None:
+        log.info(
+            "aorta bundle: recipe %s has no redaction: block; "
+            "using IdentityRedactor",
+            resolved_path,
+        )
+        return IdentityRedactor()
+
+    return RedactingRedactor(cfg)
+
+
+__all__ = [
+    "build_redactor_from_recipe",
+    "load_redaction_cfg",
+]

--- a/src/aorta/probe/bundle_hook.py
+++ b/src/aorta/probe/bundle_hook.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from aorta.bundle.redactor import IdentityRedactor, Redactor
 from aorta.probe.redaction import RedactingRedactor, RedactionCfg, parse_redaction
-from aorta.triage.recipe import load_recipe_mapping
+from aorta.triage.recipe import RecipeSchemaError, load_recipe_mapping
 
 log = logging.getLogger(__name__)
 
@@ -33,13 +33,22 @@ def load_redaction_cfg(recipe_path: Path) -> RedactionCfg | None:
     paths to thread back in). Parsing the block directly decouples the
     bundle redaction-resolve from recipe axis validity.
 
-    Returns ``None`` when the file has no ``redaction:`` key. An explicit
-    ``redaction: null`` is rejected by :func:`parse_redaction` (a null
-    block is invalid, not "no redaction"), matching the probe recipe
-    builder.
+    Returns ``None`` only when a *valid* recipe mapping has no ``redaction:``
+    key. A file that does not parse to a mapping at all (empty file, list, or
+    scalar -- i.e. a corrupted recipe / ``--redaction-from`` target) raises
+    :class:`~aorta.triage.recipe.RecipeSchemaError` rather than silently
+    returning ``None``: failing open there would emit an unredacted bundle the
+    operator believed was scrubbed. An explicit ``redaction: null`` is likewise
+    rejected by :func:`parse_redaction` (a null block is invalid, not "no
+    redaction"), matching the probe recipe builder.
     """
     data = load_recipe_mapping(recipe_path)
-    if not isinstance(data, dict) or "redaction" not in data:
+    if not isinstance(data, dict):
+        raise RecipeSchemaError(
+            f"recipe {recipe_path}: expected a top-level mapping, got "
+            f"{type(data).__name__}; refusing to fall back to no redaction"
+        )
+    if "redaction" not in data:
         return None
     return parse_redaction(data["redaction"])
 

--- a/src/aorta/probe/bundle_hook.py
+++ b/src/aorta/probe/bundle_hook.py
@@ -12,8 +12,8 @@ import logging
 from pathlib import Path
 
 from aorta.bundle.redactor import IdentityRedactor, Redactor
-from aorta.probe.redaction import RedactingRedactor, RedactionCfg
-from aorta.triage.recipe import load_recipe
+from aorta.probe.redaction import RedactingRedactor, RedactionCfg, parse_redaction
+from aorta.triage.recipe import load_recipe_mapping
 
 log = logging.getLogger(__name__)
 
@@ -21,12 +21,27 @@ _RECIPE_RESOLVED_NAME = "recipe.resolved.yaml"
 
 
 def load_redaction_cfg(recipe_path: Path) -> RedactionCfg | None:
-    """Load ``redaction:`` from a probe-mode recipe file."""
-    recipe = load_recipe(recipe_path)
-    if recipe.probe_extras is None or recipe.probe_extras.redaction is None:
+    """Parse only the ``redaction:`` block from a recipe file.
+
+    Bundling needs nothing but the ``redaction:`` mapping, so this parses
+    just that key (via :func:`~aorta.triage.recipe.load_recipe_mapping`)
+    rather than running the full recipe loader. A full
+    :func:`~aorta.triage.recipe.load_recipe` resolves the mitigation /
+    diagnostic axes against the registry, which fails for a perfectly
+    valid probe run whose recipe referenced sidecar-defined mitigations or
+    environments (the ``recipe.resolved.yaml`` fallback has no sidecar
+    paths to thread back in). Parsing the block directly decouples the
+    bundle redaction-resolve from recipe axis validity.
+
+    Returns ``None`` when the file has no ``redaction:`` key. An explicit
+    ``redaction: null`` is rejected by :func:`parse_redaction` (a null
+    block is invalid, not "no redaction"), matching the probe recipe
+    builder.
+    """
+    data = load_recipe_mapping(recipe_path)
+    if not isinstance(data, dict) or "redaction" not in data:
         return None
-    cfg: RedactionCfg = recipe.probe_extras.redaction
-    return cfg
+    return parse_redaction(data["redaction"])
 
 
 def build_redactor_from_recipe(

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -25,6 +25,7 @@ from aorta.probe.classifier.tier5_custom import (
     CompiledPattern,
     validate_custom_patterns,
 )
+from aorta.probe.redaction import RedactionCfg, parse_redaction
 from aorta.registry import get_mitigation
 from aorta.registry.errors import UnknownMitigationError
 from aorta.triage.recipe import (
@@ -112,6 +113,8 @@ class ProbeExtras:
     custom_patterns: tuple[CompiledPattern, ...] = ()
     hang_window_sec: float = DEFAULT_HANG_WINDOW_SEC
     hang_grace_period_at_start: float = DEFAULT_HANG_GRACE_SEC
+    # Phase 3 (issue #188): redaction block consumed by ``aorta bundle``.
+    redaction: RedactionCfg | None = None
 
 
 def _ensure_str_list(path_hint: str, raw: Any, *, allow_empty: bool = False) -> list[str]:
@@ -298,6 +301,8 @@ def build_probe_recipe_from_dict(
         default=DEFAULT_HANG_GRACE_SEC,
         allow_zero=True,
     )
+    redaction_raw = data.get("redaction")
+    redaction = parse_redaction(redaction_raw) if redaction_raw is not None else None
 
     # confound block is permitted (already in _PROBE_TOP_LEVEL) but
     # not meaningful for Tier-1-only Phase 1 -- pass it through with
@@ -420,6 +425,7 @@ def build_probe_recipe_from_dict(
         custom_patterns=custom_patterns,
         hang_window_sec=hang_window_sec,
         hang_grace_period_at_start=hang_grace_period_at_start,
+        redaction=redaction,
     )
 
     return Recipe(

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -301,8 +301,12 @@ def build_probe_recipe_from_dict(
         default=DEFAULT_HANG_GRACE_SEC,
         allow_zero=True,
     )
-    redaction_raw = data.get("redaction")
-    redaction = parse_redaction(redaction_raw) if redaction_raw is not None else None
+    # Use ``in`` rather than ``.get(...) is not None`` so an explicit
+    # ``redaction: null`` is treated as present-but-invalid (parse_redaction
+    # rejects None) instead of being silently conflated with "no redaction
+    # block" -- a null block should fail validation, not quietly disable
+    # scrubbing.
+    redaction = parse_redaction(data["redaction"]) if "redaction" in data else None
 
     # confound block is permitted (already in _PROBE_TOP_LEVEL) but
     # not meaningful for Tier-1-only Phase 1 -- pass it through with

--- a/src/aorta/probe/redaction.py
+++ b/src/aorta/probe/redaction.py
@@ -230,15 +230,33 @@ def _line_windows(text: str) -> list[str]:
       silent redaction miss). Paths/IPs never contain a line terminator, so
       breaking only *between* lines (``splitlines(keepends=True)``) keeps every
       token whole and ``"".join(...)`` reconstructs the input byte-for-byte.
-      A single line larger than the cap is emitted whole rather than split.
+
+    A single line whose own UTF-8 byte length exceeds the cap (e.g. a hostile
+    newline-free log) would otherwise be emitted as one over-cap window and
+    defeat the byte budget entirely, so it is hard-split into ``<= cap`` byte
+    chunks. Each chunk holds ``MAX_LOG_BYTES // 4`` code points, which is
+    ``<= MAX_LOG_BYTES`` bytes for any UTF-8 string (4 bytes/char max). A token
+    straddling such a hard-split seam may be missed -- an accepted cost for a
+    line that defeats line-based windowing by construction; correctness still
+    holds for every newline-terminated log.
     """
-    if len(text) <= MAX_LOG_BYTES // _MAX_UTF8_BYTES_PER_CHAR:
+    # max chars per window that is guaranteed <= MAX_LOG_BYTES UTF-8 bytes.
+    max_chars = max(1, MAX_LOG_BYTES // _MAX_UTF8_BYTES_PER_CHAR)
+    if len(text) <= max_chars:
         return [text]
     windows: list[str] = []
     buf: list[str] = []
     size = 0
     for line in text.splitlines(keepends=True):
         line_bytes = len(line.encode("utf-8"))
+        if line_bytes > MAX_LOG_BYTES:
+            if buf:
+                windows.append("".join(buf))
+                buf = []
+                size = 0
+            for i in range(0, len(line), max_chars):
+                windows.append(line[i : i + max_chars])
+            continue
         if buf and size + line_bytes > MAX_LOG_BYTES:
             windows.append("".join(buf))
             buf = []

--- a/src/aorta/probe/redaction.py
+++ b/src/aorta/probe/redaction.py
@@ -1,0 +1,403 @@
+"""Recipe-driven redaction scrubbers for ``aorta bundle`` (issue #188 Phase 3).
+
+Implements the three scrubbers documented in ``docs/probe-188/redaction.md``:
+
+* env-key glob removal (``fnmatch.fnmatchcase``),
+* absolute path rewriting to ``<PATH:N>``,
+* IPv4/IPv6 rewriting to ``<IPV4:N>`` / ``<IPV6:N>``.
+
+The :class:`RedactingRedactor` satisfies the :class:`aorta.bundle.redactor.Redactor`
+ABC so ``aorta bundle`` can inject it via ``bundle_run_dir(redactor=...)``.
+When a probe recipe omits the ``redaction:`` block, the bundle CLI falls
+back to :class:`aorta.bundle.redactor.IdentityRedactor`.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import ipaddress
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from aorta.bundle.redactor import RedactionCounts, Redactor
+from aorta.probe.sandbox import MAX_LOG_BYTES
+from aorta.triage.recipe import RecipeSchemaError
+
+# Path scrubber: absolute POSIX paths with at least one directory component.
+_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_./-])/(?:[A-Za-z0-9_.\-]+/)+[A-Za-z0-9_.\-]+"
+)
+
+# IPv4 candidate -- validated with :func:`ipaddress.ip_address` before rewrite.
+_IPV4_RE = re.compile(
+    r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b"
+)
+
+# IPv6 candidate -- coarse scan; only matches validated by ipaddress.
+_IPV6_CANDIDATE_RE = re.compile(r"\b(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b")
+
+_VALID_REDACTION_KEYS = frozenset({"scrub_env_keys", "scrub_paths", "scrub_ip_addresses"})
+
+_TEXT_SUFFIXES = frozenset({".log", ".md", ".yaml", ".yml", ".json", ".txt", ".env"})
+
+
+@dataclass(frozen=True)
+class RedactionCfg:
+    """Parsed ``redaction:`` block from a probe-mode recipe."""
+
+    scrub_env_keys: tuple[str, ...] = ()
+    scrub_paths: bool = False
+    scrub_ip_addresses: bool = False
+
+
+def parse_redaction(raw: Any) -> RedactionCfg:
+    """Validate and parse a recipe ``redaction:`` mapping."""
+    if raw is None:
+        raise RecipeSchemaError("recipe.redaction: must be a mapping when present")
+    if not isinstance(raw, dict):
+        raise RecipeSchemaError(
+            f"recipe.redaction: must be a mapping, got {type(raw).__name__}"
+        )
+    unknown = set(raw) - _VALID_REDACTION_KEYS
+    if unknown:
+        raise RecipeSchemaError(
+            f"recipe.redaction: unknown keys {sorted(unknown)}; "
+            f"allowed: {sorted(_VALID_REDACTION_KEYS)}"
+        )
+    keys_raw = raw.get("scrub_env_keys", [])
+    if not isinstance(keys_raw, list) or not all(isinstance(x, str) for x in keys_raw):
+        raise RecipeSchemaError(
+            "recipe.redaction.scrub_env_keys: must be a list[str], "
+            f"got {type(keys_raw).__name__}"
+        )
+    for flag_name in ("scrub_paths", "scrub_ip_addresses"):
+        flag_val = raw.get(flag_name, False)
+        if not isinstance(flag_val, bool):
+            raise RecipeSchemaError(
+                f"recipe.redaction.{flag_name}: must be a bool, got {type(flag_val).__name__}"
+            )
+    return RedactionCfg(
+        scrub_env_keys=tuple(keys_raw),
+        scrub_paths=bool(raw.get("scrub_paths", False)),
+        scrub_ip_addresses=bool(raw.get("scrub_ip_addresses", False)),
+    )
+
+
+def _key_matches_glob(key: str, globs: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatchcase(key, pattern) for pattern in globs)
+
+
+def scrub_env_keys(
+    env: dict[str, str],
+    globs: tuple[str, ...],
+) -> tuple[dict[str, str], int]:
+    """Remove env keys matching any glob pattern (case-sensitive)."""
+    if not globs:
+        return dict(env), 0
+    kept: dict[str, str] = {}
+    removed = 0
+    for key, value in env.items():
+        if _key_matches_glob(key, globs):
+            removed += 1
+        else:
+            kept[key] = value
+    return kept, removed
+
+
+class _PathIndex:
+    """Per-file deduplication index for ``<PATH:N>`` placeholders."""
+
+    def __init__(self) -> None:
+        self._seen: dict[str, int] = {}
+        self._next = 0
+        self.rewrites = 0
+
+    def replace(self, match: re.Match[str]) -> str:
+        path = match.group(0)
+        if path not in self._seen:
+            self._seen[path] = self._next
+            self._next += 1
+        self.rewrites += 1
+        return f"<PATH:{self._seen[path]}>"
+
+
+class _IpIndex:
+    """Per-file deduplication index for ``<IPV4:N>`` / ``<IPV6:N>`` placeholders."""
+
+    def __init__(self) -> None:
+        self._v4_seen: dict[str, int] = {}
+        self._v6_seen: dict[str, int] = {}
+        self._v4_next = 0
+        self._v6_next = 0
+        self.ipv4_rewrites = 0
+        self.ipv6_rewrites = 0
+
+    def _replace(self, ip_str: str, *, v4: bool) -> str:
+        if v4:
+            if ip_str not in self._v4_seen:
+                self._v4_seen[ip_str] = self._v4_next
+                self._v4_next += 1
+            self.ipv4_rewrites += 1
+            return f"<IPV4:{self._v4_seen[ip_str]}>"
+        if ip_str not in self._v6_seen:
+            self._v6_seen[ip_str] = self._v6_next
+            self._v6_next += 1
+        self.ipv6_rewrites += 1
+        return f"<IPV6:{self._v6_seen[ip_str]}>"
+
+
+def _scrub_paths_in_text(text: str, path_index: _PathIndex) -> str:
+    if not text:
+        return text
+    return _PATH_RE.sub(lambda m: path_index.replace(m), text)
+
+
+def _scrub_ips_in_text(text: str, ip_index: _IpIndex) -> str:
+    if not text:
+        return text
+
+    def _v6_sub(match: re.Match[str]) -> str:
+        candidate = match.group(0)
+        try:
+            addr = ipaddress.ip_address(candidate)
+        except ValueError:
+            return candidate
+        if addr.version != 6:
+            return candidate
+        return ip_index._replace(candidate, v4=False)
+
+    text = _IPV6_CANDIDATE_RE.sub(_v6_sub, text)
+
+    def _v4_sub(match: re.Match[str]) -> str:
+        candidate = match.group(0)
+        try:
+            addr = ipaddress.ip_address(candidate)
+        except ValueError:
+            return candidate
+        if addr.version != 4:
+            return candidate
+        return ip_index._replace(candidate, v4=True)
+
+    return _IPV4_RE.sub(_v4_sub, text)
+
+
+def scrub_text(
+    text: str,
+    *,
+    scrub_paths: bool,
+    scrub_ip_addresses: bool,
+) -> tuple[str, int, int, int]:
+    """Apply path + IP scrubbers to a text blob (per-file index scope).
+
+    Returns ``(text, paths_rewritten, ipv4_rewritten, ipv6_rewritten)``.
+    Large inputs are processed in ``MAX_LOG_BYTES`` windows so a hostile
+    log cannot blow regex CPU past the documented bound.
+    """
+    path_index = _PathIndex()
+    ip_index = _IpIndex()
+    if not scrub_paths and not scrub_ip_addresses:
+        return text, 0, 0, 0
+
+    if len(text) <= MAX_LOG_BYTES:
+        windows = [text]
+    else:
+        windows = [text[i : i + MAX_LOG_BYTES] for i in range(0, len(text), MAX_LOG_BYTES)]
+
+    out_parts: list[str] = []
+    for window in windows:
+        chunk = window
+        if scrub_paths:
+            chunk = _scrub_paths_in_text(chunk, path_index)
+        if scrub_ip_addresses:
+            chunk = _scrub_ips_in_text(chunk, ip_index)
+        out_parts.append(chunk)
+
+    return (
+        "".join(out_parts),
+        path_index.rewrites,
+        ip_index.ipv4_rewrites,
+        ip_index.ipv6_rewrites,
+    )
+
+
+def _scrub_json_value(
+    value: Any,
+    *,
+    cfg: RedactionCfg,
+    env_removed: list[int],
+) -> tuple[Any, int, int, int]:
+    if isinstance(value, dict):
+        total_p = total_v4 = total_v6 = 0
+        new_dict: dict[str, Any] = {}
+        for key, item in value.items():
+            if key == "env" and isinstance(item, dict):
+                scrubbed_env, removed = scrub_env_keys(
+                    {str(k): str(v) for k, v in item.items()},
+                    cfg.scrub_env_keys,
+                )
+                env_removed[0] += removed
+                new_dict[key] = scrubbed_env
+                continue
+            scrubbed, p, v4, v6 = _scrub_json_value(item, cfg=cfg, env_removed=env_removed)
+            new_dict[key] = scrubbed
+            total_p += p
+            total_v4 += v4
+            total_v6 += v6
+        return new_dict, total_p, total_v4, total_v6
+    if isinstance(value, list):
+        total_p = total_v4 = total_v6 = 0
+        new_list: list[Any] = []
+        for item in value:
+            scrubbed, p, v4, v6 = _scrub_json_value(item, cfg=cfg, env_removed=env_removed)
+            new_list.append(scrubbed)
+            total_p += p
+            total_v4 += v4
+            total_v6 += v6
+        return new_list, total_p, total_v4, total_v6
+    if isinstance(value, str):
+        text, paths, v4, v6 = scrub_text(
+            value,
+            scrub_paths=cfg.scrub_paths,
+            scrub_ip_addresses=cfg.scrub_ip_addresses,
+        )
+        return text, paths, v4, v6
+    return value, 0, 0, 0
+
+
+def _parse_probe_env(text: str) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        env[key] = value
+    return env
+
+
+def _format_probe_env(env: dict[str, str]) -> str:
+    return "\n".join(f"{k}={env[k]}" for k in sorted(env)) + ("\n" if env else "")
+
+
+def _is_text_artifact(path: Path) -> bool:
+    if path.name in {"probe.env", "stdout.log", "stderr.log", "matrix.md", "recipe.resolved.yaml"}:
+        return True
+    return path.suffix.lower() in _TEXT_SUFFIXES
+
+
+class RedactingRedactor(Redactor):
+    """Applies a probe recipe's ``redaction:`` block during bundling."""
+
+    kind = "probe.v1"
+
+    def __init__(self, cfg: RedactionCfg) -> None:
+        self._cfg = cfg
+
+    def scrub_file(self, src: Path, dst: Path) -> RedactionCounts:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        raw = src.read_bytes()
+        bytes_in = len(raw)
+
+        if src.name == "probe.env":
+            counts = self._scrub_probe_env(raw, dst)
+        elif src.name == "result.json":
+            counts = self._scrub_result_json(raw, dst)
+        elif src.name == "host_env.json":
+            counts = self._scrub_host_env_json(raw, dst)
+        elif _is_text_artifact(src):
+            counts = self._scrub_text_bytes(raw, dst)
+        else:
+            dst.write_bytes(raw)
+            counts = RedactionCounts(bytes_in=bytes_in, bytes_out=bytes_in)
+
+        return counts
+
+    def _scrub_probe_env(self, raw: bytes, dst: Path) -> RedactionCounts:
+        text = raw.decode("utf-8", errors="replace")
+        env = _parse_probe_env(text)
+        scrubbed, removed = scrub_env_keys(env, self._cfg.scrub_env_keys)
+        out = _format_probe_env(scrubbed)
+        dst.write_text(out, encoding="utf-8")
+        dst.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        out_bytes = out.encode("utf-8")
+        return RedactionCounts(
+            env_keys_removed=removed,
+            bytes_in=len(raw),
+            bytes_out=len(out_bytes),
+        )
+
+    def _scrub_result_json(self, raw: bytes, dst: Path) -> RedactionCounts:
+        text = raw.decode("utf-8", errors="replace")
+        doc = json.loads(text)
+        env_removed = [0]
+        scrubbed, paths, v4, v6 = _scrub_json_value(doc, cfg=self._cfg, env_removed=env_removed)
+        out = json.dumps(scrubbed, indent=2, sort_keys=False) + "\n"
+        dst.write_text(out, encoding="utf-8")
+        out_bytes = out.encode("utf-8")
+        return RedactionCounts(
+            env_keys_removed=env_removed[0],
+            paths_rewritten=paths,
+            ips_rewritten=v4 + v6,
+            bytes_in=len(raw),
+            bytes_out=len(out_bytes),
+        )
+
+    def _scrub_host_env_json(self, raw: bytes, dst: Path) -> RedactionCounts:
+        text = raw.decode("utf-8", errors="replace")
+        doc = json.loads(text)
+        env_removed = [0]
+        if isinstance(doc, dict) and "env" in doc and isinstance(doc["env"], dict):
+            scrubbed_env, removed = scrub_env_keys(
+                {str(k): str(v) for k, v in doc["env"].items()},
+                self._cfg.scrub_env_keys,
+            )
+            doc = {**doc, "env": scrubbed_env}
+            env_removed[0] += removed
+        out_text, paths, v4, v6 = scrub_text(
+            json.dumps(doc, indent=2, sort_keys=False),
+            scrub_paths=self._cfg.scrub_paths,
+            scrub_ip_addresses=self._cfg.scrub_ip_addresses,
+        )
+        dst.write_text(out_text + "\n", encoding="utf-8")
+        out_bytes = (out_text + "\n").encode("utf-8")
+        return RedactionCounts(
+            env_keys_removed=env_removed[0],
+            paths_rewritten=paths,
+            ips_rewritten=v4 + v6,
+            bytes_in=len(raw),
+            bytes_out=len(out_bytes),
+        )
+
+    def _scrub_text_bytes(self, raw: bytes, dst: Path) -> RedactionCounts:
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            dst.write_bytes(raw)
+            return RedactionCounts(bytes_in=len(raw), bytes_out=len(raw))
+        out, paths, v4, v6 = scrub_text(
+            text,
+            scrub_paths=self._cfg.scrub_paths,
+            scrub_ip_addresses=self._cfg.scrub_ip_addresses,
+        )
+        out_bytes = out.encode("utf-8")
+        dst.write_bytes(out_bytes)
+        return RedactionCounts(
+            paths_rewritten=paths,
+            ips_rewritten=v4 + v6,
+            bytes_in=len(raw),
+            bytes_out=len(out_bytes),
+        )
+
+
+__all__ = [
+    "RedactionCfg",
+    "RedactingRedactor",
+    "parse_redaction",
+    "scrub_env_keys",
+    "scrub_text",
+]

--- a/src/aorta/probe/redaction.py
+++ b/src/aorta/probe/redaction.py
@@ -19,6 +19,7 @@ import ipaddress
 import json
 import re
 import shutil
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -254,28 +255,39 @@ def _line_windows(text: str) -> list[str]:
     max_chars = max(1, MAX_LOG_BYTES // _MAX_UTF8_BYTES_PER_CHAR)
     if len(text) <= max_chars:
         return [text]
-    windows: list[str] = []
+    return list(_stream_line_windows(text.splitlines(keepends=True)))
+
+
+def _stream_line_windows(lines: Iterable[str]) -> Iterator[str]:
+    """Window an *iterable of lines* into ``<= MAX_LOG_BYTES`` byte chunks.
+
+    Same budget/no-split-token semantics as :func:`_line_windows`, but driven
+    off a line iterator so a caller streaming a large log off disk never
+    materialises the whole file. ``_line_windows`` is the in-memory adapter
+    (``str.splitlines(keepends=True)``); the streaming text path feeds a file
+    handle's lines straight in.
+    """
+    max_chars = max(1, MAX_LOG_BYTES // _MAX_UTF8_BYTES_PER_CHAR)
     buf: list[str] = []
     size = 0
-    for line in text.splitlines(keepends=True):
+    for line in lines:
         line_bytes = len(line.encode("utf-8"))
         if line_bytes > MAX_LOG_BYTES:
             if buf:
-                windows.append("".join(buf))
+                yield "".join(buf)
                 buf = []
                 size = 0
             for i in range(0, len(line), max_chars):
-                windows.append(line[i : i + max_chars])
+                yield line[i : i + max_chars]
             continue
         if buf and size + line_bytes > MAX_LOG_BYTES:
-            windows.append("".join(buf))
+            yield "".join(buf)
             buf = []
             size = 0
         buf.append(line)
         size += line_bytes
     if buf:
-        windows.append("".join(buf))
-    return windows
+        yield "".join(buf)
 
 
 def scrub_text(
@@ -294,25 +306,67 @@ def scrub_text(
     """
     path_index = _PathIndex()
     ip_index = _IpIndex()
+    out = "".join(
+        _scrub_windows_into(
+            _line_windows(text),
+            scrub_paths=scrub_paths,
+            scrub_ip_addresses=scrub_ip_addresses,
+            path_index=path_index,
+            ip_index=ip_index,
+        )
+    )
+    return (
+        out,
+        path_index.rewrites,
+        ip_index.ipv4_rewrites,
+        ip_index.ipv6_rewrites,
+    )
+
+
+def _scrub_windows_into(
+    windows: Iterable[str],
+    *,
+    scrub_paths: bool,
+    scrub_ip_addresses: bool,
+    path_index: _PathIndex,
+    ip_index: _IpIndex,
+) -> Iterator[str]:
+    """Scrub each window against *caller-owned* indices.
+
+    Sharing one ``_PathIndex`` / ``_IpIndex`` across every window (and, for
+    JSON, across every string leaf) keeps ``<PATH:N>`` / ``<IPV*:N>``
+    placeholders consistent within a single file: the same path always maps to
+    the same N and two distinct paths never collide on one N. Allocating a
+    fresh index per window/leaf (the old per-leaf ``scrub_text`` call) broke
+    that documented per-file scope.
+    """
     if not scrub_paths and not scrub_ip_addresses:
-        return text, 0, 0, 0
-
-    windows = _line_windows(text)
-
-    out_parts: list[str] = []
+        yield from windows
+        return
     for window in windows:
         chunk = window
         if scrub_paths:
             chunk = _scrub_paths_in_text(chunk, path_index)
         if scrub_ip_addresses:
             chunk = _scrub_ips_in_text(chunk, ip_index)
-        out_parts.append(chunk)
+        yield chunk
 
-    return (
-        "".join(out_parts),
-        path_index.rewrites,
-        ip_index.ipv4_rewrites,
-        ip_index.ipv6_rewrites,
+
+def _scrub_str_into(
+    text: str,
+    *,
+    cfg: RedactionCfg,
+    path_index: _PathIndex,
+    ip_index: _IpIndex,
+) -> str:
+    return "".join(
+        _scrub_windows_into(
+            _line_windows(text),
+            scrub_paths=cfg.scrub_paths,
+            scrub_ip_addresses=cfg.scrub_ip_addresses,
+            path_index=path_index,
+            ip_index=ip_index,
+        )
     )
 
 
@@ -321,9 +375,17 @@ def _scrub_json_value(
     *,
     cfg: RedactionCfg,
     env_removed: list[int],
-) -> tuple[Any, int, int, int]:
+    path_index: _PathIndex,
+    ip_index: _IpIndex,
+) -> Any:
+    """Recursively scrub a JSON value, returning the scrubbed copy.
+
+    Path/IP counts are NOT returned per node: ``path_index`` / ``ip_index``
+    are shared across the whole document walk so placeholders stay file-
+    consistent (Copilot review), and the caller reads the running totals off
+    the indices once the walk completes.
+    """
     if isinstance(value, dict):
-        total_p = total_v4 = total_v6 = 0
         new_dict: dict[str, Any] = {}
         for key, item in value.items():
             if key == "env" and isinstance(item, dict):
@@ -337,43 +399,35 @@ def _scrub_json_value(
                 # LD_LIBRARY_PATH=/home/customer/...). Scrub the values too
                 # so result.json env matches the host_env.json path, which
                 # already scrubs values via its whole-document pass.
-                scrubbed_env: dict[str, str] = {}
-                for env_key, env_val in kept_env.items():
-                    sv, p, v4, v6 = scrub_text(
-                        env_val,
-                        scrub_paths=cfg.scrub_paths,
-                        scrub_ip_addresses=cfg.scrub_ip_addresses,
+                new_dict[key] = {
+                    env_key: _scrub_str_into(
+                        env_val, cfg=cfg, path_index=path_index, ip_index=ip_index
                     )
-                    scrubbed_env[env_key] = sv
-                    total_p += p
-                    total_v4 += v4
-                    total_v6 += v6
-                new_dict[key] = scrubbed_env
+                    for env_key, env_val in kept_env.items()
+                }
                 continue
-            scrubbed, p, v4, v6 = _scrub_json_value(item, cfg=cfg, env_removed=env_removed)
-            new_dict[key] = scrubbed
-            total_p += p
-            total_v4 += v4
-            total_v6 += v6
-        return new_dict, total_p, total_v4, total_v6
+            new_dict[key] = _scrub_json_value(
+                item,
+                cfg=cfg,
+                env_removed=env_removed,
+                path_index=path_index,
+                ip_index=ip_index,
+            )
+        return new_dict
     if isinstance(value, list):
-        total_p = total_v4 = total_v6 = 0
-        new_list: list[Any] = []
-        for item in value:
-            scrubbed, p, v4, v6 = _scrub_json_value(item, cfg=cfg, env_removed=env_removed)
-            new_list.append(scrubbed)
-            total_p += p
-            total_v4 += v4
-            total_v6 += v6
-        return new_list, total_p, total_v4, total_v6
+        return [
+            _scrub_json_value(
+                item,
+                cfg=cfg,
+                env_removed=env_removed,
+                path_index=path_index,
+                ip_index=ip_index,
+            )
+            for item in value
+        ]
     if isinstance(value, str):
-        text, paths, v4, v6 = scrub_text(
-            value,
-            scrub_paths=cfg.scrub_paths,
-            scrub_ip_addresses=cfg.scrub_ip_addresses,
-        )
-        return text, paths, v4, v6
-    return value, 0, 0, 0
+        return _scrub_str_into(value, cfg=cfg, path_index=path_index, ip_index=ip_index)
+    return value
 
 
 def _parse_probe_env(text: str) -> dict[str, str]:
@@ -416,7 +470,7 @@ class RedactingRedactor(Redactor):
         elif src.name == "host_env.json":
             counts = self._scrub_host_env_json(src.read_bytes(), dst, src)
         elif _is_text_artifact(src):
-            counts = self._scrub_text_bytes(src.read_bytes(), dst)
+            counts = self._scrub_text_stream(src, dst)
         else:
             # Binary / non-scrubbable artifact (e.g. a multi-GB core dump):
             # stream the copy via shutil.copyfile rather than reading the whole
@@ -462,14 +516,22 @@ class RedactingRedactor(Redactor):
             # OSError, so the writer's OSError->BundleIOError wrap misses it).
             raise RedactionError(src, exc) from exc
         env_removed = [0]
-        scrubbed, paths, v4, v6 = _scrub_json_value(doc, cfg=self._cfg, env_removed=env_removed)
+        path_index = _PathIndex()
+        ip_index = _IpIndex()
+        scrubbed = _scrub_json_value(
+            doc,
+            cfg=self._cfg,
+            env_removed=env_removed,
+            path_index=path_index,
+            ip_index=ip_index,
+        )
         out = json.dumps(scrubbed, indent=2, sort_keys=False) + "\n"
         dst.write_text(out, encoding="utf-8")
         out_bytes = out.encode("utf-8")
         return RedactionCounts(
             env_keys_removed=env_removed[0],
-            paths_rewritten=paths,
-            ips_rewritten=v4 + v6,
+            paths_rewritten=path_index.rewrites,
+            ips_rewritten=ip_index.ipv4_rewrites + ip_index.ipv6_rewrites,
             bytes_in=len(raw),
             bytes_out=len(out_bytes),
         )
@@ -506,26 +568,40 @@ class RedactingRedactor(Redactor):
             bytes_out=len(out_bytes),
         )
 
-    def _scrub_text_bytes(self, raw: bytes, dst: Path) -> RedactionCounts:
-        # Decode with errors="replace" rather than failing open. stdout.log /
-        # stderr.log are raw subprocess bytes by design, so a single stray
-        # non-UTF-8 byte must not disable path/IP scrubbing for the whole
-        # file (a security footgun). This matches the lenient decode already
-        # used by _scrub_probe_env and the probe log reader; scrub_text still
-        # bounds CPU via its MAX_LOG_BYTES windows.
-        text = raw.decode("utf-8", errors="replace")
-        out, paths, v4, v6 = scrub_text(
-            text,
-            scrub_paths=self._cfg.scrub_paths,
-            scrub_ip_addresses=self._cfg.scrub_ip_addresses,
-        )
-        out_bytes = out.encode("utf-8")
-        dst.write_bytes(out_bytes)
+    def _scrub_text_stream(self, src: Path, dst: Path) -> RedactionCounts:
+        # stdout.log / stderr.log can be very large in real runs, so stream the
+        # scrub window-by-window off disk instead of reading the whole artifact
+        # into memory (peak ~= one MAX_LOG_BYTES window, not O(file size)).
+        #
+        # * ``newline=""`` disables universal-newline translation so CR / CRLF
+        #   terminators survive byte-for-byte; the scrubbed output is then
+        #   identical to a whole-file pass (windows are processed in file order
+        #   against one shared index, so placeholder assignment is unchanged).
+        # * ``errors="replace"`` keeps scrubbing alive on stray non-UTF-8
+        #   subprocess bytes rather than failing open -- same fail-safe as the
+        #   former whole-file decode (a single bad byte must not disable path /
+        #   IP scrubbing for the rest of the file).
+        cfg = self._cfg
+        path_index = _PathIndex()
+        ip_index = _IpIndex()
+        bytes_out = 0
+        with open(src, encoding="utf-8", errors="replace", newline="") as fh, open(
+            dst, "w", encoding="utf-8", newline=""
+        ) as out_fh:
+            for chunk in _scrub_windows_into(
+                _stream_line_windows(fh),
+                scrub_paths=cfg.scrub_paths,
+                scrub_ip_addresses=cfg.scrub_ip_addresses,
+                path_index=path_index,
+                ip_index=ip_index,
+            ):
+                out_fh.write(chunk)
+                bytes_out += len(chunk.encode("utf-8"))
         return RedactionCounts(
-            paths_rewritten=paths,
-            ips_rewritten=v4 + v6,
-            bytes_in=len(raw),
-            bytes_out=len(out_bytes),
+            paths_rewritten=path_index.rewrites,
+            ips_rewritten=ip_index.ipv4_rewrites + ip_index.ipv6_rewrites,
+            bytes_in=src.stat().st_size,
+            bytes_out=bytes_out,
         )
 
 

--- a/src/aorta/probe/redaction.py
+++ b/src/aorta/probe/redaction.py
@@ -288,11 +288,27 @@ def _scrub_json_value(
         new_dict: dict[str, Any] = {}
         for key, item in value.items():
             if key == "env" and isinstance(item, dict):
-                scrubbed_env, removed = scrub_env_keys(
+                kept_env, removed = scrub_env_keys(
                     {str(k): str(v) for k, v in item.items()},
                     cfg.scrub_env_keys,
                 )
                 env_removed[0] += removed
+                # Removing matching keys is not enough: a *retained* key's
+                # value can still carry a path or IP (e.g.
+                # LD_LIBRARY_PATH=/home/customer/...). Scrub the values too
+                # so result.json env matches the host_env.json path, which
+                # already scrubs values via its whole-document pass.
+                scrubbed_env: dict[str, str] = {}
+                for env_key, env_val in kept_env.items():
+                    sv, p, v4, v6 = scrub_text(
+                        env_val,
+                        scrub_paths=cfg.scrub_paths,
+                        scrub_ip_addresses=cfg.scrub_ip_addresses,
+                    )
+                    scrubbed_env[env_key] = sv
+                    total_p += p
+                    total_v4 += v4
+                    total_v6 += v6
                 new_dict[key] = scrubbed_env
                 continue
             scrubbed, p, v4, v6 = _scrub_json_value(item, cfg=cfg, env_removed=env_removed)

--- a/src/aorta/probe/redaction.py
+++ b/src/aorta/probe/redaction.py
@@ -29,8 +29,14 @@ from aorta.probe.sandbox import MAX_LOG_BYTES
 from aorta.triage.recipe import RecipeSchemaError
 
 # Path scrubber: absolute POSIX paths with at least one directory component.
+# The negative lookbehind anchors the match at a path START so a sub-path of a
+# larger filename token is not matched piecemeal -- but it deliberately EXCLUDES
+# '/' so a leading '/' that itself follows another '/' still matches. Including
+# '/' in the lookbehind would skip the path inside `file:///home/user/...` and
+# `//host/home/user/...` (the leading slash precedes the real path), leaking
+# exactly the absolute paths this scrubber documents it removes.
 _PATH_RE = re.compile(
-    r"(?<![A-Za-z0-9_./-])/(?:[A-Za-z0-9_.\-]+/)+[A-Za-z0-9_.\-]+"
+    r"(?<![A-Za-z0-9_.-])/(?:[A-Za-z0-9_.\-]+/)+[A-Za-z0-9_.\-]+"
 )
 
 # IPv4 candidate -- validated with :func:`ipaddress.ip_address` before rewrite.
@@ -76,8 +82,12 @@ def parse_redaction(raw: Any) -> RedactionCfg:
         )
     unknown = set(raw) - _VALID_REDACTION_KEYS
     if unknown:
+        # YAML permits non-string mapping keys (e.g. `1: x`); sorting a mixed
+        # str/int set raises TypeError, which would escape as an unhandled
+        # exception instead of a RecipeSchemaError. Sort by str repr so any
+        # bad-key recipe fails closed with the schema error.
         raise RecipeSchemaError(
-            f"recipe.redaction: unknown keys {sorted(unknown)}; "
+            f"recipe.redaction: unknown keys {sorted(map(str, unknown))}; "
             f"allowed: {sorted(_VALID_REDACTION_KEYS)}"
         )
     keys_raw = raw.get("scrub_env_keys", [])
@@ -398,20 +408,23 @@ class RedactingRedactor(Redactor):
 
     def scrub_file(self, src: Path, dst: Path) -> RedactionCounts:
         dst.parent.mkdir(parents=True, exist_ok=True)
-        raw = src.read_bytes()
-        bytes_in = len(raw)
 
         if src.name == "probe.env":
-            counts = self._scrub_probe_env(raw, dst)
+            counts = self._scrub_probe_env(src.read_bytes(), dst)
         elif src.name == "result.json":
-            counts = self._scrub_result_json(raw, dst, src)
+            counts = self._scrub_result_json(src.read_bytes(), dst, src)
         elif src.name == "host_env.json":
-            counts = self._scrub_host_env_json(raw, dst, src)
+            counts = self._scrub_host_env_json(src.read_bytes(), dst, src)
         elif _is_text_artifact(src):
-            counts = self._scrub_text_bytes(raw, dst)
+            counts = self._scrub_text_bytes(src.read_bytes(), dst)
         else:
-            dst.write_bytes(raw)
-            counts = RedactionCounts(bytes_in=bytes_in, bytes_out=bytes_in)
+            # Binary / non-scrubbable artifact (e.g. a multi-GB core dump):
+            # stream the copy via shutil.copyfile rather than reading the whole
+            # file into a bytes object and writing it back. The no-scrub branch
+            # applies no transform, so byte counts come from stat() (in == out).
+            shutil.copyfile(src, dst)
+            size = dst.stat().st_size
+            counts = RedactionCounts(bytes_in=size, bytes_out=size)
 
         # Carry the source's permission bits onto every staged copy. The
         # scrub branches all (re)create dst via write_text / write_bytes,

--- a/src/aorta/probe/redaction.py
+++ b/src/aorta/probe/redaction.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from aorta.bundle.errors import RedactionError
 from aorta.bundle.redactor import RedactionCounts, Redactor
 from aorta.probe.sandbox import MAX_LOG_BYTES
 from aorta.triage.recipe import RecipeSchemaError
@@ -207,6 +208,34 @@ def _scrub_ips_in_text(text: str, ip_index: _IpIndex) -> str:
     return _IPV4_RE.sub(_v4_sub, text)
 
 
+def _line_windows(text: str) -> list[str]:
+    """Split ``text`` into ``<= MAX_LOG_BYTES`` windows at line boundaries.
+
+    The naive ``text[i : i + MAX_LOG_BYTES]`` slicing splits at fixed
+    byte offsets, which can cut a path or IP literal in half at the seam
+    so neither regex pass matches it (a silent redaction miss). Paths and
+    IPs never contain a line terminator, so breaking only *between* lines
+    guarantees no token straddles a window. ``splitlines(keepends=True)``
+    preserves every terminator, so ``"".join(...)`` reconstructs the input
+    byte-for-byte. A single line longer than ``MAX_LOG_BYTES`` is emitted
+    whole rather than split -- correctness of redaction wins over the exact
+    byte bound for that pathological case.
+    """
+    windows: list[str] = []
+    buf: list[str] = []
+    size = 0
+    for line in text.splitlines(keepends=True):
+        if buf and size + len(line) > MAX_LOG_BYTES:
+            windows.append("".join(buf))
+            buf = []
+            size = 0
+        buf.append(line)
+        size += len(line)
+    if buf:
+        windows.append("".join(buf))
+    return windows
+
+
 def scrub_text(
     text: str,
     *,
@@ -216,8 +245,10 @@ def scrub_text(
     """Apply path + IP scrubbers to a text blob (per-file index scope).
 
     Returns ``(text, paths_rewritten, ipv4_rewritten, ipv6_rewritten)``.
-    Large inputs are processed in ``MAX_LOG_BYTES`` windows so a hostile
-    log cannot blow regex CPU past the documented bound.
+    Large inputs are processed in ``MAX_LOG_BYTES`` windows (split at line
+    boundaries by :func:`_line_windows`) so a hostile log cannot blow regex
+    CPU past the documented bound while still scrubbing tokens that would
+    otherwise fall on a fixed-slice seam.
     """
     path_index = _PathIndex()
     ip_index = _IpIndex()
@@ -227,7 +258,7 @@ def scrub_text(
     if len(text) <= MAX_LOG_BYTES:
         windows = [text]
     else:
-        windows = [text[i : i + MAX_LOG_BYTES] for i in range(0, len(text), MAX_LOG_BYTES)]
+        windows = _line_windows(text)
 
     out_parts: list[str] = []
     for window in windows:
@@ -328,9 +359,9 @@ class RedactingRedactor(Redactor):
         if src.name == "probe.env":
             counts = self._scrub_probe_env(raw, dst)
         elif src.name == "result.json":
-            counts = self._scrub_result_json(raw, dst)
+            counts = self._scrub_result_json(raw, dst, src)
         elif src.name == "host_env.json":
-            counts = self._scrub_host_env_json(raw, dst)
+            counts = self._scrub_host_env_json(raw, dst, src)
         elif _is_text_artifact(src):
             counts = self._scrub_text_bytes(raw, dst)
         else:
@@ -353,9 +384,16 @@ class RedactingRedactor(Redactor):
             bytes_out=len(out_bytes),
         )
 
-    def _scrub_result_json(self, raw: bytes, dst: Path) -> RedactionCounts:
+    def _scrub_result_json(self, raw: bytes, dst: Path, src: Path) -> RedactionCounts:
         text = raw.decode("utf-8", errors="replace")
-        doc = json.loads(text)
+        try:
+            doc = json.loads(text)
+        except json.JSONDecodeError as exc:
+            # Fail closed: a corrupt/truncated result.json must not slip
+            # through unredacted, and the raw decode error would otherwise
+            # escape staging as an unhandled traceback (it is not an
+            # OSError, so the writer's OSError->BundleIOError wrap misses it).
+            raise RedactionError(src, exc) from exc
         env_removed = [0]
         scrubbed, paths, v4, v6 = _scrub_json_value(doc, cfg=self._cfg, env_removed=env_removed)
         out = json.dumps(scrubbed, indent=2, sort_keys=False) + "\n"
@@ -369,9 +407,15 @@ class RedactingRedactor(Redactor):
             bytes_out=len(out_bytes),
         )
 
-    def _scrub_host_env_json(self, raw: bytes, dst: Path) -> RedactionCounts:
+    def _scrub_host_env_json(self, raw: bytes, dst: Path, src: Path) -> RedactionCounts:
         text = raw.decode("utf-8", errors="replace")
-        doc = json.loads(text)
+        try:
+            doc = json.loads(text)
+        except json.JSONDecodeError as exc:
+            # Fail closed for the same reason as _scrub_result_json: a
+            # parse failure must stop bundling rather than emit a
+            # potentially unredacted host_env.json.
+            raise RedactionError(src, exc) from exc
         env_removed = [0]
         if isinstance(doc, dict) and "env" in doc and isinstance(doc["env"], dict):
             scrubbed_env, removed = scrub_env_keys(
@@ -396,11 +440,13 @@ class RedactingRedactor(Redactor):
         )
 
     def _scrub_text_bytes(self, raw: bytes, dst: Path) -> RedactionCounts:
-        try:
-            text = raw.decode("utf-8")
-        except UnicodeDecodeError:
-            dst.write_bytes(raw)
-            return RedactionCounts(bytes_in=len(raw), bytes_out=len(raw))
+        # Decode with errors="replace" rather than failing open. stdout.log /
+        # stderr.log are raw subprocess bytes by design, so a single stray
+        # non-UTF-8 byte must not disable path/IP scrubbing for the whole
+        # file (a security footgun). This matches the lenient decode already
+        # used by _scrub_probe_env and the probe log reader; scrub_text still
+        # bounds CPU via its MAX_LOG_BYTES windows.
+        text = raw.decode("utf-8", errors="replace")
         out, paths, v4, v6 = scrub_text(
             text,
             scrub_paths=self._cfg.scrub_paths,

--- a/src/aorta/probe/redaction.py
+++ b/src/aorta/probe/redaction.py
@@ -18,7 +18,7 @@ import fnmatch
 import ipaddress
 import json
 import re
-import stat
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -208,29 +208,43 @@ def _scrub_ips_in_text(text: str, ip_index: _IpIndex) -> str:
     return _IPV4_RE.sub(_v4_sub, text)
 
 
-def _line_windows(text: str) -> list[str]:
-    """Split ``text`` into ``<= MAX_LOG_BYTES`` windows at line boundaries.
+# A UTF-8 code point is at most 4 bytes; if a string fits the byte cap even
+# when every char is 4 bytes, no windowing is needed and we can skip the
+# encode entirely (fast path for the many small JSON string values that
+# scrub_text is called on).
+_MAX_UTF8_BYTES_PER_CHAR = 4
 
-    The naive ``text[i : i + MAX_LOG_BYTES]`` slicing splits at fixed
-    byte offsets, which can cut a path or IP literal in half at the seam
-    so neither regex pass matches it (a silent redaction miss). Paths and
-    IPs never contain a line terminator, so breaking only *between* lines
-    guarantees no token straddles a window. ``splitlines(keepends=True)``
-    preserves every terminator, so ``"".join(...)`` reconstructs the input
-    byte-for-byte. A single line longer than ``MAX_LOG_BYTES`` is emitted
-    whole rather than split -- correctness of redaction wins over the exact
-    byte bound for that pathological case.
+
+def _line_windows(text: str) -> list[str]:
+    """Split ``text`` into ``<= MAX_LOG_BYTES`` (UTF-8 *byte*) windows, broken
+    only at line boundaries.
+
+    Two properties hold:
+
+    * **Byte budget.** ``MAX_LOG_BYTES`` is a byte cap, so window size is
+      measured in encoded UTF-8 bytes (``len(line.encode())``), not code
+      points -- a multi-byte log must not slip past the regex-DoS bound just
+      because it has fewer characters than bytes.
+    * **No split tokens.** The naive ``text[i : i + N]`` slicing cuts a path
+      or IP literal in half at the seam so neither regex pass matches it (a
+      silent redaction miss). Paths/IPs never contain a line terminator, so
+      breaking only *between* lines (``splitlines(keepends=True)``) keeps every
+      token whole and ``"".join(...)`` reconstructs the input byte-for-byte.
+      A single line larger than the cap is emitted whole rather than split.
     """
+    if len(text) <= MAX_LOG_BYTES // _MAX_UTF8_BYTES_PER_CHAR:
+        return [text]
     windows: list[str] = []
     buf: list[str] = []
     size = 0
     for line in text.splitlines(keepends=True):
-        if buf and size + len(line) > MAX_LOG_BYTES:
+        line_bytes = len(line.encode("utf-8"))
+        if buf and size + line_bytes > MAX_LOG_BYTES:
             windows.append("".join(buf))
             buf = []
             size = 0
         buf.append(line)
-        size += len(line)
+        size += line_bytes
     if buf:
         windows.append("".join(buf))
     return windows
@@ -245,20 +259,17 @@ def scrub_text(
     """Apply path + IP scrubbers to a text blob (per-file index scope).
 
     Returns ``(text, paths_rewritten, ipv4_rewritten, ipv6_rewritten)``.
-    Large inputs are processed in ``MAX_LOG_BYTES`` windows (split at line
-    boundaries by :func:`_line_windows`) so a hostile log cannot blow regex
-    CPU past the documented bound while still scrubbing tokens that would
-    otherwise fall on a fixed-slice seam.
+    Large inputs are processed in ``MAX_LOG_BYTES`` (UTF-8 byte) windows
+    split at line boundaries by :func:`_line_windows`, so a hostile log
+    cannot blow regex CPU past the documented bound while still scrubbing
+    tokens that would otherwise fall on a fixed-slice seam.
     """
     path_index = _PathIndex()
     ip_index = _IpIndex()
     if not scrub_paths and not scrub_ip_addresses:
         return text, 0, 0, 0
 
-    if len(text) <= MAX_LOG_BYTES:
-        windows = [text]
-    else:
-        windows = _line_windows(text)
+    windows = _line_windows(text)
 
     out_parts: list[str] = []
     for window in windows:
@@ -384,6 +395,13 @@ class RedactingRedactor(Redactor):
             dst.write_bytes(raw)
             counts = RedactionCounts(bytes_in=bytes_in, bytes_out=bytes_in)
 
+        # Carry the source's permission bits onto every staged copy. The
+        # scrub branches all (re)create dst via write_text / write_bytes,
+        # which land at the umask default (~0644) and would WIDEN a
+        # restrictive source (e.g. probe.env at 0600) inside the shareable
+        # bundle. Mirrors IdentityRedactor.scrub_file; never let the bundle
+        # copy be less restrictive than the original (PR #199 review).
+        shutil.copymode(src, dst)
         return counts
 
     def _scrub_probe_env(self, raw: bytes, dst: Path) -> RedactionCounts:
@@ -392,7 +410,9 @@ class RedactingRedactor(Redactor):
         scrubbed, removed = scrub_env_keys(env, self._cfg.scrub_env_keys)
         out = _format_probe_env(scrubbed)
         dst.write_text(out, encoding="utf-8")
-        dst.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        # Mode is carried from the source by scrub_file's shutil.copymode;
+        # the run-dir probe.env is written 0600 by the workload, so the
+        # staged copy stays owner-only without a hardcoded chmod here.
         out_bytes = out.encode("utf-8")
         return RedactionCounts(
             env_keys_removed=removed,

--- a/src/aorta/probe/redaction.py
+++ b/src/aorta/probe/redaction.py
@@ -37,8 +37,19 @@ _IPV4_RE = re.compile(
     r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b"
 )
 
-# IPv6 candidate -- coarse scan; only matches validated by ipaddress.
-_IPV6_CANDIDATE_RE = re.compile(r"\b(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b")
+# IPv6 bracketed literal (URL/log form): [::1], [2001:db8::1]
+_IPV6_BRACKETED_RE = re.compile(r"\[([0-9a-fA-F:.]+)\]")
+
+# IPv6 unbracketed -- no leading \b (allows ::1 / ::); validated via ipaddress.
+_IPV6_UNBRACKETED_RE = re.compile(
+    r"(?<![0-9a-fA-F:.])"
+    r"(?:"
+    r"(?:[0-9a-fA-F]{0,4}:)+[0-9a-fA-F]{0,4}|"
+    r"::(?:[0-9a-fA-F]{0,4}:){0,6}[0-9a-fA-F]{0,4}|"
+    r"[0-9a-fA-F]{0,4}::(?:[0-9a-fA-F]{0,4}:){0,6}[0-9a-fA-F]{0,4}"
+    r")"
+    r"(?![0-9a-fA-F:.])"
+)
 
 _VALID_REDACTION_KEYS = frozenset({"scrub_env_keys", "scrub_paths", "scrub_ip_addresses"})
 
@@ -156,21 +167,32 @@ def _scrub_paths_in_text(text: str, path_index: _PathIndex) -> str:
     return _PATH_RE.sub(lambda m: path_index.replace(m), text)
 
 
+def _rewrite_ipv6(candidate: str, ip_index: _IpIndex) -> str | None:
+    """Return ``<IPV6:N>`` when ``candidate`` is a valid IPv6 address."""
+    try:
+        addr = ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+    if addr.version != 6:
+        return None
+    return ip_index._replace(candidate, v4=False)
+
+
 def _scrub_ips_in_text(text: str, ip_index: _IpIndex) -> str:
     if not text:
         return text
 
-    def _v6_sub(match: re.Match[str]) -> str:
-        candidate = match.group(0)
-        try:
-            addr = ipaddress.ip_address(candidate)
-        except ValueError:
-            return candidate
-        if addr.version != 6:
-            return candidate
-        return ip_index._replace(candidate, v4=False)
+    def _bracketed_v6_sub(match: re.Match[str]) -> str:
+        repl = _rewrite_ipv6(match.group(1), ip_index)
+        return repl if repl is not None else match.group(0)
 
-    text = _IPV6_CANDIDATE_RE.sub(_v6_sub, text)
+    text = _IPV6_BRACKETED_RE.sub(_bracketed_v6_sub, text)
+
+    def _unbracketed_v6_sub(match: re.Match[str]) -> str:
+        repl = _rewrite_ipv6(match.group(0), ip_index)
+        return repl if repl is not None else match.group(0)
+
+    text = _IPV6_UNBRACKETED_RE.sub(_unbracketed_v6_sub, text)
 
     def _v4_sub(match: re.Match[str]) -> str:
         candidate = match.group(0)

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -77,6 +77,8 @@ _PROBE_TOP_LEVEL = frozenset(
         "custom_patterns",
         "hang_window_sec",
         "hang_grace_period_at_start",
+        # Phase 3 (issue #188): redaction block for aorta bundle.
+        "redaction",
     }
 )
 # Phase 3 keys -- intercepted at load time BEFORE the unknown-keys
@@ -89,7 +91,7 @@ _PROBE_TOP_LEVEL = frozenset(
 # is reserved for a future Phase 3-style "fail-the-trial-by-condition"
 # block; rejected here so a typo'd indent of a custom_patterns
 # condition can't fall through to a silent no-op.
-_PHASE_3_KEYS = frozenset({"redaction", "condition"})
+_PHASE_3_KEYS = frozenset({"condition"})
 # Union of valid keys -- used for the unknown-key rejection. Phase 2 keys
 # (``custom_patterns``, ``hang_window_sec``, ``hang_grace_period_at_start``)
 # ARE included via ``_PROBE_TOP_LEVEL`` and parsed normally when

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -763,7 +763,13 @@ def _read_recipe_document(path: Path) -> tuple[Any, str]:
 
 
 def load_recipe_mapping(path: Path) -> Any:
-    """Return a recipe file's raw parsed mapping with no schema validation.
+    """Return a recipe file's raw parsed top-level value with no validation.
+
+    The return type is whatever YAML/JSON yields for the document root -- a
+    ``dict`` for a well-formed recipe, but also ``None`` (empty file),
+    ``list``, or a scalar for a malformed one. Callers MUST check the shape
+    (e.g. ``isinstance(data, dict)``) and fail closed on a non-mapping rather
+    than assuming a ``dict``; see :func:`aorta.probe.bundle_hook.load_redaction_cfg`.
 
     Used by callers that need one block out of a recipe (e.g. the bundle
     redaction-only resolve) without resolving the mitigation / diagnostic

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -726,6 +726,26 @@ def load_recipe(
         UnknownMitigationError / UnknownEnvironmentError: A referenced
             registry name is not known. Bubbled up from B3's resolver.
     """
+    data, text = _read_recipe_document(path)
+    recipe = _build_recipe(
+        data,
+        sidecar_files=sidecar_files,
+        source_path=path,
+        source_sha256=_sha256_bytes(text),
+    )
+    return recipe
+
+
+def _read_recipe_document(path: Path) -> tuple[Any, str]:
+    """Read and YAML/JSON-parse a recipe file into ``(data, raw_text)``.
+
+    The read + parse step is split out from :func:`load_recipe` so callers
+    that need a single top-level block (e.g. ``aorta bundle`` resolving only
+    the ``redaction:`` block) can reuse it via :func:`load_recipe_mapping`
+    without running full axis/registry validation -- and without importing
+    a YAML parser themselves (the probe redaction modules are stdlib-only
+    by rubric §3.F; keeping the dependency here preserves that).
+    """
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
@@ -739,14 +759,19 @@ def load_recipe(
             data = yaml.safe_load(text)
     except (yaml.YAMLError, json.JSONDecodeError) as exc:
         raise RecipeSchemaError(f"recipe {path}: parse error ({exc})") from exc
+    return data, text
 
-    recipe = _build_recipe(
-        data,
-        sidecar_files=sidecar_files,
-        source_path=path,
-        source_sha256=_sha256_bytes(text),
-    )
-    return recipe
+
+def load_recipe_mapping(path: Path) -> Any:
+    """Return a recipe file's raw parsed mapping with no schema validation.
+
+    Used by callers that need one block out of a recipe (e.g. the bundle
+    redaction-only resolve) without resolving the mitigation / diagnostic
+    axes against the registry -- full :func:`load_recipe` would raise for a
+    valid probe run whose recipe referenced sidecar-defined names.
+    """
+    data, _ = _read_recipe_document(path)
+    return data
 
 
 def _build_recipe(

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -278,6 +278,7 @@ class SubprocessWorkload(Workload):
                     argv=argv,
                     probe_extras=probe_extras,
                     env_mode=env_mode,
+                    cell_env_snapshot=cell_env_snapshot,
                 )
             child_env["AORTA_ENV_FILE"] = str(env_file_path.absolute())
         else:
@@ -576,6 +577,7 @@ class SubprocessWorkload(Workload):
         argv: tuple[str, ...],
         probe_extras: dict[str, Any],
         env_mode: str,
+        cell_env_snapshot: dict[str, str],
     ) -> WorkloadResult:
         """Persist a Tier-1 ``fail`` artifact when probe.env validation rejects.
 
@@ -617,6 +619,10 @@ class SubprocessWorkload(Workload):
             "trial_index": self._trial_index,
             "env_passthrough_mode": env_mode,
             "timed_out": False,
+            # Mirror the normal-path result.json so every trial's env is
+            # auditable/redactable, even when probe.env validation rejected
+            # before the subprocess launched.
+            "env": dict(cell_env_snapshot),
             "failure_type": "env_file_validation_failed",
             "error_message": str(exc),
         }

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -518,6 +518,7 @@ class SubprocessWorkload(Workload):
             # them (rubric §2.B FR 2.9).
             "env_passthrough_mode": env_mode,
             "timed_out": timed_out,
+            "env": dict(cell_env_snapshot),
         }
         result_path.write_text(
             json.dumps(result_doc, indent=2, sort_keys=False),

--- a/tests/bundle/conftest.py
+++ b/tests/bundle/conftest.py
@@ -82,7 +82,13 @@ def synthetic_run_dir(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     (run_dir / "recipe.resolved.yaml").write_text(
-        "schema_version: 1\nmode: probe\n",
+        """\
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+""",
         encoding="utf-8",
     )
     (run_dir / "host_env.json").write_text("{}\n", encoding="utf-8")

--- a/tests/bundle/test_no_new_deps.py
+++ b/tests/bundle/test_no_new_deps.py
@@ -152,3 +152,25 @@ def test_bundle_submodules_collected():
     """Sanity: the package actually exposes the four submodules."""
     submodules = {m.name for m in pkgutil.iter_modules(_bundle_pkg.__path__)}
     assert {"errors", "manifest", "redactor", "writer"} <= submodules
+
+
+_PROBE_REDACTION_FILES = (
+    Path(__file__).resolve().parents[2] / "src/aorta/probe/redaction.py",
+    Path(__file__).resolve().parents[2] / "src/aorta/probe/bundle_hook.py",
+)
+
+
+def test_probe_redaction_modules_no_third_party_imports():
+    """Phase 3 redaction modules stay stdlib-only (no new top-level deps)."""
+    stdlib = set(getattr(__import__("sys"), "stdlib_module_names", set()))
+    for path in _PROBE_REDACTION_FILES:
+        for name in _imports(path):
+            top = name.split(".", 1)[0]
+            if top in stdlib:
+                continue
+            if name.startswith(_AORTA_INTERNAL_PREFIX) or name == "aorta":
+                continue
+            assert top in _ALLOWED_THIRD_PARTY, (
+                f"{path}: new third-party import {name!r}; probe redaction "
+                "is stdlib-only by rubric §3.F."
+            )

--- a/tests/bundle/test_writer.py
+++ b/tests/bundle/test_writer.py
@@ -321,18 +321,50 @@ def test_bundle_run_dir_review_no_aborts_with_typed_error(synthetic_run_dir, tmp
     assert not out.exists()
 
 
-# --- redaction-from flag is honoured but no-op until #188 Phase 3 ---------
+# --- redaction-from via CLI uses RedactingRedactor when recipe has block ---
 
 
-def test_bundle_run_dir_redaction_from_logged_when_present(synthetic_run_dir, tmp_path, caplog):
-    """Acceptance: --redaction-from is wired through (not yet consumed)."""
-    recipe = synthetic_run_dir / "recipe.resolved.yaml"  # already created by fixture
-    out = tmp_path / "out.tar.gz"
-    with caplog.at_level("INFO", logger="aorta.bundle.writer"):
-        bundle_run_dir(synthetic_run_dir, output=out, redaction_from=recipe)
-    assert any(
-        "aorta.probe.redaction is gated on issue #188 Phase 3" in r.message for r in caplog.records
+def test_bundle_cli_redaction_from_applies_scrubbers(synthetic_run_dir, tmp_path):
+    """Phase 3: --redaction-from loads redaction: and scrubs bundled files."""
+    recipe = synthetic_run_dir / "recipe.resolved.yaml"
+    recipe.write_text(
+        """\
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+redaction:
+  scrub_env_keys: ["AWS_*"]
+  scrub_paths: true
+  scrub_ip_addresses: true
+""",
+        encoding="utf-8",
     )
+    trial = synthetic_run_dir / "none-none" / "trial_0"
+    trial.joinpath("stdout.log").write_text(
+        "host 10.0.0.1 path /var/secret/data\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.tar.gz"
+    from click.testing import CliRunner
+
+    from aorta.cli import main
+
+    result = CliRunner().invoke(
+        main,
+        ["bundle", str(synthetic_run_dir), "--redaction-from", str(recipe), "--output", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    import tarfile
+
+    from aorta.bundle import MANIFEST_FILENAME, Manifest
+
+    with tarfile.open(out, "r:gz") as tar:
+        member = next(n for n in tar.getnames() if n.endswith(MANIFEST_FILENAME))
+        manifest = Manifest.from_json(tar.extractfile(member).read().decode("utf-8"))
+    assert manifest.redaction_applied is True
+    assert manifest.redactor_kind == "probe.v1"
 
 
 # --- bundle name + timestamp -----------------------------------------------

--- a/tests/probe/fixtures/redaction_input.txt
+++ b/tests/probe/fixtures/redaction_input.txt
@@ -1,0 +1,10 @@
+AWS_SECRET_ACCESS_KEY=supersecret
+HOME=/home/customer/project
+USER=customer
+PATH=/usr/local/bin:/usr/bin
+SAFE_VAR=keep-me
+LOG=/home/customer/project/run.log
+Connecting to 192.168.1.42:8080 from /home/customer/project/data/input
+Also saw fe80::1 and 2001:db8::1 on /var/log/training/stdout.backup
+Duplicate path /home/customer/project/data/input again
+Third path /opt/rocm/lib mentioned twice: /opt/rocm/lib and /opt/rocm/lib

--- a/tests/probe/test_bundle_integration.py
+++ b/tests/probe/test_bundle_integration.py
@@ -15,7 +15,7 @@ from aorta.cli import main
 from aorta.probe.bundle_hook import build_redactor_from_recipe, load_redaction_cfg
 from aorta.probe.redaction import RedactingRedactor, RedactionCfg
 from aorta.registry.errors import UnknownMitigationError
-from aorta.triage.recipe import load_recipe
+from aorta.triage.recipe import RecipeSchemaError, load_recipe
 
 
 def _member_text(tar: tarfile.TarFile, name: str) -> str:
@@ -196,6 +196,34 @@ redaction:
     assert cfg.scrub_paths is True
     redactor = build_redactor_from_recipe(None, run_dir)
     assert isinstance(redactor, RedactingRedactor)
+
+
+def test_malformed_redaction_block_clean_cli_error(tmp_path: Path):
+    """A bad redaction: block renders a clean CLI error, not a traceback.
+
+    build_redactor_from_recipe raises RecipeSchemaError (a ValueError, not
+    a BundleError) for a malformed block; the CLI now catches it (Copilot
+    review).
+    """
+    run_dir = tmp_path / "probe-out" / "TKT-BAD"
+    run_dir.mkdir(parents=True)
+    _write_trial(run_dir / "none-none")
+    (run_dir / "recipe.resolved.yaml").write_text(
+        """\
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+redaction:
+  scrub_paths: "yes-please"
+""",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(main, ["bundle", str(run_dir)])
+    assert result.exit_code != 0
+    assert "scrub_paths" in result.output
+    assert not isinstance(result.exception, RecipeSchemaError)
 
 
 def test_fallback_absent_recipe_uses_identity_redactor(tmp_path: Path):

--- a/tests/probe/test_bundle_integration.py
+++ b/tests/probe/test_bundle_integration.py
@@ -10,8 +10,19 @@ import pytest
 from click.testing import CliRunner
 
 from aorta.bundle import MANIFEST_FILENAME, Manifest, bundle_run_dir
+from aorta.bundle.redactor import IdentityRedactor
 from aorta.cli import main
+from aorta.probe.bundle_hook import build_redactor_from_recipe, load_redaction_cfg
 from aorta.probe.redaction import RedactingRedactor, RedactionCfg
+from aorta.registry.errors import UnknownMitigationError
+from aorta.triage.recipe import load_recipe
+
+
+def _member_text(tar: tarfile.TarFile, name: str) -> str:
+    """Read a tar member as UTF-8 text (``extractfile`` may return None)."""
+    fh = tar.extractfile(name)
+    assert fh is not None, f"member {name} not found in tarball"
+    return fh.read().decode("utf-8")
 
 
 def _write_trial(cell_dir: Path, trial_idx: int = 0) -> None:
@@ -115,7 +126,7 @@ def test_manifest_records_per_file_counts(redaction_run_dir: Path, tmp_path: Pat
     assert result.exit_code == 0, result.output
     with tarfile.open(out, "r:gz") as tar:
         member = next(n for n in tar.getnames() if n.endswith(MANIFEST_FILENAME))
-        manifest = Manifest.from_json(tar.extractfile(member).read().decode("utf-8"))
+        manifest = Manifest.from_json(_member_text(tar, member))
     assert manifest.redaction_applied is True
     assert manifest.redactor_kind == "probe.v1"
     stdout_row = next(f for f in manifest.files if f.path.endswith("stdout.log"))
@@ -149,6 +160,50 @@ def test_originals_untouched(redaction_run_dir: Path, tmp_path: Path):
     assert before == after
 
 
+def test_fallback_redaction_resolves_despite_unresolvable_axis(tmp_path: Path):
+    """recipe.resolved.yaml fallback must not require sidecars (oyazdanb review).
+
+    A probe run driven by sidecar-defined mitigations leaves a
+    recipe.resolved.yaml whose axes name mitigations the registry cannot
+    resolve without the original sidecar files. Bundling only needs the
+    ``redaction:`` block, so ``load_redaction_cfg`` parses just that block
+    rather than running the full recipe loader (which raises here).
+    """
+    run_dir = tmp_path / "probe-out" / "TKT-SIDE"
+    run_dir.mkdir(parents=True)
+    _write_trial(run_dir / "none-none")
+    recipe = run_dir / "recipe.resolved.yaml"
+    recipe.write_text(
+        """\
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis: [acme_customer_only_mitigation]
+diagnostic_axis: [none]
+redaction:
+  scrub_env_keys: ["AWS_*"]
+  scrub_paths: true
+  scrub_ip_addresses: true
+""",
+        encoding="utf-8",
+    )
+    # The full loader cannot resolve the sidecar-only mitigation name...
+    with pytest.raises(UnknownMitigationError):
+        load_recipe(recipe)
+    # ...but redaction resolution succeeds because it parses only the block.
+    cfg = load_redaction_cfg(recipe)
+    assert cfg is not None
+    assert cfg.scrub_paths is True
+    redactor = build_redactor_from_recipe(None, run_dir)
+    assert isinstance(redactor, RedactingRedactor)
+
+
+def test_fallback_absent_recipe_uses_identity_redactor(tmp_path: Path):
+    run_dir = tmp_path / "probe-out" / "TKT-NONE"
+    run_dir.mkdir(parents=True)
+    assert isinstance(build_redactor_from_recipe(None, run_dir), IdentityRedactor)
+
+
 def test_redaction_from_auto_fallback(redaction_run_dir: Path, tmp_path: Path):
     runner = CliRunner()
     out = tmp_path / "bundle.tar.gz"
@@ -160,6 +215,6 @@ def test_redaction_from_auto_fallback(redaction_run_dir: Path, tmp_path: Path):
     with tarfile.open(out, "r:gz") as tar:
         names = tar.getnames()
         stdout_member = next(n for n in names if n.endswith("stdout.log"))
-        text = tar.extractfile(stdout_member).read().decode("utf-8")
+        text = _member_text(tar, stdout_member)
     assert "/home/user" not in text
     assert "192.168.1.1" not in text

--- a/tests/probe/test_bundle_integration.py
+++ b/tests/probe/test_bundle_integration.py
@@ -232,6 +232,35 @@ def test_fallback_absent_recipe_uses_identity_redactor(tmp_path: Path):
     assert isinstance(build_redactor_from_recipe(None, run_dir), IdentityRedactor)
 
 
+@pytest.mark.parametrize(
+    "content",
+    ["", "- a\n- b\n", "just-a-scalar\n"],
+    ids=["empty", "list", "scalar"],
+)
+def test_non_mapping_recipe_fails_closed(tmp_path: Path, content: str):
+    """A recipe that is not a top-level mapping must fail closed (Copilot).
+
+    Returning None there would hand back an IdentityRedactor and emit an
+    unredacted bundle the operator believed was scrubbed -- a fail-open. A
+    valid mapping with no redaction: key still legitimately returns None.
+    """
+    recipe = tmp_path / "recipe.resolved.yaml"
+    recipe.write_text(content, encoding="utf-8")
+    with pytest.raises(RecipeSchemaError):
+        load_redaction_cfg(recipe)
+
+
+def test_corrupt_fallback_recipe_clean_cli_error(tmp_path: Path):
+    """A non-mapping recipe.resolved.yaml fallback renders a clean CLI error."""
+    run_dir = tmp_path / "probe-out" / "TKT-CORRUPT"
+    run_dir.mkdir(parents=True)
+    _write_trial(run_dir / "none-none")
+    (run_dir / "recipe.resolved.yaml").write_text("- not-a-mapping\n", encoding="utf-8")
+    result = CliRunner().invoke(main, ["bundle", str(run_dir)])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, RecipeSchemaError)
+
+
 def test_redaction_from_auto_fallback(redaction_run_dir: Path, tmp_path: Path):
     runner = CliRunner()
     out = tmp_path / "bundle.tar.gz"

--- a/tests/probe/test_bundle_integration.py
+++ b/tests/probe/test_bundle_integration.py
@@ -1,0 +1,165 @@
+"""End-to-end ``aorta bundle`` + redaction integration (issue #188 Phase 3)."""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from aorta.bundle import MANIFEST_FILENAME, Manifest, bundle_run_dir
+from aorta.cli import main
+from aorta.probe.redaction import RedactingRedactor, RedactionCfg
+
+
+def _write_trial(cell_dir: Path, trial_idx: int = 0) -> None:
+    trial = cell_dir / f"trial_{trial_idx}"
+    trial.mkdir(parents=True, exist_ok=True)
+    (trial / "stdout.log").write_text(
+        "connect 192.168.1.1 from /home/user/secret/data\n",
+        encoding="utf-8",
+    )
+    (trial / "stderr.log").write_text("", encoding="utf-8")
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "verdict": "pass",
+                "exit_code": 0,
+                "walltime_sec": 0.1,
+                "argv": ["/home/user/secret/train.py"],
+                "cell_name": cell_dir.name,
+                "trial_index": trial_idx,
+                "env": {"AWS_TOKEN": "secret", "HIP_VISIBLE_DEVICES": "0"},
+                "env_passthrough_mode": "inherit",
+                "timed_out": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (trial / "probe.env").write_text(
+        "AWS_TOKEN=secret\nHIP_VISIBLE_DEVICES=0\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def redaction_run_dir(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "probe-out" / "TKT-RED"
+    run_dir.mkdir(parents=True)
+    _write_trial(run_dir / "none-none")
+    (run_dir / "host_env.json").write_text(
+        json.dumps({"env": {"AWS_KEY": "x", "PATH": "/usr/bin"}}, indent=2),
+        encoding="utf-8",
+    )
+    (run_dir / "recipe.resolved.yaml").write_text(
+        """\
+schema_version: 1
+mode: probe
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+redaction:
+  scrub_env_keys: ["AWS_*"]
+  scrub_paths: true
+  scrub_ip_addresses: true
+""",
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def test_refuses_no_ticket(tmp_path: Path):
+    run_dir = tmp_path / "probe-out" / "_no_ticket_"
+    run_dir.mkdir(parents=True)
+    _write_trial(run_dir / "none-none")
+    runner = CliRunner()
+    result = runner.invoke(main, ["bundle", str(run_dir)])
+    assert result.exit_code != 0
+    assert "--ticket" in result.output
+
+
+def test_review_pause_proceed(redaction_run_dir: Path, tmp_path: Path):
+    runner = CliRunner()
+    out = tmp_path / "bundle.tar.gz"
+    result = runner.invoke(
+        main,
+        ["bundle", str(redaction_run_dir), "--review", "--output", str(out)],
+        input="y\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+
+
+def test_review_pause_abort(redaction_run_dir: Path, tmp_path: Path):
+    runner = CliRunner()
+    out = tmp_path / "bundle.tar.gz"
+    result = runner.invoke(
+        main,
+        ["bundle", str(redaction_run_dir), "--review", "--output", str(out)],
+        input="n\n",
+    )
+    assert result.exit_code == 1
+    assert not out.exists()
+
+
+def test_manifest_records_per_file_counts(redaction_run_dir: Path, tmp_path: Path):
+    runner = CliRunner()
+    out = tmp_path / "bundle.tar.gz"
+    result = runner.invoke(
+        main,
+        ["bundle", str(redaction_run_dir), "--output", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    with tarfile.open(out, "r:gz") as tar:
+        member = next(n for n in tar.getnames() if n.endswith(MANIFEST_FILENAME))
+        manifest = Manifest.from_json(tar.extractfile(member).read().decode("utf-8"))
+    assert manifest.redaction_applied is True
+    assert manifest.redactor_kind == "probe.v1"
+    stdout_row = next(f for f in manifest.files if f.path.endswith("stdout.log"))
+    assert stdout_row.paths_rewritten >= 1
+    assert stdout_row.ips_rewritten >= 1
+
+
+def test_originals_untouched(redaction_run_dir: Path, tmp_path: Path):
+    before = {
+        p: p.read_bytes()
+        for p in redaction_run_dir.rglob("*")
+        if p.is_file()
+    }
+    out = tmp_path / "bundle.tar.gz"
+    bundle_run_dir(
+        redaction_run_dir,
+        output=out,
+        redactor=RedactingRedactor(
+            RedactionCfg(
+                scrub_env_keys=("AWS_*",),
+                scrub_paths=True,
+                scrub_ip_addresses=True,
+            )
+        ),
+    )
+    after = {
+        p: p.read_bytes()
+        for p in redaction_run_dir.rglob("*")
+        if p.is_file()
+    }
+    assert before == after
+
+
+def test_redaction_from_auto_fallback(redaction_run_dir: Path, tmp_path: Path):
+    runner = CliRunner()
+    out = tmp_path / "bundle.tar.gz"
+    result = runner.invoke(
+        main,
+        ["bundle", str(redaction_run_dir), "--output", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    with tarfile.open(out, "r:gz") as tar:
+        names = tar.getnames()
+        stdout_member = next(n for n in names if n.endswith("stdout.log"))
+        text = tar.extractfile(stdout_member).read().decode("utf-8")
+    assert "/home/user" not in text
+    assert "192.168.1.1" not in text

--- a/tests/probe/test_handout_templates.py
+++ b/tests/probe/test_handout_templates.py
@@ -1,0 +1,31 @@
+"""Handout template dry-run smoke tests (issue #188 Phase 3 FR 3.7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from aorta.cli import main
+
+RECIPE_ROOT = Path(__file__).resolve().parents[2] / "recipes"
+
+TEMPLATES = [
+    "probe-template-torchrun.yaml",
+    "probe-template-buck2.yaml",
+    "probe-template-bash.yaml",
+]
+
+
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_handout_template_dry_run(template: str):
+    recipe = RECIPE_ROOT / template
+    assert recipe.is_file(), f"missing template {recipe}"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["probe", "--recipe", str(recipe), "--dry-run", "--", "echo", "hi"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "echo" in result.output

--- a/tests/probe/test_recipe.py
+++ b/tests/probe/test_recipe.py
@@ -225,6 +225,18 @@ redaction:
         load_recipe(_write_yaml(tmp_path, text))
 
 
+def test_redaction_null_rejected(tmp_path):
+    """``redaction: null`` is present-but-invalid, not "no redaction".
+
+    Using ``data.get("redaction")`` conflated an explicit null with a
+    missing key and silently disabled scrubbing. The loader now checks
+    key presence so a null block fails validation (oyazdanb review).
+    """
+    text = _PROBE_MINIMAL + "redaction:\n"
+    with pytest.raises(RecipeSchemaError, match="must be a mapping when present"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
 def test_top_level_condition_rejected_as_phase_3(tmp_path):
     """Top-level ``condition:`` (outside custom_patterns[*].match) is Phase 3."""
     text = (

--- a/tests/probe/test_recipe.py
+++ b/tests/probe/test_recipe.py
@@ -169,15 +169,60 @@ def test_phase_3_keys_rejected_with_pointer(tmp_path):
     text = (
         _PROBE_MINIMAL
         + """\
-redaction:
-  scrub_env_keys: ["AWS_*"]
+condition:
+  - "exit_code != 0"
 """
     )
     with pytest.raises(RecipeSchemaError) as exc:
         load_recipe(_write_yaml(tmp_path, text))
     msg = str(exc.value)
     assert "Phase 3" in msg
-    assert "redaction" in msg
+    assert "condition" in msg
+
+
+def test_redaction_block_accepted_in_probe_mode(tmp_path):
+    text = (
+        _PROBE_MINIMAL
+        + """\
+redaction:
+  scrub_env_keys: ["AWS_*"]
+  scrub_paths: true
+  scrub_ip_addresses: true
+"""
+    )
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.probe_extras is not None
+    assert r.probe_extras.redaction is not None
+    assert r.probe_extras.redaction.scrub_paths is True
+
+
+def test_redaction_block_rejected_in_triage_mode(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 1
+cells:
+  - name: baseline
+    mitigations: [none]
+    environment: local
+redaction:
+  scrub_paths: true
+"""
+    with pytest.raises(RecipeSchemaError, match="probe-mode only"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_redaction_block_unknown_key_rejected(tmp_path):
+    text = (
+        _PROBE_MINIMAL
+        + """\
+redaction:
+  scrub_everything: true
+"""
+    )
+    with pytest.raises(RecipeSchemaError, match="unknown keys"):
+        load_recipe(_write_yaml(tmp_path, text))
 
 
 def test_top_level_condition_rejected_as_phase_3(tmp_path):

--- a/tests/probe/test_redaction.py
+++ b/tests/probe/test_redaction.py
@@ -227,6 +227,52 @@ def test_line_windows_reconstructs_input():
     assert "".join(_line_windows(text)) == text
 
 
+def test_line_windows_counts_bytes_not_chars(monkeypatch):
+    """Windowing budget is UTF-8 bytes, not code points (Copilot review).
+
+    A char-count threshold would undercount multi-byte text and skip
+    windowing even when the byte size exceeds the cap.
+    """
+    monkeypatch.setattr("aorta.probe.redaction.MAX_LOG_BYTES", 10)
+    text = "\u00e9\u00e9\u00e9\n\u00e9\u00e9\u00e9\n"  # two 7-byte lines
+    assert len(text) == 8  # code points (<= cap)
+    assert len(text.encode("utf-8")) == 14  # bytes (> cap)
+    windows = _line_windows(text)
+    assert len(windows) == 2  # byte-aware splits; a char-aware cap would not
+    assert "".join(windows) == text
+
+
+def test_scrubbed_copy_preserves_restrictive_mode(tmp_path: Path):
+    """Every scrub branch carries the source mode; a 0600 source stays 0600.
+
+    RedactingRedactor rewrites files (write_text/write_bytes) which land at
+    the umask default and would widen a restrictive source inside the
+    shareable bundle (Copilot review; same class as IdentityRedactor #199).
+    """
+    cfg = RedactionCfg(scrub_env_keys=("AWS_*",), scrub_paths=True)
+    redactor = RedactingRedactor(cfg)
+    cases = {
+        "result.json": json.dumps({"env": {"HOME": "/home/user"}}),
+        "host_env.json": json.dumps({"env": {"HOME": "/home/user"}}),
+        "stdout.log": "loaded /home/user/x\n",
+        "probe.env": "HOME=/home/user\n",
+    }
+    for name, content in cases.items():
+        src = tmp_path / name
+        src.write_text(content, encoding="utf-8")
+        src.chmod(0o600)
+        dst = tmp_path / "out" / name
+        redactor.scrub_file(src, dst)
+        assert dst.stat().st_mode & 0o777 == 0o600, f"{name} mode widened"
+    # binary / non-text artifact -> else branch
+    binsrc = tmp_path / "core.bin"
+    binsrc.write_bytes(b"\x00\x01\x02")
+    binsrc.chmod(0o600)
+    bindst = tmp_path / "out" / "core.bin"
+    redactor.scrub_file(binsrc, bindst)
+    assert bindst.stat().st_mode & 0o777 == 0o600, "binary copy mode widened"
+
+
 def test_scrub_text_spans_window_seam(monkeypatch):
     """A path/IP must not be missed when it lands on a window boundary.
 

--- a/tests/probe/test_redaction.py
+++ b/tests/probe/test_redaction.py
@@ -242,6 +242,30 @@ def test_line_windows_counts_bytes_not_chars(monkeypatch):
     assert "".join(windows) == text
 
 
+def test_line_windows_hard_splits_oversized_line(monkeypatch):
+    """A single line longer than the cap is split, not emitted whole (Copilot).
+
+    Line-based windowing only flushes between lines, so a hostile newline-free
+    log would otherwise be passed to the regex as one over-cap window and
+    defeat the byte budget. Each emitted window must stay ``<= MAX_LOG_BYTES``.
+    """
+    monkeypatch.setattr("aorta.probe.redaction.MAX_LOG_BYTES", 20)
+    text = "/" * 73  # one 73-byte line, no terminator, > cap
+    windows = _line_windows(text)
+    assert len(windows) > 1
+    assert all(len(w.encode("utf-8")) <= 20 for w in windows)
+    assert "".join(windows) == text
+
+
+def test_line_windows_oversized_multibyte_line_stays_under_cap(monkeypatch):
+    """Hard-split budget is bytes: a multi-byte over-cap line stays bounded."""
+    monkeypatch.setattr("aorta.probe.redaction.MAX_LOG_BYTES", 20)
+    text = "\u00e9" * 40  # 40 chars, 80 bytes, no terminator
+    windows = _line_windows(text)
+    assert all(len(w.encode("utf-8")) <= 20 for w in windows)
+    assert "".join(windows) == text
+
+
 def test_scrubbed_copy_preserves_restrictive_mode(tmp_path: Path):
     """Every scrub branch carries the source mode; a 0600 source stays 0600.
 
@@ -278,9 +302,12 @@ def test_scrub_text_spans_window_seam(monkeypatch):
 
     The old fixed-slice windowing cut tokens in half at ``i*MAX_LOG_BYTES``
     so neither regex pass matched them. Line-aware windows never split a
-    line, so an IP sitting just past the byte budget is still scrubbed.
+    line (when each line is within the cap), so an IP sitting just past the
+    byte budget is still scrubbed. The cap here is set so the token-bearing
+    line fits on its own but the two lines together force a between-lines
+    break -- the seam falls on the newline, not mid-token.
     """
-    monkeypatch.setattr("aorta.probe.redaction.MAX_LOG_BYTES", 20)
+    monkeypatch.setattr("aorta.probe.redaction.MAX_LOG_BYTES", 35)
     text = "x" * 15 + "\n" + "192.168.1.1 /home/user/secret\n"
     out, paths, v4, v6 = scrub_text(text, scrub_paths=True, scrub_ip_addresses=True)
     assert v4 == 1

--- a/tests/probe/test_redaction.py
+++ b/tests/probe/test_redaction.py
@@ -1,0 +1,154 @@
+"""Unit tests for ``aorta.probe.redaction`` (issue #188 Phase 3)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from aorta.probe.redaction import (
+    RedactingRedactor,
+    RedactionCfg,
+    scrub_env_keys,
+    scrub_text,
+)
+from aorta.probe.sandbox import MAX_LOG_BYTES
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_env_key_glob():
+    env = {
+        "AWS_ACCESS_KEY_ID": "AKIA",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "PATH": "/usr/bin",
+        "SAFE": "ok",
+    }
+    scrubbed, removed = scrub_env_keys(env, ("AWS_*",))
+    assert removed == 2
+    assert scrubbed == {"PATH": "/usr/bin", "SAFE": "ok"}
+
+
+def test_env_key_glob_case_sensitive():
+    env = {"aws_secret_key": "lower", "AWS_SECRET_KEY": "upper"}
+    scrubbed, removed = scrub_env_keys(env, ("AWS_*",))
+    assert removed == 1
+    assert "aws_secret_key" in scrubbed
+    assert "AWS_SECRET_KEY" not in scrubbed
+
+
+def test_path_rewrite():
+    text = (
+        "a /home/user/a/data/file.txt\n"
+        "b /home/user/a/data/file.txt\n"
+        "c /home/user/b/other.log\n"
+        "d /opt/third/path\n"
+        "e /opt/third/path\n"
+    )
+    out, paths, v4, v6 = scrub_text(text, scrub_paths=True, scrub_ip_addresses=False)
+    assert paths == 5
+    assert "<PATH:0>" in out
+    assert "<PATH:1>" in out
+    assert "<PATH:2>" in out
+    assert "/home/user" not in out
+    assert v4 == 0 and v6 == 0
+
+
+def test_path_rewrite_no_reverse_mapping_persisted(tmp_path: Path):
+    cfg = RedactionCfg(scrub_paths=True)
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "stdout.log"
+    dst = tmp_path / "out" / "stdout.log"
+    src.write_text("loaded /secret/path/file\n", encoding="utf-8")
+    counts = redactor.scrub_file(src, dst)
+    assert counts.paths_rewritten == 1
+    bundled = dst.read_text(encoding="utf-8")
+    assert "/secret/path/file" not in bundled
+    assert "<PATH:0>" in bundled
+    assert "mapping" not in bundled.lower()
+
+
+def test_ip_rewrite():
+    text = "host 192.168.0.1 and 2001:db8::1 here"
+    out, paths, v4, v6 = scrub_text(
+        text,
+        scrub_paths=False,
+        scrub_ip_addresses=True,
+    )
+    assert paths == 0
+    assert v4 == 1
+    assert v6 == 1
+    assert "<IPV4:0>" in out
+    assert "<IPV6:0>" in out
+    assert "192.168.0.1" not in out
+
+
+def test_redactor_kind_string():
+    assert RedactingRedactor(RedactionCfg()).kind == "probe.v1"
+
+
+def test_redaction_dos_bound():
+    """10 MiB slash run completes within 5 seconds (regex DoS guard)."""
+    blob = "/" * MAX_LOG_BYTES
+    t0 = time.perf_counter()
+    scrub_text(blob, scrub_paths=True, scrub_ip_addresses=False)
+    assert time.perf_counter() - t0 < 5.0
+
+
+def test_redacting_redactor_scrubs_result_json_env(tmp_path: Path):
+    cfg = RedactionCfg(
+        scrub_env_keys=("AWS_*", "HOME", "USER"),
+        scrub_paths=True,
+    )
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "result.json"
+    dst = tmp_path / "out" / "result.json"
+    src.write_text(
+        json.dumps(
+            {
+                "verdict": "pass",
+                "env": {"AWS_TOKEN": "x", "HIP_VISIBLE_DEVICES": "0"},
+                "argv": ["/home/user/train.py"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    counts = redactor.scrub_file(src, dst)
+    assert counts.env_keys_removed == 1
+    doc = json.loads(dst.read_text(encoding="utf-8"))
+    assert "AWS_TOKEN" not in doc["env"]
+    assert "<PATH:" in doc["argv"][0]
+
+
+def test_fixture_log_scrubs_paths_and_ips(tmp_path: Path):
+    raw = (FIXTURES / "redaction_input.txt").read_text(encoding="utf-8")
+    cfg = RedactionCfg(
+        scrub_paths=True,
+        scrub_ip_addresses=True,
+    )
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "stdout.log"
+    dst = tmp_path / "out" / "stdout.log"
+    src.write_text(raw, encoding="utf-8")
+    counts = redactor.scrub_file(src, dst)
+    out = dst.read_text(encoding="utf-8")
+    assert counts.paths_rewritten >= 3
+    assert counts.ips_rewritten >= 2
+    assert "/home/customer" not in out
+    assert "192.168.1.42" not in out
+
+
+def test_probe_env_scrubs_env_keys(tmp_path: Path):
+    cfg = RedactionCfg(scrub_env_keys=("AWS_*", "HOME", "USER"))
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "probe.env"
+    dst = tmp_path / "out" / "probe.env"
+    src.write_text(
+        "AWS_SECRET_ACCESS_KEY=supersecret\nHOME=/home/user\nSAFE=1\n",
+        encoding="utf-8",
+    )
+    counts = redactor.scrub_file(src, dst)
+    out = dst.read_text(encoding="utf-8")
+    assert counts.env_keys_removed == 2
+    assert "supersecret" not in out
+    assert "SAFE=1" in out

--- a/tests/probe/test_redaction.py
+++ b/tests/probe/test_redaction.py
@@ -145,6 +145,44 @@ def test_redacting_redactor_scrubs_result_json_env(tmp_path: Path):
     assert "<PATH:" in doc["argv"][0]
 
 
+def test_result_json_env_values_scrubbed(tmp_path: Path):
+    """Retained env values are path/IP-scrubbed, not just key-filtered.
+
+    Removing matching keys left a kept key's value (e.g. a *_PATH var)
+    leaking an absolute path/IP into the bundle even with scrub_paths on
+    (Copilot review). result.json env now matches host_env.json.
+    """
+    cfg = RedactionCfg(
+        scrub_env_keys=("AWS_*",),
+        scrub_paths=True,
+        scrub_ip_addresses=True,
+    )
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "result.json"
+    dst = tmp_path / "out" / "result.json"
+    src.write_text(
+        json.dumps(
+            {
+                "verdict": "pass",
+                "env": {
+                    "AWS_TOKEN": "drop-me",
+                    "LD_LIBRARY_PATH": "/home/customer/lib",
+                    "MASTER_ADDR": "192.168.1.42",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    counts = redactor.scrub_file(src, dst)
+    doc = json.loads(dst.read_text(encoding="utf-8"))
+    assert "AWS_TOKEN" not in doc["env"]
+    assert counts.env_keys_removed == 1
+    assert "/home/customer/lib" not in doc["env"]["LD_LIBRARY_PATH"]
+    assert "192.168.1.42" not in doc["env"]["MASTER_ADDR"]
+    assert counts.paths_rewritten >= 1
+    assert counts.ips_rewritten >= 1
+
+
 def test_fixture_log_scrubs_paths_and_ips(tmp_path: Path):
     raw = (FIXTURES / "redaction_input.txt").read_text(encoding="utf-8")
     cfg = RedactionCfg(

--- a/tests/probe/test_redaction.py
+++ b/tests/probe/test_redaction.py
@@ -6,6 +6,8 @@ import json
 import time
 from pathlib import Path
 
+import pytest
+
 from aorta.probe.redaction import (
     RedactingRedactor,
     RedactionCfg,
@@ -81,6 +83,27 @@ def test_ip_rewrite():
     assert "<IPV4:0>" in out
     assert "<IPV6:0>" in out
     assert "192.168.0.1" not in out
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        "loopback ::1 ok",
+        "fe80 link fe80::1 ok",
+        "bracket [::1] ok",
+        "url http://[::1]:8080/path",
+    ],
+)
+def test_ipv6_compressed_and_bracketed_forms(snippet: str):
+    out, _, v4, v6 = scrub_text(
+        snippet,
+        scrub_paths=False,
+        scrub_ip_addresses=True,
+    )
+    assert v4 == 0
+    assert v6 >= 1
+    assert "::1" not in out
+    assert "[::1]" not in out
 
 
 def test_redactor_kind_string():

--- a/tests/probe/test_redaction.py
+++ b/tests/probe/test_redaction.py
@@ -217,6 +217,68 @@ def test_result_json_env_values_scrubbed(tmp_path: Path):
     assert counts.ips_rewritten >= 1
 
 
+def test_result_json_placeholders_consistent_across_fields(tmp_path: Path):
+    """Path/IP placeholders share one index across the whole result.json.
+
+    The old per-leaf scrub_text() call allocated a fresh index per string,
+    so two DIFFERENT paths in different fields both became <PATH:0> (a
+    collision) and the SAME path in two fields could get different Ns
+    (inconsistent). One shared per-file index fixes both (Copilot review).
+    """
+    cfg = RedactionCfg(scrub_paths=True)
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "result.json"
+    dst = tmp_path / "out" / "result.json"
+    src.write_text(
+        json.dumps(
+            {
+                "a": "load /home/user/alpha",
+                "b": "load /home/user/beta",
+                "c": "again /home/user/alpha",
+            }
+        ),
+        encoding="utf-8",
+    )
+    counts = redactor.scrub_file(src, dst)
+    doc = json.loads(dst.read_text(encoding="utf-8"))
+    # alpha (fields a & c) shares one placeholder; beta (field b) gets a
+    # distinct one -- no collision, and the same path is consistent.
+    assert doc["a"].endswith("<PATH:0>")
+    assert doc["c"].endswith("<PATH:0>")
+    assert doc["b"].endswith("<PATH:1>")
+    assert "<PATH:0>" not in doc["b"]  # distinct paths never collide on one N
+    assert counts.paths_rewritten == 3
+
+
+def test_text_stream_scrub_matches_whole_file(tmp_path: Path, monkeypatch):
+    """Streaming a multi-window log scrubs identically + byte-faithfully.
+
+    The text branch streams off disk instead of reading the whole file
+    (memory spike on big stdout.log; Copilot review). Output must equal a
+    whole-file scrub_text pass: placeholders consistent across windows and
+    CRLF terminators preserved byte-for-byte. A tiny cap forces many windows.
+    """
+    monkeypatch.setattr("aorta.probe.redaction.MAX_LOG_BYTES", 64)
+    cfg = RedactionCfg(scrub_paths=True, scrub_ip_addresses=True)
+    redactor = RedactingRedactor(cfg)
+    # Repeated path/IP across many windows so cross-window placeholder
+    # consistency (one shared index) is exercised; CRLF terminators included.
+    line = "loaded /home/user/alpha from 192.168.1.42\r\n"
+    text = line * 200
+    src = tmp_path / "stdout.log"
+    dst = tmp_path / "out" / "stdout.log"
+    src.write_bytes(text.encode("utf-8"))
+    redactor.scrub_file(src, dst)
+    expected, _, _, _ = scrub_text(text, scrub_paths=True, scrub_ip_addresses=True)
+    out_bytes = dst.read_bytes()
+    assert out_bytes == expected.encode("utf-8")
+    assert b"\r\n" in out_bytes  # CRLF preserved (no universal-newline translation)
+    out = out_bytes.decode("utf-8")
+    assert "/home/user/alpha" not in out
+    assert "192.168.1.42" not in out
+    assert out.count("<PATH:0>") == 200  # one shared index, not per-window
+
+
 def test_fixture_log_scrubs_paths_and_ips(tmp_path: Path):
     raw = (FIXTURES / "redaction_input.txt").read_text(encoding="utf-8")
     cfg = RedactionCfg(

--- a/tests/probe/test_redaction.py
+++ b/tests/probe/test_redaction.py
@@ -8,9 +8,11 @@ from pathlib import Path
 
 import pytest
 
+from aorta.bundle.errors import RedactionError
 from aorta.probe.redaction import (
     RedactingRedactor,
     RedactionCfg,
+    _line_windows,
     scrub_env_keys,
     scrub_text,
 )
@@ -159,6 +161,77 @@ def test_fixture_log_scrubs_paths_and_ips(tmp_path: Path):
     assert counts.ips_rewritten >= 2
     assert "/home/customer" not in out
     assert "192.168.1.42" not in out
+
+
+def test_invalid_utf8_log_still_scrubbed(tmp_path: Path):
+    """A stray non-UTF-8 byte must not disable scrubbing (oyazdanb review).
+
+    stdout.log / stderr.log are raw subprocess bytes by design; the
+    redactor used to fail open (byte-copy the file) on the first
+    UnicodeDecodeError, silently leaking every path/IP after it. It now
+    decodes with errors="replace" and keeps scrubbing.
+    """
+    cfg = RedactionCfg(scrub_paths=True, scrub_ip_addresses=True)
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "stdout.log"
+    dst = tmp_path / "out" / "stdout.log"
+    src.write_bytes(b"bad\xff  /home/user/secret 192.168.1.1\n")
+    counts = redactor.scrub_file(src, dst)
+    out = dst.read_text(encoding="utf-8")
+    assert counts.paths_rewritten >= 1
+    assert counts.ips_rewritten >= 1
+    assert "/home/user/secret" not in out
+    assert "192.168.1.1" not in out
+
+
+def test_line_windows_reconstructs_input():
+    text = "alpha\nbeta\r\ngamma\rdelta\nno-trailing-newline"
+    assert "".join(_line_windows(text)) == text
+
+
+def test_scrub_text_spans_window_seam(monkeypatch):
+    """A path/IP must not be missed when it lands on a window boundary.
+
+    The old fixed-slice windowing cut tokens in half at ``i*MAX_LOG_BYTES``
+    so neither regex pass matched them. Line-aware windows never split a
+    line, so an IP sitting just past the byte budget is still scrubbed.
+    """
+    monkeypatch.setattr("aorta.probe.redaction.MAX_LOG_BYTES", 20)
+    text = "x" * 15 + "\n" + "192.168.1.1 /home/user/secret\n"
+    out, paths, v4, v6 = scrub_text(text, scrub_paths=True, scrub_ip_addresses=True)
+    assert v4 == 1
+    assert paths == 1
+    assert "192.168.1.1" not in out
+    assert "/home/user/secret" not in out
+
+
+def test_corrupt_result_json_fails_closed(tmp_path: Path):
+    """Corrupt result.json fails closed with a typed BundleError (Issue E).
+
+    A raw JSONDecodeError would escape staging as a traceback and is not
+    an OSError, so the writer's OSError wrap would miss it -- and partial
+    handling risks an unredacted bundle. RedactionError is a BundleError,
+    so the CLI fails closed (no bundle written).
+    """
+    cfg = RedactionCfg(scrub_paths=True)
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "result.json"
+    dst = tmp_path / "out" / "result.json"
+    src.write_text("{ this is not valid json", encoding="utf-8")
+    with pytest.raises(RedactionError) as excinfo:
+        redactor.scrub_file(src, dst)
+    assert excinfo.value.path == src
+    assert not dst.exists()
+
+
+def test_corrupt_host_env_json_fails_closed(tmp_path: Path):
+    cfg = RedactionCfg(scrub_env_keys=("AWS_*",))
+    redactor = RedactingRedactor(cfg)
+    src = tmp_path / "host_env.json"
+    dst = tmp_path / "out" / "host_env.json"
+    src.write_text("not json at all", encoding="utf-8")
+    with pytest.raises(RedactionError):
+        redactor.scrub_file(src, dst)
 
 
 def test_probe_env_scrubs_env_keys(tmp_path: Path):

--- a/tests/probe/test_redaction.py
+++ b/tests/probe/test_redaction.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import time
 from pathlib import Path
 
 import pytest
@@ -13,10 +12,12 @@ from aorta.probe.redaction import (
     RedactingRedactor,
     RedactionCfg,
     _line_windows,
+    parse_redaction,
     scrub_env_keys,
     scrub_text,
 )
 from aorta.probe.sandbox import MAX_LOG_BYTES
+from aorta.triage.recipe import RecipeSchemaError
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -56,6 +57,31 @@ def test_path_rewrite():
     assert "<PATH:2>" in out
     assert "/home/user" not in out
     assert v4 == 0 and v6 == 0
+
+
+def test_path_rewrite_double_slash_and_file_url():
+    """A path whose leading '/' follows another '/' must still scrub (Copilot).
+
+    The negative lookbehind once included '/', which skipped the path inside
+    `file:///home/user/...` and protocol-relative `//host/home/user/...`,
+    leaking absolute paths the scrubber documents it removes.
+    """
+    text = "u file:///home/user/secret\np //host/home/user/secret\n"
+    out, paths, v4, v6 = scrub_text(text, scrub_paths=True, scrub_ip_addresses=False)
+    assert paths == 2
+    assert "/home/user/secret" not in out
+    assert "<PATH:0>" in out and "<PATH:1>" in out
+
+
+def test_parse_redaction_non_string_key_fails_closed():
+    """A non-string mapping key must raise RecipeSchemaError, not TypeError.
+
+    YAML allows `1: x`; the unknown-key error sorts the offending keys, and a
+    mixed str/int set would raise TypeError sorting -- escaping as an
+    unhandled exception instead of the recipe schema error (Copilot).
+    """
+    with pytest.raises(RecipeSchemaError, match="unknown keys"):
+        parse_redaction({1: "x", "scrub_paths": True})
 
 
 def test_path_rewrite_no_reverse_mapping_persisted(tmp_path: Path):
@@ -112,12 +138,20 @@ def test_redactor_kind_string():
     assert RedactingRedactor(RedactionCfg()).kind == "probe.v1"
 
 
+@pytest.mark.timeout(15)
 def test_redaction_dos_bound():
-    """10 MiB slash run completes within 5 seconds (regex DoS guard)."""
+    """A 10 MiB slash run must not blow up regex CPU (DoS guard).
+
+    Enforced with pytest-timeout (a declared dev dep) rather than a measured
+    ``perf_counter() < 5.0`` assertion: a wall-clock assert is flaky under CI
+    load, and -- more importantly -- if the regex DID catastrophically
+    backtrack the call would never return, so the post-hoc assert would never
+    run. The timeout marker bounds the whole test even on a true hang. The
+    15 s budget is generous headroom over the sub-second normal runtime.
+    """
     blob = "/" * MAX_LOG_BYTES
-    t0 = time.perf_counter()
-    scrub_text(blob, scrub_paths=True, scrub_ip_addresses=False)
-    assert time.perf_counter() - t0 < 5.0
+    result = scrub_text(blob, scrub_paths=True, scrub_ip_addresses=False)
+    assert len(result) == 4
 
 
 def test_redacting_redactor_scrubs_result_json_env(tmp_path: Path):
@@ -295,6 +329,23 @@ def test_scrubbed_copy_preserves_restrictive_mode(tmp_path: Path):
     bindst = tmp_path / "out" / "core.bin"
     redactor.scrub_file(binsrc, bindst)
     assert bindst.stat().st_mode & 0o777 == 0o600, "binary copy mode widened"
+
+
+def test_binary_artifact_copied_byte_identical(tmp_path: Path):
+    """The binary no-scrub branch streams via copyfile, byte-identical + counts.
+
+    The branch no longer reads the whole artifact into memory (memory spike on
+    a multi-GB core dump); it must still copy contents exactly and report
+    bytes_in == bytes_out == file size from stat() (Copilot).
+    """
+    payload = bytes(range(256)) * 8
+    src = tmp_path / "core.bin"
+    src.write_bytes(payload)
+    dst = tmp_path / "out" / "core.bin"
+    counts = RedactingRedactor(RedactionCfg(scrub_paths=True)).scrub_file(src, dst)
+    assert dst.read_bytes() == payload
+    assert counts.bytes_in == len(payload)
+    assert counts.bytes_out == len(payload)
 
 
 def test_scrub_text_spans_window_seam(monkeypatch):

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -122,6 +122,27 @@ def test_fail_minimum_result_shape(tmp_path):
     assert result.passed is False
 
 
+def test_env_file_failure_result_includes_env(tmp_path):
+    """The env-file-validation failure result.json carries env (Copilot review).
+
+    The normal path records ``env`` for audit/redaction; the failure path
+    used to omit it, so a corrupted-env trial produced a result.json with
+    no env to scrub. It now mirrors the normal shape.
+    """
+    wl = _make_workload(
+        tmp_path,
+        ["true"],
+        env_passthrough_mode="file",
+        cell_env_vars={"BAD_VALUE": "line1\nline2"},
+    )
+    wl.setup()
+    wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["failure_type"] == "env_file_validation_failed"
+    assert doc["env"] == {"BAD_VALUE": "line1\nline2"}
+
+
 def test_missing_executable_yields_fail(tmp_path):
     """argv[0] not found surfaces as a Tier-1 fail with exit_code=127."""
     wl = _make_workload(tmp_path, ["definitely-not-a-real-binary-9d8f7s6"])

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -95,13 +95,14 @@ def test_pass_minimum_result_shape(tmp_path):
     assert result_path.is_file()
     doc = json.loads(result_path.read_text(encoding="utf-8"))
     # FR 1.12: minimum shape.
-    for key in ("verdict", "exit_code", "walltime_sec", "argv", "cell_name", "trial_index"):
+    for key in ("verdict", "exit_code", "walltime_sec", "argv", "cell_name", "trial_index", "env"):
         assert key in doc, f"missing required key {key} in result.json"
     assert doc["verdict"] == "pass"
     assert doc["exit_code"] == 0
     assert doc["argv"] == ["true"]
     assert doc["cell_name"] == "none-none"
     assert doc["trial_index"] == 0
+    assert isinstance(doc["env"], dict)
     assert isinstance(doc["walltime_sec"], (int, float))
     # stdout.log and stderr.log written.
     assert (trial_dir / "stdout.log").is_file()


### PR DESCRIPTION
## Summary

Completes **Phase 3 of issue #188**: ships `aorta.probe.redaction` (env-key glob + path + IP scrubbers as `RedactingRedactor`), wires it into `aorta bundle` via `--redaction-from` / `<run-dir>/recipe.resolved.yaml` auto-fallback, accepts `redaction:` in probe-mode recipes, adds `result.json::env` for auditable cell env bundles, and publishes three handout recipe templates.

Per rubric finding **F5**, Phase 3 is gated on `aorta bundle` landing first — this branch stacks on top of the Phase 2 (#197) and bundle (#199) work already present in the commit history below `main`.

### Redactor handoff contract (from `docs/probe-188/bundle.md`)

`aorta.bundle.redactor.Redactor` is an ABC with one method: `scrub_file(src, dst) -> RedactionCounts`. **`aorta bundle` does not own the scrubbers** — Phase 3 fills in `RedactingRedactor` (`redactor_kind: "probe.v1"`) while the bundle pipeline (staging, manifest, tarball) stays redactor-agnostic.

## What's in the Phase 3 commit (`2318d43`)

- **`src/aorta/probe/redaction.py`** — `RedactionCfg`, `parse_redaction()`, three scrubbers, `RedactingRedactor`
- **`src/aorta/probe/bundle_hook.py`** — recipe → redactor adapter with auto-fallback to `recipe.resolved.yaml`
- **`src/aorta/cli/bundle.py`** — consumes redactor (drops the old “logged but not consumed” `--redaction-from` stub)
- **Recipe schema** — `redaction:` accepted in probe-mode; removed from deferred Phase 3 key rejection
- **`result.json::env`** — cell mitigation+diagnostic env bundle written by `SubprocessWorkload`
- **Handout templates** — `recipes/probe-template-{torchrun,buck2,bash}.yaml`
- **Docs** — `docs/probe-188/redaction.md`, `handout-templates.md`; updated `usage.md`, `bundle.md`, `classifier.md`

## Rubric §3.B hard gates — test coverage

| FR | Test |
|---|---|
| 3.1 no-ticket refusal | `tests/probe/test_bundle_integration.py::test_refuses_no_ticket` |
| 3.3 env-key glob | `tests/probe/test_redaction.py::test_env_key_glob` |
| 3.4 path rewrite | `tests/probe/test_redaction.py::test_path_rewrite` |
| 3.5 IP rewrite | `tests/probe/test_redaction.py::test_ip_rewrite` |
| 3.6 manifest counts | `tests/probe/test_bundle_integration.py::test_manifest_records_per_file_counts` |
| 3.9 originals untouched | `tests/probe/test_bundle_integration.py::test_originals_untouched` |

## Stacked dependencies (already on this branch, not yet on `main`)

This PR also includes commits from:

- **Phase 2 (#197)** — five-tier classifier + sandboxed `custom_patterns`
- **Bundle (#199 / #196)** — `aorta bundle` command + manifest + redactor protocol

If #197 and #199 land on `main` first, this branch can be rebased to isolate the Phase 3 diff for review.

## Security review (Open Question #1)

Redaction semantics are documented in `docs/probe-188/redaction.md` with a sign-off checklist. **Security-reviewer approval is required before external customers run `aorta bundle` on real probe artifacts.**

## Test plan

- [x] `pytest tests/probe tests/bundle tests/triage` — 592 passed
- [x] `ruff check`, `black --check`, `isort --check`, `mypy` clean on changed files
- [x] `buck2 build //:aorta_lib //:aorta` — BUILD SUCCEEDED
- [x] `aorta probe --recipe recipes/probe-template-bash.yaml --dry-run -- echo hi` — exit 0
- [x] `aorta bundle <ticket-dir> --review` with redaction recipe — manifest shows non-zero counts, originals untouched
- [ ] Security reviewer sign-off recorded in PR thread

## References

- Issue: #188 (Phase 3)
- Builds on: #197 (Phase 2), #199 / #196 (`aorta bundle`)
- Rubric: `docs/plans/aorta-probe-188-rubric.md` §PHASE 3


Made with [Cursor](https://cursor.com)