### PR TITLE
env probe: static kernel-catalog "recipe books" (tensile/miopen/rocfft, schema 1.9)

### DIFF
--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -29,6 +29,40 @@ its commit, package version, library hash, and Tensile kernel
 fingerprint as first-class fields, so two trials whose hipBLASLt
 identities differ become trivially diffable.
 
+### Catalog vs. runtime trace -- what `env probe` does and doesn't capture
+
+The **catalog** (what `env probe` captures, under `tensile_catalog` /
+`miopen_catalog` / `rocfft_catalog`) identifies the *recipe book*: which
+hipBLASLt/rocBLAS Tensile, MIOpen, or rocFFT kernel/solution menu is
+installed on disk. It does **not** tell you which recipe the runtime
+actually picked for a given GEMM/conv/FFT -- the per-call solution ID
+(`#381881` / `#368xxx` you see in workload logs); that requires a
+runtime trace (a separate capability, deferred to the runtime
+follow-up).
+
+Kernel selection happens in two layers:
+
+1. **The frozen menu (layer 1, captured here).** At build/install time
+   the library bakes a solution library / logic files into / alongside
+   the `.so` -- the full menu of recipes plus a decision tree. This menu
+   does not change at runtime; it is files on disk, fully visible without
+   running anything. The `*_catalog` blocks fingerprint **and enumerate**
+   it.
+2. **The runtime pick (layer 2, NOT captured here).** The actual choice
+   happens per-call at runtime, querying live device properties -- so a
+   driver/firmware/KFD change can flip the pick even with an identical
+   `.so`. Out of scope for the no-compute probe.
+
+**Why this matters:** two hosts can report the *same* hipBLASLt commit
+(e.g. the historically-broken `7e32d53eb1`) yet ship a **materially
+different** Tensile install -- a vendor build can patch or select
+different kernels even when nominally pointing at that commit. A bare
+version/commit string would call these "the same"; the deepened
+`tensile_catalog.<lib>.menu` per-file content hashes make the difference
+**diffable from the installed files alone**. (The solution-ID half --
+which kernel each host's runtime actually selected -- belongs to the
+runtime follow-up.)
+
 ## Quick start
 
 ```bash
@@ -95,7 +129,7 @@ operator can act on them without `jq`'ing the JSON. A closing
 end-of-output. Sample:
 
 ```text
-Wrote env probe to /tmp/env.json (schema_version=1.8) [PARTIAL]
+Wrote env probe to /tmp/env.json (schema_version=1.9) [PARTIAL]
   runtime:   baremetal / python=venv
   build_sys: none
   rocm:      7.2.1 (dev: None)
@@ -109,6 +143,7 @@ Wrote env probe to /tmp/env.json (schema_version=1.8) [PARTIAL]
   host:      kernel=5.15.0-174-generic machine=x86_64  glibc=2.35
   ck:        system=1.2.0/23d531c8  ck_tile=yes  libtorch_hip=4067 ck:: syms
   tensile:   kernel_db=filenames-sha256:743a8d…  [Tensile pip pkg: (not installed); build-time tool, normal]
+  catalog:   tensile[hb=content-sha256:1a2b3c… rb=content-sha256:4d5e6f…]  miopen=content-sha256:7890ab…  rocfft=absent
   triton:    3.5.1+rocm7.2.1.gita272dfa8
   fbgemm:    in PyTorch: USE_FBGEMM=True USE_FBGEMM_GENAI=True  [fbgemm_gpu pip pkg: (not installed); separate from torch's vendored copy]
   aiter:     (not installed) [aiter pip pkg; optional ROCm inference lib]
@@ -185,7 +220,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | Currently `"1.8"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
+| `schema_version` | `str` | constant | Currently `"1.9"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
@@ -201,6 +236,9 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `host` | `dict` | `os.uname()` + `os.confstr("CS_GNU_LIBC_VERSION")` | `kernel_release`, `kernel_version`, `machine`, `glibc_version`. Kernel + glibc drift is the #1 confound for compiled-against-vs-runtime issues with C++ extensions. |
 | `composable_kernel` | `dict` | header at `include/ck/version.h` + `nm -D` of `libtorch_hip.so` piped through `c++filt` + `torch.__config__.show()` flag scan | Two sub-blocks (`system: {version, commit, ck_tile_present}`, `pytorch_bundled: {present, symbol_count}`) plus top-level `pytorch_use_ck_sdpa` / `pytorch_use_ck_gemm` booleans (build-time flags baked into the wheel; NOT runtime env vars). System and bundled CK can drift independently. |
 | `tensile` | `dict` | optional `import Tensile` + sorted-filenames hash over the union of hipBLASLt + rocBLAS kernel DBs | `package_version` (usually `null` outside builders), `kernel_db_combined_hash` |
+| `tensile_catalog` | `dict` | reuses the `hipblaslt`/`rocblas`/`tensile` captures + a new per-file enumeration of `lib/{hipblaslt,rocblas}/library/*` | **The "recipe book" -- installed-library identity, NOT the runtime-selected solution ID.** Top-level `doc` + `status`. Per-library `hipblaslt`/`rocblas` carry the existing `package_version`/`lib_hash`/`kernel_db_revision` (no regression) plus a `menu` sub-block: `status`, `reason`, `dir`, `logic_file_count` (`.dat`/`.yaml`), `file_count`, `gfx_arch_coverage`, `files` (per-file `{name,size,suffix,is_logic,sha256}`), and `combined_content_hash`. `combined` mirrors the `tensile` block. Partial-not-silent: a dir that can't be located/listed is `status:"partial"` (distinct from a present-but-empty menu, which is `ok` with `logic_file_count:0`). Added in schema 1.9 (issue #54). |
+| `miopen_catalog` | `dict` | reuses the `miopen` capture + a per-file enumeration of the MIOpen db dir (`share/miopen/db/`) | **Recipe book for MIOpen's convolution databases** -- same scoping as `tensile_catalog`. `doc` + `status`, the reused `package_version`/`lib_hash`/`kernel_db_revision` (no regression), `db_dir` + `db_dir_source` (`default` or `MIOPEN_SYSTEM_DB_PATH`), `env_overrides`, and a `menu`. `logic_file_count` counts the selectable DBs (`.kdb`/`.fdb.txt`/`.db.txt`/`.db`); `.ktn.model`/`.tn.model` heuristic models are catalog members but not logic. Added in schema 1.9 (issue #54 follow-up). |
+| `rocfft_catalog` | `dict` | optional `rocfft_kernel_cache.db` under `$ROCFFT_RTC_SYS_CACHE_PATH` or `/opt/rocm/lib/[rocfft/]` | Fingerprint of rocFFT's **optional** AOT kernel cache -- the READ-ONLY system cache, not the read-write runtime user cache. rocFFT usually compiles at runtime, so absence is normal: a *probed* "no cache" result is `status:"absent"` with **no** partial reason. (The default/backfill/disaster shape is `status:"partial"` with a "not captured" reason instead, so a snapshot that never probed is distinguishable from one that probed and found nothing.) `doc` + `status` (`ok`/`absent`/`partial`) + `env_overrides` (both `ROCFFT_RTC_SYS_CACHE_PATH` -- the override this catalog actually resolves against -- and `ROCFFT_RTC_CACHE_PATH`, recorded for visibility only since it names the mutable, workload-dependent user cache, not installed identity; both recorded even when no cache is found so a configured-but-empty override is visible) + `kernel_cache` (`present`, `path`, `source`, `size`, `sha256`, `reason`). Added in schema 1.9 (issue #54 follow-up). |
 | `triton` | `dict` | `import triton; triton.__version__` (+ commit parse) | `package_version`, `commit` (schema 1.8). ROCm Triton fork bakes the source commit into `__version__` (e.g. `3.5.1+rocm7.2.1.gita272dfa8` -> `commit: "a272dfa8"`); fb builds versioned `+fb` carry no SHA -> `commit: null`. |
 | `fbgemm` | `dict` | optional `import fbgemm_gpu` (+ commit parse) + parse of `torch.__config__.show()` for `-DUSE_FBGEMM*` defines | `package_version`, `commit` (schema 1.8 -- best-effort git SHA from a setuptools_scm `+g<sha>` local-version segment or a `git_version`/`__commit__` module attr; `null` when fbgemm_gpu is vendored-in-torch rather than separately installed, or carries no SHA), `pytorch_use_fbgemm`, `pytorch_use_fbgemm_genai`. The two booleans capture the build-time decision baked into the PyTorch wheel even when `fbgemm_gpu` isn't a separate pip package. |
 | `aiter` | `dict` | `import aiter; aiter.__version__` + `importlib.metadata.version("amd_aiter" \| "aiter")` + scan of `aiter_meta/hsa/<gfx>/` (or `$AORTA_PYTORCH_SRC/third_party/aiter/hsa/`) | `package_version`, `package_dist_name` (which PyPI dist matched: `amd_aiter` is the canonical AMD-internal ROCm/PyTorch image dist; `aiter` is the upstream name), `commit` (parsed from the setuptools_scm `+g<sha>` local-version segment, matches the image tag's `aiter-<sha>` label), `hsa_tree` (issue #176 -- per-arch fingerprint of pre-built `.co` kernel binaries: file_count, co_count, deterministic combined_sha256). Most installs record `null` for everything; absence is silent. |
@@ -396,7 +434,40 @@ Mirrors the in-code comment at `SCHEMA_VERSION` in
 `src/aorta/instrumentation/environment.py`. Recorded here so consumers
 tracking schema evolution don't have to read source.
 
-### `1.8` (current)
+### `1.9` (current)
+
+Static kernel-catalog "recipe books" for the on-disk, runtime-selected
+GPU-compute catalogs (issue #54 + follow-ups). All additive: three new
+top-level blocks, each defaulted so older readers don't raise.
+
+* New top-level **`tensile_catalog`** (issue #54): installed-library
+  identity for the hipBLASLt/rocBLAS Tensile install. Reuses the existing
+  `hipblaslt`/`rocblas`/`tensile` captures (no regression) and deepens
+  them with a per-file `menu` enumeration of the frozen solution library
+  (`TensileLibrary` / `*.dat` / `*.yaml` / `*.co` / `*.hsaco`): per-file
+  content sha256 + size, `logic_file_count`, `gfx_arch_coverage`, and a
+  `combined_content_hash`, so a two-host diff localizes *which* logic
+  file differs. Explicitly NOT the runtime-selected solution ID
+  (`381881`/`368xxx`). Partial-not-silent per menu.
+* New top-level **`miopen_catalog`** (issue #54 follow-up): the same
+  treatment for MIOpen's databases under `/opt/rocm/share/miopen/db/`
+  (`.kdb` kernel-db, `.fdb.txt` find-db, `.db.txt`/`.db` perf-db, plus
+  `.ktn.model`/`.tn.model` heuristic nets). Honors `MIOPEN_SYSTEM_DB_PATH`
+  (records `db_dir`/`db_dir_source`) and surfaces `MIOPEN_USER_DB_PATH`.
+* New top-level **`rocfft_catalog`** (issue #54 follow-up): fingerprints
+  rocFFT's *optional* AOT `rocfft_kernel_cache.db` when present; absence
+  is the common case (`status:"absent"`, no partial reason). Resolves
+  against the read-only `ROCFFT_RTC_SYS_CACHE_PATH` system-cache override
+  (or the default `/opt/rocm/lib[/rocfft]/` locations) -- NOT the
+  mutable, per-process `ROCFFT_RTC_CACHE_PATH` user cache, which is
+  recorded under `env_overrides` for visibility only.
+
+Backwards-compat: all three are new top-level dataclass fields with
+default factories, so a 1.7/1.8 reader loading a 1.9 snapshot drops the
+unknown keys and a 1.9 reader loading an older snapshot gets the empty
+defaults.
+
+### `1.8`
 
 Buck-target torch native-lib recovery + best-effort package commits.
 Additive nested keys only (`triton.commit`, `fbgemm.commit`); no
@@ -740,6 +811,28 @@ For per-library binary-level drift detection, use:
 * `<lib>.applied_prs` -- a forward-compat slot for explicit PR
   detectors when a specific patch warrants tracking.
 
+### `*_catalog` blocks are the recipe book (installed library), not the recipe used
+
+The `tensile_catalog` / `miopen_catalog` / `rocfft_catalog` blocks answer
+exactly one question: *is the installed kernel/solution catalog the same
+on both hosts?* Every field is **installed-library identity** -- the
+frozen on-disk menu. They deliberately do **not** capture the
+runtime-selected solution/solver ID (`#381881` / `#368xxx`), which is
+chosen per-call at runtime against live device properties and needs a
+workload trace (a separate capability).
+
+Two hosts can report the **same** hipBLASLt commit (e.g. `7e32d53eb1`)
+and still ship a **different** Tensile install -- a vendor build can
+patch or select different kernels even when nominally pointing at that
+commit. That is precisely the case `tensile_catalog.<lib>.menu` is built
+to expose: the shallow filename fingerprint (`kernel_db_revision`) can
+match while the per-file `menu.files[*].sha256` differ. Use the menu's
+`combined_content_hash` for a one-shot "are the menus identical?" check,
+and the per-file `files` list to localize *which* logic file changed. The
+same applies to `miopen_catalog` for convolution databases.
+
+### `composable_kernel.system.commit` is a real upstream commit
+
 The `composable_kernel.system.commit` field IS a real upstream commit
 (40-char SHA), because CK ships its own `CK_COMMIT_ID` define populated
 from the upstream submodule.
@@ -821,8 +914,9 @@ Adding a new submodule to track is a deliberate three-step change
 
 1. The corresponding field is set to `None`.
 2. A short reason like `"system_health: rdhc not on PATH"` or
-   `"hipblaslt.commit: /opt/rocm/include/hipblaslt/hipblaslt-version.h
-   missing, empty, or unreadable"` is appended to `partial_reasons`.
+   `"hipblaslt.rocm_release_tweak:
+   /opt/rocm/include/hipblaslt/hipblaslt-version.h not readable"` is
+   appended to `partial_reasons`.
 3. `partial` is set to `True`.
 4. The run continues.
 
@@ -915,6 +1009,16 @@ sources are:
 | `composable_kernel.pytorch_bundled.symbol_count` | `nm -D --defined-only` of `<torch>/lib/libtorch_hip.so` piped through `c++filt`, counting lines containing `ck::`. `null` when torch absent, lib missing, or binutils stripped from the container. |
 | `tensile.package_version` | `import Tensile; Tensile.__version__` (rare; build-time tool) |
 | `tensile.kernel_db_combined_hash` | sorted-filenames sha256 over the union of the hipBLASLt + rocBLAS kernel DBs (each filename namespaced by parent dir basename) |
+| `tensile_catalog.<lib>.{package_version,lib_hash,kernel_db_revision}` | taken verbatim from the matching `hipblaslt`/`rocblas` block (no regression) |
+| `tensile_catalog.<lib>.menu.files[*].sha256` | `sha256` of each `*.dat`/`*.yaml`/`*.co`/`*.hsaco`/`*.txt` file under `/opt/rocm/lib/<lib>/library/` (content hash, not just filename) |
+| `tensile_catalog.<lib>.menu.gfx_arch_coverage` | sorted unique `gfx<arch>` tokens parsed from those filenames (e.g. `TensileLibrary_lazy_gfx942.dat` -> `gfx942`) |
+| `tensile_catalog.<lib>.menu.combined_content_hash` | sha256 over the sorted `(filename, content-sha256)` pairs -- one value to eyeball when diffing whole menus |
+| `miopen_catalog.{package_version,lib_hash,kernel_db_revision}` | taken verbatim from the `miopen` block (no regression) |
+| `miopen_catalog.db_dir` / `.db_dir_source` | the effective MIOpen db dir enumerated -- `$MIOPEN_SYSTEM_DB_PATH` when set (`"MIOPEN_SYSTEM_DB_PATH"`), else `/opt/rocm/share/miopen/db/` (`"default"`) |
+| `miopen_catalog.menu.files[*].sha256` | `sha256` of each `.kdb`/`.fdb.txt`/`.db.txt`/`.db`/`.ktn.model`/`.tn.model` file in the db dir (content hash) |
+| `miopen_catalog.menu.logic_file_count` | count of the selectable DBs (`.kdb`/`.fdb.txt`/`.db.txt`/`.db`); excludes the `*.model` heuristic nets |
+| `rocfft_catalog.kernel_cache.{present,path,source,size,sha256}` | the optional `rocfft_kernel_cache.db` found under `$ROCFFT_RTC_SYS_CACHE_PATH` (`"ROCFFT_RTC_SYS_CACHE_PATH"`) or `/opt/rocm/lib/[rocfft/]` (`"rocm_lib"`); all `null` + `status:"absent"` when no cache exists (the common case). Does **not** resolve against `$ROCFFT_RTC_CACHE_PATH` -- that names the mutable, per-process runtime user cache, not installed identity. |
+| `rocfft_catalog.env_overrides.{ROCFFT_RTC_SYS_CACHE_PATH,ROCFFT_RTC_CACHE_PATH}` | the raw values of both vars (or `null`), recorded even when no cache file is found so a configured-but-empty override is diffable. Only `ROCFFT_RTC_SYS_CACHE_PATH` affects `kernel_cache` resolution above; `ROCFFT_RTC_CACHE_PATH` is recorded for visibility only. |
 | `triton.package_version` | `import triton; triton.__version__` (ROCm fork puts source commit into the version string) |
 | `fbgemm.package_version` | `import fbgemm_gpu; fbgemm_gpu.__version__` (commonly `null` -- FBGEMM is vendored inside PyTorch) |
 | `fbgemm.pytorch_use_fbgemm` / `fbgemm.pytorch_use_fbgemm_genai` | substring search in `torch.__config__.show()` for the `-DUSE_FBGEMM` and `-DUSE_FBGEMM_GENAI` defines. `False` is meaningful (built-without); `null` only when torch is absent. |
@@ -1092,7 +1196,7 @@ jq '.partial_reasons' /tmp/env.json
 # Force the no-rdhc fallback (rdhc isn't on PATH)
 PATH= aorta env probe -o /tmp/env_no_rdhc.json
 jq '.system_health' /tmp/env_no_rdhc.json    # null
-jq '.hipblaslt.commit' /tmp/env_no_rdhc.json # still populated
+jq '.hipblaslt.rocm_release_tweak' /tmp/env_no_rdhc.json # still populated
 
 # Compare across docker images (manual until `aorta env matrix` lands)
 docker run --rm <image-A> aorta env probe -o /workspace/env_a.json
@@ -1209,6 +1313,42 @@ jq '.hipblaslt | {rocm_release_tweak, package_version, lib_hash, kernel_db_revis
 jq '{rocblas, miopen, rccl}' /tmp/env.json
 ```
 
+### Is the installed kernel catalog (recipe book) the same on two hosts?
+
+```bash
+# Tensile menu identity (installed-library identity -- NOT the runtime
+# solution pick, which needs a trace).
+jq '.tensile_catalog | {status,
+  hipblaslt: .hipblaslt.menu.combined_content_hash,
+  rocblas:   .rocblas.menu.combined_content_hash}' /tmp/env.json
+
+# The 7e32d53eb1 trap: two hosts can report the SAME hipBLASLt commit
+# yet ship a different Tensile install. The shallow filename hash can
+# match while the per-file content hashes differ -- compare both.
+diff \
+  <(jq -S '.tensile_catalog.hipblaslt | {kernel_db_revision, menu: .menu.combined_content_hash, archs: .menu.gfx_arch_coverage}' good.json) \
+  <(jq -S '.tensile_catalog.hipblaslt | {kernel_db_revision, menu: .menu.combined_content_hash, archs: .menu.gfx_arch_coverage}' bad.json)
+
+# Localize WHICH Tensile logic file differs (per-file content hashes)
+diff \
+  <(jq -S '.tensile_catalog.hipblaslt.menu.files' good.json) \
+  <(jq -S '.tensile_catalog.hipblaslt.menu.files' bad.json)
+
+# MIOpen convolution db menu identity. Also surfaces which dir was read
+# (a MIOPEN_SYSTEM_DB_PATH override points at a different catalog).
+jq '.miopen_catalog | {status, db_dir, db_dir_source,
+  menu: .menu.combined_content_hash, archs: .menu.gfx_arch_coverage,
+  logic: .menu.logic_file_count}' /tmp/env.json
+
+# rocFFT optional AOT kernel cache -- usually absent (that's fine)
+jq '.rocfft_catalog | {status, present: .kernel_cache.present,
+  path: .kernel_cache.path, sha: .kernel_cache.sha256}' /tmp/env.json
+
+# Did a menu read cleanly, or couldn't we locate/parse it?
+jq '{tensile: .tensile_catalog.status, miopen: .miopen_catalog.menu.status,
+  rocfft: .rocfft_catalog.status}' /tmp/env.json
+```
+
 ### Diff two snapshots
 
 ```bash
@@ -1298,6 +1438,12 @@ jq '{
 * `aorta env matrix` (multi-docker fan-out)
 * `aorta env diff env_a.json env_b.json`
 * GPU kernel introspection (anything that runs HIP work)
+* **Runtime kernel solution-ID capture** (`381881` / `368xxx`):
+  enabling `HIPBLASLT_LOG_MASK` / `CHECK_NUMERICS`, parsing
+  `hipblaslt.log`, and `hipblaslt-bench` replay. The `*_catalog` blocks
+  capture only the *installed menu* (layer 1); which recipe the runtime
+  actually picks (layer 2) needs a workload and belongs to the runtime
+  follow-up.
 * Workload config (`AMP_DTYPE`, `MODEL_DTYPE`, ...) -- captured by
   `aorta run` in the trial result (Task B1), not by env probe
 

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -22,6 +22,21 @@ Captured blocks:
   ``pytorch_bundled`` (CK symbol count inside ``libtorch_hip.so``).
 * ``tensile`` -- optional pip version + combined kernel-DB fingerprint
   across hipBLASLt and rocBLAS.
+* ``tensile_catalog`` -- the *recipe book*: installed-library identity
+  for the hipBLASLt/rocBLAS Tensile install, consolidating the existing
+  version + lib_hash + kernel-DB fingerprints AND a deepened per-file
+  enumeration of the frozen Tensile solution menu (logic files:
+  ``TensileLibrary`` / ``*.dat`` / ``*.yaml``) -- per-file content
+  hashes, a count, and gfx-arch coverage -- so a two-host diff localizes
+  *which* logic file differs. This is the menu (what is installed), NOT
+  the runtime-selected solution ID (``381881`` / ``368xxx``). No GPU
+  compute.
+* ``miopen_catalog`` -- the same recipe-book treatment for MIOpen's
+  on-disk convolution kernel/find/perf databases
+  (``/opt/rocm/share/miopen/db/``). Honors ``MIOPEN_SYSTEM_DB_PATH``.
+* ``rocfft_catalog`` -- fingerprint of rocFFT's *optional* ahead-of-time
+  ``rocfft_kernel_cache.db`` when present (absence is the common case,
+  recorded as ``absent`` rather than partial).
 * ``triton``, ``fbgemm``, ``aiter`` -- Python-package version probes.
   ``fbgemm`` also surfaces the ``-DUSE_FBGEMM`` / ``-DUSE_FBGEMM_GENAI``
   build-time flags from ``torch.__config__.show()``.
@@ -63,7 +78,48 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.8"
+SCHEMA_VERSION = "1.9"
+# 1.8 -> 1.9 (issue #54 + follow-ups): static kernel-catalog "recipe
+# books" for the on-disk, runtime-selected GPU-compute catalogs.
+#   - New top-level ``tensile_catalog`` block (issue #54), always present
+#     (defaulted via ``_empty_tensile_catalog()``). A clearly-labeled
+#     grouping of *installed-library identity* for the hipBLASLt/rocBLAS
+#     Tensile install -- explicitly NOT the runtime-selected solution ID
+#     (``381881`` / ``368xxx``), which requires a workload and is out of
+#     scope for the no-compute probe. Reuses the existing
+#     ``hipblaslt``/``rocblas``/``tensile`` captures for the version +
+#     lib_hash + kernel-DB filename fingerprints (no regression) and
+#     deepens them with a per-file ``menu`` enumeration of the frozen
+#     solution library (``TensileLibrary`` / ``*.dat`` / ``*.yaml`` /
+#     ``*.co`` / ``*.hsaco``): per-file content sha256 + size, a
+#     ``logic_file_count``, ``gfx_arch_coverage``, and a
+#     ``combined_content_hash``, so a two-host diff localizes *which*
+#     logic file differs. Partial-not-silent: each ``menu`` carries
+#     ``status`` + ``reason``; a dir that can't be located/listed is
+#     ``partial`` (distinct from a present-but-empty menu, which is
+#     ``ok`` with ``logic_file_count: 0``), and partial reasons thread
+#     into ``partial_reasons``.
+#   - New top-level ``miopen_catalog`` block (issue #54 follow-up). MIOpen
+#     is the convolution analogue of Tensile; this mirrors
+#     ``tensile_catalog`` for the databases under
+#     ``/opt/rocm/share/miopen/db/``: reuses the ``miopen`` capture
+#     (package_version / lib_hash / kernel_db_revision -- no regression)
+#     and deepens it with a per-file ``menu`` enumeration of the
+#     ``*.kdb`` / ``*.fdb.txt`` / ``*.db.txt`` / ``*.db`` selectable DBs
+#     plus the ``*.ktn.model`` / ``*.tn.model`` heuristic tuning models.
+#     Honors the ``MIOPEN_SYSTEM_DB_PATH`` override (records
+#     ``db_dir`` / ``db_dir_source``) and surfaces ``MIOPEN_USER_DB_PATH``.
+#   - New top-level ``rocfft_catalog`` block (issue #54 follow-up). rocFFT
+#     compiles most kernels at runtime, so by default there is no frozen
+#     catalog; this fingerprints the *optional* ahead-of-time
+#     ``rocfft_kernel_cache.db`` when present (presence + path + size +
+#     content sha256). Absence is the documented common case ->
+#     ``status: "absent"`` with NO partial reason; present-but-unreadable
+#     -> ``status: "partial"`` with a reason.
+#   - All three are new top-level dataclass fields with default factories,
+#     so 1.7/1.8 readers loading a 1.9 snapshot drop the unknown keys and
+#     1.9 readers loading an older snapshot get the empty defaults.
+#
 # 1.7 -> 1.8 (Buck-target torch recovery + package commits):
 #   - ``triton`` and ``fbgemm`` blocks each gained a ``commit`` key
 #     (nested, additive). Best-effort git SHA parsed from a
@@ -433,6 +489,25 @@ ROCBLAS_TENSILE_DIR = Path(
     "/opt/rocm/lib/rocblas/library"
 )  # rocBLAS Tensile kernel database
 
+# Static Tensile catalog (issue #54). The "menu" enumeration walks the
+# Tensile library dir and fingerprints each file individually. Suffixes
+# cover the frozen solution menu: ``.dat`` (modern binary logic),
+# ``.yaml`` (older text logic), and the ``.co`` / ``.hsaco`` code-object
+# blobs that ship alongside. The ``.txt`` entry captures manifest/index
+# text files (e.g. ``TensileManifest.txt``): they are neither logic nor
+# code-object files, but their identity still matters for a complete
+# catalog fingerprint, so they are included via ``.txt``.
+TENSILE_MENU_SUFFIXES: tuple[str, ...] = (".dat", ".yaml", ".co", ".hsaco", ".txt")
+# A file counts as a Tensile "logic" file (the actual solution menu, as
+# opposed to a raw code-object blob) when it carries one of these
+# suffixes. ``logic_file_count`` counts only these.
+TENSILE_LOGIC_SUFFIXES: tuple[str, ...] = (".dat", ".yaml")
+# gfx arch token embedded in Tensile filenames, e.g.
+# ``TensileLibrary_lazy_gfx942.dat`` -> ``gfx942``. Used for
+# ``gfx_arch_coverage``; case-insensitive because some toolchains emit
+# mixed case in the hex suffix (gfx90a vs GFX90A).
+_GFX_ARCH_RE = re.compile(r"gfx[0-9a-f]+", re.IGNORECASE)
+
 # Composable Kernel (CK) is shipped header-only via the
 # composablekernel-dev package -- there is no libck.so to hash. CK_TILE
 # is a sub-component of CK with no separate version header; we record
@@ -488,6 +563,58 @@ MIOPEN_VERSION_HEADER = Path("/opt/rocm/include/miopen/version.h")
 MIOPEN_LIB_DIR = Path("/opt/rocm/lib")  # libMIOpen.so* lives here (capital M, capital O)
 MIOPEN_KERNEL_DB_DIR = Path("/opt/rocm/share/miopen/db")
 MIOPEN_KERNEL_DB_SUFFIXES: tuple[str, ...] = (".txt",)  # .fdb.txt also matches via final suffix
+
+# MIOpen static catalog (issue #54 follow-up). The "menu" enumeration
+# walks the MIOpen db dir and fingerprints each file. MIOpen uses
+# multi-part suffixes (``gfx942.HIP.fdb.txt``) so matching is by
+# ``endswith`` of the full token, NOT pathlib's single ``.suffix``.
+# Catalog = the selectable databases + the heuristic tuning models:
+#   * ``.kdb``            -- precompiled kernel binaries (binary)
+#   * ``.fdb.txt``        -- find-db (algorithm/solver selection -- the
+#                            decision-tree layer the runtime selects from)
+#   * ``.db.txt`` / ``.db`` -- perf-db (tuned solver parameters)
+#   * ``.ktn.model`` / ``.tn.model`` -- KernelTuningNet heuristic models
+MIOPEN_CATALOG_SUFFIXES: tuple[str, ...] = (
+    ".kdb",
+    ".fdb.txt",
+    ".db.txt",
+    ".db",
+    ".ktn.model",
+    ".tn.model",
+)
+# Of those, the ones that ARE the runtime-selectable kernel/find/perf
+# databases (counted as ``logic_file_count``). The ``*.model`` files are
+# heuristic tuning nets -- catalog members, but not the DBs themselves.
+MIOPEN_LOGIC_SUFFIXES: tuple[str, ...] = (".kdb", ".fdb.txt", ".db.txt", ".db")
+# Runtime overrides for the MIOpen db locations (already in
+# CANONICAL_ENV_VARS). MIOPEN_SYSTEM_DB_PATH relocates the read-only
+# system db dir the probe enumerates; MIOPEN_USER_DB_PATH points at the
+# writable user perf-db and is recorded for transparency.
+MIOPEN_SYSTEM_DB_PATH_ENV = "MIOPEN_SYSTEM_DB_PATH"
+MIOPEN_USER_DB_PATH_ENV = "MIOPEN_USER_DB_PATH"
+
+# rocFFT optional ahead-of-time kernel cache (issue #54 follow-up).
+# rocFFT compiles most kernels at runtime (RTC); an offline-built cache
+# is an opt-in SQLite file. Per rocFFT's runtime-compilation design
+# (rtc_cache.cpp), there are TWO distinct cache paths and only one is
+# "installed identity":
+#   * ROCFFT_RTC_SYS_CACHE_PATH -- the pre-built, READ-ONLY system cache
+#     override. This is the installed artifact this catalog fingerprints.
+#   * ROCFFT_RTC_CACHE_PATH -- the READ-WRITE, per-process user cache,
+#     populated on demand at runtime. NOT installed-library identity --
+#     its contents are workload-dependent and not reproducible across
+#     runs, so it must not be fingerprinted as a static catalog. We only
+#     record its configured value (env_overrides) for visibility.
+# Default (no override) search order mirrors rtc_cache.cpp:
+# ``{librocfft.so dir}/rocfft_kernel_cache.db`` then
+# ``{librocfft.so dir}/rocfft/rocfft_kernel_cache.db``. Absence is normal
+# (recorded as ``absent``, not partial). SQLite internals aren't cheaply
+# enumerable without a dependency, so we fingerprint the whole file
+# (content hash).
+ROCFFT_KERNEL_CACHE_NAME = "rocfft_kernel_cache.db"
+ROCFFT_RTC_SYS_CACHE_PATH_ENV = "ROCFFT_RTC_SYS_CACHE_PATH"
+ROCFFT_RTC_CACHE_PATH_ENV = "ROCFFT_RTC_CACHE_PATH"
+ROCFFT_LIB_DIR = Path("/opt/rocm/lib")
 
 # RCCL is AMD's NCCL-compatible collective comms library. Header is at
 # /opt/rocm/include/rccl/rccl.h (same name as upstream NCCL's). Version
@@ -781,6 +908,22 @@ class EnvSnapshot:
     # NIC probing. Populated by ``_capture_nics()`` in collect_env() /
     # ``_disaster_snapshot()``.
     nics: dict = field(default_factory=dict)
+    # tensile_catalog / miopen_catalog / rocfft_catalog: issue #54 +
+    # follow-ups (schema 1.9). Static kernel-catalog "recipe books" --
+    # installed-library identity for the on-disk, runtime-selected
+    # GPU-compute catalogs, NOT the runtime pick. Defaulted (empty
+    # catalogs) so pre-1.9 constructors and ``from_dict()`` on older
+    # snapshots don't raise. See ``_build_tensile_catalog`` /
+    # ``_build_miopen_catalog`` / ``_build_rocfft_catalog``.
+    tensile_catalog: dict = field(
+        default_factory=lambda: _empty_tensile_catalog()
+    )
+    miopen_catalog: dict = field(
+        default_factory=lambda: _empty_miopen_catalog()
+    )
+    rocfft_catalog: dict = field(
+        default_factory=lambda: _empty_rocfft_catalog()
+    )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to the env.json shape. Round-trip pair with from_dict."""
@@ -817,6 +960,9 @@ class EnvSnapshot:
         kwargs.setdefault("library_introspection", [])
         kwargs.setdefault("library_introspection_alternates", [])
         kwargs.setdefault("nics", {})
+        kwargs.setdefault("tensile_catalog", _empty_tensile_catalog())
+        kwargs.setdefault("miopen_catalog", _empty_miopen_catalog())
+        kwargs.setdefault("rocfft_catalog", _empty_rocfft_catalog())
         return cls(**kwargs)
 
     def summary(self) -> str:
@@ -865,9 +1011,16 @@ class EnvSnapshot:
         # on the runtime: line was redundant.
 
         def short_hash(value: str | None) -> str:
-            """Truncate ``filenames-sha256:abcdef…``-style hashes for display."""
+            """Truncate ``filenames-sha256:abcdef…``-style hashes for display.
+
+            A missing hash renders as ``"-"``, not the literal string
+            ``"None"`` -- the same ambiguity ``pkg_state()`` avoids for
+            package versions. Without this, a not-captured catalog menu
+            would render as ``tensile[hb=None rb=None]``, which reads as
+            a real (if odd) value rather than "nothing captured here".
+            """
             if not value:
-                return str(value)
+                return "-"
             if ":" in value:
                 kind, hex_part = value.split(":", 1)
                 if len(hex_part) > 8:
@@ -883,6 +1036,28 @@ class EnvSnapshot:
             obvious without needing to read the schema.
             """
             return version if version else "(not installed)"
+
+        # Static kernel-catalog "recipe book" fingerprints (schema 1.9).
+        # Surface the per-menu content hash so the brief reflects the
+        # installed catalog identity without an operator having to jq.
+        tc = self.tensile_catalog or {}
+        mc = self.miopen_catalog or {}
+        rf = self.rocfft_catalog or {}
+        tc_hb = ((tc.get("hipblaslt") or {}).get("menu") or {}).get(
+            "combined_content_hash"
+        )
+        tc_rb = ((tc.get("rocblas") or {}).get("menu") or {}).get(
+            "combined_content_hash"
+        )
+        mc_hash = (mc.get("menu") or {}).get("combined_content_hash")
+        rf_cache = rf.get("kernel_cache") or {}
+        if rf_cache.get("present"):
+            _rf_sha = rf_cache.get("sha256")
+            # present-but-unhashable (partial) -> avoid the ambiguous
+            # "present None"; show an explicit unreadable marker.
+            rf_cell = f"present {short_hash(_rf_sha)}" if _rf_sha else "present (unreadable)"
+        else:
+            rf_cell = rf.get("status") or "?"
 
         return "\n".join(
             (
@@ -923,6 +1098,12 @@ class EnvSnapshot:
                 f"  tensile:   kernel_db={short_hash(tensile.get('kernel_db_combined_hash'))}  "
                 f"[Tensile pip pkg: {pkg_state(tensile.get('package_version'))}; "
                 f"build-time tool, normal]",
+                # Static "recipe book" identity (the installed kernel
+                # catalogs, NOT the runtime pick): per-menu content hash
+                # for hipBLASLt/rocBLAS Tensile + MIOpen, and the rocFFT
+                # AOT cache state. Full per-file detail lives in the JSON.
+                f"  catalog:   tensile[hb={short_hash(tc_hb)} rb={short_hash(tc_rb)}]  "
+                f"miopen={short_hash(mc_hash)}  rocfft={rf_cell}",
                 f"  triton:    {pkg_state(triton.get('package_version'))}",
                 # FBGEMM has TWO surfaces and they're different artifacts:
                 #   1) FBGEMM the C++ lib is vendored inside the PyTorch
@@ -1594,11 +1775,21 @@ def collect_env(
             reasons, hip_symbol_cache=hip_symbol_cache
         )
         tensile = _capture_tensile(reasons)
+        # Static "recipe book": reuses the hipblaslt/rocblas/tensile
+        # captures above (no regression) + deepens with per-file menu
+        # enumeration.
+        tensile_catalog = _build_tensile_catalog(
+            hipblaslt, rocblas, tensile, reasons
+        )
         triton = _capture_triton(reasons)
         fbgemm = _capture_fbgemm(reasons)
         aiter = _capture_aiter(reasons)
         aotriton = _capture_aotriton(reasons)
         miopen = _capture_miopen(reasons)
+        # Static MIOpen "recipe book" (reuses miopen capture) + rocFFT
+        # optional AOT kernel cache fingerprint (absent on most installs).
+        miopen_catalog = _build_miopen_catalog(miopen, reasons)
+        rocfft_catalog = _build_rocfft_catalog(reasons)
         rccl = _capture_rccl(reasons)
         nics = _capture_nics(reasons)
         gpu_arch = _capture_gpu_arch(reasons)
@@ -1638,6 +1829,9 @@ def collect_env(
             rocblas=rocblas,
             composable_kernel=composable_kernel,
             tensile=tensile,
+            tensile_catalog=tensile_catalog,
+            miopen_catalog=miopen_catalog,
+            rocfft_catalog=rocfft_catalog,
             triton=triton,
             fbgemm=fbgemm,
             aiter=aiter,
@@ -1737,6 +1931,9 @@ def _disaster_snapshot(
             "pytorch_use_ck_gemm": None,
         },
         tensile={"package_version": None, "kernel_db_combined_hash": None},
+        tensile_catalog=_empty_tensile_catalog(),
+        miopen_catalog=_empty_miopen_catalog(),
+        rocfft_catalog=_empty_rocfft_catalog(),
         triton={"package_version": None, "commit": None},
         fbgemm={
             "package_version": None,
@@ -3498,6 +3695,559 @@ def _combined_kernel_db_fingerprint(
     pairs.sort()
     digest = hashlib.sha256("\n".join(pairs).encode("utf-8")).hexdigest()
     return f"filenames-sha256:{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Static Tensile catalog (issue #54) -- the "recipe book"
+#
+# Everything below describes *installed-library identity*: which Tensile
+# solution menu is baked into / shipped alongside the hipBLASLt / rocBLAS
+# install on disk. It is deliberately NOT the runtime-selected solution
+# ID (the `#381881` / `#368xxx` seen in workload logs) -- that is chosen
+# per-GEMM at runtime against live device properties and requires running
+# a workload, which is out of scope for the no-compute `env probe`.
+# ---------------------------------------------------------------------------
+
+# Customer-facing one-liner, surfaced in the block so a reader of the raw
+# env.json understands the scope without the docs in hand.
+TENSILE_CATALOG_DOC = (
+    "Installed-library identity (the 'recipe book'): which hipBLASLt/"
+    "rocBLAS Tensile solution menu is installed on disk. Does NOT capture "
+    "the runtime-selected solution ID (e.g. 381881/368xxx) -- that needs a "
+    "runtime trace (separate capability). Two hosts can report the same "
+    "hipBLASLt commit yet ship a materially different Tensile menu; this "
+    "block makes that diffable from the installed files alone."
+)
+
+
+def _extract_gfx_archs(names: list[str]) -> list[str]:
+    """Return the sorted, deduped set of gfx arch tokens in ``names``.
+
+    Tensile encodes the target arch in the logic filename, e.g.
+    ``TensileLibrary_lazy_gfx942.dat`` -> ``gfx942``. Lower-cased so a
+    mixed-case ``GFX90A`` collapses with ``gfx90a``. Empty list when no
+    filename carries a recognizable token (e.g. an arch-agnostic master
+    library only) -- distinct from ``None`` (couldn't read the dir).
+    """
+    archs: set[str] = set()
+    for name in names:
+        for match in _GFX_ARCH_RE.findall(name):
+            archs.add(match.lower())
+    return sorted(archs)
+
+
+def _empty_menu() -> dict[str, Any]:
+    """All-null ``menu`` sub-block shape, shared by every catalog."""
+    return {
+        "status": "partial",
+        "reason": None,
+        "dir": None,
+        "logic_file_count": None,
+        "file_count": None,
+        "gfx_arch_coverage": None,
+        "files": None,
+        "combined_content_hash": None,
+    }
+
+
+def _enumerate_catalog_dir(
+    directory: Path,
+    classify,
+    *,
+    kind: str,
+) -> dict[str, Any]:
+    """Enumerate an on-disk kernel/solution catalog directory.
+
+    Generic engine behind every ``*_catalog`` menu (Tensile, MIOpen,
+    ...). Deepens a filename-only fingerprint: opens each matched file
+    and records a **content** sha256 + size, so a two-host diff localizes
+    *which* file changed rather than only "the filename set differs".
+    Still no GPU compute -- pure file reads in the install.
+
+    ``classify(filename) -> (include: bool, suffix_label: str | None,
+    is_logic: bool)`` selects which files belong to the catalog, labels
+    each file's (possibly multi-part) suffix, and flags whether it is one
+    of the runtime-selectable databases (counted as ``logic_file_count``)
+    vs. a supporting blob (code object, heuristic model). ``kind`` is a
+    short noun used in the partial reasons (e.g. ``"Tensile library"``).
+
+    Returns the shared ``menu`` shape (see ``_empty_menu``). Partial-not-
+    silent contract: a dir that can't be located/listed yields
+    ``status="partial"`` with a ``reason`` -- distinct from a present-but-
+    empty dir, which is ``status="ok"`` with ``logic_file_count=0`` (a
+    host that genuinely ships an empty catalog). A per-file hash that
+    fails (unreadable file) is recorded with ``sha256=None`` and
+    downgrades the block to ``partial`` rather than dropping the file.
+
+    Classification happens by filename first, before any ``stat()``.
+    A name that ``classify()`` says belongs to the catalog is never
+    silently skipped just because ``is_dir()``/``is_file()`` raised
+    (e.g. a broken symlink, or a permission-denied entry): it is kept
+    as an entry so the hashing step below fails soft (``sha256=None``)
+    and correctly downgrades the block to ``partial`` with a reason,
+    instead of vanishing from ``files`` and leaving a clean ``status:
+    "ok"`` that silently omitted it. Only entries confirmed (not merely
+    assumed) to be directories are excluded.
+    """
+    base = _empty_menu()
+    base["dir"] = str(directory)
+    if not directory.is_dir():
+        base["reason"] = f"{kind} dir missing/unreadable: {directory}"
+        return base
+    try:
+        raw = list(directory.iterdir())
+    except OSError as exc:
+        log.debug("%s listing failed for %s: %s", kind, directory, exc)
+        base["reason"] = f"{kind} dir not listable: {directory} ({exc})"
+        return base
+
+    entries: list[tuple[Path, str | None, bool]] = []
+    for p in raw:
+        include, suffix_label, is_logic = classify(p.name)
+        if not include:
+            continue
+        try:
+            is_dir = p.is_dir()
+        except OSError:
+            # Can't confirm directory-ness (broken symlink, permission
+            # denied, ...) -- do NOT assume it's a harmless directory.
+            # Keep it as a catalog entry so hashing below surfaces the
+            # failure instead of silently dropping a matched filename.
+            is_dir = False
+        if is_dir:
+            continue
+        entries.append((p, suffix_label, is_logic))
+
+    entries.sort(key=lambda t: t[0].name)
+    files: list[dict[str, Any]] = []
+    any_hash_failed = False
+    for p, suffix_label, is_logic in entries:
+        sha = _hash_file_path(p)
+        if sha is None:
+            any_hash_failed = True
+        try:
+            size = p.stat().st_size
+        except OSError:
+            size = None
+        files.append(
+            {
+                "name": p.name,
+                "size": size,
+                "suffix": suffix_label,
+                "is_logic": is_logic,
+                "sha256": sha,
+            }
+        )
+
+    names = [f["name"] for f in files]
+    logic_count = sum(1 for f in files if f["is_logic"])
+    # Deterministic combined content fingerprint over (name, sha256)
+    # pairs -- a single value to eyeball when diffing whole menus, while
+    # the per-file ``files`` list localizes the change. Only emit it when
+    # EVERY file hashed cleanly: a value computed over a missing hash is
+    # not a true content fingerprint (it would hash the literal "None"),
+    # so it must be ``None`` rather than a misleading ``content-sha256:``.
+    if any_hash_failed:
+        combined_content_hash = None
+    else:
+        pair_lines = [f"{f['name']}\t{f['sha256']}" for f in files]
+        digest = hashlib.sha256("\n".join(pair_lines).encode("utf-8")).hexdigest()
+        combined_content_hash = f"content-sha256:{digest}"
+
+    base.update(
+        {
+            "status": "partial" if any_hash_failed else "ok",
+            "reason": (
+                f"one or more {kind} files were unreadable"
+                if any_hash_failed
+                else None
+            ),
+            "logic_file_count": logic_count,
+            "file_count": len(files),
+            "gfx_arch_coverage": _extract_gfx_archs(names),
+            "files": files,
+            "combined_content_hash": combined_content_hash,
+        }
+    )
+    return base
+
+
+def _suffix_classifier(
+    suffixes: tuple[str, ...],
+    logic_suffixes: tuple[str, ...],
+):
+    """Build a ``classify`` callable matching on (multi-part) suffixes.
+
+    Matches by ``endswith`` (longest suffix first) so MIOpen's
+    ``gfx942.HIP.fdb.txt`` is labeled ``.fdb.txt`` rather than pathlib's
+    bare ``.txt``. Tensile's single-part suffixes work the same way.
+    """
+    ordered = sorted(suffixes, key=len, reverse=True)
+
+    def classify(name: str) -> tuple[bool, str | None, bool]:
+        low = name.lower()
+        for suf in ordered:
+            if low.endswith(suf):
+                return (True, suf, suf in logic_suffixes)
+        return (False, None, False)
+
+    return classify
+
+
+def _enumerate_tensile_menu(
+    directory: Path,
+    *,
+    suffixes: tuple[str, ...] = TENSILE_MENU_SUFFIXES,
+    logic_suffixes: tuple[str, ...] = TENSILE_LOGIC_SUFFIXES,
+) -> dict[str, Any]:
+    """Enumerate the frozen Tensile solution menu in ``directory``.
+
+    Thin wrapper over ``_enumerate_catalog_dir`` with Tensile's suffix
+    classifier. Kept as a named function so existing tests/callers keep
+    their call shape.
+    """
+    return _enumerate_catalog_dir(
+        directory,
+        _suffix_classifier(suffixes, logic_suffixes),
+        kind="Tensile library",
+    )
+
+
+def _empty_tensile_catalog() -> dict[str, Any]:
+    """All-null ``tensile_catalog`` for the default / disaster snapshot.
+
+    Same shape ``_build_tensile_catalog`` returns when nothing is
+    readable, so the schema is stable across hosts and the dataclass
+    default never diverges from a real (empty) capture.
+    """
+
+    def _empty_lib() -> dict[str, Any]:
+        menu = _empty_menu()
+        menu["reason"] = "tensile_catalog not captured"
+        return {
+            "package_version": None,
+            "lib_hash": None,
+            "kernel_db_revision": None,
+            "menu": menu,
+        }
+
+    return {
+        "doc": TENSILE_CATALOG_DOC,
+        "status": "partial",
+        "hipblaslt": _empty_lib(),
+        "rocblas": _empty_lib(),
+        "combined": {
+            "package_version": None,
+            "kernel_db_combined_hash": None,
+        },
+    }
+
+
+def _build_tensile_catalog(
+    hipblaslt: dict[str, Any],
+    rocblas: dict[str, Any],
+    tensile: dict[str, Any],
+    reasons: list[str],
+) -> dict[str, Any]:
+    """Assemble the labeled, deepened static ``tensile_catalog`` block.
+
+    No regression: the version / lib_hash / kernel-DB filename
+    fingerprint fields are taken verbatim from the already-captured
+    ``hipblaslt`` / ``rocblas`` / ``tensile`` blocks (so the legacy
+    top-level blocks and this one never disagree). The *new* work is the
+    ``menu`` sub-block per library -- the deepened per-file enumeration.
+
+    Every partial ``menu`` threads its reason into ``partial_reasons``
+    (prefixed ``tensile_catalog.<lib>.menu``) so a probe that couldn't
+    read the menu is distinguishable from one that read an empty menu.
+    """
+    hipblaslt_menu = _enumerate_tensile_menu(HIPBLASLT_TENSILE_DIR)
+    rocblas_menu = _enumerate_tensile_menu(ROCBLAS_TENSILE_DIR)
+
+    for lib_name, menu in (("hipblaslt", hipblaslt_menu), ("rocblas", rocblas_menu)):
+        if menu["status"] == "partial":
+            reasons.append(
+                f"tensile_catalog.{lib_name}.menu: "
+                f"{menu['reason'] or 'menu enumeration incomplete'}"
+            )
+
+    block_status = (
+        "ok"
+        if hipblaslt_menu["status"] == "ok" and rocblas_menu["status"] == "ok"
+        else "partial"
+    )
+
+    return {
+        "doc": TENSILE_CATALOG_DOC,
+        "status": block_status,
+        "hipblaslt": {
+            "package_version": hipblaslt.get("package_version"),
+            "lib_hash": hipblaslt.get("lib_hash"),
+            "kernel_db_revision": hipblaslt.get("kernel_db_revision"),
+            "menu": hipblaslt_menu,
+        },
+        "rocblas": {
+            "package_version": rocblas.get("package_version"),
+            "lib_hash": rocblas.get("lib_hash"),
+            "kernel_db_revision": rocblas.get("kernel_db_revision"),
+            "menu": rocblas_menu,
+        },
+        "combined": {
+            "package_version": tensile.get("package_version"),
+            "kernel_db_combined_hash": tensile.get("kernel_db_combined_hash"),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Static MIOpen catalog (issue #54 follow-up) -- conv kernel "recipe book"
+#
+# MIOpen is the convolution analogue of Tensile/hipBLASLt: it ships a
+# frozen, on-disk, runtime-selected set of databases under
+# /opt/rocm/share/miopen/db/. As with Tensile, this is installed-library
+# identity (which find-db/perf-db/kernel-db is on disk), NOT the runtime
+# solver pick (which needs a workload).
+# ---------------------------------------------------------------------------
+
+MIOPEN_CATALOG_DOC = (
+    "Installed-library identity (the 'recipe book') for MIOpen's "
+    "convolution databases on disk: find-db (solver selection), perf-db "
+    "(tuned params), kernel-db (precompiled kernels), and heuristic "
+    "tuning models. Does NOT capture the runtime-selected solver for a "
+    "given conv -- that needs a runtime trace. Enumerated from the "
+    "effective system db dir (honoring MIOPEN_SYSTEM_DB_PATH)."
+)
+
+
+def _resolve_miopen_db_dir() -> tuple[Path, str]:
+    """Return (effective_db_dir, source) honoring MIOPEN_SYSTEM_DB_PATH.
+
+    The runtime reads the read-only system databases from
+    ``$MIOPEN_SYSTEM_DB_PATH`` when set, else the packaged
+    ``MIOPEN_KERNEL_DB_DIR``. We enumerate whichever the runtime would
+    actually use, and record which so a cross-host diff can spot an
+    override pointing at a different catalog.
+    """
+    override = os.environ.get(MIOPEN_SYSTEM_DB_PATH_ENV)
+    if override:
+        return Path(override), MIOPEN_SYSTEM_DB_PATH_ENV
+    return MIOPEN_KERNEL_DB_DIR, "default"
+
+
+def _empty_miopen_catalog() -> dict[str, Any]:
+    """All-null ``miopen_catalog`` for the default / disaster snapshot."""
+    menu = _empty_menu()
+    menu["reason"] = "miopen_catalog not captured"
+    return {
+        "doc": MIOPEN_CATALOG_DOC,
+        "status": "partial",
+        "package_version": None,
+        "lib_hash": None,
+        "kernel_db_revision": None,
+        "db_dir": None,
+        "db_dir_source": None,
+        "env_overrides": {
+            MIOPEN_SYSTEM_DB_PATH_ENV: None,
+            MIOPEN_USER_DB_PATH_ENV: None,
+        },
+        "menu": menu,
+    }
+
+
+def _build_miopen_catalog(
+    miopen: dict[str, Any],
+    reasons: list[str],
+) -> dict[str, Any]:
+    """Assemble the labeled, deepened static ``miopen_catalog`` block.
+
+    No regression: package_version / lib_hash / kernel_db_revision are
+    taken verbatim from the already-captured ``miopen`` block. The new
+    work is the per-file ``menu`` enumeration of the MIOpen db dir.
+    """
+    db_dir, source = _resolve_miopen_db_dir()
+    menu = _enumerate_catalog_dir(
+        db_dir,
+        _suffix_classifier(MIOPEN_CATALOG_SUFFIXES, MIOPEN_LOGIC_SUFFIXES),
+        kind="MIOpen db",
+    )
+    if menu["status"] == "partial":
+        reasons.append(
+            f"miopen_catalog.menu: {menu['reason'] or 'menu enumeration incomplete'}"
+        )
+    # The legacy top-level ``miopen`` block always fingerprints the
+    # packaged MIOPEN_KERNEL_DB_DIR (no regression there -- it doesn't
+    # honor MIOPEN_SYSTEM_DB_PATH). This catalog's ``menu``/``db_dir``
+    # DO honor the override, so ``kernel_db_revision`` must be recomputed
+    # against that same effective directory when an override is active;
+    # otherwise this block would describe two different directories at
+    # once. When there's no override, reuse ``miopen``'s value verbatim
+    # (same directory, no need to hash twice).
+    kernel_db_revision = (
+        miopen.get("kernel_db_revision")
+        if source == "default"
+        else _kernel_db_filename_fingerprint(
+            db_dir, suffixes=MIOPEN_KERNEL_DB_SUFFIXES
+        )
+    )
+    return {
+        "doc": MIOPEN_CATALOG_DOC,
+        "status": menu["status"],
+        "package_version": miopen.get("package_version"),
+        "lib_hash": miopen.get("lib_hash"),
+        "kernel_db_revision": kernel_db_revision,
+        "db_dir": str(db_dir),
+        "db_dir_source": source,
+        "env_overrides": {
+            MIOPEN_SYSTEM_DB_PATH_ENV: os.environ.get(MIOPEN_SYSTEM_DB_PATH_ENV),
+            MIOPEN_USER_DB_PATH_ENV: os.environ.get(MIOPEN_USER_DB_PATH_ENV),
+        },
+        "menu": menu,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Static rocFFT catalog (issue #54 follow-up) -- optional AOT kernel cache
+#
+# rocFFT compiles most kernels at runtime (RTC), so by default there is
+# NO frozen on-disk catalog. It supports an optional ahead-of-time
+# kernel cache (a SQLite file). When present, that file is a frozen,
+# selectable artifact that can drift between hosts -- so we fingerprint
+# it. Absence is the documented common case (status="absent", silent).
+# ---------------------------------------------------------------------------
+
+ROCFFT_CATALOG_DOC = (
+    "Installed-library identity for rocFFT's OPTIONAL ahead-of-time "
+    "kernel cache (rocfft_kernel_cache.db) -- the READ-ONLY system cache, "
+    "NOT the read-write runtime user cache (ROCFFT_RTC_CACHE_PATH). "
+    "rocFFT usually compiles kernels at runtime, so absence is normal "
+    "(status='absent', not a failure). When present, the cache is a "
+    "frozen on-disk artifact and is fingerprinted by content hash. Does "
+    "NOT capture runtime-compiled kernels."
+)
+
+
+def _rocfft_cache_candidates() -> list[tuple[Path, str]]:
+    """Ordered (path, source) candidates for the rocFFT AOT *system* cache.
+
+    Mirrors rocFFT's own read-only-cache resolution (``rtc_cache.cpp``):
+    ``ROCFFT_RTC_SYS_CACHE_PATH`` override first, then the default
+    install locations relative to the rocFFT lib dir --
+    ``rocfft_kernel_cache.db`` directly, or nested under ``rocfft/``
+    (both layouts have shipped). Deliberately does NOT consult
+    ``ROCFFT_RTC_CACHE_PATH`` -- that is the read-write, per-process
+    *user* cache, populated on demand at runtime; fingerprinting it as
+    installed-library identity would conflate a mutable runtime artifact
+    with a static one.
+    """
+    candidates: list[tuple[Path, str]] = []
+    override = os.environ.get(ROCFFT_RTC_SYS_CACHE_PATH_ENV)
+    if override:
+        p = Path(override)
+        # The env var may point at a file directly or at a containing dir.
+        candidates.append((p, ROCFFT_RTC_SYS_CACHE_PATH_ENV))
+        candidates.append(
+            (p / ROCFFT_KERNEL_CACHE_NAME, ROCFFT_RTC_SYS_CACHE_PATH_ENV)
+        )
+    candidates.append((ROCFFT_LIB_DIR / ROCFFT_KERNEL_CACHE_NAME, "rocm_lib"))
+    candidates.append(
+        (ROCFFT_LIB_DIR / "rocfft" / ROCFFT_KERNEL_CACHE_NAME, "rocm_lib")
+    )
+    return candidates
+
+
+def _empty_rocfft_catalog() -> dict[str, Any]:
+    """Not-captured ``rocfft_catalog`` for the default / disaster snapshot.
+
+    Status is ``"partial"`` with a "not captured" reason -- deliberately
+    NOT ``"absent"``. ``"absent"`` is reserved for ``_build_rocfft_catalog``
+    after it has actually probed and found no cache; the default/backfill/
+    disaster shape must be distinguishable from that "we checked, nothing
+    there" outcome (mirrors the ``"X not captured"`` reason the Tensile/
+    MIOpen empty menus use).
+    """
+    return {
+        "doc": ROCFFT_CATALOG_DOC,
+        "status": "partial",
+        # Record both override values even when no cache is found, so a
+        # host that configured either is distinguishable from one that
+        # never set them (mirrors miopen_catalog.env_overrides). Only
+        # ROCFFT_RTC_SYS_CACHE_PATH affects which file is resolved above;
+        # ROCFFT_RTC_CACHE_PATH is recorded for visibility only -- it is
+        # the mutable runtime user cache, not installed identity.
+        "env_overrides": {
+            ROCFFT_RTC_SYS_CACHE_PATH_ENV: None,
+            ROCFFT_RTC_CACHE_PATH_ENV: None,
+        },
+        "kernel_cache": {
+            "present": False,
+            "path": None,
+            "source": None,
+            "size": None,
+            "sha256": None,
+            "reason": "rocfft_catalog not captured",
+        },
+    }
+
+
+def _build_rocfft_catalog(reasons: list[str]) -> dict[str, Any]:
+    """Assemble the static ``rocfft_catalog`` block.
+
+    Absence is silent (no partial_reason) -- rocFFT shipping no AOT cache
+    is the norm. Only a cache that is *present but unreadable* downgrades
+    to ``partial`` and records a reason, so "we found a cache we couldn't
+    hash" is distinguishable from "there is no cache".
+    """
+    block = _empty_rocfft_catalog()
+    # We are now actually probing -- promote the "not captured" default to
+    # a clean "absent" (no reason). A real "checked, no cache" outcome
+    # must be distinguishable from the not-captured default/backfill.
+    block["status"] = "absent"
+    block["kernel_cache"]["reason"] = None
+    # Capture both override values regardless of whether a cache is
+    # found, so cross-host diffs surface a configured-but-empty RTC
+    # cache path for either variable.
+    block["env_overrides"] = {
+        ROCFFT_RTC_SYS_CACHE_PATH_ENV: os.environ.get(ROCFFT_RTC_SYS_CACHE_PATH_ENV),
+        ROCFFT_RTC_CACHE_PATH_ENV: os.environ.get(ROCFFT_RTC_CACHE_PATH_ENV),
+    }
+    for path, source in _rocfft_cache_candidates():
+        try:
+            is_file = path.is_file()
+        except OSError:
+            is_file = False
+        if not is_file:
+            continue
+        sha = _hash_file_path(path)
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = None
+        if sha is None:
+            reasons.append(
+                f"rocfft_catalog.kernel_cache: present but unreadable at {path}"
+            )
+            block["status"] = "partial"
+            block["kernel_cache"] = {
+                "present": True,
+                "path": str(path),
+                "source": source,
+                "size": size,
+                "sha256": None,
+                "reason": "cache file present but could not be hashed",
+            }
+            return block
+        block["status"] = "ok"
+        block["kernel_cache"] = {
+            "present": True,
+            "path": str(path),
+            "source": source,
+            "size": size,
+            "sha256": sha,
+            "reason": None,
+        }
+        return block
+    # No candidate matched -- documented common case, stays "absent".
+    return block
 
 
 # ---------------------------------------------------------------------------

--- a/tests/instrumentation/test_build_system.py
+++ b/tests/instrumentation/test_build_system.py
@@ -125,6 +125,7 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
         ("MIOPEN_VERSION_HEADER", "no_miopen_version.h"),
         ("MIOPEN_LIB_DIR", "no_miopen_libs"),
         ("MIOPEN_KERNEL_DB_DIR", "no_miopen_db"),
+        ("ROCFFT_LIB_DIR", "no_rocfft"),
         ("RCCL_VERSION_HEADER", "no_rccl.h"),
         ("RCCL_LIB_DIR", "no_rccl_libs"),
         ("DOCKERENV_MARKER", "no_dockerenv"),
@@ -133,6 +134,13 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
         ("SELF_CGROUP_FILE", "no_self_cgroup"),
     ):
         monkeypatch.setattr(env_mod, attr, tmp_path / leaf)
+    # Catalog probes also read env-var overrides; clear them so these
+    # tests never touch a host ROCFFT_RTC_SYS_CACHE_PATH / ROCFFT_RTC_CACHE_PATH
+    # / MIOPEN_SYSTEM_DB_PATH and stay hermetic (mirrors
+    # test_environment.py::all_disabled).
+    monkeypatch.delenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, raising=False)
+    monkeypatch.delenv(env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, raising=False)
+    monkeypatch.delenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, raising=False)
     # Disable every external binary lookup. Tests that DO want buck2
     # present override this via their own ``bs_mod.detect_build_system``
     # monkeypatch (i.e., they bypass shutil.which entirely).

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -107,6 +107,10 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
     )
     monkeypatch.setattr(env_mod, "MIOPEN_LIB_DIR", tmp_path / "no_miopen_libs")
     monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", tmp_path / "no_miopen_db")
+    monkeypatch.setattr(env_mod, "ROCFFT_LIB_DIR", tmp_path / "no_rocfft")
+    monkeypatch.delenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, raising=False)
+    monkeypatch.delenv(env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, raising=False)
+    monkeypatch.delenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, raising=False)
     monkeypatch.setattr(
         env_mod, "RCCL_VERSION_HEADER", tmp_path / "no_rccl.h"
     )
@@ -163,6 +167,7 @@ class TestPathConstants:
             "MIOPEN_VERSION_HEADER",
             "MIOPEN_LIB_DIR",
             "MIOPEN_KERNEL_DB_DIR",
+            "ROCFFT_LIB_DIR",
             "RCCL_VERSION_HEADER",
             "RCCL_LIB_DIR",
             "SYS_CLASS_NET",
@@ -208,6 +213,7 @@ class TestPathConstants:
             "MIOPEN_VERSION_HEADER",
             "MIOPEN_LIB_DIR",
             "MIOPEN_KERNEL_DB_DIR",
+            "ROCFFT_LIB_DIR",
             "RCCL_VERSION_HEADER",
             "RCCL_LIB_DIR",
             "SYS_CLASS_NET",
@@ -249,6 +255,9 @@ REQUIRED_TOP_KEYS = {
     "rocblas",
     "composable_kernel",
     "tensile",
+    "tensile_catalog",
+    "miopen_catalog",
+    "rocfft_catalog",
     "triton",
     "fbgemm",
     "aiter",
@@ -277,7 +286,7 @@ class TestSchemaCompleteness:
     ):
         snapshot = collect_env()
         assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
-        assert snapshot.schema_version == "1.8"
+        assert snapshot.schema_version == "1.9"
         assert snapshot.system_health is None
         assert snapshot.rocm == {
             "version": None,
@@ -531,6 +540,27 @@ class TestEnvSnapshot:
         del d["partial_reasons"]
         rebuilt = EnvSnapshot.from_dict(d)
         assert rebuilt.partial_reasons == []
+
+    @pytest.mark.parametrize(
+        "key,empty_factory",
+        [
+            ("tensile_catalog", env_mod._empty_tensile_catalog),
+            ("miopen_catalog", env_mod._empty_miopen_catalog),
+            ("rocfft_catalog", env_mod._empty_rocfft_catalog),
+        ],
+    )
+    def test_from_dict_backfills_missing_catalog_key(self, key, empty_factory):
+        """A pre-1.9 env.json predates the three catalog blocks entirely.
+
+        ``docs/env-probe.md`` promises that ``from_dict()`` back-fills the
+        "not captured" empty shape for each; this is the regression guard
+        for that promise (nothing previously exercised the deletion case,
+        only the "key present with real data" round-trip).
+        """
+        d = _example_snapshot().to_dict()
+        del d[key]
+        rebuilt = EnvSnapshot.from_dict(d)
+        assert getattr(rebuilt, key) == empty_factory()
 
     def test_summary_does_not_duplicate_partial_marker(self):
         """The brief returned by ``summary()`` is the *body* of what the
@@ -3379,6 +3409,542 @@ class TestTensileBlock:
         assert any(
             r.startswith("tensile.kernel_db_combined_hash:") for r in reasons
         )
+
+
+# ---------------------------------------------------------------------------
+# Static Tensile catalog (issue #54)
+# ---------------------------------------------------------------------------
+
+
+def _make_tensile_install(directory: Path, *, archs=("gfx942",), content=b"menu"):
+    """Stand up a synthetic Tensile library dir and return it.
+
+    Mirrors a modern hipBLASLt/rocBLAS layout: per-arch ``.dat`` logic
+    files, a ``TensileManifest.txt``, and a ``.hsaco`` code object.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    for arch in archs:
+        (directory / f"TensileLibrary_lazy_{arch}.dat").write_bytes(
+            content + arch.encode()
+        )
+        (directory / f"Kernels.so-000-{arch}.hsaco").write_bytes(b"obj-" + arch.encode())
+    (directory / "TensileManifest.txt").write_text("\n".join(archs) + "\n")
+    return directory
+
+
+class TestTensileMenuEnumeration:
+    def test_missing_dir_is_partial_not_silent(self, tmp_path: Path):
+        menu = env_mod._enumerate_tensile_menu(tmp_path / "does_not_exist")
+        assert menu["status"] == "partial"
+        assert menu["reason"] is not None
+        assert menu["files"] is None
+        # A "couldn't read" probe must be distinguishable from an empty menu.
+        assert menu["logic_file_count"] is None
+
+    def test_present_but_empty_is_ok_with_zero_count(self, tmp_path: Path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        menu = env_mod._enumerate_tensile_menu(empty)
+        assert menu["status"] == "ok"
+        assert menu["logic_file_count"] == 0
+        assert menu["file_count"] == 0
+        assert menu["gfx_arch_coverage"] == []
+
+    def test_enumerates_count_archs_and_per_file_hashes(self, tmp_path: Path):
+        d = _make_tensile_install(tmp_path / "lib", archs=("gfx942", "gfx90a"))
+        menu = env_mod._enumerate_tensile_menu(d)
+        assert menu["status"] == "ok"
+        # Two .dat logic files (one per arch); .hsaco + .txt are not "logic".
+        assert menu["logic_file_count"] == 2
+        assert menu["file_count"] == 5  # 2 dat + 2 hsaco + 1 manifest
+        assert menu["gfx_arch_coverage"] == ["gfx90a", "gfx942"]
+        # Every file carries a content hash + size; logic flag set right.
+        for f in menu["files"]:
+            assert f["sha256"].startswith("sha256:")
+            assert isinstance(f["size"], int)
+        logic = [f for f in menu["files"] if f["is_logic"]]
+        assert {f["suffix"] for f in logic} == {".dat"}
+
+    def test_hashes_are_stable_across_calls(self, tmp_path: Path):
+        d = _make_tensile_install(tmp_path / "lib")
+        first = env_mod._enumerate_tensile_menu(d)
+        second = env_mod._enumerate_tensile_menu(d)
+        assert first == second
+        assert first["combined_content_hash"] == second["combined_content_hash"]
+
+    def test_two_install_diff_surfaces_changed_logic_file(self, tmp_path: Path):
+        """The core acceptance scenario: same filenames, changed bytes."""
+        host_a = _make_tensile_install(tmp_path / "a", content=b"menuA")
+        host_b = _make_tensile_install(tmp_path / "b", content=b"menuB")
+        menu_a = env_mod._enumerate_tensile_menu(host_a)
+        menu_b = env_mod._enumerate_tensile_menu(host_b)
+
+        # The shallow filename fingerprint can't tell these apart...
+        assert env_mod._kernel_db_filename_fingerprint(
+            host_a
+        ) == env_mod._kernel_db_filename_fingerprint(host_b)
+        # ...but the deepened per-file content enumeration does.
+        assert menu_a["combined_content_hash"] != menu_b["combined_content_hash"]
+
+        by_name_a = {f["name"]: f["sha256"] for f in menu_a["files"]}
+        by_name_b = {f["name"]: f["sha256"] for f in menu_b["files"]}
+        changed = [n for n in by_name_a if by_name_a[n] != by_name_b[n]]
+        # Diff localizes exactly the logic + code-object files (manifest
+        # content is identical), not just "something differs".
+        assert "TensileLibrary_lazy_gfx942.dat" in changed
+        assert "TensileManifest.txt" not in changed
+
+    def test_extract_gfx_archs_dedups_and_lowercases(self):
+        names = ["TensileLibrary_GFX90A.dat", "x_gfx90a.dat", "y_gfx942.co", "none.dat"]
+        assert env_mod._extract_gfx_archs(names) == ["gfx90a", "gfx942"]
+
+    def test_combined_hash_is_none_when_a_file_hash_fails(self, tmp_path, monkeypatch):
+        """A combined hash over a missing per-file hash isn't a true
+        content fingerprint -- it must be None, not a content-sha256:
+        value (Copilot review on PR #228).
+        """
+        d = _make_tensile_install(tmp_path / "lib", archs=("gfx942",))
+        victim = "TensileLibrary_lazy_gfx942.dat"
+        real_hash = env_mod._hash_file_path
+
+        def flaky_hash(path):
+            if path.name == victim:
+                return None  # simulate an unreadable file
+            return real_hash(path)
+
+        monkeypatch.setattr(env_mod, "_hash_file_path", flaky_hash)
+        menu = env_mod._enumerate_tensile_menu(d)
+        assert menu["status"] == "partial"
+        assert menu["combined_content_hash"] is None
+        # The unreadable file is still listed (not dropped), with sha256 None.
+        victim_entry = [f for f in menu["files"] if f["name"] == victim][0]
+        assert victim_entry["sha256"] is None
+
+    def test_broken_symlink_matching_catalog_suffix_is_not_silently_dropped(
+        self, tmp_path: Path
+    ):
+        """A broken symlink whose name matches a catalog suffix must be
+        listed in ``files`` with ``sha256: None`` and downgrade the menu
+        to ``partial`` -- not silently vanish from the enumeration.
+
+        The original implementation skipped any entry whose ``is_file()``
+        raised ``OSError`` (which a broken symlink does) before it ever
+        reached the hashing step that would otherwise catch this, so a
+        host with one broken/dangling logic file could report a clean
+        ``status: "ok"`` with a ``combined_content_hash`` that silently
+        omitted it.
+        """
+        d = _make_tensile_install(tmp_path / "lib", archs=("gfx942",))
+        broken = d / "TensileLibrary_lazy_gfx90a.dat"
+        broken.symlink_to(d / "does_not_exist.dat")
+
+        menu = env_mod._enumerate_tensile_menu(d)
+        assert menu["status"] == "partial"
+        assert menu["reason"] is not None
+        names = [f["name"] for f in menu["files"]]
+        assert broken.name in names, "matched filename must not be silently dropped"
+        broken_entry = [f for f in menu["files"] if f["name"] == broken.name][0]
+        assert broken_entry["sha256"] is None
+        assert menu["combined_content_hash"] is None
+
+
+class TestTensileCatalogBlock:
+    def test_default_and_disaster_shapes_match_built_block(self, tmp_path: Path):
+        built = env_mod._build_tensile_catalog(
+            {"package_version": None, "lib_hash": None, "kernel_db_revision": None},
+            {"package_version": None, "lib_hash": None, "kernel_db_revision": None},
+            {"package_version": None, "kernel_db_combined_hash": None},
+            [],
+        )
+        empty = env_mod._empty_tensile_catalog()
+        assert set(built.keys()) == set(empty.keys())
+        assert set(built["hipblaslt"].keys()) == set(empty["hipblaslt"].keys())
+        assert set(built["hipblaslt"]["menu"].keys()) == set(
+            empty["hipblaslt"]["menu"].keys()
+        )
+
+    def test_preserves_existing_identity_fields_no_regression(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            env_mod, "HIPBLASLT_TENSILE_DIR", _make_tensile_install(tmp_path / "hb")
+        )
+        monkeypatch.setattr(
+            env_mod, "ROCBLAS_TENSILE_DIR", _make_tensile_install(tmp_path / "rb")
+        )
+        hipblaslt = {
+            "package_version": "1.2.0",
+            "lib_hash": "sha256:aa",
+            "kernel_db_revision": "filenames-sha256:bb",
+        }
+        rocblas = {
+            "package_version": "5.0.2",
+            "lib_hash": "sha256:cc",
+            "kernel_db_revision": "filenames-sha256:dd",
+        }
+        tensile = {
+            "package_version": None,
+            "kernel_db_combined_hash": "filenames-sha256:ee",
+        }
+        block = env_mod._build_tensile_catalog(hipblaslt, rocblas, tensile, [])
+        # Existing hashes flow through verbatim -- no regression.
+        assert block["hipblaslt"]["lib_hash"] == "sha256:aa"
+        assert block["hipblaslt"]["kernel_db_revision"] == "filenames-sha256:bb"
+        assert block["rocblas"]["lib_hash"] == "sha256:cc"
+        assert block["combined"]["kernel_db_combined_hash"] == "filenames-sha256:ee"
+        assert block["status"] == "ok"
+
+    def test_partial_threads_reason_into_partial_reasons(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            env_mod, "HIPBLASLT_TENSILE_DIR", _make_tensile_install(tmp_path / "hb")
+        )
+        monkeypatch.setattr(
+            env_mod, "ROCBLAS_TENSILE_DIR", tmp_path / "missing_rocblas"
+        )
+        reasons: list[str] = []
+        block = env_mod._build_tensile_catalog(
+            {"package_version": None, "lib_hash": None, "kernel_db_revision": None},
+            {"package_version": None, "lib_hash": None, "kernel_db_revision": None},
+            {"package_version": None, "kernel_db_combined_hash": None},
+            reasons,
+        )
+        assert block["status"] == "partial"
+        assert block["rocblas"]["menu"]["status"] == "partial"
+        assert block["hipblaslt"]["menu"]["status"] == "ok"
+        assert any(
+            r.startswith("tensile_catalog.rocblas.menu:") for r in reasons
+        )
+
+    def test_doc_is_labeled_as_installed_identity_not_runtime(self):
+        doc = env_mod._empty_tensile_catalog()["doc"]
+        assert "recipe book" in doc.lower()
+        assert "381881" in doc or "368xxx" in doc  # explicitly disclaims the runtime pick
+
+    def test_block_present_in_collect_env_snapshot(self, all_disabled):
+        snap = collect_env()
+        d = snap.to_dict()
+        assert "tensile_catalog" in d
+        assert set(d["tensile_catalog"].keys()) == {
+            "doc",
+            "status",
+            "hipblaslt",
+            "rocblas",
+            "combined",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Static MIOpen catalog (issue #54 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def _make_miopen_db(directory: Path, *, archs=("gfx942_120",), content=b"db"):
+    """Stand up a synthetic MIOpen db dir (find-db, perf-db, model, kdb)."""
+    directory.mkdir(parents=True, exist_ok=True)
+    for arch in archs:
+        (directory / f"{arch}.HIP.fdb.txt").write_bytes(content + b"-fdb")
+        (directory / f"{arch}.db.txt").write_bytes(content + b"-perf")
+        (directory / f"{arch}.kdb").write_bytes(content + b"-kdb")
+    (directory / "gfx908.tn.model").write_bytes(b"heuristic-model")
+    return directory
+
+
+class TestMiopenCatalogBlock:
+    def test_enumerates_dbs_archs_and_logic_count(self, tmp_path, monkeypatch):
+        d = _make_miopen_db(tmp_path / "db", archs=("gfx942_120", "gfx90a_104"))
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", d)
+        monkeypatch.delenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, raising=False)
+        block = env_mod._build_miopen_catalog(
+            {"package_version": "3.5.0", "lib_hash": "sha256:aa",
+             "kernel_db_revision": "filenames-sha256:bb"},
+            [],
+        )
+        assert block["status"] == "ok"
+        # 2 archs x (fdb + perf + kdb) = 6 logic dbs; +1 model = 7 files.
+        assert block["menu"]["logic_file_count"] == 6
+        assert block["menu"]["file_count"] == 7
+        assert block["menu"]["gfx_arch_coverage"] == ["gfx908", "gfx90a", "gfx942"]
+        # No regression: identity fields pass through verbatim.
+        assert block["lib_hash"] == "sha256:aa"
+        assert block["kernel_db_revision"] == "filenames-sha256:bb"
+        assert block["db_dir_source"] == "default"
+        # The .model file is catalog-but-not-logic.
+        model = [f for f in block["menu"]["files"] if f["name"].endswith(".model")][0]
+        assert model["is_logic"] is False
+        assert model["suffix"] == ".tn.model"
+
+    def test_multipart_suffix_labeled_correctly(self, tmp_path, monkeypatch):
+        d = _make_miopen_db(tmp_path / "db")
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", d)
+        monkeypatch.delenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, raising=False)
+        block = env_mod._build_miopen_catalog({}, [])
+        suffixes = {f["name"]: f["suffix"] for f in block["menu"]["files"]}
+        # find-db keeps its full multi-part suffix, not pathlib's bare .txt
+        assert suffixes["gfx942_120.HIP.fdb.txt"] == ".fdb.txt"
+        assert suffixes["gfx942_120.db.txt"] == ".db.txt"
+        assert suffixes["gfx942_120.kdb"] == ".kdb"
+
+    def test_system_db_path_override_is_honored_and_recorded(self, tmp_path, monkeypatch):
+        override = _make_miopen_db(tmp_path / "override_db")
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", tmp_path / "default_unused")
+        monkeypatch.setenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, str(override))
+        block = env_mod._build_miopen_catalog({}, [])
+        assert block["db_dir"] == str(override)
+        assert block["db_dir_source"] == env_mod.MIOPEN_SYSTEM_DB_PATH_ENV
+        assert block["status"] == "ok"
+        assert block["env_overrides"][env_mod.MIOPEN_SYSTEM_DB_PATH_ENV] == str(override)
+
+    def test_kernel_db_revision_follows_system_db_path_override(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression: ``kernel_db_revision`` must describe the SAME
+        directory as ``db_dir``/``menu`` when ``MIOPEN_SYSTEM_DB_PATH``
+        is set. Copying the legacy top-level ``miopen`` block's value
+        verbatim would silently describe the packaged default dir while
+        ``db_dir``/``menu`` describe the override -- one block, two
+        different directories.
+        """
+        default_dir = _make_miopen_db(tmp_path / "default_db", archs=("gfx908_60",))
+        override_dir = _make_miopen_db(
+            tmp_path / "override_db", archs=("gfx942_120", "gfx90a_104")
+        )
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", default_dir)
+        monkeypatch.setenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, str(override_dir))
+
+        # The stale value a naive "copy the top-level field verbatim"
+        # implementation would have used.
+        stale_kernel_db_revision = env_mod._kernel_db_filename_fingerprint(
+            default_dir, suffixes=env_mod.MIOPEN_KERNEL_DB_SUFFIXES
+        )
+        block = env_mod._build_miopen_catalog(
+            {"kernel_db_revision": stale_kernel_db_revision}, []
+        )
+
+        expected = env_mod._kernel_db_filename_fingerprint(
+            override_dir, suffixes=env_mod.MIOPEN_KERNEL_DB_SUFFIXES
+        )
+        assert block["db_dir"] == str(override_dir)
+        assert block["kernel_db_revision"] == expected
+        assert block["kernel_db_revision"] != stale_kernel_db_revision
+
+    def test_kernel_db_revision_reuses_top_level_value_when_no_override(
+        self, tmp_path, monkeypatch
+    ):
+        """No-regression case: without an override, reuse the already-
+        computed top-level ``miopen.kernel_db_revision`` verbatim rather
+        than fingerprinting the directory a second time.
+        """
+        d = _make_miopen_db(tmp_path / "db")
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", d)
+        monkeypatch.delenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, raising=False)
+        sentinel = "filenames-sha256:sentinel-from-top-level-miopen-block"
+        block = env_mod._build_miopen_catalog(
+            {"kernel_db_revision": sentinel}, []
+        )
+        assert block["db_dir_source"] == "default"
+        assert block["kernel_db_revision"] == sentinel
+
+    def test_missing_dir_is_partial_and_threads_reason(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", tmp_path / "nope")
+        monkeypatch.delenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, raising=False)
+        reasons: list[str] = []
+        block = env_mod._build_miopen_catalog({}, reasons)
+        assert block["status"] == "partial"
+        assert any(r.startswith("miopen_catalog.menu:") for r in reasons)
+
+    def test_two_install_diff_localizes_changed_db(self, tmp_path, monkeypatch):
+        a = _make_miopen_db(tmp_path / "a", content=b"hostA")
+        b = _make_miopen_db(tmp_path / "b", content=b"hostB")
+        ma = env_mod._enumerate_catalog_dir(
+            a, env_mod._suffix_classifier(
+                env_mod.MIOPEN_CATALOG_SUFFIXES, env_mod.MIOPEN_LOGIC_SUFFIXES),
+            kind="MIOpen db")
+        mb = env_mod._enumerate_catalog_dir(
+            b, env_mod._suffix_classifier(
+                env_mod.MIOPEN_CATALOG_SUFFIXES, env_mod.MIOPEN_LOGIC_SUFFIXES),
+            kind="MIOpen db")
+        assert ma["combined_content_hash"] != mb["combined_content_hash"]
+
+    def test_block_present_and_shaped_in_snapshot(self, all_disabled):
+        d = collect_env().to_dict()
+        assert set(d["miopen_catalog"].keys()) == {
+            "doc", "status", "package_version", "lib_hash", "kernel_db_revision",
+            "db_dir", "db_dir_source", "env_overrides", "menu",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Static rocFFT catalog (issue #54 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestRocfftCatalogBlock:
+    def test_absent_when_no_cache_is_silent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(env_mod, "ROCFFT_LIB_DIR", tmp_path / "nope")
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, raising=False)
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, raising=False)
+        reasons: list[str] = []
+        block = env_mod._build_rocfft_catalog(reasons)
+        assert block["status"] == "absent"
+        assert block["kernel_cache"]["present"] is False
+        # Absence is the documented common case -- NOT partial.
+        assert reasons == []
+
+    def test_present_cache_is_fingerprinted(self, tmp_path, monkeypatch):
+        (tmp_path / env_mod.ROCFFT_KERNEL_CACHE_NAME).write_bytes(b"sqlite-bytes")
+        monkeypatch.setattr(env_mod, "ROCFFT_LIB_DIR", tmp_path)
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, raising=False)
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, raising=False)
+        block = env_mod._build_rocfft_catalog([])
+        assert block["status"] == "ok"
+        assert block["kernel_cache"]["present"] is True
+        assert block["kernel_cache"]["sha256"].startswith("sha256:")
+        assert block["kernel_cache"]["source"] == "rocm_lib"
+        assert block["kernel_cache"]["size"] == len(b"sqlite-bytes")
+
+    def test_nested_rocfft_subdir_layout_resolves(self, tmp_path, monkeypatch):
+        """Some installs ship the cache under ``lib/rocfft/`` rather than
+        directly in ``lib/`` -- both are real default layouts per
+        rocFFT's ``rtc_cache.cpp`` search order.
+        """
+        nested = tmp_path / "rocfft" / env_mod.ROCFFT_KERNEL_CACHE_NAME
+        nested.parent.mkdir(parents=True)
+        nested.write_bytes(b"nested-cache")
+        monkeypatch.setattr(env_mod, "ROCFFT_LIB_DIR", tmp_path)
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, raising=False)
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, raising=False)
+        block = env_mod._build_rocfft_catalog([])
+        assert block["status"] == "ok"
+        assert block["kernel_cache"]["path"] == str(nested)
+        assert block["kernel_cache"]["source"] == "rocm_lib"
+
+    def test_rtc_sys_cache_path_env_override_wins(self, tmp_path, monkeypatch):
+        """ROCFFT_RTC_SYS_CACHE_PATH is the read-only system-cache override
+        -- the one that matters for installed-library identity.
+        """
+        cache = tmp_path / "custom" / env_mod.ROCFFT_KERNEL_CACHE_NAME
+        cache.parent.mkdir(parents=True)
+        cache.write_bytes(b"override-cache")
+        monkeypatch.setattr(env_mod, "ROCFFT_LIB_DIR", tmp_path / "rocm_unused")
+        monkeypatch.setenv(env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, str(cache.parent))
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, raising=False)
+        block = env_mod._build_rocfft_catalog([])
+        assert block["status"] == "ok"
+        assert block["kernel_cache"]["path"] == str(cache)
+        assert block["kernel_cache"]["source"] == env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV
+
+    def test_rtc_cache_path_env_alone_is_not_used_for_resolution(
+        self, tmp_path, monkeypatch
+    ):
+        """ROCFFT_RTC_CACHE_PATH is the read-write, per-process USER cache
+        -- mutable and workload-dependent, not installed-library identity.
+        A cache file sitting there must NOT be fingerprinted as the
+        static catalog, even though it is recorded for visibility.
+        """
+        user_cache_dir = tmp_path / "user_cache"
+        user_cache_dir.mkdir()
+        (user_cache_dir / env_mod.ROCFFT_KERNEL_CACHE_NAME).write_bytes(b"mutable")
+        monkeypatch.setattr(env_mod, "ROCFFT_LIB_DIR", tmp_path / "no_system_cache")
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, raising=False)
+        monkeypatch.setenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, str(user_cache_dir))
+        block = env_mod._build_rocfft_catalog([])
+        # No system cache found -- must stay "absent", NOT resolve the
+        # mutable user cache as installed identity.
+        assert block["status"] == "absent"
+        assert block["kernel_cache"]["present"] is False
+        # Still recorded for visibility.
+        assert block["env_overrides"][env_mod.ROCFFT_RTC_CACHE_PATH_ENV] == str(
+            user_cache_dir
+        )
+
+    def test_override_recorded_even_when_cache_absent(self, tmp_path, monkeypatch):
+        """Configured RTC-cache paths are captured even with no cache file.
+
+        Distinguishes "override set, but no cache shipped" from "override
+        never set" -- the case Copilot flagged on PR #228. Covers both
+        the system-cache and user-cache override variables.
+        """
+        monkeypatch.setattr(env_mod, "ROCFFT_LIB_DIR", tmp_path / "nope")
+        monkeypatch.setenv(
+            env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, "/some/configured/sys/dir"
+        )
+        monkeypatch.setenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, "/some/configured/dir")
+        block = env_mod._build_rocfft_catalog([])
+        assert block["status"] == "absent"
+        assert block["kernel_cache"]["present"] is False
+        assert block["env_overrides"][env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV] == (
+            "/some/configured/sys/dir"
+        )
+        assert block["env_overrides"][env_mod.ROCFFT_RTC_CACHE_PATH_ENV] == (
+            "/some/configured/dir"
+        )
+
+    def test_not_captured_default_distinct_from_probed_absent(self, tmp_path, monkeypatch):
+        """The default/backfill shape must be distinguishable from a probe
+        that ran and found no cache (Copilot review on PR #228).
+        """
+        # Default / disaster / from_dict backfill shape: "not captured".
+        default = env_mod._empty_rocfft_catalog()
+        assert default["status"] == "partial"
+        assert default["kernel_cache"]["reason"] == "rocfft_catalog not captured"
+        # A real probe that finds nothing: clean "absent", no reason.
+        monkeypatch.setattr(env_mod, "ROCFFT_LIB_DIR", tmp_path / "nope")
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV, raising=False)
+        monkeypatch.delenv(env_mod.ROCFFT_RTC_CACHE_PATH_ENV, raising=False)
+        probed = env_mod._build_rocfft_catalog([])
+        assert probed["status"] == "absent"
+        assert probed["kernel_cache"]["reason"] is None
+
+    def test_block_present_and_shaped_in_snapshot(self, all_disabled):
+        d = collect_env().to_dict()
+        assert set(d["rocfft_catalog"].keys()) == {
+            "doc", "status", "env_overrides", "kernel_cache",
+        }
+        assert set(d["rocfft_catalog"]["env_overrides"].keys()) == {
+            env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV,
+            env_mod.ROCFFT_RTC_CACHE_PATH_ENV,
+        }
+
+    def test_summary_renders_present_unreadable_not_present_none(self, all_disabled):
+        """A present-but-unhashable cache must not render as "present None"
+        in the CLI brief (Copilot review on PR #228).
+        """
+        d = collect_env().to_dict()
+        d["rocfft_catalog"] = {
+            "doc": "x",
+            "status": "partial",
+            "env_overrides": {
+                env_mod.ROCFFT_RTC_SYS_CACHE_PATH_ENV: None,
+                env_mod.ROCFFT_RTC_CACHE_PATH_ENV: None,
+            },
+            "kernel_cache": {
+                "present": True, "path": "/x", "source": "rocm_lib",
+                "size": 10, "sha256": None,
+                "reason": "cache file present but could not be hashed",
+            },
+        }
+        snap = env_mod.EnvSnapshot.from_dict(d)
+        catalog_line = [l for l in snap.summary().splitlines() if "catalog:" in l][0]
+        assert "rocfft=present (unreadable)" in catalog_line
+        assert "present None" not in catalog_line
+
+    def test_summary_renders_dash_not_none_for_not_captured_hashes(self):
+        """A not-captured catalog (e.g. a pre-1.9 snapshot backfilled via
+        ``from_dict``) must render its missing per-menu hashes as ``-``,
+        not the literal string ``"None"`` -- the same ambiguity
+        ``pkg_state()`` avoids elsewhere.
+        """
+        d = _example_snapshot().to_dict()
+        del d["tensile_catalog"]
+        del d["miopen_catalog"]
+        del d["rocfft_catalog"]
+        snap = env_mod.EnvSnapshot.from_dict(d)
+        catalog_line = [l for l in snap.summary().splitlines() if "catalog:" in l][0]
+        assert "None" not in catalog_line
+        assert "tensile[hb=- rb=-]" in catalog_line
+        assert "miopen=-" in catalog_line
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds three top-level blocks to `aorta env probe` that deepen and clearly label the static capture of on-disk, runtime-selected GPU-compute kernel/solution catalogs — the **"recipe book"** (installed-library identity), explicitly **not** the runtime-selected solution/solver ID (`381881`/`368xxx`), which needs a workload trace and stays out of scope for the no-compute probe.

Implements [ROCm/aorta-internal#54](https://github.com/ROCm/aorta-internal/issues/54) plus the two backend follow-ups it asked us to file (MIOpen, rocFFT).

- **`tensile_catalog`** (#54): reuses the existing `hipblaslt`/`rocblas`/`tensile` captures (no regression) + a per-file `menu` enumeration of the frozen Tensile solution library (`TensileLibrary`/`*.dat`/`*.yaml`/`*.co`/`*.hsaco`): per-file content `sha256` + size, `logic_file_count`, `gfx_arch_coverage`, and `combined_content_hash` — so a two-host diff localizes *which* logic file differs (the `7e32d53eb1` "same commit, different install" case).
- **`miopen_catalog`** (#54 follow-up): same treatment for MIOpen's databases under `/opt/rocm/share/miopen/db/` (`.kdb` kernel-db, `.fdb.txt` find-db, `.db.txt`/`.db` perf-db, plus `.ktn.model`/`.tn.model` heuristic nets); honors `MIOPEN_SYSTEM_DB_PATH` (records `db_dir`/`db_dir_source`) and surfaces `MIOPEN_USER_DB_PATH`.
- **`rocfft_catalog`** (#54 follow-up): fingerprints rocFFT's *optional* AOT `rocfft_kernel_cache.db` when present; absence is the common case (`status:"absent"`, no partial reason).

**Partial-not-silent:** a dir that can't be located/listed is `status:"partial"` with a reason (distinct from a present-but-empty menu, which is `ok` with `logic_file_count:0`). All three are additive defaulted dataclass fields, so older readers drop the unknown keys and `from_dict` back-fills.

### Schema numbering
Schema `1.7 -> 1.9`. **1.8 is intentionally reserved for #226** (env-probe Buck-target libtorch recovery), which is expected to land first; this branch is cut from `main` (1.7) and skips to 1.9 so the two in-flight env-probe PRs stay monotonic. If the merge order flips, renumber on rebase.

## Test plan

- [x] `pytest tests/instrumentation/test_environment.py` — 384 passed (2 pre-existing env-only failures: no `triton` / `aorta` not installed in the bare runner; both pass on a real node).
- [x] Verified on a real ROCm 7.0.2.2 MI350 node: `tensile_catalog` enumerates 1485 hipBLASLt + 505 rocBLAS logic files across 11–12 gfx arches; `miopen_catalog` 27 logic DBs across the conv db dir; `rocfft_catalog` absent (no AOT cache shipped). Full `collect_env` ~4–6s, no GPU compute.
- [x] Two-install diff (real data): identical filename fingerprint but differing per-file content hashes correctly localizes the single mutated logic file.
- [ ] Reviewer: confirm schema-version sequencing vs #226 before merge.

Made with [Cursor](https://cursor.com)