### PR TITLE
probe: verdict-keyed per-trial artifact retention (#231)

### DIFF
--- a/.agents/skills/verify-run-output/reference.md
+++ b/.agents/skills/verify-run-output/reference.md
@@ -156,7 +156,13 @@ caution, not a fix.
 
 matrix.md ↔ matrix.json: `workload` and `ticket` should match; cell rows
 correspond to `cells`. matrix.md shows only `mean step (ms)`; per-cell
-percentiles, histograms, and trial paths live in matrix.json.
+percentiles, histograms, and trial paths live in matrix.json. In probe-mode
+matrix.md the row identity is the `Mitigation` + `Diagnostic` columns (the
+two recipe axes, i.e. `cells[*].mitigations = (mitigation, diagnostic)`)
+plus a trailing `Directory` column with the per-cell artifact path; the
+folder's final segment is still the `cells[*].name`
+(`<mitigation>-<diagnostic>`) join key (issue #229). Triage-mode matrix.md
+keeps the fused `Cell` + `Mitigations` columns.
 
 ---
 

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -157,6 +157,12 @@ marker) is **never** deleted, at any level. Pairs naturally with
 `stop_after`: "collect N fails with full artifacts, summary-only for the
 clean trials along the way."
 
+When a `retain` policy runs, the applied level and the list of pruned
+artifacts are written back into that trial's `result.json` under
+`capture.retention` (`{"level": ..., "deleted": [...], "freed_bytes": N}`).
+A reader of a bundled or resumed run can then tell a missing heavy artifact
+was *pruned by policy* rather than never produced.
+
 Collectors declare which of their outputs are heavy vs summary via an
 optional `artifacts.json` manifest in the trial directory
 (`{"artifacts": [{"path": "trace.pb", "class": "heavy"}, ...]}`); absent a
@@ -291,6 +297,9 @@ forward-compatible:
   `tier_durations_ms`.
 * **Issue #230 addition**: `error_detectors_fired` — the infra-error
   signals (separate from genuine failures) that drive the `error` verdict.
+* **Issue #231 addition**: `capture.retention` — present only when a
+  `retain` policy ran; records the applied `level`, the `deleted` artifact
+  list, and `freed_bytes` so pruning is auditable from the trial record.
 
 `peak_vram_mib` is a coarse high-water mark sampled from two
 `amd-smi` snapshots (pre- and post-Popen). It may be `null` when

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -134,6 +134,35 @@ built-in `tier1`-`tier4` id that isn't in that tier's catalogue ->
 (repeatable) is **unioned onto** the recipe's set, so an operator can
 silence one more detector without restating the recipe's list.
 
+Verdict-keyed artifact retention (issue #231) keeps the **heavy** per-trial
+output (profiler traces, per-layer dumps -- hundreds of MB each) only for
+the trials where it has diagnostic value, so a big sweep doesn't fill the
+disk with passing-run data:
+
+```yaml
+retain:
+  on_fail:  full       # keep everything (log + summary + heavy artifacts)
+  on_pass:  summary    # keep small summary artifacts; delete heavy ones
+  on_error: log        # keep the trial log only; drop summary + heavy
+```
+
+Levels form a ladder, each keeping everything the one below it keeps:
+`none` (the trial record only) < `log` (+ `stdout.log` / `stderr.log` /
+`probe.env`) < `summary` (+ small collector roll-ups) < `full` (+ heavy
+collector outputs; the default). Each of `on_fail` / `on_pass` / `on_error`
+is optional and defaults to `full`, so **omitting `retain` keeps everything
+exactly as before**. Deletion only ever touches *artifact files* -- the
+per-trial `result.json` (the matrix / rate bookkeeping and the probe resume
+marker) is **never** deleted, at any level. Pairs naturally with
+`stop_after`: "collect N fails with full artifacts, summary-only for the
+clean trials along the way."
+
+Collectors declare which of their outputs are heavy vs summary via an
+optional `artifacts.json` manifest in the trial directory
+(`{"artifacts": [{"path": "trace.pb", "class": "heavy"}, ...]}`); absent a
+manifest, a file is classified by convention (`*.summary.*` is a summary,
+the known logs are `log`, anything else is `heavy`).
+
 Phase 3 keys (`redaction`, top-level `condition`) are still **rejected
 at load time** with a "deferred to Phase 3" error message.
 

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -163,6 +163,17 @@ optional `artifacts.json` manifest in the trial directory
 manifest, a file is classified by convention (`*.summary.*` is a summary,
 the known logs are `log`, anything else is `heavy`).
 
+**Reading `matrix.md` (probe runs).** The reproduction-summary table
+splits the cell's two recipe axes into their own columns -- `Mitigation`
+and `Diagnostic` -- instead of a fused `<mitigation>-<diagnostic>`
+identifier, and ends with a `Directory` column giving the per-cell
+artifact path relative to `matrix.md` (e.g. `tf32_off-none/`). The folder
+name on disk is still `<mitigation>-<diagnostic>` (it stays the stable
+join key for tooling and resume); only the table presentation changed, so
+an unused diagnostic axis reads as `Diagnostic = none` rather than a
+confusing trailing `-none` (issue #229). Triage-mode runs keep the
+original `Cell` / `Mitigations` columns.
+
 Phase 3 keys (`redaction`, top-level `condition`) are still **rejected
 at load time** with a "deferred to Phase 3" error message.
 

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -41,6 +41,8 @@ from aorta.triage.recipe import (
     Recipe,
     RecipeCellError,
     RecipeSchemaError,
+    RetainPolicy,
+    _parse_retain,
     _parse_stop_after,
 )
 
@@ -134,6 +136,12 @@ class ProbeExtras:
     disable_detector_tiers: tuple[str, ...] = ()
     # Phase 3 (issue #188): redaction block consumed by ``aorta bundle``.
     redaction: RedactionCfg | None = None
+    # Issue #231: verdict-keyed per-trial artifact retention. ``None``
+    # preserves the legacy keep-everything behaviour; when set,
+    # SubprocessWorkload prunes each trial dir to the level mapped from
+    # that trial's verdict (full/summary/log/none) after classification,
+    # never dropping the trial record (``result.json``).
+    retain: RetainPolicy | None = None
 
 
 def _ensure_str_list(path_hint: str, raw: Any, *, allow_empty: bool = False) -> list[str]:
@@ -339,6 +347,7 @@ def build_probe_recipe_from_dict(
         # the bare case. Mirrors the ``recipe:`` prefix used in the triage
         # loader (aorta.triage.recipe).
         raise RecipeSchemaError(f"recipe: {exc}") from exc
+    retain = _parse_retain("recipe", data.get("retain"))
     # Use ``in`` rather than ``.get(...) is not None`` so an explicit
     # ``redaction: null`` is treated as present-but-invalid (parse_redaction
     # rejects None) instead of being silently conflated with "no redaction
@@ -471,6 +480,7 @@ def build_probe_recipe_from_dict(
         disable_detectors=disable_detectors,
         disable_detector_tiers=disable_detector_tiers,
         redaction=redaction,
+        retain=retain,
     )
 
     return Recipe(

--- a/src/aorta/run/retention.py
+++ b/src/aorta/run/retention.py
@@ -1,0 +1,255 @@
+"""Verdict-keyed per-trial artifact retention (issue #231).
+
+A probe / triage sweep runs a workload many times. Some trials emit
+**large** per-trial artifacts (profiler traces, per-layer numeric dumps --
+hundreds of MB each). Keeping them for *every* trial fills the disk on a
+big sweep (~900 trials x ~100 MB = tens of GB of mostly-useless
+passing-run data). This module prunes those heavy files per trial as a
+function of the trial's verdict, keeping the expensive output only where
+it has diagnostic value (the failures).
+
+The policy itself (the verdict -> level mapping) is a recipe-schema
+concept and lives in :class:`aorta.triage.recipe.RetainPolicy`. This
+module is the *engine*: given a trial directory and an already-resolved
+retention **level** string, it classifies each artifact and deletes the
+ones the level does not keep. It is deliberately dependency-free (stdlib
+only) and knows nothing about verdicts, recipes, or the classifier, so it
+imports cleanly from the probe workload without any cycle.
+
+Retention levels form a monotonic ladder -- each keeps everything its
+predecessors keep, plus its own class:
+
+====================  ================================================
+``none``              the trial JSON record only (bookkeeping)
+``log``               + the stdout/stderr trial log (and ``probe.env``)
+``summary``           + small collector "summary" roll-ups
+``full``              + heavy collector outputs (everything; the default)
+====================  ================================================
+
+**The trial JSON record is never deleted at any level.** Deletion is of
+the *artifact files*, not the per-trial record the matrix / rate
+bookkeeping (and probe resume) read -- those always survive regardless of
+retention level (issue #231 acceptance criterion).
+
+Collectors declare which of their outputs are heavy vs summary via an
+optional ``artifacts.json`` manifest in the trial directory (see
+:data:`RETENTION_MANIFEST_NAME`); absent a manifest, classification falls
+back to filename convention (``*.summary.*`` is a summary; anything that
+is not the record or a known log is heavy).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Retention levels, lowest -> highest. ``full`` is the default (and the
+# legacy behaviour when no ``retain`` block is present): keep everything.
+RETAIN_LEVELS: tuple[str, ...] = ("none", "log", "summary", "full")
+_LEVEL_RANK: dict[str, int] = {name: i for i, name in enumerate(RETAIN_LEVELS)}
+
+# Artifact classes, ranked low -> high. A file of class C is kept at
+# retention level L iff ``_CLASS_RANK[C] <= _LEVEL_RANK[L]``. RECORD sits
+# at rank 0 so it is kept at every level (and is additionally hard-guarded
+# against deletion below -- a buggy collector manifest can never drop it).
+RECORD = "record"  # trial JSON / probe resume marker -- never deleted
+LOG = "log"  # stdout/stderr trial log, probe.env
+SUMMARY = "summary"  # small collector roll-ups
+HEAVY = "heavy"  # big collector outputs (traces, per-layer dumps)
+_CLASS_RANK: dict[str, int] = {RECORD: 0, LOG: 1, SUMMARY: 2, HEAVY: 3}
+# Classes a collector manifest is allowed to assign. RECORD is excluded on
+# purpose: only the engine decides what the immutable trial record is.
+_MANIFEST_CLASSES: frozenset[str] = frozenset({LOG, SUMMARY, HEAVY})
+
+# Optional per-trial manifest a collector drops to declare its outputs'
+# classes. Shape: ``{"artifacts": [{"path": "trace.pb", "class": "heavy"},
+# {"path": "rollup.json", "class": "summary"}]}``. ``path`` is relative to
+# the trial directory (POSIX-style). A missing / malformed manifest is a
+# warning, not an error -- classification falls back to convention so a
+# bad manifest never aborts a run or silently keeps tens of GB.
+RETENTION_MANIFEST_NAME = "artifacts.json"
+
+# Files that ARE the trial record -- never deleted, regardless of level or
+# any manifest entry. ``result.json`` is the probe resume marker
+# (``aorta.probe.resume.is_trial_complete``) and the matrix's per-trial
+# source of truth.
+_RECORD_NAMES: frozenset[str] = frozenset({"result.json"})
+# Known small operational artifacts that ride at the ``log`` tier.
+_LOG_NAMES: frozenset[str] = frozenset({"stdout.log", "stderr.log", "probe.env"})
+
+
+@dataclass(frozen=True)
+class RetentionOutcome:
+    """What :func:`apply_retention` did to one trial directory.
+
+    Returned for logging / testing. ``deleted`` and ``kept`` are
+    trial-dir-relative POSIX paths; ``freed_bytes`` is the summed size of
+    the deleted files (best-effort -- a file that vanishes mid-sweep
+    contributes 0).
+    """
+
+    level: str
+    deleted: tuple[str, ...] = ()
+    kept: tuple[str, ...] = ()
+    freed_bytes: int = 0
+    # True when ``level`` was ``full`` (or unset) so nothing was scanned.
+    no_op: bool = False
+
+
+def classify_artifact(rel_path: str, manifest: dict[str, str] | None = None) -> str:
+    """Return the retention class of one trial artifact.
+
+    Precedence: the record guard wins first (so a collector can never mark
+    the trial record deletable), then an explicit manifest entry, then the
+    log / summary filename conventions, then a default of :data:`HEAVY`
+    (an unrecognised file is assumed to be a big collector output -- the
+    conservative choice for disk).
+    """
+    name = Path(rel_path).name
+    if name in _RECORD_NAMES:
+        return RECORD
+    if manifest and rel_path in manifest:
+        return manifest[rel_path]
+    if name == RETENTION_MANIFEST_NAME:
+        return SUMMARY
+    if name in _LOG_NAMES:
+        return LOG
+    if name.endswith(".summary.json") or ".summary." in name:
+        return SUMMARY
+    return HEAVY
+
+
+def _load_manifest(trial_dir: Path) -> dict[str, str]:
+    """Read the optional ``artifacts.json`` collector manifest.
+
+    Returns a ``{relative_posix_path: class}`` map. Tolerant by design: a
+    missing file yields ``{}``; a malformed file or an unknown class is
+    logged and skipped (that path falls back to convention) rather than
+    aborting the run.
+    """
+    manifest_path = trial_dir / RETENTION_MANIFEST_NAME
+    if not manifest_path.is_file():
+        return {}
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+        entries = raw["artifacts"]
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        log.warning(
+            "retention: ignoring malformed %s in %s (%s); "
+            "falling back to filename convention",
+            RETENTION_MANIFEST_NAME,
+            trial_dir,
+            exc,
+        )
+        return {}
+    mapping: dict[str, str] = {}
+    for entry in entries if isinstance(entries, list) else []:
+        try:
+            path = str(entry["path"])
+            cls = str(entry["class"])
+        except (TypeError, KeyError):
+            log.warning("retention: skipping malformed manifest entry %r", entry)
+            continue
+        if cls not in _MANIFEST_CLASSES:
+            log.warning(
+                "retention: manifest entry %r has unknown class %r (allowed: %s); "
+                "treating as heavy",
+                path,
+                cls,
+                sorted(_MANIFEST_CLASSES),
+            )
+            cls = HEAVY
+        mapping[path] = cls
+    return mapping
+
+
+def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
+    """Prune ``trial_dir`` to the artifacts kept by retention ``level``.
+
+    Deletes every file whose class outranks ``level`` -- except the trial
+    record, which is hard-guarded. Empty directories left behind are
+    removed. ``level == "full"`` (the default) is a fast no-op: nothing is
+    scanned or deleted, preserving today's keep-everything behaviour.
+
+    Unknown ``level`` values are treated as ``full`` (fail-safe: never
+    delete more than asked) with a warning.
+    """
+    if level not in _LEVEL_RANK:
+        log.warning("retention: unknown level %r; keeping everything (full)", level)
+        return RetentionOutcome(level="full", no_op=True)
+    if level == "full":
+        return RetentionOutcome(level="full", no_op=True)
+    if not trial_dir.is_dir():
+        return RetentionOutcome(level=level, no_op=True)
+
+    manifest = _load_manifest(trial_dir)
+    level_rank = _LEVEL_RANK[level]
+    deleted: list[str] = []
+    kept: list[str] = []
+    freed = 0
+
+    for path in sorted(trial_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(trial_dir).as_posix()
+        cls = classify_artifact(rel, manifest)
+        if cls == RECORD or _CLASS_RANK[cls] <= level_rank:
+            kept.append(rel)
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = 0
+        try:
+            path.unlink()
+        except OSError as exc:
+            log.warning("retention: could not delete %s (%s); keeping it", path, exc)
+            kept.append(rel)
+            continue
+        freed += size
+        deleted.append(rel)
+
+    _prune_empty_dirs(trial_dir)
+    return RetentionOutcome(
+        level=level,
+        deleted=tuple(deleted),
+        kept=tuple(kept),
+        freed_bytes=freed,
+    )
+
+
+def _prune_empty_dirs(trial_dir: Path) -> None:
+    """Remove now-empty subdirectories left after deleting heavy files.
+
+    Walks bottom-up so a directory emptied only because its children were
+    pruned is itself removed. The trial directory root is never removed.
+    """
+    for path in sorted(trial_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        if path == trial_dir or not path.is_dir():
+            continue
+        try:
+            next(path.iterdir())
+        except StopIteration:
+            try:
+                path.rmdir()
+            except OSError:
+                pass
+        except OSError:
+            pass
+
+
+__all__ = [
+    "HEAVY",
+    "LOG",
+    "RECORD",
+    "RETAIN_LEVELS",
+    "RETENTION_MANIFEST_NAME",
+    "SUMMARY",
+    "RetentionOutcome",
+    "apply_retention",
+    "classify_artifact",
+]

--- a/src/aorta/run/retention.py
+++ b/src/aorta/run/retention.py
@@ -148,6 +148,18 @@ def _load_manifest(trial_dir: Path) -> dict[str, str]:
       than deferring to convention.
     """
     manifest_path = trial_dir / RETENTION_MANIFEST_NAME
+    # A symlinked manifest could point read_text() at an arbitrary file
+    # outside the trial tree (is_file()/read_text() dereference symlinks).
+    # Mirror the deletion-side symlink/containment guards: treat it as
+    # malformed and fall back to filename convention.
+    if manifest_path.is_symlink():
+        log.warning(
+            "retention: %s in %s is a symlink; treating as malformed and "
+            "falling back to filename convention",
+            RETENTION_MANIFEST_NAME,
+            trial_dir,
+        )
+        return {}
     if not manifest_path.is_file():
         return {}
     try:

--- a/src/aorta/run/retention.py
+++ b/src/aorta/run/retention.py
@@ -73,11 +73,14 @@ _MANIFEST_CLASSES: frozenset[str] = frozenset({LOG, SUMMARY, HEAVY})
 # bad manifest never aborts a run or silently keeps tens of GB.
 RETENTION_MANIFEST_NAME = "artifacts.json"
 
-# Files that ARE the trial record -- never deleted, regardless of level or
-# any manifest entry. ``result.json`` is the probe resume marker
-# (``aorta.probe.resume.is_trial_complete``) and the matrix's per-trial
-# source of truth.
-_RECORD_NAMES: frozenset[str] = frozenset({"result.json"})
+# Trial-dir-relative POSIX paths that ARE the trial record -- never
+# deleted, regardless of level or any manifest entry. ``result.json`` is
+# the probe resume marker (``aorta.probe.resume.is_trial_complete``, which
+# keys off ``trial_dir/result.json`` specifically) and the matrix's
+# per-trial source of truth. Matched by exact relative path, NOT basename:
+# a heavy collector output that happens to be named ``result.json`` under a
+# subdirectory is prunable like any other artifact.
+_RECORD_PATHS: frozenset[str] = frozenset({"result.json"})
 # Known small operational artifacts that ride at the ``log`` tier.
 _LOG_NAMES: frozenset[str] = frozenset({"stdout.log", "stderr.log", "probe.env"})
 
@@ -108,10 +111,14 @@ def classify_artifact(rel_path: str, manifest: dict[str, str] | None = None) -> 
     log / summary filename conventions, then a default of :data:`HEAVY`
     (an unrecognised file is assumed to be a big collector output -- the
     conservative choice for disk).
+
+    The record guard matches the exact trial-dir-relative path (so only
+    the top-level ``result.json`` is protected); the log / summary
+    conventions match on basename.
     """
-    name = Path(rel_path).name
-    if name in _RECORD_NAMES:
+    if rel_path in _RECORD_PATHS:
         return RECORD
+    name = Path(rel_path).name
     if manifest and rel_path in manifest:
         return manifest[rel_path]
     if name == RETENTION_MANIFEST_NAME:
@@ -129,8 +136,9 @@ def _load_manifest(trial_dir: Path) -> dict[str, str]:
     Returns a ``{relative_posix_path: class}`` map. Tolerant by design,
     never aborts the run:
 
-    * A missing file, or a malformed file (bad JSON / no ``artifacts``
-      list), yields ``{}`` -- the whole trial falls back to filename
+    * A missing file, or a malformed file (bad JSON, no ``artifacts``
+      key, or an ``artifacts`` value that is not a list), yields ``{}``
+      with a warning -- the whole trial falls back to filename
       convention.
     * A malformed entry (missing ``path`` / ``class``) is logged and
       skipped, so that one path falls back to convention.
@@ -145,6 +153,10 @@ def _load_manifest(trial_dir: Path) -> dict[str, str]:
     try:
         raw = json.loads(manifest_path.read_text(encoding="utf-8"))
         entries = raw["artifacts"]
+        if not isinstance(entries, list):
+            raise TypeError(
+                f"'artifacts' must be a list, got {type(entries).__name__}"
+            )
     except (OSError, ValueError, KeyError, TypeError) as exc:
         log.warning(
             "retention: ignoring malformed %s in %s (%s); "
@@ -155,7 +167,7 @@ def _load_manifest(trial_dir: Path) -> dict[str, str]:
         )
         return {}
     mapping: dict[str, str] = {}
-    for entry in entries if isinstance(entries, list) else []:
+    for entry in entries:
         try:
             path = str(entry["path"])
             cls = str(entry["class"])
@@ -185,6 +197,11 @@ def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
 
     Unknown ``level`` values are treated as ``full`` (fail-safe: never
     delete more than asked) with a warning.
+
+    Symlinks are never unlinked, and any path that dereferences outside
+    ``trial_dir`` is skipped (kept) with a warning -- a buggy or hostile
+    collector symlink can never make retention delete files outside the
+    trial output tree.
     """
     if level not in _LEVEL_RANK:
         log.warning("retention: unknown level %r; keeping everything (full)", level)
@@ -196,14 +213,35 @@ def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
 
     manifest = _load_manifest(trial_dir)
     level_rank = _LEVEL_RANK[level]
+    root = trial_dir.resolve()
     deleted: list[str] = []
     kept: list[str] = []
     freed = 0
 
     for path in sorted(trial_dir.rglob("*")):
+        # Never unlink a symlink (deleting the link reclaims no disk and
+        # following it could escape the trial tree) and never delete a
+        # path that dereferences outside ``trial_dir``. Mirrors the
+        # containment guard in ``aorta.bundle.writer``, but retention is
+        # tolerant -- it keeps the offending entry and warns rather than
+        # aborting the sweep.
+        if path.is_symlink():
+            rel = path.relative_to(trial_dir).as_posix()
+            log.warning("retention: skipping symlink %s; not pruning it", rel)
+            kept.append(rel)
+            continue
         if not path.is_file():
             continue
         rel = path.relative_to(trial_dir).as_posix()
+        resolved = path.resolve()
+        if resolved != root and root not in resolved.parents:
+            log.warning(
+                "retention: skipping %s; resolves outside trial dir (%s); keeping it",
+                rel,
+                resolved,
+            )
+            kept.append(rel)
+            continue
         cls = classify_artifact(rel, manifest)
         if cls == RECORD or _CLASS_RANK[cls] <= level_rank:
             kept.append(rel)
@@ -237,7 +275,7 @@ def _prune_empty_dirs(trial_dir: Path) -> None:
     pruned is itself removed. The trial directory root is never removed.
     """
     for path in sorted(trial_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
-        if path == trial_dir or not path.is_dir():
+        if path == trial_dir or path.is_symlink() or not path.is_dir():
             continue
         try:
             next(path.iterdir())

--- a/src/aorta/run/retention.py
+++ b/src/aorta/run/retention.py
@@ -126,10 +126,18 @@ def classify_artifact(rel_path: str, manifest: dict[str, str] | None = None) -> 
 def _load_manifest(trial_dir: Path) -> dict[str, str]:
     """Read the optional ``artifacts.json`` collector manifest.
 
-    Returns a ``{relative_posix_path: class}`` map. Tolerant by design: a
-    missing file yields ``{}``; a malformed file or an unknown class is
-    logged and skipped (that path falls back to convention) rather than
-    aborting the run.
+    Returns a ``{relative_posix_path: class}`` map. Tolerant by design,
+    never aborts the run:
+
+    * A missing file, or a malformed file (bad JSON / no ``artifacts``
+      list), yields ``{}`` -- the whole trial falls back to filename
+      convention.
+    * A malformed entry (missing ``path`` / ``class``) is logged and
+      skipped, so that one path falls back to convention.
+    * An entry with an *unknown* class is logged and kept in the map
+      pinned to :data:`HEAVY` (the conservative choice for disk), not
+      skipped -- so it is retained/pruned as a heavy artifact rather
+      than deferring to convention.
     """
     manifest_path = trial_dir / RETENTION_MANIFEST_NAME
     if not manifest_path.is_file():

--- a/src/aorta/run/retention.py
+++ b/src/aorta/run/retention.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -213,7 +214,10 @@ def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
     Symlinks are never unlinked, and any path that dereferences outside
     ``trial_dir`` is skipped (kept) with a warning -- a buggy or hostile
     collector symlink can never make retention delete files outside the
-    trial output tree.
+    trial output tree. Enumeration uses ``os.walk(..., followlinks=False)``
+    so retention never even *descends* into a symlinked subdirectory (a
+    collector that drops a symlinked dir pointing at, say, ``/`` could
+    otherwise make a naive ``rglob`` walk an arbitrary, huge external tree).
     """
     if level not in _LEVEL_RANK:
         log.warning("retention: unknown level %r; keeping everything (full)", level)
@@ -230,18 +234,13 @@ def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
     kept: list[str] = []
     freed = 0
 
-    for path in sorted(trial_dir.rglob("*")):
-        # Never unlink a symlink (deleting the link reclaims no disk and
-        # following it could escape the trial tree) and never delete a
-        # path that dereferences outside ``trial_dir``. Mirrors the
-        # containment guard in ``aorta.bundle.writer``, but retention is
-        # tolerant -- it keeps the offending entry and warns rather than
-        # aborting the sweep.
-        if path.is_symlink():
-            rel = path.relative_to(trial_dir).as_posix()
-            log.warning("retention: skipping symlink %s; not pruning it", rel)
-            kept.append(rel)
-            continue
+    for path in _iter_trial_files(trial_dir, kept):
+        # ``_iter_trial_files`` already excluded symlinks (files and
+        # directories) and never descended into symlinked dirs. Defence in
+        # depth: still refuse to delete a path that dereferences outside
+        # ``trial_dir``. Mirrors the containment guard in
+        # ``aorta.bundle.writer``, but retention is tolerant -- it keeps the
+        # offending entry and warns rather than aborting the sweep.
         if not path.is_file():
             continue
         rel = path.relative_to(trial_dir).as_posix()
@@ -280,14 +279,58 @@ def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
     )
 
 
+def _iter_trial_files(trial_dir: Path, kept: list[str]) -> list[Path]:
+    """Enumerate the regular files under ``trial_dir``, symlink-safe.
+
+    Uses ``os.walk(..., followlinks=False)`` so retention never descends
+    into a symlinked subdirectory -- a collector that drops a symlink to an
+    external tree (e.g. ``/``) can't make retention walk an arbitrary,
+    possibly huge filesystem. (The ``resolve()`` containment check in
+    :func:`apply_retention` blocks *deletion* outside the tree, but not the
+    traversal itself, which is the DoS this avoids.)
+
+    Symlinks -- whether to files or directories -- are recorded in ``kept``
+    with a warning and never returned, so the deletion side never unlinks a
+    link (which would reclaim no disk and could escape the trial tree).
+    Returns the regular files in a deterministic sorted order.
+    """
+    files: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(trial_dir, followlinks=False):
+        base = Path(dirpath)
+        # Symlinked subdirs appear in ``dirnames``; os.walk won't recurse
+        # into them (followlinks=False). Record + drop them so they are
+        # neither descended into nor later treated as prunable.
+        symlinked_dirs = {d for d in dirnames if (base / d).is_symlink()}
+        for name in symlinked_dirs:
+            rel = (base / name).relative_to(trial_dir).as_posix()
+            log.warning("retention: skipping symlink %s; not pruning it", rel)
+            kept.append(rel)
+        dirnames[:] = [d for d in dirnames if d not in symlinked_dirs]
+        for name in filenames:
+            path = base / name
+            if path.is_symlink():
+                rel = path.relative_to(trial_dir).as_posix()
+                log.warning("retention: skipping symlink %s; not pruning it", rel)
+                kept.append(rel)
+                continue
+            files.append(path)
+    return sorted(files)
+
+
 def _prune_empty_dirs(trial_dir: Path) -> None:
     """Remove now-empty subdirectories left after deleting heavy files.
 
-    Walks bottom-up so a directory emptied only because its children were
-    pruned is itself removed. The trial directory root is never removed.
+    Walks bottom-up (``os.walk(topdown=False)``) so a directory emptied
+    only because its children were pruned is itself removed. As in
+    :func:`_iter_trial_files`, ``followlinks=False`` keeps the walk from
+    descending into symlinked dirs, and symlinked dirs are never
+    ``rmdir``-ed. The trial directory root is never removed.
     """
-    for path in sorted(trial_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
-        if path == trial_dir or path.is_symlink() or not path.is_dir():
+    for dirpath, _dirnames, _filenames in os.walk(
+        trial_dir, topdown=False, followlinks=False
+    ):
+        path = Path(dirpath)
+        if path == trial_dir or path.is_symlink():
             continue
         try:
             next(path.iterdir())

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -55,6 +55,12 @@ log = logging.getLogger(__name__)
 
 NO_TICKET_SLUG = "_no_ticket_"
 
+# The run-directory layouts ``resolve_run_dir`` / ``_cell_directory`` accept.
+# Kept as one source of truth so the two runtime guards can't drift (a value
+# accepted by one but silently mishandled by the other would render wrong
+# ``Directory`` links). Mirrors the ``Literal`` on the public signatures.
+_VALID_LAYOUTS = ("timestamped", "flat_resume")
+
 # ``flat_resume`` lockfile name. Lives at ``<run_dir>/.aorta-probe.lock``; the
 # leading dot keeps it out of casual ``ls`` output and matches the convention
 # used by other resume-state files in the run dir.
@@ -136,7 +142,7 @@ def resolve_run_dir(
     # would otherwise silently land in the timestamped branch. Reject
     # unknown values at runtime so probe-mode callers can't
     # accidentally get the wrong output tree.
-    if layout not in ("timestamped", "flat_resume"):
+    if layout not in _VALID_LAYOUTS:
         raise ValueError(
             f"resolve_run_dir: layout must be 'timestamped' or 'flat_resume', "
             f"got {layout!r}"
@@ -543,6 +549,32 @@ def _render_failure_hints(cell_stats: list[CellStats]) -> list[str]:
     return lines
 
 
+def _cell_directory(name: str, layout: Literal["timestamped", "flat_resume"]) -> str:
+    """Per-cell artifact directory, rendered relative to ``matrix.md``.
+
+    Probe runs (issue #188 ``flat_resume`` layout) put cell artifacts at
+    ``<run_dir>/<safe_slug(name)>/`` -- a sibling of ``matrix.md`` -- so the
+    relative path is just ``<slug>/``. Triage runs nest them under
+    ``cells/<slug>/``. The trailing slash marks the value as a directory.
+    The final segment is the recipe cell name (``<mitigation>-<diagnostic>``
+    in probe mode), so the on-disk folder stays the canonical join key while
+    the table itself reads the two axes from their own columns (#229).
+
+    ``layout`` is validated against the same set as :func:`resolve_run_dir`
+    so a typo (e.g. ``"flatresume"``) raises instead of silently rendering a
+    triage-style ``cells/<slug>/`` link for a probe run.
+    """
+    if layout not in _VALID_LAYOUTS:
+        raise ValueError(
+            f"_cell_directory: layout must be 'timestamped' or 'flat_resume', "
+            f"got {layout!r}"
+        )
+    slug = safe_slug(name)
+    if layout == "flat_resume":
+        return f"{slug}/"
+    return f"cells/{slug}/"
+
+
 def write_matrix_md(
     path: Path,
     recipe: Recipe,
@@ -551,8 +583,17 @@ def write_matrix_md(
     confound_tags: dict[str, tuple[ConfoundTag, float | None]],
     warnings: list[str],
     run_timestamp: str,
+    layout: Literal["timestamped", "flat_resume"] = "timestamped",
 ) -> None:
-    """Render matrix.md in the format from issue #151 §"matrix.md target format"."""
+    """Render matrix.md in the format from issue #151 §"matrix.md target format".
+
+    In probe mode (``recipe.probe_extras is not None``) the identity columns
+    are the two recipe axes -- ``Mitigation`` and ``Diagnostic`` -- plus a
+    trailing ``Directory`` column with the per-cell artifact path, instead of
+    the triage-mode fused ``Cell`` / ``Mitigations`` columns. This keeps the
+    on-disk ``<mitigation>-<diagnostic>`` folder name (the agent's join key)
+    while removing the ambiguous fused name from the rendered table (#229).
+    """
     lines: list[str] = []
     lines.append(f"# Triage Matrix - {recipe.workload}")
     lines.append("")
@@ -632,11 +673,19 @@ def write_matrix_md(
     # byte-equivalent. It surfaces error trials excluded from the failure
     # rate and flags cells whose error rate makes the rate untrustworthy.
     show_errors = any(c.error_count for c in cell_stats)
-    header_cells: list[str] = [
-        "Cell",
-        "Mitigations",
-        "Environment",
-    ]
+    # Issue #229: probe-mode runs synthesise cells as the cartesian product
+    # of ``mitigation_axis x diagnostic_axis`` and store both axes on
+    # ``cell.mitigations = (mitigation, diagnostic)``. Splitting them into
+    # their own columns (named after the recipe axes) -- plus a trailing
+    # ``Directory`` column -- removes the ambiguous fused ``<mit>-<diag>``
+    # identifier (a bare trailing ``-none`` when the diagnostic axis is
+    # unused) from the table without renaming the on-disk folder.
+    is_probe = recipe.probe_extras is not None
+    header_cells: list[str] = (
+        ["Mitigation", "Diagnostic", "Environment"]
+        if is_probe
+        else ["Cell", "Mitigations", "Environment"]
+    )
     if show_config:
         header_cells.append("Config")
     header_cells.extend(["Failure rate", "Failures"])
@@ -651,15 +700,34 @@ def write_matrix_md(
     if show_iters:
         header_cells.append("Iters")
     header_cells.extend(["Mean step (ms)", "Confound"])
+    if is_probe:
+        header_cells.append("Directory")
     header = tuple(header_cells)
     rows: list[tuple[str, ...]] = [header]
     for cell in cell_stats:
         tag, _ = confound_tags.get(cell.name, (cell.error and "error" or "-", None))
-        row: list[str] = [
-            cell.name,
-            _format_mitigations(cell.mitigations),
-            cell.environment,
-        ]
+        if is_probe:
+            # probe.recipe_builder guarantees a (mitigation, diagnostic) pair;
+            # if that invariant is ever violated, warn so it isn't hidden, but
+            # still render "—" rather than abort the whole matrix at the end of
+            # a (potentially long) run -- output paths stay tolerant here, like
+            # the resume/manifest guards (#237).
+            if len(cell.mitigations) != 2:
+                log.warning(
+                    "probe cell %r has %d mitigation axis value(s), expected the "
+                    "(mitigation, diagnostic) pair; rendering missing axes as '—'",
+                    cell.name,
+                    len(cell.mitigations),
+                )
+            mitigation = cell.mitigations[0] if cell.mitigations else "—"
+            diagnostic = cell.mitigations[1] if len(cell.mitigations) > 1 else "—"
+            row: list[str] = [mitigation, diagnostic, cell.environment]
+        else:
+            row = [
+                cell.name,
+                _format_mitigations(cell.mitigations),
+                cell.environment,
+            ]
         if show_config:
             row.append(_format_workload_config(cell, varying_config_keys))
         row.extend([_format_failure_rate(cell), _format_failures(cell)])
@@ -674,6 +742,8 @@ def write_matrix_md(
         if show_iters:
             row.append(cell.iters_display)
         row.extend([_format_step_ms(cell), _format_confound(tag)])
+        if is_probe:
+            row.append(_cell_directory(cell.name, layout))
         rows.append(tuple(row))
     widths = [max(len(r[i]) for r in rows) for i in range(len(header))]
 
@@ -689,10 +759,21 @@ def write_matrix_md(
     lines.extend(_render_failure_hints(cell_stats))
     lines.append("## Notes")
     lines.append("")
-    lines.append(
-        "- Cell name comes from the recipe; mitigations + environment columns "
-        "disambiguate when names get terse."
-    )
+    if is_probe:
+        lines.append(
+            "- `Mitigation` / `Diagnostic` come from the recipe's "
+            "`mitigation_axis` / `diagnostic_axis`; each cell is one "
+            "`(mitigation, diagnostic)` pair. `Directory` is the cell's "
+            "artifact directory (logs + per-trial `result.json`), relative to "
+            "this file; its final segment is the `<mitigation>-<diagnostic>` "
+            "cell name (#229). `none` in either axis means that axis was not "
+            "varied for the cell."
+        )
+    else:
+        lines.append(
+            "- Cell name comes from the recipe; mitigations + environment columns "
+            "disambiguate when names get terse."
+        )
     lines.append("- Confound column legend:")
     lines.append("  - `(baseline)` -- the cell against which all step-time ratios are computed.")
     lines.append("  - `-` -- the mitigation appears to work without a speed cost. Trust this cell.")

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -512,7 +512,10 @@ def _parse_retain(path_hint: str, raw: Any) -> RetainPolicy | None:
             f"allowed: {sorted(_VALID_RETAIN_KEYS)}"
         )
     levels: dict[str, str] = {}
-    for key in _VALID_RETAIN_KEYS:
+    # Iterate in a fixed (sorted) order: ``_VALID_RETAIN_KEYS`` is a
+    # frozenset, so raw iteration order is hash-seed dependent and would
+    # make the surfaced error non-deterministic when several keys are bad.
+    for key in sorted(_VALID_RETAIN_KEYS):
         if key not in raw:
             continue
         value = raw[key]

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -88,6 +88,11 @@ _PROBE_TOP_LEVEL = frozenset(
         # mode: probe (triage-mode check below rejects them otherwise).
         "disable_detectors",
         "disable_detector_tiers",
+        # Issue #231: verdict-keyed per-trial artifact retention. Probe-only
+        # (enforced by SubprocessWorkload on its own trial dir), so it is NOT
+        # added to _TRIAGE_TOP_LEVEL -- unlike stop_after, which the
+        # dispatcher enforces generically for every mode.
+        "retain",
         # Phase 3 (issue #188): redaction block for aorta bundle.
         "redaction",
     }
@@ -198,6 +203,46 @@ class StopAfter:
     events: int
     max_trials: int
     event_verdict: str = "fail"
+
+
+# Retention levels accepted in a ``retain`` block, keyed by verdict. The
+# operative ladder (none < log < summary < full) and the deletion engine
+# live in :mod:`aorta.run.retention`; this frozenset is the schema-layer
+# copy used for load-time validation. They are kept in lockstep by
+# ``tests/probe/test_recipe.py`` (a drift guard) so the schema can never
+# accept a level the engine doesn't understand, and vice versa. Duplicated
+# rather than imported to keep this module's import graph free of any
+# ``aorta.run`` dependency (which would risk a cycle via the dispatcher).
+_RETAIN_LEVELS = frozenset({"full", "summary", "log", "none"})
+_VALID_RETAIN_KEYS = frozenset({"on_fail", "on_pass", "on_error"})
+
+
+@dataclass(frozen=True)
+class RetainPolicy:
+    """Verdict-keyed per-trial artifact retention policy (issue #231).
+
+    Each field is a retention *level* (see :data:`_RETAIN_LEVELS`) applied
+    to a trial with that verdict after classification. The default is
+    ``full`` everywhere -- i.e. an explicit ``RetainPolicy()`` is
+    behaviourally identical to the legacy keep-everything default, so a
+    recipe that omits ``retain`` (``probe_extras.retain is None``) and one
+    that spells out ``full`` for all three verdicts behave the same. The
+    deletion itself is performed by :func:`aorta.run.retention.apply_retention`,
+    which never drops the trial record (``result.json``) regardless of
+    level.
+    """
+
+    on_fail: str = "full"
+    on_pass: str = "full"
+    on_error: str = "full"
+
+    def level_for(self, verdict: str) -> str:
+        """Return the retention level for ``verdict`` (``full`` if unknown)."""
+        return {
+            "fail": self.on_fail,
+            "pass": self.on_pass,
+            "error": self.on_error,
+        }.get(verdict, "full")
 
 
 @dataclass(frozen=True)
@@ -442,6 +487,41 @@ def _parse_stop_after(path_hint: str, raw: Any) -> StopAfter | None:
             f"{sorted(_STOP_AFTER_EVENT_VERDICTS)}, got {event_verdict!r}"
         )
     return StopAfter(events=events, max_trials=max_trials, event_verdict=event_verdict)
+
+
+def _parse_retain(path_hint: str, raw: Any) -> RetainPolicy | None:
+    """Parse + validate the ``retain`` block (issue #231).
+
+    ``None`` / missing -> ``None`` (legacy keep-everything behaviour --
+    the probe workload skips retention entirely). Each of ``on_fail`` /
+    ``on_pass`` / ``on_error`` is optional and defaults to ``full``; any
+    value supplied must be one of :data:`_RETAIN_LEVELS`. The verdict->level
+    mapping is applied per trial *after* classification.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise RecipeSchemaError(
+            f"{path_hint}.retain: must be a mapping, got {type(raw).__name__}"
+        )
+    unknown = set(raw) - _VALID_RETAIN_KEYS
+    if unknown:
+        raise RecipeSchemaError(
+            f"{path_hint}.retain: unknown keys {sorted(unknown)}; "
+            f"allowed: {sorted(_VALID_RETAIN_KEYS)}"
+        )
+    levels: dict[str, str] = {}
+    for key in _VALID_RETAIN_KEYS:
+        if key not in raw:
+            continue
+        value = raw[key]
+        if value not in _RETAIN_LEVELS:
+            raise RecipeSchemaError(
+                f"{path_hint}.retain.{key}: must be one of "
+                f"{sorted(_RETAIN_LEVELS)}, got {value!r}"
+            )
+        levels[key] = value
+    return RetainPolicy(**levels)
 
 
 def _parse_positive_int(path_hint: str, value: Any) -> int:

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -209,8 +209,9 @@ class StopAfter:
 # operative ladder (none < log < summary < full) and the deletion engine
 # live in :mod:`aorta.run.retention`; this frozenset is the schema-layer
 # copy used for load-time validation. They are kept in lockstep by
-# ``tests/probe/test_recipe.py`` (a drift guard) so the schema can never
-# accept a level the engine doesn't understand, and vice versa. Duplicated
+# ``tests/probe/test_retention.py::test_schema_levels_match_engine_ladder``
+# (a drift guard) so the schema can never accept a level the engine
+# doesn't understand, and vice versa. Duplicated
 # rather than imported to keep this module's import graph free of any
 # ``aorta.run`` dependency (which would risk a cycle via the dispatcher).
 _RETAIN_LEVELS = frozenset({"full", "summary", "log", "none"})
@@ -515,7 +516,10 @@ def _parse_retain(path_hint: str, raw: Any) -> RetainPolicy | None:
         if key not in raw:
             continue
         value = raw[key]
-        if value not in _RETAIN_LEVELS:
+        # Check the type before membership: ``value not in _RETAIN_LEVELS``
+        # hashes ``value``, so an unhashable YAML node (a dict/list) would
+        # raise a raw ``TypeError`` instead of a clean schema error.
+        if not isinstance(value, str) or value not in _RETAIN_LEVELS:
             raise RecipeSchemaError(
                 f"{path_hint}.retain.{key}: must be one of "
                 f"{sorted(_RETAIN_LEVELS)}, got {value!r}"

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -878,6 +878,16 @@ def _run_one_cell(
             "disable_detectors": tuple(probe_extras.disable_detectors),
             "disable_detector_tiers": tuple(probe_extras.disable_detector_tiers),
         }
+        # Issue #231: verdict-keyed artifact retention. Forwarded as a plain
+        # verdict->level mapping so SubprocessWorkload needn't import the
+        # RetainPolicy type; absent (None) when the recipe omits ``retain``,
+        # which the workload treats as keep-everything.
+        if probe_extras.retain is not None:
+            probe_extras_payload["retain"] = {
+                "on_fail": probe_extras.retain.on_fail,
+                "on_pass": probe_extras.retain.on_pass,
+                "on_error": probe_extras.retain.on_error,
+            }
 
     # save_logs is forced True for probe-mode cells because
     # SubprocessWorkload reads ``_aorta_log_prefix`` to derive its

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -1362,6 +1362,7 @@ def _run_recipe_locked(
         confound_tags=confound_tags,
         warnings=warnings,
         run_timestamp=ts,
+        layout=layout,
     )
     write_matrix_json(
         run_dir / "matrix.json",

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -74,7 +74,7 @@ from aorta.probe.classifier.verdict import (
     partition_detectors,
     verdict_from_detectors,
 )
-from aorta.run.retention import apply_retention
+from aorta.run.retention import RetentionOutcome, apply_retention
 from aorta.workloads._base import Workload, WorkloadResult
 
 log = logging.getLogger(__name__)
@@ -813,7 +813,17 @@ class SubprocessWorkload(Workload):
         # is known, keeping the level mapped from this trial's verdict.
         # Runs AFTER result.json is written so the trial record (which
         # retention never deletes) always survives for resume + the matrix.
-        self._apply_retention(trial_dir, verdict_obj.verdict, probe_extras)
+        # When retention ran, stamp its outcome back into result.json so the
+        # applied level + pruned-artifact list are auditable (oyazdanb).
+        retention_outcome = self._apply_retention(
+            trial_dir, verdict_obj.verdict, probe_extras
+        )
+        if retention_outcome is not None:
+            self._record_retention(result_doc, retention_outcome)
+            result_path.write_text(
+                json.dumps(result_doc, indent=2, sort_keys=False),
+                encoding="utf-8",
+            )
 
         # ``main_work_started`` / ``executed_iterations`` mirror
         # whether ``Popen`` actually launched a child. A normal
@@ -945,8 +955,17 @@ class SubprocessWorkload(Workload):
         # Issue #231: honor ``retain.on_error`` for this infra-error trial
         # too (mirrors the main run() path). The probe.env was already
         # unlinked above; this prunes any other heavy artifacts a prior
-        # resume left in the reused trial dir.
-        self._apply_retention(result_path.parent, "error", probe_extras)
+        # resume left in the reused trial dir. Stamp the outcome back into
+        # result.json so the applied level is auditable here too (oyazdanb).
+        retention_outcome = self._apply_retention(
+            result_path.parent, "error", probe_extras
+        )
+        if retention_outcome is not None:
+            self._record_retention(result_doc, retention_outcome)
+            result_path.write_text(
+                json.dumps(result_doc, indent=2, sort_keys=False),
+                encoding="utf-8",
+            )
         return WorkloadResult(
             passed=False,
             failure_count=1,
@@ -977,19 +996,25 @@ class SubprocessWorkload(Workload):
 
     def _apply_retention(
         self, trial_dir: Path, verdict: str, probe_extras: dict[str, Any]
-    ) -> None:
+    ) -> RetentionOutcome | None:
         """Prune this trial's heavy artifacts per ``retain`` (issue #231).
 
-        No-op when the recipe omits ``retain`` (keep-everything default) or
-        when the resolved level is ``full``. ``aorta.run.retention`` never
-        deletes the trial record (``result.json``), so resume and the
-        matrix are unaffected regardless of level. Retention failures are
-        best-effort and must never sink an already-classified trial, so any
-        error is logged and swallowed.
+        Returns the :class:`~aorta.run.retention.RetentionOutcome` so the
+        caller can record the applied level + deleted-artifact list into
+        ``result.json`` for post-hoc auditability (a reader of a bundled or
+        resumed run can tell a heavy artifact was *pruned* rather than never
+        produced). Returns ``None`` when retention did not run -- the recipe
+        omits ``retain`` (keep-everything default), the payload is malformed,
+        or the engine raised (best-effort: a retention error must never sink
+        an already-classified trial).
+
+        ``aorta.run.retention`` never deletes the trial record
+        (``result.json``), so resume and the matrix are unaffected
+        regardless of level.
         """
         retain = probe_extras.get("retain")
         if not retain:
-            return
+            return None
         # Retention is documented best-effort -- a malformed payload (e.g. a
         # string or RetainPolicy passed via programmatic config) must not
         # sink the trial with an AttributeError. Mirror the isinstance(dict)
@@ -1001,7 +1026,7 @@ class SubprocessWorkload(Workload):
                 type(retain).__name__,
                 trial_dir,
             )
-            return
+            return None
         level = retain.get(f"on_{verdict}", "full")
         try:
             outcome = apply_retention(trial_dir, level)
@@ -1012,7 +1037,7 @@ class SubprocessWorkload(Workload):
                 level,
                 exc,
             )
-            return
+            return None
         if outcome.deleted:
             log.info(
                 "retention[%s]: pruned %d artifact(s) (~%d bytes) from %s",
@@ -1021,6 +1046,25 @@ class SubprocessWorkload(Workload):
                 outcome.freed_bytes,
                 trial_dir,
             )
+        return outcome
+
+    @staticmethod
+    def _record_retention(result_doc: dict[str, Any], outcome: RetentionOutcome) -> None:
+        """Stamp the retention outcome into ``result_doc["capture"]``.
+
+        Makes the applied level + pruned-artifact list auditable from the
+        trial record alone, so a reader of a bundled/resumed run can tell a
+        missing heavy artifact was *pruned by policy* rather than never
+        produced (oyazdanb review). The trial record is itself never pruned
+        by retention, so this stays readable at every level.
+        """
+        capture = result_doc.setdefault("capture", {})
+        if isinstance(capture, dict):
+            capture["retention"] = {
+                "level": outcome.level,
+                "deleted": list(outcome.deleted),
+                "freed_bytes": outcome.freed_bytes,
+            }
 
     def _capture_cell_env(self, probe_extras: dict[str, Any]) -> dict[str, str]:
         """Compute the cell's mitigation+diagnostic env-var bundle.

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -74,6 +74,7 @@ from aorta.probe.classifier.verdict import (
     partition_detectors,
     verdict_from_detectors,
 )
+from aorta.run.retention import apply_retention
 from aorta.workloads._base import Workload, WorkloadResult
 
 log = logging.getLogger(__name__)
@@ -808,6 +809,12 @@ class SubprocessWorkload(Workload):
             encoding="utf-8",
         )
 
+        # Issue #231: prune heavy per-trial artifacts now that the verdict
+        # is known, keeping the level mapped from this trial's verdict.
+        # Runs AFTER result.json is written so the trial record (which
+        # retention never deletes) always survives for resume + the matrix.
+        self._apply_retention(trial_dir, verdict_obj.verdict, probe_extras)
+
         # ``main_work_started`` / ``executed_iterations`` mirror
         # whether ``Popen`` actually launched a child. A normal
         # non-zero child exit is still ``launched=True`` (the
@@ -935,6 +942,11 @@ class SubprocessWorkload(Workload):
             json.dumps(result_doc, indent=2, sort_keys=False),
             encoding="utf-8",
         )
+        # Issue #231: honor ``retain.on_error`` for this infra-error trial
+        # too (mirrors the main run() path). The probe.env was already
+        # unlinked above; this prunes any other heavy artifacts a prior
+        # resume left in the reused trial dir.
+        self._apply_retention(result_path.parent, "error", probe_extras)
         return WorkloadResult(
             passed=False,
             failure_count=1,
@@ -962,6 +974,41 @@ class SubprocessWorkload(Workload):
                 "warn_detectors_fired": [],
             },
         )
+
+    def _apply_retention(
+        self, trial_dir: Path, verdict: str, probe_extras: dict[str, Any]
+    ) -> None:
+        """Prune this trial's heavy artifacts per ``retain`` (issue #231).
+
+        No-op when the recipe omits ``retain`` (keep-everything default) or
+        when the resolved level is ``full``. ``aorta.run.retention`` never
+        deletes the trial record (``result.json``), so resume and the
+        matrix are unaffected regardless of level. Retention failures are
+        best-effort and must never sink an already-classified trial, so any
+        error is logged and swallowed.
+        """
+        retain = probe_extras.get("retain")
+        if not retain:
+            return
+        level = retain.get(f"on_{verdict}", "full")
+        try:
+            outcome = apply_retention(trial_dir, level)
+        except Exception as exc:  # noqa: BLE001 -- retention is best-effort
+            log.warning(
+                "retention: pruning %s at level %r failed (%s); artifacts kept",
+                trial_dir,
+                level,
+                exc,
+            )
+            return
+        if outcome.deleted:
+            log.info(
+                "retention[%s]: pruned %d artifact(s) (~%d bytes) from %s",
+                level,
+                len(outcome.deleted),
+                outcome.freed_bytes,
+                trial_dir,
+            )
 
     def _capture_cell_env(self, probe_extras: dict[str, Any]) -> dict[str, str]:
         """Compute the cell's mitigation+diagnostic env-var bundle.

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -990,6 +990,18 @@ class SubprocessWorkload(Workload):
         retain = probe_extras.get("retain")
         if not retain:
             return
+        # Retention is documented best-effort -- a malformed payload (e.g. a
+        # string or RetainPolicy passed via programmatic config) must not
+        # sink the trial with an AttributeError. Mirror the isinstance(dict)
+        # guard in _capture_cell_env and warn+skip when it isn't a mapping.
+        if not isinstance(retain, dict):
+            log.warning(
+                "retention: probe_extras['retain'] is %s, expected a mapping; "
+                "skipping retention for %s",
+                type(retain).__name__,
+                trial_dir,
+            )
+            return
         level = retain.get(f"on_{verdict}", "full")
         try:
             outcome = apply_retention(trial_dir, level)

--- a/tests/probe/test_recurring_issue_regression.py
+++ b/tests/probe/test_recurring_issue_regression.py
@@ -298,16 +298,17 @@ def test_stop_after_can_key_on_the_error_verdict():
 
 # ==========================================================================
 # GROUP E -- recipe knobs the operator-facing tasks add (#56, #57)
-# OPEN: retention + stop_after are not yet parsed onto the probe recipe.
+# FIXED: stop_after (#57/#232, run-level Recipe.stop_after) and verdict-keyed
+# retention (#56/#231, ProbeExtras.retain) both parse + validate on the probe
+# recipe now. These are permanent guards.
 # ==========================================================================
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="aorta-internal #56: verdict-keyed artifact retention not yet on "
-    "the probe recipe. Remove when ProbeExtras carries a retention policy.",
-)
 def test_recipe_accepts_verdict_keyed_retention():
+    """#56/#231 (FIXED): the probe recipe accepts a verdict-keyed ``retain``
+    block, surfaced on ``ProbeExtras.retain``. The deletion engine
+    (``aorta.run.retention``) keeps the heavy artifact only for the verdict
+    whose level is ``full`` and never drops the trial record."""
     from aorta.probe.recipe_builder import build_probe_recipe_from_dict
 
     r = build_probe_recipe_from_dict(
@@ -318,9 +319,11 @@ def test_recipe_accepts_verdict_keyed_retention():
             "mitigation_axis": ["none"],
             "diagnostic_axis": ["none"],
             "retain": {"on_fail": "full", "on_pass": "summary", "on_error": "log"},
-        }
+        },
+        [],
     )
     assert r.probe_extras.retain is not None  # type: ignore[attr-defined]
+    assert r.probe_extras.retain.level_for("fail") == "full"  # type: ignore[attr-defined]
 
 
 def test_recipe_accepts_stop_after_rule():

--- a/tests/probe/test_recurring_issue_regression.py
+++ b/tests/probe/test_recurring_issue_regression.py
@@ -8,9 +8,11 @@ behind the cluster of ``aorta probe`` bugs filed against this platform:
 * ``aorta`` #223 / #224 / aorta-internal #53 -- false-positive
   ``tier2:hang`` on a wrapper-delegated (docker/sudo) command that exits 0.
 * ``aorta`` #222 -- orphaned child process tree on interrupt/timeout.
-* aorta-internal #55 -- re-verification of #53 *plus* two still-open
-  defects: a ``failure_details[].type`` that contradicts ``exit_code``,
-  and an ambiguous ``<mitigation>-<diagnostic>`` cell name (``none-none``).
+* aorta-internal #55 -- re-verification of #53 *plus* a still-open
+  ``failure_details[].type`` that contradicts ``exit_code``. The fused
+  ``<mitigation>-<diagnostic>`` cell-name ambiguity (item 3) is fixed:
+  matrix.md now renders the two axes as separate columns plus a
+  ``Directory`` path, keeping the folder name as the agent's join key.
 * aorta-internal #58 -- the matrix has no ``error`` verdict, so an infra
   crash is silently miscounted as ``pass``/``fail``.
 * aorta-internal #56 / #57 -- verdict-keyed artifact retention and the
@@ -215,22 +217,110 @@ def test_failure_detail_type_consistent_with_zero_exit(tmp_path):
 
 
 # ==========================================================================
-# GROUP C -- cell-name disambiguation (#55 item 3)
-# OPEN on this branch: cell names are "<mit>-<diag>", rendering a confusing
-# bare trailing "-none" when the diagnostic axis is unused, with no way to
-# tell which token is the mitigation and which is the diagnostic.
+# GROUP C -- cell-name disambiguation (#55 item 3) [FIXED]
+# Probe runs still write cell artifacts to a "<mit>-<diag>" folder (the
+# agent's stable join key), but matrix.md no longer surfaces that fused name
+# as an identifier: it renders the two recipe axes as separate "Mitigation"
+# and "Diagnostic" columns plus a "Directory" column carrying the path. The
+# bare trailing "-none" stutter is gone from the table. These must stay green.
 # ==========================================================================
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="aorta-internal #55 item 3: an unused diagnostic axis renders an "
-    "ambiguous trailing '-none' (e.g. 'tf32_off-none'). Remove this marker "
-    "when cell names disambiguate mitigation vs diagnostic.",
-)
-def test_unused_diagnostic_axis_does_not_render_ambiguous_cell_name(tmp_path):
-    """With ``diagnostic_axis: [none]`` the cell name must not be a bare
-    ``<mitigation>-none`` that reads as a stutter and hides the axis roles."""
+def _probe_matrix_md(tmp_path, *, mitigation_axis, diagnostic_axis) -> str:
+    """Load a probe recipe and render its matrix.md, returning the text.
+
+    Builds one minimal :class:`CellStats` per synthesised cell so the test
+    exercises the real :func:`write_matrix_md` probe-mode column layout
+    (``flat_resume``, matching ``aorta probe``).
+    """
+    from aorta.triage.matrix import CellStats
+    from aorta.triage.output import write_matrix_md
+    from aorta.triage.recipe import load_recipe
+
+    # Emit axis values as a double-quoted YAML flow sequence (json.dumps gives
+    # exactly that) so YAML 1.1 boolean coercion of tokens like ``on``/``off``/
+    # ``yes``/``no`` can't silently rewrite an axis name into ``True``/``False``.
+    body = (
+        "schema_version: 1\n"
+        "mode: probe\n"
+        "trials: 1\n"
+        f"mitigation_axis: {json.dumps(list(mitigation_axis))}\n"
+        f"diagnostic_axis: {json.dumps(list(diagnostic_axis))}\n"
+    )
+    p = tmp_path / "r.yaml"
+    p.write_text(body, encoding="utf-8")
+    recipe = load_recipe(p)
+
+    stats = [
+        CellStats(
+            name=c.name,
+            mitigations=c.mitigations,
+            environment=c.environment,
+            extra_env={},
+            resolved_env_vars={},
+            trials=1,
+            passed_count=1,
+            failed_count=0,
+            mean_step_time_ms=10.0,
+            std_step_time_ms=0.0,
+            min_step_time_ms=10.0,
+            max_step_time_ms=10.0,
+            p50_step_time_ms=10.0,
+            p90_step_time_ms=10.0,
+            p99_step_time_ms=10.0,
+            mean_wall_clock_sec=1.0,
+            step_time_source="per_step",
+        )
+        for c in recipe.cells
+    ]
+    out = tmp_path / "matrix.md"
+    write_matrix_md(
+        out,
+        recipe,
+        stats,
+        baseline=stats[0],
+        confound_tags={s.name: ("(baseline)", None) for s in stats},
+        warnings=[],
+        run_timestamp="2026-01-01T00:00:00Z",
+        layout="flat_resume",
+    )
+    return out.read_text(encoding="utf-8")
+
+
+def test_unused_diagnostic_axis_renders_split_axis_columns(tmp_path):
+    """With ``diagnostic_axis: [none]`` matrix.md must show the mitigation and
+    diagnostic as separate columns (not a fused ``<mit>-none`` identifier),
+    with the folder path in its own ``Directory`` column (#55 item 3)."""
+    text = _probe_matrix_md(
+        tmp_path, mitigation_axis=["none", "tf32_off"], diagnostic_axis=["none"]
+    )
+    header = next(line for line in text.splitlines() if line.lstrip().startswith("| Mitigation"))
+    # The axes get their own columns; the fused triage-mode "Cell" column is gone.
+    assert "| Mitigation " in header
+    assert "| Diagnostic " in header
+    assert "| Directory " in header
+    assert "| Cell " not in header
+    # The mitigation value stands alone in its column -- never a "tf32_off-none"
+    # stutter presented as the row identifier.
+    assert "tf32_off-none" not in header
+    body_rows = [
+        line
+        for line in text.splitlines()
+        if line.startswith("|") and "tf32_off" in line and "Mitigation" not in line
+    ]
+    assert body_rows, "expected a row for the tf32_off cell"
+    row = body_rows[0]
+    cols = [c.strip() for c in row.strip().strip("|").split("|")]
+    assert cols[0] == "tf32_off", f"Mitigation column should be the bare axis value: {row!r}"
+    assert cols[1] == "none", f"Diagnostic column should be the bare axis value: {row!r}"
+    # The fused name survives only as the artifact directory path (last column).
+    assert cols[-1] == "tf32_off-none/", f"Directory column should carry the folder: {row!r}"
+
+
+def test_legacy_cell_name_still_exists_as_folder_join_key(tmp_path):
+    """The fix is presentational: the on-disk folder name stays
+    ``<mitigation>-<diagnostic>`` so the agent's baseline-parse join key is
+    untouched -- only the matrix.md *table* stopped surfacing it as an ID."""
     from aorta.triage.recipe import load_recipe
 
     recipe_text = (
@@ -243,14 +333,14 @@ def test_unused_diagnostic_axis_does_not_render_ambiguous_cell_name(tmp_path):
     p = tmp_path / "r.yaml"
     p.write_text(recipe_text, encoding="utf-8")
     r = load_recipe(p)
-    names = sorted(c.name for c in r.cells)
-    # The mitigation-only cell should read as a clean baseline, and the
-    # tf32_off cell should not carry a meaningless '-none' suffix.
-    for name in names:
-        assert not name.endswith("-none"), (
-            f"cell name {name!r} carries an ambiguous trailing '-none' when the "
-            "diagnostic axis is unused"
-        )
+    by_name = {c.name: c for c in r.cells}
+    # The folder/join key is deliberately the fused "<mit>-<diag>" string --
+    # the agent's baseline-parse logic depends on it. The disambiguation moved
+    # to matrix.md's columns (see test above), NOT to the on-disk name.
+    assert set(by_name) == {"none-none", "tf32_off-none"}
+    # And each cell still carries both axes as a (mitigation, diagnostic) pair
+    # so the renderer can split them into their own columns.
+    assert by_name["tf32_off-none"].mitigations == ("tf32_off", "none")
 
 
 # ==========================================================================

--- a/tests/probe/test_recurring_issue_regression.py
+++ b/tests/probe/test_recurring_issue_regression.py
@@ -8,8 +8,10 @@ behind the cluster of ``aorta probe`` bugs filed against this platform:
 * ``aorta`` #223 / #224 / aorta-internal #53 -- false-positive
   ``tier2:hang`` on a wrapper-delegated (docker/sudo) command that exits 0.
 * ``aorta`` #222 -- orphaned child process tree on interrupt/timeout.
-* aorta-internal #55 -- re-verification of #53 *plus* a still-open
-  ``failure_details[].type`` that contradicts ``exit_code``. The fused
+* aorta-internal #55 -- re-verification of #53. Item 2 (a
+  ``failure_details[].type`` that contradicted ``exit_code``) is now fixed:
+  the type is derived from the actual process outcome, so a clean exit
+  failed by a non-Tier-1 detector is ``detector_failure``. The fused
   ``<mitigation>-<diagnostic>`` cell-name ambiguity (item 3) is fixed:
   matrix.md now renders the two axes as separate columns plus a
   ``Directory`` path, keeping the folder name as the agent's join key.
@@ -187,22 +189,20 @@ def test_timed_out_with_latched_hang_stays_a_failure(tmp_path, monkeypatch):
 
 # ==========================================================================
 # GROUP B -- failure_details[].type must agree with exit_code (#55 item 2)
-# OPEN on this branch: the type is hard-stamped "subprocess_nonzero_exit"
-# whenever the child launched, regardless of the actual exit status.
+# FIXED on main: aorta `#229` (merged via `#233`) routed the type through
+# `_subprocess._failure_detail_type`, which derives it from the actual
+# (launched, timed_out, exit_code) outcome instead of hard-stamping
+# "subprocess_nonzero_exit" whenever the child launched. A clean exit failed
+# by a non-Tier-1 detector is now "detector_failure". Promoted from
+# xfail(strict) to a permanent guard per this module's CONVENTIONS.
 # ==========================================================================
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="aorta-internal #55 item 2: failure_details[].type is stamped "
-    "'subprocess_nonzero_exit' even when exit_code == 0 (failure came from a "
-    "non-Tier-1 detector). Remove this marker when the type is derived from "
-    "the actual exit/verdict.",
-)
 def test_failure_detail_type_consistent_with_zero_exit(tmp_path):
     """A trial that exits 0 but fails on a log-pattern (Tier 4) must not be
     labelled ``subprocess_nonzero_exit`` -- that string is self-contradictory
-    with ``exit_code == 0`` and misleads anyone reading the per-trial JSON."""
+    with ``exit_code == 0`` and misleads anyone reading the per-trial JSON.
+    The clean-exit-but-detector-failed case is stamped ``detector_failure``."""
     wl = _make_workload(tmp_path, ["bash", "-c", "echo 'loss is NaN'; exit 0"])
     wl.setup()
     result = wl.run()
@@ -211,8 +211,10 @@ def test_failure_detail_type_consistent_with_zero_exit(tmp_path):
     assert doc["verdict"] == "fail"  # tier4:nan_signature fired
     assert result.failure_details, "a failing trial must carry a failure_detail"
     detail_type = result.failure_details[0]["type"]
-    assert detail_type != "subprocess_nonzero_exit", (
-        f"failure_details[].type={detail_type!r} contradicts exit_code=0"
+    assert detail_type == "detector_failure", (
+        f"failure_details[].type={detail_type!r} must be 'detector_failure' "
+        "for a clean exit failed by a non-Tier-1 detector (not "
+        "'subprocess_nonzero_exit', which contradicts exit_code=0)"
     )
 
 

--- a/tests/probe/test_retention.py
+++ b/tests/probe/test_retention.py
@@ -1,0 +1,165 @@
+"""Schema + end-to-end tests for verdict-keyed retention (issue #231).
+
+Two layers:
+
+* **Schema** -- the ``retain`` block parses onto ``ProbeExtras.retain``
+  via :func:`aorta.probe.recipe_builder.build_probe_recipe_from_dict`,
+  with the same strict-validation contract as ``stop_after``.
+* **End-to-end** -- :class:`aorta.workloads._subprocess.SubprocessWorkload`
+  prunes each trial's heavy artifacts according to the verdict->level
+  mapping, while the trial record (``result.json``) always survives. This
+  includes the issue's disk acceptance criterion (a multi-trial cell with
+  a heavy collector retains ~one heavy artifact per *failing* trial, not
+  one per trial).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aorta.probe.recipe_builder import build_probe_recipe_from_dict
+from aorta.run.retention import RETAIN_LEVELS
+from aorta.triage.recipe import _RETAIN_LEVELS, RecipeSchemaError, RetainPolicy
+from aorta.workloads._subprocess import (
+    CONFIG_KEY_LOG_PREFIX,
+    CONFIG_KEY_PROBE_EXTRAS,
+    CONFIG_KEY_SUBPROCESS_ARGV,
+    SubprocessWorkload,
+)
+
+
+def _probe_dict(**overrides) -> dict:
+    base = {
+        "schema_version": 1,
+        "mode": "probe",
+        "trials": 1,
+        "mitigation_axis": ["none"],
+        "diagnostic_axis": ["none"],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---- schema ---------------------------------------------------------------
+
+
+def test_retain_omitted_is_none():
+    r = build_probe_recipe_from_dict(_probe_dict(), [])
+    assert r.probe_extras.retain is None
+
+
+def test_retain_parses_onto_probe_extras():
+    r = build_probe_recipe_from_dict(
+        _probe_dict(retain={"on_fail": "full", "on_pass": "summary", "on_error": "log"}),
+        [],
+    )
+    assert r.probe_extras.retain == RetainPolicy(on_fail="full", on_pass="summary", on_error="log")
+
+
+def test_retain_partial_defaults_to_full():
+    r = build_probe_recipe_from_dict(_probe_dict(retain={"on_pass": "none"}), [])
+    assert r.probe_extras.retain == RetainPolicy(on_fail="full", on_pass="none", on_error="full")
+
+
+def test_retain_rejects_unknown_key():
+    with pytest.raises(RecipeSchemaError, match="unknown keys"):
+        build_probe_recipe_from_dict(_probe_dict(retain={"on_skip": "full"}), [])
+
+
+def test_retain_rejects_bad_level():
+    with pytest.raises(RecipeSchemaError, match="must be one of"):
+        build_probe_recipe_from_dict(_probe_dict(retain={"on_fail": "everything"}), [])
+
+
+def test_retain_rejects_non_mapping():
+    with pytest.raises(RecipeSchemaError, match="must be a mapping"):
+        build_probe_recipe_from_dict(_probe_dict(retain=["full"]), [])
+
+
+def test_schema_levels_match_engine_ladder():
+    """Drift guard: the schema's accepted levels must equal the engine's."""
+    assert _RETAIN_LEVELS == set(RETAIN_LEVELS)
+
+
+# ---- end-to-end through SubprocessWorkload --------------------------------
+
+
+def _run_trial(tmp_path: Path, *, argv: list[str], trial_idx: int, retain: dict | None):
+    """Run one probe trial in its own cell dir; return (trial_dir, result)."""
+    cell_dir = tmp_path / f"cell_{trial_idx}"
+    workload_subdir = cell_dir / "_subprocess"
+    workload_subdir.mkdir(parents=True, exist_ok=True)
+    prefix = workload_subdir / f"trial_d0_m0_t{trial_idx}"
+    extras: dict = {
+        "cell_name": "none-none",
+        "env_passthrough_mode": "inherit",
+        "timeout_per_trial": None,
+        "cell_env_vars": {},
+    }
+    if retain is not None:
+        extras["retain"] = retain
+    wl = SubprocessWorkload(
+        {
+            CONFIG_KEY_SUBPROCESS_ARGV: argv,
+            CONFIG_KEY_LOG_PREFIX: str(prefix),
+            CONFIG_KEY_PROBE_EXTRAS: extras,
+        }
+    )
+    wl.setup()
+    trial_dir = cell_dir / f"trial_{trial_idx}"
+    # Simulate a collector dropping a heavy artifact during the trial.
+    (trial_dir / "trace.bin").write_text("x" * 4096, encoding="utf-8")
+    result = wl.run()
+    return trial_dir, result
+
+
+_POLICY = {"on_fail": "full", "on_pass": "summary", "on_error": "log"}
+
+
+def test_pass_trial_drops_heavy_keeps_record(tmp_path: Path):
+    trial_dir, result = _run_trial(tmp_path, argv=["true"], trial_idx=0, retain=_POLICY)
+    assert result.passed is True
+    assert not (trial_dir / "trace.bin").exists()  # heavy dropped at summary
+    assert (trial_dir / "result.json").is_file()  # record survives
+
+
+def test_fail_trial_keeps_heavy(tmp_path: Path):
+    trial_dir, result = _run_trial(tmp_path, argv=["false"], trial_idx=0, retain=_POLICY)
+    assert result.passed is False
+    assert (trial_dir / "trace.bin").is_file()  # full -> heavy kept
+    assert (trial_dir / "result.json").is_file()
+
+
+def test_default_keeps_everything(tmp_path: Path):
+    """No ``retain`` block -> legacy keep-everything behaviour."""
+    trial_dir, _ = _run_trial(tmp_path, argv=["true"], trial_idx=0, retain=None)
+    assert (trial_dir / "trace.bin").is_file()
+    assert (trial_dir / "result.json").is_file()
+
+
+def test_record_survives_at_none_level(tmp_path: Path):
+    trial_dir, _ = _run_trial(
+        tmp_path, argv=["true"], trial_idx=0, retain={"on_pass": "none"}
+    )
+    assert (trial_dir / "result.json").is_file()
+    assert not (trial_dir / "trace.bin").exists()
+    assert not (trial_dir / "stdout.log").exists()  # none drops logs too
+
+
+def test_disk_criterion_heavy_kept_only_for_fails(tmp_path: Path):
+    """A 10-trial cell with 3 fails retains 3 heavy artifacts, not 10."""
+    n_trials = 10
+    fail_idxs = {2, 5, 8}
+    heavy_kept = 0
+    records = 0
+    for i in range(n_trials):
+        argv = ["false"] if i in fail_idxs else ["true"]
+        trial_dir, _ = _run_trial(tmp_path, argv=argv, trial_idx=i, retain=_POLICY)
+        if (trial_dir / "trace.bin").is_file():
+            heavy_kept += 1
+        if (trial_dir / "result.json").is_file():
+            records += 1
+    assert heavy_kept == len(fail_idxs)  # ~3 heavy, not 10
+    assert records == n_trials  # every trial's bookkeeping survives

--- a/tests/probe/test_retention.py
+++ b/tests/probe/test_retention.py
@@ -78,6 +78,15 @@ def test_retain_rejects_non_mapping():
         build_probe_recipe_from_dict(_probe_dict(retain=["full"]), [])
 
 
+@pytest.mark.parametrize("bad_value", [{"nested": "full"}, ["full"]])
+def test_retain_rejects_unhashable_level_value(bad_value):
+    # An unhashable YAML node (dict/list) as a level value must surface a
+    # clean RecipeSchemaError, not a raw TypeError from the set-membership
+    # check (`value not in _RETAIN_LEVELS` hashes `value`).
+    with pytest.raises(RecipeSchemaError, match="must be one of"):
+        build_probe_recipe_from_dict(_probe_dict(retain={"on_fail": bad_value}), [])
+
+
 def test_schema_levels_match_engine_ladder():
     """Drift guard: the schema's accepted levels must equal the engine's."""
     assert _RETAIN_LEVELS == set(RETAIN_LEVELS)

--- a/tests/probe/test_retention.py
+++ b/tests/probe/test_retention.py
@@ -167,6 +167,28 @@ def test_record_survives_at_none_level(tmp_path: Path):
     assert not (trial_dir / "stdout.log").exists()  # none drops logs too
 
 
+def test_non_dict_retain_payload_warns_and_skips(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """A malformed programmatic ``retain`` payload (e.g. a bare string, not a
+    mapping) must not sink the trial -- retention is best-effort, so warn +
+    skip and keep every artifact (the schema path rejects this, but a
+    programmatic caller can bypass it)."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        trial_dir, result = _run_trial(
+            tmp_path,
+            argv=["true"],
+            trial_idx=0,
+            retain="summary",  # type: ignore[arg-type]
+        )
+    assert result.passed is True
+    assert (trial_dir / "trace.bin").is_file()  # nothing pruned
+    assert (trial_dir / "result.json").is_file()
+    assert any("expected a mapping" in r.getMessage() for r in caplog.records)
+
+
 def test_disk_criterion_heavy_kept_only_for_fails(tmp_path: Path):
     """A 10-trial cell with 3 fails retains 3 heavy artifacts, not 10."""
     n_trials = 10

--- a/tests/probe/test_retention.py
+++ b/tests/probe/test_retention.py
@@ -87,6 +87,16 @@ def test_retain_rejects_unhashable_level_value(bad_value):
         build_probe_recipe_from_dict(_probe_dict(retain={"on_fail": bad_value}), [])
 
 
+def test_retain_multiple_bad_keys_report_deterministically():
+    # With several invalid level values, the validator iterates keys in a
+    # fixed (sorted) order so the surfaced error is stable across runs /
+    # hash seeds. Sorted order is on_error < on_fail < on_pass, so on_fail
+    # is reported first here.
+    bad = {"on_pass": "bogus_p", "on_fail": "bogus_f"}
+    with pytest.raises(RecipeSchemaError, match=r"retain\.on_fail: must be one of"):
+        build_probe_recipe_from_dict(_probe_dict(retain=bad), [])
+
+
 def test_schema_levels_match_engine_ladder():
     """Drift guard: the schema's accepted levels must equal the engine's."""
     assert _RETAIN_LEVELS == set(RETAIN_LEVELS)

--- a/tests/probe/test_retention.py
+++ b/tests/probe/test_retention.py
@@ -15,6 +15,7 @@ Two layers:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -187,6 +188,38 @@ def test_non_dict_retain_payload_warns_and_skips(
     assert (trial_dir / "trace.bin").is_file()  # nothing pruned
     assert (trial_dir / "result.json").is_file()
     assert any("expected a mapping" in r.getMessage() for r in caplog.records)
+
+
+def _read_result(trial_dir: Path) -> dict:
+    return json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
+
+
+def test_retention_outcome_recorded_in_result_json(tmp_path: Path):
+    """A pruning trial stamps the applied level + deleted list into the
+    record so a missing heavy artifact is auditable post-bundle (oyazdanb)."""
+    trial_dir, _ = _run_trial(tmp_path, argv=["true"], trial_idx=0, retain=_POLICY)
+    retention = _read_result(trial_dir).get("capture", {}).get("retention")
+    assert retention is not None, "capture.retention missing from result.json"
+    assert retention.get("level") == "summary"  # on_pass=summary
+    assert "trace.bin" in retention.get("deleted", [])
+    assert retention.get("freed_bytes", 0) >= 4096
+
+
+def test_retention_record_absent_without_policy(tmp_path: Path):
+    """No ``retain`` block -> no retention audit key (keep-everything)."""
+    trial_dir, _ = _run_trial(tmp_path, argv=["true"], trial_idx=0, retain=None)
+    assert "retention" not in _read_result(trial_dir).get("capture", {})
+
+
+def test_retention_record_on_full_is_noop_but_audited(tmp_path: Path):
+    """A failing trial at ``full`` keeps everything; the audit record still
+    notes the level so a reader sees retention was active (deleted empty)."""
+    trial_dir, _ = _run_trial(tmp_path, argv=["false"], trial_idx=0, retain=_POLICY)
+    retention = _read_result(trial_dir).get("capture", {}).get("retention")
+    assert retention is not None, "capture.retention missing from result.json"
+    assert retention.get("level") == "full"
+    assert retention.get("deleted") == []
+    assert (trial_dir / "trace.bin").is_file()  # nothing pruned at full
 
 
 def test_disk_criterion_heavy_kept_only_for_fails(tmp_path: Path):

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -215,6 +215,37 @@ def test_non_list_artifacts_is_malformed(tmp_path: Path, caplog: pytest.LogCaptu
     assert _names(d) == {"result.json"}
 
 
+def test_symlinked_manifest_is_malformed(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    """A symlinked artifacts.json must not be dereferenced (it could read a
+    file outside the trial tree). Treat it as malformed + fall back."""
+    # A valid manifest living outside the trial dir that, if followed, would
+    # keep huge.bin as a summary (i.e. survive pruning at level "none").
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    real_manifest = outside / "real.json"
+    real_manifest.write_text(
+        json.dumps({"artifacts": [{"path": "huge.bin", "class": "summary"}]}),
+        encoding="utf-8",
+    )
+
+    d = tmp_path / "trial_0"
+    d.mkdir()
+    (d / "result.json").write_text("{}", encoding="utf-8")
+    (d / "huge.bin").write_text("q" * 100, encoding="utf-8")
+    (d / RETENTION_MANIFEST_NAME).symlink_to(real_manifest)
+
+    with caplog.at_level("WARNING"):
+        apply_retention(d, "none")
+
+    # The symlink was NOT followed: warned about symlink, fell back to
+    # convention, and huge.bin (heavy by name) was pruned at level none.
+    # The manifest symlink itself survives (deletion side skips symlinks).
+    assert any("symlink" in r.getMessage() for r in caplog.records)
+    survivors = _names(d)
+    assert "huge.bin" not in survivors  # pruned by convention
+    assert "result.json" in survivors  # record always kept
+
+
 def test_symlink_escaping_trial_dir_is_not_deleted(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ):

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -1,0 +1,188 @@
+"""Unit tests for the artifact-retention engine (issue #231).
+
+Covers the pure :mod:`aorta.run.retention` classify/apply layer: the
+level ladder, the record hard-guard, filename-convention classification,
+the optional collector manifest (including malformed-manifest tolerance),
+empty-dir pruning, and the ``full`` fast no-op.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aorta.run.retention import (
+    HEAVY,
+    LOG,
+    RECORD,
+    RETAIN_LEVELS,
+    RETENTION_MANIFEST_NAME,
+    SUMMARY,
+    apply_retention,
+    classify_artifact,
+)
+
+
+def _populate(trial_dir: Path) -> None:
+    """Drop one artifact of every class (incl. a heavy file in a subdir)."""
+    trial_dir.mkdir(parents=True, exist_ok=True)
+    (trial_dir / "result.json").write_text('{"verdict": "fail"}', encoding="utf-8")
+    (trial_dir / "stdout.log").write_text("out", encoding="utf-8")
+    (trial_dir / "stderr.log").write_text("err", encoding="utf-8")
+    (trial_dir / "probe.env").write_text("K=V", encoding="utf-8")
+    (trial_dir / "rollup.summary.json").write_text("{}", encoding="utf-8")
+    (trial_dir / "trace.bin").write_text("x" * 1000, encoding="utf-8")
+    sub = trial_dir / "prof"
+    sub.mkdir()
+    (sub / "big.pb").write_text("y" * 2000, encoding="utf-8")
+
+
+def _names(trial_dir: Path) -> set[str]:
+    return {p.relative_to(trial_dir).as_posix() for p in trial_dir.rglob("*") if p.is_file()}
+
+
+# ---- classify_artifact ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rel", "expected"),
+    [
+        ("result.json", RECORD),
+        ("stdout.log", LOG),
+        ("stderr.log", LOG),
+        ("probe.env", LOG),
+        ("rollup.summary.json", SUMMARY),
+        ("prof.summary.pb", SUMMARY),
+        ("artifacts.json", SUMMARY),
+        ("trace.bin", HEAVY),
+        ("prof/big.pb", HEAVY),
+        ("anything_else", HEAVY),
+    ],
+)
+def test_classify_by_convention(rel: str, expected: str):
+    assert classify_artifact(rel) == expected
+
+
+def test_manifest_overrides_convention():
+    manifest = {"data.json": HEAVY, "roll.json": SUMMARY}
+    assert classify_artifact("data.json", manifest) == HEAVY
+    assert classify_artifact("roll.json", manifest) == SUMMARY
+
+
+def test_record_guard_beats_manifest():
+    """A manifest can never reclassify the trial record as deletable."""
+    assert classify_artifact("result.json", {"result.json": HEAVY}) == RECORD
+
+
+# ---- apply_retention: the level ladder ------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("level", "present", "gone"),
+    [
+        ("full", {"result.json", "stdout.log", "trace.bin", "rollup.summary.json", "prof/big.pb"}, set()),
+        ("summary", {"result.json", "stdout.log", "rollup.summary.json"}, {"trace.bin", "prof/big.pb"}),
+        ("log", {"result.json", "stdout.log", "stderr.log", "probe.env"}, {"trace.bin", "rollup.summary.json", "prof/big.pb"}),
+        ("none", {"result.json"}, {"stdout.log", "trace.bin", "rollup.summary.json", "prof/big.pb"}),
+    ],
+)
+def test_apply_levels(tmp_path: Path, level: str, present: set[str], gone: set[str]):
+    d = tmp_path / "trial_0"
+    _populate(d)
+    apply_retention(d, level)
+    survivors = _names(d)
+    assert present <= survivors, (level, "missing", present - survivors)
+    assert not (gone & survivors), (level, "should be gone", gone & survivors)
+    # The trial record is sacrosanct at every level.
+    assert (d / "result.json").is_file()
+
+
+def test_full_is_a_noop(tmp_path: Path):
+    d = tmp_path / "trial_0"
+    _populate(d)
+    before = _names(d)
+    outcome = apply_retention(d, "full")
+    assert outcome.no_op is True
+    assert outcome.deleted == ()
+    assert _names(d) == before
+
+
+def test_unknown_level_keeps_everything(tmp_path: Path):
+    d = tmp_path / "trial_0"
+    _populate(d)
+    before = _names(d)
+    outcome = apply_retention(d, "bogus")
+    assert outcome.no_op is True
+    assert _names(d) == before
+
+
+def test_freed_bytes_and_deleted_list(tmp_path: Path):
+    d = tmp_path / "trial_0"
+    _populate(d)
+    outcome = apply_retention(d, "summary")
+    assert set(outcome.deleted) == {"trace.bin", "prof/big.pb"}
+    assert outcome.freed_bytes == 3000  # 1000 + 2000
+
+
+def test_empty_subdirs_are_pruned(tmp_path: Path):
+    d = tmp_path / "trial_0"
+    _populate(d)
+    apply_retention(d, "log")  # drops the only file under prof/
+    assert not (d / "prof").exists()
+
+
+def test_missing_trial_dir_is_noop(tmp_path: Path):
+    outcome = apply_retention(tmp_path / "does_not_exist", "none")
+    assert outcome.no_op is True
+
+
+# ---- manifest behaviour ---------------------------------------------------
+
+
+def test_apply_honors_manifest(tmp_path: Path):
+    d = tmp_path / "trial_0"
+    d.mkdir()
+    (d / "result.json").write_text("{}", encoding="utf-8")
+    (d / "data.json").write_text("z" * 500, encoding="utf-8")  # heavy by convention
+    (d / "roll.json").write_text("{}", encoding="utf-8")  # heavy by convention
+    (d / RETENTION_MANIFEST_NAME).write_text(
+        json.dumps(
+            {"artifacts": [{"path": "data.json", "class": HEAVY}, {"path": "roll.json", "class": SUMMARY}]}
+        ),
+        encoding="utf-8",
+    )
+    apply_retention(d, "summary")
+    survivors = _names(d)
+    assert "data.json" not in survivors  # manifest heavy -> pruned
+    assert "roll.json" in survivors  # manifest summary -> kept
+    assert "result.json" in survivors
+
+
+def test_malformed_manifest_falls_back_to_convention(tmp_path: Path):
+    d = tmp_path / "trial_0"
+    d.mkdir()
+    (d / "result.json").write_text("{}", encoding="utf-8")
+    (d / RETENTION_MANIFEST_NAME).write_text("not json{", encoding="utf-8")
+    (d / "huge.bin").write_text("q" * 100, encoding="utf-8")
+    # Must not raise; heavy file pruned by convention; record kept.
+    apply_retention(d, "none")
+    survivors = _names(d)
+    assert survivors == {"result.json"}
+
+
+def test_unknown_manifest_class_treated_as_heavy(tmp_path: Path):
+    d = tmp_path / "trial_0"
+    d.mkdir()
+    (d / "result.json").write_text("{}", encoding="utf-8")
+    (d / "mystery.dat").write_text("m" * 50, encoding="utf-8")
+    (d / RETENTION_MANIFEST_NAME).write_text(
+        json.dumps({"artifacts": [{"path": "mystery.dat", "class": "weird"}]}), encoding="utf-8"
+    )
+    apply_retention(d, "summary")  # heavy dropped at summary
+    assert "mystery.dat" not in _names(d)
+
+
+def test_levels_constant_is_the_documented_ladder():
+    assert RETAIN_LEVELS == ("none", "log", "summary", "full")

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -94,10 +94,10 @@ def test_record_guard_matches_exact_path_not_basename():
 @pytest.mark.parametrize(
     ("level", "present", "gone"),
     [
-        ("full", {"result.json", "stdout.log", "trace.bin", "rollup.summary.json", "prof/big.pb"}, set()),
-        ("summary", {"result.json", "stdout.log", "rollup.summary.json"}, {"trace.bin", "prof/big.pb"}),
+        ("full", {"result.json", "stdout.log", "stderr.log", "probe.env", "trace.bin", "rollup.summary.json", "prof/big.pb"}, set()),
+        ("summary", {"result.json", "stdout.log", "stderr.log", "probe.env", "rollup.summary.json"}, {"trace.bin", "prof/big.pb"}),
         ("log", {"result.json", "stdout.log", "stderr.log", "probe.env"}, {"trace.bin", "rollup.summary.json", "prof/big.pb"}),
-        ("none", {"result.json"}, {"stdout.log", "trace.bin", "rollup.summary.json", "prof/big.pb"}),
+        ("none", {"result.json"}, {"stdout.log", "stderr.log", "probe.env", "trace.bin", "rollup.summary.json", "prof/big.pb"}),
     ],
 )
 def test_apply_levels(tmp_path: Path, level: str, present: set[str], gone: set[str]):

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -76,6 +76,18 @@ def test_record_guard_beats_manifest():
     assert classify_artifact("result.json", {"result.json": HEAVY}) == RECORD
 
 
+def test_record_guard_matches_exact_path_not_basename():
+    """Only the top-level result.json is the record; a nested one is heavy.
+
+    Resume / matrix completion keys off ``trial_dir/result.json``
+    specifically, so a same-named heavy collector file under a subdir must
+    stay prunable rather than being protected by basename.
+    """
+    assert classify_artifact("result.json") == RECORD
+    assert classify_artifact("sub/result.json") == HEAVY
+    assert classify_artifact("prof/nested/result.json") == HEAVY
+
+
 # ---- apply_retention: the level ladder ------------------------------------
 
 
@@ -170,6 +182,61 @@ def test_malformed_manifest_falls_back_to_convention(tmp_path: Path):
     apply_retention(d, "none")
     survivors = _names(d)
     assert survivors == {"result.json"}
+
+
+def test_nested_result_json_is_pruned(tmp_path: Path):
+    """A heavy collector file named result.json under a subdir is prunable."""
+    d = tmp_path / "trial_0"
+    d.mkdir()
+    (d / "result.json").write_text("{}", encoding="utf-8")  # the real record
+    sub = d / "collector"
+    sub.mkdir()
+    (sub / "result.json").write_text("z" * 500, encoding="utf-8")  # heavy
+    apply_retention(d, "none")
+    survivors = _names(d)
+    assert survivors == {"result.json"}  # nested one pruned, real record kept
+
+
+def test_non_list_artifacts_is_malformed(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    """A manifest whose ``artifacts`` is not a list warns + falls back."""
+    d = tmp_path / "trial_0"
+    d.mkdir()
+    (d / "result.json").write_text("{}", encoding="utf-8")
+    (d / "huge.bin").write_text("q" * 100, encoding="utf-8")
+    (d / RETENTION_MANIFEST_NAME).write_text(
+        json.dumps({"artifacts": {"path": "huge.bin", "class": "summary"}}),
+        encoding="utf-8",
+    )
+    with caplog.at_level("WARNING"):
+        apply_retention(d, "none")
+    # Warned about the malformed manifest...
+    assert any("malformed" in r.getMessage() for r in caplog.records)
+    # ...and fell back to convention: huge.bin is heavy -> pruned at none.
+    assert _names(d) == {"result.json"}
+
+
+def test_symlink_escaping_trial_dir_is_not_deleted(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """A symlink pointing outside the trial dir is skipped, never unlinked."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "precious.bin"
+    victim.write_text("do not delete", encoding="utf-8")
+
+    d = tmp_path / "trial_0"
+    d.mkdir()
+    (d / "result.json").write_text("{}", encoding="utf-8")
+    link = d / "escape.bin"  # heavy name; would be pruned if treated as a file
+    link.symlink_to(victim)
+
+    with caplog.at_level("WARNING"):
+        outcome = apply_retention(d, "none")
+
+    assert link.is_symlink()  # the link itself survives
+    assert victim.is_file() and victim.read_text() == "do not delete"
+    assert "escape.bin" not in outcome.deleted
+    assert any("symlink" in r.getMessage() for r in caplog.records)
 
 
 def test_unknown_manifest_class_treated_as_heavy(tmp_path: Path):

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -270,6 +270,39 @@ def test_symlink_escaping_trial_dir_is_not_deleted(
     assert any("symlink" in r.getMessage() for r in caplog.records)
 
 
+def test_symlinked_subdir_is_not_descended(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """A symlinked *directory* must be kept and never walked into.
+
+    Enumeration uses ``os.walk(followlinks=False)`` so a collector that
+    drops a symlinked subdir pointing at an external (possibly huge) tree
+    can't make retention traverse it. The link is kept, its target is
+    untouched, and nothing under it is pruned.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "external_heavy.bin").write_text("z" * 4096, encoding="utf-8")
+
+    d = tmp_path / "trial_0"
+    d.mkdir()
+    (d / "result.json").write_text("{}", encoding="utf-8")
+    (d / "trace.bin").write_text("x" * 1000, encoding="utf-8")  # heavy, real file
+    (d / "linkdir").symlink_to(outside, target_is_directory=True)
+
+    with caplog.at_level("WARNING"):
+        outcome = apply_retention(d, "none")
+
+    # The real heavy file was pruned; the symlinked dir + its target survive.
+    assert "trace.bin" in outcome.deleted
+    assert (d / "linkdir").is_symlink()
+    assert (outside / "external_heavy.bin").is_file()  # never descended/pruned
+    assert "linkdir" in outcome.kept
+    # The external file was never even enumerated as a candidate.
+    assert "linkdir/external_heavy.bin" not in outcome.deleted
+    assert any("symlink" in r.getMessage() for r in caplog.records)
+
+
 def test_unknown_manifest_class_treated_as_heavy(tmp_path: Path):
     d = tmp_path / "trial_0"
     d.mkdir()

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -214,6 +214,23 @@ def test_resolve_run_dir_rejects_unknown_layout(tmp_path):
         resolve_run_dir(tmp_path, r, layout="")  # type: ignore[arg-type]
 
 
+def test_cell_directory_rejects_unknown_layout():
+    """Regression for PR #241 review: ``_cell_directory`` shares the
+    ``layout`` contract with ``resolve_run_dir`` but used to treat it as a
+    free-form str, so a typo (``"flatresume"``) silently rendered a
+    triage-style ``cells/<slug>/`` link for a probe run. It must reject
+    unknown values too.
+    """
+    from aorta.triage.output import _cell_directory
+
+    assert _cell_directory("a-b", "flat_resume") == "a-b/"
+    assert _cell_directory("a-b", "timestamped") == "cells/a-b/"
+    with pytest.raises(ValueError, match="layout must be"):
+        _cell_directory("a-b", "flatresume")
+    with pytest.raises(ValueError, match="layout must be"):
+        _cell_directory("a-b", "")
+
+
 def test_default_layout_is_byte_equivalent_to_timestamped(tmp_path):
     """Existing callers see no behaviour change -- the default is 'timestamped'."""
     r = _simple_recipe(ticket="PROJ-1")


### PR DESCRIPTION
## Summary

Adds a recipe `retain` block that keeps **heavy** per-trial artifacts
(profiler traces, per-layer numeric dumps — hundreds of MB each) only for
the trials where they have diagnostic value, keyed on each trial's
three-way verdict. Without it, a ~900-trial sweep at ~100 MB/trial buries
the disk in tens of GB of mostly-useless passing-run data (issue #231).

```yaml
retain:
  on_fail:  full       # keep everything (log + summary + heavy)
  on_pass:  summary    # keep small summaries; delete heavy
  on_error: log        # keep the trial log only; drop summary + heavy
```

Levels form a ladder, each a superset of the one below:
`none` < `log` < `summary` < `full`. Each key is optional and defaults to
`full`, so **omitting `retain` is byte-for-byte the legacy keep-everything
behaviour**.

### Changes
- **recipe schema** (`recipe.py`): `RetainPolicy` dataclass + `_parse_retain`
  with strict validation (unknown keys, bad levels, non-mapping all rejected),
  mirroring `_parse_stop_after`. Surfaced on `ProbeExtras.retain` — a
  probe-only key (enforced by the workload), unlike the generically-enforced
  run-level `stop_after`.
- **engine** (`aorta/run/retention.py`, new, stdlib-only): classifies each
  trial artifact into record / log / summary / heavy and prunes everything the
  resolved level doesn't keep. Collectors declare heavy vs summary via an
  optional `artifacts.json` manifest; absent that, filename convention applies
  (`*.summary.*` → summary, known logs → log, else heavy). The trial record
  (`result.json`) is **hard-guarded and never deleted** — a buggy manifest
  can't drop it — so the matrix/rate bookkeeping and probe resume survive at
  every level. `full` is a fast no-op; empty subdirs are pruned.
- **`_subprocess`**: applies retention after writing `result.json` (both the
  normal path and the env-file-rejection error path), mapping verdict → level.
  Best-effort: a retention error never sinks an already-classified trial.
- **runner**: forwards the policy into the probe payload as a plain
  verdict→level map (no type coupling).
- **docs + regression battery**: documents the block; the #56 invariant
  (`ProbeExtras.retain`) is now a permanent guard (xfail→guard promotion).
  Also promotes the #55-item-2 `failure_details[].type` guard: the underlying
  fix landed on `main` (#229 via #233), so after rebasing this branch onto
  `main` the stale `xfail(strict)` marker now XPASSes — deleted and promoted
  to assert the exact `detector_failure` type.

### Rebased onto `main`
Originally stacked on `feat/three-way-verdict-230` (#236) → `feat/stop-after-232`
(#235). Both have since squash-merged into `main`, so this branch was rebased
directly onto `main`: the two absorbed dep commits were dropped and the
retention (#231) + matrix-split (#241) work replayed on top.

## Test plan
- [x] `tests/run/test_retention.py` — engine: level ladder, record guard,
      convention + manifest classification, malformed-manifest tolerance,
      empty-dir prune, freed-bytes, no-op (25 tests)
- [x] `tests/probe/test_retention.py` — schema validation + end-to-end through
      `SubprocessWorkload`, incl. the disk acceptance criterion (10-trial cell,
      3 fails → 3 heavy artifacts kept, 10 records survive) (12 tests)
- [x] `tests/probe/test_recipe.py`, `tests/triage/test_recipe.py`,
      `tests/triage/test_stop_after.py`, `tests/run/test_dispatcher.py`,
      `tests/triage/test_runner_b1_api.py` — 278 passed
- [x] ruff clean on all changed files
- [x] `amd-smi`/`Popen` monkeypatch tests in `test_subprocess_workload.py`
      now pass — **56/56 green** on this rebased branch. The 3 failures the
      original plan flagged as "known-unrelated, pre-exist on `main`" were
      fixed by the Tier-3 / detector-disable refactor (#229, merged via #234),
      which routed amd-smi/dmesg probing through the module-level
      `poll_amd_smi`/`scan_dmesg` the tests monkeypatch; the rebase picks that up.

Made with [Cursor](https://cursor.com)