### PR TITLE
Guard cleanup() against partially-initialized workload instance

### DIFF
--- a/src/aorta/workloads/llm_determinism.py
+++ b/src/aorta/workloads/llm_determinism.py
@@ -290,7 +290,13 @@ class LlmDeterminismWorkload(Workload):
         )
 
     def cleanup(self) -> None:
-        self._hooks.remove()
+        # setup() assigns _hooks partway through; if it raised before reaching
+        # that line (e.g. port conflict in dist.init_process_group), _hooks is
+        # never set. cleanup() runs unconditionally in the dispatcher's finally
+        # block, so guard against a partially-initialized instance.
+        hooks = getattr(self, "_hooks", None)
+        if hooks is not None:
+            hooks.remove()
         if dist.is_initialized():
             dist.barrier()
         # Process group teardown left to the launcher.


### PR DESCRIPTION
## Summary

- `LlmDeterminismWorkload.cleanup()` crashed with `AttributeError` when `setup()` raised before assigning `self._hooks` (e.g. port conflict in `dist.init_process_group`)
- The dispatcher's `finally` block calls `cleanup()` unconditionally, so it must tolerate a half-initialized instance
- Replace bare `self._hooks.remove()` with a `getattr` guard — no-op if the attr was never set, normal removal otherwise

## Root cause (from triage)

Observed on MI300X: `MASTER_PORT=29500` was already in use (`EADDRINUSE`), causing `dist.init_process_group` to raise in `setup()` before `_hooks` was assigned. The cleanup crash was noise on top of the real failure, but it polluted the logs and looked like a second failure.

## Test plan

- [ ] Run `aorta triage run --recipe tests/recipes/example-llm-determinism-smoke.yaml` on a machine where the port is free — trial should complete without `did_not_run`
- [ ] Verify no `AttributeError` in cleanup logs when setup fails for any reason (kill the port, re-run, confirm clean log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)