### PR TITLE
feat: add HRX HIP-launch probe + perf workloads, perf.md report & sweep --strict (#273)

### DIFF
--- a/docs/hrx-workload.md
+++ b/docs/hrx-workload.md
@@ -121,6 +121,20 @@ The workload reports every timed iteration as `step_times_ms`, so
 Achieved throughput (`gflops` / `gbps`) is in each trial's `result.json`
 `metrics` and in `matrix.json`.
 
+### `perf.md` — per-run performance report
+
+Every `aorta sweep run` also writes a `perf.md` next to `matrix.md` /
+`matrix.json` in the run directory (no flag needed — it is pure formatting of
+data already collected). It carries a per-cell step-timing percentile table
+(mean / std / min / max / p50 / p90 / p99 step ms + mean wall clock) and, when
+a cell reported numeric `metrics`, a workload-throughput table (`gflops` /
+`gbps` / `mean_step_ms`). The same aggregates are in
+`matrix.json::cells[*].metrics_summary`. Read it alongside `matrix.md`:
+
+```bash
+cat triage_results/HRX-PERF-GEMM/hrx_perf/*/perf.md
+```
+
 Example (`hrx_off` baseline; `hrx_on` here shows `did_not_run` because the
 recipe still has the placeholder HRX path — fill it in to get a real number):
 

--- a/docs/hrx-workload.md
+++ b/docs/hrx-workload.md
@@ -1,0 +1,85 @@
+# HRX HIP-launch workload
+
+The `hrx` workload runs the HRX HIP-compatibility-layer launch probes so the
+HRX runtime can be exercised and A/B-compared (HRX-on vs stock ROCm HIP)
+through the normal `aorta run` / `aorta triage` / `aorta sweep` flows.
+
+It originates from the `ROCm/hrx-system` #156 / #158 / #160 investigation
+(see issue #273).
+
+## What it does
+
+Each probe computes `out[i] = in[i] + 100` (with `in = 7`, `out` pre-zeroed)
+over a single HIP kernel-launch path and prints a verdict derived from
+`out[0]`:
+
+| `out[0]` | verdict | meaning |
+|---|---|---|
+| `107` | `FULLY_WORKS` | read + write + copies all correct (the only pass) |
+| `100` | `INPUT_READ_ZERO` | H2D / input argument broken |
+| `0` | `OUTPUT_NOT_WRITTEN` | kernel write never reached the host buffer |
+| other | `GARBAGE` | address mismatch |
+
+Select the path with `workload_config.probe`:
+
+| `probe` | HIP path under test |
+|---|---|
+| `static` | `hipLaunchKernelGGL` (statically registered) |
+| `module` (default) | `hipModuleLaunchKernel` (pre-packed `extra` buffer) |
+| `graph_add` | `hipGraphAddKernelNode` (`extra`) |
+| `graph_setparams` | `hipGraphKernelNodeSetParams` (`extra`) |
+| `graph_execsetparams` | `hipGraphExecKernelNodeSetParams` (`extra`) |
+
+## How HRX-on vs HRX-off works
+
+The workload does not decide the runtime. It builds the probe with `hipcc` and
+execs it as a **child** process; which `libamdhip64.so` that child loads is an
+environment concern set per cell:
+
+- **hrx_off** — no routing; the child uses stock ROCm HIP.
+- **hrx_on** — an `LD_PRELOAD` + `LD_LIBRARY_PATH` + `HRX_GPU_DRIVER` bundle
+  points the child at HRX's `libamdhip64.so`. `LD_PRELOAD` is honored at
+  `exec()`, which is exactly why the probe is a subprocess.
+
+See `recipes/hrx-launch-probe-smoke.yaml` for a ready-to-edit A/B recipe.
+
+## Config keys
+
+| key | default | meaning |
+|---|---|---|
+| `probe` | `module` | which launch path (table above) |
+| `gpu_arch` | `gfx942` | `hipcc --offload-arch` target |
+| `hipcc` | `$HIPCC` / `/opt/rocm/bin/hipcc` / PATH | compiler |
+| `build_dir` | temp dir | where probe binaries are built |
+| `timeout_sec` | `120` | per-run subprocess timeout |
+| `keep_build` | `false` | keep `build_dir` after cleanup |
+
+## Prerequisites
+
+A ROCm/`hipcc` toolchain (the workload compiles the probe from vendored
+source). On a host without `hipcc`/GPU, `setup()` raises and the cell is
+classified as a setup failure / `did_not_run` — it never reports a false
+`OUTPUT_NOT_WRITTEN`.
+
+## Quick run
+
+The A/B matrix (both cells, one command) comes from the recipe:
+
+```bash
+aorta sweep run --recipe recipes/hrx-launch-probe-smoke.yaml \
+  --output ./triage_results --ticket HRX-273-SMOKE
+cat triage_results/HRX-273-SMOKE/hrx/*/matrix.md
+```
+
+`aorta run` has no per-workload-config flag, so it uses the default `module`
+probe on stock HIP; select a different `probe` or route through HRX via a
+recipe's `workload_config` / cell `extra_env` (as the recipe above does):
+
+```bash
+# default module probe, stock HIP, single run
+aorta run --workload hrx
+
+# route the child through an installed HRX prefix
+aorta run --workload hrx --extra-env \
+  "HRX_GPU_DRIVER=amdgpu,LD_LIBRARY_PATH=/path/to/hrx-root/lib,LD_PRELOAD=/path/to/hrx-root/lib/libamdhip64.so"
+```

--- a/docs/hrx-workload.md
+++ b/docs/hrx-workload.md
@@ -66,8 +66,9 @@ classified as a setup failure / `did_not_run` — it never reports a false
 The A/B matrix (both cells, one command) comes from the recipe:
 
 ```bash
-aorta sweep run --recipe recipes/hrx-launch-probe-smoke.yaml \
-  --output ./triage_results --ticket HRX-273-SMOKE
+# The ticket comes from the recipe (ticket: HRX-273-SMOKE); passing --ticket
+# too would fail ("--recipe conflicts with --ticket").
+aorta sweep run --recipe recipes/hrx-launch-probe-smoke.yaml --output ./triage_results
 cat triage_results/HRX-273-SMOKE/hrx/*/matrix.md
 ```
 

--- a/docs/hrx-workload.md
+++ b/docs/hrx-workload.md
@@ -2,7 +2,7 @@
 
 The `hrx` workload runs the HRX HIP-compatibility-layer launch probes so the
 HRX runtime can be exercised and A/B-compared (HRX-on vs stock ROCm HIP)
-through the normal `aorta run` / `aorta triage` / `aorta sweep` flows.
+through the normal `aorta run` / `aorta sweep run` workload flows.
 
 It originates from the `ROCm/hrx-system` #156 / #158 / #160 investigation
 (see issue #273).

--- a/docs/hrx-workload.md
+++ b/docs/hrx-workload.md
@@ -57,9 +57,11 @@ See `recipes/hrx-launch-probe-smoke.yaml` for a ready-to-edit A/B recipe.
 ## Prerequisites
 
 A ROCm/`hipcc` toolchain (the workload compiles the probe from vendored
-source). On a host without `hipcc`/GPU, `setup()` raises and the cell is
-classified as a setup failure / `did_not_run` — it never reports a false
-`OUTPUT_NOT_WRITTEN`.
+source) and an accessible ROCm GPU. `setup()` raises when `hipcc` is missing
+**or** when no GPU is reachable (it checks that `/dev/kfd` is readable+writable,
+the node HIP needs to initialise a device), so a CPU-only host or a container
+started without `--device=/dev/kfd` classifies the cell as a setup failure /
+`did_not_run` — it never reports a false `OUTPUT_NOT_WRITTEN`.
 
 ## Quick run
 

--- a/docs/hrx-workload.md
+++ b/docs/hrx-workload.md
@@ -84,3 +84,80 @@ aorta run --workload hrx
 aorta run --workload hrx --extra-env \
   "HRX_GPU_DRIVER=amdgpu,LD_LIBRARY_PATH=/path/to/hrx-root/lib,LD_PRELOAD=/path/to/hrx-root/lib/libamdhip64.so"
 ```
+
+# HRX performance workload (`hrx_perf`)
+
+Where `hrx` checks *correctness*, the companion `hrx_perf` workload measures
+*speed* under HRX vs stock ROCm HIP. It builds a deliberately **big** HIP
+benchmark with `hipcc` and execs it, timing each iteration host-side (launch +
+`hipDeviceSynchronize`) so the per-step number includes runtime/launch overhead
+— the axis on which an alternate HIP runtime can differ.
+
+## Benchmarks
+
+Select with `workload_config.bench`:
+
+| `bench` | kind | what it stresses | throughput metric |
+|---|---|---|---|
+| `gemm` (default) | compute-bound tiled SGEMM (`C = A*B`, N×N floats) | FLOPs + launch path | `metrics.gflops` |
+| `triad` | bandwidth-bound STREAM triad (`a = b + s*c`) | HBM bandwidth + launch path | `metrics.gbps` |
+
+Each bench runs `warmup` untimed then `iters` timed iterations and verifies a
+checksum (a wrong result → `PERF_FAIL`, so a bogus runtime can't yield a
+meaningless "fast" number).
+
+## How the comparison shows up
+
+The workload reports every timed iteration as `step_times_ms`, so
+`aorta sweep run`'s matrix renders:
+
+- **Mean step (ms)** per cell — the mean timed iteration.
+- **Confound** — `hrx_on`'s step time as a ratio of the `hrx_off` baseline.
+  `speed (+N%)` means HRX was N% slower per iteration; `-` means no meaningful
+  slowdown.
+
+Achieved throughput (`gflops` / `gbps`) is in each trial's `result.json`
+`metrics` and in `matrix.json`.
+
+Example (`hrx_off` baseline; `hrx_on` here shows `did_not_run` because the
+recipe still has the placeholder HRX path — fill it in to get a real number):
+
+```
+| Cell    | ... | Iters | Mean step (ms) | Confound    |
+|---------|-----|-------|----------------|-------------|
+| hrx_off | ... | 50/50 | 9.6            | (baseline)  |
+| hrx_on  | ... | —     | n/a            | did_not_run |
+```
+
+## Config keys
+
+| key | default | meaning |
+|---|---|---|
+| `bench` | `gemm` | `gemm` or `triad` |
+| `gpu_arch` | `gfx942` | `hipcc --offload-arch` target |
+| `size` | gemm `4096`, triad `64000000` | matrix dim N (gemm) / element count (triad) |
+| `iters` | `50` | timed iterations (reported as per-step times) |
+| `warmup` | `10` | untimed warmup iterations |
+| `hipcc` | `$HIPCC` / `/opt/rocm/bin/hipcc` / PATH | compiler |
+| `build_dir` | temp dir | where bench binaries are built |
+| `timeout_sec` | `600` | per-run subprocess timeout |
+| `keep_build` | `false` | keep `build_dir` after cleanup |
+
+HRX-on vs HRX-off routing, the `hipcc` build-env sanitization, and the
+`LD_PRELOAD` guards (nonexistent path fails setup; ignored preload fails the
+run) are identical to the `hrx` workload above.
+
+## Quick run
+
+```bash
+# compute-bound A/B (add --strict to fail if a cell errors or never runs)
+aorta sweep run --recipe recipes/hrx-perf-gemm.yaml --output ./triage_results --strict
+cat triage_results/HRX-PERF-GEMM/hrx_perf/*/matrix.md
+
+# bandwidth-bound A/B
+aorta sweep run --recipe recipes/hrx-perf-triad.yaml --output ./triage_results --strict
+cat triage_results/HRX-PERF-TRIAD/hrx_perf/*/matrix.md
+
+# single run, stock HIP, defaults (gemm 4096)
+aorta run --workload hrx_perf
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ aorta = "aorta.cli:main"
 [project.entry-points."aorta.workloads"]
 _subprocess = "aorta.workloads._subprocess:SubprocessWorkload"
 hrx = "aorta.workloads.hrx:HrxWorkload"
+hrx_perf = "aorta.workloads.hrx_perf:HrxPerfWorkload"
 inference = "aorta.workloads.inference:InferenceWorkload"
 llm_determinism = "aorta.workloads.llm_determinism:LlmDeterminismWorkload"
 race = "aorta.workloads.race:RaceWorkload"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ aorta = "aorta.cli:main"
 # reserved argv config key is only injected by ``aorta probe``.
 [project.entry-points."aorta.workloads"]
 _subprocess = "aorta.workloads._subprocess:SubprocessWorkload"
+hrx = "aorta.workloads.hrx:HrxWorkload"
 inference = "aorta.workloads.inference:InferenceWorkload"
 llm_determinism = "aorta.workloads.llm_determinism:LlmDeterminismWorkload"
 race = "aorta.workloads.race:RaceWorkload"
@@ -173,7 +174,13 @@ where = ["src"]
 include = ["aorta*"]
 
 [tool.setuptools.package-data]
-aorta = ["py.typed", "ebpf/scripts/*.bt", "ebpf/scripts/PROVENANCE.md"]
+aorta = [
+    "py.typed",
+    "ebpf/scripts/*.bt",
+    "ebpf/scripts/PROVENANCE.md",
+    "workloads/hrx_kernels/*.cpp",
+    "workloads/hrx_kernels/README.md",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/recipes/hrx-launch-probe-all.yaml
+++ b/recipes/hrx-launch-probe-all.yaml
@@ -1,0 +1,103 @@
+# HRX HIP-launch probe -- full A/B sweep across ALL launch paths.
+#
+# Runs every HRX HIP kernel-launch probe (issue #273) against both the stock
+# ROCm HIP runtime and the HRX HIP-compatibility layer. This is the "run all
+# the hrx tests with both nohrx and hrx cells" recipe: 5 probe variants x 2
+# runtime states = 10 cells.
+#
+# There is no CLI flag to sweep the probe axis -- each variant is a cell whose
+# per-cell `workload_config.probe` overrides the recipe-level default. The
+# `hrx_on_*` cells add `extra_env` to LD_PRELOAD HRX's libamdhip64 at the
+# probe's exec(); the `hrx_off_*` cells run stock ROCm HIP (the baseline).
+#
+# A green run shows each hrx_on_* cell matching its hrx_off_* twin with verdict
+# FULLY_WORKS; the #156-class bug shows up as an hrx_on_* cell reporting
+# OUTPUT_NOT_WRITTEN while its hrx_off_* twin stays FULLY_WORKS.
+#
+# PREREQUISITES
+#   * A ROCm/hipcc toolchain (the workload compiles the probes).
+#   * An installed HRX public dist. Replace /path/to/hrx-root below with its
+#     prefix (the dir that contains lib/libamdhip64.so). extra_env values are
+#     passed verbatim (no shell expansion), so the paths MUST be ABSOLUTE.
+#
+# Run (the ticket comes from `ticket:` below -- do NOT also pass --ticket, it
+# conflicts with --recipe):
+#   aorta sweep run --recipe recipes/hrx-launch-probe-all.yaml --output ./triage_results
+# Read:
+#   cat triage_results/HRX-273-ALL/hrx/*/matrix.md
+
+schema_version: 1
+
+ticket: HRX-273-ALL
+workload: hrx
+
+trials: 1
+steps: 1
+
+save_logs: true
+
+# Recipe-scope defaults; each cell overrides `probe` on top of this.
+workload_config:
+  gpu_arch: gfx942
+  timeout_sec: 120
+
+cells:
+  # --- static launch -------------------------------------------------------
+  - name: hrx_off_static
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: static}
+  - name: hrx_on_static
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: static}
+    # EDIT: replace /path/to/hrx-root with your installed HRX prefix. The other
+    # hrx_on_* cells reuse this block via the *hrx_on_env YAML alias.
+    extra_env: &hrx_on_env
+      HRX_GPU_DRIVER: "amdgpu"
+      LD_LIBRARY_PATH: "/path/to/hrx-root/lib"
+      LD_PRELOAD: "/path/to/hrx-root/lib/libamdhip64.so"
+
+  # --- module (hipModuleLaunchKernel) --------------------------------------
+  - name: hrx_off_module
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: module}
+  - name: hrx_on_module
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: module}
+    extra_env: *hrx_on_env
+
+  # --- graph_add (hipGraphAddKernelNode) -----------------------------------
+  - name: hrx_off_graph_add
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: graph_add}
+  - name: hrx_on_graph_add
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: graph_add}
+    extra_env: *hrx_on_env
+
+  # --- graph_setparams (hipGraphKernelNodeSetParams) -----------------------
+  - name: hrx_off_graph_setparams
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: graph_setparams}
+  - name: hrx_on_graph_setparams
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: graph_setparams}
+    extra_env: *hrx_on_env
+
+  # --- graph_execsetparams (hipGraphExecKernelNodeSetParams) ---------------
+  - name: hrx_off_graph_execsetparams
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: graph_execsetparams}
+  - name: hrx_on_graph_execsetparams
+    mitigations: [none]
+    environment: local
+    workload_config: {probe: graph_execsetparams}
+    extra_env: *hrx_on_env

--- a/recipes/hrx-launch-probe-smoke.yaml
+++ b/recipes/hrx-launch-probe-smoke.yaml
@@ -20,9 +20,9 @@
 #     ABSOLUTE -- extra_env values are passed verbatim (no shell expansion), so
 #     edit the placeholder before running.
 #
-# Run:
-#   aorta sweep run --recipe recipes/hrx-launch-probe-smoke.yaml \
-#     --output ./triage_results --ticket HRX-273-SMOKE
+# Run (the ticket comes from `ticket:` below -- do NOT also pass --ticket, it
+# conflicts with --recipe):
+#   aorta sweep run --recipe recipes/hrx-launch-probe-smoke.yaml --output ./triage_results
 # Read:
 #   cat triage_results/HRX-273-SMOKE/hrx/*/matrix.md
 

--- a/recipes/hrx-launch-probe-smoke.yaml
+++ b/recipes/hrx-launch-probe-smoke.yaml
@@ -1,0 +1,57 @@
+# HRX HIP-launch probe -- HRX-on vs stock-ROCm A/B smoke recipe.
+#
+# Exercises one HRX HIP kernel-launch path (issue #273) and compares the HRX
+# HIP-compatibility layer against the stock ROCm HIP runtime. The `hrx`
+# workload builds the probe from vendored source with hipcc at setup and execs
+# it as a child process; each cell's `extra_env` decides which libamdhip64 that
+# child loads:
+#
+#   hrx_off : stock ROCm HIP (no routing) -- the baseline.
+#   hrx_on  : HRX's libamdhip64.so LD_PRELOADed at exec().
+#
+# A green run shows hrx_on matching hrx_off with verdict FULLY_WORKS (out[0]=107);
+# the #156 bug shows up as hrx_on -> OUTPUT_NOT_WRITTEN (out[0]=0) while hrx_off
+# stays FULLY_WORKS.
+#
+# PREREQUISITES
+#   * A ROCm/hipcc toolchain (the workload compiles the probe).
+#   * An installed HRX public dist. Set HRX_ROOT below to its prefix (the dir
+#     that contains lib/libamdhip64.so). The paths under `extra_env` must be
+#     ABSOLUTE -- extra_env values are passed verbatim (no shell expansion), so
+#     edit the placeholder before running.
+#
+# Run:
+#   aorta sweep run --recipe recipes/hrx-launch-probe-smoke.yaml \
+#     --output ./triage_results --ticket HRX-273-SMOKE
+# Read:
+#   cat triage_results/HRX-273-SMOKE/hrx/*/matrix.md
+
+schema_version: 1
+
+ticket: HRX-273-SMOKE
+workload: hrx
+
+trials: 1
+steps: 1
+
+save_logs: true
+
+workload_config:
+  # One of: static | module | graph_add | graph_setparams | graph_execsetparams
+  probe: module
+  gpu_arch: gfx942
+  timeout_sec: 120
+
+cells:
+  - name: hrx_off
+    mitigations: [none]
+    environment: local
+
+  - name: hrx_on
+    mitigations: [none]
+    environment: local
+    # EDIT: replace /path/to/hrx-root with your installed HRX prefix.
+    extra_env:
+      HRX_GPU_DRIVER: "amdgpu"
+      LD_LIBRARY_PATH: "/path/to/hrx-root/lib"
+      LD_PRELOAD: "/path/to/hrx-root/lib/libamdhip64.so"

--- a/recipes/hrx-perf-gemm.yaml
+++ b/recipes/hrx-perf-gemm.yaml
@@ -1,0 +1,60 @@
+# HRX perf -- compute-bound SGEMM, HRX-on vs stock-ROCm A/B.
+#
+# Measures how fast a big tiled SGEMM (C = A*B, N x N floats) runs under the HRX
+# HIP-compatibility layer vs the stock ROCm HIP runtime. The `hrx_perf` workload
+# builds the bench with hipcc at setup and execs it; each timed iteration is
+# measured host-side (launch + hipDeviceSynchronize), so per-step time includes
+# runtime/launch overhead -- where HRX can differ from stock HIP.
+#
+# HOW TO READ THE RESULT
+#   The matrix's per-cell "Mean step (ms)" is the mean timed iteration; the
+#   Confound column reports hrx_on's step time as a ratio of the hrx_off
+#   baseline (e.g. "speed (+8%)" means HRX was 8% slower per iteration).
+#   Achieved GFLOP/s is in each trial's result.json metrics (metrics.gflops)
+#   and matrix.json.
+#
+# PREREQUISITES
+#   * A ROCm/hipcc toolchain (the workload compiles the bench).
+#   * An installed HRX public dist. Replace /path/to/hrx-root in the hrx_on
+#     cell below with its prefix (the dir containing lib/libamdhip64.so). Paths
+#     under extra_env are passed verbatim (no shell expansion) -- use ABSOLUTE
+#     paths. A wrong/placeholder path fails setup instead of silently measuring
+#     stock HIP.
+#
+# Run (ticket comes from `ticket:` below; add --strict to fail if a cell errors
+# or never runs):
+#   aorta sweep run --recipe recipes/hrx-perf-gemm.yaml --output ./triage_results --strict
+# Read:
+#   cat triage_results/HRX-PERF-GEMM/hrx_perf/*/matrix.md
+
+schema_version: 1
+
+ticket: HRX-PERF-GEMM
+workload: hrx_perf
+
+trials: 3
+steps: 1
+
+save_logs: true
+
+workload_config:
+  bench: gemm
+  gpu_arch: gfx942
+  size: 4096
+  iters: 50
+  warmup: 10
+  timeout_sec: 600
+
+cells:
+  - name: hrx_off
+    mitigations: [none]
+    environment: local
+
+  - name: hrx_on
+    mitigations: [none]
+    environment: local
+    # EDIT: replace /path/to/hrx-root with your installed HRX prefix.
+    extra_env:
+      HRX_GPU_DRIVER: "amdgpu"
+      LD_LIBRARY_PATH: "/path/to/hrx-root/lib"
+      LD_PRELOAD: "/path/to/hrx-root/lib/libamdhip64.so"

--- a/recipes/hrx-perf-triad.yaml
+++ b/recipes/hrx-perf-triad.yaml
@@ -1,0 +1,61 @@
+# HRX perf -- bandwidth-bound STREAM triad, HRX-on vs stock-ROCm A/B.
+#
+# Memory-bound counterpart to hrx-perf-gemm: a big STREAM triad
+# (a = b + s*c over N floats) that stresses HBM bandwidth and per-launch
+# overhead rather than compute. The `hrx_perf` workload builds the bench with
+# hipcc at setup and execs it; each timed iteration is measured host-side
+# (launch + hipDeviceSynchronize), so per-step time includes runtime/launch
+# overhead -- where HRX can differ from stock HIP.
+#
+# HOW TO READ THE RESULT
+#   The matrix's per-cell "Mean step (ms)" is the mean timed iteration; the
+#   Confound column reports hrx_on's step time as a ratio of the hrx_off
+#   baseline. Achieved bandwidth is in each trial's result.json metrics
+#   (metrics.gbps) and matrix.json.
+#
+# PREREQUISITES
+#   * A ROCm/hipcc toolchain (the workload compiles the bench).
+#   * An installed HRX public dist. Replace /path/to/hrx-root in the hrx_on
+#     cell below with its prefix (the dir containing lib/libamdhip64.so). Paths
+#     under extra_env are passed verbatim -- use ABSOLUTE paths. A
+#     wrong/placeholder path fails setup instead of silently measuring stock HIP.
+#   * size=64000000 floats => ~768 MB across 3 arrays; lower `size` for a
+#     smaller GPU.
+#
+# Run (ticket comes from `ticket:` below; add --strict to fail if a cell errors
+# or never runs):
+#   aorta sweep run --recipe recipes/hrx-perf-triad.yaml --output ./triage_results --strict
+# Read:
+#   cat triage_results/HRX-PERF-TRIAD/hrx_perf/*/matrix.md
+
+schema_version: 1
+
+ticket: HRX-PERF-TRIAD
+workload: hrx_perf
+
+trials: 3
+steps: 1
+
+save_logs: true
+
+workload_config:
+  bench: triad
+  gpu_arch: gfx942
+  size: 64000000
+  iters: 100
+  warmup: 20
+  timeout_sec: 600
+
+cells:
+  - name: hrx_off
+    mitigations: [none]
+    environment: local
+
+  - name: hrx_on
+    mitigations: [none]
+    environment: local
+    # EDIT: replace /path/to/hrx-root with your installed HRX prefix.
+    extra_env:
+      HRX_GPU_DRIVER: "amdgpu"
+      LD_LIBRARY_PATH: "/path/to/hrx-root/lib"
+      LD_PRELOAD: "/path/to/hrx-root/lib/libamdhip64.so"

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -356,6 +356,17 @@ def sweep() -> None:
     ),
 )
 @click.option(
+    "--strict",
+    is_flag=True,
+    help=(
+        "Workload flow only. Exit non-zero if any cell errored or never ran "
+        "(every trial did_not_run, e.g. a setup failure). A cell that RAN but "
+        "reported a failure (a real bug repro) does NOT trip this. The matrix "
+        "is still written. Useful in CI to catch a cell that silently didn't "
+        "run (e.g. a rejected LD_PRELOAD)."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -386,6 +397,7 @@ def sweep_run(
     disable_detectors: tuple[str, ...],
     mitigation_files: tuple[Path, ...],
     collect: str,
+    strict: bool,
     verbose: int,
     argv: tuple[str, ...],
 ) -> None:
@@ -426,6 +438,12 @@ def sweep_run(
                 "on a probe/subprocess run (a user command after '--' or a "
                 "'mode: probe' recipe)."
             )
+        if strict:
+            raise click.UsageError(
+                "--strict applies to the workload flow only; a probe/subprocess "
+                "run (a user command after '--' or a 'mode: probe' recipe) "
+                "reports per-cell verdicts differently."
+            )
         _dispatch_probe_flow(
             recipe=recipe,
             output=output,
@@ -465,6 +483,7 @@ def sweep_run(
             max_trials=max_trials,
             disable_detectors=disable_detectors,
             collect=collect,
+            strict=strict,
         )
 
 
@@ -538,6 +557,7 @@ def _dispatch_workload_flow(
     max_trials: int | None,
     disable_detectors: tuple[str, ...],
     collect: str = "",
+    strict: bool = False,
 ) -> None:
     """Validate workload-flow-specific preconditions, then run the workload flow."""
     if env_passthrough_mode is not None:
@@ -572,6 +592,7 @@ def _dispatch_workload_flow(
         output_dir=output if output is not None else Path("triage_results"),
         mitigation_files=mitigation_files,
         collect=collect,
+        strict=strict,
     )
 
 

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -40,7 +40,12 @@ from aorta.triage.recipe import (
     build_recipe_from_flags,
     load_recipe,
 )
-from aorta.triage.runner import MatrixIncompleteError, _is_rank_zero, run_recipe
+from aorta.triage.runner import (
+    MatrixIncompleteError,
+    MatrixStrictError,
+    _is_rank_zero,
+    run_recipe,
+)
 
 
 @click.group()
@@ -165,6 +170,17 @@ def triage() -> None:
     ),
 )
 @click.option(
+    "--strict",
+    is_flag=True,
+    help=(
+        "Exit non-zero if any cell errored or never ran (every trial "
+        "did_not_run, e.g. a setup failure). A cell that RAN but reported a "
+        "failure (a real bug repro) does NOT trip this -- that's an expected "
+        "matrix outcome. The matrix is still written. Useful in CI to catch a "
+        "cell that silently didn't run (e.g. a rejected LD_PRELOAD)."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -194,6 +210,7 @@ def triage_run(
     output_dir: Path,
     mitigation_files: tuple[Path, ...],
     collect: str,
+    strict: bool,
     verbose: int,
 ) -> None:
     """Run the triage matrix: sweep mitigations x environments x trials, write matrix.md + matrix.json."""
@@ -214,6 +231,7 @@ def triage_run(
         output_dir=output_dir,
         mitigation_files=mitigation_files,
         collect=collect,
+        strict=strict,
     )
 
 
@@ -233,6 +251,7 @@ def execute_triage_run(
     output_dir: Path,
     mitigation_files: tuple[Path, ...],
     collect: str = "",
+    strict: bool = False,
 ) -> None:
     """Workload-flow body shared by ``aorta sweep run`` and ``aorta triage run``.
 
@@ -338,15 +357,17 @@ def execute_triage_run(
             r,
             output_dir=output_dir,
             dry_run=dry_run,
+            strict=strict,
         )
-    except MatrixIncompleteError as exc:
+    except (MatrixIncompleteError, MatrixStrictError) as exc:
         # Artifacts ARE written for inspection -- print where they
         # landed first, then raise ClickException so the CLI exits
         # non-zero with the degradation reason. This is distinct from
         # RecipeCellError below: that's pre-execution validation
         # failure (no artifacts), this is post-execution degradation
         # (matrix.md / matrix.json present but classification couldn't
-        # anchor). Only rank 0 wrote artifacts, so only rank 0 reports.
+        # anchor, or --strict caught an errored/did_not_run cell). Only
+        # rank 0 wrote artifacts, so only rank 0 reports.
         if _is_rank_zero():
             click.echo(f"Wrote matrix to {exc.run_dir}")
         raise click.ClickException(str(exc)) from exc

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -547,6 +547,13 @@ def _percentile(samples: list[float], q: float) -> float:
 def _aggregate_metrics(trials: list[Any]) -> dict[str, dict[str, float]]:
     """Aggregate scalar ``result["metrics"]`` values across a cell's trials.
 
+    Only trials that represent a **valid, successful observation** are
+    aggregated -- ``trial_verdict(trial) == "pass"``. ``perf.md`` presents these
+    as performance numbers, so metrics from failed / errored trials (partial
+    output, a preflight failure that still emitted some numeric fields, a
+    ``PERF_FAIL`` checksum) would be misleading and are skipped. A cell whose
+    trials all failed therefore contributes no metrics (empty summary).
+
     For every metric key whose value is a real int/float scalar (``bool`` is
     excluded -- it is an ``int`` subclass but not a measurement), collect the
     per-trial values and reduce them to ``{"mean", "min", "max", "n"}``. Keys
@@ -554,11 +561,14 @@ def _aggregate_metrics(trials: list[Any]) -> dict[str, dict[str, float]]:
     that trial (so the ``failure_detectors_fired`` list channel never leaks
     into the perf summary); a key that is scalar in some trials and non-scalar
     in others is aggregated over just the scalar occurrences. Returns ``{}``
-    when no trial reported any numeric metric -- the common case for
+    when no passing trial reported any numeric metric -- the common case for
     correctness / triage workloads, which then render no throughput table.
     """
     collected: dict[str, list[float]] = {}
     for trial in trials:
+        # Only successful trials yield trustworthy perf numbers (see docstring).
+        if trial_verdict(trial) != "pass":
+            continue
         result = getattr(trial, "result", None)
         if not isinstance(result, dict):
             continue

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -560,9 +560,12 @@ def _aggregate_metrics(trials: list[Any]) -> dict[str, dict[str, float]]:
     whose value is a list / dict / string / bool in any trial are ignored for
     that trial (so the ``failure_detectors_fired`` list channel never leaks
     into the perf summary); a key that is scalar in some trials and non-scalar
-    in others is aggregated over just the scalar occurrences. Returns ``{}``
-    when no passing trial reported any numeric metric -- the common case for
-    correctness / triage workloads, which then render no throughput table.
+    in others is aggregated over just the scalar occurrences. Non-finite floats
+    (NaN / +-Inf) are also skipped -- they are not usable measurements and would
+    serialize as invalid JSON (``NaN`` / ``Infinity``) in ``matrix.json``.
+    Returns ``{}`` when no passing trial reported any numeric metric -- the
+    common case for correctness / triage workloads, which then render no
+    throughput table.
     """
     collected: dict[str, list[float]] = {}
     for trial in trials:
@@ -579,6 +582,13 @@ def _aggregate_metrics(trials: list[Any]) -> dict[str, dict[str, float]]:
             # ``bool`` is an ``int`` subclass; a True/False flag is not a
             # performance measurement, so exclude it explicitly.
             if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            # Skip non-finite values (NaN / +-Inf): they are not usable perf
+            # numbers and json.dumps would serialize them as ``NaN`` /
+            # ``Infinity``, which is invalid JSON for strict parsers. They are
+            # realistically reachable -- e.g. a workload that initializes a
+            # metric to ``float("nan")`` and reports it.
+            if not math.isfinite(value):
                 continue
             collected.setdefault(str(key), []).append(float(value))
     summary: dict[str, dict[str, float]] = {}

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -209,6 +209,17 @@ class CellStats:
     # ``error`` verdict). Excluded from the ``failure_rate`` denominator;
     # surfaced via ``error_rate`` and the matrix.md "Errors" column.
     error_count: int = 0
+    # Aggregated workload-reported performance metrics. Each entry is one
+    # scalar key from a trial's ``result["metrics"]`` (e.g. ``gflops``,
+    # ``gbps``, ``mean_step_ms``), aggregated across the cell's trials into
+    # ``{"mean", "min", "max", "n"}`` where ``n`` is the number of trials
+    # that reported that key. Only int/float scalars are aggregated -- list
+    # / dict / bool values (e.g. the ``failure_detectors_fired`` channel) are
+    # skipped, so a workload that emits no numeric metrics leaves this ``{}``.
+    # Surfaced in ``perf.md`` and ``matrix.json`` so throughput numbers
+    # (which ``matrix.md`` never showed) are recoverable without opening each
+    # per-trial JSON. Empty for error cells.
+    metrics_summary: dict[str, dict[str, float]] = field(default_factory=dict)
     # Issue #282: True when this cell's trials were hydrated from a prior
     # run's on-disk artifacts (probe ``flat_resume`` layout) instead of
     # being re-executed -- the resume short-circuit in
@@ -533,6 +544,46 @@ def _percentile(samples: list[float], q: float) -> float:
     return data[f] + (data[c] - data[f]) * (k - f)
 
 
+def _aggregate_metrics(trials: list[Any]) -> dict[str, dict[str, float]]:
+    """Aggregate scalar ``result["metrics"]`` values across a cell's trials.
+
+    For every metric key whose value is a real int/float scalar (``bool`` is
+    excluded -- it is an ``int`` subclass but not a measurement), collect the
+    per-trial values and reduce them to ``{"mean", "min", "max", "n"}``. Keys
+    whose value is a list / dict / string / bool in any trial are ignored for
+    that trial (so the ``failure_detectors_fired`` list channel never leaks
+    into the perf summary); a key that is scalar in some trials and non-scalar
+    in others is aggregated over just the scalar occurrences. Returns ``{}``
+    when no trial reported any numeric metric -- the common case for
+    correctness / triage workloads, which then render no throughput table.
+    """
+    collected: dict[str, list[float]] = {}
+    for trial in trials:
+        result = getattr(trial, "result", None)
+        if not isinstance(result, dict):
+            continue
+        metrics = result.get("metrics")
+        if not isinstance(metrics, dict):
+            continue
+        for key, value in metrics.items():
+            # ``bool`` is an ``int`` subclass; a True/False flag is not a
+            # performance measurement, so exclude it explicitly.
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            collected.setdefault(str(key), []).append(float(value))
+    summary: dict[str, dict[str, float]] = {}
+    for key, values in collected.items():
+        if not values:
+            continue
+        summary[key] = {
+            "mean": float(statistics.fmean(values)),
+            "min": float(min(values)),
+            "max": float(max(values)),
+            "n": float(len(values)),
+        }
+    return summary
+
+
 def aggregate_cell(
     name: str,
     mitigations: tuple[str, ...],
@@ -713,6 +764,7 @@ def aggregate_cell(
         top_warn_detector_id=top_warn_id,
         stop_after_note=stop_after_note,
         error_count=errored,
+        metrics_summary=_aggregate_metrics(trials),
         resumed=resumed,
     )
 

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -1287,7 +1287,10 @@ def write_perf_report(
         "mirrors `matrix.md`: iterations executed vs. configured. `Source` is "
         "the step-time fidelity (`per_step` > `elapsed_per_iter` > "
         "`wall_clock_total` > `missing`); rows with `Source = missing` show "
-        "`n/a` timing because any number would fold setup/teardown."
+        "`n/a` for the per-step columns (`Mean`..`Max`) because any per-step "
+        "number would fold in setup/teardown. `Wall (s)` is still the real "
+        "end-to-end wall clock and is always shown (it reads `error` only for "
+        "error cells)."
     )
     lines.append(
         "- Percentiles are over the concatenated per-step samples across the "

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -1137,8 +1137,13 @@ def write_matrix_json(
     path.write_text(json.dumps(doc, indent=2, sort_keys=False), encoding="utf-8")
 
 
-def _fmt_perf_ms(value: float) -> str:
-    """Format a millisecond figure for perf.md (3 decimals, fixed)."""
+def _fmt_perf_fixed3(value: float) -> str:
+    """Format a numeric figure for perf.md as a fixed 3-decimal string.
+
+    Unit-agnostic: used for both the millisecond step-time columns and the
+    seconds-valued ``Wall (s)`` column, so the unit lives in the table header,
+    not the formatter.
+    """
     return f"{value:.3f}"
 
 
@@ -1203,10 +1208,13 @@ def write_perf_report(
     for cell in cell_stats:
         label = cell.name + (" (baseline)" if cell.name == baseline.name else "")
         if cell.error is not None:
+            # Every measured column is "error" for an error cell -- including
+            # Wall, which would otherwise print a misleading 0.000 (error rows
+            # force mean_wall_clock_sec to 0.0, not a real measurement).
             timing_rows.append(
                 (label, str(cell.trials), cell.iters_display,
                  "error", "error", "error", "error", "error", "error",
-                 "error", _fmt_perf_ms(cell.mean_wall_clock_sec), "error")
+                 "error", "error", "error")
             )
             continue
         # A cell with no usable per-step timing (setup-only crash / did-not-run)
@@ -1216,13 +1224,13 @@ def write_perf_report(
             step_cells = ("n/a",) * 7
         else:
             step_cells = (
-                _fmt_perf_ms(cell.mean_step_time_ms),
-                _fmt_perf_ms(cell.std_step_time_ms),
-                _fmt_perf_ms(cell.min_step_time_ms),
-                _fmt_perf_ms(cell.p50_step_time_ms),
-                _fmt_perf_ms(cell.p90_step_time_ms),
-                _fmt_perf_ms(cell.p99_step_time_ms),
-                _fmt_perf_ms(cell.max_step_time_ms),
+                _fmt_perf_fixed3(cell.mean_step_time_ms),
+                _fmt_perf_fixed3(cell.std_step_time_ms),
+                _fmt_perf_fixed3(cell.min_step_time_ms),
+                _fmt_perf_fixed3(cell.p50_step_time_ms),
+                _fmt_perf_fixed3(cell.p90_step_time_ms),
+                _fmt_perf_fixed3(cell.p99_step_time_ms),
+                _fmt_perf_fixed3(cell.max_step_time_ms),
             )
         # Reorder step_cells (mean, std, min, p50, p90, p99, max) into the
         # header order (Mean, Std, Min, p50, p90, p99, Max) -- identical here,
@@ -1231,7 +1239,7 @@ def write_perf_report(
         timing_rows.append(
             (label, str(cell.trials), cell.iters_display,
              mean, std, mn, p50, p90, p99, mx,
-             _fmt_perf_ms(cell.mean_wall_clock_sec), cell.step_time_source)
+             _fmt_perf_fixed3(cell.mean_wall_clock_sec), cell.step_time_source)
         )
     lines.extend(_perf_table(timing_rows))
     lines.append("")

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -1245,11 +1245,14 @@ def write_perf_report(
     lines.append("")
 
     # --- Workload throughput / metrics (conditional) ---------------------
-    metric_keys: list[str] = []
+    # Sort the column keys so perf.md is byte-stable across runs: the union
+    # of metric names is otherwise ordered by cell-iteration / dict-insertion
+    # order, which can shift between workloads / Python versions and produce
+    # noisy diffs when comparing two runs of the same recipe.
+    metric_key_set: set[str] = set()
     for cell in cell_stats:
-        for key in cell.metrics_summary:
-            if key not in metric_keys:
-                metric_keys.append(key)
+        metric_key_set.update(cell.metrics_summary)
+    metric_keys: list[str] = sorted(metric_key_set)
     if metric_keys:
         lines.append("## Workload metrics (mean across trials)")
         lines.append("")

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -55,6 +55,11 @@ log = logging.getLogger(__name__)
 
 NO_TICKET_SLUG = "_no_ticket_"
 
+# Human-readable performance summary written next to matrix.md / matrix.json
+# on every run (see :func:`write_perf_report`). Kept as one constant so the
+# writer and the matrix.md pointer note can't drift.
+PERF_REPORT_FILENAME = "perf.md"
+
 # The run-directory layouts ``resolve_run_dir`` / ``_cell_directory`` accept.
 # Kept as one source of truth so the two runtime guards can't drift (a value
 # accepted by one but silently mishandled by the other would render wrong
@@ -1026,6 +1031,14 @@ def write_matrix_md(
         "per-trial JSON paths are in `matrix.json`."
     )
     lines.append(
+        f"- **Performance numbers**: see `{PERF_REPORT_FILENAME}` (alongside this "
+        "file) for the per-cell timing percentiles (mean / std / min / max / p50 / "
+        "p90 / p99 step ms + mean wall clock) and any workload-reported throughput "
+        "metrics (e.g. `gflops` / `gbps`). It is written for every run from data "
+        "already collected here; the same aggregates are in "
+        "`matrix.json::cells[*].metrics_summary`."
+    )
+    lines.append(
         "- `recipe.resolved.yaml` (alongside this file) is a strict, reloadable "
         "recipe: inline-docker cells are pinned via `{docker: <ref>}`, but named "
         "mitigations / environments are NOT expanded -- a later registry change "
@@ -1122,6 +1135,156 @@ def write_matrix_json(
         doc["cells"].append(entry)
 
     path.write_text(json.dumps(doc, indent=2, sort_keys=False), encoding="utf-8")
+
+
+def _fmt_perf_ms(value: float) -> str:
+    """Format a millisecond figure for perf.md (3 decimals, fixed)."""
+    return f"{value:.3f}"
+
+
+def _fmt_perf_metric(value: float) -> str:
+    """Format a workload metric value (thousands-separated, 3 decimals)."""
+    return f"{value:,.3f}"
+
+
+def _perf_table(rows: list[tuple[str, ...]]) -> list[str]:
+    """Render a GitHub-flavoured markdown table with padded columns."""
+    widths = [max(len(r[i]) for r in rows) for i in range(len(rows[0]))]
+
+    def _row(cells: tuple[str, ...]) -> str:
+        return "| " + " | ".join(c.ljust(widths[i]) for i, c in enumerate(cells)) + " |"
+
+    out = [_row(rows[0]), "|" + "|".join("-" * (w + 2) for w in widths) + "|"]
+    out.extend(_row(r) for r in rows[1:])
+    return out
+
+
+def write_perf_report(
+    path: Path,
+    recipe: Recipe,
+    cell_stats: list[CellStats],
+    baseline: CellStats,
+    run_timestamp: str,
+) -> None:
+    """Render ``perf.md`` -- the per-run performance summary next to matrix.md.
+
+    Written on **every** run: it is pure formatting of data aorta already
+    collected (per-step time samples + wall clock + any workload-reported
+    ``metrics``), so it adds no measurement cost. It always carries a step-
+    timing percentile table; a second throughput table appears only when at
+    least one cell reported numeric ``metrics`` (e.g. ``gflops`` / ``gbps``),
+    which ``matrix.md`` never surfaced. The same aggregates live in
+    ``matrix.json::cells[*].metrics_summary`` for machine consumers.
+    """
+    lines: list[str] = []
+    lines.append(f"# Performance Report - {recipe.workload}")
+    lines.append("")
+    lines.append(f"**Ticket**: {recipe.ticket or '(none)'}  ")
+    lines.append(f"**Workload**: {recipe.workload}  ")
+    lines.append(f"**Run timestamp**: {run_timestamp}  ")
+    lines.append(f"**Baseline cell**: {baseline.name}  ")
+    lines.append("")
+    lines.append(
+        "Generated for every run from the same per-trial data behind "
+        "`matrix.md` -- these are unchanged aggregates, not a second "
+        "measurement. See `matrix.md` for pass/fail + confound classification "
+        "and `matrix.json::cells[*]` for the raw per-trial series."
+    )
+    lines.append("")
+
+    # --- Step-timing percentiles (always) --------------------------------
+    lines.append("## Step timing (ms)")
+    lines.append("")
+    timing_header = (
+        "Cell", "Trials", "Iters", "Mean", "Std", "Min",
+        "p50", "p90", "p99", "Max", "Wall (s)", "Source",
+    )
+    timing_rows: list[tuple[str, ...]] = [timing_header]
+    for cell in cell_stats:
+        label = cell.name + (" (baseline)" if cell.name == baseline.name else "")
+        if cell.error is not None:
+            timing_rows.append(
+                (label, str(cell.trials), cell.iters_display,
+                 "error", "error", "error", "error", "error", "error",
+                 "error", _fmt_perf_ms(cell.mean_wall_clock_sec), "error")
+            )
+            continue
+        # A cell with no usable per-step timing (setup-only crash / did-not-run)
+        # reports mean_step_time_ms == 0.0 with source "missing"; render the
+        # step columns as n/a rather than a misleading 0.000.
+        if cell.step_time_source == "missing" or not cell.step_times_ms:
+            step_cells = ("n/a",) * 7
+        else:
+            step_cells = (
+                _fmt_perf_ms(cell.mean_step_time_ms),
+                _fmt_perf_ms(cell.std_step_time_ms),
+                _fmt_perf_ms(cell.min_step_time_ms),
+                _fmt_perf_ms(cell.p50_step_time_ms),
+                _fmt_perf_ms(cell.p90_step_time_ms),
+                _fmt_perf_ms(cell.p99_step_time_ms),
+                _fmt_perf_ms(cell.max_step_time_ms),
+            )
+        # Reorder step_cells (mean, std, min, p50, p90, p99, max) into the
+        # header order (Mean, Std, Min, p50, p90, p99, Max) -- identical here,
+        # kept explicit so a header edit is a one-place change.
+        mean, std, mn, p50, p90, p99, mx = step_cells
+        timing_rows.append(
+            (label, str(cell.trials), cell.iters_display,
+             mean, std, mn, p50, p90, p99, mx,
+             _fmt_perf_ms(cell.mean_wall_clock_sec), cell.step_time_source)
+        )
+    lines.extend(_perf_table(timing_rows))
+    lines.append("")
+
+    # --- Workload throughput / metrics (conditional) ---------------------
+    metric_keys: list[str] = []
+    for cell in cell_stats:
+        for key in cell.metrics_summary:
+            if key not in metric_keys:
+                metric_keys.append(key)
+    if metric_keys:
+        lines.append("## Workload metrics (mean across trials)")
+        lines.append("")
+        metrics_header = ("Cell", *metric_keys)
+        metrics_rows: list[tuple[str, ...]] = [metrics_header]
+        for cell in cell_stats:
+            label = cell.name + (" (baseline)" if cell.name == baseline.name else "")
+            row = [label]
+            for key in metric_keys:
+                agg = cell.metrics_summary.get(key)
+                row.append(_fmt_perf_metric(agg["mean"]) if agg else "—")
+            metrics_rows.append(tuple(row))
+        lines.extend(_perf_table(metrics_rows))
+        lines.append("")
+        lines.append(
+            "> Each value is the mean of the metric across the cell's trials. "
+            "Per-metric `min` / `max` / trial-count `n` are in "
+            "`matrix.json::cells[*].metrics_summary`. `—` = the cell did not "
+            "report that metric."
+        )
+        lines.append("")
+
+    lines.append("## Notes")
+    lines.append("")
+    lines.append(
+        "- This file is written for **every** run (no flag) so any run "
+        "directory is self-describing for performance -- it reuses the "
+        "per-trial data already collected, so it costs no extra measurement."
+    )
+    lines.append(
+        "- `Trials` is the number of trials aggregated for the cell. `Iters` "
+        "mirrors `matrix.md`: iterations executed vs. configured. `Source` is "
+        "the step-time fidelity (`per_step` > `elapsed_per_iter` > "
+        "`wall_clock_total` > `missing`); rows with `Source = missing` show "
+        "`n/a` timing because any number would fold setup/teardown."
+    )
+    lines.append(
+        "- Percentiles are over the concatenated per-step samples across the "
+        "cell's trials, matching `matrix.json::cells[*]`. `matrix.md` shows "
+        "only the mean + a confound ratio vs the baseline cell."
+    )
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
 
 
 def write_resolved_recipe(

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -65,6 +65,7 @@ from aorta.triage.matrix import (
     aggregate_cell,
 )
 from aorta.triage.output import (
+    PERF_REPORT_FILENAME,
     acquire_flat_resume_lock,
     format_run_summary,
     format_timestamp,
@@ -72,6 +73,7 @@ from aorta.triage.output import (
     safe_slug,
     write_matrix_json,
     write_matrix_md,
+    write_perf_report,
     write_resolved_recipe,
 )
 from aorta.triage.recipe import InlineEnv, Recipe, RecipeCellError
@@ -1638,6 +1640,13 @@ def _run_recipe_locked(
         run_timestamp=ts,
         warnings=warnings,
         sidecar_files=sidecar_files,
+    )
+    write_perf_report(
+        run_dir / PERF_REPORT_FILENAME,
+        recipe=recipe,
+        cell_stats=cell_stats,
+        baseline=baseline_stats,
+        run_timestamp=ts,
     )
     write_resolved_recipe(
         run_dir / "recipe.resolved.yaml",

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -1707,13 +1707,21 @@ def _run_recipe_locked(
             s.name for s in cell_stats if s.error is not None or is_did_not_run_cell(s)
         ]
         if invalid:
+            # Emit the concrete per-cell artifact paths (slugified exactly as
+            # they land on disk, see _run_one_cell / _cells_dir) rather than a
+            # ``<cell>``/``<workload>`` placeholder, so an operator can
+            # copy/paste straight to the offending trials -- cell names are
+            # slugified on disk, so the verbatim name wouldn't resolve.
+            inspect_paths = "; ".join(
+                f"cells/{safe_slug(name)}/{recipe.workload}/trial_*.json"
+                for name in invalid
+            )
             raise MatrixStrictError(
                 f"strict mode: {len(invalid)} of {len(cell_stats)} cell(s) never "
                 f"produced a valid result (errored or did_not_run): "
-                f"{', '.join(invalid)}. Inspect "
-                f"cells/<cell>/<workload>/trial_*.json for the cause (a common "
-                f"one is a rejected LD_PRELOAD / setup failure). Drop --strict to "
-                f"treat these as tolerated per-cell failures.",
+                f"{', '.join(invalid)}. Inspect {inspect_paths} for the cause (a "
+                f"common one is a rejected LD_PRELOAD / setup failure). Drop "
+                f"--strict to treat these as tolerated per-cell failures.",
                 run_dir,
                 invalid,
             )

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -1716,4 +1716,4 @@ def _run_recipe_locked(
     return run_dir
 
 
-__all__ = ["MatrixIncompleteError", "run_recipe"]
+__all__ = ["MatrixIncompleteError", "MatrixStrictError", "run_recipe"]

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -1210,7 +1210,12 @@ def run_recipe(
     subprocess_argv: tuple[str, ...] | None = None,
     strict: bool = False,
 ) -> Path:
-    """Execute a recipe and write matrix.md / matrix.json / recipe.resolved.yaml.
+    """Execute a recipe and write matrix.md / matrix.json / perf.md / recipe.resolved.yaml.
+
+    ``perf.md`` is a per-run performance report written next to
+    ``matrix.md`` / ``matrix.json`` on every run (pure formatting of the
+    already-collected per-trial timing + metrics; no flag, no extra
+    measurement).
 
     Args:
         recipe: Pre-validated recipe (from :func:`aorta.triage.recipe.load_recipe`

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -132,6 +132,27 @@ class MatrixIncompleteError(Exception):
         self.run_dir = run_dir
 
 
+class MatrixStrictError(Exception):
+    """Raised AFTER ``run_recipe`` writes its artifacts when ``strict=True``
+    and one or more cells never produced a valid observation -- i.e. the whole
+    cell errored (``CellStats.error is not None``) or every trial in the cell
+    classified as ``did_not_run`` (:func:`is_did_not_run_cell`).
+
+    This is deliberately narrower than "a cell failed": a cell that *reproduces*
+    a bug (``passed=False`` with trials that actually ran) is an expected matrix
+    outcome and does NOT trip strict mode -- otherwise every A/B repro run would
+    exit non-zero. Strict only catches cells whose result is meaningless because
+    they never ran (e.g. an ``hrx_on`` cell whose ``LD_PRELOAD`` was rejected at
+    setup). The matrix artifacts ARE present (the exception carries ``run_dir``);
+    the exception signals the degradation to the CLI so it can exit non-zero.
+    """
+
+    def __init__(self, message: str, run_dir: Path, cells: list[str]) -> None:
+        super().__init__(message)
+        self.run_dir = run_dir
+        self.cells = cells
+
+
 def _merge_sidecar_files(
     recipe_files: tuple[Path, ...],
     extra: tuple[Path, ...],
@@ -1185,6 +1206,7 @@ def run_recipe(
     layout: Literal["timestamped", "flat_resume"] = "timestamped",
     resume_existing: bool = False,
     subprocess_argv: tuple[str, ...] | None = None,
+    strict: bool = False,
 ) -> Path:
     """Execute a recipe and write matrix.md / matrix.json / recipe.resolved.yaml.
 
@@ -1218,6 +1240,11 @@ def run_recipe(
             cell's :class:`SubprocessWorkload` via the typed
             ``RunRequest.subprocess_argv`` field. Required for probe-mode;
             ignored in triage-mode.
+        strict: When True, raise :class:`MatrixStrictError` (after writing
+            artifacts) if any cell errored or every trial in it did_not_run.
+            A cell that merely reproduces a bug (ran but ``passed=False``) does
+            NOT trip this. Off by default so the matrix flow keeps tolerating
+            per-cell failures.
 
     Returns:
         The run directory path (``<output-dir>/<ticket>/<workload>/<timestamp>``
@@ -1276,6 +1303,7 @@ def run_recipe(
             layout=layout,
             resume_existing=resume_existing,
             subprocess_argv=subprocess_argv,
+            strict=strict,
             should_write=should_write,
         )
 
@@ -1289,6 +1317,7 @@ def _run_recipe_locked(
     layout: Literal["timestamped", "flat_resume"],
     resume_existing: bool,
     subprocess_argv: tuple[str, ...] | None,
+    strict: bool = False,
     should_write: bool = True,
 ) -> Path:
     """Body of :func:`run_recipe` after the flat_resume lock is held.
@@ -1653,6 +1682,27 @@ def _run_recipe_locked(
         # message and exit non-zero. Tests / programmatic callers can
         # ``except MatrixIncompleteError`` to inspect ``run_dir``.
         raise MatrixIncompleteError(incomplete_reason, run_dir)
+
+    if strict:
+        # A cell is "invalid" only if it never produced a usable observation:
+        # the whole cell errored, or every trial did_not_run. A cell that ran
+        # but reported passed=False (a real bug repro) is an expected matrix
+        # outcome and must NOT trip strict mode. Checked after the incomplete
+        # guard so a degraded baseline keeps its more-specific message.
+        invalid = [
+            s.name for s in cell_stats if s.error is not None or is_did_not_run_cell(s)
+        ]
+        if invalid:
+            raise MatrixStrictError(
+                f"strict mode: {len(invalid)} of {len(cell_stats)} cell(s) never "
+                f"produced a valid result (errored or did_not_run): "
+                f"{', '.join(invalid)}. Inspect "
+                f"cells/<cell>/<workload>/trial_*.json for the cause (a common "
+                f"one is a rejected LD_PRELOAD / setup failure). Drop --strict to "
+                f"treat these as tolerated per-cell failures.",
+                run_dir,
+                invalid,
+            )
 
     return run_dir
 

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -197,10 +197,15 @@ class HrxWorkload(Workload):
 
         build_dir = self.config.get("build_dir")
         if build_dir:
-            self._build_dir = Path(build_dir)
+            # Resolve to absolute: _run_hipcc runs with cwd=_KERNELS_DIR and
+            # run() with cwd=self._build_dir, so a relative build_dir would send
+            # the hipcc -o output under _KERNELS_DIR and make the probe exec look
+            # for <build_dir>/<build_dir>/<binary>.
+            self._build_dir = Path(build_dir).resolve()
             self._build_dir.mkdir(parents=True, exist_ok=True)
             self._owns_build_dir = False
         else:
+            # mkdtemp already returns an absolute path.
             self._build_dir = Path(tempfile.mkdtemp(prefix="aorta-hrx-"))
             self._owns_build_dir = True
 

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -344,7 +344,16 @@ class HrxWorkload(Workload):
         # supplied build_dir. Assumes that dir is not shared across differing
         # probe/arch configs -- the binary name encodes neither -- which is the
         # same assumption a fixed build_dir already implies.
-        if binary.is_file() and (kernel_obj is None or kernel_obj.is_file()):
+        # Require the execute bit before reusing: a leftover artifact with wrong
+        # permissions or a partial write would otherwise be reused and fail
+        # run() with PermissionError -- a cell error rather than a recoverable
+        # rebuild. The kernel code object is loaded (not exec'd), so it only
+        # needs to exist.
+        if (
+            binary.is_file()
+            and os.access(binary, os.X_OK)
+            and (kernel_obj is None or kernel_obj.is_file())
+        ):
             log.debug("hrx: reusing existing %s in %s", spec.binary, self._build_dir)
             return binary
         # Standalone code object first (module path only), placed next to the

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -3,7 +3,8 @@
 Exposes the HRX HIP-compatibility-layer launch probes (from the
 ``ROCm/hrx-system`` #156 / #158 / #160 investigation) as an ``aorta``
 workload so they can be run and A/B-compared (HRX-on vs stock ROCm HIP)
-through the normal ``aorta run`` / ``aorta triage`` / ``aorta probe`` flows.
+through the normal ``aorta run`` / ``aorta sweep run`` flows (the in-process
+workload flow; not the deprecated ``aorta probe`` subprocess alias).
 
 Design:
     * **What to run** is this workload: one of a fixed set of single-purpose

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -261,7 +261,14 @@ class HrxWorkload(Workload):
         self._probe = self._validated_probe()
         self._spec = _PROBES[self._probe]
         self._arch = str(self.config.get("gpu_arch", _DEFAULT_ARCH))
+        # Validate here: subprocess.run(..., timeout=<=0) would raise at run()
+        # time and be misclassified as an infrastructure failure. Fail fast in
+        # setup() with a clear config error instead.
         self._timeout = int(self.config.get("timeout_sec", _DEFAULT_TIMEOUT_SEC))
+        if self._timeout <= 0:
+            raise ValueError(
+                f"hrx: timeout_sec ({self._timeout}) must be > 0"
+            )
         # Validate explicitly rather than bool(...): a stray "false"/"0" string
         # from a recipe would coerce to True and silently keep build dirs.
         keep_build = self.config.get("keep_build", False)

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -139,8 +139,19 @@ def _validated_arch(arch: str) -> str:
     path separator, so rejecting separators / traversal sentinels / absolute
     paths only rejects clearly-invalid or hostile input while leaving every
     legitimate arch untouched (so it stays usable for ``--offload-arch`` too).
+
+    A non-string value (e.g. ``gpu_arch: null`` in a recipe) is rejected up
+    front rather than coerced with ``str(...)`` -- ``str(None)`` would become
+    the literal ``'None'``, silently passing the path checks and producing a
+    confusing ``<build_dir>/None/`` directory and ``--offload-arch=None`` build
+    failure instead of a clear configuration error.
     """
-    arch = str(arch).strip()
+    if not isinstance(arch, str):
+        raise ValueError(
+            f"hrx: gpu_arch must be a string --offload-arch target (e.g. "
+            f"'gfx942'), got {type(arch).__name__} {arch!r}."
+        )
+    arch = arch.strip()
     if (
         not arch
         or arch in (".", "..")

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -187,6 +187,31 @@ def _resolve_hipcc(configured: str | None) -> str | None:
     return None
 
 
+# The ROCm kernel-fusion driver node. HIP cannot initialise a GPU context
+# without opening it read/write, so its absence/inaccessibility is the
+# canonical "no usable ROCm GPU here" signal (a CPU-only host or a container
+# started without ``--device=/dev/kfd``).
+_GPU_KFD_NODE = "/dev/kfd"
+
+
+def _gpu_available() -> bool:
+    """Best-effort check that a ROCm GPU is reachable by the HIP runtime.
+
+    Returns ``True`` when the KFD compute node (:data:`_GPU_KFD_NODE`) is
+    readable+writable by this process. This is a cheap, dependency-free proxy
+    for "HIP can init a device" -- it does not spawn ``rocminfo`` and does not
+    prove a *specific* arch is present, only that the compute driver node is
+    accessible. It is deliberately conservative (checks only the definitive
+    node) so a real ROCm host never false-negatives; the point is to catch the
+    plainly-no-GPU case in :meth:`HrxWorkload.setup` so the cell is classified
+    ``did_not_run`` instead of minting a false ``OUTPUT_NOT_WRITTEN``.
+
+    Split out as a module-level function so GPU-free unit tests can monkeypatch
+    it.
+    """
+    return os.access(_GPU_KFD_NODE, os.R_OK | os.W_OK)
+
+
 class HrxWorkload(Workload):
     """Run one HRX HIP-launch probe and report its verdict.
 
@@ -256,6 +281,20 @@ class HrxWorkload(Workload):
             )
         self._hipcc = hipcc
 
+        # Fail in setup() (not run()) when no GPU is reachable, so a host with
+        # hipcc but no accessible device is classified did_not_run (a setup
+        # failure, excluded from the failure rate) rather than producing a
+        # passed=False result the matrix would miscount as a reproduced bug.
+        if not _gpu_available():
+            raise RuntimeError(
+                f"hrx: no accessible ROCm GPU ({_GPU_KFD_NODE} is not "
+                "readable+writable). This workload dispatches a real HIP kernel "
+                "and needs a GPU; run it on a ROCm host (or a container started "
+                "with --device=/dev/kfd --device=/dev/dri and the render group). "
+                "Raising here keeps the cell classified as did_not_run rather "
+                "than a false OUTPUT_NOT_WRITTEN."
+            )
+
         build_dir = self.config.get("build_dir")
         if build_dir:
             # Resolve to absolute: _run_hipcc runs with cwd=_KERNELS_DIR and
@@ -287,6 +326,20 @@ class HrxWorkload(Workload):
 
     def _build(self) -> Path:
         spec = self._spec
+        binary = self._build_dir / spec.binary
+        kernel_obj = (
+            self._build_dir / spec.kernel_object if spec.kernel_object else None
+        )
+        # Reuse an already-built probe. setup() runs once per trial, so a run
+        # that pins a shared build_dir would otherwise recompile identical
+        # artifacts every trial. The default build_dir is a fresh temp dir
+        # (unique per setup), so this fast-path only fires for an operator-
+        # supplied build_dir. Assumes that dir is not shared across differing
+        # probe/arch configs -- the binary name encodes neither -- which is the
+        # same assumption a fixed build_dir already implies.
+        if binary.is_file() and (kernel_obj is None or kernel_obj.is_file()):
+            log.debug("hrx: reusing existing %s in %s", spec.binary, self._build_dir)
+            return binary
         # Standalone code object first (module path only), placed next to the
         # binary because the probe loads it from its own exe directory.
         if spec.kernel_source and spec.kernel_object:
@@ -300,7 +353,6 @@ class HrxWorkload(Workload):
                 ],
                 spec.kernel_object,
             )
-        binary = self._build_dir / spec.binary
         self._run_hipcc(
             [
                 "-O2",

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -302,7 +302,7 @@ class HrxWorkload(Workload):
             elif verdict is None:
                 hint = (
                     f"probe {self._probe!r} produced no VERDICT line "
-                    f"(exit {exit_code}); see stderr"
+                    f"(exit {exit_code}); see stdout/stderr"
                 )
             else:
                 hint = f"probe {self._probe!r} verdict {verdict} (out[0]={out0}, expected 107)"
@@ -313,6 +313,10 @@ class HrxWorkload(Workload):
                     "out0": out0,
                     "exit_code": exit_code,
                     "timed_out": timed_out,
+                    # The probes printf HIP errors / diagnostics to stdout, so
+                    # capture both tails -- for a crash before the VERDICT line,
+                    # the useful signal is on stdout, not stderr.
+                    "stdout_tail": stdout.strip()[-2000:],
                     "stderr_tail": stderr.strip()[-2000:],
                     "hint": hint,
                 }

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -323,16 +323,23 @@ class HrxWorkload(Workload):
                 }
             )
 
+        # No iteration ran unless the probe dispatched and read back. Report 0
+        # iterations (and no failing-iteration index) when main work never
+        # started, so the matrix elapsed_per_iter fallback -- which divides
+        # elapsed_sec by total_iterations *before* the did-not-run suppression
+        # (aorta.triage.matrix._extract_step_times) -- can't mint a misleading
+        # step time for a setup-only crash/timeout.
+        executed = 1 if main_work_started else 0
         return WorkloadResult(
             passed=passed,
             failure_count=0 if passed else 1,
-            first_failure_iteration=None if passed else 0,
+            first_failure_iteration=0 if (not passed and main_work_started) else None,
             failure_details=failure_details,
-            total_iterations=1,
+            total_iterations=executed,
             elapsed_sec=elapsed,
             metrics=metrics,
             main_work_started=main_work_started,
-            executed_iterations=1 if main_work_started else 0,
+            executed_iterations=executed,
             configured_iterations=1,
         )
 

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -1,0 +1,333 @@
+"""HRX HIP-launch probe workload.
+
+Exposes the HRX HIP-compatibility-layer launch probes (from the
+``ROCm/hrx-system`` #156 / #158 / #160 investigation) as an ``aorta``
+workload so they can be run and A/B-compared (HRX-on vs stock ROCm HIP)
+through the normal ``aorta run`` / ``aorta triage`` / ``aorta probe`` flows.
+
+Design:
+    * **What to run** is this workload: one of a fixed set of single-purpose
+      HIP kernel-launch probes, selected by ``workload_config.probe``. Each
+      computes ``out[i] = in[i] + 100`` (in=7, out pre-zeroed) and prints a
+      ``VERDICT=`` line + an ``out[0]=`` sentinel. ``107``/``FULLY_WORKS`` is
+      the only passing outcome; ``0``/``OUTPUT_NOT_WRITTEN`` is the #156 bug.
+    * **Which runtime** (HRX vs stock HIP) is NOT decided here. It is an
+      environment/mitigation concern: the HRX-on cell applies an
+      ``LD_PRELOAD`` + ``LD_LIBRARY_PATH`` + ``HRX_GPU_DRIVER`` env bundle.
+      Because the probe is exec'd as a *child* process, that ``LD_PRELOAD``
+      takes effect at ``exec()`` (an in-process torch workload could not do
+      this — see the HRX handover notes).
+    * That routing bundle is stripped from the ``hipcc`` build env (see
+      :data:`_RUNTIME_ROUTING_VARS`): the dispatcher merges the cell env into
+      ``os.environ`` before ``setup()`` runs, so without stripping, a preloaded
+      HRX ``libamdhip64.so`` would run inside the *compiler/link* step. Building
+      against the stock toolchain makes the binary identical across cells; only
+      :meth:`run` inherits the bundle, so routing applies to the probe alone.
+
+The probe binary is built from vendored source with ``hipcc`` at
+:meth:`setup`. On a host without ``hipcc`` (or without a GPU) ``setup``
+raises, which the runner classifies as a setup failure / ``did_not_run`` —
+never a false ``OUTPUT_NOT_WRITTEN``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+from aorta.workloads._base import Workload, WorkloadResult
+
+log = logging.getLogger(__name__)
+
+_KERNELS_DIR = Path(__file__).parent / "hrx_kernels"
+
+# The only passing verdict. All probes print "VERDICT=<TOKEN> ..." where TOKEN
+# is one of these; the trailing parenthetical (e.g. "(H2D/in-arg broken)") is
+# descriptive and not part of the token.
+_PASS_VERDICT = "FULLY_WORKS"
+_VERDICT_RE = re.compile(r"^VERDICT=([A-Z_]+)", re.MULTILINE)
+_OUT0_RE = re.compile(r"^out\[0\]=([-\d.eE+]+)", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class _ProbeSpec:
+    """Build recipe for one probe.
+
+    Attributes:
+        source: main ``.cpp`` compiled to the probe executable.
+        binary: output executable name.
+        kernel_source: optional device ``.cpp`` compiled to a standalone
+            code object with ``--genco`` and loaded at runtime (module path).
+        kernel_object: output ``.code`` name for ``kernel_source``.
+    """
+
+    source: str
+    binary: str
+    kernel_source: str | None = None
+    kernel_object: str | None = None
+
+
+# Registry of supported probes. Keys are the user-facing ``probe`` config values.
+_PROBES: dict[str, _ProbeSpec] = {
+    "static": _ProbeSpec("hrx_probe.cpp", "hrx_probe"),
+    "module": _ProbeSpec(
+        "hrx_probe_module.cpp",
+        "hrx_probe_module",
+        kernel_source="hrx_probe_module_kernel.cpp",
+        kernel_object="hrx_probe_module_kernel.code",
+    ),
+    "graph_add": _ProbeSpec("hrx_probe_graph_add.cpp", "hrx_probe_graph_add"),
+    "graph_setparams": _ProbeSpec(
+        "hrx_probe_graph_setparams.cpp", "hrx_probe_graph_setparams"
+    ),
+    "graph_execsetparams": _ProbeSpec(
+        "hrx_probe_graph_execsetparams.cpp", "hrx_probe_graph_execsetparams"
+    ),
+}
+
+_DEFAULT_PROBE = "module"
+_DEFAULT_ARCH = "gfx942"
+_DEFAULT_TIMEOUT_SEC = 120
+
+# Env vars the HRX-on cell injects to route the *probe exec* through an
+# alternate HIP runtime. The dispatcher merges the cell env into os.environ
+# before setup() (the build) runs, so these are stripped from the hipcc build
+# env -- otherwise a preloaded HRX libamdhip64.so (or its LD_LIBRARY_PATH)
+# would run inside the compiler/link step instead of the probe. run() still
+# inherits os.environ, so routing takes effect at the probe's exec().
+_RUNTIME_ROUTING_VARS = ("LD_PRELOAD", "LD_LIBRARY_PATH", "HRX_GPU_DRIVER")
+
+
+def _build_env() -> dict[str, str]:
+    """os.environ minus the HRX runtime-routing vars (for the hipcc build)."""
+    return {k: v for k, v in os.environ.items() if k not in _RUNTIME_ROUTING_VARS}
+
+# Platform-injected config keys that are not HrxWorkload knobs (the dispatcher
+# writes `steps` into every workload config; `_aorta_*` carry probe/env
+# metadata). Kept silent so the unknown-key guard doesn't spam warnings.
+_RESERVED_KEYS = {"steps"}
+_KNOWN_KEYS = {
+    "probe",
+    "gpu_arch",
+    "hipcc",
+    "build_dir",
+    "timeout_sec",
+    "keep_build",
+}
+
+
+def _resolve_hipcc(configured: str | None) -> str | None:
+    """Return an invocable hipcc path, or None if none is found."""
+    candidates = [
+        configured,
+        os.environ.get("HIPCC"),
+        "/opt/rocm/bin/hipcc",
+        "hipcc",
+    ]
+    for cand in candidates:
+        if not cand:
+            continue
+        found = shutil.which(cand) or (cand if os.path.isfile(cand) and os.access(cand, os.X_OK) else None)
+        if found:
+            return found
+    return None
+
+
+class HrxWorkload(Workload):
+    """Run one HRX HIP-launch probe and report its verdict.
+
+    ``workload_config`` keys:
+        probe: which launch path to exercise (default ``"module"``); one of
+            ``static`` / ``module`` / ``graph_add`` / ``graph_setparams`` /
+            ``graph_execsetparams``.
+        gpu_arch: ``--offload-arch`` target (default ``"gfx942"``).
+        hipcc: explicit hipcc path (default: ``$HIPCC`` /
+            ``/opt/rocm/bin/hipcc`` / ``hipcc`` on PATH).
+        build_dir: directory for built binaries (default: a temp dir removed
+            on cleanup unless ``keep_build`` is set).
+        timeout_sec: per-run subprocess timeout (default ``120``).
+        keep_build: keep ``build_dir`` after cleanup (default ``False``).
+    """
+
+    name: ClassVar[str] = "hrx"
+
+    def _validated_probe(self) -> str:
+        for key in self.config:
+            if key in _KNOWN_KEYS or key in _RESERVED_KEYS or key.startswith("_aorta_"):
+                continue
+            log.warning("hrx: ignoring unknown workload_config key %r", key)
+        probe = self.config.get("probe", _DEFAULT_PROBE)
+        if probe not in _PROBES:
+            raise ValueError(
+                f"hrx: unknown probe {probe!r}; choose one of {sorted(_PROBES)}"
+            )
+        return probe
+
+    def setup(self) -> None:
+        self._probe = self._validated_probe()
+        self._spec = _PROBES[self._probe]
+        self._arch = str(self.config.get("gpu_arch", _DEFAULT_ARCH))
+        self._timeout = int(self.config.get("timeout_sec", _DEFAULT_TIMEOUT_SEC))
+        # Validate explicitly rather than bool(...): a stray "false"/"0" string
+        # from a recipe would coerce to True and silently keep build dirs.
+        keep_build = self.config.get("keep_build", False)
+        if not isinstance(keep_build, bool):
+            raise ValueError(
+                f"hrx: keep_build must be a bool, got {type(keep_build).__name__}"
+            )
+        self._keep_build = keep_build
+
+        hipcc = _resolve_hipcc(self.config.get("hipcc"))
+        if hipcc is None:
+            raise RuntimeError(
+                "hrx: hipcc not found (looked at $HIPCC, /opt/rocm/bin/hipcc, "
+                "and PATH). This workload builds HIP probes from source and "
+                "requires a ROCm/hipcc toolchain. Run it in a ROCm environment, "
+                "or set workload_config.hipcc."
+            )
+        self._hipcc = hipcc
+
+        build_dir = self.config.get("build_dir")
+        if build_dir:
+            self._build_dir = Path(build_dir)
+            self._build_dir.mkdir(parents=True, exist_ok=True)
+            self._owns_build_dir = False
+        else:
+            self._build_dir = Path(tempfile.mkdtemp(prefix="aorta-hrx-"))
+            self._owns_build_dir = True
+
+        self._binary = self._build()
+
+    def _run_hipcc(self, args: list[str], what: str) -> None:
+        cmd = [self._hipcc, *args]
+        log.debug("hrx: building %s: %s", what, " ".join(cmd))
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=str(_KERNELS_DIR), env=_build_env()
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"hrx: hipcc failed to build {what} (exit {proc.returncode}).\n"
+                f"cmd: {' '.join(cmd)}\n"
+                f"stderr:\n{proc.stderr.strip()}"
+            )
+
+    def _build(self) -> Path:
+        spec = self._spec
+        # Standalone code object first (module path only), placed next to the
+        # binary because the probe loads it from its own exe directory.
+        if spec.kernel_source and spec.kernel_object:
+            self._run_hipcc(
+                [
+                    "--genco",
+                    f"--offload-arch={self._arch}",
+                    str(_KERNELS_DIR / spec.kernel_source),
+                    "-o",
+                    str(self._build_dir / spec.kernel_object),
+                ],
+                spec.kernel_object,
+            )
+        binary = self._build_dir / spec.binary
+        self._run_hipcc(
+            [
+                "-O2",
+                f"--offload-arch={self._arch}",
+                str(_KERNELS_DIR / spec.source),
+                "-o",
+                str(binary),
+            ],
+            spec.binary,
+        )
+        return binary
+
+    def run(self) -> WorkloadResult:
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                [str(self._binary)],
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+                cwd=str(self._build_dir),
+            )
+            timed_out = False
+            stdout, stderr, exit_code = proc.stdout, proc.stderr, proc.returncode
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            exit_code = None
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode(errors="replace")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode(errors="replace")
+        elapsed = time.monotonic() - start
+
+        verdict_match = _VERDICT_RE.search(stdout)
+        out0_match = _OUT0_RE.search(stdout)
+        verdict = verdict_match.group(1) if verdict_match else None
+        out0 = float(out0_match.group(1)) if out0_match else None
+
+        # main_work_started: the probe reached the point of printing a result
+        # (it dispatched / read back), as opposed to dying during HIP init.
+        main_work_started = out0_match is not None or verdict_match is not None
+
+        passed = (not timed_out) and exit_code == 0 and verdict == _PASS_VERDICT
+
+        metrics: dict[str, Any] = {
+            "probe": self._probe,
+            "gpu_arch": self._arch,
+            "verdict": verdict,
+            "out0": out0,
+            "exit_code": exit_code,
+            "timed_out": timed_out,
+        }
+
+        failure_details: list[dict[str, Any]] = []
+        if not passed:
+            if timed_out:
+                hint = f"probe {self._probe!r} hung (>{self._timeout}s) at launch/sync"
+            elif verdict is None:
+                hint = (
+                    f"probe {self._probe!r} produced no VERDICT line "
+                    f"(exit {exit_code}); see stderr"
+                )
+            else:
+                hint = f"probe {self._probe!r} verdict {verdict} (out[0]={out0}, expected 107)"
+            failure_details.append(
+                {
+                    "probe": self._probe,
+                    "verdict": verdict,
+                    "out0": out0,
+                    "exit_code": exit_code,
+                    "timed_out": timed_out,
+                    "stderr_tail": stderr.strip()[-2000:],
+                    "hint": hint,
+                }
+            )
+
+        return WorkloadResult(
+            passed=passed,
+            failure_count=0 if passed else 1,
+            first_failure_iteration=None if passed else 0,
+            failure_details=failure_details,
+            total_iterations=1,
+            elapsed_sec=elapsed,
+            metrics=metrics,
+            main_work_started=main_work_started,
+            executed_iterations=1 if main_work_started else 0,
+            configured_iterations=1,
+        )
+
+    def cleanup(self) -> None:
+        if getattr(self, "_owns_build_dir", False) and not getattr(
+            self, "_keep_build", False
+        ):
+            shutil.rmtree(self._build_dir, ignore_errors=True)

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -128,6 +128,63 @@ def _build_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if k not in _RUNTIME_ROUTING_VARS}
 
 
+def _validated_arch(arch: str) -> str:
+    """Return ``arch`` if it is safe to use as a build-directory component.
+
+    ``gpu_arch`` is used verbatim as a ``<build_dir>/<arch>/`` path component
+    (see :meth:`HrxWorkload._build_root`), so an operator-supplied value like
+    ``../evil`` or ``/etc`` must not be able to escape ``build_dir``. Real
+    ``hipcc --offload-arch`` targets are of the form ``gfxNNN`` with optional
+    ``:feature+/-`` qualifiers (e.g. ``gfx90a:xnack+``) and never contain a
+    path separator, so rejecting separators / traversal sentinels / absolute
+    paths only rejects clearly-invalid or hostile input while leaving every
+    legitimate arch untouched (so it stays usable for ``--offload-arch`` too).
+    """
+    arch = str(arch).strip()
+    if (
+        not arch
+        or arch in (".", "..")
+        or "/" in arch
+        or "\\" in arch
+        or "\x00" in arch
+        or os.path.isabs(arch)
+    ):
+        raise ValueError(
+            f"hrx: gpu_arch {arch!r} is not a valid --offload-arch target -- it "
+            "is used as a build-directory name and must be a single path "
+            "component (no '/', '\\', '..', or absolute paths that could escape "
+            "build_dir)."
+        )
+    return arch
+
+
+def _persist_full_logs(config: dict[str, Any], stdout: str, stderr: str) -> None:
+    """Write the child's *full* stdout/stderr when the platform requested logs.
+
+    ``failure_details`` only keeps truncated 2 KB tails, and only on failure.
+    When ``save_logs`` is set the dispatcher injects ``_aorta_save_logs`` +
+    ``_aorta_log_prefix`` (an absolute path stem) and expects a subprocess
+    wrapper to write its own capture to a sibling
+    ``<prefix>.subprocess.{stdout,stderr}.log`` (see
+    :mod:`aorta.run.dispatcher` -- ``redirect_stdout`` does not catch a child
+    process's output). Honor that here so the complete HRX child output is
+    preserved alongside the trial artifacts, not just the tails. Best-effort:
+    a write failure is logged, never raised, so it can't turn a real result
+    into a cell error.
+    """
+    if not config.get("_aorta_save_logs"):
+        return
+    prefix = config.get("_aorta_log_prefix")
+    if not isinstance(prefix, str) or not prefix:
+        return
+    for suffix, content in (("stdout", stdout), ("stderr", stderr)):
+        dest = f"{prefix}.subprocess.{suffix}.log"
+        try:
+            Path(dest).write_text(content, encoding="utf-8", errors="backslashreplace")
+        except OSError as exc:
+            log.warning("hrx: could not write full %s log to %s: %s", suffix, dest, exc)
+
+
 def _missing_preload_objects() -> list[str]:
     """Path-like ``LD_PRELOAD`` entries that don't resolve to an existing file.
 
@@ -260,7 +317,7 @@ class HrxWorkload(Workload):
             )
         self._probe = self._validated_probe()
         self._spec = _PROBES[self._probe]
-        self._arch = str(self.config.get("gpu_arch", _DEFAULT_ARCH))
+        self._arch = _validated_arch(self.config.get("gpu_arch", _DEFAULT_ARCH))
         # Validate here: subprocess.run(..., timeout=<=0) would raise at run()
         # time and be misclassified as an infrastructure failure. Fail fast in
         # setup() with a clear config error instead.
@@ -418,6 +475,10 @@ class HrxWorkload(Workload):
             if isinstance(stderr, bytes):
                 stderr = stderr.decode(errors="replace")
         elapsed = time.monotonic() - start
+
+        # Persist the complete child output when the run requested save_logs;
+        # failure_details below only keeps truncated tails (and only on failure).
+        _persist_full_logs(self.config, stdout, stderr)
 
         verdict_match = _VERDICT_RE.search(stdout)
         out0_match = _OUT0_RE.search(stdout)

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -17,7 +17,11 @@ Design:
       ``LD_PRELOAD`` + ``LD_LIBRARY_PATH`` + ``HRX_GPU_DRIVER`` env bundle.
       Because the probe is exec'd as a *child* process, that ``LD_PRELOAD``
       takes effect at ``exec()`` (an in-process torch workload could not do
-      this — see the HRX handover notes).
+      this — see the HRX handover notes). A bad routing bundle is caught, not
+      run silently: :meth:`setup` fails if ``LD_PRELOAD`` names a path that
+      doesn't exist, and :meth:`run` marks the result failed if ``ld.so`` reports
+      it ignored the preload — either case would otherwise fall back to the
+      default HIP runtime and mint a misleading ``FULLY_WORKS``.
     * That routing bundle is stripped from the ``hipcc`` build env (see
       :data:`_RUNTIME_ROUTING_VARS`): the dispatcher merges the cell env into
       ``os.environ`` before ``setup()`` runs, so without stripping, a preloaded
@@ -56,6 +60,18 @@ _KERNELS_DIR = Path(__file__).parent / "hrx_kernels"
 _PASS_VERDICT = "FULLY_WORKS"
 _VERDICT_RE = re.compile(r"^VERDICT=([A-Z_]+)", re.MULTILINE)
 _OUT0_RE = re.compile(r"^out\[0\]=([-\d.eE+]+)", re.MULTILINE)
+
+# ld.so emits this (to stderr) when it cannot load an LD_PRELOAD object and
+# falls back to running the process WITHOUT it, e.g.
+#   ERROR: ld.so: object '/x/libamdhip64.so' from LD_PRELOAD cannot be
+#   preloaded (cannot open shared object file): ignored.
+# For this workload that silent fallback means the probe ran against the
+# default HIP runtime, not the one the cell intended -- a false green.
+_LDSO_PRELOAD_IGNORED_RE = re.compile(r"from LD_PRELOAD cannot be preloaded")
+
+# ld.so dynamic string tokens are expanded by the loader at exec time; we can't
+# resolve them here, so LD_PRELOAD entries containing them are not existence-checked.
+_LD_DYNAMIC_TOKEN_RE = re.compile(r"\$(?:ORIGIN|LIB|PLATFORM)\b|\$\{")
 
 
 @dataclass(frozen=True)
@@ -110,6 +126,35 @@ _RUNTIME_ROUTING_VARS = ("LD_PRELOAD", "LD_LIBRARY_PATH", "HRX_GPU_DRIVER")
 def _build_env() -> dict[str, str]:
     """os.environ minus the HRX runtime-routing vars (for the hipcc build)."""
     return {k: v for k, v in os.environ.items() if k not in _RUNTIME_ROUTING_VARS}
+
+
+def _missing_preload_objects() -> list[str]:
+    """Path-like ``LD_PRELOAD`` entries that don't resolve to an existing file.
+
+    A missing ``LD_PRELOAD`` object is NOT fatal to the dynamic loader: ``ld.so``
+    prints a warning to stderr and runs the process anyway -- against the
+    *default* ``libamdhip64``. For this workload that means an ``hrx_on`` cell
+    whose ``LD_PRELOAD`` points at a placeholder or mistyped path would silently
+    exercise stock HIP and report a misleading ``FULLY_WORKS``. Surface it
+    up-front instead.
+
+    Only *path-like* entries (absolute, or containing a ``/``) are checked;
+    bare sonames are resolved via ``LD_LIBRARY_PATH`` / the ldconfig cache, which
+    we can't reliably enumerate here (the run()-time stderr backstop catches
+    those). Entries with unresolved dynamic tokens ($ORIGIN/$LIB/$PLATFORM) are
+    skipped for the same reason.
+    """
+    raw = os.environ.get("LD_PRELOAD", "").strip()
+    if not raw:
+        return []
+    missing: list[str] = []
+    # The loader accepts whitespace and ``:`` as LD_PRELOAD separators.
+    for entry in (p for p in re.split(r"[:\s]+", raw) if p):
+        if _LD_DYNAMIC_TOKEN_RE.search(entry):
+            continue
+        if (os.path.isabs(entry) or "/" in entry) and not os.path.isfile(entry):
+            missing.append(entry)
+    return missing
 
 # Platform-injected config keys that are not HrxWorkload knobs (the dispatcher
 # writes `steps` into every workload config; `_aorta_*` carry probe/env
@@ -173,6 +218,21 @@ class HrxWorkload(Workload):
         return probe
 
     def setup(self) -> None:
+        # Fail fast on a bad routing bundle: a nonexistent LD_PRELOAD object is
+        # only a stderr warning to the loader, so an hrx_on cell would otherwise
+        # silently run against stock HIP and report a false FULLY_WORKS.
+        missing = _missing_preload_objects()
+        if missing:
+            raise RuntimeError(
+                "hrx: LD_PRELOAD names object(s) that do not exist: "
+                + ", ".join(repr(m) for m in missing)
+                + ". The dynamic loader would ignore these with only a stderr "
+                "warning and run the probe against the DEFAULT HIP runtime, so "
+                "the cell would silently test stock HIP and report a misleading "
+                "FULLY_WORKS. Fix the path(s) in the cell's extra_env -- replace "
+                "the /path/to/hrx-root placeholder with your installed HRX "
+                "prefix, and make sure LD_PRELOAD/LD_LIBRARY_PATH are absolute."
+            )
         self._probe = self._validated_probe()
         self._spec = _PROBES[self._probe]
         self._arch = str(self.config.get("gpu_arch", _DEFAULT_ARCH))
@@ -285,7 +345,22 @@ class HrxWorkload(Workload):
         # (it dispatched / read back), as opposed to dying during HIP init.
         main_work_started = out0_match is not None or verdict_match is not None
 
-        passed = (not timed_out) and exit_code == 0 and verdict == _PASS_VERDICT
+        # Even a FULLY_WORKS verdict is a false green if the cell requested an
+        # LD_PRELOAD that the loader ended up ignoring: the probe then ran
+        # against the default HIP runtime, not the intended one. The setup-time
+        # check catches nonexistent paths; this catches exists-but-unloadable
+        # (wrong arch, missing transitive deps) via ld.so's stderr warning.
+        preload_requested = bool(os.environ.get("LD_PRELOAD", "").strip())
+        preload_ignored = preload_requested and bool(
+            _LDSO_PRELOAD_IGNORED_RE.search(stderr)
+        )
+
+        passed = (
+            (not timed_out)
+            and exit_code == 0
+            and verdict == _PASS_VERDICT
+            and not preload_ignored
+        )
 
         metrics: dict[str, Any] = {
             "probe": self._probe,
@@ -294,11 +369,20 @@ class HrxWorkload(Workload):
             "out0": out0,
             "exit_code": exit_code,
             "timed_out": timed_out,
+            "preload_ignored": preload_ignored,
         }
 
         failure_details: list[dict[str, Any]] = []
         if not passed:
-            if timed_out:
+            if preload_ignored:
+                hint = (
+                    f"probe {self._probe!r}: LD_PRELOAD was set but the loader "
+                    "ignored it (see stderr) -- the probe ran against the "
+                    "DEFAULT HIP runtime, so this result does NOT reflect the "
+                    "intended runtime. Check the LD_PRELOAD object's path, "
+                    "architecture, and shared-library dependencies."
+                )
+            elif timed_out:
                 hint = f"probe {self._probe!r} hung (>{self._timeout}s) at launch/sync"
             elif verdict is None:
                 hint = (
@@ -314,6 +398,7 @@ class HrxWorkload(Workload):
                     "out0": out0,
                     "exit_code": exit_code,
                     "timed_out": timed_out,
+                    "preload_ignored": preload_ignored,
                     # The probes printf HIP errors / diagnostics to stdout, so
                     # capture both tails -- for a crash before the VERDICT line,
                     # the useful signal is on stdout, not stderr.

--- a/src/aorta/workloads/hrx.py
+++ b/src/aorta/workloads/hrx.py
@@ -331,19 +331,34 @@ class HrxWorkload(Workload):
                 f"stderr:\n{proc.stderr.strip()}"
             )
 
+    def _build_root(self) -> Path:
+        """Arch-specific artifact directory under ``build_dir``.
+
+        The binary/code-object names encode the probe but NOT the GPU arch, so a
+        shared ``build_dir`` reused across differing ``--offload-arch`` builds
+        would otherwise reuse a binary compiled for the wrong arch and silently
+        run the wrong thing. Isolating artifacts in a ``<build_dir>/<arch>/``
+        subdir makes reuse arch-safe; the probe loads its code object from its
+        own exe directory (``/proc/self/exe``), so the relative name still
+        resolves inside the subdir.
+        """
+        root = self._build_dir / self._arch
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+
     def _build(self) -> Path:
         spec = self._spec
-        binary = self._build_dir / spec.binary
+        build_root = self._build_root()
+        binary = build_root / spec.binary
         kernel_obj = (
-            self._build_dir / spec.kernel_object if spec.kernel_object else None
+            build_root / spec.kernel_object if spec.kernel_object else None
         )
         # Reuse an already-built probe. setup() runs once per trial, so a run
         # that pins a shared build_dir would otherwise recompile identical
         # artifacts every trial. The default build_dir is a fresh temp dir
         # (unique per setup), so this fast-path only fires for an operator-
-        # supplied build_dir. Assumes that dir is not shared across differing
-        # probe/arch configs -- the binary name encodes neither -- which is the
-        # same assumption a fixed build_dir already implies.
+        # supplied build_dir. Artifacts live in an arch subdir (see
+        # _build_root), so reuse across differing arch configs is safe.
         # Require the execute bit before reusing: a leftover artifact with wrong
         # permissions or a partial write would otherwise be reused and fail
         # run() with PermissionError -- a cell error rather than a recoverable
@@ -354,7 +369,7 @@ class HrxWorkload(Workload):
             and os.access(binary, os.X_OK)
             and (kernel_obj is None or kernel_obj.is_file())
         ):
-            log.debug("hrx: reusing existing %s in %s", spec.binary, self._build_dir)
+            log.debug("hrx: reusing existing %s in %s", spec.binary, build_root)
             return binary
         # Standalone code object first (module path only), placed next to the
         # binary because the probe loads it from its own exe directory.
@@ -365,7 +380,7 @@ class HrxWorkload(Workload):
                     f"--offload-arch={self._arch}",
                     str(_KERNELS_DIR / spec.kernel_source),
                     "-o",
-                    str(self._build_dir / spec.kernel_object),
+                    str(build_root / spec.kernel_object),
                 ],
                 spec.kernel_object,
             )

--- a/src/aorta/workloads/hrx_kernels/README.md
+++ b/src/aorta/workloads/hrx_kernels/README.md
@@ -1,0 +1,28 @@
+# HRX HIP-launch probe kernels
+
+Vendored source for the `hrx` workload (`aorta.workloads.hrx:HrxWorkload`).
+
+Each probe isolates one HIP kernel-launch path and computes `out[i] = in[i] + 100`
+with `in = 7` and `out` pre-zeroed, then prints a `VERDICT=` line derived from
+`out[0]`:
+
+| `out[0]` | verdict | meaning |
+|---|---|---|
+| `107` | `FULLY_WORKS` | read + write + copies all correct |
+| `100` | `INPUT_READ_ZERO` | H2D / input argument broken |
+| `0` | `OUTPUT_NOT_WRITTEN` | kernel write / output argument never reached host |
+| other | `GARBAGE` | address mismatch |
+
+| file | probe id | HIP path under test |
+|---|---|---|
+| `hrx_probe.cpp` | `static` | `hipLaunchKernelGGL` (statically registered) |
+| `hrx_probe_module.cpp` (+ `hrx_probe_module_kernel.cpp`) | `module` | `hipModuleLaunchKernel` (pre-packed `extra` buffer) |
+| `hrx_probe_graph_add.cpp` | `graph_add` | `hipGraphAddKernelNode` (`extra`) |
+| `hrx_probe_graph_setparams.cpp` | `graph_setparams` | `hipGraphKernelNodeSetParams` (`extra`) |
+| `hrx_probe_graph_execsetparams.cpp` | `graph_execsetparams` | `hipGraphExecKernelNodeSetParams` (`extra`) |
+
+`hrx_probe_module_kernel.cpp` is compiled to a standalone code object with
+`hipcc --genco` and loaded at runtime by the `module` probe via
+`hipModuleLoad`; the other probes embed their kernel and are compiled directly.
+
+These originate from the `ROCm/hrx-system` #156 / #158 / #160 investigation.

--- a/src/aorta/workloads/hrx_kernels/hrx_perf_gemm.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_perf_gemm.cpp
@@ -1,0 +1,114 @@
+// HRX perf benchmark: compute-bound tiled SGEMM (C = A * B, float, N x N).
+//
+// Part of the `hrx_perf` aorta workload. Runs `warmup` untimed iterations then
+// `iters` timed iterations; each timed iteration is bracketed by a host-side
+// steady_clock around the launch + hipDeviceSynchronize, so the reported
+// per-step time includes kernel execution AND host/runtime launch overhead --
+// the latter is where an alternate HIP runtime (HRX) can differ from stock HIP.
+//
+// Output (parsed by src/aorta/workloads/hrx_perf.py):
+//   bench=gemm size=<N> iters=<M> warmup=<W>
+//   step_ms=<t>              (one per timed iteration)
+//   GFLOPS=<x>               (from the mean timed step)
+//   checksum=<v> expected=<e>
+//   RESULT=PERF_OK | RESULT=PERF_FAIL
+//
+// A=1.0, B=1.0 so every C[i] == N; the checksum guards against a silently
+// wrong result (e.g. a broken runtime) turning a perf number meaningless.
+
+#include <hip/hip_runtime.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define TILE 16
+
+#define HIP_CHECK(cmd)                                                        \
+  do {                                                                        \
+    hipError_t _e = (cmd);                                                    \
+    if (_e != hipSuccess) {                                                   \
+      printf("HIP_ERR %s at %s:%d\n", hipGetErrorString(_e), __FILE__,        \
+             __LINE__);                                                       \
+      printf("RESULT=PERF_FAIL\n");                                           \
+      return 2;                                                               \
+    }                                                                         \
+  } while (0)
+
+__global__ void sgemm_tiled(const float* A, const float* B, float* C, int N) {
+  __shared__ float As[TILE][TILE];
+  __shared__ float Bs[TILE][TILE];
+  int row = blockIdx.y * TILE + threadIdx.y;
+  int col = blockIdx.x * TILE + threadIdx.x;
+  float acc = 0.0f;
+  for (int t = 0; t < N; t += TILE) {
+    As[threadIdx.y][threadIdx.x] =
+        (row < N && t + threadIdx.x < N) ? A[row * N + t + threadIdx.x] : 0.0f;
+    Bs[threadIdx.y][threadIdx.x] =
+        (col < N && t + threadIdx.y < N) ? B[(t + threadIdx.y) * N + col] : 0.0f;
+    __syncthreads();
+    for (int k = 0; k < TILE; ++k) acc += As[threadIdx.y][k] * Bs[k][threadIdx.x];
+    __syncthreads();
+  }
+  if (row < N && col < N) C[row * N + col] = acc;
+}
+
+int main(int argc, char** argv) {
+  int N = (argc > 1) ? atoi(argv[1]) : 4096;
+  int iters = (argc > 2) ? atoi(argv[2]) : 50;
+  int warmup = (argc > 3) ? atoi(argv[3]) : 10;
+  if (N <= 0 || iters <= 0 || warmup < 0) {
+    printf("bad args: size iters warmup must be positive\nRESULT=PERF_FAIL\n");
+    return 2;
+  }
+  printf("bench=gemm size=%d iters=%d warmup=%d\n", N, iters, warmup);
+
+  size_t elems = (size_t)N * (size_t)N;
+  size_t bytes = elems * sizeof(float);
+
+  std::vector<float> hA(elems, 1.0f), hB(elems, 1.0f);
+  float *dA = nullptr, *dB = nullptr, *dC = nullptr;
+  HIP_CHECK(hipMalloc(&dA, bytes));
+  HIP_CHECK(hipMalloc(&dB, bytes));
+  HIP_CHECK(hipMalloc(&dC, bytes));
+  HIP_CHECK(hipMemcpy(dA, hA.data(), bytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(dB, hB.data(), bytes, hipMemcpyHostToDevice));
+
+  dim3 block(TILE, TILE);
+  dim3 grid((N + TILE - 1) / TILE, (N + TILE - 1) / TILE);
+
+  for (int i = 0; i < warmup; ++i) {
+    sgemm_tiled<<<grid, block>>>(dA, dB, dC, N);
+  }
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  double total_ms = 0.0;
+  for (int i = 0; i < iters; ++i) {
+    auto t0 = std::chrono::steady_clock::now();
+    sgemm_tiled<<<grid, block>>>(dA, dB, dC, N);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    auto t1 = std::chrono::steady_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    total_ms += ms;
+    printf("step_ms=%.4f\n", ms);
+  }
+
+  std::vector<float> hC(elems);
+  HIP_CHECK(hipMemcpy(hC.data(), dC, bytes, hipMemcpyDeviceToHost));
+
+  double mean_ms = total_ms / iters;
+  double gflops = (2.0 * (double)N * (double)N * (double)N) / (mean_ms / 1e3) / 1e9;
+  printf("GFLOPS=%.2f\n", gflops);
+  printf("checksum=%.1f expected=%d\n", hC[0], N);
+
+  HIP_CHECK(hipFree(dA));
+  HIP_CHECK(hipFree(dB));
+  HIP_CHECK(hipFree(dC));
+
+  bool ok = (hC[0] == (float)N);
+  printf("RESULT=%s\n", ok ? "PERF_OK" : "PERF_FAIL");
+  return ok ? 0 : 1;
+}

--- a/src/aorta/workloads/hrx_kernels/hrx_perf_triad.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_perf_triad.cpp
@@ -1,0 +1,104 @@
+// HRX perf benchmark: bandwidth-bound STREAM triad (a[i] = b[i] + s*c[i]).
+//
+// Part of the `hrx_perf` aorta workload. A memory-bound counterpart to the
+// GEMM bench: each timed iteration touches 3 * size * 4 bytes of HBM, so the
+// reported GB/s reflects achieved bandwidth. Per-iteration time is measured
+// host-side (steady_clock around launch + hipDeviceSynchronize) so it includes
+// runtime/launch overhead -- the axis on which HRX can differ from stock HIP.
+//
+// Output (parsed by src/aorta/workloads/hrx_perf.py):
+//   bench=triad size=<N> iters=<M> warmup=<W>
+//   step_ms=<t>              (one per timed iteration)
+//   GBPS=<x>                 (effective HBM bandwidth from the mean timed step)
+//   checksum=<v> expected=<e>
+//   RESULT=PERF_OK | RESULT=PERF_FAIL
+
+#include <hip/hip_runtime.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+#define BLOCK 256
+
+#define HIP_CHECK(cmd)                                                        \
+  do {                                                                        \
+    hipError_t _e = (cmd);                                                    \
+    if (_e != hipSuccess) {                                                   \
+      printf("HIP_ERR %s at %s:%d\n", hipGetErrorString(_e), __FILE__,        \
+             __LINE__);                                                       \
+      printf("RESULT=PERF_FAIL\n");                                           \
+      return 2;                                                               \
+    }                                                                         \
+  } while (0)
+
+__global__ void fill(float* x, float v, size_t n) {
+  size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) x[i] = v;
+}
+
+__global__ void triad(float* a, const float* b, const float* c, float s, size_t n) {
+  size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) a[i] = b[i] + s * c[i];
+}
+
+int main(int argc, char** argv) {
+  size_t N = (argc > 1) ? (size_t)strtoull(argv[1], nullptr, 10) : 64000000ULL;
+  int iters = (argc > 2) ? atoi(argv[2]) : 100;
+  int warmup = (argc > 3) ? atoi(argv[3]) : 20;
+  if (N == 0 || iters <= 0 || warmup < 0) {
+    printf("bad args: size iters warmup must be positive\nRESULT=PERF_FAIL\n");
+    return 2;
+  }
+  printf("bench=triad size=%zu iters=%d warmup=%d\n", N, iters, warmup);
+
+  size_t bytes = N * sizeof(float);
+  float *da = nullptr, *db = nullptr, *dc = nullptr;
+  HIP_CHECK(hipMalloc(&da, bytes));
+  HIP_CHECK(hipMalloc(&db, bytes));
+  HIP_CHECK(hipMalloc(&dc, bytes));
+
+  size_t grid = (N + BLOCK - 1) / BLOCK;
+  const float scalar = 3.0f;
+  fill<<<grid, BLOCK>>>(db, 1.0f, N);
+  fill<<<grid, BLOCK>>>(dc, 2.0f, N);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  for (int i = 0; i < warmup; ++i) {
+    triad<<<grid, BLOCK>>>(da, db, dc, scalar, N);
+  }
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  double total_ms = 0.0;
+  for (int i = 0; i < iters; ++i) {
+    auto t0 = std::chrono::steady_clock::now();
+    triad<<<grid, BLOCK>>>(da, db, dc, scalar, N);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    auto t1 = std::chrono::steady_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    total_ms += ms;
+    printf("step_ms=%.4f\n", ms);
+  }
+
+  float a0 = 0.0f;
+  HIP_CHECK(hipMemcpy(&a0, da, sizeof(float), hipMemcpyDeviceToHost));
+
+  double mean_ms = total_ms / iters;
+  // Triad moves 3 arrays per iteration: read b, read c, write a.
+  double gbps = (3.0 * (double)N * sizeof(float)) / (mean_ms / 1e3) / 1e9;
+  printf("GBPS=%.2f\n", gbps);
+  float expected = 1.0f + scalar * 2.0f;  // 7.0
+  printf("checksum=%.1f expected=%.1f\n", a0, expected);
+
+  HIP_CHECK(hipFree(da));
+  HIP_CHECK(hipFree(db));
+  HIP_CHECK(hipFree(dc));
+
+  bool ok = (fabsf(a0 - expected) < 1e-3f);
+  printf("RESULT=%s\n", ok ? "PERF_OK" : "PERF_FAIL");
+  return ok ? 0 : 1;
+}

--- a/src/aorta/workloads/hrx_kernels/hrx_probe.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_probe.cpp
@@ -39,5 +39,8 @@ int main() {
   else if (out_h[0] == 100.0f) printf("VERDICT=INPUT_READ_ZERO (H2D/in-arg broken)\n");
   else if (out_h[0] == 0.0f)   printf("VERDICT=OUTPUT_NOT_WRITTEN (kernel-write/out-arg broken)\n");
   else                         printf("VERDICT=GARBAGE (address mismatch)\n");
-  return 0;
+  // Exit 0 on 107 (works), 1 otherwise -- mirrors the other probe variants so
+  // downstream tooling can tell success from failure by exit code even if
+  // stdout parsing changes.
+  return out_h[0] == 107.0f ? 0 : 1;
 }

--- a/src/aorta/workloads/hrx_kernels/hrx_probe.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_probe.cpp
@@ -1,0 +1,43 @@
+// hrx_probe.cpp — localizes the HRX wrong-result bug.
+// out[i] = in[i] + 100, with in=7 and out pre-set to 0 via hipMemset.
+//   107 -> fully works (read + write + copies all OK)
+//   100 -> input read as 0 (H2D / input-arg broken)
+//     0 -> output write never reached host buffer (kernel-write / out-arg broken)
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+
+__global__ void add100(float* out, const float* in, unsigned long n) {
+  unsigned long i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i] + 100.0f;
+}
+
+#define CK(c) do{ hipError_t e=(c); if(e!=hipSuccess){ \
+  printf("HIP_ERR %s at %d: %s\n",#c,__LINE__,hipGetErrorString(e)); return 2;} }while(0)
+
+int main() {
+  const unsigned long N = 1000000;
+  const size_t bytes = N * sizeof(float);
+  float* in_h  = (float*)malloc(bytes);
+  float* out_h = (float*)malloc(bytes);
+  for (unsigned long i = 0; i < N; i++) { in_h[i] = 7.0f; out_h[i] = -1.0f; }
+
+  float *in_d, *out_d;
+  CK(hipMalloc(&in_d, bytes));
+  CK(hipMalloc(&out_d, bytes));
+  CK(hipMemset(out_d, 0, bytes));                               // out_d = 0
+  CK(hipMemcpy(in_d, in_h, bytes, hipMemcpyHostToDevice));      // in_d  = 7
+  CK(hipDeviceSynchronize());
+
+  add100<<<(N + 255) / 256, 256>>>(out_d, in_d, N);
+  CK(hipDeviceSynchronize());
+  CK(hipMemcpy(out_h, out_d, bytes, hipMemcpyDeviceToHost));
+  CK(hipDeviceSynchronize());
+
+  printf("out[0]=%g (expect 107)\n", out_h[0]);
+  if      (out_h[0] == 107.0f) printf("VERDICT=FULLY_WORKS\n");
+  else if (out_h[0] == 100.0f) printf("VERDICT=INPUT_READ_ZERO (H2D/in-arg broken)\n");
+  else if (out_h[0] == 0.0f)   printf("VERDICT=OUTPUT_NOT_WRITTEN (kernel-write/out-arg broken)\n");
+  else                         printf("VERDICT=GARBAGE (address mismatch)\n");
+  return 0;
+}

--- a/src/aorta/workloads/hrx_kernels/hrx_probe_graph_add.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_probe_graph_add.cpp
@@ -1,0 +1,76 @@
+// hrx_probe_graph_add.cpp - isolates the hipGraphAddKernelNode "extra"
+// (HIP_LAUNCH_PARAM pre-packed buffer) path. Nothing else touches the node.
+//
+// add100: out[i] = in[i] + 100, in=7, out pre-set to 0.
+//   107 -> FULLY_WORKS
+//   100 -> INPUT_READ_ZERO
+//     0 -> OUTPUT_NOT_WRITTEN (graph AddKernelNode extra/out-arg not resolved)
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+__global__ void add100(float* out, const float* in, unsigned long n) {
+  unsigned long i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i] + 100.0f;
+}
+
+#define CK(c) do{ hipError_t e=(c); if(e!=hipSuccess){ \
+  printf("HIP_ERR %s at %d: %s\n",#c,__LINE__,hipGetErrorString(e)); return 2;} }while(0)
+
+struct Args { void* out; void* in; unsigned long n; };
+
+static const char* verdict(float v) {
+  if (v == 107.0f) return "FULLY_WORKS";
+  if (v == 100.0f) return "INPUT_READ_ZERO";
+  if (v == 0.0f)   return "OUTPUT_NOT_WRITTEN (AddKernelNode extra/out-arg broken)";
+  return "GARBAGE";
+}
+
+int main() {
+  const unsigned long N = 1000000;
+  const size_t bytes = N * sizeof(float);
+  float* in_h  = (float*)malloc(bytes);
+  float* out_h = (float*)malloc(bytes);
+  for (unsigned long i = 0; i < N; i++) { in_h[i] = 7.0f; out_h[i] = -1.0f; }
+
+  float *in_d, *out_d;
+  CK(hipMalloc(&in_d, bytes));
+  CK(hipMalloc(&out_d, bytes));
+  CK(hipMemset(out_d, 0, bytes));
+  CK(hipMemcpy(in_d, in_h, bytes, hipMemcpyHostToDevice));
+  CK(hipDeviceSynchronize());
+
+  Args args; args.out = out_d; args.in = in_d; args.n = N;
+  size_t arg_size = sizeof(args);
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args,
+                    HIP_LAUNCH_PARAM_BUFFER_SIZE, &arg_size,
+                    HIP_LAUNCH_PARAM_END};
+
+  const unsigned block = 256;
+  const unsigned grid  = (N + block - 1) / block;
+
+  hipKernelNodeParams kp;
+  memset(&kp, 0, sizeof(kp));
+  kp.func = (void*)add100;
+  kp.gridDim = dim3(grid, 1, 1);
+  kp.blockDim = dim3(block, 1, 1);
+  kp.sharedMemBytes = 0;
+  kp.kernelParams = NULL;
+  kp.extra = config;  // <-- the path under test
+
+  hipGraph_t graph;
+  CK(hipGraphCreate(&graph, 0));
+  hipGraphNode_t knode;
+  CK(hipGraphAddKernelNode(&knode, graph, NULL, 0, &kp));
+  hipGraphExec_t exec;
+  CK(hipGraphInstantiate(&exec, graph, NULL, NULL, 0));
+  CK(hipGraphLaunch(exec, 0));
+  CK(hipDeviceSynchronize());
+  CK(hipMemcpy(out_h, out_d, bytes, hipMemcpyDeviceToHost));
+  CK(hipDeviceSynchronize());
+
+  printf("out[0]=%g (expect 107)\n", out_h[0]);
+  printf("VERDICT=%s\n", verdict(out_h[0]));
+  return out_h[0] == 107.0f ? 0 : 1;
+}

--- a/src/aorta/workloads/hrx_kernels/hrx_probe_graph_execsetparams.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_probe_graph_execsetparams.cpp
@@ -1,0 +1,97 @@
+// hrx_probe_graph_execsetparams.cpp - isolates the hipGraphExecKernelNodeSetParams
+// "extra" (HIP_LAUNCH_PARAM pre-packed buffer) path, which updates an already
+// INSTANTIATED (executable) graph in place.
+//
+// Setup uses kernelParams (known-good ARGS_ARRAY path) for both the node add and
+// the initial instantiate, so this repro exercises ONLY the exec-update-with-
+// extra path. hipGraphExecKernelNodeSetParams delegates to
+// hipGraphKernelNodeSetParams internally, then rebuilds the executable graph.
+//
+// add100: out[i] = in[i] + 100, in=7, out pre-set to 0.
+//   107 -> FULLY_WORKS
+//   100 -> INPUT_READ_ZERO
+//     0 -> OUTPUT_NOT_WRITTEN (ExecKernelNodeSetParams extra/out-arg broken)
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+__global__ void add100(float* out, const float* in, unsigned long n) {
+  unsigned long i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i] + 100.0f;
+}
+
+#define CK(c) do{ hipError_t e=(c); if(e!=hipSuccess){ \
+  printf("HIP_ERR %s at %d: %s\n",#c,__LINE__,hipGetErrorString(e)); return 2;} }while(0)
+
+struct Args { void* out; void* in; unsigned long n; };
+
+static const char* verdict(float v) {
+  if (v == 107.0f) return "FULLY_WORKS";
+  if (v == 100.0f) return "INPUT_READ_ZERO";
+  if (v == 0.0f)   return "OUTPUT_NOT_WRITTEN (ExecKernelNodeSetParams extra/out-arg broken)";
+  return "GARBAGE";
+}
+
+int main() {
+  const unsigned long N = 1000000;
+  const size_t bytes = N * sizeof(float);
+  float* in_h  = (float*)malloc(bytes);
+  float* out_h = (float*)malloc(bytes);
+  for (unsigned long i = 0; i < N; i++) { in_h[i] = 7.0f; out_h[i] = -1.0f; }
+
+  float *in_d, *out_d;
+  CK(hipMalloc(&in_d, bytes));
+  CK(hipMalloc(&out_d, bytes));
+  CK(hipMemset(out_d, 0, bytes));
+  CK(hipMemcpy(in_d, in_h, bytes, hipMemcpyHostToDevice));
+  CK(hipDeviceSynchronize());
+
+  const unsigned block = 256;
+  const unsigned grid  = (N + block - 1) / block;
+
+  hipGraph_t graph;
+  CK(hipGraphCreate(&graph, 0));
+
+  // --- Add node + instantiate via kernelParams (known-good ARGS_ARRAY path) --
+  unsigned long n_val = N;
+  void* kernel_params[] = {&out_d, &in_d, &n_val};
+  hipKernelNodeParams kp_add;
+  memset(&kp_add, 0, sizeof(kp_add));
+  kp_add.func = (void*)add100;
+  kp_add.gridDim = dim3(grid, 1, 1);
+  kp_add.blockDim = dim3(block, 1, 1);
+  kp_add.sharedMemBytes = 0;
+  kp_add.kernelParams = kernel_params;
+  kp_add.extra = NULL;
+  hipGraphNode_t knode;
+  CK(hipGraphAddKernelNode(&knode, graph, NULL, 0, &kp_add));
+
+  hipGraphExec_t exec;
+  CK(hipGraphInstantiate(&exec, graph, NULL, NULL, 0));
+
+  // --- Update the EXECUTABLE graph node via extra (path under test) ---------
+  Args args; args.out = out_d; args.in = in_d; args.n = N;
+  size_t arg_size = sizeof(args);
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args,
+                    HIP_LAUNCH_PARAM_BUFFER_SIZE, &arg_size,
+                    HIP_LAUNCH_PARAM_END};
+  hipKernelNodeParams kp_set;
+  memset(&kp_set, 0, sizeof(kp_set));
+  kp_set.func = (void*)add100;
+  kp_set.gridDim = dim3(grid, 1, 1);
+  kp_set.blockDim = dim3(block, 1, 1);
+  kp_set.sharedMemBytes = 0;
+  kp_set.kernelParams = NULL;
+  kp_set.extra = config;  // <-- the path under test
+  CK(hipGraphExecKernelNodeSetParams(exec, knode, &kp_set));
+
+  CK(hipGraphLaunch(exec, 0));
+  CK(hipDeviceSynchronize());
+  CK(hipMemcpy(out_h, out_d, bytes, hipMemcpyDeviceToHost));
+  CK(hipDeviceSynchronize());
+
+  printf("out[0]=%g (expect 107)\n", out_h[0]);
+  printf("VERDICT=%s\n", verdict(out_h[0]));
+  return out_h[0] == 107.0f ? 0 : 1;
+}

--- a/src/aorta/workloads/hrx_kernels/hrx_probe_graph_setparams.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_probe_graph_setparams.cpp
@@ -1,0 +1,97 @@
+// hrx_probe_graph_setparams.cpp - isolates the hipGraphKernelNodeSetParams
+// "extra" (HIP_LAUNCH_PARAM pre-packed buffer) path.
+//
+// The node is FIRST created with kernelParams (the ARGS_ARRAY path, a different
+// and known-good mechanism), then updated via hipGraphKernelNodeSetParams using
+// the `extra` buffer - so this repro exercises ONLY the SetParams-with-extra
+// path, independent of hipGraphAddKernelNode-with-extra. The graph is
+// instantiated AFTER SetParams so the launch reflects the updated params.
+//
+// add100: out[i] = in[i] + 100, in=7, out pre-set to 0.
+//   107 -> FULLY_WORKS
+//   100 -> INPUT_READ_ZERO
+//     0 -> OUTPUT_NOT_WRITTEN (SetParams extra/out-arg not resolved)
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+__global__ void add100(float* out, const float* in, unsigned long n) {
+  unsigned long i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i] + 100.0f;
+}
+
+#define CK(c) do{ hipError_t e=(c); if(e!=hipSuccess){ \
+  printf("HIP_ERR %s at %d: %s\n",#c,__LINE__,hipGetErrorString(e)); return 2;} }while(0)
+
+struct Args { void* out; void* in; unsigned long n; };
+
+static const char* verdict(float v) {
+  if (v == 107.0f) return "FULLY_WORKS";
+  if (v == 100.0f) return "INPUT_READ_ZERO";
+  if (v == 0.0f)   return "OUTPUT_NOT_WRITTEN (SetParams extra/out-arg broken)";
+  return "GARBAGE";
+}
+
+int main() {
+  const unsigned long N = 1000000;
+  const size_t bytes = N * sizeof(float);
+  float* in_h  = (float*)malloc(bytes);
+  float* out_h = (float*)malloc(bytes);
+  for (unsigned long i = 0; i < N; i++) { in_h[i] = 7.0f; out_h[i] = -1.0f; }
+
+  float *in_d, *out_d;
+  CK(hipMalloc(&in_d, bytes));
+  CK(hipMalloc(&out_d, bytes));
+  CK(hipMemset(out_d, 0, bytes));
+  CK(hipMemcpy(in_d, in_h, bytes, hipMemcpyHostToDevice));
+  CK(hipDeviceSynchronize());
+
+  const unsigned block = 256;
+  const unsigned grid  = (N + block - 1) / block;
+
+  hipGraph_t graph;
+  CK(hipGraphCreate(&graph, 0));
+
+  // --- Create the node via kernelParams (known-good ARGS_ARRAY path) --------
+  unsigned long n_val = N;
+  void* kernel_params[] = {&out_d, &in_d, &n_val};
+  hipKernelNodeParams kp_add;
+  memset(&kp_add, 0, sizeof(kp_add));
+  kp_add.func = (void*)add100;
+  kp_add.gridDim = dim3(grid, 1, 1);
+  kp_add.blockDim = dim3(block, 1, 1);
+  kp_add.sharedMemBytes = 0;
+  kp_add.kernelParams = kernel_params;
+  kp_add.extra = NULL;
+  hipGraphNode_t knode;
+  CK(hipGraphAddKernelNode(&knode, graph, NULL, 0, &kp_add));
+
+  // --- Update the SAME node via SetParams using `extra` (path under test) ---
+  Args args; args.out = out_d; args.in = in_d; args.n = N;
+  size_t arg_size = sizeof(args);
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args,
+                    HIP_LAUNCH_PARAM_BUFFER_SIZE, &arg_size,
+                    HIP_LAUNCH_PARAM_END};
+  hipKernelNodeParams kp_set;
+  memset(&kp_set, 0, sizeof(kp_set));
+  kp_set.func = (void*)add100;
+  kp_set.gridDim = dim3(grid, 1, 1);
+  kp_set.blockDim = dim3(block, 1, 1);
+  kp_set.sharedMemBytes = 0;
+  kp_set.kernelParams = NULL;
+  kp_set.extra = config;  // <-- the path under test
+  CK(hipGraphKernelNodeSetParams(knode, &kp_set));
+
+  // Instantiate AFTER SetParams so the launch reflects the updated params.
+  hipGraphExec_t exec;
+  CK(hipGraphInstantiate(&exec, graph, NULL, NULL, 0));
+  CK(hipGraphLaunch(exec, 0));
+  CK(hipDeviceSynchronize());
+  CK(hipMemcpy(out_h, out_d, bytes, hipMemcpyDeviceToHost));
+  CK(hipDeviceSynchronize());
+
+  printf("out[0]=%g (expect 107)\n", out_h[0]);
+  printf("VERDICT=%s\n", verdict(out_h[0]));
+  return out_h[0] == 107.0f ? 0 : 1;
+}

--- a/src/aorta/workloads/hrx_kernels/hrx_probe_module.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_probe_module.cpp
@@ -1,0 +1,80 @@
+// hrx_probe_module.cpp - dynamic-module-launch variant of hrx_probe.
+//
+// Same computation and verdict logic as hrx_probe (out[i] = in[i] + 100, in=7,
+// out pre-set to 0), but the kernel is loaded at runtime from a SEPARATE code
+// object (hrx_probe_module_kernel.code) via the HIP driver/module API
+// (hipModuleLoad -> hipModuleGetFunction -> hipModuleLaunchKernel) instead of the
+// statically-registered hipLaunchKernelGGL path.
+//
+// Verdict from out[0]:
+//   107 -> FULLY_WORKS (read + write + copies all OK)
+//   100 -> INPUT_READ_ZERO (H2D / input-arg broken)
+//     0 -> OUTPUT_NOT_WRITTEN (module-launch kernel-write / out-arg broken)
+//
+// Loads the .code from next to the executable, so it runs from any cwd.
+// Exits 0 on 107 (works), 1 otherwise.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <unistd.h>
+#include <libgen.h>
+#include <string>
+
+#define CK(c) do{ hipError_t e=(c); if(e!=hipSuccess){ \
+  printf("HIP_ERR %s at %d: %s\n",#c,__LINE__,hipGetErrorString(e)); return 2;} }while(0)
+
+static std::string exe_dir() {
+  char buf[4096];
+  ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+  if (n < 0) return ".";
+  buf[n] = '\0';
+  return std::string(dirname(buf));
+}
+
+int main() {
+  const unsigned long N = 1000000;
+  const size_t bytes = N * sizeof(float);
+  float* in_h  = (float*)malloc(bytes);
+  float* out_h = (float*)malloc(bytes);
+  for (unsigned long i = 0; i < N; i++) { in_h[i] = 7.0f; out_h[i] = -1.0f; }
+
+  float *in_d, *out_d;
+  CK(hipMalloc(&in_d, bytes));
+  CK(hipMalloc(&out_d, bytes));
+  CK(hipMemset(out_d, 0, bytes));                               // out_d = 0
+  CK(hipMemcpy(in_d, in_h, bytes, hipMemcpyHostToDevice));      // in_d  = 7
+  CK(hipDeviceSynchronize());
+
+  std::string code_path = exe_dir() + "/hrx_probe_module_kernel.code";
+  printf("info: hipModuleLoad %s\n", code_path.c_str());
+  hipModule_t module;
+  hipFunction_t func;
+  CK(hipModuleLoad(&module, code_path.c_str()));
+  CK(hipModuleGetFunction(&func, module, "add100"));
+
+  struct { void* out; void* in; unsigned long n; } args;
+  args.out = out_d;
+  args.in  = in_d;
+  args.n   = N;
+  size_t arg_size = sizeof(args);
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args,
+                    HIP_LAUNCH_PARAM_BUFFER_SIZE, &arg_size,
+                    HIP_LAUNCH_PARAM_END};
+
+  const unsigned block = 256;
+  const unsigned grid  = (N + block - 1) / block;
+  printf("info: hipModuleLaunchKernel 'add100'\n");
+  CK(hipModuleLaunchKernel(func, grid, 1, 1, block, 1, 1, 0, 0, NULL, (void**)&config));
+  CK(hipDeviceSynchronize());
+
+  CK(hipMemcpy(out_h, out_d, bytes, hipMemcpyDeviceToHost));
+  CK(hipDeviceSynchronize());
+
+  printf("out[0]=%g (expect 107)\n", out_h[0]);
+  if      (out_h[0] == 107.0f) printf("VERDICT=FULLY_WORKS\n");
+  else if (out_h[0] == 100.0f) printf("VERDICT=INPUT_READ_ZERO (H2D/in-arg broken)\n");
+  else if (out_h[0] == 0.0f)   printf("VERDICT=OUTPUT_NOT_WRITTEN (module-launch out-arg broken)\n");
+  else                         printf("VERDICT=GARBAGE (address mismatch)\n");
+
+  return out_h[0] == 107.0f ? 0 : 1;
+}

--- a/src/aorta/workloads/hrx_kernels/hrx_probe_module_kernel.cpp
+++ b/src/aorta/workloads/hrx_kernels/hrx_probe_module_kernel.cpp
@@ -1,0 +1,9 @@
+// Device kernel for the dynamic-module-launch repro.
+// Compiled to a SEPARATE code object via `hipcc --genco --offload-arch=gfx942`.
+// extern "C" keeps the symbol name "add100" for hipModuleGetFunction.
+#include <hip/hip_runtime.h>
+
+extern "C" __global__ void add100(float* out, const float* in, unsigned long n) {
+  unsigned long i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i] + 100.0f;
+}

--- a/src/aorta/workloads/hrx_perf.py
+++ b/src/aorta/workloads/hrx_perf.py
@@ -165,7 +165,14 @@ class HrxPerfWorkload(Workload):
         self._bench, self._size, self._iters, self._warmup = self._validated_config()
         self._spec = _BENCHES[self._bench]
         self._arch = str(self.config.get("gpu_arch", _DEFAULT_ARCH))
+        # Validate here: subprocess.run(..., timeout=<=0) would raise at run()
+        # time and be misclassified as an infrastructure failure. Fail fast in
+        # setup() with a clear config error instead.
         self._timeout = int(self.config.get("timeout_sec", _DEFAULT_TIMEOUT_SEC))
+        if self._timeout <= 0:
+            raise ValueError(
+                f"hrx_perf: timeout_sec ({self._timeout}) must be > 0"
+            )
         keep_build = self.config.get("keep_build", False)
         if not isinstance(keep_build, bool):
             raise ValueError(

--- a/src/aorta/workloads/hrx_perf.py
+++ b/src/aorta/workloads/hrx_perf.py
@@ -1,0 +1,334 @@
+"""HRX performance benchmark workload.
+
+Companion to the correctness-focused :mod:`aorta.workloads.hrx` probe workload.
+Where ``hrx`` answers "does this HIP launch path produce the right bytes under
+HRX?", ``hrx_perf`` answers "how *fast* is it under HRX vs stock ROCm HIP?".
+
+It builds one of a small set of deliberately *big* HIP benchmarks with
+``hipcc`` at :meth:`setup` and execs it as a child process:
+
+    * ``gemm``  -- compute-bound tiled SGEMM (C = A*B, N x N floats).
+    * ``triad`` -- bandwidth-bound STREAM triad (a = b + s*c over N floats).
+
+Each bench runs ``warmup`` untimed then ``iters`` timed iterations, timing each
+iteration host-side (launch + ``hipDeviceSynchronize``) so the per-step number
+includes runtime/launch overhead -- the axis on which an alternate HIP runtime
+can differ. Those per-iteration times are reported as
+:attr:`WorkloadResult.step_times_ms`, so ``aorta sweep run``'s matrix renders a
+per-cell **Mean step (ms)** and a confound ratio between the ``hrx_on`` and
+``hrx_off`` cells -- i.e. the HRX-vs-stock speed comparison. Achieved throughput
+(GFLOP/s or GB/s) is reported in :attr:`WorkloadResult.metrics`.
+
+Runtime routing (HRX vs stock HIP) is an environment concern, identical to the
+``hrx`` workload: the ``hrx_on`` cell injects an ``LD_PRELOAD`` +
+``LD_LIBRARY_PATH`` + ``HRX_GPU_DRIVER`` bundle that takes effect at the
+probe's ``exec()``. The same guards apply -- the bundle is stripped from the
+``hipcc`` build env, a nonexistent ``LD_PRELOAD`` fails setup, and an ignored
+preload fails the run -- so a misrouted cell can't silently benchmark the wrong
+runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+from aorta.workloads._base import Workload, WorkloadResult
+from aorta.workloads.hrx import (
+    _LDSO_PRELOAD_IGNORED_RE,
+    _build_env,
+    _missing_preload_objects,
+    _resolve_hipcc,
+)
+
+log = logging.getLogger(__name__)
+
+_KERNELS_DIR = Path(__file__).parent / "hrx_kernels"
+
+_PASS_RESULT = "PERF_OK"
+_RESULT_RE = re.compile(r"^RESULT=([A-Z_]+)", re.MULTILINE)
+_STEP_RE = re.compile(r"^step_ms=([-\d.eE+]+)", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class _BenchSpec:
+    """Build + parse recipe for one benchmark.
+
+    Attributes:
+        source: vendored ``.cpp`` compiled to the benchmark executable.
+        binary: output executable name.
+        throughput_token: stdout token carrying the achieved throughput
+            (``GFLOPS`` or ``GBPS``).
+        throughput_metric: key under which the parsed throughput lands in
+            ``WorkloadResult.metrics``.
+        default_size: problem size when ``workload_config.size`` is unset
+            (matrix dimension N for gemm; element count for triad).
+    """
+
+    source: str
+    binary: str
+    throughput_token: str
+    throughput_metric: str
+    default_size: int
+
+
+_BENCHES: dict[str, _BenchSpec] = {
+    "gemm": _BenchSpec("hrx_perf_gemm.cpp", "hrx_perf_gemm", "GFLOPS", "gflops", 4096),
+    "triad": _BenchSpec("hrx_perf_triad.cpp", "hrx_perf_triad", "GBPS", "gbps", 64_000_000),
+}
+
+_DEFAULT_BENCH = "gemm"
+_DEFAULT_ARCH = "gfx942"
+_DEFAULT_ITERS = 50
+_DEFAULT_WARMUP = 10
+_DEFAULT_TIMEOUT_SEC = 600
+
+_RESERVED_KEYS = {"steps"}
+_KNOWN_KEYS = {
+    "bench",
+    "gpu_arch",
+    "size",
+    "iters",
+    "warmup",
+    "hipcc",
+    "build_dir",
+    "timeout_sec",
+    "keep_build",
+}
+
+
+class HrxPerfWorkload(Workload):
+    """Build and time a big HIP benchmark; report per-step times + throughput.
+
+    ``workload_config`` keys:
+        bench: which benchmark to run (default ``"gemm"``); ``gemm`` or ``triad``.
+        gpu_arch: ``--offload-arch`` target (default ``"gfx942"``).
+        size: problem size (gemm: matrix dim N; triad: element count).
+            Defaults per bench (gemm 4096, triad 64e6).
+        iters: timed iterations (default ``50``).
+        warmup: untimed warmup iterations (default ``10``).
+        hipcc: explicit hipcc path (default: ``$HIPCC`` /
+            ``/opt/rocm/bin/hipcc`` / ``hipcc`` on PATH).
+        build_dir: directory for built binaries (default: a temp dir removed
+            on cleanup unless ``keep_build`` is set).
+        timeout_sec: per-run subprocess timeout (default ``600``).
+        keep_build: keep ``build_dir`` after cleanup (default ``False``).
+    """
+
+    name: ClassVar[str] = "hrx_perf"
+
+    def _validated_config(self) -> tuple[str, int, int, int]:
+        for key in self.config:
+            if key in _KNOWN_KEYS or key in _RESERVED_KEYS or key.startswith("_aorta_"):
+                continue
+            log.warning("hrx_perf: ignoring unknown workload_config key %r", key)
+        bench = self.config.get("bench", _DEFAULT_BENCH)
+        if bench not in _BENCHES:
+            raise ValueError(
+                f"hrx_perf: unknown bench {bench!r}; choose one of {sorted(_BENCHES)}"
+            )
+        spec = _BENCHES[bench]
+        size = int(self.config.get("size", spec.default_size))
+        iters = int(self.config.get("iters", _DEFAULT_ITERS))
+        warmup = int(self.config.get("warmup", _DEFAULT_WARMUP))
+        if size <= 0 or iters <= 0 or warmup < 0:
+            raise ValueError(
+                f"hrx_perf: size ({size}) and iters ({iters}) must be > 0 and "
+                f"warmup ({warmup}) must be >= 0"
+            )
+        return bench, size, iters, warmup
+
+    def setup(self) -> None:
+        # Same fail-fast guard as the hrx workload: a nonexistent LD_PRELOAD is
+        # only a loader warning, so an hrx_on cell would otherwise benchmark the
+        # DEFAULT HIP runtime and report a meaningless comparison.
+        missing = _missing_preload_objects()
+        if missing:
+            raise RuntimeError(
+                "hrx_perf: LD_PRELOAD names object(s) that do not exist: "
+                + ", ".join(repr(m) for m in missing)
+                + ". The dynamic loader would ignore these with only a stderr "
+                "warning and run the benchmark against the DEFAULT HIP runtime, "
+                "so the cell would silently measure stock HIP. Fix the path(s) "
+                "in the cell's extra_env (absolute paths)."
+            )
+        self._bench, self._size, self._iters, self._warmup = self._validated_config()
+        self._spec = _BENCHES[self._bench]
+        self._arch = str(self.config.get("gpu_arch", _DEFAULT_ARCH))
+        self._timeout = int(self.config.get("timeout_sec", _DEFAULT_TIMEOUT_SEC))
+        keep_build = self.config.get("keep_build", False)
+        if not isinstance(keep_build, bool):
+            raise ValueError(
+                f"hrx_perf: keep_build must be a bool, got {type(keep_build).__name__}"
+            )
+        self._keep_build = keep_build
+
+        hipcc = _resolve_hipcc(self.config.get("hipcc"))
+        if hipcc is None:
+            raise RuntimeError(
+                "hrx_perf: hipcc not found (looked at $HIPCC, /opt/rocm/bin/hipcc, "
+                "and PATH). This workload builds HIP benchmarks from source and "
+                "requires a ROCm/hipcc toolchain. Run it in a ROCm environment, "
+                "or set workload_config.hipcc."
+            )
+        self._hipcc = hipcc
+
+        build_dir = self.config.get("build_dir")
+        if build_dir:
+            # Absolutize: _build runs hipcc with cwd=_KERNELS_DIR and run() execs
+            # with cwd=build_dir, so a relative path would split -o from the exec.
+            self._build_dir = Path(build_dir).resolve()
+            self._build_dir.mkdir(parents=True, exist_ok=True)
+            self._owns_build_dir = False
+        else:
+            self._build_dir = Path(tempfile.mkdtemp(prefix="aorta-hrx-perf-"))
+            self._owns_build_dir = True
+
+        self._binary = self._build()
+
+    def _build(self) -> Path:
+        binary = self._build_dir / self._spec.binary
+        cmd = [
+            self._hipcc,
+            "-O3",
+            f"--offload-arch={self._arch}",
+            str(_KERNELS_DIR / self._spec.source),
+            "-o",
+            str(binary),
+        ]
+        log.debug("hrx_perf: building %s: %s", self._spec.binary, " ".join(cmd))
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=str(_KERNELS_DIR), env=_build_env()
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"hrx_perf: hipcc failed to build {self._spec.binary} "
+                f"(exit {proc.returncode}).\ncmd: {' '.join(cmd)}\n"
+                f"stderr:\n{proc.stderr.strip()}"
+            )
+        return binary
+
+    def run(self) -> WorkloadResult:
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                [str(self._binary), str(self._size), str(self._iters), str(self._warmup)],
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+                cwd=str(self._build_dir),
+            )
+            timed_out = False
+            stdout, stderr, exit_code = proc.stdout, proc.stderr, proc.returncode
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            exit_code = None
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode(errors="replace")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode(errors="replace")
+        elapsed = time.monotonic() - start
+
+        step_times = [float(m) for m in _STEP_RE.findall(stdout)]
+        result_match = _RESULT_RE.search(stdout)
+        result_token = result_match.group(1) if result_match else None
+        throughput = self._parse_throughput(stdout)
+
+        # Measurable work == at least one timed iteration. A bare RESULT line
+        # with no step_ms (only the C bad-args path, unreachable given the
+        # Python-side validation) is NOT work, so it must not mint a
+        # did-run/iteration signal for the matrix (issue #274, KB #7).
+        main_work_started = bool(step_times)
+
+        preload_requested = bool(os.environ.get("LD_PRELOAD", "").strip())
+        preload_ignored = preload_requested and bool(
+            _LDSO_PRELOAD_IGNORED_RE.search(stderr)
+        )
+
+        passed = (
+            (not timed_out)
+            and exit_code == 0
+            and result_token == _PASS_RESULT
+            and not preload_ignored
+        )
+
+        mean_step_ms = sum(step_times) / len(step_times) if step_times else None
+        metrics: dict[str, Any] = {
+            "bench": self._bench,
+            "gpu_arch": self._arch,
+            "size": self._size,
+            "iters": self._iters,
+            "warmup": self._warmup,
+            "result": result_token,
+            "mean_step_ms": mean_step_ms,
+            self._spec.throughput_metric: throughput,
+            "exit_code": exit_code,
+            "timed_out": timed_out,
+            "preload_ignored": preload_ignored,
+        }
+
+        failure_details: list[dict[str, Any]] = []
+        if not passed:
+            if preload_ignored:
+                hint = (
+                    f"bench {self._bench!r}: LD_PRELOAD was set but the loader "
+                    "ignored it (see stderr) -- the benchmark ran against the "
+                    "DEFAULT HIP runtime, so this timing does NOT reflect the "
+                    "intended runtime. Check the LD_PRELOAD path/arch/deps."
+                )
+            elif timed_out:
+                hint = f"bench {self._bench!r} timed out (>{self._timeout}s)"
+            elif result_token is None:
+                hint = (
+                    f"bench {self._bench!r} produced no RESULT line "
+                    f"(exit {exit_code}); see stdout/stderr"
+                )
+            else:
+                hint = f"bench {self._bench!r} result {result_token} (expected PERF_OK)"
+            failure_details.append(
+                {
+                    "bench": self._bench,
+                    "result": result_token,
+                    "exit_code": exit_code,
+                    "timed_out": timed_out,
+                    "preload_ignored": preload_ignored,
+                    "stdout_tail": stdout.strip()[-2000:],
+                    "stderr_tail": stderr.strip()[-2000:],
+                    "hint": hint,
+                }
+            )
+
+        executed = len(step_times)
+        return WorkloadResult(
+            passed=passed,
+            failure_count=0 if passed else 1,
+            first_failure_iteration=None,
+            failure_details=failure_details,
+            total_iterations=executed,
+            step_times_ms=step_times,
+            elapsed_sec=elapsed,
+            metrics=metrics,
+            main_work_started=main_work_started,
+            executed_iterations=executed,
+            configured_iterations=self._iters,
+        )
+
+    def _parse_throughput(self, stdout: str) -> float | None:
+        m = re.search(rf"^{self._spec.throughput_token}=([-\d.eE+]+)", stdout, re.MULTILINE)
+        return float(m.group(1)) if m else None
+
+    def cleanup(self) -> None:
+        if getattr(self, "_owns_build_dir", False) and not getattr(
+            self, "_keep_build", False
+        ):
+            shutil.rmtree(self._build_dir, ignore_errors=True)

--- a/src/aorta/workloads/hrx_perf.py
+++ b/src/aorta/workloads/hrx_perf.py
@@ -331,10 +331,17 @@ class HrxPerfWorkload(Workload):
             )
 
         executed = len(step_times)
+        # Contract (WorkloadResult): None only when passing. When we failed but
+        # timed iterations did run (e.g. a PERF_FAIL checksum after the timed
+        # loop), report a best-effort index of 0 -- the perf failure isn't tied
+        # to a single iteration, but 0 keeps us within the documented
+        # 0..total_iterations-1 range and consistent with the hrx workload. A
+        # setup-only failure/timeout (no step_times) stays None.
+        first_failure_iteration = 0 if (not passed and main_work_started) else None
         return WorkloadResult(
             passed=passed,
             failure_count=0 if passed else 1,
-            first_failure_iteration=None,
+            first_failure_iteration=first_failure_iteration,
             failure_details=failure_details,
             total_iterations=executed,
             step_times_ms=step_times,

--- a/src/aorta/workloads/hrx_perf.py
+++ b/src/aorta/workloads/hrx_perf.py
@@ -48,7 +48,9 @@ from aorta.workloads.hrx import (
     _build_env,
     _gpu_available,
     _missing_preload_objects,
+    _persist_full_logs,
     _resolve_hipcc,
+    _validated_arch,
 )
 
 log = logging.getLogger(__name__)
@@ -164,7 +166,7 @@ class HrxPerfWorkload(Workload):
             )
         self._bench, self._size, self._iters, self._warmup = self._validated_config()
         self._spec = _BENCHES[self._bench]
-        self._arch = str(self.config.get("gpu_arch", _DEFAULT_ARCH))
+        self._arch = _validated_arch(self.config.get("gpu_arch", _DEFAULT_ARCH))
         # Validate here: subprocess.run(..., timeout=<=0) would raise at run()
         # time and be misclassified as an infrastructure failure. Fail fast in
         # setup() with a clear config error instead.
@@ -277,6 +279,10 @@ class HrxPerfWorkload(Workload):
             if isinstance(stderr, bytes):
                 stderr = stderr.decode(errors="replace")
         elapsed = time.monotonic() - start
+
+        # Persist the complete child output when the run requested save_logs;
+        # failure_details below only keeps truncated tails (and only on failure).
+        _persist_full_logs(self.config, stdout, stderr)
 
         step_times = [float(m) for m in _STEP_RE.findall(stdout)]
         result_match = _RESULT_RE.search(stdout)

--- a/src/aorta/workloads/hrx_perf.py
+++ b/src/aorta/workloads/hrx_perf.py
@@ -216,18 +216,24 @@ class HrxPerfWorkload(Workload):
         self._binary = self._build()
 
     def _build(self) -> Path:
-        binary = self._build_dir / self._spec.binary
+        # Artifacts live in an arch subdir so a shared build_dir reused across
+        # differing --offload-arch builds can't reuse a benchmark compiled for a
+        # different GPU arch (the binary name encodes the bench but not the
+        # arch). size/iters/warmup are runtime argv, not compile-time, so arch
+        # is the only compile-time discriminator that needs isolating.
+        build_root = self._build_dir / self._arch
+        build_root.mkdir(parents=True, exist_ok=True)
+        binary = build_root / self._spec.binary
         # Reuse an already-built benchmark. setup() runs per trial, so a run
         # pinning a shared build_dir would otherwise recompile the same binary
         # each trial. The default build_dir is a fresh temp dir, so this only
-        # fires for an operator-supplied build_dir (assumed not shared across
-        # differing bench/arch configs -- the binary name encodes neither).
+        # fires for an operator-supplied build_dir.
         # Require the execute bit before reusing: a leftover artifact with wrong
         # permissions or a partial write would otherwise be reused and fail
         # run() with PermissionError -- a cell error rather than a recoverable
         # rebuild.
         if binary.is_file() and os.access(binary, os.X_OK):
-            log.debug("hrx_perf: reusing existing %s in %s", self._spec.binary, self._build_dir)
+            log.debug("hrx_perf: reusing existing %s in %s", self._spec.binary, build_root)
             return binary
         cmd = [
             self._hipcc,

--- a/src/aorta/workloads/hrx_perf.py
+++ b/src/aorta/workloads/hrx_perf.py
@@ -43,8 +43,10 @@ from typing import Any, ClassVar
 
 from aorta.workloads._base import Workload, WorkloadResult
 from aorta.workloads.hrx import (
+    _GPU_KFD_NODE,
     _LDSO_PRELOAD_IGNORED_RE,
     _build_env,
+    _gpu_available,
     _missing_preload_objects,
     _resolve_hipcc,
 )
@@ -181,6 +183,18 @@ class HrxPerfWorkload(Workload):
             )
         self._hipcc = hipcc
 
+        # Fail in setup() (not run()) when no GPU is reachable: a benchmark with
+        # no device produces no step times, which the matrix would treat as a
+        # did-not-run anyway, but raising here makes the classification explicit
+        # and matches the hrx workload's contract.
+        if not _gpu_available():
+            raise RuntimeError(
+                f"hrx_perf: no accessible ROCm GPU ({_GPU_KFD_NODE} is not "
+                "readable+writable). This workload times a real HIP benchmark "
+                "and needs a GPU; run it on a ROCm host (or a container started "
+                "with --device=/dev/kfd --device=/dev/dri and the render group)."
+            )
+
         build_dir = self.config.get("build_dir")
         if build_dir:
             # Absolutize: _build runs hipcc with cwd=_KERNELS_DIR and run() execs
@@ -196,6 +210,14 @@ class HrxPerfWorkload(Workload):
 
     def _build(self) -> Path:
         binary = self._build_dir / self._spec.binary
+        # Reuse an already-built benchmark. setup() runs per trial, so a run
+        # pinning a shared build_dir would otherwise recompile the same binary
+        # each trial. The default build_dir is a fresh temp dir, so this only
+        # fires for an operator-supplied build_dir (assumed not shared across
+        # differing bench/arch configs -- the binary name encodes neither).
+        if binary.is_file():
+            log.debug("hrx_perf: reusing existing %s in %s", self._spec.binary, self._build_dir)
+            return binary
         cmd = [
             self._hipcc,
             "-O3",

--- a/src/aorta/workloads/hrx_perf.py
+++ b/src/aorta/workloads/hrx_perf.py
@@ -222,7 +222,11 @@ class HrxPerfWorkload(Workload):
         # each trial. The default build_dir is a fresh temp dir, so this only
         # fires for an operator-supplied build_dir (assumed not shared across
         # differing bench/arch configs -- the binary name encodes neither).
-        if binary.is_file():
+        # Require the execute bit before reusing: a leftover artifact with wrong
+        # permissions or a partial write would otherwise be reused and fail
+        # run() with PermissionError -- a cell error rather than a recoverable
+        # rebuild.
+        if binary.is_file() and os.access(binary, os.X_OK):
             log.debug("hrx_perf: reusing existing %s in %s", self._spec.binary, self._build_dir)
             return binary
         cmd = [

--- a/tests/sweep/test_sweep_cli.py
+++ b/tests/sweep/test_sweep_cli.py
@@ -166,6 +166,54 @@ def test_triage_recipe_routes_to_workload_flow(mock_run_recipe, tmp_path):
     assert kwargs.get("subprocess_argv") is None
 
 
+def test_strict_threads_to_workload_flow(mock_run_recipe, tmp_path):
+    """`--strict` reaches run_recipe as strict=True on the workload flow."""
+    recipe = _write_triage_recipe(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["sweep", "run", "--recipe", str(recipe), "--output", str(tmp_path / "out"), "--strict"],
+    )
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_run_recipe.call_args
+    assert kwargs.get("strict") is True
+
+
+def test_strict_defaults_false_in_workload_flow(mock_run_recipe, tmp_path):
+    """Without `--strict`, run_recipe is called with strict=False (opt-in)."""
+    recipe = _write_triage_recipe(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["sweep", "run", "--recipe", str(recipe), "--output", str(tmp_path / "out")]
+    )
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_run_recipe.call_args
+    assert kwargs.get("strict") is False
+
+
+def test_strict_rejected_in_probe_flow(mock_run_recipe, tmp_path):
+    """`--strict` is a workload-flow flag; combining it with a probe run errors."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "sweep",
+            "run",
+            "--recipe",
+            str(PROBE_MINIMAL),
+            "--output",
+            str(tmp_path / "out"),
+            "--strict",
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--strict applies to the workload flow only" in result.output
+    mock_run_recipe.assert_not_called()
+
+
 def test_flag_mode_routes_to_workload_flow(mock_run_recipe, tmp_path):
     """Flag-shim (no recipe, no command) runs the workload flow."""
     runner = CliRunner()

--- a/tests/triage/test_matrix.py
+++ b/tests/triage/test_matrix.py
@@ -889,3 +889,29 @@ def test_metrics_summary_empty_for_error_cell():
     trials = [_metric_trial({"gflops": 100.0})]
     stats = _default_call(trials=trials, error="docker pull failed")
     assert stats.metrics_summary == {}
+
+
+def test_metrics_summary_skips_non_finite_values():
+    """NaN / +-Inf are not measurements and would serialize as invalid JSON
+    (``NaN`` / ``Infinity``) in matrix.json, so they are dropped entirely."""
+    trials = [
+        _metric_trial({"final_loss": float("nan"), "gflops": 100.0}),
+        _metric_trial({"final_loss": float("inf"), "gflops": 200.0}),
+    ]
+    stats = _default_call(trials=trials)
+    # final_loss saw only non-finite values -> dropped completely.
+    assert "final_loss" not in stats.metrics_summary
+    assert stats.metrics_summary["gflops"]["n"] == 2.0
+
+
+def test_metrics_summary_aggregates_finite_and_skips_non_finite_for_same_key():
+    """A key with a mix of finite and non-finite values aggregates only the
+    finite occurrences."""
+    trials = [
+        _metric_trial({"gflops": 100.0}),
+        _metric_trial({"gflops": float("nan")}),
+        _metric_trial({"gflops": 300.0}),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.metrics_summary["gflops"]["n"] == 2.0
+    assert stats.metrics_summary["gflops"]["mean"] == 200.0

--- a/tests/triage/test_matrix.py
+++ b/tests/triage/test_matrix.py
@@ -791,3 +791,69 @@ def test_workload_config_persisted_on_error_cell():
     stats = _default_call(trials=[_trial()], error="docker pull failed",
                           workload_config={"shampoo_api": "old"})
     assert stats.workload_config == {"shampoo_api": "old"}
+
+
+# ---- workload metrics aggregation (perf.md / matrix.json) ----------------
+
+
+def _metric_trial(metrics: dict, passed: bool = True):
+    """Trial stand-in carrying a ``result["metrics"]`` dict."""
+    return SimpleNamespace(
+        exit_status="ok" if passed else "workload_failed",
+        wall_clock_sec=1.0,
+        result={"passed": passed, "metrics": metrics},
+    )
+
+
+def test_metrics_summary_defaults_empty_when_no_metrics():
+    stats = _default_call(trials=[_trial()])
+    assert stats.metrics_summary == {}
+
+
+def test_metrics_summary_aggregates_scalar_metrics_mean_min_max_n():
+    trials = [
+        _metric_trial({"gflops": 100.0, "mean_step_ms": 9.0}),
+        _metric_trial({"gflops": 200.0, "mean_step_ms": 11.0}),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.metrics_summary["gflops"] == {
+        "mean": 150.0,
+        "min": 100.0,
+        "max": 200.0,
+        "n": 2.0,
+    }
+    assert stats.metrics_summary["mean_step_ms"]["mean"] == 10.0
+
+
+def test_metrics_summary_skips_non_scalar_and_bool_values():
+    """Lists (e.g. failure_detectors_fired) and bools are not measurements."""
+    trials = [
+        _metric_trial(
+            {
+                "gbps": 3800.0,
+                "failure_detectors_fired": ["tier1:x"],
+                "healthy": True,
+                "label": "run-a",
+            }
+        )
+    ]
+    stats = _default_call(trials=trials)
+    assert set(stats.metrics_summary) == {"gbps"}
+
+
+def test_metrics_summary_aggregates_only_trials_reporting_the_key():
+    """A key present in some trials aggregates over just those; n reflects it."""
+    trials = [
+        _metric_trial({"gflops": 100.0}),
+        _metric_trial({}),  # this trial reported no metrics
+        _metric_trial({"gflops": 300.0}),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.metrics_summary["gflops"]["n"] == 2.0
+    assert stats.metrics_summary["gflops"]["mean"] == 200.0
+
+
+def test_metrics_summary_empty_for_error_cell():
+    trials = [_metric_trial({"gflops": 100.0})]
+    stats = _default_call(trials=trials, error="docker pull failed")
+    assert stats.metrics_summary == {}

--- a/tests/triage/test_matrix.py
+++ b/tests/triage/test_matrix.py
@@ -25,6 +25,7 @@ def _trial(
     main_work_started: bool | None = None,
     executed_iterations: int | None = None,
     configured_iterations: int | None = None,
+    metrics: dict | None = None,
 ):
     """Build a TrialResult-shaped stand-in. aggregate_cell uses duck typing."""
     result: dict = {"passed": passed}
@@ -42,6 +43,8 @@ def _trial(
         result["executed_iterations"] = executed_iterations
     if configured_iterations is not None:
         result["configured_iterations"] = configured_iterations
+    if metrics is not None:
+        result["metrics"] = metrics
     return SimpleNamespace(
         exit_status=exit_status,
         wall_clock_sec=wall_clock_sec,
@@ -71,6 +74,35 @@ def test_all_pass_no_failures():
     assert stats.failed_count == 0
     assert stats.failure_rate == 0.0
     assert stats.error is None
+
+
+def test_metrics_summary_aggregates_only_passing_trials():
+    """perf.md presents metrics_summary as performance numbers, so metrics from
+    failed / errored trials (partial output, a checksum failure that still
+    emitted numbers) must not be aggregated -- only valid (passing) trials."""
+    trials = [
+        _trial(passed=True, metrics={"gflops": 100.0}),
+        _trial(passed=True, metrics={"gflops": 300.0}),
+        # A failed trial that still emitted a (suspect) number -- must be excluded.
+        _trial(passed=False, metrics={"gflops": 9999.0}),
+        # An infra error trial with a number -- must be excluded.
+        _trial(passed=True, exit_status="infrastructure_failed", metrics={"gflops": 5.0}),
+    ]
+    stats = _default_call(trials=trials)
+    agg = stats.metrics_summary["gflops"]
+    assert agg["n"] == 2.0  # only the two passing trials
+    assert agg["mean"] == 200.0
+    assert agg["max"] == 300.0  # not the failed trial's 9999
+
+
+def test_metrics_summary_empty_when_no_passing_trial():
+    """A cell whose trials all failed contributes no perf metrics."""
+    trials = [
+        _trial(passed=False, metrics={"gflops": 123.0}),
+        _trial(passed=True, exit_status="infrastructure_failed", metrics={"gflops": 4.0}),
+    ]
+    stats = _default_call(trials=trials)
+    assert stats.metrics_summary == {}
 
 
 def test_mixed_pass_fail_counts_correctly():

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -626,7 +626,11 @@ def _fake_trial_with_metrics(
     return _FakeTrial(
         result={
             "passed": True,
-            "step_times_ms": step_times_ms or [100.0],
+            # Explicit ``is None`` (not ``or``) so a caller can model a trial
+            # that reported metrics but an empty ``step_times_ms`` ([] stays [],
+            # a realistic did_not_run / missing-per-step-timing shape) instead
+            # of it silently becoming the [100.0] default.
+            "step_times_ms": [100.0] if step_times_ms is None else step_times_ms,
             "metrics": metrics,
         }
     )

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -696,6 +696,56 @@ def test_perf_report_marks_did_not_run_timing_na(tmp_path, patched_env, monkeypa
     assert "missing" in text
 
 
+def test_perf_report_error_cell_wall_is_error_not_zero(tmp_path):
+    """An error cell renders EVERY measured column -- including Wall -- as
+    'error', never a misleading 0.000 (error rows force wall to 0.0)."""
+    from aorta.triage.matrix import CellStats
+    from aorta.triage.output import write_perf_report
+
+    def _cell(name, *, error=None, wall=1.0, source="per_step"):
+        return CellStats(
+            name=name,
+            mitigations=("none",),
+            environment="local",
+            extra_env={},
+            resolved_env_vars={},
+            trials=2,
+            passed_count=2,
+            failed_count=0,
+            mean_step_time_ms=10.0,
+            std_step_time_ms=0.0,
+            min_step_time_ms=10.0,
+            max_step_time_ms=10.0,
+            p50_step_time_ms=10.0,
+            p90_step_time_ms=10.0,
+            p99_step_time_ms=10.0,
+            mean_wall_clock_sec=wall,
+            step_time_source=source,
+            step_times_ms=[10.0, 10.0] if error is None else [],
+            error=error,
+            error_count=0 if error is None else 2,
+        )
+
+    baseline = _cell("none-local")
+    errored = _cell("boom-local", error="docker pull failed", wall=0.0, source="missing")
+    out = tmp_path / "perf.md"
+    write_perf_report(
+        out,
+        build_recipe_from_flags(
+            workload="echo", mitigation_axis="none", environment_axis="local",
+            trials=2, steps=1,
+        ),
+        [baseline, errored],
+        baseline=baseline,
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    text = out.read_text()
+    # Isolate the error cell's table row and assert Wall is 'error', not 0.000.
+    err_row = next(ln for ln in text.splitlines() if ln.startswith("| boom-local"))
+    assert "0.000" not in err_row
+    assert err_row.count("error") >= 8  # every measured column + source
+
+
 def test_resolved_recipe_is_loadable_by_load_recipe(tmp_path, patched_env, patched_run_trials):
     """`recipe.resolved.yaml` must round-trip through load_recipe() -- no debug fields."""
     from aorta.triage.recipe import load_recipe

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -617,6 +617,85 @@ def test_matrix_md_failures_column_renders_failed_over_total(tmp_path, patched_e
     assert "`Failures` is `failed_count / valid_trials`" in md
 
 
+# ---- perf.md report ------------------------------------------------------
+
+
+def _fake_trial_with_metrics(
+    metrics: dict, step_times_ms: list[float] | None = None
+) -> _FakeTrial:
+    return _FakeTrial(
+        result={
+            "passed": True,
+            "step_times_ms": step_times_ms or [100.0],
+            "metrics": metrics,
+        }
+    )
+
+
+def test_perf_report_written_every_run(tmp_path, patched_env, patched_run_trials):
+    """perf.md is written next to matrix.md/json on a plain run, with the
+    always-on step-timing table and no throughput table (no metrics)."""
+    r = _simple_recipe(ticket="T-1")
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    perf = run_dir / "perf.md"
+    assert perf.exists()
+    text = perf.read_text()
+    assert "# Performance Report - fsdp" in text
+    assert "**Ticket**: T-1" in text
+    assert "## Step timing (ms)" in text
+    # Percentile columns present.
+    for col in ("Mean", "Std", "p50", "p90", "p99", "Max", "Wall (s)", "Source"):
+        assert col in text
+    assert "none-local" in text and "tf32_off-local" in text
+    # No workload emitted numeric metrics -> throughput table omitted.
+    assert "## Workload metrics" not in text
+
+
+def test_matrix_md_points_to_perf_report(tmp_path, patched_env, patched_run_trials):
+    run_dir = runner.run_recipe(_simple_recipe(), output_dir=tmp_path)
+    md = (run_dir / "matrix.md").read_text()
+    assert "perf.md" in md
+
+
+def test_perf_report_includes_workload_metrics(tmp_path, patched_env, monkeypatch):
+    """When a workload reports numeric metrics, perf.md gains a throughput
+    table and matrix.json carries the aggregated metrics_summary."""
+    trials = [
+        _fake_trial_with_metrics({"gflops": 100.0}),
+        _fake_trial_with_metrics({"gflops": 300.0}),
+    ]
+    monkeypatch.setattr(runner, "run_trials", MagicMock(return_value=trials))
+    run_dir = runner.run_recipe(_simple_recipe(ticket="T-1"), output_dir=tmp_path)
+
+    text = (run_dir / "perf.md").read_text()
+    assert "## Workload metrics" in text
+    assert "gflops" in text
+    # mean of 100 and 300 -> 200.000 (thousands-separated formatter).
+    assert "200.000" in text
+
+    doc = json.loads((run_dir / "matrix.json").read_text())
+    base = next(c for c in doc["cells"] if c["name"] == "none-local")
+    assert base["metrics_summary"]["gflops"]["mean"] == 200.0
+    assert base["metrics_summary"]["gflops"]["n"] == 2.0
+
+
+def test_perf_report_marks_did_not_run_timing_na(tmp_path, patched_env, monkeypatch):
+    """A cell whose trials never started shows n/a timing (source=missing),
+    not a misleading 0.000. The baseline cell still runs so the matrix
+    completes (an all-did_not_run recipe has no usable baseline)."""
+    # run_trials is called once per cell in recipe order: none-local (baseline)
+    # then tf32_off-local. Only the second cell "did not run".
+    monkeypatch.setattr(
+        runner,
+        "run_trials",
+        MagicMock(side_effect=[[_fake_trial(), _fake_trial()], [_fake_trial_did_not_run()]]),
+    )
+    run_dir = runner.run_recipe(_simple_recipe(), output_dir=tmp_path)
+    text = (run_dir / "perf.md").read_text()
+    assert "n/a" in text
+    assert "missing" in text
+
+
 def test_resolved_recipe_is_loadable_by_load_recipe(tmp_path, patched_env, patched_run_trials):
     """`recipe.resolved.yaml` must round-trip through load_recipe() -- no debug fields."""
     from aorta.triage.recipe import load_recipe

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -746,6 +746,61 @@ def test_perf_report_error_cell_wall_is_error_not_zero(tmp_path):
     assert err_row.count("error") >= 8  # every measured column + source
 
 
+def test_perf_report_missing_source_row_keeps_real_wall(tmp_path):
+    """A non-error ``Source = missing`` row shows ``n/a`` for the per-step
+    columns but a *real* ``Wall (s)`` value -- wall clock is measured even when
+    per-step timing is absent, so the Notes wording (n/a per-step, Wall still
+    shown) must match what the row actually prints."""
+    from aorta.triage.matrix import CellStats
+    from aorta.triage.output import write_perf_report
+
+    def _cell(name, *, wall, source, step_times):
+        return CellStats(
+            name=name,
+            mitigations=("none",),
+            environment="local",
+            extra_env={},
+            resolved_env_vars={},
+            trials=2,
+            passed_count=2,
+            failed_count=0,
+            mean_step_time_ms=10.0,
+            std_step_time_ms=0.0,
+            min_step_time_ms=10.0,
+            max_step_time_ms=10.0,
+            p50_step_time_ms=10.0,
+            p90_step_time_ms=10.0,
+            p99_step_time_ms=10.0,
+            mean_wall_clock_sec=wall,
+            step_time_source=source,
+            step_times_ms=step_times,
+            error=None,
+            error_count=0,
+        )
+
+    baseline = _cell("none-local", wall=1.0, source="per_step", step_times=[10.0, 10.0])
+    # Real end-to-end wall clock, but no usable per-step series -> source missing.
+    missing = _cell("slow-local", wall=42.5, source="missing", step_times=[])
+    out = tmp_path / "perf.md"
+    write_perf_report(
+        out,
+        build_recipe_from_flags(
+            workload="echo", mitigation_axis="none", environment_axis="local",
+            trials=2, steps=1,
+        ),
+        [baseline, missing],
+        baseline=baseline,
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    text = out.read_text()
+    missing_row = next(ln for ln in text.splitlines() if ln.startswith("| slow-local"))
+    # Per-step columns render n/a; Wall is the genuine measurement, not n/a.
+    assert "n/a" in missing_row
+    assert "42.500" in missing_row
+    # The Notes must not claim the whole row is n/a timing.
+    assert "n/a` for the per-step columns" in text
+
+
 def test_perf_report_metric_columns_sorted(tmp_path):
     """The workload-metrics table columns are sorted, so perf.md is byte-stable
     regardless of the order metric keys were first seen across cells / trials."""
@@ -795,7 +850,11 @@ def test_perf_report_metric_columns_sorted(tmp_path):
         run_timestamp="2026-01-01T00:00:00Z",
     )
     text = out.read_text()
-    header = next(ln for ln in text.splitlines() if ln.startswith("| Cell "))
+    # Scope to the workload-metrics section: the step-timing table also has a
+    # ``| Cell ...`` header (Trials/Iters/... -- deliberately unsorted), so pick
+    # the first ``| Cell`` row *after* the metrics heading.
+    metrics_section = text.split("## Workload metrics", 1)[1]
+    header = next(ln for ln in metrics_section.splitlines() if ln.startswith("| Cell "))
     cols = [c.strip() for c in header.strip().strip("|").split("|")][1:]
     assert cols == sorted(cols)
     assert cols == ["gflops", "mean_step_ms", "triad_gbps"]

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -746,6 +746,61 @@ def test_perf_report_error_cell_wall_is_error_not_zero(tmp_path):
     assert err_row.count("error") >= 8  # every measured column + source
 
 
+def test_perf_report_metric_columns_sorted(tmp_path):
+    """The workload-metrics table columns are sorted, so perf.md is byte-stable
+    regardless of the order metric keys were first seen across cells / trials."""
+    from aorta.triage.matrix import CellStats
+    from aorta.triage.output import write_perf_report
+
+    def _cell(name, metrics):
+        return CellStats(
+            name=name,
+            mitigations=("none",),
+            environment="local",
+            extra_env={},
+            resolved_env_vars={},
+            trials=1,
+            passed_count=1,
+            failed_count=0,
+            mean_step_time_ms=10.0,
+            std_step_time_ms=0.0,
+            min_step_time_ms=10.0,
+            max_step_time_ms=10.0,
+            p50_step_time_ms=10.0,
+            p90_step_time_ms=10.0,
+            p99_step_time_ms=10.0,
+            mean_wall_clock_sec=1.0,
+            step_time_source="per_step",
+            step_times_ms=[10.0],
+            metrics_summary=metrics,
+        )
+
+    def _agg(mean):
+        return {"mean": mean, "min": mean, "max": mean, "n": 1.0}
+
+    # Deliberately insert keys in a non-alphabetical order, and give each cell
+    # a different insertion order + a key the other lacks. Without sorting the
+    # header order would depend on this iteration order.
+    baseline = _cell("none-local", {"triad_gbps": _agg(1.0), "gflops": _agg(2.0)})
+    other = _cell("tf32_off-local", {"mean_step_ms": _agg(3.0), "gflops": _agg(4.0)})
+    out = tmp_path / "perf.md"
+    write_perf_report(
+        out,
+        build_recipe_from_flags(
+            workload="echo", mitigation_axis="none", environment_axis="local",
+            trials=1, steps=1,
+        ),
+        [baseline, other],
+        baseline=baseline,
+        run_timestamp="2026-01-01T00:00:00Z",
+    )
+    text = out.read_text()
+    header = next(ln for ln in text.splitlines() if ln.startswith("| Cell "))
+    cols = [c.strip() for c in header.strip().strip("|").split("|")][1:]
+    assert cols == sorted(cols)
+    assert cols == ["gflops", "mean_step_ms", "triad_gbps"]
+
+
 def test_resolved_recipe_is_loadable_by_load_recipe(tmp_path, patched_env, patched_run_trials):
     """`recipe.resolved.yaml` must round-trip through load_recipe() -- no debug fields."""
     from aorta.triage.recipe import load_recipe

--- a/tests/triage/test_runner_b1_api.py
+++ b/tests/triage/test_runner_b1_api.py
@@ -697,6 +697,12 @@ def test_run_recipe_strict_raises_matrix_strict_error(tmp_path, patched_env, mon
             r, output_dir=tmp_path, timestamp="2026-01-01T00-00-00", strict=True
         )
     assert excinfo.value.cells == ["tf32_off-local"]
+    # The message points at the concrete slugified per-cell artifact path
+    # (cells/<safe_slug(cell)>/<workload>/trial_*.json), not a <cell>/<workload>
+    # placeholder, so an operator can copy/paste straight to the trials (#274).
+    msg = str(excinfo.value)
+    assert "cells/tf32_off-local/fsdp/trial_*.json" in msg
+    assert "<cell>" not in msg
     assert (excinfo.value.run_dir / "matrix.json").exists()
 
 

--- a/tests/triage/test_runner_b1_api.py
+++ b/tests/triage/test_runner_b1_api.py
@@ -540,6 +540,166 @@ cells:
     assert "did_not_run" in md
 
 
+def _write_two_cell_recipe(tmp_path: Path, ticket: str) -> Path:
+    """A baseline cell + one other cell, both local, 1 trial / 50 steps."""
+    recipe = tmp_path / f"{ticket}.yaml"
+    recipe.write_text(
+        f"""\
+schema_version: 1
+ticket: {ticket}
+workload: fsdp
+trials: 1
+steps: 50
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+  - name: bad-local
+    mitigations: [tf32_off]
+    environment: local
+""",
+        encoding="utf-8",
+    )
+    return recipe
+
+
+def _ok_trials():
+    from types import SimpleNamespace
+
+    return [
+        SimpleNamespace(
+            exit_status="ok",
+            wall_clock_sec=1.0,
+            result={"passed": True, "step_times_ms": [100.0], "elapsed_sec": 1.0},
+        )
+    ]
+
+
+def _did_not_run_trials():
+    """workload_failed with no step times + zero elapsed -> platform infers did_not_run."""
+    from types import SimpleNamespace
+
+    return [
+        SimpleNamespace(
+            exit_status="workload_failed",
+            wall_clock_sec=3.5,
+            result={"passed": False, "step_times_ms": [], "elapsed_sec": 0.0},
+        )
+    ]
+
+
+def test_strict_exits_nonzero_when_a_cell_did_not_run(tmp_path, patched_env, monkeypatch):
+    """--strict must catch a cell that never ran (setup crash -> did_not_run),
+    while the same recipe without --strict tolerates it (exit 0). The matrix is
+    written either way so the operator can inspect the cause.
+    """
+    import aorta.triage.runner as runner_mod
+
+    def per_cell(request):
+        return _ok_trials() if request.mitigations == ("none",) else _did_not_run_trials()
+
+    monkeypatch.setattr(runner_mod, "run_trials", per_cell)
+    recipe = _write_two_cell_recipe(tmp_path, "STRICT-DNR")
+    cli = CliRunner()
+    out = tmp_path / "out"
+
+    default = cli.invoke(triage, ["run", "--recipe", str(recipe), "--output-dir", str(out)])
+    assert default.exit_code == 0, default.output
+
+    strict = cli.invoke(
+        triage, ["run", "--recipe", str(recipe), "--output-dir", str(out), "--strict"]
+    )
+    assert strict.exit_code != 0, strict.output
+    assert "strict mode" in strict.output
+    assert "1 of 2 cell(s)" in strict.output  # only the bad cell, not the baseline
+    assert "bad-local" in strict.output
+    assert "Wrote matrix to" in strict.output
+
+
+def test_strict_exits_nonzero_when_a_cell_errored(tmp_path, patched_env, monkeypatch):
+    """--strict must catch a whole-cell error (run_trials raised)."""
+    import aorta.triage.runner as runner_mod
+
+    def per_cell(request):
+        if request.mitigations == ("none",):
+            return _ok_trials()
+        raise RuntimeError("cell blew up inside run_trials")
+
+    monkeypatch.setattr(runner_mod, "run_trials", per_cell)
+    recipe = _write_two_cell_recipe(tmp_path, "STRICT-ERR")
+    cli = CliRunner()
+    out = tmp_path / "out"
+
+    strict = cli.invoke(
+        triage, ["run", "--recipe", str(recipe), "--output-dir", str(out), "--strict"]
+    )
+    assert strict.exit_code != 0, strict.output
+    assert "bad-local" in strict.output
+    assert "Wrote matrix to" in strict.output
+
+
+def test_strict_tolerates_a_real_bug_repro(tmp_path, patched_env, monkeypatch):
+    """A cell that RAN but failed (a genuine bug repro) is an expected matrix
+    outcome and must NOT trip --strict.
+    """
+    from types import SimpleNamespace
+
+    import aorta.triage.runner as runner_mod
+
+    def per_cell(request):
+        if request.mitigations == ("none",):
+            return _ok_trials()
+        return [
+            SimpleNamespace(
+                exit_status="workload_failed",
+                wall_clock_sec=2.0,
+                result={
+                    "passed": False,
+                    "step_times_ms": [120.0],
+                    "elapsed_sec": 2.0,
+                    "main_work_started": True,
+                },
+            )
+        ]
+
+    monkeypatch.setattr(runner_mod, "run_trials", per_cell)
+    recipe = _write_two_cell_recipe(tmp_path, "STRICT-REPRO")
+    cli = CliRunner()
+    out = tmp_path / "out"
+
+    strict = cli.invoke(
+        triage, ["run", "--recipe", str(recipe), "--output-dir", str(out), "--strict"]
+    )
+    assert strict.exit_code == 0, strict.output
+
+
+def test_run_recipe_strict_raises_matrix_strict_error(tmp_path, patched_env, monkeypatch):
+    """Programmatic run_recipe(strict=True) raises MatrixStrictError naming the
+    offending cell(s), with artifacts already written.
+    """
+    import aorta.triage.runner as runner_mod
+    from aorta.triage.runner import MatrixStrictError
+
+    def per_cell(request):
+        return _ok_trials() if request.mitigations == ("none",) else _did_not_run_trials()
+
+    monkeypatch.setattr(runner_mod, "run_trials", per_cell)
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none,tf32_off",
+        environment_axis="local",
+        trials=1,
+        steps=50,
+        ticket="STRICT-API",
+    )
+    with pytest.raises(MatrixStrictError) as excinfo:
+        runner.run_recipe(
+            r, output_dir=tmp_path, timestamp="2026-01-01T00-00-00", strict=True
+        )
+    assert excinfo.value.cells == ["tf32_off-local"]
+    assert (excinfo.value.run_dir / "matrix.json").exists()
+
+
 def test_cli_recipe_mode_dry_run(tmp_path, patched_env, patched_run_trials):
     recipe = tmp_path / "recipe.yaml"
     recipe.write_text(

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -89,11 +89,18 @@ def test_gpu_available_uses_kfd_access(monkeypatch):
     assert seen["path"] == hrx_mod._GPU_KFD_NODE
 
 
+def _arch_dir(build_dir, arch=hrx_mod._DEFAULT_ARCH):
+    """Artifacts live in <build_dir>/<arch>/ (see HrxWorkload._build_root)."""
+    d = build_dir / arch
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
 def test_build_reuses_existing_binary(monkeypatch, tmp_path):
     """A pre-built (executable) binary in a shared build_dir is reused."""
     monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
     # static probe: single binary, no code object.
-    binary = tmp_path / _PROBES["static"].binary
+    binary = _arch_dir(tmp_path) / _PROBES["static"].binary
     binary.write_bytes(b"\x7fELF")
     binary.chmod(0o755)
 
@@ -111,7 +118,7 @@ def test_build_rebuilds_when_binary_not_executable(monkeypatch, tmp_path):
     is NOT reused -- reusing it would fail run() with PermissionError, so it
     must rebuild instead."""
     monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
-    binary = tmp_path / _PROBES["static"].binary
+    binary = _arch_dir(tmp_path) / _PROBES["static"].binary
     binary.write_bytes(b"\x7fELF")
     binary.chmod(0o644)  # readable but not executable
     calls: list[list[str]] = []
@@ -125,12 +132,35 @@ def test_build_rebuilds_when_binary_not_executable(monkeypatch, tmp_path):
     assert calls, "hipcc must run when the existing binary is not executable"
 
 
+def test_build_rebuilds_for_different_arch(monkeypatch, tmp_path):
+    """A binary built for one arch must NOT be reused when a different arch is
+    requested against the same build_dir -- reuse is isolated per arch subdir,
+    so a shared build_dir can't silently run a wrong-arch binary."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    # An executable binary present under gfx90a...
+    other = _arch_dir(tmp_path, "gfx90a") / _PROBES["static"].binary
+    other.write_bytes(b"\x7fELF")
+    other.chmod(0o755)
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    # ...but we request gfx942, so it must rebuild rather than reuse gfx90a's.
+    HrxWorkload(
+        {"probe": "static", "gpu_arch": "gfx942", "build_dir": str(tmp_path)}
+    ).setup()
+    assert calls, "hipcc must run when only a different-arch binary exists"
+
+
 def test_build_recompiles_when_code_object_missing(monkeypatch, tmp_path):
     """Module probe with a stale binary but no code object must rebuild."""
     monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
     # Binary present + executable, but the required .code object is absent ->
     # not reusable, so the rebuild reason is purely the missing code object.
-    binary = tmp_path / _PROBES["module"].binary
+    binary = _arch_dir(tmp_path) / _PROBES["module"].binary
     binary.write_bytes(b"\x7fELF")
     binary.chmod(0o755)
     calls: list[list[str]] = []

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -129,6 +129,18 @@ def test_setup_rejects_non_bool_keep_build(monkeypatch):
         wl.setup()
 
 
+@pytest.mark.parametrize("bad", [0, -1])
+def test_setup_rejects_nonpositive_timeout(monkeypatch, bad):
+    """A zero/negative timeout_sec fails fast in setup() with a config error,
+    rather than raising from subprocess.run(timeout=...) at run() time and being
+    misclassified as an infrastructure failure."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: self._build_dir / "x")
+    wl = HrxWorkload({"probe": "module", "timeout_sec": bad})
+    with pytest.raises(ValueError, match="timeout_sec"):
+        wl.setup()
+
+
 def test_build_env_strips_runtime_routing_vars(monkeypatch, tmp_path):
     """hipcc must build against the stock toolchain, not the HRX-on cell env.
 

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -84,6 +84,33 @@ def test_build_env_strips_runtime_routing_vars(monkeypatch, tmp_path):
     assert build_env.get("ROCM_PATH") == "/opt/rocm"
 
 
+def test_relative_build_dir_is_resolved_absolute(monkeypatch, tmp_path):
+    """A relative build_dir must be absolutized so hipcc -o / probe cwd agree.
+
+    _run_hipcc runs with cwd=_KERNELS_DIR and run() with cwd=build_dir, so a
+    relative build_dir would split the -o output from the probe exec.
+    """
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    wl = HrxWorkload({"probe": "static", "build_dir": "relbuild"})
+    wl.setup()
+
+    assert wl._build_dir.is_absolute()
+    assert wl._binary.is_absolute()
+    assert wl._build_dir == (tmp_path / "relbuild").resolve()
+    # The hipcc -o target must be the absolute binary path, not a relative one.
+    out_arg = captured["cmd"][captured["cmd"].index("-o") + 1]
+    assert Path(out_arg).is_absolute()
+
+
 def _prep_workload(monkeypatch, tmp_path: Path) -> HrxWorkload:
     """A workload whose setup() succeeds without a real toolchain."""
     monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -424,3 +424,76 @@ def test_run_no_verdict_is_failure(monkeypatch, tmp_path):
     detail = res.failure_details[0]
     assert "hipMalloc" in detail.get("stdout_tail", "")
     assert "stdout" in detail.get("hint", "")
+
+
+@pytest.mark.parametrize(
+    "bad", ["../evil", "/abs/gfx942", "a/b", "..", ".", "", "gfx\\942", "gfx\x00x"]
+)
+def test_validated_arch_rejects_path_escapes(bad):
+    """gpu_arch is a build-dir path component; separators/traversal/absolute
+    values that could escape build_dir must be rejected."""
+    with pytest.raises(ValueError, match="gpu_arch"):
+        hrx_mod._validated_arch(bad)
+
+
+@pytest.mark.parametrize(
+    "good",
+    ["gfx942", "gfx90a", "gfx1100", "gfx90a:xnack+", "gfx942:sramecc+:xnack-"],
+)
+def test_validated_arch_accepts_real_targets(good):
+    """Real --offload-arch targets (incl. :feature+/- qualifiers) pass through
+    untouched so they stay usable as both a dir name and an offload-arch."""
+    assert hrx_mod._validated_arch(good) == good
+
+
+def test_setup_rejects_unsafe_gpu_arch(monkeypatch, tmp_path):
+    """A hostile gpu_arch is rejected in setup() (wired to _validated_arch)."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: self._build_dir / "x")
+    wl = HrxWorkload(
+        {"probe": "module", "gpu_arch": "../../etc", "build_dir": str(tmp_path)}
+    )
+    with pytest.raises(ValueError, match="gpu_arch"):
+        wl.setup()
+
+
+def test_run_writes_full_logs_when_save_logs(monkeypatch, tmp_path):
+    """With save_logs, run() writes the child's FULL stdout/stderr to sibling
+    ``<prefix>.subprocess.*.log`` files -- not just the truncated failure tails."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: tmp_path / self._spec.binary)
+    log_prefix = tmp_path / "trial_d0_m0_t0"
+    wl = HrxWorkload(
+        {
+            "probe": "module",
+            "build_dir": str(tmp_path),
+            "_aorta_save_logs": True,
+            "_aorta_log_prefix": str(log_prefix),
+        }
+    )
+    wl.setup()
+    # > 2 KB each, so the full-log write is provably not the failure tail.
+    stdout = "out[0]=107 (expect 107)\nVERDICT=FULLY_WORKS\n" + "x" * 5000
+    stderr = "some hip chatter\n" + "y" * 5000
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _fake_completed(stdout, 0, stderr)
+    )
+
+    res = wl.run()
+
+    assert res.passed is True
+    out_log = tmp_path / "trial_d0_m0_t0.subprocess.stdout.log"
+    err_log = tmp_path / "trial_d0_m0_t0.subprocess.stderr.log"
+    assert out_log.read_text() == stdout
+    assert err_log.read_text() == stderr
+
+
+def test_run_no_logs_without_save_logs(monkeypatch, tmp_path):
+    """save_logs and the full-log capture are decoupled: no prefix -> no files."""
+    wl = _prep_workload(monkeypatch, tmp_path)
+    stdout = "out[0]=107 (expect 107)\nVERDICT=FULLY_WORKS\n"
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_completed(stdout, 0))
+
+    wl.run()
+
+    assert not list(tmp_path.glob("*.subprocess.*.log"))

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -90,10 +90,12 @@ def test_gpu_available_uses_kfd_access(monkeypatch):
 
 
 def test_build_reuses_existing_binary(monkeypatch, tmp_path):
-    """A pre-built binary in a shared build_dir is reused (no recompile)."""
+    """A pre-built (executable) binary in a shared build_dir is reused."""
     monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
     # static probe: single binary, no code object.
-    (tmp_path / _PROBES["static"].binary).write_bytes(b"\x7fELF")
+    binary = tmp_path / _PROBES["static"].binary
+    binary.write_bytes(b"\x7fELF")
+    binary.chmod(0o755)
 
     def _fail_run(*a, **k):
         raise AssertionError("hipcc must not run when the binary already exists")
@@ -101,14 +103,36 @@ def test_build_reuses_existing_binary(monkeypatch, tmp_path):
     monkeypatch.setattr(subprocess, "run", _fail_run)
     wl = HrxWorkload({"probe": "static", "build_dir": str(tmp_path)})
     wl.setup()
-    assert wl._binary == (tmp_path / _PROBES["static"].binary)
+    assert wl._binary == binary
+
+
+def test_build_rebuilds_when_binary_not_executable(monkeypatch, tmp_path):
+    """A leftover binary without the execute bit (wrong perms / partial write)
+    is NOT reused -- reusing it would fail run() with PermissionError, so it
+    must rebuild instead."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    binary = tmp_path / _PROBES["static"].binary
+    binary.write_bytes(b"\x7fELF")
+    binary.chmod(0o644)  # readable but not executable
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    HrxWorkload({"probe": "static", "build_dir": str(tmp_path)}).setup()
+    assert calls, "hipcc must run when the existing binary is not executable"
 
 
 def test_build_recompiles_when_code_object_missing(monkeypatch, tmp_path):
     """Module probe with a stale binary but no code object must rebuild."""
     monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
-    # Binary present but the required .code object is absent -> not reusable.
-    (tmp_path / _PROBES["module"].binary).write_bytes(b"\x7fELF")
+    # Binary present + executable, but the required .code object is absent ->
+    # not reusable, so the rebuild reason is purely the missing code object.
+    binary = tmp_path / _PROBES["module"].binary
+    binary.write_bytes(b"\x7fELF")
+    binary.chmod(0o755)
     calls: list[list[str]] = []
 
     def _fake_run(cmd, *a, **k):

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -187,3 +187,9 @@ def test_run_no_verdict_is_failure(monkeypatch, tmp_path):
     assert res.metrics.get("verdict") is None
     assert res.main_work_started is False
     assert res.executed_iterations == 0
+    # The crash diagnostic is on stdout (probes printf there), so it must be
+    # persisted in the failure detail, and the hint must point at stdout.
+    assert res.failure_details, "expected a failure detail"
+    detail = res.failure_details[0]
+    assert "hipMalloc" in detail.get("stdout_tail", "")
+    assert "stdout" in detail.get("hint", "")

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -16,6 +16,21 @@ import pytest
 from aorta.workloads import hrx as hrx_mod
 from aorta.workloads.hrx import _PROBES, HrxWorkload
 
+# Captured before the autouse GPU stub below masks it, so the check's own
+# logic can be exercised directly.
+_REAL_GPU_AVAILABLE = hrx_mod._gpu_available
+
+
+@pytest.fixture(autouse=True)
+def _gpu_present(monkeypatch):
+    """Pretend a GPU is reachable so setup() stays GPU-free by default.
+
+    setup() now raises when no ROCm GPU is accessible; unit tests must not
+    depend on real hardware, so stub the check True. Tests that exercise the
+    no-GPU path override this within their body.
+    """
+    monkeypatch.setattr(hrx_mod, "_gpu_available", lambda: True)
+
 
 def test_vendored_sources_present():
     """Every registered probe's source (and code object source) is vendored."""
@@ -45,6 +60,64 @@ def test_setup_raises_without_hipcc(monkeypatch):
     wl = HrxWorkload({"probe": "module"})
     with pytest.raises(RuntimeError, match="hipcc not found"):
         wl.setup()
+
+
+def test_setup_raises_without_gpu(monkeypatch, tmp_path):
+    """hipcc present but no reachable GPU -> setup failure (did_not_run).
+
+    Without this, run() would produce passed=False, which the matrix miscounts
+    as a reproduced bug rather than an environment gap.
+    """
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(hrx_mod, "_gpu_available", lambda: False)
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: self._build_dir / "x")
+    wl = HrxWorkload({"probe": "module", "build_dir": str(tmp_path)})
+    with pytest.raises(RuntimeError, match="no accessible ROCm GPU"):
+        wl.setup()
+
+
+def test_gpu_available_uses_kfd_access(monkeypatch):
+    """_gpu_available() keys off read+write access to the KFD node."""
+    seen: dict[str, str] = {}
+
+    def _fake_access(path, mode):
+        seen["path"] = path
+        return False
+
+    monkeypatch.setattr(hrx_mod.os, "access", _fake_access)
+    assert _REAL_GPU_AVAILABLE() is False
+    assert seen["path"] == hrx_mod._GPU_KFD_NODE
+
+
+def test_build_reuses_existing_binary(monkeypatch, tmp_path):
+    """A pre-built binary in a shared build_dir is reused (no recompile)."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    # static probe: single binary, no code object.
+    (tmp_path / _PROBES["static"].binary).write_bytes(b"\x7fELF")
+
+    def _fail_run(*a, **k):
+        raise AssertionError("hipcc must not run when the binary already exists")
+
+    monkeypatch.setattr(subprocess, "run", _fail_run)
+    wl = HrxWorkload({"probe": "static", "build_dir": str(tmp_path)})
+    wl.setup()
+    assert wl._binary == (tmp_path / _PROBES["static"].binary)
+
+
+def test_build_recompiles_when_code_object_missing(monkeypatch, tmp_path):
+    """Module probe with a stale binary but no code object must rebuild."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    # Binary present but the required .code object is absent -> not reusable.
+    (tmp_path / _PROBES["module"].binary).write_bytes(b"\x7fELF")
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    HrxWorkload({"probe": "module", "build_dir": str(tmp_path)}).setup()
+    assert calls, "hipcc must run when the code object is missing"
 
 
 def test_setup_rejects_non_bool_keep_build(monkeypatch):

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -62,8 +62,13 @@ def test_build_env_strips_runtime_routing_vars(monkeypatch, tmp_path):
     The dispatcher merges the cell env into os.environ before setup() runs, so
     a preloaded HRX libamdhip64.so would otherwise run inside the compiler.
     """
-    for var in hrx_mod._RUNTIME_ROUTING_VARS:
-        monkeypatch.setenv(var, "/some/hrx/value")
+    # Use real paths so the setup-time LD_PRELOAD existence check passes; this
+    # test is about build-env stripping, not routing validation.
+    real_lib = tmp_path / "libamdhip64.so"
+    real_lib.write_bytes(b"\x7fELF")
+    monkeypatch.setenv("LD_PRELOAD", str(real_lib))
+    monkeypatch.setenv("LD_LIBRARY_PATH", str(tmp_path))
+    monkeypatch.setenv("HRX_GPU_DRIVER", "amdgpu")
     monkeypatch.setenv("ROCM_PATH", "/opt/rocm")  # unrelated var must survive
 
     captured: dict[str, dict[str, str] | None] = {}
@@ -111,6 +116,38 @@ def test_relative_build_dir_is_resolved_absolute(monkeypatch, tmp_path):
     assert Path(out_arg).is_absolute()
 
 
+def test_setup_rejects_nonexistent_ld_preload(monkeypatch, tmp_path):
+    """A placeholder/typo'd LD_PRELOAD must fail setup, not silently fall back.
+
+    ld.so only warns and runs against the default HIP runtime, so an hrx_on cell
+    would otherwise report a misleading FULLY_WORKS.
+    """
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: self._build_dir / "x")
+    monkeypatch.setenv("LD_PRELOAD", "/path/to/hrx-root/lib/libamdhip64.so")
+    wl = HrxWorkload({"probe": "module", "build_dir": str(tmp_path)})
+    with pytest.raises(RuntimeError, match="LD_PRELOAD names object"):
+        wl.setup()
+
+
+def test_setup_accepts_existing_ld_preload(monkeypatch, tmp_path):
+    """An LD_PRELOAD that points at a real file must pass the existence check."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: self._build_dir / "x")
+    real_lib = tmp_path / "libamdhip64.so"
+    real_lib.write_bytes(b"\x7fELF")
+    monkeypatch.setenv("LD_PRELOAD", str(real_lib))
+    HrxWorkload({"probe": "module", "build_dir": str(tmp_path)}).setup()
+
+
+def test_setup_skips_bare_soname_ld_preload(monkeypatch, tmp_path):
+    """A bare soname (no '/') is resolved via LD_LIBRARY_PATH -- don't false-fail."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: self._build_dir / "x")
+    monkeypatch.setenv("LD_PRELOAD", "libamdhip64.so")
+    HrxWorkload({"probe": "module", "build_dir": str(tmp_path)}).setup()
+
+
 def _prep_workload(monkeypatch, tmp_path: Path) -> HrxWorkload:
     """A workload whose setup() succeeds without a real toolchain."""
     monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
@@ -120,8 +157,12 @@ def _prep_workload(monkeypatch, tmp_path: Path) -> HrxWorkload:
     return wl
 
 
-def _fake_completed(stdout: str, returncode: int) -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(args=["probe"], returncode=returncode, stdout=stdout, stderr="")
+def _fake_completed(
+    stdout: str, returncode: int, stderr: str = ""
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["probe"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
 
 
 def test_run_fully_works(monkeypatch, tmp_path):
@@ -138,6 +179,49 @@ def test_run_fully_works(monkeypatch, tmp_path):
     assert res.metrics.get("out0") == 107.0
     assert res.main_work_started is True
     assert res.executed_iterations == 1
+
+
+def test_run_preload_ignored_is_failure(monkeypatch, tmp_path):
+    """FULLY_WORKS + an ld.so 'ignored' warning is a false green -> fail it.
+
+    Catches the exists-but-unloadable case (wrong arch / missing deps) that the
+    setup existence check can't see.
+    """
+    wl = _prep_workload(monkeypatch, tmp_path)
+    monkeypatch.setenv("LD_PRELOAD", "/some/hrx/libamdhip64.so")
+    stdout = "out[0]=107 (expect 107)\nVERDICT=FULLY_WORKS\n"
+    stderr = (
+        "ERROR: ld.so: object '/some/hrx/libamdhip64.so' from LD_PRELOAD cannot "
+        "be preloaded (cannot open shared object file): ignored.\n"
+    )
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _fake_completed(stdout, 0, stderr)
+    )
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.metrics.get("preload_ignored") is True
+    assert res.metrics.get("verdict") == "FULLY_WORKS"
+    assert res.failure_details, "expected a failure detail"
+    assert "ignored" in res.failure_details[0].get("hint", "").lower()
+
+
+def test_run_no_preload_no_false_positive(monkeypatch, tmp_path):
+    """With LD_PRELOAD unset, a passing verdict must stay green (no backstop)."""
+    wl = _prep_workload(monkeypatch, tmp_path)
+    monkeypatch.delenv("LD_PRELOAD", raising=False)
+    stdout = "out[0]=107 (expect 107)\nVERDICT=FULLY_WORKS\n"
+    # Stray stderr text must not be misread as an ld.so preload warning.
+    stderr = "some unrelated warning: cannot be preloaded elsewhere\n"
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _fake_completed(stdout, 0, stderr)
+    )
+
+    res = wl.run()
+
+    assert res.passed is True
+    assert res.metrics.get("preload_ignored") is False
 
 
 def test_run_output_not_written(monkeypatch, tmp_path):

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -436,6 +436,14 @@ def test_validated_arch_rejects_path_escapes(bad):
         hrx_mod._validated_arch(bad)
 
 
+@pytest.mark.parametrize("bad", [None, 942, 90.0, ["gfx942"], {"arch": "gfx942"}])
+def test_validated_arch_rejects_non_string(bad):
+    """A non-string gpu_arch (e.g. ``gpu_arch: null``) is rejected up front,
+    not coerced via ``str(...)`` into the literal build-dir name 'None'."""
+    with pytest.raises(ValueError, match="gpu_arch"):
+        hrx_mod._validated_arch(bad)
+
+
 @pytest.mark.parametrize(
     "good",
     ["gfx942", "gfx90a", "gfx1100", "gfx90a:xnack+", "gfx942:sramecc+:xnack-"],

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -1,0 +1,162 @@
+"""Unit tests for the `hrx` HIP-launch probe workload.
+
+Unit-level: no hipcc, no GPU. Build and run are monkeypatched so the verdict
+parsing and result mapping are tested in isolation, plus the setup-time guard
+when hipcc is absent.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aorta.workloads import hrx as hrx_mod
+from aorta.workloads.hrx import _PROBES, HrxWorkload
+
+
+def test_vendored_sources_present():
+    """Every registered probe's source (and code object source) is vendored."""
+    for spec in _PROBES.values():
+        assert (hrx_mod._KERNELS_DIR / spec.source).is_file()
+        if spec.kernel_source:
+            assert (hrx_mod._KERNELS_DIR / spec.kernel_source).is_file()
+
+
+def test_unknown_probe_rejected():
+    wl = HrxWorkload({"probe": "does_not_exist"})
+    with pytest.raises(ValueError, match="unknown probe"):
+        wl.setup()
+
+
+def test_unknown_config_key_warns(caplog):
+    wl = HrxWorkload({"probe": "module", "bogus": 1})
+    with caplog.at_level(logging.WARNING, logger="aorta.workloads.hrx"):
+        probe = wl._validated_probe()
+    assert probe == "module"
+    assert any("bogus" in r.message for r in caplog.records)
+
+
+def test_setup_raises_without_hipcc(monkeypatch):
+    """No hipcc -> clean setup failure (classified did_not_run, not a repro)."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: None)
+    wl = HrxWorkload({"probe": "module"})
+    with pytest.raises(RuntimeError, match="hipcc not found"):
+        wl.setup()
+
+
+def test_setup_rejects_non_bool_keep_build(monkeypatch):
+    """A "false" string must not coerce to True (loose-typing guard)."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: self._build_dir / "x")
+    wl = HrxWorkload({"probe": "module", "keep_build": "false"})
+    with pytest.raises(ValueError, match="keep_build must be a bool"):
+        wl.setup()
+
+
+def test_build_env_strips_runtime_routing_vars(monkeypatch, tmp_path):
+    """hipcc must build against the stock toolchain, not the HRX-on cell env.
+
+    The dispatcher merges the cell env into os.environ before setup() runs, so
+    a preloaded HRX libamdhip64.so would otherwise run inside the compiler.
+    """
+    for var in hrx_mod._RUNTIME_ROUTING_VARS:
+        monkeypatch.setenv(var, "/some/hrx/value")
+    monkeypatch.setenv("ROCM_PATH", "/opt/rocm")  # unrelated var must survive
+
+    captured: dict[str, dict[str, str] | None] = {}
+
+    def _fake_run(cmd, *a, **k):
+        captured["env"] = k.get("env")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    HrxWorkload({"probe": "static", "build_dir": str(tmp_path)}).setup()
+
+    build_env = captured.get("env")
+    assert build_env is not None, "build must pass an explicit sanitized env"
+    for var in hrx_mod._RUNTIME_ROUTING_VARS:
+        assert var not in build_env, f"{var} must be stripped from the build env"
+    assert build_env.get("ROCM_PATH") == "/opt/rocm"
+
+
+def _prep_workload(monkeypatch, tmp_path: Path) -> HrxWorkload:
+    """A workload whose setup() succeeds without a real toolchain."""
+    monkeypatch.setattr(hrx_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxWorkload, "_build", lambda self: tmp_path / self._spec.binary)
+    wl = HrxWorkload({"probe": "module", "build_dir": str(tmp_path)})
+    wl.setup()
+    return wl
+
+
+def _fake_completed(stdout: str, returncode: int) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["probe"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_run_fully_works(monkeypatch, tmp_path):
+    wl = _prep_workload(monkeypatch, tmp_path)
+    stdout = "out[0]=107 (expect 107)\nVERDICT=FULLY_WORKS\n"
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_completed(stdout, 0))
+
+    res = wl.run()
+
+    assert res.passed is True
+    assert res.failure_count == 0
+    assert res.failure_details == []
+    assert res.metrics.get("verdict") == "FULLY_WORKS"
+    assert res.metrics.get("out0") == 107.0
+    assert res.main_work_started is True
+    assert res.executed_iterations == 1
+
+
+def test_run_output_not_written(monkeypatch, tmp_path):
+    wl = _prep_workload(monkeypatch, tmp_path)
+    stdout = "out[0]=0 (expect 107)\nVERDICT=OUTPUT_NOT_WRITTEN (module-launch out-arg broken)\n"
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_completed(stdout, 1))
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.failure_count == 1
+    assert res.metrics.get("verdict") == "OUTPUT_NOT_WRITTEN"
+    assert res.metrics.get("out0") == 0.0
+    assert res.failure_details, "expected a failure detail"
+    detail = res.failure_details[0]
+    assert detail.get("verdict") == "OUTPUT_NOT_WRITTEN"
+    assert "OUTPUT_NOT_WRITTEN" in detail.get("hint", "")
+    # It still dispatched and read back, so main work started.
+    assert res.main_work_started is True
+
+
+def test_run_timeout_is_failure(monkeypatch, tmp_path):
+    wl = _prep_workload(monkeypatch, tmp_path)
+
+    def _raise_timeout(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="probe", timeout=wl._timeout, output="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.metrics.get("timed_out") is True
+    assert res.failure_details, "expected a failure detail"
+    assert "hung" in res.failure_details[0].get("hint", "")
+
+
+def test_run_no_verdict_is_failure(monkeypatch, tmp_path):
+    """A HIP init crash before any verdict must not pass."""
+    wl = _prep_workload(monkeypatch, tmp_path)
+    stdout = "HIP_ERR hipMalloc at 27: out of memory\n"
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_completed(stdout, 2))
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.metrics.get("verdict") is None
+    assert res.main_work_started is False
+    assert res.executed_iterations == 0

--- a/tests/workloads/test_hrx.py
+++ b/tests/workloads/test_hrx.py
@@ -149,6 +149,8 @@ def test_run_output_not_written(monkeypatch, tmp_path):
 
     assert res.passed is False
     assert res.failure_count == 1
+    assert res.total_iterations == 1
+    assert res.first_failure_iteration == 0
     assert res.metrics.get("verdict") == "OUTPUT_NOT_WRITTEN"
     assert res.metrics.get("out0") == 0.0
     assert res.failure_details, "expected a failure detail"
@@ -171,6 +173,8 @@ def test_run_timeout_is_failure(monkeypatch, tmp_path):
 
     assert res.passed is False
     assert res.metrics.get("timed_out") is True
+    # Hung before printing anything -> did-not-run shape, no phantom iteration.
+    assert res.total_iterations == 0
     assert res.failure_details, "expected a failure detail"
     assert "hung" in res.failure_details[0].get("hint", "")
 
@@ -187,6 +191,10 @@ def test_run_no_verdict_is_failure(monkeypatch, tmp_path):
     assert res.metrics.get("verdict") is None
     assert res.main_work_started is False
     assert res.executed_iterations == 0
+    # Never started -> 0 iterations + no failing index, so the matrix
+    # elapsed_per_iter fallback can't mint a misleading step time.
+    assert res.total_iterations == 0
+    assert res.first_failure_iteration is None
     # The crash diagnostic is on stdout (probes printf there), so it must be
     # persisted in the failure detail, and the hint must point at stdout.
     assert res.failure_details, "expected a failure detail"

--- a/tests/workloads/test_hrx_perf.py
+++ b/tests/workloads/test_hrx_perf.py
@@ -79,9 +79,11 @@ def test_setup_raises_without_gpu(monkeypatch, tmp_path):
 
 
 def test_build_reuses_existing_binary(monkeypatch, tmp_path):
-    """A pre-built benchmark in a shared build_dir is reused (no recompile)."""
+    """A pre-built (executable) benchmark in a shared build_dir is reused."""
     monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
-    (tmp_path / _BENCHES["gemm"].binary).write_bytes(b"\x7fELF")
+    binary = tmp_path / _BENCHES["gemm"].binary
+    binary.write_bytes(b"\x7fELF")
+    binary.chmod(0o755)
 
     def _fail_run(*a, **k):
         raise AssertionError("hipcc must not run when the binary already exists")
@@ -89,7 +91,25 @@ def test_build_reuses_existing_binary(monkeypatch, tmp_path):
     monkeypatch.setattr(subprocess, "run", _fail_run)
     wl = HrxPerfWorkload({"bench": "gemm", "build_dir": str(tmp_path)})
     wl.setup()
-    assert wl._binary == (tmp_path / _BENCHES["gemm"].binary)
+    assert wl._binary == binary
+
+
+def test_build_rebuilds_when_binary_not_executable(monkeypatch, tmp_path):
+    """A leftover benchmark binary without the execute bit is NOT reused --
+    reusing it would fail run() with PermissionError, so it must rebuild."""
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    binary = tmp_path / _BENCHES["gemm"].binary
+    binary.write_bytes(b"\x7fELF")
+    binary.chmod(0o644)  # readable but not executable
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    HrxPerfWorkload({"bench": "gemm", "build_dir": str(tmp_path)}).setup()
+    assert calls, "hipcc must run when the existing binary is not executable"
 
 
 def test_build_passes_sanitized_env_and_arch(monkeypatch, tmp_path):

--- a/tests/workloads/test_hrx_perf.py
+++ b/tests/workloads/test_hrx_perf.py
@@ -1,0 +1,184 @@
+"""Unit tests for the `hrx_perf` HIP performance benchmark workload.
+
+Unit-level: no hipcc, no GPU. Build and run are monkeypatched so per-step /
+throughput parsing and result mapping are tested in isolation, plus the
+setup-time guards (hipcc absent, bad LD_PRELOAD).
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from aorta.workloads import hrx_perf as perf_mod
+from aorta.workloads.hrx_perf import _BENCHES, HrxPerfWorkload
+
+
+def test_vendored_bench_sources_present():
+    for spec in _BENCHES.values():
+        assert (perf_mod._KERNELS_DIR / spec.source).is_file()
+
+
+def test_unknown_bench_rejected():
+    wl = HrxPerfWorkload({"bench": "does_not_exist"})
+    with pytest.raises(ValueError, match="unknown bench"):
+        wl.setup()
+
+
+def test_non_positive_size_rejected(monkeypatch):
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxPerfWorkload, "_build", lambda self: self._build_dir / "x")
+    wl = HrxPerfWorkload({"bench": "gemm", "size": 0})
+    with pytest.raises(ValueError, match="must be > 0"):
+        wl.setup()
+
+
+def test_setup_raises_without_hipcc(monkeypatch):
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: None)
+    wl = HrxPerfWorkload({"bench": "gemm"})
+    with pytest.raises(RuntimeError, match="hipcc not found"):
+        wl.setup()
+
+
+def test_setup_rejects_nonexistent_ld_preload(monkeypatch, tmp_path):
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxPerfWorkload, "_build", lambda self: self._build_dir / "x")
+    monkeypatch.setenv("LD_PRELOAD", "/path/to/hrx-root/lib/libamdhip64.so")
+    wl = HrxPerfWorkload({"bench": "gemm", "build_dir": str(tmp_path)})
+    with pytest.raises(RuntimeError, match="LD_PRELOAD names object"):
+        wl.setup()
+
+
+def test_build_passes_sanitized_env_and_arch(monkeypatch, tmp_path):
+    """The build must strip HRX routing vars and target the configured arch."""
+    for var in ("LD_PRELOAD", "LD_LIBRARY_PATH", "HRX_GPU_DRIVER"):
+        # Real path for LD_PRELOAD so the setup existence guard passes.
+        if var == "LD_PRELOAD":
+            lib = tmp_path / "libamdhip64.so"
+            lib.write_bytes(b"\x7fELF")
+            monkeypatch.setenv(var, str(lib))
+        else:
+            monkeypatch.setenv(var, str(tmp_path))
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+        captured["env"] = k.get("env")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    HrxPerfWorkload(
+        {"bench": "triad", "gpu_arch": "gfx90a", "build_dir": str(tmp_path)}
+    ).setup()
+
+    for var in ("LD_PRELOAD", "LD_LIBRARY_PATH", "HRX_GPU_DRIVER"):
+        assert var not in (captured["env"] or {})
+    assert "--offload-arch=gfx90a" in captured["cmd"]
+    assert "-O3" in captured["cmd"]
+
+
+def _prep(monkeypatch, tmp_path, config=None):
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxPerfWorkload, "_build", lambda self: tmp_path / self._spec.binary)
+    cfg = {"bench": "gemm", "build_dir": str(tmp_path), "iters": 3}
+    if config:
+        cfg.update(config)
+    wl = HrxPerfWorkload(cfg)
+    wl.setup()
+    return wl
+
+
+def _completed(stdout, returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        args=["bench"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_run_parses_step_times_and_throughput(monkeypatch, tmp_path):
+    wl = _prep(monkeypatch, tmp_path)
+    stdout = (
+        "bench=gemm size=4096 iters=3 warmup=10\n"
+        "step_ms=12.5\nstep_ms=12.0\nstep_ms=13.0\n"
+        "GFLOPS=1234.5\nchecksum=4096.0 expected=4096\nRESULT=PERF_OK\n"
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed(stdout, 0))
+
+    res = wl.run()
+
+    assert res.passed is True
+    assert res.step_times_ms == [12.5, 12.0, 13.0]
+    assert res.total_iterations == 3
+    assert res.executed_iterations == 3
+    assert res.configured_iterations == 3
+    assert res.main_work_started is True
+    assert res.metrics.get("gflops") == 1234.5
+    assert res.metrics.get("mean_step_ms") == pytest.approx((12.5 + 12.0 + 13.0) / 3)
+    assert res.metrics.get("result") == "PERF_OK"
+
+
+def test_run_triad_throughput_metric_is_gbps(monkeypatch, tmp_path):
+    wl = _prep(monkeypatch, tmp_path, {"bench": "triad", "size": 1000})
+    stdout = (
+        "bench=triad size=1000 iters=3 warmup=20\n"
+        "step_ms=0.5\nstep_ms=0.6\nstep_ms=0.4\n"
+        "GBPS=987.6\nchecksum=7.0 expected=7.0\nRESULT=PERF_OK\n"
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed(stdout, 0))
+
+    res = wl.run()
+
+    assert res.passed is True
+    assert res.metrics.get("gbps") == 987.6
+    assert "gflops" not in res.metrics
+
+
+def test_run_failed_result_is_failure(monkeypatch, tmp_path):
+    wl = _prep(monkeypatch, tmp_path)
+    stdout = "bench=gemm size=4096 iters=3 warmup=10\nchecksum=0.0 expected=4096\nRESULT=PERF_FAIL\n"
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed(stdout, 1))
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.failure_count == 1
+    assert res.failure_details, "expected a failure detail"
+    assert res.metrics.get("result") == "PERF_FAIL"
+
+
+def test_run_preload_ignored_fails_even_with_ok_result(monkeypatch, tmp_path):
+    """A PERF_OK timing measured against the wrong runtime is not a valid A/B."""
+    wl = _prep(monkeypatch, tmp_path)
+    monkeypatch.setenv("LD_PRELOAD", "/some/hrx/libamdhip64.so")
+    stdout = "step_ms=12.0\nGFLOPS=1000.0\nRESULT=PERF_OK\n"
+    stderr = (
+        "ERROR: ld.so: object '/some/hrx/libamdhip64.so' from LD_PRELOAD cannot "
+        "be preloaded (cannot open shared object file): ignored.\n"
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed(stdout, 0, stderr))
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.metrics.get("preload_ignored") is True
+    assert "ignored" in res.failure_details[0].get("hint", "").lower()
+
+
+def test_run_timeout_is_failure(monkeypatch, tmp_path):
+    wl = _prep(monkeypatch, tmp_path)
+
+    def _raise_timeout(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="bench", timeout=wl._timeout, output="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.metrics.get("timed_out") is True
+    assert res.total_iterations == 0
+    assert res.main_work_started is False
+    assert "timed out" in res.failure_details[0].get("hint", "")

--- a/tests/workloads/test_hrx_perf.py
+++ b/tests/workloads/test_hrx_perf.py
@@ -296,3 +296,43 @@ def test_run_timeout_is_failure(monkeypatch, tmp_path):
     assert res.total_iterations == 0
     assert res.main_work_started is False
     assert "timed out" in res.failure_details[0].get("hint", "")
+
+
+def test_setup_rejects_unsafe_gpu_arch(monkeypatch, tmp_path):
+    """A hostile gpu_arch must not escape build_dir (shared _validated_arch)."""
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxPerfWorkload, "_build", lambda self: self._build_dir / "x")
+    wl = HrxPerfWorkload(
+        {"bench": "gemm", "gpu_arch": "../../etc", "build_dir": str(tmp_path)}
+    )
+    with pytest.raises(ValueError, match="gpu_arch"):
+        wl.setup()
+
+
+def test_run_writes_full_logs_when_save_logs(monkeypatch, tmp_path):
+    """With save_logs, run() writes the child's FULL stdout/stderr to sibling
+    ``<prefix>.subprocess.*.log`` files -- not just the truncated failure tails."""
+    log_prefix = tmp_path / "trial_d0_m0_t0"
+    wl = _prep(
+        monkeypatch,
+        tmp_path,
+        {
+            "_aorta_save_logs": True,
+            "_aorta_log_prefix": str(log_prefix),
+        },
+    )
+    stdout = (
+        "bench=gemm size=4096 iters=3 warmup=10\n"
+        "step_ms=12.5\nstep_ms=12.0\nstep_ms=13.0\n"
+        "GFLOPS=1234.5\nchecksum=4096.0 expected=4096\nRESULT=PERF_OK\n"
+    ) + "x" * 5000
+    stderr = "some hip chatter\n" + "y" * 5000
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed(stdout, 0, stderr))
+
+    res = wl.run()
+
+    assert res.passed is True
+    out_log = tmp_path / "trial_d0_m0_t0.subprocess.stdout.log"
+    err_log = tmp_path / "trial_d0_m0_t0.subprocess.stderr.log"
+    assert out_log.read_text() == stdout
+    assert err_log.read_text() == stderr

--- a/tests/workloads/test_hrx_perf.py
+++ b/tests/workloads/test_hrx_perf.py
@@ -15,6 +15,12 @@ from aorta.workloads import hrx_perf as perf_mod
 from aorta.workloads.hrx_perf import _BENCHES, HrxPerfWorkload
 
 
+@pytest.fixture(autouse=True)
+def _gpu_present(monkeypatch):
+    """Stub GPU reachability True so setup() stays GPU-free by default."""
+    monkeypatch.setattr(perf_mod, "_gpu_available", lambda: True)
+
+
 def test_vendored_bench_sources_present():
     for spec in _BENCHES.values():
         assert (perf_mod._KERNELS_DIR / spec.source).is_file()
@@ -48,6 +54,30 @@ def test_setup_rejects_nonexistent_ld_preload(monkeypatch, tmp_path):
     wl = HrxPerfWorkload({"bench": "gemm", "build_dir": str(tmp_path)})
     with pytest.raises(RuntimeError, match="LD_PRELOAD names object"):
         wl.setup()
+
+
+def test_setup_raises_without_gpu(monkeypatch, tmp_path):
+    """hipcc present but no reachable GPU -> setup failure (did_not_run)."""
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(perf_mod, "_gpu_available", lambda: False)
+    monkeypatch.setattr(HrxPerfWorkload, "_build", lambda self: self._build_dir / "x")
+    wl = HrxPerfWorkload({"bench": "gemm", "build_dir": str(tmp_path)})
+    with pytest.raises(RuntimeError, match="no accessible ROCm GPU"):
+        wl.setup()
+
+
+def test_build_reuses_existing_binary(monkeypatch, tmp_path):
+    """A pre-built benchmark in a shared build_dir is reused (no recompile)."""
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    (tmp_path / _BENCHES["gemm"].binary).write_bytes(b"\x7fELF")
+
+    def _fail_run(*a, **k):
+        raise AssertionError("hipcc must not run when the binary already exists")
+
+    monkeypatch.setattr(subprocess, "run", _fail_run)
+    wl = HrxPerfWorkload({"bench": "gemm", "build_dir": str(tmp_path)})
+    wl.setup()
+    assert wl._binary == (tmp_path / _BENCHES["gemm"].binary)
 
 
 def test_build_passes_sanitized_env_and_arch(monkeypatch, tmp_path):

--- a/tests/workloads/test_hrx_perf.py
+++ b/tests/workloads/test_hrx_perf.py
@@ -78,10 +78,17 @@ def test_setup_raises_without_gpu(monkeypatch, tmp_path):
         wl.setup()
 
 
+def _arch_dir(build_dir, arch=perf_mod._DEFAULT_ARCH):
+    """Artifacts live in <build_dir>/<arch>/ (see HrxPerfWorkload._build)."""
+    d = build_dir / arch
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
 def test_build_reuses_existing_binary(monkeypatch, tmp_path):
     """A pre-built (executable) benchmark in a shared build_dir is reused."""
     monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
-    binary = tmp_path / _BENCHES["gemm"].binary
+    binary = _arch_dir(tmp_path) / _BENCHES["gemm"].binary
     binary.write_bytes(b"\x7fELF")
     binary.chmod(0o755)
 
@@ -98,7 +105,7 @@ def test_build_rebuilds_when_binary_not_executable(monkeypatch, tmp_path):
     """A leftover benchmark binary without the execute bit is NOT reused --
     reusing it would fail run() with PermissionError, so it must rebuild."""
     monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
-    binary = tmp_path / _BENCHES["gemm"].binary
+    binary = _arch_dir(tmp_path) / _BENCHES["gemm"].binary
     binary.write_bytes(b"\x7fELF")
     binary.chmod(0o644)  # readable but not executable
     calls: list[list[str]] = []
@@ -110,6 +117,26 @@ def test_build_rebuilds_when_binary_not_executable(monkeypatch, tmp_path):
     monkeypatch.setattr(subprocess, "run", _fake_run)
     HrxPerfWorkload({"bench": "gemm", "build_dir": str(tmp_path)}).setup()
     assert calls, "hipcc must run when the existing binary is not executable"
+
+
+def test_build_rebuilds_for_different_arch(monkeypatch, tmp_path):
+    """A benchmark built for one arch must NOT be reused when a different arch is
+    requested against the same build_dir -- reuse is isolated per arch subdir."""
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    other = _arch_dir(tmp_path, "gfx90a") / _BENCHES["gemm"].binary
+    other.write_bytes(b"\x7fELF")
+    other.chmod(0o755)
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    HrxPerfWorkload(
+        {"bench": "gemm", "gpu_arch": "gfx942", "build_dir": str(tmp_path)}
+    ).setup()
+    assert calls, "hipcc must run when only a different-arch binary exists"
 
 
 def test_build_passes_sanitized_env_and_arch(monkeypatch, tmp_path):

--- a/tests/workloads/test_hrx_perf.py
+++ b/tests/workloads/test_hrx_perf.py
@@ -177,6 +177,31 @@ def test_run_failed_result_is_failure(monkeypatch, tmp_path):
     assert res.failure_count == 1
     assert res.failure_details, "expected a failure detail"
     assert res.metrics.get("result") == "PERF_FAIL"
+    # No timed iterations ran here -> did-not-run shape, index stays None.
+    assert res.first_failure_iteration is None
+
+
+def test_run_failed_with_iterations_reports_failure_index(monkeypatch, tmp_path):
+    """A PERF_FAIL that still produced timed steps reports index 0, not None.
+
+    WorkloadResult documents None only for the passing case; when iterations
+    executed but the trial failed, the index must land in 0..total-1 (mirrors
+    the hrx workload) so downstream consumers don't special-case hrx_perf.
+    """
+    wl = _prep(monkeypatch, tmp_path)
+    stdout = (
+        "bench=gemm size=4096 iters=3 warmup=10\n"
+        "step_ms=12.5\nstep_ms=12.0\nstep_ms=13.0\n"
+        "checksum=0.0 expected=4096\nRESULT=PERF_FAIL\n"
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed(stdout, 1))
+
+    res = wl.run()
+
+    assert res.passed is False
+    assert res.main_work_started is True
+    assert res.total_iterations == 3
+    assert res.first_failure_iteration == 0
 
 
 def test_run_preload_ignored_fails_even_with_ok_result(monkeypatch, tmp_path):

--- a/tests/workloads/test_hrx_perf.py
+++ b/tests/workloads/test_hrx_perf.py
@@ -40,6 +40,18 @@ def test_non_positive_size_rejected(monkeypatch):
         wl.setup()
 
 
+@pytest.mark.parametrize("bad", [0, -1])
+def test_setup_rejects_nonpositive_timeout(monkeypatch, bad):
+    """A zero/negative timeout_sec fails fast in setup() with a config error,
+    rather than raising from subprocess.run(timeout=...) at run() time and being
+    misclassified as an infrastructure failure."""
+    monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: "/usr/bin/hipcc")
+    monkeypatch.setattr(HrxPerfWorkload, "_build", lambda self: self._build_dir / "x")
+    wl = HrxPerfWorkload({"bench": "gemm", "timeout_sec": bad})
+    with pytest.raises(ValueError, match="timeout_sec"):
+        wl.setup()
+
+
 def test_setup_raises_without_hipcc(monkeypatch):
     monkeypatch.setattr(perf_mod, "_resolve_hipcc", lambda _cfg: None)
     wl = HrxPerfWorkload({"bench": "gemm"})


### PR DESCRIPTION
## Summary

Adds the HRX HIP-compatibility-layer workloads and the triage reporting to support them, so the HRX runtime can be exercised and A/B-compared (HRX-on vs stock ROCm HIP) through the normal `aorta run` / `aorta sweep run` flows. Closes #273.

**Correctness — `hrx` workload** (`src/aorta/workloads/hrx.py`): builds one probe — `static` | `module` | `graph_add` | `graph_setparams` | `graph_execsetparams` — from vendored source with `hipcc` at `setup()`, execs it as a child process, and parses its `VERDICT=` / `out[0]=` output into a `WorkloadResult` (`passed == FULLY_WORKS`; `0` / `OUTPUT_NOT_WRITTEN` is the #156 bug). Missing `hipcc` **or** no accessible GPU (checks `/dev/kfd` is readable+writable) raises in `setup()` so the cell classifies as `did_not_run` rather than a false `OUTPUT_NOT_WRITTEN`.

**Performance — `hrx_perf` workload** (`src/aorta/workloads/hrx_perf.py`): builds one of a set of deliberately large HIP benchmarks (`gemm` compute-bound / `triad` bandwidth-bound), times each iteration host-side, and reports `step_times_ms` + achieved throughput (`gflops` / `gbps`) so the matrix renders per-cell mean step time and an HRX-vs-stock confound ratio. Shares the `hrx` runtime-routing guards and GPU/hipcc prerequisites; reuses an existing build in a shared `build_dir`.

**Runtime routing is an environment concern, not the workload's:** the `hrx_on` cell applies an `LD_PRELOAD` + `LD_LIBRARY_PATH` + `HRX_GPU_DRIVER` bundle, honored at the child's `exec()`. The bundle is **stripped from the `hipcc` build env** (`_RUNTIME_ROUTING_VARS`) — the dispatcher merges the cell env into `os.environ` before `setup()`, so without stripping, a preloaded HRX `libamdhip64.so` would run inside the compiler/link step. Building against the stock toolchain also makes the binary identical across cells. A nonexistent `LD_PRELOAD` fails `setup()`, and an ignored preload fails `run()`, so a misrouted cell can't mint a false green.

**Triage reporting additions (supporting the above):**
- **`perf.md`** — a per-run performance report written next to `matrix.md` / `matrix.json` on every run (no flag; pure formatting of already-collected per-trial data): a step-timing percentile table plus a conditional workload-throughput table. `matrix.md` gains a pointer note to it.
- **`metrics_summary`** — scalar workload metrics (`gflops` / `gbps` / `mean_step_ms` / …) aggregated per cell into `CellStats.metrics_summary` and surfaced in `matrix.json::cells[*]`.
- **`sweep run --strict`** — fail a sweep when any cell errors or never runs.

**Also:** vendored probe/bench sources under `src/aorta/workloads/hrx_kernels/`, recipes (`recipes/hrx-*.yaml`), a docs note (`docs/hrx-workload.md`), packaging (`pyproject.toml` entry-points + package-data), and GPU-free unit tests for all of the above.

## Test plan

- [x] `ruff check` clean on changed files.
- [x] `pytest tests/workloads/test_hrx.py tests/workloads/test_hrx_perf.py` — passing (verdict/throughput parsing, timeout, no-verdict crash, no-GPU setup failure, build reuse, `keep_build` type guard, build-env stripping, failure-index contract).
- [x] `pytest tests/triage/` — passing (`perf.md` written every run, throughput table when metrics present, error/did-not-run rows render `error`/`n/a` not `0.000`, `metrics_summary` aggregation, `--strict`).
- [x] Real `hipcc` build + run of the `static` probe on a gfx942 host → `FULLY_WORKS`, `out[0]=107`.
- [ ] Reviewer: run the A/B recipe on a host with both a stock ROCm and an installed HRX prefix:
      `aorta sweep run --recipe recipes/hrx-launch-probe-smoke.yaml --output ./triage_results --ticket HRX-273-SMOKE`

## Notes

- `aorta probe` is Linux/ROCm-only by design; these workloads require a ROCm/`hipcc` toolchain **and** an accessible GPU, and are guarded accordingly (`setup()` raises with a clear message otherwise).
- Test `monkeypatch.setattr` targets all exist, so `raising=False` is intentionally omitted (it would mask a future rename typo).

Made with [Cursor](https://cursor.com)