### PR TITLE
probe/triage: stop_after collect-until-N stopping rule (#232)

### DIFF
--- a/.agents/skills/verify-run-output/reference.md
+++ b/.agents/skills/verify-run-output/reference.md
@@ -46,25 +46,34 @@ name exactly what couldn't be captured (rdhc, headers, submodule SHAs, …).
 
 Produced by `aorta probe` at `<cell>/trial_<n>/result.json`.
 
-Keys: `verdict` (`"pass"|"fail"`), `exit_code` (int), `walltime_sec` (float),
-`peak_vram_mib` (int|null), `argv` (list[str]), `cell_name` (str),
-`trial_index` (int), `failure_detectors_fired` (list[str]),
+Keys: `verdict` (`"pass"|"fail"|"error"`), `exit_code` (int),
+`walltime_sec` (float), `peak_vram_mib` (int|null), `argv` (list[str]),
+`cell_name` (str), `trial_index` (int), `failure_detectors_fired` (list[str]),
+`error_detectors_fired` (list[str]; issue #230, optional on legacy files),
 `warn_detectors_fired` (list[str]), `capture` (dict),
 `tier_durations_ms` (dict), `env` (dict[str,str], cell env bundle),
 `env_passthrough_mode` (`"inherit"|"file"`), `timed_out` (bool).
 
-Verdict precedence (from `classifier.md`):
-1. Any `tier1:`/`tier2:`/`tier3:`/`tier4:` detector OR any `on_match: fail`
-   custom (`custom:<id>`) pattern fires → `verdict = "fail"`.
-2. A `required_for_pass: true` pattern that did NOT fire injects
-   `meta:missing_pass_signal` and flips to `fail`.
+Verdict precedence (three-way, **fail > error > pass**; from `classifier.md`):
+1. Any `tier1:`/`tier2:`/`tier3:`/`tier4:` detector (other than the error
+   detectors below) OR any `on_match: fail` custom (`custom:<id>`) pattern
+   fires → `verdict = "fail"`. A `required_for_pass: true` pattern that did
+   NOT fire injects `meta:missing_pass_signal` and is a `fail`.
+2. Else, if only an error detector fired
+   (`tier1:timeout` with no co-firing `tier2:hang`, `tier1:exec_failed`, or
+   `meta:env_file_validation_failed`) → `verdict = "error"` (no valid
+   observation; excluded from the matrix event-rate denominator).
 3. Otherwise → `verdict = "pass"`.
 
 Consistency rules:
 - `failure_detectors_fired` non-empty ⟹ `verdict == "fail"`. Else = FAIL.
+- `error_detectors_fired` non-empty AND `failure_detectors_fired` empty ⟹
+  `verdict == "error"`. Else = FAIL.
 - `verdict == "fail"` with empty `failure_detectors_fired` = WARN (expect a
-  detector or `meta:missing_pass_signal`).
-- `timed_out == true` ⟺ a `…:timeout` detector present. Mismatch = WARN.
+  detector or `meta:missing_pass_signal`); `verdict == "error"` with empty
+  `error_detectors_fired` = FAIL (an error must name its reason).
+- `timed_out == true` ⟺ a `…:timeout` detector present (in EITHER list —
+  `tier1:timeout` is an error detector). Mismatch = WARN.
 - `warn_detectors_fired` / `capture` never change the verdict.
 - Detector IDs are stable strings; built-in (`tierN:`) and `custom:<id>` are
   peers. Do not treat a `custom:` ID as invalid — it is recipe-declared.
@@ -116,17 +125,23 @@ Both `aorta probe` and `aorta triage run` write these via the shared engine.
 `cells` (list).
 
 Each cell (CellStats): `name`, `mitigations`, `environment`, `extra_env`,
-`resolved_env_vars`, `trials`, `passed_count`, `failed_count`, `failure_rate`,
+`resolved_env_vars`, `trials`, `passed_count`, `failed_count`,
+`error_count` (issue #230), `failure_rate`, `error_rate`, `unreliable`,
 `mean_step_time_ms` (+ std/min/max/p50/p90/p99), `mean_wall_clock_sec`,
 `exit_status_counts` (dict), `step_times_ms`, `trial_paths`, `error`
 (str|null), `step_time_source`, `failure_hints`, `outcome_counts`,
 `executed_iter_min/max`, `configured_iters`, `iters_display`,
 `workload_config`, `confound`, `step_time_ratio`, `resolved_environment`,
-`top_failure_detector_id`, `top_warn_detector_id`.
+`top_failure_detector_id`, `top_warn_detector_id`, `stop_after_note`.
 
 Consistency rules (non-error cells):
-- `passed_count + failed_count == trials`. Else = FAIL.
-- `failure_rate == failed_count / trials`. Else = FAIL.
+- `passed_count + failed_count + error_count == trials`. Else = FAIL.
+- `failure_rate == failed_count / (passed_count + failed_count)` — the event
+  rate over *valid* trials; `error` trials are excluded from the denominator
+  (issue #230). `0.0` when there are no valid trials. Else = FAIL.
+- `error_rate == error_count / trials`. Else = FAIL.
+- `unreliable == true` when `error_rate >= 0.10` (advisory; the event rate
+  rests on too few valid trials).
 - `sum(exit_status_counts.values()) == trials`. Else = WARN.
 - `error != null` ⟹ row is preserved with zeroed numerics; `failure_rate`
   reported `n/a` in matrix.md. This is intentional completeness, not a bug.

--- a/.agents/skills/verify-run-output/scripts/verify_run.py
+++ b/.agents/skills/verify-run-output/scripts/verify_run.py
@@ -42,7 +42,7 @@ _TRIAL_EXIT_STATUS = {
     "workload_setup_failed",
     "infrastructure_failed",
 }
-_PROBE_VERDICTS = {"pass", "fail"}
+_PROBE_VERDICTS = {"pass", "fail", "error"}
 # Top-level env.json keys that should always be present (a subset chosen
 # to be stable across schema 1.x; absence is a real problem, not drift).
 _ENV_REQUIRED_KEYS = {
@@ -142,27 +142,57 @@ def check_probe_result(doc: dict, target: str, rep: Report) -> None:
     if not isinstance(fired, list):
         rep.fail(target, "failure_detectors_fired must be a list")
         fired = []
+    # Issue #230: infra-error signals live in their own list. Optional for
+    # legacy result.json that predates the three-way verdict.
+    errored = doc.get("error_detectors_fired")
+    if errored is None:
+        errored = []
+    elif not isinstance(errored, list):
+        rep.warn(target, "error_detectors_fired present but not a list")
+        errored = []
     warned = doc.get("warn_detectors_fired")
     if warned is not None and not isinstance(warned, list):
         rep.warn(target, "warn_detectors_fired present but not a list")
 
-    # Verdict precedence: any failure detector => verdict must be fail.
-    if fired and verdict == "pass":
+    # Verdict precedence (fail > error > pass, issue #230):
+    # - any failure detector  => verdict must be ``fail``
+    # - else any error detector => verdict must be ``error``
+    # - else                    => verdict must be ``pass``
+    if fired and verdict != "fail":
         rep.fail(
             target,
-            f"verdict=pass but failure_detectors_fired is non-empty ({fired})",
+            f"verdict={verdict!r} but failure_detectors_fired is non-empty "
+            f"({fired}); failures outrank everything -> expected fail",
         )
-    if not fired and verdict == "fail":
-        rep.warn(
+    if not fired and errored and verdict != "error":
+        rep.fail(
             target,
-            "verdict=fail with empty failure_detectors_fired "
-            "(expected at least one detector or meta:missing_pass_signal)",
+            f"verdict={verdict!r} but only error detectors fired ({errored}); "
+            "expected error",
         )
+    if not fired and not errored and verdict not in ("pass",):
+        # verdict=fail/error with nothing fired. fail keeps its legacy warn
+        # (meta:missing_pass_signal may have been the cause and dropped);
+        # error with no error detector is a contradiction.
+        if verdict == "fail":
+            rep.warn(
+                target,
+                "verdict=fail with empty failure_detectors_fired "
+                "(expected at least one detector or meta:missing_pass_signal)",
+            )
+        elif verdict == "error":
+            rep.fail(
+                target,
+                "verdict=error with empty error_detectors_fired "
+                "(an error verdict must name its infra-error reason)",
+            )
 
-    # timeout consistency.
+    # timeout consistency. ``tier1:timeout`` is an *error* detector, so look
+    # in both lists (a recognised hang co-fires tier2:hang -> the timeout
+    # may sit in error_detectors_fired even on a fail verdict).
     timed_out = doc.get("timed_out")
     has_timeout_detector = any(
-        isinstance(d, str) and d.endswith("timeout") for d in fired
+        isinstance(d, str) and d.endswith("timeout") for d in (*fired, *errored)
     )
     if timed_out is True and not has_timeout_detector:
         rep.warn(target, "timed_out=true but no tier1:timeout detector fired")
@@ -272,20 +302,37 @@ def check_matrix_json(doc: dict, target: str, rep: Report) -> None:
         trials = cell.get("trials")
         passed = cell.get("passed_count")
         failed = cell.get("failed_count")
+        # Issue #230: error trials are a third bucket. Optional/0 for legacy
+        # matrix.json that predates the three-way verdict.
+        errored = cell.get("error_count", 0)
+        if not isinstance(errored, int):
+            errored = 0
         err = cell.get("error")
         if err is None and all(isinstance(x, int) for x in (trials, passed, failed)):
-            if passed + failed != trials:
+            if passed + failed + errored != trials:
                 rep.fail(
                     ct,
-                    f"passed_count({passed})+failed_count({failed}) != trials({trials})",
+                    f"passed_count({passed})+failed_count({failed})+"
+                    f"error_count({errored}) != trials({trials})",
                 )
             rate = cell.get("failure_rate")
-            if _is_number(rate) and trials:
-                expect = failed / trials
+            if _is_number(rate):
+                # Event rate excludes error trials from the denominator.
+                valid = passed + failed
+                expect = (failed / valid) if valid else 0.0
                 if abs(rate - expect) > 1e-6:
                     rep.fail(
                         ct,
-                        f"failure_rate={rate} != failed/trials={expect:.6f}",
+                        f"failure_rate={rate} != failed/valid_trials={expect:.6f} "
+                        f"(valid = passed+failed = {valid}; errors excluded)",
+                    )
+            erate = cell.get("error_rate")
+            if _is_number(erate) and trials:
+                expect_e = errored / trials
+                if abs(erate - expect_e) > 1e-6:
+                    rep.fail(
+                        ct,
+                        f"error_rate={erate} != error/trials={expect_e:.6f}",
                     )
             hist = cell.get("exit_status_counts")
             if isinstance(hist, dict) and hist:

--- a/docs/probe-188/classifier.md
+++ b/docs/probe-188/classifier.md
@@ -24,10 +24,17 @@ Source: `src/aorta/probe/classifier/tier1_process.py`.
 | `tier1:sigbus` | `returncode == -signal.SIGBUS` |
 | `tier1:timeout` | `Popen.wait(timeout=recipe.timeout_per_trial)` raised `TimeoutExpired` |
 | `tier1:coredump` | Any `core.*` (or bare `core`) file exists directly under `<trial_dir>/` post-exit |
+| `tier1:exec_failed` | The wrapped command never launched — `Popen` raised ENOENT / EACCES / ENOEXEC |
 
-Encounter order: timeout > signal > exit_nonzero, then coredump
-appended regardless. The verdict resolver preserves this order in
-`failure_detectors_fired`.
+Encounter order: exec_failed (alone, suppresses everything else) →
+timeout > signal > exit_nonzero, then coredump appended regardless.
+The verdict resolver preserves this order.
+
+`tier1:timeout` and `tier1:exec_failed` are **error detectors** (issue
+#230): a trial whose only fired detectors are these resolves to
+`verdict = "error"` (no valid observation), not `"fail"`. They land in
+`error_detectors_fired`, not `failure_detectors_fired`. See
+[Verdict Precedence](#verdict-precedence).
 
 **Coredump caveat.** The dispatcher does **not** force
 `cwd=<trial_dir>` on the workload's `Popen` -- the user's `--`
@@ -179,20 +186,34 @@ pattern does **not** fire, the verdict resolver injects
 
 | ID | Source |
 |---|---|
-| `meta:missing_pass_signal` | Verdict resolver (`src/aorta/probe/classifier/verdict.py`). Synthesised when a `required_for_pass` pattern did not fire. |
+| `meta:missing_pass_signal` | Verdict resolver (`src/aorta/probe/classifier/verdict.py`). Synthesised when a `required_for_pass` pattern did not fire. A genuine **failure**. |
+| `meta:env_file_validation_failed` | `SubprocessWorkload` when a `probe.env` (`env_passthrough_mode: file`) bundle is rejected before launch. An **error** (config/infra; the command never ran). |
 
 ## Verdict Precedence
 
-Implemented in `src/aorta/probe/classifier/verdict.py::resolve`.
+Implemented in `src/aorta/probe/classifier/verdict.py::resolve`. The
+verdict is three-way (issue #230): **`fail` > `error` > `pass`**.
 
-1. Any Tier 1–4 detector OR any `on_match: fail` custom pattern
-   fires → `verdict = "fail"`.
-2. `failure_detectors_fired` lists ALL fired in encounter order:
-   T1 → T2 → T3 → T4 → custom-fail → `meta:missing_pass_signal`.
-3. A `required_for_pass: true` pattern that did NOT fire adds
-   `meta:missing_pass_signal` to `failure_detectors_fired` and flips
-   the verdict to `fail`.
-4. Otherwise → `verdict = "pass"`.
+1. **`fail`** — the event of interest manifested. Any Tier 1–4 detector
+   (other than the error detectors below) OR any `on_match: fail` custom
+   pattern fires. A `required_for_pass: true` pattern that did NOT fire
+   adds `meta:missing_pass_signal` and is a `fail`.
+2. **`error`** — the trial produced **no valid observation**: its only
+   fired detectors are error detectors
+   (`ERROR_DETECTOR_IDS = {tier1:timeout, tier1:exec_failed}`, plus the
+   `meta:env_file_validation_failed` path). An infra crash, a launch
+   failure, or a timeout the hang monitor did **not** recognise as a hang.
+   Excluded from the matrix event-rate denominator.
+3. **`pass`** — nothing fired.
+
+Precedence is **fail > error > pass**: a timeout that the monitor *does*
+recognise as a hang fires both `tier1:timeout` (error) and `tier2:hang`
+(fail) → the hang wins → `fail`. Only when error detectors fired and no
+failure detector did is the verdict `error`.
+
+`failure_detectors_fired` and `error_detectors_fired` each list the
+matching fired detectors in encounter order
+(T1 → T2 → T3 → T4 → custom-fail → `meta:*`).
 
 `on_match: warn` contributes only to `warn_detectors_fired`;
 `on_match: info` only to `capture`. Neither changes the verdict.
@@ -201,7 +222,7 @@ Implemented in `src/aorta/probe/classifier/verdict.py::resolve`.
 
 ```jsonc
 {
-  "verdict": "pass" | "fail",
+  "verdict": "pass" | "fail" | "error",
   "exit_code": int,
   "walltime_sec": float,
   "peak_vram_mib": int | null,
@@ -209,6 +230,7 @@ Implemented in `src/aorta/probe/classifier/verdict.py::resolve`.
   "cell_name": string,
   "trial_index": int,
   "failure_detectors_fired": [string, ...],
+  "error_detectors_fired": [string, ...],   // issue #230 — infra-error signals
   "warn_detectors_fired": [string, ...],
   "capture": {string: (string | float | int)},
   "tier_durations_ms": {"tier1": float, "tier2": float, "tier3": float, "tier4": float, "tier5": float},

--- a/docs/probe-188/classifier.md
+++ b/docs/probe-188/classifier.md
@@ -26,8 +26,10 @@ Source: `src/aorta/probe/classifier/tier1_process.py`.
 | `tier1:coredump` | Any `core.*` (or bare `core`) file exists directly under `<trial_dir>/` post-exit |
 | `tier1:exec_failed` | The wrapped command never launched — `Popen` raised ENOENT / EACCES / ENOEXEC |
 
-Encounter order: exec_failed (alone, suppresses everything else) →
-timeout > signal > exit_nonzero, then coredump appended regardless.
+Encounter order: when the command never launched, `exec_failed` fires
+alone and suppresses every other detector (including coredump).
+Otherwise (the command launched) the order is timeout > signal >
+exit_nonzero, with coredump appended after whichever of those fired.
 The verdict resolver preserves this order.
 
 `tier1:timeout` and `tier1:exec_failed` are **error detectors** (issue

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -85,6 +85,28 @@ custom_patterns:                   # Tier 5 user-defined patterns
     required_for_pass: false          # only valid with on_match: fail
 ```
 
+Collect-until-N stopping rule (issue #232) replaces a fixed trial count
+with an event-count target plus a hard cap -- the right primitive for an
+intermittent bug:
+
+```yaml
+stop_after:
+  events: 3            # stop this cell once 3 trials match the event verdict
+  max_trials: 160      # hard cap -- always honored, required when events is set
+  event_verdict: fail  # which verdict counts (default: fail; 'pass' also valid)
+```
+
+A cell runs until `events` qualifying verdicts are observed **or**
+`max_trials` trials have run, whichever comes first. The matrix records
+both the realised event count and the trials actually run, so the rate is
+`events / trials_run`; `matrix.md` gains a **Stop after** column showing
+"stopped early" vs "cap reached", and `matrix.json` carries the rule plus
+each cell's `stop_after_note`. Resume is rule-aware: a cell whose on-disk
+prefix already satisfies the rule is skipped. CLI escape hatch:
+`--stop-after-events K --max-trials N` (unioned over the recipe's block).
+`event_verdict: error` arrives with the three-way verdict (#230); it is
+rejected at load until then.
+
 Phase 3 keys (`redaction`, top-level `condition`) are still **rejected
 at load time** with a "deferred to Phase 3" error message.
 

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -93,7 +93,7 @@ intermittent bug:
 stop_after:
   events: 3            # stop this cell once 3 trials match the event verdict
   max_trials: 160      # hard cap -- always honored, required when events is set
-  event_verdict: fail  # which verdict counts (default: fail; 'pass' also valid)
+  event_verdict: fail  # which verdict counts: fail (default) | pass | error
 ```
 
 A cell runs until `events` qualifying verdicts are observed **or**
@@ -104,8 +104,9 @@ both the realised event count and the trials actually run, so the rate is
 each cell's `stop_after_note`. Resume is rule-aware: a cell whose on-disk
 prefix already satisfies the rule is skipped. CLI escape hatch:
 `--stop-after-events K --max-trials N` (unioned over the recipe's block).
-`event_verdict: error` arrives with the three-way verdict (#230); it is
-rejected at load until then.
+`event_verdict: error` (issue #230) counts *error* trials -- handy to bail
+out of a sweep that's mostly flaking on infrastructure rather than
+reproducing the bug.
 
 Phase 3 keys (`redaction`, top-level `condition`) are still **rejected
 at load time** with a "deferred to Phase 3" error message.
@@ -195,6 +196,7 @@ forward-compatible:
   "cell_name": "none-none",
   "trial_index": 0,
   "failure_detectors_fired": ["tier1:exit_nonzero", "tier4:hip_error"],
+  "error_detectors_fired": [],
   "warn_detectors_fired": ["custom:slow_iter"],
   "capture": {"loss": "nan"},
   "tier_durations_ms": {"tier1": 0.4, "tier2": 0.1, "tier3": 12.1, "tier4": 1.8, "tier5": 0.3},
@@ -210,6 +212,8 @@ forward-compatible:
 * **Phase-2 additions** (new in this PR, never replaced or removed):
   `failure_detectors_fired`, `warn_detectors_fired`, `capture`,
   `tier_durations_ms`.
+* **Issue #230 addition**: `error_detectors_fired` — the infra-error
+  signals (separate from genuine failures) that drive the `error` verdict.
 
 `peak_vram_mib` is a coarse high-water mark sampled from two
 `amd-smi` snapshots (pre- and post-Popen). It may be `null` when
@@ -217,13 +221,18 @@ forward-compatible:
 that reference it bind `null -> 0` inside `aorta.probe.sandbox.evaluate`
 so they stay deterministic.
 
-The verdict comes from `aorta.probe.classifier`:
+The verdict is three-way (`pass` / `fail` / `error`; issue #230) and comes
+from `aorta.probe.classifier`, with precedence **fail > error > pass**:
 
-1. Any `tier1:*` / `tier2:*` / `tier3:*` / `tier4:*` detector fires
-   OR any `custom_patterns[*]` with `on_match: fail` fires →
-   `verdict = "fail"`.
-2. `required_for_pass: true` patterns that don't fire add
-   `meta:missing_pass_signal` and flip the verdict.
+1. Any `tier1:*` / `tier2:*` / `tier3:*` / `tier4:*` detector (other than
+   the error detectors below) fires OR any `custom_patterns[*]` with
+   `on_match: fail` fires → `verdict = "fail"`. `required_for_pass: true`
+   patterns that don't fire add `meta:missing_pass_signal` (a fail).
+2. Else, if only an error detector fired — `tier1:timeout` with no
+   recognised hang, `tier1:exec_failed` (the command never launched), or a
+   rejected `probe.env` — → `verdict = "error"`. An `error` trial produced
+   no valid observation and is excluded from the matrix event-rate
+   denominator.
 3. Otherwise → `verdict = "pass"`.
 
 Full ordering rules + per-tier detector IDs:

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -162,6 +162,17 @@ of the three built-ins above) when copy-pasting this template.
   (the per-trial coordinate would have to round-trip through the dispatcher
   and the dispatcher currently writes its own `trial_<N>.json` set
   unconditionally).
+* When the recipe carries a `stop_after` rule the skip test is
+  rule-aware instead of counting against `trials`: the runner walks the
+  **contiguous** on-disk trial prefix from `trial_0` and skips the cell
+  only when that prefix already satisfies the stopping rule -- i.e. it
+  has accumulated `stop_after.events` qualifying verdicts **or** reached
+  `stop_after.max_trials`. A cell that legitimately stopped early
+  therefore resumes as a skip even though it has fewer than `max_trials`
+  trials on disk. If the contiguous prefix has neither hit the event
+  target nor reached the cap (or a trial in it is missing/malformed), the
+  **whole cell** re-runs from `trial_0`; the re-run is bounded because the
+  dispatcher applies the same early-stop.
 
 ## 5. CLI / recipe interaction
 

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -51,7 +51,7 @@ from aorta.probe.cli_helpers import (
     ProbeUsageError,
     apply_recipe_overrides,
     help_token_in_option_zone,
-    parse_env_passthrough_mode,
+    parse_env_passthrough_mode_opt,
     reject_flag_shaped_value,
     require_double_dash_separator,
     validate_trailing_argv,
@@ -290,6 +290,27 @@ class _ProbeCommand(click.Command):
     ),
 )
 @click.option(
+    "--stop-after-events",
+    type=int,
+    default=None,
+    metavar="K",
+    help=(
+        "Stop each cell once K trials match the event verdict (default "
+        "verdict: fail), instead of running a fixed count. Requires "
+        "--max-trials. Overlays the recipe's 'stop_after:' block (#232)."
+    ),
+)
+@click.option(
+    "--max-trials",
+    type=int,
+    default=None,
+    metavar="N",
+    help=(
+        "Hard cap on trials per cell when --stop-after-events is set "
+        "(always honored). Required whenever --stop-after-events is passed."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -304,6 +325,8 @@ def probe(
     ticket: str | None,
     dry_run: bool,
     env_passthrough_mode: str | None,
+    stop_after_events: int | None,
+    max_trials: int | None,
     mitigation_files: tuple[Path, ...],
     verbose: int,
     argv: tuple[str, ...],
@@ -332,11 +355,7 @@ def probe(
         # ``--env-passthrough-mode`` defaults to None so the handler can
         # distinguish "user passed the flag" from "user omitted it"; per
         # FR 1.10 the CLI wins only when present (see apply_recipe_overrides).
-        cli_passthrough_mode = (
-            parse_env_passthrough_mode(env_passthrough_mode)
-            if env_passthrough_mode is not None
-            else None
-        )
+        cli_passthrough_mode = parse_env_passthrough_mode_opt(env_passthrough_mode)
         clean_argv = validate_trailing_argv(argv)
         r = load_recipe(recipe, sidecar_files=mitigation_files or None)
         if r.probe_extras is None:
@@ -344,7 +363,10 @@ def probe(
                 f"recipe {recipe} is not a probe-mode recipe; "
                 "set 'mode: probe' at the recipe top level"
             )
-        r = apply_recipe_overrides(r, ticket=ticket, cli_passthrough_mode=cli_passthrough_mode)
+        r = apply_recipe_overrides(
+            r, ticket=ticket, cli_passthrough_mode=cli_passthrough_mode,
+            cli_stop_after_events=stop_after_events, cli_max_trials=max_trials,
+        )
     except (ProbeUsageError, RecipeSchemaError, RecipeCellError, RegistryError, LookupError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -296,8 +296,9 @@ class _ProbeCommand(click.Command):
     metavar="K",
     help=(
         "Stop each cell once K trials match the event verdict (default "
-        "verdict: fail), instead of running a fixed count. Requires "
-        "--max-trials. Overlays the recipe's 'stop_after:' block (#232)."
+        "verdict: fail), instead of running a fixed count. The loop needs "
+        "a hard cap: pass --max-trials unless the recipe's 'stop_after:' "
+        "block already supplies one. Overlays that block (#232)."
     ),
 )
 @click.option(
@@ -306,8 +307,10 @@ class _ProbeCommand(click.Command):
     default=None,
     metavar="N",
     help=(
-        "Hard cap on trials per cell when --stop-after-events is set "
-        "(always honored). Required whenever --stop-after-events is passed."
+        "Hard cap on trials per cell when stop-after is active (always "
+        "honored). Pair with --stop-after-events; either flag may be "
+        "omitted when the recipe's 'stop_after:' block already supplies "
+        "that half (so --max-trials alone overrides just the recipe's cap)."
     ),
 )
 @click.option(

--- a/src/aorta/probe/classifier/__init__.py
+++ b/src/aorta/probe/classifier/__init__.py
@@ -67,6 +67,10 @@ class TrialContext:
     log_text: str
     custom_patterns: tuple[CompiledPattern, ...] = ()
     hang_detected: bool = False
+    # Exec-time ``Popen`` failure -- the wrapped command never launched.
+    # Routed to ``tier1:exec_failed`` (an error detector, issue #230) so
+    # a command-not-found resolves to ``error``, not ``fail``.
+    exec_failed: bool = False
     peak_vram_mib: int | None = None
     dmesg_text: str | None = None
     tier3_state: Tier3State | None = None
@@ -108,6 +112,7 @@ def classify_trial(ctx: TrialContext) -> tuple[Verdict, dict[str, float]]:
             exit_code=ctx.exit_code,
             timed_out=ctx.timed_out,
             trial_dir=ctx.trial_dir,
+            exec_failed=ctx.exec_failed,
         )
     )
     tier_durations_ms["tier1"] = (time.perf_counter() - t0) * 1000.0

--- a/src/aorta/probe/classifier/tier1_process.py
+++ b/src/aorta/probe/classifier/tier1_process.py
@@ -48,6 +48,13 @@ DETECTOR_SIGABRT = "tier1:sigabrt"
 DETECTOR_SIGBUS = "tier1:sigbus"
 DETECTOR_TIMEOUT = "tier1:timeout"
 DETECTOR_COREDUMP = "tier1:coredump"
+# The wrapped command never launched (``Popen`` raised ENOENT / EACCES /
+# ENOEXEC). Distinct from ``exit_nonzero``: a command-not-found never
+# exercised the code path under test, so the three-way verdict resolver
+# (issue #230) treats it as an ``error`` (no valid observation) rather
+# than a ``fail`` (the event manifested). See
+# :data:`aorta.probe.classifier.verdict.ERROR_DETECTOR_IDS`.
+DETECTOR_EXEC_FAILED = "tier1:exec_failed"
 
 # Map ``returncode`` (negative when the process died via signal) to
 # the corresponding detector ID. ``signal`` constants are platform-
@@ -80,11 +87,20 @@ class Tier1Context:
     suppresses the ``exit_nonzero`` detector (a process killed by
     ``proc.kill()`` after a timeout always exits with a non-zero
     code; we want the more informative detector ID to fire alone).
+
+    ``exec_failed`` marks an exec-time ``Popen`` failure -- the
+    wrapped command never launched (ENOENT / EACCES / ENOEXEC). It
+    fires ``tier1:exec_failed`` *alone* (the synthetic 127/126/1 exit
+    code the workload assigns is bookkeeping, not a real child exit,
+    so ``exit_nonzero`` would be misleading) and suppresses every
+    other Tier-1 detector -- a process that never started cannot have
+    timed out, taken a signal, or dumped core.
     """
 
     exit_code: int
     timed_out: bool
     trial_dir: Path
+    exec_failed: bool = False
 
 
 def detect(ctx: Tier1Context) -> list[str]:
@@ -99,6 +115,11 @@ def detect(ctx: Tier1Context) -> list[str]:
     fired (the trial's Tier 1 status is "pass — exit zero").
     """
     fired: list[str] = []
+
+    # Exec-time launch failure: the command never started, so no other
+    # Tier-1 signal is meaningful. Fire ``tier1:exec_failed`` alone.
+    if ctx.exec_failed:
+        return [DETECTOR_EXEC_FAILED]
 
     if ctx.timed_out:
         fired.append(DETECTOR_TIMEOUT)
@@ -143,12 +164,14 @@ ALL_DETECTOR_IDS = (
     DETECTOR_SIGBUS,
     DETECTOR_EXIT_NONZERO,
     DETECTOR_COREDUMP,
+    DETECTOR_EXEC_FAILED,
 )
 
 
 __all__ = [
     "ALL_DETECTOR_IDS",
     "DETECTOR_COREDUMP",
+    "DETECTOR_EXEC_FAILED",
     "DETECTOR_EXIT_NONZERO",
     "DETECTOR_SIGABRT",
     "DETECTOR_SIGBUS",

--- a/src/aorta/probe/classifier/verdict.py
+++ b/src/aorta/probe/classifier/verdict.py
@@ -13,14 +13,17 @@ Combines the per-tier detector outputs into the final
     command never launched (``tier1:exec_failed``) or it ran to the
     deadline without the hang monitor recognising a hang
     (``tier1:timeout`` with no co-firing ``tier2:hang``). The
-    classifier's own error detectors are listed in
-    :data:`ERROR_DETECTOR_IDS`; this is *not* an exhaustive list of
-    what ``error_detectors_fired`` may contain -- a workload can inject
-    additional ``meta:`` infra-error IDs ahead of :func:`resolve` (e.g.
-    ``meta:env_file_validation_failed`` written by
-    :class:`aorta.workloads.SubprocessWorkload`). ``error`` is excluded
-    from the matrix event-rate denominator so an infra flake doesn't
-    inflate (or deflate) the reproduction rate.
+    error detectors that :func:`resolve` recognises are exactly
+    :data:`ERROR_DETECTOR_IDS` -- :func:`partition_detectors` treats no
+    other ID as an error. The ``error_detectors_fired`` list in
+    ``result.json`` can still carry additional ``meta:`` infra-error IDs,
+    but those are written **directly** by a workload that bypasses
+    :func:`resolve` entirely (e.g.
+    :class:`aorta.workloads.SubprocessWorkload` emits a hand-built
+    ``error`` ``result.json`` with ``meta:env_file_validation_failed``);
+    they are not produced by, and do not flow through, this resolver.
+    ``error`` is excluded from the matrix event-rate denominator so an
+    infra flake doesn't inflate (or deflate) the reproduction rate.
 
 (c) ``pass`` -- nothing fired.
 

--- a/src/aorta/probe/classifier/verdict.py
+++ b/src/aorta/probe/classifier/verdict.py
@@ -1,28 +1,46 @@
 """Verdict precedence resolver for ``aorta probe`` Phase 2 (issue #188).
 
 Combines the per-tier detector outputs into the final
-``result.json`` shape. The rules (rubric §2.B FR 2.8) are:
+``result.json`` shape. The three-way verdict (issue #230) is one of
+``pass`` / ``fail`` / ``error``:
 
-(a) Any Tier 1–4 detector fires OR any ``custom_patterns[*]``
-    with ``on_match: fail`` fires → ``verdict = "fail"``.
+(a) ``fail`` -- the event of interest manifested. Any Tier 1–4
+    detector fires (other than the *error* detectors below) OR any
+    ``custom_patterns[*]`` with ``on_match: fail`` fires.
 
-(b) ``result.json::failure_detectors_fired`` lists ALL fired in a
-    fixed encounter order: Tier 1, Tier 2, Tier 3, Tier 4, then
-    Tier 5 (``custom_patterns`` failures). The order is set
-    explicitly by :func:`resolve` as a fixed tier sequence (not by
-    the :class:`VerdictInputs` field order), independent of when each
-    tier physically fires
-    relative to the workload exit. The in-flight Tier 2 hang monitor
-    contributes its detector IDs to ``inputs.tier2`` before
-    :func:`resolve` is called, so even though the predicate fires
-    mid-run, the IDs always land between Tier 1 and Tier 3 in the
-    serialised list.
+(b) ``error`` -- the trial broke for an infrastructure reason and
+    produced *no valid observation* of the thing under test: the
+    command never launched (``tier1:exec_failed``) or it ran to the
+    deadline without the hang monitor recognising a hang
+    (``tier1:timeout`` with no co-firing ``tier2:hang``). Error
+    detectors are listed in :data:`ERROR_DETECTOR_IDS`. ``error``
+    is excluded from the matrix event-rate denominator so an infra
+    flake doesn't inflate (or deflate) the reproduction rate.
 
-(c) Any ``custom_patterns[*]`` with ``required_for_pass: true``
-    AND none of them fired → add ``meta:missing_pass_signal`` to
-    ``failure_detectors_fired`` AND ``verdict = "fail"``.
+(c) ``pass`` -- nothing fired.
 
-(d) Otherwise → ``verdict = "pass"``.
+Precedence is **fail > error > pass**: if any genuine failure
+detector fired, the trial failed *even if* an error detector also
+fired (a timeout that the monitor recognised as a hang fires both
+``tier1:timeout`` and ``tier2:hang`` -> the hang wins -> ``fail``).
+Only when error detectors fired and no failure detector did does
+the verdict become ``error``.
+
+``result.json`` carries two ordered lists: ``failure_detectors_fired``
+(the fail signals) and ``error_detectors_fired`` (the error signals),
+each in a fixed encounter order: Tier 1, Tier 2, Tier 3, Tier 4,
+then Tier 5 (``custom_patterns`` failures). The order is set
+explicitly by :func:`resolve` as a fixed tier sequence (not by the
+:class:`VerdictInputs` field order), independent of when each tier
+physically fires relative to the workload exit. The in-flight Tier 2
+hang monitor contributes its detector IDs to ``inputs.tier2`` before
+:func:`resolve` is called, so even though the predicate fires
+mid-run, the IDs always land between Tier 1 and Tier 3 in the
+serialised list.
+
+``custom_patterns[*]`` with ``required_for_pass: true`` AND none of
+them fired → add ``meta:missing_pass_signal`` to
+``failure_detectors_fired`` AND ``verdict = "fail"``.
 
 ``on_match: warn`` populates ``warn_detectors_fired`` only.
 ``on_match: info`` populates ``capture`` only.
@@ -37,12 +55,57 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from aorta.probe.classifier.tier1_process import (
+    DETECTOR_EXEC_FAILED,
+    DETECTOR_TIMEOUT,
+)
 from aorta.probe.classifier.tier5_custom import CompiledPattern, CustomScanResult
 
 # Synthesised detector ID for "the recipe asked for one required
 # pattern to fire and none did". The ``meta:`` prefix marks it as
 # coming from the verdict resolver, not from any tier directly.
 DETECTOR_MISSING_PASS_SIGNAL = "meta:missing_pass_signal"
+
+# Detector IDs that mean "no valid observation" rather than "the event
+# fired" (issue #230). A trial whose only fired detectors are in this
+# set resolves to ``error``; one that also fired a genuine failure
+# detector resolves to ``fail`` (fail > error). Keeping this set tiny
+# and explicit is deliberate -- a plain non-zero exit
+# (``tier1:exit_nonzero``), a signal death, a coredump, a kernel fault,
+# or a log-pattern match are all *valid observations of a failure* and
+# stay ``fail``. Only launch failures and unrecognised timeouts are
+# infrastructure noise.
+ERROR_DETECTOR_IDS = frozenset({DETECTOR_TIMEOUT, DETECTOR_EXEC_FAILED})
+
+# Canonical three-way verdict vocabulary (issue #230). The single source
+# of truth downstream code (matrix aggregation, the ``stop_after`` rule,
+# the verify-run-output skill) validates against, so a fourth bucket can
+# never be introduced by a typo in one layer. Ordered by precedence for
+# readability; membership, not order, is the contract.
+VALID_VERDICTS = frozenset({"fail", "error", "pass"})
+
+
+def partition_detectors(fired: list[str]) -> tuple[list[str], list[str]]:
+    """Split fired detector IDs into ``(failure, error)`` preserving order.
+
+    A detector is an *error* signal iff it is in
+    :data:`ERROR_DETECTOR_IDS`; everything else is a *failure* signal.
+    Shared by :func:`resolve` and the Tier-1-only fallback in
+    :mod:`aorta.workloads._subprocess` so both agree on the three-way
+    split.
+    """
+    failures = [d for d in fired if d not in ERROR_DETECTOR_IDS]
+    errors = [d for d in fired if d in ERROR_DETECTOR_IDS]
+    return failures, errors
+
+
+def verdict_from_detectors(failures: list[str], errors: list[str]) -> str:
+    """Apply the **fail > error > pass** precedence to split detector lists."""
+    if failures:
+        return "fail"
+    if errors:
+        return "error"
+    return "pass"
 
 
 @dataclass
@@ -86,12 +149,19 @@ class Verdict:
     Each list is freshly constructed (not a reference to a
     caller's mutable list) so a downstream consumer can mutate the
     result without affecting cached classifier state.
+
+    ``error_detectors_fired`` carries the infrastructure-error signals
+    (see :data:`ERROR_DETECTOR_IDS`) separately from the genuine
+    failure signals in ``failure_detectors_fired`` so downstream
+    tooling can tell "the bug reproduced" from "the trial never
+    validly ran".
     """
 
-    verdict: str  # "pass" | "fail"
+    verdict: str  # "pass" | "fail" | "error"
     failure_detectors_fired: list[str]
     warn_detectors_fired: list[str]
     capture: dict[str, str | float | int]
+    error_detectors_fired: list[str] = field(default_factory=list)
 
 
 def resolve(inputs: VerdictInputs) -> Verdict:
@@ -101,22 +171,23 @@ def resolve(inputs: VerdictInputs) -> Verdict:
     testing (rubric §2.B FR 2.8 — verdict precedence is a hard
     gate).
     """
-    failures: list[str] = []
-    failures.extend(inputs.tier1)
-    failures.extend(inputs.tier2)
-    failures.extend(inputs.tier3)
-    failures.extend(inputs.tier4)
-    failures.extend(inputs.custom_result.fail_detectors)
+    fired: list[str] = []
+    fired.extend(inputs.tier1)
+    fired.extend(inputs.tier2)
+    fired.extend(inputs.tier3)
+    fired.extend(inputs.tier4)
+    fired.extend(inputs.custom_result.fail_detectors)
 
     # required_for_pass: every pattern in the recipe whose flag is
     # True must have fired. If at least one didn't, synthesise
     # ``meta:missing_pass_signal`` so the trial fails with a
     # clear, namespaced reason. The check considers ONLY patterns
     # whose .required_for_pass is True; non-required patterns
-    # have no effect here.
+    # have no effect here. (A missing required signal is a genuine
+    # failure, never an infra error.)
     required_ids = {p.detector_id for p in inputs.custom_required_patterns if p.required_for_pass}
     if required_ids and not (required_ids <= inputs.custom_result.fired_required_ids):
-        failures.append(DETECTOR_MISSING_PASS_SIGNAL)
+        fired.append(DETECTOR_MISSING_PASS_SIGNAL)
 
     # Built-in advisory (warn) detectors precede user custom warns, mirroring
     # the tier-before-custom ordering used for failures above.
@@ -124,18 +195,25 @@ def resolve(inputs: VerdictInputs) -> Verdict:
     warns.extend(inputs.custom_result.warn_detectors)
     capture = dict(inputs.custom_result.capture)
 
-    verdict = "fail" if failures else "pass"
+    # Partition into genuine failures vs infrastructure errors, then
+    # apply fail > error > pass precedence (issue #230).
+    failures, errors = partition_detectors(fired)
     return Verdict(
-        verdict=verdict,
+        verdict=verdict_from_detectors(failures, errors),
         failure_detectors_fired=failures,
         warn_detectors_fired=warns,
         capture=capture,
+        error_detectors_fired=errors,
     )
 
 
 __all__ = [
     "DETECTOR_MISSING_PASS_SIGNAL",
+    "ERROR_DETECTOR_IDS",
+    "VALID_VERDICTS",
     "Verdict",
     "VerdictInputs",
+    "partition_detectors",
     "resolve",
+    "verdict_from_detectors",
 ]

--- a/src/aorta/probe/classifier/verdict.py
+++ b/src/aorta/probe/classifier/verdict.py
@@ -12,10 +12,15 @@ Combines the per-tier detector outputs into the final
     produced *no valid observation* of the thing under test: the
     command never launched (``tier1:exec_failed``) or it ran to the
     deadline without the hang monitor recognising a hang
-    (``tier1:timeout`` with no co-firing ``tier2:hang``). Error
-    detectors are listed in :data:`ERROR_DETECTOR_IDS`. ``error``
-    is excluded from the matrix event-rate denominator so an infra
-    flake doesn't inflate (or deflate) the reproduction rate.
+    (``tier1:timeout`` with no co-firing ``tier2:hang``). The
+    classifier's own error detectors are listed in
+    :data:`ERROR_DETECTOR_IDS`; this is *not* an exhaustive list of
+    what ``error_detectors_fired`` may contain -- a workload can inject
+    additional ``meta:`` infra-error IDs ahead of :func:`resolve` (e.g.
+    ``meta:env_file_validation_failed`` written by
+    :class:`aorta.workloads.SubprocessWorkload`). ``error`` is excluded
+    from the matrix event-rate denominator so an infra flake doesn't
+    inflate (or deflate) the reproduction rate.
 
 (c) ``pass`` -- nothing fired.
 

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -151,6 +151,16 @@ def parse_env_passthrough_mode(value: str) -> Literal["inherit", "file"]:
     return value  # type: ignore[return-value]
 
 
+def parse_env_passthrough_mode_opt(value: str | None) -> Literal["inherit", "file"] | None:
+    """Parse ``--env-passthrough-mode`` preserving the "flag omitted" signal.
+
+    ``None`` in -> ``None`` out so :func:`apply_recipe_overrides` can tell
+    "user passed the flag" from "user omitted it" (FR 1.10 precedence).
+    Keeps the Click handler a thin shim by hosting the None-guard here.
+    """
+    return None if value is None else parse_env_passthrough_mode(value)
+
+
 def validate_trailing_argv(argv: tuple[str, ...]) -> tuple[str, ...]:
     """Reject an empty / clearly-misparsed trailing-argv list.
 
@@ -183,14 +193,21 @@ def apply_recipe_overrides(
     *,
     ticket: str | None,
     cli_passthrough_mode: Literal["inherit", "file"] | None,
+    cli_stop_after_events: int | None = None,
+    cli_max_trials: int | None = None,
 ) -> Recipe:
     """Layer CLI flags on top of a loaded probe-mode ``Recipe``.
 
-    Two overlays today:
+    Overlays today:
 
     * ``--ticket`` -- when set, replaces ``recipe.ticket``;
     * ``--env-passthrough-mode`` -- when set (i.e. the user actually
-      passed the flag), replaces ``recipe.probe_extras.env_passthrough_mode``.
+      passed the flag), replaces ``recipe.probe_extras.env_passthrough_mode``;
+    * ``--stop-after-events`` / ``--max-trials`` -- when either is passed,
+      builds (or overlays) the recipe's ``stop_after`` rule (issue #232).
+      Missing halves fall back to the recipe's existing ``stop_after``;
+      a target with no cap (neither flag nor recipe supplies ``max_trials``)
+      is rejected so the loop is never unbounded.
 
     The caller must verify ``recipe.probe_extras is not None`` before
     invoking this helper (probe-mode discriminator is the CLI's
@@ -206,10 +223,47 @@ def apply_recipe_overrides(
         recipe = dataclasses.replace(
             recipe,
             probe_extras=dataclasses.replace(
-                probe_extras, env_passthrough_mode=cli_passthrough_mode
+                recipe.probe_extras, env_passthrough_mode=cli_passthrough_mode
             ),
         )
+    if cli_stop_after_events is not None or cli_max_trials is not None:
+        recipe = _overlay_stop_after(recipe, cli_stop_after_events, cli_max_trials)
     return recipe
+
+
+def _overlay_stop_after(
+    recipe: Recipe,
+    cli_events: int | None,
+    cli_max_trials: int | None,
+) -> Recipe:
+    """Build the ``stop_after`` overlay from the CLI flags (issue #232).
+
+    CLI halves win over the recipe's existing block; the other half (and
+    ``event_verdict``) fall back to the recipe. Validation mirrors the
+    recipe loader: positive ints, ``max_trials >= events``, and a
+    mandatory cap. Errors raise :class:`ProbeUsageError` for a friendly
+    CLI message.
+    """
+    from aorta.triage.recipe import StopAfter
+
+    base = recipe.stop_after
+    events = cli_events if cli_events is not None else (base.events if base else None)
+    max_trials = cli_max_trials if cli_max_trials is not None else (base.max_trials if base else None)
+    if events is None:
+        raise ProbeUsageError("--max-trials requires --stop-after-events")
+    if max_trials is None:
+        raise ProbeUsageError("--stop-after-events requires --max-trials (the loop needs a hard cap)")
+    if events < 1 or max_trials < 1:
+        raise ProbeUsageError("--stop-after-events and --max-trials must be >= 1")
+    if max_trials < events:
+        raise ProbeUsageError(
+            f"--max-trials ({max_trials}) must be >= --stop-after-events ({events})"
+        )
+    event_verdict = base.event_verdict if base else "fail"
+    return dataclasses.replace(
+        recipe,
+        stop_after=StopAfter(events=events, max_trials=max_trials, event_verdict=event_verdict),
+    )
 
 
 def format_dry_run_line(
@@ -234,6 +288,7 @@ __all__ = [
     "format_dry_run_line",
     "help_token_in_option_zone",
     "parse_env_passthrough_mode",
+    "parse_env_passthrough_mode_opt",
     "reject_flag_shaped_value",
     "require_double_dash_separator",
     "validate_trailing_argv",

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -223,7 +223,7 @@ def apply_recipe_overrides(
         recipe = dataclasses.replace(
             recipe,
             probe_extras=dataclasses.replace(
-                recipe.probe_extras, env_passthrough_mode=cli_passthrough_mode
+                probe_extras, env_passthrough_mode=cli_passthrough_mode
             ),
         )
     if cli_stop_after_events is not None or cli_max_trials is not None:

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -36,6 +36,7 @@ from aorta.triage.recipe import (
     Recipe,
     RecipeCellError,
     RecipeSchemaError,
+    _parse_stop_after,
 )
 
 # Fixed workload name for probe-mode cells. Leading underscore is
@@ -312,6 +313,7 @@ def build_probe_recipe_from_dict(
             f"{type(tier3_vram_growth_raw).__name__} ({tier3_vram_growth_raw!r})"
         )
     tier3_vram_growth = tier3_vram_growth_raw
+    stop_after = _parse_stop_after("recipe", data.get("stop_after"))
     # Use ``in`` rather than ``.get(...) is not None`` so an explicit
     # ``redaction: null`` is treated as present-but-invalid (parse_redaction
     # rejects None) instead of being silently conflated with "no redaction
@@ -463,6 +465,7 @@ def build_probe_recipe_from_dict(
         source_sha256=source_sha256,
         workload_config={},
         save_logs=False,
+        stop_after=stop_after,
         probe_extras=probe_extras,
     )
 

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -248,6 +248,14 @@ class RunRequest:
     save_logs: bool = False
     subprocess_argv: tuple[str, ...] | None = None
     probe_extras: dict[str, Any] | None = None
+    # Issue #232: collect-until-N stopping rule. When set (a
+    # :class:`aorta.triage.recipe.StopAfter`), ``trials`` is the hard cap
+    # (``max_trials``) and the loop breaks early once ``events``
+    # qualifying verdicts are observed. Typed as ``Any`` to keep this
+    # module's import graph cycle-free (same rationale as
+    # ``Recipe.probe_extras``); the loop only duck-types ``.events`` /
+    # ``.event_verdict``. ``kw_only`` so positional callers are unaffected.
+    stop_after: Any | None = field(default=None, kw_only=True)
 
     def __post_init__(self) -> None:
         # Defensively deep-copy mutable dict fields.  ``frozen=True``
@@ -414,6 +422,11 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
             request.steps if request.steps is not None else "(workload default)",
         )
     results: list[TrialResult] = []
+    # Issue #232: ``request.trials`` is the hard cap (``max_trials`` when a
+    # stop_after rule is attached). ``events_seen`` tracks qualifying
+    # verdicts so the loop can break early once the target is met.
+    stop_after = request.stop_after
+    events_seen = 0
     for trial_idx in range(request.trials):
         if should_write:
             logger.info("trial %d/%d: starting", trial_idx + 1, request.trials)
@@ -440,8 +453,43 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
                 result.exit_status,
             )
         results.append(result)
+        if stop_after is not None and _trial_is_event(result, stop_after.event_verdict):
+            events_seen += 1
+            if events_seen >= stop_after.events:
+                if should_write:
+                    logger.info(
+                        "stop_after: %d %r event(s) observed in %d trial(s) "
+                        "(target %d, cap %d) -- stopping cell early",
+                        events_seen,
+                        stop_after.event_verdict,
+                        len(results),
+                        stop_after.events,
+                        request.trials,
+                    )
+                break
 
     return results
+
+
+def _trial_is_event(result: TrialResult, event_verdict: str) -> bool:
+    """Decide whether ``result`` counts as a ``stop_after`` event.
+
+    Aligned with :func:`aorta.run.cli_helpers.summarize_results`'s
+    pass/fail predicate (a trial passes iff ``exit_status == "ok"``) so
+    the stop-count and the matrix pass/fail columns can never disagree:
+
+    * ``event_verdict == "fail"`` -> any non-``ok`` exit (the bug
+      reproduced, infra flaked, setup died).
+    * ``event_verdict == "pass"`` -> a clean ``ok`` trial.
+
+    ``error`` is not yet a distinct outcome (binary verdict space until
+    the three-way verdict task #230); the recipe loader rejects it, so
+    it never reaches here.
+    """
+    passed = result.exit_status == "ok"
+    if event_verdict == "pass":
+        return passed
+    return not passed
 
 
 def _run_single_trial(

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -23,7 +23,7 @@ from aorta.instrumentation.environment import collect_env
 from aorta.registry import Environment, get_environment, get_mitigation
 from aorta.run.collectors import KNOWN_RECIPES
 from aorta.run.discovery import get_workload_class
-from aorta.run.results import TrialResult
+from aorta.run.results import TrialResult, trial_verdict
 from aorta.run.validation import validate_launch_mode
 from aorta.workloads import Workload, WorkloadResult
 
@@ -474,22 +474,21 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
 def _trial_is_event(result: TrialResult, event_verdict: str) -> bool:
     """Decide whether ``result`` counts as a ``stop_after`` event.
 
-    Aligned with :func:`aorta.run.cli_helpers.summarize_results`'s
-    pass/fail predicate (a trial passes iff ``exit_status == "ok"``) so
-    the stop-count and the matrix pass/fail columns can never disagree:
+    Uses the shared three-way :func:`aorta.run.results.trial_verdict`
+    predicate (issue #230) so the stop-count and the matrix pass / fail /
+    error columns can never disagree:
 
-    * ``event_verdict == "fail"`` -> any non-``ok`` exit (the bug
-      reproduced, infra flaked, setup died).
-    * ``event_verdict == "pass"`` -> a clean ``ok`` trial.
+    * ``event_verdict == "fail"`` -> the bug reproduced (genuine failure).
+    * ``event_verdict == "pass"`` -> a clean trial.
+    * ``event_verdict == "error"`` -> the trial never validly ran (infra
+      crash, launch failure, timeout with no recognised hang). Useful to
+      bail out of a sweep that's mostly flaking on infrastructure.
 
-    ``error`` is not yet a distinct outcome (binary verdict space until
-    the three-way verdict task #230); the recipe loader rejects it, so
-    it never reaches here.
+    Note this is a behaviour refinement over the pre-#230 predicate
+    (``fail`` == any non-``ok`` exit): infra errors no longer count as
+    ``fail`` events -- they count as ``error`` events instead.
     """
-    passed = result.exit_status == "ok"
-    if event_verdict == "pass":
-        return passed
-    return not passed
+    return trial_verdict(result) == event_verdict
 
 
 def _run_single_trial(

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -457,14 +457,19 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
             events_seen += 1
             if events_seen >= stop_after.events:
                 if should_write:
+                    # "early" only when trials remain in the budget; hitting
+                    # the target on the final allowed trial is a cap reach,
+                    # not an early stop -- don't mislead operator logs.
+                    stopped_early = len(results) < request.trials
                     logger.info(
                         "stop_after: %d %r event(s) observed in %d trial(s) "
-                        "(target %d, cap %d) -- stopping cell early",
+                        "(target %d, cap %d) -- %s",
                         events_seen,
                         stop_after.event_verdict,
                         len(results),
                         stop_after.events,
                         request.trials,
+                        "stopping cell early" if stopped_early else "cap reached",
                     )
                 break
 

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -490,11 +490,29 @@ def _trial_is_event(result: TrialResult, event_verdict: str) -> bool:
     ``error`` is not yet a distinct outcome (binary verdict space until
     the three-way verdict task #230); the recipe loader rejects it, so
     it never reaches here.
+
+    Raises:
+        ValueError: if ``event_verdict`` is not one of the canonical
+            :data:`aorta.triage.recipe._STOP_AFTER_EVENT_VERDICTS`
+            values. The recipe loader validates this up front, so a bad
+            value here means a programmatic caller bypassed the loader;
+            fail loudly rather than silently treat an unknown/typo'd
+            verdict as ``"fail"``.
     """
+    # Compare against the canonical vocabulary the recipe schema exports
+    # rather than re-hardcoding {"pass", "fail"} here. Imported locally
+    # because a module-level ``aorta.triage`` import would invert the
+    # layering (aorta.triage.runner imports this function) -- same
+    # rationale as ``RunRequest.stop_after`` being typed ``Any``.
+    from aorta.triage.recipe import _STOP_AFTER_EVENT_VERDICTS
+
+    if not isinstance(event_verdict, str) or event_verdict not in _STOP_AFTER_EVENT_VERDICTS:
+        raise ValueError(
+            f"event_verdict must be one of {sorted(_STOP_AFTER_EVENT_VERDICTS)}, "
+            f"got {event_verdict!r}"
+        )
     passed = result.exit_status == "ok"
-    if event_verdict == "pass":
-        return passed
-    return not passed
+    return passed if event_verdict == "pass" else not passed
 
 
 def _run_single_trial(

--- a/src/aorta/run/results.py
+++ b/src/aorta/run/results.py
@@ -166,7 +166,16 @@ def trial_verdict(trial: Any) -> str:
         metrics = result.get("metrics")
         if isinstance(metrics, dict):
             v = metrics.get("verdict")
-            if v in ("pass", "fail", "error"):
+            # Use the classifier's canonical vocabulary so this can't drift
+            # from the producer. Imported locally to keep aorta.run free of a
+            # module-load dependency on aorta.probe (no cycle today, but the
+            # local import keeps it that way if probe ever needs this
+            # predicate). The isinstance guard ensures a non-string metric
+            # value can never match (and never reaches frozenset membership
+            # with an unhashable type).
+            from aorta.probe.classifier.verdict import VALID_VERDICTS
+
+            if isinstance(v, str) and v in VALID_VERDICTS:
                 return v
 
     status = getattr(trial, "exit_status", None)

--- a/src/aorta/run/results.py
+++ b/src/aorta/run/results.py
@@ -137,4 +137,46 @@ class TrialResult:
         )
 
 
-__all__ = ["TrialResult"]
+def trial_verdict(trial: Any) -> str:
+    """Three-way verdict (``"pass"`` / ``"fail"`` / ``"error"``) for a trial.
+
+    This is the single shared predicate (issue #230) used by the matrix
+    aggregator (pass / fail / error counts) and the ``stop_after`` event
+    counter (:mod:`aorta.run.dispatcher`) so the two can never disagree
+    about whether a trial reproduced the bug, failed for an infra reason,
+    or passed.
+
+    Accepts any object exposing ``exit_status`` and a ``result`` dict
+    (duck-typed -- callers pass :class:`TrialResult` or lightweight
+    stand-ins in tests). Resolution order:
+
+    1. **Probe trials** carry the classifier's three-way verdict in
+       ``result["metrics"]["verdict"]``; it is authoritative. (A probe
+       ``error`` trial reports ``passed=False`` and therefore
+       ``exit_status == "workload_failed"``, so the metric is the only
+       place the error/fail distinction survives.)
+    2. **Other trials** (triage workloads with no probe verdict) derive
+       it from ``exit_status``: an ``infrastructure_failed`` /
+       ``workload_setup_failed`` trial never validly ran the measurement
+       -> ``error``; any other non-``ok`` status, or a ``WorkloadResult``
+       reporting ``passed is False`` -> ``fail``; otherwise ``pass``.
+    """
+    result = getattr(trial, "result", None)
+    if isinstance(result, dict):
+        metrics = result.get("metrics")
+        if isinstance(metrics, dict):
+            v = metrics.get("verdict")
+            if v in ("pass", "fail", "error"):
+                return v
+
+    status = getattr(trial, "exit_status", None)
+    if status in ("infrastructure_failed", "workload_setup_failed"):
+        return "error"
+    if status is not None and status != "ok":
+        return "fail"
+    if isinstance(result, dict) and result.get("passed") is False:
+        return "fail"
+    return "pass"
+
+
+__all__ = ["TrialResult", "trial_verdict"]

--- a/src/aorta/run/results.py
+++ b/src/aorta/run/results.py
@@ -146,15 +146,22 @@ def trial_verdict(trial: Any) -> str:
     about whether a trial reproduced the bug, failed for an infra reason,
     or passed.
 
-    Accepts any object exposing ``exit_status`` and a ``result`` dict
-    (duck-typed -- callers pass :class:`TrialResult` or lightweight
-    stand-ins in tests). Resolution order:
+    Accepts any object exposing ``workload`` / ``exit_status`` and a
+    ``result`` dict (duck-typed -- callers pass :class:`TrialResult` or
+    lightweight stand-ins in tests). Resolution order:
 
     1. **Probe trials** carry the classifier's three-way verdict in
        ``result["metrics"]["verdict"]``; it is authoritative. (A probe
        ``error`` trial reports ``passed=False`` and therefore
        ``exit_status == "workload_failed"``, so the metric is the only
-       place the error/fail distinction survives.)
+       place the error/fail distinction survives.)  This is trusted
+       **only** for the probe producer (``trial.workload ==
+       _subprocess``).  ``metrics`` is otherwise a free-form,
+       workload-owned field, so a non-probe workload could legitimately
+       stash its own ``metrics["verdict"]`` -- trusting it for every
+       workload would let a failed trial be miscounted as a pass in the
+       matrix and the ``stop_after`` rule.  Gating on the producer keeps
+       the metric authoritative exactly where ``_subprocess`` writes it.
     2. **Other trials** (triage workloads with no probe verdict) derive
        it from ``exit_status``: an ``infrastructure_failed`` /
        ``workload_setup_failed`` trial never validly ran the measurement
@@ -162,21 +169,26 @@ def trial_verdict(trial: Any) -> str:
        reporting ``passed is False`` -> ``fail``; otherwise ``pass``.
     """
     result = getattr(trial, "result", None)
-    if isinstance(result, dict):
-        metrics = result.get("metrics")
-        if isinstance(metrics, dict):
-            v = metrics.get("verdict")
-            # Use the classifier's canonical vocabulary so this can't drift
-            # from the producer. Imported locally to keep aorta.run free of a
-            # module-load dependency on aorta.probe (no cycle today, but the
-            # local import keeps it that way if probe ever needs this
-            # predicate). The isinstance guard ensures a non-string metric
-            # value can never match (and never reaches frozenset membership
-            # with an unhashable type).
-            from aorta.probe.classifier.verdict import VALID_VERDICTS
+    workload = getattr(trial, "workload", None)
+    # Only the probe producer's metric verdict is authoritative (see
+    # docstring). The producer name and verdict vocabulary are imported
+    # locally from their canonical sources so neither can drift from this
+    # predicate, and so aorta.run keeps no module-load dependency on
+    # aorta.probe (no cycle today; the local imports keep it that way).
+    if isinstance(result, dict) and workload is not None:
+        from aorta.probe.recipe_builder import SUBPROCESS_WORKLOAD_NAME
 
-            if isinstance(v, str) and v in VALID_VERDICTS:
-                return v
+        if workload == SUBPROCESS_WORKLOAD_NAME:
+            metrics = result.get("metrics")
+            if isinstance(metrics, dict):
+                v = metrics.get("verdict")
+                from aorta.probe.classifier.verdict import VALID_VERDICTS
+
+                # The isinstance guard ensures a non-string metric value can
+                # never match (and never reaches frozenset membership with an
+                # unhashable type).
+                if isinstance(v, str) and v in VALID_VERDICTS:
+                    return v
 
     status = getattr(trial, "exit_status", None)
     if status in ("infrastructure_failed", "workload_setup_failed"):

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -175,9 +175,12 @@ class CellStats:
     top_warn_detector_id: str | None = None
     # Issue #232: human-readable stop_after outcome for the cell, e.g.
     # "stopped early (3 fail in 24)" vs "cap reached (0 fail in 160)".
-    # ``None`` for cells with no stop_after rule -- the matrix renderer
-    # hides the column entirely when NO cell carries a note, so legacy
-    # runs stay byte-equivalent.
+    # ``None`` for cells with no stop_after rule, and also for cells that
+    # errored before a note could be computed. The matrix renderer shows
+    # the "Stop after" column whenever the recipe carries a stop_after
+    # rule (config-gated, not note-gated, so an all-errored run still
+    # surfaces it); cells without a note render "—". Legacy runs with no
+    # stop_after rule stay byte-equivalent.
     stop_after_note: str | None = None
 
     @property

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -26,16 +26,29 @@ compare cells whose timing came from different fallback levels (mixing
 "per_step" against "wall_clock_total" is comparing different kinds of
 numbers; see :func:`aorta.triage.confound.classify`).
 
-A trial is counted as a failure (``failed_count += 1``) if either its
-``exit_status != "ok"`` OR the wrapped ``WorkloadResult.passed`` is False.
-The aggregator does NOT inspect *why* a trial failed (NaN vs corruption vs
-divergence vs infrastructure crash); that's :class:`WorkloadResult` /
-``exit_status`` territory and is preserved separately via the
-``exit_status_counts`` histogram so callers can distinguish e.g.
-``workload_failed`` (run() returned passed=False) from
-``workload_setup_failed`` (setup() raised, never reached the
-measurement) from ``infrastructure_failed`` (construction or run()
-itself raised) when triaging.
+Each trial is sorted into one of three verdicts via the shared
+:func:`aorta.run.results.trial_verdict` predicate (issue #230):
+
+* ``pass`` -- ran clean.
+* ``fail`` -- the event of interest manifested (``passed=False`` from a
+  workload that actually ran, or a probe classifier ``fail``).
+* ``error`` -- the trial never validly ran: an infra crash
+  (``infrastructure_failed`` / ``workload_setup_failed``) or a probe
+  classifier ``error`` (launch failure, timeout with no recognised
+  hang). Counted in ``error_count``.
+
+The cell's ``failure_rate`` (event rate) is ``failed / (passed + failed)``
+-- **error trials are excluded from the denominator** so an infra flake
+doesn't make the bug look rarer or more reproducible than it is.
+``error_rate`` (``error / trials``) is surfaced separately.
+
+The aggregator does NOT inspect *why* a fail happened (NaN vs corruption
+vs divergence); that's :class:`WorkloadResult` / ``exit_status`` territory
+and is preserved separately via the ``exit_status_counts`` histogram so
+callers can distinguish e.g. ``workload_failed`` (run() returned
+passed=False) from ``workload_setup_failed`` (setup() raised, never
+reached the measurement) from ``infrastructure_failed`` (construction or
+run() itself raised) when triaging.
 """
 
 from __future__ import annotations
@@ -46,7 +59,16 @@ from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from aorta.run.results import trial_verdict
+
 StepTimeSource = Literal["per_step", "elapsed_per_iter", "wall_clock_total", "missing"]
+
+# Issue #230: a cell whose error_rate (infra-error trials / total) meets
+# this threshold is flagged "unreliable" in matrix.md -- its event-rate
+# is computed over too few valid trials to trust. Same spirit as the
+# speed-confound flag: a loud advisory, not a hard gate. Module-level
+# (not recipe-configurable) for now; revisit if operators need to tune it.
+UNRELIABLE_ERROR_RATE_THRESHOLD = 0.10
 
 # Per-trial outcome enum. Snake-case so the JSON key, the Confound tag, and
 # the matrix.md / terminal display string are all the same string -- avoids
@@ -179,21 +201,55 @@ class CellStats:
     # hides the column entirely when NO cell carries a note, so legacy
     # runs stay byte-equivalent.
     stop_after_note: str | None = None
+    # Issue #230: trials that never validly ran (infra crash / probe
+    # ``error`` verdict). Excluded from the ``failure_rate`` denominator;
+    # surfaced via ``error_rate`` and the matrix.md "Errors" column.
+    error_count: int = 0
 
     @property
     def failure_rate(self) -> float:
-        """Fraction of trials that failed for ANY reason. 0.0 for an empty cell.
+        """Event rate: ``failed / (passed + failed)``. 0.0 when no valid trials.
 
-        Counts every trial whose ``exit_status != "ok"`` or whose wrapped
-        ``WorkloadResult.passed`` is False. This is *not* a NaN-specific
-        rate -- :class:`aorta.run.WorkloadResult.failure_count` is generic
-        (NaN / corruption / divergence / infrastructure crash) and the
-        aggregator does not try to disambiguate. Callers that need to
-        distinguish failure modes should read ``exit_status_counts``.
+        Issue #230: ``error`` trials (infra crash, probe ``error`` verdict)
+        are **excluded from the denominator** -- a bug-rate of "2/128" is
+        meaningless if 40 of those 128 were infra errors that never reached
+        the code path under test. For a cell with no error trials this is
+        identical to ``failed / trials`` (the pre-#230 definition), so
+        legacy matrices are unchanged.
+
+        This is *not* a NaN-specific rate -- :class:`WorkloadResult.failure_count`
+        is generic (NaN / corruption / divergence). Callers that need to
+        distinguish failure modes should read ``exit_status_counts``;
+        callers that need the error share should read :attr:`error_rate`.
+        """
+        valid = self.passed_count + self.failed_count
+        if valid == 0:
+            return 0.0
+        return self.failed_count / valid
+
+    @property
+    def error_rate(self) -> float:
+        """Fraction of ALL trials that errored (infra, no valid observation).
+
+        ``error_count / trials``; 0.0 for an empty cell. Denominator is the
+        *total* trial count (not valid trials) -- this is the share of the
+        cell's runs that were wasted on infrastructure breakage.
         """
         if self.trials == 0:
             return 0.0
-        return self.failed_count / self.trials
+        return self.error_count / self.trials
+
+    @property
+    def is_unreliable(self) -> bool:
+        """True when the cell's error rate makes its event rate untrustworthy.
+
+        Fires when ``error_rate >= UNRELIABLE_ERROR_RATE_THRESHOLD`` (and at
+        least one trial errored). Whole-cell error rows (``error is not
+        None``) are not flagged here -- they already render ``n/a``.
+        """
+        return self.error is None and self.error_count > 0 and (
+            self.error_rate >= UNRELIABLE_ERROR_RATE_THRESHOLD
+        )
 
 
 def _step_times_from_trial(trial: Any, effective_steps: int) -> tuple[list[float], StepTimeSource]:
@@ -451,16 +507,13 @@ def _aggregate_failure_hints(trials: list[Any]) -> list[tuple[str, int]]:
 
 
 def _trial_passed(trial: Any) -> bool:
-    """A trial passed iff its exit_status is ok AND its WorkloadResult.passed is True."""
-    status = getattr(trial, "exit_status", None)
-    if status != "ok":
-        return False
-    result = getattr(trial, "result", None)
-    if isinstance(result, dict):
-        passed = result.get("passed")
-        if passed is False:
-            return False
-    return True
+    """A trial passed iff its three-way verdict is ``"pass"`` (issue #230).
+
+    Thin wrapper over the shared :func:`aorta.run.results.trial_verdict`
+    so the matrix, the per-cell log line, and the stop_after event counter
+    all agree on what "passed" means.
+    """
+    return trial_verdict(trial) == "pass"
 
 
 def _percentile(samples: list[float], q: float) -> float:
@@ -554,11 +607,17 @@ def aggregate_cell(
             top_failure_detector_id=None,
             top_warn_detector_id=None,
             stop_after_note=stop_after_note,
+            error_count=0,
         )
 
     trial_count = len(trials)
-    passed = sum(1 for t in trials if _trial_passed(t))
-    failed = trial_count - passed
+    # Three-way split (issue #230): pass / fail / error. ``failed`` is
+    # genuine failures only; infra errors land in ``errored`` and are
+    # excluded from the event-rate denominator (see CellStats.failure_rate).
+    verdicts = [trial_verdict(t) for t in trials]
+    passed = sum(1 for v in verdicts if v == "pass")
+    errored = sum(1 for v in verdicts if v == "error")
+    failed = trial_count - passed - errored
 
     all_step_times: list[float] = []
     wall_clocks: list[float] = []
@@ -644,6 +703,7 @@ def aggregate_cell(
         top_failure_detector_id=top_failure_id,
         top_warn_detector_id=top_warn_id,
         stop_after_note=stop_after_note,
+        error_count=errored,
     )
 
 

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -173,6 +173,12 @@ class CellStats:
     # NO cell carries data — so triage-mode runs stay byte-equivalent.
     top_failure_detector_id: str | None = None
     top_warn_detector_id: str | None = None
+    # Issue #232: human-readable stop_after outcome for the cell, e.g.
+    # "stopped early (3 fail in 24)" vs "cap reached (0 fail in 160)".
+    # ``None`` for cells with no stop_after rule -- the matrix renderer
+    # hides the column entirely when NO cell carries a note, so legacy
+    # runs stay byte-equivalent.
+    stop_after_note: str | None = None
 
     @property
     def failure_rate(self) -> float:
@@ -482,6 +488,7 @@ def aggregate_cell(
     trial_paths: list[str] | None = None,
     error: str | None = None,
     workload_config: dict[str, Any] | None = None,
+    stop_after_note: str | None = None,
 ) -> CellStats:
     """Aggregate a list of TrialResult-shaped objects into a :class:`CellStats`.
 
@@ -546,6 +553,7 @@ def aggregate_cell(
             workload_config=workload_config,
             top_failure_detector_id=None,
             top_warn_detector_id=None,
+            stop_after_note=stop_after_note,
         )
 
     trial_count = len(trials)
@@ -635,6 +643,7 @@ def aggregate_cell(
         workload_config=workload_config,
         top_failure_detector_id=top_failure_id,
         top_warn_detector_id=top_warn_id,
+        stop_after_note=stop_after_note,
     )
 
 

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -506,16 +506,6 @@ def _aggregate_failure_hints(trials: list[Any]) -> list[tuple[str, int]]:
     return [(hint, counts[hint]) for hint in order]
 
 
-def _trial_passed(trial: Any) -> bool:
-    """A trial passed iff its three-way verdict is ``"pass"`` (issue #230).
-
-    Thin wrapper over the shared :func:`aorta.run.results.trial_verdict`
-    so the matrix, the per-cell log line, and the stop_after event counter
-    all agree on what "passed" means.
-    """
-    return trial_verdict(trial) == "pass"
-
-
 def _percentile(samples: list[float], q: float) -> float:
     if not samples:
         return 0.0

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -174,7 +174,8 @@ class CellStats:
     top_failure_detector_id: str | None = None
     top_warn_detector_id: str | None = None
     # Issue #232: human-readable stop_after outcome for the cell, e.g.
-    # "stopped early (3 fail in 24)" vs "cap reached (0 fail in 160)".
+    # "stopped early: 3 fail event(s) in 24 trial(s)" vs
+    # "cap reached: 0 fail event(s) in 160 trial(s)".
     # ``None`` for cells with no stop_after rule, and also for cells that
     # errored before a note could be computed. The matrix renderer shows
     # the "Stop after" column whenever the recipe carries a stop_after

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -577,10 +577,16 @@ def write_matrix_md(
     # matrix.md layout is byte-equivalent.
     show_top_failure = any(c.top_failure_detector_id for c in cell_stats)
     show_top_warn = any(c.top_warn_detector_id for c in cell_stats)
-    # Issue #232: the "Stop after" column appears only when at least one
-    # cell ran under a stop_after rule, so legacy / fixed-trials runs stay
+    # Issue #232: the "Stop after" column appears whenever the recipe
+    # carries a stop_after rule, so legacy / fixed-trials runs stay
     # byte-equivalent. It distinguishes "stopped early" from "cap reached".
-    show_stop_after = any(c.stop_after_note for c in cell_stats)
+    # Gate on the recipe (configuration) rather than on any cell's
+    # ``stop_after_note``: the note is only populated for cells that ran
+    # cleanly (``error is None``), so an all-errored run would otherwise
+    # hide the column even though the rule was active (and matrix.json
+    # still carries ``stop_after``). Errored cells render "—" in the
+    # column.
+    show_stop_after = recipe.stop_after is not None
     header_cells: list[str] = [
         "Cell",
         "Mitigations",

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -409,10 +409,18 @@ def _format_failures(cell: CellStats) -> str:
     trials" -- the previous "Trials" header on this same value confused
     readers into reading 3/8 as a trial-count column (issue #160 review
     round 6).
+
+    When every trial errored (no whole-cell ``error`` but zero valid
+    trials), a bare ``0 / 0`` reads as a degenerate count, so the column
+    is annotated ``0 / 0 (no valid trials)`` to make clear there was no
+    valid observation to compute a failure rate over (issue #230 review).
     """
     if cell.error is not None:
         return "n/a"
-    return f"{cell.failed_count} / {cell.passed_count + cell.failed_count}"
+    valid = cell.passed_count + cell.failed_count
+    if valid == 0:
+        return "0 / 0 (no valid trials)"
+    return f"{cell.failed_count} / {valid}"
 
 
 def _format_errors(cell: CellStats) -> str:

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -48,7 +48,7 @@ import yaml
 
 from aorta.registry import get_environment
 from aorta.triage.confound import CONFOUND_DID_NOT_RUN, ConfoundTag
-from aorta.triage.matrix import CellStats
+from aorta.triage.matrix import UNRELIABLE_ERROR_RATE_THRESHOLD, CellStats
 from aorta.triage.recipe import Recipe
 
 log = logging.getLogger(__name__)
@@ -396,16 +396,39 @@ def _format_failure_rate(cell: CellStats) -> str:
 
 
 def _format_failures(cell: CellStats) -> str:
-    """Render the Failures column as ``failed / trials`` (e.g. ``3 / 8``).
+    """Render the Failures column as ``failed / valid`` (e.g. ``3 / 8``).
+
+    The denominator is the count of *valid* trials (``passed + failed``)
+    so the column matches the ``Failure rate`` percentage exactly --
+    error trials are excluded from both (issue #230). For a cell with no
+    error trials ``passed + failed == trials``, so the rendering is
+    byte-identical to the pre-#230 ``failed / trials`` form.
 
     Both numerator and denominator are spelled out so the column header
-    ("Failures") and the value together read as "3 failures out of 8 trials"
-    -- the previous "Trials" header on this same value confused readers
-    into reading 3/8 as a trial-count column (issue #160 review round 6).
+    ("Failures") and the value together read as "3 failures out of 8 valid
+    trials" -- the previous "Trials" header on this same value confused
+    readers into reading 3/8 as a trial-count column (issue #160 review
+    round 6).
     """
     if cell.error is not None:
         return "n/a"
-    return f"{cell.failed_count} / {cell.trials}"
+    return f"{cell.failed_count} / {cell.passed_count + cell.failed_count}"
+
+
+def _format_errors(cell: CellStats) -> str:
+    """Render the Errors column as ``error / trials`` (issue #230).
+
+    Appended with ``(unreliable)`` when the cell's error rate crosses the
+    advisory threshold -- the event rate is computed over too few valid
+    trials to trust. Whole-cell error rows render ``n/a`` (their numerics
+    are already n/a).
+    """
+    if cell.error is not None:
+        return "n/a"
+    base = f"{cell.error_count} / {cell.trials}"
+    if cell.is_unreliable:
+        return f"{base} (unreliable)"
+    return base
 
 
 def _format_step_ms(cell: CellStats) -> str:
@@ -581,6 +604,11 @@ def write_matrix_md(
     # cell ran under a stop_after rule, so legacy / fixed-trials runs stay
     # byte-equivalent. It distinguishes "stopped early" from "cap reached".
     show_stop_after = any(c.stop_after_note for c in cell_stats)
+    # Issue #230: the "Errors" column appears only when at least one cell
+    # had an infra-error trial, so legacy / error-free runs stay
+    # byte-equivalent. It surfaces error trials excluded from the failure
+    # rate and flags cells whose error rate makes the rate untrustworthy.
+    show_errors = any(c.error_count for c in cell_stats)
     header_cells: list[str] = [
         "Cell",
         "Mitigations",
@@ -589,6 +617,8 @@ def write_matrix_md(
     if show_config:
         header_cells.append("Config")
     header_cells.extend(["Failure rate", "Failures"])
+    if show_errors:
+        header_cells.append("Errors")
     if show_top_failure:
         header_cells.append("Top failure")
     if show_top_warn:
@@ -610,6 +640,8 @@ def write_matrix_md(
         if show_config:
             row.append(_format_workload_config(cell, varying_config_keys))
         row.extend([_format_failure_rate(cell), _format_failures(cell)])
+        if show_errors:
+            row.append(_format_errors(cell))
         if show_top_failure:
             row.append(cell.top_failure_detector_id or "—")
         if show_top_warn:
@@ -705,16 +737,32 @@ def write_matrix_md(
             "when no cell sets `workload_config`, or when every cell agrees on every key."
         )
     lines.append(
-        "- `Failures` is `failed_count / trial_count` (e.g. `3 / 8` = three failed out "
-        "of eight). `Failure rate` is the same data as a percentage and counts every "
-        "trial whose `exit_status != ok` or whose `WorkloadResult.passed` is False; "
-        "neither is NaN-specific. Use `matrix.json::cells[*].exit_status_counts` to "
-        "break failures down by mode: `workload_failed` (run() reported "
-        "passed=False), `workload_setup_failed` (setup() raised, so the "
-        "workload never reached the measurement -- a 100% setup-fail row is "
-        "NOT a 100% reproduction), `infrastructure_failed` (construction or "
-        "run() itself raised), `unknown`, etc."
+        "- `Failures` is `failed_count / valid_trials` where `valid_trials = "
+        "passed + failed` (e.g. `3 / 8` = three failed out of eight valid trials). "
+        "`Failure rate` is the same data as a percentage. Both **exclude `error` "
+        "trials** -- trials that never validly ran (infra crash, launch failure, "
+        "timeout with no recognised hang) -- from the denominator so an infra "
+        "flake can't make the bug look rarer or more reproducible than it is "
+        "(issue #230). Neither is NaN-specific. Use "
+        "`matrix.json::cells[*].exit_status_counts` to break failures down by "
+        "mode: `workload_failed` (run() reported passed=False), "
+        "`workload_setup_failed` (setup() raised, so the workload never reached "
+        "the measurement -- a 100% setup-fail row is NOT a 100% reproduction), "
+        "`infrastructure_failed` (construction or run() itself raised), "
+        "`unknown`, etc."
     )
+    if show_errors:
+        lines.append(
+            "- `Errors` is `error_count / trial_count` -- trials that produced no "
+            "valid observation of the thing under test (a probe `error` verdict: "
+            "launch failure or a timeout with no recognised hang; or a triage "
+            "`infrastructure_failed` / `workload_setup_failed`). Error trials are "
+            "excluded from `Failure rate`. A cell tagged `(unreliable)` had an "
+            f"error rate \u2265 {int(round(UNRELIABLE_ERROR_RATE_THRESHOLD * 100))}% "
+            "-- its failure rate rests on too few valid trials to trust; inspect "
+            "the per-trial JSON before drawing conclusions. The column is hidden "
+            "entirely when no cell had an error trial."
+        )
     lines.append(
         "- Only `mean step (ms)` is shown here. Per-cell `std`, `min`, `max`, "
         "`p50`, `p90`, `p99`, raw step-time arrays, exit-status histogram, and "
@@ -785,7 +833,13 @@ def write_matrix_json(
     for cell in cell_stats:
         tag, ratio = confound_tags.get(cell.name, ("-", None))
         entry = asdict(cell)
+        # ``failure_rate`` is the event rate (failed / valid trials, errors
+        # excluded -- issue #230); ``error_rate`` and ``unreliable`` surface
+        # the error share and the advisory flag. ``error_count`` is a
+        # dataclass field so ``asdict`` already included it.
         entry["failure_rate"] = cell.failure_rate
+        entry["error_rate"] = cell.error_rate
+        entry["unreliable"] = cell.is_unreliable
         entry["confound"] = tag
         entry["step_time_ratio"] = ratio
         try:

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -577,6 +577,10 @@ def write_matrix_md(
     # matrix.md layout is byte-equivalent.
     show_top_failure = any(c.top_failure_detector_id for c in cell_stats)
     show_top_warn = any(c.top_warn_detector_id for c in cell_stats)
+    # Issue #232: the "Stop after" column appears only when at least one
+    # cell ran under a stop_after rule, so legacy / fixed-trials runs stay
+    # byte-equivalent. It distinguishes "stopped early" from "cap reached".
+    show_stop_after = any(c.stop_after_note for c in cell_stats)
     header_cells: list[str] = [
         "Cell",
         "Mitigations",
@@ -589,6 +593,8 @@ def write_matrix_md(
         header_cells.append("Top failure")
     if show_top_warn:
         header_cells.append("Top warn")
+    if show_stop_after:
+        header_cells.append("Stop after")
     if show_iters:
         header_cells.append("Iters")
     header_cells.extend(["Mean step (ms)", "Confound"])
@@ -608,6 +614,8 @@ def write_matrix_md(
             row.append(cell.top_failure_detector_id or "—")
         if show_top_warn:
             row.append(cell.top_warn_detector_id or "—")
+        if show_stop_after:
+            row.append(cell.stop_after_note or "—")
         if show_iters:
             row.append(cell.iters_display)
         row.extend([_format_step_ms(cell), _format_confound(tag)])
@@ -755,6 +763,18 @@ def write_matrix_json(
             "threshold": recipe.confound.threshold,
             "baseline_cell_configured": recipe.confound.baseline_cell,
         },
+        # Issue #232: the collect-until-N rule in force for this run (None
+        # for legacy fixed-trials runs). Per-cell realised outcomes live on
+        # each cell's ``stop_after_note`` / ``trials`` fields.
+        "stop_after": (
+            {
+                "events": recipe.stop_after.events,
+                "max_trials": recipe.stop_after.max_trials,
+                "event_verdict": recipe.stop_after.event_verdict,
+            }
+            if recipe.stop_after is not None
+            else None
+        ),
         "warnings": list(warnings),
         "recipe_source": {
             "path": str(recipe.source_path) if recipe.source_path else None,

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -761,7 +761,16 @@ def write_matrix_json(
         "schema_version": 1,
         "workload": recipe.workload,
         "ticket": recipe.ticket,
-        "trials_per_cell": recipe.trials,
+        # The per-cell trial budget. With a ``stop_after`` rule the budget is
+        # the cap (``max_trials``) -- which cells may stop short of -- not the
+        # fixed ``recipe.trials`` (often ``1`` on probe recipes), so report the
+        # cap to keep the summary truthful. Per-cell ``trials:`` overrides and
+        # realised counts live on each cell entry's ``trials`` field.
+        "trials_per_cell": (
+            recipe.stop_after.max_trials
+            if recipe.stop_after is not None
+            else recipe.trials
+        ),
         "steps_per_trial": recipe.steps,
         "run_timestamp": run_timestamp,
         "baseline_cell": baseline_name,

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -837,6 +837,10 @@ def write_resolved_recipe(
     mitigation env-var bundle) live in ``matrix.json`` instead, where they
     belong as run-time state.
 
+    An active ``stop_after`` rule (issue #232) is re-emitted so a rerun from
+    the resolved YAML preserves the stopping behaviour rather than silently
+    reverting to fixed ``trials``.
+
     For runs that used ``--mitigations-file``, the resolved YAML still
     references those mitigation/environment names by name -- it is **not**
     self-contained on its own. The runner snapshots the operator-supplied
@@ -900,6 +904,15 @@ def write_resolved_recipe(
         "threshold": recipe.confound.threshold,
         "baseline_cell": recipe.confound.baseline_cell,
     }
+    if recipe.stop_after is not None:
+        # Re-emit the active stop_after rule so a rerun from this resolved
+        # YAML preserves the stopping behaviour. Without it the rerun would
+        # silently fall back to fixed ``trials`` (often 1 in probe mode).
+        doc["stop_after"] = {
+            "events": recipe.stop_after.events,
+            "max_trials": recipe.stop_after.max_trials,
+            "event_verdict": recipe.stop_after.event_verdict,
+        }
     doc["cells"] = resolved_cells
 
     path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -540,7 +540,16 @@ def write_matrix_md(
     else:
         recipe_line += "(flag-mode; in-memory)"
     lines.append(recipe_line + "  ")
-    lines.append(f"**Trials per cell**: {recipe.trials}  ")
+    # With a ``stop_after`` rule the per-cell budget is the hard cap
+    # (``max_trials``), not ``recipe.trials`` (often ``1`` on probe
+    # recipes); render it as "up to N" so the header matches the real
+    # budget. Legacy runs with no rule stay byte-equivalent.
+    trial_budget = (
+        f"up to {recipe.stop_after.max_trials}"
+        if recipe.stop_after is not None
+        else str(recipe.trials)
+    )
+    lines.append(f"**Trials per cell**: {trial_budget}  ")
     lines.append(f"**Steps per trial**: {recipe.steps}  ")
     lines.append(f"**Run timestamp**: {run_timestamp}  ")
     baseline_step = (

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -166,12 +166,12 @@ class ConfoundCfg:
     baseline_cell: str | None = None
 
 
-# Verdicts that may be counted as a ``stop_after`` event. ``error`` is
-# intentionally excluded: the verdict space is binary (pass/fail) until
-# the three-way verdict task (#230) lands a real ``error`` outcome, so
-# accepting it here would silently never match. Re-add ``error`` in the
-# same change that wires it through the classifier.
-_STOP_AFTER_EVENT_VERDICTS = frozenset({"fail", "pass"})
+# Verdicts that may be counted as a ``stop_after`` event. The three-way
+# verdict (#230) wired ``error`` through the classifier and the shared
+# ``aorta.run.results.trial_verdict`` predicate, so all three outcomes are
+# now countable (e.g. ``event_verdict: error`` to stop a flaky-infra sweep
+# early once enough trials have errored).
+_STOP_AFTER_EVENT_VERDICTS = frozenset({"fail", "pass", "error"})
 
 
 @dataclass(frozen=True)
@@ -429,12 +429,9 @@ def _parse_stop_after(path_hint: str, raw: Any) -> StopAfter | None:
         )
     event_verdict = raw.get("event_verdict", "fail")
     if event_verdict not in _STOP_AFTER_EVENT_VERDICTS:
-        hint = ""
-        if event_verdict == "error":
-            hint = " ('error' counts arrive with the three-way verdict, #230)"
         raise RecipeSchemaError(
             f"{path_hint}.stop_after.event_verdict: must be one of "
-            f"{sorted(_STOP_AFTER_EVENT_VERDICTS)}, got {event_verdict!r}{hint}"
+            f"{sorted(_STOP_AFTER_EVENT_VERDICTS)}, got {event_verdict!r}"
         )
     return StopAfter(events=events, max_trials=max_trials, event_verdict=event_verdict)
 

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -53,6 +53,8 @@ _TRIAGE_TOP_LEVEL = frozenset(
         "cells",
         "workload_config",
         "save_logs",
+        # Issue #232: collect-until-N stopping rule (valid in both modes).
+        "stop_after",
     }
 )
 _PROBE_TOP_LEVEL = frozenset(
@@ -80,6 +82,8 @@ _PROBE_TOP_LEVEL = frozenset(
         # Disable Tier-3 pre/post VRAM delta for opaque docker wrappers
         # where GPU allocation is expected, not a leak signal.
         "tier3_vram_growth",
+        # Issue #232: collect-until-N stopping rule (valid in both modes).
+        "stop_after",
         # Phase 3 (issue #188): redaction block for aorta bundle.
         "redaction",
     }
@@ -160,6 +164,36 @@ class ConfoundCfg:
 
     threshold: float = 1.15
     baseline_cell: str | None = None
+
+
+# Verdicts that may be counted as a ``stop_after`` event. ``error`` is
+# intentionally excluded: the verdict space is binary (pass/fail) until
+# the three-way verdict task (#230) lands a real ``error`` outcome, so
+# accepting it here would silently never match. Re-add ``error`` in the
+# same change that wires it through the classifier.
+_STOP_AFTER_EVENT_VERDICTS = frozenset({"fail", "pass"})
+
+
+@dataclass(frozen=True)
+class StopAfter:
+    """Collect-until-N stopping rule for a cell's trial loop (issue #232).
+
+    A cell runs until ``events`` qualifying verdicts are observed OR
+    ``max_trials`` trials have run, whichever comes first. ``max_trials``
+    is mandatory so the loop is never unbounded. ``event_verdict`` selects
+    which classifier outcome counts (default ``fail`` -- "the bug
+    reproduced").
+
+    When trials run in batches of width W the count is checked at the
+    batch boundary, so the realised event count may overshoot ``events``
+    by up to W-1; the engine records the *actual* count rather than the
+    target (today's loop is sequential, so W == 1 and there is no
+    overshoot).
+    """
+
+    events: int
+    max_trials: int
+    event_verdict: str = "fail"
 
 
 @dataclass(frozen=True)
@@ -285,6 +319,11 @@ class Recipe:
     source_sha256: str | None = None
     workload_config: dict[str, Any] = field(default_factory=dict)
     save_logs: bool = False
+    # Issue #232: collect-until-N stopping rule applied per cell. ``None``
+    # preserves the legacy fixed-``trials`` behaviour. When set, the cell
+    # runs up to ``stop_after.max_trials`` trials, stopping early once
+    # ``stop_after.events`` qualifying verdicts are seen.
+    stop_after: StopAfter | None = None
     # Probe-mode (issue #188) extras attached to the recipe so the
     # runner can branch on layout / resume / env-passthrough without
     # re-parsing the YAML. ``None`` for every triage-mode recipe;
@@ -344,6 +383,70 @@ def _parse_confound(path_hint: str, raw: Any) -> ConfoundCfg:
             f"{path_hint}.confound.baseline_cell: must be a string, got {type(baseline).__name__}"
         )
     return ConfoundCfg(threshold=float(threshold), baseline_cell=baseline)
+
+
+_VALID_STOP_AFTER_KEYS = frozenset({"events", "max_trials", "event_verdict"})
+
+
+def _parse_stop_after(path_hint: str, raw: Any) -> StopAfter | None:
+    """Parse + validate the ``stop_after`` block (issue #232).
+
+    ``None`` / missing -> ``None`` (legacy fixed-``trials`` behaviour).
+    ``events`` and ``max_trials`` must be positive ints with
+    ``max_trials >= events`` (``max_trials`` is the always-honored cap,
+    so a cap below the target would be unreachable). ``event_verdict``
+    defaults to ``fail`` and must be one of
+    :data:`_STOP_AFTER_EVENT_VERDICTS`.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise RecipeSchemaError(
+            f"{path_hint}.stop_after: must be a mapping, got {type(raw).__name__}"
+        )
+    unknown = set(raw) - _VALID_STOP_AFTER_KEYS
+    if unknown:
+        raise RecipeSchemaError(
+            f"{path_hint}.stop_after: unknown keys {sorted(unknown)}; "
+            f"allowed: {sorted(_VALID_STOP_AFTER_KEYS)}"
+        )
+    if "events" not in raw:
+        raise RecipeSchemaError(f"{path_hint}.stop_after: missing required key 'events'")
+    # ``max_trials`` is mandatory whenever ``events`` is set -- never an
+    # unbounded loop (acceptance criterion).
+    if "max_trials" not in raw:
+        raise RecipeSchemaError(
+            f"{path_hint}.stop_after: 'max_trials' is required when 'events' is set "
+            "(the loop must always have a hard cap)"
+        )
+    events = _parse_positive_int(f"{path_hint}.stop_after.events", raw["events"])
+    max_trials = _parse_positive_int(f"{path_hint}.stop_after.max_trials", raw["max_trials"])
+    if max_trials < events:
+        raise RecipeSchemaError(
+            f"{path_hint}.stop_after: max_trials ({max_trials}) must be >= "
+            f"events ({events}); the cap is always honored, so a smaller cap "
+            "could never reach the target"
+        )
+    event_verdict = raw.get("event_verdict", "fail")
+    if event_verdict not in _STOP_AFTER_EVENT_VERDICTS:
+        hint = ""
+        if event_verdict == "error":
+            hint = " ('error' counts arrive with the three-way verdict, #230)"
+        raise RecipeSchemaError(
+            f"{path_hint}.stop_after.event_verdict: must be one of "
+            f"{sorted(_STOP_AFTER_EVENT_VERDICTS)}, got {event_verdict!r}{hint}"
+        )
+    return StopAfter(events=events, max_trials=max_trials, event_verdict=event_verdict)
+
+
+def _parse_positive_int(path_hint: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RecipeSchemaError(
+            f"{path_hint}: must be an integer, got {type(value).__name__} ({value!r})"
+        )
+    if value < 1:
+        raise RecipeSchemaError(f"{path_hint}: must be >= 1, got {value}")
+    return value
 
 
 def _parse_environment(path_hint: str, raw: Any, inline_envs: dict[str, InlineEnv]) -> str:
@@ -827,6 +930,7 @@ def _build_recipe(
 
     confound = _parse_confound("recipe", data.get("confound"))
     workload_config = _parse_workload_config("recipe", data.get("workload_config"))
+    stop_after = _parse_stop_after("recipe", data.get("stop_after"))
 
     raw_save_logs = data.get("save_logs", False)
     if not isinstance(raw_save_logs, bool):
@@ -868,6 +972,7 @@ def _build_recipe(
         source_sha256=source_sha256,
         workload_config=workload_config,
         save_logs=raw_save_logs,
+        stop_after=stop_after,
     )
 
 

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -947,6 +947,23 @@ def _build_recipe(
     _validate_unique_cell_names(cells)
     cells_tuple = tuple(cells)
 
+    # Issue #232: when ``stop_after`` is active the per-cell trial budget is
+    # ``stop_after.max_trials`` (see ``runner._run_one_cell``, which sets
+    # ``cap`` from ``max_trials`` and ignores ``cell.effective_trials``). A
+    # per-cell ``trials:`` override would therefore be silently dropped and a
+    # cell could run far more trials than configured. Reject the combination at
+    # load time rather than surprise the operator with an expensive run.
+    if stop_after is not None:
+        overridden = [c.name for c in cells_tuple if c.trials is not None]
+        if overridden:
+            raise RecipeSchemaError(
+                "recipe.stop_after is incompatible with per-cell 'trials' "
+                f"overrides (cells: {overridden}); when stop_after is set, "
+                "stop_after.max_trials is the per-cell cap, so a cell-level "
+                "'trials' would be silently ignored. Drop the per-cell "
+                "'trials' or remove stop_after."
+            )
+
     _validate_names_resolve(cells_tuple, inline_envs, sidecar_files)
     _validate_no_mitigation_collisions(cells_tuple, sidecar_files)
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -388,6 +388,81 @@ def _collect_trial_paths(results_dir: Path) -> list[str]:
     return [str(p) for p in found]
 
 
+def _stop_after_note(stop_after: Any, trials: list[TrialResult]) -> str:
+    """Render the matrix annotation for a ``stop_after`` cell (issue #232).
+
+    Distinguishes "cap reached" (ran the full ``max_trials`` budget) from
+    "stopped early" (hit the event target first) so a reader can tell a
+    confirmed-rare bug from an exhausted budget. ``cap reached`` is
+    checked first: a target hit on the very last allowed trial still ran
+    the whole budget, so it is not "early".
+    """
+    from aorta.run.dispatcher import _trial_is_event
+
+    events = sum(1 for t in trials if _trial_is_event(t, stop_after.event_verdict))
+    trials_run = len(trials)
+    verb = stop_after.event_verdict
+    if trials_run >= stop_after.max_trials:
+        return f"cap reached: {events} {verb} event(s) in {trials_run} trial(s)"
+    if events >= stop_after.events:
+        return f"stopped early: {events} {verb} event(s) in {trials_run} trial(s)"
+    return f"{events} {verb} event(s) in {trials_run} trial(s)"
+
+
+def _resume_stop_after_cell(
+    cell: Any,
+    cell_dir: Path,
+    cap: int,
+    stop_after: Any,
+    resolved_env_vars: dict[str, str],
+) -> tuple[list[TrialResult], None, dict[str, str], list[str]] | None:
+    """Resume short-circuit for a ``stop_after`` cell (issue #232).
+
+    Returns the hydrated ``(trials, error, env, paths)`` tuple iff the
+    on-disk trial prefix ALREADY satisfies the stopping rule -- i.e. the
+    contiguous run of complete ``trial_<i>`` directories from index 0
+    either hit the event target or reached the cap. Otherwise returns
+    ``None`` so the caller re-runs the cell from scratch (re-running is
+    bounded: the dispatcher applies the same early-stop).
+
+    Unlike the fixed-``trials`` resume path this never requires all of
+    ``range(cap)`` to be present, because a cell that stopped early has
+    fewer than ``cap`` trials on disk by design.
+    """
+    from aorta.probe.resume import is_trial_complete
+    from aorta.run.dispatcher import _trial_is_event
+
+    contiguous = 0
+    while contiguous < cap and is_trial_complete(cell_dir / f"trial_{contiguous}"):
+        contiguous += 1
+    if contiguous == 0:
+        return None
+
+    hydrated_by_index = _hydrate_trials_by_index(_collect_trial_paths(cell_dir))
+    required = set(range(contiguous))
+    if not required.issubset(hydrated_by_index.keys()):
+        # A complete-looking trial dir whose dispatcher JSON didn't
+        # hydrate -- treat the cell as not-resumable so matrix counts
+        # stay consistent (mirror the fixed-trials path's subset check).
+        return None
+    hydrated = [hydrated_by_index[i].trial for i in range(contiguous)]
+    trial_paths = [hydrated_by_index[i].path for i in range(contiguous)]
+    events = sum(1 for t in hydrated if _trial_is_event(t, stop_after.event_verdict))
+    if events >= stop_after.events or contiguous >= cap:
+        log.info(
+            "cell %r: stop_after already satisfied on resume -- %d %r event(s) "
+            "in %d trial(s) (target %d, cap %d); skipping",
+            cell.name,
+            events,
+            stop_after.event_verdict,
+            contiguous,
+            stop_after.events,
+            cap,
+        )
+        return hydrated, None, resolved_env_vars, trial_paths
+    return None
+
+
 @dataclass(frozen=True)
 class _HydratedTrial:
     """One successfully hydrated dispatcher JSON, keyed by parsed trial index.
@@ -677,6 +752,11 @@ def _run_one_cell(
 
     resolved_env_vars = _resolve_cell_env_vars(cell.mitigations, cell.extra_env, sidecar_files)
     effective_trials = cell.effective_trials(recipe.trials)
+    # Issue #232: a ``stop_after`` rule turns ``max_trials`` into the hard
+    # cap and lets the dispatcher break early once the event target is met.
+    # Without it, ``cap == effective_trials`` and behaviour is unchanged.
+    stop_after = recipe.stop_after
+    cap = stop_after.max_trials if stop_after is not None else effective_trials
 
     # Resume short-circuit: if every trial directory under this cell
     # carries a valid result.json + non-empty verdict, the cell is
@@ -693,7 +773,17 @@ def _run_one_cell(
     # the dispatcher's ``trial_<N>.json``; or schema drift). Re-running
     # a complete cell is wasteful but preserves matrix correctness;
     # silently returning [] would not.
-    if resume_existing and layout == "flat_resume":
+    if resume_existing and layout == "flat_resume" and stop_after is not None:
+        # stop_after cells legitimately run FEWER than ``cap`` trials (they
+        # stop early at the event target), so the "all of range(cap) must
+        # be present" check below cannot apply. Resume only when the
+        # on-disk prefix already satisfies the stopping rule; otherwise
+        # fall through to a full re-run (the dispatcher will itself stop
+        # early, so re-running is bounded by ``cap``).
+        resumed = _resume_stop_after_cell(cell, cell_dir, cap, stop_after, resolved_env_vars)
+        if resumed is not None:
+            return resumed
+    elif resume_existing and layout == "flat_resume":
         from aorta.probe.resume import is_trial_complete
 
         completed = sum(
@@ -794,7 +884,7 @@ def _run_one_cell(
 
     request = RunRequest(
         workload=recipe.workload,
-        trials=effective_trials,
+        trials=cap,
         environment=cell.environment,
         mitigations=tuple(cell.mitigations),
         extra_env=dict(cell.extra_env),
@@ -805,6 +895,7 @@ def _run_one_cell(
         save_logs=save_logs,
         subprocess_argv=subprocess_argv,
         probe_extras=probe_extras_payload,
+        stop_after=stop_after,
     )
 
     try:
@@ -1145,6 +1236,11 @@ def _run_recipe_locked(
         # ``_aorta_save_logs``) which are runtime/platform-supplied and
         # deliberately not surfaced in the matrix. Stays {} when neither
         # scope sets workload_config.
+        stop_after_note = (
+            _stop_after_note(recipe.stop_after, trials)
+            if recipe.stop_after is not None and error is None
+            else None
+        )
         stats = aggregate_cell(
             name=cell.name,
             mitigations=tuple(cell.mitigations),
@@ -1156,6 +1252,7 @@ def _run_recipe_locked(
             trial_paths=trial_paths,
             error=error,
             workload_config={**recipe.workload_config, **cell.workload_config},
+            stop_after_note=stop_after_note,
         )
         cell_stats.append(stats)
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -530,15 +530,14 @@ def _hydrate_trials_by_index(trial_paths: list[str]) -> dict[int, _HydratedTrial
 
 
 def _trial_passed_for_log(trial: Any) -> bool:
-    """Mirror of ``aorta.triage.matrix._trial_passed`` for the per-cell
-    log line.
+    """Per-cell-log pass predicate, kept consistent with the matrix
+    ``passed_count``.
 
-    Kept local rather than imported from the matrix module's private
-    namespace so the runner doesn't depend on a leading-underscore
-    callable (Python convention: private to defining module). The
-    semantic is identical -- a trial passes iff ``exit_status == "ok"``
-    AND the wrapped ``WorkloadResult.passed`` is not False -- so the
-    log line and the matrix.md row agree on what counts as a pass.
+    Kept local rather than reaching into another module's private
+    namespace (Python convention: private to defining module). A trial
+    passes iff ``exit_status == "ok"`` AND the wrapped
+    ``WorkloadResult.passed`` is not False, so the log line and the
+    matrix.md row agree on what counts as a pass.
     """
     if getattr(trial, "exit_status", None) != "ok":
         return False
@@ -1206,8 +1205,7 @@ def _run_recipe_locked(
                 cell_elapsed,
             )
         else:
-            # Use the canonical pass/fail predicate from
-            # ``aorta.triage.matrix._trial_passed`` so the per-cell log line
+            # Use the local pass/fail predicate so the per-cell log line
             # agrees with the matrix-level passed_count: a trial is "passed"
             # iff its exit_status is "ok" AND its WorkloadResult.passed is
             # not False. Reading only ``result.get("passed")`` ignores the

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -834,17 +834,28 @@ class SubprocessWorkload(Workload):
             # subprocess could start" -- distinct from 126/127 which we
             # reserve for chmod/PATH problems on argv[0].
             "exit_code": 2,
-            "failure_detectors_fired": [],
-            "error_detectors_fired": ["meta:env_file_validation_failed"],
             # Walltime is 0 because the subprocess never launched; we
             # spent only the env-file-validation pass which is bounded
             # to a few hundred microseconds. Reporting 0.0 keeps the
             # matrix's step-time aggregates from being polluted by a
             # cell that never produced step times.
             "walltime_sec": 0.0,
+            # No subprocess and no Tier-3 amd-smi probe ran, so VRAM was
+            # never measured -- ``None`` (the normal path's "unavailable"
+            # value), not 0.
+            "peak_vram_mib": None,
             "argv": list(argv),
             "cell_name": probe_extras.get("cell_name", "_unknown_"),
             "trial_index": self._trial_index,
+            "failure_detectors_fired": [],
+            "error_detectors_fired": ["meta:env_file_validation_failed"],
+            # The remaining detector / capture / tier-timing keys are empty
+            # here but PRESENT so this error artifact is schema-identical to
+            # the normal probe path -- downstream parsers (and the documented
+            # result.json schema) never have to special-case env-file errors.
+            "warn_detectors_fired": [],
+            "capture": {},
+            "tier_durations_ms": {},
             "env_passthrough_mode": env_mode,
             "timed_out": False,
             # Mirror the normal-path result.json so every trial's env is
@@ -882,6 +893,7 @@ class SubprocessWorkload(Workload):
                 "result_json_path": str(result_path),
                 "failure_detectors_fired": [],
                 "error_detectors_fired": ["meta:env_file_validation_failed"],
+                "warn_detectors_fired": [],
             },
         )
 

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -701,6 +701,7 @@ class SubprocessWorkload(Workload):
                 exit_code=exit_code,
                 timed_out=timed_out,
                 trial_dir=trial_dir,
+                exec_failed=not launched,
                 classifier_exc=classifier_exc,
             )
 
@@ -975,6 +976,7 @@ def _tier1_only_fallback_verdict(
     exit_code: int,
     timed_out: bool,
     trial_dir: Path,
+    exec_failed: bool,
     classifier_exc: BaseException,
 ) -> tuple[Verdict, dict[str, float]]:
     """Build a deterministic verdict when :func:`classify_trial` raises.
@@ -997,12 +999,19 @@ def _tier1_only_fallback_verdict(
     ``error``, a genuine Tier-1 signal to ``fail``, nothing to
     ``pass``. Matches the resolver so a classifier crash doesn't
     silently flip an infra error back into a fail.
+
+    ``exec_failed`` (the workload's ``not launched`` flag) is
+    forwarded into :class:`Tier1Context` so the fallback can still
+    emit ``tier1:exec_failed`` (and suppress the misleading
+    ``exit_nonzero`` from the synthetic 127/126/1 exit code) even
+    when the full classifier is the thing that crashed.
     """
     fired = tier1_detect(
         Tier1Context(
             exit_code=exit_code,
             timed_out=timed_out,
             trial_dir=trial_dir,
+            exec_failed=exec_failed,
         )
     )
     failures, errors = partition_detectors(list(fired))

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -65,7 +65,11 @@ from aorta.probe.classifier.tier3_kernel import (
     poll_amd_smi,
     scan_dmesg,
 )
-from aorta.probe.classifier.verdict import Verdict
+from aorta.probe.classifier.verdict import (
+    Verdict,
+    partition_detectors,
+    verdict_from_detectors,
+)
 from aorta.workloads._base import Workload, WorkloadResult
 
 log = logging.getLogger(__name__)
@@ -682,6 +686,7 @@ class SubprocessWorkload(Workload):
                     log_text=log_text,
                     custom_patterns=custom_patterns,
                     hang_detected=hang_detected,
+                    exec_failed=not launched,
                     peak_vram_mib=peak_vram_mib,
                     dmesg_text=dmesg_text,
                     amd_smi_pre=amd_smi_pre,
@@ -708,6 +713,10 @@ class SubprocessWorkload(Workload):
             "cell_name": probe_extras.get("cell_name", "_unknown_"),
             "trial_index": self._trial_index,
             "failure_detectors_fired": list(verdict_obj.failure_detectors_fired),
+            # Issue #230: infra-error signals (timeout-without-hang,
+            # exec-failed) kept separate from genuine failures so the
+            # matrix can exclude them from the event-rate denominator.
+            "error_detectors_fired": list(verdict_obj.error_detectors_fired),
             "warn_detectors_fired": list(verdict_obj.warn_detectors_fired),
             "capture": dict(verdict_obj.capture),
             "tier_durations_ms": dict(tier_durations_ms),
@@ -772,6 +781,7 @@ class SubprocessWorkload(Workload):
                 "exit_code": exit_code,
                 "result_json_path": str(result_path),
                 "failure_detectors_fired": list(verdict_obj.failure_detectors_fired),
+                "error_detectors_fired": list(verdict_obj.error_detectors_fired),
                 "warn_detectors_fired": list(verdict_obj.warn_detectors_fired),
             },
         )
@@ -788,7 +798,7 @@ class SubprocessWorkload(Workload):
         env_mode: str,
         cell_env_snapshot: dict[str, str],
     ) -> WorkloadResult:
-        """Persist a Tier-1 ``fail`` artifact when probe.env validation rejects.
+        """Persist an ``error``-verdict artifact when probe.env validation rejects.
 
         Mirrors the exec-failed bookkeeping in :meth:`run` so the per-trial
         directory always contains both ``stderr.log`` (with the validation
@@ -811,12 +821,20 @@ class SubprocessWorkload(Workload):
         except OSError:
             pass
         result_doc: dict[str, Any] = {
-            "verdict": "fail",
+            # Issue #230: a rejected probe.env is an infrastructure/config
+            # failure -- the subprocess never launched, so the trial made
+            # no valid observation of the thing under test. It resolves to
+            # ``error`` (excluded from the matrix event-rate denominator),
+            # not ``fail``. ``meta:env_file_validation_failed`` names the
+            # error reason in the dedicated error list.
+            "verdict": "error",
             # Exit-code 2 mirrors the ``_setup_validation`` convention used
             # elsewhere in the codebase for "config rejected before
             # subprocess could start" -- distinct from 126/127 which we
             # reserve for chmod/PATH problems on argv[0].
             "exit_code": 2,
+            "failure_detectors_fired": [],
+            "error_detectors_fired": ["meta:env_file_validation_failed"],
             # Walltime is 0 because the subprocess never launched; we
             # spent only the env-file-validation pass which is bounded
             # to a few hundred microseconds. Reporting 0.0 keeps the
@@ -858,9 +876,11 @@ class SubprocessWorkload(Workload):
             configured_iterations=1,
             elapsed_sec=0.0,
             metrics={
-                "verdict": "fail",
+                "verdict": "error",
                 "exit_code": 2,
                 "result_json_path": str(result_path),
+                "failure_detectors_fired": [],
+                "error_detectors_fired": ["meta:env_file_validation_failed"],
             },
         )
 
@@ -971,10 +991,12 @@ def _tier1_only_fallback_verdict(
     ``capture`` rather than the per-tier breakdown -- the other
     four tiers genuinely did not run.
 
-    Verdict rule: any Tier 1 detector fires -> ``fail``; else
-    ``pass``. Matches the existing Phase-1 fallback shape so
-    downstream tooling that already parses ``failure_detectors_fired``
-    keeps working.
+    Verdict rule: the same fail > error > pass precedence the full
+    resolver applies (issue #230) -- a Tier-1 ``tier1:timeout`` with
+    no recognised hang or a ``tier1:exec_failed`` resolves to
+    ``error``, a genuine Tier-1 signal to ``fail``, nothing to
+    ``pass``. Matches the resolver so a classifier crash doesn't
+    silently flip an infra error back into a fail.
     """
     fired = tier1_detect(
         Tier1Context(
@@ -983,15 +1005,16 @@ def _tier1_only_fallback_verdict(
             trial_dir=trial_dir,
         )
     )
-    verdict_str = "fail" if fired else "pass"
+    failures, errors = partition_detectors(list(fired))
     capture: dict[str, str | float | int] = {
         "classifier_error": f"{type(classifier_exc).__name__}: {classifier_exc}",
     }
     verdict = Verdict(
-        verdict=verdict_str,
-        failure_detectors_fired=list(fired),
+        verdict=verdict_from_detectors(failures, errors),
+        failure_detectors_fired=failures,
         warn_detectors_fired=[],
         capture=capture,
+        error_detectors_fired=errors,
     )
     # Per-tier durations: Tier 1 ran, everything else was skipped.
     tier_durations_ms = {

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -808,13 +808,14 @@ class SubprocessWorkload(Workload):
         and re-runs the same broken cell on every subsequent
         ``aorta probe`` invocation.
 
-        Also unlinks ``probe.env`` (best-effort) before writing the fail
-        result so the trial directory cannot leave behind a misleading
-        artifact: ``_write_env_file`` is now validation-first
-        (atomic-on-failure), but a stale probe.env from a PRIOR run of
-        the same ``trial_<n>/`` directory (resume + flat_resume reuse
-        the same dir) would otherwise survive the validation rejection
-        and contradict ``result.json::failure_type==env_file_validation_failed``.
+        Also unlinks ``probe.env`` (best-effort) before writing the
+        ``error``-verdict result so the trial directory cannot leave
+        behind a misleading artifact: ``_write_env_file`` is now
+        validation-first (atomic-on-failure), but a stale probe.env from
+        a PRIOR run of the same ``trial_<n>/`` directory (resume +
+        flat_resume reuse the same dir) would otherwise survive the
+        validation rejection and contradict
+        ``result.json::failure_type==env_file_validation_failed``.
         """
         env_file_path.unlink(missing_ok=True)
         try:

--- a/tests/probe/classifier/test_tier1.py
+++ b/tests/probe/classifier/test_tier1.py
@@ -39,6 +39,20 @@ def test_timeout_fires_alone(tmp_path):
     assert tier1_process.DETECTOR_EXIT_NONZERO not in detectors
 
 
+def test_exec_failed_fires_alone(tmp_path):
+    """``exec_failed`` fires ``tier1:exec_failed`` and suppresses every
+    other Tier-1 detector -- a command that never launched (issue #230)."""
+    ctx = Tier1Context(exit_code=127, timed_out=False, trial_dir=tmp_path, exec_failed=True)
+    assert tier1_process.detect(ctx) == [tier1_process.DETECTOR_EXEC_FAILED]
+
+
+def test_exec_failed_suppresses_timeout_and_coredump(tmp_path):
+    """Even with timed_out + a stray core file, exec_failed wins alone."""
+    (tmp_path / "core.1").write_bytes(b"")
+    ctx = Tier1Context(exit_code=-1, timed_out=True, trial_dir=tmp_path, exec_failed=True)
+    assert tier1_process.detect(ctx) == [tier1_process.DETECTOR_EXEC_FAILED]
+
+
 @pytest.mark.parametrize(
     "sig,detector",
     [

--- a/tests/probe/classifier/test_verdict.py
+++ b/tests/probe/classifier/test_verdict.py
@@ -9,9 +9,16 @@ import pytest
 from aorta.probe.classifier.tier5_custom import CompiledPattern, CustomScanResult
 from aorta.probe.classifier.verdict import (
     DETECTOR_MISSING_PASS_SIGNAL,
+    VALID_VERDICTS,
     VerdictInputs,
     resolve,
 )
+
+
+def test_valid_verdicts_is_the_three_way_vocabulary():
+    """The canonical verdict set downstream layers validate against is exactly
+    {pass, fail, error} -- no more, no less (issue #230)."""
+    assert VALID_VERDICTS == {"pass", "fail", "error"}
 
 
 def _required_pattern(raw_id: str) -> CompiledPattern:
@@ -163,6 +170,62 @@ def test_required_for_pass_no_required_patterns_no_meta():
     """When the recipe declares no required patterns, meta detector is never injected."""
     verdict = resolve(_inputs())
     assert DETECTOR_MISSING_PASS_SIGNAL not in verdict.failure_detectors_fired
+
+
+# ---- Three-way verdict: error (issue #230) ------------------------------
+
+
+def test_timeout_alone_is_error():
+    """A timeout with no recognised hang is an ``error`` (no valid obs)."""
+    verdict = resolve(_inputs(tier1=["tier1:timeout"]))
+    assert verdict.verdict == "error"
+    assert verdict.error_detectors_fired == ["tier1:timeout"]
+    assert verdict.failure_detectors_fired == []
+
+
+def test_exec_failed_is_error():
+    """A launch failure (``tier1:exec_failed``) is an ``error``."""
+    verdict = resolve(_inputs(tier1=["tier1:exec_failed"]))
+    assert verdict.verdict == "error"
+    assert verdict.error_detectors_fired == ["tier1:exec_failed"]
+    assert verdict.failure_detectors_fired == []
+
+
+def test_timeout_with_hang_is_fail_not_error():
+    """fail > error: a recognised hang co-firing with a timeout wins."""
+    verdict = resolve(_inputs(tier1=["tier1:timeout"], tier2=["tier2:hang"]))
+    assert verdict.verdict == "fail"
+    # The timeout still surfaces in the error list for the operator, but the
+    # hang (a genuine failure) drives the verdict.
+    assert verdict.failure_detectors_fired == ["tier2:hang"]
+    assert verdict.error_detectors_fired == ["tier1:timeout"]
+
+
+def test_fail_beats_error_across_tiers():
+    """A real failure anywhere outranks a co-firing error detector."""
+    verdict = resolve(
+        _inputs(tier1=["tier1:exec_failed"], tier4=["tier4:hip_error"])
+    )
+    assert verdict.verdict == "fail"
+    assert verdict.failure_detectors_fired == ["tier4:hip_error"]
+    assert verdict.error_detectors_fired == ["tier1:exec_failed"]
+
+
+def test_exit_nonzero_stays_fail_not_error():
+    """A plain non-zero exit is a *valid* observation of a failure -> fail."""
+    verdict = resolve(_inputs(tier1=["tier1:exit_nonzero"]))
+    assert verdict.verdict == "fail"
+    assert verdict.error_detectors_fired == []
+
+
+def test_partition_helper_splits_by_error_set():
+    from aorta.probe.classifier.verdict import partition_detectors
+
+    failures, errors = partition_detectors(
+        ["tier1:timeout", "tier1:exit_nonzero", "tier1:exec_failed", "tier4:nan"]
+    )
+    assert failures == ["tier1:exit_nonzero", "tier4:nan"]
+    assert errors == ["tier1:timeout", "tier1:exec_failed"]
 
 
 def test_returned_lists_are_fresh_copies():

--- a/tests/probe/test_env_passthrough.py
+++ b/tests/probe/test_env_passthrough.py
@@ -188,8 +188,8 @@ def test_env_file_rejects_newline_in_value(tmp_path):
     ``result.json`` was on disk, which made ``flat_resume``'s
     ``is_trial_complete`` predicate re-run the broken cell on every
     subsequent ``aorta probe`` invocation. The new contract synthesises
-    a ``result.json`` (verdict=fail, ``failure_type=env_file_validation_failed``)
-    so resume sees the cell as complete and the operator gets a
+    a ``result.json`` (verdict=error, ``failure_type=env_file_validation_failed``;
+    issue #230) so resume sees the cell as complete and the operator gets a
     grep-able cause in the artifact tree.
     """
     wl = _make_workload(
@@ -210,7 +210,8 @@ def test_env_file_rejects_newline_in_value(tmp_path):
     import json
 
     doc = json.loads(result_path.read_text(encoding="utf-8"))
-    assert doc["verdict"] == "fail"
+    # Issue #230: env-file validation rejection is an infra/config error.
+    assert doc["verdict"] == "error"
     assert doc["failure_type"] == "env_file_validation_failed"
     assert "newline" in doc["error_message"]
     assert doc["env_passthrough_mode"] == "file"
@@ -239,7 +240,7 @@ def test_env_file_rejects_newline_in_value(tmp_path):
     ],
 )
 def test_env_file_rejects_unsafe_chars_in_key(tmp_path, bad_key):
-    """Hostile sidecar keys -> Tier-1 fail artifact.
+    """Hostile sidecar keys -> ``error``-verdict artifact (issue #230).
 
     Original regression (PR #194 round 4): hostile mitigation sidecars
     could smuggle ``\\n``, ``\\r``, or ``=`` into env *keys* to inject
@@ -249,7 +250,7 @@ def test_env_file_rejects_unsafe_chars_in_key(tmp_path, bad_key):
     on-disk KEY=VALUE row shape.
 
     Pre-fix behaviour was a raw ``ValueError`` escape; post-fix the
-    rejection is recorded as ``verdict=fail`` /
+    rejection is recorded as ``verdict=error`` /
     ``failure_type=env_file_validation_failed`` in ``result.json`` so
     flat_resume can move past the broken cell.
     """
@@ -266,7 +267,7 @@ def test_env_file_rejects_unsafe_chars_in_key(tmp_path, bad_key):
     import json
 
     doc = json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
-    assert doc["verdict"] == "fail"
+    assert doc["verdict"] == "error"
     assert doc["failure_type"] == "env_file_validation_failed"
     assert "env key" in doc["error_message"]
     assert result.passed is False

--- a/tests/probe/test_recurring_issue_regression.py
+++ b/tests/probe/test_recurring_issue_regression.py
@@ -1,0 +1,409 @@
+"""Regression battery for the recurring ``aorta probe`` issue family.
+
+This module is a *single* place that encodes the behavioural invariants
+behind the cluster of ``aorta probe`` bugs filed against this platform:
+
+* ``aorta`` #220 / aorta-internal #52  -- spurious ``(null): No such file
+  or directory`` env-probe stderr noise.
+* ``aorta`` #223 / #224 / aorta-internal #53 -- false-positive
+  ``tier2:hang`` on a wrapper-delegated (docker/sudo) command that exits 0.
+* ``aorta`` #222 -- orphaned child process tree on interrupt/timeout.
+* aorta-internal #55 -- re-verification of #53 *plus* two still-open
+  defects: a ``failure_details[].type`` that contradicts ``exit_code``,
+  and an ambiguous ``<mitigation>-<diagnostic>`` cell name (``none-none``).
+* aorta-internal #58 -- the matrix has no ``error`` verdict, so an infra
+  crash is silently miscounted as ``pass``/``fail``.
+* aorta-internal #56 / #57 -- verdict-keyed artifact retention and the
+  ``stop_after`` collect-until-N stopping rule.
+
+WHY THIS FILE EXISTS
+--------------------
+aorta-internal #55 is a *re-report* of #53: a fix landed, then the bug was
+observed again on a later build. The recurrence is the signal this battery
+guards against. Several existing tests pin the *current* (buggy) behaviour
+-- e.g. ``test_cell_synthesis_and_collision`` asserts the cell name is
+literally ``"none-none"`` -- so a defect can be "tested" yet still ship.
+The tests here assert the *desired* invariant instead.
+
+CONVENTIONS
+-----------
+* Tests for invariants that are FIXED on this branch are plain asserts and
+  must stay green (they are the regression guards proper).
+* Tests for invariants that are still OPEN on this branch are marked
+  ``xfail(strict=True)`` with the owning issue. They document the contract
+  and will flip to a hard failure ("XPASS") the moment the fix lands --
+  forcing whoever fixes it to delete the marker and promote the test to a
+  permanent guard. This is deliberate: it converts every open issue into an
+  executable acceptance check.
+* The #52 env redirect and #222 teardown fixes are merged into ``main``;
+  their tests here are guarded with a capability skip so the battery still
+  runs unchanged on an older branch that predates those fixes (it skips
+  instead of erroring). The scattered-branch history -- where ``main`` and
+  the #224/#225 branch each held only half the fixes -- is itself part of
+  why these bugs recurred (see aorta-internal #55 re-reporting #53).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aorta.workloads import _subprocess as workload_mod
+from aorta.workloads._subprocess import (
+    CONFIG_KEY_LOG_PREFIX,
+    CONFIG_KEY_PROBE_EXTRAS,
+    CONFIG_KEY_SUBPROCESS_ARGV,
+    SubprocessWorkload,
+)
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _make_workload(tmp_path: Path, argv: list[str], **extras) -> SubprocessWorkload:
+    """Build a SubprocessWorkload wired exactly as the dispatcher wires it.
+
+    Mirrors the ``_make_workload`` helper in ``test_subprocess_workload.py``
+    so this battery is self-contained: a synthetic ``_aorta_log_prefix`` of
+    ``<cell>/_subprocess/trial_d0_m0_t0`` decodes to ``<cell>/trial_0/``.
+    """
+    workload_subdir = tmp_path / "_subprocess"
+    workload_subdir.mkdir(parents=True, exist_ok=True)
+    prefix = workload_subdir / "trial_d0_m0_t0"
+    cfg = {
+        CONFIG_KEY_SUBPROCESS_ARGV: argv,
+        CONFIG_KEY_LOG_PREFIX: str(prefix),
+        CONFIG_KEY_PROBE_EXTRAS: {
+            "cell_name": "none-none",
+            "env_passthrough_mode": "inherit",
+            "timeout_per_trial": None,
+            "cell_env_vars": {},
+            **extras,
+        },
+    }
+    return SubprocessWorkload(cfg)
+
+
+def _read_result(tmp_path: Path) -> dict:
+    return json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+
+
+def _force_latched_hang(monkeypatch) -> None:
+    """Make the in-flight HangMonitor always latch ``hang_detected=True``.
+
+    Reproduces the structural blind spot behind #53/#55: for a command that
+    delegates its real work to a child tree (sudo -> bash -> docker -> python),
+    the wrapper PID goes quiet and idle, tripping two of the monitor's three
+    legs even though the workload is alive and busy.
+    """
+    real_monitor = workload_mod.HangMonitor
+
+    class _AlwaysHangMonitor(real_monitor):  # type: ignore[misc, valid-type]
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self.hang_detected = True
+
+        def start(self):  # no real polling thread needed
+            return None
+
+        def stop(self):
+            return None
+
+    monkeypatch.setattr(workload_mod, "HangMonitor", _AlwaysHangMonitor)
+
+
+# ==========================================================================
+# GROUP A -- tier2:hang false-positive invariants (#53, #55 item 1) [FIXED]
+# These must stay green; they guard against #55 re-reporting #53 yet again.
+# ==========================================================================
+
+
+def test_clean_exit_with_latched_hang_is_not_a_failure(tmp_path, monkeypatch):
+    """A wrapper-delegated command that exits 0 within its timeout is a
+    clean baseline, never ``tier2:hang`` -- the #55 headline regression."""
+    _force_latched_hang(monkeypatch)
+    wl = _make_workload(tmp_path, ["bash", "-c", "echo working; exit 0"])
+    wl.setup()
+    result = wl.run()
+    doc = _read_result(tmp_path)
+    assert doc["verdict"] == "pass", "clean exit-0 misclassified as fail (#55/#53)"
+    assert "tier2:hang" not in doc["failure_detectors_fired"]
+    assert result.passed is True
+
+
+def test_reconciled_hang_leaves_durable_breadcrumb(tmp_path, monkeypatch):
+    """When a latched hang is reconciled away on a clean exit, the trial
+    records ``tier2_hang_latched_but_reconciled`` so the #224 follow-up work
+    on a descendant-tree-aware predicate can study the false positives."""
+    _force_latched_hang(monkeypatch)
+    wl = _make_workload(tmp_path, ["bash", "-c", "exit 0"])
+    wl.setup()
+    wl.run()
+    doc = _read_result(tmp_path)
+    assert doc["capture"].get("tier2_hang_latched_but_reconciled") is True
+
+
+def test_reconciliation_only_drops_the_hang_leg_not_the_whole_verdict(tmp_path, monkeypatch):
+    """Reconciling away a latched hang on a clean exit must NOT whitewash a
+    genuine failure detected by another tier.
+
+    A command can exit 0 yet still be a real failure (e.g. it printed a NaN
+    signature that Tier 4 catches). The reconciliation gate drops only the
+    advisory ``tier2:hang`` leg; the Tier-4 failure must survive. This case
+    is not covered by the existing reconciliation tests and is exactly the
+    interaction that makes an over-broad "exit 0 => pass" shortcut dangerous.
+    """
+    _force_latched_hang(monkeypatch)
+    wl = _make_workload(tmp_path, ["bash", "-c", "echo 'loss is NaN'; exit 0"])
+    wl.setup()
+    wl.run()
+    doc = _read_result(tmp_path)
+    assert "tier2:hang" not in doc["failure_detectors_fired"], "hang leg should be reconciled away"
+    assert "tier4:nan_signature" in doc["failure_detectors_fired"], "real Tier-4 failure was lost"
+    assert doc["verdict"] == "fail"
+    # The breadcrumb still records that a hang was latched-then-reconciled.
+    assert doc["capture"].get("tier2_hang_latched_but_reconciled") is True
+
+
+def test_timed_out_with_latched_hang_stays_a_failure(tmp_path, monkeypatch):
+    """A genuine hang (the process did NOT voluntarily exit 0) must keep the
+    ``tier2:hang`` verdict -- the reconciliation must not over-reach."""
+    _force_latched_hang(monkeypatch)
+    # 'sleep' that is killed by the 0.5s timeout -> timed_out=True, exit -1.
+    wl = _make_workload(tmp_path, ["sleep", "30"], timeout_per_trial=0.5)
+    wl.setup()
+    wl.run()
+    doc = _read_result(tmp_path)
+    assert doc["timed_out"] is True
+    assert "tier2:hang" in doc["failure_detectors_fired"]
+    assert doc["verdict"] == "fail"
+    assert "tier2_hang_latched_but_reconciled" not in doc["capture"]
+
+
+# ==========================================================================
+# GROUP B -- failure_details[].type must agree with exit_code (#55 item 2)
+# OPEN on this branch: the type is hard-stamped "subprocess_nonzero_exit"
+# whenever the child launched, regardless of the actual exit status.
+# ==========================================================================
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="aorta-internal #55 item 2: failure_details[].type is stamped "
+    "'subprocess_nonzero_exit' even when exit_code == 0 (failure came from a "
+    "non-Tier-1 detector). Remove this marker when the type is derived from "
+    "the actual exit/verdict.",
+)
+def test_failure_detail_type_consistent_with_zero_exit(tmp_path):
+    """A trial that exits 0 but fails on a log-pattern (Tier 4) must not be
+    labelled ``subprocess_nonzero_exit`` -- that string is self-contradictory
+    with ``exit_code == 0`` and misleads anyone reading the per-trial JSON."""
+    wl = _make_workload(tmp_path, ["bash", "-c", "echo 'loss is NaN'; exit 0"])
+    wl.setup()
+    result = wl.run()
+    doc = _read_result(tmp_path)
+    assert doc["exit_code"] == 0
+    assert doc["verdict"] == "fail"  # tier4:nan_signature fired
+    assert result.failure_details, "a failing trial must carry a failure_detail"
+    detail_type = result.failure_details[0]["type"]
+    assert detail_type != "subprocess_nonzero_exit", (
+        f"failure_details[].type={detail_type!r} contradicts exit_code=0"
+    )
+
+
+# ==========================================================================
+# GROUP C -- cell-name disambiguation (#55 item 3)
+# OPEN on this branch: cell names are "<mit>-<diag>", rendering a confusing
+# bare trailing "-none" when the diagnostic axis is unused, with no way to
+# tell which token is the mitigation and which is the diagnostic.
+# ==========================================================================
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="aorta-internal #55 item 3: an unused diagnostic axis renders an "
+    "ambiguous trailing '-none' (e.g. 'tf32_off-none'). Remove this marker "
+    "when cell names disambiguate mitigation vs diagnostic.",
+)
+def test_unused_diagnostic_axis_does_not_render_ambiguous_cell_name(tmp_path):
+    """With ``diagnostic_axis: [none]`` the cell name must not be a bare
+    ``<mitigation>-none`` that reads as a stutter and hides the axis roles."""
+    from aorta.triage.recipe import load_recipe
+
+    recipe_text = (
+        "schema_version: 1\n"
+        "mode: probe\n"
+        "trials: 1\n"
+        "mitigation_axis: [none, tf32_off]\n"
+        "diagnostic_axis: [none]\n"
+    )
+    p = tmp_path / "r.yaml"
+    p.write_text(recipe_text, encoding="utf-8")
+    r = load_recipe(p)
+    names = sorted(c.name for c in r.cells)
+    # The mitigation-only cell should read as a clean baseline, and the
+    # tf32_off cell should not carry a meaningless '-none' suffix.
+    for name in names:
+        assert not name.endswith("-none"), (
+            f"cell name {name!r} carries an ambiguous trailing '-none' when the "
+            "diagnostic axis is unused"
+        )
+
+
+# ==========================================================================
+# GROUP D -- three-way verdict honesty (#58)
+# FIXED (#230): the verdict vocabulary is now {pass, fail, error}; an infra
+# crash (launch failure, unrecognised timeout, rejected env) resolves to
+# ``error`` and is excluded from the bug-rate denominator, so the
+# "honest by construction" claim (deck slide 9) holds. This guard is now a
+# permanent regression check -- if the ``error`` bucket is ever dropped it
+# fails immediately.
+# ==========================================================================
+
+
+def test_verdict_vocabulary_includes_error_bucket():
+    """The verdict layer must be able to represent ``error`` distinctly from
+    ``pass`` and ``fail`` so per-cell rates can exclude invalid trials."""
+    from aorta.probe.classifier import verdict as verdict_mod
+
+    valid = set(getattr(verdict_mod, "VALID_VERDICTS", {"pass", "fail"}))
+    assert "error" in valid
+    assert {"pass", "fail"} <= valid
+
+
+def test_stop_after_can_key_on_the_error_verdict():
+    """#230: once ``error`` is a first-class verdict, a ``stop_after`` rule
+    can collect-until-N on it (e.g. "stop once 3 infra errors pile up"). The
+    Phase-1 schema rejected ``event_verdict: error`` because the bucket did
+    not exist; #230 lifts that restriction."""
+    from aorta.probe.recipe_builder import build_probe_recipe_from_dict
+
+    r = build_probe_recipe_from_dict(
+        {
+            "schema_version": 1,
+            "mode": "probe",
+            "trials": 1,
+            "mitigation_axis": ["none"],
+            "diagnostic_axis": ["none"],
+            "stop_after": {"events": 3, "max_trials": 160, "event_verdict": "error"},
+        },
+        [],
+    )
+    assert r.stop_after is not None
+    assert r.stop_after.event_verdict == "error"
+
+
+# ==========================================================================
+# GROUP E -- recipe knobs the operator-facing tasks add (#56, #57)
+# OPEN: retention + stop_after are not yet parsed onto the probe recipe.
+# ==========================================================================
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="aorta-internal #56: verdict-keyed artifact retention not yet on "
+    "the probe recipe. Remove when ProbeExtras carries a retention policy.",
+)
+def test_recipe_accepts_verdict_keyed_retention():
+    from aorta.probe.recipe_builder import build_probe_recipe_from_dict
+
+    r = build_probe_recipe_from_dict(
+        {
+            "schema_version": 1,
+            "mode": "probe",
+            "trials": 1,
+            "mitigation_axis": ["none"],
+            "diagnostic_axis": ["none"],
+            "retain": {"on_fail": "full", "on_pass": "summary", "on_error": "log"},
+        }
+    )
+    assert r.probe_extras.retain is not None  # type: ignore[attr-defined]
+
+
+def test_recipe_accepts_stop_after_rule():
+    """#57/#232 (FIXED): the probe recipe accepts a ``stop_after``
+    collect-until-N rule. It is surfaced as the run-level ``Recipe.stop_after``
+    field (a stopping rule governs the whole trial loop, not a probe-only
+    extra), parsed and validated by ``_parse_stop_after``."""
+    from aorta.probe.recipe_builder import build_probe_recipe_from_dict
+
+    r = build_probe_recipe_from_dict(
+        {
+            "schema_version": 1,
+            "mode": "probe",
+            "trials": 1,
+            "mitigation_axis": ["none"],
+            "diagnostic_axis": ["none"],
+            "stop_after": {"events": 3, "max_trials": 160, "event_verdict": "fail"},
+        },
+        [],
+    )
+    assert r.stop_after is not None
+
+
+# ==========================================================================
+# GROUP F -- fixes merged into main (#52 env redirect, #222 teardown)
+# Capability-guarded so the battery still runs on older pre-fix branches.
+# ==========================================================================
+
+
+def test_env_probe_suppresses_inprocess_stderr_noise():
+    """#52/#220: the in-process env probe must redirect OS-level fds 1/2 so
+    HIP/C-runtime ``(null): No such file or directory`` noise never reaches
+    the operator's terminal. ``contextlib.redirect_stderr`` is insufficient.
+    """
+    from aorta.instrumentation import environment as env_mod
+
+    redirect_cls = getattr(env_mod, "_ProbeStdioRedirect", None)
+    if redirect_cls is None:
+        pytest.skip("#221 env-probe fd redirect not on this branch yet")
+
+    import os
+
+    redirect = redirect_cls()
+    redirect.start()
+    try:
+        # A raw fd-2 write -- the kind contextlib.redirect_stderr cannot catch.
+        os.write(2, b"(null): No such file or directory\n")
+    finally:
+        # _ProbeStdioRedirect is never-raises by contract; restore is its job.
+        stop = getattr(redirect, "stop", None) or getattr(redirect, "_restore_fds", None)
+        if stop is not None:
+            stop()
+    # If we got here without the noise reaching the real terminal, the fd-level
+    # capture is doing its job. The strong assertion (captured at DEBUG) lives
+    # in tests/instrumentation/test_environment.py on the #221 branch.
+
+
+def test_subprocess_child_starts_new_session_for_teardown(tmp_path, monkeypatch):
+    """#222: the wrapped child must be launched with ``start_new_session=True``
+    so an interrupt/timeout can reap the whole process group (sudo -> bash ->
+    docker -> python) instead of orphaning GPU-pinned descendants."""
+    if not hasattr(workload_mod, "_terminate_process_tree"):
+        pytest.skip("#222 process-tree teardown not on this branch yet")
+
+    # NOTE: ``workload_mod.subprocess`` is the shared stdlib module, so
+    # patching its ``Popen`` also intercepts the ``subprocess.run`` calls the
+    # Tier-3 amd-smi / dmesg probes make *after* the child launches. Record
+    # every call's kwargs and assert the CHILD launch (argv == our command)
+    # got ``start_new_session=True`` -- don't let a later probe overwrite it.
+    calls: list[dict] = []
+    real_popen = workload_mod.subprocess.Popen
+
+    class _SpyPopen(real_popen):  # type: ignore[misc, valid-type]
+        def __init__(self, *a, **k):
+            argv = a[0] if a else k.get("args")
+            calls.append({"argv": argv, "start_new_session": k.get("start_new_session")})
+            super().__init__(*a, **k)
+
+    monkeypatch.setattr(workload_mod.subprocess, "Popen", _SpyPopen)
+    argv = ["bash", "-c", "exit 0"]
+    wl = _make_workload(tmp_path, argv)
+    wl.setup()
+    wl.run()
+    child_calls = [c for c in calls if c["argv"] == argv]
+    assert child_calls, "the wrapped child was never launched via Popen"
+    assert child_calls[0]["start_new_session"] is True

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -139,19 +139,28 @@ def test_env_file_failure_result_includes_env(tmp_path):
     wl.setup()
     wl.run()
     doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
-    assert doc["verdict"] == "fail"
+    # Issue #230: a rejected probe.env is an infra/config error (no valid
+    # observation), not a fail.
+    assert doc["verdict"] == "error"
     assert doc["failure_type"] == "env_file_validation_failed"
     assert doc["env"] == {"BAD_VALUE": "line1\nline2"}
 
 
-def test_missing_executable_yields_fail(tmp_path):
-    """argv[0] not found surfaces as a Tier-1 fail with exit_code=127."""
+def test_missing_executable_yields_error(tmp_path):
+    """argv[0] not found surfaces as an ``error`` verdict (issue #230).
+
+    A command-not-found never launched, so it produced no valid
+    observation -- ``tier1:exec_failed`` -> ``error`` (not ``fail``). The
+    synthetic exit_code 127 is still recorded for the operator.
+    """
     wl = _make_workload(tmp_path, ["definitely-not-a-real-binary-9d8f7s6"])
     wl.setup()
     result = wl.run()
     doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
-    assert doc["verdict"] == "fail"
+    assert doc["verdict"] == "error"
     assert doc["exit_code"] == 127
+    assert "tier1:exec_failed" in doc["error_detectors_fired"]
+    assert doc["failure_detectors_fired"] == []
     assert result.passed is False
 
 
@@ -205,10 +214,10 @@ def test_successful_trial_flags_main_work_started(tmp_path):
     assert result.failure_details[0]["type"] == "subprocess_nonzero_exit"
 
 
-def test_non_executable_script_yields_fail(tmp_path):
+def test_non_executable_script_yields_error(tmp_path):
     """A user command pointing at a file without the +x bit must land
-    as a Tier-1 fail (exit_code=126), NOT escape to the dispatcher as
-    ``infrastructure_failed``.
+    as an ``error`` verdict (exit_code=126; issue #230), NOT escape to
+    the dispatcher as ``infrastructure_failed``.
 
     Regression for PR #194 review: previously only ``FileNotFoundError``
     was caught. ``PermissionError`` (EACCES, raised by ``Popen`` when
@@ -228,8 +237,9 @@ def test_non_executable_script_yields_fail(tmp_path):
         "captured as a Tier-1 fail (regression of PR #194 review fix)"
     )
     doc = json.loads(result_path.read_text(encoding="utf-8"))
-    assert doc["verdict"] == "fail"
+    assert doc["verdict"] == "error"
     assert doc["exit_code"] == 126
+    assert "tier1:exec_failed" in doc["error_detectors_fired"]
     assert result.passed is False
     # stderr.log should carry the diagnostic so the operator knows
     # which exec-time error fired.
@@ -237,11 +247,11 @@ def test_non_executable_script_yields_fail(tmp_path):
     assert "Permission" in stderr_text or "permitted" in stderr_text.lower()
 
 
-def test_popen_oserror_yields_fail(tmp_path, monkeypatch):
+def test_popen_oserror_yields_error(tmp_path, monkeypatch):
     """A generic ``OSError`` from ``Popen`` (e.g. ENOEXEC "Exec format
-    error" for a shebang-less script) also lands as a Tier-1 fail
-    with the artifact tree intact, rather than escaping to the
-    dispatcher.
+    error" for a shebang-less script) also lands as an ``error`` verdict
+    (issue #230) with the artifact tree intact, rather than escaping to
+    the dispatcher.
 
     Regression for PR #194 review: only ``FileNotFoundError`` and
     ``PermissionError`` were named explicitly in the previous handler;
@@ -261,9 +271,10 @@ def test_popen_oserror_yields_fail(tmp_path, monkeypatch):
         "result.json missing: bare OSError escaped instead of being " "captured as a Tier-1 fail"
     )
     doc = json.loads(result_path.read_text(encoding="utf-8"))
-    assert doc["verdict"] == "fail"
+    assert doc["verdict"] == "error"
     # Exit code falls back to 1 for non-{FileNotFound,Permission} OSError.
     assert doc["exit_code"] == 1
+    assert "tier1:exec_failed" in doc["error_detectors_fired"]
     assert result.passed is False
     stderr_text = (tmp_path / "trial_0" / "stderr.log").read_text(encoding="utf-8")
     assert "Exec format error" in stderr_text
@@ -323,7 +334,12 @@ def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
     # proc.kill() would propagate ProcessLookupError out of run().
     result = wl.run()
     doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
-    assert doc["verdict"] == "fail"
+    # Issue #230: a timeout with no recognised hang is an ``error`` (the
+    # trial never produced a valid observation), not a ``fail``. A timeout
+    # the hang monitor DOES latch co-fires tier2:hang and stays ``fail``
+    # (see test_timed_out_keeps_latched_hang_flag).
+    assert doc["verdict"] == "error"
+    assert "tier1:timeout" in doc["error_detectors_fired"]
     assert doc["timed_out"] is True
     assert doc["exit_code"] == -1
     assert result.passed is False

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -176,6 +176,15 @@ def test_env_file_failure_result_includes_env(tmp_path):
     assert doc["verdict"] == "error"
     assert doc["failure_type"] == "env_file_validation_failed"
     assert doc["env"] == {"BAD_VALUE": "line1\nline2"}
+    # Schema parity with the normal probe path: the failure artifact carries
+    # the same detector/capture/tier-timing/vram keys (empty, but present) so
+    # downstream parsers never special-case env-file errors.
+    for key in ("warn_detectors_fired", "capture", "tier_durations_ms", "peak_vram_mib"):
+        assert key in doc, f"env-file failure result.json missing {key!r}"
+    assert doc["warn_detectors_fired"] == []
+    assert doc["capture"] == {}
+    assert doc["tier_durations_ms"] == {}
+    assert doc["peak_vram_mib"] is None
 
 
 def test_missing_executable_yields_error(tmp_path):

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -18,7 +18,39 @@ from aorta.workloads._subprocess import (
     CONFIG_KEY_PROBE_EXTRAS,
     CONFIG_KEY_SUBPROCESS_ARGV,
     SubprocessWorkload,
+    _tier1_only_fallback_verdict,
 )
+
+# ---- Issue #230: classifier-crash fallback honours exec_failed ----------
+
+
+def test_fallback_verdict_exec_failed_resolves_to_error(tmp_path):
+    # When the full classifier crashes AND the command never launched,
+    # the Tier-1-only fallback must emit tier1:exec_failed -> error
+    # (not exit_nonzero -> fail) from the synthetic 127 exit code.
+    verdict, _ = _tier1_only_fallback_verdict(
+        exit_code=127,
+        timed_out=False,
+        trial_dir=tmp_path,
+        exec_failed=True,
+        classifier_exc=RuntimeError("boom"),
+    )
+    assert verdict.verdict == "error"
+    assert "tier1:exec_failed" in verdict.error_detectors_fired
+    assert "tier1:exit_nonzero" not in verdict.failure_detectors_fired
+
+
+def test_fallback_verdict_nonzero_exit_resolves_to_fail(tmp_path):
+    # A genuine non-zero child exit (launched) still resolves to fail.
+    verdict, _ = _tier1_only_fallback_verdict(
+        exit_code=1,
+        timed_out=False,
+        trial_dir=tmp_path,
+        exec_failed=False,
+        classifier_exc=RuntimeError("boom"),
+    )
+    assert verdict.verdict == "fail"
+    assert "tier1:exit_nonzero" in verdict.failure_detectors_fired
 
 # ---- FR 1.17 (entry-point resolution) ------------------------------------
 

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -337,6 +337,14 @@ def test_timeout_kill_race_does_not_crash(tmp_path, monkeypatch):
     """
     import subprocess as _subprocess
 
+    from aorta.workloads import _subprocess as workload_mod
+
+    # The amd-smi pre/post snapshots in run() shell out via subprocess.run
+    # (which uses ``with Popen(...)``). Neutralise the Tier-3 poll so the
+    # global Popen patch below only governs the workload's own child launch
+    # -- the fake Popen has no context-manager protocol.
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", lambda _state: None)
+
     real_popen = _subprocess.Popen
 
     class _RacingPopen:
@@ -582,6 +590,7 @@ def test_keyboard_interrupt_reaps_tree_and_reraises(tmp_path, monkeypatch):
     def _spy_teardown(proc, grace_sec=workload_mod._TERMINATE_GRACE_SEC):
         torn_down.append(proc)
 
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", lambda _state: None)
     monkeypatch.setattr(workload_mod.subprocess, "Popen", _InterruptingPopen)
     monkeypatch.setattr(workload_mod, "_terminate_process_tree", _spy_teardown)
 
@@ -634,6 +643,7 @@ def test_keyboard_interrupt_during_monitor_start_reaps_tree(tmp_path, monkeypatc
     def _spy_teardown(proc, grace_sec=workload_mod._TERMINATE_GRACE_SEC):
         torn_down.append(proc)
 
+    monkeypatch.setattr(workload_mod, "poll_amd_smi", lambda _state: None)
     monkeypatch.setattr(workload_mod.subprocess, "Popen", _OkPopen)
     monkeypatch.setattr(workload_mod, "HangMonitor", _InterruptingMonitor)
     monkeypatch.setattr(workload_mod, "_terminate_process_tree", _spy_teardown)

--- a/tests/run/test_results.py
+++ b/tests/run/test_results.py
@@ -1,8 +1,57 @@
 """Tests for TrialResult dataclass."""
 
+from types import SimpleNamespace
+
 import pytest
 
-from aorta.run.results import TrialResult
+from aorta.run.results import TrialResult, trial_verdict
+
+
+class TestTrialVerdict:
+    """Three-way shared verdict predicate (issue #230)."""
+
+    @staticmethod
+    def _trial(exit_status="ok", *, passed=None, metrics_verdict=None):
+        result = {}
+        if passed is not None:
+            result["passed"] = passed
+        if metrics_verdict is not None:
+            result["metrics"] = {"verdict": metrics_verdict}
+        return SimpleNamespace(exit_status=exit_status, result=result)
+
+    def test_probe_metric_verdict_is_authoritative(self):
+        # A probe ``error`` trial reports passed=False / workload_failed, but
+        # the metric carries the real three-way outcome.
+        t = self._trial(
+            exit_status="workload_failed", passed=False, metrics_verdict="error"
+        )
+        assert trial_verdict(t) == "error"
+
+    def test_probe_fail_metric(self):
+        t = self._trial(exit_status="workload_failed", passed=False, metrics_verdict="fail")
+        assert trial_verdict(t) == "fail"
+
+    def test_probe_pass_metric(self):
+        t = self._trial(exit_status="ok", passed=True, metrics_verdict="pass")
+        assert trial_verdict(t) == "pass"
+
+    def test_infra_failed_without_metric_is_error(self):
+        assert trial_verdict(self._trial("infrastructure_failed", passed=False)) == "error"
+
+    def test_setup_failed_without_metric_is_error(self):
+        assert trial_verdict(self._trial("workload_setup_failed", passed=False)) == "error"
+
+    def test_workload_failed_without_metric_is_fail(self):
+        assert trial_verdict(self._trial("workload_failed", passed=False)) == "fail"
+
+    def test_ok_passed_false_is_fail(self):
+        assert trial_verdict(self._trial("ok", passed=False)) == "fail"
+
+    def test_ok_is_pass(self):
+        assert trial_verdict(self._trial("ok", passed=True)) == "pass"
+
+    def test_missing_result_defaults_to_pass_on_ok(self):
+        assert trial_verdict(SimpleNamespace(exit_status="ok")) == "pass"
 
 
 class TestTrialResult:

--- a/tests/run/test_results.py
+++ b/tests/run/test_results.py
@@ -53,6 +53,18 @@ class TestTrialVerdict:
     def test_missing_result_defaults_to_pass_on_ok(self):
         assert trial_verdict(SimpleNamespace(exit_status="ok")) == "pass"
 
+    def test_unknown_metric_verdict_falls_through_to_status(self):
+        # A verdict string outside the canonical VALID_VERDICTS set is
+        # ignored; resolution falls back to exit_status.
+        t = self._trial(exit_status="ok", passed=True, metrics_verdict="bogus")
+        assert trial_verdict(t) == "pass"
+
+    def test_non_string_metric_verdict_is_ignored(self):
+        # A non-string verdict metric must never match (or raise on
+        # frozenset membership) -- fall back to exit_status.
+        t = self._trial(exit_status="workload_failed", passed=False, metrics_verdict=1)
+        assert trial_verdict(t) == "fail"
+
 
 class TestTrialResult:
     """Tests for TrialResult serialization and deserialization."""

--- a/tests/run/test_results.py
+++ b/tests/run/test_results.py
@@ -11,13 +11,16 @@ class TestTrialVerdict:
     """Three-way shared verdict predicate (issue #230)."""
 
     @staticmethod
-    def _trial(exit_status="ok", *, passed=None, metrics_verdict=None):
+    def _trial(exit_status="ok", *, passed=None, metrics_verdict=None, workload="_subprocess"):
+        # ``workload`` defaults to the probe producer (``_subprocess``)
+        # because the metric-verdict path is only trusted for it; pass a
+        # different name to model a non-probe triage workload.
         result = {}
         if passed is not None:
             result["passed"] = passed
         if metrics_verdict is not None:
             result["metrics"] = {"verdict": metrics_verdict}
-        return SimpleNamespace(exit_status=exit_status, result=result)
+        return SimpleNamespace(exit_status=exit_status, result=result, workload=workload)
 
     def test_probe_metric_verdict_is_authoritative(self):
         # A probe ``error`` trial reports passed=False / workload_failed, but
@@ -64,6 +67,32 @@ class TestTrialVerdict:
         # frozenset membership) -- fall back to exit_status.
         t = self._trial(exit_status="workload_failed", passed=False, metrics_verdict=1)
         assert trial_verdict(t) == "fail"
+
+    def test_non_probe_metric_verdict_is_not_trusted(self):
+        # ``metrics`` is a workload-owned free-form field: a non-probe
+        # workload may stash its own ``metrics["verdict"]`` that means
+        # something else. trial_verdict() must only trust it for the probe
+        # producer (``_subprocess``), so here a failed triage trial that
+        # happens to carry ``metrics["verdict"] == "pass"`` still resolves
+        # to ``fail`` from exit_status (review: oyazdanb, PR #236).
+        t = self._trial(
+            exit_status="workload_failed",
+            passed=False,
+            metrics_verdict="pass",
+            workload="some_triage_workload",
+        )
+        assert trial_verdict(t) == "fail"
+
+    def test_non_probe_error_status_ignores_pass_metric(self):
+        # Same guard for the infra-error path: a non-probe workload that
+        # crashed in infrastructure but left a stale ``metrics["verdict"]``
+        # of ``pass`` must still resolve to ``error``.
+        t = self._trial(
+            exit_status="infrastructure_failed",
+            metrics_verdict="pass",
+            workload="some_triage_workload",
+        )
+        assert trial_verdict(t) == "error"
 
 
 class TestTrialResult:

--- a/tests/triage/test_matrix.py
+++ b/tests/triage/test_matrix.py
@@ -81,14 +81,50 @@ def test_mixed_pass_fail_counts_correctly():
     assert abs(stats.failure_rate - (1 / 3)) < 1e-9
 
 
-def test_infrastructure_failed_exit_status_counts_as_failure():
+def test_infrastructure_failed_exit_status_counts_as_error():
+    """Issue #230: infra crashes are ``error`` (no valid observation), not
+    ``fail`` -- they're excluded from the event-rate denominator."""
     trials = [
         _trial(passed=True, exit_status="ok"),
         _trial(passed=True, exit_status="infrastructure_failed"),
     ]
     stats = _default_call(trials=trials)
     assert stats.passed_count == 1
+    assert stats.failed_count == 0
+    assert stats.error_count == 1
+    # Event rate excludes the error trial from the denominator: 0 fails / 1
+    # valid trial == 0.0 (not 0/2 either -- the error trial isn't counted).
+    assert stats.failure_rate == 0.0
+    assert stats.error_rate == 0.5
+
+
+def test_workload_setup_failed_counts_as_error():
+    """``workload_setup_failed`` -> ``error`` (setup died before the
+    measurement; issue #230)."""
+    trials = [
+        _trial(passed=False, exit_status="workload_failed"),
+        _trial(passed=False, exit_status="workload_setup_failed"),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.passed_count == 0
     assert stats.failed_count == 1
+    assert stats.error_count == 1
+    # 1 genuine fail / 1 valid trial == 1.0; the setup-failed error is excluded.
+    assert stats.failure_rate == 1.0
+    assert stats.error_rate == 0.5
+
+
+def test_all_error_cell_has_zero_event_rate():
+    """A cell where every trial errored has event_rate 0.0 (no valid trials),
+    not a division-by-zero."""
+    trials = [_trial(passed=False, exit_status="infrastructure_failed") for _ in range(3)]
+    stats = _default_call(trials=trials)
+    assert stats.passed_count == 0
+    assert stats.failed_count == 0
+    assert stats.error_count == 3
+    assert stats.failure_rate == 0.0
+    assert stats.error_rate == 1.0
+    assert stats.is_unreliable is True
 
 
 def test_step_times_preferred_over_fallback():
@@ -217,8 +253,14 @@ def test_exit_status_histogram_distinguishes_failure_modes():
     }
     # Histogram total must equal trial count, by construction.
     assert sum(stats.exit_status_counts.values()) == stats.trials
-    # And the failure_rate is consistent with the histogram (4 of 6 not "ok").
-    assert abs(stats.failure_rate - (4.0 / 6.0)) < 1e-9
+    # Issue #230 three-way split: ok=2 (pass), workload_failed=1 (fail),
+    # workload_setup_failed + 2x infrastructure_failed = 3 (error).
+    assert stats.passed_count == 2
+    assert stats.failed_count == 1
+    assert stats.error_count == 3
+    # Event rate excludes the 3 error trials: 1 fail / (2 pass + 1 fail) = 1/3.
+    assert abs(stats.failure_rate - (1.0 / 3.0)) < 1e-9
+    assert abs(stats.error_rate - (3.0 / 6.0)) < 1e-9
 
 
 def test_failure_rate_docstring_is_general_not_nan_specific():

--- a/tests/triage/test_matrix_error_column.py
+++ b/tests/triage/test_matrix_error_column.py
@@ -99,6 +99,15 @@ def test_errors_column_no_unreliable_below_threshold(tmp_path: Path):
     assert "1 / 20 (unreliable)" not in text
 
 
+def test_failures_column_flags_no_valid_trials(tmp_path: Path):
+    # Every trial errored (no whole-cell error, but zero valid trials):
+    # the Failures column must read "0 / 0 (no valid trials)" rather than
+    # a bare, degenerate "0 / 0" (issue #230 review).
+    stats = [_stats("c", trials=3, passed=0, failed=0, error=3)]
+    text = _write_md(tmp_path, stats)
+    assert "0 / 0 (no valid trials)" in text
+
+
 def test_matrix_json_carries_error_fields(tmp_path: Path):
     stats = [_stats("c", trials=4, passed=2, failed=1, error=1)]
     out = tmp_path / "matrix.json"

--- a/tests/triage/test_matrix_error_column.py
+++ b/tests/triage/test_matrix_error_column.py
@@ -1,0 +1,120 @@
+"""Tests for the issue #230 ``Errors`` column + unreliable flag in matrix.md.
+
+The column appears ONLY when at least one cell has an ``error_count`` > 0,
+so legacy / error-free runs render byte-equivalently. Mirrors the
+visibility pattern of the Phase-2 ``Top failure`` columns.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aorta.triage.matrix import CellStats
+from aorta.triage.output import write_matrix_json, write_matrix_md
+from aorta.triage.recipe import Recipe, build_recipe_from_flags
+
+
+def _minimal_recipe() -> Recipe:
+    return build_recipe_from_flags(
+        workload="echo",
+        mitigation_axis="none",
+        environment_axis="local",
+        trials=1,
+        steps=1,
+    )
+
+
+def _stats(
+    name: str,
+    *,
+    trials: int,
+    passed: int,
+    failed: int,
+    error: int,
+) -> CellStats:
+    return CellStats(
+        name=name,
+        mitigations=("none",),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=trials,
+        passed_count=passed,
+        failed_count=failed,
+        mean_step_time_ms=10.0,
+        std_step_time_ms=0.0,
+        min_step_time_ms=10.0,
+        max_step_time_ms=10.0,
+        p50_step_time_ms=10.0,
+        p90_step_time_ms=10.0,
+        p99_step_time_ms=10.0,
+        mean_wall_clock_sec=1.0,
+        step_time_source="per_step",
+        error_count=error,
+    )
+
+
+def _write_md(tmp_path: Path, stats: list[CellStats]) -> str:
+    out = tmp_path / "matrix.md"
+    write_matrix_md(
+        out,
+        _minimal_recipe(),
+        stats,
+        baseline=stats[0],
+        confound_tags={s.name: ("(baseline)", None) for s in stats},
+        warnings=[],
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    return out.read_text(encoding="utf-8")
+
+
+def test_errors_column_hidden_when_no_errors(tmp_path: Path):
+    stats = [_stats("none-local", trials=4, passed=4, failed=0, error=0)]
+    text = _write_md(tmp_path, stats)
+    assert "Errors" not in text
+    assert "unreliable" not in text
+
+
+def test_errors_column_visible_when_a_cell_errors(tmp_path: Path):
+    # 1 error out of 4 (25% >= 10% threshold) -> unreliable.
+    stats = [_stats("c", trials=4, passed=2, failed=1, error=1)]
+    text = _write_md(tmp_path, stats)
+    assert "| Errors " in text
+    assert "1 / 4 (unreliable)" in text
+    # Failure rate is computed over valid trials (2 pass + 1 fail = 3): 1/3 ~ 33%.
+    assert "33%" in text
+    # Failures column matches the rate's denominator: 1 / 3.
+    assert "1 / 3" in text
+
+
+def test_errors_column_no_unreliable_below_threshold(tmp_path: Path):
+    # 1 error out of 20 == 5% < 10% threshold: column shows, no flag.
+    stats = [_stats("c", trials=20, passed=15, failed=4, error=1)]
+    text = _write_md(tmp_path, stats)
+    assert "| Errors " in text
+    assert "1 / 20" in text
+    # The cell value must not carry the marker (the legend prose still
+    # explains what ``(unreliable)`` means -- that's expected).
+    assert "1 / 20 (unreliable)" not in text
+
+
+def test_matrix_json_carries_error_fields(tmp_path: Path):
+    stats = [_stats("c", trials=4, passed=2, failed=1, error=1)]
+    out = tmp_path / "matrix.json"
+    write_matrix_json(
+        out,
+        _minimal_recipe(),
+        stats,
+        baseline_name="c",
+        confound_tags={"c": ("(baseline)", None)},
+        run_timestamp="2026-01-01T00:00:00Z",
+        warnings=[],
+    )
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    cell = doc["cells"][0]
+    assert cell["error_count"] == 1
+    assert abs(cell["error_rate"] - 0.25) < 1e-9
+    # failure_rate is the event rate over valid trials: 1 / (2 + 1).
+    assert abs(cell["failure_rate"] - (1.0 / 3.0)) < 1e-9
+    assert cell["unreliable"] is True

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -467,6 +467,28 @@ def test_resolved_recipe_round_trips_workload_config(
     assert reloaded.cells[1].workload_config == {"shampoo_api": "old"}
 
 
+def test_resolved_recipe_round_trips_stop_after(
+    tmp_path, patched_env, patched_run_trials
+):
+    """An active stop_after rule must survive load -> run -> reload, so a rerun
+    from recipe.resolved.yaml keeps the stopping behaviour (issue #232)."""
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe, StopAfter, load_recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(Cell(name="a", mitigations=("none",), environment="local"),),
+        ticket="SA-RT",
+        confound=ConfoundCfg(baseline_cell="a"),
+        stop_after=StopAfter(events=2, max_trials=5, event_verdict="fail"),
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    reloaded = load_recipe(run_dir / "recipe.resolved.yaml")
+    assert reloaded.stop_after == StopAfter(events=2, max_trials=5, event_verdict="fail")
+
+
 # ---- Config column (diffs-only workload_config) --------------------------
 #
 # The column surfaces per-cell workload_config keys whose value varies

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -384,10 +384,11 @@ def test_matrix_md_failures_column_renders_failed_over_total(tmp_path, patched_e
     r = _simple_recipe(ticket="T-1")
     run_dir = runner.run_recipe(r, output_dir=tmp_path)
     md = (run_dir / "matrix.md").read_text()
-    # The baseline row's numeric cell: 0 failures of 2 trials.
+    # The baseline row's numeric cell: 0 failures of 2 valid trials.
     assert "0 / 2" in md
-    # Legend line documents what "Failures" means.
-    assert "`Failures` is `failed_count / trial_count`" in md
+    # Legend line documents what "Failures" means (issue #230: denominator
+    # is valid trials = passed + failed, errors excluded).
+    assert "`Failures` is `failed_count / valid_trials`" in md
 
 
 def test_resolved_recipe_is_loadable_by_load_recipe(tmp_path, patched_env, patched_run_trials):

--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -222,6 +222,34 @@ def test_stop_after_note_cap_reached():
     assert "0 fail event(s) in 3 trial(s)" in note
 
 
+def test_stop_after_column_shown_when_all_cells_error(tmp_path):
+    # The "Stop after" column must reflect the *configured* rule, not the
+    # success of individual cells: an all-errored run leaves every
+    # ``stop_after_note`` None, but the rule was still active and
+    # matrix.json still carries ``stop_after``. Gating on any cell's note
+    # would hide the column here. Errored cells render "—" in the column.
+    from aorta.triage.matrix import aggregate_cell
+    from aorta.triage.output import write_matrix_md
+
+    recipe = _probe_recipe(tmp_path, "stop_after:\n  events: 2\n  max_trials: 6\n")
+    errored = aggregate_cell(
+        name="none-none",
+        mitigations=("none",),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=[],
+        effective_steps=10,
+        error="infrastructure_failed: boom",
+    )
+    out = tmp_path / "matrix.md"
+    write_matrix_md(out, recipe, [errored], errored, {}, [], "2026-06-17T00:00:00Z")
+    md = out.read_text(encoding="utf-8")
+    assert "Stop after" in md
+    note_row = next(line for line in md.splitlines() if line.startswith("| none-none "))
+    assert "| — " in note_row
+
+
 # --------------------------------------------------------------------------
 # CLI overlay (apply_recipe_overrides)
 # --------------------------------------------------------------------------

--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -1,0 +1,345 @@
+"""Tests for the ``stop_after`` collect-until-N stopping rule (issue #232).
+
+Coverage:
+
+* schema parse + validation (``_parse_stop_after`` via the loaders);
+* the dispatcher's event predicate + early-stop loop;
+* the matrix "stopped early" vs "cap reached" annotation;
+* the ``--stop-after-events`` / ``--max-trials`` CLI overlay;
+* end-to-end via ``aorta probe`` (real subprocess argv), including the
+  resume short-circuit for a cell that already satisfied its rule.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from aorta.cli.probe import probe
+from aorta.probe.cli_helpers import ProbeUsageError, apply_recipe_overrides
+from aorta.run.dispatcher import RunRequest, _trial_is_event, run_trials
+from aorta.triage.recipe import RecipeSchemaError, StopAfter, load_recipe
+from aorta.triage.runner import _stop_after_note
+from aorta.workloads import Workload, WorkloadResult
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    p = tmp_path / "r.yaml"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+_PROBE_HEAD = (
+    "schema_version: 1\n"
+    "mode: probe\n"
+    "trials: 1\n"
+    "mitigation_axis: [none]\n"
+    "diagnostic_axis: [none]\n"
+)
+
+
+# --------------------------------------------------------------------------
+# Schema
+# --------------------------------------------------------------------------
+def test_stop_after_parses(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  events: 3\n  max_trials: 160\n"
+    r = load_recipe(_write(tmp_path, text))
+    assert r.stop_after == StopAfter(events=3, max_trials=160, event_verdict="fail")
+
+
+def test_stop_after_event_verdict_pass(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  events: 2\n  max_trials: 10\n  event_verdict: pass\n"
+    r = load_recipe(_write(tmp_path, text))
+    assert r.stop_after.event_verdict == "pass"
+
+
+def test_stop_after_absent_is_none(tmp_path):
+    r = load_recipe(_write(tmp_path, _PROBE_HEAD))
+    assert r.stop_after is None
+
+
+def test_stop_after_requires_max_trials(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  events: 3\n"
+    with pytest.raises(RecipeSchemaError, match="max_trials' is required"):
+        load_recipe(_write(tmp_path, text))
+
+
+def test_stop_after_requires_events(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  max_trials: 10\n"
+    with pytest.raises(RecipeSchemaError, match="missing required key 'events'"):
+        load_recipe(_write(tmp_path, text))
+
+
+def test_stop_after_cap_below_target_rejected(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  events: 9\n  max_trials: 3\n"
+    with pytest.raises(RecipeSchemaError, match="must be >="):
+        load_recipe(_write(tmp_path, text))
+
+
+def test_stop_after_error_verdict_points_to_230(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  events: 1\n  max_trials: 5\n  event_verdict: error\n"
+    with pytest.raises(RecipeSchemaError, match="#230"):
+        load_recipe(_write(tmp_path, text))
+
+
+def test_stop_after_non_int_rejected(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  events: 1.5\n  max_trials: 5\n"
+    with pytest.raises(RecipeSchemaError, match="must be an integer"):
+        load_recipe(_write(tmp_path, text))
+
+
+def test_stop_after_unknown_key_rejected(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  events: 1\n  max_trials: 5\n  bogus: 1\n"
+    with pytest.raises(RecipeSchemaError, match="unknown keys"):
+        load_recipe(_write(tmp_path, text))
+
+
+def test_stop_after_valid_in_triage_mode(tmp_path):
+    text = (
+        "schema_version: 1\n"
+        "workload: fsdp\n"
+        "trials: 2\n"
+        "steps: 10\n"
+        "stop_after:\n  events: 1\n  max_trials: 8\n"
+        "cells:\n"
+        "  - name: baseline-local\n"
+        "    mitigations: [none]\n"
+        "    environment: local\n"
+    )
+    r = load_recipe(_write(tmp_path, text))
+    assert r.stop_after == StopAfter(events=1, max_trials=8, event_verdict="fail")
+
+
+# --------------------------------------------------------------------------
+# Event predicate
+# --------------------------------------------------------------------------
+def _tr(exit_status: str) -> SimpleNamespace:
+    return SimpleNamespace(exit_status=exit_status)
+
+
+@pytest.mark.parametrize(
+    "exit_status,verdict,expected",
+    [
+        ("ok", "fail", False),
+        ("workload_failed", "fail", True),
+        ("infrastructure_failed", "fail", True),
+        ("ok", "pass", True),
+        ("workload_failed", "pass", False),
+    ],
+)
+def test_trial_is_event(exit_status, verdict, expected):
+    assert _trial_is_event(_tr(exit_status), verdict) is expected
+
+
+# --------------------------------------------------------------------------
+# Dispatcher early-stop loop
+# --------------------------------------------------------------------------
+class _FailWL(Workload):
+    launch_mode = "single_process"
+    min_world_size = 1
+
+    def setup(self) -> None:
+        pass
+
+    def run(self) -> WorkloadResult:
+        return WorkloadResult(passed=False, failure_count=1)
+
+    def cleanup(self) -> None:
+        pass
+
+
+class _PassWL(Workload):
+    launch_mode = "single_process"
+    min_world_size = 1
+
+    def setup(self) -> None:
+        pass
+
+    def run(self) -> WorkloadResult:
+        return WorkloadResult(passed=True, total_iterations=1, elapsed_sec=0.1)
+
+    def cleanup(self) -> None:
+        pass
+
+
+def _run_trials_with(workload_cls, stop_after, tmp_path, trials):
+    mock_ep = MagicMock()
+    mock_ep.name = "w"
+    mock_ep.load.return_value = workload_cls
+    mock_eps = MagicMock()
+    mock_eps.select.return_value = [mock_ep]
+    with patch("importlib.metadata.entry_points", return_value=mock_eps):
+        req = RunRequest(
+            workload="w", trials=trials, results_dir=tmp_path, stop_after=stop_after
+        )
+        return run_trials(req)
+
+
+def test_dispatcher_stops_early_on_events(tmp_path):
+    sa = StopAfter(events=2, max_trials=10)
+    results = _run_trials_with(_FailWL, sa, tmp_path, trials=sa.max_trials)
+    assert len(results) == 2  # stopped after the 2nd failing trial
+
+
+def test_dispatcher_runs_to_cap_when_target_unmet(tmp_path):
+    sa = StopAfter(events=3, max_trials=4)  # passing workload -> 0 fail events
+    results = _run_trials_with(_PassWL, sa, tmp_path, trials=sa.max_trials)
+    assert len(results) == 4  # cap reached
+
+
+def test_dispatcher_event_verdict_pass(tmp_path):
+    sa = StopAfter(events=2, max_trials=10, event_verdict="pass")
+    results = _run_trials_with(_PassWL, sa, tmp_path, trials=sa.max_trials)
+    assert len(results) == 2
+
+
+def test_dispatcher_no_stop_after_runs_all(tmp_path):
+    results = _run_trials_with(_FailWL, None, tmp_path, trials=3)
+    assert len(results) == 3
+
+
+# --------------------------------------------------------------------------
+# Matrix annotation
+# --------------------------------------------------------------------------
+def test_stop_after_note_stopped_early():
+    sa = StopAfter(events=2, max_trials=10)
+    trials = [_tr("workload_failed"), _tr("ok"), _tr("workload_failed")]
+    note = _stop_after_note(sa, trials)
+    assert note.startswith("stopped early")
+    assert "2 fail event(s) in 3 trial(s)" in note
+
+
+def test_stop_after_note_cap_reached():
+    sa = StopAfter(events=3, max_trials=3)
+    trials = [_tr("ok"), _tr("ok"), _tr("ok")]
+    note = _stop_after_note(sa, trials)
+    assert note.startswith("cap reached")
+    assert "0 fail event(s) in 3 trial(s)" in note
+
+
+# --------------------------------------------------------------------------
+# CLI overlay (apply_recipe_overrides)
+# --------------------------------------------------------------------------
+def _probe_recipe(tmp_path, stop_after_block=""):
+    return load_recipe(_write(tmp_path, _PROBE_HEAD + stop_after_block))
+
+
+def test_cli_overlay_builds_stop_after(tmp_path):
+    r = _probe_recipe(tmp_path)
+    out = apply_recipe_overrides(
+        r, ticket=None, cli_passthrough_mode=None,
+        cli_stop_after_events=3, cli_max_trials=20,
+    )
+    assert out.stop_after == StopAfter(events=3, max_trials=20, event_verdict="fail")
+
+
+def test_cli_overlay_half_falls_back_to_recipe(tmp_path):
+    r = _probe_recipe(tmp_path, "stop_after:\n  events: 2\n  max_trials: 9\n  event_verdict: pass\n")
+    # Only override the cap; events + verdict come from the recipe.
+    out = apply_recipe_overrides(
+        r, ticket=None, cli_passthrough_mode=None, cli_max_trials=50
+    )
+    assert out.stop_after == StopAfter(events=2, max_trials=50, event_verdict="pass")
+
+
+def test_cli_overlay_events_without_cap_rejected(tmp_path):
+    r = _probe_recipe(tmp_path)
+    with pytest.raises(ProbeUsageError, match="requires --max-trials"):
+        apply_recipe_overrides(
+            r, ticket=None, cli_passthrough_mode=None, cli_stop_after_events=3
+        )
+
+
+def test_cli_overlay_cap_below_target_rejected(tmp_path):
+    r = _probe_recipe(tmp_path)
+    with pytest.raises(ProbeUsageError, match="must be >="):
+        apply_recipe_overrides(
+            r, ticket=None, cli_passthrough_mode=None,
+            cli_stop_after_events=9, cli_max_trials=2,
+        )
+
+
+# --------------------------------------------------------------------------
+# End-to-end via aorta probe
+# --------------------------------------------------------------------------
+def _probe_e2e(output: Path, recipe: Path, argv: list[str], extra: list[str] | None = None):
+    args = [
+        "--recipe", str(recipe), "--output", str(output), "--ticket", "SA-1",
+        *(extra or []), "--", *argv,
+    ]
+    result = CliRunner().invoke(probe, args)
+    if result.exit_code != 0 and result.exception:
+        import traceback
+
+        traceback.print_exception(
+            type(result.exception), result.exception, result.exception.__traceback__
+        )
+    return result
+
+
+def _matrix_cell(output: Path):
+    doc = json.loads((output / "SA-1" / "matrix.json").read_text(encoding="utf-8"))
+    return doc, doc["cells"][0]
+
+
+def test_e2e_stops_early_on_failures(tmp_path):
+    recipe = _write(tmp_path, _PROBE_HEAD + "stop_after:\n  events: 2\n  max_trials: 6\n")
+    output = tmp_path / "out"
+    res = _probe_e2e(output, recipe, ["sh", "-c", "exit 1"])
+    assert res.exit_code == 0, res.output
+    cell_dir = output / "SA-1" / "none-none"
+    # Stopped at the 2nd failure: trial_0 + trial_1 exist, trial_2 does not.
+    assert (cell_dir / "trial_0" / "result.json").is_file()
+    assert (cell_dir / "trial_1" / "result.json").is_file()
+    assert not (cell_dir / "trial_2").exists()
+    doc, cell = _matrix_cell(output)
+    assert cell["trials"] == 2
+    assert cell["failed_count"] == 2
+    assert "stopped early" in (cell["stop_after_note"] or "")
+    assert doc["stop_after"] == {"events": 2, "max_trials": 6, "event_verdict": "fail"}
+
+
+def test_e2e_cap_reached_when_all_pass(tmp_path):
+    recipe = _write(tmp_path, _PROBE_HEAD + "stop_after:\n  events: 2\n  max_trials: 3\n")
+    output = tmp_path / "out"
+    res = _probe_e2e(output, recipe, ["sh", "-c", "exit 0"])
+    assert res.exit_code == 0, res.output
+    _doc, cell = _matrix_cell(output)
+    assert cell["trials"] == 3  # ran the full cap
+    assert cell["passed_count"] == 3
+    assert "cap reached" in (cell["stop_after_note"] or "")
+    # matrix.md surfaces the column when a stop_after rule is active.
+    md = (output / "SA-1" / "matrix.md").read_text(encoding="utf-8")
+    assert "Stop after" in md
+
+
+def test_e2e_cli_flags_override_recipe(tmp_path):
+    # Recipe has no stop_after; the CLI flags introduce one.
+    recipe = _write(tmp_path, _PROBE_HEAD)
+    output = tmp_path / "out"
+    res = _probe_e2e(
+        output, recipe, ["sh", "-c", "exit 1"],
+        extra=["--stop-after-events", "1", "--max-trials", "5"],
+    )
+    assert res.exit_code == 0, res.output
+    _doc, cell = _matrix_cell(output)
+    assert cell["trials"] == 1  # stopped at the first failure
+
+
+def test_e2e_resume_skips_satisfied_cell(tmp_path):
+    recipe = _write(tmp_path, _PROBE_HEAD + "stop_after:\n  events: 2\n  max_trials: 6\n")
+    output = tmp_path / "out"
+    assert _probe_e2e(output, recipe, ["sh", "-c", "exit 1"]).exit_code == 0
+    trial1 = output / "SA-1" / "none-none" / "trial_1" / "result.json"
+    first_mtime = trial1.stat().st_mtime
+    # Re-run: the on-disk prefix already has 2 failures == target, so the
+    # cell must be skipped (no re-execution, mtime unchanged).
+    assert _probe_e2e(output, recipe, ["sh", "-c", "exit 1"]).exit_code == 0
+    assert trial1.stat().st_mtime == first_mtime
+    _doc, cell = _matrix_cell(output)
+    assert cell["trials"] == 2

--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -81,9 +81,18 @@ def test_stop_after_cap_below_target_rejected(tmp_path):
         load_recipe(_write(tmp_path, text))
 
 
-def test_stop_after_error_verdict_points_to_230(tmp_path):
+def test_stop_after_error_verdict_now_accepted(tmp_path):
+    """Issue #230 landed the three-way verdict, so ``event_verdict: error``
+    is now a valid stopping rule (e.g. bail out of an infra-flaky sweep)."""
     text = _PROBE_HEAD + "stop_after:\n  events: 1\n  max_trials: 5\n  event_verdict: error\n"
-    with pytest.raises(RecipeSchemaError, match="#230"):
+    recipe = load_recipe(_write(tmp_path, text))
+    assert recipe.stop_after is not None
+    assert recipe.stop_after.event_verdict == "error"
+
+
+def test_stop_after_unknown_verdict_rejected(tmp_path):
+    text = _PROBE_HEAD + "stop_after:\n  events: 1\n  max_trials: 5\n  event_verdict: bogus\n"
+    with pytest.raises(RecipeSchemaError, match="event_verdict"):
         load_recipe(_write(tmp_path, text))
 
 
@@ -127,9 +136,15 @@ def _tr(exit_status: str) -> SimpleNamespace:
     [
         ("ok", "fail", False),
         ("workload_failed", "fail", True),
-        ("infrastructure_failed", "fail", True),
+        # Issue #230: an infra crash is an ``error`` event, NOT a ``fail``
+        # event -- it never validly reproduced the bug.
+        ("infrastructure_failed", "fail", False),
+        ("infrastructure_failed", "error", True),
+        ("workload_setup_failed", "error", True),
+        ("workload_failed", "error", False),
         ("ok", "pass", True),
         ("workload_failed", "pass", False),
+        ("infrastructure_failed", "pass", False),
     ],
 )
 def test_trial_is_event(exit_status, verdict, expected):
@@ -162,6 +177,23 @@ class _PassWL(Workload):
 
     def run(self) -> WorkloadResult:
         return WorkloadResult(passed=True, total_iterations=1, elapsed_sec=0.1)
+
+    def cleanup(self) -> None:
+        pass
+
+
+class _ErrorWL(Workload):
+    """Setup raises -> dispatcher records exit_status='workload_setup_failed'
+    -> three-way verdict 'error' (issue #230)."""
+
+    launch_mode = "single_process"
+    min_world_size = 1
+
+    def setup(self) -> None:
+        raise RuntimeError("infra boom")
+
+    def run(self) -> WorkloadResult:  # pragma: no cover - never reached
+        return WorkloadResult(passed=True)
 
     def cleanup(self) -> None:
         pass
@@ -201,6 +233,22 @@ def test_dispatcher_event_verdict_pass(tmp_path):
 def test_dispatcher_no_stop_after_runs_all(tmp_path):
     results = _run_trials_with(_FailWL, None, tmp_path, trials=3)
     assert len(results) == 3
+
+
+def test_dispatcher_event_verdict_error_stops_early(tmp_path):
+    """Issue #230: ``event_verdict: error`` stops a cell once enough trials
+    have errored (e.g. bail out of an infra-flaky sweep)."""
+    sa = StopAfter(events=2, max_trials=10, event_verdict="error")
+    results = _run_trials_with(_ErrorWL, sa, tmp_path, trials=sa.max_trials)
+    assert len(results) == 2
+
+
+def test_dispatcher_errors_do_not_count_as_fail_events(tmp_path):
+    """An all-error workload never satisfies an ``event_verdict: fail`` rule,
+    so the cell runs to the cap (errors are not fails -- issue #230)."""
+    sa = StopAfter(events=2, max_trials=3, event_verdict="fail")
+    results = _run_trials_with(_ErrorWL, sa, tmp_path, trials=sa.max_trials)
+    assert len(results) == 3  # cap reached, never stopped early on a "fail"
 
 
 # --------------------------------------------------------------------------

--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -203,6 +203,24 @@ def test_dispatcher_no_stop_after_runs_all(tmp_path):
     assert len(results) == 3
 
 
+def test_dispatcher_log_says_early_when_budget_remains(tmp_path, caplog):
+    sa = StopAfter(events=2, max_trials=10)
+    with caplog.at_level("INFO", logger="aorta.run.dispatcher"):
+        _run_trials_with(_FailWL, sa, tmp_path, trials=sa.max_trials)
+    stop_logs = [r.getMessage() for r in caplog.records if "stop_after:" in r.getMessage()]
+    assert stop_logs and "stopping cell early" in stop_logs[-1]
+
+
+def test_dispatcher_log_says_cap_reached_on_final_trial(tmp_path, caplog):
+    # Target met exactly on the last allowed trial -> not "early", it's a cap reach.
+    sa = StopAfter(events=3, max_trials=3)
+    with caplog.at_level("INFO", logger="aorta.run.dispatcher"):
+        _run_trials_with(_FailWL, sa, tmp_path, trials=sa.max_trials)
+    stop_logs = [r.getMessage() for r in caplog.records if "stop_after:" in r.getMessage()]
+    assert stop_logs and "cap reached" in stop_logs[-1]
+    assert "stopping cell early" not in stop_logs[-1]
+
+
 # --------------------------------------------------------------------------
 # Matrix annotation
 # --------------------------------------------------------------------------
@@ -330,6 +348,8 @@ def test_e2e_stops_early_on_failures(tmp_path):
     assert cell["failed_count"] == 2
     assert "stopped early" in (cell["stop_after_note"] or "")
     assert doc["stop_after"] == {"events": 2, "max_trials": 6, "event_verdict": "fail"}
+    # trials_per_cell reflects the cap (max_trials), not recipe.trials (1).
+    assert doc["trials_per_cell"] == 6
 
 
 def test_e2e_cap_reached_when_all_pass(tmp_path):
@@ -339,6 +359,7 @@ def test_e2e_cap_reached_when_all_pass(tmp_path):
     assert res.exit_code == 0, res.output
     _doc, cell = _matrix_cell(output)
     assert cell["trials"] == 3  # ran the full cap
+    assert _doc["trials_per_cell"] == 3  # cap, not recipe.trials (1)
     assert cell["passed_count"] == 3
     assert "cap reached" in (cell["stop_after_note"] or "")
     # matrix.md surfaces the column when a stop_after rule is active.

--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -115,6 +115,26 @@ def test_stop_after_valid_in_triage_mode(tmp_path):
     assert r.stop_after == StopAfter(events=1, max_trials=8, event_verdict="fail")
 
 
+def test_stop_after_rejects_per_cell_trials_override(tmp_path):
+    # Issue #232: stop_after.max_trials is the per-cell cap, so a per-cell
+    # ``trials:`` override would be silently ignored at run time. Reject the
+    # combination at load time instead of surprising the operator.
+    text = (
+        "schema_version: 1\n"
+        "workload: fsdp\n"
+        "trials: 2\n"
+        "steps: 10\n"
+        "stop_after:\n  events: 1\n  max_trials: 8\n"
+        "cells:\n"
+        "  - name: baseline-local\n"
+        "    mitigations: [none]\n"
+        "    environment: local\n"
+        "    trials: 3\n"
+    )
+    with pytest.raises(RecipeSchemaError, match="incompatible with per-cell 'trials'"):
+        load_recipe(_write(tmp_path, text))
+
+
 # --------------------------------------------------------------------------
 # Event predicate
 # --------------------------------------------------------------------------

--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -268,6 +268,36 @@ def test_stop_after_column_shown_when_all_cells_error(tmp_path):
     assert "| — " in note_row
 
 
+def test_matrix_md_trials_per_cell_reflects_cap(tmp_path):
+    # The matrix.md "Trials per cell" header must show the stop_after cap
+    # ("up to N"), not ``recipe.trials`` (often 1 on probe recipes), so the
+    # header matches the real per-cell budget. A rule-less recipe still
+    # renders the bare ``recipe.trials``.
+    from aorta.triage.matrix import aggregate_cell
+    from aorta.triage.output import write_matrix_md
+
+    def _render(recipe):
+        cell = aggregate_cell(
+            name="none-none",
+            mitigations=("none",),
+            environment="local",
+            extra_env={},
+            resolved_env_vars={},
+            trials=[],
+            effective_steps=10,
+            error="infrastructure_failed: boom",
+        )
+        out = tmp_path / "matrix.md"
+        write_matrix_md(out, recipe, [cell], cell, {}, [], "2026-06-17T00:00:00Z")
+        return out.read_text(encoding="utf-8")
+
+    with_rule = _render(_probe_recipe(tmp_path, "stop_after:\n  events: 2\n  max_trials: 6\n"))
+    assert "**Trials per cell**: up to 6" in with_rule
+
+    without_rule = _render(_probe_recipe(tmp_path))
+    assert "**Trials per cell**: 1" in without_rule
+
+
 # --------------------------------------------------------------------------
 # CLI overlay (apply_recipe_overrides)
 # --------------------------------------------------------------------------

--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -156,6 +156,15 @@ def test_trial_is_event(exit_status, verdict, expected):
     assert _trial_is_event(_tr(exit_status), verdict) is expected
 
 
+@pytest.mark.parametrize("bad_verdict", ["error", "FAIL", "fial", "", None, 1])
+def test_trial_is_event_rejects_unknown_verdict(bad_verdict):
+    # An unknown/typo'd verdict must raise rather than silently fall through
+    # to the "fail" branch -- otherwise a programmatic caller that bypassed
+    # the recipe loader would get misinterpreted semantics (#236 r3 pattern).
+    with pytest.raises(ValueError, match="event_verdict must be one of"):
+        _trial_is_event(_tr("ok"), bad_verdict)
+
+
 # --------------------------------------------------------------------------
 # Dispatcher early-stop loop
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements #232. `aorta probe` / `triage` currently run a **fixed** `trials: N`. For an **intermittent** bug that's the wrong primitive — you don't want "128 trials," you want "keep running until you've seen the bug K times, but give up after at most N trials." This adds an event-count stopping rule with a target and a mandatory hard cap.

### Recipe (valid in both `probe` and `triage`)

```yaml
stop_after:
  events: 3            # stop this cell once 3 trials match the event verdict
  max_trials: 160      # hard cap — always honored; required when events is set
  event_verdict: fail  # which verdict counts (default: fail; 'pass' also valid)
```

### CLI escape hatch (on `aorta probe`)

```
aorta probe --recipe r.yaml --stop-after-events 3 --max-trials 160 -- <cmd>
```

Flags are **unioned over** the recipe's block (each half falls back to the recipe; a target with no cap is rejected).

## Semantics

- A cell runs until `events` qualifying verdicts are observed **or** `max_trials` trials run, whichever first. The dispatcher loop breaks early.
- The matrix records **both** the realised event count and the trials actually run, so the rate is `events / trials_run` (free — aggregation already counts the returned trials).
- `matrix.md` gains a **Stop after** column distinguishing *"stopped early"* from *"cap reached"* (hidden entirely when no cell has a rule, so legacy runs stay byte-equivalent). `matrix.json` carries the recipe-level rule plus each cell's `stop_after_note`.
- **Resume is rule-aware:** a cell whose on-disk trial prefix already satisfies the rule (hit the target, or reached the cap) is skipped; otherwise it re-runs (bounded — the dispatcher applies the same early-stop).
- The event predicate is shared with the matrix pass/fail predicate (`exit_status == "ok"`), so the stop-count and the matrix columns can never disagree.

## Design notes

- `max_trials` is **mandatory** when `events` is set — never an unbounded loop (rejected at load).
- `event_verdict: error` depends on the three-way verdict (#230); rejected at load until then so it can't silently never match. (`fail`/`pass` supported now.)
- Concurrency: the loop is sequential today (W=1, no overshoot); the engine records the *actual* count, so a future batched runner that overshoots by W-1 needs no schema change.

## Test plan

- [x] `tests/triage/test_stop_after.py` — schema validation (missing cap, cap<target, bad verdict, error→#230, non-int, unknown key, triage-mode); event predicate; dispatcher early-stop (fail/pass/cap/no-rule, via stub workloads); matrix annotation; CLI overlay + precedence + rejections; end-to-end `aorta probe` (stops early on failures, cap reached on all-pass, CLI flags introduce a rule, resume skips a satisfied cell)
- [x] Regression: `tests/run/test_dispatcher.py`, `tests/triage/test_matrix*.py`, `tests/triage/test_output_layout.py`, `tests/probe/test_recipe.py`, `tests/probe/test_cli_parsing.py`, `tests/probe/test_resume.py` all green
- [x] Docs updated (`docs/probe-188/usage.md`)

Closes #232.

Made with [Cursor](https://cursor.com)