### PR TITLE
recipes: add race_smoke.yaml fabric-agnostic smoke test

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -190,8 +190,13 @@ aorta sweep run --recipe recipes/example-fsdp-smoke.yaml --dry-run
 torchrun --standalone --nproc_per_node=2 $(which aorta) sweep run \
   --recipe recipes/example-fsdp-smoke.yaml
 
-# multi-node (1 rank/host x N hosts -- the AINIC topology):
+# multi-node, 1 rank per host (AINIC/Pollara -- 1 process owns all GPUs on the node):
 torchrun --nnodes=N --nproc_per_node=1 --rdzv-backend=c10d \
+  --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) sweep run \
+  --recipe recipes/example-fsdp-smoke.yaml
+
+# multi-node, 1 rank per GPU (IB / NVLink / generic fabric):
+torchrun --nnodes=N --nproc_per_node=8 --rdzv-backend=c10d \
   --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) sweep run \
   --recipe recipes/example-fsdp-smoke.yaml
 ```
@@ -210,6 +215,26 @@ launch model as the `llm_determinism` workload.
 > `race: ignoring unknown workload_config key ...` and fix the recipe.
 > Note `verify_iterations` defaults to `10000` and `simulate_compute` to
 > `True`; cap these for smoke runs or a trial takes hours.
+
+### Race smoke recipes
+
+| Recipe | Purpose | Fabric |
+|---|---|---|
+| `recipes/race_smoke.yaml` | Fabric-agnostic sanity check (1 trial, 5 iters, model_dim=512). Works on NVLink, IB, AINIC, or SHM. | Any |
+| `recipes/ainic-smoke.yaml` | Same but forces `NCCL_NET_GDR_LEVEL=SYS` + dmabuf + GDR read to validate the AINIC/Pollara GDR path specifically. | AINIC only |
+
+Confirmed working on a single node with 8 GPUs (one rank per GPU):
+
+```bash
+# single node, 8 GPUs:
+torchrun --standalone --nproc_per_node=8 $(which aorta) sweep run \
+  --recipe recipes/race_smoke.yaml
+
+# AINIC cluster, multi-node (1 rank per host via Slurm):
+# see rccl_ainic/run-cell.sbatch
+```
+
+A green run proves: `compute_type=transformer`, `layers_verified > 0`, `layer_checksum_mismatches == 0`, `passed=true`. Use `recipes/ainic-gdr-flush-sdc.yaml` for the full SDC triage matrix.
 
 ## Output layout
 

--- a/recipes/race_smoke.yaml
+++ b/recipes/race_smoke.yaml
@@ -1,0 +1,65 @@
+# Race smoke test -- fast fabric-agnostic sanity check.
+#
+# Purpose: confirm the full real path works end-to-end on any distributed GPU
+# cluster in seconds. Exercises the same code path as the full SDC matrix:
+# real RepeatedTransformerBlock compute, real_backward gradient kernels, the
+# per-layer int16 checksum detector, and real all_gather / reduce_scatter --
+# just sized down (1 cell, 1 trial, 5 iters, smaller model).
+#
+# Works on any fabric: NVLink (single node), InfiniBand, AINIC (Pollara RoCEv2),
+# or SHM. RCCL auto-negotiates the best transport for the hardware it finds.
+# For AINIC-specific GDR path validation use recipes/ainic-smoke.yaml instead.
+#
+# What a green smoke run proves (check metrics in the trial JSON / matrix.json):
+#   compute_type == transformer        (real transformer path, not GEMM fallback)
+#   layers_verified > 0                (per-layer checksum detector actually ran)
+#   layer_checksum_mismatches == 0     (clean)
+#   avg_step_time_ms > 0               (real compute, not a no-op)
+#   exit_status == ok, passed == true  (collectives + verify completed)
+#
+# Run (same command on every rank, one rank per GPU):
+#   aorta sweep run --recipe recipes/race_smoke.yaml
+# Read:
+#   cat triage_results/RACE-SMOKE/race/*/matrix.md
+#
+# NOTE: this is a sanity check, not a reproduction attempt -- too small/short to
+# meaningfully exercise SDC. Use ainic-gdr-flush-sdc.yaml for the full matrix.
+# Minimum 2 ranks required (min_world_size=2 in the race workload).
+
+schema_version: 1
+
+ticket: RACE-SMOKE
+workload: race
+
+# 1 trial, tiny iter budget -> finishes in seconds.
+trials: 1
+steps: 5
+
+save_logs: true
+
+workload_config:
+  mode: fsdp
+  warmup_iterations: 0
+  verify_iterations: 5
+  stop_on_first_corruption: false
+  log_interval: 1
+  dtype: bfloat16
+
+  # Smaller shard + model than the full recipe so the smoke run is fast while
+  # still exercising the real transformer block, real backward, and checksums.
+  fsdp_shard_size: 250000
+  simulate_compute: true
+  compute_type: transformer
+  model_dim: 512
+  num_layers: 4
+  include_backward_compute: true
+  shared_layer_weights: true
+  real_backward: true
+
+cells:
+  - name: smoke
+    mitigations: [none]
+    environment: local
+    extra_env:
+      NCCL_PROTO: "Simple"
+      NCCL_DEBUG: "INFO"


### PR DESCRIPTION
## Summary

- Add `recipes/race_smoke.yaml`: fabric-agnostic alternative to `ainic-smoke.yaml`. Same workload config (FSDP mode, model_dim=512, 4 layers, shared_layer_weights, real_backward, 1 trial × 5 iters) but without AINIC-specific GDR env vars — RCCL auto-negotiates transport for the hardware (NVLink, IB, AINIC, SHM).
- Update `recipes/README.md`: add smoke recipes comparison table, single-node and multi-node launch examples for both topologies (1 rank/host for AINIC, 1 rank/GPU for IB/NVLink/generic).

## Test plan

- [ ] Confirmed working on single node with 8 GPUs: `torchrun --standalone --nproc_per_node=8 $(which aorta) sweep run --recipe recipes/race_smoke.yaml`
- [ ] Green run shows: `compute_type=transformer`, `layers_verified > 0`, `layer_checksum_mismatches == 0`, `passed=true`
- [ ] Dry-run validates: `aorta sweep run --recipe recipes/race_smoke.yaml --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)