### PR TITLE
probe/triage: address post-merge review on stop_after (#235)

### DIFF
--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -237,7 +237,7 @@ def apply_recipe_overrides(
         recipe = dataclasses.replace(
             recipe,
             probe_extras=dataclasses.replace(
-                recipe.probe_extras, env_passthrough_mode=cli_passthrough_mode
+                probe_extras, env_passthrough_mode=cli_passthrough_mode
             ),
         )
     if cli_stop_after_events is not None or cli_max_trials is not None:

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -432,7 +432,11 @@ def _parse_stop_after(path_hint: str, raw: Any) -> StopAfter | None:
             "could never reach the target"
         )
     event_verdict = raw.get("event_verdict", "fail")
-    if event_verdict not in _STOP_AFTER_EVENT_VERDICTS:
+    # Guard ``isinstance(str)`` BEFORE the membership test: an unhashable
+    # YAML value (e.g. ``event_verdict: [fail]``) would otherwise raise a
+    # raw ``TypeError`` from ``x in frozenset`` instead of a helpful
+    # RecipeSchemaError. Mirrors the dispatcher's ``_trial_is_event`` guard.
+    if not isinstance(event_verdict, str) or event_verdict not in _STOP_AFTER_EVENT_VERDICTS:
         raise RecipeSchemaError(
             f"{path_hint}.stop_after.event_verdict: must be one of "
             f"{sorted(_STOP_AFTER_EVENT_VERDICTS)}, got {event_verdict!r}"

--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -96,6 +96,15 @@ def test_stop_after_unknown_verdict_rejected(tmp_path):
         load_recipe(_write(tmp_path, text))
 
 
+def test_stop_after_unhashable_verdict_rejected(tmp_path):
+    """An unhashable ``event_verdict`` (e.g. a YAML list) must raise a
+    RecipeSchemaError, not a raw TypeError from the frozenset membership
+    test -- the loader guards ``isinstance(str)`` first."""
+    text = _PROBE_HEAD + "stop_after:\n  events: 1\n  max_trials: 5\n  event_verdict: [fail]\n"
+    with pytest.raises(RecipeSchemaError, match="event_verdict"):
+        load_recipe(_write(tmp_path, text))
+
+
 def test_stop_after_non_int_rejected(tmp_path):
     text = _PROBE_HEAD + "stop_after:\n  events: 1.5\n  max_trials: 5\n"
     with pytest.raises(RecipeSchemaError, match="must be an integer"):


### PR DESCRIPTION
## Summary

Follow-up to the merged #235. Two Copilot review comments on that PR were never folded in before it merged (the second one arrived a couple of minutes *after* merge), so they ship as small defects on `main`. This PR fixes both.

- **`src/aorta/triage/recipe.py`** — `_parse_stop_after` now guards `isinstance(event_verdict, str)` **before** the `_STOP_AFTER_EVENT_VERDICTS` membership test. An unhashable YAML value (e.g. `event_verdict: [fail]`) previously raised a raw `TypeError` from `x in frozenset` instead of a friendly `RecipeSchemaError`. This mirrors the guard already present in the dispatcher's `_trial_is_event`. (Copilot comment [3465072201](https://github.com/ROCm/aorta/pull/235#discussion_r3465072201))
- **`src/aorta/probe/cli_helpers.py`** — the `--env-passthrough-mode` overlay builds the replacement `Recipe` from the narrowed local `probe_extras` (already asserted non-None) instead of `recipe.probe_extras`. This was originally fixed on the #235 branch but the fix was lost when `origin/main` was merged into the branch and the conflict resolved against main's older shape. Restores the mypy-clean / no-dead-binding form. (Copilot comment [3468739855](https://github.com/ROCm/aorta/pull/235#discussion_r3468739855))

Both are runtime-equivalent on the happy path; this is hardening (clear schema error) + type-correctness.

The third post-merge comment ([3468739899](https://github.com/ROCm/aorta/pull/235#discussion_r3468739899)) only asked to update the now-merged PR's *description* re `event_verdict: error`; the shipped code and docs already document `error` support correctly, so there is no code change for it.

## Test plan

- [x] New `tests/triage/test_stop_after.py::test_stop_after_unhashable_verdict_rejected` (asserts `RecipeSchemaError`, not `TypeError`).
- [x] Regression: `tests/triage/test_stop_after.py`, `tests/probe/test_cli_parsing.py`, `tests/probe/test_recipe.py` — 107 passed.
- [x] `ruff check` clean on changed files.

Made with [Cursor](https://cursor.com)