### PR TITLE
probe: demote tier3:vram_growth to a warn + add tier3_vram_growth opt-out

### DIFF
--- a/docs/probe-188/classifier.md
+++ b/docs/probe-188/classifier.md
@@ -76,10 +76,18 @@ Source: `src/aorta/probe/classifier/tier3_kernel.py`.
 
 `amd-smi` snapshot diff IDs:
 
-| ID | Fires when |
-|---|---|
-| `tier3:vram_growth` | `vram_used_mib(post) - vram_used_mib(pre) >= 256 MiB` |
-| `tier3:thermal_throttle` | `thermal_throttle_count(post) > thermal_throttle_count(pre)` |
+| ID | Fires when | Severity |
+|---|---|---|
+| `tier3:vram_growth` | `vram_used_mib(post) - vram_used_mib(pre) >= 256 MiB` | **warn** |
+| `tier3:thermal_throttle` | `thermal_throttle_count(post) > thermal_throttle_count(pre)` | fail |
+
+> **`tier3:vram_growth` is advisory (warn), not a failure.** The probe samples
+> WHOLE-GPU VRAM at only two points (pre/post the opaque subprocess) and cannot
+> attribute the delta to the trial's own process on a multi-tenant host, so it
+> never flips the verdict to `fail` — it lands in `warn_detectors_fired`. The
+> kernel-fault `dmesg` IDs above stay hard failures. The set of advisory IDs is
+> `TIER3_WARN_DETECTOR_IDS` in `tier3_kernel.py`. A recipe can suppress the
+> check entirely (no warn) with `tier3_vram_growth: false`.
 
 **Fail-soft**: missing `dmesg` / `amd-smi` binaries log
 `tier3 disabled: <reason>` exactly **once per `aorta probe`

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -32,7 +32,11 @@ from aorta.probe.classifier import (
 )
 from aorta.probe.classifier.tier1_process import Tier1Context
 from aorta.probe.classifier.tier2_hang import DETECTOR_HANG
-from aorta.probe.classifier.tier3_kernel import AmdSmiSnapshot, Tier3State
+from aorta.probe.classifier.tier3_kernel import (
+    TIER3_WARN_DETECTOR_IDS,
+    AmdSmiSnapshot,
+    Tier3State,
+)
 from aorta.probe.classifier.tier5_custom import CompiledPattern
 from aorta.probe.classifier.verdict import Verdict, VerdictInputs, resolve
 
@@ -76,6 +80,7 @@ class TrialContext:
     # can supply IDs without the source text and the classifier can
     # supply the source text without the IDs -- the two paths union.
     tier3_extra: tuple[str, ...] = ()
+    tier3_vram_growth: bool = True
 
 
 def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
@@ -126,7 +131,12 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
             tier3.extend(tier3_kernel.scan_dmesg_text(ctx.dmesg_text))
         if ctx.amd_smi_pre is not None and ctx.amd_smi_post is not None:
             tier3.extend(
-                tier3_kernel.scan_amd_smi(ctx.tier3_state, ctx.amd_smi_pre, ctx.amd_smi_post)
+                tier3_kernel.scan_amd_smi(
+                    ctx.tier3_state,
+                    ctx.amd_smi_pre,
+                    ctx.amd_smi_post,
+                    check_vram_growth=ctx.tier3_vram_growth,
+                )
             )
     tier_durations_ms["tier3"] = (time.perf_counter() - t0) * 1000.0
 
@@ -144,12 +154,19 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
     )
     tier_durations_ms["tier5"] = (time.perf_counter() - t0) * 1000.0
 
+    # Split Tier-3 IDs into hard failures vs. advisory warns. ``vram_growth``
+    # is advisory (see TIER3_WARN_DETECTOR_IDS) so it never flips the verdict;
+    # kernel-fault IDs stay failures. Preserve encounter order within each.
+    tier3_fail = [d for d in tier3 if d not in TIER3_WARN_DETECTOR_IDS]
+    tier3_warn = [d for d in tier3 if d in TIER3_WARN_DETECTOR_IDS]
+
     verdict = resolve(
         VerdictInputs(
             tier1=tier1,
             tier2=tier2,
-            tier3=tier3,
+            tier3=tier3_fail,
             tier4=tier4,
+            tier3_warn=tier3_warn,
             custom_result=custom_result,
             custom_required_patterns=ctx.custom_patterns,
         )

--- a/src/aorta/probe/classifier/tier3_kernel.py
+++ b/src/aorta/probe/classifier/tier3_kernel.py
@@ -67,6 +67,16 @@ DETECTOR_THERMAL_THROTTLE = "tier3:thermal_throttle"
 # processes can move VRAM by a few MiB during the trial.
 VRAM_GROWTH_THRESHOLD_MIB = 256
 
+# Tier-3 detector IDs that are advisory (warn) rather than hard failures.
+# ``tier3:vram_growth`` is a warn because the probe samples WHOLE-GPU VRAM at
+# only two points (pre/post the opaque subprocess) and cannot attribute the
+# delta to the trial's own process on a shared host -- too unreliable to flip
+# a verdict, but still worth surfacing. The verdict resolver routes these IDs
+# to ``warn_detectors_fired`` instead of ``failure_detectors_fired``. The
+# kernel-fault detectors (GPU reset, SDMA timeout, VM/L2 fault, XGMI, AER)
+# stay hard failures -- they are unambiguous and self-attributing.
+TIER3_WARN_DETECTOR_IDS = frozenset({DETECTOR_VRAM_GROWTH})
+
 # Cap on the amount of dmesg text we scan per trial. Same rationale
 # as :data:`aorta.probe.sandbox.MAX_LOG_BYTES`: a runaway dmesg
 # producing > 10MiB of output in one trial would point at a kernel
@@ -243,6 +253,8 @@ def scan_amd_smi(
     state: Tier3State,
     pre: AmdSmiSnapshot | None,
     post: AmdSmiSnapshot | None,
+    *,
+    check_vram_growth: bool = True,
 ) -> list[str]:
     """Diff two amd-smi snapshots and return the fired Tier 3 detectors.
 
@@ -261,7 +273,10 @@ def scan_amd_smi(
         )
         return []
     fired: list[str] = []
-    if post.vram_used_mib - pre.vram_used_mib >= VRAM_GROWTH_THRESHOLD_MIB:
+    if (
+        check_vram_growth
+        and post.vram_used_mib - pre.vram_used_mib >= VRAM_GROWTH_THRESHOLD_MIB
+    ):
         fired.append(DETECTOR_VRAM_GROWTH)
     if post.thermal_throttle_count > pre.thermal_throttle_count:
         fired.append(DETECTOR_THERMAL_THROTTLE)
@@ -551,6 +566,7 @@ __all__ = [
     "GPU_IDLE_UTILIZATION_THRESHOLD_PCT",
     "MAX_DMESG_BYTES",
     "Tier3State",
+    "TIER3_WARN_DETECTOR_IDS",
     "VRAM_GROWTH_THRESHOLD_MIB",
     "gpu_idle_probe_from_state",
     "poll_amd_smi",

--- a/src/aorta/probe/classifier/tier3_kernel.py
+++ b/src/aorta/probe/classifier/tier3_kernel.py
@@ -264,6 +264,11 @@ def scan_amd_smi(
     :data:`VRAM_GROWTH_THRESHOLD_MIB` and
     :data:`DETECTOR_THERMAL_THROTTLE` if the throttle counter went
     up during the trial.
+
+    ``check_vram_growth=False`` (recipe knob ``tier3_vram_growth:
+    false``) suppresses :data:`DETECTOR_VRAM_GROWTH` entirely — used
+    where whole-device VRAM is meaningless (shared/multi-tenant GPUs).
+    The thermal-throttle detector is unaffected.
     """
     if pre is None or post is None:
         _log_disabled_once(

--- a/src/aorta/probe/classifier/verdict.py
+++ b/src/aorta/probe/classifier/verdict.py
@@ -65,6 +65,9 @@ class VerdictInputs:
     tier2: list[str] = field(default_factory=list)
     tier3: list[str] = field(default_factory=list)
     tier4: list[str] = field(default_factory=list)
+    # Advisory Tier-3 detectors (e.g. ``tier3:vram_growth``) that surface as
+    # warns rather than failures -- they never flip the verdict to fail.
+    tier3_warn: list[str] = field(default_factory=list)
     custom_result: CustomScanResult = field(default_factory=CustomScanResult)
     custom_required_patterns: tuple[CompiledPattern, ...] = ()
 
@@ -108,7 +111,10 @@ def resolve(inputs: VerdictInputs) -> Verdict:
     if required_ids and not (required_ids <= inputs.custom_result.fired_required_ids):
         failures.append(DETECTOR_MISSING_PASS_SIGNAL)
 
-    warns = list(inputs.custom_result.warn_detectors)
+    # Built-in advisory (warn) detectors precede user custom warns, mirroring
+    # the tier-before-custom ordering used for failures above.
+    warns = list(inputs.tier3_warn)
+    warns.extend(inputs.custom_result.warn_detectors)
     capture = dict(inputs.custom_result.capture)
 
     verdict = "fail" if failures else "pass"

--- a/src/aorta/probe/classifier/verdict.py
+++ b/src/aorta/probe/classifier/verdict.py
@@ -8,9 +8,10 @@ Combines the per-tier detector outputs into the final
 
 (b) ``result.json::failure_detectors_fired`` lists ALL fired in a
     fixed encounter order: Tier 1, Tier 2, Tier 3, Tier 4, then
-    Tier 5 (``custom_patterns`` failures). The order is set by
-    :func:`resolve` (and the :class:`VerdictInputs` field order it
-    iterates), independent of when each tier physically fires
+    Tier 5 (``custom_patterns`` failures). The order is set
+    explicitly by :func:`resolve` as a fixed tier sequence (not by
+    the :class:`VerdictInputs` field order), independent of when each
+    tier physically fires
     relative to the workload exit. The in-flight Tier 2 hang monitor
     contributes its detector IDs to ``inputs.tier2`` before
     :func:`resolve` is called, so even though the predicate fires
@@ -48,11 +49,17 @@ DETECTOR_MISSING_PASS_SIGNAL = "meta:missing_pass_signal"
 class VerdictInputs:
     """Per-tier outputs the resolver merges.
 
-    Order MATTERS for ``failure_detectors_fired``: the resolver
-    walks the lists in the order they appear on this struct
-    (tier1, tier2, tier3, tier4, custom-fail, meta) and appends in
-    that order so the final list is reproducible across runs
-    given the same inputs.
+    Field order on this struct does NOT drive ``failure_detectors_fired``
+    ordering: :func:`resolve` appends the failure lists in a fixed tier
+    sequence (tier1, tier2, tier3, tier4, custom-fail, then the
+    synthesised ``meta:`` signal), so the serialised list is reproducible
+    across runs given the same inputs regardless of how the fields are
+    laid out here.
+
+    ``tier3_warn`` carries advisory Tier-3 detectors (e.g.
+    ``tier3:vram_growth``) that contribute ONLY to
+    ``warn_detectors_fired`` -- they never appear in
+    ``failure_detectors_fired`` and never flip the verdict to fail.
 
     ``custom_required_patterns`` is the list of ``CompiledPattern``
     objects with ``required_for_pass=True``, regardless of whether

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -113,6 +113,10 @@ class ProbeExtras:
     custom_patterns: tuple[CompiledPattern, ...] = ()
     hang_window_sec: float = DEFAULT_HANG_WINDOW_SEC
     hang_grace_period_at_start: float = DEFAULT_HANG_GRACE_SEC
+    # When False, skip the Tier-3 pre/post VRAM delta check. Useful for
+    # opaque docker wrappers where GPU allocation is normal workload
+    # behaviour rather than a leak signal.
+    tier3_vram_growth: bool = True
     # Phase 3 (issue #188): redaction block consumed by ``aorta bundle``.
     redaction: RedactionCfg | None = None
 
@@ -301,6 +305,13 @@ def build_probe_recipe_from_dict(
         default=DEFAULT_HANG_GRACE_SEC,
         allow_zero=True,
     )
+    tier3_vram_growth_raw = data.get("tier3_vram_growth", True)
+    if not isinstance(tier3_vram_growth_raw, bool):
+        raise RecipeSchemaError(
+            "recipe.tier3_vram_growth: must be a boolean, got "
+            f"{type(tier3_vram_growth_raw).__name__} ({tier3_vram_growth_raw!r})"
+        )
+    tier3_vram_growth = tier3_vram_growth_raw
     # Use ``in`` rather than ``.get(...) is not None`` so an explicit
     # ``redaction: null`` is treated as present-but-invalid (parse_redaction
     # rejects None) instead of being silently conflated with "no redaction
@@ -429,6 +440,7 @@ def build_probe_recipe_from_dict(
         custom_patterns=custom_patterns,
         hang_window_sec=hang_window_sec,
         hang_grace_period_at_start=hang_grace_period_at_start,
+        tier3_vram_growth=tier3_vram_growth,
         redaction=redaction,
     )
 

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -77,6 +77,9 @@ _PROBE_TOP_LEVEL = frozenset(
         "custom_patterns",
         "hang_window_sec",
         "hang_grace_period_at_start",
+        # Disable Tier-3 pre/post VRAM delta for opaque docker wrappers
+        # where GPU allocation is expected, not a leak signal.
+        "tier3_vram_growth",
         # Phase 3 (issue #188): redaction block for aorta bundle.
         "redaction",
     }

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -783,6 +783,7 @@ def _run_one_cell(
             "custom_patterns": tuple(probe_extras.custom_patterns),
             "hang_window_sec": probe_extras.hang_window_sec,
             "hang_grace_period_at_start": probe_extras.hang_grace_period_at_start,
+            "tier3_vram_growth": probe_extras.tier3_vram_growth,
         }
 
     # save_logs is forced True for probe-mode cells because

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -230,6 +230,7 @@ class SubprocessWorkload(Workload):
         hang_grace_sec = (
             DEFAULT_HANG_GRACE_SEC if _hang_grace_raw is None else float(_hang_grace_raw)
         )
+        tier3_vram_growth = bool(probe_extras.get("tier3_vram_growth", True))
 
         # ``inherit`` mode: the dispatcher has already stamped the
         # cell's mitigation + diagnostic env vars onto os.environ in
@@ -489,6 +490,7 @@ class SubprocessWorkload(Workload):
                     amd_smi_post=amd_smi_post,
                     tier3_extra=tuple(fired_kernel_ids),
                     tier3_state=_TIER3_STATE,
+                    tier3_vram_growth=tier3_vram_growth,
                 )
             )
         except Exception as classifier_exc:  # noqa: BLE001 -- classifier crash containment

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -230,7 +230,22 @@ class SubprocessWorkload(Workload):
         hang_grace_sec = (
             DEFAULT_HANG_GRACE_SEC if _hang_grace_raw is None else float(_hang_grace_raw)
         )
-        tier3_vram_growth = bool(probe_extras.get("tier3_vram_growth", True))
+        # ``tier3_vram_growth`` is a validated boolean on the
+        # recipe-builder side (RecipeSchemaError on non-bool) and is
+        # serialized from a typed ``ProbeExtras`` field, so the payload
+        # is contractually a bool. Validate-and-fail-fast rather than
+        # ``bool(...)``: truthiness coercion would turn a malformed
+        # payload (e.g. the string ``"false"``) into ``True`` and
+        # silently re-enable the detector. This mirrors the sibling
+        # ``float(...)`` knobs above, which also surface a bad payload
+        # instead of swallowing it.
+        _vram_growth_raw = probe_extras.get("tier3_vram_growth", True)
+        if not isinstance(_vram_growth_raw, bool):
+            raise TypeError(
+                "probe_extras['tier3_vram_growth'] must be a bool, got "
+                f"{type(_vram_growth_raw).__name__} ({_vram_growth_raw!r})"
+            )
+        tier3_vram_growth = _vram_growth_raw
 
         # ``inherit`` mode: the dispatcher has already stamped the
         # cell's mitigation + diagnostic env vars onto os.environ in

--- a/tests/probe/classifier/test_tier3.py
+++ b/tests/probe/classifier/test_tier3.py
@@ -137,6 +137,17 @@ def test_amdsmi_fake_env_var_thermal_throttle(monkeypatch):
     assert tier3_kernel.DETECTOR_THERMAL_THROTTLE in fired
 
 
+def test_amdsmi_vram_growth_can_be_disabled(monkeypatch):
+    """``check_vram_growth=False`` skips the pre/post VRAM delta leg."""
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=100,throttle=0")
+    state = Tier3State()
+    pre = poll_amd_smi(state)
+    monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=500,throttle=0")
+    post = poll_amd_smi(state)
+    fired = scan_amd_smi(state, pre, post, check_vram_growth=False)
+    assert tier3_kernel.DETECTOR_VRAM_GROWTH not in fired
+
+
 def test_amdsmi_below_threshold_does_not_fire(monkeypatch):
     """VRAM delta under the threshold stays silent (noise floor)."""
     monkeypatch.setenv("AORTA_PROBE_AMDSMI_FAKE", "vram=100,throttle=0")

--- a/tests/probe/classifier/test_verdict.py
+++ b/tests/probe/classifier/test_verdict.py
@@ -81,6 +81,24 @@ def test_warn_alone_is_pass():
     assert verdict.warn_detectors_fired == ["custom:slow_iter"]
 
 
+def test_tier3_warn_is_pass_not_fail():
+    """Advisory Tier-3 detectors (e.g. vram_growth) warn, never fail."""
+    verdict = resolve(_inputs(tier3_warn=["tier3:vram_growth"]))
+    assert verdict.verdict == "pass"
+    assert verdict.failure_detectors_fired == []
+    assert verdict.warn_detectors_fired == ["tier3:vram_growth"]
+
+
+def test_tier3_warn_does_not_mask_a_real_failure():
+    """A warn-level tier3 ID coexists with a hard failure from another tier."""
+    verdict = resolve(
+        _inputs(tier3=["tier3:amdgpu_reset"], tier3_warn=["tier3:vram_growth"])
+    )
+    assert verdict.verdict == "fail"
+    assert verdict.failure_detectors_fired == ["tier3:amdgpu_reset"]
+    assert verdict.warn_detectors_fired == ["tier3:vram_growth"]
+
+
 def test_info_match_populates_capture_only():
     """Info-only patterns populate ``capture`` but never the verdict lists."""
     custom = CustomScanResult(capture={"bw": "240"})

--- a/tests/probe/test_recipe.py
+++ b/tests/probe/test_recipe.py
@@ -453,3 +453,38 @@ hang_grace_period_at_start: -1
     )
     with pytest.raises(RecipeSchemaError, match="hang_grace_period_at_start.*>= 0"):
         load_recipe(recipe_path)
+
+
+# ---- tier3_vram_growth opt-out round-trip (PR #215 review) ----------------
+
+
+def test_tier3_vram_growth_defaults_true(tmp_path):
+    """Omitting ``tier3_vram_growth`` leaves the Tier-3 VRAM delta check
+    enabled -- the knob defaults to ``True`` so existing recipes are
+    unchanged. Pins the recipe -> ``ProbeExtras`` path that the original
+    PR #215 left untested (Sonbol review).
+    """
+    recipe = load_recipe(_write_yaml(tmp_path, _PROBE_MINIMAL))
+    assert recipe.probe_extras is not None
+    assert recipe.probe_extras.tier3_vram_growth is True
+
+
+def test_tier3_vram_growth_false_round_trips(tmp_path):
+    """``tier3_vram_growth: false`` parses to a real bool and lands on
+    ``ProbeExtras.tier3_vram_growth`` so the dispatcher can forward it into
+    ``probe_extras`` and the workload can skip the whole-device VRAM check.
+    """
+    text = _PROBE_MINIMAL + "tier3_vram_growth: false\n"
+    recipe = load_recipe(_write_yaml(tmp_path, text))
+    assert recipe.probe_extras is not None
+    assert recipe.probe_extras.tier3_vram_growth is False
+
+
+def test_tier3_vram_growth_non_bool_rejected(tmp_path):
+    """A non-bool ``tier3_vram_growth`` is rejected at load. Truthiness
+    coercion (``bool("false") is True``) would silently re-enable the
+    detector, so the builder fails closed with ``RecipeSchemaError``.
+    """
+    text = _PROBE_MINIMAL + 'tier3_vram_growth: "notabool"\n'
+    with pytest.raises(RecipeSchemaError, match="tier3_vram_growth.*must be a boolean"):
+        load_recipe(_write_yaml(tmp_path, text))

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -457,6 +457,45 @@ def test_hang_grace_zero_survives_runtime_extraction(tmp_path, monkeypatch):
     assert captured["hang_window_sec"] == 30.0
 
 
+def test_tier3_vram_growth_threaded_into_classifier(tmp_path, monkeypatch):
+    """Regression for PR #215 review (Sonbol): ``probe_extras["tier3_vram_growth"]``
+    must thread through the workload into the ``TrialContext`` handed to
+    ``classify_trial`` so the recipe opt-out actually reaches the Tier-3
+    VRAM check. Spy on ``classify_trial`` and assert it observed ``False``.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    captured: dict[str, object] = {}
+    real_classify = workload_mod.classify_trial
+
+    def _spy_classify(ctx):
+        captured["tier3_vram_growth"] = ctx.tier3_vram_growth
+        return real_classify(ctx)
+
+    monkeypatch.setattr(workload_mod, "classify_trial", _spy_classify)
+
+    wl = _make_workload(tmp_path, ["true"], tier3_vram_growth=False)
+    wl.setup()
+    wl.run()
+    assert captured["tier3_vram_growth"] is False, (
+        "probe_extras['tier3_vram_growth']=False did not reach the "
+        "TrialContext -- the recipe opt-out is silently ignored."
+    )
+
+
+def test_tier3_vram_growth_non_bool_payload_raises(tmp_path):
+    """A malformed ``tier3_vram_growth`` payload (e.g. the string "false")
+    raises ``TypeError`` rather than being truthily coerced to ``True`` and
+    silently re-enabling the detector. Mirrors the recipe-builder guard and
+    the sibling ``float(...)`` knobs that surface a bad payload instead of
+    swallowing it.
+    """
+    wl = _make_workload(tmp_path, ["true"], tier3_vram_growth="false")
+    wl.setup()
+    with pytest.raises(TypeError, match="tier3_vram_growth.*must be a bool"):
+        wl.run()
+
+
 def test_classifier_crash_still_writes_result_json(tmp_path, monkeypatch):
     """Regression for PR #197 round-3 review: if ``classify_trial``
     raises (regex catastrophe, future refactor edge case, etc.),

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -477,9 +477,10 @@ def test_tier3_vram_growth_threaded_into_classifier(tmp_path, monkeypatch):
     wl = _make_workload(tmp_path, ["true"], tier3_vram_growth=False)
     wl.setup()
     wl.run()
-    assert captured["tier3_vram_growth"] is False, (
+    assert captured.get("tier3_vram_growth") is False, (
         "probe_extras['tier3_vram_growth']=False did not reach the "
-        "TrialContext -- the recipe opt-out is silently ignored."
+        "TrialContext -- the recipe opt-out is silently ignored "
+        "(or classify_trial was never called, so the spy never ran)."
     )
 
 


### PR DESCRIPTION
## Summary
The `tier3:vram_growth` detector reads **whole-device** VRAM, so on a shared / multi-tenant GPU a neighbour's allocation looks like the workload leaking memory and the trial **fails** — a false positive unrelated to the reproducer under test.

Two changes, both narrowing how much this detector can hurt a verdict:

1. **`tier3:vram_growth` is now warn-level.** It still fires and is surfaced in the verdict (`warn_detectors_fired`), but it no longer flips a trial to `fail`. Real fail signals (numeric divergence, crashes, the other tier3 kernel detectors) are unaffected. Implemented via a `TIER3_WARN_DETECTOR_IDS` set in `tier3_kernel.py`, a `tier3_warn` input on `VerdictInputs`, and a fail/warn partition in `classify_trial`.
2. **New per-recipe `tier3_vram_growth` knob (default `True`)** lets a recipe disable the detector entirely where whole-device VRAM is meaningless. Plumbed through probe recipe → `probe_extras` → `_subprocess` → classifier.

Docs (`docs/probe-188/classifier.md`) updated to describe `vram_growth` as advisory.

## Test plan
- [x] `tests/probe/classifier/test_verdict.py` — new cases: vram_growth alone → `pass`/warn, not `fail`; warn coexists with a real fail.
- [x] `tests/probe/classifier/test_tier3.py` — detector still fires/serializes; opt-out suppresses it.
- [x] `tests/probe/test_recipe.py`, `tests/probe/test_subprocess_workload.py` — knob round-trips through the recipe and into `probe_extras`.
- [x] Full affected suite: 94 passed.

## Notes
Independent of #214 (lazy torch import); both branch off `main` and can merge in any order.

Made with [Cursor](https://cursor.com)