### PR TITLE
ci: migrate remaining workflows to Node 24 action majors

### DIFF
--- a/.github/workflows/gemm-sweep-analysis.yml
+++ b/.github/workflows/gemm-sweep-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout AORTA repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ROCm/aorta
           ref : prosenj_gh_action
@@ -94,14 +94,14 @@ jobs:
           "
 
       - name: Upload sweep results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gemm-sweep-results
           path: aorta/${{ steps.setup.outputs.sweep_dir }}
           retention-days: 30
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -156,7 +156,7 @@ jobs:
           docker compose -f ${{ env.DOCKER_COMPOSE_FILE }} down
 
       - name: Upload analysis results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gemm-analysis-results
           path: |
@@ -167,7 +167,7 @@ jobs:
 
 
       - name: Checkout aorta-report repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ROCm/aorta-report
           ref: main

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/rccl-warp-speed-analysis.yml
+++ b/.github/workflows/rccl-warp-speed-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout AORTA repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ROCm/aorta
           ref: ${{ github.ref }}
@@ -312,14 +312,14 @@ jobs:
           echo "- HTML performance report" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rccl-warp-speed-results
           path: aorta/${{ steps.find_experiment.outputs.experiment_dir }}
           retention-days: 30
 
       - name: Upload comparison results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rccl-comparison-results
           path: |
@@ -328,7 +328,7 @@ jobs:
           retention-days: 30
 
       - name: Upload final report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rccl-final-report
           path: aorta/${{ steps.find_experiment.outputs.experiment_dir }}/
@@ -350,13 +350,13 @@ jobs:
 
     steps:
       - name: Download experiment results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: rccl-final-report
           path: results
 
       - name: Checkout aorta-report repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ROCm/aorta-report
           ref: main


### PR DESCRIPTION
## Summary

Brings the repo's older workflows up to the **Node 24** action majors already used by `release.yml`/`nightly.yml` (introduced in #243 / #246), clearing the version-skew that Copilot flagged on those PRs. Rather than downgrade the new workflows back to Node 20, this lifts the rest of the repo.

Per-action bump applied across the three remaining Node-20 workflows:

| Action | Before (Node 20) | After (Node 24) |
| --- | --- | --- |
| `actions/checkout` | `@v4` | `@v5` |
| `actions/setup-python` | `@v5` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v6` |
| `actions/download-artifact` | `@v4` | `@v7` |

Files changed:
- `.github/workflows/pre-commit.yml` — checkout, setup-python
- `.github/workflows/gemm-sweep-analysis.yml` — 2× checkout, setup-python, 2× upload-artifact
- `.github/workflows/rccl-warp-speed-analysis.yml` — 2× checkout, 3× upload-artifact, 1× download-artifact

The `upload-artifact@v6` / `download-artifact@v7` pairing matches the cross-major pairing already established in `release.yml`, so the in-workflow artifact handoff in `rccl-warp-speed-analysis.yml` stays consistent with the repo convention.

This is a pure version-bump diff (13 lines, no logic changes). After this PR, no workflow under `.github/` remains on the deprecated Node 20 majors.

> Note for reviewers/bots: pinning these actions *back* to `@v4`/`@v5` "for consistency" would re-introduce the deprecated Node 20 runtime — which is exactly what this PR clears. The goal is consistency on the **Node 24** majors.

## Test plan

- [ ] CI green on this PR (pre-commit + any triggered analysis workflows resolve the new action majors).
- [ ] Confirm no remaining `checkout@v4` / `setup-python@v5` / `upload-artifact@v4` / `download-artifact@v4` under `.github/`.

Closes #250

Made with [Cursor](https://cursor.com)