### PR TITLE
registry: add HSA_DISABLE_CACHE + DEBUG_HIP_DYNAMIC_QUEUES built-in mitigation pairs (follow-up to #195)

### DIFF
--- a/recipes/probe-flag-sweep.yaml
+++ b/recipes/probe-flag-sweep.yaml
@@ -45,6 +45,8 @@ mitigation_axis:
   - roc_aql_queue_size_1024      # caps CPU-GPU AQL queue depth (backpressure)
   - nccl_launch_order_implicit   # serializes RCCL launches device-wide
   - hsa_no_scratch_reclaim
+  - hsa_disable_cache            # HSA_DISABLE_CACHE=1
+  - hsa_enable_cache             # HSA_DISABLE_CACHE=0
   - hsa_no_sdma
   - pytorch_no_cuda_memory_caching
   - pytorch_alloc_expandable_segments

--- a/recipes/probe-flag-sweep.yaml
+++ b/recipes/probe-flag-sweep.yaml
@@ -42,6 +42,8 @@ trials: 1
 mitigation_axis:
   - none
   - gpu_max_hw_queues_2          # caps hardware queue parallelism
+  - debug_hip_dynamic_queues_1   # DEBUG_HIP_DYNAMIC_QUEUES=1
+  - debug_hip_dynamic_queues_2   # DEBUG_HIP_DYNAMIC_QUEUES=2
   - roc_aql_queue_size_1024      # caps CPU-GPU AQL queue depth (backpressure)
   - nccl_launch_order_implicit   # serializes RCCL launches device-wide
   - hsa_no_scratch_reclaim

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -262,7 +262,7 @@ internal sidecar for stack-specific vars:
 
 | Surface | Location | Contents |
 |---|---|---|
-| Runtime mitigations | Built-in registry (`mitigations.py`) | `gpu_max_hw_queues_2`, `roc_aql_queue_size_1024`, `nccl_launch_order_implicit`, `hsa_no_scratch_reclaim`, `pytorch_no_cuda_memory_caching`, `fa_prefer_ck` / `fa_prefer_aotriton`, and others — see `aorta mitigations list` |
+| Runtime mitigations | Built-in registry (`mitigations.py`) | `gpu_max_hw_queues_2`, `roc_aql_queue_size_1024`, `nccl_launch_order_implicit`, `hsa_no_scratch_reclaim`, `hsa_disable_cache` / `hsa_enable_cache`, `pytorch_no_cuda_memory_caching`, `fa_prefer_ck` / `fa_prefer_aotriton`, and others — see `aorta mitigations list` |
 | Workload-internal flags | [`examples/probe-flag-sidecar.json`](../../../examples/probe-flag-sidecar.json) | `FBGEMM_*`, `TORCHINDUCTOR_*`, `EVAL_DISABLE_PIPELINING` — only effective when the workload reads them |
 | Ready-made probe recipe | [`recipes/probe-flag-sweep.yaml`](../../../recipes/probe-flag-sweep.yaml) | `mitigation_axis` + `diagnostic_axis` covering the built-in set |
 

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -262,7 +262,7 @@ internal sidecar for stack-specific vars:
 
 | Surface | Location | Contents |
 |---|---|---|
-| Runtime mitigations | Built-in registry (`mitigations.py`) | `gpu_max_hw_queues_2`, `roc_aql_queue_size_1024`, `nccl_launch_order_implicit`, `hsa_no_scratch_reclaim`, `hsa_disable_cache` / `hsa_enable_cache`, `pytorch_no_cuda_memory_caching`, `fa_prefer_ck` / `fa_prefer_aotriton`, and others — see `aorta mitigations list` |
+| Runtime mitigations | Built-in registry (`mitigations.py`) | `gpu_max_hw_queues_2`, `debug_hip_dynamic_queues_1` / `debug_hip_dynamic_queues_2`, `roc_aql_queue_size_1024`, `nccl_launch_order_implicit`, `hsa_no_scratch_reclaim`, `hsa_disable_cache` / `hsa_enable_cache`, `pytorch_no_cuda_memory_caching`, `fa_prefer_ck` / `fa_prefer_aotriton`, and others — see `aorta mitigations list` |
 | Workload-internal flags | [`examples/probe-flag-sidecar.json`](../../../examples/probe-flag-sidecar.json) | `FBGEMM_*`, `TORCHINDUCTOR_*`, `EVAL_DISABLE_PIPELINING` — only effective when the workload reads them |
 | Ready-made probe recipe | [`recipes/probe-flag-sweep.yaml`](../../../recipes/probe-flag-sweep.yaml) | `mitigation_axis` + `diagnostic_axis` covering the built-in set |
 

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -48,6 +48,12 @@ BUILTIN_MITIGATIONS: dict[str, dict[str, str]] = {
     "hsa_no_scratch_reclaim": {
         "HSA_NO_SCRATCH_RECLAIM": "1",
     },
+    "hsa_disable_cache": {
+        "HSA_DISABLE_CACHE": "1",
+    },
+    "hsa_enable_cache": {
+        "HSA_DISABLE_CACHE": "0",
+    },
     "roc_signal_pool_16k": {
         "ROC_SIGNAL_POOL_SIZE": "16384",
     },

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -39,6 +39,12 @@ BUILTIN_MITIGATIONS: dict[str, dict[str, str]] = {
     "gpu_max_hw_queues_2": {
         "GPU_MAX_HW_QUEUES": "2",
     },
+    "debug_hip_dynamic_queues_1": {
+        "DEBUG_HIP_DYNAMIC_QUEUES": "1",
+    },
+    "debug_hip_dynamic_queues_2": {
+        "DEBUG_HIP_DYNAMIC_QUEUES": "2",
+    },
     "roc_aql_queue_size_1024": {
         "ROC_AQL_QUEUE_SIZE": "1024",
     },

--- a/tests/registry/test_mitigations.py
+++ b/tests/registry/test_mitigations.py
@@ -26,6 +26,8 @@ PROBE_FLAG_BUILTIN_EXPECTED: dict[str, dict[str, str]] = {
     "gpu_force_blit_copy_128": {"GPU_FORCE_BLIT_COPY_SIZE": "128"},
     "gpu_max_hw_queues_2": {"GPU_MAX_HW_QUEUES": "2"},
     "hip_launch_blocking": {"HIP_LAUNCH_BLOCKING": "1"},
+    "hsa_disable_cache": {"HSA_DISABLE_CACHE": "1"},
+    "hsa_enable_cache": {"HSA_DISABLE_CACHE": "0"},
     "hsa_no_scratch_reclaim": {"HSA_NO_SCRATCH_RECLAIM": "1"},
     "hsa_no_sdma": {"HSA_ENABLE_SDMA": "0"},
     "nccl_launch_order_implicit": {"NCCL_LAUNCH_ORDER_IMPLICIT": "1"},

--- a/tests/registry/test_mitigations.py
+++ b/tests/registry/test_mitigations.py
@@ -21,6 +21,8 @@ from aorta.registry.mitigations import BUILTIN_MITIGATIONS, get_mitigation, load
 PROBE_FLAG_BUILTIN_EXPECTED: dict[str, dict[str, str]] = {
     "amd_log_level_4": {"AMD_LOG_LEVEL": "4"},
     "debug_clr_no_batch_cpu_sync": {"DEBUG_CLR_BATCH_CPU_SYNC_SIZE": "0"},
+    "debug_hip_dynamic_queues_1": {"DEBUG_HIP_DYNAMIC_QUEUES": "1"},
+    "debug_hip_dynamic_queues_2": {"DEBUG_HIP_DYNAMIC_QUEUES": "2"},
     "fa_prefer_aotriton": {"TORCH_ROCM_FA_PREFER_CK": "0"},
     "fa_prefer_ck": {"TORCH_ROCM_FA_PREFER_CK": "1"},
     "gpu_force_blit_copy_128": {"GPU_FORCE_BLIT_COPY_SIZE": "128"},


### PR DESCRIPTION
Follow-up to #198 / #195.

## Summary

Registers two runtime built-in mitigation pairs so they can be referenced by name in `aorta probe` sweeps:

**`HSA_DISABLE_CACHE`** (mirrors the `fa_prefer_ck` / `fa_prefer_aotriton` pattern for `TORCH_ROCM_FA_PREFER_CK`):

| Name | Env vars |
| --- | --- |
| `hsa_disable_cache` | `HSA_DISABLE_CACHE=1` |
| `hsa_enable_cache` | `HSA_DISABLE_CACHE=0` |

**`DEBUG_HIP_DYNAMIC_QUEUES`** (mirrors the `gpu_max_hw_queues_2` value-in-name convention for queue knobs; controls dynamic HIP queue assignment for busy streams such as a2a / torchrec `sparse_dist`):

| Name | Env vars |
| --- | --- |
| `debug_hip_dynamic_queues_1` | `DEBUG_HIP_DYNAMIC_QUEUES=1` |
| `debug_hip_dynamic_queues_2` | `DEBUG_HIP_DYNAMIC_QUEUES=2` |

Both pairs are wired into `recipes/probe-flag-sweep.yaml` and the hand-spelled `PROBE_FLAG_BUILTIN_EXPECTED` test dict, and documented in the registry README.

## Out of scope

- `TORCH_ROCM_FA_PREFER_CK=1` — already registered in #198 as `fa_prefer_ck`.
- `DEBUG_HIP_DYNAMIC_QUEUES=0` (disable) — the `none` cell already provides the no-flag baseline.
- Experiment narrative (LSE corruption / multi-process fwd+bwd race) — the flags are registered as generic ROCm runtime knobs, consistent with #198's generic framing.

## Test plan

- [x] `PYTHONPATH=src pytest tests/registry/test_mitigations.py` — 29 passed (was 27; +2 parametrised cases for the `DEBUG_HIP_DYNAMIC_QUEUES` pair)
- [x] `buck2 run //:aorta -- probe --recipe recipes/probe-flag-sweep.yaml --dry-run -- echo hi` — exits 0, **54 cells** (was 42 → 48 → 54 across the two pairs)
- [x] `ruff check` on touched Python files — clean

## Commits

1. `registry: add HSA_DISABLE_CACHE built-in mitigation pair` — `HSA_DISABLE_CACHE=1/0`
2. `registry: add DEBUG_HIP_DYNAMIC_QUEUES built-in mitigation pair` — `DEBUG_HIP_DYNAMIC_QUEUES=1/2`

Squash-on-merge collapses these into a single registration commit.