### PR TITLE
triage: thread --collect through sweep/triage into every cell

### DIFF
--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -43,7 +43,7 @@ from aorta.cli.triage import (
     execute_list_mitigations,
     execute_triage_run,
 )
-from aorta.run.cli_helpers import configure_verbose_logging
+from aorta.run.cli_helpers import configure_verbose_logging, parse_csv
 from aorta.triage.recipe import RecipeSchemaError, load_recipe_mapping
 
 _BYPASS_TOKENS: frozenset[str] = frozenset({"--help", "-h"})
@@ -415,7 +415,7 @@ def sweep_run(
 
     is_probe_flow = has_command or recipe_mode == "probe"
     if is_probe_flow:
-        if collect:
+        if parse_csv(collect):
             raise click.UsageError(
                 "--collect applies to the workload flow only; it has no effect "
                 "on a probe/subprocess run (a user command after '--' or a "

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -346,6 +346,16 @@ def sweep() -> None:
     ),
 )
 @click.option(
+    "--collect",
+    default="",
+    help=(
+        "Comma-separated collector recipe names to attach to every cell "
+        "(e.g. 'layer_numerics' for the per-layer NaN logger). Cross-cutting "
+        "capture, not a matrix axis -- allowed together with --recipe, where "
+        "it overrides any recipe-pinned 'collect:'. Workload flow only."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -370,6 +380,7 @@ def sweep_run(
     max_trials: int | None,
     disable_detectors: tuple[str, ...],
     mitigation_files: tuple[Path, ...],
+    collect: str,
     verbose: int,
     argv: tuple[str, ...],
 ) -> None:
@@ -404,6 +415,12 @@ def sweep_run(
 
     is_probe_flow = has_command or recipe_mode == "probe"
     if is_probe_flow:
+        if collect:
+            raise click.UsageError(
+                "--collect applies to the workload flow only; it has no effect "
+                "on a probe/subprocess run (a user command after '--' or a "
+                "'mode: probe' recipe)."
+            )
         _dispatch_probe_flow(
             recipe=recipe,
             output=output,
@@ -442,6 +459,7 @@ def sweep_run(
             stop_after_events=stop_after_events,
             max_trials=max_trials,
             disable_detectors=disable_detectors,
+            collect=collect,
         )
 
 
@@ -514,6 +532,7 @@ def _dispatch_workload_flow(
     stop_after_events: int | None,
     max_trials: int | None,
     disable_detectors: tuple[str, ...],
+    collect: str = "",
 ) -> None:
     """Validate workload-flow-specific preconditions, then run the workload flow."""
     if env_passthrough_mode is not None:
@@ -547,6 +566,7 @@ def _dispatch_workload_flow(
         confound_threshold=confound_threshold,
         output_dir=output if output is not None else Path("triage_results"),
         mitigation_files=mitigation_files,
+        collect=collect,
     )
 
 

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -21,6 +21,7 @@ mitigations / environments come from ``aorta`` vs a plugin / sidecar.
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 
 import click
@@ -31,10 +32,11 @@ from aorta.registry import (
     load_environments,
     load_mitigations,
 )
-from aorta.run.cli_helpers import configure_verbose_logging
+from aorta.run.cli_helpers import configure_verbose_logging, parse_csv
 from aorta.triage.recipe import (
     RecipeCellError,
     RecipeSchemaError,
+    _parse_collect,
     build_recipe_from_flags,
     load_recipe,
 )
@@ -152,6 +154,17 @@ def triage() -> None:
     ),
 )
 @click.option(
+    "--collect",
+    default="",
+    help=(
+        "Comma-separated collector recipe names to attach to every cell "
+        "(e.g. 'layer_numerics' for the per-layer NaN logger). Cross-cutting "
+        "capture, not a matrix axis -- allowed together with --recipe, where "
+        "it overrides any recipe-pinned 'collect:'. Names are validated "
+        "against the known collector recipes."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -180,6 +193,7 @@ def triage_run(
     confound_threshold: float | None,
     output_dir: Path,
     mitigation_files: tuple[Path, ...],
+    collect: str,
     verbose: int,
 ) -> None:
     """Run the triage matrix: sweep mitigations x environments x trials, write matrix.md + matrix.json."""
@@ -199,6 +213,7 @@ def triage_run(
         confound_threshold=confound_threshold,
         output_dir=output_dir,
         mitigation_files=mitigation_files,
+        collect=collect,
     )
 
 
@@ -217,12 +232,20 @@ def execute_triage_run(
     confound_threshold: float | None,
     output_dir: Path,
     mitigation_files: tuple[Path, ...],
+    collect: str = "",
 ) -> None:
     """Workload-flow body shared by ``aorta sweep run`` and ``aorta triage run``.
 
     Logging is configured by the Click handler before this is called;
     keeping it out of here lets ``aorta sweep run`` own verbose setup once
     regardless of which flow it dispatches to.
+
+    ``collect`` is a comma-separated list of collector recipe names
+    (cross-cutting capture, e.g. ``layer_numerics``). It is allowed
+    alongside ``--recipe`` -- unlike the flag-mode axis args -- because it
+    is not a matrix axis. When passed with ``--recipe`` it OVERRIDES any
+    ``collect:`` the recipe pins; when the flag is empty a recipe-pinned
+    value is preserved.
     """
     # Defence-in-depth: Click's ``Choice(["matrix"])`` already enforces this,
     # but the CLI advertises ``--mode optimize`` as a future P1 addition (per
@@ -243,6 +266,14 @@ def execute_triage_run(
         )
         try:
             r = load_recipe(recipe, sidecar_files=mitigation_files or None)
+            # --collect is not a flag-mode axis arg, so it's allowed with
+            # --recipe. When provided, it overrides a recipe-pinned collect;
+            # validate the names via the same loader path the recipe uses.
+            cli_collect = parse_csv(collect)
+            if cli_collect:
+                r = dataclasses.replace(
+                    r, collect=_parse_collect("--collect", list(cli_collect))
+                )
         except (RecipeSchemaError, RecipeCellError, RegistryError) as exc:
             raise click.ClickException(str(exc)) from exc
     else:
@@ -272,6 +303,7 @@ def execute_triage_run(
                 baseline_cell=baseline_cell,
                 confound_threshold=1.15 if confound_threshold is None else confound_threshold,
                 sidecar_files=mitigation_files or None,
+                collect=parse_csv(collect),
             )
         except (RecipeSchemaError, RecipeCellError, RegistryError) as exc:
             raise click.ClickException(str(exc)) from exc

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -664,14 +664,15 @@ def _parse_collect(path_hint: str, raw: Any) -> tuple[str, ...]:
 
     if raw is None:
         return ()
+    label = path_hint if path_hint.startswith("--") else f"{path_hint}.collect"
     if not isinstance(raw, list) or not all(isinstance(x, str) for x in raw):
         raise RecipeSchemaError(
-            f"{path_hint}.collect: must be a list of strings, got {raw!r}"
+            f"{label}: must be a list of strings, got {raw!r}"
         )
     unknown = [x for x in raw if x not in KNOWN_RECIPES]
     if unknown:
         raise RecipeSchemaError(
-            f"{path_hint}.collect: unknown collector recipe(s) {unknown}; "
+            f"{label}: unknown collector recipe(s) {unknown}; "
             f"valid: {sorted(KNOWN_RECIPES)}"
         )
     # De-duplicate, preserving first-seen order (dict keys are ordered).

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -53,6 +53,9 @@ _TRIAGE_TOP_LEVEL = frozenset(
         "cells",
         "workload_config",
         "save_logs",
+        # Cross-cutting collector names attached to every cell (e.g.
+        # layer_numerics). Not a matrix axis.
+        "collect",
         # Issue #232: collect-until-N stopping rule (valid in both modes).
         "stop_after",
     }
@@ -354,6 +357,14 @@ class Recipe:
             **rank-0 only** -- matches the trial-JSON write guarantee.
             Wrappers running on non-rank-0 won't see the keys and
             should treat capture as off there.
+        collect: Collector recipe names attached to every cell (e.g.
+            ``("layer_numerics",)``). Cross-cutting capture, not a matrix
+            axis -- the same collectors run in every cell. Forwarded to each
+            cell's ``RunRequest.collect``; the dispatcher validates them
+            against ``KNOWN_RECIPES`` and threads them into
+            ``config['_aorta_collect']`` for the workload to act on. Empty
+            tuple (default) means no collector -- identical to today's
+            recipes. Set via the recipe ``collect:`` key or ``--collect``.
     """
 
     schema_version: int
@@ -369,6 +380,15 @@ class Recipe:
     source_sha256: str | None = None
     workload_config: dict[str, Any] = field(default_factory=dict)
     save_logs: bool = False
+    # Collector recipe names attached to every cell (e.g. ``layer_numerics``
+    # for the per-layer NaN logger). Cross-cutting capture, NOT a matrix
+    # axis -- the same collectors run in every cell. Forwarded verbatim to
+    # each cell's ``RunRequest.collect``; the dispatcher validates the names
+    # against ``KNOWN_RECIPES`` and threads them to ``config['_aorta_collect']``
+    # for the workload to act on. Empty tuple (the default) is behaviourally
+    # identical to today's recipes (no collector). Settable from the recipe
+    # ``collect:`` key or the ``--collect`` CLI flag (both flow here).
+    collect: tuple[str, ...] = ()
     # Issue #232: collect-until-N stopping rule applied per cell. ``None``
     # preserves the legacy fixed-``trials`` behaviour. When set, the cell
     # runs up to ``stop_after.max_trials`` trials, stopping early once
@@ -624,6 +644,38 @@ def _parse_workload_config(path_hint: str, raw: Any) -> dict[str, Any]:
             )
         out[k] = v
     return out
+
+
+def _parse_collect(path_hint: str, raw: Any) -> tuple[str, ...]:
+    """Validate a ``collect:`` list of collector recipe names.
+
+    Returns an empty tuple when ``raw`` is None / missing so the caller can
+    call ``_parse_collect(hint, data.get("collect"))`` without branching.
+    Names are validated against :data:`aorta.run.collectors.KNOWN_RECIPES`
+    at load time so an unknown collector fails the whole recipe up front
+    (matching the dispatcher's runtime check) rather than after cells have
+    already run. Order is preserved and duplicates are de-duplicated while
+    keeping first-seen order.
+    """
+    # Local import keeps the triage->run layering explicit; collectors is a
+    # leaf module so there is no cycle, but importing at call time avoids any
+    # top-of-module import-order coupling.
+    from aorta.run.collectors import KNOWN_RECIPES
+
+    if raw is None:
+        return ()
+    if not isinstance(raw, list) or not all(isinstance(x, str) for x in raw):
+        raise RecipeSchemaError(
+            f"{path_hint}.collect: must be a list of strings, got {raw!r}"
+        )
+    unknown = [x for x in raw if x not in KNOWN_RECIPES]
+    if unknown:
+        raise RecipeSchemaError(
+            f"{path_hint}.collect: unknown collector recipe(s) {unknown}; "
+            f"valid: {sorted(KNOWN_RECIPES)}"
+        )
+    # De-duplicate, preserving first-seen order (dict keys are ordered).
+    return tuple(dict.fromkeys(raw))
 
 
 def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
@@ -1030,6 +1082,8 @@ def _build_recipe(
             f"recipe.save_logs: must be a boolean, got {type(raw_save_logs).__name__}"
         )
 
+    collect = _parse_collect("recipe", data.get("collect"))
+
     raw_cells = data["cells"]
     if not isinstance(raw_cells, list) or not raw_cells:
         raise RecipeSchemaError(f"recipe.cells: must be a non-empty list, got {raw_cells!r}")
@@ -1081,6 +1135,7 @@ def _build_recipe(
         source_sha256=source_sha256,
         workload_config=workload_config,
         save_logs=raw_save_logs,
+        collect=collect,
         stop_after=stop_after,
     )
 
@@ -1095,6 +1150,7 @@ def build_recipe_from_flags(
     baseline_cell: str | None = None,
     confound_threshold: float = 1.15,
     sidecar_files: tuple[Path, ...] | None = None,
+    collect: tuple[str, ...] = (),
 ) -> Recipe:
     """Construct an in-memory :class:`Recipe` from the CLI flag shim.
 
@@ -1200,6 +1256,7 @@ def build_recipe_from_flags(
         sidecar_files=tuple(sidecar_files) if sidecar_files else (),
         source_path=None,
         source_sha256=None,
+        collect=_parse_collect("--collect", list(collect) if collect else None),
     )
 
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -909,6 +909,7 @@ def _run_one_cell(
         subprocess_argv=subprocess_argv,
         probe_extras=probe_extras_payload,
         stop_after=stop_after,
+        collect=tuple(recipe.collect),
     )
 
     try:

--- a/tests/sweep/test_sweep_cli.py
+++ b/tests/sweep/test_sweep_cli.py
@@ -94,6 +94,29 @@ def test_trailing_command_routes_to_probe_flow(mock_run_recipe, tmp_path):
     assert kwargs.get("subprocess_argv") == ("echo", "hi")
 
 
+def test_empty_collect_csv_is_ignored_in_probe_flow(mock_run_recipe, tmp_path):
+    """An effectively empty ``--collect`` value should not block subprocess flow."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "sweep",
+            "run",
+            "--recipe",
+            str(PROBE_MINIMAL),
+            "--collect",
+            " , , ",
+            "--output",
+            str(tmp_path / "out"),
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_run_recipe.assert_called_once()
+
+
 def test_probe_recipe_without_command_routes_to_probe_flow_guard(mock_run_recipe):
     """A probe-mode recipe with no trailing command is a clear usage error."""
     runner = CliRunner()

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -19,6 +19,7 @@ from aorta.triage.recipe import (
     Recipe,
     RecipeCellError,
     RecipeSchemaError,
+    _parse_collect,
     build_recipe_from_flags,
     inline_env_name,
     load_recipe,
@@ -169,6 +170,11 @@ def test_collect_wrong_type_rejected(tmp_path):
         load_recipe(_write_yaml(tmp_path, text))
 
 
+def test_collect_recipe_error_uses_recipe_field_label():
+    with pytest.raises(RecipeSchemaError, match=r"^recipe\.collect:"):
+        _parse_collect("recipe", "layer_numerics")
+
+
 def test_collect_from_flags(tmp_path):
     r = build_recipe_from_flags(
         workload="fsdp",
@@ -179,6 +185,18 @@ def test_collect_from_flags(tmp_path):
         collect=("layer_numerics",),
     )
     assert r.collect == ("layer_numerics",)
+
+
+def test_collect_flag_error_uses_cli_label():
+    with pytest.raises(RecipeSchemaError, match=r"^--collect:"):
+        build_recipe_from_flags(
+            workload="fsdp",
+            mitigation_axis="none",
+            environment_axis="local",
+            trials=1,
+            steps=1,
+            collect=("not_a_collector",),
+        )
 
 
 def test_unknown_top_level_key_rejected(tmp_path):

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -137,6 +137,50 @@ def test_missing_required_top_level(tmp_path):
         load_recipe(_write_yaml(tmp_path, text))
 
 
+# ---- collect (collector recipes) ------------------------------------------
+
+
+def test_collect_defaults_empty(tmp_path):
+    r = load_recipe(_write_yaml(tmp_path, _MINIMAL_YAML))
+    assert r.collect == ()
+
+
+def test_collect_parsed_from_recipe(tmp_path):
+    text = _MINIMAL_YAML + "collect: [layer_numerics]\n"
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.collect == ("layer_numerics",)
+
+
+def test_collect_dedups_preserving_order(tmp_path):
+    text = _MINIMAL_YAML + "collect: [layer_numerics, rocprof, layer_numerics]\n"
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.collect == ("layer_numerics", "rocprof")
+
+
+def test_collect_unknown_recipe_rejected(tmp_path):
+    text = _MINIMAL_YAML + "collect: [not_a_collector]\n"
+    with pytest.raises(RecipeSchemaError, match="unknown collector recipe"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_wrong_type_rejected(tmp_path):
+    text = _MINIMAL_YAML + "collect: layer_numerics\n"  # string, not a list
+    with pytest.raises(RecipeSchemaError, match="must be a list of strings"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_from_flags(tmp_path):
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none",
+        environment_axis="local",
+        trials=1,
+        steps=1,
+        collect=("layer_numerics",),
+    )
+    assert r.collect == ("layer_numerics",)
+
+
 def test_unknown_top_level_key_rejected(tmp_path):
     text = _MINIMAL_YAML + "garbage: 42\n"
     with pytest.raises(RecipeSchemaError, match="unknown top-level keys"):


### PR DESCRIPTION
## Summary
Wire the `--collect` flag (already on `aorta run`) through the matrix path so collectors attach to **every cell** of a sweep:

```
aorta sweep run --recipe r.yaml --collect layer_numerics
```

- `Recipe` gains a `collect` field + `collect:` schema key, validated against `KNOWN_RECIPES` at load time (fail-fast, matching the dispatcher's runtime check).
- CLI `--collect` added to both `sweep run` and the deprecated `triage run`, threaded through the shared `execute_triage_run` body. **Allowed alongside `--recipe`** (it's cross-cutting capture, not a matrix axis); when passed it overrides a recipe-pinned `collect`. Rejected in the probe flow.
- The runner passes `recipe.collect` into each cell's `RunRequest`.

## Why
`--collect` existed on `aorta run` but the sweep/triage path never forwarded it — so you couldn't attach a collector across a matrix. This closes that gap, completing the `--collect layer_numerics` end-to-end path on the platform side.

## Behavior
- Empty `collect` (the default) is behaviourally identical to today's recipes.
- Both `aorta sweep run` (new) and `aorta triage run` (deprecated) funnel through the same shared body, so one wiring covers both.

## Stacked on
Base is #262 (`dispatcher-collect-contract`), which is itself on #261. Merge in order: #261 → #262 → this.

## Test plan
- [x] `pytest tests/triage/test_recipe.py` (76 passed) incl. 6 new: default empty, parsed from recipe, dedup-preserving-order, unknown rejected, wrong-type rejected, flag-mode.
- [x] `pytest tests/run/test_dispatcher.py tests/triage/test_recipe.py tests/instrumentation/test_layer_numerics.py` — 144 passed.
- Note: CLI-level tests for the new option can't be collected on Windows due to a **pre-existing** `signal.SIGBUS` import in `probe/classifier/tier1_process.py` (Linux-only, unrelated to this PR). The CLI wiring mirrors the existing `save_logs` flow exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)