### PR TITLE
ci: gate PRs with a CPU test suite (closes #264)

### DIFF
--- a/.github/ci-constraints.txt
+++ b/.github/ci-constraints.txt
@@ -1,0 +1,15 @@
+# pip constraints for the CPU Tests CI gate (.github/workflows/cpu-tests.yml).
+#
+# These pin ONLY the pieces that are known-incompatible with the existing test
+# suite, so the gate stays reproducible without silencing real breakage. Keep
+# this list as small as possible and remove entries as the underlying tests are
+# updated.
+#
+# click<8.2:
+#   tests/sweep/test_sweep_cli.py constructs CliRunner(mix_stderr=False). Click
+#   8.2 removed the `mix_stderr` argument, so those tests raise TypeError on
+#   click>=8.2. The runtime package floor is click>=8.0 (pyproject.toml), and
+#   those tests rely on the pre-8.2 separated-stderr behaviour, so we pin the
+#   test environment rather than editing the tests.
+#   Follow-up: modernize test_sweep_cli.py for click>=8.2 and drop this pin.
+click<8.2

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -64,14 +64,16 @@ jobs:
       - name: Install CPU PyTorch
         run: pip install torch --index-url https://download.pytorch.org/whl/cpu
 
-      # dev  -> pytest + xdist + forked (isolation) + tooling
+      # tests -> pytest + xdist + forked (isolation) + timeout/cov plugins only
+      #          (the slim test extra; no black/isort/mypy/ruff/pre-commit, which
+      #          this pytest-only job never uses).
       # hw-queue -> numpy/pandas/tabulate needed by hw_queue_eval tests
       # triton -> the env-probe contract tests treat a "clean full probe" as
       #           non-partial only when triton is importable.
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,hw-queue]"
+          pip install -e ".[tests,hw-queue]"
           pip install triton
 
       # Per-test process isolation (--forked) is deliberate: the suite has

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -1,0 +1,82 @@
+name: CPU Tests
+
+# PR merge gate: run the CPU-runnable slice of the pytest suite on every pull
+# request (and on pushes to main). GPU-only tests (markers `gpu` / `rocm`) are
+# deselected here and will get their own workflow once a GPU/self-hosted runner
+# is available -- see docs/ci-testing-plan.md.
+#
+# Mark the `tests` jobs as required status checks on `main` so a red suite
+# blocks merge.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Least privilege: this gate only checks out code and runs tests.
+permissions:
+  contents: read
+
+# A newer push to the same PR/branch cancels the older, still-running gate:
+# the only thing that matters is whether the tip commit is green.
+concurrency:
+  group: cpu-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: pytest (CPU, py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    env:
+      # Reproducible pins for known test/dependency incompatibilities. Kept
+      # deliberately small; see the file for rationale and follow-ups.
+      PIP_CONSTRAINT: ${{ github.workspace }}/.github/ci-constraints.txt
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-dev.txt
+
+      # The aorta.ebpf runner tests configure an explicit bpftrace_path and the
+      # runner validates that a real file exists there before building the
+      # command (the subprocess itself is mocked in the tests). apt installs the
+      # binary at /usr/bin/bpftrace, which is exactly the path those tests use.
+      - name: Install bpftrace (for aorta.ebpf tests)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bpftrace
+
+      # CPU-only PyTorch: several test modules import torch at collection time,
+      # but no CPU test needs a GPU. Pull from the CPU wheel index so we don't
+      # drag in CUDA/ROCm runtimes.
+      - name: Install CPU PyTorch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      # dev  -> pytest + xdist + forked (isolation) + tooling
+      # hw-queue -> numpy/pandas/tabulate needed by hw_queue_eval tests
+      # triton -> the env-probe contract tests treat a "clean full probe" as
+      #           non-partial only when triton is importable.
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,hw-queue]"
+          pip install triton
+
+      # Per-test process isolation (--forked) is deliberate: the suite has
+      # pre-existing cross-file state pollution that only appears when the whole
+      # suite shares one interpreter (every affected file passes on its own).
+      # Forking each test keeps the gate deterministic; -n auto keeps it fast.
+      - name: Run CPU test suite
+        run: pytest -m "not gpu and not rocm" -n auto --forked

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -45,9 +45,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          # Track the inputs this job actually resolves from: the package
+          # metadata (extras) and the CI constraints file (pinned versions via
+          # PIP_CONSTRAINT). This job never installs requirements-dev.txt.
           cache-dependency-path: |
             pyproject.toml
-            requirements-dev.txt
+            .github/ci-constraints.txt
 
       # The aorta.ebpf runner tests configure an explicit bpftrace_path and the
       # runner validates that a real file exists there before building the

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -46,7 +46,7 @@ assume, and nothing heavier:
 | Dependency | Why it is needed |
 | --- | --- |
 | CPU-only PyTorch (`--index-url .../whl/cpu`) | Several test modules `import torch` at collection time. No CPU test needs a GPU, so the CPU wheel avoids pulling CUDA/ROCm runtimes. |
-| `.[dev]` | pytest, `pytest-xdist`, `pytest-forked`, and lint/type tooling. |
+| `.[tests]` | pytest + `pytest-xdist` / `pytest-forked` / `pytest-timeout` / `pytest-cov` only. This slim extra deliberately excludes the lint/type tooling in `.[dev]` (black/isort/mypy/ruff/pre-commit), which the pytest-only job never uses. |
 | `.[hw-queue]` | `numpy` / `pandas` / `tabulate` required by the `hw_queue_eval` tests (they error at collection without them). |
 | `triton` | The env-probe contract tests (`tests/instrumentation/test_environment.py`) treat a "clean full probe" as non-partial only when `triton` is importable. |
 | `bpftrace` (apt) | The `aorta.ebpf` runner tests set an explicit `bpftrace_path` and the runner validates a real file exists at `/usr/bin/bpftrace` before building the command. The subprocess itself is mocked (`FakePopen`), so only the binary's presence matters; apt installs it at exactly that path. |

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -60,6 +60,29 @@ environment instead of editing the tests. The file is intentionally minimal --
 pin only known-incompatible pieces so the gate stays reproducible without hiding
 real breakage; drop each pin as the underlying test is modernized.
 
+The pin lives in the constraints file rather than the `tests` extra on purpose:
+`tests` feeds `dev` and `all`, so a `click<8.2` cap there would leak a temporary
+compat bound into every dev/full install (and none of the other extras carry an
+upper bound). Keeping it in `PIP_CONSTRAINT` keeps the cap CI-scoped and trivial
+to drop.
+
+### Running the gate locally
+
+Reproduce the exact CI environment (including the `click<8.2` pin) by pointing
+pip at the same constraints file -- no manual version juggling:
+
+```bash
+export PIP_CONSTRAINT=.github/ci-constraints.txt
+pip install -e ".[tests,hw-queue]"
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install triton
+pytest -m "not gpu and not rocm" -n auto --forked
+```
+
+(`bpftrace` still needs to be on the box for the `aorta.ebpf` tests; on Ubuntu
+that's `sudo apt-get install -y bpftrace`. Or just `pip install "click<8.2"`
+into the venv if you'd rather not set the env var -- the pin is temporary.)
+
 ### Why per-test process isolation (`--forked`)
 
 The command is:

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -1,0 +1,137 @@
+# CI testing plan
+
+Tracking issue: [#264](https://github.com/ROCm/aorta/issues/264)
+
+This document describes how automated tests gate pull requests in this repo,
+and the phased plan for growing that coverage from CPU-only today to GPU
+hardware once a suitable runner exists.
+
+## Goal
+
+Every pull request must run the automated test suite, and a PR must not merge
+while those tests are red. We start with the large CPU-runnable slice of the
+existing `tests/` suite (Phase 1), and add GPU-hardware coverage later on a
+self-hosted runner (Phase 2).
+
+## Current CI (before this plan)
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `pre-commit.yml` | PR + push to `main` | Runs `pre-commit` hooks (whitespace, EOF, YAML) |
+| `nightly.yml` | cron + dispatch | Builds/publishes rolling dev wheels |
+| `release.yml` / `cleanup_releases.yml` | tags / cron | Release packaging + asset pruning |
+| `gemm-sweep-analysis.yml`, `rccl-warp-speed-analysis.yml` | cron / dispatch | Scheduled analysis jobs |
+
+Notably, **the `tests/` suite was not run in CI**. `pre-commit.yml` only lints;
+it never executes pytest. A PR could break ~2,000 tests and still merge.
+
+## Phase 1 - CPU test gate (implemented)
+
+Workflow: [`.github/workflows/cpu-tests.yml`](../.github/workflows/cpu-tests.yml)
+
+- **Triggers:** `pull_request` (every PR) and `push` to `main`.
+- **Runner / matrix:** `ubuntu-latest`, Python `3.10`, `3.11`, `3.12` (the
+  versions declared in `pyproject.toml`). `fail-fast: false` so one version's
+  failure still reports the others.
+- **Concurrency:** newer pushes to the same ref cancel the older run.
+- **Selection:** `pytest -m "not gpu and not rocm"`. The `gpu` and `rocm`
+  markers already exist (`pytest.ini`); GPU-only tests are deferred to Phase 2.
+
+### Environment the CPU tests need
+
+The "CPU" slice is not pure standard-library unit tests; parts of it exercise
+real integration surfaces. The workflow provides exactly what those tests
+assume, and nothing heavier:
+
+| Dependency | Why it is needed |
+| --- | --- |
+| CPU-only PyTorch (`--index-url .../whl/cpu`) | Several test modules `import torch` at collection time. No CPU test needs a GPU, so the CPU wheel avoids pulling CUDA/ROCm runtimes. |
+| `.[dev]` | pytest, `pytest-xdist`, `pytest-forked`, and lint/type tooling. |
+| `.[hw-queue]` | `numpy` / `pandas` / `tabulate` required by the `hw_queue_eval` tests (they error at collection without them). |
+| `triton` | The env-probe contract tests (`tests/instrumentation/test_environment.py`) treat a "clean full probe" as non-partial only when `triton` is importable. |
+| `bpftrace` (apt) | The `aorta.ebpf` runner tests set an explicit `bpftrace_path` and the runner validates a real file exists at `/usr/bin/bpftrace` before building the command. The subprocess itself is mocked (`FakePopen`), so only the binary's presence matters; apt installs it at exactly that path. |
+
+Installs go through a small pip constraints file,
+[`.github/ci-constraints.txt`](../.github/ci-constraints.txt) (wired in via
+`PIP_CONSTRAINT`). Today it pins only `click<8.2`: `tests/sweep/test_sweep_cli.py`
+uses `CliRunner(mix_stderr=False)`, which Click 8.2 removed. The runtime floor is
+`click>=8.0` and those tests depend on the pre-8.2 behaviour, so we pin the test
+environment instead of editing the tests. The file is intentionally minimal --
+pin only known-incompatible pieces so the gate stays reproducible without hiding
+real breakage; drop each pin as the underlying test is modernized.
+
+### Why per-test process isolation (`--forked`)
+
+The command is:
+
+```
+pytest -m "not gpu and not rocm" -n auto --forked
+```
+
+Running the whole suite in a single interpreter produces ~100 failures whose
+membership shifts with test ordering. Every affected file passes cleanly when
+run on its own, which is the signature of **cross-file global-state pollution**
+(leaked env vars, patched module globals, cached imports), not real breakage.
+
+Rather than couple the gate to that latent pollution (which would make it flaky
+and order-dependent), each test runs in its own forked subprocess
+(`pytest-forked`), and `-n auto` (`pytest-xdist`) parallelizes across cores to
+keep wall-clock time down (~1-2 min). This is deterministic today and stays
+green as the offending fixtures are cleaned up over time.
+
+> Follow-up (out of scope for the gate): track down and fix the specific
+> fixtures that leak global state so the suite can eventually run pollution-free
+> in a single process. Until then, `--forked` is the safety net, not a crutch to
+> hide new pollution behind.
+
+### Making it a required check
+
+To actually block merges, add the `tests` jobs as **required status checks** on
+the `main` branch:
+
+`Settings -> Branches -> Branch protection rules -> main -> Require status
+checks to pass before merging`, then select:
+
+- `pytest (CPU, py3.10)`
+- `pytest (CPU, py3.11)`
+- `pytest (CPU, py3.12)`
+
+(The workflow runs on PRs regardless; branch protection is what makes a red run
+*block* the merge.)
+
+## Phase 2 - GPU test gate (planned, needs a GPU runner)
+
+Blocked on: a GPU/self-hosted CI runner being wired up (e.g. MI300X/MI350X).
+
+When that runner exists, add a `gpu-tests.yml` workflow:
+
+- **Runner:** `runs-on: [self-hosted, gpu]` (label the runner accordingly).
+- **Selection:** `pytest -m "gpu or rocm"` -- the complement of the Phase-1
+  selection, so the two gates together cover the full suite with no overlap.
+- **Real-hardware surfaces** currently only smoke-tested or mocked on CPU:
+  - `aorta.ebpf` against a real `bpftrace` + BPF (needs `CAP_BPF`/`CAP_PERFMON`
+    or root on the runner).
+  - torch GPU workloads (`race`, `training`, `inference`, `llm_determinism`)
+    on real devices.
+  - `gpu_control` lock-clock / power-limit against real `rocm-smi`.
+- **Triggers:** start on `workflow_dispatch` + nightly `schedule` to protect
+  scarce GPU capacity; promote to a required `pull_request` check for
+  GPU-touching paths once it is proven stable.
+- **Regression gates:** fold in the nightly `aorta run` / `aorta triage`
+  regression pattern (pin docker images by digest) once the runner and images
+  are reachable from CI.
+
+### Cost / capacity notes
+
+- Keep GPU runs off the hot PR path initially (dispatch + nightly) so a queue of
+  PRs cannot starve the single GPU runner.
+- Consider a `paths:` filter so GPU CI only triggers for changes under GPU-
+  relevant directories (`src/aorta/race/**`, `src/aorta/ebpf/**`,
+  `src/aorta/utils/gpu_control.py`, workloads) once it becomes a PR check.
+
+## Summary
+
+| Phase | Runner | Selection | Status |
+| --- | --- | --- | --- |
+| 1 - CPU gate | `ubuntu-latest` (3.10-3.12) | `not gpu and not rocm`, `--forked` | Implemented (`cpu-tests.yml`) |
+| 2 - GPU gate | `[self-hosted, gpu]` | `gpu or rocm` + real-hw + regression | Planned (needs runner) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,13 +92,19 @@ agent = [
 # (or sudo); no Python deps beyond the base.
 ebpf = []
 
-# Development dependencies
-dev = [
+# Test-only tooling (pytest + plugins). Kept separate from `dev` so the CI
+# test jobs can install a slim environment without the lint/type tooling.
+tests = [
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.3.0",
     "pytest-forked>=1.6.0",  # per-test process isolation for the CPU CI gate
+]
+
+# Development dependencies (tests + lint/type tooling)
+dev = [
+    "amd-aorta[tests]",
     "pre-commit>=3.0.0",
     "black>=23.0.0",
     "isort>=5.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.3.0",
+    "pytest-forked>=1.6.0",  # per-test process isolation for the CPU CI gate
     "pre-commit>=3.0.0",
     "black>=23.0.0",
     "isort>=5.12.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ pre-commit>=3.0.0
 # Optional: useful testing utilities
 pytest-timeout>=2.1.0
 pytest-xdist>=3.3.0  # For parallel test execution
+pytest-forked>=1.6.0  # Per-test process isolation (used by the CPU CI gate; see docs/ci-testing-plan.md)


### PR DESCRIPTION
## Summary

Adds a **CPU Tests** workflow that runs the CPU-runnable slice of the pytest suite on every pull request (and pushes to `main`), so a red suite blocks merge. Until now the only PR check was `pre-commit.yml`, which lints but never runs pytest.

Implements Phase 1 of the plan in `docs/ci-testing-plan.md` (Phase 2 = a GPU/self-hosted runner, documented as follow-up). Tracking issue: #264.

## What it runs

- `ubuntu-latest`, Python `3.10 / 3.11 / 3.12` matrix (`fail-fast: false`).
- Installs exactly what the existing CPU tests assume:
  - **CPU-only PyTorch** (`--index-url .../whl/cpu`) — several modules `import torch` at collection time.
  - **`.[dev,hw-queue]`** — pytest/xdist/forked + `numpy`/`pandas`/`tabulate` for `hw_queue_eval`.
  - **`triton`** — the env-probe contract test treats a "clean full probe" as non-partial only when triton imports.
  - **`bpftrace`** via apt — the `aorta.ebpf` runner tests validate a real `/usr/bin/bpftrace` up front; `Popen` itself is mocked (`FakePopen`), so only the binary's presence matters.
- `pytest -m "not gpu and not rocm" -n auto --forked`.

## Why `--forked` (per-test process isolation)

Running the whole suite in one interpreter yields ~100 failures whose membership shifts with ordering; every affected file passes in isolation — classic cross-file global-state pollution, not real breakage. `pytest-forked` runs each test in its own process (deterministic), `-n auto` keeps it to ~1–2 min. Cleaning up the offending fixtures so a single-process run is pollution-free is captured as a follow-up in the doc.

## Why the `click<8.2` pin

`tests/sweep/test_sweep_cli.py` uses `CliRunner(mix_stderr=False)`, which Click 8.2 removed. The runtime floor is `click>=8.0` and those tests rely on pre-8.2 behaviour, so I pin the **test environment** via `.github/ci-constraints.txt` rather than editing the tests (removing the kwarg would break on the supported floor). The file is intentionally minimal; the follow-up is to modernize the test and drop the pin.

## Local verification

Clean-room venv replicating the workflow (minus apt `bpftrace`, which isn't installable without root locally):

```
2042 passed, 87 skipped  — the only failures are the 17 ebpf tests that need
/usr/bin/bpftrace, all failing at the same up-front file-existence check before
the mocked Popen; the apt step provides that binary in CI.
```

## Follow-ups

Tracked as separate issues so each can be picked up independently (branch protection is a repo setting, not a code change, so it stays here rather than as an issue):

- [ ] Make the `pytest (CPU, py3.x)` jobs **required status checks** on `main` (branch protection) — this PR adds the workflow; branch protection is a repo setting.
- [ ] Phase 2: GPU test gate on a `[self-hosted, gpu]` runner (`-m "gpu or rocm"` + real-hardware ebpf/workloads + regression gates). Tracked in #268.
- [ ] Fix `test_sweep_cli.py` for click>=8.2 and drop the pin. Tracked in #269.
- [ ] Track down the fixtures leaking global state so the suite can eventually run pollution-free in one process. Tracked in #270.

## Notes for reviewers
- No `permissions` were needed beyond `contents: read` (declared explicitly, least-privilege).
- Action majors (`checkout@v5`, `setup-python@v6`) match `pre-commit.yml`.

Closes #264

Made with [Cursor](https://cursor.com)
