### PR TITLE
env probe: suppress in-process HIP/C-runtime stderr noise (#220)

### DIFF
--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1276,6 +1276,97 @@ class EnvSnapshot:
 # ---------------------------------------------------------------------------
 
 
+class _ProbeStdioRedirect:
+    """OS-level fd 1/2 capture for the duration of the env-probe body.
+
+    ``collect_env`` imports torch in-process to read versions / scan kernels
+    (``_capture_pytorch_version`` and the other torch-touching probes). On a
+    multi-GPU ROCm host the in-process HIP runtime ``dlopen`` performs a
+    device-topology enumeration that writes one benign
+    ``(null): No such file or directory`` line per GPU **directly to file
+    descriptor 2** (a C-runtime ``perror`` with a NULL program name), plus
+    occasional toolchain chatter on fd 1. Because the probe runs in the
+    long-lived ``aorta`` parent process, that noise lands on the operator's
+    terminal and looks like a fatal workload error (#220).
+
+    ``contextlib.redirect_stderr`` cannot intercept this -- it only swaps the
+    Python ``sys.stderr`` object and never moves the real fd 2 -- so we
+    ``dup2`` fds 1/2 onto a temp file for the probe and re-emit any captured
+    bytes at DEBUG level afterwards.
+
+    Fail-soft, matching ``collect_env``'s never-raises contract: if the real
+    descriptors can't be duplicated (already closed / detached), the probe
+    runs unredirected rather than risk losing the snapshot. ``stop`` is
+    idempotent so the caller can restore early (before disaster logging) and
+    still rely on a ``finally`` safety net.
+    """
+
+    def __init__(self) -> None:
+        self._saved_out: int | None = None
+        self._saved_err: int | None = None
+        self._capture: Any | None = None
+
+    def start(self) -> None:
+        try:
+            self._saved_out = os.dup(1)
+            self._saved_err = os.dup(2)
+        except OSError:
+            # No real stdio fds to protect (e.g. detached/closed). Probe as-is.
+            self._saved_out = None
+            self._saved_err = None
+            return
+        try:
+            self._capture = tempfile.TemporaryFile(mode="w+b")
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os.dup2(self._capture.fileno(), 1)
+            os.dup2(self._capture.fileno(), 2)
+        except OSError:
+            # Redirect setup failed after dup(); undo and probe unredirected.
+            self._restore_fds()
+
+    def _restore_fds(self) -> None:
+        if self._saved_out is not None:
+            try:
+                os.dup2(self._saved_out, 1)
+            finally:
+                os.close(self._saved_out)
+                self._saved_out = None
+        if self._saved_err is not None:
+            try:
+                os.dup2(self._saved_err, 2)
+            finally:
+                os.close(self._saved_err)
+                self._saved_err = None
+
+    def stop(self) -> None:
+        if self._saved_out is None and self._saved_err is None:
+            return
+        sys.stdout.flush()
+        sys.stderr.flush()
+        self._restore_fds()
+        noise = ""
+        if self._capture is not None:
+            try:
+                self._capture.seek(0)
+                noise = (
+                    self._capture.read().decode("utf-8", errors="replace").strip()
+                )
+            except OSError:
+                noise = ""
+            finally:
+                self._capture.close()
+                self._capture = None
+        if noise:
+            log.debug(
+                "env probe suppressed %d byte(s) of low-level stdout/stderr "
+                "(benign HIP/C-runtime device-enumeration noise on ROCm hosts; "
+                "see #220): %s",
+                len(noise),
+                noise,
+            )
+
+
 def collect_env(
     buck_target: str | None = None,
     buck_timeout: int = 10,
@@ -1312,6 +1403,12 @@ def collect_env(
     subprocess (seconds; default 10).
     """
     reasons: list[str] = []
+    # Capture fds 1/2 at the OS level for the probe body so that the benign
+    # HIP/C-runtime device-enumeration noise the in-process ``import torch``
+    # below emits straight to fd 2 never reaches the operator's terminal
+    # (#220). It is re-emitted at DEBUG level instead.
+    _probe_stdio = _ProbeStdioRedirect()
+    _probe_stdio.start()
     try:
         runtime_context = _detect_runtime_context()  # never partial; always populates
         system_health = _run_rdhc(reasons)
@@ -1398,6 +1495,9 @@ def collect_env(
             nics=nics,
         )
     except Exception as exc:  # noqa: BLE001 -- this is the never-raises gate
+        # Restore stdio before logging so the disaster trace reaches the
+        # operator's terminal rather than the captured (and discarded) buffer.
+        _probe_stdio.stop()
         log.info("collect_env() hit unexpected exception", exc_info=True)
         return _disaster_snapshot(
             preceding_reasons=reasons,
@@ -1406,6 +1506,9 @@ def collect_env(
                 f"({type(exc).__name__}: {exc})"
             ),
         )
+    finally:
+        # Idempotent: a no-op if the except branch already restored stdio.
+        _probe_stdio.stop()
 
 
 def _disaster_snapshot(

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1377,18 +1377,28 @@ class _ProbeStdioRedirect:
             passthrough = os.fdopen(os.dup(self._saved_err), "w", closefd=True)
         except Exception:
             return
-        root = logging.getLogger()
+        # Scan both the root logger and the "aorta" logger: the CLI's
+        # ``configure_verbose_logging`` installs the -v/-vv StreamHandler on the
+        # "aorta" logger and sets ``propagate=False`` (see run/cli_helpers.py),
+        # so a root-only sweep would miss it and the operator's -v/-vv output
+        # would still be swallowed into the capture file. Dedup handler
+        # instances in case the same handler is attached to both.
         rerouted: list[tuple[logging.Handler, Any]] = []
-        for handler in list(root.handlers):
-            if isinstance(handler, logging.StreamHandler) and getattr(
-                handler, "stream", None
-            ) in (sys.stdout, sys.stderr):
-                try:
-                    original = handler.stream
-                    handler.setStream(passthrough)
-                    rerouted.append((handler, original))
-                except Exception:
-                    pass
+        seen: set[int] = set()
+        for logger in (logging.getLogger(), logging.getLogger("aorta")):
+            for handler in list(logger.handlers):
+                if id(handler) in seen:
+                    continue
+                if isinstance(handler, logging.StreamHandler) and getattr(
+                    handler, "stream", None
+                ) in (sys.stdout, sys.stderr):
+                    try:
+                        original = handler.stream
+                        handler.setStream(passthrough)
+                        rerouted.append((handler, original))
+                        seen.add(id(handler))
+                    except Exception:
+                        pass
         if not rerouted:
             try:
                 passthrough.close()

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1331,7 +1331,15 @@ class _ProbeStdioRedirect:
             os.dup2(self._capture.fileno(), 2)
         except OSError:
             # Redirect setup failed after dup(); undo and probe unredirected.
+            # Close the capture file here: _restore_fds() clears the saved fds,
+            # so a later stop() short-circuits and would otherwise leak it.
             self._restore_fds()
+            if self._capture is not None:
+                try:
+                    self._capture.close()
+                except OSError:
+                    pass
+                self._capture = None
 
     def _restore_fds(self) -> None:
         if self._saved_out is not None:

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1305,6 +1305,10 @@ class _ProbeStdioRedirect:
         self._saved_out: int | None = None
         self._saved_err: int | None = None
         self._capture: Any | None = None
+        # Aorta's own stdout/stderr log handlers, repointed at the real
+        # terminal for the redirect window (see _reroute_loggers).
+        self._rerouted_handlers: list[tuple[logging.Handler, Any]] = []
+        self._passthrough: Any | None = None
 
     @staticmethod
     def _flush_std_streams() -> None:
@@ -1352,6 +1356,66 @@ class _ProbeStdioRedirect:
                 except Exception:
                     pass
                 self._capture = None
+            return
+        # fd 1/2 now point at the capture file. That also swallows aorta's own
+        # Python logs (e.g. _run_rdhc's log.info), which would otherwise vanish
+        # at -v or be mislabeled as benign HIP noise at -vv. Repoint aorta's
+        # stdout/stderr log handlers at the real terminal for the window.
+        if self._capture is not None and self._saved_err is not None:
+            self._reroute_loggers()
+
+    def _reroute_loggers(self) -> None:
+        """Point aorta's stdout/stderr log handlers at the saved real fd.
+
+        Keeps real Python-level diagnostics on the operator's terminal while
+        the raw fd 1/2 redirect still swallows the C-runtime ``(null)`` noise.
+        Fail-soft: any failure leaves the handlers untouched (logs fall back to
+        the capture file, the pre-existing behaviour) rather than risk the
+        never-raises contract.
+        """
+        try:
+            passthrough = os.fdopen(os.dup(self._saved_err), "w", closefd=True)
+        except Exception:
+            return
+        root = logging.getLogger()
+        rerouted: list[tuple[logging.Handler, Any]] = []
+        for handler in list(root.handlers):
+            if isinstance(handler, logging.StreamHandler) and getattr(
+                handler, "stream", None
+            ) in (sys.stdout, sys.stderr):
+                try:
+                    original = handler.stream
+                    handler.setStream(passthrough)
+                    rerouted.append((handler, original))
+                except Exception:
+                    pass
+        if not rerouted:
+            try:
+                passthrough.close()
+            except Exception:
+                pass
+            return
+        self._passthrough = passthrough
+        self._rerouted_handlers = rerouted
+
+    def _restore_loggers(self) -> None:
+        """Undo :meth:`_reroute_loggers`. Idempotent and fail-soft."""
+        for handler, original in self._rerouted_handlers:
+            try:
+                handler.setStream(original)
+            except Exception:
+                pass
+        self._rerouted_handlers = []
+        if self._passthrough is not None:
+            try:
+                self._passthrough.flush()
+            except Exception:
+                pass
+            try:
+                self._passthrough.close()
+            except Exception:
+                pass
+            self._passthrough = None
 
     def _restore_fds(self) -> None:
         # Fail-soft: called from stop() inside collect_env()'s except/finally,
@@ -1385,6 +1449,7 @@ class _ProbeStdioRedirect:
             return
         self._flush_std_streams()
         self._restore_fds()
+        self._restore_loggers()
         noise = ""
         noise_bytes = 0
         if self._capture is not None:
@@ -1408,8 +1473,9 @@ class _ProbeStdioRedirect:
         if noise:
             log.debug(
                 "env probe suppressed %d byte(s) of low-level stdout/stderr "
-                "(benign HIP/C-runtime device-enumeration noise on ROCm hosts; "
-                "see #220): %s",
+                "(expected: benign HIP/C-runtime device-enumeration noise on "
+                "ROCm hosts; aorta's own logs are routed to the terminal "
+                "separately; see #220): %s",
                 noise_bytes,
                 noise,
             )

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1311,7 +1311,15 @@ class _ProbeStdioRedirect:
             self._saved_out = os.dup(1)
             self._saved_err = os.dup(2)
         except OSError:
-            # No real stdio fds to protect (e.g. detached/closed). Probe as-is.
+            # No real stdio fds to protect (e.g. detached/closed), or the
+            # second dup() raised after the first succeeded. Close any orphan
+            # descriptor from a partial dup() so we don't leak it, then probe
+            # unredirected.
+            if self._saved_out is not None:
+                try:
+                    os.close(self._saved_out)
+                except OSError:
+                    pass
             self._saved_out = None
             self._saved_err = None
             return
@@ -1346,14 +1354,16 @@ class _ProbeStdioRedirect:
         sys.stderr.flush()
         self._restore_fds()
         noise = ""
+        noise_bytes = 0
         if self._capture is not None:
             try:
                 self._capture.seek(0)
-                noise = (
-                    self._capture.read().decode("utf-8", errors="replace").strip()
-                )
+                raw = self._capture.read()
+                noise_bytes = len(raw)
+                noise = raw.decode("utf-8", errors="replace").strip()
             except OSError:
                 noise = ""
+                noise_bytes = 0
             finally:
                 self._capture.close()
                 self._capture = None
@@ -1362,7 +1372,7 @@ class _ProbeStdioRedirect:
                 "env probe suppressed %d byte(s) of low-level stdout/stderr "
                 "(benign HIP/C-runtime device-enumeration noise on ROCm hosts; "
                 "see #220): %s",
-                len(noise),
+                noise_bytes,
                 noise,
             )
 

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1306,6 +1306,16 @@ class _ProbeStdioRedirect:
         self._saved_err: int | None = None
         self._capture: Any | None = None
 
+    @staticmethod
+    def _flush_std_streams() -> None:
+        # Best-effort: a closed/detached stream raises ValueError (not OSError)
+        # on flush(); never let that escape (collect_env never-raises contract).
+        for stream in (sys.stdout, sys.stderr):
+            try:
+                stream.flush()
+            except Exception:
+                pass
+
     def start(self) -> None:
         try:
             self._saved_out = os.dup(1)
@@ -1325,41 +1335,55 @@ class _ProbeStdioRedirect:
             return
         try:
             self._capture = tempfile.TemporaryFile(mode="w+b")
-            sys.stdout.flush()
-            sys.stderr.flush()
+            self._flush_std_streams()
             os.dup2(self._capture.fileno(), 1)
             os.dup2(self._capture.fileno(), 2)
-        except OSError:
-            # Redirect setup failed after dup(); undo and probe unredirected.
+        except Exception:
+            # Broadened from OSError: TemporaryFile/dup2 can raise OSError and
+            # a closed stream's flush() raises ValueError. start() runs *before*
+            # collect_env()'s try/except, so any escape would violate the
+            # never-raises contract -- fail soft and probe unredirected.
             # Close the capture file here: _restore_fds() clears the saved fds,
             # so a later stop() short-circuits and would otherwise leak it.
             self._restore_fds()
             if self._capture is not None:
                 try:
                     self._capture.close()
-                except OSError:
+                except Exception:
                     pass
                 self._capture = None
 
     def _restore_fds(self) -> None:
+        # Fail-soft: called from stop() inside collect_env()'s except/finally,
+        # so a dup2()/close() failure (e.g. EBADF on an invalidated fd) must
+        # never raise or it would mask the snapshot / original exception.
         if self._saved_out is not None:
             try:
                 os.dup2(self._saved_out, 1)
+            except OSError:
+                pass
             finally:
-                os.close(self._saved_out)
+                try:
+                    os.close(self._saved_out)
+                except OSError:
+                    pass
                 self._saved_out = None
         if self._saved_err is not None:
             try:
                 os.dup2(self._saved_err, 2)
+            except OSError:
+                pass
             finally:
-                os.close(self._saved_err)
+                try:
+                    os.close(self._saved_err)
+                except OSError:
+                    pass
                 self._saved_err = None
 
     def stop(self) -> None:
         if self._saved_out is None and self._saved_err is None:
             return
-        sys.stdout.flush()
-        sys.stderr.flush()
+        self._flush_std_streams()
         self._restore_fds()
         noise = ""
         noise_bytes = 0
@@ -1369,11 +1393,17 @@ class _ProbeStdioRedirect:
                 raw = self._capture.read()
                 noise_bytes = len(raw)
                 noise = raw.decode("utf-8", errors="replace").strip()
-            except OSError:
+            except Exception:
+                # Broadened from OSError: seek/read on a closed file raises
+                # ValueError. stop() runs in collect_env()'s finally and must
+                # never raise.
                 noise = ""
                 noise_bytes = 0
             finally:
-                self._capture.close()
+                try:
+                    self._capture.close()
+                except Exception:
+                    pass
                 self._capture = None
         if noise:
             log.debug(

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -660,6 +660,34 @@ class TestProbeStdioRedirect:
             restore()
         assert outer.read_text() == ""
 
+    def test_start_partial_dup_failure_does_not_leak_fd(self, monkeypatch):
+        """A partial ``dup()`` must not orphan the first descriptor (#221).
+
+        If ``os.dup(1)`` succeeds but ``os.dup(2)`` raises (fd 2 already
+        closed/detached), ``start()`` falls back to probing unredirected -- but
+        the fd from the successful first ``dup()`` must be closed, not leaked.
+        """
+        redirect = env_mod._ProbeStdioRedirect()
+        real_dup = os.dup
+        duped: list[int] = []
+
+        def flaky_dup(fd):
+            if not duped:
+                new = real_dup(fd)
+                duped.append(new)
+                return new
+            raise OSError("simulated: fd 2 closed/detached")
+
+        monkeypatch.setattr(env_mod.os, "dup", flaky_dup)
+        redirect.start()
+
+        assert redirect._saved_out is None
+        assert redirect._saved_err is None
+        assert duped, "test should have exercised the first dup()"
+        with pytest.raises(OSError):
+            os.fstat(duped[0])  # orphan fd was closed, not leaked
+        redirect.stop()  # unredirected instance -> no-op, must not crash
+
     def test_collect_env_does_not_leak_probe_noise(
         self, all_disabled, tmp_path, monkeypatch
     ):

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -595,6 +595,98 @@ class TestEnvSnapshot:
 # ---------------------------------------------------------------------------
 
 
+class TestProbeStdioRedirect:
+    """fd-level capture of benign HIP/C-runtime probe noise (#220).
+
+    On a multi-GPU ROCm host the in-process ``import torch`` during the env
+    probe makes the HIP runtime ``dlopen`` write one
+    ``(null): No such file or directory`` line per GPU straight to fd 2.
+    ``_ProbeStdioRedirect`` must intercept those raw ``write(2, ...)`` syscalls
+    (which ``contextlib.redirect_stderr`` cannot) so they never reach the
+    operator's terminal, and re-emit them at DEBUG for post-hoc debugging.
+    """
+
+    def _with_outer_terminal(self, tmp_path: Path):
+        """Install a temp file on real fds 1/2; return (path, restore())."""
+        outer = tmp_path / "outer_terminal.txt"
+        sys.stdout.flush()
+        sys.stderr.flush()
+        outer_fd = os.open(
+            str(outer), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644
+        )
+        saved1, saved2 = os.dup(1), os.dup(2)
+        os.dup2(outer_fd, 1)
+        os.dup2(outer_fd, 2)
+
+        def restore():
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os.dup2(saved1, 1)
+            os.dup2(saved2, 2)
+            os.close(saved1)
+            os.close(saved2)
+            os.close(outer_fd)
+
+        return outer, restore
+
+    def test_raw_fd2_writes_are_captured_not_leaked(self, tmp_path, caplog):
+        outer, restore = self._with_outer_terminal(tmp_path)
+        try:
+            redirect = env_mod._ProbeStdioRedirect()
+            redirect.start()
+            for _ in range(8):  # one (null) line per GPU on an 8-GPU host
+                os.write(2, b"(null): No such file or directory\n")
+            os.write(1, b"some toolchain chatter\n")
+            with caplog.at_level("DEBUG", logger=env_mod.log.name):
+                redirect.stop()
+        finally:
+            restore()
+
+        assert outer.read_text() == "", "probe noise leaked to the terminal"
+        assert any(
+            "(null): No such file or directory" in rec.getMessage()
+            for rec in caplog.records
+        ), "captured noise should be re-emitted at DEBUG"
+
+    def test_stop_is_idempotent(self, tmp_path):
+        outer, restore = self._with_outer_terminal(tmp_path)
+        try:
+            redirect = env_mod._ProbeStdioRedirect()
+            redirect.start()
+            os.write(2, b"noise\n")
+            redirect.stop()
+            redirect.stop()  # must be a no-op, not crash or re-restore
+        finally:
+            restore()
+        assert outer.read_text() == ""
+
+    def test_collect_env_does_not_leak_probe_noise(
+        self, all_disabled, tmp_path, monkeypatch
+    ):
+        """End-to-end: fd-2 noise from a probe never reaches the terminal."""
+        original = env_mod._detect_runtime_context
+
+        def noisy_detect():
+            for _ in range(8):
+                os.write(2, b"(null): No such file or directory\n")
+            return original()
+
+        monkeypatch.setattr(env_mod, "_detect_runtime_context", noisy_detect)
+
+        outer, restore = self._with_outer_terminal(tmp_path)
+        try:
+            snapshot = collect_env()
+        finally:
+            restore()
+
+        assert isinstance(snapshot, EnvSnapshot)
+        assert outer.read_text() == "", "env probe leaked HIP noise to terminal"
+        # The benign noise is NOT a probe failure -> must not inflate partial.
+        assert not any(
+            "(null)" in reason for reason in snapshot.partial_reasons
+        )
+
+
 class TestCollectEnvContract:
     def test_collect_env_never_raises_when_all_probes_fail(self, all_disabled):
         """Acceptance: monkeypatch every probe to fail, still get an EnvSnapshot."""

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -715,6 +715,73 @@ class TestProbeStdioRedirect:
         assert redirect._capture is None, "capture temp file was leaked"
         redirect.stop()  # no-op, must not crash
 
+    def test_start_fail_soft_on_non_oserror_flush(self, monkeypatch):
+        """A closed stream's flush() raises ValueError; start() must fail soft.
+
+        ``start()`` runs *before* ``collect_env()``'s try/except, so any
+        exception escaping it (here a ``ValueError`` from ``sys.stdout.flush``)
+        would break the never-raises contract (#221).
+        """
+        redirect = env_mod._ProbeStdioRedirect()
+
+        class _ClosedStream:
+            def flush(self):
+                raise ValueError("I/O operation on closed file")
+
+        monkeypatch.setattr(env_mod.sys, "stdout", _ClosedStream())
+        redirect.start()  # must not raise
+        redirect.stop()
+        # Setup aborted -> nothing left dangling.
+        assert redirect._saved_out is None
+        assert redirect._saved_err is None
+        assert redirect._capture is None
+
+    def test_stop_never_raises_when_streams_closed(self, tmp_path, monkeypatch):
+        """stop() runs in collect_env()'s finally and must never raise (#221)."""
+        outer, restore = self._with_outer_terminal(tmp_path)
+        try:
+            redirect = env_mod._ProbeStdioRedirect()
+            redirect.start()
+            os.write(2, b"noise\n")
+
+            class _ClosedStream:
+                def flush(self):
+                    raise ValueError("closed")
+
+            monkeypatch.setattr(env_mod.sys, "stdout", _ClosedStream())
+            try:
+                redirect.stop()  # must not raise despite flush ValueError
+            finally:
+                # Undo the closed-stdout patch before the outer-terminal
+                # teardown, which flushes sys.stdout itself.
+                monkeypatch.undo()
+        finally:
+            restore()
+        assert redirect._capture is None
+
+    def test_restore_fds_swallows_dup2_failure(self, tmp_path, monkeypatch):
+        """_restore_fds() must be best-effort: a dup2 EBADF must not escape."""
+        outer, restore = self._with_outer_terminal(tmp_path)
+        try:
+            redirect = env_mod._ProbeStdioRedirect()
+            redirect.start()
+            real_dup2 = os.dup2
+
+            def boom_dup2(*_a, **_k):
+                raise OSError("simulated: EBADF on restore")
+
+            monkeypatch.setattr(env_mod.os, "dup2", boom_dup2)
+            try:
+                redirect.stop()  # must not raise even though restore dup2 fails
+            finally:
+                # Restore the real dup2 before the outer terminal teardown,
+                # which itself dup2()s fds 1/2 back to the test runner.
+                monkeypatch.setattr(env_mod.os, "dup2", real_dup2)
+        finally:
+            restore()
+        assert redirect._saved_out is None
+        assert redirect._saved_err is None
+
     def test_collect_env_does_not_leak_probe_noise(
         self, all_disabled, tmp_path, monkeypatch
     ):

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -647,6 +648,47 @@ class TestProbeStdioRedirect:
             "(null): No such file or directory" in rec.getMessage()
             for rec in caplog.records
         ), "captured noise should be re-emitted at DEBUG"
+
+    def test_aorta_logs_reach_terminal_during_redirect(self, tmp_path):
+        """Aorta's own logs must survive the fd redirect (#221 review).
+
+        The redirect captures *all* of fd 1/2 for the probe body, which would
+        otherwise swallow aorta's own ``log.info`` (vanishing at -v, mislabeled
+        as benign HIP noise at -vv). ``_reroute_loggers`` repoints the stderr
+        StreamHandler at the real terminal for the window, so a real diagnostic
+        still reaches the operator while the C-level ``(null)`` noise does not.
+        """
+        root = logging.getLogger()
+        saved_handlers = root.handlers[:]
+        saved_level = root.level
+        outer, restore = self._with_outer_terminal(tmp_path)
+        try:
+            for handler in saved_handlers:
+                root.removeHandler(handler)
+            stream_handler = logging.StreamHandler(sys.stderr)
+            stream_handler.setLevel(logging.INFO)
+            root.addHandler(stream_handler)
+            root.setLevel(logging.INFO)
+
+            redirect = env_mod._ProbeStdioRedirect()
+            redirect.start()
+            env_mod.log.info("real diagnostic from a probe")
+            os.write(2, b"(null): No such file or directory\n")
+            redirect.stop()
+        finally:
+            root.removeHandler(stream_handler)
+            for handler in saved_handlers:
+                root.addHandler(handler)
+            root.setLevel(saved_level)
+            restore()
+
+        terminal_text = outer.read_text()
+        assert "real diagnostic from a probe" in terminal_text, (
+            "aorta's own INFO log was swallowed by the probe fd redirect"
+        )
+        assert "(null): No such file or directory" not in terminal_text, (
+            "benign HIP noise leaked to the terminal"
+        )
 
     def test_stop_is_idempotent(self, tmp_path):
         outer, restore = self._with_outer_terminal(tmp_path)

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -649,7 +649,19 @@ class TestProbeStdioRedirect:
             for rec in caplog.records
         ), "captured noise should be re-emitted at DEBUG"
 
-    def test_aorta_logs_reach_terminal_during_redirect(self, tmp_path):
+    @pytest.mark.parametrize(
+        "logger_name, propagate",
+        [
+            # utils.setup_logging: stderr handler on the root logger.
+            ("", True),
+            # CLI configure_verbose_logging (-v/-vv): handler on the "aorta"
+            # logger with propagate=False -- a root-only reroute would miss it.
+            ("aorta", False),
+        ],
+    )
+    def test_aorta_logs_reach_terminal_during_redirect(
+        self, tmp_path, logger_name, propagate
+    ):
         """Aorta's own logs must survive the fd redirect (#221 review).
 
         The redirect captures *all* of fd 1/2 for the probe body, which would
@@ -657,18 +669,22 @@ class TestProbeStdioRedirect:
         as benign HIP noise at -vv). ``_reroute_loggers`` repoints the stderr
         StreamHandler at the real terminal for the window, so a real diagnostic
         still reaches the operator while the C-level ``(null)`` noise does not.
+        Covers both wiring styles: the root logger (``setup_logging``) and the
+        "aorta" logger with ``propagate=False`` (the CLI verbosity path).
         """
-        root = logging.getLogger()
-        saved_handlers = root.handlers[:]
-        saved_level = root.level
+        target = logging.getLogger(logger_name)
+        saved_handlers = target.handlers[:]
+        saved_level = target.level
+        saved_propagate = target.propagate
+        stream_handler = logging.StreamHandler(sys.stderr)
         outer, restore = self._with_outer_terminal(tmp_path)
         try:
             for handler in saved_handlers:
-                root.removeHandler(handler)
-            stream_handler = logging.StreamHandler(sys.stderr)
+                target.removeHandler(handler)
             stream_handler.setLevel(logging.INFO)
-            root.addHandler(stream_handler)
-            root.setLevel(logging.INFO)
+            target.addHandler(stream_handler)
+            target.setLevel(logging.INFO)
+            target.propagate = propagate
 
             redirect = env_mod._ProbeStdioRedirect()
             redirect.start()
@@ -676,10 +692,11 @@ class TestProbeStdioRedirect:
             os.write(2, b"(null): No such file or directory\n")
             redirect.stop()
         finally:
-            root.removeHandler(stream_handler)
+            target.removeHandler(stream_handler)
             for handler in saved_handlers:
-                root.addHandler(handler)
-            root.setLevel(saved_level)
+                target.addHandler(handler)
+            target.setLevel(saved_level)
+            target.propagate = saved_propagate
             restore()
 
         terminal_text = outer.read_text()

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -688,6 +688,33 @@ class TestProbeStdioRedirect:
             os.fstat(duped[0])  # orphan fd was closed, not leaked
         redirect.stop()  # unredirected instance -> no-op, must not crash
 
+    def test_start_dup2_failure_closes_capture_file(self, monkeypatch):
+        """A ``dup2()`` failure after the temp file is created must close it (#221).
+
+        ``start()`` dups fds 1/2 successfully, then ``dup2`` raises. The
+        fallback restores the real fds (clearing ``_saved_out/_saved_err``),
+        which makes a later ``stop()`` short-circuit -- so ``start()`` itself
+        must close the capture file or it leaks the handle.
+        """
+        redirect = env_mod._ProbeStdioRedirect()
+        real_dup2 = os.dup2
+        calls: list[int] = []
+
+        def flaky_dup2(*args, **kwargs):
+            # Fail the first capture redirect; let _restore_fds() succeed.
+            if not calls:
+                calls.append(1)
+                raise OSError("simulated: dup2 failed")
+            return real_dup2(*args, **kwargs)
+
+        monkeypatch.setattr(env_mod.os, "dup2", flaky_dup2)
+        redirect.start()
+
+        assert redirect._saved_out is None
+        assert redirect._saved_err is None
+        assert redirect._capture is None, "capture temp file was leaked"
+        redirect.stop()  # no-op, must not crash
+
     def test_collect_env_does_not_leak_probe_noise(
         self, all_disabled, tmp_path, monkeypatch
     ):

--- a/tests/probe/test_probe_env_noise_e2e.py
+++ b/tests/probe/test_probe_env_noise_e2e.py
@@ -1,0 +1,109 @@
+"""End-to-end guard for the issue #220 minimal repro.
+
+The issue's minimal repro is::
+
+    aorta probe --recipe ... -- bash -c 'echo hi; sleep 100'
+    # -> NUM_GPUS x "(null): No such file or directory" on the terminal
+
+The real trigger is an in-process ``import torch`` -> HIP runtime ``dlopen``
+on a multi-GPU ROCm host, which writes one ``(null)`` line per GPU straight to
+fd 2 from inside the env probe that ``aorta probe`` runs at start. That trigger
+needs a GPU host, so here we reproduce its *shape* on any host: we drive the
+real ``aorta probe`` CLI -> ``run_recipe`` -> ``_capture_env`` -> ``collect_env``
+path wrapping a trivial command, and inject synthetic raw ``write(2, ...)``
+noise from inside the env probe. The fix (``_ProbeStdioRedirect``) must keep
+that noise off the operator's terminal (fd 2), which ``contextlib`` /
+``CliRunner`` capture cannot do because they only swap the Python ``sys.stderr``
+object and never move fd 2.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import aorta.instrumentation.environment as env_mod
+from aorta.cli.probe import probe
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+_NULL_LINE = b"(null): No such file or directory\n"
+
+
+def _with_outer_terminal(tmp_path: Path):
+    """Install a temp file on the real fds 1/2; return (path, restore()).
+
+    Stands in for the operator's terminal: anything written straight to fd 1/2
+    (bypassing Python-level ``sys.stdout`` / ``sys.stderr``) lands here. The
+    fix must keep the probe noise out of this file.
+    """
+    outer = tmp_path / "outer_terminal.txt"
+    sys.stdout.flush()
+    sys.stderr.flush()
+    outer_fd = os.open(str(outer), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    saved1, saved2 = os.dup(1), os.dup(2)
+    os.dup2(outer_fd, 1)
+    os.dup2(outer_fd, 2)
+
+    def restore():
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(saved1, 1)
+        os.dup2(saved2, 2)
+        os.close(saved1)
+        os.close(saved2)
+        os.close(outer_fd)
+
+    return outer, restore
+
+
+def test_aorta_probe_does_not_leak_env_probe_noise_to_terminal(tmp_path, monkeypatch):
+    """`aorta probe -- bash -c 'echo hi'` must not print `(null)` to fd 2.
+
+    Mirrors the issue #220 minimal repro at the CLI/runner level (synthetic
+    noise, since the real torch/ROCm trigger needs a GPU host).
+    """
+    # Inject the noise from inside the env probe body, exactly where the real
+    # HIP dlopen noise originates -- the first probe call after the fd capture
+    # context is entered in collect_env(). Counting calls proves the noisy
+    # path actually ran, so a clean terminal means the noise was *captured*,
+    # not merely never produced.
+    original_detect = env_mod._detect_runtime_context
+    calls = {"n": 0}
+
+    def noisy_detect():
+        calls["n"] += 1
+        for _ in range(8):  # one (null) line per GPU on an 8-GPU host
+            os.write(2, _NULL_LINE)
+        return original_detect()
+
+    monkeypatch.setattr(env_mod, "_detect_runtime_context", noisy_detect)
+
+    outer, restore = _with_outer_terminal(tmp_path)
+    try:
+        result = CliRunner().invoke(
+            probe,
+            [
+                "--recipe",
+                str(FIXTURES / "probe_minimal.yaml"),
+                "--output",
+                str(tmp_path / "out"),
+                "--",
+                "bash",
+                "-c",
+                "echo hi",
+            ],
+        )
+    finally:
+        restore()
+
+    assert result.exit_code == 0, result.output
+    assert calls["n"] >= 1, "env probe (the noise source) never ran"
+    terminal_text = outer.read_text()
+    assert "(null): No such file or directory" not in terminal_text, (
+        "env-probe noise leaked to the operator's terminal (fd 2):\n"
+        f"{terminal_text!r}"
+    )


### PR DESCRIPTION
## Summary

Addresses the **first finding** in #220: `aorta probe` / `aorta run` / `aorta env` print a burst of `(null): No such file or directory` (one line per GPU) on the operator's terminal, even for a trivial wrapped command. The lines look like a fatal workload error but are benign ROCm env-probe noise.

Root cause: `collect_env()` imports torch in-process to read versions / scan kernels. On a multi-GPU ROCm host the HIP runtime `dlopen` performs a device-topology enumeration that writes one `(null): No such file or directory` line per GPU **straight to fd 2** (a C-runtime `perror` with a NULL program name). Because the probe runs in the long-lived `aorta` parent process, that noise reaches the terminal. `contextlib.redirect_stderr` (used by the dispatcher) cannot intercept it because it only swaps the Python `sys.stderr` object and never moves the real fd 2.

## What changed

- New `_ProbeStdioRedirect` in `instrumentation/environment.py` that `dup2()`s fds 1/2 onto a temp file for the duration of the `collect_env()` probe body and re-emits any captured bytes at `DEBUG` level.
- Wired into `collect_env()` so all three callers (`probe`, `run`, `env`) are covered.

Design notes:
- **Fail-soft** — if the real fds can't be duplicated (detached/closed) the probe runs unredirected; never loses the snapshot (honors the never-raises contract).
- **Non-inflating** — benign noise is logged at DEBUG, not folded into `partial_reasons`, so it won't falsely mark every ROCm host's snapshot `partial`.
- **Disaster-safe** — stdio is restored before the `except` branch logs, so genuine crash traces still reach the terminal. `stop()` is idempotent with a `finally` safety net.

## Test plan

- [x] `tests/instrumentation/test_environment.py::TestProbeStdioRedirect` — raw `write(2, ...)` noise during the probe is captured (not leaked to a stand-in terminal fd) and re-emitted at DEBUG; `stop()` is idempotent; end-to-end `collect_env()` does not leak fd-2 noise and does not inflate `partial_reasons`.
- [x] Full `tests/instrumentation/test_environment.py` (357 passed) + dispatcher/runner/recipe env tests green.

## Related

- Part of #220. The second finding (orphaned child processes on interrupt) is handled in #222.