### PR TITLE
workloads: import torch lazily so discovery doesn't require it

### DIFF
--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -53,11 +53,21 @@ from aorta.workloads._base import Workload, WorkloadResult
 # runs). The class methods and module helpers reference these as module
 # globals; they are bound for real whenever torch is installed. setup() raises
 # a clear error if torch is unavailable when the workload actually runs.
+#
+# Only the torch imports are guarded, and they catch ``Exception`` (not just
+# ``ImportError``) because a broken install -- mismatched CUDA/ROCm runtime,
+# unloadable shared library -- surfaces as OSError/RuntimeError, and discovery
+# must stay clean for all of those. The torch-dependent ``aorta`` helpers live
+# in ``else`` so a genuine bug in those modules raises loudly during discovery
+# instead of being misattributed to "torch not importable".
 try:
     import torch
     import torch.distributed as dist
     from torch import nn  # noqa: F401  (referenced only in string annotations)
-
+except Exception as exc:
+    _DTYPES: dict[str, torch.dtype] = {}
+    _IMPORT_ERROR: Exception | None = exc
+else:
     from aorta.instrumentation.checksum import (
         ChecksumSet,
         compare,
@@ -67,15 +77,12 @@ try:
     from aorta.instrumentation.determinism import enable_deterministic
     from aorta.models import BlockConfig, RepeatedBlockModel
 
-    _DTYPES: dict[str, "torch.dtype"] = {
+    _DTYPES = {
         "bf16": torch.bfloat16,
         "fp16": torch.float16,
         "fp32": torch.float32,
     }
-    _IMPORT_ERROR: ImportError | None = None
-except ImportError as exc:
-    _DTYPES = {}
-    _IMPORT_ERROR = exc
+    _IMPORT_ERROR = None
 
 log = logging.getLogger(__name__)
 

--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -45,23 +45,43 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
-import torch
-import torch.distributed as dist
-from torch import nn
-
-from aorta.instrumentation.checksum import (
-    ChecksumSet,
-    compare,
-    global_checksum,
-    tensor_checksum,
-)
-from aorta.instrumentation.determinism import enable_deterministic
-from aorta.models import BlockConfig, RepeatedBlockModel
 from aorta.workloads._base import Workload, WorkloadResult
+
+# torch (and the torch-dependent aorta helpers) are imported lazily so this
+# module can be IMPORTED for workload discovery / registration in a lightweight
+# environment that has no torch (e.g. a CLI venv that only drives docker-based
+# runs). The class methods and module helpers reference these as module
+# globals; they are bound for real whenever torch is installed. setup() raises
+# a clear error if torch is unavailable when the workload actually runs.
+try:
+    import torch
+    import torch.distributed as dist
+    from torch import nn  # noqa: F401  (referenced only in string annotations)
+
+    from aorta.instrumentation.checksum import (
+        ChecksumSet,
+        compare,
+        global_checksum,
+        tensor_checksum,
+    )
+    from aorta.instrumentation.determinism import enable_deterministic
+    from aorta.models import BlockConfig, RepeatedBlockModel
+
+    _DTYPES: dict[str, "torch.dtype"] = {
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+        "fp32": torch.float32,
+    }
+    _IMPORT_ERROR: ImportError | None = None
+except ImportError as exc:
+    _DTYPES = {}
+    _IMPORT_ERROR = exc
 
 log = logging.getLogger(__name__)
 
-_DTYPES: dict[str, torch.dtype] = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+# dtype names valid in a recipe, kept independent of torch so config validation
+# works even when torch is not importable.
+_VALID_DTYPE_NAMES = ("bf16", "fp16", "fp32")
 
 
 @dataclass
@@ -96,8 +116,8 @@ class LlmDeterminismConfig:
     def from_dict(cls, d: dict[str, Any]) -> LlmDeterminismConfig:
         known = set(cls.__dataclass_fields__)
         cfg = cls(**{k: v for k, v in d.items() if k in known})
-        if cfg.dtype not in _DTYPES:
-            raise ValueError(f"dtype must be one of {list(_DTYPES)}, got {cfg.dtype!r}")
+        if cfg.dtype not in _VALID_DTYPE_NAMES:
+            raise ValueError(f"dtype must be one of {list(_VALID_DTYPE_NAMES)}, got {cfg.dtype!r}")
         if cfg.checksum_mode not in ("per_rank", "global"):
             raise ValueError(f"checksum_mode must be per_rank|global, got {cfg.checksum_mode!r}")
         if cfg.steps < 1:
@@ -169,6 +189,12 @@ class LlmDeterminismWorkload(Workload):
     min_world_size: ClassVar[int] = 1  # also runs single-rank for local dev.
 
     def setup(self) -> None:
+        if _IMPORT_ERROR is not None:
+            raise RuntimeError(
+                "llm_determinism requires PyTorch, which is not importable in "
+                f"this environment: {_IMPORT_ERROR}. Install torch, or run this "
+                "workload inside the container/venv that provides it."
+            ) from _IMPORT_ERROR
         self._cfg = LlmDeterminismConfig.from_dict(self.config)
         if not dist.is_initialized():
             backend = "nccl" if torch.cuda.is_available() else "gloo"

--- a/src/aorta/workloads/race.py
+++ b/src/aorta/workloads/race.py
@@ -20,12 +20,25 @@ import logging
 import os
 from typing import Any, ClassVar, Literal
 
-import torch
-import torch.distributed as dist
-
-from aorta.race.config import ReproducerConfig
-from aorta.race.modes import create_reproducer
 from aorta.workloads._base import Workload, WorkloadResult
+
+# torch (and the ``aorta.race`` package, whose ``__init__`` eagerly pulls a
+# torch-dependent reproducer base) is imported lazily so this module can be
+# IMPORTED for workload discovery / registration in a lightweight environment
+# that has no torch (e.g. a CLI venv that only drives docker-based runs). The
+# class methods reference these names as module globals; they are bound for
+# real whenever torch is installed. setup() raises a clear error if torch is
+# unavailable when the workload actually runs.
+try:
+    import torch
+    import torch.distributed as dist
+
+    from aorta.race.config import ReproducerConfig
+    from aorta.race.modes import create_reproducer
+
+    _IMPORT_ERROR: ImportError | None = None
+except ImportError as exc:
+    _IMPORT_ERROR = exc
 
 log = logging.getLogger(__name__)
 
@@ -76,6 +89,12 @@ class RaceWorkload(Workload):
         return cfg
 
     def setup(self) -> None:
+        if _IMPORT_ERROR is not None:
+            raise RuntimeError(
+                "race requires PyTorch, which is not importable in this "
+                f"environment: {_IMPORT_ERROR}. Install torch, or run this "
+                "workload inside the container/venv that provides it."
+            ) from _IMPORT_ERROR
         if not dist.is_initialized():
             backend = "nccl" if torch.cuda.is_available() else "gloo"
             dist.init_process_group(backend=backend)

--- a/src/aorta/workloads/race.py
+++ b/src/aorta/workloads/race.py
@@ -29,16 +29,23 @@ from aorta.workloads._base import Workload, WorkloadResult
 # class methods reference these names as module globals; they are bound for
 # real whenever torch is installed. setup() raises a clear error if torch is
 # unavailable when the workload actually runs.
+#
+# Only ``import torch`` is guarded, and it catches ``Exception`` (not just
+# ``ImportError``) because a broken install -- mismatched CUDA/ROCm runtime,
+# unloadable shared library -- surfaces as OSError/RuntimeError, and discovery
+# must stay clean for all of those. The ``aorta.race`` imports live in ``else``
+# so a genuine bug in that package raises loudly during discovery instead of
+# being misattributed to "torch not importable".
 try:
     import torch
     import torch.distributed as dist
-
+except Exception as exc:
+    _IMPORT_ERROR: Exception | None = exc
+else:
     from aorta.race.config import ReproducerConfig
     from aorta.race.modes import create_reproducer
 
-    _IMPORT_ERROR: ImportError | None = None
-except ImportError as exc:
-    _IMPORT_ERROR = exc
+    _IMPORT_ERROR = None
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- `aorta` discovers every `aorta.workloads` entry-point by **importing its module**. `llm_determinism` and `race` did `import torch` (and pulled torch-dependent `aorta` helpers / the `aorta.race` package) at module top level, so in an environment **without** torch — e.g. a lightweight CLI venv that only drives docker-based runs — discovery emitted a full `ImportError` traceback for each, even though the workload actually being run (`_subprocess`) needs no torch.
- Torch (and, for `race`, the `aorta.race` imports whose package `__init__` eagerly pulls a torch-dependent reproducer base) are now imported lazily in a `try/except` that records the failure. The class is still defined and registered, so discovery stays clean.
- `setup()` raises a clear, actionable `RuntimeError` **only if the workload is actually run** without torch.

Behavior with torch present is unchanged: the same module globals are bound and method bodies are untouched.

## Test plan
- [x] Simulated torch-absent import: both modules import, register their classes, and `setup()` raises a clear `RuntimeError`.
- [x] `tests/run/test_discovery.py` passes in an env with **no torch** (the bug's repro), including `test_race_entry_point_resolves`.
- [ ] CI runs the full suite in a torch-enabled environment (no behavior change expected).

Made with [Cursor](https://cursor.com)