### PR TITLE
_subprocess: reap the whole child tree on timeout / interrupt (#220)

### DIFF
--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -114,6 +114,14 @@ _LOG_PREFIX_TRIAL_RE = re.compile(r"trial_d\d+_m\d+_t(\d+)$")
 # SIGTERM to the container's PID 1 and let it stop cleanly.
 _TERMINATE_GRACE_SEC = 10.0
 
+# Reap budget (seconds) for the ``proc.wait()`` *after* a SIGKILL has gone out.
+# SIGKILL is uncatchable, so the group is torn down by the kernel almost
+# immediately; this wait only exists to reap zombies, not to give the child a
+# chance to react. Capping it (rather than reusing the full SIGTERM grace) keeps
+# Ctrl-C aborts and timeout handling responsive instead of stalling up to
+# ``grace_sec`` on a process that is already dead.
+_REAP_AFTER_KILL_SEC = 1.0
+
 
 def _terminate_process_tree(
     proc: subprocess.Popen, grace_sec: float = _TERMINATE_GRACE_SEC
@@ -168,11 +176,13 @@ def _terminate_process_tree(
         except (ProcessLookupError, OSError):
             pass
 
+    reap_sec = min(grace_sec, _REAP_AFTER_KILL_SEC)
+
     def _reap_after_kill() -> None:
         # The group has already been SIGKILLed; give it a brief, fully
         # interrupt-tolerant chance to be reaped so we don't leave zombies.
         try:
-            proc.wait(timeout=grace_sec)
+            proc.wait(timeout=reap_sec)
         except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
             pass
         except KeyboardInterrupt:
@@ -194,7 +204,7 @@ def _terminate_process_tree(
         raise
     _send(signal.SIGKILL)
     try:
-        proc.wait(timeout=grace_sec)
+        proc.wait(timeout=reap_sec)
     except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
         pass
     except KeyboardInterrupt:
@@ -489,8 +499,9 @@ class SubprocessWorkload(Workload):
                     # terminal's SIGINT). Reap the whole child tree before the
                     # interrupt unwinds the run, otherwise sudo/docker/python
                     # grandchildren survive and exhaust the GPUs (#220), then
-                    # re-raise so the run aborts as the operator intended.
-                    timed_out = True
+                    # re-raise so the run aborts as the operator intended. We
+                    # do NOT set ``timed_out`` here: an operator abort isn't a
+                    # timeout, and the re-raise skips ``result.json`` anyway.
                     _terminate_process_tree(proc)
                     raise
                 finally:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -41,6 +41,7 @@ Phase-1 minimum shape keeps working.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import signal
@@ -66,6 +67,8 @@ from aorta.probe.classifier.tier3_kernel import (
 )
 from aorta.probe.classifier.verdict import Verdict
 from aorta.workloads._base import Workload, WorkloadResult
+
+log = logging.getLogger(__name__)
 
 # Process-wide Tier 3 state. Shared across every SubprocessWorkload
 # instance the dispatcher constructs over one ``aorta probe`` invocation
@@ -141,11 +144,14 @@ def _terminate_process_tree(
     and is not in this group; tearing it down needs an explicit ``docker kill``
     in the workload wrapper.
 
-    A race where the group already exited (``ESRCH``) is the expected common
-    case, not an error. As a safety net it refuses to signal the caller's own
-    process group -- which can only happen if the child was not started in a
-    new session -- so a misconfiguration can never take down the ``aorta``
-    process itself.
+    A race where the group already exited (``ESRCH`` /
+    ``ProcessLookupError``) is the expected common case, not an error, and is
+    swallowed silently. Any *other* signal-delivery failure (e.g. ``EPERM``)
+    is logged at WARNING -- it means the group could not be torn down and the
+    tree may leak, which the operator needs to see. As a safety net it refuses
+    to signal the caller's own process group -- which can only happen if the
+    child was not started in a new session -- so a misconfiguration can never
+    take down the ``aorta`` process itself.
 
     The only exception it propagates is ``KeyboardInterrupt``: a second
     ``Ctrl-C`` landing while we wait out the grace period must not abandon the
@@ -169,12 +175,36 @@ def _terminate_process_tree(
             try:
                 os.killpg(pgid, sig)
                 return
-            except (ProcessLookupError, OSError):
+            except ProcessLookupError:
+                # Expected ESRCH race: the group exited between the decision
+                # to signal and delivery. Not an error -- fall through to the
+                # direct-child attempt (also a likely ESRCH no-op).
                 pass
+            except OSError as exc:
+                # Non-ESRCH failure (e.g. EPERM): the group could NOT be
+                # signalled, so the child tree may survive and keep its GPUs
+                # pinned (#220). Surface it instead of leaking silently, then
+                # still try the direct child as a best-effort fallback.
+                log.warning(
+                    "killpg(%d, %s) failed: %s; the child process group may "
+                    "not be fully reaped (orphaned grandchildren can keep "
+                    "their GPUs pinned, #220)",
+                    pgid,
+                    signal.Signals(sig).name,
+                    exc,
+                )
         try:
             proc.send_signal(sig)
-        except (ProcessLookupError, OSError):
+        except ProcessLookupError:
             pass
+        except OSError as exc:
+            log.warning(
+                "send_signal(%s) to child pid %s failed: %s; the child may "
+                "not be reaped (#220)",
+                signal.Signals(sig).name,
+                getattr(proc, "pid", "?"),
+                exc,
+            )
 
     reap_sec = min(grace_sec, _REAP_AFTER_KILL_SEC)
 

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import signal
 import stat
 import subprocess
 import time
@@ -105,6 +106,75 @@ CONFIG_KEY_PROBE_EXTRAS = "_aorta_probe_extras"
 # ``_aorta_log_prefix``. Captured group is the trial index; we use it
 # to compute ``trial_<idx>/`` per the probe-mode artifact layout.
 _LOG_PREFIX_TRIAL_RE = re.compile(r"trial_d\d+_m\d+_t(\d+)$")
+
+
+# Grace period (seconds) between the SIGTERM and the SIGKILL escalation in
+# ``_terminate_process_tree``. Short enough that an interrupted operator isn't
+# left waiting, long enough that a foreground ``docker run`` can forward the
+# SIGTERM to the container's PID 1 and let it stop cleanly.
+_TERMINATE_GRACE_SEC = 10.0
+
+
+def _terminate_process_tree(
+    proc: subprocess.Popen, grace_sec: float = _TERMINATE_GRACE_SEC
+) -> None:
+    """Best-effort teardown of the child's *entire* process group.
+
+    The child is launched with ``start_new_session=True`` so it leads its own
+    process group; signalling that group (``os.killpg``) rather than just
+    ``proc.pid`` reaps grandchildren too -- e.g. a
+    ``sudo -> bash -> docker run -> python3`` tree that would otherwise survive
+    an interrupted or timed-out trial and keep its GPUs pinned (#220).
+
+    Escalation: ``SIGTERM`` first (a foreground ``docker run`` forwards it to
+    the container's PID 1, giving the container a chance to stop cleanly), then
+    ``SIGKILL`` after ``grace_sec`` for anything that ignored it. Note that a
+    *detached* ``docker run -d`` container is reparented to the docker daemon
+    and is not in this group; tearing it down needs an explicit ``docker kill``
+    in the workload wrapper.
+
+    Never raises. A race where the group already exited (``ESRCH``) is the
+    expected common case, not an error. As a safety net it refuses to signal
+    the caller's own process group -- which can only happen if the child was
+    not started in a new session -- so a misconfiguration can never take down
+    the ``aorta`` process itself.
+    """
+    pgid: int | None
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, OSError):
+        pgid = None
+    if pgid is not None and pgid == os.getpgrp():
+        # Defensive: child not in its own session (should never happen in
+        # production). Fall back to signalling just the direct child so we
+        # never nuke our own process group.
+        pgid = None
+
+    def _send(sig: int) -> None:
+        if pgid is not None:
+            try:
+                os.killpg(pgid, sig)
+                return
+            except (ProcessLookupError, OSError):
+                pass
+        try:
+            proc.send_signal(sig)
+        except (ProcessLookupError, OSError):
+            pass
+
+    _send(signal.SIGTERM)
+    try:
+        proc.wait(timeout=grace_sec)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    except (ProcessLookupError, OSError):
+        return
+    _send(signal.SIGKILL)
+    try:
+        proc.wait(timeout=grace_sec)
+    except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
+        pass
 
 
 class SubprocessWorkload(Workload):
@@ -338,6 +408,12 @@ class SubprocessWorkload(Workload):
                     stdout=out_fh,
                     stderr=err_fh,
                     env=child_env,
+                    # Lead a new session/process group so the *whole* child
+                    # tree (sudo -> bash -> docker run -> python3, etc.) can
+                    # be reaped via os.killpg on timeout / interrupt instead
+                    # of orphaning grandchildren that keep their GPUs pinned
+                    # (#220). See _terminate_process_tree.
+                    start_new_session=True,
                 )
                 launched = True
                 # Wire the third leg of the two-of-three Tier 2
@@ -362,27 +438,27 @@ class SubprocessWorkload(Workload):
                     exit_code = proc.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
                     timed_out = True
-                    # Race-safe shutdown: the child can exit between
-                    # the ``wait()`` timeout and our ``kill()`` (e.g.
-                    # the workload finished while the kernel was
-                    # delivering the SIGALRM the timeout uses), which
-                    # makes ``Popen.kill()`` raise
-                    # ``ProcessLookupError`` (ESRCH) on Linux. Swallow
-                    # that one specific case so the trial deterministically
-                    # records ``timed_out=True`` and ``exit_code=-1``
-                    # rather than crashing the workload and leaving the
-                    # trial with no ``result.json``. Any other OSError
-                    # from kill() (EPERM etc.) re-raises so we don't
-                    # silently swallow a genuine bug.
-                    try:
-                        proc.kill()
-                    except ProcessLookupError:
-                        pass
-                    try:
-                        proc.wait()
-                    except ProcessLookupError:
-                        pass
+                    # Tear down the whole child process group, not just the
+                    # direct child: a timed-out trial may have spawned a
+                    # sudo/docker/python grandchild tree that would otherwise
+                    # survive and keep its GPUs pinned (#220).
+                    # ``_terminate_process_tree`` is race-safe -- it swallows
+                    # the ESRCH that occurs when the child exits between the
+                    # timeout firing and the signal landing -- so the trial
+                    # deterministically records ``timed_out=True`` and
+                    # ``exit_code=-1`` with a ``result.json`` on disk.
+                    _terminate_process_tree(proc)
                     exit_code = -1
+                except KeyboardInterrupt:
+                    # Operator Ctrl-C (SIGINT delivered to the aorta parent;
+                    # the child is in its own session and does NOT receive the
+                    # terminal's SIGINT). Reap the whole child tree before the
+                    # interrupt unwinds the run, otherwise sudo/docker/python
+                    # grandchildren survive and exhaust the GPUs (#220), then
+                    # re-raise so the run aborts as the operator intended.
+                    timed_out = True
+                    _terminate_process_tree(proc)
+                    raise
                 finally:
                     if hang_monitor is not None:
                         hang_monitor.stop()

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -133,11 +133,17 @@ def _terminate_process_tree(
     and is not in this group; tearing it down needs an explicit ``docker kill``
     in the workload wrapper.
 
-    Never raises. A race where the group already exited (``ESRCH``) is the
-    expected common case, not an error. As a safety net it refuses to signal
-    the caller's own process group -- which can only happen if the child was
-    not started in a new session -- so a misconfiguration can never take down
-    the ``aorta`` process itself.
+    A race where the group already exited (``ESRCH``) is the expected common
+    case, not an error. As a safety net it refuses to signal the caller's own
+    process group -- which can only happen if the child was not started in a
+    new session -- so a misconfiguration can never take down the ``aorta``
+    process itself.
+
+    The only exception it propagates is ``KeyboardInterrupt``: a second
+    ``Ctrl-C`` landing while we wait out the grace period must not abandon the
+    teardown mid-escalation and re-orphan the tree (#220). In that case we
+    force ``SIGKILL`` on the group, reap best-effort, and *then* re-raise so
+    the operator's interrupt still aborts the run.
     """
     pgid: int | None
     try:
@@ -162,6 +168,16 @@ def _terminate_process_tree(
         except (ProcessLookupError, OSError):
             pass
 
+    def _reap_after_kill() -> None:
+        # The group has already been SIGKILLed; give it a brief, fully
+        # interrupt-tolerant chance to be reaped so we don't leave zombies.
+        try:
+            proc.wait(timeout=grace_sec)
+        except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
+            pass
+        except KeyboardInterrupt:
+            pass
+
     _send(signal.SIGTERM)
     try:
         proc.wait(timeout=grace_sec)
@@ -170,11 +186,21 @@ def _terminate_process_tree(
         pass
     except (ProcessLookupError, OSError):
         return
+    except KeyboardInterrupt:
+        # Don't abandon teardown mid-escalation: force-kill the group and
+        # reap before propagating the operator's interrupt.
+        _send(signal.SIGKILL)
+        _reap_after_kill()
+        raise
     _send(signal.SIGKILL)
     try:
         proc.wait(timeout=grace_sec)
     except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
         pass
+    except KeyboardInterrupt:
+        # Group already got SIGKILL; reap what we can, then propagate.
+        _reap_after_kill()
+        raise
 
 
 class SubprocessWorkload(Workload):

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -442,25 +442,33 @@ class SubprocessWorkload(Workload):
                     start_new_session=True,
                 )
                 launched = True
-                # Wire the third leg of the two-of-three Tier 2
-                # predicate. The closure spawns one ``amd-smi monitor``
-                # call per HangMonitor poll (~12/min at the default 5s
-                # poll cadence) and returns True iff the busiest GPU
-                # reports < GPU_IDLE_UTILIZATION_THRESHOLD_PCT. When
-                # amd-smi is missing or unparseable the closure returns
-                # False, so the predicate gracefully degrades to the
-                # 2-of-2 ``stdout_silent`` + ``io_idle`` shape that the
-                # round-1 wiring was already covering (rubric §2.B FR
-                # 2.11 fail-soft policy).
-                hang_monitor = HangMonitor(
-                    pid=proc.pid,
-                    stdout_path=stdout_path,
-                    hang_window_sec=hang_window_sec,
-                    hang_grace_period_at_start=hang_grace_sec,
-                    gpu_idle_probe=gpu_idle_probe_from_state(_TIER3_STATE),
-                )
-                hang_monitor.start()
+                # Everything from the monitor wiring through proc.wait() is in
+                # one try so a Ctrl-C landing *anywhere* after Popen -- e.g.
+                # during HangMonitor.start() -- still reaches the
+                # ``except KeyboardInterrupt`` that reaps the child tree, and
+                # the ``finally`` always stops the monitor thread. Otherwise an
+                # interrupt between Popen and the wait would orphan the
+                # sudo/docker/python grandchildren this PR is meant to reap
+                # (#220) and leak the monitor thread.
                 try:
+                    # Wire the third leg of the two-of-three Tier 2
+                    # predicate. The closure spawns one ``amd-smi monitor``
+                    # call per HangMonitor poll (~12/min at the default 5s
+                    # poll cadence) and returns True iff the busiest GPU
+                    # reports < GPU_IDLE_UTILIZATION_THRESHOLD_PCT. When
+                    # amd-smi is missing or unparseable the closure returns
+                    # False, so the predicate gracefully degrades to the
+                    # 2-of-2 ``stdout_silent`` + ``io_idle`` shape that the
+                    # round-1 wiring was already covering (rubric §2.B FR
+                    # 2.11 fail-soft policy).
+                    hang_monitor = HangMonitor(
+                        pid=proc.pid,
+                        stdout_path=stdout_path,
+                        hang_window_sec=hang_window_sec,
+                        hang_grace_period_at_start=hang_grace_sec,
+                        gpu_idle_probe=gpu_idle_probe_from_state(_TIER3_STATE),
+                    )
+                    hang_monitor.start()
                     exit_code = proc.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
                     timed_out = True

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -415,6 +415,46 @@ def test_terminate_process_tree_refuses_own_group(monkeypatch):
     assert sent == [signal.SIGTERM], "must fall back to signalling the child"
 
 
+def test_terminate_process_tree_warns_on_non_esrch_killpg(monkeypatch, caplog):
+    """A non-ESRCH killpg failure (e.g. EPERM) must be surfaced, not swallowed.
+
+    The expected ESRCH race stays silent, but an EPERM means the group could
+    not be torn down and the tree may leak (#220). The operator needs that
+    visibility, and teardown still falls back to signalling the direct child.
+    """
+    import logging
+
+    from aorta.workloads import _subprocess as workload_mod
+
+    fake_pgid = 626262
+    sent: list = []
+
+    monkeypatch.setattr(workload_mod.os, "getpgid", lambda pid: fake_pgid)
+    monkeypatch.setattr(workload_mod.os, "getpgrp", lambda: fake_pgid + 1)
+
+    def _eperm_killpg(pgid, sig):
+        raise PermissionError("Operation not permitted")
+
+    monkeypatch.setattr(workload_mod.os, "killpg", _eperm_killpg)
+
+    class _Child:
+        pid = 999
+
+        def send_signal(self, sig):
+            sent.append(sig)
+
+        def wait(self, timeout=None):
+            return 0
+
+    with caplog.at_level(logging.WARNING, logger=workload_mod.log.name):
+        workload_mod._terminate_process_tree(_Child(), grace_sec=0.01)
+
+    assert any("killpg" in r.message for r in caplog.records), (
+        "non-ESRCH killpg failure must be logged at WARNING"
+    )
+    assert sent == [signal.SIGTERM], "must still fall back to the direct child"
+
+
 def test_terminate_process_tree_escalates_to_kill_on_interrupt(monkeypatch):
     """A Ctrl-C during the SIGTERM grace wait must still SIGKILL, then re-raise.
 

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -7,6 +7,7 @@ shape), and the Tier-1 verdict rule.
 from __future__ import annotations
 
 import json
+import signal
 from pathlib import Path
 
 import pytest
@@ -289,7 +290,13 @@ def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
     class _RacingPopen:
         def __init__(self, *args, **kwargs):
             self._real = real_popen(
-                ["true"], **{k: v for k, v in kwargs.items() if k in ("stdout", "stderr", "env")}
+                ["true"],
+                start_new_session=True,
+                **{
+                    k: v
+                    for k, v in kwargs.items()
+                    if k in ("stdout", "stderr", "env")
+                },
             )
             self.pid = self._real.pid
             self._wait_calls = 0
@@ -300,10 +307,12 @@ def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
                 # First ``proc.wait(timeout=...)`` -- pretend the
                 # child is still running so the timeout branch fires.
                 raise _subprocess.TimeoutExpired(cmd="true", timeout=timeout)
-            # Second ``proc.wait()`` after kill() -- child is gone.
+            # Second ``proc.wait()`` inside the teardown -- child is gone.
             raise ProcessLookupError(3, "No such process")
 
-        def kill(self):
+        def send_signal(self, sig):
+            # The teardown fallback path (when the process group is gone)
+            # signals the direct child; the child already exited -> ESRCH.
             raise ProcessLookupError(3, "No such process")
 
     monkeypatch.setattr(_subprocess, "Popen", _RacingPopen)
@@ -318,6 +327,133 @@ def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
     assert doc["timed_out"] is True
     assert doc["exit_code"] == -1
     assert result.passed is False
+
+
+# ---- #220 (orphaned child teardown on timeout / interrupt) ---------------
+
+
+def test_child_started_in_new_session(tmp_path, monkeypatch):
+    """The child must lead its own session so the whole tree is reapable.
+
+    Without ``start_new_session=True`` a ``sudo -> bash -> docker run -> python3``
+    tree cannot be torn down via ``os.killpg`` and survives an interrupted /
+    timed-out trial, keeping its GPUs pinned (#220).
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    captured: dict = {}
+    real_popen = workload_mod.subprocess.Popen
+
+    def _spy_popen(*args, **kwargs):
+        captured.update(kwargs)
+        return real_popen(*args, **kwargs)
+
+    monkeypatch.setattr(workload_mod.subprocess, "Popen", _spy_popen)
+
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    wl.run()
+    assert captured.get("start_new_session") is True
+
+
+def test_terminate_process_tree_escalates_term_then_kill(monkeypatch):
+    """SIGTERM first, then SIGKILL after the grace period, on the group."""
+    from aorta.workloads import _subprocess as workload_mod
+
+    signals: list[int] = []
+    fake_pgid = 424242
+
+    monkeypatch.setattr(workload_mod.os, "getpgid", lambda pid: fake_pgid)
+    # Ensure the self-group guard does not trip (pgid != our group).
+    monkeypatch.setattr(workload_mod.os, "getpgrp", lambda: fake_pgid + 1)
+    monkeypatch.setattr(
+        workload_mod.os, "killpg", lambda pgid, sig: signals.append(sig)
+    )
+
+    class _Stubborn:
+        pid = 777
+
+        def __init__(self):
+            self._waits = 0
+
+        def wait(self, timeout=None):
+            self._waits += 1
+            if self._waits == 1:
+                # Ignored SIGTERM -> force the SIGKILL escalation.
+                raise workload_mod.subprocess.TimeoutExpired(cmd="x", timeout=timeout)
+            return -9
+
+    workload_mod._terminate_process_tree(_Stubborn(), grace_sec=0.01)
+    assert signals == [signal.SIGTERM, signal.SIGKILL]
+
+
+def test_terminate_process_tree_refuses_own_group(monkeypatch):
+    """Safety net: never signal the aorta process's own group via killpg."""
+    from aorta.workloads import _subprocess as workload_mod
+
+    killpg_calls: list = []
+    sent: list = []
+    our_group = 555
+
+    monkeypatch.setattr(workload_mod.os, "getpgid", lambda pid: our_group)
+    monkeypatch.setattr(workload_mod.os, "getpgrp", lambda: our_group)
+    monkeypatch.setattr(
+        workload_mod.os, "killpg", lambda pgid, sig: killpg_calls.append(sig)
+    )
+
+    class _Child:
+        pid = 888
+
+        def send_signal(self, sig):
+            sent.append(sig)
+
+        def wait(self, timeout=None):
+            return 0
+
+    workload_mod._terminate_process_tree(_Child(), grace_sec=0.01)
+    assert killpg_calls == [], "must not killpg our own process group"
+    assert sent == [signal.SIGTERM], "must fall back to signalling the child"
+
+
+def test_keyboard_interrupt_reaps_tree_and_reraises(tmp_path, monkeypatch):
+    """Ctrl-C during a trial must reap the child tree, then re-raise.
+
+    Regression for #220: an interrupted probe previously left the wrapped
+    child tree running. The workload must signal the group and propagate the
+    ``KeyboardInterrupt`` so the run aborts as the operator intended.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    real_popen = workload_mod.subprocess.Popen
+    torn_down: list = []
+
+    class _InterruptingPopen:
+        def __init__(self, *args, **kwargs):
+            self._real = real_popen(
+                ["true"],
+                start_new_session=True,
+                **{
+                    k: v
+                    for k, v in kwargs.items()
+                    if k in ("stdout", "stderr", "env")
+                },
+            )
+            self.pid = self._real.pid
+
+        def wait(self, timeout=None):
+            raise KeyboardInterrupt()
+
+    def _spy_teardown(proc, grace_sec=workload_mod._TERMINATE_GRACE_SEC):
+        torn_down.append(proc)
+
+    monkeypatch.setattr(workload_mod.subprocess, "Popen", _InterruptingPopen)
+    monkeypatch.setattr(workload_mod, "_terminate_process_tree", _spy_teardown)
+
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    with pytest.raises(KeyboardInterrupt):
+        wl.run()
+    assert len(torn_down) == 1, "child tree must be torn down on interrupt"
 
 
 # ---- FR 2.9 (Phase 2 result.json shape) ----------------------------------

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -495,6 +495,59 @@ def test_keyboard_interrupt_reaps_tree_and_reraises(tmp_path, monkeypatch):
     assert len(torn_down) == 1, "child tree must be torn down on interrupt"
 
 
+def test_keyboard_interrupt_during_monitor_start_reaps_tree(tmp_path, monkeypatch):
+    """Ctrl-C during HangMonitor.start() (before proc.wait) must still reap.
+
+    Regression for the #222 follow-up: the monitor wiring + start() now live
+    in the same try as proc.wait(), so an interrupt landing between Popen and
+    the wait reaches the ``except KeyboardInterrupt`` teardown instead of
+    orphaning the child tree.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    real_popen = workload_mod.subprocess.Popen
+    torn_down: list = []
+
+    class _OkPopen:
+        def __init__(self, *args, **kwargs):
+            self._real = real_popen(
+                ["true"],
+                start_new_session=True,
+                **{
+                    k: v
+                    for k, v in kwargs.items()
+                    if k in ("stdout", "stderr", "env")
+                },
+            )
+            self.pid = self._real.pid
+
+        def wait(self, timeout=None):  # should never be reached
+            return self._real.wait(timeout=timeout)
+
+    class _InterruptingMonitor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise KeyboardInterrupt()
+
+        def stop(self):
+            pass
+
+    def _spy_teardown(proc, grace_sec=workload_mod._TERMINATE_GRACE_SEC):
+        torn_down.append(proc)
+
+    monkeypatch.setattr(workload_mod.subprocess, "Popen", _OkPopen)
+    monkeypatch.setattr(workload_mod, "HangMonitor", _InterruptingMonitor)
+    monkeypatch.setattr(workload_mod, "_terminate_process_tree", _spy_teardown)
+
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    with pytest.raises(KeyboardInterrupt):
+        wl.run()
+    assert len(torn_down) == 1, "tree must be reaped even if Ctrl-C precedes proc.wait()"
+
+
 # ---- FR 2.9 (Phase 2 result.json shape) ----------------------------------
 
 

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -415,6 +415,45 @@ def test_terminate_process_tree_refuses_own_group(monkeypatch):
     assert sent == [signal.SIGTERM], "must fall back to signalling the child"
 
 
+def test_terminate_process_tree_escalates_to_kill_on_interrupt(monkeypatch):
+    """A Ctrl-C during the SIGTERM grace wait must still SIGKILL, then re-raise.
+
+    Regression for the #220 follow-up: if ``KeyboardInterrupt`` propagated out
+    of the first ``proc.wait()`` the function would skip the SIGKILL
+    escalation and re-orphan a SIGTERM-ignoring group (e.g. a stubborn
+    ``docker run`` client). It must force-kill the group before propagating.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    signals: list[int] = []
+    fake_pgid = 313131
+
+    monkeypatch.setattr(workload_mod.os, "getpgid", lambda pid: fake_pgid)
+    monkeypatch.setattr(workload_mod.os, "getpgrp", lambda: fake_pgid + 1)
+    monkeypatch.setattr(
+        workload_mod.os, "killpg", lambda pgid, sig: signals.append(sig)
+    )
+
+    class _InterruptingChild:
+        pid = 999
+
+        def __init__(self):
+            self._waits = 0
+
+        def wait(self, timeout=None):
+            self._waits += 1
+            if self._waits == 1:
+                # Operator hits Ctrl-C again while we wait out the grace.
+                raise KeyboardInterrupt()
+            return -9
+
+    with pytest.raises(KeyboardInterrupt):
+        workload_mod._terminate_process_tree(_InterruptingChild(), grace_sec=0.01)
+    assert signals == [signal.SIGTERM, signal.SIGKILL], (
+        "interrupt during grace must still escalate to SIGKILL before re-raising"
+    )
+
+
 def test_keyboard_interrupt_reaps_tree_and_reraises(tmp_path, monkeypatch):
     """Ctrl-C during a trial must reap the child tree, then re-raise.
 


### PR DESCRIPTION
## Summary

Addresses the **second finding** in #220: an interrupted (`Ctrl-C` / timeout) `aorta probe` / `aorta run` did **not** tear down the wrapped child process tree. The `Popen` was not started in a new session, so signalling only `proc.pid` left grandchildren — e.g. `sudo -> bash -> docker run -> python3` — alive and holding their GPUs. Repeated interrupted runs silently exhausted the host's GPUs.

## What changed

- **`start_new_session=True`** on the child `Popen` so it leads its own process group and the whole tree is reapable via `os.killpg`.
- **`_terminate_process_tree()`** — `SIGTERM` the whole group first (a foreground `docker run` forwards SIGTERM to the container's PID 1, giving it a chance to stop cleanly), then `SIGKILL` after a grace period. It is never-raises (swallows the `ESRCH` race when the child exits between the signal decision and delivery) and, as a safety net, **refuses to signal aorta's own process group**.
- **Timeout path** now reaps the group instead of a bare `proc.kill()`.
- **New `KeyboardInterrupt` handler** reaps the group, then re-raises so the run aborts as the operator intended. (The child is in its own session and no longer receives the terminal's SIGINT directly, so explicit teardown is required.)

### Scope note

A *detached* `docker run -d` container is reparented to the docker daemon and is out of this process group; fully tearing it down still needs an explicit `docker kill` in the workload wrapper. This is called out in the `_terminate_process_tree` docstring. Foreground `docker run` is handled here via SIGTERM forwarding.

## Test plan

- [x] `tests/probe/test_subprocess_workload.py`:
  - `test_child_started_in_new_session` — `Popen` receives `start_new_session=True`.
  - `test_terminate_process_tree_escalates_term_then_kill` — group gets SIGTERM then SIGKILL on a stubborn child.
  - `test_terminate_process_tree_refuses_own_group` — never `killpg`s our own group; falls back to signalling the direct child.
  - `test_keyboard_interrupt_reaps_tree_and_reraises` — Ctrl-C reaps the tree and propagates `KeyboardInterrupt`.
  - Updated `test_timeout_kill_race_does_not_crash` for the new teardown path.
- [x] Full `tests/probe/` suite green (312 passed).

## Related

- Part of #220. The first finding (cosmetic `(null)` env-probe noise) is handled in #221.

Made with [Cursor](https://cursor.com)