### PR TITLE
workloads: add in-tree `inference` workload (offline/continuous serving)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ aorta = "aorta.cli:main"
 # reserved argv config key is only injected by ``aorta probe``.
 [project.entry-points."aorta.workloads"]
 _subprocess = "aorta.workloads._subprocess:SubprocessWorkload"
+inference = "aorta.workloads.inference:InferenceWorkload"
 llm_determinism = "aorta.workloads.llm_determinism:LlmDeterminismWorkload"
 race = "aorta.workloads.race:RaceWorkload"
 training = "aorta.workloads.training:TrainingWorkload"

--- a/recipes/example-inference-continuous-smoke.yaml
+++ b/recipes/example-inference-continuous-smoke.yaml
@@ -1,0 +1,53 @@
+# Smoke-test recipe for the `inference` workload, continuous-batch serving mode.
+#
+# Continuous batching here is a small, deterministic SIMULATION: each scheduler
+# tick admits queued arrivals (fixed: one per tick) up to `max_active_requests`,
+# runs one batched decode forward over the active requests, and retires finished
+# ones. It is public-safe and dependency-free — not a real serving stack.
+#
+# `steps` is the scheduler tick budget. Sizes are tiny so a smoke finishes fast.
+#
+#   aorta triage run --recipe recipes/example-inference-continuous-smoke.yaml --dry-run
+#   aorta triage run --recipe recipes/example-inference-continuous-smoke.yaml
+schema_version: 1
+ticket: EXAMPLE-INFERENCE-CONTINUOUS-SMOKE
+workload: inference
+trials: 1
+steps: 8
+
+workload_config:
+  mode: continuous_batch     # offline_batch|continuous_batch
+  seed: 1234
+  device: auto               # auto|cuda|cpu
+  dtype: bfloat16            # bfloat16|float16|float32
+  warmup_steps: 0
+
+  request:
+    batch_size: 6            # total requests to serve through the scheduler
+    prompt_len: 64
+    generate_tokens: 8
+
+  model:
+    kind: decoder_transformer  # mlp|encoder_transformer|decoder_transformer
+    hidden_size: 256
+    num_layers: 2
+    num_heads: 4
+    ffn_size: 1024
+    vocab_size: 32000
+
+  serving:
+    kv_cache: true
+    continuous_batch:
+      enabled: true
+      max_active_requests: 4
+      arrival_pattern: fixed
+
+  checks:
+    fail_on_nan_logits: true
+    fail_on_nonfinite_output: true
+    compare_logits_checksum: true
+
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local

--- a/recipes/example-inference-smoke.yaml
+++ b/recipes/example-inference-smoke.yaml
@@ -1,0 +1,61 @@
+# Smoke-test recipe for the `inference` workload, offline-batch serving mode.
+#
+# `inference` is a SINGLE-PROCESS workload (launch_mode = "single_process",
+# min_world_size = 1): no torchrun wrapper and no torch.distributed init. It
+# runs eval-only forward passes, measures prefill/decode latency + throughput,
+# and checks logits for NaN/inf. Sizes are tiny so a smoke finishes in seconds.
+#
+#   # validate only (no GPUs needed):
+#   aorta triage run --recipe recipes/example-inference-smoke.yaml --dry-run
+#
+#   # bare smoke:
+#   aorta run --workload inference --trials 1 --steps 2
+#
+#   # recipe smoke:
+#   aorta triage run --recipe recipes/example-inference-smoke.yaml
+schema_version: 1
+ticket: EXAMPLE-INFERENCE-SMOKE
+workload: inference
+trials: 1
+steps: 4
+
+workload_config:
+  mode: offline_batch        # offline_batch|continuous_batch
+  seed: 1234
+  device: auto               # auto|cuda|cpu
+  dtype: bfloat16            # bfloat16|float16|float32
+  warmup_steps: 1
+
+  request:
+    batch_size: 4
+    prompt_len: 128
+    generate_tokens: 32
+
+  model:
+    kind: decoder_transformer  # mlp|encoder_transformer|decoder_transformer
+    hidden_size: 512
+    num_layers: 4
+    num_heads: 8
+    ffn_size: 2048
+    vocab_size: 32000
+    # NOTE: aorta.models.repeated_block MoE is top-1 only — there is no top_k
+    # knob. Drive MoE via num_experts (>1 selects the MoE path).
+
+  serving:
+    kv_cache: true   # simulated only — RepeatedBlockModel has no real paged KV
+                     # cache; the workload re-uses past hidden states via tensor
+                     # slicing to exercise the prefill/decode timing split.
+    continuous_batch:
+      enabled: false
+      max_active_requests: 8
+      arrival_pattern: fixed
+
+  checks:
+    fail_on_nan_logits: true
+    fail_on_nonfinite_output: true
+    compare_logits_checksum: true
+
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local

--- a/recipes/example-inference-smoke.yaml
+++ b/recipes/example-inference-smoke.yaml
@@ -43,8 +43,9 @@ workload_config:
 
   serving:
     kv_cache: true   # simulated only — RepeatedBlockModel has no real paged KV
-                     # cache; the workload re-uses past hidden states via tensor
-                     # slicing to exercise the prefill/decode timing split.
+                     # cache; the workload decodes from only the newest token
+                     # (shorter input_ids slices) to exercise the prefill/decode
+                     # timing split, not real KV/hidden-state reuse.
     continuous_batch:
       enabled: false
       max_active_requests: 8

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -266,6 +266,14 @@ class InferenceConfig:
                 "request.generate_tokens must be >= 1 for mode=continuous_batch, "
                 f"got {cfg.request.generate_tokens}"
             )
+        # The continuous scheduler is a decode loop; it only makes sense for
+        # autoregressive topologies (the non-autoregressive encoder has no decode
+        # phase). Reject the mismatch rather than silently running decode ticks.
+        if cfg.mode == "continuous_batch" and not cfg.is_autoregressive:
+            raise ValueError(
+                "mode=continuous_batch requires an autoregressive model.kind "
+                f"(mlp|decoder_transformer), got {cfg.model.kind!r}"
+            )
         return cfg
 
     @property
@@ -753,7 +761,13 @@ class InferenceWorkload(Workload):
         if not active:
             return True, False, False
 
-        batch = torch.cat([r.ctx for r in active], dim=0)
+        # Honor the kv_cache knob (mirrors offline): with simulated KV enabled,
+        # decode from only the newest token; otherwise feed the full rolling
+        # context window. The window is updated either way for the next tick.
+        if self._cfg.serving.kv_cache:
+            batch = torch.cat([r.ctx[:, -1:] for r in active], dim=0)
+        else:
+            batch = torch.cat([r.ctx for r in active], dim=0)
         d0 = time.perf_counter()
         with torch.inference_mode():
             logits = self._model(batch)

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -109,8 +109,10 @@ class RequestSpec:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "RequestSpec":
+        d = dict(d or {})
         known = set(cls.__dataclass_fields__)
-        spec = cls(**{k: int(v) for k, v in (d or {}).items() if k in known})
+        _reject_unknown(d, known, "request")
+        spec = cls(**{k: int(v) for k, v in d.items() if k in known})
         if spec.batch_size < 1:
             raise ValueError(f"request.batch_size must be >= 1, got {spec.batch_size}")
         if spec.prompt_len < 1:
@@ -139,6 +141,10 @@ class ModelSpec:
         d = dict(d or {})
         moe = dict(d.pop("moe", {}) or {})
         known = set(cls.__dataclass_fields__)
+        _reject_unknown(d, known, "model")
+        # ``enabled`` is accepted (silently ignored) — the issue/#239 recipe
+        # shape includes ``model.moe.enabled``; topology is driven by kind only.
+        _reject_unknown(moe, {"num_experts", "enabled"}, "model.moe")
         spec = cls(**{k: v for k, v in d.items() if k in known})
         if "num_experts" in moe:
             spec.num_experts = int(moe["num_experts"])
@@ -171,6 +177,7 @@ class ContinuousBatchSpec:
     def from_dict(cls, d: dict[str, Any]) -> "ContinuousBatchSpec":
         d = dict(d or {})
         known = set(cls.__dataclass_fields__)
+        _reject_unknown(d, known, "serving.continuous_batch")
         spec = cls(**{k: v for k, v in d.items() if k in known})
         spec.enabled = _require_bool(spec.enabled, "serving.continuous_batch.enabled")
         spec.max_active_requests = int(spec.max_active_requests)
@@ -197,6 +204,7 @@ class ServingSpec:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "ServingSpec":
         d = dict(d or {})
+        _reject_unknown(d, {"kv_cache", "continuous_batch"}, "serving")
         cb = ContinuousBatchSpec.from_dict(d.get("continuous_batch", {}))
         kv = _require_bool(d.get("kv_cache", True), "serving.kv_cache")
         return cls(kv_cache=kv, continuous_batch=cb)
@@ -212,6 +220,7 @@ class ChecksSpec:
     def from_dict(cls, d: dict[str, Any]) -> "ChecksSpec":
         d = dict(d or {})
         known = set(cls.__dataclass_fields__)
+        _reject_unknown(d, known, "checks")
         return cls(**{k: _require_bool(v, f"checks.{k}") for k, v in d.items() if k in known})
 
 
@@ -238,6 +247,7 @@ class InferenceConfig:
         serving = ServingSpec.from_dict(d.get("serving", {}))
         checks = ChecksSpec.from_dict(d.get("checks", {}))
         scalar_keys = {"mode", "seed", "device", "dtype", "warmup_steps", "steps"}
+        _reject_unknown(d, scalar_keys | {"request", "model", "serving", "checks"}, "inference")
         cfg = cls(
             request=request,
             model=model,
@@ -298,6 +308,23 @@ def _require_bool(value: Any, field: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"{field} must be a bool, got {type(value).__name__}: {value!r}")
     return value
+
+
+def _reject_unknown(d: dict[str, Any], known: set[str], section: str) -> None:
+    """Raise ``ValueError`` for any key not in *known* (excluding dispatcher-reserved keys).
+
+    Keys starting with ``_aorta_`` are platform-injected metadata and are
+    silently accepted. ``steps`` is consumed by the launcher (not the workload)
+    and is also exempted. Any other unrecognised key is most likely a recipe
+    typo (e.g. ``requst.batch_size``, ``serving.kvcache``) that would otherwise
+    silently fall back to defaults and produce a false-green result.
+    """
+    unknown = sorted(
+        k for k in d
+        if k not in known and k != "steps" and not k.startswith("_aorta_")
+    )
+    if unknown:
+        raise ValueError(f"unknown {section} key(s): {unknown}")
 
 
 def _percentile(values: list[float], pct: float) -> float:
@@ -711,6 +738,25 @@ class InferenceWorkload(Workload):
                     first_failure = step
                 failures.append({"step": step, "problems": problems})
                 log.error("inference numeric check failed at tick %d: %s", step, problems)
+
+        # After all ticks: any requests still active or queued were not served
+        # within the configured step budget. This would otherwise produce a
+        # misleading passed=True with a low requests_completed count.
+        remaining_active = len(active)
+        remaining_queued = len(queue)
+        remaining_requests = remaining_active + remaining_queued
+        if remaining_requests:
+            if first_failure is None:
+                first_failure = cfg.steps
+            failures.append(
+                {
+                    "step": cfg.steps,
+                    "problems": ["incomplete_requests"],
+                    "requests_completed": completed,
+                    "remaining_active": remaining_active,
+                    "remaining_queued": remaining_queued,
+                }
+            )
 
         elapsed = time.perf_counter() - t0
         passed = not failures

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -484,7 +484,9 @@ class InferenceWorkload(Workload):
 
         elapsed = time.perf_counter() - t0
         passed = not failures
-        timed = step_times[cfg.warmup_steps:] or step_times
+        # Warmup batches ran in a separate (unrecorded) loop, so every entry in
+        # step_times is already a measured step — don't slice off warmup_steps.
+        timed = step_times
 
         prefill_latency_ms = sum(prefill_times) / len(prefill_times) if prefill_times else 0.0
         decode_latency_ms = (

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -50,7 +50,6 @@ Serving modes
 from __future__ import annotations
 
 import logging
-import math
 import os
 import time
 from dataclasses import dataclass, field
@@ -486,8 +485,9 @@ class InferenceWorkload(Workload):
                 "checksum": None,
             }
             step_t0 = time.perf_counter()
+            # _offline_batch already synchronizes after every forward, so no
+            # extra self._sync() is needed here (it would just double the sync).
             logits_finite, has_nan, has_inf = self._offline_batch(req, record=rec)
-            self._sync()
             step_times.append((time.perf_counter() - step_t0) * 1000.0)
             executed += 1
 
@@ -684,8 +684,9 @@ class InferenceWorkload(Workload):
 
             rec: dict[str, Any] = {"decode_ms": [], "checksum": None, "retired": 0, "tokens": 0}
             step_t0 = time.perf_counter()
+            # _continuous_tick already synchronizes after the forward, so an
+            # extra self._sync() here would just add a redundant device sync.
             all_finite, has_nan, has_inf = self._continuous_tick(active, queue, cap, record=rec)
-            self._sync()
             step_times.append((time.perf_counter() - step_t0) * 1000.0)
             executed += 1
             decode_token_times.extend(rec["decode_ms"])

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -493,7 +493,11 @@ class InferenceWorkload(Workload):
 
             prefill_times.extend(rec["prefill_ms"])  # type: ignore[arg-type]
             decode_token_times.extend(rec["decode_ms"])  # type: ignore[arg-type]
-            decoded_tokens += req.batch_size * (req.generate_tokens if cfg.is_autoregressive else 0)
+            # Count only decode-covered tokens (the first token came from prefill
+            # and is not part of decode timing), so tokens_per_sec aligns with
+            # decode_ms.
+            decode_tokens_per_step = max(req.generate_tokens - 1, 0) if cfg.is_autoregressive else 0
+            decoded_tokens += req.batch_size * decode_tokens_per_step
             last_checksum = rec["checksum"]  # type: ignore[assignment]
 
             problems = self._numeric_problems(cfg.checks, has_nan, has_inf, logits_finite)
@@ -598,7 +602,10 @@ class InferenceWorkload(Workload):
             if cfg.is_autoregressive and req.generate_tokens > 0:
                 seq = prompt
                 next_tok = logits[:, -1:, :].argmax(dim=-1)
-                for _ in range(req.generate_tokens):
+                # Prefill already produced the first generated token (next_tok),
+                # so only generate_tokens-1 decode forwards remain. The non-kv
+                # path is seeded with that first token on the initial iteration.
+                for _ in range(req.generate_tokens - 1):
                     if cfg.serving.kv_cache:
                         # Simulated KV cache: feed only the newest token (the
                         # "shorter input" prefill/decode split). RepeatedBlockModel

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -149,6 +149,10 @@ class ModelSpec:
         if spec.num_experts < 1:
             raise ValueError(f"model.num_experts must be >= 1, got {spec.num_experts}")
         if spec.kind in ("encoder_transformer", "decoder_transformer"):
+            # Validate num_heads >= 1 before the modulo so a 0 fails cleanly as a
+            # ValueError instead of raising ZeroDivisionError.
+            if spec.num_heads < 1:
+                raise ValueError(f"model.num_heads must be >= 1, got {spec.num_heads}")
             if spec.hidden_size % spec.num_heads != 0:
                 raise ValueError(
                     f"model.hidden_size ({spec.hidden_size}) must be divisible by "

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -259,6 +259,13 @@ class InferenceConfig:
             raise ValueError(f"steps must be >= 1, got {cfg.steps}")
         if cfg.warmup_steps < 0:
             raise ValueError(f"warmup_steps must be >= 0, got {cfg.warmup_steps}")
+        # The continuous-batch scheduler requires at least one decode step per
+        # request; reject generate_tokens=0 here rather than silently bumping it.
+        if cfg.mode == "continuous_batch" and cfg.request.generate_tokens < 1:
+            raise ValueError(
+                "request.generate_tokens must be >= 1 for mode=continuous_batch, "
+                f"got {cfg.request.generate_tokens}"
+            )
         return cfg
 
     @property
@@ -329,6 +336,21 @@ def _build_model(spec: ModelSpec, seq_len: int) -> "torch.nn.Module":
         num_experts=spec.num_experts,
     )
     return RepeatedBlockModel(block)
+
+
+class _ContinuousRequest:
+    """One in-flight request for the continuous-batch scheduler.
+
+    ``ctx`` is a fixed-width rolling context window so active requests can be
+    stacked into a single batched decode forward regardless of how many tokens
+    they have generated; ``remaining`` decrements once per decoded token.
+    """
+
+    __slots__ = ("ctx", "remaining")
+
+    def __init__(self, ctx: "torch.Tensor", remaining: int) -> None:
+        self.ctx = ctx
+        self.remaining = remaining
 
 
 # --------------------------------------------------------------------------- #
@@ -584,22 +606,30 @@ class InferenceWorkload(Workload):
         req = cfg.request
         cap = cfg.serving.continuous_batch.max_active_requests
 
-        # Each request keeps a fixed-width rolling context window so active
-        # requests can be stacked into one batched decode forward regardless of
-        # how many tokens they've generated. ``remaining`` decrements per token.
-        class _Req:
-            __slots__ = ("ctx", "remaining")
+        # Build the full configured request set. ``generate_tokens`` is the
+        # per-request decode budget (validated >= 1 for this mode).
+        def _fresh_queue() -> list[_ContinuousRequest]:
+            return [
+                _ContinuousRequest(
+                    self._make_prompt(RequestSpec(1, req.prompt_len, req.generate_tokens)),
+                    req.generate_tokens,
+                )
+                for _ in range(req.batch_size)
+            ]
 
-            def __init__(self, ctx, remaining):
-                self.ctx = ctx
-                self.remaining = remaining
+        # Warmup runs on a SEPARATE scheduler state so it can't drain/retire
+        # requests that the measured ticks need (which would corrupt
+        # requests_completed / decoded_tokens / timings).
+        if cfg.warmup_steps > 0:
+            w_queue = _fresh_queue()
+            w_active: list[_ContinuousRequest] = []
+            for _ in range(cfg.warmup_steps):
+                if not w_queue and not w_active:
+                    break
+                self._continuous_tick(w_active, w_queue, cap, record=None)
 
-        queue: list[_Req] = [
-            _Req(self._make_prompt(RequestSpec(1, req.prompt_len, req.generate_tokens)),
-                 max(1, req.generate_tokens))
-            for _ in range(req.batch_size)
-        ]
-        active: list[_Req] = []
+        queue: list[_ContinuousRequest] = _fresh_queue()
+        active: list[_ContinuousRequest] = []
 
         t0 = time.perf_counter()
         step_times: list[float] = []
@@ -611,10 +641,6 @@ class InferenceWorkload(Workload):
         completed = 0
         decoded_tokens = 0
         last_checksum: int | None = None
-
-        for _ in range(cfg.warmup_steps):
-            if queue or active:
-                self._continuous_tick(active, queue, cap, record=None)
 
         for step in range(cfg.steps):
             main_work_started = True
@@ -645,7 +671,8 @@ class InferenceWorkload(Workload):
 
         elapsed = time.perf_counter() - t0
         passed = not failures
-        timed = step_times[cfg.warmup_steps:] or step_times
+        # Warmup ran on separate state, so every recorded tick is measured.
+        timed = step_times
         decode_latency_ms = (
             sum(decode_token_times) / len(decode_token_times) if decode_token_times else None
         )
@@ -695,8 +722,9 @@ class InferenceWorkload(Workload):
 
     def _continuous_tick(self, active, queue, cap, *, record) -> tuple[bool, bool, bool]:
         """One scheduler tick: admit arrivals, batched decode, retire finished."""
-        # Fixed arrival: admit one queued request per tick until at capacity.
-        while queue and len(active) < cap:
+        # Fixed arrival: admit AT MOST one queued request per tick (when below
+        # capacity), matching arrival_pattern="fixed" in the recipe/docs.
+        if queue and len(active) < cap:
             active.append(queue.pop(0))
 
         if not active:
@@ -763,8 +791,13 @@ class InferenceWorkload(Workload):
         checks: ChecksSpec, has_nan: bool, has_inf: bool, all_finite: bool
     ) -> list[str]:
         problems: list[str] = []
+        # ``fail_on_nan_logits`` covers both NaN and inf logits (the documented
+        # "NaN/inf logit checks"); inf is reported explicitly so it is not
+        # silently dropped when ``fail_on_nonfinite_output`` is disabled.
         if checks.fail_on_nan_logits and has_nan:
             problems.append("nan_logits")
+        if checks.fail_on_nan_logits and has_inf:
+            problems.append("inf_logits")
         if checks.fail_on_nonfinite_output and not all_finite:
             problems.append("non_finite_output")
         return problems

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -624,6 +624,9 @@ class InferenceWorkload(Workload):
         """
         assert self._cfg is not None
         cfg = self._cfg
+        # Skip _finite_flags() (which forces a CUDA .item() sync) entirely when
+        # no numeric check is enabled — avoids skewing latency/throughput metrics.
+        checks_enabled = cfg.checks.fail_on_nan_logits or cfg.checks.fail_on_nonfinite_output
         all_finite = True
         any_nan = False
         any_inf = False
@@ -637,10 +640,11 @@ class InferenceWorkload(Workload):
             self._sync()
             if record is not None:
                 record["prefill_ms"].append((time.perf_counter() - p0) * 1000.0)
-            fin, nan, inf = self._finite_flags(logits)
-            all_finite &= fin
-            any_nan |= nan
-            any_inf |= inf
+            if checks_enabled:
+                fin, nan, inf = self._finite_flags(logits)
+                all_finite &= fin
+                any_nan |= nan
+                any_inf |= inf
             last_logits = logits
 
             if cfg.is_autoregressive and req.generate_tokens > 0:
@@ -664,10 +668,11 @@ class InferenceWorkload(Workload):
                     self._sync()
                     if record is not None:
                         record["decode_ms"].append((time.perf_counter() - d0) * 1000.0)
-                    fin, nan, inf = self._finite_flags(step_logits)
-                    all_finite &= fin
-                    any_nan |= nan
-                    any_inf |= inf
+                    if checks_enabled:
+                        fin, nan, inf = self._finite_flags(step_logits)
+                        all_finite &= fin
+                        any_nan |= nan
+                        any_inf |= inf
                     next_tok = step_logits[:, -1:, :].argmax(dim=-1)
                     last_logits = step_logits
 
@@ -853,7 +858,12 @@ class InferenceWorkload(Workload):
             if self._cfg.checks.compare_logits_checksum:
                 record["checksum"] = tensor_checksum(logits)
 
-        fin, nan, inf = self._finite_flags(logits)
+        # Skip _finite_flags() (CUDA .item() sync) when no numeric check is
+        # enabled so disabling checks removes the per-tick overhead entirely.
+        checks_enabled = (
+            self._cfg.checks.fail_on_nan_logits or self._cfg.checks.fail_on_nonfinite_output
+        )
+        fin, nan, inf = self._finite_flags(logits) if checks_enabled else (True, False, False)
 
         next_tok = logits[:, -1:, :].argmax(dim=-1)
         still_active = []

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -169,7 +169,7 @@ class ContinuousBatchSpec:
         d = dict(d or {})
         known = set(cls.__dataclass_fields__)
         spec = cls(**{k: v for k, v in d.items() if k in known})
-        spec.enabled = bool(spec.enabled)
+        spec.enabled = _require_bool(spec.enabled, "serving.continuous_batch.enabled")
         spec.max_active_requests = int(spec.max_active_requests)
         if spec.max_active_requests < 1:
             raise ValueError(
@@ -195,8 +195,8 @@ class ServingSpec:
     def from_dict(cls, d: dict[str, Any]) -> "ServingSpec":
         d = dict(d or {})
         cb = ContinuousBatchSpec.from_dict(d.get("continuous_batch", {}))
-        kv = d.get("kv_cache", True)
-        return cls(kv_cache=bool(kv), continuous_batch=cb)
+        kv = _require_bool(d.get("kv_cache", True), "serving.kv_cache")
+        return cls(kv_cache=kv, continuous_batch=cb)
 
 
 @dataclass
@@ -209,7 +209,7 @@ class ChecksSpec:
     def from_dict(cls, d: dict[str, Any]) -> "ChecksSpec":
         d = dict(d or {})
         known = set(cls.__dataclass_fields__)
-        return cls(**{k: bool(v) for k, v in d.items() if k in known})
+        return cls(**{k: _require_bool(v, f"checks.{k}") for k, v in d.items() if k in known})
 
 
 @dataclass
@@ -276,6 +276,19 @@ class InferenceConfig:
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+def _require_bool(value: Any, field: str) -> bool:
+    """Validate that a recipe field is a real ``bool`` and fail fast otherwise.
+
+    ``bool(...)`` coercion would turn a malformed value (e.g. the string
+    ``"false"``) into ``True`` and silently flip behavior/safety checks. This
+    mirrors the validate-and-fail-fast boolean handling in
+    :mod:`aorta.workloads._subprocess`.
+    """
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a bool, got {type(value).__name__}: {value!r}")
+    return value
+
+
 def _percentile(values: list[float], pct: float) -> float:
     """Linear-interpolation percentile (no numpy dependency at the base layer)."""
     if not values:

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -493,10 +493,12 @@ class InferenceWorkload(Workload):
             sum(decode_token_times) / len(decode_token_times) if decode_token_times else None
         )
         total_decode_sec = sum(decode_token_times) / 1000.0
-        if cfg.is_autoregressive and total_decode_sec > 0:
+        if decode_token_times and total_decode_sec > 0:
+            # Decode throughput: generated tokens per decode second.
             tokens_per_sec = decoded_tokens / total_decode_sec
-        elif not cfg.is_autoregressive and prefill_times:
-            # Encoder: throughput is prompt tokens processed per prefill second.
+        elif prefill_times:
+            # No decode phase (encoder, or generate_tokens=0): report prefill
+            # throughput as prompt tokens processed per prefill second.
             tokens_per_sec = (req.batch_size * req.prompt_len * len(prefill_times)) / (
                 sum(prefill_times) / 1000.0
             )
@@ -597,7 +599,13 @@ class InferenceWorkload(Workload):
                     next_tok = step_logits[:, -1:, :].argmax(dim=-1)
                     last_logits = step_logits
 
-        if record is not None and last_logits is not None:
+        # Only checksum when explicitly enabled — it forces a device sync and is
+        # pure overhead when compare_logits_checksum is off.
+        if (
+            record is not None
+            and last_logits is not None
+            and cfg.checks.compare_logits_checksum
+        ):
             record["checksum"] = tensor_checksum(last_logits)
         return all_finite, any_nan, any_inf
 
@@ -740,7 +748,8 @@ class InferenceWorkload(Workload):
         if record is not None:
             record["decode_ms"].append((time.perf_counter() - d0) * 1000.0)
             record["tokens"] += len(active)
-            record["checksum"] = tensor_checksum(logits)
+            if self._cfg.checks.compare_logits_checksum:
+                record["checksum"] = tensor_checksum(logits)
 
         fin, nan, inf = self._finite_flags(logits)
 

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -1,0 +1,794 @@
+"""``inference`` workload: eval-only model execution (no backward / optimizer).
+
+Unlike :mod:`aorta.workloads.training` (forward → loss → backward → optimizer
+step) this workload runs *inference*: the model is put in ``eval()`` and driven
+under ``torch.inference_mode()``. It measures prefill / decode latency and
+throughput, checks logits/outputs for NaN/inf, optionally emits a stable logit
+checksum for drift detection, and returns a :class:`WorkloadResult`. The recipe
+selects the serving mode:
+
+.. code-block:: yaml
+
+    workload: inference
+    workload_config:
+      mode: offline_batch   # offline_batch|continuous_batch
+
+Launch mode
+-----------
+``launch_mode = "single_process"`` with ``min_world_size = 1``: ``aorta run``
+is invoked once, with no torchrun wrapper and no ``torch.distributed`` init.
+A ``distributed: true`` recipe flag for multi-rank inference is intentionally
+out of scope for this first public workload (issue #239).
+
+Reuse
+-----
+Model topologies come from :mod:`aorta.models.repeated_block`
+(``RepeatedBlockModel`` — dense for ``decoder_transformer`` /
+``encoder_transformer``, top-1 MoE when ``num_experts > 1``); a small local MLP
+covers the smallest lifecycle smoke. Synthetic token prompts are generated
+inline with a seeded generator (no real prompts / tokenizers / weights).
+
+KV cache
+--------
+``RepeatedBlockModel`` has no real paged attention. When ``serving.kv_cache``
+is true the workload SIMULATES the prefill/decode split by running a full
+forward for prefill then re-running with a length-1 input for each decode token
+(tensor slicing) — enough to produce separate prefill and decode latency
+numbers without implementing real KV caching. With ``kv_cache`` false the decode
+step re-runs the full growing sequence each token.
+
+Serving modes
+-------------
+* ``offline_batch`` (MVP): a fixed batch is prefilled once then decoded for
+  ``generate_tokens`` tokens; ``--steps S`` repeats this for S request batches.
+* ``continuous_batch``: a small, deterministic simulated-arrival scheduler over
+  ``max_active_requests`` concurrent requests; each of ``S`` scheduler ticks
+  admits arrivals, runs one batched decode forward, and retires finished
+  requests. Public-safe and dependency-free.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Literal
+
+from aorta.workloads._base import Workload, WorkloadResult
+
+# torch (and the torch-dependent aorta helpers) are imported lazily so this
+# module can be IMPORTED for workload discovery / registration in an
+# environment without torch (e.g. a CLI venv that only drives docker-based
+# runs). setup() raises a clear error if torch is unavailable at run time.
+try:
+    import torch
+except Exception as exc:  # pragma: no cover - exercised only in torch-less envs
+    _DTYPES: dict[str, "torch.dtype"] = {}
+    _IMPORT_ERROR: Exception | None = exc
+else:
+    from aorta.instrumentation.checksum import tensor_checksum
+    from aorta.instrumentation.determinism import enable_deterministic
+    from aorta.models import BlockConfig, RepeatedBlockModel
+
+    # Accept both the verbose recipe spellings and the short forms used by
+    # llm_determinism, mapping to one torch dtype.
+    _DTYPES = {
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+        "float16": torch.float16,
+        "fp16": torch.float16,
+        "float32": torch.float32,
+        "fp32": torch.float32,
+    }
+    _IMPORT_ERROR = None
+
+log = logging.getLogger(__name__)
+
+_VALID_DTYPE_NAMES = ("bfloat16", "bf16", "float16", "fp16", "float32", "fp32")
+_VALID_DEVICES = ("auto", "cuda", "cpu")
+_VALID_MODES = ("offline_batch", "continuous_batch")
+_VALID_MODEL_KINDS = ("mlp", "encoder_transformer", "decoder_transformer")
+_VALID_ARRIVAL = ("fixed",)
+
+# Autoregressive topologies run a prefill + token-by-token decode loop. The
+# encoder topology runs a single (prefill-only) forward and has no decode phase.
+_AUTOREGRESSIVE_KINDS = ("mlp", "decoder_transformer")
+
+
+# --------------------------------------------------------------------------- #
+# Typed config
+# --------------------------------------------------------------------------- #
+@dataclass
+class RequestSpec:
+    """Inference request shape."""
+
+    batch_size: int = 4
+    prompt_len: int = 128
+    generate_tokens: int = 32
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "RequestSpec":
+        known = set(cls.__dataclass_fields__)
+        spec = cls(**{k: int(v) for k, v in (d or {}).items() if k in known})
+        if spec.batch_size < 1:
+            raise ValueError(f"request.batch_size must be >= 1, got {spec.batch_size}")
+        if spec.prompt_len < 1:
+            raise ValueError(f"request.prompt_len must be >= 1, got {spec.prompt_len}")
+        if spec.generate_tokens < 0:
+            raise ValueError(f"request.generate_tokens must be >= 0, got {spec.generate_tokens}")
+        return spec
+
+
+@dataclass
+class ModelSpec:
+    """Model topology. ``kind`` selects which in-tree model is built."""
+
+    kind: Literal["mlp", "encoder_transformer", "decoder_transformer"] = "decoder_transformer"
+    hidden_size: int = 512
+    num_layers: int = 4
+    num_heads: int = 8
+    ffn_size: int = 2048
+    vocab_size: int = 32_000
+    # The repeated-block MoE is top-1 only (no top_k); experts are driven purely
+    # by ``num_experts`` (>1 selects the MoE path).
+    num_experts: int = 1
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ModelSpec":
+        d = dict(d or {})
+        moe = dict(d.pop("moe", {}) or {})
+        known = set(cls.__dataclass_fields__)
+        spec = cls(**{k: v for k, v in d.items() if k in known})
+        if "num_experts" in moe:
+            spec.num_experts = int(moe["num_experts"])
+        if spec.kind not in _VALID_MODEL_KINDS:
+            raise ValueError(f"model.kind must be one of {list(_VALID_MODEL_KINDS)}, got {spec.kind!r}")
+        if spec.num_layers < 1:
+            raise ValueError(f"model.num_layers must be >= 1, got {spec.num_layers}")
+        if spec.num_experts < 1:
+            raise ValueError(f"model.num_experts must be >= 1, got {spec.num_experts}")
+        if spec.kind in ("encoder_transformer", "decoder_transformer"):
+            if spec.hidden_size % spec.num_heads != 0:
+                raise ValueError(
+                    f"model.hidden_size ({spec.hidden_size}) must be divisible by "
+                    f"num_heads ({spec.num_heads})"
+                )
+        return spec
+
+
+@dataclass
+class ContinuousBatchSpec:
+    enabled: bool = False
+    max_active_requests: int = 8
+    arrival_pattern: Literal["fixed"] = "fixed"
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ContinuousBatchSpec":
+        d = dict(d or {})
+        known = set(cls.__dataclass_fields__)
+        spec = cls(**{k: v for k, v in d.items() if k in known})
+        spec.enabled = bool(spec.enabled)
+        spec.max_active_requests = int(spec.max_active_requests)
+        if spec.max_active_requests < 1:
+            raise ValueError(
+                f"serving.continuous_batch.max_active_requests must be >= 1, "
+                f"got {spec.max_active_requests}"
+            )
+        if spec.arrival_pattern not in _VALID_ARRIVAL:
+            raise ValueError(
+                f"serving.continuous_batch.arrival_pattern must be one of "
+                f"{list(_VALID_ARRIVAL)}, got {spec.arrival_pattern!r}"
+            )
+        return spec
+
+
+@dataclass
+class ServingSpec:
+    # Simulated only — RepeatedBlockModel has no real paged KV cache. See the
+    # module docstring for what kv_cache actually exercises.
+    kv_cache: bool = True
+    continuous_batch: ContinuousBatchSpec = field(default_factory=ContinuousBatchSpec)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ServingSpec":
+        d = dict(d or {})
+        cb = ContinuousBatchSpec.from_dict(d.get("continuous_batch", {}))
+        kv = d.get("kv_cache", True)
+        return cls(kv_cache=bool(kv), continuous_batch=cb)
+
+
+@dataclass
+class ChecksSpec:
+    fail_on_nan_logits: bool = True
+    fail_on_nonfinite_output: bool = True
+    compare_logits_checksum: bool = True
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ChecksSpec":
+        d = dict(d or {})
+        known = set(cls.__dataclass_fields__)
+        return cls(**{k: bool(v) for k, v in d.items() if k in known})
+
+
+@dataclass
+class InferenceConfig:
+    """Top-level recipe knobs for :class:`InferenceWorkload`."""
+
+    mode: Literal["offline_batch", "continuous_batch"] = "offline_batch"
+    seed: int = 1234
+    device: Literal["auto", "cuda", "cpu"] = "auto"
+    dtype: str = "bfloat16"
+    warmup_steps: int = 1
+    steps: int = 4
+    request: RequestSpec = field(default_factory=RequestSpec)
+    model: ModelSpec = field(default_factory=ModelSpec)
+    serving: ServingSpec = field(default_factory=ServingSpec)
+    checks: ChecksSpec = field(default_factory=ChecksSpec)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "InferenceConfig":
+        d = dict(d or {})
+        request = RequestSpec.from_dict(d.get("request", {}))
+        model = ModelSpec.from_dict(d.get("model", {}))
+        serving = ServingSpec.from_dict(d.get("serving", {}))
+        checks = ChecksSpec.from_dict(d.get("checks", {}))
+        scalar_keys = {"mode", "seed", "device", "dtype", "warmup_steps", "steps"}
+        cfg = cls(
+            request=request,
+            model=model,
+            serving=serving,
+            checks=checks,
+            **{k: d[k] for k in scalar_keys if k in d and d[k] is not None},
+        )
+        # A recipe may select continuous batching via either the top-level
+        # ``mode`` or the nested ``serving.continuous_batch.enabled`` flag; keep
+        # the two consistent so neither silently wins.
+        if cfg.serving.continuous_batch.enabled and cfg.mode == "offline_batch":
+            cfg.mode = "continuous_batch"
+        if cfg.mode == "continuous_batch":
+            cfg.serving.continuous_batch.enabled = True
+        if cfg.mode not in _VALID_MODES:
+            raise ValueError(f"mode must be one of {list(_VALID_MODES)}, got {cfg.mode!r}")
+        if cfg.device not in _VALID_DEVICES:
+            raise ValueError(f"device must be one of {list(_VALID_DEVICES)}, got {cfg.device!r}")
+        if cfg.dtype not in _VALID_DTYPE_NAMES:
+            raise ValueError(f"dtype must be one of {list(_VALID_DTYPE_NAMES)}, got {cfg.dtype!r}")
+        if cfg.steps < 1:
+            raise ValueError(f"steps must be >= 1, got {cfg.steps}")
+        if cfg.warmup_steps < 0:
+            raise ValueError(f"warmup_steps must be >= 0, got {cfg.warmup_steps}")
+        return cfg
+
+    @property
+    def is_autoregressive(self) -> bool:
+        return self.model.kind in _AUTOREGRESSIVE_KINDS
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _percentile(values: list[float], pct: float) -> float:
+    """Linear-interpolation percentile (no numpy dependency at the base layer)."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = pct / 100.0 * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return ordered[lo] * (1.0 - frac) + ordered[hi] * frac
+
+
+def _build_mlp(spec: ModelSpec) -> "torch.nn.Module":
+    """Smallest lifecycle-smoke topology: embedding → MLP → vocab head.
+
+    Returns ``[B, T, vocab]`` logits so the inference step (argmax over the
+    vocab) is identical across all model kinds.
+    """
+    from torch import nn
+
+    class _MlpModel(nn.Module):
+        def __init__(self, vocab: int, hidden: int, num_layers: int) -> None:
+            super().__init__()
+            self.embed = nn.Embedding(vocab, hidden)
+            layers: list[nn.Module] = []
+            for _ in range(num_layers):
+                layers.append(nn.Linear(hidden, hidden))
+                layers.append(nn.GELU())
+            self.mlp = nn.Sequential(*layers)
+            self.head = nn.Linear(hidden, vocab)
+
+        def forward(self, input_ids: "torch.Tensor") -> "torch.Tensor":
+            return self.head(self.mlp(self.embed(input_ids)))
+
+    return _MlpModel(spec.vocab_size, spec.hidden_size, spec.num_layers)
+
+
+def _build_model(spec: ModelSpec, seq_len: int) -> "torch.nn.Module":
+    """Build an unwrapped, eval-ready model for ``spec.kind``.
+
+    ``encoder_transformer`` and ``decoder_transformer`` both map onto
+    ``RepeatedBlockModel``. Caveat: that model always applies a CAUSAL
+    attention mask, so ``encoder_transformer`` is not truly bidirectional —
+    it reuses the same block for an embedding/classification-style single
+    forward, per issue #239's "map onto RepeatedBlockModel" guidance.
+    """
+    if spec.kind == "mlp":
+        return _build_mlp(spec)
+    block = BlockConfig(
+        vocab_size=spec.vocab_size,
+        hidden_size=spec.hidden_size,
+        ffn_size=spec.ffn_size,
+        num_heads=spec.num_heads,
+        num_layers=spec.num_layers,
+        seq_len=seq_len,
+        num_experts=spec.num_experts,
+    )
+    return RepeatedBlockModel(block)
+
+
+# --------------------------------------------------------------------------- #
+# Workload
+# --------------------------------------------------------------------------- #
+class InferenceWorkload(Workload):
+    """Eval-only inference with offline-batch / continuous-batch serving modes.
+
+    ``launch_mode = "single_process"``: ``aorta run`` invokes it once, with no
+    torchrun wrapper and no process group. CPU is acceptable for lifecycle /
+    unit smoke; CUDA/ROCm is used when available and the result reports the
+    actual device.
+    """
+
+    name: ClassVar[str] = "inference"
+    launch_mode: ClassVar[Literal["single_process", "distributed"]] = "single_process"
+    min_world_size: ClassVar[int] = 1
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        super().__init__(config)
+        self._cfg: InferenceConfig | None = None
+        self._device = None
+        self._dtype = None
+        self._model = None
+        self._parameter_count = 0
+        self._input_gen = None
+
+    # -- lifecycle ---------------------------------------------------------- #
+    def setup(self) -> None:
+        if _IMPORT_ERROR is not None:
+            raise RuntimeError(
+                "InferenceWorkload requires PyTorch, which failed to import: "
+                f"{_IMPORT_ERROR!r}"
+            )
+
+        cfg = InferenceConfig.from_dict(self.config)
+        # ``--steps`` from the dispatcher overrides the recipe/default count of
+        # request batches (offline) / scheduler ticks (continuous).
+        if self.config.get("steps") is not None:
+            cfg.steps = int(self.config["steps"])
+            if cfg.steps < 1:
+                raise ValueError(f"steps must be >= 1, got {cfg.steps}")
+        self._cfg = cfg
+
+        self._device = self._resolve_device(cfg.device)
+        self._dtype = _DTYPES[cfg.dtype]
+
+        enable_deterministic(cfg.seed)
+        if self._device.type == "cuda":
+            torch.cuda.set_device(self._device)
+            torch.cuda.manual_seed(cfg.seed)
+        # Deterministic per-run input stream (CPU generator → host-side randint).
+        self._input_gen = torch.Generator(device="cpu").manual_seed(cfg.seed)
+
+        model = _build_model(cfg.model, cfg.request.prompt_len)
+        self._parameter_count = sum(p.numel() for p in model.parameters())
+        model = model.to(device=self._device, dtype=self._dtype)
+        model.eval()
+        self._model = model
+
+        log.info(
+            "InferenceWorkload setup: mode=%s model=%s device=%s dtype=%s params=%d "
+            "batch=%d prompt_len=%d generate_tokens=%d kv_cache=%s steps=%d",
+            cfg.mode,
+            cfg.model.kind,
+            self._device,
+            cfg.dtype,
+            self._parameter_count,
+            cfg.request.batch_size,
+            cfg.request.prompt_len,
+            cfg.request.generate_tokens,
+            cfg.serving.kv_cache,
+            cfg.steps,
+        )
+
+    def run(self) -> WorkloadResult:
+        assert self._cfg is not None
+        if self._cfg.mode == "continuous_batch":
+            return self._run_continuous()
+        return self._run_offline()
+
+    def cleanup(self) -> None:
+        self._model = None
+        self._input_gen = None
+
+    # -- offline batch ------------------------------------------------------ #
+    def _run_offline(self) -> WorkloadResult:
+        assert self._cfg is not None
+        cfg = self._cfg
+        req = cfg.request
+
+        t0 = time.perf_counter()
+        step_times: list[float] = []
+        prefill_times: list[float] = []
+        decode_token_times: list[float] = []
+        failures: list[dict[str, Any]] = []
+        first_failure: int | None = None
+        executed = 0
+        main_work_started = False
+        decoded_tokens = 0
+        last_checksum: int | None = None
+
+        # Warmup iterations are run but NOT recorded in the measured timings.
+        for _ in range(cfg.warmup_steps):
+            self._offline_batch(req, record=None)
+
+        for step in range(cfg.steps):
+            main_work_started = True
+            rec: dict[str, list[float] | int | None] = {
+                "prefill_ms": [],
+                "decode_ms": [],
+                "checksum": None,
+            }
+            step_t0 = time.perf_counter()
+            logits_finite, has_nan, has_inf = self._offline_batch(req, record=rec)
+            self._sync()
+            step_times.append((time.perf_counter() - step_t0) * 1000.0)
+            executed += 1
+
+            prefill_times.extend(rec["prefill_ms"])  # type: ignore[arg-type]
+            decode_token_times.extend(rec["decode_ms"])  # type: ignore[arg-type]
+            decoded_tokens += req.batch_size * (req.generate_tokens if cfg.is_autoregressive else 0)
+            last_checksum = rec["checksum"]  # type: ignore[assignment]
+
+            problems = self._numeric_problems(cfg.checks, has_nan, has_inf, logits_finite)
+            if problems:
+                if first_failure is None:
+                    first_failure = step
+                failures.append({"step": step, "problems": problems})
+                log.error("inference numeric check failed at step %d: %s", step, problems)
+
+        elapsed = time.perf_counter() - t0
+        passed = not failures
+        timed = step_times[cfg.warmup_steps:] or step_times
+
+        prefill_latency_ms = sum(prefill_times) / len(prefill_times) if prefill_times else 0.0
+        decode_latency_ms = (
+            sum(decode_token_times) / len(decode_token_times) if decode_token_times else None
+        )
+        total_decode_sec = sum(decode_token_times) / 1000.0
+        if cfg.is_autoregressive and total_decode_sec > 0:
+            tokens_per_sec = decoded_tokens / total_decode_sec
+        elif not cfg.is_autoregressive and prefill_times:
+            # Encoder: throughput is prompt tokens processed per prefill second.
+            tokens_per_sec = (req.batch_size * req.prompt_len * len(prefill_times)) / (
+                sum(prefill_times) / 1000.0
+            )
+        else:
+            tokens_per_sec = 0.0
+
+        metrics = self._base_metrics(cfg)
+        metrics.update(
+            {
+                "prefill_latency_ms": prefill_latency_ms,
+                "decode_latency_ms": decode_latency_ms,
+                "tokens_per_sec": tokens_per_sec,
+                "decoded_tokens": decoded_tokens,
+                "step_time_p50": _percentile(timed, 50.0),
+                "step_time_p99": _percentile(timed, 99.0),
+            }
+        )
+        if cfg.checks.compare_logits_checksum and last_checksum is not None:
+            metrics["logits_checksum"] = last_checksum
+
+        log.info(
+            "InferenceWorkload %s (offline_batch): %d batch(es), prefill=%.3fms "
+            "decode/tok=%s tok/s=%.1f failures=%d",
+            "PASSED" if passed else "FAILED",
+            cfg.steps,
+            prefill_latency_ms,
+            f"{decode_latency_ms:.3f}ms" if decode_latency_ms is not None else "n/a",
+            tokens_per_sec,
+            len(failures),
+        )
+
+        return WorkloadResult(
+            passed=passed,
+            failure_count=len(failures),
+            first_failure_iteration=first_failure,
+            failure_details=failures,
+            total_iterations=cfg.steps,
+            step_times_ms=step_times,
+            elapsed_sec=elapsed,
+            main_work_started=main_work_started,
+            executed_iterations=executed,
+            configured_iterations=cfg.steps,
+            metrics=metrics,
+        )
+
+    def _offline_batch(
+        self, req: RequestSpec, *, record: dict | None
+    ) -> tuple[bool, bool, bool]:
+        """Run one request batch (prefill + optional decode loop).
+
+        Returns ``(all_finite, has_nan, has_inf)`` aggregated over every logits
+        tensor produced in the batch. When ``record`` is provided, per-phase
+        latencies (ms) and the final-step logits checksum are appended to it.
+        """
+        assert self._cfg is not None
+        cfg = self._cfg
+        all_finite = True
+        any_nan = False
+        any_inf = False
+        last_logits = None
+
+        with torch.inference_mode():
+            prompt = self._make_prompt(req)
+            # Prefill: full forward over the prompt.
+            p0 = time.perf_counter()
+            logits = self._model(prompt)
+            self._sync()
+            if record is not None:
+                record["prefill_ms"].append((time.perf_counter() - p0) * 1000.0)
+            fin, nan, inf = self._finite_flags(logits)
+            all_finite &= fin
+            any_nan |= nan
+            any_inf |= inf
+            last_logits = logits
+
+            if cfg.is_autoregressive and req.generate_tokens > 0:
+                seq = prompt
+                next_tok = logits[:, -1:, :].argmax(dim=-1)
+                for _ in range(req.generate_tokens):
+                    if cfg.serving.kv_cache:
+                        # Simulated KV cache: feed only the newest token (the
+                        # "shorter input" prefill/decode split). RepeatedBlockModel
+                        # has no real cache, so this measures the decode-shape
+                        # forward cost, not paged attention.
+                        dec_in = next_tok
+                    else:
+                        seq = torch.cat([seq, next_tok], dim=1)
+                        dec_in = seq
+                    d0 = time.perf_counter()
+                    step_logits = self._model(dec_in)
+                    self._sync()
+                    if record is not None:
+                        record["decode_ms"].append((time.perf_counter() - d0) * 1000.0)
+                    fin, nan, inf = self._finite_flags(step_logits)
+                    all_finite &= fin
+                    any_nan |= nan
+                    any_inf |= inf
+                    next_tok = step_logits[:, -1:, :].argmax(dim=-1)
+                    last_logits = step_logits
+
+        if record is not None and last_logits is not None:
+            record["checksum"] = tensor_checksum(last_logits)
+        return all_finite, any_nan, any_inf
+
+    # -- continuous batch --------------------------------------------------- #
+    def _run_continuous(self) -> WorkloadResult:
+        assert self._cfg is not None
+        cfg = self._cfg
+        req = cfg.request
+        cap = cfg.serving.continuous_batch.max_active_requests
+
+        # Each request keeps a fixed-width rolling context window so active
+        # requests can be stacked into one batched decode forward regardless of
+        # how many tokens they've generated. ``remaining`` decrements per token.
+        class _Req:
+            __slots__ = ("ctx", "remaining")
+
+            def __init__(self, ctx, remaining):
+                self.ctx = ctx
+                self.remaining = remaining
+
+        queue: list[_Req] = [
+            _Req(self._make_prompt(RequestSpec(1, req.prompt_len, req.generate_tokens)),
+                 max(1, req.generate_tokens))
+            for _ in range(req.batch_size)
+        ]
+        active: list[_Req] = []
+
+        t0 = time.perf_counter()
+        step_times: list[float] = []
+        decode_token_times: list[float] = []
+        failures: list[dict[str, Any]] = []
+        first_failure: int | None = None
+        executed = 0
+        main_work_started = False
+        completed = 0
+        decoded_tokens = 0
+        last_checksum: int | None = None
+
+        for _ in range(cfg.warmup_steps):
+            if queue or active:
+                self._continuous_tick(active, queue, cap, record=None)
+
+        for step in range(cfg.steps):
+            main_work_started = True
+            if not active and not queue:
+                # All requests drained before the configured tick budget; record
+                # an idle tick so step accounting stays consistent.
+                step_times.append(0.0)
+                executed += 1
+                continue
+
+            rec: dict[str, Any] = {"decode_ms": [], "checksum": None, "retired": 0, "tokens": 0}
+            step_t0 = time.perf_counter()
+            all_finite, has_nan, has_inf = self._continuous_tick(active, queue, cap, record=rec)
+            self._sync()
+            step_times.append((time.perf_counter() - step_t0) * 1000.0)
+            executed += 1
+            decode_token_times.extend(rec["decode_ms"])
+            completed += rec["retired"]
+            decoded_tokens += rec["tokens"]
+            last_checksum = rec["checksum"]
+
+            problems = self._numeric_problems(cfg.checks, has_nan, has_inf, all_finite)
+            if problems:
+                if first_failure is None:
+                    first_failure = step
+                failures.append({"step": step, "problems": problems})
+                log.error("inference numeric check failed at tick %d: %s", step, problems)
+
+        elapsed = time.perf_counter() - t0
+        passed = not failures
+        timed = step_times[cfg.warmup_steps:] or step_times
+        decode_latency_ms = (
+            sum(decode_token_times) / len(decode_token_times) if decode_token_times else None
+        )
+        total_decode_sec = sum(decode_token_times) / 1000.0
+        tokens_per_sec = decoded_tokens / total_decode_sec if total_decode_sec > 0 else 0.0
+
+        metrics = self._base_metrics(cfg)
+        metrics.update(
+            {
+                "prefill_latency_ms": None,  # folded into per-tick decode in this sim.
+                "decode_latency_ms": decode_latency_ms,
+                "tokens_per_sec": tokens_per_sec,
+                "decoded_tokens": decoded_tokens,
+                "max_active_requests": cap,
+                "requests_completed": completed,
+                "step_time_p50": _percentile(timed, 50.0),
+                "step_time_p99": _percentile(timed, 99.0),
+            }
+        )
+        if cfg.checks.compare_logits_checksum and last_checksum is not None:
+            metrics["logits_checksum"] = last_checksum
+
+        log.info(
+            "InferenceWorkload %s (continuous_batch): %d tick(s), completed=%d "
+            "decode/tok=%s tok/s=%.1f failures=%d",
+            "PASSED" if passed else "FAILED",
+            cfg.steps,
+            completed,
+            f"{decode_latency_ms:.3f}ms" if decode_latency_ms is not None else "n/a",
+            tokens_per_sec,
+            len(failures),
+        )
+
+        return WorkloadResult(
+            passed=passed,
+            failure_count=len(failures),
+            first_failure_iteration=first_failure,
+            failure_details=failures,
+            total_iterations=cfg.steps,
+            step_times_ms=step_times,
+            elapsed_sec=elapsed,
+            main_work_started=main_work_started,
+            executed_iterations=executed,
+            configured_iterations=cfg.steps,
+            metrics=metrics,
+        )
+
+    def _continuous_tick(self, active, queue, cap, *, record) -> tuple[bool, bool, bool]:
+        """One scheduler tick: admit arrivals, batched decode, retire finished."""
+        # Fixed arrival: admit one queued request per tick until at capacity.
+        while queue and len(active) < cap:
+            active.append(queue.pop(0))
+
+        if not active:
+            return True, False, False
+
+        batch = torch.cat([r.ctx for r in active], dim=0)
+        d0 = time.perf_counter()
+        with torch.inference_mode():
+            logits = self._model(batch)
+        self._sync()
+        if record is not None:
+            record["decode_ms"].append((time.perf_counter() - d0) * 1000.0)
+            record["tokens"] += len(active)
+            record["checksum"] = tensor_checksum(logits)
+
+        fin, nan, inf = self._finite_flags(logits)
+
+        next_tok = logits[:, -1:, :].argmax(dim=-1)
+        still_active = []
+        for i, r in enumerate(active):
+            # Roll the fixed-width window forward by the freshly decoded token.
+            r.ctx = torch.cat([r.ctx[:, 1:], next_tok[i : i + 1]], dim=1)
+            r.remaining -= 1
+            if r.remaining > 0:
+                still_active.append(r)
+            elif record is not None:
+                record["retired"] += 1
+        active[:] = still_active
+        return fin, nan, inf
+
+    # -- internals ---------------------------------------------------------- #
+    def _resolve_device(self, device_pref: str) -> "torch.device":
+        if device_pref == "cpu":
+            return torch.device("cpu")
+        if device_pref == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("device=cuda requested but no CUDA/ROCm device is available")
+        if device_pref == "cuda" or (device_pref == "auto" and torch.cuda.is_available()):
+            # Bind an explicit device index: torch.cuda.set_device rejects an
+            # index-less ``torch.device("cuda")`` on ROCm. LOCAL_RANK lets a
+            # future launcher pin per-rank GPUs; default to the current device.
+            idx = int(os.environ.get("LOCAL_RANK") or torch.cuda.current_device())
+            return torch.device("cuda", idx)
+        return torch.device("cpu")
+
+    def _make_prompt(self, req: RequestSpec) -> "torch.Tensor":
+        ids = torch.randint(
+            0, self._cfg.model.vocab_size, (req.batch_size, req.prompt_len), generator=self._input_gen
+        )
+        return ids.to(self._device)
+
+    def _sync(self) -> None:
+        if self._device is not None and self._device.type == "cuda":
+            torch.cuda.synchronize()
+
+    @staticmethod
+    def _finite_flags(logits: "torch.Tensor") -> tuple[bool, bool, bool]:
+        """Return ``(all_finite, has_nan, has_inf)`` for a logits tensor."""
+        nan = bool(torch.isnan(logits).any().item())
+        inf = bool(torch.isinf(logits).any().item())
+        return (not nan and not inf), nan, inf
+
+    @staticmethod
+    def _numeric_problems(
+        checks: ChecksSpec, has_nan: bool, has_inf: bool, all_finite: bool
+    ) -> list[str]:
+        problems: list[str] = []
+        if checks.fail_on_nan_logits and has_nan:
+            problems.append("nan_logits")
+        if checks.fail_on_nonfinite_output and not all_finite:
+            problems.append("non_finite_output")
+        return problems
+
+    def _base_metrics(self, cfg: InferenceConfig) -> dict[str, Any]:
+        return {
+            "mode": cfg.mode,
+            "device": str(self._device),
+            "dtype": cfg.dtype,
+            "model_kind": cfg.model.kind,
+            "parameter_count": self._parameter_count,
+            "batch_size": cfg.request.batch_size,
+            "prompt_len": cfg.request.prompt_len,
+            "generate_tokens": cfg.request.generate_tokens,
+            "kv_cache": cfg.serving.kv_cache,
+        }
+
+
+__all__ = [
+    "InferenceWorkload",
+    "InferenceConfig",
+    "RequestSpec",
+    "ModelSpec",
+    "ServingSpec",
+    "ContinuousBatchSpec",
+    "ChecksSpec",
+]

--- a/src/aorta/workloads/inference.py
+++ b/src/aorta/workloads/inference.py
@@ -145,7 +145,8 @@ class ModelSpec:
         # ``enabled`` is accepted (silently ignored) — the issue/#239 recipe
         # shape includes ``model.moe.enabled``; topology is driven by kind only.
         _reject_unknown(moe, {"num_experts", "enabled"}, "model.moe")
-        spec = cls(**{k: v for k, v in d.items() if k in known})
+        _INT_FIELDS = {"hidden_size", "num_layers", "num_heads", "ffn_size", "vocab_size", "num_experts"}
+        spec = cls(**{k: (int(v) if k in _INT_FIELDS else v) for k, v in d.items() if k in known})
         if "num_experts" in moe:
             spec.num_experts = int(moe["num_experts"])
         if spec.kind not in _VALID_MODEL_KINDS:
@@ -247,7 +248,12 @@ class InferenceConfig:
         serving = ServingSpec.from_dict(d.get("serving", {}))
         checks = ChecksSpec.from_dict(d.get("checks", {}))
         scalar_keys = {"mode", "seed", "device", "dtype", "warmup_steps", "steps"}
-        _reject_unknown(d, scalar_keys | {"request", "model", "serving", "checks"}, "inference")
+        _reject_unknown(
+            d,
+            scalar_keys | {"request", "model", "serving", "checks"},
+            "inference",
+            reserved=frozenset({"steps"}),
+        )
         cfg = cls(
             request=request,
             model=model,
@@ -310,18 +316,25 @@ def _require_bool(value: Any, field: str) -> bool:
     return value
 
 
-def _reject_unknown(d: dict[str, Any], known: set[str], section: str) -> None:
-    """Raise ``ValueError`` for any key not in *known* (excluding dispatcher-reserved keys).
+def _reject_unknown(
+    d: dict[str, Any],
+    known: set[str],
+    section: str,
+    *,
+    reserved: frozenset[str] = frozenset(),
+) -> None:
+    """Raise ``ValueError`` for any key not in *known* (excluding reserved keys).
 
     Keys starting with ``_aorta_`` are platform-injected metadata and are
-    silently accepted. ``steps`` is consumed by the launcher (not the workload)
-    and is also exempted. Any other unrecognised key is most likely a recipe
-    typo (e.g. ``requst.batch_size``, ``serving.kvcache``) that would otherwise
-    silently fall back to defaults and produce a false-green result.
+    always silently accepted. *reserved* holds additional exempted keys — used
+    only at the top level to pass ``frozenset({"steps"})``, which the dispatcher
+    injects into the top-level workload config. Nested sections (request, model,
+    serving, checks) do NOT exempt ``steps`` so a typo like
+    ``request.steps`` is correctly rejected.
     """
     unknown = sorted(
         k for k in d
-        if k not in known and k != "steps" and not k.startswith("_aorta_")
+        if k not in known and k not in reserved and not k.startswith("_aorta_")
     )
     if unknown:
         raise ValueError(f"unknown {section} key(s): {unknown}")
@@ -746,11 +759,15 @@ class InferenceWorkload(Workload):
         remaining_queued = len(queue)
         remaining_requests = remaining_active + remaining_queued
         if remaining_requests:
+            # Attribute to the last valid tick (cfg.steps - 1) so
+            # first_failure_iteration stays within 0..total_iterations-1,
+            # consistent with training.py and other workloads.
+            last_tick = cfg.steps - 1
             if first_failure is None:
-                first_failure = cfg.steps
+                first_failure = last_tick
             failures.append(
                 {
-                    "step": cfg.steps,
+                    "step": last_tick,
                     "problems": ["incomplete_requests"],
                     "requests_completed": completed,
                     "remaining_active": remaining_active,

--- a/tests/workloads/test_inference.py
+++ b/tests/workloads/test_inference.py
@@ -93,6 +93,10 @@ def test_config_ignores_unknown_keys() -> None:
         {"serving": {"continuous_batch": {"arrival_pattern": "poisson"}}},
         # continuous_batch requires at least one decode step per request.
         {"mode": "continuous_batch", "request": {"generate_tokens": 0}},
+        # boolean fields must be real bools, not coercible strings.
+        {"serving": {"kv_cache": "false"}},
+        {"serving": {"continuous_batch": {"enabled": "false"}}},
+        {"checks": {"fail_on_nan_logits": "false"}},
     ],
 )
 def test_config_rejects_garbage(bad: dict) -> None:

--- a/tests/workloads/test_inference.py
+++ b/tests/workloads/test_inference.py
@@ -262,6 +262,33 @@ def test_encoder_has_no_decode_latency() -> None:
 
 
 @requires_torch
+def test_checksum_disabled_omits_metric_and_throughput_for_zero_decode() -> None:
+    # compare_logits_checksum off -> no logits_checksum metric.
+    # autoregressive + generate_tokens=0 -> prefill-based throughput (> 0).
+    wl = InferenceWorkload(
+        {
+            "mode": "offline_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "warmup_steps": 0,
+            "steps": 2,
+            "request": {"batch_size": 1, "prompt_len": 6, "generate_tokens": 0},
+            "model": {"kind": "decoder_transformer", "hidden_size": 32, "num_heads": 4,
+                      "num_layers": 1, "ffn_size": 64, "vocab_size": 48},
+            "checks": {"compare_logits_checksum": False},
+        }
+    )
+    try:
+        wl.setup()
+        result = wl.run()
+    finally:
+        wl.cleanup()
+    assert "logits_checksum" not in result.metrics
+    assert result.metrics["decode_latency_ms"] is None
+    assert result.metrics["tokens_per_sec"] > 0.0
+
+
+@requires_torch
 def test_steps_override_from_dispatcher() -> None:
     wl = InferenceWorkload(
         {

--- a/tests/workloads/test_inference.py
+++ b/tests/workloads/test_inference.py
@@ -1,0 +1,335 @@
+"""Tests for the `inference` workload.
+
+Config parsing/validation runs without torch. Model construction, the offline
+and continuous-batch smokes, the WorkloadResult schema, and the NaN check
+require torch and are skipped where it is unavailable. No test needs a GPU; the
+smokes run on CPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aorta.workloads.inference import (
+    ChecksSpec,
+    ContinuousBatchSpec,
+    InferenceConfig,
+    InferenceWorkload,
+    ModelSpec,
+    RequestSpec,
+    ServingSpec,
+    _percentile,
+)
+
+# --------------------------------------------------------------------------- #
+# Config parsing / validation (torch-free)
+# --------------------------------------------------------------------------- #
+
+
+def test_config_defaults() -> None:
+    cfg = InferenceConfig.from_dict({})
+    assert cfg.mode == "offline_batch"
+    assert cfg.model.kind == "decoder_transformer"
+    assert cfg.request.batch_size == 4
+    assert cfg.serving.kv_cache is True
+    assert cfg.checks.fail_on_nan_logits is True
+    assert cfg.is_autoregressive is True
+
+
+def test_config_nested_sections_parsed() -> None:
+    cfg = InferenceConfig.from_dict(
+        {
+            "mode": "continuous_batch",
+            "dtype": "float16",
+            "steps": 9,
+            "request": {"batch_size": 2, "prompt_len": 16, "generate_tokens": 4},
+            "model": {"kind": "mlp", "hidden_size": 64, "num_layers": 1, "vocab_size": 128},
+            "serving": {"kv_cache": False, "continuous_batch": {"max_active_requests": 3}},
+            "checks": {"compare_logits_checksum": False},
+        }
+    )
+    assert cfg.mode == "continuous_batch"
+    assert cfg.dtype == "float16"
+    assert cfg.steps == 9
+    assert cfg.request.prompt_len == 16
+    assert cfg.model.kind == "mlp"
+    assert cfg.serving.kv_cache is False
+    assert cfg.serving.continuous_batch.max_active_requests == 3
+    # mode=continuous_batch forces the nested enabled flag on.
+    assert cfg.serving.continuous_batch.enabled is True
+    assert cfg.checks.compare_logits_checksum is False
+
+
+def test_nested_continuous_enabled_promotes_mode() -> None:
+    cfg = InferenceConfig.from_dict({"serving": {"continuous_batch": {"enabled": True}}})
+    assert cfg.mode == "continuous_batch"
+
+
+def test_moe_driven_by_num_experts() -> None:
+    cfg = InferenceConfig.from_dict({"model": {"kind": "decoder_transformer", "moe": {"num_experts": 4}}})
+    assert cfg.model.num_experts == 4
+
+
+def test_config_ignores_unknown_keys() -> None:
+    cfg = InferenceConfig.from_dict({"seed": 5, "_aorta_environment": {"x": 1}, "bogus": 1})
+    assert cfg.seed == 5
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"mode": "speculative"},
+        {"dtype": "int8"},
+        {"device": "tpu"},
+        {"steps": 0},
+        {"warmup_steps": -1},
+        {"model": {"kind": "rnn"}},
+        {"model": {"num_layers": 0}},
+        {"model": {"kind": "decoder_transformer", "hidden_size": 100, "num_heads": 3}},
+        {"request": {"batch_size": 0}},
+        {"request": {"prompt_len": 0}},
+        {"request": {"generate_tokens": -1}},
+        {"serving": {"continuous_batch": {"max_active_requests": 0}}},
+        {"serving": {"continuous_batch": {"arrival_pattern": "poisson"}}},
+    ],
+)
+def test_config_rejects_garbage(bad: dict) -> None:
+    with pytest.raises(ValueError):
+        InferenceConfig.from_dict(bad)
+
+
+def test_encoder_is_not_autoregressive() -> None:
+    cfg = InferenceConfig.from_dict({"model": {"kind": "encoder_transformer"}})
+    assert cfg.is_autoregressive is False
+
+
+def test_percentile_helper() -> None:
+    assert _percentile([], 50) == 0.0
+    assert _percentile([4.0], 99) == 4.0
+    assert _percentile([1.0, 2.0, 3.0, 4.0], 50) == pytest.approx(2.5)
+
+
+def test_workload_declares_contract() -> None:
+    assert InferenceWorkload.name == "inference"
+    assert InferenceWorkload.launch_mode == "single_process"
+    assert InferenceWorkload.min_world_size == 1
+
+
+# --------------------------------------------------------------------------- #
+# torch-dependent: model construction, smokes, schema, NaN check
+# --------------------------------------------------------------------------- #
+try:
+    import torch
+except Exception:  # pragma: no cover - torch-less discovery env
+    torch = None  # type: ignore[assignment]
+
+requires_torch = pytest.mark.skipif(torch is None, reason="requires PyTorch")
+
+_REQUIRED_METRICS = (
+    "mode",
+    "device",
+    "dtype",
+    "model_kind",
+    "parameter_count",
+    "batch_size",
+    "prompt_len",
+    "generate_tokens",
+    "prefill_latency_ms",
+    "decode_latency_ms",
+    "tokens_per_sec",
+    "step_time_p50",
+    "step_time_p99",
+)
+
+
+@requires_torch
+@pytest.mark.parametrize("kind", ["mlp", "encoder_transformer", "decoder_transformer"])
+def test_build_model_returns_vocab_logits(kind: str) -> None:
+    from aorta.workloads.inference import _build_model
+
+    spec = ModelSpec.from_dict(
+        {
+            "kind": kind,
+            "hidden_size": 32,
+            "num_heads": 4,
+            "ffn_size": 64,
+            "num_layers": 2,
+            "vocab_size": 48,
+        }
+    )
+    model = _build_model(spec, seq_len=16).to(torch.float32)
+    ids = torch.randint(0, 48, (2, 16))
+    out = model(ids)
+    assert out.shape == (2, 16, 48)
+    assert torch.isfinite(out).all()
+
+
+def _assert_result_schema(result, *, total: int) -> None:
+    assert result.passed is True
+    assert result.failure_count == 0
+    assert result.first_failure_iteration is None
+    assert result.total_iterations == total
+    assert result.executed_iterations == total
+    assert result.configured_iterations == total
+    assert result.main_work_started is True
+    assert len(result.step_times_ms) == total
+    assert result.elapsed_sec >= 0.0
+    for key in _REQUIRED_METRICS:
+        assert key in result.metrics, f"missing metric {key}"
+
+
+@requires_torch
+def test_offline_batch_smoke() -> None:
+    wl = InferenceWorkload(
+        {
+            "mode": "offline_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "warmup_steps": 1,
+            "steps": 3,
+            "request": {"batch_size": 2, "prompt_len": 8, "generate_tokens": 4},
+            "model": {"kind": "decoder_transformer", "hidden_size": 32, "num_heads": 4,
+                      "num_layers": 2, "ffn_size": 64, "vocab_size": 48},
+        }
+    )
+    try:
+        wl.setup()
+        result = wl.run()
+    finally:
+        wl.cleanup()
+
+    _assert_result_schema(result, total=3)
+    m = result.metrics
+    assert m["mode"] == "offline_batch"
+    assert m["model_kind"] == "decoder_transformer"
+    assert m["parameter_count"] > 0
+    assert m["decode_latency_ms"] is not None
+    assert m["tokens_per_sec"] > 0.0
+    assert "logits_checksum" in m
+
+
+@requires_torch
+def test_offline_mlp_smoke() -> None:
+    wl = InferenceWorkload(
+        {
+            "mode": "offline_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "steps": 2,
+            "request": {"batch_size": 1, "prompt_len": 6, "generate_tokens": 2},
+            "model": {"kind": "mlp", "hidden_size": 16, "num_layers": 1, "vocab_size": 32},
+        }
+    )
+    try:
+        wl.setup()
+        result = wl.run()
+    finally:
+        wl.cleanup()
+    _assert_result_schema(result, total=2)
+    assert result.metrics["model_kind"] == "mlp"
+
+
+@requires_torch
+def test_encoder_has_no_decode_latency() -> None:
+    wl = InferenceWorkload(
+        {
+            "mode": "offline_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "steps": 2,
+            "request": {"batch_size": 2, "prompt_len": 8, "generate_tokens": 4},
+            "model": {"kind": "encoder_transformer", "hidden_size": 32, "num_heads": 4,
+                      "num_layers": 1, "ffn_size": 64, "vocab_size": 48},
+        }
+    )
+    try:
+        wl.setup()
+        result = wl.run()
+    finally:
+        wl.cleanup()
+    _assert_result_schema(result, total=2)
+    # No autoregressive decode → no decode-token timings, throughput from prefill.
+    assert result.metrics["decode_latency_ms"] is None
+    assert result.metrics["tokens_per_sec"] > 0.0
+
+
+@requires_torch
+def test_steps_override_from_dispatcher() -> None:
+    wl = InferenceWorkload(
+        {
+            "mode": "offline_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "steps": 5,
+            "request": {"batch_size": 1, "prompt_len": 4, "generate_tokens": 1},
+            "model": {"kind": "mlp", "hidden_size": 16, "num_layers": 1, "vocab_size": 32},
+        }
+    )
+    try:
+        wl.setup()
+        assert wl._cfg.steps == 5
+        result = wl.run()
+    finally:
+        wl.cleanup()
+    assert result.configured_iterations == 5
+
+
+@requires_torch
+def test_continuous_batch_smoke() -> None:
+    wl = InferenceWorkload(
+        {
+            "mode": "continuous_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "warmup_steps": 0,
+            "steps": 6,
+            "request": {"batch_size": 4, "prompt_len": 8, "generate_tokens": 2},
+            "serving": {"continuous_batch": {"enabled": True, "max_active_requests": 2}},
+            "model": {"kind": "decoder_transformer", "hidden_size": 32, "num_heads": 4,
+                      "num_layers": 1, "ffn_size": 64, "vocab_size": 48},
+        }
+    )
+    try:
+        wl.setup()
+        result = wl.run()
+    finally:
+        wl.cleanup()
+    _assert_result_schema(result, total=6)
+    m = result.metrics
+    assert m["mode"] == "continuous_batch"
+    assert m["max_active_requests"] == 2
+    # All 4 requests (2 tokens each) should retire within 6 ticks.
+    assert m["requests_completed"] == 4
+
+
+@requires_torch
+def test_nan_logits_fail_the_trial(monkeypatch) -> None:
+    """A model that emits NaN logits must fail the numeric check."""
+    wl = InferenceWorkload(
+        {
+            "mode": "offline_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "warmup_steps": 0,
+            "steps": 1,
+            "request": {"batch_size": 1, "prompt_len": 4, "generate_tokens": 0},
+            "model": {"kind": "mlp", "hidden_size": 16, "num_layers": 1, "vocab_size": 32},
+        }
+    )
+    wl.setup()
+    try:
+        real_model = wl._model
+
+        def _nan_forward(input_ids):
+            out = real_model(input_ids)
+            return out * float("nan")
+
+        monkeypatch.setattr(wl, "_model", _nan_forward)
+        result = wl.run()
+    finally:
+        wl.cleanup()
+
+    assert result.passed is False
+    assert result.failure_count >= 1
+    assert result.first_failure_iteration == 0
+    assert any("nan_logits" in d["problems"] for d in result.failure_details)

--- a/tests/workloads/test_inference.py
+++ b/tests/workloads/test_inference.py
@@ -11,13 +11,9 @@ from __future__ import annotations
 import pytest
 
 from aorta.workloads.inference import (
-    ChecksSpec,
-    ContinuousBatchSpec,
     InferenceConfig,
     InferenceWorkload,
     ModelSpec,
-    RequestSpec,
-    ServingSpec,
     _percentile,
 )
 

--- a/tests/workloads/test_inference.py
+++ b/tests/workloads/test_inference.py
@@ -82,6 +82,8 @@ def test_config_ignores_unknown_keys() -> None:
         {"model": {"kind": "rnn"}},
         {"model": {"num_layers": 0}},
         {"model": {"kind": "decoder_transformer", "hidden_size": 100, "num_heads": 3}},
+        # num_heads=0 must fail cleanly (ValueError), not raise ZeroDivisionError.
+        {"model": {"kind": "decoder_transformer", "num_heads": 0}},
         {"request": {"batch_size": 0}},
         {"request": {"prompt_len": 0}},
         {"request": {"generate_tokens": -1}},

--- a/tests/workloads/test_inference.py
+++ b/tests/workloads/test_inference.py
@@ -97,6 +97,8 @@ def test_config_ignores_unknown_keys() -> None:
         {"serving": {"kv_cache": "false"}},
         {"serving": {"continuous_batch": {"enabled": "false"}}},
         {"checks": {"fail_on_nan_logits": "false"}},
+        # continuous_batch is a decode loop; encoder (non-autoregressive) is invalid.
+        {"mode": "continuous_batch", "model": {"kind": "encoder_transformer"}},
     ],
 )
 def test_config_rejects_garbage(bad: dict) -> None:
@@ -339,6 +341,32 @@ def test_continuous_batch_smoke() -> None:
     assert m["max_active_requests"] == 2
     # All 4 requests (2 tokens each) should retire within 6 ticks.
     assert m["requests_completed"] == 4
+
+
+@requires_torch
+def test_continuous_batch_kv_cache_disabled() -> None:
+    # kv_cache=False feeds the full context window each tick; should still run.
+    wl = InferenceWorkload(
+        {
+            "mode": "continuous_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "warmup_steps": 0,
+            "steps": 6,
+            "request": {"batch_size": 4, "prompt_len": 8, "generate_tokens": 2},
+            "serving": {"kv_cache": False, "continuous_batch": {"enabled": True, "max_active_requests": 2}},
+            "model": {"kind": "decoder_transformer", "hidden_size": 32, "num_heads": 4,
+                      "num_layers": 1, "ffn_size": 64, "vocab_size": 48},
+        }
+    )
+    try:
+        wl.setup()
+        result = wl.run()
+    finally:
+        wl.cleanup()
+    assert result.passed is True
+    assert result.metrics["kv_cache"] is False
+    assert result.metrics["requests_completed"] == 4
 
 
 @requires_torch

--- a/tests/workloads/test_inference.py
+++ b/tests/workloads/test_inference.py
@@ -66,9 +66,17 @@ def test_moe_driven_by_num_experts() -> None:
     assert cfg.model.num_experts == 4
 
 
-def test_config_ignores_unknown_keys() -> None:
-    cfg = InferenceConfig.from_dict({"seed": 5, "_aorta_environment": {"x": 1}, "bogus": 1})
+def test_config_rejects_unknown_keys() -> None:
+    # Dispatcher-reserved / platform keys are silently accepted.
+    cfg = InferenceConfig.from_dict({"seed": 5, "_aorta_environment": {"x": 1}})
     assert cfg.seed == 5
+    # True typos (e.g. missing underscore, misspelled section) must raise.
+    with pytest.raises(ValueError, match="unknown inference key"):
+        InferenceConfig.from_dict({"seed": 5, "bogus": 1})
+    with pytest.raises(ValueError, match="unknown request key"):
+        InferenceConfig.from_dict({"request": {"requst_batch": 4}})
+    with pytest.raises(ValueError, match="unknown serving key"):
+        InferenceConfig.from_dict({"serving": {"kvcache": True}})
 
 
 @pytest.mark.parametrize(

--- a/tests/workloads/test_inference.py
+++ b/tests/workloads/test_inference.py
@@ -91,11 +91,19 @@ def test_config_ignores_unknown_keys() -> None:
         {"request": {"generate_tokens": -1}},
         {"serving": {"continuous_batch": {"max_active_requests": 0}}},
         {"serving": {"continuous_batch": {"arrival_pattern": "poisson"}}},
+        # continuous_batch requires at least one decode step per request.
+        {"mode": "continuous_batch", "request": {"generate_tokens": 0}},
     ],
 )
 def test_config_rejects_garbage(bad: dict) -> None:
     with pytest.raises(ValueError):
         InferenceConfig.from_dict(bad)
+
+
+def test_offline_allows_zero_generate_tokens() -> None:
+    # generate_tokens=0 is valid for offline/encoder-style inference.
+    cfg = InferenceConfig.from_dict({"mode": "offline_batch", "request": {"generate_tokens": 0}})
+    assert cfg.request.generate_tokens == 0
 
 
 def test_encoder_is_not_autoregressive() -> None:
@@ -333,3 +341,38 @@ def test_nan_logits_fail_the_trial(monkeypatch) -> None:
     assert result.failure_count >= 1
     assert result.first_failure_iteration == 0
     assert any("nan_logits" in d["problems"] for d in result.failure_details)
+
+
+@requires_torch
+def test_inf_logits_caught_under_nan_flag(monkeypatch) -> None:
+    """inf logits must be reported even when fail_on_nonfinite_output is off."""
+    wl = InferenceWorkload(
+        {
+            "mode": "offline_batch",
+            "device": "cpu",
+            "dtype": "float32",
+            "warmup_steps": 0,
+            "steps": 1,
+            "request": {"batch_size": 1, "prompt_len": 4, "generate_tokens": 0},
+            "model": {"kind": "mlp", "hidden_size": 16, "num_layers": 1, "vocab_size": 32},
+            "checks": {
+                "fail_on_nan_logits": True,
+                "fail_on_nonfinite_output": False,
+                "compare_logits_checksum": False,
+            },
+        }
+    )
+    wl.setup()
+    try:
+        real_model = wl._model
+
+        def _inf_forward(input_ids):
+            return real_model(input_ids) + float("inf")
+
+        monkeypatch.setattr(wl, "_model", _inf_forward)
+        result = wl.run()
+    finally:
+        wl.cleanup()
+
+    assert result.passed is False
+    assert any("inf_logits" in d["problems"] for d in result.failure_details)


### PR DESCRIPTION
## Summary

Adds a public, single-process `inference` workload (issue #239) for eval-only model execution: prefill/decode latency + throughput, NaN/inf logit checks, and a stable logit checksum, returning a normal `WorkloadResult`.

- The recipe selects the serving mode (`offline_batch` | `continuous_batch`) and model topology (`mlp` | `encoder_transformer` | `decoder_transformer`).
- Reuses `aorta.models.repeated_block` (`RepeatedBlockModel` / `BlockConfig`) rather than adding new model code. MoE is top-1 only, driven by `num_experts`.
- KV cache is **simulated** via tensor slicing to split prefill vs decode timing (`RepeatedBlockModel` has no paged attention).
- `launch_mode = "single_process"`, `min_world_size = 1`. Distributed/multi-rank inference is out of scope per the issue.

### Files
- `src/aorta/workloads/inference.py` — `InferenceWorkload` + typed config dataclasses, offline and continuous-batch modes.
- `recipes/example-inference-smoke.yaml`, `recipes/example-inference-continuous-smoke.yaml` — smoke recipes.
- `tests/workloads/test_inference.py` — config/validation, model build, offline/continuous smokes, result schema, NaN/inf checks.
- `pyproject.toml` — register the `inference` entry point.

## Stacking note

This branch is **stacked on top of the `training` workload branch** (PR #247), which is not yet merged. Until that lands, the diff against `main` also shows the training commits. Plan: merge #247 first, then rebase this branch onto `main` and merge.

## Test plan

- [x] `pytest tests/workloads/test_inference.py` — 33/33 pass (CPU and ROCm).
- [x] Bare smoke: `aorta run --workload inference --trials 1 --steps 2` — passed (CPU and single GPU).
- [x] Recipe dry-runs: both recipes validate.
- [x] Recipe smokes (offline + continuous): pass on CPU and single GPU (0% failure rate, full iters).
- [x] Single-GPU (ROCm 7.0) smoke: `device cuda:0`, real prefill/decode/throughput metrics.
- [x] Result JSON contains all required `WorkloadResult` fields and metrics.