### PR TITLE
docs: fix README inaccuracies + redact ainic recipe comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ diff <(jq -S . env_a.json) <(jq -S . env_b.json) # diff two snapshots
 aorta sweep run --recipe recipes/example-llm-determinism.yaml --dry-run   # validate only
 aorta sweep run --recipe recipes/example-llm-determinism.yaml             # run the matrix
 
-# Distributed workloads (e.g. the `race` recipe) launch under torchrun:
+# Distributed workloads launch under torchrun (llm_determinism, race, fsdp):
 torchrun --standalone --nproc_per_node=2 $(which aorta) \
   sweep run --recipe recipes/example-fsdp-smoke.yaml
+torchrun --standalone --nproc_per_node=1 $(which aorta) \
+  run --workload llm_determinism --trials 1 --steps 50
 
 # --- Unified sweep (wrap an opaque launch command) ---
 aorta sweep run --recipe recipes/probe-template-bash.yaml \
@@ -105,13 +107,14 @@ aorta sweep list-patterns
 aorta mitigations list                           # standalone registry view
 aorta environments list
 
-# --- Single workload trial (no matrix) ---
-aorta run --workload llm_determinism --trials 1 --steps 50
+# --- Single workload trial (no matrix) — training/inference only ---
+aorta run --workload training --trials 1 --steps 50
+aorta run --workload inference --trials 1 --steps 50
 
 # --- Hardware queue evaluation (requires amd-aorta[hw-queue] + torch) ---
 aorta bench hw_queue_eval list
 aorta bench hw_queue_eval run hetero_kernels --streams 8
-aorta bench hw_queue_eval sweep hetero_kernels --streams 1,2,4,8,16
+aorta bench hw_queue_eval sweep hetero_kernels --streams 2,4,8,16
 ```
 
 ## Main Workflows
@@ -145,7 +148,9 @@ concurrent streams. See [`docs/hw-queue-eval.md`](docs/hw-queue-eval.md).
 
 `aorta run --workload <name>` runs one workload directly (trials/steps,
 environment overlay, mitigations) without building a matrix — handy for iterating
-on a single reproducer.
+on a single reproducer. Note: `llm_determinism` and `race` require a distributed
+environment and must be launched under `torchrun`; `training` and `inference`
+self-bootstrap a single process.
 
 ## Workloads
 

--- a/recipes/ainic-gdr-flush-sdc.yaml
+++ b/recipes/ainic-gdr-flush-sdc.yaml
@@ -39,9 +39,8 @@
 #
 # References
 # ----------
-#   Developer on the user team, brain dump (Jun 3 2026 onsite):
-#     Path b -- GPU HBM write -> CPU proxy signal -> AINIC PCIe read
-#   User team 2K GPU overnight confirmation: NCCL_GDR_FLUSH_DISABLE=0 cleans corruption
+#   Root cause analysis: path b -- GPU HBM write -> CPU proxy signal -> AINIC PCIe read
+#   2K GPU overnight confirmation: NCCL_GDR_FLUSH_DISABLE=0 cleans corruption
 #   Doc: sdc_writeup/executive_summary.md
 
 schema_version: 1
@@ -50,7 +49,7 @@ ticket: AINIC-SDC-001
 workload: race
 
 # 16 trials per cell: corruption hits iter-0 on new QPs; 16 trials gives
-# statistical confidence given the ~35% per-attempt rate at the user team's scale.
+# statistical confidence given the ~35% per-attempt rate at this scale.
 trials: 16
 
 # 200 steps: only iter-0 is vulnerable, but run 200 steps to confirm
@@ -115,7 +114,7 @@ workload_config:
   # the AINIC collectives) instead of the forward-rerun timing proxy. Grads are
   # discarded -- not routed through reduce_scatter, no optimizer step -- so the
   # per-layer checksum detector + rank-fill/reduce_scatter-sum invariants are
-  # preserved. The war room asked for real gradients; flip to false for the
+  # preserved. real_backward=true uses real gradient kernels; flip to false for the
   # cheaper timing-proxy backward.
   real_backward: true
 
@@ -153,8 +152,8 @@ cells:
   #                                    flush itself would reintroduce the race)
   #
   # Expected: zero corruption. ~18% allreduce throughput penalty vs baseline
-  # (330->270 GB/s observed at the user team's 2K scale).
-  # Confirmed clean: user team 2K GPU overnight run, multiple restarts (Jun 3 2026).
+  # (330->270 GB/s observed at 2K scale).
+  # Confirmed clean: 2K GPU overnight run, multiple restarts.
   - name: gdr-flush
     mitigations: [none]
     environment: local

--- a/recipes/ainic-sdc-stress-reproducer.yaml
+++ b/recipes/ainic-sdc-stress-reproducer.yaml
@@ -4,7 +4,7 @@
 # ----------
 # FSDP2 all_gather on cross-node process groups (1 rank / host, all traffic
 # over AMD AINIC / Pollara RoCEv2) produces silent zero corruption on received
-# tensors at iteration 0 only.  Root cause (path b, Jun 3 2026):
+# tensors at iteration 0 only.  Root cause (path b):
 #
 #   GPU kernel writes param shard -> lands in L2 cache
 #   CPU proxy posts WQE before L2->HBM writeback completes
@@ -22,7 +22,7 @@
 #   2. Increase the number of independent trials (more all_gather calls per step).
 #   3. Replicate the multi-stream topology from the production training stack.
 #
-# Production training stream topology (confirmed Jun 3 2026):
+# Production training stream topology:
 #   ~6-7 CUDA streams live per step.  All communication streams are created as
 #   HIGH-PRIORITY streams (cudaStreamNonBlocking with priority -1).  On AMD
 #   hardware, high-priority streams get preferential HW queue scheduling, which
@@ -77,9 +77,8 @@
 #
 # References
 # ----------
-#   Developer on the user team, brain dump (Jun 3 2026 onsite):
-#     Path b -- GPU HBM write -> CPU proxy signal -> AINIC PCIe read
-#   User team 2K GPU overnight confirmation: NCCL_GDR_FLUSH_DISABLE=0 cleans corruption
+#   Root cause analysis: path b -- GPU HBM write -> CPU proxy signal -> AINIC PCIe read
+#   2K GPU overnight confirmation: NCCL_GDR_FLUSH_DISABLE=0 cleans corruption
 #   Production training topology: ~6-7 streams/step, all comms on high-priority streams
 #   Companion recipe: recipes/ainic-gdr-flush-sdc.yaml (baseline, fix, controls)
 #   Aorta race workload: src/aorta/race/modes/fsdp.py
@@ -91,7 +90,7 @@ ticket: AINIC-SDC-001
 workload: race
 
 # 24 trials: stressed config raises per-attempt rate above the baseline ~35%
-# (observed at the user team's scale); 24 trials gives >99.9% detection
+# (observed at scale); 24 trials gives >99.9% detection
 # probability if per-trial rate is >=25%.
 trials: 24
 
@@ -186,7 +185,7 @@ cells:
   # Expected: zero corruption despite maximum stress and high-priority stream
   # scheduling pressure.
   # ~18% allreduce throughput penalty vs baseline (330->270 GB/s at 2K scale).
-  # Confirmed clean: user team 2K GPU overnight run, multiple restarts (Jun 3 2026).
+  # Confirmed clean: 2K GPU overnight run, multiple restarts.
   - name: gdr-flush-stressed
     mitigations: [none]
     environment: local


### PR DESCRIPTION
## Summary

### README fixes (from smoke test)
- `llm_determinism` requires `torchrun` — move it under the torchrun block; plain `aorta run --workload llm_determinism` fails with `RANK not set`
- `aorta bench hw_queue_eval sweep --streams 1,2,4,8,16` silently drops `1`; example changed to `2,4,8,16`
- "Single-workload runs" section: note that `llm_determinism` / `race` need `torchrun`; `training` / `inference` self-bootstrap

### ainic recipe comment redaction
- Remove `Jun 3 2026 onsite` dates, `Developer on the user team, brain dump` attribution, `war room` mention, and `user team` phrasing from `ainic-gdr-flush-sdc.yaml` and `ainic-sdc-stress-reproducer.yaml`
- Technical content, env vars, cell structure, and trial counts unchanged

## Test plan
- [ ] README Quick Start torchrun block renders correctly on GitHub
- [ ] `aorta bench hw_queue_eval sweep hetero_kernels --streams 2,4,8,16` produces 4 rows
- [ ] `git grep -n "war room\|user team\|brain dump\|Jun 3\|onsite" recipes/ainic-*.yaml` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)