### PR TITLE
layer_numerics: add address capture, bad-value locate, allocator snap…

### DIFF
--- a/src/aorta/instrumentation/layer_numerics/LOGGER_REFERENCE.md
+++ b/src/aorta/instrumentation/layer_numerics/LOGGER_REFERENCE.md
@@ -1,0 +1,581 @@
+# NaN Logger v2 — per-layer origin tracker + aliasing-writer finder
+
+## ⮕ What to run and send back
+
+Run your existing reproducer through this logger. Replace `/path/to/repro.py`
+with your reproducer script. This command watches **all `nn.Linear` layers** (99
+modules — projections, interaction towers, dense arch, task heads) on the
+**3 key channels** with **address capture + bad-value locate + allocator
+snapshot**, so a run that reproduces the NaN captures everything needed to
+(1) name the first-bad layer, (2) pinpoint the corruption position, (3) identify
+the aliasing donor, and (4) prove or rule out cross-stream allocator reuse.
+
+```bash
+NANLOG_DIR=/output/nanlog \
+NANLOG_CHANNELS=act,input,igrad \
+NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate \
+NANLOG_ADDR=1 NANLOG_LOCATE=1 NANLOG_BAD_VALUES=1 \
+NANLOG_ALLOC_SNAPSHOT=1 \
+NANLOG_PRE_CONTEXT=20 \
+  python3 instrument_nan_logger.py /path/to/repro.py
+```
+
+**Send back:** the output directory `/output/nanlog` — it contains
+`layers_rank*.jsonl`, `summary_rank*.json`, and (if NaN was detected)
+`alloc_snapshot_step*_rank*.pickle` — plus the console/stderr log from
+the run.
+
+**Quick self-check before sending:** in the startup log you should see
+`attached layer hooks to N module(s)` with **N > 0** and
+`capture_addr=True; locate=True; bad_values=True; alloc_snapshot=True`.
+With the recommended `NANLOG_WATCH_TYPES` this reproducer reports **~156
+module(s)**. If N is 0, the hooks did not bind — see "What it hooks" below.
+
+> **Why the wide type list?** `attn.dot_proj` is a `LinearProjection` (uses
+> `self.w @ x + self.b`, not `nn.Linear`), so the bare `Linear` default misses
+> it. The recommended type list covers all module classes that run matmuls:
+> `nn.Linear` (99 modules), `LinearProjection` (projections like `attn.dot_proj`),
+> `AttentionBlock` (in-forward matmul), `InteractionLayer`, `MLP`, `EmbeddingGate`
+> — **~156 modules** total. The NaN first appears in the **input** of
+> `projections.10`, but the corruption **donor** (the producer whose buffer was
+> reused) could be any of these — particularly `attn.dot_proj`, which is the
+> leading suspect. Full coverage lets you cross-reference `storage_ptr` across
+> all layers to find the actual writer.
+>
+> **Why `act,input,igrad`?** The NaN appears in the forward **input**, not the
+> output. The `input` channel captures the input tensor's address so
+> `NANLOG_ADDR` can trace which memory block it occupies. `act` (output) and
+> `igrad` (backward grad) complete the picture. To also monitor weights and
+> gradients, add `weight,bias,wgrad,bgrad` to `NANLOG_CHANNELS`.
+>
+> **To watch only projections** (smaller JSONL, lower perturbation):
+> `NANLOG_WATCH_NAMES=emb_proj.projections` — this auto-disables the `Linear`
+> type default and watches only the 62 projection layers. But note this will
+> miss `attn.dot_proj` (a `LinearProjection`) as a donor candidate.
+
+---
+
+A single-file PyTorch sidecar that watches the **model layers** (forward
+activations + backward gradients) so a NaN/Inf can be walked **upstream** to the
+layer/step where it is born. Each step it records, per tracked layer:
+
+```text
+nan_count / inf_count / huge_count   # |x| > threshold counts
+finite_abs_max / finite_max / min    # magnitude EVERY step, even when nan_count==0
+tf32_path                            # is this layer on the fp32 + allow_tf32 (TF32) path
+matmul_calls_so_far                  # non-syncing counter; lines up with a GEMM tool's "call #N"
+layer_name / direction / rank/gpu/host/pid
+```
+
+The most valuable signal is the **finite → huge → NaN magnitude trajectory**. A
+NaN-only check fires only once the tensor is already 100% NaN; this logger
+records `finite_abs_max` every step, so a value blowing up is visible *before* it
+becomes NaN.
+
+No monitoring happens inside any matrix multiplication. Per-layer hooks compute
+their reductions on-device and stash GPU scalars **without** `.item()`; once per
+step every stashed scalar is stacked and copied to the host in a **single**
+`.cpu().tolist()` transfer (the one implicit device sync per step — all watched
+tensors for the step flushed together, automatic and with no fixed count; ~300
+per step in the validated run: 156 layers × fwd/bwd). GPU kernel launch order is
+therefore unchanged and timing-sensitive behavior is preserved.
+
+---
+
+## What changed since the previous version
+
+If you have run an earlier version of this logger:
+
+- **Address capture (`NANLOG_ADDR`, default ON).** Every record carries the
+  watched tensor's GPU address (`data_ptr`) and backing-storage extent
+  (`storage_ptr`, `storage_offset_bytes`, `storage_nbytes`). Pure host-side
+  metadata — **no GPU sync, kernel order unchanged**. This is the key to tracing
+  memory-**aliasing** corruption to the producer buffer (see "Finding the aliasing
+  writer from addresses"). **Important:** `NANLOG_ADDR` records the address for
+  every enabled channel. Since the NaN appears in the forward **input**, the
+  `input` channel must be enabled (`NANLOG_CHANNELS=act,input,igrad`) to capture
+  the input tensor's address. With the default `act,igrad` only, the input address
+  is not recorded.
+- **Row-locate (`NANLOG_LOCATE`, default OFF).** Adds `bad_rows` (how many dim-0
+  rows hold a NaN/Inf/huge element). `bad_rows==1` on an 8 MiB `[1024,2048]`
+  input = one tile-sized late write (aliasing); large `bad_rows` = numeric blowup.
+- **Bad-value locate (`NANLOG_BAD_VALUES`, default OFF).** *(new)* For each bad
+  tensor, records the first corrupted element's exact position and value:
+  `first_bad_flat_idx`, `first_bad_row`, `first_bad_col`, `first_bad_value`.
+  Combined with `NANLOG_ADDR`, the precise byte offset into the 8 MiB storage
+  block can be computed: `storage_offset_bytes + first_bad_flat_idx × 4` (fp32).
+  Implemented as GPU-side `argmax` + scalar indexing — no extra host sync.
+- **Allocator snapshot (`NANLOG_ALLOC_SNAPSHOT`, default OFF).** *(new)* Enables
+  PyTorch's caching allocator event recorder at model init. On the first NaN
+  detection, dumps a full snapshot (pickle) containing every alloc/free event with
+  **GPU address, size, stream ID, timestamp, and Python call stack**. This is the
+  definitive proof for cross-stream allocator reuse: the trace shows `(free
+  addr=X on stream A)` then `(alloc addr=X on stream B)`, pinpointing the reuse.
+  ~10% per-step overhead from stack capture; GPU kernel timing unaffected. Dump
+  is one-shot; recording stops automatically after.
+- **Expanded watch scope.** The default `NANLOG_WATCH_TYPES=Linear` now covers
+  99 modules across the model (not just projections): `emb_proj.projections`
+  (62), `interaction.towers` (26), `task_heads` (4), `dense_arch` (3),
+  `combiner.gate` (3), `interaction.fuse` (1).
+
+The output format is otherwise unchanged and the new fields are additive (old
+parsers ignore unknown keys). All new features default to OFF; the recommended
+command at the top enables them.
+
+---
+
+## Quick start
+
+1. Drop these files anywhere reachable on the training host
+   (e.g. `/opt/nan_logger_v2`):
+
+    ```bash
+    unzip nan_logger_v2.zip -d /opt/nan_logger_v2
+    ```
+
+2. Choose an output directory — set `NANLOG_DIR` to any writable path (the logger
+   creates it if it doesn't exist; defaults to `./nan_logger_v2_out`). The command
+   below sets it inline, so there is nothing to export separately.
+
+3. Run your reproducer **through** the logger — it arms the hooks, then runs your
+   script via `runpy` so the hooks attach to the real eager module tree. This is
+   the same command shown at the top of this file:
+
+    ```bash
+    NANLOG_DIR=/output/nanlog \
+    NANLOG_CHANNELS=act,input,igrad \
+    NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate \
+    NANLOG_ADDR=1 NANLOG_LOCATE=1 NANLOG_BAD_VALUES=1 \
+    NANLOG_ALLOC_SNAPSHOT=1 \
+    NANLOG_PRE_CONTEXT=20 \
+      python3 instrument_nan_logger.py /path/to/repro.py [args...]
+    ```
+
+   This wrapper invocation is the recommended, tested path — it arms the hooks and
+   then runs your script for you. The wide `NANLOG_WATCH_TYPES` covers all ~156
+   matmul-bearing modules including `attn.dot_proj` (`LinearProjection`). To
+   narrow scope, use `NANLOG_WATCH_NAMES=emb_proj.projections` (only the 62
+   projection layers — but misses `LinearProjection` donor candidates).
+   To also monitor weights and gradients, add `weight,bias,wgrad,bgrad` to
+   `NANLOG_CHANNELS` and set `NANLOG_MAX_PARAM_NUMEL=100000000`.
+
+   *Advanced / alternative:* if you'd rather launch your script the usual way
+   (e.g. through an existing `torchrun` line you can't change), add **three lines
+   at the very top** of the script — **before the model is built** — and set
+   `NANLOG_*` env vars in your shell as usual:
+
+    ```python
+    import sys
+    sys.path.insert(0, "/opt/nan_logger_v2")   # path to instrument_nan_logger.py
+    import instrument_nan_logger  # noqa: F401  (importing this arms the hooks)
+    ```
+
+That's it. On startup you'll see one line confirming the hooks are armed, and
+one line when they attach to the built model (see "Expected log lines"). Output
+appears under `NANLOG_DIR`.
+
+**Sanity check the startup lines:** you must see
+`attached layer hooks to N module(s)` with **N > 0**, and on the same line
+`capture_addr=True; locate=True; bad_values=True; alloc_snapshot=True`. With the
+recommended `NANLOG_WATCH_TYPES`, N should be **~156** on this model. If N is 0
+(or that line never appears), the model isn't going through
+`DistributedModelParallel` and the hooks didn't bind — see "What it hooks" below.
+
+**A clean run** (no NaN reproduced) ends with `first_bad` = `null` in the
+summary. That's the logger working correctly and finding nothing — not a
+failure. `first_bad` is populated only when a layer actually goes NaN/Inf/huge.
+
+To disable the instrumentation, drop the wrapper invocation (or comment out the
+`import instrument_nan_logger` line) — nothing else needs to be undone.
+
+---
+
+## What it hooks (and changing it)
+
+By default the logger hooks every `torch.nn.Linear` in the model. It attaches by
+auto-wrapping
+`torchrec.distributed.model_parallel.DistributedModelParallel.__init__`, so the
+hooks bind to the **real sharded module tree** the moment it is built — no edit
+to the (frozen) reproducer. The model is eager (only `@torch._dynamo.disable` on
+the embedding lookup), so `nn.Module` hooks bind cleanly.
+
+To watch other module types, set a comma list of class names:
+
+```bash
+export NANLOG_WATCH_TYPES=Linear,LinearProjection,EmbeddingGate
+```
+
+**Recommended for this reproducer — cast a wider net.** The default `Linear`
+filter covers the dense `nn.Linear` layers (where the upstream TF32 GEMM that
+originates the NaN lives), but it misses matmuls written as raw `@` / functional
+ops inside other modules — e.g. `LinearProjection` (`self.w @ x + self.b`) and
+`AttentionBlock` (an in-`forward` matmul). A hook sees a module's **output**
+tensor, so adding these classes catches a NaN *emerging from* that block even
+though the internal matmul itself isn't a `Linear`. Cost is negligible (a few
+extra on-device reductions per step, still one batched sync), so grab them all:
+
+```bash
+export NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate
+```
+
+### Targeting a specific layer or block (`NANLOG_WATCH_NAMES`)
+
+To investigate one layer instead of the whole model, match on the module **path**
+with `NANLOG_WATCH_NAMES` (comma-separated substrings):
+
+```bash
+# only this exact layer — no NANLOG_WATCH_TYPES needed:
+export NANLOG_WATCH_NAMES=emb_proj.projections.10.layers.0
+
+# the whole projection-10 block (every sub-layer under it):
+export NANLOG_WATCH_NAMES=emb_proj.projections.10
+```
+
+A module is watched if its class name matches `NANLOG_WATCH_TYPES` **or** its path
+contains any `NANLOG_WATCH_NAMES` substring (union). Setting `NANLOG_WATCH_NAMES`
+alone automatically turns off the `Linear` type default, so you get exactly the
+named layers — you do **not** need to clear `NANLOG_WATCH_TYPES`. To watch named
+layers **and** a class at once, set both (e.g. `NANLOG_WATCH_NAMES=...` plus
+`NANLOG_WATCH_TYPES=MoELayer`). The startup log prints the matched module names
+when 10 or fewer are watched, so you can confirm you targeted the right one.
+
+Two scope notes for this model:
+
+- **Embedding tables are intentionally not in the list.** They are a
+  `torchrec.EmbeddingBagCollection`; after sharding the lookup goes through a
+  distributed gather/all-to-all (not a clean forward tensor), backward grads are
+  sparse (drop the `igrad` channel from `NANLOG_CHANNELS` if they misbehave), and
+  the analysis already places them **downstream** — they receive already-NaN
+  grads, they don't originate the NaN. Nothing needs to be pulled from another
+  library; the layers that matter are native and covered above. The `weight`/
+  `bias` param channels also skip embedding modules by type (logged in the
+  summary's `skipped_params`).
+- **Compiled regions lose per-layer granularity.** This reproducer runs eager
+  (only `@torch._dynamo.disable` on the embedding lookup), so hooks bind cleanly.
+  If you `torch.compile` a block, hooks on modules *inside* the compiled region
+  generally do not fire — you'd only see the outermost compiled module's output.
+
+*What* each watched layer records (activations, gradients, parameter values) is
+controlled separately by `NANLOG_CHANNELS` — see "Capture channels" below. The
+command at the top of this file already enables all of them.
+
+---
+
+## Expected log lines
+
+On startup (you should see these, once each):
+
+```text
+nanlog: auto-hook armed (will attach when DistributedModelParallel is built)
+nanlog: allocator snapshot: recording enabled (stacks=python, max_entries=500000). ...
+nanlog: attached layer hooks to 156 module(s) (types=['Linear', 'LinearProjection', 'AttentionBlock', 'InteractionLayer', 'MLP', 'EmbeddingGate'], names=[]); channels=['act', 'igrad', 'input']; capture_addr=True; locate=True; bad_values=True; alloc_snapshot=True; params_scanned=0; params_skipped=0; per-step drain installed on DMP root
+```
+
+(The allocator snapshot line appears only when `NANLOG_ALLOC_SNAPSHOT=1`.)
+
+When you enable a gradient channel (`wgrad`/`bgrad`), you will also see, once at
+startup and once per optimizer:
+
+```text
+nanlog: grad channels ['bgrad', 'wgrad'] enabled; will read gradients at the optimizer step boundary
+nanlog: grad channels ['bgrad', 'wgrad']: hooked optimizer <OptimizerClass> to read gradients
+```
+
+You will also see two benign PyTorch warnings once at startup; both are expected
+and do not affect logging:
+
+```text
+UserWarning: Full backward hook is firing when gradients are computed with respect to module outputs since no inputs require gradients.
+UserWarning: For backward hooks to be called, module output should be a Tensor ... but received <class 'torch.fx.proxy.Proxy'>
+```
+
+The second comes from the FX-traced sparse/embedding path (those modules are out
+of scope by design); dense-path backward hooks still fire normally.
+
+On the first layer that goes bad (once per run):
+
+```text
+19:58:12 [PID=1033357 rank=0] nanlog: FIRST BAD: step=84 layer=_dmp_wrapped_module.module.train_module.model.dense_arch.gating.layers.0 dir=bwd kind=nan call#~8050 tf32=True
+```
+
+`FIRST BAD` is the cross-run fingerprint — `step` / `layer` / `dir` (fwd|bwd) /
+`kind` (nan|inf|huge) / approximate `call#` / TF32 flag. Diff it across runs:
+
+- **stable** step+layer across runs → looks deterministic → argues *numerics*.
+- **jittery** (different layer/step each run) on the TF32 path → consistent with
+  timing nondeterminism. **Suggestive only.**
+
+At exit, one line points at the summary:
+
+```text
+13:36:10 [PID=1 rank=0] nanlog: summary -> /output/nanlog/summary_rank0.json (first_bad={...})
+```
+
+---
+
+## Configuration (env vars)
+
+| variable                | default                 | meaning                                                          |
+| ----------------------- | ----------------------- | ---------------------------------------------------------------- |
+| `NANLOG_DIR`            | `./nan_logger_v2_out`   | where JSONL + summary are written                                |
+| `NANLOG_HUGE_THRESHOLD` | `1e10`                  | finite-but-huge cutoff treated as corruption (`huge_count`)      |
+| `NANLOG_SAMPLE_EVERY`   | `50`                    | write a CLEAN layer record 1-in-N steps (bad layers ALWAYS written) |
+| `NANLOG_MAX_RECORDS`    | `200000`                | hard cap on JSONL records                                        |
+| `NANLOG_WATCH_TYPES`    | `Linear`                | module **class** names to hook (comma-separated); unioned with `NANLOG_WATCH_NAMES` |
+| `NANLOG_WATCH_NAMES`    | _(empty)_               | substrings matched against module **paths**; watch a specific layer/block (see below) |
+| `NANLOG_CHANNELS`       | `act,igrad`             | capture channels (see table below); replaces `NANLOG_BWD`        |
+| `NANLOG_MAX_PARAM_NUMEL`| `50000000`              | param channels skip params bigger than this (embeddings skipped by type) |
+| `NANLOG_PRE_CONTEXT`    | `0`                     | keep last K steps in memory, dump on first bad (0 = off)         |
+| `NANLOG_ADDR`           | `1`                     | record `data_ptr` + storage extent per tensor (sync-free); the key to naming an aliasing writer |
+| `NANLOG_LOCATE`         | `0`                     | also record `bad_rows` (dim-0 rows holding any NaN/Inf/huge); `bad_rows==1` ⇒ tile-sized late write |
+| `NANLOG_BAD_VALUES`     | `0`                     | record `first_bad_flat_idx/row/col/value` for each bad tensor (sync-free GPU scalar reductions) |
+| `NANLOG_ALLOC_SNAPSHOT` | `0`                     | record allocator alloc/free events; dump snapshot (pickle) on first NaN (~10% step overhead) |
+| `NANLOG_STOP_ON_FIRST`  | `0`                     | stop writing clean records after the first bad layer is seen     |
+| `NANLOG_VERBOSE`        | `0`                     | log one line every step (worst bad layer / abs_max)              |
+
+### Capture channels (`NANLOG_CHANNELS`)
+
+Comma-separated. Each channel is an independent observation adding its own on-GPU
+reductions; all feed the **same single per-step drain**, so no channel adds a host
+sync. New (non-default) channels are off unless listed, so the default keeps the
+original activation-only timing profile.
+
+| channel  | reads                          | fires in           | default |
+| -------- | ------------------------------ | ------------------ | ------- |
+| `act`    | forward output activation      | fwd hook           | **on**  |
+| `input`  | forward input activation       | fwd hook           | off     |
+| `igrad`  | grad w.r.t. inputs (grad_input)| bwd hook           | **on**  |
+| `weight` | param values, `ndim >= 2`      | root pre-hook      | off     |
+| `bias`   | param values, `ndim == 1`      | root pre-hook      | off     |
+| `wgrad`  | `param.grad`, `ndim >= 2`      | optimizer step-hook| off     |
+| `bgrad`  | `param.grad`, `ndim == 1`      | optimizer step-hook| off     |
+
+The `weight`/`bias` channels are read at the **start** of the step (root
+pre-hook), so their values are the **previous** step's (the only sync-free read
+point for persistent params) — each such record carries
+`value_is_from_prev_step: true`.
+
+The `wgrad`/`bgrad` channels read `param.grad` at the **optimizer
+`step_pre_hook`** (after backward, before the update), so they are the **current**
+step's grad (`value_is_from_prev_step: false`) and still sync-free / outside the
+autograd graph. They require a `torch.optim.Optimizer` (auto-discovered — any
+subclass, library or custom; no script edit). If grads are freed during backward
+(optimizer-in-backward / fused) or there is no optimizer at all, a **one-time
+WARNING** is logged and these channels produce nothing — use `weight`/`bias`
+instead.
+
+The weight/bias split is by **shape** (`ndim`), so custom param names (`.w`,
+`.scale`, `.b`) are handled correctly; the exact name is in `param_name`.
+Embedding tables are skipped (by type) and catalogued in the summary's
+`skipped_params` — embedding scanning is a separate deferred follow-up.
+
+`RANK` / `LOCAL_RANK` (set by `torchrun`) are read to name the per-rank output
+files; no need to set them yourself.
+
+### Gradient channels (`wgrad` / `bgrad`)
+
+These read `param.grad` and have two requirements:
+
+1. **PyTorch >= 2.1** (they use `Optimizer.register_step_pre_hook`).
+2. **A standard optimizer** whose gradients persist until `optimizer.step()`.
+   They do **not** work when the optimizer update is fused into the backward pass
+   (e.g. `apply_optimizer_in_backward`), because each gradient is freed during
+   backward before it can be read.
+
+If either requirement is unmet, the logger prints a one-time warning and these
+channels produce no records — the rest of the run is unaffected. To confirm they
+worked, check the summary: `optimizer_hook_registered` should be `true` and
+`grad_records_stashed` should be greater than 0. If grads are not readable on your
+model, use the `weight`/`bias` channels instead.
+
+---
+
+## Output layout
+
+```text
+<NANLOG_DIR>/
+  layers_rank<N>.jsonl                          # one record per (layer, step) written
+  summary_rank<N>.json                          # first_bad fingerprint + totals (at exit)
+  alloc_snapshot_step<S>_rank<N>.pickle         # allocator snapshot (only if NaN detected)
+```
+
+- `layers_rank<N>.jsonl` — every **bad** layer is written; **clean** layers are
+  sampled 1-in-`NANLOG_SAMPLE_EVERY` (keeps the file small while still sampling
+  the magnitude trajectory). Each record is self-contained — no line arithmetic
+  needed to recover step/layer/shape/path.
+- `summary_rank<N>.json` — `first_bad` (the determinism fingerprint),
+  `steps_seen`, `records_written`, `matmul_calls_total`, `tf32_allowed`,
+  `watched_count` / `watched_names`, `channels`, `capture_addr`, `locate`,
+  `bad_values`, `alloc_snapshot`, `alloc_snapshot_dumped`,
+  `params_scanned` / `skipped_params`, and (when grad channels are on)
+  `optimizer_hook_registered` / `grad_params_planned` / `grad_records_stashed`.
+- `alloc_snapshot_step<S>_rank<N>.pickle` — *(only when `NANLOG_ALLOC_SNAPSHOT=1`
+  and NaN is detected)* full caching allocator snapshot containing `segments`
+  (current memory layout) and `device_traces` (timestamped alloc/free events with
+  GPU address, size, **stream ID**, and Python call stack). Load with
+  `pickle.load()` or PyTorch's built-in memory visualizer.
+
+One JSONL record:
+
+```jsonc
+{
+  "type": "layer_step",
+  "step": 23, "rank": 5, "gpu": 5, "host": "node-03", "pid": 558400,
+  "layer_name": "model.blocks.7.mlp.fc2",
+  "direction": "fwd",                // fwd | bwd | param | grad
+  "role": "input",                   // act|input|igrad|weight|bias|wgrad|bgrad
+  "param_name": "",                  // owned-param name for param/grad roles; "" otherwise
+  "value_is_from_prev_step": false,  // true for weight/bias (read at step start); false for grads
+  "shape": [1024, 2048], "dtype": "torch.float32",
+  "tf32_path": true,                 // fp32 operands + allow_tf32 -> TF32 path
+  "matmul_calls_so_far": 8050,       // lines up with a GEMM tool's "call #N"
+  "data_ptr": "0x7efeedb71200",      // tensor address (NANLOG_ADDR=1, default)
+  "storage_ptr": "0x7efeedb71200",   // start of the backing block
+  "storage_offset_bytes": 0,         // tensor offset into that block
+  "storage_nbytes": 8388608,         // size of the backing block (8 MiB here)
+  "bad_rows": 1,                     // rows with any bad elem (NANLOG_LOCATE=1)
+  "nan_count": 1, "inf_count": 0, "huge_count": 4,
+  "finite_count": 2097147,
+  "finite_abs_max": 3.13e36,         // logged EVEN when nan_count==0  <-- the value-add
+  "finite_max": 3.13e36, "finite_min": -2.87e36,
+  "numel": 2097152, "bad": true,
+  "first_bad_flat_idx": 344164,      // flat index of first bad element (NANLOG_BAD_VALUES=1)
+  "first_bad_row": 42,               // dim-0 index
+  "first_bad_col": 100,              // offset within that dim-0 slice
+  "first_bad_value": "NaN"           // "NaN" / "Inf" / "-Inf" / numeric (JSON-safe)
+}
+```
+
+`data_ptr` / `storage_*` appear when `NANLOG_ADDR=1` (the default); `bad_rows`
+appears when `NANLOG_LOCATE=1`; `first_bad_*` fields appear when
+`NANLOG_BAD_VALUES=1` **and** the record is bad.
+
+The default run emits only `role: "act"` and `role: "igrad"` records. The
+`weight` / `bias` / `wgrad` / `bgrad` roles appear only when you enable those
+channels via `NANLOG_CHANNELS`; those records carry the owning `param_name`.
+`weight`/`bias` carry `value_is_from_prev_step: true` (read at step start);
+`wgrad`/`bgrad` carry `value_is_from_prev_step: false` (read at the optimizer
+step boundary, current step).
+
+When a tensor is **entirely** non-finite (`finite_count == 0`, e.g. an all-NaN
+gradient — the typical first-bad case), `finite_abs_max` / `finite_max` /
+`finite_min` are written as JSON `null` (there is no finite value to report).
+The output is always valid, strict-parseable JSON.
+
+### How to read the output — decision table
+
+A layer record is **bad** when any of `nan_count` / `inf_count` / `huge_count`
+> 0; otherwise **clean**. Read the trajectory of the first-bad layer:
+
+| `finite_abs_max` trend before first NaN | `huge_count` | Conclusion |
+| --------------------------------------- | ------------ | ---------- |
+| flat / normal, then NaN appears abruptly | 0 | **NaN arrived from elsewhere** — this layer is downstream of the origin; look at earlier `matmul_calls_so_far` / other layers same step. |
+| climbing over steps, crosses threshold, then NaN | >0 before NaN | **Finite blowup originating here** — precision/overflow growth on this layer (check `tf32_path`); the NaN-only checks would have missed this. |
+| bad on the **TF32 path** layers only, jittery across runs | (any) | TF32 path implicated; combined with a jittery fingerprint → consistent with timing nondeterminism (suggestive, never proof). |
+
+The columns map directly to JSONL fields: `finite_abs_max`, `huge_count`,
+`nan_count`, `tf32_path`, `matmul_calls_so_far`.
+
+---
+
+## Finding the aliasing writer from addresses
+
+The decision table above identifies the **victim** (the first layer/step that
+goes bad). The address fields go one step further and identify the **producer**
+whose buffer was reused/overwritten — the donor/writer of a cross-stream aliasing
+late-write. The idea: a freed block is recycled as the victim's input while a
+producer kernel is still writing it, so the victim's storage range will **equal
+or overlap** a producer's output (or param) storage range.
+
+Two fast signatures, computed entirely from the JSONL (no GPU, offline):
+
+1. **Aliasing signature on the victim itself.** With `NANLOG_LOCATE=1`, the
+   first-bad `emb_proj.projections.10.layers.0` `input` record should show
+   `bad_rows == 1` (a single ~8 KiB row of an 8 MiB `[1024,2048]` block — one GEMM
+   tile's worth of a stray write), **not** a large/spread `bad_rows`. A spread
+   pattern argues a genuine numeric blowup instead; `bad_rows==1` + flat
+   `finite_abs_max` history (no run-up) argues a foreign write.
+
+2. **Address match to a producer.** Take the victim record's
+   `[storage_ptr, storage_ptr + storage_nbytes)` range at the bad step `S`. Scan
+   the **same step and step S-1** for any **other** watched record (`act`, or a
+   `weight`/`wgrad` of a producer like `attn.dot_proj`) whose storage range equals
+   or overlaps it. A hit names the donor/writer: that producer's output buffer was
+   handed to proj.10's input. Equal `storage_ptr` is the strongest hit; an overlap
+   (different offset, same block) is also conclusive.
+
+```python
+import json, collections
+recs = [json.loads(l) for l in open("nanlog/layers_rank0.jsonl")]
+# 1) the first-bad victim input
+bad = next(r for r in recs if r["bad"] and "projections.10" in r["layer_name"]
+           and r["role"] == "input")
+lo = int(bad["storage_ptr"], 16); hi = lo + bad["storage_nbytes"]; S = bad["step"]
+print("victim", bad["layer_name"], "step", S, "bad_rows", bad.get("bad_rows"),
+      "block", hex(lo), bad["storage_nbytes"])
+# 2) producers sharing that block at step S or S-1
+for r in recs:
+    if r is bad or r["step"] not in (S, S - 1) or "storage_ptr" not in r:
+        continue
+    a = int(r["storage_ptr"], 16); b = a + r.get("storage_nbytes", 0)
+    if a < hi and lo < b:               # ranges overlap
+        print("ALIAS WRITER:", r["step"], r["layer_name"], r["role"],
+              r["shape"], hex(a), r.get("storage_nbytes"))
+```
+
+Notes and limits:
+
+- The caching allocator reuses freed blocks aggressively, so an **equal address in
+  the SAME step** between an unrelated freed tensor and proj.10's input is normal
+  and expected — that alone is not proof. The strong evidence is the **conjunction**:
+  proj.10 input first-bad **+** `bad_rows==1` **+** flat magnitude history **+** the
+  matching block belonging to a plausible upstream **producer that ran just before**
+  the prefetch (e.g. `attn.dot_proj`). Use the candidate as the suspect, not the
+  verdict.
+- This logger observes **tensor-level** addresses, not kernel completion order. To
+  pin the exact writing kernel, cross-reference the suspect producer + step with a
+  `HIPBLASLT_LOG` / rocprof trace (kernel name, stream, end time vs. the prefetch
+  copy's start). The address match tells you *which buffer*; the trace tells you
+  *which kernel and when*.
+- Addresses are virtual and per-process; only compare within one rank's JSONL.
+
+---
+
+## Files in this drop
+
+| file                       | purpose                                                          |
+| -------------------------- | --------------------------------------------------------------- |
+| `instrument_nan_logger.py` | the logger itself (importing/running it arms the hooks)          |
+| `README.md`                | run instructions (what to run, what to send back)                |
+| `LOGGER_REFERENCE.md`      | this file — full technical reference                             |
+
+No pip install, no extra dependencies beyond PyTorch (already required by the
+training run). All new features (`NANLOG_BAD_VALUES`, `NANLOG_ALLOC_SNAPSHOT`)
+default to OFF and do not affect existing repro runs unless explicitly enabled.
+
+---
+
+## Appendix: Address Comparability
+
+The `storage_ptr` values recorded by the logger are **absolute GPU virtual
+addresses** within the process, obtained via `tensor.untyped_storage().data_ptr()`.
+
+- **Within one rank's JSONL:** All records share the same virtual address space.
+  Comparing `[storage_ptr, storage_ptr + storage_nbytes)` between any two records
+  (regardless of layer, step, channel, or role) is a direct apples-to-apples
+  comparison. Overlapping ranges prove that two tensors share the same underlying
+  physical GPU memory block.
+
+- **Across ranks / processes:** Each process has its own virtual address space
+  (confirmed with multi-process experiments: zero shared base pointers). Do NOT
+  compare `storage_ptr` values from different ranks.
+
+- **Across steps (same rank):** Addresses are stable within a process lifetime.
+  The same `storage_ptr` at step S and step S+1 means the allocator handed out
+  the same block twice (expected — caching allocators reuse). Combined with
+  `bad==true` at step S on the victim and a donor at step S or S-1, this is the
+  aliasing evidence.
+
+- **No GPU sync:** `data_ptr()` and `untyped_storage().data_ptr()` are pure
+  host-side metadata queries. They do NOT trigger device synchronization or
+  change kernel launch order — safe for timing-sensitive reproduction runs.

--- a/src/aorta/instrumentation/layer_numerics/README.md
+++ b/src/aorta/instrumentation/layer_numerics/README.md
@@ -1,107 +1,387 @@
-# layer_numerics — per-layer NaN / magnitude logger
+# NaN Logger v2 — Diagnostic Runs for ef[10] INPUT NaN
 
-Workload-agnostic instrumentation sidecar that traces a NaN/Inf back to the
-**layer and step where it first appears**, and captures the finite-magnitude
-run-up leading to it (a value growing large → huge → NaN over steps, which a
-NaN-only check cannot see).
+## Background
 
-It arms hooks on a torchrec `DistributedModelParallel` root and (optionally)
-every `torch.optim.Optimizer` the moment they are built — **no edit to the
-training/repro script is required**. All per-layer reductions run on the GPU and
-are drained to the host in **one batched transfer per step**, so no per-GEMM sync
-is introduced and timing-sensitive behavior is preserved.
+`emb_proj.projections.10.layers.0` (a `Linear(2048, 128)` layer) intermittently
+receives an input tensor that already contains NaN values. The leading hypothesis
+is cross-stream allocator reuse combined with the AMD `s_waitcnt` hardware defect:
+the GPU reports a kernel as "complete" before its global memory writes have
+actually landed, causing `record_stream`'s protection to be insufficient — the
+allocator hands a freed buffer to this layer's input while a prior kernel's
+writes to that buffer are still in-flight.
 
-## Provenance
+These diagnostic runs collect the evidence needed to:
+1. Confirm ef[10] INPUT NaN under instrumentation
+2. Capture the corrupted tensor's GPU memory address
+3. Identify the **donor** (which other layer's freed buffer was reused)
+4. Prove cross-stream allocator reuse via the allocator event trace
 
-- **Upstream:** `instrument_nan_logger.py`, the NaN logger — captures activation,
-  input, grad-input, parameter value (`weight`/`bias`), and parameter gradient
-  (`wgrad`/`bgrad`) channels.
-- **Treat as a drop.** Do not refactor `instrument_nan_logger.py`'s hook/reduction
-  logic here — the same artifact is used for standalone handoff, and
-  standalone/collector parity depends on it staying in lockstep. Behavior changes
-  go upstream, then re-vendor.
-- **Field-proven.** It has been used to isolate a training-time NaN to a
-  **corrupted input activation** arriving from upstream of the flagged layer
-  (the layer's own weights/grads stayed clean), distinguishing an injected
-  out-of-distribution value from a numerical blowup in the layer's parameters.
+---
 
-## Two ways to run
+## What's Included
 
-### 1. Standalone (handoff — unchanged)
+| File | Purpose |
+|------|---------|
+| `instrument_nan_logger.py` | The logger (single file, no extra dependencies beyond PyTorch) |
+| `README.md` | This file — run instructions |
+| `LOGGER_REFERENCE.md` | Full technical reference (all env vars, output format, analysis recipes) |
 
-A self-contained invocation for handing to a partner running the repro on their
-own host. Works from a bare checkout of just the script; no `aorta` install
-needed:
+---
 
-```bash
-HIP_VISIBLE_DEVICES=0 NUM_STEPS=1000 \
-  NANLOG_DIR=/output/layer_numerics \
-  NANLOG_WATCH_NAMES=encoder.blocks \
-  NANLOG_PRE_CONTEXT=10 \
-  python instrument_nan_logger.py /path/to/standalone_single_file.py
-```
+## Prerequisites
 
-From an installed `aorta` package, the same thing without needing the file path:
+- **PyTorch** with ROCm (the logger uses standard PyTorch APIs)
+- **torchrec** (if using the standalone reproducer with `TrainPipelineSparseDist`)
+- **No pip install needed** — `instrument_nan_logger.py` has zero dependencies beyond PyTorch
+- **Disk space:** ~500 MB per run (Run 1 with `SAMPLE_EVERY=1` and allocator snapshot)
+- **GPU memory:** same as your normal training run (logger adds <10 MB host memory)
+- **Run duration:** recommend **5000+ steps** per trial (NaN typically appears within
+  100–2000 steps, but can be intermittent)
 
-```bash
-python -m aorta.instrumentation.layer_numerics /path/to/standalone_single_file.py
-```
+---
 
-Both forms are byte-equivalent (`__main__.py` just `runpy`-execs the script).
+## Setup
 
-### 2. As the `layer_numerics` collector (sweeps)
+### Step 1: Place the logger
 
-Attach it to every cell of a mitigation × environment sweep:
+Copy `instrument_nan_logger.py` to a directory accessible from the training host:
 
 ```bash
-aorta sweep run --recipe <recipe>.yaml \
-  --mitigations-file <sidecar>.json \
-  --collect layer_numerics
+mkdir -p /opt/nan_logger_v2
+cp instrument_nan_logger.py /opt/nan_logger_v2/
 ```
 
-Each cell's outputs land under `<cell>/layer_numerics/` and are included by
-`aorta bundle`. The collector applies a default `NANLOG_*` bundle (see
-[`build_env`](__init__.py)); recipe/CLI overrides win.
+### Step 2: Choose invocation method
 
-## Output
+**Option A — wrapper invocation (preferred, tested):**
 
-Written under `NANLOG_DIR` (the collector points this at
-`<results_dir>/layer_numerics`):
+```bash
+NANLOG_DIR=/output/nanlog \
+NANLOG_CHANNELS=... \
+  python3 /opt/nan_logger_v2/instrument_nan_logger.py /path/to/your_training_script.py [args...]
+```
 
-- `summary_rank<N>.json` — the headline: `first_bad` fingerprint
-  (step / layer / direction / kind / `matmul_calls_so_far` / `tf32_path`) plus
-  totals and per-channel stats.
-- `layers_rank<N>.jsonl` — the full per-(layer, step, channel) trajectory.
+The wrapper arms the hooks, then runs your script via `runpy`. Hooks bind to the
+model the moment `DistributedModelParallel` is constructed.
 
-## Tunables (`NANLOG_*`)
+**Option B — import at script top (if you can't change the launch command):**
 
-All configuration is via environment variables; the authoritative reference is
-the module docstring at the top of
-[`instrument_nan_logger.py`](instrument_nan_logger.py). Most-used knobs:
+Add these 3 lines at the very top of your training script, **before** the model
+is built:
 
-| Var | Purpose | Default |
-|---|---|---|
-| `NANLOG_DIR` | Output dir for the JSONL + summary | `nan_logger_out` |
-| `NANLOG_CHANNELS` | Capture channels (`act,input,igrad,weight,bias,wgrad,bgrad`) | `act,igrad` |
-| `NANLOG_WATCH_NAMES` | Substrings matched against module paths (target a block/layer) | (empty) |
-| `NANLOG_WATCH_TYPES` | Module class names to watch (e.g. `Linear`, `MoELayer`) | `Linear` (unless `WATCH_NAMES` set) |
-| `NANLOG_PRE_CONTEXT` | Buffer the last K clean steps; dump on first-bad for full run-up | `0` (off) |
-| `NANLOG_SAMPLE_EVERY` | Write a clean layer's record 1 step in N (bad always written) | `50` |
-| `NANLOG_HUGE_THRESHOLD` | `\|x\| > T` counts as "huge" | `1e10` |
-| `NANLOG_MAX_RECORDS` | Hard cap on records written | `200000` |
-| `NANLOG_STOP_ON_FIRST` | Stop writing clean records after first bad | `0` |
-| `NANLOG_VERBOSE` | One log line per step | `0` |
+```python
+import sys
+sys.path.insert(0, "/opt/nan_logger_v2")
+import instrument_nan_logger  # noqa: F401
+```
 
-Collector defaults (applied by `build_env`): `NANLOG_CHANNELS` = all seven,
-`NANLOG_PRE_CONTEXT=10`, `NANLOG_SAMPLE_EVERY=50`.
+Then set `NANLOG_*` env vars in your shell as usual.
 
-## Notes / limitations
+---
 
-- Locates the first **layer/step** to go bad; it does not, by itself, prove a
-  kernel-level timing race (that needs per-GEMM ordering / a per-GEMM sync, which
-  would change timing).
-- `weight`/`bias` value channels are read at the start of the step, so they hold
-  the **previous** step's value (`value_is_from_prev_step=true`); `wgrad`/`bgrad`
-  are read at the optimizer step boundary (current step). Grad channels require a
-  `torch.optim.Optimizer`; if the update is fused into backward, a one-time
-  warning is logged — use `weight`/`bias` instead.
+## Sanity Check (verify at startup — MUST pass before counting the run)
+
+In the startup log (stderr), look for:
+
+```
+nanlog: attached layer hooks to N module(s) (types=[...], names=[...]); channels=[...]; capture_addr=True; ...
+```
+
+**Verification checklist:**
+
+| Check | Expected |
+|-------|----------|
+| `N > 0` | Hooks attached. If N = 0, hooks didn't bind — see Troubleshooting. |
+| N ≈ 156 | Full watch (Run 1). |
+| N ≈ 99 | Linear-only (Run 2 fallback). |
+| `capture_addr=True` | Address recording is on. |
+| `locate=True` | Row-locate enabled. |
+| `bad_values=True` | Bad-value position enabled. |
+| `alloc_snapshot=True` | Allocator event trace on (Run 1). |
+
+If N = 0, the model isn't going through `DistributedModelParallel`, or the
+logger was imported after the model was built. See Troubleshooting below.
+
+---
+
+## Run 1: Full Diagnostic (primary)
+
+**Purpose:** Capture the complete evidence chain — GPU memory address overlap,
+corruption pattern, corrupted tensor dump, and allocator event trace — in a
+single run.
+
+```bash
+NANLOG_DIR=/output/run1_full \
+NANLOG_CHANNELS=act,input,igrad,weight,bias,wgrad,bgrad \
+NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate \
+NANLOG_ADDR=1 \
+NANLOG_LOCATE=1 \
+NANLOG_BAD_VALUES=1 \
+NANLOG_DUMP_TENSOR=1 \
+NANLOG_ALLOC_SNAPSHOT=1 \
+NANLOG_PRE_CONTEXT=20 \
+NANLOG_SAMPLE_EVERY=1 \
+  python3 /opt/nan_logger_v2/instrument_nan_logger.py /path/to/your_training_script.py
+```
+
+**What each option does:**
+
+| Option | Purpose |
+|--------|---------|
+| `CHANNELS=act,input,igrad,weight,bias,wgrad,bgrad` | Record all channels: forward output (`act`), forward **input**, backward grad (`igrad`), parameter values (`weight`,`bias`), and parameter gradients (`wgrad`,`bgrad`). The `input` channel is **required** to capture ef[10]'s input address. |
+| `WATCH_TYPES=Linear,...` | Watch ~156 modules (all matmul-bearing layers). Needed to find the donor whose output buffer was reused as ef[10]'s input. |
+| `ADDR=1` | Record `storage_ptr` + `storage_nbytes` for every watched tensor. These are absolute per-process GPU virtual addresses — directly comparable within one rank's JSONL. |
+| `LOCATE=1` | Record `bad_rows` (how many dim-0 rows have NaN). `bad_rows==1` on `[1024,2048]` = one-tile late write (aliasing signature). |
+| `BAD_VALUES=1` | Record exact position (`first_bad_row`, `first_bad_col`) and value of first corrupted element. |
+| `DUMP_TENSOR=1` | Save the full corrupted tensor to disk (`.pt` file) on first NaN detection. One-shot (~8 MB). |
+| `ALLOC_SNAPSHOT=1` | Enable PyTorch allocator event recording. On first NaN, dump full trace (pickle) with every alloc/free: address, size, **stream ID**, timestamp, call stack. |
+| `PRE_CONTEXT=20` | Buffer last 20 steps in memory; dump all on first NaN (full-resolution address history leading up to the corruption). |
+| `SAMPLE_EVERY=1` | Log every step (maximum resolution for address tracking). |
+
+**Overhead:** ~10% per-step from allocator stack capture. GPU kernel timing and
+launch order are NOT affected (the overhead is host-side bookkeeping only).
+
+**Recommended:** Run **3 independent trials** (different output dirs:
+`run1_full_t1`, `run1_full_t2`, `run1_full_t3`). The NaN is intermittent —
+multiple trials increase capture probability and provide cross-validation.
+
+**Step count:** 5000 steps minimum. If no NaN by 5000 steps, continue to 10000.
+
+**Expected output:**
+```
+/output/run1_full/
+  layers_rank0.jsonl                    # per-layer, per-step records with GPU addresses
+  summary_rank0.json                    # first_bad fingerprint + run metadata
+  alloc_snapshot_step*_rank0.pickle     # allocator event trace (only if NaN detected)
+  bad_tensor_step*_rank0.pt            # full corrupted tensor (only if NaN detected)
+```
+
+**Success criteria:**
+- `summary_rank0.json` → `first_bad` is NOT null
+- `first_bad` layer contains `projections.10`
+- `first_bad` role = `input`
+- `alloc_snapshot_step*_rank0.pickle` exists
+
+---
+
+## Run 2: Lightweight Fallback (only if Run 1 does NOT reproduce)
+
+**Purpose:** If Run 1's 10% allocator-snapshot overhead masks the bug (changes
+timing enough to prevent the race), this lighter configuration preserves original
+timing as closely as possible while still capturing addresses and NaN position.
+
+```bash
+NANLOG_DIR=/output/run2_light \
+NANLOG_CHANNELS=act,input,igrad,weight,bias,wgrad,bgrad \
+NANLOG_WATCH_TYPES=Linear \
+NANLOG_ADDR=1 \
+NANLOG_LOCATE=1 \
+NANLOG_BAD_VALUES=1 \
+NANLOG_DUMP_TENSOR=1 \
+NANLOG_ALLOC_SNAPSHOT=0 \
+NANLOG_PRE_CONTEXT=20 \
+NANLOG_SAMPLE_EVERY=50 \
+  python3 /opt/nan_logger_v2/instrument_nan_logger.py /path/to/your_training_script.py
+```
+
+**Differences from Run 1:**
+
+| Setting | Run 1 | Run 2 | Why |
+|---------|-------|-------|-----|
+| `WATCH_TYPES` | 6 types (~156 modules) | `Linear` only (~99 modules) | Less perturbation |
+| `ALLOC_SNAPSHOT` | 1 | **0** | No allocator overhead |
+| `SAMPLE_EVERY` | 1 | **50** | Smaller JSONL, less host work |
+
+**Overhead:** <1%. This is nearly invisible to GPU timing.
+
+**Trade-off:** Without `ALLOC_SNAPSHOT`, we lose the definitive allocator event
+trace (the `free→alloc` sequence with stream IDs). We still get addresses and
+can identify the donor from address overlap, but cannot prove the cross-stream
+mechanism from the allocator log alone.
+
+---
+
+## Summary: Test Matrix
+
+| Run | When to use | Watch scope | Allocator snapshot | Sample rate | Overhead |
+|-----|-------------|-------------|--------------------|-------------|----------|
+| 1 | **Always start here** | Full (156 modules) | **On** | Every step | ~10% |
+| 2 | Only if Run 1 doesn't reproduce | Linear only (99) | Off | 1-in-50 | <1% |
+
+Recommend 3 trials per run, 5000 steps each.
+
+---
+
+## What to Send Back
+
+For **each completed trial**, please send:
+
+### Required:
+
+1. **The entire `NANLOG_DIR` folder** — contains:
+   - `layers_rank*.jsonl` (per-layer per-step records with GPU addresses)
+   - `summary_rank*.json` (first_bad fingerprint + metadata)
+   - `alloc_snapshot_step*_rank*.pickle` (Run 1 only, if NaN detected)
+   - `bad_tensor_step*_rank*.pt` (if NaN detected)
+
+2. **Console/stderr log** from the training run — should contain:
+   - The `nanlog: attached layer hooks to N module(s) ...` startup line
+   - The `nanlog: FIRST BAD: ...` line (if NaN was detected)
+
+### Also helpful:
+
+3. **`summary_rank0.json` pasted inline** (small file, <1 KB) — for quick triage
+
+4. **Which run config** (Run 1 or Run 2, trial number)
+
+5. **Number of steps completed** before stopping
+
+### Data organization suggestion:
+
+```
+results/
+  run1_full_t1/
+    layers_rank0.jsonl
+    summary_rank0.json
+    alloc_snapshot_step84_rank0.pickle
+    bad_tensor_step84_rank0.pt
+    console.log
+  run1_full_t2/
+    ...
+```
+
+---
+
+## How We'll Analyze the Data
+
+### Step 1: Identify the victim
+
+Find the first record where `projections.10.layers.0` with `role=="input"` has
+`bad==true`. Verify `bad_rows == 1` (single-tile aliasing signature).
+
+### Step 2: Find the donor (address overlap)
+
+Take the victim's `[storage_ptr, storage_ptr + storage_nbytes)` range. Search
+all other records at the same step and step-1 for any layer whose storage range
+overlaps. A match names the donor — the layer whose freed buffer was recycled as
+ef[10]'s input.
+
+```python
+import json
+recs = [json.loads(l) for l in open("layers_rank0.jsonl")]
+bad = next(r for r in recs if r["bad"] and "projections.10" in r["layer_name"]
+           and r["role"] == "input")
+lo = int(bad["storage_ptr"], 16); hi = lo + bad["storage_nbytes"]; S = bad["step"]
+
+for r in recs:
+    if r is bad or r["step"] not in (S, S - 1) or "storage_ptr" not in r:
+        continue
+    a = int(r["storage_ptr"], 16); b = a + r.get("storage_nbytes", 0)
+    if a < hi and lo < b:
+        print(f"DONOR: step={r['step']} {r['layer_name']}|{r['role']} "
+              f"shape={r['shape']} ptr={r['storage_ptr']}")
+```
+
+### Step 3: Allocator event trace (Run 1)
+
+In `alloc_snapshot_step*_rank*.pickle`, search for:
+```
+(free addr=X on stream A) → (alloc addr=X on stream B)
+```
+at the victim's `storage_ptr` address. This proves the allocator handed out a
+block still in-use on a different stream.
+
+### Step 4: Examine the corrupted tensor
+
+Load `bad_tensor_step*_rank0.pt` and inspect the NaN pattern:
+- Single contiguous row of NaN = tile-sized late write (aliasing)
+- Scattered NaN = numeric blowup (different root cause)
+
+---
+
+## Technical Notes
+
+### Address Comparability (apple-to-apple)
+
+The `storage_ptr` values are **absolute GPU virtual addresses** within the
+process (via `tensor.untyped_storage().data_ptr()`). All records in a single
+rank's JSONL share the same virtual address space. Comparing `storage_ptr`
+ranges between any two records in the same file is a direct apples-to-apples
+comparison — overlapping ranges = same physical GPU memory block.
+
+### What "input" captures for ef[10]
+
+The logger's forward hook records the first tensor argument passed to
+`module.forward()`. For `projections.10.layers.0` (`nn.Linear(2048, 128)`),
+this is the 8 MiB `[1024, 2048]` buffer from the embedding lookup output.
+
+### No GPU sync from address capture
+
+`data_ptr()` and `untyped_storage().data_ptr()` are pure host-side metadata
+queries — NO GPU synchronization, NO kernel launch order change.
+
+---
+
+## Troubleshooting
+
+### N = 0 (no modules hooked)
+
+The logger patches `DistributedModelParallel.__init__`. If N = 0:
+- The model was built before the logger was imported → move the import earlier
+- The model doesn't use `DistributedModelParallel` → see `LOGGER_REFERENCE.md`
+
+### No NaN reproduced after 5000 steps
+
+- Run more trials (5–10) or longer (10000–20000 steps)
+- The bug is timing-sensitive and intermittent
+- If Run 1 never reproduces but you know the NaN happens in production, try Run 2
+  (lower overhead preserves original timing better)
+
+### JSONL is empty
+
+- Check `NANLOG_CHANNELS` includes `input` (default is `act,igrad` only)
+- Check N > 0 in startup log
+
+### Allocator snapshot missing despite NaN
+
+- Verify `NANLOG_ALLOC_SNAPSHOT=1` is set
+- Check startup log for `alloc_snapshot=True`
+- On some PyTorch builds, `torch.cuda.memory._record_memory_history` may not be
+  available — the logger prints a warning if so
+
+---
+
+## Quick Reference: Copy-Paste Commands
+
+### Run 1 (full diagnostic):
+```bash
+NANLOG_DIR=/output/run1_full_t1 \
+NANLOG_CHANNELS=act,input,igrad,weight,bias,wgrad,bgrad \
+NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate \
+NANLOG_ADDR=1 NANLOG_LOCATE=1 NANLOG_BAD_VALUES=1 \
+NANLOG_DUMP_TENSOR=1 NANLOG_ALLOC_SNAPSHOT=1 \
+NANLOG_PRE_CONTEXT=20 NANLOG_SAMPLE_EVERY=1 \
+  python3 /opt/nan_logger_v2/instrument_nan_logger.py \
+  /path/to/your_training_script.py 2>&1 | tee /output/run1_full_t1/console.log
+```
+
+### Run 2 (lightweight, only if Run 1 doesn't reproduce):
+```bash
+NANLOG_DIR=/output/run2_light_t1 \
+NANLOG_CHANNELS=act,input,igrad,weight,bias,wgrad,bgrad \
+NANLOG_WATCH_TYPES=Linear \
+NANLOG_ADDR=1 NANLOG_LOCATE=1 NANLOG_BAD_VALUES=1 \
+NANLOG_DUMP_TENSOR=1 NANLOG_ALLOC_SNAPSHOT=0 \
+NANLOG_PRE_CONTEXT=20 NANLOG_SAMPLE_EVERY=50 \
+  python3 /opt/nan_logger_v2/instrument_nan_logger.py \
+  /path/to/your_training_script.py 2>&1 | tee /output/run2_light_t1/console.log
+```
+
+---
+
+## Version
+
+- **Logger:** June 29, 2026 (NaN Logger v2)
+- **Capabilities:** address capture, bad-value locate, allocator snapshot,
+  tensor dump, pre-context buffer, input channel
+- **Tested on:** PyTorch 2.x with ROCm, single-node multi-GPU, torchrec 0.5+

--- a/src/aorta/instrumentation/layer_numerics/USAGE_GUIDE.md
+++ b/src/aorta/instrumentation/layer_numerics/USAGE_GUIDE.md
@@ -1,0 +1,286 @@
+# NaN Logger v2 (June 29) — Usage Guide (staged runs)
+
+**Target NaN:** `emb_proj.projections.10.layers.0` **INPUT** goes bad for one step
+(`3.13e36` + 1 NaN + 4 huge), which poisons the weight and cascades to the
+step-999 Shampoo eigendecomp crash. Leading hypothesis: a freed buffer is handed
+to `projections.10`'s input while a kernel on another CUDA stream is still writing
+it (cross-stream allocator free→reuse aliasing).
+
+This guide walks the new flags as a **staged escalation**: start with the run that
+is *least* likely to disturb the race (and gives basic info), and only escalate to
+heavier instrumentation once the NaN is confirmed to still reproduce. Each round is
+a self-contained command you can copy/paste.
+
+---
+
+## Why staged? (the perturbation ladder)
+
+The logger is built so its measurement work is on-GPU and drained once per step —
+no per-op host sync. But some flags still change timing or memory lifetime, and the
+target bug is timing-sensitive. Order of increasing risk of *changing/suppressing*
+the NaN:
+
+| Flag / setting | What it costs | Can it hide the bug? |
+| --- | --- | --- |
+| `NANLOG_ADDR` (default on) | host-side pointer read | No — zero GPU/timing effect |
+| `NANLOG_LOCATE`, `NANLOG_BAD_VALUES` | extra on-GPU reductions, same single drain | Very unlikely |
+| extra `NANLOG_CHANNELS` (`input`, `weight`…) | more on-GPU reductions, same drain | Unlikely |
+| wider `NANLOG_WATCH_TYPES` | more layers reduced per step | Unlikely |
+| `NANLOG_SAMPLE_EVERY=1`, `NANLOG_PRE_CONTEXT` | more disk writes + host memory | Unlikely (off GPU path) |
+| `NANLOG_ALLOC_SNAPSHOT=1` | ~10% step slowdown (per-alloc stack capture) | **Maybe** — shifts overall timing / race window |
+| `NANLOG_DUMP_TENSOR=1` | holds one extra tensor ref per step | **Maybe** — delays free→reuse, can *suppress* the aliasing write |
+
+Rule of thumb: **Round 1 first** to confirm the NaN and name the donor with minimal
+disturbance; **Round 2** for the definitive allocator proof (~10% timing shift);
+**Round 3 last** for the full tensor dump, since it is the most likely to move the
+race window / suppress the bug.
+
+### Each round introduces one new June29 feature (cumulatively)
+
+The three June29-new capabilities are staged one per round, in increasing
+perturbation order, and **flags are cumulative** — each round keeps everything from
+the previous round and turns on one more:
+
+| Round | New June29 feature turned on | Carried forward |
+| --- | --- | --- |
+| 1 | `NANLOG_BAD_VALUES` + expanded watch scope (wide `WATCH_TYPES`) | `NANLOG_ADDR`, `NANLOG_LOCATE` (June26) |
+| 2 | `NANLOG_ALLOC_SNAPSHOT` | all of Round 1 |
+| 3 | `NANLOG_DUMP_TENSOR` | all of Round 2 |
+
+Cumulative matters because `ALLOC_SNAPSHOT` and `DUMP_TENSOR` are only interpretable
+*with* the Round-1 fields: the allocator trace is proof only when its addresses can
+be tied to `projections.10`'s input via `NANLOG_ADDR` + the wide scope, and a dumped
+`.pt` is meaningless without the JSONL naming its layer/step/position.
+
+---
+
+## One-time setup (all rounds)
+
+Drop `instrument_nan_logger.py` anywhere on the training host, then run your
+existing reproducer **through** it (the wrapper arms hooks, then runs your script
+via `runpy`; no edit to the training script needed):
+
+```bash
+python3 instrument_nan_logger.py /path/to/your_repro.py [args...]
+```
+
+If you cannot change the launch command (e.g. a fixed `torchrun` line), instead add
+3 lines at the **very top** of the training script, before the model is built:
+
+```python
+import sys
+sys.path.insert(0, "/path/to/nan_logger_v2")   # dir holding instrument_nan_logger.py
+import instrument_nan_logger  # noqa: F401  (import arms the hooks)
+```
+
+**Pre-flight self-check (every run).** In the startup log you must see:
+
+```
+nanlog: attached layer hooks to N module(s) (... ); channels=[...]; capture_addr=True; ...
+```
+
+- `N` must be **> 0**. With the wide `NANLOG_WATCH_TYPES` below it is **~156**; with
+  `NANLOG_WATCH_TYPES=Linear` it is **~99**.
+- If `N == 0`, the model is not going through `DistributedModelParallel` and hooks
+  did not bind — fix that before spending a run.
+- A **clean** run ends with `first_bad: null` in `summary_rank*.json`. That is the
+  logger working correctly and finding nothing, not a failure.
+
+---
+
+## Round 1 — `NANLOG_BAD_VALUES` + wide watch scope (confirm + victim + donor)
+
+**Goal:** prove the NaN still reproduces with the logger attached, name the
+first-bad layer/step, confirm the aliasing signature on the victim
+(`bad_rows == 1`, exact bad position/value), **and** name the aliasing donor from
+addresses. This is the lightest new-feature set (all on-GPU, one drain, no host
+sync), so if the race is fragile it still fires.
+
+```bash
+NANLOG_DIR=/output/run1_bad_values_widescope \
+NANLOG_CHANNELS=act,input,igrad \
+NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate \
+NANLOG_ADDR=1 \
+NANLOG_LOCATE=1 \
+NANLOG_BAD_VALUES=1 \
+NANLOG_ALLOC_SNAPSHOT=0 \
+NANLOG_DUMP_TENSOR=0 \
+NANLOG_SAMPLE_EVERY=1 \
+  python3 instrument_nan_logger.py /path/to/your_repro.py
+```
+
+Notes:
+- The `input` channel is **required** — the NaN is in the forward *input*, not the
+  output. With only the default `act,igrad` you would miss it.
+- **Expanded watch scope** (~156 modules) is the June29 feature here: the donor
+  could be a `LinearProjection` (e.g. `attn.dot_proj`), `AttentionBlock`,
+  `InteractionLayer`, `MLP`, or `EmbeddingGate` matmul that the bare `Linear`
+  (~99 modules) filter misses.
+- `NANLOG_BAD_VALUES` (June29) gives `first_bad_flat_idx/row/col/value`;
+  `NANLOG_LOCATE` (June26) gives `bad_rows`; `NANLOG_ADDR` (June26, default on)
+  gives the storage ranges. All are cheap on-GPU reductions / host-side reads (no
+  host sync).
+- `SAMPLE_EVERY=1` writes clean records too, so a producer's storage range at
+  step S-1 is present to match against the victim. *(Lower-disk alternative for a
+  long run: `NANLOG_SAMPLE_EVERY=50 NANLOG_PRE_CONTEXT=20` — the run-up buffer
+  still captures the S-1 producers around the event.)*
+
+**What we learn:**
+- `summary_rank*.json → first_bad` (step/layer/dir/kind).
+- On the victim `projections.10.layers.0|input` record: `bad_rows == 1` (single
+  ~8 KiB tile = a stray write, *not* a spread numeric blowup) + flat
+  `finite_abs_max` history + exact `first_bad_*`.
+- **Donor:** match the victim's `[storage_ptr, storage_ptr + storage_nbytes)` range
+  at step S against every other watched record at step S and S-1; an
+  equal/overlapping range names the donor (strongest = equal `storage_ptr`).
+  Byte offset into the 8 MiB block:
+  `byte_offset = storage_offset_bytes + first_bad_flat_idx * 4` (fp32). We run this
+  with `alias_fingerprint.py`.
+
+**If the NaN does NOT reproduce here**, stop and tell us — this set is too light to
+be the cause, so the repro config itself changed. Don't escalate blindly.
+
+---
+
+## Round 2 — add `NANLOG_ALLOC_SNAPSHOT` (definitive cross-stream proof)
+
+**Goal:** capture the allocator event trace that shows `(free addr=X on stream A) →
+(alloc addr=X on stream B)` at the victim's address — the direct proof of
+cross-stream reuse. Everything from Round 1 is kept; this only adds the snapshot.
+Run **after** Round 1 confirms the NaN, since this is the first round that perturbs
+timing meaningfully (~10%).
+
+```bash
+NANLOG_DIR=/output/run2_alloc_snapshot \
+NANLOG_CHANNELS=act,input,igrad \
+NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate \
+NANLOG_ADDR=1 \
+NANLOG_LOCATE=1 \
+NANLOG_BAD_VALUES=1 \
+NANLOG_ALLOC_SNAPSHOT=1 \
+NANLOG_DUMP_TENSOR=0 \
+NANLOG_SAMPLE_EVERY=1 \
+  python3 instrument_nan_logger.py /path/to/your_repro.py
+```
+
+Notes / cautions:
+- `NANLOG_ALLOC_SNAPSHOT=1` (June29) adds ~10% per-step overhead (Python stack
+  capture per allocation; GPU kernel timing itself is unaffected). It records the
+  full alloc/free history and dumps a one-shot pickle
+  (`alloc_snapshot_step*_rank*.pickle`) on the first NaN, then stops recording.
+- If the NaN disappears in this round but was present in Round 1, that itself is
+  evidence the bug is timing/allocation-sensitive (consistent with the cross-stream
+  race) — report it; do not treat it as "not reproducible."
+
+**What we learn:** the `device_traces` in the pickle give per-event GPU address,
+size, **stream ID**, timestamp, and Python call stack. Cross-referenced with the
+Round-1 donor address, this upgrades "named suspect" to a proven cross-stream
+free→reuse at the victim address.
+
+---
+
+## Round 3 — add `NANLOG_DUMP_TENSOR` (full corrupted tensor; bonus, run last)
+
+**Goal:** save the entire corrupted tensor to disk for exhaustive post-hoc
+inspection (all bad element positions/values/context, no schema limit). Everything
+from Round 2 is kept; this only adds the tensor dump.
+
+```bash
+NANLOG_DIR=/output/run3_dump_tensor \
+NANLOG_CHANNELS=act,input,igrad \
+NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate \
+NANLOG_ADDR=1 \
+NANLOG_LOCATE=1 \
+NANLOG_BAD_VALUES=1 \
+NANLOG_ALLOC_SNAPSHOT=1 \
+NANLOG_DUMP_TENSOR=1 \
+NANLOG_SAMPLE_EVERY=1 \
+  python3 instrument_nan_logger.py /path/to/your_repro.py
+```
+
+Notes / cautions:
+- **This is the most likely round to suppress the bug.** `NANLOG_DUMP_TENSOR=1`
+  holds an extra reference to each watched tensor until the next step's drain,
+  which delays allocator free→reuse — the exact mechanism under investigation. It
+  can produce a **false negative** (NaN vanishes because the logger prevented the
+  reuse). That is why it is **last**: by now Rounds 1–2 already have the donor and
+  the cross-stream proof, so this round is pure bonus — if it suppresses the NaN,
+  nothing is lost.
+- On the first bad step it writes `bad_tensor_step*_<layer>_<role>_rank*.pt`
+  (~1 ms GPU→host copy + ~10 ms disk write, one-shot).
+
+**What we learn:** the full `[1024, 2048]` corrupted input tensor on disk — every
+corrupted element, not just the first — for confirming the single-tile stray-write
+pattern beyond the `bad_rows`/`first_bad_*` summary.
+
+---
+
+## Optional add-on — persistence channels (why the NaN sticks)
+
+To also record how a one-step input NaN gets *baked into the weight* (NaN wgrad →
+optimizer writes NaNs into the weight → all-NaN forever), add the param/grad
+channels to any round above:
+
+```bash
+NANLOG_CHANNELS=act,input,igrad,weight,wgrad \
+NANLOG_MAX_PARAM_NUMEL=100000000 \
+```
+
+- `weight` is read at step start (previous step's value, `value_is_from_prev_step:
+  true`); `wgrad` is read at the optimizer `step_pre_hook` (current step). Both are
+  sync-free.
+- Requires PyTorch ≥ 2.1 and a standard optimizer (grads must survive to
+  `optimizer.step()`). If the optimizer update is fused into backward
+  (`apply_optimizer_in_backward`) or grads are freed early, `wgrad`/`bgrad` log a
+  one-time warning and produce nothing — use `weight`/`bias` instead. Confirm via
+  the summary: `optimizer_hook_registered: true` and `grad_records_stashed > 0`.
+
+---
+
+## Control run — does `record_stream` remove the NaN?
+
+Run the **same config as Round 1**, but with your normal `record_stream` behavior
+enabled (i.e. do **not** disable it). Expected: `first_bad: null`. If the NaN
+vanishes, that strongly supports the cross-stream allocator-aliasing hypothesis; if
+it persists, a different mechanism is also in play.
+
+```bash
+NANLOG_DIR=/output/run4_control_recordstream \
+NANLOG_CHANNELS=act,input,igrad \
+NANLOG_WATCH_TYPES=Linear,LinearProjection,AttentionBlock,InteractionLayer,MLP,EmbeddingGate \
+NANLOG_ADDR=1 NANLOG_LOCATE=1 NANLOG_BAD_VALUES=1 \
+NANLOG_SAMPLE_EVERY=1 NANLOG_PRE_CONTEXT=20 \
+  python3 instrument_nan_logger.py /path/to/your_repro.py
+```
+
+---
+
+## New-flag quick reference
+
+| Flag | Default | New in | Round | What it adds | Perturbation |
+| --- | --- | --- | --- | --- | --- |
+| `NANLOG_ADDR` | `1` (on) | June26 | 1+ | `data_ptr`, `storage_ptr`, `storage_offset_bytes`, `storage_nbytes` per record → bridge to the donor buffer | none (host-side) |
+| `NANLOG_LOCATE` | `0` | June26 | 1+ | `bad_rows` (dim-0 rows with any bad elem); `==1` ⇒ tile-sized late write | negligible (on-GPU, same drain) |
+| `NANLOG_CHANNELS=…input…` | `act,igrad` | — | 1+ | capture the forward **input** (required for this NaN) + optional `weight,bias,wgrad,bgrad` | low |
+| `NANLOG_SAMPLE_EVERY=1` | `50` | — | 1+ | write clean records too (needed to see producers at step S-1) | low (disk) |
+| `NANLOG_BAD_VALUES` | `0` | **June29** | 1+ | `first_bad_flat_idx/row/col/value` of the first bad element | negligible (on-GPU, same drain) |
+| `NANLOG_WATCH_TYPES` (wide) | `Linear` | **June29** | 1+ | also watch `LinearProjection`/`AttentionBlock`/`InteractionLayer`/`MLP`/`EmbeddingGate` so the donor isn't missed | low |
+| `NANLOG_ALLOC_SNAPSHOT` | `0` | **June29** | 2+ | allocator alloc/free trace w/ stream IDs; pickle dumped on first NaN | ~10% step slowdown |
+| `NANLOG_DUMP_TENSOR` | `0` | **June29** | 3 | save the full bad tensor to `.pt` on first detection | **may suppress the aliasing bug** — run last |
+
+---
+
+## What to send back (per round)
+
+For each round, send the **entire** `NANLOG_DIR`:
+- `layers_rank*.jsonl` — per-(layer, step) records
+- `summary_rank*.json` — `first_bad` fingerprint + totals + the flags that were on
+- `alloc_snapshot_step*_rank*.pickle` — Rounds 2–3 only, if a NaN was detected
+- `bad_tensor_step*_*.pt` — Round 3 only, if a NaN was detected
+- the console/stderr log of the run (has the `attached … N module(s)` and
+  `FIRST BAD:` lines)
+
+The single most valuable artifact is a **Round 1** `NANLOG_DIR` from a run that
+actually reproduced the NaN (`first_bad` populated) — that alone names the donor
+via addresses. Round 2's pickle then upgrades it from "named suspect" to
+"cross-stream proof"; Round 3's `.pt` is exhaustive confirmation.

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -134,12 +134,15 @@ Settings (environment variables):
                          was late-written, vs a numeric blowup whose bad elements
                          would be at the tail of the value range. Default 0.
   NANLOG_DUMP_TENSOR     "1" -> on the first NaN/Inf/huge detection, save the full
-                         bad tensor(s) to disk as .pt files (one per bad tensor in
-                         that step). Post-hoc analysis can then inspect ALL bad
-                         element locations, values, and surrounding context without
-                         any schema or size limit. Implementation: _stash holds an
-                         extra tensor reference each step (no GPU sync, no copy);
-                         _drain_step saves on first bad then releases all refs.
+                         bad tensor to disk as a .pt file (one-shot: the FIRST bad
+                         tensor in that step's drain order; the forward hook stashes
+                         a layer's input before its output, so when both are bad the
+                         INPUT — the aliasing origin — is the one saved). Post-hoc
+                         analysis can then inspect ALL bad element locations, values,
+                         and surrounding context without any schema or size limit.
+                         Implementation: _stash holds an extra tensor reference each
+                         step (no GPU sync, no copy); _drain_step saves on first bad
+                         then releases all refs.
                          Cost: zero on clean steps (just a Python ref, tensor is
                          already alive for autograd); ~1 ms GPU→Host copy + ~10 ms
                          disk write on the ONE step that triggers. Risk: holding an
@@ -609,14 +612,22 @@ def _first_tensor(x):
 
 def _fwd_hook(name):
     def hook(_module, inp, out):
-        if "act" in _CHANNELS:
-            t = _first_tensor(out)
-            if torch.is_tensor(t):
-                _stash(name, "fwd", t, role="act")
+        # Stash the INPUT before the output (act). When an aliasing corruption
+        # makes BOTH a layer's input and its resulting output bad in the same
+        # step, the one-shot NANLOG_DUMP_TENSOR then captures the INPUT (the
+        # corrupt origin / 8 MiB block) rather than the output (a downstream
+        # consequence of feeding that garbage through the GEMM). This is the
+        # whole point of the emb_proj aliasing workflow; it also matches the
+        # natural input->output order. Layers where only the output is bad still
+        # dump the output (the input isn't a bad candidate), so nothing is lost.
         if "input" in _CHANNELS:
             t = _first_tensor(inp)
             if torch.is_tensor(t):
                 _stash(name, "fwd", t, role="input")
+        if "act" in _CHANNELS:
+            t = _first_tensor(out)
+            if torch.is_tensor(t):
+                _stash(name, "fwd", t, role="act")
     return hook
 
 

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -32,14 +32,14 @@ Known limitations:
 
 How to run:
   HIP_VISIBLE_DEVICES=0 NUM_STEPS=1000 \
-    NANLOG_DIR=/output/nan_logger \
+    NANLOG_DIR=/output/nan_logger_v2 \
     python instrument_nan_logger.py /path/to/standalone_single_file.py
 
   The logger arms its hooks, then runs your script. The hooks attach to the real
   model the moment it is built, so no edit to the training script is needed.
 
 Settings (environment variables):
-  NANLOG_DIR             output dir for the JSONL + summary (default ./nan_logger_out)
+  NANLOG_DIR             output dir for the JSONL + summary (default ./nan_logger_v2_out)
   NANLOG_HUGE_THRESHOLD  "huge" cutoff, |x| > T             (default 1e10)
   NANLOG_SAMPLE_EVERY    write a record for a CLEAN layer 1 step in N (default 50;
                          layers with NaN/Inf/huge are ALWAYS written). Keeps the
@@ -61,9 +61,9 @@ Settings (environment variables):
                          CONTAINS any of them (default empty = match nothing by
                          name). Use to target a specific layer or block without
                          editing the model, e.g.
-                           NANLOG_WATCH_NAMES=encoder.blocks.3.mlp.fc1
+                           NANLOG_WATCH_NAMES=emb_proj.projections.10.layers.0
                          watches only that layer (no NANLOG_WATCH_TYPES needed);
-                           NANLOG_WATCH_NAMES=encoder.blocks.3
+                           NANLOG_WATCH_NAMES=emb_proj.projections.10
                          watches the whole block (all sub-layers). To watch named
                          layers AND a class, set both (e.g. add
                          NANLOG_WATCH_TYPES=MoELayer for that block + all MoE).
@@ -105,10 +105,68 @@ Settings (environment variables):
   NANLOG_STOP_ON_FIRST   "1" -> stop writing clean records after the first bad
                          layer is seen (default 0)
   NANLOG_VERBOSE         "1" -> print one line per step       (default 0)
+  NANLOG_ADDR            "1" (default) -> record each watched tensor's GPU address
+                         (`data_ptr`) + backing-storage extent (`storage_ptr`,
+                         `storage_offset_bytes`, `storage_nbytes`). Pure host-side
+                         metadata: NO GPU sync, kernel order unchanged. This is the
+                         key to naming a memory-ALIASING producer: when proj.10's
+                         INPUT goes bad, its storage range identifies the 8 MiB
+                         block; any OTHER watched module whose output/param shares
+                         that range (same step or step-1) is the donor/writer.
+                         Set "0" to omit (smaller JSONL, e.g. byte-for-byte parity
+                         with the pre-address schema).
+  NANLOG_LOCATE          "1" -> also record `bad_rows`: how many rows (dim 0) hold
+                         a NaN/Inf/huge element. The aliasing acceptance test is
+                         bad_rows==1 on the proj.10 input (one ~8 KiB row = a
+                         tile-sized late write), vs a large/spread bad_rows for a
+                         numeric blowup. Extra on-GPU reduction feeding the SAME
+                         per-step drain (no host sync); default 0 to keep the base
+                         repro's GPU kernel mix unchanged.
+  NANLOG_BAD_VALUES      "1" -> for each BAD tensor, record `first_bad_flat_idx`,
+                         `first_bad_row`, `first_bad_col`, and `first_bad_value`
+                         (the position and value of the first NaN/Inf/huge element).
+                         These are GPU scalar reductions (argmax + indexing) that
+                         feed the same per-step drain — no extra host sync. Use with
+                         NANLOG_ADDR to compute the exact byte offset into the
+                         storage block:
+                           byte_offset = storage_offset_bytes + first_bad_flat_idx * element_size
+                         This names the precise cache line in the 8 MiB block that
+                         was late-written, vs a numeric blowup whose bad elements
+                         would be at the tail of the value range. Default 0.
+  NANLOG_DUMP_TENSOR     "1" -> on the first NaN/Inf/huge detection, save the full
+                         bad tensor(s) to disk as .pt files (one per bad tensor in
+                         that step). Post-hoc analysis can then inspect ALL bad
+                         element locations, values, and surrounding context without
+                         any schema or size limit. Implementation: _stash holds an
+                         extra tensor reference each step (no GPU sync, no copy);
+                         _drain_step saves on first bad then releases all refs.
+                         Cost: zero on clean steps (just a Python ref, tensor is
+                         already alive for autograd); ~1 ms GPU→Host copy + ~10 ms
+                         disk write on the ONE step that triggers. Risk: holding an
+                         extra reference may delay allocator reuse, which could
+                         suppress a timing-sensitive aliasing bug — leave OFF for
+                         the initial repro run, enable after pattern is confirmed
+                         stable. Default 0.
+  NANLOG_ALLOC_SNAPSHOT  "1" -> enable PyTorch's caching allocator event recorder
+                         (torch.cuda.memory._record_memory_history) at startup,
+                         then dump a full allocator snapshot on the first NaN/Inf/huge
+                         detection. The snapshot contains:
+                           - segments: current GPU memory block layout
+                           - device_traces: timestamped alloc/free events with
+                             GPU address, size, STREAM ID, and Python call stack
+                         This is the definitive proof for allocator-reuse aliasing:
+                         trace shows (free addr=X on stream A) then (alloc addr=X on
+                         stream B), pinpointing the cross-stream reuse. The snapshot
+                         is written as a pickle file; view with torch.cuda.memory's
+                         built-in visualizer or manual inspection.
+                         Overhead: ~10% training-step slowdown (Python stack capture
+                         per allocation; GPU kernel timing NOT affected). Default 0
+                         to keep the base repro unchanged.
 """
 from __future__ import annotations
 
 import json
+import math
 import os
 import runpy
 import socket
@@ -117,17 +175,12 @@ import time
 from collections import deque
 from pathlib import Path
 
-if __name__ == "__main__" and len(sys.argv) < 2:
-    sys.stderr.write("nanlog: usage: python instrument_nan_logger.py <target_script.py> [args...]\n")
-    sys.stderr.flush()
-    sys.exit(2)
-
-import torch  # noqa: E402 - keep no-arg usage path dependency-light.
+import torch
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-_DIR = Path(os.environ.get("NANLOG_DIR", "nan_logger_out"))
+_DIR = Path(os.environ.get("NANLOG_DIR", "nan_logger_v2_out"))
 _HUGE = float(os.environ.get("NANLOG_HUGE_THRESHOLD", "1e10"))
 _SAMPLE_EVERY = int(os.environ.get("NANLOG_SAMPLE_EVERY", "50"))
 _PRE_CONTEXT = int(os.environ.get("NANLOG_PRE_CONTEXT", "0"))
@@ -142,7 +195,7 @@ _MAX_RECORDS = int(os.environ.get("NANLOG_MAX_RECORDS", "200000"))
 # watches exactly those named layers — the "Linear" default does NOT silently
 # union in every Linear, so you never have to write NANLOG_WATCH_TYPES= to clear
 # it. To watch named layers AND a type, set both explicitly:
-#   NANLOG_WATCH_NAMES=encoder.blocks.3                   -> only that block
+#   NANLOG_WATCH_NAMES=emb_proj.projections.10            -> only that block
 #   NANLOG_WATCH_NAMES=...  NANLOG_WATCH_TYPES=MoELayer   -> that block + all MoE
 # The bare default (neither var set) stays types=Linear -> original behavior.
 _WATCH_NAMES = tuple(
@@ -191,6 +244,32 @@ _EMBEDDING_TYPES = ("Embedding", "EmbeddingBag", "EmbeddingBagCollection",
                     "ShardedEmbeddingCollection")
 _STOP_ON_FIRST = os.environ.get("NANLOG_STOP_ON_FIRST", "0") == "1"
 _VERBOSE = os.environ.get("NANLOG_VERBOSE", "0") == "1"
+# Address capture (default ON, sync-free). Records each watched tensor's GPU
+# virtual address + backing storage extent. This is the bridge that lets a
+# memory-ALIASING corruption be traced to its PRODUCER: when projections.10's
+# INPUT goes bad at step S, its data_ptr/storage names the exact 8 MiB block; any
+# OTHER watched module whose output/param shares that storage at a nearby step is
+# the donor/writer. data_ptr()/storage queries are pure host-side metadata — no
+# GPU sync, no kernel-order change — so this is safe to leave on for repro runs.
+_CAPTURE_ADDR = os.environ.get("NANLOG_ADDR", "1") == "1"
+# Locate (default OFF). For each watched tensor also reduce how many ROWS (dim 0)
+# contain a NaN/Inf/huge element -> `bad_rows`. The acceptance test for the
+# aliasing hypothesis is bad_rows==1 on the proj.10 input (a single ~8 KiB row =
+# one tile-sized late write, vs a spread-out numeric blowup). This is an extra
+# on-GPU reduction that feeds the SAME per-step drain, so it adds no host sync; it
+# is off by default to keep the base repro's GPU kernel mix unchanged.
+_LOCATE = os.environ.get("NANLOG_LOCATE", "0") == "1"
+# Bad-value capture (default OFF). For each watched tensor also find the FIRST bad
+# element's flat index, row, col, and actual value. All are GPU scalar reductions
+# (argmax + indexing) that feed the same per-step drain -> no host sync.
+_BAD_VALUES = os.environ.get("NANLOG_BAD_VALUES", "0") == "1"
+# Allocator snapshot (default OFF). Records full caching-allocator alloc/free event
+# history with stream IDs and Python call stacks. On first NaN detection, dumps the
+# snapshot to a pickle file for post-hoc aliasing analysis. Adds ~10% step overhead
+# from per-allocation stack capture; GPU kernel timing unaffected.
+_ALLOC_SNAPSHOT = os.environ.get("NANLOG_ALLOC_SNAPSHOT", "0") == "1"
+# Dump full bad tensor(s) on first detection (default OFF — see docstring for risk).
+_DUMP_TENSOR = os.environ.get("NANLOG_DUMP_TENSOR", "0") == "1"
 
 # Create the output dir. If it is not writable (e.g. the default lands in a
 # read-only working dir), fall back to a temp dir rather than crashing the
@@ -199,7 +278,7 @@ try:
     _DIR.mkdir(parents=True, exist_ok=True)
 except OSError as _e:
     import tempfile
-    _fallback = Path(tempfile.gettempdir()) / "nan_logger_out"
+    _fallback = Path(tempfile.gettempdir()) / "nan_logger_v2_out"
     _fallback.mkdir(parents=True, exist_ok=True)
     sys.stderr.write(
         f"nanlog: WARNING: cannot write NANLOG_DIR={_DIR} ({_e}); "
@@ -289,7 +368,7 @@ def _device_stats(t: torch.Tensor) -> dict:
     pos_inf = torch.full((), float("inf"), dtype=t.dtype, device=t.device)
     safe_max = torch.where(fin, t, neg_inf)
     safe_min = torch.where(fin, t, pos_inf)
-    return {
+    stats = {
         "nan_count": torch.isnan(t).sum(),
         "inf_count": torch.isinf(t).sum(),
         "finite_count": fin.sum(),
@@ -299,6 +378,27 @@ def _device_stats(t: torch.Tensor) -> dict:
         "finite_min": safe_min.min(),
         "numel": torch.tensor(t.numel(), device=t.device),
     }
+    if _LOCATE or _BAD_VALUES:
+        bad = (~fin) | (fin & (t.abs() > _HUGE))
+    if _LOCATE:
+        rows = t.shape[0] if t.dim() >= 1 else 1
+        stats["bad_rows"] = bad.reshape(rows, -1).any(dim=1).sum()
+    if _BAD_VALUES:
+        flat_bad = bad.reshape(-1).to(torch.int64)
+        first_idx = flat_bad.argmax()          # GPU scalar: flat index of first bad
+        stats["first_bad_flat"] = first_idx
+        stats["first_bad_val"] = t.reshape(-1)[first_idx]  # GPU scalar via GPU-scalar indexing
+        if t.dim() >= 2:
+            # Elements per dim-0 slice — consistent with bad_rows (which reshapes
+            # to (shape[0], -1)). For a [256,8192] tensor this is 8192; for a
+            # [B,C,H,W] tensor this is C*H*W.
+            elems_per_row = t.numel() // t.shape[0]
+            stats["first_bad_row"] = first_idx // elems_per_row
+            stats["first_bad_col"] = first_idx % elems_per_row
+        else:
+            stats["first_bad_row"] = torch.zeros((), dtype=torch.int64, device=t.device)
+            stats["first_bad_col"] = first_idx
+    return stats
 
 
 def _is_tf32_path(t: torch.Tensor) -> bool:
@@ -351,7 +451,21 @@ def _stash(layer_name: str, direction: str, t: torch.Tensor, role: str = "act",
         "tf32_path": _is_tf32_path(t),
         "matmul_calls_so_far": _matmul_calls,
     }
-    _pending.append((rec, _device_stats(t)))
+    if _CAPTURE_ADDR:
+        # Pure host-side metadata (no GPU sync): the tensor's address and the
+        # extent of its backing block. Correlate ACROSS records of the SAME step
+        # (or step-1) to find which producer's buffer aliases a corrupted input:
+        # equal/overlapping [storage_ptr, storage_ptr+storage_nbytes) ranges name
+        # the donor/writer pair that delivered the garbage to proj.10's input.
+        try:
+            st = t.untyped_storage()
+            rec["data_ptr"] = hex(t.data_ptr())
+            rec["storage_ptr"] = hex(st.data_ptr())
+            rec["storage_offset_bytes"] = int(t.storage_offset() * t.element_size())
+            rec["storage_nbytes"] = int(st.nbytes())
+        except Exception:
+            rec["data_ptr"] = hex(t.data_ptr())
+    _pending.append((rec, _device_stats(t), t if _DUMP_TENSOR and not _tensor_dumped else None))
 
 
 # ---------------------------------------------------------------------------
@@ -369,7 +483,7 @@ def _write_rec(rec: dict) -> None:
 
 def _drain_step() -> None:
     """Flush last step's pending reductions with a single batched sync."""
-    global _records_written, _first_bad, _pre_flushed
+    global _records_written, _first_bad, _pre_flushed, _tensor_dumped
     if not _pending:
         return
     pending, _pending[:] = list(_pending), []
@@ -377,8 +491,12 @@ def _drain_step() -> None:
     # Batch every scalar into one stacked tensor -> ONE .tolist() host transfer.
     keys = ["nan_count", "inf_count", "finite_count", "huge_count",
             "finite_abs_max", "finite_max", "finite_min", "numel"]
+    if _LOCATE:
+        keys = keys + ["bad_rows"]
+    if _BAD_VALUES:
+        keys = keys + ["first_bad_flat", "first_bad_val", "first_bad_row", "first_bad_col"]
     flat = []
-    for _rec, stats in pending:
+    for _rec, stats, _held_t in pending:
         for k in keys:
             flat.append(stats[k].to(torch.float64).reshape(()))
     try:
@@ -391,7 +509,7 @@ def _drain_step() -> None:
     worst = None
     bad_this_step = False        # did first_bad trigger during THIS drain?
     step_records = []            # all records this step, in order, for buffering
-    for i, (rec, _stats) in enumerate(pending):
+    for i, (rec, _stats, held_t) in enumerate(pending):
         base = i * len(keys)
         d = dict(zip(keys, vals[base:base + len(keys)]))
         rec["nan_count"] = int(d["nan_count"])
@@ -408,8 +526,21 @@ def _drain_step() -> None:
         rec["finite_max"] = d["finite_max"] if has_finite else None
         rec["finite_min"] = d["finite_min"] if has_finite else None
         rec["numel"] = int(d["numel"])
+        if _LOCATE:
+            rec["bad_rows"] = int(d["bad_rows"])
         bad = rec["nan_count"] or rec["inf_count"] or rec["huge_count"]
         rec["bad"] = bool(bad)
+        if _BAD_VALUES and bad:
+            rec["first_bad_flat_idx"] = int(d["first_bad_flat"])
+            rec["first_bad_row"] = int(d["first_bad_row"])
+            rec["first_bad_col"] = int(d["first_bad_col"])
+            val = d["first_bad_val"]
+            if math.isnan(val):
+                rec["first_bad_value"] = "NaN"
+            elif math.isinf(val):
+                rec["first_bad_value"] = "Inf" if val > 0 else "-Inf"
+            else:
+                rec["first_bad_value"] = val
         step_records.append(rec)
 
         if bad and _first_bad is None:
@@ -422,6 +553,10 @@ def _drain_step() -> None:
             _log(f"FIRST BAD: step={rec['step']} layer={rec['layer_name']} "
                  f"dir={rec['direction']} kind={kind} "
                  f"call#~{rec['matmul_calls_so_far']} tf32={rec['tf32_path']}")
+            _dump_alloc_snapshot(rec["step"])
+
+        if bad and not _tensor_dumped and held_t is not None:
+            _dump_bad_tensor(rec, held_t)
 
         if bad and rec["finite_abs_max"] is not None and rec["finite_abs_max"] > worst_abs:
             worst_abs, worst = rec["finite_abs_max"], rec
@@ -652,12 +787,16 @@ def _install_autohook() -> None:
         global _root_installed
         if _root_installed:
             return
+        _start_alloc_recording()
         n = _attach(self)
         # Drive one drain+step per training iteration off the root forward.
         self.register_forward_pre_hook(_root_pre_hook)
         _root_installed = True
         _log(f"attached layer hooks to {n} module(s) (types={list(_WATCH_TYPES)}, "
              f"names={list(_WATCH_NAMES)}); channels={sorted(_CHANNELS)}; "
+             f"capture_addr={_CAPTURE_ADDR}; locate={_LOCATE}; "
+             f"bad_values={_BAD_VALUES}; dump_tensor={_DUMP_TENSOR}; "
+             f"alloc_snapshot={_ALLOC_SNAPSHOT}; "
              f"params_scanned={len(_scan_plan)}; params_skipped={len(_skipped_params)}; "
              f"per-step drain installed on DMP root")
         if 0 < n <= 10:
@@ -716,7 +855,15 @@ def _write_summary() -> None:
         "watch_types": list(_WATCH_TYPES),
         "watch_names": list(_WATCH_NAMES),
         "watched_count": len(_watched_names),
+        "watched_names": list(_watched_names),
         "channels": sorted(_CHANNELS),
+        "capture_addr": _CAPTURE_ADDR,
+        "locate": _LOCATE,
+        "bad_values": _BAD_VALUES,
+        "dump_tensor": _DUMP_TENSOR,
+        "dump_tensor_dumped": _tensor_dumped,
+        "alloc_snapshot": _ALLOC_SNAPSHOT,
+        "alloc_snapshot_dumped": _snapshot_dumped,
         "max_param_numel": _MAX_PARAM_NUMEL,
         "params_scanned": len(_scan_plan),
         "grad_params_planned": len(_grad_plan),
@@ -741,8 +888,77 @@ def _write_summary() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Allocator snapshot (NANLOG_ALLOC_SNAPSHOT)
+# ---------------------------------------------------------------------------
+_snapshot_dumped = False
+_tensor_dumped = False
+
+
+_alloc_recording_started = False
+
+
+def _start_alloc_recording() -> None:
+    """Enable allocator event recording. Safe to call multiple times (idempotent).
+
+    Deferred to the DMP __init__ hook so CUDA is guaranteed to be initialized.
+    Calling at import time would fail with 'No CUDA GPUs available' because
+    torch.cuda is not yet set up."""
+    global _alloc_recording_started
+    if not _ALLOC_SNAPSHOT or _alloc_recording_started:
+        return
+    try:
+        torch.cuda.memory._record_memory_history(
+            enabled="all", stacks="python", max_entries=500000)
+        _alloc_recording_started = True
+        _log("allocator snapshot: recording enabled (stacks=python, "
+             "max_entries=500000). Overhead: ~10% per step from stack capture; "
+             "GPU kernel timing unchanged.")
+    except Exception as e:
+        _log(f"WARNING: allocator snapshot: could not enable recording: {e!r}. "
+             "NANLOG_ALLOC_SNAPSHOT will be inactive.")
+
+
+def _dump_bad_tensor(rec: dict, t: torch.Tensor) -> None:
+    """Save the full bad tensor to disk on first detection. One-shot."""
+    global _tensor_dumped
+    if _tensor_dumped or not _DUMP_TENSOR:
+        return
+    _tensor_dumped = True
+    layer_safe = rec["layer_name"].replace(".", "_").replace("/", "_")
+    pt_path = _DIR / f"bad_tensor_step{rec['step']}_{layer_safe}_{rec['role']}_rank{_RANK}.pt"
+    try:
+        torch.save(t.detach().cpu(), pt_path)
+        _log(f"dump_tensor -> {pt_path} (shape={list(t.shape)}, dtype={t.dtype}, "
+             f"{t.numel() * t.element_size() / 1024:.0f} KB)")
+    except Exception as e:
+        _log(f"WARNING: dump_tensor failed: {e!r}")
+
+
+def _dump_alloc_snapshot(step: int) -> None:
+    """Dump the allocator snapshot on first NaN detection, then stop recording."""
+    global _snapshot_dumped
+    if _snapshot_dumped or not _ALLOC_SNAPSHOT:
+        return
+    _snapshot_dumped = True
+    snap_path = _DIR / f"alloc_snapshot_step{step}_rank{_RANK}.pickle"
+    try:
+        torch.cuda.memory._dump_snapshot(str(snap_path))
+        _log(f"allocator snapshot -> {snap_path}")
+    except Exception as e:
+        _log(f"WARNING: allocator snapshot dump failed: {e!r}")
+    try:
+        torch.cuda.memory._record_memory_history(enabled=None)
+        _log("allocator snapshot: recording stopped after dump")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Install + run target
 # ---------------------------------------------------------------------------
+_install_autohook()
+_install_optimizer_autohook()
+
 if __name__ == "__main__":
     import atexit
     atexit.register(_write_summary)
@@ -750,8 +966,6 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         _log("usage: python instrument_nan_logger.py <target_script.py> [args...]")
         sys.exit(2)
-    _install_autohook()
-    _install_optimizer_autohook()
     target = Path(sys.argv[1]).resolve()
     sys.argv = [str(target)] + sys.argv[2:]
     _log(f"running target {target}")

--- a/src/aorta/instrumentation/layer_numerics/test_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/test_logger.py
@@ -1,0 +1,1410 @@
+#!/usr/bin/env python3
+"""Comprehensive test suite for instrument_nan_logger.py before customer delivery.
+
+Run inside a Docker container with GPU:
+    python test_logger.py
+
+Tests:
+  1. Backward compatibility: default config produces identical schema to original
+  2. NANLOG_BAD_VALUES: various corruption patterns
+  3. NANLOG_ALLOC_SNAPSHOT: full lifecycle
+  4. Edge cases: empty tensor, scalar, 1D, inf-only, huge-only, all-NaN, large
+  5. JSON compliance: every record parseable by json.loads
+  6. Graceful degradation: bad env values don't crash
+  7. NANLOG_DUMP_TENSOR: full lifecycle, content verification, one-shot guard
+  8. NANLOG_DUMP_TENSOR + input channel: validates embed_proj aliasing workflow
+  9. NANLOG_DUMP_TENSOR disabled by default: no files, no extra references
+ 10. NANLOG_DUMP_TENSOR with all flags combined: no interaction bugs
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import os
+import pickle
+import shutil
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+import torch
+
+PASS = 0
+FAIL = 0
+TESTS: list[str] = []
+
+
+def _header(name: str) -> None:
+    print(f"\n{'='*72}")
+    print(f"  TEST: {name}")
+    print(f"{'='*72}")
+
+
+def _ok(msg: str) -> None:
+    global PASS
+    PASS += 1
+    TESTS.append(f"  PASS: {msg}")
+    print(f"  \u2705 {msg}")
+
+
+def _fail(msg: str) -> None:
+    global FAIL
+    FAIL += 1
+    TESTS.append(f"  FAIL: {msg}")
+    print(f"  \u274c {msg}")
+
+
+def _assert(cond: bool, msg: str) -> None:
+    if cond:
+        _ok(msg)
+    else:
+        _fail(msg)
+
+
+def _reload_logger(**env_overrides) -> "module":
+    """Reload instrument_nan_logger with fresh env vars.
+
+    Returns the reloaded module. Caller must set NANLOG_DIR to a temp dir."""
+    for k in list(os.environ):
+        if k.startswith("NANLOG"):
+            del os.environ[k]
+    for k, v in env_overrides.items():
+        os.environ[k] = v
+
+    mod_name = "instrument_nan_logger"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+
+    import instrument_nan_logger as nl
+    importlib.reload(nl)
+    return nl
+
+
+# ============================================================================
+# Test 1: Backward compatibility
+# ============================================================================
+def test_backward_compat():
+    _header("1. Backward Compatibility — default config schema unchanged")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test1_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir)
+
+        _assert(nl._BAD_VALUES is False, "BAD_VALUES defaults to OFF")
+        _assert(nl._ALLOC_SNAPSHOT is False, "ALLOC_SNAPSHOT defaults to OFF")
+        _assert(nl._LOCATE is False, "LOCATE defaults to OFF")
+        _assert(nl._CAPTURE_ADDR is True, "ADDR defaults to ON")
+        _assert(nl._DUMP_TENSOR is False, "DUMP_TENSOR defaults to OFF")
+
+        t = torch.randn(64, 128, device="cuda")
+        stats = nl._device_stats(t)
+        expected_keys = {"nan_count", "inf_count", "finite_count", "huge_count",
+                         "finite_abs_max", "finite_max", "finite_min", "numel"}
+        _assert(set(stats.keys()) == expected_keys,
+                f"Default stats keys = {sorted(expected_keys)} (no locate/bad_values keys)")
+
+        # Stash + drain produces a record with no extra fields
+        nl._pending.clear()
+        nl._stash("test.layer", "fwd", t, role="act")
+        _assert(len(nl._pending) == 1, "One pending record after stash")
+        rec, gpu_stats, held_ref = nl._pending[0]
+        _assert("first_bad_flat" not in gpu_stats, "No first_bad_flat in GPU stats")
+        _assert("bad_rows" not in gpu_stats, "No bad_rows in GPU stats")
+        _assert(held_ref is None, "No tensor ref held when DUMP_TENSOR=0")
+        nl._pending.clear()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 2: NANLOG_BAD_VALUES — various corruption patterns
+# ============================================================================
+def test_bad_values():
+    _header("2. NANLOG_BAD_VALUES — corruption pattern identification")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test2_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_BAD_VALUES="1",
+                            NANLOG_LOCATE="1")
+        _assert(nl._BAD_VALUES is True, "BAD_VALUES is ON")
+
+        drain_keys = ["nan_count", "inf_count", "finite_count", "huge_count",
+                      "finite_abs_max", "finite_max", "finite_min", "numel",
+                      "bad_rows",
+                      "first_bad_flat", "first_bad_val", "first_bad_row", "first_bad_col"]
+
+        def _run_stats(t: torch.Tensor) -> dict:
+            stats = nl._device_stats(t)
+            flat = [stats[k].to(torch.float64).reshape(()) for k in drain_keys]
+            vals = torch.stack(flat).cpu().tolist()
+            return dict(zip(drain_keys, vals))
+
+        # Pattern A: single NaN at known position
+        t_a = torch.randn(256, 8192, device="cuda")
+        t_a[42, 100] = float("nan")
+        d = _run_stats(t_a)
+        _assert(int(d["nan_count"]) == 1, "PatternA: nan_count=1")
+        _assert(int(d["first_bad_row"]) == 42, "PatternA: first_bad_row=42")
+        _assert(int(d["first_bad_col"]) == 100, "PatternA: first_bad_col=100")
+        _assert(math.isnan(d["first_bad_val"]), "PatternA: first_bad_value is NaN")
+        _assert(int(d["bad_rows"]) == 1, "PatternA: bad_rows=1")
+
+        # Pattern B: 1 NaN + 4 huge (Meta's production pattern)
+        t_b = torch.randn(256, 8192, device="cuda")
+        t_b[42, 100] = float("nan")
+        t_b[42, 101] = 3.13e36
+        t_b[42, 102] = -2.87e36
+        t_b[42, 103] = 1.56e36
+        t_b[42, 104] = -4.21e36
+        d = _run_stats(t_b)
+        _assert(int(d["nan_count"]) == 1 and int(d["huge_count"]) == 4,
+                "PatternB: 1 NaN + 4 huge")
+        _assert(int(d["bad_rows"]) == 1, "PatternB: all bad in 1 row")
+        _assert(int(d["first_bad_row"]) == 42, "PatternB: first_bad at row 42")
+
+        # Pattern C: bad spread across multiple rows (numeric blowup)
+        t_c = torch.randn(256, 8192, device="cuda")
+        t_c[10, :] = float("nan")
+        t_c[20, :] = float("inf")
+        t_c[30, :] = 1e20
+        d = _run_stats(t_c)
+        _assert(int(d["bad_rows"]) >= 3, f"PatternC: bad_rows={int(d['bad_rows'])} >= 3 (blowup)")
+        _assert(int(d["first_bad_row"]) == 10, "PatternC: first bad at row 10 (first NaN row)")
+
+        # Pattern D: inf-only, no NaN
+        t_d = torch.randn(64, 64, device="cuda")
+        t_d[5, 10] = float("inf")
+        t_d[5, 11] = float("-inf")
+        d = _run_stats(t_d)
+        _assert(int(d["nan_count"]) == 0 and int(d["inf_count"]) == 2,
+                "PatternD: 0 NaN, 2 Inf")
+        _assert(int(d["first_bad_row"]) == 5, "PatternD: first bad row=5")
+        _assert(int(d["first_bad_col"]) == 10, "PatternD: first bad col=10")
+        _assert(math.isinf(d["first_bad_val"]), "PatternD: first_bad_val is Inf")
+
+        # Pattern E: huge-only, no NaN/Inf
+        t_e = torch.randn(32, 32, device="cuda")
+        t_e[0, 0] = 2e15
+        d = _run_stats(t_e)
+        _assert(int(d["nan_count"]) == 0 and int(d["inf_count"]) == 0 and int(d["huge_count"]) == 1,
+                "PatternE: 0 NaN, 0 Inf, 1 huge")
+        _assert(int(d["first_bad_row"]) == 0 and int(d["first_bad_col"]) == 0,
+                "PatternE: first bad at [0,0]")
+        _assert(abs(d["first_bad_val"] - 2e15) < 1e10,
+                f"PatternE: first_bad_val={d['first_bad_val']:.3e} ≈ 2e15")
+
+        # Pattern F: 1D tensor
+        t_f = torch.randn(4096, device="cuda")
+        t_f[999] = float("nan")
+        d = _run_stats(t_f)
+        _assert(int(d["first_bad_col"]) == 999, "Pattern1D: first_bad_col=999 for 1D tensor")
+        _assert(int(d["first_bad_row"]) == 0, "Pattern1D: first_bad_row=0 for 1D tensor")
+
+        # Pattern G: all-NaN tensor
+        t_g = torch.full((16, 16), float("nan"), device="cuda")
+        d = _run_stats(t_g)
+        _assert(int(d["nan_count"]) == 256, "AllNaN: nan_count=256")
+        _assert(int(d["first_bad_flat"]) == 0, "AllNaN: first_bad_flat=0")
+
+        # Pattern H: clean tensor — no bad elements
+        t_h = torch.randn(128, 256, device="cuda")
+        d = _run_stats(t_h)
+        _assert(int(d["nan_count"]) == 0 and int(d["huge_count"]) == 0,
+                "Clean: no bad elements")
+        _assert(isinstance(d["first_bad_flat"], float), "Clean: first_bad_flat is a number (ignored)")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 3: NANLOG_ALLOC_SNAPSHOT lifecycle
+# ============================================================================
+def test_alloc_snapshot():
+    _header("3. NANLOG_ALLOC_SNAPSHOT — recording + dump + stop lifecycle")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test3_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_ALLOC_SNAPSHOT="1")
+        _assert(nl._ALLOC_SNAPSHOT is True, "ALLOC_SNAPSHOT is ON")
+        _assert(nl._snapshot_dumped is False, "Not dumped yet")
+
+        # Start recording (in production this is called inside DMP __init__ hook;
+        # in this unit test we call it explicitly since there's no DMP)
+        nl._start_alloc_recording()
+        _assert(nl._alloc_recording_started is True, "Recording started")
+
+        # Do some GPU work
+        for _ in range(10):
+            x = torch.randn(512, 512, device="cuda")
+            y = torch.mm(x, x)
+            del x, y
+        torch.cuda.synchronize()
+
+        # Trigger dump
+        nl._dump_alloc_snapshot(step=99)
+        _assert(nl._snapshot_dumped is True, "Dump flag set after first dump")
+
+        snap_files = list(Path(tmpdir).glob("alloc_snapshot_*.pickle"))
+        _assert(len(snap_files) == 1, f"Exactly 1 snapshot file: {[f.name for f in snap_files]}")
+
+        if snap_files:
+            with open(snap_files[0], "rb") as f:
+                snap = pickle.load(f)
+            _assert("segments" in snap, "Snapshot contains 'segments'")
+            _assert("device_traces" in snap, "Snapshot contains 'device_traces'")
+            _assert("allocator_settings" in snap, "Snapshot contains 'allocator_settings'")
+
+            trace = snap["device_traces"][0] if snap["device_traces"] else []
+            _assert(len(trace) > 0, f"Device 0 has {len(trace)} trace events")
+            if trace:
+                ev0 = trace[0]
+                _assert("action" in ev0, "Trace event has 'action'")
+                _assert("addr" in ev0, "Trace event has 'addr'")
+                _assert("stream" in ev0, "Trace event has 'stream'")
+                _assert("time_us" in ev0, "Trace event has 'time_us'")
+                _assert("frames" in ev0, "Trace event has 'frames' (call stack)")
+
+        # Second dump should be skipped (guard)
+        nl._dump_alloc_snapshot(step=100)
+        snap_files2 = list(Path(tmpdir).glob("alloc_snapshot_*.pickle"))
+        _assert(len(snap_files2) == 1, "Second dump is skipped (still 1 file)")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 4: ALLOC_SNAPSHOT disabled by default
+# ============================================================================
+def test_alloc_snapshot_off():
+    _header("4. NANLOG_ALLOC_SNAPSHOT=0 — no recording, no dump")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test4_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir)
+        _assert(nl._ALLOC_SNAPSHOT is False, "ALLOC_SNAPSHOT defaults to OFF")
+
+        nl._dump_alloc_snapshot(step=1)
+        snap_files = list(Path(tmpdir).glob("alloc_snapshot_*.pickle"))
+        _assert(len(snap_files) == 0, "No snapshot file when disabled")
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 5: Edge cases — tensor shapes
+# ============================================================================
+def test_edge_cases():
+    _header("5. Edge cases — unusual tensor shapes and dtypes")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test5_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_BAD_VALUES="1",
+                            NANLOG_LOCATE="1")
+
+        # Scalar tensor (0-dim)
+        t_scalar = torch.tensor(float("nan"), device="cuda")
+        stats = nl._device_stats(t_scalar)
+        flat_idx = stats["first_bad_flat"].cpu().item()
+        _assert(flat_idx == 0, f"Scalar NaN: first_bad_flat=0 (got {flat_idx})")
+
+        # Empty tensor (numel=0) — should not crash _stash
+        t_empty = torch.empty(0, 128, device="cuda")
+        nl._pending.clear()
+        nl._stash("test.empty", "fwd", t_empty, role="act")
+        _assert(len(nl._pending) == 0, "Empty tensor: stash skips (numel=0)")
+
+        # Very large tensor (ensure no OOM from extra reductions)
+        try:
+            t_large = torch.randn(4096, 4096, device="cuda")
+            t_large[0, 0] = float("nan")
+            stats = nl._device_stats(t_large)
+            row = stats["first_bad_row"].cpu().item()
+            _assert(row == 0, f"Large tensor: first_bad_row=0 (got {row})")
+            del t_large
+        except torch.cuda.OutOfMemoryError:
+            _ok("Large tensor: skipped (OOM on this GPU)")
+
+        # fp16 tensor
+        t_fp16 = torch.randn(64, 64, device="cuda", dtype=torch.float16)
+        t_fp16[3, 7] = float("nan")
+        stats = nl._device_stats(t_fp16)
+        row = stats["first_bad_row"].cpu().item()
+        col = stats["first_bad_col"].cpu().item()
+        _assert(row == 3 and col == 7, f"fp16: first_bad at [{row},{col}] (expected [3,7])")
+
+        # bf16 tensor
+        t_bf16 = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+        t_bf16[1, 2] = float("inf")
+        stats = nl._device_stats(t_bf16)
+        row = stats["first_bad_row"].cpu().item()
+        col = stats["first_bad_col"].cpu().item()
+        _assert(row == 1 and col == 2, f"bf16: first_bad at [{row},{col}] (expected [1,2])")
+
+        # 3D tensor: row = dim0 index, col = flat offset within that dim0 slice
+        t_3d = torch.randn(8, 32, 64, device="cuda")
+        t_3d[2, 10, 30] = float("nan")
+        stats = nl._device_stats(t_3d)
+        flat_idx = stats["first_bad_flat"].cpu().item()
+        expected_flat = 2 * 32 * 64 + 10 * 64 + 30
+        _assert(int(flat_idx) == expected_flat,
+                f"3D tensor: first_bad_flat={int(flat_idx)} (expected {expected_flat})")
+        row = stats["first_bad_row"].cpu().item()
+        col = stats["first_bad_col"].cpu().item()
+        _assert(int(row) == 2, f"3D tensor: first_bad_row={int(row)} (expected 2, dim0 index)")
+        expected_col = 10 * 64 + 30  # flat offset within dim0 slice
+        _assert(int(col) == expected_col,
+                f"3D tensor: first_bad_col={int(col)} (expected {expected_col})")
+
+        # 4D tensor (batch, channel, H, W)
+        t_4d = torch.randn(2, 3, 8, 8, device="cuda")
+        t_4d[1, 2, 3, 4] = float("nan")
+        stats = nl._device_stats(t_4d)
+        row = stats["first_bad_row"].cpu().item()
+        col = stats["first_bad_col"].cpu().item()
+        _assert(int(row) == 1, f"4D tensor: first_bad_row={int(row)} (expected 1, dim0 index)")
+        expected_col_4d = 2 * 8 * 8 + 3 * 8 + 4
+        _assert(int(col) == expected_col_4d,
+                f"4D tensor: first_bad_col={int(col)} (expected {expected_col_4d})")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 6: Full drain + JSONL output + JSON compliance
+# ============================================================================
+def test_jsonl_output():
+    _header("6. JSONL output — full drain cycle with JSON compliance")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test6_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_BAD_VALUES="1",
+                            NANLOG_LOCATE="1", NANLOG_ADDR="1",
+                            NANLOG_SAMPLE_EVERY="1")
+
+        # Reset state
+        nl._step = 0
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._pending.clear()
+
+        # Step 1: clean tensor
+        nl._step = 1
+        t1 = torch.randn(64, 128, device="cuda")
+        nl._stash("model.layer0", "fwd", t1, role="act")
+        nl._drain_step()
+
+        # Step 2: bad tensor (NaN + huge)
+        nl._step = 2
+        t2 = torch.randn(256, 8192, device="cuda")
+        t2[42, 100] = float("nan")
+        t2[42, 101] = 3.13e36
+        nl._stash("model.proj10", "fwd", t2, role="act")
+        nl._drain_step()
+
+        # Step 3: inf tensor
+        nl._step = 3
+        t3 = torch.randn(32, 32, device="cuda")
+        t3[0, 0] = float("inf")
+        nl._stash("model.layer1", "bwd", t3, role="igrad")
+        nl._drain_step()
+
+        # Read and validate JSONL
+        jsonl_files = list(Path(tmpdir).glob("layers_rank*.jsonl"))
+        _assert(len(jsonl_files) == 1, f"Exactly 1 JSONL file: {[f.name for f in jsonl_files]}")
+
+        if jsonl_files:
+            records = []
+            parse_errors = 0
+            with open(jsonl_files[0]) as fh:
+                for i, line in enumerate(fh, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                        records.append(rec)
+                    except json.JSONDecodeError as e:
+                        parse_errors += 1
+                        _fail(f"Line {i} JSON parse error: {e}")
+
+            _assert(parse_errors == 0, f"All {len(records)} records are valid JSON")
+            _assert(len(records) >= 3, f"At least 3 records written (got {len(records)})")
+
+            # Check clean record has no bad_values fields
+            clean_recs = [r for r in records if not r.get("bad")]
+            if clean_recs:
+                _assert("first_bad_value" not in clean_recs[0],
+                        "Clean records have no first_bad_* fields")
+
+            # Check bad record has bad_values fields
+            bad_recs = [r for r in records if r.get("bad")]
+            _assert(len(bad_recs) >= 2, f"{len(bad_recs)} bad records found")
+            if bad_recs:
+                br = bad_recs[0]
+                _assert("first_bad_flat_idx" in br, "Bad record has first_bad_flat_idx")
+                _assert("first_bad_row" in br, "Bad record has first_bad_row")
+                _assert("first_bad_col" in br, "Bad record has first_bad_col")
+                _assert("first_bad_value" in br, "Bad record has first_bad_value")
+                _assert(br["first_bad_value"] in ("NaN", "Inf", "-Inf") or isinstance(br["first_bad_value"], (int, float)),
+                        f"first_bad_value is JSON-safe: {br['first_bad_value']!r}")
+
+                # Check address fields
+                _assert("data_ptr" in br, "Bad record has data_ptr")
+                _assert("storage_ptr" in br, "Bad record has storage_ptr")
+                _assert("storage_nbytes" in br, "Bad record has storage_nbytes")
+
+                # Verify the NaN record specifically
+                nan_recs = [r for r in bad_recs if r.get("nan_count", 0) > 0]
+                if nan_recs:
+                    nr = nan_recs[0]
+                    _assert(nr["first_bad_row"] == 42, f"NaN record: row={nr['first_bad_row']} (expected 42)")
+                    _assert(nr["first_bad_col"] == 100, f"NaN record: col={nr['first_bad_col']} (expected 100)")
+                    _assert(nr["first_bad_value"] == "NaN", f"NaN record: value={nr['first_bad_value']!r}")
+                    _assert(nr["bad_rows"] == 1, f"NaN record: bad_rows={nr['bad_rows']} (expected 1)")
+
+            # Validate JSON re-serialization roundtrip
+            for rec in records:
+                try:
+                    s = json.dumps(rec)
+                    json.loads(s)
+                except Exception as e:
+                    _fail(f"Roundtrip failed for record step={rec.get('step')}: {e}")
+                    break
+            else:
+                _ok("All records pass JSON roundtrip (dumps->loads)")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 7: Summary file
+# ============================================================================
+def test_summary():
+    _header("7. Summary file — includes all settings")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test7_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_BAD_VALUES="1",
+                            NANLOG_ALLOC_SNAPSHOT="1", NANLOG_LOCATE="1",
+                            NANLOG_DUMP_TENSOR="1")
+
+        nl._step = 5
+        nl._first_bad = {"step": 3, "layer": "test", "direction": "fwd", "kind": "nan"}
+        nl._write_summary()
+
+        summary_files = list(Path(tmpdir).glob("summary_rank*.json"))
+        _assert(len(summary_files) == 1, "Exactly 1 summary file")
+
+        if summary_files:
+            with open(summary_files[0]) as fh:
+                summary = json.load(fh)
+            _assert(summary.get("bad_values") is True, "Summary: bad_values=true")
+            _assert(summary.get("alloc_snapshot") is True, "Summary: alloc_snapshot=true")
+            _assert(summary.get("locate") is True, "Summary: locate=true")
+            _assert(summary.get("capture_addr") is True, "Summary: capture_addr=true")
+            _assert(summary.get("dump_tensor") is True, "Summary: dump_tensor=true")
+            _assert("dump_tensor_dumped" in summary, "Summary: dump_tensor_dumped present")
+            _assert("alloc_snapshot_dumped" in summary, "Summary: alloc_snapshot_dumped present")
+            _assert(summary.get("first_bad") is not None, "Summary: first_bad recorded")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 8: Address capture cross-referencing
+# ============================================================================
+def test_addr_cross_ref():
+    _header("8. NANLOG_ADDR — cross-reference aliasing between tensors")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test8_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_ADDR="1",
+                            NANLOG_SAMPLE_EVERY="1")
+
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._pending.clear()
+
+        # Create two tensors that alias the same storage
+        base = torch.randn(256, 8192, device="cuda")
+        view = base[42:43, :]  # View of row 42
+
+        nl._stash("model.proj10", "fwd", base, role="act")
+        nl._stash("model.proj10.view", "fwd", view, role="input")
+        nl._drain_step()
+
+        jsonl_files = list(Path(tmpdir).glob("layers_rank*.jsonl"))
+        if jsonl_files:
+            records = []
+            with open(jsonl_files[0]) as fh:
+                for line in fh:
+                    records.append(json.loads(line.strip()))
+
+            _assert(len(records) == 2, f"2 records from aliased tensors")
+            r0, r1 = records[0], records[1]
+            _assert(r0.get("storage_ptr") == r1.get("storage_ptr"),
+                    f"Aliased tensors share storage_ptr: {r0.get('storage_ptr')}")
+            _assert(r0.get("storage_nbytes") == r1.get("storage_nbytes"),
+                    f"Same storage_nbytes: {r0.get('storage_nbytes')}")
+            _assert(r0.get("data_ptr") != r1.get("data_ptr"),
+                    "Different data_ptr (view offset)")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 9: BAD_VALUES byte-offset diagnostic
+# ============================================================================
+def test_byte_offset_diagnostic():
+    _header("9. BAD_VALUES byte offset — precise cache-line identification")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test9_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_BAD_VALUES="1",
+                            NANLOG_ADDR="1", NANLOG_SAMPLE_EVERY="1")
+
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._pending.clear()
+
+        t = torch.randn(256, 8192, device="cuda")
+        t[42, 100] = float("nan")
+
+        nl._stash("model.proj10", "fwd", t, role="act")
+        nl._drain_step()
+
+        jsonl_files = list(Path(tmpdir).glob("layers_rank*.jsonl"))
+        if jsonl_files:
+            with open(jsonl_files[0]) as fh:
+                rec = json.loads(fh.readline().strip())
+
+            if rec.get("bad"):
+                flat_idx = rec["first_bad_flat_idx"]
+                element_size = 4  # fp32
+                storage_offset = rec.get("storage_offset_bytes", 0)
+                byte_offset = storage_offset + flat_idx * element_size
+
+                expected_flat = 42 * 8192 + 100
+                expected_byte = expected_flat * 4
+                _assert(flat_idx == expected_flat,
+                        f"flat_idx={flat_idx} == {expected_flat}")
+                _assert(byte_offset == expected_byte,
+                        f"byte_offset={byte_offset} == {expected_byte} ({byte_offset/1024:.1f} KB into buffer)")
+
+                storage_ptr = rec.get("storage_ptr")
+                _assert(storage_ptr is not None,
+                        f"storage_ptr={storage_ptr} + byte_offset={byte_offset} = exact corrupt address")
+            else:
+                _fail("Expected bad record")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 10: Graceful degradation
+# ============================================================================
+def test_graceful_degradation():
+    _header("10. Graceful degradation — bad values don't crash")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test10_")
+
+    # Test with bad NANLOG_DIR (read-only)
+    try:
+        ro_dir = tempfile.mkdtemp(prefix="nanlog_ro_")
+        os.chmod(ro_dir, 0o444)
+        nl = _reload_logger(NANLOG_DIR=ro_dir)
+        _ok("Logger survives read-only NANLOG_DIR (falls back to temp)")
+        os.chmod(ro_dir, 0o755)
+        shutil.rmtree(ro_dir, ignore_errors=True)
+    except Exception as e:
+        _fail(f"Crashed on read-only dir: {e}")
+
+    # Test _dump_alloc_snapshot when recording was never started
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_ALLOC_SNAPSHOT="0")
+        nl._dump_alloc_snapshot(step=1)
+        _ok("_dump_alloc_snapshot safe when ALLOC_SNAPSHOT=0")
+    except Exception as e:
+        _fail(f"_dump_alloc_snapshot crashed when disabled: {e}")
+
+    # Test _dump_bad_tensor when DUMP_TENSOR is disabled
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="0")
+        t = torch.randn(32, 32, device="cuda")
+        t[0, 0] = float("nan")
+        rec = {"step": 1, "layer_name": "test", "role": "act"}
+        nl._dump_bad_tensor(rec, t)
+        _ok("_dump_bad_tensor safe when DUMP_TENSOR=0")
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 0, "No .pt file when DUMP_TENSOR=0")
+    except Exception as e:
+        _fail(f"_dump_bad_tensor crashed when disabled: {e}")
+
+    # Test with non-tensor input to _stash
+    try:
+        nl._stash("test", "fwd", None, role="act")
+        nl._stash("test", "fwd", "not_a_tensor", role="act")
+        nl._stash("test", "fwd", 42, role="act")
+        _ok("_stash handles non-tensor inputs gracefully")
+    except Exception as e:
+        _fail(f"_stash crashed on non-tensor input: {e}")
+
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 11: NANLOG_DUMP_TENSOR — full lifecycle
+# ============================================================================
+def test_dump_tensor_lifecycle():
+    _header("11. NANLOG_DUMP_TENSOR — full lifecycle: stash, detect, dump, one-shot guard")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test11_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1", NANLOG_ADDR="1")
+        _assert(nl._DUMP_TENSOR is True, "DUMP_TENSOR is ON")
+        _assert(nl._tensor_dumped is False, "tensor_dumped starts False")
+
+        # Reset state
+        nl._step = 0
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._pending.clear()
+
+        # --- Step 1: clean tensor → no dump ---
+        nl._step = 1
+        t_clean = torch.randn(64, 128, device="cuda")
+        nl._stash("model.layer0", "fwd", t_clean, role="act")
+
+        # Verify tensor ref IS held (DUMP_TENSOR=1, not yet dumped)
+        _assert(len(nl._pending) == 1, "Step1: 1 pending after stash")
+        _, _, held = nl._pending[0]
+        _assert(held is not None, "Step1: tensor ref IS held (DUMP_TENSOR=1)")
+        _assert(held.data_ptr() == t_clean.data_ptr(), "Step1: held ref is the same tensor")
+
+        nl._drain_step()
+        _assert(nl._tensor_dumped is False, "Step1: no dump on clean tensor")
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 0, "Step1: no .pt file for clean tensor")
+
+        # --- Step 2: bad tensor → dump triggered ---
+        nl._step = 2
+        t_bad = torch.randn(256, 8192, device="cuda")
+        t_bad[42, 100] = float("nan")
+        t_bad[42, 101] = 3.13e36
+        t_bad[42, 102] = -2.87e36
+
+        nl._stash("model.emb_proj.projections.10.layers.0", "fwd", t_bad, role="input")
+
+        # Verify ref held
+        _, _, held = nl._pending[0]
+        _assert(held is not None, "Step2: tensor ref held for bad tensor")
+
+        nl._drain_step()
+        _assert(nl._tensor_dumped is True, "Step2: dump triggered on first bad")
+        _assert(nl._first_bad is not None, "Step2: first_bad set")
+
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, f"Step2: exactly 1 .pt file (got {len(pt_files)})")
+
+        if pt_files:
+            # Verify filename format
+            fname = pt_files[0].name
+            _assert("step2" in fname, f"Filename contains step: {fname}")
+            _assert("input" in fname, f"Filename contains role: {fname}")
+            _assert("rank" in fname, f"Filename contains rank: {fname}")
+
+            # Load and verify content
+            loaded = torch.load(pt_files[0], weights_only=True)
+            _assert(loaded.shape == torch.Size([256, 8192]),
+                    f"Loaded shape={list(loaded.shape)} matches original")
+            _assert(loaded.dtype == torch.float32, f"Loaded dtype={loaded.dtype}")
+            _assert(loaded.device == torch.device("cpu"),
+                    "Loaded tensor is on CPU (was copied from GPU)")
+
+            # Verify the actual bad values are preserved
+            _assert(torch.isnan(loaded[42, 100]).item(),
+                    "Loaded tensor: NaN at [42,100] preserved")
+            _assert(loaded[42, 101].item() > 3e36,
+                    f"Loaded tensor: huge at [42,101]={loaded[42,101].item():.3e} preserved")
+            _assert(loaded[42, 102].item() < -2e36,
+                    f"Loaded tensor: huge at [42,102]={loaded[42,102].item():.3e} preserved")
+
+            # Verify clean values are also preserved (not corrupted by the dump)
+            _assert(torch.isfinite(loaded[0, 0]).item(),
+                    "Loaded tensor: clean value at [0,0] is finite")
+            _assert(torch.isfinite(loaded[100, 100]).item(),
+                    "Loaded tensor: clean value at [100,100] is finite")
+
+            # Verify we can do full post-hoc analysis on the dumped tensor
+            bad_mask = torch.isnan(loaded) | torch.isinf(loaded) | (loaded.abs() > 1e10)
+            bad_locs = torch.nonzero(bad_mask)
+            _assert(len(bad_locs) == 3,
+                    f"Post-hoc analysis: found {len(bad_locs)} bad elements (expected 3)")
+            _assert(bad_locs[0].tolist() == [42, 100],
+                    f"Post-hoc: first bad at {bad_locs[0].tolist()} (expected [42,100])")
+
+        # --- Step 3: another bad tensor → should NOT produce a second dump ---
+        nl._step = 3
+        t_bad2 = torch.randn(64, 64, device="cuda")
+        t_bad2[0, 0] = float("inf")
+        nl._stash("model.layer1", "fwd", t_bad2, role="act")
+
+        # After first dump, refs should NOT be held anymore
+        _, _, held = nl._pending[0]
+        _assert(held is None, "Step3: tensor ref NOT held after dump already done")
+
+        nl._drain_step()
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, "Step3: one-shot guard — still only 1 .pt file")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 12: DUMP_TENSOR with input channel — validates aliasing workflow
+# ============================================================================
+def test_dump_tensor_input_channel():
+    _header("12. DUMP_TENSOR + input channel — embed_proj aliasing workflow")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test12_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_CHANNELS="act,input,igrad",
+                            NANLOG_ADDR="1", NANLOG_WATCH_TYPES="Linear",
+                            NANLOG_SAMPLE_EVERY="1")
+
+        _assert("input" in nl._CHANNELS, "input channel is enabled")
+        _assert("act" in nl._CHANNELS, "act channel is enabled")
+
+        # Build a simple model simulating embed_proj.projections.10
+        model = torch.nn.Sequential(
+            torch.nn.Linear(8192, 256, bias=False),
+        ).cuda()
+
+        # Reset state and attach hooks
+        nl._step = 0
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+        nl._watched_names.clear()
+        n = nl._attach(model)
+        _assert(n == 1, f"Attached to {n} module (Linear)")
+
+        # Create an input with NaN (simulating aliased corrupt memory)
+        x = torch.randn(256, 8192, device="cuda")
+        x[42, 100] = float("nan")
+        input_data_ptr = hex(x.data_ptr())
+        input_storage_ptr = hex(x.untyped_storage().data_ptr())
+
+        # Forward pass — hooks should fire
+        nl._step = 1
+        out = model(x)
+        _assert(len(nl._pending) >= 2,
+                f"After forward: {len(nl._pending)} pending (expect >=2: act+input)")
+
+        # Find the input record in pending
+        input_entries = [(r, s, h) for r, s, h in nl._pending if r.get("role") == "input"]
+        _assert(len(input_entries) >= 1, f"Found {len(input_entries)} input-role pending entries")
+        if input_entries:
+            rec, _, held = input_entries[0]
+            _assert(rec.get("data_ptr") == input_data_ptr,
+                    f"Input record data_ptr={rec.get('data_ptr')} matches x ({input_data_ptr})")
+            _assert(rec.get("storage_ptr") == input_storage_ptr,
+                    f"Input record storage_ptr={rec.get('storage_ptr')} matches x ({input_storage_ptr})")
+            _assert(held is not None, "Input tensor ref IS held for dump")
+
+        # Drain — should detect NaN in the input and dump it
+        nl._drain_step()
+        _assert(nl._tensor_dumped is True, "Dump triggered on NaN input")
+
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, f"1 dump file produced (got {len(pt_files)})")
+
+        if pt_files:
+            loaded = torch.load(pt_files[0], weights_only=True)
+            _assert(torch.isnan(loaded[42, 100]).item(),
+                    "Dumped input tensor has NaN at [42,100]")
+            _assert(loaded.shape == torch.Size([256, 8192]),
+                    f"Dumped input shape={list(loaded.shape)} (the input, not output)")
+
+        # Verify JSONL also has the input record with address
+        jsonl_files = list(Path(tmpdir).glob("layers_rank*.jsonl"))
+        if jsonl_files:
+            records = []
+            with open(jsonl_files[0]) as fh:
+                for line in fh:
+                    if line.strip():
+                        records.append(json.loads(line.strip()))
+            input_recs = [r for r in records if r.get("role") == "input"]
+            _assert(len(input_recs) >= 1, f"JSONL has {len(input_recs)} input records")
+            if input_recs:
+                ir = input_recs[0]
+                _assert(ir.get("bad") is True, "Input record marked bad=true")
+                _assert(ir.get("data_ptr") == input_data_ptr,
+                        "JSONL input record has correct data_ptr for cross-referencing")
+                _assert(ir.get("storage_ptr") == input_storage_ptr,
+                        "JSONL input record has correct storage_ptr for cross-referencing")
+
+        del out
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 13: DUMP_TENSOR disabled — no refs held, no files
+# ============================================================================
+def test_dump_tensor_off():
+    _header("13. NANLOG_DUMP_TENSOR=0 — no tensor refs held, no .pt files")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test13_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="0",
+                            NANLOG_SAMPLE_EVERY="1")
+        _assert(nl._DUMP_TENSOR is False, "DUMP_TENSOR is OFF")
+
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._pending.clear()
+
+        t = torch.randn(64, 128, device="cuda")
+        t[0, 0] = float("nan")
+        nl._stash("model.layer0", "fwd", t, role="act")
+
+        # Verify no tensor ref held
+        _, _, held = nl._pending[0]
+        _assert(held is None, "No tensor ref held when DUMP_TENSOR=0")
+
+        nl._drain_step()
+        _assert(nl._tensor_dumped is False, "tensor_dumped stays False")
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 0, "No .pt files when DUMP_TENSOR=0")
+
+        # first_bad still detected normally
+        _assert(nl._first_bad is not None, "first_bad detection still works without DUMP_TENSOR")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 14: DUMP_TENSOR with all flags combined — no interaction bugs
+# ============================================================================
+def test_dump_tensor_all_flags():
+    _header("14. DUMP_TENSOR + all flags — no interaction or crash")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test14_")
+    try:
+        nl = _reload_logger(
+            NANLOG_DIR=tmpdir,
+            NANLOG_DUMP_TENSOR="1",
+            NANLOG_BAD_VALUES="1",
+            NANLOG_LOCATE="1",
+            NANLOG_ADDR="1",
+            NANLOG_CHANNELS="act,input,igrad",
+            NANLOG_WATCH_TYPES="Linear",
+            NANLOG_SAMPLE_EVERY="1",
+            NANLOG_VERBOSE="1",
+        )
+
+        _assert(nl._DUMP_TENSOR is True, "DUMP_TENSOR ON")
+        _assert(nl._BAD_VALUES is True, "BAD_VALUES ON")
+        _assert(nl._LOCATE is True, "LOCATE ON")
+        _assert(nl._CAPTURE_ADDR is True, "ADDR ON")
+        _assert("input" in nl._CHANNELS, "input channel ON")
+
+        # Build model
+        model = torch.nn.Sequential(
+            torch.nn.Linear(128, 64, bias=True),
+            torch.nn.ReLU(),
+            torch.nn.Linear(64, 32, bias=True),
+        ).cuda()
+
+        nl._step = 0
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+        nl._watched_names.clear()
+        n = nl._attach(model)
+        _assert(n == 2, f"Attached to {n} Linear modules")
+
+        # Step 1: clean forward — all channels fire, no dump
+        nl._step = 1
+        x1 = torch.randn(16, 128, device="cuda")
+        out1 = model(x1)
+        nl._drain_step()
+        _assert(nl._tensor_dumped is False, "No dump on clean forward")
+
+        # Step 2: NaN input to second layer (inject between)
+        nl._step = 2
+        x2 = torch.randn(16, 128, device="cuda")
+        # Hook the intermediate: corrupt the ReLU output which is Linear[1]'s input
+        with torch.no_grad():
+            mid = model[0](x2)
+            mid = torch.relu(mid)
+            mid[3, 10] = float("nan")
+            # Manually stash as if the hook caught it (simulating the input channel)
+            nl._stash("1", "fwd", mid, role="input")
+            # Also stash the output (simulating act channel)
+            out2 = model[2](mid)
+            nl._stash("2", "fwd", out2, role="act")
+
+        nl._drain_step()
+        _assert(nl._tensor_dumped is True, "Dump triggered with all flags")
+        _assert(nl._first_bad is not None, "first_bad set with all flags")
+
+        # Verify files
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, f"Exactly 1 .pt file with all flags (got {len(pt_files)})")
+
+        jsonl_files = list(Path(tmpdir).glob("layers_rank*.jsonl"))
+        if jsonl_files:
+            records = []
+            with open(jsonl_files[0]) as fh:
+                for line in fh:
+                    if line.strip():
+                        records.append(json.loads(line.strip()))
+
+            bad_recs = [r for r in records if r.get("bad")]
+            if bad_recs:
+                br = bad_recs[0]
+                # All enrichment fields present together
+                _assert("first_bad_flat_idx" in br, "BAD_VALUES fields present alongside DUMP_TENSOR")
+                _assert("bad_rows" in br, "LOCATE fields present alongside DUMP_TENSOR")
+                _assert("data_ptr" in br, "ADDR fields present alongside DUMP_TENSOR")
+                _assert("storage_ptr" in br, "storage_ptr present alongside DUMP_TENSOR")
+
+        # Summary includes everything
+        nl._write_summary()
+        summary_files = list(Path(tmpdir).glob("summary_rank*.json"))
+        if summary_files:
+            with open(summary_files[0]) as fh:
+                summary = json.load(fh)
+            _assert(summary.get("dump_tensor") is True, "Summary: dump_tensor=true")
+            _assert(summary.get("dump_tensor_dumped") is True, "Summary: dump_tensor_dumped=true")
+            _assert(summary.get("bad_values") is True, "Summary: bad_values=true")
+            _assert(summary.get("locate") is True, "Summary: locate=true")
+
+        del out1, out2
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 15: DUMP_TENSOR — multiple bad tensors in same step, only first dumped
+# ============================================================================
+def test_dump_tensor_multiple_bad_same_step():
+    _header("15. DUMP_TENSOR — multiple bad tensors same step, first one wins")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test15_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1")
+
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+
+        # Two bad tensors in the same step
+        t1 = torch.randn(32, 64, device="cuda")
+        t1[5, 10] = float("nan")
+        t2 = torch.randn(64, 128, device="cuda")
+        t2[10, 20] = float("inf")
+
+        nl._stash("model.layer_A", "fwd", t1, role="act")
+        nl._stash("model.layer_B", "fwd", t2, role="act")
+
+        # Both should have refs held (not yet dumped)
+        _, _, h1 = nl._pending[0]
+        _, _, h2 = nl._pending[1]
+        _assert(h1 is not None, "First bad tensor ref held")
+        _assert(h2 is not None, "Second bad tensor ref held")
+
+        nl._drain_step()
+        _assert(nl._tensor_dumped is True, "Dump triggered")
+
+        pt_files = sorted(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, f"Only 1 .pt file (one-shot), got {len(pt_files)}")
+
+        if pt_files:
+            loaded = torch.load(pt_files[0], weights_only=True)
+            # First bad in drain order is t1 (layer_A)
+            _assert(loaded.shape == torch.Size([32, 64]),
+                    f"Dumped tensor is the FIRST bad one (shape={list(loaded.shape)})")
+            _assert(torch.isnan(loaded[5, 10]).item(),
+                    "Dumped tensor has NaN at [5,10] (from layer_A)")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 16: DUMP_TENSOR — various dtypes (fp16, bf16, fp32)
+# ============================================================================
+def test_dump_tensor_dtypes():
+    _header("16. DUMP_TENSOR — fp16, bf16, fp32 tensors all dump correctly")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test16_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1")
+
+        dtypes = [
+            (torch.float32, "fp32"),
+            (torch.float16, "fp16"),
+            (torch.bfloat16, "bf16"),
+        ]
+
+        for dt, name in dtypes:
+            # Fresh state for each dtype test
+            nl._step = 0
+            nl._records_written = 0
+            nl._first_bad = None
+            nl._tensor_dumped = False
+            nl._pending.clear()
+
+            nl._step = 1
+            t = torch.randn(64, 64, device="cuda", dtype=dt)
+            t[7, 13] = float("nan")
+            nl._stash(f"model.{name}_layer", "fwd", t, role="act")
+            nl._drain_step()
+
+            pt_files = sorted(Path(tmpdir).glob(f"bad_tensor_*{name}*"))
+            _assert(len(pt_files) == 1, f"{name}: dump file created")
+            if pt_files:
+                loaded = torch.load(pt_files[0], weights_only=True)
+                _assert(loaded.dtype == dt, f"{name}: dtype preserved ({loaded.dtype})")
+                _assert(loaded.shape == torch.Size([64, 64]), f"{name}: shape preserved")
+                _assert(torch.isnan(loaded[7, 13]).item(), f"{name}: NaN at [7,13] preserved")
+                _assert(loaded.device == torch.device("cpu"), f"{name}: on CPU after dump")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 17: DUMP_TENSOR — large tensor (production-size embed_proj input)
+# ============================================================================
+def test_dump_tensor_large():
+    _header("17. DUMP_TENSOR — production-size tensor (256x8192 fp32 = 8 MB)")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test17_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1")
+
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+
+        # Production-size: 256 x 8192 fp32 = 8 MiB
+        t = torch.randn(256, 8192, device="cuda")
+        # Meta's observed pattern: 1 NaN + 4 huge in one row
+        t[42, 100] = float("nan")
+        t[42, 101] = 3.13e36
+        t[42, 102] = -2.87e36
+        t[42, 103] = 1.56e36
+        t[42, 104] = -4.21e36
+
+        nl._stash("model.emb_proj.projections.10.layers.0", "fwd", t, role="input")
+        nl._drain_step()
+
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, "Large tensor dump produced")
+
+        if pt_files:
+            file_size = pt_files[0].stat().st_size
+            _assert(file_size > 7 * 1024 * 1024,
+                    f"File size={file_size/1024/1024:.1f} MB (expected ~8 MB for 256x8192 fp32)")
+
+            loaded = torch.load(pt_files[0], weights_only=True)
+            _assert(loaded.shape == torch.Size([256, 8192]), "Shape correct")
+
+            # Verify ALL bad values preserved exactly
+            _assert(torch.isnan(loaded[42, 100]).item(), "NaN preserved")
+            _assert(abs(loaded[42, 101].item() - 3.13e36) < 1e33, "Huge[101] preserved")
+            _assert(abs(loaded[42, 102].item() - (-2.87e36)) < 1e33, "Huge[102] preserved")
+            _assert(abs(loaded[42, 103].item() - 1.56e36) < 1e33, "Huge[103] preserved")
+            _assert(abs(loaded[42, 104].item() - (-4.21e36)) < 1e33, "Huge[104] preserved")
+
+            # Full post-hoc analysis: find all bad, verify row pattern
+            bad_mask = torch.isnan(loaded) | torch.isinf(loaded) | (loaded.abs() > 1e10)
+            bad_locs = torch.nonzero(bad_mask)
+            _assert(len(bad_locs) == 5, f"Post-hoc: 5 bad elements found (got {len(bad_locs)})")
+            bad_rows = bad_locs[:, 0].unique()
+            _assert(len(bad_rows) == 1 and bad_rows[0].item() == 42,
+                    f"Post-hoc: all bad in row 42 (aliasing signature)")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 18: DUMP_TENSOR — tensor that is a view (non-contiguous)
+# ============================================================================
+def test_dump_tensor_view():
+    _header("18. DUMP_TENSOR — view/non-contiguous tensor dumps correctly")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test18_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1", NANLOG_ADDR="1")
+
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+
+        # Create a view (non-contiguous slice) — this is common in production
+        # when the input to a layer is a slice of a larger buffer
+        base = torch.randn(512, 8192, device="cuda")
+        view = base[42:43, :]  # single row view, non-contiguous in storage
+        view[0, 0] = float("nan")
+
+        _assert(not view.is_contiguous() or view.storage_offset() > 0,
+                "View is offset from base storage (realistic aliasing scenario)")
+
+        nl._stash("model.proj10", "fwd", view, role="input")
+        nl._drain_step()
+
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, "View tensor dump produced")
+
+        if pt_files:
+            loaded = torch.load(pt_files[0], weights_only=True)
+            _assert(loaded.shape == torch.Size([1, 8192]),
+                    f"Dumped view shape={list(loaded.shape)} (just the view, not full base)")
+            _assert(torch.isnan(loaded[0, 0]).item(), "NaN at [0,0] preserved in view dump")
+
+            # The dump should contain ONLY the view data, not the full 512x8192 base
+            file_size = pt_files[0].stat().st_size
+            _assert(file_size < 100 * 1024,
+                    f"File size={file_size/1024:.0f} KB (view is small, not full base)")
+
+        # Verify JSONL has the STORAGE address (pointing to base), not just data_ptr
+        jsonl_files = list(Path(tmpdir).glob("layers_rank*.jsonl"))
+        if jsonl_files:
+            with open(jsonl_files[0]) as fh:
+                rec = json.loads(fh.readline().strip())
+            _assert(rec.get("storage_ptr") == hex(base.untyped_storage().data_ptr()),
+                    "JSONL storage_ptr points to base buffer (for aliasing cross-ref)")
+            _assert(rec.get("storage_offset_bytes") > 0,
+                    f"storage_offset_bytes={rec.get('storage_offset_bytes')} > 0 (view is offset)")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 19: DUMP_TENSOR — inf-triggered and huge-triggered dumps
+# ============================================================================
+def test_dump_tensor_inf_and_huge():
+    _header("19. DUMP_TENSOR — triggers on Inf and huge (not just NaN)")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test19_")
+    try:
+        # Test Inf trigger
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1")
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+
+        t_inf = torch.randn(32, 32, device="cuda")
+        t_inf[2, 3] = float("inf")
+        nl._stash("model.layer_inf", "fwd", t_inf, role="act")
+        nl._drain_step()
+
+        _assert(nl._tensor_dumped is True, "Dump triggers on Inf")
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, "Inf-triggered dump file exists")
+        if pt_files:
+            loaded = torch.load(pt_files[0], weights_only=True)
+            _assert(torch.isinf(loaded[2, 3]).item(), "Inf preserved in dump")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    # Test huge trigger (separate run to get clean state)
+    tmpdir2 = tempfile.mkdtemp(prefix="nanlog_test19b_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir2, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1",
+                            NANLOG_HUGE_THRESHOLD="1e5")
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+
+        t_huge = torch.randn(32, 32, device="cuda")
+        t_huge[4, 5] = 2e6  # above threshold of 1e5
+        nl._stash("model.layer_huge", "fwd", t_huge, role="act")
+        nl._drain_step()
+
+        _assert(nl._tensor_dumped is True, "Dump triggers on huge (above threshold)")
+        pt_files = list(Path(tmpdir2).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, "Huge-triggered dump file exists")
+        if pt_files:
+            loaded = torch.load(pt_files[0], weights_only=True)
+            _assert(abs(loaded[4, 5].item() - 2e6) < 100,
+                    f"Huge value preserved: {loaded[4, 5].item():.3e}")
+
+    finally:
+        shutil.rmtree(tmpdir2, ignore_errors=True)
+
+
+# ============================================================================
+# Test 20: DUMP_TENSOR — file naming with special characters in layer name
+# ============================================================================
+def test_dump_tensor_filename_safety():
+    _header("20. DUMP_TENSOR — safe filename from complex layer names")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test20_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1")
+        nl._step = 42
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+
+        t = torch.randn(16, 16, device="cuda")
+        t[0, 0] = float("nan")
+
+        # Realistic complex layer name with dots
+        nl._stash("model.emb_proj.projections.10.layers.0.linear", "fwd", t, role="input")
+        nl._drain_step()
+
+        pt_files = list(Path(tmpdir).glob("bad_tensor_*.pt"))
+        _assert(len(pt_files) == 1, "Dump file created for complex layer name")
+        if pt_files:
+            fname = pt_files[0].name
+            # Should not contain dots (replaced with _) except .pt extension
+            name_without_ext = fname.rsplit(".pt", 1)[0]
+            _assert("." not in name_without_ext,
+                    f"No dots in filename body (safe for filesystems): {fname}")
+            _assert("step42" in fname, f"Step in filename: {fname}")
+            _assert("input" in fname, f"Role in filename: {fname}")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Test 21: DUMP_TENSOR — _dump_bad_tensor is exception-safe
+# ============================================================================
+def test_dump_tensor_exception_safety():
+    _header("21. DUMP_TENSOR — exception in dump does not crash training")
+    tmpdir = tempfile.mkdtemp(prefix="nanlog_test21_")
+    try:
+        nl = _reload_logger(NANLOG_DIR=tmpdir, NANLOG_DUMP_TENSOR="1",
+                            NANLOG_SAMPLE_EVERY="1")
+        nl._step = 1
+        nl._records_written = 0
+        nl._first_bad = None
+        nl._tensor_dumped = False
+        nl._pending.clear()
+
+        # Create a read-only output dir AFTER logger init (to force save failure)
+        ro_subdir = Path(tmpdir) / "locked"
+        ro_subdir.mkdir()
+        os.chmod(str(ro_subdir), 0o444)
+
+        # Point logger to the locked dir
+        nl._DIR = ro_subdir
+
+        t = torch.randn(16, 16, device="cuda")
+        t[0, 0] = float("nan")
+        rec = {"step": 1, "layer_name": "test.layer", "role": "act"}
+
+        # Should not raise — exception is caught internally
+        try:
+            nl._dump_bad_tensor(rec, t)
+            _ok("_dump_bad_tensor does not crash on write failure")
+        except Exception as e:
+            _fail(f"_dump_bad_tensor raised: {e}")
+
+        # Guard should still be set (don't retry on next bad)
+        _assert(nl._tensor_dumped is True, "Guard set even on failure (no infinite retries)")
+
+        os.chmod(str(ro_subdir), 0o755)
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ============================================================================
+# Main
+# ============================================================================
+def main():
+    print("=" * 72)
+    print("  NaN Logger v2 — Comprehensive Pre-delivery Test Suite")
+    print(f"  PyTorch: {torch.__version__}")
+    print(f"  CUDA available: {torch.cuda.is_available()}")
+    if torch.cuda.is_available():
+        print(f"  GPU: {torch.cuda.get_device_name(0)}")
+    print("=" * 72)
+
+    if not torch.cuda.is_available():
+        print("\nFATAL: No GPU available. Tests require CUDA/ROCm GPU.")
+        sys.exit(1)
+
+    # Ensure the logger module is importable
+    logger_dir = Path(__file__).parent
+    if str(logger_dir) not in sys.path:
+        sys.path.insert(0, str(logger_dir))
+
+    tests = [
+        test_backward_compat,
+        test_bad_values,
+        test_alloc_snapshot,
+        test_alloc_snapshot_off,
+        test_edge_cases,
+        test_jsonl_output,
+        test_summary,
+        test_addr_cross_ref,
+        test_byte_offset_diagnostic,
+        test_graceful_degradation,
+        test_dump_tensor_lifecycle,
+        test_dump_tensor_input_channel,
+        test_dump_tensor_off,
+        test_dump_tensor_all_flags,
+        test_dump_tensor_multiple_bad_same_step,
+        test_dump_tensor_dtypes,
+        test_dump_tensor_large,
+        test_dump_tensor_view,
+        test_dump_tensor_inf_and_huge,
+        test_dump_tensor_filename_safety,
+        test_dump_tensor_exception_safety,
+    ]
+
+    for test_fn in tests:
+        try:
+            test_fn()
+        except Exception:
+            _fail(f"TEST CRASHED: {test_fn.__name__}")
+            traceback.print_exc()
+
+    print(f"\n{'='*72}")
+    print(f"  RESULTS: {PASS} passed, {FAIL} failed, {PASS+FAIL} total")
+    print(f"{'='*72}")
+    for t in TESTS:
+        print(t)
+    print()
+
+    if FAIL > 0:
+        print(f"  *** {FAIL} FAILURE(S) — DO NOT DELIVER ***")
+        sys.exit(1)
+    else:
+        print("  *** ALL TESTS PASSED — READY FOR DELIVERY ***")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…shot, and tensor dump

Add v2 diagnostic capabilities to the NaN logger for tracing memory-aliasing corruption to its producer buffer:

- NANLOG_ADDR: record GPU data_ptr + storage extent per tensor (default ON, sync-free)
- NANLOG_LOCATE: count bad rows per tensor to distinguish tile-sized late writes from numeric blowup
- NANLOG_BAD_VALUES: record first bad element position and value (GPU-side reductions, no host sync)
- NANLOG_ALLOC_SNAPSHOT: enable PyTorch allocator event recorder, dump on first NaN detection
- NANLOG_DUMP_TENSOR: save full corrupted tensor to disk on first detection

Also adds LOGGER_REFERENCE.md (full technical reference) and updates README.md with streamlined run instructions.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
