### PR TITLE
Register `race` workload + make distributed triage runs rank-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ node_ip_list.txt
 
 # Experiment results
 results/
+triage_results/
+run_logs/
 
 # Buck2 build artifacts (issue #183 - Buck-buildable CLI).
 # `buck-out/` is buck2's per-project output dir; can hit hundreds of MB.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ aorta = "aorta.cli:main"
 [project.entry-points."aorta.workloads"]
 _subprocess = "aorta.workloads._subprocess:SubprocessWorkload"
 llm_determinism = "aorta.workloads.llm_determinism:LlmDeterminismWorkload"
+race = "aorta.workloads.race:RaceWorkload"
 
 [project.optional-dependencies]
 # For analysis/visualization scripts

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -142,6 +142,44 @@ cells:
 Every validation error reports a path like `cells[2].mitigations` so the
 failure is localisable without reading the loader source.
 
+## Workloads
+
+The `workload:` name is resolved through the `aorta.workloads` entry-point
+group at **cell-execution time, not recipe-load time**. A recipe naming an
+unregistered workload loads and validates fine; it fails per-cell when the
+cell runs. So "the recipe is valid" does not imply "the workload exists" --
+confirm registration with a dry-run (or `pip install -e .` after adding a
+new entry-point).
+
+### `race`
+
+Wraps the in-tree RCCL race reproducer (`aorta.race`). `launch_mode:
+distributed`, `min_world_size: 2`. The communication pattern is selected by
+the `mode` config key, not by a separate workload name:
+
+```yaml
+workload: race
+workload_config:
+  mode: fsdp            # default | ddp | fsdp
+  warmup_iterations: 0
+  verify_iterations: 50
+  dtype: bfloat16       # bfloat16 | float16 | float32
+```
+
+`workload_config` accepts any field of
+`aorta.race.config.ReproducerConfig` (e.g. `h2d_tensor_size`,
+`fsdp_shard_size`, `gemm_layers`, `simulate_compute`, `h2d_prefetch`,
+`same_stream_mode`, `stop_on_first_corruption`, `log_interval`).
+
+> [!IMPORTANT]
+> Unknown `workload_config` keys are **dropped with a `WARNING`**, not
+> errors. A key that isn't a `ReproducerConfig` field is silently ignored
+> at runtime -- which for a stress recipe means a lever you thought you set
+> never applied (a false green). Watch the run log for
+> `race: ignoring unknown workload_config key ...` and fix the recipe.
+> Note `verify_iterations` defaults to `10000` and `simulate_compute` to
+> `True`; cap these for smoke runs or a trial takes hours.
+
 ## Output layout
 
 ```

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -171,6 +171,31 @@ workload_config:
 `fsdp_shard_size`, `gemm_layers`, `simulate_compute`, `h2d_prefetch`,
 `same_stream_mode`, `stop_on_first_corruption`, `log_interval`).
 
+Because `race` is `launch_mode: distributed`, it MUST be launched under
+torchrun (a bare `aorta triage run` starts one process, WORLD_SIZE=1, and is
+refused by launch-mode validation). Use the `aorta` console script as
+torchrun's target -- `-m aorta` is not a runnable module:
+
+```bash
+# validate only (no GPUs / no launcher):
+aorta triage run --recipe recipes/example-fsdp-smoke.yaml --dry-run
+
+# single node, 2 ranks (bump --nproc_per_node to your GPU count):
+torchrun --standalone --nproc_per_node=2 $(which aorta) triage run \
+  --recipe recipes/example-fsdp-smoke.yaml
+
+# multi-node (1 rank/host x N hosts -- the AINIC topology):
+torchrun --nnodes=N --nproc_per_node=1 --rdzv-backend=c10d \
+  --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) triage run \
+  --recipe recipes/example-fsdp-smoke.yaml
+```
+
+Each rank runs the full `triage run`; the ranks find each other in
+`dist.init_process_group()`. Cells run in-process per rank (sequentially),
+and results are written by **rank 0 only** (the dispatcher gates writes on
+`RANK`), so multi-rank launches don't clobber each other. This is the same
+launch model as the `llm_determinism` workload.
+
 > [!IMPORTANT]
 > Unknown `workload_config` keys are **dropped with a `WARNING`**, not
 > errors. A key that isn't a `ReproducerConfig` field is silently ignored

--- a/recipes/example-fsdp-smoke.yaml
+++ b/recipes/example-fsdp-smoke.yaml
@@ -1,22 +1,38 @@
 # Smoke-test recipe for `aorta triage run --mode matrix`.
 #
-# Matches the invocation in issue #151 §"How to test":
 #   aorta triage run --recipe recipes/example-fsdp-smoke.yaml --dry-run
 #   aorta triage run --recipe recipes/example-fsdp-smoke.yaml
 #
-# Resolution happens at load time (schema validation + registry lookups for
-# every mitigation / environment name below). If the public `aorta` build
-# hasn't yet bundled the `fsdp` workload class under the `aorta.workloads`
-# entry-point group, the recipe still validates -- B1's runner surfaces
-# `UnknownWorkloadError` at cell execution time, which this runner catches
-# and reports as a cell-level error without aborting the whole matrix.
+# Runs the `race` workload in `mode: fsdp` (the simulated-collective FSDP
+# harness in `aorta.race.modes.fsdp`). This is a PUBLIC, non-NDA smoke: it
+# exercises the adapter -> create_reproducer -> real RCCL/NCCL collectives
+# path end-to-end on any GPU box. It is NOT expected to reproduce the AINIC
+# SDC bug on non-AINIC hardware (e.g. CX-7 / RCCL) -- a clean `passed: True`
+# is the expected smoke result; the point is that the workload runs.
+#
+# `race` requires torch.distributed: launch under a 2+ rank launcher
+# (torchrun / the distributed environment). Iterations are capped small so a
+# smoke finishes in seconds -- the ReproducerConfig defaults
+# (verify_iterations=10000, simulate_compute=True) would otherwise run for
+# many minutes.
+#
+# Workload names resolve at cell-EXECUTION time, not load time: this recipe
+# validates even before `pip install -e .` registers `race`; an unregistered
+# name surfaces as a per-cell error at run time, not a load error.
 schema_version: 1
 
 ticket: EXAMPLE-151
-workload: fsdp
+workload: race
 
 trials: 2
 steps: 100
+
+workload_config:
+  mode: fsdp
+  warmup_iterations: 2
+  verify_iterations: 5
+  simulate_compute: false   # skip GEMM work so the smoke is fast
+  fsdp_shard_size: 100000
 
 confound:
   threshold: 1.15

--- a/recipes/example-fsdp-smoke.yaml
+++ b/recipes/example-fsdp-smoke.yaml
@@ -1,20 +1,36 @@
-# Smoke-test recipe for `aorta triage run --mode matrix`.
+# Smoke-test recipe for the `race` workload (`mode: fsdp`).
 #
+# `race` is a DISTRIBUTED workload (min_world_size=2), so it MUST be launched
+# under torchrun -- a bare `aorta triage run` starts a single process
+# (WORLD_SIZE=1) and is correctly refused by launch-mode validation. Use the
+# `aorta` console script as torchrun's target (`-m aorta` is NOT a runnable
+# module):
+#
+#   # validate only (no GPUs / no launcher needed):
 #   aorta triage run --recipe recipes/example-fsdp-smoke.yaml --dry-run
-#   aorta triage run --recipe recipes/example-fsdp-smoke.yaml
 #
-# Runs the `race` workload in `mode: fsdp` (the simulated-collective FSDP
-# harness in `aorta.race.modes.fsdp`). This is a PUBLIC, non-NDA smoke: it
-# exercises the adapter -> create_reproducer -> real RCCL/NCCL collectives
-# path end-to-end on any GPU box. It is NOT expected to reproduce the AINIC
-# SDC bug on non-AINIC hardware (e.g. CX-7 / RCCL) -- a clean `passed: True`
-# is the expected smoke result; the point is that the workload runs.
+#   # single node, 2 ranks (CX-7 / RCCL smoke; bump to your GPU count):
+#   torchrun --standalone --nproc_per_node=2 $(which aorta) triage run \
+#     --recipe recipes/example-fsdp-smoke.yaml
 #
-# `race` requires torch.distributed: launch under a 2+ rank launcher
-# (torchrun / the distributed environment). Iterations are capped small so a
-# smoke finishes in seconds -- the ReproducerConfig defaults
-# (verify_iterations=10000, simulate_compute=True) would otherwise run for
-# many minutes.
+#   # multi-node (e.g. 1 rank/host x 40 hosts -- the AINIC topology):
+#   torchrun --nnodes=40 --nproc_per_node=1 --rdzv-backend=c10d \
+#     --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) triage run \
+#     --recipe recipes/example-fsdp-smoke.yaml
+#
+# Results are written by rank 0 only (dispatcher gates on RANK), so multi-rank
+# launches don't clobber each other.
+#
+# Runs the simulated-collective FSDP harness in `aorta.race.modes.fsdp`. This
+# is a PUBLIC, non-NDA smoke: it exercises the adapter -> create_reproducer ->
+# real RCCL/NCCL collectives path end-to-end on any GPU box. It is NOT expected
+# to reproduce the AINIC SDC bug on non-AINIC hardware (e.g. CX-7 / RCCL) -- a
+# clean `passed: True` is the expected smoke result; the point is that the
+# workload runs.
+#
+# Iterations are capped small so a smoke finishes in seconds -- the
+# ReproducerConfig defaults (verify_iterations=10000, simulate_compute=True)
+# would otherwise run for many minutes.
 #
 # Workload names resolve at cell-EXECUTION time, not load time: this recipe
 # validates even before `pip install -e .` registers `race`; an unregistered

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -30,7 +30,7 @@ from aorta.triage.recipe import (
     build_recipe_from_flags,
     load_recipe,
 )
-from aorta.triage.runner import MatrixIncompleteError, run_recipe
+from aorta.triage.runner import MatrixIncompleteError, _is_rank_zero, run_recipe
 
 
 @click.group()
@@ -250,12 +250,16 @@ def triage_run(
         # RecipeCellError below: that's pre-execution validation
         # failure (no artifacts), this is post-execution degradation
         # (matrix.md / matrix.json present but classification couldn't
-        # anchor).
-        click.echo(f"Wrote matrix to {exc.run_dir}")
+        # anchor). Only rank 0 wrote artifacts, so only rank 0 reports.
+        if _is_rank_zero():
+            click.echo(f"Wrote matrix to {exc.run_dir}")
         raise click.ClickException(str(exc)) from exc
     except (RegistryError, RecipeCellError, RecipeSchemaError) as exc:
         raise click.ClickException(str(exc)) from exc
-    if not dry_run:
+    # Under torchrun only rank 0 writes the matrix; non-zero ranks ran the
+    # trials into a scratch dir that no longer exists, so they must not claim
+    # to have written anything.
+    if not dry_run and _is_rank_zero():
         click.echo(f"Wrote matrix to {run_dir}")
 
 

--- a/src/aorta/run/validation.py
+++ b/src/aorta/run/validation.py
@@ -64,7 +64,9 @@ def validate_launch_mode(workload_cls: type[Workload]) -> None:
         raise RuntimeError(
             f"Workload '{workload_cls.__name__}' requires WORLD_SIZE >= {min_world_size} "
             f"(got {world_size}); launch with: "
-            f"torchrun --nproc_per_node={min_world_size} -m aorta run ..."
+            f"torchrun --standalone --nproc_per_node={min_world_size} "
+            f"$(which aorta) run --workload ... "
+            f"(use the 'aorta' console script; '-m aorta' is not a runnable module)"
         )
 
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -30,8 +30,10 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 import re
 import shutil
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -71,6 +73,24 @@ log = logging.getLogger(__name__)
 
 _INLINE_SIDECAR_NAME = "inline_environments.sidecar.json"
 _OPERATOR_SIDECAR_DIR = "sidecars"
+
+
+def _is_rank_zero() -> bool:
+    """True if this process should write run artifacts.
+
+    Mirrors the dispatcher's per-trial write gate (``RANK == 0``): under a
+    distributed launcher every rank runs ``run_recipe`` so the workload's
+    collectives complete on all ranks, but only rank 0 owns the output tree.
+    ``RANK`` is unset for single-process ``aorta triage run`` (treated as
+    rank 0). A non-integer ``RANK`` is treated defensively as rank 0 so a
+    misconfigured launcher writes rather than silently dropping artifacts.
+    """
+    raw_rank = os.environ.get("RANK", "0")
+    try:
+        return int(raw_rank) == 0
+    except ValueError:
+        log.warning("Ignoring non-integer RANK=%r; treating this process as rank 0.", raw_rank)
+        return True
 
 
 class MatrixIncompleteError(Exception):
@@ -933,21 +953,40 @@ def run_recipe(
         return Path(".")
 
     ts = timestamp or format_timestamp()
-    run_dir = resolve_run_dir(output_dir, recipe, timestamp=ts, layout=layout)
 
-    # ``flat_resume`` reuses a stable ``<output>/<ticket>/`` directory across
-    # invocations so resume can detect per-trial ``result.json`` files as
-    # already complete. That same property means two concurrent ``aorta
-    # probe`` invocations against the same ``--output``/``--ticket`` would
-    # race on ``matrix.json``, ``matrix.md``, and per-cell artifacts. Take
-    # an advisory PID+host lock for the duration of the matrix run; the
-    # ``"timestamped"`` layout (``aorta triage run``) is unaffected because
-    # ``resolve_run_dir`` already gives each invocation a fresh leaf via the
-    # ``-N`` suffix loop. ``ExitStack`` keeps the lock optional without
-    # forcing a re-indent of the entire matrix loop.
+    # Under a distributed launcher (torchrun) EVERY rank runs this function:
+    # the cells must execute on all ranks so the collectives inside the
+    # workload actually complete. But only RANK 0 should write artifacts.
+    # The per-trial JSON is already rank-0-gated in the dispatcher; here we
+    # gate the matrix layer too. Without this, every non-zero rank calls
+    # ``resolve_run_dir`` (mkdir(exist_ok=False)) and collides into a
+    # redundant ``<timestamp>-2`` / ``-3`` / ... directory, then writes its
+    # own matrix.md / matrix.json there. Non-zero ranks get a throwaway temp
+    # run_dir (auto-removed) so every write in ``_run_recipe_locked`` lands
+    # in scratch and is discarded; rank 0 gets the real one. Every write site
+    # is rooted at ``run_dir``, so a scratch root is sufficient -- no
+    # per-site gating needed.
+    should_write = _is_rank_zero()
+
     with contextlib.ExitStack() as stack:
-        if layout == "flat_resume":
-            stack.enter_context(acquire_flat_resume_lock(run_dir))
+        if should_write:
+            run_dir = resolve_run_dir(output_dir, recipe, timestamp=ts, layout=layout)
+            # ``flat_resume`` reuses a stable ``<output>/<ticket>/`` directory
+            # across invocations so resume can detect per-trial ``result.json``
+            # files as already complete. That same property means two concurrent
+            # ``aorta probe`` invocations against the same ``--output``/
+            # ``--ticket`` would race on ``matrix.json``, ``matrix.md``, and
+            # per-cell artifacts. Take an advisory PID+host lock for the
+            # duration of the matrix run; the ``"timestamped"`` layout (``aorta
+            # triage run``) is unaffected because ``resolve_run_dir`` already
+            # gives each invocation a fresh leaf via the ``-N`` suffix loop.
+            if layout == "flat_resume":
+                stack.enter_context(acquire_flat_resume_lock(run_dir))
+        else:
+            # Non-rank-0: scratch root, removed on exit. No lock (we never
+            # touch the shared tree).
+            run_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="aorta-rank-")))
+
         return _run_recipe_locked(
             recipe=recipe,
             extra_sidecar_files=extra_sidecar_files,

--- a/src/aorta/workloads/race.py
+++ b/src/aorta/workloads/race.py
@@ -32,6 +32,15 @@ log = logging.getLogger(__name__)
 _VALID_MODES = {"default", "ddp", "fsdp"}
 _VALID_DTYPES = {"bfloat16", "float16", "float32"}
 
+# Platform-injected config keys that are NOT ReproducerConfig fields but are
+# always present (the dispatcher writes `steps` into every workload config;
+# `_aorta_*` keys carry environment / probe metadata). These are expected, not
+# user typos, so the unknown-key guard must stay silent on them -- otherwise
+# every run logs a spurious "ignoring unknown ... key 'steps'" that dilutes the
+# real false-green warning. `steps` is consumed by the launcher, not by the
+# reproducer (race uses warmup_iterations + verify_iterations).
+_RESERVED_KEYS = {"steps"}
+
 
 class RaceWorkload(Workload):
     """Thin adapter over the `aorta.race` reproducer (modes: default|ddp|fsdp)."""
@@ -43,7 +52,7 @@ class RaceWorkload(Workload):
     def _race_config_from_dict(self, d: dict[str, Any]) -> ReproducerConfig:
         known = set(ReproducerConfig.__dataclass_fields__)
         for key in d:
-            if key in known or key.startswith("_aorta_"):
+            if key in known or key in _RESERVED_KEYS or key.startswith("_aorta_"):
                 continue
             log.warning("race: ignoring unknown workload_config key %r", key)
         cfg = ReproducerConfig(**{k: v for k, v in d.items() if k in known})

--- a/src/aorta/workloads/race.py
+++ b/src/aorta/workloads/race.py
@@ -1,0 +1,95 @@
+"""Adapter exposing the in-tree RCCL race reproducer as an `aorta` workload.
+
+`aorta run` resolves ``workload: race`` to this class. It is a thin adapter
+over :mod:`aorta.race` — it filters the recipe's ``workload_config`` to known
+:class:`~aorta.race.config.ReproducerConfig` fields, builds the config, and
+delegates to :func:`aorta.race.modes.create_reproducer`. The reproducer mode
+(``default`` / ``ddp`` / ``fsdp``) is selected by the ``mode`` config key, not
+by separate workload registrations.
+
+Unknown ``workload_config`` keys are DROPPED (we never do
+``ReproducerConfig(**config)``, which would ``TypeError`` on an unknown key).
+Because a silently dropped stress lever is a false green for the war room,
+every dropped key is logged at WARNING so a misconfigured recipe is visible
+rather than passing as a no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, ClassVar, Literal
+
+import torch
+import torch.distributed as dist
+
+from aorta.race.config import ReproducerConfig
+from aorta.race.modes import create_reproducer
+from aorta.workloads._base import Workload, WorkloadResult
+
+log = logging.getLogger(__name__)
+
+_VALID_MODES = {"default", "ddp", "fsdp"}
+_VALID_DTYPES = {"bfloat16", "float16", "float32"}
+
+
+class RaceWorkload(Workload):
+    """Thin adapter over the `aorta.race` reproducer (modes: default|ddp|fsdp)."""
+
+    name: ClassVar[str] = "race"
+    launch_mode: ClassVar[Literal["single_process", "distributed"]] = "distributed"
+    min_world_size: ClassVar[int] = 2
+
+    def _race_config_from_dict(self, d: dict[str, Any]) -> ReproducerConfig:
+        known = set(ReproducerConfig.__dataclass_fields__)
+        for key in d:
+            if key in known or key.startswith("_aorta_"):
+                continue
+            log.warning("race: ignoring unknown workload_config key %r", key)
+        cfg = ReproducerConfig(**{k: v for k, v in d.items() if k in known})
+        if cfg.mode not in _VALID_MODES:
+            raise ValueError(f"mode must be one of {sorted(_VALID_MODES)}, got {cfg.mode!r}")
+        if cfg.dtype not in _VALID_DTYPES:
+            raise ValueError(f"dtype must be one of {sorted(_VALID_DTYPES)}, got {cfg.dtype!r}")
+        return cfg
+
+    def setup(self) -> None:
+        if not dist.is_initialized():
+            backend = "nccl" if torch.cuda.is_available() else "gloo"
+            dist.init_process_group(backend=backend)
+        self._rank = dist.get_rank()
+        self._world = dist.get_world_size()
+        # set_device before any CUDA work so we don't create an incidental
+        # cuda:0 context on every rank (mirrors llm_determinism).
+        if torch.cuda.is_available():
+            torch.cuda.set_device(
+                int(os.environ.get("LOCAL_RANK", self._rank % max(1, torch.cuda.device_count())))
+            )
+        self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._cfg = self._race_config_from_dict(self.config)
+
+    def run(self) -> WorkloadResult:
+        rep = create_reproducer(self._cfg, self._rank, self._world)
+        res = rep.run()
+        return WorkloadResult(
+            passed=res.passed,
+            failure_count=res.corruption_count,
+            first_failure_iteration=res.first_corruption_iter,
+            failure_details=res.corruption_details,
+            total_iterations=res.total_iterations,
+            elapsed_sec=res.elapsed_time_sec,
+            metrics={
+                "avg_step_time_ms": res.avg_step_time_ms,
+                "mode": self._cfg.mode,
+                "rank": self._rank,
+                "world_size": self._world,
+            },
+            main_work_started=True,
+            executed_iterations=res.total_iterations,
+            configured_iterations=self._cfg.warmup_iterations + self._cfg.verify_iterations,
+        )
+
+    def cleanup(self) -> None:
+        if dist.is_initialized():
+            dist.barrier()
+        # Process group teardown left to the launcher.

--- a/tests/run/test_discovery.py
+++ b/tests/run/test_discovery.py
@@ -56,6 +56,22 @@ class TestDiscoverWorkloads:
 
         assert workloads == {"registered_one": MockWorkload}
 
+    def test_race_entry_point_resolves(self):
+        """The `race` entry-point resolves to RaceWorkload."""
+        from aorta.workloads.race import RaceWorkload
+
+        mock_ep = MagicMock()
+        mock_ep.name = "race"
+        mock_ep.load.return_value = RaceWorkload
+
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            workloads = discover_workloads()
+
+        assert workloads == {"race": RaceWorkload}
+
     def test_handles_load_failure_gracefully(self, caplog):
         """Failed workload loads are logged but don't crash discovery."""
         import logging

--- a/tests/run/test_validation.py
+++ b/tests/run/test_validation.py
@@ -182,5 +182,7 @@ class TestErrorMessages:
                 validate_launch_mode(DistributedWorkload)
 
             error_msg = str(exc_info.value)
-            assert "torchrun --nproc_per_node=2" in error_msg
-            assert "-m aorta run" in error_msg
+            assert "torchrun --standalone --nproc_per_node=2" in error_msg
+            # Must steer users to the console script, not the non-runnable
+            # `-m aorta run` form the message previously suggested.
+            assert "$(which aorta) run" in error_msg

--- a/tests/triage/test_runner_b1_api.py
+++ b/tests/triage/test_runner_b1_api.py
@@ -755,3 +755,66 @@ cells:
     assert "Error:" in result.output
     assert "baseline" in result.output.lower()
     assert "Traceback" not in result.output
+
+
+# ---- Distributed rank-0 write gate ---------------------------------------
+
+
+def _simple_recipe():
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe
+
+    return Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=5,
+        cells=(Cell(name="a", mitigations=("none",), environment="local"),),
+        ticket="RANK-1",
+        confound=ConfoundCfg(baseline_cell="a"),
+    )
+
+
+def test_rank_zero_writes_matrix(tmp_path, patched_env, patched_run_trials, monkeypatch):
+    """RANK=0 (or unset) writes the matrix into the real output tree."""
+    monkeypatch.setenv("RANK", "0")
+    run_dir = runner.run_recipe(
+        _simple_recipe(), output_dir=tmp_path, timestamp="2026-01-01T00-00-00"
+    )
+    assert (run_dir / "matrix.json").exists()
+    assert (run_dir / "matrix.md").exists()
+    # The real run dir lives under the requested output tree.
+    assert tmp_path in run_dir.parents
+
+
+def test_nonzero_rank_writes_nothing_to_output_tree(
+    tmp_path, patched_env, patched_run_trials, monkeypatch
+):
+    """A non-zero rank still RUNS every cell (collectives must complete) but
+    writes no artifacts into the shared output tree -- preventing the
+    duplicate ``<timestamp>-2`` run dir torchrun produced before this gate."""
+    out = tmp_path / "out"
+    monkeypatch.setenv("RANK", "1")
+    runner.run_recipe(_simple_recipe(), output_dir=out, timestamp="2026-01-01T00-00-00")
+
+    # Trials still executed on this rank (the workload's collectives need it).
+    assert patched_run_trials.call_count == 1
+    # But nothing was written under the output dir -- the scratch run_dir was
+    # a TemporaryDirectory that is removed on exit.
+    assert not out.exists() or not any(out.rglob("matrix.json"))
+
+
+def test_nonzero_rank_does_not_collide_with_rank_zero(
+    tmp_path, patched_env, patched_run_trials, monkeypatch
+):
+    """Rank 0 and a non-zero rank pointed at the same output dir + timestamp
+    must NOT both create a leaf -- rank 0 owns the real dir, the other goes to
+    scratch. Before the gate this produced ``<ts>`` and ``<ts>-2``."""
+    out = tmp_path / "out"
+    monkeypatch.setenv("RANK", "0")
+    runner.run_recipe(_simple_recipe(), output_dir=out, timestamp="2026-01-01T00-00-00")
+    monkeypatch.setenv("RANK", "1")
+    runner.run_recipe(_simple_recipe(), output_dir=out, timestamp="2026-01-01T00-00-00")
+
+    leaves = list((out / "RANK-1" / "fsdp").iterdir())
+    assert len(leaves) == 1
+    assert leaves[0].name == "2026-01-01T00-00-00"

--- a/tests/workloads/test_race.py
+++ b/tests/workloads/test_race.py
@@ -1,0 +1,120 @@
+"""Unit tests for the `race` workload adapter.
+
+These are unit-level: no real torch.distributed. The config filter is tested
+directly, and result mapping is tested by monkeypatching `create_reproducer`
+and stubbing the distributed init in `setup()`.
+"""
+
+import logging
+
+import pytest
+
+from aorta.race.config import ReproducerConfig, ReproducerResult
+from aorta.workloads.race import RaceWorkload
+
+
+class _StubReproducer:
+    def __init__(self, result: ReproducerResult) -> None:
+        self._result = result
+
+    def run(self) -> ReproducerResult:
+        return self._result
+
+
+def test_race_config_from_dict_filters_unknown(caplog):
+    """Unknown keys are dropped with a warning; known keys map onto the config."""
+    wl = RaceWorkload({})
+    cfg_in = {
+        "mode": "fsdp",
+        "warmup_iterations": 0,
+        "verify_iterations": 50,
+        "h2d_prefetch": True,
+        "fsdp_shard_size": 1_000_000,
+        "dtype": "bfloat16",
+        # unknown keys that must be dropped + warned:
+        "mixed_precision": "bf16",
+        "foo": 123,
+    }
+    with caplog.at_level(logging.WARNING, logger="aorta.workloads.race"):
+        cfg = wl._race_config_from_dict(cfg_in)
+
+    assert isinstance(cfg, ReproducerConfig)
+    assert cfg.mode == "fsdp"
+    assert cfg.warmup_iterations == 0
+    assert cfg.verify_iterations == 50
+    assert cfg.h2d_prefetch is True
+    assert cfg.fsdp_shard_size == 1_000_000
+    assert cfg.dtype == "bfloat16"
+
+    warned = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("mixed_precision" in m for m in warned)
+    assert any("foo" in m for m in warned)
+    # Known keys must NOT be warned about.
+    assert not any("h2d_prefetch" in m for m in warned)
+    assert not any("fsdp_shard_size" in m for m in warned)
+
+
+def test_race_config_reserved_aorta_keys_not_warned(caplog):
+    """`_aorta_*` platform keys are reserved and silently ignored."""
+    wl = RaceWorkload({})
+    with caplog.at_level(logging.WARNING, logger="aorta.workloads.race"):
+        wl._race_config_from_dict({"mode": "default", "_aorta_trial_id": 7})
+    assert not any("_aorta_trial_id" in r.getMessage() for r in caplog.records)
+
+
+def test_race_config_from_dict_rejects_bad_mode():
+    wl = RaceWorkload({})
+    with pytest.raises(ValueError, match="mode must be one of"):
+        wl._race_config_from_dict({"mode": "nope"})
+
+
+def test_race_config_from_dict_rejects_bad_dtype():
+    wl = RaceWorkload({})
+    with pytest.raises(ValueError, match="dtype must be one of"):
+        wl._race_config_from_dict({"dtype": "int8"})
+
+
+def test_race_workload_maps_result(monkeypatch):
+    """run() maps every ReproducerResult field onto WorkloadResult."""
+    stub_result = ReproducerResult(
+        passed=False,
+        total_iterations=42,
+        corruption_count=3,
+        first_corruption_iter=7,
+        corruption_details=[{"iter": 7, "rank": 0}],
+        elapsed_time_sec=1.5,
+        avg_step_time_ms=35.7,
+    )
+
+    captured = {}
+
+    def fake_create_reproducer(cfg, rank, world_size):
+        captured["cfg"] = cfg
+        captured["rank"] = rank
+        captured["world_size"] = world_size
+        return _StubReproducer(stub_result)
+
+    monkeypatch.setattr("aorta.workloads.race.create_reproducer", fake_create_reproducer)
+
+    wl = RaceWorkload({"mode": "default", "warmup_iterations": 2, "verify_iterations": 3})
+    # Bypass real distributed init.
+    wl._rank = 0
+    wl._world = 2
+    wl._cfg = wl._race_config_from_dict(wl.config)
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.failure_count == 3
+    assert res.first_failure_iteration == 7
+    assert res.failure_details == [{"iter": 7, "rank": 0}]
+    assert res.total_iterations == 42
+    assert res.elapsed_sec == 1.5
+    assert res.executed_iterations == 42
+    assert res.configured_iterations == 5  # warmup 2 + verify 3
+    assert res.main_work_started is True
+    assert res.metrics["avg_step_time_ms"] == 35.7
+    assert res.metrics["mode"] == "default"
+    assert res.metrics["rank"] == 0
+    assert res.metrics["world_size"] == 2
+    assert captured["rank"] == 0 and captured["world_size"] == 2

--- a/tests/workloads/test_race.py
+++ b/tests/workloads/test_race.py
@@ -62,6 +62,17 @@ def test_race_config_reserved_aorta_keys_not_warned(caplog):
     assert not any("_aorta_trial_id" in r.getMessage() for r in caplog.records)
 
 
+def test_race_config_steps_key_not_warned(caplog):
+    """`steps` is injected into every workload config by the dispatcher; it is
+    a platform key (not a race field), so it must be dropped WITHOUT a warning
+    -- otherwise every real run logs a spurious unknown-key warning."""
+    wl = RaceWorkload({})
+    with caplog.at_level(logging.WARNING, logger="aorta.workloads.race"):
+        cfg = wl._race_config_from_dict({"mode": "default", "steps": 100})
+    assert not any("steps" in r.getMessage() for r in caplog.records)
+    assert not hasattr(cfg, "steps")  # not a ReproducerConfig field
+
+
 def test_race_config_from_dict_rejects_bad_mode():
     wl = RaceWorkload({})
     with pytest.raises(ValueError, match="mode must be one of"):


### PR DESCRIPTION
## Summary

Registers the in-tree RCCL `race` reproducer as a runnable `aorta` workload so recipes can use `workload: race` (modes `default`/`ddp`/`fsdp`), and fixes two distributed-launch issues surfaced while validating it on a CX-7/RCCL cluster.

- **`race` workload adapter** (`src/aorta/workloads/race.py` + `pyproject.toml` entry-point). Thin wrapper over `aorta.race` — filters `workload_config` to known `ReproducerConfig` fields and **logs a WARNING on every dropped key** (a silently-dropped stress lever is a false green for the war room). Maps `ReproducerResult` → `WorkloadResult`. Zero changes to `race/modes/*`.
- **Docs for distributed launch**: `race` is `launch_mode: distributed` (`min_world_size=2`), so a bare `aorta triage run` is correctly refused. The smoke recipe header + `recipes/README.md` now show the working `torchrun --standalone --nproc_per_node=N $(which aorta) triage run ...` forms (single- and multi-node). The misleading `-m aorta run` hint in the launch-mode error is corrected to `$(which aorta) run`.
- **`steps` false-positive fix**: the dispatcher injects `steps` into every workload config; the race unknown-key guard now treats it as reserved (alongside `_aorta_*`) so real runs don't log a spurious warning that dilutes the genuine false-green signal.
- **Rank-0 matrix-write gate** (`src/aorta/triage/runner.py`): under torchrun every rank ran `run_recipe` and each non-zero rank collided into a redundant `<timestamp>-2` run dir with its own matrix. Non-zero ranks now run every cell (collectives must complete on all ranks) but write into a throwaway temp dir; only rank 0 writes the real artifacts. This was a pre-existing bug affecting all distributed workloads, not just `race`.
- Repoints `recipes/example-fsdp-smoke.yaml` to `race`/`mode:fsdp` with capped iterations so the public smoke is actually runnable.

Verified on hardware (2-rank torchrun, gfx950): 6/6 trials passed, `metrics.world_size=2`, correct result mapping. The companion #205 recipe fixes live on the `ainic-sdc-recipes` branch (separate change).

## Test plan

- [x] `pip install -e .` registers `race`; `discover_workloads()` includes it
- [x] `pytest tests/workloads/test_race.py tests/run/test_discovery.py tests/run/test_validation.py` (30 passed)
- [x] 2-rank torchrun smoke on CX-7/RCCL: all cells pass, no spurious `steps` warning, single matrix dir (rank-0 gate)
- [ ] Multi-node run on the AINIC allocation (1 rank/host) — pending cluster slot
- [ ] New `tests/triage/test_runner_b1_api.py` rank-gate tests run in Linux CI (uncollectable on the Windows dev box via the pre-existing `signal.SIGBUS` import chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)