### PR TITLE
Merge `aorta triage` + `aorta probe` into unified `aorta sweep` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ AORTA generates comprehensive performance reports comparing ROCm versions across
 | [Configuration](docs/configuration.md) | FSDP tuning, RCCL variables, profiler settings |
 | [Profiling](docs/profiling.md) | Torch profiler, rocprofv3, overlap reports |
 | [Environment Probe](docs/env-probe.md) | Capture / diff / query a versioned environment snapshot; jq cookbook |
-| [`aorta probe`](docs/probe-188/usage.md) | Wrap-and-collect opaque launch commands; matrix + classifier |
+| [`aorta sweep`](docs/probe-188/usage.md) | Unified matrix runner — built-in workloads **or** opaque launch commands (replaces `aorta triage` / `aorta probe`) |
 | [`aorta agent`](docs/agent/agentic-testing-guide.md) | Closed-loop mitigation search (optional LLM proposer) |
 | [`aorta bundle`](docs/probe-188/bundle.md) | Package probe artifacts with recipe-driven redaction |
-| [Buck2](docs/buck2.md) | Build / run the AORTA CLI via Buck2; hermetic Python, `env probe` + `triage` walkthroughs |
+| [Buck2](docs/buck2.md) | Build / run the AORTA CLI via Buck2; hermetic Python, `env probe` + `sweep` walkthroughs |
 | [Releasing](docs/releasing.md) | Cut a customer-installable release; maintainer + customer install flow |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues |
 

--- a/docs/buck2.md
+++ b/docs/buck2.md
@@ -158,10 +158,14 @@ environment isn't an error condition, it's just one of the two
 documented shapes; see
 [`src/aorta/instrumentation/build_system.py`]).
 
-## `aorta triage` under Buck2
+## `aorta sweep` under Buck2
 
-`aorta triage` runs a mitigation x environment matrix. Three discovery
-subcommands are read-only and demo-friendly; `triage run` actually
+> **Renamed (issue #248):** `aorta triage` is now `aorta sweep`. The
+> commands below use `sweep`; `triage` still works as a deprecated alias.
+
+`aorta sweep` runs a mitigation x environment matrix (built-in workload
+flow) or wraps an opaque user command (subprocess flow). Three discovery
+subcommands are read-only and demo-friendly; `sweep run` actually
 executes cells.
 
 Built-in mitigations are defined in `src/aorta/registry/mitigations.py`
@@ -172,20 +176,20 @@ the command on your machine prints the full set.
 
 ```bash
 # Inspect the registries (built-ins + any installed plugins)
-buck2 run aorta -- triage list-mitigations
+buck2 run aorta -- sweep list-mitigations
 # NAME      SOURCE  ENV
 # none      aorta   (none)
 # tf32_off  aorta   DISABLE_TF32=1
 # xnack     aorta   HSA_XNACK=1
 # ... (~19 more ROCm / HIP / RCCL / PyTorch / SDPA entries; truncated)
 
-buck2 run aorta -- triage list-environments
+buck2 run aorta -- sweep list-environments
 # NAME     SOURCE  DOCKER  VENV
 # default  aorta   -       -
 # local    aorta   -       -
 
 # Validate a recipe without executing it
-buck2 run aorta -- triage run --recipe recipes/example-fsdp-smoke.yaml --dry-run
+buck2 run aorta -- sweep run --recipe recipes/example-fsdp-smoke.yaml --dry-run
 # Dry run: fsdp / ticket=EXAMPLE-151
 # Cells (3):
 #   - baseline-local: mitigations=['none'] environment=local trials=2 steps=100
@@ -201,11 +205,11 @@ register via a separate package's entry-points; see
 below).
 The example recipe targets `workload: fsdp`, so each cell will error
 with `Workload 'fsdp' not found. Available: []`. That's intentional --
-the recipe's own header documents it -- and `aorta triage` is built to
+the recipe's own header documents it -- and `aorta sweep` is built to
 keep going:
 
 ```bash
-buck2 run aorta -- triage run --recipe recipes/example-fsdp-smoke.yaml -v
+buck2 run aorta -- sweep run --recipe recipes/example-fsdp-smoke.yaml -v
 ```
 
 What you get back (under `triage_results/EXAMPLE-151/fsdp/<timestamp>/`):
@@ -241,9 +245,9 @@ matrix you can inspect with `jq '.cells[].confound' triage_results/.../matrix.js
 For ad-hoc experiments without installing a plugin:
 
 ```bash
-buck2 run aorta -- triage list-mitigations \
+buck2 run aorta -- sweep list-mitigations \
     --mitigations-file examples/mitigations-sidecar.json
-buck2 run aorta -- triage list-environments \
+buck2 run aorta -- sweep list-environments \
     --mitigations-file examples/mitigations-sidecar.json
 ```
 
@@ -287,8 +291,8 @@ prebuilt_python_library(
 ```
 
 Then add `"//third-party/python:my_plugin"` to your fork of `:aorta`'s
-`deps`. After rebuild, `buck2 run aorta -- triage list-mitigations` and
-`buck2 run aorta -- triage run --workload my_workload ...` see the
+`deps`. After rebuild, `buck2 run aorta -- sweep list-mitigations` and
+`buck2 run aorta -- sweep run --workload my_workload ...` see the
 plugin.
 
 `discover_workloads()` catches any import-time exception per

--- a/docs/probe-188/handout-templates.md
+++ b/docs/probe-188/handout-templates.md
@@ -19,18 +19,20 @@ All three templates use a 2×2 mitigation × diagnostic matrix (`none` /
 ## Workflow
 
 1. Copy or symlink the template; set `ticket:` to the customer's ticket id.
-2. Run probe (customer prepends `aorta probe`, keeps their argv after `--`):
+2. Run the sweep (customer prepends `aorta sweep run`, keeps their argv after `--`):
 
    ```bash
-   aorta probe --recipe recipes/probe-template-bash.yaml \
+   aorta sweep run --recipe recipes/probe-template-bash.yaml \
        --output ./probe-out --ticket TICKET-1234 -- \
        bash launch.sh
    ```
 
+   (`aorta probe` still works as a deprecated alias.)
+
 3. Dry-run first when validating the recipe on your side:
 
    ```bash
-   aorta probe --recipe recipes/probe-template-bash.yaml --dry-run -- echo hi
+   aorta sweep run --recipe recipes/probe-template-bash.yaml --dry-run -- echo hi
    ```
 
 4. After the matrix completes, bundle the ticket leaf:

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -1,5 +1,22 @@
 # `aorta probe` — Usage Walkthrough (issue #188, Phases 1–3)
 
+> **⚠️ Renamed (issue #248):** `aorta probe` and `aorta triage` are now the
+> single unified command **`aorta sweep`**. The subprocess flow described
+> here is `aorta sweep run ... -- <command>`; the built-in-workload flow is
+> `aorta sweep run` with a `mode: triage` recipe or the `--workload` flag
+> shim. `aorta probe` / `aorta triage` still work as deprecated aliases
+> (they print a one-line notice and delegate to the same engine) but will be
+> removed in a future release. Everywhere this guide says `aorta probe`,
+> read `aorta sweep run`.
+>
+> | Old | New |
+> | --- | --- |
+> | `aorta probe --recipe r.yaml -- <cmd>` | `aorta sweep run --recipe r.yaml -- <cmd>` |
+> | `aorta probe --list-patterns` | `aorta sweep list-patterns` |
+> | `aorta triage run --recipe r.yaml` | `aorta sweep run --recipe r.yaml` |
+> | `aorta triage list-mitigations` | `aorta sweep list-mitigations` |
+> | `aorta triage list-environments` | `aorta sweep list-environments` |
+
 > **Phase 1 (Tier 1 only)**: verdict is `exit_code == 0 ? "pass" : "fail"`.
 > **Phase 2**: five-tier classifier + `custom_patterns` + `--list-patterns`.
 > **Phase 3 (this section)**: `redaction:` recipe block, `aorta bundle`,
@@ -18,7 +35,7 @@ trials and records the exit code.
 ## 1. Quick start
 
 ```bash
-aorta probe \
+aorta sweep run \
     --recipe my_probe.yaml \
     --output ./probe_results \
     --ticket ROCM-1234 \

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -1,4 +1,4 @@
-# `aorta probe` — Usage Walkthrough (issue #188, Phases 1–3)
+# `aorta sweep` (subprocess flow) — Usage Walkthrough (issue #188, Phases 1–3; formerly `aorta probe`)
 
 > **⚠️ Renamed (issue #248):** `aorta probe` and `aorta triage` are now the
 > single unified command **`aorta sweep`**. The subprocess flow described

--- a/docs/probe-188/usage.md
+++ b/docs/probe-188/usage.md
@@ -342,19 +342,21 @@ Full ordering rules + per-tier detector IDs:
 [classifier.md](classifier.md). `condition:` expression whitelist:
 [sandbox.md](sandbox.md).
 
-## 7. `--list-patterns` (Phase 2 deviation)
+## 7. `list-patterns`
 
-The rubric's `aorta probe list-patterns` subcommand is implemented as
-a **flag** on the existing `aorta probe` command:
+The Tier-4 pattern catalogue is printed by the `aorta sweep list-patterns`
+subcommand:
 
 ```bash
-aorta probe --list-patterns          # full Tier 4 catalogue (one entry per pattern)
-aorta probe --list-patterns --version  # 'aorta probe pattern library v1 (aorta <pkg>)'
+aorta sweep list-patterns            # full Tier 4 catalogue (one entry per pattern)
+aorta sweep list-patterns --version  # 'aorta sweep pattern library v1 (aorta <pkg>)'
 ```
 
-This deviation preserves the Phase-1 CLI surface byte-equivalently —
-`aorta probe -- <argv>` still works without a subcommand prefix. The
-flag short-circuits before recipe loading.
+The deprecated `aorta probe --list-patterns` flag still works for the
+transition period — it short-circuits before recipe loading, prints the
+same catalogue to stdout, and warns on stderr to use
+`aorta sweep list-patterns`. It was the Phase-1 surface, implemented as a
+flag on `aorta probe` rather than the rubric's subcommand.
 
 ## 8. Shared engine guarantee
 

--- a/recipes/README-running-recipes.md
+++ b/recipes/README-running-recipes.md
@@ -41,7 +41,7 @@ env:
 ```bash
 torchrun --nnodes=<N> --nproc-per-node=<GPUS_PER_NODE> \
   --rdzv-backend=c10d --rdzv-endpoint=<HEAD_HOST>:<PORT> \
-  $(command -v aorta) triage run --recipe <recipe>
+  $(command -v aorta) sweep run --recipe <recipe>
 ```
 
 Launch contract (read once):

--- a/recipes/README-running-recipes.md
+++ b/recipes/README-running-recipes.md
@@ -29,7 +29,7 @@ python -m pytest tests/ -q
 ## 3. Validate a recipe without running it
 
 ```bash
-aorta triage run --recipe <recipe> --dry-run
+aorta sweep run --recipe <recipe> --dry-run
 ```
 
 ## 4. Run on the cluster
@@ -49,7 +49,7 @@ Launch contract (read once):
 - Distributed workloads call `dist.init_process_group(backend="nccl")` with no
   args, reading the standard env: `RANK`, `WORLD_SIZE`, `MASTER_ADDR`,
   `MASTER_PORT`, `LOCAL_RANK` (used to bind the GPU). Any launcher that sets
-  these works (torchrun shown; under Slurm drive the same `aorta triage run`
+  these works (torchrun shown; under Slurm drive the same `aorta sweep run`
   line via `srun` / `torchrun`).
 - Run the **same** command on every rank. Only rank 0 writes result artifacts;
   other ranks participate in the collectives.

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -187,16 +187,16 @@ torchrun's target -- `-m aorta` is not a runnable module:
 aorta sweep run --recipe recipes/example-fsdp-smoke.yaml --dry-run
 
 # single node, 2 ranks (bump --nproc_per_node to your GPU count):
-torchrun --standalone --nproc_per_node=2 $(which aorta) triage run \
+torchrun --standalone --nproc_per_node=2 $(which aorta) sweep run \
   --recipe recipes/example-fsdp-smoke.yaml
 
 # multi-node (1 rank/host x N hosts -- the AINIC topology):
 torchrun --nnodes=N --nproc_per_node=1 --rdzv-backend=c10d \
-  --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) triage run \
+  --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) sweep run \
   --recipe recipes/example-fsdp-smoke.yaml
 ```
 
-Each rank runs the full `triage run`; the ranks find each other in
+Each rank runs the full `sweep run`; the ranks find each other in
 `dist.init_process_group()`. Cells run in-process per rank (sequentially),
 and results are written by **rank 0 only** (the dispatcher gates writes on
 `RANK`), so multi-rank launches don't clobber each other. This is the same

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -6,8 +6,8 @@
 > subprocess (former `aorta probe`) flow. The old commands still work as
 > deprecated aliases that print a notice and delegate to the same engine.
 
-A triage **recipe** is the authoritative description of a `aorta sweep run
---mode matrix` invocation: which `(mitigation x environment)` cells to run,
+A triage **recipe** is the authoritative description of an `aorta sweep run --mode matrix`
+invocation: which `(mitigation x environment)` cells to run,
 per-cell trial / step counts, the ticket the matrix belongs to, and the
 speed-confound detection config.
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,6 +1,12 @@
 # Triage recipes
 
-A triage **recipe** is the authoritative description of a `aorta triage run
+> **Renamed (issue #248):** `aorta triage` and `aorta probe` are now the
+> single command **`aorta sweep`**. Use `aorta sweep run` everywhere this
+> guide says `aorta triage run`, and `aorta sweep run ... -- <cmd>` for the
+> subprocess (former `aorta probe`) flow. The old commands still work as
+> deprecated aliases that print a notice and delegate to the same engine.
+
+A triage **recipe** is the authoritative description of a `aorta sweep run
 --mode matrix` invocation: which `(mitigation x environment)` cells to run,
 per-cell trial / step counts, the ticket the matrix belongs to, and the
 speed-confound detection config.
@@ -172,13 +178,13 @@ workload_config:
 `same_stream_mode`, `stop_on_first_corruption`, `log_interval`).
 
 Because `race` is `launch_mode: distributed`, it MUST be launched under
-torchrun (a bare `aorta triage run` starts one process, WORLD_SIZE=1, and is
+torchrun (a bare `aorta sweep run` starts one process, WORLD_SIZE=1, and is
 refused by launch-mode validation). Use the `aorta` console script as
 torchrun's target -- `-m aorta` is not a runnable module:
 
 ```bash
 # validate only (no GPUs / no launcher):
-aorta triage run --recipe recipes/example-fsdp-smoke.yaml --dry-run
+aorta sweep run --recipe recipes/example-fsdp-smoke.yaml --dry-run
 
 # single node, 2 ranks (bump --nproc_per_node to your GPU count):
 torchrun --standalone --nproc_per_node=2 $(which aorta) triage run \
@@ -268,7 +274,7 @@ real paths; a future B1 follow-up can drop this level of nesting via a
 
 Every run writes `recipe.resolved.yaml` alongside the matrix. The file is
 **a strict, schema-valid recipe** -- you can pass it back to
-`aorta triage run --recipe ...` directly. Inline-docker cells are
+`aorta sweep run --recipe ...` directly. Inline-docker cells are
 re-emitted in the `{ docker: <ref> }` shorthand so the same
 `_inline_<hash>` is re-derived without needing to ship a sidecar JSON
 next to the file.
@@ -280,7 +286,7 @@ so the run directory is self-contained for replay. The runner also prints
 the exact rerun command on stdout when sidecars are involved, e.g.:
 
 ```
-cd <run_dir> && aorta triage run --recipe recipe.resolved.yaml \
+cd <run_dir> && aorta sweep run --recipe recipe.resolved.yaml \
   --mitigations-file sidecars/foo.json
 ```
 
@@ -304,7 +310,7 @@ audit data is still preserved next to the run.
 The equivalent of `recipes/example-fsdp-smoke.yaml` as flag-mode CLI:
 
 ```
-aorta triage run --mode matrix \
+aorta sweep run --mode matrix \
   --workload fsdp \
   --mitigation-axis none,tf32_off,xnack \
   --environment-axis local \
@@ -333,7 +339,7 @@ packaging artifacts for sharing.
 Dry-run smoke:
 
 ```
-aorta probe --recipe recipes/probe-template-bash.yaml --dry-run -- echo hi
+aorta sweep run --recipe recipes/probe-template-bash.yaml --dry-run -- echo hi
 ```
 
 See `docs/probe-188/handout-templates.md` for per-template walkthroughs.

--- a/recipes/ainic-gdr-flush-sdc.yaml
+++ b/recipes/ainic-gdr-flush-sdc.yaml
@@ -23,10 +23,10 @@
 # Usage
 # -----
 #   # Dry-run validation:
-#   aorta triage run --recipe recipes/ainic-gdr-flush-sdc.yaml --dry-run
+#   aorta sweep run --recipe recipes/ainic-gdr-flush-sdc.yaml --dry-run
 #
 #   # Full matrix (requires 10-12 MI355X nodes, all AINIC interconnect):
-#   aorta triage run --recipe recipes/ainic-gdr-flush-sdc.yaml
+#   aorta sweep run --recipe recipes/ainic-gdr-flush-sdc.yaml
 #
 # Required environment
 # --------------------

--- a/recipes/ainic-sdc-stress-reproducer.yaml
+++ b/recipes/ainic-sdc-stress-reproducer.yaml
@@ -60,10 +60,10 @@
 # Usage
 # -----
 #   # Dry-run validation (no GPU required):
-#   aorta triage run --recipe recipes/ainic-sdc-stress-reproducer.yaml --dry-run
+#   aorta sweep run --recipe recipes/ainic-sdc-stress-reproducer.yaml --dry-run
 #
 #   # Full matrix (10-40 MI355X nodes, all AINIC interconnect):
-#   aorta triage run --recipe recipes/ainic-sdc-stress-reproducer.yaml
+#   aorta sweep run --recipe recipes/ainic-sdc-stress-reproducer.yaml
 #
 # Required environment
 # --------------------

--- a/recipes/ainic-smoke.yaml
+++ b/recipes/ainic-smoke.yaml
@@ -15,7 +15,7 @@
 #   exit_status == ok, passed == true   (collectives + verify completed)
 #
 # Run (same command on every rank, one rank per GPU):
-#   aorta triage run --recipe recipes/ainic-smoke.yaml
+#   aorta sweep run --recipe recipes/ainic-smoke.yaml
 # Read:
 #   cat triage_results/AINIC-SMOKE/race/*/matrix.md
 #

--- a/recipes/example-fsdp-smoke.yaml
+++ b/recipes/example-fsdp-smoke.yaml
@@ -10,12 +10,12 @@
 #   aorta sweep run --recipe recipes/example-fsdp-smoke.yaml --dry-run
 #
 #   # single node, 2 ranks (CX-7 / RCCL smoke; bump to your GPU count):
-#   torchrun --standalone --nproc_per_node=2 $(which aorta) triage run \
+#   torchrun --standalone --nproc_per_node=2 $(which aorta) sweep run \
 #     --recipe recipes/example-fsdp-smoke.yaml
 #
 #   # multi-node (e.g. 1 rank/host x 40 hosts -- the AINIC topology):
 #   torchrun --nnodes=40 --nproc_per_node=1 --rdzv-backend=c10d \
-#     --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) triage run \
+#     --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) sweep run \
 #     --recipe recipes/example-fsdp-smoke.yaml
 #
 # Results are written by rank 0 only (dispatcher gates on RANK), so multi-rank

--- a/recipes/example-fsdp-smoke.yaml
+++ b/recipes/example-fsdp-smoke.yaml
@@ -1,13 +1,13 @@
 # Smoke-test recipe for the `race` workload (`mode: fsdp`).
 #
 # `race` is a DISTRIBUTED workload (min_world_size=2), so it MUST be launched
-# under torchrun -- a bare `aorta triage run` starts a single process
+# under torchrun -- a bare `aorta sweep run` starts a single process
 # (WORLD_SIZE=1) and is correctly refused by launch-mode validation. Use the
 # `aorta` console script as torchrun's target (`-m aorta` is NOT a runnable
 # module):
 #
 #   # validate only (no GPUs / no launcher needed):
-#   aorta triage run --recipe recipes/example-fsdp-smoke.yaml --dry-run
+#   aorta sweep run --recipe recipes/example-fsdp-smoke.yaml --dry-run
 #
 #   # single node, 2 ranks (CX-7 / RCCL smoke; bump to your GPU count):
 #   torchrun --standalone --nproc_per_node=2 $(which aorta) triage run \

--- a/recipes/example-probe-smoke.yaml
+++ b/recipes/example-probe-smoke.yaml
@@ -1,8 +1,8 @@
-# Smoke-test recipe for `aorta probe` (issue #188).
+# Smoke-test recipe for `aorta sweep run` probe flow (issue #188; #248).
 #
 # Opaque user launch command:
 #
-#   aorta probe \
+#   aorta sweep run \
 #       --recipe recipes/example-probe-smoke.yaml \
 #       --output ./probe_results \
 #       --ticket PROBE-188 \

--- a/recipes/probe-flag-sweep.yaml
+++ b/recipes/probe-flag-sweep.yaml
@@ -8,7 +8,7 @@
 # motivated registering the flag.
 #
 # Usage:
-#   aorta probe \
+#   aorta sweep run \
 #       --recipe recipes/probe-flag-sweep.yaml \
 #       --output ./probe_results \
 #       --ticket PROBE-FLAG-SWEEP \

--- a/recipes/probe-template-bash.yaml
+++ b/recipes/probe-template-bash.yaml
@@ -1,6 +1,6 @@
 # Generic probe handout template for bash / shell-script launches.
 # Usage:
-#   aorta probe --recipe recipes/probe-template-bash.yaml \
+#   aorta sweep run --recipe recipes/probe-template-bash.yaml \
 #       --output ./probe-out --ticket TICKET-1234 -- \
 #       bash launch.sh --extra-args
 schema_version: 1

--- a/recipes/probe-template-buck2.yaml
+++ b/recipes/probe-template-buck2.yaml
@@ -1,6 +1,6 @@
 # Generic probe handout template for buck2 run-style launches.
 # Usage:
-#   aorta probe --recipe recipes/probe-template-buck2.yaml \
+#   aorta sweep run --recipe recipes/probe-template-buck2.yaml \
 #       --output ./probe-out --ticket TICKET-1234 -- \
 #       buck2 run //path/to:target -- --flag value
 schema_version: 1

--- a/recipes/probe-template-torchrun.yaml
+++ b/recipes/probe-template-torchrun.yaml
@@ -1,6 +1,6 @@
 # Generic probe handout template for torchrun-style launches.
 # Usage:
-#   aorta probe --recipe recipes/probe-template-torchrun.yaml \
+#   aorta sweep run --recipe recipes/probe-template-torchrun.yaml \
 #       --output ./probe-out --ticket TICKET-1234 -- \
 #       torchrun --nproc_per_node=8 train.py --config configs/default.yaml
 schema_version: 1

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -2,7 +2,7 @@
 
 import click
 
-from aorta.cli import agent, bundle, env, environments, mitigations, probe, run, triage
+from aorta.cli import agent, bundle, env, environments, mitigations, probe, run, sweep, triage
 
 
 @click.group()
@@ -16,6 +16,8 @@ main.add_command(bundle.bundle)
 main.add_command(env.env)
 main.add_command(environments.environments)
 main.add_command(mitigations.mitigations)
+main.add_command(sweep.sweep)
+# Deprecated aliases (issue #248): kept working, delegate to the same engine.
 main.add_command(probe.probe)
 main.add_command(run.run)
 main.add_command(triage.triage)

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -17,7 +17,7 @@ main.add_command(env.env)
 main.add_command(environments.environments)
 main.add_command(mitigations.mitigations)
 main.add_command(sweep.sweep)
-# Deprecated aliases (issue #248): kept working, delegate to the same engine.
+# Deprecated aliases (issue #248): keep working, delegate to the same engine.
 main.add_command(probe.probe)
 main.add_command(run.run)
 main.add_command(triage.triage)

--- a/src/aorta/cli/_deprecation.py
+++ b/src/aorta/cli/_deprecation.py
@@ -1,0 +1,34 @@
+"""Shared deprecation-notice helper for legacy CLI command aliases.
+
+``aorta triage`` and ``aorta probe`` were merged into the single
+``aorta sweep`` front door (issue #248). The old commands keep working --
+they delegate to the very same ``execute_*`` functions ``aorta sweep``
+calls -- but each invocation prints a one-line notice naming the exact
+replacement so users migrate without guessing.
+
+The notice goes to **stderr** (``err=True``) so it never contaminates
+stdout / artifact-path output that scripts may parse. The wording is
+deliberately free of substrings that existing CLI tests assert on
+(e.g. "double-dash", "Missing option", "Invalid value", "looks like").
+"""
+
+from __future__ import annotations
+
+import click
+
+
+def emit_deprecation(old_command: str, new_command: str) -> None:
+    """Print a stderr deprecation notice mapping ``old`` -> ``new``.
+
+    Args:
+        old_command: The legacy invocation, e.g. ``"aorta triage run"``.
+        new_command: The supported replacement, e.g. ``"aorta sweep run"``.
+    """
+    click.echo(
+        f"warning: '{old_command}' is deprecated and will be removed in a "
+        f"future release; use '{new_command}' instead.",
+        err=True,
+    )
+
+
+__all__ = ["emit_deprecation"]

--- a/src/aorta/cli/agent.py
+++ b/src/aorta/cli/agent.py
@@ -61,10 +61,12 @@ def _echo_agent_result(result: object) -> None:
 def _retarget_probe_usage(message: str) -> str:
     """Rewrite shared probe-helper usage strings for the ``agent`` command.
 
-    ``require_double_dash_separator`` / ``validate_trailing_argv`` live in
-    ``aorta.probe.cli_helpers`` and hard-code ``Usage: aorta probe ...``.
-    Reused verbatim, ``aorta agent`` would print the wrong command name, so
-    we translate at the CLI boundary rather than forking the helpers.
+    ``require_double_dash_separator`` lives in ``aorta.probe.cli_helpers``
+    and hard-codes ``Usage: aorta probe ...``. Reused verbatim, ``aorta
+    agent`` would print the wrong command name, so we translate at the CLI
+    boundary rather than forking that helper. (``validate_trailing_argv``
+    takes an explicit ``command_label``, so ``aorta agent`` is passed there
+    directly; this fallback still covers any other probe-helper strings.)
     """
     return message.replace("aorta probe", "aorta agent")
 
@@ -227,7 +229,7 @@ def agent(
     """Closed-loop mitigation search via the probe engine."""
     configure_verbose_logging(verbose)
     try:
-        clean_argv = validate_trailing_argv(argv)
+        clean_argv = validate_trailing_argv(argv, command_label="aorta agent")
         policy = AgentPolicy(
             max_iterations=max_iterations,
             max_walltime_sec=max_walltime_sec,

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -43,6 +43,7 @@ from pathlib import Path
 
 import click
 
+from aorta.cli._deprecation import emit_deprecation
 from aorta.probe.classifier.tier4_patterns import (
     BUILTIN_PATTERN_VERSION,
     all_patterns,
@@ -353,7 +354,11 @@ def probe(
     All arguments after ``--`` are forwarded byte-for-byte to the user
     command. Aorta never parses them; the only "boundary" is the
     optional ``probe.env`` file written under ``--env-passthrough-mode file``.
+
+    DEPRECATED: this command is now a thin alias for ``aorta sweep run``.
+    It prints a stderr notice and delegates to the same shared engine.
     """
+    emit_deprecation("aorta probe", "aorta sweep run")
     if list_patterns:
         _print_list_patterns(show_version=show_version)
         return
@@ -368,6 +373,41 @@ def probe(
             "Missing option '--recipe'. Pass --recipe <path>, or run "
             "with --list-patterns to print the built-in pattern catalogue."
         )
+    execute_probe(
+        recipe=recipe,
+        output=output,
+        ticket=ticket,
+        dry_run=dry_run,
+        env_passthrough_mode=env_passthrough_mode,
+        stop_after_events=stop_after_events,
+        max_trials=max_trials,
+        disable_detectors=disable_detectors,
+        mitigation_files=mitigation_files,
+        argv=argv,
+    )
+
+
+def execute_probe(
+    *,
+    recipe: Path,
+    output: Path,
+    ticket: str | None,
+    dry_run: bool,
+    env_passthrough_mode: str | None,
+    stop_after_events: int | None = None,
+    max_trials: int | None = None,
+    disable_detectors: tuple[str, ...] = (),
+    mitigation_files: tuple[Path, ...],
+    argv: tuple[str, ...],
+) -> None:
+    """Subprocess-flow body shared by ``aorta sweep run`` and ``aorta probe``.
+
+    The caller guarantees ``recipe is not None`` and has already configured
+    verbose logging and handled the ``--list-patterns`` / ``--version``
+    short-circuits. Everything from recipe load through artifact write
+    lives here so both front doors reach an identical code path (the
+    shared-engine contract in ``tests/probe/test_shared_engine.py``).
+    """
     try:
         # ``--env-passthrough-mode`` defaults to None so the handler can
         # distinguish "user passed the flag" from "user omitted it"; per
@@ -409,4 +449,4 @@ def probe(
         click.echo(f"Wrote probe artifacts to {run_dir}")
 
 
-__all__ = ["probe", "ProbeExtras"]
+__all__ = ["probe", "execute_probe", "ProbeExtras"]

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -87,20 +87,25 @@ def _aorta_package_version() -> str:
         return "unknown"
 
 
-def _print_list_patterns(show_version: bool) -> None:
+def _print_list_patterns(show_version: bool, banner_prefix: str = "aorta probe") -> None:
     """Render the Tier-4 catalogue or the version banner (rubric FR 2.5).
 
     Plain stdout writes (no JSON) so the output is greppable from a
     shell. Each pattern emits a stable three-line entry: ID,
     description, sample regex match line.
+
+    ``banner_prefix`` names the invoking command in the banner (defaults
+    to ``"aorta probe"``); ``aorta sweep list-patterns`` passes
+    ``"aorta sweep"`` so the header matches what the user actually ran.
+    The catalogue itself is identical -- only the banner text changes.
     """
     if show_version:
         click.echo(
-            f"aorta probe pattern library v{BUILTIN_PATTERN_VERSION} "
+            f"{banner_prefix} pattern library v{BUILTIN_PATTERN_VERSION} "
             f"(aorta {_aorta_package_version()})"
         )
         return
-    click.echo(f"aorta probe built-in pattern library (v{BUILTIN_PATTERN_VERSION})")
+    click.echo(f"{banner_prefix} built-in pattern library (v{BUILTIN_PATTERN_VERSION})")
     click.echo("")
     for pattern in all_patterns():
         click.echo(f"  {pattern.detector_id}")

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -404,6 +404,7 @@ def execute_probe(
     disable_detectors: tuple[str, ...] = (),
     mitigation_files: tuple[Path, ...],
     argv: tuple[str, ...],
+    command_label: str = "aorta probe",
 ) -> None:
     """Subprocess-flow body shared by ``aorta sweep run`` and ``aorta probe``.
 
@@ -412,13 +413,18 @@ def execute_probe(
     short-circuits. Everything from recipe load through artifact write
     lives here so both front doors reach an identical code path (the
     shared-engine contract in ``tests/probe/test_shared_engine.py``).
+
+    ``command_label`` names the front door for usage errors raised while
+    validating the trailing argv; ``aorta sweep run`` passes its own label
+    so a leaked-flag error points at the invoked command, not the
+    deprecated ``aorta probe`` alias.
     """
     try:
         # ``--env-passthrough-mode`` defaults to None so the handler can
         # distinguish "user passed the flag" from "user omitted it"; per
         # FR 1.10 the CLI wins only when present (see apply_recipe_overrides).
         cli_passthrough_mode = parse_env_passthrough_mode_opt(env_passthrough_mode)
-        clean_argv = validate_trailing_argv(argv)
+        clean_argv = validate_trailing_argv(argv, command_label=command_label)
         r = load_recipe(recipe, sidecar_files=mitigation_files or None)
         if r.probe_extras is None:
             raise ProbeUsageError(

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -363,10 +363,14 @@ def probe(
     DEPRECATED: this command is now a thin alias for ``aorta sweep run``.
     It prints a stderr notice and delegates to the same shared engine.
     """
-    emit_deprecation("aorta probe", "aorta sweep run")
     if list_patterns:
+        # The catalogue surface moved to its own subcommand, so point this
+        # alias at 'aorta sweep list-patterns' rather than the generic
+        # 'aorta sweep run'. Notice stays on stderr; stdout is the catalogue.
+        emit_deprecation("aorta probe --list-patterns", "aorta sweep list-patterns")
         _print_list_patterns(show_version=show_version)
         return
+    emit_deprecation("aorta probe", "aorta sweep run")
     if show_version:
         # ``--version`` is only meaningful with ``--list-patterns``;
         # see :func:`_reject_bare_version_flag` for the rationale.

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -504,11 +504,11 @@ def sweep_list_environments(files: tuple[Path, ...]) -> None:
     "--version",
     "show_version",
     is_flag=True,
-    help="Print 'aorta probe pattern library v<N> (aorta <pkg-version>)' and exit.",
+    help="Print 'aorta sweep pattern library v<N> (aorta <pkg-version>)' and exit.",
 )
 def sweep_list_patterns(show_version: bool) -> None:
     """Print the built-in Tier-4 failure-signature pattern catalogue and exit."""
-    _print_list_patterns(show_version=show_version)
+    _print_list_patterns(show_version=show_version, banner_prefix="aorta sweep")
 
 
 __all__ = ["sweep"]

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -1,0 +1,514 @@
+"""``aorta sweep`` -- unified matrix runner (merges ``triage`` + ``probe``).
+
+Both legacy commands drove the same engine
+(:func:`aorta.triage.runner.run_recipe`); they differed only in how a
+trial body is produced -- a built-in **workload** run in-process
+(``triage``) vs. an opaque **user command** wrapped as a subprocess
+(``probe``). ``aorta sweep`` is the single front door for both flows.
+
+Flow selection is automatic, with no new mandatory flag:
+
+* **Subprocess flow** when a trailing ``-- <command>`` is supplied *or*
+  the loaded recipe is ``mode: probe``. Engine knobs:
+  ``layout="flat_resume"``, ``resume_existing=True``, ``subprocess_argv=...``.
+* **Workload flow** otherwise (``mode: triage`` recipe, default, or the
+  flag shim ``--workload ... --mitigation-axis ...``). Engine defaults.
+
+Consistency guards reject mismatches up-front (probe-mode recipe with no
+command; a trailing command with a workload recipe) instead of failing
+deep in the engine. The mandatory ``--`` separator from ``aorta probe``
+is preserved so a stray positional can never be silently swept into the
+user command.
+
+The actual flow bodies live in :func:`aorta.cli.triage.execute_triage_run`
+and :func:`aorta.cli.probe.execute_probe` -- ``aorta sweep`` and the
+deprecated ``aorta triage`` / ``aorta probe`` aliases all reach the same
+code, so there is no behavioural drift between front doors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import click
+
+from aorta.cli.probe import (
+    _print_list_patterns,
+    _reject_flag_shaped_callback,
+    execute_probe,
+)
+from aorta.cli.triage import (
+    execute_list_environments,
+    execute_list_mitigations,
+    execute_triage_run,
+)
+from aorta.run.cli_helpers import configure_verbose_logging
+from aorta.triage.recipe import RecipeSchemaError, load_recipe_mapping
+
+_BYPASS_TOKENS: frozenset[str] = frozenset({"--help", "-h"})
+
+
+def _peek_recipe_mode(path: Path) -> str | None:
+    """Best-effort read of a recipe's top-level ``mode`` for flow dispatch.
+
+    Returns ``"probe"``, ``"triage"``, or ``None`` when the file can't be
+    parsed / isn't a mapping. ``None`` defers to the trailing-argv signal
+    and lets the real loader (inside the chosen flow) raise the canonical,
+    fully-validated error -- this peek never becomes the error surface.
+    """
+    try:
+        data = load_recipe_mapping(path)
+    except (RecipeSchemaError, OSError):
+        return None
+    if isinstance(data, dict):
+        mode = data.get("mode", "triage")
+        return "probe" if mode == "probe" else "triage"
+    return None
+
+
+def _bare_positional_before_separator(
+    args: Sequence[str], value_taking_options: frozenset[str]
+) -> bool:
+    """True iff a non-option positional appears before any ``--`` separator.
+
+    Walks ``--opt value`` / ``--opt=value`` / flag tokens the same way
+    :func:`aorta.probe.cli_helpers.help_token_in_option_zone` does. The
+    first bare positional with no preceding ``--`` is the ambiguous case
+    ``aorta probe`` guards against (a stray token silently becoming the
+    user command); ``aorta sweep run`` rejects it and tells the user to
+    introduce the command with ``--``. A ``--help``/``-h`` in the option
+    zone short-circuits so help still renders.
+    """
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token in _BYPASS_TOKENS:
+            return False
+        if token == "--":
+            return False
+        if token.startswith("--"):
+            opt = token.split("=", 1)[0]
+            if "=" in token or opt not in value_taking_options:
+                i += 1
+                continue
+            i += 2  # consume the option's value too
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        return True  # bare positional, no preceding '--'
+    return False
+
+
+class _SweepRunCommand(click.Command):
+    """``sweep run`` command requiring ``--`` *only* when a user command is given.
+
+    The workload flow (``aorta sweep run --recipe r.yaml``) has no
+    trailing command and needs no separator. The subprocess flow
+    (``aorta sweep run --recipe r.yaml -- python repro.py``) does, and a
+    bare positional without ``--`` is rejected so it can't be misparsed
+    as the user command. This mirrors ``aorta.cli.probe._ProbeCommand``
+    but relaxes the always-required separator to the conditional rule.
+    """
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if not ctx.resilient_parsing and _bare_positional_before_separator(
+            args, self._value_taking_option_tokens()
+        ):
+            raise click.UsageError(
+                "missing '--' separator before the user command. A workload "
+                "run takes no trailing command; a probe run must place the "
+                "command after a literal '--'. "
+                "Usage: aorta sweep run [options] -- <command> [args...]",
+                ctx=ctx,
+            )
+        return super().parse_args(ctx, args)
+
+    def _value_taking_option_tokens(self) -> frozenset[str]:
+        """Long-form options that consume a value (derived from ``self.params``)."""
+        tokens: set[str] = set()
+        for param in self.params:
+            if not isinstance(param, click.Option):
+                continue
+            if param.is_flag or param.count:
+                continue
+            for opt in param.opts:
+                if opt.startswith("--"):
+                    tokens.add(opt)
+        return frozenset(tokens)
+
+
+def _reject_triage_only_flags_in_probe_flow(
+    *,
+    workload: str | None,
+    mitigation_axis: str | None,
+    environment_axis: str | None,
+    trials: int | None,
+    steps: int | None,
+    baseline_cell: str | None,
+    confound_threshold: float | None,
+) -> None:
+    """Reject workload-flow-only knobs when a subprocess command is supplied."""
+    offenders = {
+        "--workload": workload,
+        "--mitigation-axis": mitigation_axis,
+        "--environment-axis": environment_axis,
+        "--trials": trials,
+        "--steps": steps,
+        "--baseline-cell": baseline_cell,
+        "--confound-threshold": confound_threshold,
+    }
+    set_flags = [k for k, v in offenders.items() if v not in (None, "")]
+    if set_flags:
+        raise click.UsageError(
+            f"{', '.join(set_flags)} only apply to the workload flow and "
+            "cannot be combined with a '-- <command>' (subprocess) run."
+        )
+
+
+@click.group()
+def sweep() -> None:
+    """Unified matrix runner: sweep mitigations x {environments|diagnostics} x trials.
+
+    Runs both flows from one command -- a built-in workload, or your own
+    command after '--'. Replaces the deprecated 'aorta triage' and
+    'aorta probe'.
+    """
+
+
+@sweep.command(
+    name="run",
+    cls=_SweepRunCommand,
+    context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
+)
+@click.option(
+    "--recipe",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    callback=_reject_flag_shaped_callback,
+    help="Path to a YAML or JSON recipe file ('mode: triage' or 'mode: probe').",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Validate and print the resolved plan (cells; argv for a probe run) without executing.",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["matrix"]),
+    default="matrix",
+    show_default=True,
+    help="matrix = full contingency table. 'optimize' deferred to a future release.",
+)
+@click.option(
+    "--workload",
+    default=None,
+    help="Workload name (workload flow, flag mode; from the aorta.workloads entry-point group).",
+)
+@click.option(
+    "--mitigation-axis",
+    default=None,
+    help=(
+        "Comma-separated mitigation names for the matrix row axis. "
+        "Include 'none' for the baseline row. Workload flow, flag mode."
+    ),
+)
+@click.option(
+    "--environment-axis",
+    default=None,
+    help=(
+        "Comma-separated environment names for the matrix column axis. "
+        "Bare names resolve via the registry; 'image:<ref>' items declare an "
+        "inline docker cell. Workload flow, flag mode."
+    ),
+)
+@click.option(
+    "--trials",
+    type=int,
+    default=None,
+    help="Trials per cell (workload flow, flag mode; recipe mode takes this from the file).",
+)
+@click.option(
+    "--steps",
+    type=int,
+    default=None,
+    help="Steps per trial (workload flow, flag mode; recipe mode takes this from the file).",
+)
+@click.option(
+    "--ticket",
+    default=None,
+    callback=_reject_flag_shaped_callback,
+    help=(
+        "Ticket ID for output-dir grouping. Absence routes to '_no_ticket_'. "
+        "Recipe mode takes this from the file's 'ticket' key (workload flow "
+        "rejects passing it together with --recipe; probe flow lets it override)."
+    ),
+)
+@click.option(
+    "--baseline-cell",
+    default=None,
+    help=(
+        "Override the auto-resolved baseline cell (workload flow). Recipe mode "
+        "takes this from 'confound.baseline_cell'; passing it with --recipe is rejected."
+    ),
+)
+@click.option(
+    "--confound-threshold",
+    type=float,
+    default=None,
+    help=(
+        "cell_step_time / baseline_step_time above this -> 'speed (+N%)' flag "
+        "(workload flow). Flag-mode default 1.15. Recipe mode takes this from "
+        "'confound.threshold'; passing it with --recipe is rejected."
+    ),
+)
+@click.option(
+    "--output",
+    "--output-dir",
+    "output",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    callback=_reject_flag_shaped_callback,
+    help=(
+        "Top-level output directory. Defaults to 'triage_results' for a "
+        "workload run and 'probe_results' for a subprocess run. "
+        "('--output-dir' is accepted as a back-compat alias.)"
+    ),
+)
+@click.option(
+    "--env-passthrough-mode",
+    type=click.Choice(["inherit", "file"]),
+    default=None,
+    help=(
+        "Probe flow only. How per-cell env vars reach the user command: "
+        "'inherit' stamps them on os.environ (the child inherits); 'file' "
+        "additionally writes a chmod-0600 probe.env and exports AORTA_ENV_FILE. "
+        "When omitted, the recipe's 'env_passthrough_mode:' is used "
+        "(default 'inherit'); when present, this flag overrides the recipe."
+    ),
+)
+@click.option(
+    "--mitigations-file",
+    "mitigation_files",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    help=(
+        "JSON sidecar file with ad-hoc mitigations and/or environments "
+        "(repeatable). Merged with built-ins, plugins, and inline-docker envs "
+        "at recipe load time."
+    ),
+)
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Stream per-cell progress to stderr. -v = INFO, -vv = DEBUG (aorta.* logger).",
+)
+@click.argument("argv", nargs=-1, type=click.UNPROCESSED)
+def sweep_run(
+    recipe: Path | None,
+    dry_run: bool,
+    mode: str,
+    workload: str | None,
+    mitigation_axis: str | None,
+    environment_axis: str | None,
+    trials: int | None,
+    steps: int | None,
+    ticket: str | None,
+    baseline_cell: str | None,
+    confound_threshold: float | None,
+    output: Path | None,
+    env_passthrough_mode: str | None,
+    mitigation_files: tuple[Path, ...],
+    verbose: int,
+    argv: tuple[str, ...],
+) -> None:
+    """Run a matrix sweep. Built-in workload, or your own command after '--'.
+
+    Examples:
+
+      aorta sweep run --recipe triage.yaml
+
+      aorta sweep run --workload fsdp --mitigation-axis none,foo
+          --environment-axis local --trials 3 --steps 50
+
+      aorta sweep run --recipe probe.yaml --ticket ROCM-1234 -- python repro.py
+    """
+    configure_verbose_logging(verbose)
+    has_command = bool(argv)
+    recipe_mode = _peek_recipe_mode(recipe) if recipe is not None else None
+
+    # --- consistency guards (clear up-front errors, no silent fallback) ---
+    if recipe_mode == "probe" and not has_command:
+        raise click.UsageError(
+            f"recipe {recipe} is a probe-mode recipe; it requires a user "
+            "command after '--'. "
+            "Usage: aorta sweep run --recipe <file> -- <command> [args...]"
+        )
+    if has_command and recipe_mode == "triage":
+        raise click.UsageError(
+            "a trailing '-- <command>' is only valid for a probe-mode run. "
+            "Drop the command to run the workload flow, or set 'mode: probe' "
+            "in the recipe."
+        )
+
+    is_probe_flow = has_command or recipe_mode == "probe"
+    if is_probe_flow:
+        _dispatch_probe_flow(
+            recipe=recipe,
+            output=output,
+            ticket=ticket,
+            dry_run=dry_run,
+            env_passthrough_mode=env_passthrough_mode,
+            mitigation_files=mitigation_files,
+            argv=argv,
+            workload=workload,
+            mitigation_axis=mitigation_axis,
+            environment_axis=environment_axis,
+            trials=trials,
+            steps=steps,
+            baseline_cell=baseline_cell,
+            confound_threshold=confound_threshold,
+        )
+    else:
+        _dispatch_workload_flow(
+            recipe=recipe,
+            dry_run=dry_run,
+            mode=mode,
+            workload=workload,
+            mitigation_axis=mitigation_axis,
+            environment_axis=environment_axis,
+            trials=trials,
+            steps=steps,
+            ticket=ticket,
+            baseline_cell=baseline_cell,
+            confound_threshold=confound_threshold,
+            output=output,
+            mitigation_files=mitigation_files,
+            env_passthrough_mode=env_passthrough_mode,
+        )
+
+
+def _dispatch_probe_flow(
+    *,
+    recipe: Path | None,
+    output: Path | None,
+    ticket: str | None,
+    dry_run: bool,
+    env_passthrough_mode: str | None,
+    mitigation_files: tuple[Path, ...],
+    argv: tuple[str, ...],
+    workload: str | None,
+    mitigation_axis: str | None,
+    environment_axis: str | None,
+    trials: int | None,
+    steps: int | None,
+    baseline_cell: str | None,
+    confound_threshold: float | None,
+) -> None:
+    """Validate probe-flow-specific preconditions, then run the subprocess flow."""
+    _reject_triage_only_flags_in_probe_flow(
+        workload=workload,
+        mitigation_axis=mitigation_axis,
+        environment_axis=environment_axis,
+        trials=trials,
+        steps=steps,
+        baseline_cell=baseline_cell,
+        confound_threshold=confound_threshold,
+    )
+    if recipe is None:
+        raise click.UsageError(
+            "a probe run needs a recipe. Pass --recipe <path> (a 'mode: probe' "
+            "file) together with the user command after '--'."
+        )
+    execute_probe(
+        recipe=recipe,
+        output=output if output is not None else Path("probe_results"),
+        ticket=ticket,
+        dry_run=dry_run,
+        env_passthrough_mode=env_passthrough_mode,
+        mitigation_files=mitigation_files,
+        argv=argv,
+    )
+
+
+def _dispatch_workload_flow(
+    *,
+    recipe: Path | None,
+    dry_run: bool,
+    mode: str,
+    workload: str | None,
+    mitigation_axis: str | None,
+    environment_axis: str | None,
+    trials: int | None,
+    steps: int | None,
+    ticket: str | None,
+    baseline_cell: str | None,
+    confound_threshold: float | None,
+    output: Path | None,
+    mitigation_files: tuple[Path, ...],
+    env_passthrough_mode: str | None,
+) -> None:
+    """Validate workload-flow-specific preconditions, then run the workload flow."""
+    if env_passthrough_mode is not None:
+        raise click.UsageError(
+            "--env-passthrough-mode applies to the probe flow only (a user "
+            "command after '--'); it has no effect on a workload run."
+        )
+    execute_triage_run(
+        recipe=recipe,
+        dry_run=dry_run,
+        mode=mode,
+        workload=workload,
+        mitigation_axis=mitigation_axis,
+        environment_axis=environment_axis,
+        trials=trials,
+        steps=steps,
+        ticket=ticket,
+        baseline_cell=baseline_cell,
+        confound_threshold=confound_threshold,
+        output_dir=output if output is not None else Path("triage_results"),
+        mitigation_files=mitigation_files,
+    )
+
+
+@sweep.command(name="list-mitigations")
+@click.option(
+    "--mitigations-file",
+    "files",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    help="JSON sidecar to merge into the listing (repeatable).",
+)
+def sweep_list_mitigations(files: tuple[Path, ...]) -> None:
+    """List every registered mitigation with its source_package and env-var bundle."""
+    execute_list_mitigations(files)
+
+
+@sweep.command(name="list-environments")
+@click.option(
+    "--mitigations-file",
+    "files",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    help="JSON sidecar to merge into the listing (repeatable).",
+)
+def sweep_list_environments(files: tuple[Path, ...]) -> None:
+    """List every registered environment with its source_package and docker/venv."""
+    execute_list_environments(files)
+
+
+@sweep.command(name="list-patterns")
+@click.option(
+    "--version",
+    "show_version",
+    is_flag=True,
+    help="Print 'aorta probe pattern library v<N> (aorta <pkg-version>)' and exit.",
+)
+def sweep_list_patterns(show_version: bool) -> None:
+    """Print the built-in Tier-4 failure-signature pattern catalogue and exit."""
+    _print_list_patterns(show_version=show_version)
+
+
+__all__ = ["sweep"]

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -439,6 +439,7 @@ def _dispatch_probe_flow(
         env_passthrough_mode=env_passthrough_mode,
         mitigation_files=mitigation_files,
         argv=argv,
+        command_label="aorta sweep run",
     )
 
 

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -309,6 +309,43 @@ def sweep() -> None:
     ),
 )
 @click.option(
+    "--stop-after-events",
+    type=int,
+    default=None,
+    metavar="K",
+    help=(
+        "Probe flow only. Stop each cell once K trials match the event "
+        "verdict (default verdict: fail), instead of running a fixed count. "
+        "The loop needs a hard cap: pass --max-trials unless the recipe's "
+        "'stop_after:' block already supplies one. Overlays that block (#232)."
+    ),
+)
+@click.option(
+    "--max-trials",
+    type=int,
+    default=None,
+    metavar="N",
+    help=(
+        "Probe flow only. Hard cap on trials per cell when stop-after is "
+        "active (always honored). Pair with --stop-after-events; either flag "
+        "may be omitted when the recipe's 'stop_after:' block already supplies "
+        "that half (so --max-trials alone overrides just the recipe's cap)."
+    ),
+)
+@click.option(
+    "--disable-detector",
+    "disable_detectors",
+    multiple=True,
+    metavar="TIER[:ID]",
+    help=(
+        "Probe flow only. Silence a detector or whole tier (repeatable). Pass "
+        "a tier name ('tier3') to skip the entire tier, or a '<tier>:<id>' "
+        "token ('tier2:hang') to skip one detector. A disabled detector is "
+        "not evaluated and never counts toward the verdict. Unioned with any "
+        "'disable_detectors:' / 'disable_detector_tiers:' set in the recipe."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -329,6 +366,9 @@ def sweep_run(
     confound_threshold: float | None,
     output: Path | None,
     env_passthrough_mode: str | None,
+    stop_after_events: int | None,
+    max_trials: int | None,
+    disable_detectors: tuple[str, ...],
     mitigation_files: tuple[Path, ...],
     verbose: int,
     argv: tuple[str, ...],
@@ -370,6 +410,9 @@ def sweep_run(
             ticket=ticket,
             dry_run=dry_run,
             env_passthrough_mode=env_passthrough_mode,
+            stop_after_events=stop_after_events,
+            max_trials=max_trials,
+            disable_detectors=disable_detectors,
             mitigation_files=mitigation_files,
             argv=argv,
             workload=workload,
@@ -396,6 +439,9 @@ def sweep_run(
             output=output,
             mitigation_files=mitigation_files,
             env_passthrough_mode=env_passthrough_mode,
+            stop_after_events=stop_after_events,
+            max_trials=max_trials,
+            disable_detectors=disable_detectors,
         )
 
 
@@ -406,6 +452,9 @@ def _dispatch_probe_flow(
     ticket: str | None,
     dry_run: bool,
     env_passthrough_mode: str | None,
+    stop_after_events: int | None,
+    max_trials: int | None,
+    disable_detectors: tuple[str, ...],
     mitigation_files: tuple[Path, ...],
     argv: tuple[str, ...],
     workload: str | None,
@@ -437,6 +486,9 @@ def _dispatch_probe_flow(
         ticket=ticket,
         dry_run=dry_run,
         env_passthrough_mode=env_passthrough_mode,
+        stop_after_events=stop_after_events,
+        max_trials=max_trials,
+        disable_detectors=disable_detectors,
         mitigation_files=mitigation_files,
         argv=argv,
         command_label="aorta sweep run",
@@ -459,12 +511,27 @@ def _dispatch_workload_flow(
     output: Path | None,
     mitigation_files: tuple[Path, ...],
     env_passthrough_mode: str | None,
+    stop_after_events: int | None,
+    max_trials: int | None,
+    disable_detectors: tuple[str, ...],
 ) -> None:
     """Validate workload-flow-specific preconditions, then run the workload flow."""
     if env_passthrough_mode is not None:
         raise click.UsageError(
             "--env-passthrough-mode applies to the probe flow only (a user "
             "command after '--'); it has no effect on a workload run."
+        )
+    probe_only_flags = {
+        "--stop-after-events": stop_after_events,
+        "--max-trials": max_trials,
+        "--disable-detector": disable_detectors,
+    }
+    set_probe_only = [k for k, v in probe_only_flags.items() if v not in (None, ())]
+    if set_probe_only:
+        raise click.UsageError(
+            f"{', '.join(set_probe_only)} only apply to the probe/subprocess "
+            "flow (a user command after '--' or a 'mode: probe' recipe); they "
+            "have no effect on a workload run."
         )
     execute_triage_run(
         recipe=recipe,

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -63,7 +63,14 @@ def _peek_recipe_mode(path: Path) -> str | None:
         return None
     if isinstance(data, dict):
         mode = data.get("mode", "triage")
-        return "probe" if mode == "probe" else "triage"
+        if mode == "probe":
+            return "probe"
+        if mode == "triage":
+            return "triage"
+        # Unknown/malformed mode (typo, null, non-str): don't guess "triage"
+        # and mis-dispatch -- return None so the real loader raises the
+        # canonical RecipeSchemaError instead of a misleading sweep usage error.
+        return None
     return None
 
 
@@ -199,7 +206,9 @@ def sweep() -> None:
     type=click.Choice(["matrix"]),
     default="matrix",
     show_default=True,
-    help="matrix = full contingency table. 'optimize' deferred to a future release.",
+    help="matrix = full contingency table. 'optimize' deferred to a future release. "
+    "Applies to the workload/matrix flow only; ignored for probe/subprocess "
+    "runs (recipe 'mode: probe' or a '-- <command>' invocation).",
 )
 @click.option(
     "--workload",

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -1,12 +1,19 @@
-"""`aorta triage` - mitigation x environment matrix runner.
+"""`aorta triage` - DEPRECATED alias for the workload flow of `aorta sweep`.
 
-Two equivalent entry points (both converge on :func:`aorta.triage.run_recipe`):
+`aorta triage` has been merged into the unified `aorta sweep` command
+(issue #248). It keeps working as a thin deprecation shim: every command
+here prints a stderr notice naming the `aorta sweep` replacement and then
+delegates to the shared ``execute_*`` functions that `aorta sweep` also
+calls -- so behaviour stays byte-identical.
 
-* ``aorta triage run --recipe <file>`` -- primary mode. Recipe file is the
-  source of truth; validated at load time.
-* ``aorta triage run --mode matrix --workload ... --mitigation-axis ...
-  --environment-axis ...`` -- flag shim. Internally builds a :class:`Recipe`
-  via :func:`aorta.triage.recipe.build_recipe_from_flags` and dispatches.
+The shared engine entry points (both converge on
+:func:`aorta.triage.run_recipe`):
+
+* ``--recipe <file>`` -- primary mode. Recipe file is the source of truth;
+  validated at load time.
+* ``--mode matrix --workload ... --mitigation-axis ... --environment-axis
+  ...`` -- flag shim. Internally builds a :class:`Recipe` via
+  :func:`aorta.triage.recipe.build_recipe_from_flags` and dispatches.
 
 Discovery subcommands delegate to B3's resolver so users can see which
 mitigations / environments come from ``aorta`` vs a plugin / sidecar.
@@ -18,6 +25,7 @@ from pathlib import Path
 
 import click
 
+from aorta.cli._deprecation import emit_deprecation
 from aorta.registry import (
     RegistryError,
     load_environments,
@@ -175,7 +183,47 @@ def triage_run(
     verbose: int,
 ) -> None:
     """Run the triage matrix: sweep mitigations x environments x trials, write matrix.md + matrix.json."""
+    emit_deprecation("aorta triage run", "aorta sweep run")
     configure_verbose_logging(verbose)
+    execute_triage_run(
+        recipe=recipe,
+        dry_run=dry_run,
+        mode=mode,
+        workload=workload,
+        mitigation_axis=mitigation_axis,
+        environment_axis=environment_axis,
+        trials=trials,
+        steps=steps,
+        ticket=ticket,
+        baseline_cell=baseline_cell,
+        confound_threshold=confound_threshold,
+        output_dir=output_dir,
+        mitigation_files=mitigation_files,
+    )
+
+
+def execute_triage_run(
+    *,
+    recipe: Path | None,
+    dry_run: bool,
+    mode: str,
+    workload: str | None,
+    mitigation_axis: str | None,
+    environment_axis: str | None,
+    trials: int | None,
+    steps: int | None,
+    ticket: str | None,
+    baseline_cell: str | None,
+    confound_threshold: float | None,
+    output_dir: Path,
+    mitigation_files: tuple[Path, ...],
+) -> None:
+    """Workload-flow body shared by ``aorta sweep run`` and ``aorta triage run``.
+
+    Logging is configured by the Click handler before this is called;
+    keeping it out of here lets ``aorta sweep run`` own verbose setup once
+    regardless of which flow it dispatches to.
+    """
     # Defence-in-depth: Click's ``Choice(["matrix"])`` already enforces this,
     # but the CLI advertises ``--mode optimize`` as a future P1 addition (per
     # D11) and the dispatch site for that branch does not exist yet. Assert
@@ -313,6 +361,12 @@ def _reject_flag_mode_args(
 )
 def list_mitigations(files: tuple[Path, ...]) -> None:
     """List every registered mitigation with its source_package and env-var bundle."""
+    emit_deprecation("aorta triage list-mitigations", "aorta sweep list-mitigations")
+    execute_list_mitigations(files)
+
+
+def execute_list_mitigations(files: tuple[Path, ...]) -> None:
+    """Print the mitigation registry; shared by ``aorta sweep`` + ``aorta triage``."""
     # Wrap RegistryError the same way `triage run` and `aorta run` do: a
     # malformed or colliding --mitigations-file should surface as a one-line
     # ClickException, not a Python traceback.
@@ -339,6 +393,12 @@ def list_mitigations(files: tuple[Path, ...]) -> None:
 )
 def list_environments(files: tuple[Path, ...]) -> None:
     """List every registered environment with its source_package and docker/venv."""
+    emit_deprecation("aorta triage list-environments", "aorta sweep list-environments")
+    execute_list_environments(files)
+
+
+def execute_list_environments(files: tuple[Path, ...]) -> None:
+    """Print the environment registry; shared by ``aorta sweep`` + ``aorta triage``."""
     try:
         registry = load_environments(extra_files=list(files) or None)
     except RegistryError as exc:

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -167,7 +167,9 @@ def parse_env_passthrough_mode_opt(value: str | None) -> Literal["inherit", "fil
     return None if value is None else parse_env_passthrough_mode(value)
 
 
-def validate_trailing_argv(argv: tuple[str, ...]) -> tuple[str, ...]:
+def validate_trailing_argv(
+    argv: tuple[str, ...], command_label: str = "aorta probe"
+) -> tuple[str, ...]:
     """Reject an empty / clearly-misparsed trailing-argv list.
 
     ``aorta probe -- <argv>`` is the only legal channel for the user
@@ -180,16 +182,21 @@ def validate_trailing_argv(argv: tuple[str, ...]) -> tuple[str, ...]:
     command's executable name is essentially never dash-prefixed, but a
     leaked aorta option (e.g. ``-v`` smuggled past Click) is. Catching
     this here turns a 127 exit-code "fail" trial into a clear usage error.
+
+    ``command_label`` names the invoking front door in the usage hint
+    (defaults to ``"aorta probe"``); ``aorta sweep run`` passes its own
+    label so a leaked flag through the sweep front door doesn't point the
+    user at the deprecated ``aorta probe`` command.
     """
     if not argv:
         raise ProbeUsageError(
-            "no trailing argv supplied. Usage: aorta probe [options] -- <command> [args...]"
+            f"no trailing argv supplied. Usage: {command_label} [options] -- <command> [args...]"
         )
     if argv[0].startswith("-"):
         raise ProbeUsageError(
             f"user command starts with {argv[0]!r}, which looks like a flag. "
             "Place all aorta options before '--' and the user command after. "
-            "Usage: aorta probe [options] -- <command> [args...]"
+            f"Usage: {command_label} [options] -- <command> [args...]"
         )
     return argv
 

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -50,6 +50,17 @@ def test_agent_requires_double_dash_separator():
     assert "separator" in result.output.lower() or "Usage" in result.output
 
 
+def test_agent_leaked_flag_usage_error_names_agent_not_probe():
+    # A dash-prefixed trailing token (a leaked flag) trips
+    # validate_trailing_argv; the usage hint must name the invoked command
+    # (`aorta agent`), never the shared-helper default `aorta probe`.
+    runner = CliRunner()
+    result = runner.invoke(agent, ["--output", "/tmp/o", "--", "-c"])
+    assert result.exit_code != 0
+    assert "aorta agent" in result.output
+    assert "aorta probe" not in result.output
+
+
 def test_error_outcome_has_dedicated_headline(monkeypatch, tmp_path):
     # run_agent_loop can return outcome="error" from its generic exception
     # handler; the CLI must show a specific headline, not the generic fallback.

--- a/tests/sweep/test_sweep_cli.py
+++ b/tests/sweep/test_sweep_cli.py
@@ -243,6 +243,9 @@ def test_list_patterns_runs():
     runner = CliRunner()
     result = runner.invoke(main, ["sweep", "list-patterns"])
     assert result.exit_code == 0, result.output
+    # Banner names the command the user actually ran, not "aorta probe".
+    assert "aorta sweep built-in pattern library" in result.output
+    assert "aorta probe" not in result.output
 
 
 def test_list_patterns_version_banner():
@@ -250,6 +253,7 @@ def test_list_patterns_version_banner():
     result = runner.invoke(main, ["sweep", "list-patterns", "--version"])
     assert result.exit_code == 0, result.output
     assert "pattern library v" in result.output
+    assert result.output.startswith("aorta sweep pattern library v")
 
 
 # --- deprecation aliases -------------------------------------------------

--- a/tests/sweep/test_sweep_cli.py
+++ b/tests/sweep/test_sweep_cli.py
@@ -314,3 +314,77 @@ def test_triage_list_mitigations_warns():
     assert result.exit_code == 0, result.output
     assert "deprecated" in result.stderr
     assert "aorta sweep list-mitigations" in result.stderr
+
+
+# --- cross-front-door parity --------------------------------------------
+#
+# The PR's headline guarantee is that ``aorta sweep run`` is byte-identical
+# to the legacy ``aorta triage run`` / ``aorta probe`` aliases because every
+# front door delegates to the same shared engine. The tests above pin each
+# front door's ``run_recipe`` call against hard-coded expectations *in
+# isolation*; that lets the two paths drift apart while both still pass (a
+# future edit could change one dispatcher's engine kwargs without the other).
+# These tests pin the calls to be *equal* for identical input, so a
+# divergence between front doors fails loudly instead of silently. They are
+# the ``aorta sweep`` extension of ``tests/probe/test_shared_engine.py``,
+# which only ever covered the original probe<->triage pair.
+
+
+def _capture_engine_call(mock, invoke):
+    """Run one CLI invocation; return ``(recipe, kwargs_without_recipe)``.
+
+    Asserts the invocation succeeded and reached ``run_recipe`` exactly
+    once. ``recipe`` is normalised out of ``args``/``kwargs`` so the
+    comparison doesn't depend on whether a flow passes it positionally.
+    """
+    mock.reset_mock()
+    result = invoke()
+    assert result.exit_code == 0, result.output
+    mock.assert_called_once()
+    args, kwargs = mock.call_args
+    kwargs = dict(kwargs)
+    recipe_arg = args[0] if args else kwargs.pop("recipe", None)
+    return recipe_arg, kwargs
+
+
+def test_workload_flow_parity_sweep_vs_triage(mock_run_recipe, tmp_path):
+    """`aorta sweep run` reaches run_recipe identically to `aorta triage run`."""
+    recipe = _write_triage_recipe(tmp_path)
+    out = str(tmp_path / "out")
+    runner = CliRunner()
+
+    sweep_recipe, sweep_kwargs = _capture_engine_call(
+        mock_run_recipe,
+        lambda: runner.invoke(main, ["sweep", "run", "--recipe", str(recipe), "--output", out]),
+    )
+    triage_recipe, triage_kwargs = _capture_engine_call(
+        mock_run_recipe,
+        lambda: runner.invoke(triage, ["run", "--recipe", str(recipe), "--output-dir", out]),
+    )
+
+    assert sweep_recipe == triage_recipe
+    assert sweep_kwargs == triage_kwargs
+
+
+def test_subprocess_flow_parity_sweep_vs_probe(mock_run_recipe, tmp_path):
+    """`aorta sweep run -- <cmd>` reaches run_recipe identically to `aorta probe -- <cmd>`."""
+    out = str(tmp_path / "out")
+    runner = CliRunner()
+
+    sweep_recipe, sweep_kwargs = _capture_engine_call(
+        mock_run_recipe,
+        lambda: runner.invoke(
+            main,
+            ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "--output", out, "--", "echo", "hi"],
+        ),
+    )
+    probe_recipe, probe_kwargs = _capture_engine_call(
+        mock_run_recipe,
+        lambda: runner.invoke(
+            probe,
+            ["--recipe", str(PROBE_MINIMAL), "--output", out, "--", "echo", "hi"],
+        ),
+    )
+
+    assert sweep_recipe == probe_recipe
+    assert sweep_kwargs == probe_kwargs

--- a/tests/sweep/test_sweep_cli.py
+++ b/tests/sweep/test_sweep_cli.py
@@ -256,6 +256,28 @@ def test_list_patterns_version_banner():
     assert result.output.startswith("aorta sweep pattern library v")
 
 
+# --- _peek_recipe_mode dispatch helper -----------------------------------
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("mode: probe\n", "probe"),
+        ("mode: triage\n", "triage"),
+        ("workload: fsdp\n", "triage"),  # mode absent -> triage default
+        ("mode: prboe\n", None),  # typo: defer to the real loader, don't guess
+        ("mode: null\n", None),
+        ("- just\n- a\n- list\n", None),  # not a mapping
+    ],
+)
+def test_peek_recipe_mode(tmp_path, body, expected):
+    from aorta.cli.sweep import _peek_recipe_mode
+
+    p = tmp_path / "r.yaml"
+    p.write_text("schema_version: 1\n" + body, encoding="utf-8")
+    assert _peek_recipe_mode(p) == expected
+
+
 # --- deprecation aliases -------------------------------------------------
 
 

--- a/tests/sweep/test_sweep_cli.py
+++ b/tests/sweep/test_sweep_cli.py
@@ -1,0 +1,290 @@
+"""CLI tests for the unified ``aorta sweep`` command (issue #248).
+
+``aorta sweep`` merges ``aorta triage`` and ``aorta probe`` into one
+front door. These tests pin:
+
+* automatic flow dispatch (workload vs. subprocess) and the engine knobs
+  each flow hands to ``run_recipe``;
+* the consistency guards that reject mismatched inputs up-front;
+* the ``--`` separator safety inherited from ``aorta probe``;
+* the discovery subcommands; and
+* that the deprecated ``triage`` / ``probe`` aliases still work but emit a
+  stderr deprecation notice while reaching the same engine.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+import aorta.cli.probe as probe_cli
+import aorta.cli.triage as triage_cli
+from aorta.cli import main
+from aorta.cli.probe import probe
+from aorta.cli.triage import triage
+from aorta.triage.recipe import Recipe
+
+PROBE_FIXTURES = Path(__file__).parent.parent / "probe" / "fixtures"
+PROBE_MINIMAL = PROBE_FIXTURES / "probe_minimal.yaml"
+
+_TRIAGE_RECIPE_TEXT = (
+    "schema_version: 1\n"
+    "workload: fsdp\n"
+    "trials: 1\n"
+    "steps: 1\n"
+    "cells:\n"
+    "  - name: baseline-local\n"
+    "    mitigations: [none]\n"
+    "    environment: local\n"
+)
+
+
+@pytest.fixture
+def mock_run_recipe(monkeypatch):
+    """Patch ``run_recipe`` at both binding sites the flows reach.
+
+    ``execute_triage_run`` and ``execute_probe`` live in the ``triage`` /
+    ``probe`` modules and reference each module's own ``run_recipe`` global;
+    ``aorta sweep`` calls those functions, so patching both modules covers
+    every dispatch path.
+    """
+    mock = MagicMock(return_value=Path("/tmp/sweep-mock-run-dir"))
+    monkeypatch.setattr(probe_cli, "run_recipe", mock)
+    monkeypatch.setattr(triage_cli, "run_recipe", mock)
+    return mock
+
+
+def _write_triage_recipe(tmp_path: Path) -> Path:
+    path = tmp_path / "triage.yaml"
+    path.write_text(_TRIAGE_RECIPE_TEXT, encoding="utf-8")
+    return path
+
+
+# --- flow dispatch -------------------------------------------------------
+
+
+def test_trailing_command_routes_to_probe_flow(mock_run_recipe, tmp_path):
+    """`aorta sweep run --recipe <probe> -- echo hi` runs the subprocess flow."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "sweep",
+            "run",
+            "--recipe",
+            str(PROBE_MINIMAL),
+            "--output",
+            str(tmp_path / "out"),
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_run_recipe.assert_called_once()
+    args, kwargs = mock_run_recipe.call_args
+    recipe_arg = args[0] if args else kwargs.get("recipe")
+    assert isinstance(recipe_arg, Recipe)
+    assert recipe_arg.probe_extras is not None
+    assert kwargs.get("layout") == "flat_resume"
+    assert kwargs.get("resume_existing") is True
+    assert kwargs.get("subprocess_argv") == ("echo", "hi")
+
+
+def test_probe_recipe_without_command_routes_to_probe_flow_guard(mock_run_recipe):
+    """A probe-mode recipe with no trailing command is a clear usage error."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "run", "--recipe", str(PROBE_MINIMAL)])
+    assert result.exit_code != 0
+    assert "requires a user command after '--'" in result.output
+    mock_run_recipe.assert_not_called()
+
+
+def test_triage_recipe_routes_to_workload_flow(mock_run_recipe, tmp_path):
+    """`aorta sweep run --recipe <triage>` runs the in-process workload flow."""
+    recipe = _write_triage_recipe(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["sweep", "run", "--recipe", str(recipe), "--output", str(tmp_path / "out")]
+    )
+    assert result.exit_code == 0, result.output
+    mock_run_recipe.assert_called_once()
+    args, kwargs = mock_run_recipe.call_args
+    recipe_arg = args[0] if args else kwargs.get("recipe")
+    assert isinstance(recipe_arg, Recipe)
+    assert recipe_arg.probe_extras is None  # workload flow never sets this
+    assert kwargs.get("layout", "timestamped") == "timestamped"
+    assert kwargs.get("subprocess_argv") is None
+
+
+def test_flag_mode_routes_to_workload_flow(mock_run_recipe, tmp_path):
+    """Flag-shim (no recipe, no command) runs the workload flow."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "sweep",
+            "run",
+            "--workload",
+            "fsdp",
+            "--mitigation-axis",
+            "none",
+            "--environment-axis",
+            "local",
+            "--trials",
+            "1",
+            "--steps",
+            "1",
+            "--output",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_run_recipe.assert_called_once()
+    args, kwargs = mock_run_recipe.call_args
+    recipe_arg = args[0] if args else kwargs.get("recipe")
+    assert recipe_arg.probe_extras is None
+
+
+def test_default_output_dir_per_flow(mock_run_recipe, tmp_path):
+    """`--output` default resolves to probe_results / triage_results per flow."""
+    runner = CliRunner()
+    r1 = runner.invoke(main, ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "--", "echo", "hi"])
+    assert r1.exit_code == 0, r1.output
+    _, kwargs = mock_run_recipe.call_args
+    assert kwargs.get("output_dir") == Path("probe_results")
+
+    mock_run_recipe.reset_mock()
+    recipe = _write_triage_recipe(tmp_path)
+    r2 = runner.invoke(main, ["sweep", "run", "--recipe", str(recipe)])
+    assert r2.exit_code == 0, r2.output
+    _, kwargs = mock_run_recipe.call_args
+    assert kwargs.get("output_dir") == Path("triage_results")
+
+
+# --- consistency guards --------------------------------------------------
+
+
+def test_command_with_triage_recipe_rejected(mock_run_recipe, tmp_path):
+    """A trailing command with a workload recipe is rejected."""
+    recipe = _write_triage_recipe(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "run", "--recipe", str(recipe), "--", "echo", "hi"])
+    assert result.exit_code != 0
+    assert "only valid for a probe-mode run" in result.output
+    mock_run_recipe.assert_not_called()
+
+
+def test_env_passthrough_rejected_in_workload_flow(mock_run_recipe, tmp_path):
+    """`--env-passthrough-mode` is meaningless without a subprocess command."""
+    recipe = _write_triage_recipe(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["sweep", "run", "--recipe", str(recipe), "--env-passthrough-mode", "file"],
+    )
+    assert result.exit_code != 0
+    assert "probe flow only" in result.output
+    mock_run_recipe.assert_not_called()
+
+
+def test_triage_only_flag_rejected_in_probe_flow(mock_run_recipe):
+    """Workload-only knobs cannot be combined with a subprocess command."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "--trials", "3", "--", "echo", "hi"],
+    )
+    assert result.exit_code != 0
+    assert "only apply to the workload flow" in result.output
+    mock_run_recipe.assert_not_called()
+
+
+def test_bare_positional_without_separator_rejected(mock_run_recipe):
+    """A bare positional with no `--` is refused (inherited probe safety)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "SMOKE-1", "echo", "hi"]
+    )
+    assert result.exit_code != 0
+    assert "missing '--' separator" in result.output
+    mock_run_recipe.assert_not_called()
+
+
+def test_empty_argv_after_separator_rejected(mock_run_recipe):
+    """`-- ` with nothing after it exits non-zero."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "--"])
+    assert result.exit_code != 0
+    mock_run_recipe.assert_not_called()
+
+
+# --- discovery subcommands -----------------------------------------------
+
+
+def test_list_mitigations_runs():
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "list-mitigations"])
+    assert result.exit_code == 0, result.output
+    assert "NAME" in result.output and "SOURCE" in result.output
+
+
+def test_list_environments_runs():
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "list-environments"])
+    assert result.exit_code == 0, result.output
+    assert "NAME" in result.output and "DOCKER" in result.output
+
+
+def test_list_patterns_runs():
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "list-patterns"])
+    assert result.exit_code == 0, result.output
+
+
+def test_list_patterns_version_banner():
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "list-patterns", "--version"])
+    assert result.exit_code == 0, result.output
+    assert "pattern library v" in result.output
+
+
+# --- deprecation aliases -------------------------------------------------
+
+
+def test_triage_run_warns_and_delegates(mock_run_recipe, tmp_path):
+    """`aorta triage run` still works but prints a stderr deprecation notice."""
+    recipe = _write_triage_recipe(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        triage, ["run", "--recipe", str(recipe), "--output-dir", str(tmp_path / "o")]
+    )
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.stderr
+    assert "aorta sweep run" in result.stderr
+    assert "deprecated" not in result.stdout  # notice must not pollute stdout
+    mock_run_recipe.assert_called_once()
+
+
+def test_probe_warns_and_delegates(mock_run_recipe, tmp_path):
+    """`aorta probe` still works but prints a stderr deprecation notice."""
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        probe,
+        ["--recipe", str(PROBE_MINIMAL), "--output", str(tmp_path / "o"), "--", "echo", "hi"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.stderr
+    assert "aorta sweep run" in result.stderr
+    mock_run_recipe.assert_called_once()
+
+
+def test_triage_list_mitigations_warns():
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(triage, ["list-mitigations"])
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.stderr
+    assert "aorta sweep list-mitigations" in result.stderr

--- a/tests/sweep/test_sweep_cli.py
+++ b/tests/sweep/test_sweep_cli.py
@@ -222,6 +222,36 @@ def test_empty_argv_after_separator_rejected(mock_run_recipe):
     mock_run_recipe.assert_not_called()
 
 
+def test_leaked_dash_flag_without_separator_names_sweep(mock_run_recipe):
+    """A dash-prefixed leaked token (no `--`) errors naming `aorta sweep run`, not `aorta probe`.
+
+    `_bare_positional_before_separator` skips dash tokens, so a forgotten
+    `--` with a flag-shaped first token (`-c`) slips past the sweep guard
+    into `execute_probe`'s `validate_trailing_argv`. That usage error must
+    point the user at the front door they actually invoked.
+    """
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "-c"])
+    assert result.exit_code != 0
+    assert "looks like a flag" in result.output
+    assert "aorta sweep run" in result.output
+    assert "aorta probe" not in result.output
+    mock_run_recipe.assert_not_called()
+
+
+def test_dash_command_after_separator_names_sweep(mock_run_recipe):
+    """Same class with `--` present: a dash-shaped user command names the sweep front door."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "--", "-c"]
+    )
+    assert result.exit_code != 0
+    assert "looks like a flag" in result.output
+    assert "aorta sweep run" in result.output
+    assert "aorta probe" not in result.output
+    mock_run_recipe.assert_not_called()
+
+
 # --- discovery subcommands -----------------------------------------------
 
 

--- a/tests/sweep/test_sweep_cli.py
+++ b/tests/sweep/test_sweep_cli.py
@@ -203,6 +203,25 @@ def test_triage_only_flag_rejected_in_probe_flow(mock_run_recipe):
     mock_run_recipe.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "extra_flags",
+    [
+        ["--stop-after-events", "3"],
+        ["--max-trials", "20"],
+        ["--disable-detector", "tier3"],
+    ],
+)
+def test_probe_only_flag_rejected_in_workload_flow(mock_run_recipe, tmp_path, extra_flags):
+    """Probe-only knobs have no effect on a workload run and are rejected up-front."""
+    recipe = _write_triage_recipe(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["sweep", "run", "--recipe", str(recipe), *extra_flags])
+    assert result.exit_code != 0
+    assert "only apply to the probe/subprocess flow" in result.output
+    assert extra_flags[0] in result.output
+    mock_run_recipe.assert_not_called()
+
+
 def test_bare_positional_without_separator_rejected(mock_run_recipe):
     """A bare positional with no `--` is refused (inherited probe safety)."""
     runner = CliRunner()
@@ -346,6 +365,31 @@ def test_triage_list_mitigations_warns():
     assert "aorta sweep list-mitigations" in result.stderr
 
 
+def test_probe_list_patterns_points_at_sweep_list_patterns():
+    """`aorta probe --list-patterns` warns toward `aorta sweep list-patterns`, not `run`."""
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(probe, ["--list-patterns"])
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.stderr
+    assert "aorta sweep list-patterns" in result.stderr
+    # The generic `aorta sweep run` target is wrong for this surface.
+    assert "aorta sweep run" not in result.stderr
+    # Notice stays on stderr; stdout remains the catalogue.
+    assert "deprecated" not in result.stdout
+    assert "pattern" in result.stdout.lower()
+
+
+def test_probe_list_patterns_version_points_at_sweep_list_patterns():
+    """`aorta probe --list-patterns --version` keeps the notice on stderr, stdout parseable."""
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(probe, ["--list-patterns", "--version"])
+    assert result.exit_code == 0, result.output
+    assert "aorta sweep list-patterns" in result.stderr
+    assert "aorta sweep run" not in result.stderr
+    assert "deprecated" not in result.stdout
+    assert result.stdout.startswith("aorta probe pattern library v")
+
+
 # --- cross-front-door parity --------------------------------------------
 #
 # The PR's headline guarantee is that ``aorta sweep run`` is byte-identical
@@ -413,6 +457,56 @@ def test_subprocess_flow_parity_sweep_vs_probe(mock_run_recipe, tmp_path):
         lambda: runner.invoke(
             probe,
             ["--recipe", str(PROBE_MINIMAL), "--output", out, "--", "echo", "hi"],
+        ),
+    )
+
+    assert sweep_recipe == probe_recipe
+    assert sweep_kwargs == probe_kwargs
+
+
+def test_subprocess_flow_parity_sweep_vs_probe_with_stop_after(mock_run_recipe, tmp_path):
+    """`--stop-after-events`/`--max-trials` reach run_recipe identically across front doors."""
+    out = str(tmp_path / "out")
+    flags = ["--stop-after-events", "3", "--max-trials", "20"]
+    runner = CliRunner()
+
+    sweep_recipe, sweep_kwargs = _capture_engine_call(
+        mock_run_recipe,
+        lambda: runner.invoke(
+            main,
+            ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "--output", out, *flags, "--", "echo", "hi"],
+        ),
+    )
+    probe_recipe, probe_kwargs = _capture_engine_call(
+        mock_run_recipe,
+        lambda: runner.invoke(
+            probe,
+            ["--recipe", str(PROBE_MINIMAL), "--output", out, *flags, "--", "echo", "hi"],
+        ),
+    )
+
+    assert sweep_recipe == probe_recipe
+    assert sweep_kwargs == probe_kwargs
+
+
+def test_subprocess_flow_parity_sweep_vs_probe_with_disable_detector(mock_run_recipe, tmp_path):
+    """`--disable-detector` (repeatable) reaches run_recipe identically across front doors."""
+    out = str(tmp_path / "out")
+    flags = ["--disable-detector", "tier3", "--disable-detector", "tier2:hang"]
+    runner = CliRunner()
+
+    sweep_recipe, sweep_kwargs = _capture_engine_call(
+        mock_run_recipe,
+        lambda: runner.invoke(
+            main,
+            ["sweep", "run", "--recipe", str(PROBE_MINIMAL), "--output", out, *flags, "--", "echo", "hi"],
+        ),
+    )
+    probe_recipe, probe_kwargs = _capture_engine_call(
+        mock_run_recipe,
+        lambda: runner.invoke(
+            probe,
+            ["--recipe", str(PROBE_MINIMAL), "--output", out, *flags, "--", "echo", "hi"],
         ),
     )
 


### PR DESCRIPTION
## Summary

Merges the two front-door CLIs that already drove the same engine
(`aorta.triage.runner.run_recipe`) into a single unified command,
**`aorta sweep`**. `aorta triage` and `aorta probe` differed only in how a
trial body is produced — an in-process built-in **workload** vs. a wrapped
**subprocess** — plus a few output/resume knobs that the recipe `mode:`
field already discriminates.

Closes #248.

### What changed

- **New `aorta sweep` group** (`src/aorta/cli/sweep.py`):
  - `aorta sweep run` auto-dispatches by intent — a trailing `-- <command>`
    or a `mode: probe` recipe selects the subprocess flow
    (`layout="flat_resume"`, `resume_existing=True`, `subprocess_argv=...`);
    otherwise the in-process workload flow runs with engine defaults.
  - Up-front **consistency guards** (clear `UsageError`s, no silent
    fallback): probe-mode recipe with no command; a trailing command with a
    workload recipe; probe-only `--env-passthrough-mode` in the workload
    flow; workload-only flags (`--workload`, axes, `--trials`, …) with a
    subprocess command.
  - The mandatory `--` separator safety inherited from `aorta probe` is
    preserved (relaxed to *only* fire when a user command is supplied).
  - `aorta sweep list-mitigations | list-environments | list-patterns`
    fold the old discovery surfaces into one consistent group.
- **No functionality degradation:** the flow bodies are extracted into
  shared `execute_triage_run` / `execute_probe` functions that `aorta sweep`
  **and** the legacy commands all call — behaviour is byte-identical across
  front doors (the existing shared-engine + thin-shim tests still pass).
- **Deprecation aliases:** `aorta triage` and `aorta probe` keep working but
  print a one-line **stderr** notice naming the exact `aorta sweep`
  replacement, then delegate to the same engine. The notice goes to stderr
  so it never contaminates stdout/artifact-path output.
- **Docs:** README, `docs/probe-188/usage.md` (migration banner + old→new
  table), `docs/buck2.md`, `recipes/README*.md`, recipe headers, and
  handout templates updated to lead with `aorta sweep`.

### Migration

| Old | New |
| --- | --- |
| `aorta triage run --recipe r.yaml` | `aorta sweep run --recipe r.yaml` |
| `aorta triage run --workload fsdp ...` | `aorta sweep run --workload fsdp ...` |
| `aorta triage list-mitigations` | `aorta sweep list-mitigations` |
| `aorta triage list-environments` | `aorta sweep list-environments` |
| `aorta probe --recipe r.yaml -- <cmd>` | `aorta sweep run --recipe r.yaml -- <cmd>` |
| `aorta probe --list-patterns` | `aorta sweep list-patterns` |

## Test plan

- [x] New `tests/sweep/test_sweep_cli.py` (19 tests): flow dispatch + engine
  knobs, default output-dir per flow, all consistency guards, `--` separator
  safety, discovery subcommands, and that legacy aliases warn on stderr +
  delegate.
- [x] **Cross-front-door engine parity** (`test_workload_flow_parity_sweep_vs_triage`,
  `test_subprocess_flow_parity_sweep_vs_probe`): for identical input, `aorta sweep
  run` and the legacy `aorta triage run` / `aorta probe` reach `run_recipe` with an
  **equal `Recipe` and identical engine kwargs** — pinning the "byte-identical
  across front doors" guarantee that the per-flow tests above only checked in
  isolation (so a future divergence in one dispatcher's engine call now fails
  loudly instead of silently). Extends `tests/probe/test_shared_engine.py`, which
  only covered the original probe↔triage pair, to the new `sweep` front door.
- [x] `tests/probe`, `tests/triage`, `tests/run`, `tests/bundle` — 805
  passed, no regressions (shared-engine + thin-shim contracts intact).
- [x] `ruff check` / `ruff format` clean on changed files.
- [ ] Reviewer: confirm the deprecation-notice wording/UX is acceptable.

