### PR TITLE
probe: derive failure_details[].type from actual exit state (#229)

### DIFF
--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -756,8 +756,10 @@ class SubprocessWorkload(Workload):
                     {
                         "exit_code": exit_code,
                         "timed_out": timed_out,
-                        "type": (
-                            "subprocess_nonzero_exit" if launched else "subprocess_exec_failed"
+                        "type": _failure_detail_type(
+                            launched=launched,
+                            timed_out=timed_out,
+                            exit_code=exit_code,
                         ),
                         "failure_detectors_fired": list(verdict_obj.failure_detectors_fired),
                     }
@@ -914,6 +916,37 @@ def _validate_env_file_entries(env: dict[str, str]) -> None:
                 "probe.env uses bare KEY=VALUE format and cannot "
                 "encode multi-line values"
             )
+
+
+def _failure_detail_type(*, launched: bool, timed_out: bool, exit_code: int) -> str:
+    """Map a failing trial's process outcome to a ``failure_details[].type``.
+
+    The type must agree with the trial's actual exit state. The previous
+    inline expression hard-coded ``subprocess_nonzero_exit`` whenever the
+    child *launched*, which contradicted the artifact for a trial that
+    exited ``0`` but was failed by a non-Tier-1 detector (e.g. a Tier-4 log
+    pattern) -- ``{"exit_code": 0, "type": "subprocess_nonzero_exit"}`` is
+    impossible to reconcile by anyone reading the JSON (issue #229).
+
+    Precedence (most-specific first):
+
+    * ``not launched`` -> ``subprocess_exec_failed`` -- exec-time ``Popen``
+      failure (ENOENT / EACCES / ENOEXEC); the child never started.
+    * ``timed_out``    -> ``subprocess_timeout`` -- killed by the per-trial
+      timeout (``exit_code`` is the synthetic ``-1`` in this case, so it is
+      neither a "nonzero exit" the operator chose nor a clean exit).
+    * ``exit_code != 0`` -> ``subprocess_nonzero_exit`` -- the child ran and
+      exited non-zero (the original, still-correct case).
+    * otherwise (``exit_code == 0``) -> ``detector_failure`` -- the child
+      exited cleanly; the failure came purely from a classifier detector.
+    """
+    if not launched:
+        return "subprocess_exec_failed"
+    if timed_out:
+        return "subprocess_timeout"
+    if exit_code != 0:
+        return "subprocess_nonzero_exit"
+    return "detector_failure"
 
 
 def _read_log_text(stdout_path: Path, stderr_path: Path) -> str:

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -205,6 +205,43 @@ def test_successful_trial_flags_main_work_started(tmp_path):
     assert result.failure_details[0]["type"] == "subprocess_nonzero_exit"
 
 
+def test_failure_detail_type_is_detector_failure_on_clean_exit(tmp_path):
+    """Issue #229: a trial that exits 0 but is failed by a non-Tier-1
+    detector (here a Tier-4 NaN log pattern) must NOT be labelled
+    ``subprocess_nonzero_exit`` -- that contradicts ``exit_code == 0``.
+
+    This is the exact minimal repro from the issue body. The failure came
+    purely from the classifier, so the type is ``detector_failure``.
+    """
+    wl = _make_workload(tmp_path, ["bash", "-c", "echo 'loss is NaN'; exit 0"])
+    wl.setup()
+    result = wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    # The classifier failed the trial on Tier 4, despite a clean exit.
+    assert doc["exit_code"] == 0
+    assert doc["verdict"] == "fail"
+    assert "tier4:nan_signature" in doc["failure_detectors_fired"]
+    # The failure-detail type now agrees with the actual exit state.
+    assert result.failure_details[0]["exit_code"] == 0
+    assert result.failure_details[0]["type"] == "detector_failure", (
+        "failure_details[].type must not say 'subprocess_nonzero_exit' when "
+        "exit_code == 0 (issue #229)"
+    )
+
+
+def test_failure_detail_type_is_timeout_when_timed_out(tmp_path):
+    """Issue #229: a timed-out trial reports ``subprocess_timeout`` rather
+    than ``subprocess_nonzero_exit`` -- the child did not voluntarily exit
+    with a non-zero status; it was killed by the per-trial timeout."""
+    wl = _make_workload(tmp_path, ["sleep", "30"], timeout_per_trial=0.5)
+    wl.setup()
+    result = wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["timed_out"] is True
+    assert result.failure_details[0]["timed_out"] is True
+    assert result.failure_details[0]["type"] == "subprocess_timeout"
+
+
 def test_non_executable_script_yields_fail(tmp_path):
     """A user command pointing at a file without the +x bit must land
     as a Tier-1 fail (exit_code=126), NOT escape to the dispatcher as


### PR DESCRIPTION
## Summary

Fixes finding 1 of #229. A failing probe trial's `failure_details[].type`
was hard-coded to `subprocess_nonzero_exit` whenever the child launched —
independent of the actual exit. A command that exits `0` but is failed by a
non-Tier-1 detector (e.g. a Tier-4 log pattern) produced a
self-contradictory artifact:

```json
{ "exit_code": 0, "type": "subprocess_nonzero_exit", "failure_detectors_fired": ["tier4:nan_signature"] }
```

The type is now derived from the trial's real outcome:

| condition | type |
|---|---|
| child never launched (ENOENT/EACCES/ENOEXEC) | `subprocess_exec_failed` |
| killed by per-trial timeout | `subprocess_timeout` |
| ran, exited non-zero | `subprocess_nonzero_exit` |
| exited `0`, failed on a classifier detector | `detector_failure` |

No `src/` consumer keys on these strings; the change is in
`_subprocess.py` only, behind a small documented helper.

## Test plan

- [x] New: `test_failure_detail_type_is_detector_failure_on_clean_exit` — the exact #229 minimal repro (`bash -c 'echo "loss is NaN"; exit 0'`) now yields `type=detector_failure`, not `subprocess_nonzero_exit`.
- [x] New: `test_failure_detail_type_is_timeout_when_timed_out`.
- [x] Existing `test_exec_time_failure_flags_main_work_not_started` (exec_failed) and `test_successful_trial_flags_main_work_started` (nonzero_exit) unchanged and passing.
- [x] `ruff check` clean.

Note: `test_timeout_kill_race_does_not_crash` fails on hosts with `amd-smi` on PATH (a pre-existing test-mock issue where `poll_amd_smi`'s `subprocess.run` hits a mocked `Popen`); it fails identically on unmodified `main` and is unrelated to this change.

Made with [Cursor](https://cursor.com)