### PR TITLE
Add llm_determinism workload: per-block FSDP2 replay probe for SDC / nondeterminism

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Stress-test GPU queue scheduling with 8-64+ concurrent streams. Includes 15 work
 **Environment Snapshot for Reproducibility**
 Capture a versioned, schema-stable snapshot of the trial environment — ROCm / HIP / hipBLASLt / rocBLAS / MIOpen / RCCL identities, GPU arch, PyTorch build flags + cmake cache + per-target HIPCC defines, runtime SDPA backend state, ~30 numerics-relevant env vars — so cross-environment regressions become a `jq` diff instead of a multi-day investigation. Used standalone (`aorta env probe`) and embedded automatically into every trial result.
 
+**LLM Determinism Probe**
+Catch kernel-level nondeterminism / silent data corruption in a transformer training step. Runs the same forward+backward twice on the same inputs (params + RNG restored between runs) and compares bit-exact checksums of every per-block boundary activation, loss, logits, every grad, and every param. FSDP2-aware, RCCL-safe, optional MoE. See [`docs/llm-determinism.md`](docs/llm-determinism.md) for the quick start.
+
 
 ## Quick Start
 

--- a/docs/llm-determinism.md
+++ b/docs/llm-determinism.md
@@ -1,0 +1,113 @@
+# LLM Determinism Recipe
+
+War-room helper for catching kernel-level nondeterminism / silent data
+corruption in a transformer training step. Runs the **same** forward+
+backward twice on the same inputs, with parameters and RNG restored
+between runs, and compares bit-exact checksums of:
+
+- every per-block boundary activation (entering and leaving each
+  repetition of the single repeated block — the FSDP2 comm boundary)
+- the final loss and logits
+- every grad and every param after backward
+
+If any checksum drifts → some kernel (matmul, attention, reduction,
+collective) is producing different bits for the same inputs.
+
+## Why a single repeated block?
+
+The war-room execution model is a chain of repeating
+`comm_kernel_i → compute_kernel_i` stages. One repetition of the same
+transformer block is one such stage, and under FSDP2 `fully_shard` the
+block boundary is also the all-gather / reduce-scatter boundary. So
+checksumming the activation at every block boundary checksums the
+tensor that actually crosses GPUs at every repetition.
+
+This is **not a faithful LLM**. Weights are random init, the specific
+architecture (LayerNorm + MHA + GLU FFN, optional top-1 MoE) is generic
+on purpose. The model and its size are knobs to control how much data
+crosses GPU boundaries, nothing more.
+
+## What it doesn't do
+
+- Not a quality benchmark.
+- Not a perf benchmark — manual attention, no `torch.compile`, no graphs.
+- Not a multi-step trainer by default; `steps` is configurable but each
+  step is a self-contained replay.
+- Does not intercept kernels directly. Module forward pre/post hooks are
+  the practical proxy for the comm boundary; documented limitation.
+
+## Running
+
+```bash
+# 40-GPU capture run (adjust to your cluster shape):
+torchrun --nproc_per_node=8 --nnodes=5 -m aorta.cli run \
+  --workload llm_determinism \
+  --recipe recipes/example-llm-determinism.yaml
+
+# Single rank / local dev:
+python -m aorta.cli run --workload llm_determinism
+```
+
+Pass → every per-rank per-block (and per-param) checksum matched.
+Fail → workload prints which checksums diverged on which rank and which
+block index.
+
+## Knobs
+
+| Key | Default | Notes |
+|---|---|---|
+| `num_layers` | 24 | Block repetitions = comm/compute stages. Drop to scale down with rank count. |
+| `hidden_size` | 2048 | Per-block hidden width. |
+| `ffn_size` | 5632 | GLU FFN width. |
+| `num_heads` | 16 | Must divide `hidden_size`. |
+| `vocab_size` | 32000 | Random embedding table. |
+| `seq_len` | 512 | Per-rank batch sequence length. |
+| `batch_size` | 1 | Per-rank batch. |
+| `num_experts` | 1 | 1 = dense FFN; ≥2 = top-1 MoE router across N experts. |
+| `dtype` | `bf16` | `bf16` / `fp16` / `fp32`. |
+| `seed` | 1234 | Synthetic batch + RNG seed. |
+| `steps` | 1 | Number of independent replay steps. |
+| `checksum_mode` | `per_rank` | `global` also all-reduces a fingerprint. |
+| `capture_dir` | unset | When set, every step writes `rank<NNN>.jsonl` for offline inspection. |
+| `model_label` | `generic-repeated-block` | Advisory only; recorded in metrics. |
+
+## Rule-#4 compliance
+
+By default (`checksum_mode: per_rank`) each rank only compares its own
+run-1 vs run-2 shards / block boundaries. Pass/fail is OR'd across ranks
+via a single all-reduced integer flag. `checksum_mode: global` opts in
+to additionally comparing an all-reduced loss⊕output fingerprint, which
+catches collective ordering drift but no longer satisfies the strict
+"single-rank only" guard.
+
+## Determinism caveats
+
+`torch.use_deterministic_algorithms(True, warn_only=True)` is enabled at
+setup. Some ops have no deterministic implementation; we tolerate that
+because the checksum compare is what actually proves replayability.
+`CUBLAS_WORKSPACE_CONFIG=:4096:8` is set if not already present —
+hipBLAS / cuBLAS require this for deterministic matmul.
+
+## Capture-mode output
+
+When `capture_dir` is set, each rank writes one line per (run, step):
+
+```json
+{"rank": 7, "step": 0, "run": "r1", "loss_bits": 12345, "output_bits": 67890,
+ "block_pre": [<int per block>], "block_post": [<int per block>]}
+```
+
+This is the raw material for offline analysis on the 40-GPU capture run —
+e.g. `jq` for ranks whose `block_pre[i]` differs between `r1` and `r2`,
+or a comparison of the same rank's checksums across two whole captures
+collected on different nodes / dates.
+
+## Metrics surface (stable for detector parsing)
+
+`WorkloadResult.metrics` includes:
+
+- `ranks_with_divergence`
+- `steps[*].loss_bits_r1`, `loss_bits_r2`, `num_blocks_checked`
+- `divergence_reasons` (first 32, when present)
+- `model_label`, `num_layers`, `num_experts`, `dtype`, `checksum_mode`,
+  `capture_dir`

--- a/docs/llm-determinism.md
+++ b/docs/llm-determinism.md
@@ -54,7 +54,7 @@ torchrun --standalone --nproc_per_node=8 /tmp/run_llm_det.py
 **Expected on a healthy stack:**
 - Exit 0; every rank prints `passed=True failures=0 ranks_with_divergence=0`
 - `/tmp/llm_det_capture/rank000.jsonl` … `rank007.jsonl` exist, 2 lines each (`run=r1`, `run=r2`)
-- `loss_bits` is non-zero (~1.15e9 with defaults) and **equal between r1 and r2 on each rank**
+- `loss_bits` is non-zero and **equal between r1 and r2 on each rank** (with the defaults this lands around ±1.1e9 — the loss is a single fp32 scalar viewed bit-for-bit as int32, so the value is an int near `loss.item()`'s fp32 bit pattern, not a numeric magnitude)
 - `block_pre` / `block_post` lists are length `num_layers`
 
 ### Validate the detector actually flags real divergence
@@ -214,7 +214,7 @@ Tar up:
 | `num_experts` | 1 | 1 = dense FFN; ≥2 = top-1 MoE router across N experts. |
 | `dtype` | `bf16` | `bf16` / `fp16` / `fp32`. |
 | `seed` | 1234 | Synthetic batch + RNG seed. |
-| `steps` | 1 | Number of independent replay steps. |
+| `steps` | 1 | Number of replay steps. Each step is a fresh snapshot → r1 → restore → r2 → compare. There is no optimizer step between steps, so on a healthy stack every step's checksums are bit-identical to step 0's — `steps > 1` is useful as a flake-detector / soak, not as training progress. |
 | `checksum_mode` | `per_rank` | `global` also all-reduces a fingerprint across ranks. |
 | `capture_dir` | unset | When set, every step writes `rank<NNN>.jsonl` for offline inspection. |
 | `model_label` | `generic-repeated-block` | Advisory only; recorded in metrics. |

--- a/docs/llm-determinism.md
+++ b/docs/llm-determinism.md
@@ -145,16 +145,22 @@ cells:
       capture_dir: ./llm_det_capture/moe4-bf16-12L
 ```
 
-Launch:
+Launch (use the `aorta` console script — `python -m aorta.triage.cli` is **not** a runnable module):
 
 ```bash
-torchrun --standalone --nproc_per_node=8 \
-  -m aorta.triage.cli run --recipe recipes/example-llm-determinism.yaml
+torchrun --standalone --nproc_per_node=8 $(which aorta) triage run \
+  --recipe recipes/example-llm-determinism.yaml
 ```
 
 Two schema gotchas the loader enforces:
 - `steps` is a first-class recipe field; putting it in `workload_config` is rejected (would be silently clobbered).
 - Keys starting with `_aorta_` are reserved and rejected.
+
+**Per-cell step times include warmup.** Cells run sequentially in one
+process; the first cell absorbs FSDP2 / RCCL / hipBLAS warmup, so its
+step time is typically much higher than later cells (in one 4-cell
+smoke we saw 2453 ms on the first cell vs 78–912 ms on later ones).
+That is not a determinism signal — the per-rank checksum compare is.
 
 ### If you see divergence — what to send back
 

--- a/docs/llm-determinism.md
+++ b/docs/llm-determinism.md
@@ -1,62 +1,145 @@
 # LLM Determinism Recipe
 
-War-room helper for catching kernel-level nondeterminism / silent data
-corruption in a transformer training step. Runs the **same** forward+
-backward twice on the same inputs, with parameters and RNG restored
-between runs, and compares bit-exact checksums of:
-
-- every per-block boundary activation (entering and leaving each
-  repetition of the single repeated block — the FSDP2 comm boundary)
-- the final loss and logits
-- every grad and every param after backward
+Catch kernel-level nondeterminism / silent data corruption (SDC) in a
+transformer training step. Runs the **same** forward+backward twice on
+the same inputs, with parameters and RNG restored between runs, and
+compares bit-exact checksums of every per-block boundary activation,
+the loss, the logits, every grad, and every param.
 
 If any checksum drifts → some kernel (matmul, attention, reduction,
 collective) is producing different bits for the same inputs.
 
-## Why a single repeated block?
+---
 
-The war-room execution model is a chain of repeating
-`comm_kernel_i → compute_kernel_i` stages. One repetition of the same
-transformer block is one such stage, and under FSDP2 `fully_shard` the
-block boundary is also the all-gather / reduce-scatter boundary. So
-checksumming the activation at every block boundary checksums the
-tensor that actually crosses GPUs at every repetition.
+## Quick Start
 
-This is **not a faithful LLM**. Weights are random init, the specific
-architecture (LayerNorm + MHA + GLU FFN, optional top-1 MoE) is generic
-on purpose. The model and its size are knobs to control how much data
-crosses GPU boundaries, nothing more.
+### Prerequisites
 
-## What it doesn't do
+- A node with ≥1 AMD GPU (smoke verified on 8× MI350X, gfx950).
+- PyTorch built with ROCm/HIP (`torch.version.hip` non-empty,
+  `torch.cuda.is_available()` true). Verified on
+  `torch 2.10.0.dev+rocm7.0`.
+- `pip install -e .` from the repo root.
 
-- Not a quality benchmark.
-- Not a perf benchmark — manual attention, no `torch.compile`, no graphs.
-- Not a multi-step trainer by default; `steps` is configurable but each
-  step is a self-contained replay.
-- Does not intercept kernels directly. Module forward pre/post hooks are
-  the practical proxy for the comm boundary; documented limitation.
+### Smoke (≈5 s on 8 GPUs)
 
-## Running
+Create `/tmp/run_llm_det.py`:
 
-```bash
-# 40-GPU capture run (adjust to your cluster shape):
-torchrun --nproc_per_node=8 --nnodes=5 -m aorta.cli run \
-  --workload llm_determinism \
-  --recipe recipes/example-llm-determinism.yaml
+```python
+import os, sys
+from aorta.workloads.llm_determinism import LlmDeterminismWorkload
 
-# Single rank / local dev:
-python -m aorta.cli run --workload llm_determinism
+cfg = {
+    "num_layers": 24, "hidden_size": 2048, "ffn_size": 5632,
+    "num_heads": 16, "seq_len": 512, "batch_size": 1,
+    "dtype": "bf16", "seed": 1234, "steps": 1,
+    "checksum_mode": "per_rank",
+    "capture_dir": "/tmp/llm_det_capture",
+}
+w = LlmDeterminismWorkload(cfg)
+w.setup(); r = w.run(); w.cleanup()
+print(f"[rank {os.environ.get('RANK')}] passed={r.passed} "
+      f"failures={r.failure_count} elapsed={r.elapsed_sec:.2f}s "
+      f"ranks_with_divergence={r.metrics['ranks_with_divergence']}")
+sys.exit(0 if r.passed else 1)
 ```
 
-Pass → every per-rank per-block (and per-param) checksum matched.
-Fail → workload prints which checksums diverged on which rank and which
-block index.
+Run it:
+
+```bash
+rm -rf /tmp/llm_det_capture
+torchrun --standalone --nproc_per_node=8 /tmp/run_llm_det.py
+```
+
+**Expected on a healthy stack:**
+- Exit 0; every rank prints `passed=True failures=0 ranks_with_divergence=0`
+- `/tmp/llm_det_capture/rank000.jsonl` … `rank007.jsonl` exist, 2 lines each (`run=r1`, `run=r2`)
+- `loss_bits` is non-zero (~1.15e9 with defaults) and **equal between r1 and r2 on each rank**
+- `block_pre` / `block_post` lists are length `num_layers`
+
+### Validate the detector actually flags real divergence
+
+A green smoke alone doesn't prove the detector works in your environment.
+Inject a known difference between r1 and r2 by perturbing `_input_ids`
+(not snapshotted/restored, so survives only into r2):
+
+Save as `/tmp/run_llm_det_fail.py`:
+
+```python
+import os, sys, torch
+from aorta.workloads.llm_determinism import LlmDeterminismWorkload
+
+cfg = {"num_layers": 24, "hidden_size": 2048, "ffn_size": 5632,
+       "num_heads": 16, "seq_len": 512, "batch_size": 1,
+       "dtype": "bf16", "seed": 1234, "steps": 1,
+       "checksum_mode": "per_rank",
+       "capture_dir": "/tmp/llm_det_capture_fail"}
+w = LlmDeterminismWorkload(cfg); w.setup()
+_orig, n = w._run_once, [0]
+def patched():
+    n[0] += 1
+    if n[0] == 2:                              # perturb after r1, before r2
+        w._input_ids[0, 0] = (int(w._input_ids[0, 0]) + 1) % w._cfg.vocab_size
+    return _orig()
+w._run_once = patched
+r = w.run(); w.cleanup()
+print(f"[rank {os.environ.get('RANK')}] passed={r.passed} "
+      f"failures={r.failure_count}")
+for reason in r.metrics.get("divergence_reasons", [])[:5]:
+    print(f"[rank {os.environ.get('RANK')}] {reason}")
+sys.exit(0 if r.passed else 1)
+```
+
+```bash
+rm -rf /tmp/llm_det_capture_fail
+torchrun --standalone --nproc_per_node=8 /tmp/run_llm_det_fail.py
+echo "exit=$?"
+```
+
+**Expected:** non-zero exit; every rank prints `passed=False`; `divergence_reasons` lists `block[0..N].pre/post`, `loss_bits`, `output_bits`, and many `grad[*]` entries. Params should **not** appear in reasons (snapshot/restore unchanged).
+
+### Reading the capture
+
+```bash
+# r1 vs r2 equality, per rank — expect "true" on every line.
+for f in /tmp/llm_det_capture/rank*.jsonl; do
+  jq -s --arg f "$f" '$f + ": " + (.[0].block_post == .[1].block_post | tostring)' "$f"
+done
+
+# loss_bits across ranks (sanity-check non-zero, near each other):
+jq -c '{rank, run, loss_bits}' /tmp/llm_det_capture/rank*.jsonl
+
+# First divergent block index on rank 0 (after a failing run):
+jq -s '[.[0].block_post, .[1].block_post] | transpose
+        | map(.[0]==.[1]) | index(false)' \
+   /tmp/llm_det_capture_fail/rank000.jsonl
+```
+
+### If you see divergence — what to send back
+
+Tar up:
+- `/tmp/llm_det_capture/` (or your `capture_dir`) — every `rank*.jsonl`
+- Full torchrun stdout/stderr (all `divergence_reasons` lines)
+- `aorta env probe -o env.json` output (PyTorch / ROCm / HIP / RCCL versions, env vars, GPU arch)
+- The exact launcher script you used, the GPU count, and which knobs you changed from defaults
+
+### Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| `RuntimeError: Expected all tensors to be on the same device` | Stale checkout — pull the branch; the fix is on `users/oyazdanb/llm-determinism-recipe`. |
+| Every rank hangs at `init_process_group` | Set `NCCL_DEBUG=INFO`; try `NCCL_P2P_DISABLE=1`. RCCL honours `NCCL_*` env vars. |
+| `loss_bits` reported as 0 | Stale checkout — the label shift fix (`torch.roll`) avoids the degenerate loss-collapse. |
+| OOM | Drop `num_layers: 12` first, then `hidden_size: 1024, ffn_size: 2816`, then `seq_len: 256`. One knob at a time. |
+| Determinism flagged but suspect false positive | Bump `checksum_mode: global` to also compare an all-reduced loss⊕output fingerprint; rerun. |
+
+---
 
 ## Knobs
 
 | Key | Default | Notes |
 |---|---|---|
-| `num_layers` | 24 | Block repetitions = comm/compute stages. Drop to scale down with rank count. |
+| `num_layers` | 24 | Block repetitions = comm/compute stages. Scale down with rank count. |
 | `hidden_size` | 2048 | Per-block hidden width. |
 | `ffn_size` | 5632 | GLU FFN width. |
 | `num_heads` | 16 | Must divide `hidden_size`. |
@@ -67,47 +150,88 @@ block index.
 | `dtype` | `bf16` | `bf16` / `fp16` / `fp32`. |
 | `seed` | 1234 | Synthetic batch + RNG seed. |
 | `steps` | 1 | Number of independent replay steps. |
-| `checksum_mode` | `per_rank` | `global` also all-reduces a fingerprint. |
+| `checksum_mode` | `per_rank` | `global` also all-reduces a fingerprint across ranks. |
 | `capture_dir` | unset | When set, every step writes `rank<NNN>.jsonl` for offline inspection. |
 | `model_label` | `generic-repeated-block` | Advisory only; recorded in metrics. |
 
-## Rule-#4 compliance
-
-By default (`checksum_mode: per_rank`) each rank only compares its own
-run-1 vs run-2 shards / block boundaries. Pass/fail is OR'd across ranks
-via a single all-reduced integer flag. `checksum_mode: global` opts in
-to additionally comparing an all-reduced loss⊕output fingerprint, which
-catches collective ordering drift but no longer satisfies the strict
-"single-rank only" guard.
-
-## Determinism caveats
-
-`torch.use_deterministic_algorithms(True, warn_only=True)` is enabled at
-setup. Some ops have no deterministic implementation; we tolerate that
-because the checksum compare is what actually proves replayability.
-`CUBLAS_WORKSPACE_CONFIG=:4096:8` is set if not already present —
-hipBLAS / cuBLAS require this for deterministic matmul.
-
 ## Capture-mode output
 
-When `capture_dir` is set, each rank writes one line per (run, step):
+Each rank writes one JSON line per (run, step):
 
 ```json
 {"rank": 7, "step": 0, "run": "r1", "loss_bits": 12345, "output_bits": 67890,
  "block_pre": [<int per block>], "block_post": [<int per block>]}
 ```
 
-This is the raw material for offline analysis on the 40-GPU capture run —
-e.g. `jq` for ranks whose `block_pre[i]` differs between `r1` and `r2`,
-or a comparison of the same rank's checksums across two whole captures
-collected on different nodes / dates.
-
 ## Metrics surface (stable for detector parsing)
 
 `WorkloadResult.metrics` includes:
 
-- `ranks_with_divergence`
+- `ranks_with_divergence` — count of ranks whose local compare flagged
 - `steps[*].loss_bits_r1`, `loss_bits_r2`, `num_blocks_checked`
-- `divergence_reasons` (first 32, when present)
-- `model_label`, `num_layers`, `num_experts`, `dtype`, `checksum_mode`,
-  `capture_dir`
+- `divergence_reasons` — first 32 reasons (when present)
+- `model_label`, `num_layers`, `num_experts`, `dtype`, `checksum_mode`, `capture_dir`
+
+---
+
+## Design notes
+
+### Why a single repeated block
+
+The execution model is a chain of repeating
+`comm_kernel_i → compute_kernel_i` stages. One repetition of the same
+transformer block is one such stage; under FSDP2 `fully_shard` the
+block boundary is also the all-gather / reduce-scatter boundary, so
+checksumming the activation at every block boundary checksums the
+tensor that actually crosses GPUs at every repetition.
+
+**This is not a faithful LLM.** Weights are random init, the architecture
+(LayerNorm + MHA + GLU FFN, optional top-1 MoE) is generic on purpose.
+The model and its size are knobs to control how much data crosses GPU
+boundaries — nothing more.
+
+### What it doesn't do
+
+- Not a quality benchmark.
+- Not a perf benchmark — manual attention, no `torch.compile`, no graphs.
+- Not a multi-step trainer by default; `steps` is configurable but each
+  step is a self-contained replay.
+- Does not intercept kernels directly. Module forward pre/post hooks are
+  the practical proxy for the comm boundary; documented limitation.
+
+### Checksum contract
+
+The checksum is a **bit-pattern** sum, not a numeric sum: tensor storage
+is re-interpreted (`view`, not `to`) as the signed integer of matching
+element size, then accumulated into `int64`.
+
+- bf16, fp16 (2-byte) → `int16` view
+- fp32 (4-byte) → `int32` view
+- fp64 (8-byte) → `int64` view
+
+Two tensors with identical bits → identical checksums. Two tensors that
+differ in a single bit (including NaN payload bits and the +0 vs -0
+distinction that a numeric sum would erase) → different checksums.
+Accumulator wraps mod 2^64 — fine, because we only ever compare two
+checksums for equality, never reason about magnitude.
+
+Note for cross-tool comparison: these numbers are **not** directly
+comparable to other tools' checksums unless they use the identical
+view-dtype mapping, the same hook points, and the same reduction.
+
+### Single-rank-only compare (default)
+
+`checksum_mode: per_rank` (default) compares each rank's run-1 vs run-2
+shards / block boundaries only. Pass/fail is OR'd across ranks via a
+single all-reduced integer flag, no checksum values cross ranks.
+`checksum_mode: global` opts in to additionally comparing an
+all-reduced loss⊕output fingerprint — catches collective ordering
+drift, but no longer satisfies the strict "single-rank only" guard.
+
+### Determinism caveats
+
+`torch.use_deterministic_algorithms(True, warn_only=True)` is enabled
+at setup. Some ops have no deterministic implementation; we tolerate
+that because the checksum compare is what actually proves replayability.
+`CUBLAS_WORKSPACE_CONFIG=:4096:8` is set if not already present —
+hipBLAS / cuBLAS require this for deterministic matmul.

--- a/docs/llm-determinism.md
+++ b/docs/llm-determinism.md
@@ -192,9 +192,9 @@ Tar up:
 
 | Symptom | Likely cause / fix |
 |---|---|
-| `RuntimeError: Expected all tensors to be on the same device` | Stale checkout — pull the branch; the fix is on `users/oyazdanb/llm-determinism-recipe`. |
+| `RuntimeError: Expected all tensors to be on the same device` | Stale checkout — `git pull` `main` and reinstall (`pip install -e .`). |
 | Every rank hangs at `init_process_group` | Set `NCCL_DEBUG=INFO`; try `NCCL_P2P_DISABLE=1`. RCCL honours `NCCL_*` env vars. |
-| `loss_bits` reported as 0 | Stale checkout — the label shift fix (`torch.roll`) avoids the degenerate loss-collapse. |
+| `loss_bits` reported as 0 | Stale checkout — `git pull` `main` and reinstall; labels are shifted by one (`torch.roll`) to avoid the degenerate loss-collapse. |
 | OOM | Drop `num_layers: 12` first, then `hidden_size: 1024, ffn_size: 2816`, then `seq_len: 256`. One knob at a time. |
 | Determinism flagged but suspect false positive | Bump `checksum_mode: global` to also compare an all-reduced loss⊕output fingerprint; rerun. |
 

--- a/docs/llm-determinism.md
+++ b/docs/llm-determinism.md
@@ -115,6 +115,47 @@ jq -s '[.[0].block_post, .[1].block_post] | transpose
    /tmp/llm_det_capture_fail/rank000.jsonl
 ```
 
+### Running via recipe (multi-cell sweep)
+
+The launcher script above runs one configuration. To sweep multiple
+configurations in one invocation, use the recipe at
+[`recipes/example-llm-determinism.yaml`](../recipes/example-llm-determinism.yaml).
+Pass workload knobs through `workload_config`:
+
+```yaml
+# Recipe-scope defaults applied to every cell:
+workload_config:
+  hidden_size: 2048
+  dtype: bf16
+  checksum_mode: per_rank
+
+cells:
+  - name: baseline-bf16-24L
+    mitigations: [none]
+    environment: local
+    workload_config:       # cell wins on key collision
+      num_layers: 24
+      capture_dir: ./llm_det_capture/baseline-bf16-24L
+  - name: moe4-bf16-12L
+    mitigations: [none]
+    environment: local
+    workload_config:
+      num_layers: 12
+      num_experts: 4
+      capture_dir: ./llm_det_capture/moe4-bf16-12L
+```
+
+Launch:
+
+```bash
+torchrun --standalone --nproc_per_node=8 \
+  -m aorta.triage.cli run --recipe recipes/example-llm-determinism.yaml
+```
+
+Two schema gotchas the loader enforces:
+- `steps` is a first-class recipe field; putting it in `workload_config` is rejected (would be silently clobbered).
+- Keys starting with `_aorta_` are reserved and rejected.
+
 ### If you see divergence — what to send back
 
 Tar up:

--- a/docs/llm-determinism.md
+++ b/docs/llm-determinism.md
@@ -162,6 +162,24 @@ step time is typically much higher than later cells (in one 4-cell
 smoke we saw 2453 ms on the first cell vs 78–912 ms on later ones).
 That is not a determinism signal — the per-rank checksum compare is.
 
+**Where the checksum content lives.** The triage `matrix.md` table only
+reports pass/fail per cell (failure rate, failures count, mean step time,
+confound tag). It does **not** include checksum bits or
+`divergence_reasons`. To inspect the actual checksum stream:
+
+```bash
+# Per-trial WorkloadResult (loss_bits per step, ranks_with_divergence,
+# divergence_reasons when failing, model_label, etc.):
+find triage_results -name result.json -exec \
+  jq '{passed, rwd: .metrics.ranks_with_divergence,
+       loss_r1: .metrics.steps[0].loss_bits_r1,
+       reasons: .metrics.divergence_reasons}' {} \;
+
+# Per-block / per-rank fingerprints (the big artifact for offline
+# analysis) live wherever each cell's `workload_config.capture_dir`
+# pointed — NOT inside the triage output tree.
+```
+
 ### If you see divergence — what to send back
 
 Tar up:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ aorta = "aorta.cli:main"
 # reserved argv config key is only injected by ``aorta probe``.
 [project.entry-points."aorta.workloads"]
 _subprocess = "aorta.workloads._subprocess:SubprocessWorkload"
+llm_determinism = "aorta.workloads.llm_determinism:LlmDeterminismWorkload"
 
 [project.optional-dependencies]
 # For analysis/visualization scripts

--- a/recipes/example-llm-determinism.yaml
+++ b/recipes/example-llm-determinism.yaml
@@ -1,31 +1,18 @@
 # Per-block deterministic-replay recipe for a single repeated transformer block.
 #
-# 40-GPU capture run (single node, adjust nproc / nnodes to your cluster):
-#   torchrun --nproc_per_node=8 --nnodes=5 -m aorta.cli run \
-#     --workload llm_determinism \
+# Pass workload knobs through `workload_config` at recipe scope (every cell
+# inherits) and/or `workload_config` at cell scope (cell wins on key
+# collision). The dispatcher forwards the merged dict to
+# `LlmDeterminismWorkload(config)` verbatim — same keys the standalone
+# launcher in docs/llm-determinism.md uses.
+#
+# Run on a multi-GPU node:
+#   torchrun --standalone --nproc_per_node=8 -m aorta.triage.cli run \
 #     --recipe recipes/example-llm-determinism.yaml
-#   # Sets capture_dir; per-rank JSONL lands in ./llm_det_capture/rank###.jsonl
 #
-# Local single-rank smoke (CPU works too if no GPUs are visible):
-#   python -m aorta.cli run --workload llm_determinism
-#
-# What it does: builds N repetitions of one transformer block (optionally
-# MoE), wraps each block in FSDP2, then runs the SAME forward+backward
-# twice on the same input with params+RNG restored between runs. Forward
-# hooks on every block checksum the activation entering and leaving each
-# block (the FSDP comm boundary). Fails the trial if any per-rank
-# per-block / loss / grad / param checksum drifts. No torch.compile,
-# no CUDA/HIP graphs, no optimizer step between replays.
-#
-# War-room knobs (override per-cell via extra_env once dispatcher supports
-# inline JSON, or edit the workload config block when invoking directly):
-#   num_layers      - repetition count == amount of cross-GPU traffic.
-#   hidden_size / ffn_size - per-block compute size.
-#   num_experts     - 1 == dense FFN; >1 == top-1 MoE router.
-#   dtype           - bf16 (default) | fp16 | fp32.
-#   checksum_mode   - per_rank (rule #4 safe) | global (all-reduced fingerprint).
-#   capture_dir     - directory for per-rank JSONL capture; omit to skip.
-#   seed            - bumping rotates the synthetic batch.
+# Each cell writes its own capture_dir, so results don't collide.
+# `steps` is a first-class recipe field — the loader rejects it inside
+# workload_config (the dispatcher would silently clobber it otherwise).
 schema_version: 1
 
 ticket: LLM-DET-001
@@ -37,15 +24,48 @@ steps: 1
 confound:
   threshold: 1.15
 
+# Recipe-scope defaults — applied to every cell, overridden per-cell below.
+workload_config:
+  hidden_size: 2048
+  ffn_size: 5632
+  num_heads: 16
+  seq_len: 512
+  batch_size: 1
+  dtype: bf16
+  seed: 1234
+  checksum_mode: per_rank
+
 cells:
+  # Baseline: 24-layer bf16, default everything else.
   - name: baseline-bf16-24L
     mitigations: [none]
     environment: local
+    workload_config:
+      num_layers: 24
+      capture_dir: ./llm_det_capture/baseline-bf16-24L
 
+  # Half the comm/compute stages — useful for scaling down with rank count.
   - name: bf16-12L
     mitigations: [none]
     environment: local
+    workload_config:
+      num_layers: 12
+      capture_dir: ./llm_det_capture/bf16-12L
 
+  # Same shape as baseline but with tf32_off mitigation. Catches matmul
+  # paths whose determinism depends on TF32 reduction ordering.
   - name: tf32_off-bf16-24L
     mitigations: [tf32_off]
     environment: local
+    workload_config:
+      num_layers: 24
+      capture_dir: ./llm_det_capture/tf32_off-bf16-24L
+
+  # MoE variant — top-1 router over 4 GLU experts. Different kernel mix.
+  - name: moe4-bf16-12L
+    mitigations: [none]
+    environment: local
+    workload_config:
+      num_layers: 12
+      num_experts: 4
+      capture_dir: ./llm_det_capture/moe4-bf16-12L

--- a/recipes/example-llm-determinism.yaml
+++ b/recipes/example-llm-determinism.yaml
@@ -1,0 +1,51 @@
+# Per-block deterministic-replay recipe for a single repeated transformer block.
+#
+# 40-GPU capture run (single node, adjust nproc / nnodes to your cluster):
+#   torchrun --nproc_per_node=8 --nnodes=5 -m aorta.cli run \
+#     --workload llm_determinism \
+#     --recipe recipes/example-llm-determinism.yaml
+#   # Sets capture_dir; per-rank JSONL lands in ./llm_det_capture/rank###.jsonl
+#
+# Local single-rank smoke (CPU works too if no GPUs are visible):
+#   python -m aorta.cli run --workload llm_determinism
+#
+# What it does: builds N repetitions of one transformer block (optionally
+# MoE), wraps each block in FSDP2, then runs the SAME forward+backward
+# twice on the same input with params+RNG restored between runs. Forward
+# hooks on every block checksum the activation entering and leaving each
+# block (the FSDP comm boundary). Fails the trial if any per-rank
+# per-block / loss / grad / param checksum drifts. No torch.compile,
+# no CUDA/HIP graphs, no optimizer step between replays.
+#
+# War-room knobs (override per-cell via extra_env once dispatcher supports
+# inline JSON, or edit the workload config block when invoking directly):
+#   num_layers      - repetition count == amount of cross-GPU traffic.
+#   hidden_size / ffn_size - per-block compute size.
+#   num_experts     - 1 == dense FFN; >1 == top-1 MoE router.
+#   dtype           - bf16 (default) | fp16 | fp32.
+#   checksum_mode   - per_rank (rule #4 safe) | global (all-reduced fingerprint).
+#   capture_dir     - directory for per-rank JSONL capture; omit to skip.
+#   seed            - bumping rotates the synthetic batch.
+schema_version: 1
+
+ticket: LLM-DET-001
+workload: llm_determinism
+
+trials: 1
+steps: 1
+
+confound:
+  threshold: 1.15
+
+cells:
+  - name: baseline-bf16-24L
+    mitigations: [none]
+    environment: local
+
+  - name: bf16-12L
+    mitigations: [none]
+    environment: local
+
+  - name: tf32_off-bf16-24L
+    mitigations: [tf32_off]
+    environment: local

--- a/recipes/example-llm-determinism.yaml
+++ b/recipes/example-llm-determinism.yaml
@@ -6,11 +6,18 @@
 # `LlmDeterminismWorkload(config)` verbatim — same keys the standalone
 # launcher in docs/llm-determinism.md uses.
 #
-# Run on a multi-GPU node:
-#   torchrun --standalone --nproc_per_node=8 -m aorta.triage.cli run \
+# Run on a multi-GPU node (the `aorta` console script is the entry point;
+# `python -m aorta.triage.cli` is NOT a runnable module):
+#   torchrun --standalone --nproc_per_node=8 $(which aorta) triage run \
 #     --recipe recipes/example-llm-determinism.yaml
 #
 # Each cell writes its own capture_dir, so results don't collide.
+#
+# Note on per-cell step times: cells run sequentially in one process and
+# the first cell absorbs FSDP2 / RCCL / hipBLAS warmup, so its step time
+# is typically much higher than later cells. Don't read warmup as a
+# determinism signal — the per-rank checksum compare is what proves
+# replayability.
 # `steps` is a first-class recipe field — the loader rejects it inside
 # workload_config (the dispatcher would silently clobber it otherwise).
 schema_version: 1

--- a/src/aorta/instrumentation/checksum.py
+++ b/src/aorta/instrumentation/checksum.py
@@ -1,0 +1,116 @@
+"""Bit-exact tensor checksums for nondeterminism detection.
+
+The checksum is a **bit-pattern** sum, not a numeric sum: tensor storage is
+re-interpreted (``view``, not ``to``) as the signed integer of matching
+element size, then accumulated into ``int64``. Two tensors with identical
+bits produce identical checksums; two tensors that differ in a single bit
+(including NaN payload bits and the +0 vs -0 distinction that a numeric
+sum would erase) produce different checksums.
+
+Use for war-room replay checks where the question is "did this kernel
+produce the same bytes twice", not "are the values numerically close".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+# Each floating dtype maps to the signed integer of the same element size.
+# Lookup by dtype handles bf16/fp16 (both 2-byte) -> int16, fp32 -> int32, etc.
+_VIEW_DTYPE: dict[torch.dtype, torch.dtype] = {
+    torch.bfloat16: torch.int16,
+    torch.float16: torch.int16,
+    torch.float32: torch.int32,
+    torch.float64: torch.int64,
+    torch.int8: torch.int8,
+    torch.int16: torch.int16,
+    torch.int32: torch.int32,
+    torch.int64: torch.int64,
+    torch.bool: torch.int8,
+}
+
+
+def tensor_checksum(t: torch.Tensor) -> int:
+    """Return a bit-exact int64 checksum of ``t``'s storage.
+
+    Casts the dtype with ``view`` (zero-copy bit reinterpretation), not
+    ``to`` (numeric conversion). The accumulator is int64 so the sum
+    wraps modulo 2**64 deterministically — wraparound is fine because we
+    only ever compare two checksums, never reason about the magnitude.
+    """
+    if t.numel() == 0:
+        return 0
+    view_dtype = _VIEW_DTYPE.get(t.dtype)
+    if view_dtype is None:
+        raise TypeError(f"tensor_checksum: unsupported dtype {t.dtype}")
+    flat = t.detach().contiguous().view(-1)
+    as_int = flat.view(view_dtype) if view_dtype != flat.dtype else flat
+    return int(as_int.to(torch.int64).sum().item())
+
+
+def state_checksum(named: dict[str, torch.Tensor]) -> dict[str, int]:
+    """Per-tensor checksums for a name->tensor mapping (e.g. ``state_dict``)."""
+    return {name: tensor_checksum(t) for name, t in named.items()}
+
+
+def global_checksum(local: int, group: object | None = None) -> int:
+    """All-reduce a local checksum into a rank-agnostic global checksum.
+
+    Sum-reduces in int64 so the result is order-independent across ranks.
+    Returns the local value unchanged when torch.distributed isn't
+    initialised, which keeps single-process callers working.
+    """
+    import torch.distributed as dist
+
+    if not dist.is_available() or not dist.is_initialized():
+        return local
+    buf = torch.tensor([local], dtype=torch.int64)
+    if torch.cuda.is_available():
+        buf = buf.cuda()
+    dist.all_reduce(buf, op=dist.ReduceOp.SUM, group=group)
+    return int(buf.item())
+
+
+@dataclass
+class ChecksumSet:
+    """Loss + grad + output checksums for one replay of one step.
+
+    Fields are plain ints so ``a == b`` is the entire comparison the
+    caller needs. ``grads`` and ``params`` are per-tensor so a divergence
+    report can name *which* parameter drifted.
+    """
+
+    loss_bits: int
+    output_bits: int
+    grads: dict[str, int]
+    params: dict[str, int]
+    global_bits: int | None = None
+
+
+def compare(a: ChecksumSet, b: ChecksumSet) -> list[str]:
+    """Return a list of human-readable divergence reasons; empty == match."""
+    reasons: list[str] = []
+    if a.loss_bits != b.loss_bits:
+        reasons.append(f"loss_bits {a.loss_bits} != {b.loss_bits}")
+    if a.output_bits != b.output_bits:
+        reasons.append(f"output_bits {a.output_bits} != {b.output_bits}")
+    if a.global_bits != b.global_bits:
+        reasons.append(f"global_bits {a.global_bits} != {b.global_bits}")
+    for name in sorted(set(a.grads) | set(b.grads)):
+        if a.grads.get(name) != b.grads.get(name):
+            reasons.append(f"grad[{name}] {a.grads.get(name)} != {b.grads.get(name)}")
+    for name in sorted(set(a.params) | set(b.params)):
+        if a.params.get(name) != b.params.get(name):
+            reasons.append(f"param[{name}] {a.params.get(name)} != {b.params.get(name)}")
+    return reasons
+
+
+__all__ = [
+    "ChecksumSet",
+    "compare",
+    "global_checksum",
+    "state_checksum",
+    "tensor_checksum",
+]

--- a/src/aorta/instrumentation/checksum.py
+++ b/src/aorta/instrumentation/checksum.py
@@ -68,7 +68,9 @@ def global_checksum(local: int, group: object | None = None) -> int:
         return local
     buf = torch.tensor([local], dtype=torch.int64)
     if torch.cuda.is_available():
-        buf = buf.cuda()
+        # current_device() respects LOCAL_RANK; the default `.cuda()` would
+        # land on cuda:0 on every rank, which NCCL rejects on multi-GPU runs.
+        buf = buf.to(torch.device("cuda", torch.cuda.current_device()))
     dist.all_reduce(buf, op=dist.ReduceOp.SUM, group=group)
     return int(buf.item())
 

--- a/src/aorta/instrumentation/determinism.py
+++ b/src/aorta/instrumentation/determinism.py
@@ -1,0 +1,42 @@
+"""Best-effort PyTorch determinism setup for replay-style workloads.
+
+Not all kernels have deterministic implementations; ``warn_only=True``
+lets a workload run instead of hard-failing on the first
+nondeterministic op. The companion checksum compare in
+:mod:`aorta.instrumentation.checksum` is what actually proves bitwise
+equality between two replays.
+
+Does NOT touch ``torch.compile`` or HIP graphs — the llm_determinism
+recipe explicitly avoids both at the call site and we don't want this
+helper silently re-enabling them anywhere it's reused.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+
+import torch
+
+CUBLAS_WORKSPACE_ENV = "CUBLAS_WORKSPACE_CONFIG"
+CUBLAS_WORKSPACE_VALUE = ":4096:8"
+
+
+def enable_deterministic(seed: int) -> None:
+    """Seed RNGs and flip PyTorch into deterministic mode.
+
+    Sets ``CUBLAS_WORKSPACE_CONFIG`` if unset — cuBLAS/hipBLAS require it
+    before the first CUDA context, otherwise ``use_deterministic_algorithms``
+    raises at the first matmul.
+    """
+    os.environ.setdefault(CUBLAS_WORKSPACE_ENV, CUBLAS_WORKSPACE_VALUE)
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    torch.use_deterministic_algorithms(True, warn_only=True)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+__all__ = ["CUBLAS_WORKSPACE_ENV", "CUBLAS_WORKSPACE_VALUE", "enable_deterministic"]

--- a/src/aorta/instrumentation/determinism.py
+++ b/src/aorta/instrumentation/determinism.py
@@ -28,12 +28,15 @@ def enable_deterministic(seed: int) -> None:
     Sets ``CUBLAS_WORKSPACE_CONFIG`` if unset — cuBLAS/hipBLAS require it
     before the first CUDA context, otherwise ``use_deterministic_algorithms``
     raises at the first matmul.
+
+    Seeds only the CPU + Python RNGs here. The per-rank CUDA device must
+    be seeded by the caller AFTER ``torch.cuda.set_device(LOCAL_RANK)``,
+    using ``torch.cuda.manual_seed`` (NOT ``manual_seed_all``) so we don't
+    initialize CUDA contexts on every visible GPU in every torchrun rank.
     """
     os.environ.setdefault(CUBLAS_WORKSPACE_ENV, CUBLAS_WORKSPACE_VALUE)
     random.seed(seed)
     torch.manual_seed(seed)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(seed)
     torch.use_deterministic_algorithms(True, warn_only=True)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False

--- a/src/aorta/models/__init__.py
+++ b/src/aorta/models/__init__.py
@@ -1,5 +1,12 @@
 """Model definitions."""
 
 from .ranking_transformer import ModelConfig, RankingTransformerModel
+from .repeated_block import BlockConfig, RepeatedBlockModel, RepeatedTransformerBlock
 
-__all__ = ["ModelConfig", "RankingTransformerModel"]
+__all__ = [
+    "BlockConfig",
+    "ModelConfig",
+    "RankingTransformerModel",
+    "RepeatedBlockModel",
+    "RepeatedTransformerBlock",
+]

--- a/src/aorta/models/repeated_block.py
+++ b/src/aorta/models/repeated_block.py
@@ -1,0 +1,149 @@
+"""Single transformer block repeated N times — comm/compute stage probe.
+
+The war-room execution model is a series of repeating
+``comm_kernel_i -> compute_kernel_i`` stages. Each block here IS one such
+stage: under FSDP2 ``fully_shard`` the block's parameters are all-gathered
+on entry and grads reduce-scattered on exit, so the activation entering
+and leaving each block is the tensor that crosses GPU boundaries. The
+determinism workload hooks the per-block boundary to checksum exactly
+those tensors at every repetition.
+
+Optional MoE: when ``num_experts > 1`` the FFN is a top-1 token-router
+over ``num_experts`` GLU experts. The router selection is deterministic
+under a fixed seed and exercises the same all-to-all-shaped traffic an
+MoE workload would generate (without depending on a real MoE framework).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+
+@dataclass
+class BlockConfig:
+    """Knobs for one repeated transformer block + how many times to repeat it.
+
+    ``num_layers`` is the repetition count — the only knob that scales the
+    amount of cross-GPU traffic when wrapped in FSDP2. Everything else
+    sizes the per-block compute.
+    """
+
+    vocab_size: int = 32_000
+    hidden_size: int = 2048
+    ffn_size: int = 5632
+    num_heads: int = 16
+    num_layers: int = 24
+    seq_len: int = 512
+    num_experts: int = 1  # 1 == dense FFN; >1 == top-1 MoE router.
+    norm_eps: float = 1e-5
+
+    def __post_init__(self) -> None:
+        if self.hidden_size % self.num_heads != 0:
+            raise ValueError("hidden_size must be divisible by num_heads")
+        if self.num_layers < 1:
+            raise ValueError("num_layers must be >= 1")
+        if self.num_experts < 1:
+            raise ValueError("num_experts must be >= 1")
+
+
+class _GluFFN(nn.Module):
+    def __init__(self, hidden: int, ffn: int) -> None:
+        super().__init__()
+        self.gate = nn.Linear(hidden, ffn, bias=False)
+        self.up = nn.Linear(hidden, ffn, bias=False)
+        self.down = nn.Linear(ffn, hidden, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down(torch.nn.functional.silu(self.gate(x)) * self.up(x))
+
+
+class _Top1MoE(nn.Module):
+    """Top-1 token routing across ``num_experts`` GLU experts.
+
+    Token dispatch uses ``argmax`` + indexed gather — deterministic under a
+    fixed seed. No load balancing loss; this is a structural stand-in for
+    MoE traffic patterns, not an MoE quality model.
+    """
+
+    def __init__(self, hidden: int, ffn: int, num_experts: int) -> None:
+        super().__init__()
+        self.router = nn.Linear(hidden, num_experts, bias=False)
+        self.experts = nn.ModuleList([_GluFFN(hidden, ffn) for _ in range(num_experts)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, t, h = x.shape
+        flat = x.reshape(b * t, h)
+        choice = self.router(flat).argmax(dim=-1)
+        out = torch.zeros_like(flat)
+        for idx, expert in enumerate(self.experts):
+            mask = choice == idx
+            if mask.any():
+                out[mask] = expert(flat[mask])
+        return out.reshape(b, t, h)
+
+
+class RepeatedTransformerBlock(nn.Module):
+    """One pre-norm transformer block: LayerNorm + MHA + FFN (dense or MoE).
+
+    Manual scaled-dot-product attention so the kernel sequence is the same
+    on every call — ``torch.nn.functional.scaled_dot_product_attention``
+    picks a backend whose determinism varies by build.
+    """
+
+    def __init__(self, cfg: BlockConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.attn_norm = nn.LayerNorm(cfg.hidden_size, eps=cfg.norm_eps)
+        self.qkv = nn.Linear(cfg.hidden_size, 3 * cfg.hidden_size, bias=False)
+        self.attn_out = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=False)
+        self.ffn_norm = nn.LayerNorm(cfg.hidden_size, eps=cfg.norm_eps)
+        if cfg.num_experts == 1:
+            self.ffn: nn.Module = _GluFFN(cfg.hidden_size, cfg.ffn_size)
+        else:
+            self.ffn = _Top1MoE(cfg.hidden_size, cfg.ffn_size, cfg.num_experts)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, t, h = x.shape
+        head_dim = h // self.cfg.num_heads
+        qkv = self.qkv(self.attn_norm(x))
+        q, k, v = qkv.chunk(3, dim=-1)
+        q = q.view(b, t, self.cfg.num_heads, head_dim).transpose(1, 2)
+        k = k.view(b, t, self.cfg.num_heads, head_dim).transpose(1, 2)
+        v = v.view(b, t, self.cfg.num_heads, head_dim).transpose(1, 2)
+        scale = head_dim ** -0.5
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+        mask = torch.triu(torch.full((t, t), float("-inf"), device=x.device, dtype=scores.dtype), diagonal=1)
+        attn = torch.softmax((scores + mask).float(), dim=-1).to(x.dtype)
+        ctx = torch.matmul(attn, v).transpose(1, 2).reshape(b, t, h)
+        x = x + self.attn_out(ctx)
+        x = x + self.ffn(self.ffn_norm(x))
+        return x
+
+
+class RepeatedBlockModel(nn.Module):
+    """``cfg.num_layers`` repetitions of one ``RepeatedTransformerBlock``.
+
+    Each repetition is the war-room "comm+compute" stage. Hooks attached
+    by the workload run before and after each block's ``forward`` to
+    checksum the boundary tensors.
+    """
+
+    def __init__(self, cfg: BlockConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.embed = nn.Embedding(cfg.vocab_size, cfg.hidden_size)
+        self.blocks = nn.ModuleList([RepeatedTransformerBlock(cfg) for _ in range(cfg.num_layers)])
+        self.final_norm = nn.LayerNorm(cfg.hidden_size, eps=cfg.norm_eps)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        x = self.embed(input_ids)
+        for block in self.blocks:
+            x = block(x)
+        x = self.final_norm(x)
+        return torch.nn.functional.linear(x, self.embed.weight)
+
+
+__all__ = ["BlockConfig", "RepeatedBlockModel", "RepeatedTransformerBlock"]

--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -196,7 +196,7 @@ class LlmDeterminismWorkload(Workload):
         gen = torch.Generator(device="cpu").manual_seed(self._cfg.seed + self._rank)
         ids = torch.randint(0, self._cfg.vocab_size, (self._cfg.batch_size, self._cfg.seq_len), generator=gen)
         self._input_ids = ids.to(self._device)
-        self._labels = ids.clone()
+        self._labels = self._input_ids.clone()
 
         self._capture_path: Path | None = None
         if self._cfg.capture_dir:

--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -1,0 +1,374 @@
+"""Per-block deterministic-replay probe for a repeated transformer block.
+
+War-room execution model (from the diagram): a training step is a chain
+of repeating ``comm_kernel_i -> compute_kernel_i`` stages. We model one
+such stage as one repetition of a single transformer block (see
+:mod:`aorta.models.repeated_block`). Under FSDP2 ``fully_shard`` each
+block boundary is also a collective boundary — the activation entering /
+leaving each block is the tensor crossing GPU boundaries.
+
+What this workload does
+-----------------------
+1. Build the repeated-block model and wrap each block with FSDP2.
+2. Register forward pre/post hooks on every block to compute a bit-exact
+   checksum (see :mod:`aorta.instrumentation.checksum`) of the boundary
+   activation.
+3. One-step replay: snapshot params + RNG, run fwd+bwd, capture per-block
+   checksums + loss + per-param grad/param checksums. Restore. Run the
+   same fwd+bwd. Compare.
+4. RANK-LOCAL pass/fail (rule #4 of the spec): each rank compares its
+   own run-1 vs run-2 lists; the trial fails if any rank diverges.
+5. Capture mode: when ``capture_dir`` is set, every step on every rank
+   writes a ``rank<N>.jsonl`` line with all per-block checksums for
+   offline inspection on the 40-GPU capture run.
+
+What this workload does NOT do
+------------------------------
+* No ``torch.compile``, no CUDA/HIP graphs.
+* No optimizer step between the two replays.
+* No cross-rank checksum equality assertion by default (rule #4). The
+  optional ``checksum_mode: "global"`` adds an all-reduced fingerprint
+  for the replay compare only; capture mode keeps per-rank data raw.
+* No kernel-level interception. Module hooks are a practical proxy for
+  the comm boundary — documented limitation, per the spec's "if direct
+  kernel interception is not practical" clause.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar, Literal
+
+import torch
+import torch.distributed as dist
+from torch import nn
+
+from aorta.instrumentation.checksum import (
+    ChecksumSet,
+    compare,
+    global_checksum,
+    tensor_checksum,
+)
+from aorta.instrumentation.determinism import enable_deterministic
+from aorta.models import BlockConfig, RepeatedBlockModel
+from aorta.workloads._base import Workload, WorkloadResult
+
+log = logging.getLogger(__name__)
+
+_DTYPES: dict[str, torch.dtype] = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+
+
+@dataclass
+class LlmDeterminismConfig:
+    """Knobs exposed to the recipe / CLI.
+
+    Defaults are sensible for local-rank smoke; the 40-GPU capture run
+    typically only overrides ``capture_dir``, ``num_layers``, and the
+    launcher's world size.
+    """
+
+    # Model shape — see BlockConfig. Size is a knob for how much data
+    # crosses GPU boundaries, not a parameter-count target.
+    num_layers: int = 24
+    hidden_size: int = 2048
+    ffn_size: int = 5632
+    num_heads: int = 16
+    vocab_size: int = 32_000
+    seq_len: int = 512
+    batch_size: int = 1
+    num_experts: int = 1
+    dtype: Literal["bf16", "fp16", "fp32"] = "bf16"
+
+    # Replay / capture knobs.
+    seed: int = 1234
+    steps: int = 1
+    checksum_mode: Literal["per_rank", "global"] = "per_rank"
+    capture_dir: str | None = None  # when set, dump per-step per-block JSONL.
+    model_label: str = "generic-repeated-block"  # advisory metric only.
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LlmDeterminismConfig:
+        known = set(cls.__dataclass_fields__)
+        cfg = cls(**{k: v for k, v in d.items() if k in known})
+        if cfg.dtype not in _DTYPES:
+            raise ValueError(f"dtype must be one of {list(_DTYPES)}, got {cfg.dtype!r}")
+        if cfg.checksum_mode not in ("per_rank", "global"):
+            raise ValueError(f"checksum_mode must be per_rank|global, got {cfg.checksum_mode!r}")
+        if cfg.steps < 1:
+            raise ValueError(f"steps must be >= 1, got {cfg.steps}")
+        return cfg
+
+
+@dataclass
+class _BlockChecksums:
+    """One forward pass worth of per-block boundary checksums."""
+
+    pre: list[int] = field(default_factory=list)   # activation entering each block.
+    post: list[int] = field(default_factory=list)  # activation leaving each block.
+
+
+class _BlockHookManager:
+    """Attaches forward pre/post hooks to a list of blocks and collects checksums.
+
+    The hooks intentionally checksum only the first positional input/output
+    tensor. The repeated block's contract is ``(b, t, h) -> (b, t, h)``;
+    that's also the FSDP2 comm-boundary tensor.
+    """
+
+    def __init__(self, blocks: list[nn.Module]) -> None:
+        self._handles: list[torch.utils.hooks.RemovableHandle] = []
+        self._current: _BlockChecksums | None = None
+        for idx, block in enumerate(blocks):
+            self._handles.append(block.register_forward_pre_hook(self._make_pre(idx)))
+            self._handles.append(block.register_forward_hook(self._make_post(idx)))
+        self._num_blocks = len(blocks)
+
+    def _make_pre(self, idx: int):
+        def _hook(_module: nn.Module, args: tuple) -> None:
+            if self._current is None or not args or not isinstance(args[0], torch.Tensor):
+                return
+            # Resize to num_blocks on first record so out-of-order calls would surface.
+            while len(self._current.pre) <= idx:
+                self._current.pre.append(0)
+            self._current.pre[idx] = tensor_checksum(args[0].detach())
+        return _hook
+
+    def _make_post(self, idx: int):
+        def _hook(_module: nn.Module, _args: tuple, output: torch.Tensor) -> None:
+            if self._current is None or not isinstance(output, torch.Tensor):
+                return
+            while len(self._current.post) <= idx:
+                self._current.post.append(0)
+            self._current.post[idx] = tensor_checksum(output.detach())
+        return _hook
+
+    def start_capture(self) -> _BlockChecksums:
+        self._current = _BlockChecksums()
+        return self._current
+
+    def stop_capture(self) -> None:
+        self._current = None
+
+    def remove(self) -> None:
+        for h in self._handles:
+            h.remove()
+        self._handles.clear()
+
+
+class LlmDeterminismWorkload(Workload):
+    """Per-block deterministic replay on a single repeated transformer block."""
+
+    name: ClassVar[str] = "llm_determinism"
+    launch_mode: ClassVar[Literal["single_process", "distributed"]] = "distributed"
+    min_world_size: ClassVar[int] = 1  # also runs single-rank for local dev.
+
+    def setup(self) -> None:
+        self._cfg = LlmDeterminismConfig.from_dict(self.config)
+        enable_deterministic(self._cfg.seed)
+        if not dist.is_initialized():
+            backend = "nccl" if torch.cuda.is_available() else "gloo"
+            dist.init_process_group(backend=backend)
+        self._rank = dist.get_rank()
+        self._world = dist.get_world_size()
+        if torch.cuda.is_available():
+            torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", self._rank % max(1, torch.cuda.device_count()))))
+        self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._dtype = _DTYPES[self._cfg.dtype]
+
+        model_cfg = BlockConfig(
+            vocab_size=self._cfg.vocab_size,
+            hidden_size=self._cfg.hidden_size,
+            ffn_size=self._cfg.ffn_size,
+            num_heads=self._cfg.num_heads,
+            num_layers=self._cfg.num_layers,
+            seq_len=self._cfg.seq_len,
+            num_experts=self._cfg.num_experts,
+        )
+        model = RepeatedBlockModel(model_cfg).to(self._device).to(self._dtype)
+        self._model = _maybe_fsdp_shard(model)
+        self._hooks = _BlockHookManager(list(self._raw_blocks()))
+
+        gen = torch.Generator(device="cpu").manual_seed(self._cfg.seed + self._rank)
+        ids = torch.randint(0, self._cfg.vocab_size, (self._cfg.batch_size, self._cfg.seq_len), generator=gen)
+        self._input_ids = ids.to(self._device)
+        self._labels = ids.clone()
+
+        self._capture_path: Path | None = None
+        if self._cfg.capture_dir:
+            cdir = Path(self._cfg.capture_dir)
+            cdir.mkdir(parents=True, exist_ok=True)
+            self._capture_path = cdir / f"rank{self._rank:03d}.jsonl"
+            # Truncate so a replay from the same dir doesn't append to stale data.
+            self._capture_path.write_text("")
+
+    def run(self) -> WorkloadResult:
+        t0 = time.perf_counter()
+        all_reasons: list[str] = []
+        per_step_metrics: list[dict[str, Any]] = []
+
+        for step in range(self._cfg.steps):
+            snapshot = _snapshot(self._model)
+            r1, blocks1 = self._run_once()
+            _restore(self._model, snapshot)
+            r2, blocks2 = self._run_once()
+
+            reasons = compare(r1, r2)
+            reasons += _compare_block_lists(blocks1, blocks2)
+            all_reasons.extend(f"step{step}: {r}" for r in reasons)
+
+            if self._capture_path is not None:
+                self._dump_capture(step, r1, blocks1, run="r1")
+                self._dump_capture(step, r2, blocks2, run="r2")
+
+            per_step_metrics.append({
+                "step": step,
+                "loss_bits_r1": r1.loss_bits,
+                "loss_bits_r2": r2.loss_bits,
+                "num_blocks_checked": len(blocks1.post),
+            })
+
+        local_fail = 1 if all_reasons else 0
+        global_fail = local_fail
+        if dist.is_initialized() and self._world > 1:
+            t = torch.tensor([local_fail], dtype=torch.int64, device=self._device)
+            dist.all_reduce(t, op=dist.ReduceOp.SUM)
+            global_fail = int(t.item())
+
+        elapsed = time.perf_counter() - t0
+        passed = global_fail == 0
+        metrics: dict[str, Any] = {
+            "rank": self._rank,
+            "world_size": self._world,
+            "num_layers": self._cfg.num_layers,
+            "num_experts": self._cfg.num_experts,
+            "dtype": self._cfg.dtype,
+            "checksum_mode": self._cfg.checksum_mode,
+            "capture_dir": self._cfg.capture_dir,
+            "model_label": self._cfg.model_label,
+            "ranks_with_divergence": global_fail,
+            "steps": per_step_metrics,
+        }
+        if all_reasons:
+            metrics["divergence_reasons"] = all_reasons[:32]
+            log.error("[rank %d] llm_determinism divergence:\n  %s", self._rank, "\n  ".join(all_reasons[:32]))
+
+        return WorkloadResult(
+            passed=passed,
+            failure_count=len(all_reasons),
+            first_failure_iteration=0 if all_reasons else None,
+            failure_details=[{"rank": self._rank, "reason": r} for r in all_reasons],
+            total_iterations=self._cfg.steps * 2,
+            elapsed_sec=elapsed,
+            metrics=metrics,
+            main_work_started=True,
+            executed_iterations=self._cfg.steps * 2,
+            configured_iterations=self._cfg.steps * 2,
+        )
+
+    def cleanup(self) -> None:
+        self._hooks.remove()
+        if dist.is_initialized():
+            dist.barrier()
+        # Process group teardown left to the launcher.
+
+    def _run_once(self) -> tuple[ChecksumSet, _BlockChecksums]:
+        torch.manual_seed(self._cfg.seed + 1)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(self._cfg.seed + 1)
+
+        self._model.zero_grad(set_to_none=True)
+        block_cs = self._hooks.start_capture()
+        logits = self._model(self._input_ids)
+        loss = torch.nn.functional.cross_entropy(
+            logits.view(-1, logits.size(-1)).float(),
+            self._labels.view(-1),
+        )
+        loss.backward()
+        self._hooks.stop_capture()
+
+        loss_bits = tensor_checksum(loss.detach())
+        output_bits = tensor_checksum(logits.detach())
+        grads = {n: tensor_checksum(p.grad) for n, p in self._model.named_parameters() if p.grad is not None}
+        params = {n: tensor_checksum(p.detach()) for n, p in self._model.named_parameters()}
+        gbits = global_checksum(loss_bits ^ output_bits) if self._cfg.checksum_mode == "global" else None
+        return (
+            ChecksumSet(loss_bits=loss_bits, output_bits=output_bits, grads=grads, params=params, global_bits=gbits),
+            block_cs,
+        )
+
+    def _raw_blocks(self):
+        # Underlying ``RepeatedBlockModel.blocks`` is intact even after
+        # FSDP2 ``fully_shard`` (it's a composable wrapper, not a module-swap).
+        return self._model.blocks
+
+    def _dump_capture(self, step: int, cs: ChecksumSet, blocks: _BlockChecksums, *, run: str) -> None:
+        assert self._capture_path is not None  # narrowing for mypy/readers.
+        record = {
+            "rank": self._rank,
+            "step": step,
+            "run": run,
+            "loss_bits": cs.loss_bits,
+            "output_bits": cs.output_bits,
+            "block_pre": blocks.pre,
+            "block_post": blocks.post,
+        }
+        with self._capture_path.open("a") as f:
+            f.write(json.dumps(record) + "\n")
+
+
+def _compare_block_lists(a: _BlockChecksums, b: _BlockChecksums) -> list[str]:
+    """Per-block-index divergence reasons. Empty == every block matched."""
+    reasons: list[str] = []
+    if len(a.pre) != len(b.pre) or len(a.post) != len(b.post):
+        return [f"block-list shape mismatch: pre {len(a.pre)} vs {len(b.pre)}, post {len(a.post)} vs {len(b.post)}"]
+    for i, (x, y) in enumerate(zip(a.pre, b.pre, strict=True)):
+        if x != y:
+            reasons.append(f"block[{i}].pre {x} != {y}")
+    for i, (x, y) in enumerate(zip(a.post, b.post, strict=True)):
+        if x != y:
+            reasons.append(f"block[{i}].post {x} != {y}")
+    return reasons
+
+
+def _maybe_fsdp_shard(model: nn.Module) -> nn.Module:
+    """Wrap each repeated block + the top-level model with FSDP2 ``fully_shard``.
+
+    Falls back to the unwrapped model when FSDP2 isn't importable or when
+    CUDA isn't available — keeps the CPU dev path runnable.
+    """
+    try:
+        from torch.distributed._composable.fsdp import fully_shard
+    except ImportError:
+        log.warning("FSDP2 fully_shard not available; running unsharded")
+        return model
+    if not torch.cuda.is_available():
+        return model
+    for block in model.blocks:
+        fully_shard(block)
+    fully_shard(model)
+    return model
+
+
+def _snapshot(model: nn.Module) -> dict[str, Any]:
+    return {
+        "params": {n: p.detach().clone() for n, p in model.named_parameters()},
+        "cpu_rng": torch.get_rng_state(),
+        "cuda_rng": torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None,
+    }
+
+
+def _restore(model: nn.Module, snap: dict[str, Any]) -> None:
+    with torch.no_grad():
+        for n, p in model.named_parameters():
+            p.copy_(snap["params"][n])
+    torch.set_rng_state(snap["cpu_rng"])
+    if snap["cuda_rng"] is not None and torch.cuda.is_available():
+        torch.cuda.set_rng_state_all(snap["cuda_rng"])
+
+
+__all__ = ["LlmDeterminismConfig", "LlmDeterminismWorkload"]

--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -197,7 +197,12 @@ class LlmDeterminismWorkload(Workload):
         gen = torch.Generator(device="cpu").manual_seed(self._cfg.seed + self._rank)
         ids = torch.randint(0, self._cfg.vocab_size, (self._cfg.batch_size, self._cfg.seq_len), generator=gen)
         self._input_ids = ids.to(self._device)
-        self._labels = self._input_ids.clone()
+        # Next-token labels (shifted by one, last position wraps). Identity
+        # labels (`= self._input_ids.clone()`) collapse to loss=0 with the
+        # tied-embedding LM head: residual path lets the input token dominate
+        # its own logit, so the model trivially "predicts" itself. Shifting
+        # breaks that and gives a non-trivial loss signal to checksum.
+        self._labels = torch.roll(self._input_ids, shifts=-1, dims=-1)
 
         self._capture_path: Path | None = None
         if self._cfg.capture_dir:

--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -170,16 +170,22 @@ class LlmDeterminismWorkload(Workload):
 
     def setup(self) -> None:
         self._cfg = LlmDeterminismConfig.from_dict(self.config)
-        enable_deterministic(self._cfg.seed)
         if not dist.is_initialized():
             backend = "nccl" if torch.cuda.is_available() else "gloo"
             dist.init_process_group(backend=backend)
         self._rank = dist.get_rank()
         self._world = dist.get_world_size()
+        # set_device BEFORE any CUDA work (incl. determinism setup) so we
+        # don't create an incidental cuda:0 context on every rank.
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", self._rank % max(1, torch.cuda.device_count()))))
         self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self._dtype = _DTYPES[self._cfg.dtype]
+        # CPU + Python RNGs seeded here; per-rank CUDA seed goes through
+        # manual_seed (current device only) to avoid touching non-local GPUs.
+        enable_deterministic(self._cfg.seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed(self._cfg.seed)
 
         model_cfg = BlockConfig(
             vocab_size=self._cfg.vocab_size,
@@ -290,14 +296,13 @@ class LlmDeterminismWorkload(Workload):
         # Process group teardown left to the launcher.
 
     def _run_once(self) -> tuple[ChecksumSet, _BlockChecksums]:
-        # Re-seed CPU + CUDA-default + Python `random` so both replays enter
-        # forward with identical RNG. `random` covers anything (FSDP2,
-        # DataLoader, future MoE noise) that goes through stdlib RNG —
-        # _snapshot also captures torch RNG state for the same reason.
+        # Re-seed CPU + CUDA-current-device + Python `random` so both
+        # replays enter forward with identical RNG. `manual_seed` (not
+        # `_all`) keeps the reseed scoped to LOCAL_RANK's device.
         random.seed(self._cfg.seed + 1)
         torch.manual_seed(self._cfg.seed + 1)
         if torch.cuda.is_available():
-            torch.cuda.manual_seed_all(self._cfg.seed + 1)
+            torch.cuda.manual_seed(self._cfg.seed + 1)
 
         self._model.zero_grad(set_to_none=True)
         block_cs = self._hooks.start_capture()
@@ -390,10 +395,13 @@ def _maybe_fsdp_shard(model: nn.Module) -> nn.Module:
 
 
 def _snapshot(model: nn.Module) -> dict[str, Any]:
+    # `get_rng_state()` defaults to the current CUDA device — does NOT
+    # touch every visible GPU like `get_rng_state_all()` would. Each
+    # torchrun rank owns one LOCAL_RANK device; that's all we need.
     return {
         "params": {n: p.detach().clone() for n, p in model.named_parameters()},
         "cpu_rng": torch.get_rng_state(),
-        "cuda_rng": torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None,
+        "cuda_rng": torch.cuda.get_rng_state() if torch.cuda.is_available() else None,
         "py_rng": random.getstate(),
     }
 
@@ -404,7 +412,7 @@ def _restore(model: nn.Module, snap: dict[str, Any]) -> None:
             p.copy_(snap["params"][n])
     torch.set_rng_state(snap["cpu_rng"])
     if snap["cuda_rng"] is not None and torch.cuda.is_available():
-        torch.cuda.set_rng_state_all(snap["cuda_rng"])
+        torch.cuda.set_rng_state(snap["cuda_rng"])
     random.setstate(snap["py_rng"])
 
 

--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -216,6 +216,7 @@ class LlmDeterminismWorkload(Workload):
         t0 = time.perf_counter()
         all_reasons: list[str] = []
         per_step_metrics: list[dict[str, Any]] = []
+        first_failure_step: int | None = None
 
         for step in range(self._cfg.steps):
             snapshot = _snapshot(self._model)
@@ -225,6 +226,8 @@ class LlmDeterminismWorkload(Workload):
 
             reasons = compare(r1, r2)
             reasons += _compare_block_lists(blocks1, blocks2)
+            if reasons and first_failure_step is None:
+                first_failure_step = step
             all_reasons.extend(f"step{step}: {r}" for r in reasons)
 
             if self._capture_path is not None:
@@ -263,17 +266,21 @@ class LlmDeterminismWorkload(Workload):
             metrics["divergence_reasons"] = all_reasons[:32]
             log.error("[rank %d] llm_determinism divergence:\n  %s", self._rank, "\n  ".join(all_reasons[:32]))
 
+        # One iteration = one replay PAIR (r1+r2), matching the recipe's
+        # `steps:` semantics. The earlier `steps * 2` accounting made the
+        # matrix.md "Iters" column disagree with the recipe and halved the
+        # elapsed-per-iter fallback timing.
         return WorkloadResult(
             passed=passed,
             failure_count=len(all_reasons),
-            first_failure_iteration=0 if all_reasons else None,
+            first_failure_iteration=first_failure_step,
             failure_details=[{"rank": self._rank, "reason": r} for r in all_reasons],
-            total_iterations=self._cfg.steps * 2,
+            total_iterations=self._cfg.steps,
             elapsed_sec=elapsed,
             metrics=metrics,
             main_work_started=True,
-            executed_iterations=self._cfg.steps * 2,
-            configured_iterations=self._cfg.steps * 2,
+            executed_iterations=self._cfg.steps,
+            configured_iterations=self._cfg.steps,
         )
 
     def cleanup(self) -> None:

--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import random
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -135,7 +136,7 @@ class _BlockHookManager:
             # Resize to num_blocks on first record so out-of-order calls would surface.
             while len(self._current.pre) <= idx:
                 self._current.pre.append(0)
-            self._current.pre[idx] = tensor_checksum(args[0].detach())
+            self._current.pre[idx] = tensor_checksum(_local(args[0].detach()))
         return _hook
 
     def _make_post(self, idx: int):
@@ -144,7 +145,7 @@ class _BlockHookManager:
                 return
             while len(self._current.post) <= idx:
                 self._current.post.append(0)
-            self._current.post[idx] = tensor_checksum(output.detach())
+            self._current.post[idx] = tensor_checksum(_local(output.detach()))
         return _hook
 
     def start_capture(self) -> _BlockChecksums:
@@ -277,6 +278,11 @@ class LlmDeterminismWorkload(Workload):
         # Process group teardown left to the launcher.
 
     def _run_once(self) -> tuple[ChecksumSet, _BlockChecksums]:
+        # Re-seed CPU + CUDA-default + Python `random` so both replays enter
+        # forward with identical RNG. `random` covers anything (FSDP2,
+        # DataLoader, future MoE noise) that goes through stdlib RNG —
+        # _snapshot also captures torch RNG state for the same reason.
+        random.seed(self._cfg.seed + 1)
         torch.manual_seed(self._cfg.seed + 1)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(self._cfg.seed + 1)
@@ -293,8 +299,12 @@ class LlmDeterminismWorkload(Workload):
 
         loss_bits = tensor_checksum(loss.detach())
         output_bits = tensor_checksum(logits.detach())
-        grads = {n: tensor_checksum(p.grad) for n, p in self._model.named_parameters() if p.grad is not None}
-        params = {n: tensor_checksum(p.detach()) for n, p in self._model.named_parameters()}
+        # Under FSDP2 `fully_shard`, params/grads are DTensors; `tensor_checksum`
+        # needs a plain tensor (bit-reinterpret + local sum, not a distributed
+        # reduction). `_local` returns the rank-local shard so the per-rank
+        # compare actually compares this rank's bytes.
+        grads = {n: tensor_checksum(_local(p.grad)) for n, p in self._model.named_parameters() if p.grad is not None}
+        params = {n: tensor_checksum(_local(p.detach())) for n, p in self._model.named_parameters()}
         gbits = global_checksum(loss_bits ^ output_bits) if self._cfg.checksum_mode == "global" else None
         return (
             ChecksumSet(loss_bits=loss_bits, output_bits=output_bits, grads=grads, params=params, global_bits=gbits),
@@ -319,6 +329,19 @@ class LlmDeterminismWorkload(Workload):
         }
         with self._capture_path.open("a") as f:
             f.write(json.dumps(record) + "\n")
+
+
+def _local(t: torch.Tensor) -> torch.Tensor:
+    """Return the rank-local shard for DTensor params; passthrough otherwise.
+
+    FSDP2 `fully_shard` turns parameters into DTensors. Checksumming a DTensor
+    directly would trigger a distributed reduction (and `.view(int_dtype)`
+    isn't supported on DTensor). We want each rank to checksum *its* shard
+    so the per-rank replay compare actually catches a kernel that produced
+    different bits on this rank between the two runs.
+    """
+    to_local = getattr(t, "to_local", None)
+    return to_local() if callable(to_local) else t
 
 
 def _compare_block_lists(a: _BlockChecksums, b: _BlockChecksums) -> list[str]:
@@ -359,6 +382,7 @@ def _snapshot(model: nn.Module) -> dict[str, Any]:
         "params": {n: p.detach().clone() for n, p in model.named_parameters()},
         "cpu_rng": torch.get_rng_state(),
         "cuda_rng": torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None,
+        "py_rng": random.getstate(),
     }
 
 
@@ -369,6 +393,7 @@ def _restore(model: nn.Module, snap: dict[str, Any]) -> None:
     torch.set_rng_state(snap["cpu_rng"])
     if snap["cuda_rng"] is not None and torch.cuda.is_available():
         torch.cuda.set_rng_state_all(snap["cuda_rng"])
+    random.setstate(snap["py_rng"])
 
 
 __all__ = ["LlmDeterminismConfig", "LlmDeterminismWorkload"]

--- a/tests/instrumentation/test_checksum.py
+++ b/tests/instrumentation/test_checksum.py
@@ -6,6 +6,7 @@ import torch
 from aorta.instrumentation.checksum import (
     ChecksumSet,
     compare,
+    global_checksum,
     state_checksum,
     tensor_checksum,
 )
@@ -46,3 +47,9 @@ def test_compare_reports_divergent_keys() -> None:
 def test_unsupported_dtype_raises() -> None:
     with pytest.raises(TypeError):
         tensor_checksum(torch.tensor([1 + 2j], dtype=torch.complex64))
+
+
+def test_global_checksum_returns_local_without_dist() -> None:
+    # When torch.distributed isn't initialised, global_checksum must be a
+    # pass-through so single-process callers don't trip a no-op all_reduce.
+    assert global_checksum(12345) == 12345

--- a/tests/instrumentation/test_checksum.py
+++ b/tests/instrumentation/test_checksum.py
@@ -1,0 +1,48 @@
+"""Bit-equality and divergence detection for the checksum helper."""
+
+import pytest
+import torch
+
+from aorta.instrumentation.checksum import (
+    ChecksumSet,
+    compare,
+    state_checksum,
+    tensor_checksum,
+)
+
+
+def test_identical_tensors_match() -> None:
+    a = torch.randn(64, 64, dtype=torch.bfloat16)
+    assert tensor_checksum(a) == tensor_checksum(a.clone())
+
+
+def test_one_bit_flip_diverges() -> None:
+    a = torch.zeros(8, dtype=torch.float32)
+    b = a.clone()
+    b[0] = 1.0
+    assert tensor_checksum(a) != tensor_checksum(b)
+
+
+def test_plus_zero_vs_minus_zero_diverges() -> None:
+    # Numeric sum would say these are equal; bit checksum must not.
+    a = torch.zeros(1, dtype=torch.float32)
+    b = torch.tensor([-0.0], dtype=torch.float32)
+    assert tensor_checksum(a) != tensor_checksum(b)
+
+
+def test_state_dict_checksum_keyed_per_tensor() -> None:
+    sd = {"w": torch.ones(4, dtype=torch.bfloat16), "b": torch.zeros(4, dtype=torch.bfloat16)}
+    cs = state_checksum(sd)
+    assert set(cs) == {"w", "b"} and cs["w"] != cs["b"]
+
+
+def test_compare_reports_divergent_keys() -> None:
+    a = ChecksumSet(loss_bits=1, output_bits=2, grads={"x": 10}, params={"y": 20})
+    b = ChecksumSet(loss_bits=1, output_bits=2, grads={"x": 11}, params={"y": 20})
+    reasons = compare(a, b)
+    assert len(reasons) == 1 and "grad[x]" in reasons[0]
+
+
+def test_unsupported_dtype_raises() -> None:
+    with pytest.raises(TypeError):
+        tensor_checksum(torch.tensor([1 + 2j], dtype=torch.complex64))

--- a/tests/workloads/test_llm_determinism.py
+++ b/tests/workloads/test_llm_determinism.py
@@ -1,0 +1,75 @@
+"""Config parsing + per-block replay-equality contract on a tiny model (CPU)."""
+
+import pytest
+import torch
+
+from aorta.instrumentation.checksum import tensor_checksum
+from aorta.instrumentation.determinism import enable_deterministic
+from aorta.models import BlockConfig, RepeatedBlockModel
+from aorta.workloads.llm_determinism import (
+    LlmDeterminismConfig,
+    _BlockHookManager,
+    _compare_block_lists,
+)
+
+
+def test_config_from_dict_picks_known_keys() -> None:
+    cfg = LlmDeterminismConfig.from_dict({"num_layers": 4, "dtype": "fp32", "unknown": "ignored"})
+    assert cfg.num_layers == 4 and cfg.dtype == "fp32"
+
+
+@pytest.mark.parametrize("bad", [{"dtype": "fp8"}, {"checksum_mode": "everyone"}, {"steps": 0}])
+def test_config_validation_rejects_garbage(bad: dict) -> None:
+    with pytest.raises(ValueError):
+        LlmDeterminismConfig.from_dict(bad)
+
+
+def _tiny_model() -> RepeatedBlockModel:
+    return RepeatedBlockModel(BlockConfig(
+        vocab_size=128, hidden_size=64, ffn_size=128, num_heads=4,
+        num_layers=3, seq_len=16,
+    )).to(torch.float32)
+
+
+def test_moe_path_runs_and_routes_all_tokens() -> None:
+    cfg = BlockConfig(vocab_size=64, hidden_size=32, ffn_size=64, num_heads=4,
+                      num_layers=1, seq_len=8, num_experts=4)
+    m = RepeatedBlockModel(cfg).to(torch.float32)
+    y = m(torch.randint(0, 64, (1, 8)))
+    assert y.shape == (1, 8, 64) and torch.isfinite(y).all()
+
+
+def test_per_block_replay_is_bit_identical_on_cpu() -> None:
+    enable_deterministic(seed=7)
+    model = _tiny_model()
+    hooks = _BlockHookManager(list(model.blocks))
+    ids = torch.randint(0, 128, (1, 16))
+    snap = {n: p.detach().clone() for n, p in model.named_parameters()}
+
+    def step() -> tuple[int, list[int], list[int]]:
+        model.zero_grad(set_to_none=True)
+        cs = hooks.start_capture()
+        logits = model(ids)
+        loss = torch.nn.functional.cross_entropy(logits.view(-1, 128).float(), ids.view(-1))
+        loss.backward()
+        hooks.stop_capture()
+        return tensor_checksum(logits.detach()), list(cs.pre), list(cs.post)
+
+    o1, pre1, post1 = step()
+    with torch.no_grad():
+        for n, p in model.named_parameters():
+            p.copy_(snap[n])
+    o2, pre2, post2 = step()
+
+    hooks.remove()
+    assert o1 == o2
+    assert pre1 == pre2 and post1 == post2
+    assert len(pre1) == 3 and len(post1) == 3
+
+
+def test_block_list_compare_flags_per_block_divergence() -> None:
+    from aorta.workloads.llm_determinism import _BlockChecksums
+    a = _BlockChecksums(pre=[1, 2, 3], post=[10, 20, 30])
+    b = _BlockChecksums(pre=[1, 99, 3], post=[10, 20, 30])
+    reasons = _compare_block_lists(a, b)
+    assert len(reasons) == 1 and "block[1].pre" in reasons[0]

--- a/tests/workloads/test_llm_determinism.py
+++ b/tests/workloads/test_llm_determinism.py
@@ -31,12 +31,20 @@ def _tiny_model() -> RepeatedBlockModel:
     )).to(torch.float32)
 
 
-def test_moe_path_runs_and_routes_all_tokens() -> None:
+def test_moe_path_routes_to_multiple_experts() -> None:
+    enable_deterministic(seed=11)
     cfg = BlockConfig(vocab_size=64, hidden_size=32, ffn_size=64, num_heads=4,
-                      num_layers=1, seq_len=8, num_experts=4)
+                      num_layers=1, seq_len=32, num_experts=4)
     m = RepeatedBlockModel(cfg).to(torch.float32)
-    y = m(torch.randint(0, 64, (1, 8)))
-    assert y.shape == (1, 8, 64) and torch.isfinite(y).all()
+    ids = torch.randint(0, 64, (1, 32))
+    y = m(ids)
+    # Route the same tokens through the router and confirm >1 expert is picked,
+    # otherwise the per-expert `if mask.any()` branches could be dead and the
+    # shape/finite assertions wouldn't catch it.
+    flat = m.embed(ids).reshape(-1, 32)
+    choice = m.blocks[0].ffn.router(flat).argmax(-1)
+    assert y.shape == (1, 32, 64) and torch.isfinite(y).all()
+    assert choice.unique().numel() > 1
 
 
 def test_per_block_replay_is_bit_identical_on_cpu() -> None:
@@ -73,3 +81,19 @@ def test_block_list_compare_flags_per_block_divergence() -> None:
     b = _BlockChecksums(pre=[1, 99, 3], post=[10, 20, 30])
     reasons = _compare_block_lists(a, b)
     assert len(reasons) == 1 and "block[1].pre" in reasons[0]
+
+
+def test_block_list_compare_flags_shape_mismatch() -> None:
+    from aorta.workloads.llm_determinism import _BlockChecksums
+    a = _BlockChecksums(pre=[1, 2], post=[10, 20])
+    b = _BlockChecksums(pre=[1], post=[10, 20])
+    reasons = _compare_block_lists(a, b)
+    assert len(reasons) == 1 and "shape mismatch" in reasons[0]
+
+
+def test_local_passes_plain_tensor_through() -> None:
+    # If `_local` ever assumes DTensor (e.g., `return t.to_local()`), CPU
+    # and single-rank paths would break silently.
+    from aorta.workloads.llm_determinism import _local
+    t = torch.zeros(3)
+    assert _local(t) is t


### PR DESCRIPTION
## Summary

New `llm_determinism` workload for catching kernel-level nondeterminism and silent data corruption in a transformer training step on ROCm. Runs the same forward+backward twice on the same inputs with parameters and RNG restored between runs, then compares bit-exact checksums of every per-block boundary activation, the loss, the logits, every grad, and every param. Designed to model the comm/compute repetition pattern: one repeated generic transformer block (optionally top-1 MoE), wrapped per-block with FSDP2 `fully_shard` so each block boundary is also the all-gather / reduce-scatter boundary.

Smoke-validated on 8× MI350X (gfx950) with torch 2.10.0.dev+rocm7.0:
- Unit tests: 13/13 pass.
- 8-GPU torchrun smoke: all ranks `passed=True`, `loss_bits` non-zero (~1.15e9) and equal between r1 and r2 per rank, per-rank JSONL capture written with 24-block fingerprints.
- 8-GPU recipe sweep (4 cells: baseline-24L / 12L / tf32_off-24L / MoE-4-12L): every cell passed; per-cell `workload_config` correctly threaded to the workload (`n_blocks` matched each cell's configured `num_layers`).
- Detector validation: between-runs `_input_ids` perturbation produces non-zero exit and populated `divergence_reasons` covering `block[*].pre/post`, `loss_bits`, `output_bits`, and `grad[*]` (params correctly stay unchanged — they're restored).

## What's added

- **`src/aorta/instrumentation/checksum.py`** — `tensor_checksum` (cast-not-convert: view tensor bits as signed int of matching width, accumulate in int64), `state_checksum`, `global_checksum`, `ChecksumSet` + `compare()`. Distinguishes ±0 and NaN payloads that a numeric sum would erase.
- **`src/aorta/instrumentation/determinism.py`** — `enable_deterministic()`: torch deterministic algos (warn_only), cudnn flags, `CUBLAS_WORKSPACE_CONFIG`, CPU + CUDA seeds.
- **`src/aorta/models/repeated_block.py`** — `BlockConfig` + `RepeatedBlockModel`: one generic transformer block (LayerNorm + MHA + GLU FFN, optional top-1 MoE) repeated N times. Manual SDPA so the kernel sequence is stable across replays.
- **`src/aorta/workloads/llm_determinism.py`** — `LlmDeterminismWorkload` subclass: FSDP2-wrapped model, forward pre/post hooks on each block, two-run replay compare, capture mode (per-rank JSONL with per-block fingerprints), rank-local pass/fail by default.
- **Entry-point** registered in `pyproject.toml` as `llm_determinism`.
- **`recipes/example-llm-determinism.yaml`** — multi-cell sweep demonstrating recipe-scope and per-cell `workload_config` plumbing (4 cells: baseline / 12L / tf32_off / MoE-4).
- **`docs/llm-determinism.md`** — Quick Start (prereqs, copy-paste launcher, expected output, detector-validation snippet, capture-reading `jq` one-liners, hand-off checklist, troubleshooting) and Design notes (why a single repeated block, checksum contract, single-rank-only compare, determinism caveats).
- **`README.md`** — one-line entry under "What It Does" pointing at the doc.
- **Tests** — `tests/instrumentation/test_checksum.py` (bit equality, +0/-0 distinction, divergence detection) + `tests/workloads/test_llm_determinism.py` (config parsing, MoE path, per-block replay equality, block-list compare).

## What's intentionally NOT here

- No `torch.compile`, no CUDA/HIP graphs (would defeat the replay).
- No optimizer step between the two replays (would defeat the snapshot).
- No cross-rank checksum equality by default (rule-of-thumb: single-rank-only compare). Optional `checksum_mode: global` opts in to an all-reduced fingerprint.
- No kernel-level interception — module forward pre/post hooks are the practical proxy for the comm boundary, documented as a limitation.

## Notable bugs caught and fixed during validation

These are commits within the branch; mentioning them so reviewers know what the smoke loop surfaced:

- `a0a5f74` — labels were cloned from CPU source instead of device-resident input, causing `cross_entropy` device mismatch on every rank.
- `3ad3af1` — DTensor-unsafe checksums under FSDP2 (`p.grad` / `p.detach()` are DTensors); `global_checksum` placed its all-reduce buffer on `cuda:0` rather than the local-rank device; Python `random` RNG wasn't snapshotted/restored.
- `c95eb2d` — identity labels collapsed cross-entropy to exactly 0.0 with the tied-embedding LM head (residual path lets the input token dominate its own logit). Roll labels by -1 to give a non-trivial loss signal.

## Test plan

- [ ] `pip install -e .` cleanly on a ROCm box.
- [ ] `pytest tests/instrumentation/test_checksum.py tests/workloads/test_llm_determinism.py -q` → 13 passed.
- [ ] 8-GPU smoke per `docs/llm-determinism.md` Quick Start → all ranks `passed=True`, `loss_bits` non-zero, r1 == r2 per rank, capture dir populated.
- [ ] Detector validation per `docs/llm-determinism.md` "Validate the detector actually flags real divergence" → non-zero exit, `divergence_reasons` populated, params unchanged.
- [ ] `aorta triage run --recipe recipes/example-llm-determinism.yaml --dry-run` → enumerates 4 cells with merged config.
- [ ] `torchrun --standalone --nproc_per_node=8 $(which aorta) triage run --recipe recipes/example-llm-determinism.yaml` → all 4 cells pass; per-cell `capture_dir/rank*.jsonl` shows `n_blocks` matching each cell's `num_layers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)