### PR TITLE
probe: discard latched tier2:hang flag on clean subprocess exit

### DIFF
--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -41,6 +41,7 @@ Phase-1 minimum shape keeps working.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import stat
@@ -65,6 +66,8 @@ from aorta.probe.classifier.tier3_kernel import (
 )
 from aorta.probe.classifier.verdict import Verdict
 from aorta.workloads._base import Workload, WorkloadResult
+
+log = logging.getLogger(__name__)
 
 # Process-wide Tier 3 state. Shared across every SubprocessWorkload
 # instance the dispatcher constructs over one ``aorta probe`` invocation
@@ -428,6 +431,36 @@ class SubprocessWorkload(Workload):
         # are bugs, not trial outcomes).
         log_text = _read_log_text(stdout_path, stderr_path)
         hang_detected = bool(hang_monitor and hang_monitor.hang_detected)
+        # Reconcile the latched hang flag against the actual exit.
+        #
+        # The in-flight HangMonitor watches three signals on the
+        # *wrapper* PID: stdout silence on this trial's stdout.log, I/O
+        # idleness on /proc/<wrapper_pid>/io, and GPU idleness. For a
+        # workload that delegates its real work to a child process tree
+        # the parent can't see (``sudo`` -> ``bash run.sh`` ->
+        # ``docker run`` -> container -> ``python3``), the wrapper goes
+        # quiet and does almost no I/O of its own while the descendants
+        # do all the work. That trips ``stdout_silent`` + ``io_idle``
+        # (two of three) and latches ``hang_detected`` even though the
+        # workload is alive and busy. Those two legs are structurally
+        # blind to delegated work, so a mid-run latch is advisory only.
+        #
+        # A process that voluntarily exited 0 within its timeout was, by
+        # definition, not hung -- a real hang would have either kept the
+        # process alive until ``proc.wait(timeout=...)`` fired
+        # (``timed_out=True``) or surfaced as a non-zero exit. Drop the
+        # latched flag in that case so a clean run is never classified
+        # ``tier2:hang``. Genuine hangs (``timed_out=True``) and crashes
+        # (``exit_code != 0``) keep the flag and still classify as fail.
+        if hang_detected and exit_code == 0 and not timed_out:
+            log.info(
+                "tier2:hang latched mid-run for argv[0]=%r but the process "
+                "exited 0 within the timeout; discarding the advisory flag "
+                "(the monitor's stdout/io legs are blind to work delegated "
+                "to a child process tree).",
+                argv[0] if argv else "<unknown>",
+            )
+            hang_detected = False
 
         # Best-effort ``peak_vram_mib`` from the Tier-3 amd-smi
         # snapshots. We only have two samples (pre + post Popen) so

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -452,6 +452,7 @@ class SubprocessWorkload(Workload):
         # latched flag in that case so a clean run is never classified
         # ``tier2:hang``. Genuine hangs (``timed_out=True``) and crashes
         # (``exit_code != 0``) keep the flag and still classify as fail.
+        hang_reconciled_away = False
         if hang_detected and exit_code == 0 and not timed_out:
             log.info(
                 "tier2:hang latched mid-run for argv[0]=%r but the process "
@@ -461,6 +462,7 @@ class SubprocessWorkload(Workload):
                 argv[0] if argv else "<unknown>",
             )
             hang_detected = False
+            hang_reconciled_away = True
 
         # Best-effort ``peak_vram_mib`` from the Tier-3 amd-smi
         # snapshots. We only have two samples (pre + post Popen) so
@@ -571,6 +573,13 @@ class SubprocessWorkload(Workload):
             "timed_out": timed_out,
             "env": dict(cell_env_snapshot),
         }
+        # Durable per-trial breadcrumb when a latched tier2:hang was
+        # reconciled away on a clean exit. The verdict stays a clean pass,
+        # but the #224 follow-ups (descendant-tree-aware hang predicate)
+        # need to study exactly these wrapper-delegated false positives, so
+        # leave a trace in result.json rather than only the log.info above.
+        if hang_reconciled_away:
+            result_doc["capture"]["tier2_hang_latched_but_reconciled"] = True
         result_path.write_text(
             json.dumps(result_doc, indent=2, sort_keys=False),
             encoding="utf-8",

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -574,10 +574,12 @@ class SubprocessWorkload(Workload):
             "env": dict(cell_env_snapshot),
         }
         # Durable per-trial breadcrumb when a latched tier2:hang was
-        # reconciled away on a clean exit. The verdict stays a clean pass,
-        # but the #224 follow-ups (descendant-tree-aware hang predicate)
-        # need to study exactly these wrapper-delegated false positives, so
-        # leave a trace in result.json rather than only the log.info above.
+        # reconciled away on a clean exit (exit 0, not timed out). Only the
+        # tier2:hang signal is dropped -- the final verdict still reflects the
+        # other tiers, so a clean exit can still fail on Tier-3/4/5. The #224
+        # follow-ups (descendant-tree-aware hang predicate) need to study these
+        # wrapper-delegated false positives, so leave a trace in result.json
+        # rather than only the log.info above.
         if hang_reconciled_away:
             result_doc["capture"]["tier2_hang_latched_but_reconciled"] = True
         result_path.write_text(

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -721,6 +721,9 @@ def test_clean_exit_discards_latched_hang_flag(tmp_path, monkeypatch):
     assert doc["exit_code"] == 0
     assert doc["timed_out"] is False
     assert "tier2:hang" not in doc["failure_detectors_fired"]
+    # Durable breadcrumb: the verdict is a clean pass, but the discarded
+    # latch is recorded for the #224 follow-up to study.
+    assert doc["capture"].get("tier2_hang_latched_but_reconciled") is True
     assert result.passed is True
 
 
@@ -748,6 +751,8 @@ def test_nonzero_exit_keeps_latched_hang_flag(tmp_path, monkeypatch):
     assert doc["verdict"] == "fail"
     assert doc["exit_code"] != 0
     assert "tier2:hang" in doc["failure_detectors_fired"]
+    # No reconciliation happened -> no breadcrumb on a preserved-flag fail.
+    assert "tier2_hang_latched_but_reconciled" not in doc["capture"]
     assert result.passed is False
 
 
@@ -772,4 +777,5 @@ def test_timed_out_keeps_latched_hang_flag(tmp_path, monkeypatch):
     assert doc["timed_out"] is True
     assert doc["verdict"] == "fail"
     assert "tier2:hang" in doc["failure_detectors_fired"]
+    assert "tier2_hang_latched_but_reconciled" not in doc["capture"]
     assert result.passed is False

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -653,3 +653,123 @@ def test_read_log_text_uses_replace_not_backslashreplace(tmp_path):
         "backslashreplace and a binary-heavy log can quadruple the "
         "regex-input size, defeating the cap."
     )
+
+
+# ---- Latched-hang reconciliation against exit (false-positive fix) -------
+
+
+def _force_latched_hang(monkeypatch):
+    """Replace ``HangMonitor`` with a stub whose ``hang_detected`` is True.
+
+    The real monitor's stdout/io legs are blind to work delegated to a
+    child process tree (``sudo`` -> ``bash`` -> ``docker run`` ->
+    container -> ``python3``): the wrapper goes silent and does almost
+    no I/O of its own, so the monitor latches ``hang_detected`` on a
+    perfectly healthy run. This stub reproduces that latch
+    deterministically -- no real subprocess hang, no /proc polling, no
+    amd-smi -- so the reconciliation logic in ``run()`` can be pinned.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    real_monitor = workload_mod.HangMonitor
+
+    class _AlwaysHangMonitor(real_monitor):  # type: ignore[misc, valid-type]
+        def start(self) -> None:
+            self.hang_detected = True
+
+        def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(workload_mod, "HangMonitor", _AlwaysHangMonitor)
+
+
+def _spy_classify_hang(monkeypatch, captured: dict):
+    """Spy on ``classify_trial`` to capture the ``hang_detected`` it sees."""
+    from aorta.workloads import _subprocess as workload_mod
+
+    real_classify = workload_mod.classify_trial
+
+    def _spy(ctx):
+        captured["hang_detected"] = ctx.hang_detected
+        return real_classify(ctx)
+
+    monkeypatch.setattr(workload_mod, "classify_trial", _spy)
+
+
+def test_clean_exit_discards_latched_hang_flag(tmp_path, monkeypatch):
+    """A wrapped command that exits 0 within the timeout is NEVER
+    classified ``tier2:hang``, even when the in-flight monitor latched
+    ``hang_detected`` (issue: false-positive ``tier2:hang`` on
+    docker/sudo-delegated workloads). A voluntary exit 0 within the
+    timeout cannot have been hung, so the advisory flag is dropped
+    before it reaches the classifier.
+    """
+    captured: dict = {}
+    _force_latched_hang(monkeypatch)
+    _spy_classify_hang(monkeypatch, captured)
+
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    result = wl.run()
+
+    assert captured["hang_detected"] is False, (
+        "latched hang flag reached classify_trial despite a clean exit 0 "
+        "within the timeout -- the reconciliation gate is missing"
+    )
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "pass"
+    assert doc["exit_code"] == 0
+    assert doc["timed_out"] is False
+    assert "tier2:hang" not in doc["failure_detectors_fired"]
+    assert result.passed is True
+
+
+def test_nonzero_exit_keeps_latched_hang_flag(tmp_path, monkeypatch):
+    """A latched hang flag survives when the process exits non-zero.
+
+    Reconciliation only discards the flag for a *clean* exit
+    (``exit_code == 0 and not timed_out``). A non-zero exit is a real
+    failure, so the hang signal is preserved and ``tier2:hang`` still
+    surfaces -- the fix must not blanket-suppress the detector.
+    """
+    captured: dict = {}
+    _force_latched_hang(monkeypatch)
+    _spy_classify_hang(monkeypatch, captured)
+
+    wl = _make_workload(tmp_path, ["false"])
+    wl.setup()
+    result = wl.run()
+
+    assert captured["hang_detected"] is True, (
+        "the reconciliation gate over-reached: it discarded the latched "
+        "hang flag on a non-zero exit, where the signal is still meaningful"
+    )
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["exit_code"] != 0
+    assert "tier2:hang" in doc["failure_detectors_fired"]
+    assert result.passed is False
+
+
+def test_timed_out_keeps_latched_hang_flag(tmp_path, monkeypatch):
+    """A latched hang flag survives a genuine timeout.
+
+    When ``proc.wait(timeout=...)`` fires, the process is killed
+    (``exit_code == -1``, ``timed_out == True``) -- a real hang. The
+    reconciliation gate keys off ``exit_code == 0 and not timed_out``,
+    so a timed-out trial keeps ``tier2:hang``.
+    """
+    captured: dict = {}
+    _force_latched_hang(monkeypatch)
+    _spy_classify_hang(monkeypatch, captured)
+
+    wl = _make_workload(tmp_path, ["sleep", "30"], timeout_per_trial=0.2)
+    wl.setup()
+    result = wl.run()
+
+    assert captured["hang_detected"] is True
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["timed_out"] is True
+    assert doc["verdict"] == "fail"
+    assert "tier2:hang" in doc["failure_detectors_fired"]
+    assert result.passed is False


### PR DESCRIPTION
## Summary

Fixes #224.

`aorta probe` could emit a **false-positive `tier2:hang`** for a wrapped
command that delegates its real work to a child process tree
(`sudo → bash launch.sh → docker run → container → python3`). The trial
exited `0`, did not time out, and the workload reported success — yet it
was classified `fail / tier2:hang`.

- The Tier-2 `HangMonitor` watches three signals on the **wrapper** PID:
  stdout silence, `/proc/<pid>/io` idleness, and GPU idleness. For a
  wrapper-delegated workload the parent goes quiet and does almost no
  I/O of its own while the descendants do the work, tripping
  `stdout_silent` + `io_idle` (two of three) and latching `hang_detected`
  on a healthy run.
- The latched flag was passed straight into `classify_trial(...)` with
  **no reconciliation** against the actual exit.

This change gates the latched flag in `SubprocessWorkload.run()`: a
process that voluntarily exited `0` within its timeout was not hung, so
the advisory flag is dropped. Genuine hangs (`timed_out=True`) and
crashes (`exit_code != 0`) keep the flag and still classify as `fail`.

The larger follow-ups from #224 (descendant-tree-aware hang predicate,
distinct matrix outcome classes) are intentionally out of scope here to
keep this a small, surgical correctness fix.

## Changes

- `src/aorta/workloads/_subprocess.py`: reconcile `hang_detected`
  against `exit_code == 0 and not timed_out` after `proc.wait(...)`;
  add a module logger and an `info`-level breadcrumb when the flag is
  discarded.
- `tests/probe/test_subprocess_workload.py`: 3 regression tests.

## Test plan

- [x] `test_clean_exit_discards_latched_hang_flag` — exit 0 within timeout, latched flag → dropped, verdict `pass`, no `tier2:hang`.
- [x] `test_nonzero_exit_keeps_latched_hang_flag` — exit != 0, latched flag preserved, `tier2:hang` fires.
- [x] `test_timed_out_keeps_latched_hang_flag` — real timeout, latched flag preserved, `tier2:hang` fires.
- [x] Full probe suite green (`pytest tests/probe`, 311 passed).

Made with [Cursor](https://cursor.com)