### PR TITLE
probe: add detector-disable knob (#229)

### DIFF
--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -85,6 +85,26 @@ custom_patterns:                   # Tier 5 user-defined patterns
     required_for_pass: false          # only valid with on_match: fail
 ```
 
+Detector-disable knobs (issue #229) silence detectors that fire on
+benign, workload-specific behaviour:
+
+```yaml
+disable_detector_tiers:            # skip whole tiers (not evaluated)
+  - tier3                          #   e.g. all kernel/GPU-counter checks
+disable_detectors:                 # skip individual detectors
+  - tier2:hang                     #   a repro that legitimately idles
+  - tier3:vram_growth              #   opaque docker wrapper allocates VRAM
+  - custom:my_pattern              #   a custom_patterns[*] id
+```
+
+A disabled detector is **not evaluated** and **never counts** toward the
+verdict or the `failure_detectors_fired` / `warn_detectors_fired` lists;
+the disabled set is echoed into `result.json::capture` for audit. Tokens
+are validated at load time (unknown tier or malformed `<tier>:<id>` ->
+`RecipeSchemaError`). The `--disable-detector TIER[:ID]` CLI flag
+(repeatable) is **unioned onto** the recipe's set, so an operator can
+silence one more detector without restating the recipe's list.
+
 Phase 3 keys (`redaction`, top-level `condition`) are still **rejected
 at load time** with a "deferred to Phase 3" error message.
 

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -99,9 +99,15 @@ disable_detectors:                 # skip individual detectors
 
 A disabled detector is **not evaluated** and **never counts** toward the
 verdict or the `failure_detectors_fired` / `warn_detectors_fired` lists;
-the disabled set is echoed into `result.json::capture` for audit. Tokens
-are validated at load time (unknown tier or malformed `<tier>:<id>` ->
-`RecipeSchemaError`). The `--disable-detector TIER[:ID]` CLI flag
+the disabled set is echoed into `result.json::capture` for audit. The one
+exception is a command that never launches (exec-time failure such as
+command-not-found): Tier 1 is forced back on for that trial so a run that
+did no real work can't resolve to a green verdict, even if the operator
+disabled Tier 1. Tokens
+are validated at load time (unknown tier, malformed `<tier>:<id>`, or a
+built-in `tier1`-`tier4` id that isn't in that tier's catalogue ->
+`RecipeSchemaError`); `custom:<id>` ids stay free-form. The
+`--disable-detector TIER[:ID]` CLI flag
 (repeatable) is **unioned onto** the recipe's set, so an operator can
 silence one more detector without restating the recipe's list.
 

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -51,7 +51,7 @@ from aorta.probe.cli_helpers import (
     ProbeUsageError,
     apply_recipe_overrides,
     help_token_in_option_zone,
-    parse_env_passthrough_mode,
+    parse_env_passthrough_mode_opt,
     reject_flag_shaped_value,
     require_double_dash_separator,
     validate_trailing_argv,
@@ -290,6 +290,19 @@ class _ProbeCommand(click.Command):
     ),
 )
 @click.option(
+    "--disable-detector",
+    "disable_detectors",
+    multiple=True,
+    metavar="TIER[:ID]",
+    help=(
+        "Silence a detector or whole tier (repeatable). Pass a tier name "
+        "('tier3') to skip the entire tier, or a '<tier>:<id>' token "
+        "('tier2:hang') to skip one detector. A disabled detector is not "
+        "evaluated and never counts toward the verdict. Unioned with any "
+        "'disable_detectors:' / 'disable_detector_tiers:' set in the recipe."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -304,6 +317,7 @@ def probe(
     ticket: str | None,
     dry_run: bool,
     env_passthrough_mode: str | None,
+    disable_detectors: tuple[str, ...],
     mitigation_files: tuple[Path, ...],
     verbose: int,
     argv: tuple[str, ...],
@@ -332,11 +346,7 @@ def probe(
         # ``--env-passthrough-mode`` defaults to None so the handler can
         # distinguish "user passed the flag" from "user omitted it"; per
         # FR 1.10 the CLI wins only when present (see apply_recipe_overrides).
-        cli_passthrough_mode = (
-            parse_env_passthrough_mode(env_passthrough_mode)
-            if env_passthrough_mode is not None
-            else None
-        )
+        cli_passthrough_mode = parse_env_passthrough_mode_opt(env_passthrough_mode)
         clean_argv = validate_trailing_argv(argv)
         r = load_recipe(recipe, sidecar_files=mitigation_files or None)
         if r.probe_extras is None:
@@ -344,7 +354,10 @@ def probe(
                 f"recipe {recipe} is not a probe-mode recipe; "
                 "set 'mode: probe' at the recipe top level"
             )
-        r = apply_recipe_overrides(r, ticket=ticket, cli_passthrough_mode=cli_passthrough_mode)
+        r = apply_recipe_overrides(
+            r, ticket=ticket, cli_passthrough_mode=cli_passthrough_mode,
+            cli_disable_detectors=disable_detectors,
+        )
     except (ProbeUsageError, RecipeSchemaError, RecipeCellError, RegistryError, LookupError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -163,12 +163,21 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
             # signal and shouldn't redundantly re-run the regex set.
             tier3.extend(tier3_kernel.scan_dmesg_text(ctx.dmesg_text))
         if ctx.amd_smi_pre is not None and ctx.amd_smi_post is not None:
+            # ``tier3:vram_growth`` is an operator-disable-able warn
+            # detector. Honour the disable *before* the scan -- not only
+            # via the post-hoc ``_keep`` filter below -- so a silenced
+            # detector never runs its VRAM delta check, mirroring the
+            # ``tier3_vram_growth`` recipe knob. (oyazdanb review)
+            check_vram_growth = (
+                ctx.tier3_vram_growth
+                and tier3_kernel.DETECTOR_VRAM_GROWTH not in disabled_detectors
+            )
             tier3.extend(
                 tier3_kernel.scan_amd_smi(
                     ctx.tier3_state,
                     ctx.amd_smi_pre,
                     ctx.amd_smi_post,
-                    check_vram_growth=ctx.tier3_vram_growth,
+                    check_vram_growth=check_vram_growth,
                 )
             )
     tier3 = _keep(tier3)

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -86,7 +86,11 @@ class TrialContext:
     # at all -- its scan is skipped so side-effecting probes (dmesg /
     # amd-smi) don't run. A disabled detector id (``disabled_detectors``,
     # e.g. ``"tier2:hang"``) is filtered out of the tier's result after
-    # the (cheap, side-effect-free) scan. Either way a disabled detector
+    # the (cheap, side-effect-free) Tier 1-4 scan. Disabled Tier 5
+    # ``custom:*`` detectors are instead filtered *before* the scan,
+    # because a custom scan runs sandbox ``condition``s and populates
+    # ``capture`` -- post-hoc filtering would let a silenced detector
+    # still leave observable side effects. Either way a disabled detector
     # never reaches :func:`resolve`, so it cannot flip the verdict or
     # appear in ``failure_detectors_fired`` / ``warn_detectors_fired``.
     # Validated upstream by :mod:`aorta.probe.classifier.disables`.
@@ -183,25 +187,27 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
         custom_result = tier5_custom.CustomScanResult()
         custom_required_patterns: tuple[CompiledPattern, ...] = ()
     else:
+        # Unlike Tiers 1-4 (cheap, side-effect-free scans we can filter
+        # post-hoc), a custom detector's scan runs its sandbox
+        # ``condition`` and populates ``capture``. Filtering disabled ids
+        # out *before* the scan keeps "disabled == not evaluated" honest:
+        # no condition runs and no capture surfaces for a silenced
+        # detector, and the same filtered tuple feeds the resolver so a
+        # disabled ``required_for_pass`` pattern can't synthesise
+        # ``meta:missing_pass_signal``.
+        if disabled_detectors:
+            custom_required_patterns = tuple(
+                p for p in ctx.custom_patterns if p.detector_id not in disabled_detectors
+            )
+        else:
+            custom_required_patterns = ctx.custom_patterns
         custom_result = tier5_custom.scan(
             ctx.log_text,
-            ctx.custom_patterns,
+            custom_required_patterns,
             exit_code=ctx.exit_code,
             walltime_sec=ctx.walltime_sec,
             peak_vram_mib=ctx.peak_vram_mib,
         )
-        custom_required_patterns = ctx.custom_patterns
-        if disabled_detectors:
-            # Filter disabled custom ids out of the fired lists so they
-            # neither flip the verdict nor surface as fired detectors.
-            custom_result.fail_detectors = _keep(custom_result.fail_detectors)
-            custom_result.warn_detectors = _keep(custom_result.warn_detectors)
-            custom_result.fired_required_ids = {
-                i for i in custom_result.fired_required_ids if i not in disabled_detectors
-            }
-            custom_required_patterns = tuple(
-                p for p in ctx.custom_patterns if p.detector_id not in disabled_detectors
-            )
     tier_durations_ms["tier5"] = (time.perf_counter() - t0) * 1000.0
 
     # Split Tier-3 IDs into hard failures vs. advisory warns. ``vram_growth``

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -83,8 +83,10 @@ class TrialContext:
     tier3_vram_growth: bool = True
     # Issue #229: operator-supplied detector-disable knobs. A disabled
     # whole tier (``disabled_tiers``, e.g. ``"tier3"``) is not evaluated
-    # at all -- its scan is skipped so side-effecting probes (dmesg /
-    # amd-smi) don't run. A disabled detector id (``disabled_detectors``,
+    # at all -- ``classify_trial`` skips its scan, and the workload
+    # (:meth:`SubprocessWorkload.run`) skips the Tier-3 collection too, so
+    # the side-effecting probes (dmesg / amd-smi) don't run. A disabled
+    # detector id (``disabled_detectors``,
     # e.g. ``"tier2:hang"``) is filtered out of the tier's result after
     # the (cheap, side-effect-free) Tier 1-4 scan. Disabled Tier 5
     # ``custom:*`` detectors are instead filtered *before* the scan,

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -196,25 +196,25 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
     # resolver expects) so no ``custom:*`` id can fire.
     if "tier5" in disabled_tiers:
         custom_result = tier5_custom.CustomScanResult()
-        custom_required_patterns: tuple[CompiledPattern, ...] = ()
+        active_custom_patterns: tuple[CompiledPattern, ...] = ()
     else:
         # Unlike Tiers 1-4 (cheap, side-effect-free scans we can filter
         # post-hoc), a custom detector's scan runs its sandbox
         # ``condition`` and populates ``capture``. Filtering disabled ids
         # out *before* the scan keeps "disabled == not evaluated" honest:
         # no condition runs and no capture surfaces for a silenced
-        # detector, and the same filtered tuple feeds the resolver so a
-        # disabled ``required_for_pass`` pattern can't synthesise
-        # ``meta:missing_pass_signal``.
+        # detector. The same disable-filtered set also seeds the resolver's
+        # required-pattern subset below, so a disabled ``required_for_pass``
+        # pattern can't synthesise ``meta:missing_pass_signal``.
         if disabled_detectors:
-            custom_required_patterns = tuple(
+            active_custom_patterns = tuple(
                 p for p in ctx.custom_patterns if p.detector_id not in disabled_detectors
             )
         else:
-            custom_required_patterns = ctx.custom_patterns
+            active_custom_patterns = ctx.custom_patterns
         custom_result = tier5_custom.scan(
             ctx.log_text,
-            custom_required_patterns,
+            active_custom_patterns,
             exit_code=ctx.exit_code,
             walltime_sec=ctx.walltime_sec,
             peak_vram_mib=ctx.peak_vram_mib,
@@ -235,7 +235,15 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
             tier4=tier4,
             tier3_warn=tier3_warn,
             custom_result=custom_result,
-            custom_required_patterns=custom_required_patterns,
+            # ``VerdictInputs.custom_required_patterns`` is contractually the
+            # ``required_for_pass=True`` subset (the resolver only inspects
+            # those). Narrow here rather than handing over the full active
+            # set so the field matches its documented meaning. Derived from
+            # the disable-filtered ``active_custom_patterns``, so a disabled
+            # required pattern stays excluded.
+            custom_required_patterns=tuple(
+                p for p in active_custom_patterns if p.required_for_pass
+            ),
         )
     )
     return verdict, tier_durations_ms

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -81,6 +81,17 @@ class TrialContext:
     # supply the source text without the IDs -- the two paths union.
     tier3_extra: tuple[str, ...] = ()
     tier3_vram_growth: bool = True
+    # Issue #229: operator-supplied detector-disable knobs. A disabled
+    # whole tier (``disabled_tiers``, e.g. ``"tier3"``) is not evaluated
+    # at all -- its scan is skipped so side-effecting probes (dmesg /
+    # amd-smi) don't run. A disabled detector id (``disabled_detectors``,
+    # e.g. ``"tier2:hang"``) is filtered out of the tier's result after
+    # the (cheap, side-effect-free) scan. Either way a disabled detector
+    # never reaches :func:`resolve`, so it cannot flip the verdict or
+    # appear in ``failure_detectors_fired`` / ``warn_detectors_fired``.
+    # Validated upstream by :mod:`aorta.probe.classifier.disables`.
+    disabled_tiers: frozenset[str] = frozenset()
+    disabled_detectors: frozenset[str] = frozenset()
 
 
 def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
@@ -101,24 +112,40 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
     import time
 
     tier_durations_ms: dict[str, float] = {}
+    disabled_tiers = ctx.disabled_tiers
+    disabled_detectors = ctx.disabled_detectors
+
+    def _keep(ids: list[str]) -> list[str]:
+        """Drop any operator-disabled detector ids, preserving order."""
+        if not disabled_detectors:
+            return ids
+        return [d for d in ids if d not in disabled_detectors]
 
     t0 = time.perf_counter()
-    tier1 = tier1_process.detect(
-        Tier1Context(
-            exit_code=ctx.exit_code,
-            timed_out=ctx.timed_out,
-            trial_dir=ctx.trial_dir,
+    if "tier1" in disabled_tiers:
+        tier1: list[str] = []
+    else:
+        tier1 = _keep(
+            tier1_process.detect(
+                Tier1Context(
+                    exit_code=ctx.exit_code,
+                    timed_out=ctx.timed_out,
+                    trial_dir=ctx.trial_dir,
+                )
+            )
         )
-    )
     tier_durations_ms["tier1"] = (time.perf_counter() - t0) * 1000.0
 
     t0 = time.perf_counter()
-    tier2 = [DETECTOR_HANG] if ctx.hang_detected else []
+    if "tier2" in disabled_tiers:
+        tier2: list[str] = []
+    else:
+        tier2 = _keep([DETECTOR_HANG] if ctx.hang_detected else [])
     tier_durations_ms["tier2"] = (time.perf_counter() - t0) * 1000.0
 
     t0 = time.perf_counter()
     tier3: list[str] = []
-    if ctx.tier3_state is not None:
+    if "tier3" not in disabled_tiers and ctx.tier3_state is not None:
         # Caller-pre-collected IDs come first so the call order in
         # ``failure_detectors_fired`` matches the chronological order
         # of detection (workload polls dmesg before classify_trial
@@ -138,20 +165,43 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
                     check_vram_growth=ctx.tier3_vram_growth,
                 )
             )
+    tier3 = _keep(tier3)
     tier_durations_ms["tier3"] = (time.perf_counter() - t0) * 1000.0
 
     t0 = time.perf_counter()
-    tier4 = tier4_patterns.scan(ctx.log_text)
+    if "tier4" in disabled_tiers:
+        tier4: list[str] = []
+    else:
+        tier4 = _keep(tier4_patterns.scan(ctx.log_text))
     tier_durations_ms["tier4"] = (time.perf_counter() - t0) * 1000.0
 
     t0 = time.perf_counter()
-    custom_result = tier5_custom.scan(
-        ctx.log_text,
-        ctx.custom_patterns,
-        exit_code=ctx.exit_code,
-        walltime_sec=ctx.walltime_sec,
-        peak_vram_mib=ctx.peak_vram_mib,
-    )
+    # ``tier5`` is the tier token for the custom-pattern scanner; when
+    # disabled, skip the scan entirely (an empty result is the no-op the
+    # resolver expects) so no ``custom:*`` id can fire.
+    if "tier5" in disabled_tiers:
+        custom_result = tier5_custom.CustomScanResult()
+        custom_required_patterns: tuple[CompiledPattern, ...] = ()
+    else:
+        custom_result = tier5_custom.scan(
+            ctx.log_text,
+            ctx.custom_patterns,
+            exit_code=ctx.exit_code,
+            walltime_sec=ctx.walltime_sec,
+            peak_vram_mib=ctx.peak_vram_mib,
+        )
+        custom_required_patterns = ctx.custom_patterns
+        if disabled_detectors:
+            # Filter disabled custom ids out of the fired lists so they
+            # neither flip the verdict nor surface as fired detectors.
+            custom_result.fail_detectors = _keep(custom_result.fail_detectors)
+            custom_result.warn_detectors = _keep(custom_result.warn_detectors)
+            custom_result.fired_required_ids = {
+                i for i in custom_result.fired_required_ids if i not in disabled_detectors
+            }
+            custom_required_patterns = tuple(
+                p for p in ctx.custom_patterns if p.detector_id not in disabled_detectors
+            )
     tier_durations_ms["tier5"] = (time.perf_counter() - t0) * 1000.0
 
     # Split Tier-3 IDs into hard failures vs. advisory warns. ``vram_growth``
@@ -168,7 +218,7 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
             tier4=tier4,
             tier3_warn=tier3_warn,
             custom_result=custom_result,
-            custom_required_patterns=ctx.custom_patterns,
+            custom_required_patterns=custom_required_patterns,
         )
     )
     return verdict, tier_durations_ms

--- a/src/aorta/probe/classifier/disables.py
+++ b/src/aorta/probe/classifier/disables.py
@@ -18,9 +18,13 @@ Two token shapes:
   Disables the whole tier; ``tier5`` is the custom-pattern tier.
 * detector-id token -- ``<prefix>:<id>`` where ``prefix`` is in
   :data:`KNOWN_DETECTOR_PREFIXES` (e.g. ``tier2:hang``,
-  ``tier3:vram_growth``, ``custom:my_pattern``). The ``id`` half is
-  free-form (custom patterns are user-named) so we validate the
-  prefix and the presence of an id, not the full catalogue.
+  ``tier3:vram_growth``, ``custom:my_pattern``). A built-in
+  (``tier1`` .. ``tier4``) id is validated against that tier's
+  exported ``ALL_DETECTOR_IDS`` catalogue, so a typo like
+  ``tier3:vram_growht`` fails at recipe/CLI parse time instead of
+  silently disabling nothing. A ``custom:<id>`` id stays free-form
+  (custom patterns are user-named) -- only its prefix and the
+  presence of an id are checked.
 """
 
 from __future__ import annotations
@@ -56,6 +60,24 @@ def normalize_tier(token: str) -> str:
     return cleaned
 
 
+def _known_builtin_detector_ids() -> dict[str, frozenset[str]]:
+    """Map each built-in tier prefix to its exported detector-id catalogue.
+
+    Imported lazily so this module (loaded by the recipe-builder and the
+    CLI) stays cheap and free of an import cycle through the classifier
+    package.
+    """
+    from aorta.probe.classifier import tier1_process, tier3_kernel, tier4_patterns
+    from aorta.probe.classifier.tier2_hang import ALL_DETECTOR_IDS as TIER2_IDS
+
+    return {
+        "tier1": frozenset(tier1_process.ALL_DETECTOR_IDS),
+        "tier2": frozenset(TIER2_IDS),
+        "tier3": frozenset(tier3_kernel.ALL_DETECTOR_IDS),
+        "tier4": frozenset(tier4_patterns.ALL_DETECTOR_IDS),
+    }
+
+
 def normalize_detector_id(token: str) -> str:
     """Validate a ``<prefix>:<id>`` detector-id disable token.
 
@@ -65,9 +87,12 @@ def normalize_detector_id(token: str) -> str:
     user-named and case-sensitive). Stripping the id matters: a
     copy/paste token like ``'tier2: hang'`` would otherwise normalise to
     ``'tier2: hang'`` and never match the fired id ``'tier2:hang'``,
-    silently disabling nothing. Raises :class:`DetectorSpecError` when
-    the colon / id / prefix is missing or unknown (an id that is empty
-    after trimming counts as missing).
+    silently disabling nothing. A built-in (``tier1`` .. ``tier4``) id is
+    additionally checked against that tier's exported
+    ``ALL_DETECTOR_IDS`` catalogue so a typo fails here rather than
+    silently disabling nothing; ``custom:*`` ids stay free-form. Raises
+    :class:`DetectorSpecError` when the colon / id / prefix is missing or
+    unknown (an id that is empty after trimming counts as missing).
     """
     cleaned = token.strip()
     prefix, sep, rest = cleaned.partition(":")
@@ -78,12 +103,23 @@ def normalize_detector_id(token: str) -> str:
             f"malformed detector id {token!r}; expected '<tier>:<id>' "
             f"(e.g. 'tier2:hang')"
         )
-    if prefix.lower() not in KNOWN_DETECTOR_PREFIXES:
+    prefix_lower = prefix.lower()
+    if prefix_lower not in KNOWN_DETECTOR_PREFIXES:
         raise DetectorSpecError(
             f"unknown detector prefix {prefix!r} in {token!r}; expected one "
             f"of {', '.join(KNOWN_DETECTOR_PREFIXES)}"
         )
-    return f"{prefix.lower()}:{rest}"
+    normalized = f"{prefix_lower}:{rest}"
+    # ``custom:*`` ids are user-named and stay free-form; built-in tiers
+    # are a fixed catalogue, so validate against it to catch typos.
+    if prefix_lower != "custom":
+        known = _known_builtin_detector_ids()[prefix_lower]
+        if normalized not in known:
+            raise DetectorSpecError(
+                f"unknown detector id {normalized!r}; expected one of "
+                f"{', '.join(sorted(known))}"
+            )
+    return normalized
 
 
 def normalize_tiers(tokens: object) -> tuple[str, ...]:

--- a/src/aorta/probe/classifier/disables.py
+++ b/src/aorta/probe/classifier/disables.py
@@ -60,13 +60,19 @@ def normalize_detector_id(token: str) -> str:
     """Validate a ``<prefix>:<id>`` detector-id disable token.
 
     The prefix is lower-cased and checked against
-    :data:`KNOWN_DETECTOR_PREFIXES`; the id half is preserved verbatim
-    (custom-pattern ids are user-named and case-sensitive). Raises
-    :class:`DetectorSpecError` when the colon / id / prefix is missing
-    or unknown.
+    :data:`KNOWN_DETECTOR_PREFIXES`; the id half has surrounding
+    whitespace stripped but its case preserved (custom-pattern ids are
+    user-named and case-sensitive). Stripping the id matters: a
+    copy/paste token like ``'tier2: hang'`` would otherwise normalise to
+    ``'tier2: hang'`` and never match the fired id ``'tier2:hang'``,
+    silently disabling nothing. Raises :class:`DetectorSpecError` when
+    the colon / id / prefix is missing or unknown (an id that is empty
+    after trimming counts as missing).
     """
     cleaned = token.strip()
     prefix, sep, rest = cleaned.partition(":")
+    prefix = prefix.strip()
+    rest = rest.strip()
     if not sep or not rest:
         raise DetectorSpecError(
             f"malformed detector id {token!r}; expected '<tier>:<id>' "

--- a/src/aorta/probe/classifier/disables.py
+++ b/src/aorta/probe/classifier/disables.py
@@ -1,0 +1,116 @@
+"""Detector-disable knob for ``aorta probe`` (issue #229).
+
+Operators sometimes need to silence a detector that fires on benign,
+workload-specific behaviour (e.g. ``tier2:hang`` on a repro that
+legitimately idles, or ``tier3:vram_growth`` on an opaque docker
+wrapper where allocation is normal). Rather than editing the
+classifier, a recipe (or ``--disable-detector`` CLI flag) can name
+detectors / whole tiers to skip.
+
+A disabled detector is NOT evaluated and does NOT count toward the
+verdict or the fired-detector lists. This module is the single source
+of truth for which tokens are valid so the recipe-builder, the CLI,
+and :func:`aorta.probe.classifier.classify_trial` agree.
+
+Two token shapes:
+
+* tier token -- one of :data:`KNOWN_TIERS` (``tier1`` .. ``tier5``).
+  Disables the whole tier; ``tier5`` is the custom-pattern tier.
+* detector-id token -- ``<prefix>:<id>`` where ``prefix`` is in
+  :data:`KNOWN_DETECTOR_PREFIXES` (e.g. ``tier2:hang``,
+  ``tier3:vram_growth``, ``custom:my_pattern``). The ``id`` half is
+  free-form (custom patterns are user-named) so we validate the
+  prefix and the presence of an id, not the full catalogue.
+"""
+
+from __future__ import annotations
+
+KNOWN_TIERS: tuple[str, ...] = ("tier1", "tier2", "tier3", "tier4", "tier5")
+
+# ``custom`` is the detector-id prefix the Tier-5 scanner stamps
+# (``custom:<id>``); the tier token for that tier is ``tier5``.
+KNOWN_DETECTOR_PREFIXES: tuple[str, ...] = (
+    "tier1",
+    "tier2",
+    "tier3",
+    "tier4",
+    "custom",
+)
+
+
+class DetectorSpecError(ValueError):
+    """A disable-spec token is malformed or names an unknown tier/prefix."""
+
+
+def normalize_tier(token: str) -> str:
+    """Validate + canonicalise a whole-tier disable token.
+
+    Case-insensitive; surrounding whitespace stripped. Raises
+    :class:`DetectorSpecError` for anything not in :data:`KNOWN_TIERS`.
+    """
+    cleaned = token.strip().lower()
+    if cleaned not in KNOWN_TIERS:
+        raise DetectorSpecError(
+            f"unknown tier {token!r}; expected one of {', '.join(KNOWN_TIERS)}"
+        )
+    return cleaned
+
+
+def normalize_detector_id(token: str) -> str:
+    """Validate a ``<prefix>:<id>`` detector-id disable token.
+
+    The prefix is lower-cased and checked against
+    :data:`KNOWN_DETECTOR_PREFIXES`; the id half is preserved verbatim
+    (custom-pattern ids are user-named and case-sensitive). Raises
+    :class:`DetectorSpecError` when the colon / id / prefix is missing
+    or unknown.
+    """
+    cleaned = token.strip()
+    prefix, sep, rest = cleaned.partition(":")
+    if not sep or not rest:
+        raise DetectorSpecError(
+            f"malformed detector id {token!r}; expected '<tier>:<id>' "
+            f"(e.g. 'tier2:hang')"
+        )
+    if prefix.lower() not in KNOWN_DETECTOR_PREFIXES:
+        raise DetectorSpecError(
+            f"unknown detector prefix {prefix!r} in {token!r}; expected one "
+            f"of {', '.join(KNOWN_DETECTOR_PREFIXES)}"
+        )
+    return f"{prefix.lower()}:{rest}"
+
+
+def normalize_tiers(tokens: object) -> tuple[str, ...]:
+    """Validate a list of tier tokens into a de-duplicated, ordered tuple."""
+    return _normalize_list("disable_detector_tiers", tokens, normalize_tier)
+
+
+def normalize_detector_ids(tokens: object) -> tuple[str, ...]:
+    """Validate a list of detector-id tokens into an ordered tuple."""
+    return _normalize_list("disable_detectors", tokens, normalize_detector_id)
+
+
+def _normalize_list(field: str, tokens: object, fn) -> tuple[str, ...]:
+    if tokens is None:
+        return ()
+    if isinstance(tokens, str) or not isinstance(tokens, (list, tuple)):
+        raise DetectorSpecError(f"{field}: must be a list of strings, got {tokens!r}")
+    out: list[str] = []
+    for tok in tokens:
+        if not isinstance(tok, str):
+            raise DetectorSpecError(f"{field}: entries must be strings, got {tok!r}")
+        norm = fn(tok)
+        if norm not in out:
+            out.append(norm)
+    return tuple(out)
+
+
+__all__ = [
+    "KNOWN_TIERS",
+    "KNOWN_DETECTOR_PREFIXES",
+    "DetectorSpecError",
+    "normalize_tier",
+    "normalize_detector_id",
+    "normalize_tiers",
+    "normalize_detector_ids",
+]

--- a/src/aorta/probe/classifier/tier4_patterns.py
+++ b/src/aorta/probe/classifier/tier4_patterns.py
@@ -140,6 +140,13 @@ _BUILTIN_PATTERNS: tuple[BuiltinPattern, ...] = (
 )
 
 
+# Catalogue of every detector id this tier can fire, in catalogue
+# order. Parity with ``tier{1,2,3}.ALL_DETECTOR_IDS`` so the disable
+# knob (:mod:`aorta.probe.classifier.disables`) can validate
+# ``tier4:<id>`` tokens against the real catalogue at parse time.
+ALL_DETECTOR_IDS: tuple[str, ...] = tuple(p.detector_id for p in _BUILTIN_PATTERNS)
+
+
 def all_patterns() -> tuple[BuiltinPattern, ...]:
     """Return the immutable Tier 4 pattern catalogue."""
     return _BUILTIN_PATTERNS
@@ -222,6 +229,7 @@ def _iter_windows(text: str, window: int):
 
 
 __all__ = [
+    "ALL_DETECTOR_IDS",
     "BUILTIN_PATTERN_VERSION",
     "BuiltinPattern",
     "DETECTOR_COLLECTIVE_TIMEOUT",

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -12,6 +12,12 @@ import dataclasses
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
+from aorta.probe.classifier.disables import (
+    DetectorSpecError,
+    normalize_detector_ids,
+    normalize_tiers,
+)
+
 if TYPE_CHECKING:
     from aorta.triage.recipe import Recipe
 
@@ -151,6 +157,16 @@ def parse_env_passthrough_mode(value: str) -> Literal["inherit", "file"]:
     return value  # type: ignore[return-value]
 
 
+def parse_env_passthrough_mode_opt(value: str | None) -> Literal["inherit", "file"] | None:
+    """Parse ``--env-passthrough-mode`` preserving the "flag omitted" signal.
+
+    ``None`` in -> ``None`` out so :func:`apply_recipe_overrides` can tell
+    "user passed the flag" from "user omitted it" (FR 1.10 precedence).
+    Keeps the Click handler a thin shim by hosting the None-guard here.
+    """
+    return None if value is None else parse_env_passthrough_mode(value)
+
+
 def validate_trailing_argv(argv: tuple[str, ...]) -> tuple[str, ...]:
     """Reject an empty / clearly-misparsed trailing-argv list.
 
@@ -183,14 +199,22 @@ def apply_recipe_overrides(
     *,
     ticket: str | None,
     cli_passthrough_mode: Literal["inherit", "file"] | None,
+    cli_disable_detectors: tuple[str, ...] = (),
 ) -> Recipe:
     """Layer CLI flags on top of a loaded probe-mode ``Recipe``.
 
-    Two overlays today:
+    Overlays today:
 
     * ``--ticket`` -- when set, replaces ``recipe.ticket``;
     * ``--env-passthrough-mode`` -- when set (i.e. the user actually
-      passed the flag), replaces ``recipe.probe_extras.env_passthrough_mode``.
+      passed the flag), replaces ``recipe.probe_extras.env_passthrough_mode``;
+    * ``--disable-detector`` -- when passed (repeatable), each token is
+      a whole-tier name (``tier3``) or a ``<tier>:<id>`` detector id
+      (``tier2:hang``). Tokens are validated + classified here and
+      UNIONed onto whatever the recipe already disables, so the CLI is
+      additive rather than a replacement (an operator silencing one
+      more detector on top of a recipe shouldn't have to restate the
+      recipe's list).
 
     The caller must verify ``recipe.probe_extras is not None`` before
     invoking this helper (probe-mode discriminator is the CLI's
@@ -206,10 +230,39 @@ def apply_recipe_overrides(
         recipe = dataclasses.replace(
             recipe,
             probe_extras=dataclasses.replace(
-                probe_extras, env_passthrough_mode=cli_passthrough_mode
+                recipe.probe_extras, env_passthrough_mode=cli_passthrough_mode
             ),
         )
+    if cli_disable_detectors:
+        recipe = _overlay_disable_detectors(recipe, cli_disable_detectors)
     return recipe
+
+
+def _overlay_disable_detectors(recipe: Recipe, tokens: tuple[str, ...]) -> Recipe:
+    """Classify ``--disable-detector`` tokens and union them onto the recipe.
+
+    A token with a ``:`` is a detector id (``tier2:hang``); a bare
+    token is a whole-tier name (``tier3``). Invalid tokens raise
+    :class:`ProbeUsageError` so the CLI surfaces a friendly message
+    rather than a stack trace.
+    """
+    probe_extras = recipe.probe_extras
+    assert probe_extras is not None
+    tier_tokens = [t for t in tokens if ":" not in t]
+    id_tokens = [t for t in tokens if ":" in t]
+    try:
+        new_ids = normalize_detector_ids(list(probe_extras.disable_detectors) + id_tokens)
+        new_tiers = normalize_tiers(list(probe_extras.disable_detector_tiers) + tier_tokens)
+    except DetectorSpecError as exc:
+        raise ProbeUsageError(f"--disable-detector: {exc}") from exc
+    return dataclasses.replace(
+        recipe,
+        probe_extras=dataclasses.replace(
+            probe_extras,
+            disable_detectors=new_ids,
+            disable_detector_tiers=new_tiers,
+        ),
+    )
 
 
 def format_dry_run_line(
@@ -234,6 +287,7 @@ __all__ = [
     "format_dry_run_line",
     "help_token_in_option_zone",
     "parse_env_passthrough_mode",
+    "parse_env_passthrough_mode_opt",
     "reject_flag_shaped_value",
     "require_double_dash_separator",
     "validate_trailing_argv",

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -330,7 +330,13 @@ def build_probe_recipe_from_dict(
         disable_detectors = normalize_detector_ids(data.get("disable_detectors"))
         disable_detector_tiers = normalize_tiers(data.get("disable_detector_tiers"))
     except DetectorSpecError as exc:
-        raise RecipeSchemaError(f"recipe.{exc}") from exc
+        # ``DetectorSpecError`` messages either already carry a field prefix
+        # (e.g. ``disable_detectors: ...``) or are a bare token diagnostic
+        # (e.g. ``unknown tier 'tier9'``). ``recipe: {exc}`` reads cleanly for
+        # both, whereas ``recipe.{exc}`` produced ``recipe.unknown tier`` for
+        # the bare case. Mirrors the ``recipe:`` prefix used in the triage
+        # loader (aorta.triage.recipe).
+        raise RecipeSchemaError(f"recipe: {exc}") from exc
     # Use ``in`` rather than ``.get(...) is not None`` so an explicit
     # ``redaction: null`` is treated as present-but-invalid (parse_redaction
     # rejects None) instead of being silently conflated with "no redaction

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -17,6 +17,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from aorta.probe.classifier.disables import (
+    DetectorSpecError,
+    normalize_detector_ids,
+    normalize_tiers,
+)
 from aorta.probe.classifier.tier2_hang import (
     DEFAULT_HANG_GRACE_SEC,
     DEFAULT_HANG_WINDOW_SEC,
@@ -117,6 +122,15 @@ class ProbeExtras:
     # opaque docker wrappers where GPU allocation is normal workload
     # behaviour rather than a leak signal.
     tier3_vram_growth: bool = True
+    # Issue #229: operator detector-disable knobs. ``disable_detectors``
+    # holds ``<tier>:<id>`` tokens (e.g. ``"tier2:hang"``);
+    # ``disable_detector_tiers`` holds whole-tier tokens (``"tier3"``).
+    # Validated at load time by ``aorta.probe.classifier.disables``; a
+    # disabled detector is never evaluated and never counts toward the
+    # verdict. Empty tuples are the no-op default so recipes that don't
+    # set the knobs round-trip exactly.
+    disable_detectors: tuple[str, ...] = ()
+    disable_detector_tiers: tuple[str, ...] = ()
     # Phase 3 (issue #188): redaction block consumed by ``aorta bundle``.
     redaction: RedactionCfg | None = None
 
@@ -312,6 +326,11 @@ def build_probe_recipe_from_dict(
             f"{type(tier3_vram_growth_raw).__name__} ({tier3_vram_growth_raw!r})"
         )
     tier3_vram_growth = tier3_vram_growth_raw
+    try:
+        disable_detectors = normalize_detector_ids(data.get("disable_detectors"))
+        disable_detector_tiers = normalize_tiers(data.get("disable_detector_tiers"))
+    except DetectorSpecError as exc:
+        raise RecipeSchemaError(f"recipe.{exc}") from exc
     # Use ``in`` rather than ``.get(...) is not None`` so an explicit
     # ``redaction: null`` is treated as present-but-invalid (parse_redaction
     # rejects None) instead of being silently conflated with "no redaction
@@ -441,6 +460,8 @@ def build_probe_recipe_from_dict(
         hang_window_sec=hang_window_sec,
         hang_grace_period_at_start=hang_grace_period_at_start,
         tier3_vram_growth=tier3_vram_growth,
+        disable_detectors=disable_detectors,
+        disable_detector_tiers=disable_detector_tiers,
         redaction=redaction,
     )
 

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -80,6 +80,10 @@ _PROBE_TOP_LEVEL = frozenset(
         # Disable Tier-3 pre/post VRAM delta for opaque docker wrappers
         # where GPU allocation is expected, not a leak signal.
         "tier3_vram_growth",
+        # Issue #229: operator detector-disable knobs. Accepted only in
+        # mode: probe (triage-mode check below rejects them otherwise).
+        "disable_detectors",
+        "disable_detector_tiers",
         # Phase 3 (issue #188): redaction block for aorta bundle.
         "redaction",
     }

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -784,6 +784,10 @@ def _run_one_cell(
             "hang_window_sec": probe_extras.hang_window_sec,
             "hang_grace_period_at_start": probe_extras.hang_grace_period_at_start,
             "tier3_vram_growth": probe_extras.tier3_vram_growth,
+            # Issue #229: operator detector-disable knobs threaded to the
+            # workload so the classifier can skip them per trial.
+            "disable_detectors": tuple(probe_extras.disable_detectors),
+            "disable_detector_tiers": tuple(probe_extras.disable_detector_tiers),
         }
 
     # save_logs is forced True for probe-mode cells because
@@ -864,6 +868,11 @@ def _print_dry_run(
         )
         click.echo(f"Argv (forwarded byte-for-byte): {argv_display}")
         click.echo(f"Env-passthrough mode: {recipe.probe_extras.env_passthrough_mode}")
+        disabled = list(recipe.probe_extras.disable_detector_tiers) + list(
+            recipe.probe_extras.disable_detectors
+        )
+        if disabled:
+            click.echo(f"Disabled detectors: {', '.join(disabled)}")
         for cell in recipe.cells:
             env_bundle = recipe.probe_extras.cell_envs.get(cell.name, {})
             env_str = " ".join(f"{k}={v}" for k, v in sorted(env_bundle.items())) or "(no env)"

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -383,6 +383,12 @@ class SubprocessWorkload(Workload):
             )
         tier3_vram_growth = _vram_growth_raw
 
+        # Issue #229: detector-disable knobs. Validated on the
+        # recipe-builder side; default to empty so non-probe / legacy
+        # payloads are the no-op (every detector active).
+        disabled_detectors = frozenset(probe_extras.get("disable_detectors") or ())
+        disabled_tiers = frozenset(probe_extras.get("disable_detector_tiers") or ())
+
         # ``inherit`` mode: the dispatcher has already stamped the
         # cell's mitigation + diagnostic env vars onto os.environ in
         # _run_single_trial's pre-run overlay (it restores them in the
@@ -689,6 +695,8 @@ class SubprocessWorkload(Workload):
                     tier3_extra=tuple(fired_kernel_ids),
                     tier3_state=_TIER3_STATE,
                     tier3_vram_growth=tier3_vram_growth,
+                    disabled_tiers=disabled_tiers,
+                    disabled_detectors=disabled_detectors,
                 )
             )
         except Exception as classifier_exc:  # noqa: BLE001 -- classifier crash containment
@@ -730,6 +738,13 @@ class SubprocessWorkload(Workload):
         # rather than only the log.info above.
         if hang_reconciled_away:
             result_doc["capture"]["tier2_hang_latched_but_reconciled"] = True
+        # Issue #229: surface the operator's disable knobs in the trial
+        # artifact so a reader knows a detector was intentionally silenced
+        # rather than simply not firing.
+        if disabled_detectors:
+            result_doc["capture"]["disabled_detectors"] = sorted(disabled_detectors)
+        if disabled_tiers:
+            result_doc["capture"]["disabled_detector_tiers"] = sorted(disabled_tiers)
         result_path.write_text(
             json.dumps(result_doc, indent=2, sort_keys=False),
             encoding="utf-8",

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -60,6 +60,7 @@ from aorta.probe.classifier.tier2_hang import (
     HangMonitor,
 )
 from aorta.probe.classifier.tier3_kernel import (
+    AmdSmiSnapshot,
     Tier3State,
     gpu_idle_probe_from_state,
     poll_amd_smi,
@@ -392,6 +393,11 @@ class SubprocessWorkload(Workload):
         disabled_tiers = _coerce_disable_tokens(
             probe_extras.get("disable_detector_tiers"), "disable_detector_tiers"
         )
+        # Disabling a whole tier means "not evaluated at all" -- for Tier 3
+        # that includes the side-effecting amd-smi / dmesg probes, not just
+        # their contribution to the verdict. Gate the collection itself so
+        # the knob actually avoids the probe overhead + permission noise.
+        tier3_enabled = "tier3" not in disabled_tiers
 
         # ``inherit`` mode: the dispatcher has already stamped the
         # cell's mitigation + diagnostic env vars onto os.environ in
@@ -461,7 +467,8 @@ class SubprocessWorkload(Workload):
         # ``None`` and contributes nothing without aborting the trial.
         # The shared ``_TIER3_STATE`` ensures the "amd-smi disabled"
         # log fires at most once across the full probe invocation.
-        amd_smi_pre = poll_amd_smi(_TIER3_STATE)
+        # Skipped entirely when Tier 3 is operator-disabled.
+        amd_smi_pre = poll_amd_smi(_TIER3_STATE) if tier3_enabled else None
 
         t0 = time.perf_counter()
         exit_code: int
@@ -643,23 +650,26 @@ class SubprocessWorkload(Workload):
         # still land in the window. Both helpers are fail-soft and
         # share ``_TIER3_STATE`` with the pre-snapshot above so the
         # one-warning-per-invocation contract holds.
-        amd_smi_post = poll_amd_smi(_TIER3_STATE)
-        dmesg_text: str | None
-        try:
-            fired_kernel_ids = scan_dmesg(
-                _TIER3_STATE,
-                since_seconds=walltime_sec + _DMESG_SINCE_PAD_SEC,
-            )
-            # ``scan_dmesg`` returns the fired detector IDs directly;
-            # rebuild a synthetic text blob so the classifier's
-            # ``scan_dmesg_text`` second pass is a no-op (it would
-            # otherwise re-scan ``None`` and emit []). The empty
-            # string here keeps Tier 3's text path inert; the
-            # already-fired IDs are surfaced via ``tier3_extra``.
-            dmesg_text = "" if fired_kernel_ids else None
-        except Exception:
-            fired_kernel_ids = []
-            dmesg_text = None
+        amd_smi_post: AmdSmiSnapshot | None = None
+        dmesg_text: str | None = None
+        fired_kernel_ids: list[str] = []
+        if tier3_enabled:
+            amd_smi_post = poll_amd_smi(_TIER3_STATE)
+            try:
+                fired_kernel_ids = scan_dmesg(
+                    _TIER3_STATE,
+                    since_seconds=walltime_sec + _DMESG_SINCE_PAD_SEC,
+                )
+                # ``scan_dmesg`` returns the fired detector IDs directly;
+                # rebuild a synthetic text blob so the classifier's
+                # ``scan_dmesg_text`` second pass is a no-op (it would
+                # otherwise re-scan ``None`` and emit []). The empty
+                # string here keeps Tier 3's text path inert; the
+                # already-fired IDs are surfaced via ``tier3_extra``.
+                dmesg_text = "" if fired_kernel_ids else None
+            except Exception:
+                fired_kernel_ids = []
+                dmesg_text = None
 
         peak_vram_mib: int | None
         if amd_smi_pre is not None and amd_smi_post is not None:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -653,10 +653,18 @@ class SubprocessWorkload(Workload):
         # still land in the window. Both helpers are fail-soft and
         # share ``_TIER3_STATE`` with the pre-snapshot above so the
         # one-warning-per-invocation contract holds.
+        #
+        # Skipped when the subprocess never launched (exec-time Popen
+        # failure -- ENOENT / EACCES / ENOEXEC): a command-not-found
+        # trial did no GPU work, so the post-snapshot + dmesg scan add
+        # only overhead and permission noise, and any amdgpu/kernel
+        # message in the window belongs to an unrelated process -- not
+        # this trial. Gating on ``launched`` keeps those events from
+        # being misattributed to a trial that never ran. (Copilot review)
         amd_smi_post: AmdSmiSnapshot | None = None
         dmesg_text: str | None = None
         fired_kernel_ids: list[str] = []
-        if tier3_enabled:
+        if tier3_enabled and launched:
             amd_smi_post = poll_amd_smi(_TIER3_STATE)
             try:
                 fired_kernel_ids = scan_dmesg(

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -52,7 +52,10 @@ from pathlib import Path
 from typing import Any
 
 from aorta.probe.classifier import TrialContext, classify_trial
-from aorta.probe.classifier.tier1_process import Tier1Context
+from aorta.probe.classifier.tier1_process import (
+    DETECTOR_EXIT_NONZERO,
+    Tier1Context,
+)
 from aorta.probe.classifier.tier1_process import detect as tier1_detect
 from aorta.probe.classifier.tier2_hang import (
     DEFAULT_HANG_GRACE_SEC,
@@ -692,6 +695,19 @@ class SubprocessWorkload(Workload):
         # verdict derived from the same Tier 1 inputs, record the
         # classifier exception under ``capture['classifier_error']``
         # for the operator, and continue.
+        # A subprocess that never launched (exec-time Popen failure --
+        # ENOENT / EACCES / ENOEXEC) has only Tier 1 to speak to its
+        # outcome. Honouring a Tier-1 disable on that path would let a
+        # command-not-found resolve to a green verdict -- a run that did
+        # no real work yet looks like a pass. Force Tier 1 (and its
+        # ``exit_nonzero`` detector) back on for the exec-failure path so
+        # the failure always surfaces; the disable still applies on every
+        # launched trial. (oyazdanb review)
+        effective_disabled_tiers = disabled_tiers
+        effective_disabled_detectors = disabled_detectors
+        if not launched:
+            effective_disabled_tiers = disabled_tiers - {"tier1"}
+            effective_disabled_detectors = disabled_detectors - {DETECTOR_EXIT_NONZERO}
         try:
             verdict_obj, tier_durations_ms = classify_trial(
                 TrialContext(
@@ -709,8 +725,8 @@ class SubprocessWorkload(Workload):
                     tier3_extra=tuple(fired_kernel_ids),
                     tier3_state=_TIER3_STATE,
                     tier3_vram_growth=tier3_vram_growth,
-                    disabled_tiers=disabled_tiers,
-                    disabled_detectors=disabled_detectors,
+                    disabled_tiers=effective_disabled_tiers,
+                    disabled_detectors=effective_disabled_detectors,
                 )
             )
         except Exception as classifier_exc:  # noqa: BLE001 -- classifier crash containment
@@ -719,6 +735,8 @@ class SubprocessWorkload(Workload):
                 timed_out=timed_out,
                 trial_dir=trial_dir,
                 classifier_exc=classifier_exc,
+                disabled_tiers=effective_disabled_tiers,
+                disabled_detectors=effective_disabled_detectors,
             )
 
         result_doc: dict[str, Any] = {
@@ -1017,6 +1035,8 @@ def _tier1_only_fallback_verdict(
     timed_out: bool,
     trial_dir: Path,
     classifier_exc: BaseException,
+    disabled_tiers: frozenset[str] = frozenset(),
+    disabled_detectors: frozenset[str] = frozenset(),
 ) -> tuple[Verdict, dict[str, float]]:
     """Build a deterministic verdict when :func:`classify_trial` raises.
 
@@ -1032,18 +1052,31 @@ def _tier1_only_fallback_verdict(
     ``capture`` rather than the per-tier breakdown -- the other
     four tiers genuinely did not run.
 
-    Verdict rule: any Tier 1 detector fires -> ``fail``; else
-    ``pass``. Matches the existing Phase-1 fallback shape so
+    The operator's detector-disable knobs apply here too, so this
+    fallback honours the same contract as :func:`classify_trial`: a
+    silenced ``tier1`` / ``tier1:<id>`` doesn't fire. The caller passes
+    the *effective* set (Tier 1 forced back on for an exec-failure trial)
+    so a command-not-found still fails even with Tier 1 disabled.
+
+    Verdict rule: any (non-disabled) Tier 1 detector fires -> ``fail``;
+    else ``pass``. Matches the existing Phase-1 fallback shape so
     downstream tooling that already parses ``failure_detectors_fired``
     keeps working.
     """
-    fired = tier1_detect(
-        Tier1Context(
-            exit_code=exit_code,
-            timed_out=timed_out,
-            trial_dir=trial_dir,
-        )
-    )
+    if "tier1" in disabled_tiers:
+        fired: list[str] = []
+    else:
+        fired = [
+            d
+            for d in tier1_detect(
+                Tier1Context(
+                    exit_code=exit_code,
+                    timed_out=timed_out,
+                    trial_dir=trial_dir,
+                )
+            )
+            if d not in disabled_detectors
+        ]
     verdict_str = "fail" if fired else "pass"
     capture: dict[str, str | float | int] = {
         "classifier_error": f"{type(classifier_exc).__name__}: {classifier_exc}",

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -386,8 +386,12 @@ class SubprocessWorkload(Workload):
         # Issue #229: detector-disable knobs. Validated on the
         # recipe-builder side; default to empty so non-probe / legacy
         # payloads are the no-op (every detector active).
-        disabled_detectors = frozenset(probe_extras.get("disable_detectors") or ())
-        disabled_tiers = frozenset(probe_extras.get("disable_detector_tiers") or ())
+        disabled_detectors = _coerce_disable_tokens(
+            probe_extras.get("disable_detectors"), "disable_detectors"
+        )
+        disabled_tiers = _coerce_disable_tokens(
+            probe_extras.get("disable_detector_tiers"), "disable_detector_tiers"
+        )
 
         # ``inherit`` mode: the dispatcher has already stamped the
         # cell's mitigation + diagnostic env vars onto os.environ in
@@ -892,6 +896,27 @@ class SubprocessWorkload(Workload):
         if not isinstance(bundle, dict):
             return {}
         return {str(k): str(v) for k, v in bundle.items()}
+
+
+def _coerce_disable_tokens(raw: object, key: str) -> frozenset[str]:
+    """Build a disable-token set from a ``probe_extras`` payload, fail-fast.
+
+    ``probe_extras`` is an untyped dict at runtime, so a malformed payload
+    where the value is a bare string (e.g. ``"tier3"``) would otherwise
+    iterate per-character and yield ``{'t','i','e','r','3'}``. Reject
+    strings explicitly so a bad payload surfaces instead of silently
+    mis-disabling. ``None`` is the documented no-op (every detector
+    active). Mirrors the fail-fast posture of the sibling
+    ``tier3_vram_growth`` knob.
+    """
+    if raw is None:
+        return frozenset()
+    if isinstance(raw, str) or not isinstance(raw, (list, tuple, set, frozenset)):
+        raise TypeError(
+            f"probe_extras[{key!r}] must be a list/tuple of tokens, got "
+            f"{type(raw).__name__} ({raw!r})"
+        )
+    return frozenset(raw)
 
 
 def _validate_env_file_entries(env: dict[str, str]) -> None:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -772,11 +772,19 @@ class SubprocessWorkload(Workload):
             result_doc["capture"]["tier2_hang_latched_but_reconciled"] = True
         # Issue #229: surface the operator's disable knobs in the trial
         # artifact so a reader knows a detector was intentionally silenced
-        # rather than simply not firing.
-        if disabled_detectors:
-            result_doc["capture"]["disabled_detectors"] = sorted(disabled_detectors)
-        if disabled_tiers:
-            result_doc["capture"]["disabled_detector_tiers"] = sorted(disabled_tiers)
+        # rather than simply not firing. Record the *effective* set the
+        # classifier actually honoured -- on the exec-failure path Tier 1
+        # is forced back on, so echoing the requested set here would make
+        # the artifact self-contradictory (claim ``tier1`` disabled while
+        # ``tier1:exit_nonzero`` shows as fired). (Copilot review)
+        if effective_disabled_detectors:
+            result_doc["capture"]["disabled_detectors"] = sorted(
+                effective_disabled_detectors
+            )
+        if effective_disabled_tiers:
+            result_doc["capture"]["disabled_detector_tiers"] = sorted(
+                effective_disabled_tiers
+            )
         result_path.write_text(
             json.dumps(result_doc, indent=2, sort_keys=False),
             encoding="utf-8",

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -960,8 +960,8 @@ def _coerce_disable_tokens(raw: object, key: str) -> frozenset[str]:
         return frozenset()
     if isinstance(raw, str) or not isinstance(raw, (list, tuple, set, frozenset)):
         raise TypeError(
-            f"probe_extras[{key!r}] must be a list/tuple/set of string tokens "
-            f"(a non-string sequence), got {type(raw).__name__} ({raw!r})"
+            f"probe_extras[{key!r}] must be a list/tuple/set/frozenset of string "
+            f"tokens (a non-string sequence), got {type(raw).__name__} ({raw!r})"
         )
     tokens: list[str] = []
     for tok in raw:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -915,9 +915,12 @@ def _coerce_disable_tokens(raw: object, key: str) -> frozenset[str]:
     where the value is a bare string (e.g. ``"tier3"``) would otherwise
     iterate per-character and yield ``{'t','i','e','r','3'}``. Reject
     strings explicitly so a bad payload surfaces instead of silently
-    mis-disabling. ``None`` is the documented no-op (every detector
-    active). Mirrors the fail-fast posture of the sibling
-    ``tier3_vram_growth`` knob.
+    mis-disabling. Each element must itself be a ``str`` -- a non-string
+    token (e.g. ``["tier3", 5]``) would otherwise survive into the
+    set and later crash ``sorted(disabled_detectors)`` (TypeError on
+    mixed types) or silently no-op against the string detector IDs.
+    ``None`` is the documented no-op (every detector active). Mirrors
+    the fail-fast posture of the sibling ``tier3_vram_growth`` knob.
     """
     if raw is None:
         return frozenset()
@@ -926,7 +929,15 @@ def _coerce_disable_tokens(raw: object, key: str) -> frozenset[str]:
             f"probe_extras[{key!r}] must be a list/tuple of tokens, got "
             f"{type(raw).__name__} ({raw!r})"
         )
-    return frozenset(raw)
+    tokens: list[str] = []
+    for tok in raw:
+        if not isinstance(tok, str):
+            raise TypeError(
+                f"probe_extras[{key!r}] tokens must all be strings, got "
+                f"{type(tok).__name__} ({tok!r})"
+            )
+        tokens.append(tok)
+    return frozenset(tokens)
 
 
 def _validate_env_file_entries(env: dict[str, str]) -> None:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -926,8 +926,8 @@ def _coerce_disable_tokens(raw: object, key: str) -> frozenset[str]:
         return frozenset()
     if isinstance(raw, str) or not isinstance(raw, (list, tuple, set, frozenset)):
         raise TypeError(
-            f"probe_extras[{key!r}] must be a list/tuple of tokens, got "
-            f"{type(raw).__name__} ({raw!r})"
+            f"probe_extras[{key!r}] must be a list/tuple/set of string tokens "
+            f"(a non-string sequence), got {type(raw).__name__} ({raw!r})"
         )
     tokens: list[str] = []
     for tok in raw:

--- a/tests/probe/classifier/test_disables.py
+++ b/tests/probe/classifier/test_disables.py
@@ -21,7 +21,11 @@ from aorta.probe.classifier.disables import (
     normalize_tier,
     normalize_tiers,
 )
-from aorta.probe.classifier.tier3_kernel import Tier3State
+from aorta.probe.classifier.tier3_kernel import (
+    DETECTOR_VRAM_GROWTH,
+    AmdSmiSnapshot,
+    Tier3State,
+)
 from aorta.probe.classifier.tier5_custom import CompiledPattern
 
 
@@ -53,8 +57,47 @@ def test_normalize_detector_id_accepts_known_prefixes(tok: str) -> None:
 
 def test_normalize_detector_id_lowercases_prefix_only() -> None:
     # Prefix canonicalised; the id half is preserved verbatim because
-    # custom-pattern ids are user-named and case-sensitive.
-    assert normalize_detector_id("TIER2:Hang") == "tier2:Hang"
+    # custom-pattern ids are user-named and case-sensitive. (Built-in
+    # ids are validated against the catalogue below, so a custom id is
+    # the right vehicle for the case-preservation contract.)
+    assert normalize_detector_id("CUSTOM:My_Id") == "custom:My_Id"
+
+
+@pytest.mark.parametrize(
+    "tok",
+    [
+        "tier1:exit_nonzero",
+        "tier2:hang",
+        "tier3:vram_growth",
+        "tier4:nan_signature",
+    ],
+)
+def test_normalize_detector_id_accepts_known_builtin_ids(tok: str) -> None:
+    # Built-in ids that exist in their tier's ALL_DETECTOR_IDS catalogue
+    # pass validation unchanged.
+    assert normalize_detector_id(tok) == tok
+
+
+@pytest.mark.parametrize(
+    "tok",
+    [
+        "tier1:nope",
+        "tier3:vram_growht",  # typo
+        "tier4:python_tracback",  # typo
+        "tier2:Hang",  # built-in id is case-sensitive against catalogue
+    ],
+)
+def test_normalize_detector_id_rejects_unknown_builtin_id(tok: str) -> None:
+    # A built-in (tier1-4) id that is not in its tier's catalogue is a
+    # typo and must fail at parse time instead of silently disabling
+    # nothing.
+    with pytest.raises(DetectorSpecError):
+        normalize_detector_id(tok)
+
+
+def test_normalize_detector_id_custom_stays_free_form() -> None:
+    # custom:* ids are user-named -- any non-empty id is accepted.
+    assert normalize_detector_id("custom:anything_goes") == "custom:anything_goes"
 
 
 @pytest.mark.parametrize("tok", ["hang", "tier2:", ":hang", "tier9:foo", "tierX:y"])
@@ -178,6 +221,31 @@ def test_disable_tier3_skips_dmesg_scan(tmp_path: Path) -> None:
     )
     assert "tier3:amdgpu_reset" not in verdict.failure_detectors_fired
     assert verdict.verdict == "pass"
+
+
+def test_disable_tier3_vram_growth_id_suppresses_warn(tmp_path: Path) -> None:
+    # Disabling the warn-level ``tier3:vram_growth`` detector by id must
+    # keep it out of the fired lists -- the classifier gates the VRAM
+    # delta check on the disabled set before the scan, not only via the
+    # post-hoc filter.
+    pre = AmdSmiSnapshot(vram_used_mib=4000, thermal_throttle_count=0)
+    post = AmdSmiSnapshot(vram_used_mib=71234, thermal_throttle_count=0)
+    baseline, _ = classify_trial(
+        _ctx(tmp_path, tier3_state=Tier3State(), amd_smi_pre=pre, amd_smi_post=post)
+    )
+    assert DETECTOR_VRAM_GROWTH in baseline.warn_detectors_fired
+
+    verdict, _ = classify_trial(
+        _ctx(
+            tmp_path,
+            tier3_state=Tier3State(),
+            amd_smi_pre=pre,
+            amd_smi_post=post,
+            disabled_detectors=frozenset({DETECTOR_VRAM_GROWTH}),
+        )
+    )
+    assert DETECTOR_VRAM_GROWTH not in verdict.warn_detectors_fired
+    assert DETECTOR_VRAM_GROWTH not in verdict.failure_detectors_fired
 
 
 def test_disable_custom_pattern(tmp_path: Path) -> None:

--- a/tests/probe/classifier/test_disables.py
+++ b/tests/probe/classifier/test_disables.py
@@ -63,6 +63,28 @@ def test_normalize_detector_id_rejects_malformed(tok: str) -> None:
         normalize_detector_id(tok)
 
 
+@pytest.mark.parametrize(
+    ("tok", "expected"),
+    [
+        ("tier2: hang", "tier2:hang"),
+        ("  tier2 : hang  ", "tier2:hang"),
+        ("custom:  My_Id ", "custom:My_Id"),
+    ],
+)
+def test_normalize_detector_id_strips_whitespace_around_id(tok: str, expected: str) -> None:
+    # A copy/paste token with a space after the colon must canonicalise to
+    # the bare id so it actually matches the fired detector id; case in the
+    # id half is still preserved.
+    assert normalize_detector_id(tok) == expected
+
+
+@pytest.mark.parametrize("tok", ["tier2:   ", "custom: \t "])
+def test_normalize_detector_id_rejects_whitespace_only_id(tok: str) -> None:
+    # An id that is empty after trimming counts as missing.
+    with pytest.raises(DetectorSpecError):
+        normalize_detector_id(tok)
+
+
 def test_normalize_lists_dedupe_preserve_order() -> None:
     assert normalize_tiers(["tier3", "tier2", "tier3"]) == ("tier3", "tier2")
     assert normalize_detector_ids(["tier2:hang", "tier2:hang"]) == ("tier2:hang",)

--- a/tests/probe/classifier/test_disables.py
+++ b/tests/probe/classifier/test_disables.py
@@ -326,3 +326,51 @@ def test_disable_required_custom_pattern_does_not_synthesize_missing_signal(
     )
     assert verdict.verdict == "pass"
     assert all("missing_pass_signal" not in d for d in verdict.failure_detectors_fired)
+
+
+def test_classify_trial_passes_only_required_patterns_to_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Contract guard: ``VerdictInputs.custom_required_patterns`` is documented
+    # to carry only ``required_for_pass=True`` patterns. ``classify_trial``
+    # must narrow to that subset before building ``VerdictInputs`` -- even
+    # though ``resolve`` re-filters -- so the API contract can't silently
+    # drift back to the full active set.
+    import aorta.probe.classifier as classifier_mod
+
+    required = CompiledPattern(
+        detector_id="custom:must_see",
+        regex=re.compile("seen"),
+        condition_code=None,
+        condition_source=None,
+        on_match="fail",
+        required_for_pass=True,
+    )
+    optional = CompiledPattern(
+        detector_id="custom:maybe",
+        regex=re.compile("maybe"),
+        condition_code=None,
+        condition_source=None,
+        on_match="warn",
+        required_for_pass=False,
+    )
+
+    captured: dict[str, tuple[CompiledPattern, ...]] = {}
+    real_resolve = classifier_mod.resolve
+
+    def _spy_resolve(inputs):  # type: ignore[no-untyped-def]
+        captured["required"] = inputs.custom_required_patterns
+        return real_resolve(inputs)
+
+    # raising=True (the default, explicit here): if ``resolve`` is ever
+    # renamed/removed this guard should fail loudly rather than no-op.
+    monkeypatch.setattr(classifier_mod, "resolve", _spy_resolve, raising=True)
+
+    classify_trial(
+        _ctx(tmp_path, log_text="seen\n", custom_patterns=(required, optional))
+    )
+
+    captured_required = captured.get("required")
+    assert captured_required is not None, "resolve() was not invoked"
+    assert {p.detector_id for p in captured_required} == {"custom:must_see"}
+    assert all(p.required_for_pass for p in captured_required)

--- a/tests/probe/classifier/test_disables.py
+++ b/tests/probe/classifier/test_disables.py
@@ -184,6 +184,34 @@ def test_disable_custom_pattern(tmp_path: Path) -> None:
     assert verdict.verdict == "pass"
 
 
+def test_disable_custom_pattern_leaves_no_capture_side_effect(tmp_path: Path) -> None:
+    # A disabled custom detector must be truly *not evaluated*: its
+    # ``capture`` named groups must not surface (and, by the same token,
+    # its sandbox ``condition`` must not run). Filtering happens before
+    # the Tier-5 scan, so the silenced detector leaves no trace.
+    pat = CompiledPattern(
+        detector_id="custom:metric",
+        regex=re.compile(r"loss=(?P<loss>[0-9.]+)"),
+        condition_code=None,
+        condition_source=None,
+        on_match="info",
+        required_for_pass=False,
+    )
+    log = "step 1 loss=3.14\n"
+    baseline, _ = classify_trial(_ctx(tmp_path, log_text=log, custom_patterns=(pat,)))
+    assert baseline.capture.get("loss") == "3.14"
+
+    verdict, _ = classify_trial(
+        _ctx(
+            tmp_path,
+            log_text=log,
+            custom_patterns=(pat,),
+            disabled_detectors=frozenset({"custom:metric"}),
+        )
+    )
+    assert "loss" not in verdict.capture
+
+
 def test_disable_required_custom_pattern_does_not_synthesize_missing_signal(
     tmp_path: Path,
 ) -> None:

--- a/tests/probe/classifier/test_disables.py
+++ b/tests/probe/classifier/test_disables.py
@@ -1,0 +1,210 @@
+"""Tests for the detector-disable knob (issue #229).
+
+Covers the token-validation layer (:mod:`aorta.probe.classifier.disables`)
+and its effect inside :func:`aorta.probe.classifier.classify_trial`: a
+disabled detector must never flip the verdict nor appear in the fired
+lists, and a disabled whole tier must skip evaluation entirely.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from aorta.probe.classifier import TrialContext, classify_trial
+from aorta.probe.classifier.disables import (
+    DetectorSpecError,
+    normalize_detector_id,
+    normalize_detector_ids,
+    normalize_tier,
+    normalize_tiers,
+)
+from aorta.probe.classifier.tier3_kernel import Tier3State
+from aorta.probe.classifier.tier5_custom import CompiledPattern
+
+
+# --------------------------------------------------------------------------
+# Token validation
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("tok", ["tier1", "tier2", "tier3", "tier4", "tier5"])
+def test_normalize_tier_accepts_known(tok: str) -> None:
+    assert normalize_tier(tok) == tok
+
+
+def test_normalize_tier_is_case_insensitive_and_trims() -> None:
+    assert normalize_tier("  TIER3 ") == "tier3"
+
+
+@pytest.mark.parametrize("tok", ["tier0", "tier6", "hang", "tier3:hang", ""])
+def test_normalize_tier_rejects_unknown(tok: str) -> None:
+    with pytest.raises(DetectorSpecError):
+        normalize_tier(tok)
+
+
+@pytest.mark.parametrize(
+    "tok",
+    ["tier2:hang", "tier3:vram_growth", "tier4:hip_error", "custom:my_id"],
+)
+def test_normalize_detector_id_accepts_known_prefixes(tok: str) -> None:
+    assert normalize_detector_id(tok) == tok
+
+
+def test_normalize_detector_id_lowercases_prefix_only() -> None:
+    # Prefix canonicalised; the id half is preserved verbatim because
+    # custom-pattern ids are user-named and case-sensitive.
+    assert normalize_detector_id("TIER2:Hang") == "tier2:Hang"
+
+
+@pytest.mark.parametrize("tok", ["hang", "tier2:", ":hang", "tier9:foo", "tierX:y"])
+def test_normalize_detector_id_rejects_malformed(tok: str) -> None:
+    with pytest.raises(DetectorSpecError):
+        normalize_detector_id(tok)
+
+
+def test_normalize_lists_dedupe_preserve_order() -> None:
+    assert normalize_tiers(["tier3", "tier2", "tier3"]) == ("tier3", "tier2")
+    assert normalize_detector_ids(["tier2:hang", "tier2:hang"]) == ("tier2:hang",)
+
+
+def test_normalize_lists_none_is_empty() -> None:
+    assert normalize_tiers(None) == ()
+    assert normalize_detector_ids(None) == ()
+
+
+@pytest.mark.parametrize("bad", ["tier3", 5, {"a": 1}])
+def test_normalize_lists_reject_non_list(bad: object) -> None:
+    # A bare string is a common mistake (forgetting the YAML list dash);
+    # it must be rejected rather than iterated character-by-character.
+    with pytest.raises(DetectorSpecError):
+        normalize_tiers(bad)
+
+
+# --------------------------------------------------------------------------
+# classify_trial integration
+# --------------------------------------------------------------------------
+def _ctx(tmp_path: Path, **kw: object) -> TrialContext:
+    base: dict[str, object] = {
+        "exit_code": 0,
+        "timed_out": False,
+        "walltime_sec": 1.0,
+        "trial_dir": tmp_path,
+        "log_text": "",
+    }
+    base.update(kw)
+    return TrialContext(**base)  # type: ignore[arg-type]
+
+
+def test_hang_fires_when_not_disabled(tmp_path: Path) -> None:
+    verdict, _ = classify_trial(_ctx(tmp_path, hang_detected=True))
+    assert verdict.verdict == "fail"
+    assert "tier2:hang" in verdict.failure_detectors_fired
+
+
+def test_disable_tier2_suppresses_hang(tmp_path: Path) -> None:
+    verdict, _ = classify_trial(
+        _ctx(tmp_path, hang_detected=True, disabled_tiers=frozenset({"tier2"}))
+    )
+    assert verdict.verdict == "pass"
+    assert "tier2:hang" not in verdict.failure_detectors_fired
+
+
+def test_disable_detector_id_suppresses_hang(tmp_path: Path) -> None:
+    verdict, _ = classify_trial(
+        _ctx(tmp_path, hang_detected=True, disabled_detectors=frozenset({"tier2:hang"}))
+    )
+    assert verdict.verdict == "pass"
+    assert "tier2:hang" not in verdict.failure_detectors_fired
+
+
+def test_disable_tier4_suppresses_log_pattern(tmp_path: Path) -> None:
+    log = "Traceback... HIP error: out of memory\n"
+    fired, _ = classify_trial(_ctx(tmp_path, log_text=log))
+    assert fired.verdict == "fail"  # baseline: tier4 fires
+
+    verdict, _ = classify_trial(
+        _ctx(tmp_path, log_text=log, disabled_tiers=frozenset({"tier4"}))
+    )
+    assert "tier4:hip_error" not in verdict.failure_detectors_fired
+
+
+def test_disable_specific_tier4_id_keeps_others(tmp_path: Path) -> None:
+    log = "HIP error: boom\ncudaError_LaunchFailure\n"
+    verdict, _ = classify_trial(
+        _ctx(tmp_path, log_text=log, disabled_detectors=frozenset({"tier4:hip_error"}))
+    )
+    assert "tier4:hip_error" not in verdict.failure_detectors_fired
+    assert "tier4:cuda_error" in verdict.failure_detectors_fired
+    assert verdict.verdict == "fail"
+
+
+def test_disable_tier3_skips_dmesg_scan(tmp_path: Path) -> None:
+    dmesg = "amdgpu: GPU reset begin!\n"
+    baseline, _ = classify_trial(
+        _ctx(tmp_path, dmesg_text=dmesg, tier3_state=Tier3State())
+    )
+    assert "tier3:amdgpu_reset" in baseline.failure_detectors_fired
+
+    verdict, _ = classify_trial(
+        _ctx(
+            tmp_path,
+            dmesg_text=dmesg,
+            tier3_state=Tier3State(),
+            disabled_tiers=frozenset({"tier3"}),
+        )
+    )
+    assert "tier3:amdgpu_reset" not in verdict.failure_detectors_fired
+    assert verdict.verdict == "pass"
+
+
+def test_disable_custom_pattern(tmp_path: Path) -> None:
+    pat = CompiledPattern(
+        detector_id="custom:boom",
+        regex=re.compile("boom"),
+        condition_code=None,
+        condition_source=None,
+        on_match="fail",
+        required_for_pass=False,
+    )
+    log = "...boom...\n"
+    baseline, _ = classify_trial(_ctx(tmp_path, log_text=log, custom_patterns=(pat,)))
+    assert "custom:boom" in baseline.failure_detectors_fired
+    assert baseline.verdict == "fail"
+
+    verdict, _ = classify_trial(
+        _ctx(
+            tmp_path,
+            log_text=log,
+            custom_patterns=(pat,),
+            disabled_detectors=frozenset({"custom:boom"}),
+        )
+    )
+    assert "custom:boom" not in verdict.failure_detectors_fired
+    assert verdict.verdict == "pass"
+
+
+def test_disable_required_custom_pattern_does_not_synthesize_missing_signal(
+    tmp_path: Path,
+) -> None:
+    # A required-for-pass pattern that the operator disables must not
+    # leave behind a meta:missing_pass_signal failure -- disabling means
+    # "ignore this detector entirely", required-ness included.
+    pat = CompiledPattern(
+        detector_id="custom:must_see",
+        regex=re.compile("never-matches-zzz"),
+        condition_code=None,
+        condition_source=None,
+        on_match="fail",
+        required_for_pass=True,
+    )
+    verdict, _ = classify_trial(
+        _ctx(
+            tmp_path,
+            log_text="nothing here\n",
+            custom_patterns=(pat,),
+            disabled_detectors=frozenset({"custom:must_see"}),
+        )
+    )
+    assert verdict.verdict == "pass"
+    assert all("missing_pass_signal" not in d for d in verdict.failure_detectors_fired)

--- a/tests/probe/test_cli_parsing.py
+++ b/tests/probe/test_cli_parsing.py
@@ -363,6 +363,48 @@ def test_default_passthrough_mode_when_neither_set(monkeypatch, tmp_path):
     assert recipe_arg.probe_extras.env_passthrough_mode == "inherit"
 
 
+# ---- issue #229: --disable-detector overlay ------------------------------
+
+
+def test_cli_disable_detector_unions_onto_recipe(monkeypatch, tmp_path):
+    """``--disable-detector`` adds to (does not replace) the recipe's set."""
+    recipe_text = _RECIPE_NO_MODE + "disable_detectors: [custom:from_recipe]\n"
+    recipe_arg = _invoke_probe_capturing_recipe(
+        monkeypatch,
+        tmp_path,
+        recipe_text=recipe_text,
+        cli_extra=["--disable-detector", "tier2:hang", "--disable-detector", "tier3"],
+    )
+    assert recipe_arg.probe_extras is not None
+    assert recipe_arg.probe_extras.disable_detectors == ("custom:from_recipe", "tier2:hang")
+    assert recipe_arg.probe_extras.disable_detector_tiers == ("tier3",)
+
+
+def test_cli_disable_detector_invalid_token_errors(monkeypatch, tmp_path):
+    """A malformed token surfaces a friendly CLI error, not a traceback."""
+    mock = MagicMock(return_value=tmp_path / "run-dir")
+    monkeypatch.setattr(probe_cli, "run_recipe", mock)
+    recipe_path = tmp_path / "r.yaml"
+    recipe_path.write_text(_RECIPE_NO_MODE, encoding="utf-8")
+    result = CliRunner().invoke(
+        probe,
+        [
+            "--recipe",
+            str(recipe_path),
+            "--output",
+            str(tmp_path / "out"),
+            "--disable-detector",
+            "tier9:nope",
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--disable-detector" in result.output
+    mock.assert_not_called()
+
+
 def test_cli_env_passthrough_mode_file_overrides_no_recipe_key(monkeypatch, tmp_path):
     """Recipe omits the key, CLI says ``file`` -> ``file`` wins."""
     recipe_arg = _invoke_probe_capturing_recipe(

--- a/tests/probe/test_recipe.py
+++ b/tests/probe/test_recipe.py
@@ -339,6 +339,54 @@ def test_timeout_per_trial_must_be_positive(tmp_path):
         load_recipe(_write_yaml(tmp_path, text))
 
 
+# ---- issue #229: detector-disable knobs ----------------------------------
+
+
+def test_disable_detector_knobs_parse(tmp_path):
+    text = _PROBE_MINIMAL + (
+        "disable_detectors: [tier2:hang, custom:my_id]\n"
+        "disable_detector_tiers: [tier3]\n"
+    )
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.probe_extras is not None
+    assert r.probe_extras.disable_detectors == ("tier2:hang", "custom:my_id")
+    assert r.probe_extras.disable_detector_tiers == ("tier3",)
+
+
+def test_disable_detector_knobs_default_empty(tmp_path):
+    r = load_recipe(_write_yaml(tmp_path, _PROBE_MINIMAL))
+    assert r.probe_extras is not None
+    assert r.probe_extras.disable_detectors == ()
+    assert r.probe_extras.disable_detector_tiers == ()
+
+
+def test_disable_detector_bad_id_rejected(tmp_path):
+    text = _PROBE_MINIMAL + "disable_detectors: [hang]\n"
+    with pytest.raises(RecipeSchemaError, match="malformed detector id"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_disable_detector_tier_unknown_rejected(tmp_path):
+    text = _PROBE_MINIMAL + "disable_detector_tiers: [tier9]\n"
+    with pytest.raises(RecipeSchemaError, match="unknown tier"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_disable_detector_keys_rejected_in_triage_mode(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+disable_detectors: [tier2:hang]
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+"""
+    with pytest.raises(RecipeSchemaError, match="probe-mode only"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
 # ---- PR #194 round-3 review: probe confound rejects unknown keys ---------
 
 

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -745,19 +745,27 @@ def test_disable_tier3_skips_probes(tmp_path, monkeypatch):
 
 def test_tier3_probes_run_when_not_disabled(tmp_path, monkeypatch):
     # Counterpart to the disable test: with tier3 active the probes run.
+    # Spy on BOTH probes so the test stays hermetic -- the real scan_dmesg()
+    # shells out to `dmesg` (host-permission dependent, flaky/slow).
     from aorta.workloads import _subprocess as workload_mod
 
-    calls = {"poll": 0}
+    calls = {"poll": 0, "dmesg": 0}
 
     def _spy_poll(_state):
         calls["poll"] += 1
         return None
 
+    def _spy_dmesg(_state, **_kw):
+        calls["dmesg"] += 1
+        return []
+
     monkeypatch.setattr(workload_mod, "poll_amd_smi", _spy_poll)
+    monkeypatch.setattr(workload_mod, "scan_dmesg", _spy_dmesg)
     wl = _make_workload(tmp_path, ["true"])
     wl.setup()
     wl.run()
     assert calls["poll"] >= 1
+    assert calls["dmesg"] >= 1
 
 
 def test_hang_grace_zero_survives_runtime_extraction(tmp_path, monkeypatch):

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -185,6 +185,55 @@ def test_missing_executable_yields_fail(tmp_path):
     assert result.passed is False
 
 
+@pytest.mark.parametrize(
+    "extras",
+    [
+        {"disable_detector_tiers": ["tier1"]},
+        {"disable_detectors": ["tier1:exit_nonzero"]},
+    ],
+)
+def test_disabled_tier1_does_not_pass_unlaunched_command(tmp_path, extras):
+    """A command that never launches must fail even if Tier 1 is disabled.
+
+    Regression for oyazdanb's #234 review: honouring a Tier-1 disable on
+    the exec-failure path would let a command-not-found resolve to a green
+    verdict -- a run that did no real work yet looks like a pass. The
+    workload forces Tier 1 back on for the unlaunched path; the disable
+    still applies to launched trials (asserted in the sibling test).
+    """
+    wl = _make_workload(tmp_path, ["definitely-not-a-real-binary-9d8f7s6"], **extras)
+    wl.setup()
+    result = wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert doc["exit_code"] == 127
+    assert "tier1:exit_nonzero" in doc["failure_detectors_fired"]
+    assert result.passed is False
+
+
+@pytest.mark.parametrize(
+    "extras",
+    [
+        {"disable_detector_tiers": ["tier1"]},
+        {"disable_detectors": ["tier1:exit_nonzero"]},
+    ],
+)
+def test_disabled_tier1_still_passes_launched_nonzero_exit(tmp_path, extras):
+    """The Tier-1 disable still applies on a launched trial.
+
+    Pins the lower bound of the unlaunched-path guard above: a child that
+    actually ran and exited non-zero is silenced by the disable as the
+    operator intended (the override is scoped to the exec-failure path).
+    """
+    wl = _make_workload(tmp_path, ["false"], **extras)  # launches, exits 1
+    wl.setup()
+    result = wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "pass"
+    assert "tier1:exit_nonzero" not in doc["failure_detectors_fired"]
+    assert result.passed is True
+
+
 def test_exec_time_failure_flags_main_work_not_started(tmp_path):
     """Exec-time ``Popen`` failures must report
     ``main_work_started=False`` / ``executed_iterations=0`` so the
@@ -880,6 +929,60 @@ def test_classifier_crash_still_writes_result_json(tmp_path, monkeypatch):
     assert "synthetic classifier crash" in doc["capture"]["classifier_error"]
     # The workload result still reports the failure (not a hang) so
     # the dispatcher records a failed trial deterministically.
+    assert result.passed is False
+
+
+def test_classifier_crash_fallback_honours_tier1_disable(tmp_path, monkeypatch):
+    """The Tier-1-only crash fallback must honour the disable knob too.
+
+    Bugbot #234 follow-up: a launched trial with Tier 1 silenced should
+    stay ``pass`` even when ``classify_trial`` crashes -- the fallback
+    applies the same disabled set, so a disabled ``tier1:exit_nonzero``
+    is not re-fired behind the operator's back.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    def _exploding_classify(_ctx):
+        raise RuntimeError("synthetic classifier crash")
+
+    monkeypatch.setattr(workload_mod, "classify_trial", _exploding_classify)
+    wl = _make_workload(tmp_path, ["false"], disable_detectors=["tier1:exit_nonzero"])
+    wl.setup()
+    result = wl.run()
+
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "pass"
+    assert "tier1:exit_nonzero" not in doc["failure_detectors_fired"]
+    assert "classifier_error" in doc["capture"]
+    assert result.passed is True
+
+
+def test_classifier_crash_fallback_still_fails_unlaunched_with_tier1_disabled(
+    tmp_path, monkeypatch
+):
+    """A command that never launches must fail in the crash fallback too.
+
+    The exec-failure path forces Tier 1 back on (the ``effective_*`` set),
+    and that same set feeds the fallback, so a command-not-found can't
+    resolve green even when Tier 1 is disabled and the classifier crashed.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    def _exploding_classify(_ctx):
+        raise RuntimeError("synthetic classifier crash")
+
+    monkeypatch.setattr(workload_mod, "classify_trial", _exploding_classify)
+    wl = _make_workload(
+        tmp_path,
+        ["definitely-not-a-real-binary-9d8f7s6"],
+        disable_detector_tiers=["tier1"],
+    )
+    wl.setup()
+    result = wl.run()
+
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["verdict"] == "fail"
+    assert "tier1:exit_nonzero" in doc["failure_detectors_fired"]
     assert result.passed is False
 
 

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -209,6 +209,12 @@ def test_disabled_tier1_does_not_pass_unlaunched_command(tmp_path, extras):
     assert doc["exit_code"] == 127
     assert "tier1:exit_nonzero" in doc["failure_detectors_fired"]
     assert result.passed is False
+    # Capture must echo the *effective* disabled set the classifier honoured,
+    # not the requested one -- else the artifact would claim tier1 was
+    # disabled while tier1:exit_nonzero shows as fired (Copilot #234 review).
+    capture = doc["capture"]
+    assert "tier1" not in capture.get("disabled_detector_tiers", [])
+    assert "tier1:exit_nonzero" not in capture.get("disabled_detectors", [])
 
 
 @pytest.mark.parametrize(
@@ -232,6 +238,13 @@ def test_disabled_tier1_still_passes_launched_nonzero_exit(tmp_path, extras):
     assert doc["verdict"] == "pass"
     assert "tier1:exit_nonzero" not in doc["failure_detectors_fired"]
     assert result.passed is True
+    # On a launched trial the disable is honoured, so the effective set
+    # equals the requested set and is recorded in capture for audit.
+    capture = doc["capture"]
+    recorded = capture.get("disabled_detector_tiers", []) + capture.get(
+        "disabled_detectors", []
+    )
+    assert recorded == list(extras.values())[0]
 
 
 def test_exec_time_failure_flags_main_work_not_started(tmp_path):

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -830,6 +830,48 @@ def test_tier3_probes_run_when_not_disabled(tmp_path, monkeypatch):
     assert calls["dmesg"] >= 1
 
 
+def test_tier3_probes_skipped_when_not_launched(tmp_path, monkeypatch):
+    """Copilot #234 review: an exec-time Popen failure (the subprocess
+    never launched) must skip the Tier-3 *post*-snapshot + dmesg scan.
+
+    A command-not-found trial did no GPU work, so running those probes only
+    adds overhead / permission noise and risks misattributing an unrelated
+    host kernel/GPU event to a trial that never ran. The pre-snapshot still
+    fires once -- it happens before the Popen attempt, so ``launched`` is
+    not yet known -- but the post-launch collection is gated on ``launched``.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    calls = {"poll": 0, "dmesg": 0}
+
+    def _spy_poll(_state):
+        calls["poll"] += 1
+        return None
+
+    def _spy_dmesg(_state, **_kw):
+        calls["dmesg"] += 1
+        return []
+
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", _spy_poll)
+    monkeypatch.setattr(workload_mod, "scan_dmesg", _spy_dmesg)
+
+    # Tier 3 stays enabled: the gate under test is the unlaunched flag, not
+    # an operator disable (covered by test_disable_tier3_skips_probes).
+    wl = _make_workload(tmp_path, ["definitely-not-a-real-binary-9d8f7s6"])
+    wl.setup()
+    wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc["exit_code"] == 127  # exec-time (ENOENT) failure path
+    assert calls["poll"] == 1, (
+        "expected only the pre-snapshot to run; the post-snapshot must be "
+        "skipped when the subprocess never launched"
+    )
+    assert calls["dmesg"] == 0, (
+        "scan_dmesg ran for a subprocess that never launched; an unrelated "
+        "kernel event could be misattributed to a command-not-found trial"
+    )
+
+
 def test_hang_grace_zero_survives_runtime_extraction(tmp_path, monkeypatch):
     """Regression for PR #197 review: ``probe_extras["hang_grace_period_at_start"]
     == 0.0`` is a validated "no grace, fire as soon as the window

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -705,6 +705,52 @@ def test_tier3_actually_runs_per_trial(tmp_path, monkeypatch):
     )
 
 
+def test_disable_tier3_skips_probes(tmp_path, monkeypatch):
+    """Issue #229 review: disabling the ``tier3`` tier must skip the
+    side-effecting amd-smi / dmesg probes in the workload, not merely
+    drop their verdict contribution. Spy on both and assert neither runs.
+    """
+    from aorta.workloads import _subprocess as workload_mod
+
+    calls = {"poll": 0, "dmesg": 0}
+
+    def _spy_poll(_state):
+        calls["poll"] += 1
+        return None
+
+    def _spy_dmesg(_state, **_kw):
+        calls["dmesg"] += 1
+        return []
+
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", _spy_poll)
+    monkeypatch.setattr(workload_mod, "scan_dmesg", _spy_dmesg)
+
+    wl = _make_workload(tmp_path, ["true"], disable_detector_tiers=["tier3"])
+    wl.setup()
+    wl.run()
+    assert calls == {"poll": 0, "dmesg": 0}, (
+        "disabling tier3 still ran the amd-smi/dmesg probes; the knob only "
+        "filtered the verdict instead of skipping the collection"
+    )
+
+
+def test_tier3_probes_run_when_not_disabled(tmp_path, monkeypatch):
+    # Counterpart to the disable test: with tier3 active the probes run.
+    from aorta.workloads import _subprocess as workload_mod
+
+    calls = {"poll": 0}
+
+    def _spy_poll(_state):
+        calls["poll"] += 1
+        return None
+
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", _spy_poll)
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    wl.run()
+    assert calls["poll"] >= 1
+
+
 def test_hang_grace_zero_survives_runtime_extraction(tmp_path, monkeypatch):
     """Regression for PR #197 review: ``probe_extras["hang_grace_period_at_start"]
     == 0.0`` is a validated "no grace, fire as soon as the window

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -41,6 +41,15 @@ def test_coerce_disable_tokens_rejects_non_sequence(bad):
     with pytest.raises(TypeError, match="disable_detectors"):
         _coerce_disable_tokens(bad, "disable_detectors")
 
+
+@pytest.mark.parametrize("bad", [["tier3", 5], ("tier2:hang", None), [b"tier3"]])
+def test_coerce_disable_tokens_rejects_non_string_elements(bad):
+    # A non-string token would survive into the set and later crash
+    # sorted(disabled_detectors) (mixed types) or silently no-op against
+    # the string detector IDs -- reject per-entry, fail fast.
+    with pytest.raises(TypeError, match="must all be strings"):
+        _coerce_disable_tokens(bad, "disable_detectors")
+
 # ---- FR 1.17 (entry-point resolution) ------------------------------------
 
 

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -18,7 +18,28 @@ from aorta.workloads._subprocess import (
     CONFIG_KEY_PROBE_EXTRAS,
     CONFIG_KEY_SUBPROCESS_ARGV,
     SubprocessWorkload,
+    _coerce_disable_tokens,
 )
+
+# ---- Issue #229: disable-token payload coercion --------------------------
+
+
+def test_coerce_disable_tokens_none_is_empty():
+    assert _coerce_disable_tokens(None, "disable_detectors") == frozenset()
+
+
+def test_coerce_disable_tokens_accepts_sequence():
+    assert _coerce_disable_tokens(["tier2:hang", "tier3"], "disable_detectors") == frozenset(
+        {"tier2:hang", "tier3"}
+    )
+
+
+@pytest.mark.parametrize("bad", ["tier3", 5, {"a": 1}])
+def test_coerce_disable_tokens_rejects_non_sequence(bad):
+    # A bare string would otherwise iterate per-character into a set of
+    # letters; fail fast like the sibling tier3_vram_growth knob.
+    with pytest.raises(TypeError, match="disable_detectors"):
+        _coerce_disable_tokens(bad, "disable_detectors")
 
 # ---- FR 1.17 (entry-point resolution) ------------------------------------
 


### PR DESCRIPTION
## Summary

Implements the **detector-disable knob** from #229 (the additive, self-contained part of that issue; the `failure_details[].type` fix is already up in #233).

Operators sometimes need to silence a detector that fires on benign, workload-specific behaviour — e.g. `tier2:hang` on a repro that legitimately idles, or `tier3:vram_growth` on an opaque docker wrapper where GPU allocation is normal rather than a leak. Today the only options are editing the classifier or living with false-positive failures. This adds a first-class opt-out.

### What you can do now

Recipe:
```yaml
disable_detector_tiers: [tier3]            # skip a whole tier (not evaluated)
disable_detectors: [tier2:hang, custom:my_id]  # skip individual detectors
```

CLI (repeatable, unioned onto the recipe's set):
```
aorta probe --recipe r.yaml --disable-detector tier2:hang --disable-detector tier4 -- <cmd>
```

### Semantics

- A disabled **whole tier** is *not evaluated* — its scan is skipped, so side-effecting probes (dmesg / amd-smi) don't run.
- A disabled **detector id** is filtered out after the (cheap, side-effect-free) scan.
- Either way the detector never reaches the verdict resolver, so it cannot flip the verdict or appear in `failure_detectors_fired` / `warn_detectors_fired`. Disabling a `required_for_pass` custom pattern also suppresses its `meta:missing_pass_signal`.
- The effective disabled set is echoed into `result.json::capture` and the probe dry-run header so a reader knows a detector was *intentionally silenced* rather than simply not firing.

### Design

- New `aorta.probe.classifier.disables` module is the single source of truth for valid tokens (`tier1`..`tier5`; `<prefix>:<id>` with prefix in `tier1..4`/`custom`), shared by the recipe-builder and the CLI. Invalid tokens fail at load time (`RecipeSchemaError`) or as a friendly CLI error.
- Threaded through the existing typed `ProbeExtras` → `RunRequest.probe_extras` → `SubprocessWorkload` → `TrialContext` path; no new plumbing channels.
- Click handler stays under its 60-line thin-shim ceiling (logic lives in `cli_helpers` / the classifier).

## Test plan

- [x] `tests/probe/classifier/test_disables.py` — token validation + `classify_trial` behaviour (tier skip, id filter, tier3 dmesg-scan skip, custom + required-pattern handling)
- [x] `tests/probe/test_recipe.py` — recipe parse/validation + triage-mode rejection
- [x] `tests/probe/test_cli_parsing.py` — CLI union/precedence + invalid-token error + thin-shim ceiling
- [x] Full `tests/probe` suite green except 3 pre-existing failures unrelated to this change (global `Popen` mock vs `poll_amd_smi`'s `subprocess.run`, fail identically on `main`)
- [x] Manual dry-run + real `aorta probe` run: disabled set unioned from recipe+CLI and recorded in `result.json::capture`

Part of #229.

Made with [Cursor](https://cursor.com)