### PR TITLE
probe: split matrix.md cell name into Mitigation/Diagnostic + Directory columns (#229)

### DIFF
--- a/.agents/skills/verify-run-output/reference.md
+++ b/.agents/skills/verify-run-output/reference.md
@@ -156,7 +156,13 @@ caution, not a fix.
 
 matrix.md ↔ matrix.json: `workload` and `ticket` should match; cell rows
 correspond to `cells`. matrix.md shows only `mean step (ms)`; per-cell
-percentiles, histograms, and trial paths live in matrix.json.
+percentiles, histograms, and trial paths live in matrix.json. In probe-mode
+matrix.md the row identity is the `Mitigation` + `Diagnostic` columns (the
+two recipe axes, i.e. `cells[*].mitigations = (mitigation, diagnostic)`)
+plus a trailing `Directory` column with the per-cell artifact path; the
+folder's final segment is still the `cells[*].name`
+(`<mitigation>-<diagnostic>`) join key (issue #229). Triage-mode matrix.md
+keeps the fused `Cell` + `Mitigations` columns.
 
 ---
 

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -137,6 +137,17 @@ optional `artifacts.json` manifest in the trial directory
 manifest, a file is classified by convention (`*.summary.*` is a summary,
 the known logs are `log`, anything else is `heavy`).
 
+**Reading `matrix.md` (probe runs).** The reproduction-summary table
+splits the cell's two recipe axes into their own columns -- `Mitigation`
+and `Diagnostic` -- instead of a fused `<mitigation>-<diagnostic>`
+identifier, and ends with a `Directory` column giving the per-cell
+artifact path relative to `matrix.md` (e.g. `tf32_off-none/`). The folder
+name on disk is still `<mitigation>-<diagnostic>` (it stays the stable
+join key for tooling and resume); only the table presentation changed, so
+an unused diagnostic axis reads as `Diagnostic = none` rather than a
+confusing trailing `-none` (issue #229). Triage-mode runs keep the
+original `Cell` / `Mitigations` columns.
+
 Phase 3 keys (`redaction`, top-level `condition`) are still **rejected
 at load time** with a "deferred to Phase 3" error message.
 

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -535,6 +535,23 @@ def _render_failure_hints(cell_stats: list[CellStats]) -> list[str]:
     return lines
 
 
+def _cell_directory(name: str, layout: str) -> str:
+    """Per-cell artifact directory, rendered relative to ``matrix.md``.
+
+    Probe runs (issue #188 ``flat_resume`` layout) put cell artifacts at
+    ``<run_dir>/<safe_slug(name)>/`` -- a sibling of ``matrix.md`` -- so the
+    relative path is just ``<slug>/``. Triage runs nest them under
+    ``cells/<slug>/``. The trailing slash marks the value as a directory.
+    The final segment is the recipe cell name (``<mitigation>-<diagnostic>``
+    in probe mode), so the on-disk folder stays the canonical join key while
+    the table itself reads the two axes from their own columns (#229).
+    """
+    slug = safe_slug(name)
+    if layout == "flat_resume":
+        return f"{slug}/"
+    return f"cells/{slug}/"
+
+
 def write_matrix_md(
     path: Path,
     recipe: Recipe,
@@ -543,8 +560,17 @@ def write_matrix_md(
     confound_tags: dict[str, tuple[ConfoundTag, float | None]],
     warnings: list[str],
     run_timestamp: str,
+    layout: str = "timestamped",
 ) -> None:
-    """Render matrix.md in the format from issue #151 §"matrix.md target format"."""
+    """Render matrix.md in the format from issue #151 §"matrix.md target format".
+
+    In probe mode (``recipe.probe_extras is not None``) the identity columns
+    are the two recipe axes -- ``Mitigation`` and ``Diagnostic`` -- plus a
+    trailing ``Directory`` column with the per-cell artifact path, instead of
+    the triage-mode fused ``Cell`` / ``Mitigations`` columns. This keeps the
+    on-disk ``<mitigation>-<diagnostic>`` folder name (the agent's join key)
+    while removing the ambiguous fused name from the rendered table (#229).
+    """
     lines: list[str] = []
     lines.append(f"# Triage Matrix - {recipe.workload}")
     lines.append("")
@@ -609,11 +635,19 @@ def write_matrix_md(
     # byte-equivalent. It surfaces error trials excluded from the failure
     # rate and flags cells whose error rate makes the rate untrustworthy.
     show_errors = any(c.error_count for c in cell_stats)
-    header_cells: list[str] = [
-        "Cell",
-        "Mitigations",
-        "Environment",
-    ]
+    # Issue #229: probe-mode runs synthesise cells as the cartesian product
+    # of ``mitigation_axis x diagnostic_axis`` and store both axes on
+    # ``cell.mitigations = (mitigation, diagnostic)``. Splitting them into
+    # their own columns (named after the recipe axes) -- plus a trailing
+    # ``Directory`` column -- removes the ambiguous fused ``<mit>-<diag>``
+    # identifier (a bare trailing ``-none`` when the diagnostic axis is
+    # unused) from the table without renaming the on-disk folder.
+    is_probe = recipe.probe_extras is not None
+    header_cells: list[str] = (
+        ["Mitigation", "Diagnostic", "Environment"]
+        if is_probe
+        else ["Cell", "Mitigations", "Environment"]
+    )
     if show_config:
         header_cells.append("Config")
     header_cells.extend(["Failure rate", "Failures"])
@@ -628,15 +662,22 @@ def write_matrix_md(
     if show_iters:
         header_cells.append("Iters")
     header_cells.extend(["Mean step (ms)", "Confound"])
+    if is_probe:
+        header_cells.append("Directory")
     header = tuple(header_cells)
     rows: list[tuple[str, ...]] = [header]
     for cell in cell_stats:
         tag, _ = confound_tags.get(cell.name, (cell.error and "error" or "-", None))
-        row: list[str] = [
-            cell.name,
-            _format_mitigations(cell.mitigations),
-            cell.environment,
-        ]
+        if is_probe:
+            mitigation = cell.mitigations[0] if cell.mitigations else "—"
+            diagnostic = cell.mitigations[1] if len(cell.mitigations) > 1 else "—"
+            row: list[str] = [mitigation, diagnostic, cell.environment]
+        else:
+            row = [
+                cell.name,
+                _format_mitigations(cell.mitigations),
+                cell.environment,
+            ]
         if show_config:
             row.append(_format_workload_config(cell, varying_config_keys))
         row.extend([_format_failure_rate(cell), _format_failures(cell)])
@@ -651,6 +692,8 @@ def write_matrix_md(
         if show_iters:
             row.append(cell.iters_display)
         row.extend([_format_step_ms(cell), _format_confound(tag)])
+        if is_probe:
+            row.append(_cell_directory(cell.name, layout))
         rows.append(tuple(row))
     widths = [max(len(r[i]) for r in rows) for i in range(len(header))]
 
@@ -666,10 +709,21 @@ def write_matrix_md(
     lines.extend(_render_failure_hints(cell_stats))
     lines.append("## Notes")
     lines.append("")
-    lines.append(
-        "- Cell name comes from the recipe; mitigations + environment columns "
-        "disambiguate when names get terse."
-    )
+    if is_probe:
+        lines.append(
+            "- `Mitigation` / `Diagnostic` come from the recipe's "
+            "`mitigation_axis` / `diagnostic_axis`; each cell is one "
+            "`(mitigation, diagnostic)` pair. `Directory` is the cell's "
+            "artifact directory (logs + per-trial `result.json`), relative to "
+            "this file; its final segment is the `<mitigation>-<diagnostic>` "
+            "cell name (#229). `none` in either axis means that axis was not "
+            "varied for the cell."
+        )
+    else:
+        lines.append(
+            "- Cell name comes from the recipe; mitigations + environment columns "
+            "disambiguate when names get terse."
+        )
     lines.append("- Confound column legend:")
     lines.append("  - `(baseline)` -- the cell against which all step-time ratios are computed.")
     lines.append("  - `-` -- the mitigation appears to work without a speed cost. Trust this cell.")

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -55,6 +55,12 @@ log = logging.getLogger(__name__)
 
 NO_TICKET_SLUG = "_no_ticket_"
 
+# The run-directory layouts ``resolve_run_dir`` / ``_cell_directory`` accept.
+# Kept as one source of truth so the two runtime guards can't drift (a value
+# accepted by one but silently mishandled by the other would render wrong
+# ``Directory`` links). Mirrors the ``Literal`` on the public signatures.
+_VALID_LAYOUTS = ("timestamped", "flat_resume")
+
 # ``flat_resume`` lockfile name. Lives at ``<run_dir>/.aorta-probe.lock``; the
 # leading dot keeps it out of casual ``ls`` output and matches the convention
 # used by other resume-state files in the run dir.
@@ -136,7 +142,7 @@ def resolve_run_dir(
     # would otherwise silently land in the timestamped branch. Reject
     # unknown values at runtime so probe-mode callers can't
     # accidentally get the wrong output tree.
-    if layout not in ("timestamped", "flat_resume"):
+    if layout not in _VALID_LAYOUTS:
         raise ValueError(
             f"resolve_run_dir: layout must be 'timestamped' or 'flat_resume', "
             f"got {layout!r}"
@@ -545,7 +551,16 @@ def _cell_directory(name: str, layout: str) -> str:
     The final segment is the recipe cell name (``<mitigation>-<diagnostic>``
     in probe mode), so the on-disk folder stays the canonical join key while
     the table itself reads the two axes from their own columns (#229).
+
+    ``layout`` is validated against the same set as :func:`resolve_run_dir`
+    so a typo (e.g. ``"flatresume"``) raises instead of silently rendering a
+    triage-style ``cells/<slug>/`` link for a probe run.
     """
+    if layout not in _VALID_LAYOUTS:
+        raise ValueError(
+            f"_cell_directory: layout must be 'timestamped' or 'flat_resume', "
+            f"got {layout!r}"
+        )
     slug = safe_slug(name)
     if layout == "flat_resume":
         return f"{slug}/"

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -541,7 +541,7 @@ def _render_failure_hints(cell_stats: list[CellStats]) -> list[str]:
     return lines
 
 
-def _cell_directory(name: str, layout: str) -> str:
+def _cell_directory(name: str, layout: Literal["timestamped", "flat_resume"]) -> str:
     """Per-cell artifact directory, rendered relative to ``matrix.md``.
 
     Probe runs (issue #188 ``flat_resume`` layout) put cell artifacts at
@@ -575,7 +575,7 @@ def write_matrix_md(
     confound_tags: dict[str, tuple[ConfoundTag, float | None]],
     warnings: list[str],
     run_timestamp: str,
-    layout: str = "timestamped",
+    layout: Literal["timestamped", "flat_resume"] = "timestamped",
 ) -> None:
     """Render matrix.md in the format from issue #151 §"matrix.md target format".
 
@@ -684,6 +684,18 @@ def write_matrix_md(
     for cell in cell_stats:
         tag, _ = confound_tags.get(cell.name, (cell.error and "error" or "-", None))
         if is_probe:
+            # probe.recipe_builder guarantees a (mitigation, diagnostic) pair;
+            # if that invariant is ever violated, warn so it isn't hidden, but
+            # still render "—" rather than abort the whole matrix at the end of
+            # a (potentially long) run -- output paths stay tolerant here, like
+            # the resume/manifest guards (#237).
+            if len(cell.mitigations) != 2:
+                log.warning(
+                    "probe cell %r has %d mitigation axis value(s), expected the "
+                    "(mitigation, diagnostic) pair; rendering missing axes as '—'",
+                    cell.name,
+                    len(cell.mitigations),
+                )
             mitigation = cell.mitigations[0] if cell.mitigations else "—"
             diagnostic = cell.mitigations[1] if len(cell.mitigations) > 1 else "—"
             row: list[str] = [mitigation, diagnostic, cell.environment]

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -1355,6 +1355,7 @@ def _run_recipe_locked(
         confound_tags=confound_tags,
         warnings=warnings,
         run_timestamp=ts,
+        layout=layout,
     )
     write_matrix_json(
         run_dir / "matrix.json",

--- a/tests/probe/test_recurring_issue_regression.py
+++ b/tests/probe/test_recurring_issue_regression.py
@@ -8,9 +8,11 @@ behind the cluster of ``aorta probe`` bugs filed against this platform:
 * ``aorta`` #223 / #224 / aorta-internal #53 -- false-positive
   ``tier2:hang`` on a wrapper-delegated (docker/sudo) command that exits 0.
 * ``aorta`` #222 -- orphaned child process tree on interrupt/timeout.
-* aorta-internal #55 -- re-verification of #53 *plus* two still-open
-  defects: a ``failure_details[].type`` that contradicts ``exit_code``,
-  and an ambiguous ``<mitigation>-<diagnostic>`` cell name (``none-none``).
+* aorta-internal #55 -- re-verification of #53 *plus* a still-open
+  ``failure_details[].type`` that contradicts ``exit_code``. The fused
+  ``<mitigation>-<diagnostic>`` cell-name ambiguity (item 3) is fixed:
+  matrix.md now renders the two axes as separate columns plus a
+  ``Directory`` path, keeping the folder name as the agent's join key.
 * aorta-internal #58 -- the matrix has no ``error`` verdict, so an infra
   crash is silently miscounted as ``pass``/``fail``.
 * aorta-internal #56 / #57 -- verdict-keyed artifact retention and the
@@ -215,22 +217,107 @@ def test_failure_detail_type_consistent_with_zero_exit(tmp_path):
 
 
 # ==========================================================================
-# GROUP C -- cell-name disambiguation (#55 item 3)
-# OPEN on this branch: cell names are "<mit>-<diag>", rendering a confusing
-# bare trailing "-none" when the diagnostic axis is unused, with no way to
-# tell which token is the mitigation and which is the diagnostic.
+# GROUP C -- cell-name disambiguation (#55 item 3) [FIXED]
+# Probe runs still write cell artifacts to a "<mit>-<diag>" folder (the
+# agent's stable join key), but matrix.md no longer surfaces that fused name
+# as an identifier: it renders the two recipe axes as separate "Mitigation"
+# and "Diagnostic" columns plus a "Directory" column carrying the path. The
+# bare trailing "-none" stutter is gone from the table. These must stay green.
 # ==========================================================================
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="aorta-internal #55 item 3: an unused diagnostic axis renders an "
-    "ambiguous trailing '-none' (e.g. 'tf32_off-none'). Remove this marker "
-    "when cell names disambiguate mitigation vs diagnostic.",
-)
-def test_unused_diagnostic_axis_does_not_render_ambiguous_cell_name(tmp_path):
-    """With ``diagnostic_axis: [none]`` the cell name must not be a bare
-    ``<mitigation>-none`` that reads as a stutter and hides the axis roles."""
+def _probe_matrix_md(tmp_path, *, mitigation_axis, diagnostic_axis) -> str:
+    """Load a probe recipe and render its matrix.md, returning the text.
+
+    Builds one minimal :class:`CellStats` per synthesised cell so the test
+    exercises the real :func:`write_matrix_md` probe-mode column layout
+    (``flat_resume``, matching ``aorta probe``).
+    """
+    from aorta.triage.matrix import CellStats
+    from aorta.triage.output import write_matrix_md
+    from aorta.triage.recipe import load_recipe
+
+    body = (
+        "schema_version: 1\n"
+        "mode: probe\n"
+        "trials: 1\n"
+        f"mitigation_axis: [{', '.join(mitigation_axis)}]\n"
+        f"diagnostic_axis: [{', '.join(diagnostic_axis)}]\n"
+    )
+    p = tmp_path / "r.yaml"
+    p.write_text(body, encoding="utf-8")
+    recipe = load_recipe(p)
+
+    stats = [
+        CellStats(
+            name=c.name,
+            mitigations=c.mitigations,
+            environment=c.environment,
+            extra_env={},
+            resolved_env_vars={},
+            trials=1,
+            passed_count=1,
+            failed_count=0,
+            mean_step_time_ms=10.0,
+            std_step_time_ms=0.0,
+            min_step_time_ms=10.0,
+            max_step_time_ms=10.0,
+            p50_step_time_ms=10.0,
+            p90_step_time_ms=10.0,
+            p99_step_time_ms=10.0,
+            mean_wall_clock_sec=1.0,
+            step_time_source="per_step",
+        )
+        for c in recipe.cells
+    ]
+    out = tmp_path / "matrix.md"
+    write_matrix_md(
+        out,
+        recipe,
+        stats,
+        baseline=stats[0],
+        confound_tags={s.name: ("(baseline)", None) for s in stats},
+        warnings=[],
+        run_timestamp="2026-01-01T00:00:00Z",
+        layout="flat_resume",
+    )
+    return out.read_text(encoding="utf-8")
+
+
+def test_unused_diagnostic_axis_renders_split_axis_columns(tmp_path):
+    """With ``diagnostic_axis: [none]`` matrix.md must show the mitigation and
+    diagnostic as separate columns (not a fused ``<mit>-none`` identifier),
+    with the folder path in its own ``Directory`` column (#55 item 3)."""
+    text = _probe_matrix_md(
+        tmp_path, mitigation_axis=["none", "tf32_off"], diagnostic_axis=["none"]
+    )
+    header = next(line for line in text.splitlines() if line.lstrip().startswith("| Mitigation"))
+    # The axes get their own columns; the fused triage-mode "Cell" column is gone.
+    assert "| Mitigation " in header
+    assert "| Diagnostic " in header
+    assert "| Directory " in header
+    assert "| Cell " not in header
+    # The mitigation value stands alone in its column -- never a "tf32_off-none"
+    # stutter presented as the row identifier.
+    assert "tf32_off-none" not in header
+    body_rows = [
+        line
+        for line in text.splitlines()
+        if line.startswith("|") and "tf32_off" in line and "Mitigation" not in line
+    ]
+    assert body_rows, "expected a row for the tf32_off cell"
+    row = body_rows[0]
+    cols = [c.strip() for c in row.strip().strip("|").split("|")]
+    assert cols[0] == "tf32_off", f"Mitigation column should be the bare axis value: {row!r}"
+    assert cols[1] == "none", f"Diagnostic column should be the bare axis value: {row!r}"
+    # The fused name survives only as the artifact directory path (last column).
+    assert cols[-1] == "tf32_off-none/", f"Directory column should carry the folder: {row!r}"
+
+
+def test_legacy_cell_name_still_exists_as_folder_join_key(tmp_path):
+    """The fix is presentational: the on-disk folder name stays
+    ``<mitigation>-<diagnostic>`` so the agent's baseline-parse join key is
+    untouched -- only the matrix.md *table* stopped surfacing it as an ID."""
     from aorta.triage.recipe import load_recipe
 
     recipe_text = (
@@ -243,14 +330,14 @@ def test_unused_diagnostic_axis_does_not_render_ambiguous_cell_name(tmp_path):
     p = tmp_path / "r.yaml"
     p.write_text(recipe_text, encoding="utf-8")
     r = load_recipe(p)
-    names = sorted(c.name for c in r.cells)
-    # The mitigation-only cell should read as a clean baseline, and the
-    # tf32_off cell should not carry a meaningless '-none' suffix.
-    for name in names:
-        assert not name.endswith("-none"), (
-            f"cell name {name!r} carries an ambiguous trailing '-none' when the "
-            "diagnostic axis is unused"
-        )
+    by_name = {c.name: c for c in r.cells}
+    # The folder/join key is deliberately the fused "<mit>-<diag>" string --
+    # the agent's baseline-parse logic depends on it. The disambiguation moved
+    # to matrix.md's columns (see test above), NOT to the on-disk name.
+    assert set(by_name) == {"none-none", "tf32_off-none"}
+    # And each cell still carries both axes as a (mitigation, diagnostic) pair
+    # so the renderer can split them into their own columns.
+    assert by_name["tf32_off-none"].mitigations == ("tf32_off", "none")
 
 
 # ==========================================================================

--- a/tests/probe/test_recurring_issue_regression.py
+++ b/tests/probe/test_recurring_issue_regression.py
@@ -237,12 +237,15 @@ def _probe_matrix_md(tmp_path, *, mitigation_axis, diagnostic_axis) -> str:
     from aorta.triage.output import write_matrix_md
     from aorta.triage.recipe import load_recipe
 
+    # Emit axis values as a double-quoted YAML flow sequence (json.dumps gives
+    # exactly that) so YAML 1.1 boolean coercion of tokens like ``on``/``off``/
+    # ``yes``/``no`` can't silently rewrite an axis name into ``True``/``False``.
     body = (
         "schema_version: 1\n"
         "mode: probe\n"
         "trials: 1\n"
-        f"mitigation_axis: [{', '.join(mitigation_axis)}]\n"
-        f"diagnostic_axis: [{', '.join(diagnostic_axis)}]\n"
+        f"mitigation_axis: {json.dumps(list(mitigation_axis))}\n"
+        f"diagnostic_axis: {json.dumps(list(diagnostic_axis))}\n"
     )
     p = tmp_path / "r.yaml"
     p.write_text(body, encoding="utf-8")

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -214,6 +214,23 @@ def test_resolve_run_dir_rejects_unknown_layout(tmp_path):
         resolve_run_dir(tmp_path, r, layout="")  # type: ignore[arg-type]
 
 
+def test_cell_directory_rejects_unknown_layout():
+    """Regression for PR #241 review: ``_cell_directory`` shares the
+    ``layout`` contract with ``resolve_run_dir`` but used to treat it as a
+    free-form str, so a typo (``"flatresume"``) silently rendered a
+    triage-style ``cells/<slug>/`` link for a probe run. It must reject
+    unknown values too.
+    """
+    from aorta.triage.output import _cell_directory
+
+    assert _cell_directory("a-b", "flat_resume") == "a-b/"
+    assert _cell_directory("a-b", "timestamped") == "cells/a-b/"
+    with pytest.raises(ValueError, match="layout must be"):
+        _cell_directory("a-b", "flatresume")
+    with pytest.raises(ValueError, match="layout must be"):
+        _cell_directory("a-b", "")
+
+
 def test_default_layout_is_byte_equivalent_to_timestamped(tmp_path):
     """Existing callers see no behaviour change -- the default is 'timestamped'."""
     r = _simple_recipe(ticket="PROJ-1")


### PR DESCRIPTION
## Summary

Resolves the long-deferred **cell-naming ambiguity** (public #229 / aorta-internal #55 item 3) at the *presentation* layer, with no folder rename and no agent-parser churn.

Probe runs synthesise cells as the cartesian product of `mitigation_axis x diagnostic_axis` and store both axes on `cell.mitigations = (mitigation, diagnostic)`. Until now `matrix.md` fused them into a single `<mitigation>-<diagnostic>` **Cell** column, which:
- read as a confusing bare trailing `-none` when the diagnostic axis was unused (e.g. `tf32_off-none`), and
- gave no way to tell which token was the mitigation and which was the diagnostic.

This PR changes the probe-mode reproduction-summary table to:
- replace the fused `Cell` / `Mitigations` columns with **`Mitigation`** and **`Diagnostic`** columns (named after the recipe axes), and
- append a trailing **`Directory`** column with the per-cell artifact path relative to `matrix.md` (e.g. `tf32_off-none/`).

### Why this sidesteps the original blocker

The original fix was deferred because renaming cells would break the agent's baseline-parse / resume logic, which splits the on-disk `<mitigation>-<diagnostic>` folder name as a join key. **This change keeps that folder name exactly as-is** — it only changes how the table renders. The fused name now appears solely as the `Directory` path (its own column), not as an identifier readers have to mentally split. Triage-mode `matrix.md` is untouched (no diagnostic axis there).

Example probe output:

```
| Mitigation | Diagnostic | Environment | Failure rate | Failures | Mean step (ms) | Confound   | Directory      |
|------------|------------|-------------|--------------|----------|----------------|------------|----------------|
| none       | none       | local       | 33%          | 1 / 3    | 12.3           | (baseline) | none-none/     |
| tf32_off   | none       | local       | 33%          | 1 / 3    | 12.3           | -          | tf32_off-none/ |
```

## Changes

- `src/aorta/triage/output.py` — `write_matrix_md` gains a `layout` arg and a probe-mode branch (Mitigation/Diagnostic identity columns + trailing Directory column), plus a mode-aware Notes legend bullet and a `_cell_directory` helper.
- `src/aorta/triage/runner.py` — pass `layout` through to `write_matrix_md`.
- `tests/probe/test_recurring_issue_regression.py` — promote the #55-item-3 `xfail` to a passing guard asserting the split-column contract; add a guard that the folder/join key stays `<mitigation>-<diagnostic>`.
- `docs/probe-188/usage.md`, `.agents/skills/verify-run-output/reference.md` — document the probe matrix.md columns.

## Test plan

- [x] `tests/probe/test_recurring_issue_regression.py` (12 passed, 1 xfailed — the still-open item-2)
- [x] `tests/triage` + `tests/probe/test_end_to_end.py` + `tests/agent` (164 passed)
- [x] `tests/triage` + shared-engine + recipe + dispatcher (403 passed)
- [x] No code parses `matrix.md` text — the agent reads `matrix.json` / `result.json`, so this is presentation-only.

Stacked on #237 (retention) → base `feat/retention-231`.

Made with [Cursor](https://cursor.com)