### PR TITLE
test(triage): fix stale stop_after probe-matrix row lookup for split Mitigation/Diagnostic columns

### DIFF
--- a/tests/triage/test_stop_after.py
+++ b/tests/triage/test_stop_after.py
@@ -340,7 +340,7 @@ def test_stop_after_column_shown_when_all_cells_error(tmp_path):
     recipe = _probe_recipe(tmp_path, "stop_after:\n  events: 2\n  max_trials: 6\n")
     errored = aggregate_cell(
         name="none-none",
-        mitigations=("none",),
+        mitigations=("none", "none"),
         environment="local",
         extra_env={},
         resolved_env_vars={},
@@ -352,8 +352,10 @@ def test_stop_after_column_shown_when_all_cells_error(tmp_path):
     write_matrix_md(out, recipe, [errored], errored, {}, [], "2026-06-17T00:00:00Z")
     md = out.read_text(encoding="utf-8")
     assert "Stop after" in md
-    note_row = next(line for line in md.splitlines() if line.startswith("| none-none "))
-    assert "| — " in note_row
+    # The probe matrix renders split ``Mitigation`` | ``Diagnostic`` columns
+    # (#229), so the row starts with the ``Mitigation`` axis value ("none").
+    note_row = next(line for line in md.splitlines() if line.startswith("| none "))
+    assert "| — " in note_row  # Stop after column is "—" for the all-errored run
 
 
 def test_matrix_md_trials_per_cell_reflects_cap(tmp_path):
@@ -367,7 +369,7 @@ def test_matrix_md_trials_per_cell_reflects_cap(tmp_path):
     def _render(recipe):
         cell = aggregate_cell(
             name="none-none",
-            mitigations=("none",),
+            mitigations=("none", "none"),
             environment="local",
             extra_env={},
             resolved_env_vars={},


### PR DESCRIPTION
## Summary

Fixes #255.

`tests/triage/test_stop_after.py::test_stop_after_column_shown_when_all_cells_error` fails on a pristine `main` (verified at `dcf1f4d`). It is a **pre-existing, test-only staleness** — not introduced by any open PR — surfaced while rebasing #249.

The test looked up the probe `matrix.md` row by the **old fused cell name** `none-none`:

```python
note_row = next(line for line in md.splitlines() if line.startswith("| none-none "))
```

But the probe matrix now renders **split `Mitigation` | `Diagnostic` columns** (the `is_probe` branch in `src/aorta/triage/output.py`, #229), so the data row starts with the `Mitigation` axis value (`none`), never `none-none` → `StopIteration`.

## Changes (test-only)

- Match the split-column layout: look up the row by `| none ` (the `Mitigation` column) instead of the retired `| none-none `, with a comment citing #229.
- Pass a faithful `(mitigation, diagnostic)` pair (`mitigations=("none", "none")`) instead of a 1-tuple. This mirrors what `probe.recipe_builder` guarantees and clears the tolerant-render invariant warning at `output.py:715` (`probe cell 'none-none' has 1 mitigation axis value(s)...`).
- Apply the same 2-tuple fixture fix to the sibling `test_matrix_md_trials_per_cell_reflects_cap`, which used the identical unfaithful 1-tuple and silently emitted the same warning.

No production-code change is needed — the test was simply not updated when the matrix switched to split columns. The intent of the test (the `Stop after` column renders `—` for an all-errored run) is preserved.

## Test plan

- [x] `pytest tests/triage/test_stop_after.py::test_stop_after_column_shown_when_all_cells_error -q` → passes
- [x] `pytest tests/triage/test_stop_after.py -q` → `47 passed`, no `output.py:715` invariant warning
- [x] `ruff check` clean on the changed file

Made with [Cursor](https://cursor.com)