### PR TITLE
dispatcher: inject _aorta_collect_dir without requiring save_logs

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -24,6 +24,7 @@ workload: fsdp                       # required; resolved via aorta.workloads en
 trials: 8                            # required; per-cell trial count
 steps: 5000                          # required; per-cell step count
 save_logs: false                     # optional; when true, dispatcher writes per-trial stdout/stderr files
+collect: [layer_numerics]            # optional; collector names -- does NOT require save_logs
 
 confound:
   threshold: 1.15                    # default; > 1.15 -> "speed (+N%)" flag
@@ -116,6 +117,24 @@ cells:
   `results_dir`. The dispatcher already holds the
   `<prefix>.{stdout,stderr}.log` paths open, so wrappers must NOT
   write to them directly.
+- **`collect`** -- optional `list[str]` or mapping, default absent (no
+  collectors). Names one or more cross-cutting collectors to attach to every
+  cell (e.g. `[layer_numerics]` for the per-layer NaN/magnitude logger).
+  List form enables collectors with default options; mapping form passes
+  per-collector options:
+
+  ```yaml
+  # list form (default options):
+  collect: [layer_numerics]
+
+  # mapping form (per-collector options):
+  collect:
+    layer_numerics:
+      NANLOG_SAMPLE_EVERY: "10"
+  ```
+
+  Unknown collector names are rejected at load time (validated against
+  `aorta.run.collectors.KNOWN_RECIPES`).
 - **`workload_config`** -- optional `dict[str, Any]`, allowed at both
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -662,18 +662,19 @@ def _run_single_trial(
             name: dict(opts) for name, opts in request.collect_options.items()
         }
 
-    # When a collector is active, thread the per-trial output directory so a
+    # When a collector is active, thread the per-trial output path stem so a
     # workload can write collector artifacts (e.g. the layer_numerics NaN
     # logger's summary/jsonl) into the results tree -- WITHOUT requiring
     # ``save_logs``. Previously a subprocess wrapper had to piggy-back on
     # ``_aorta_log_prefix``, which the dispatcher only sets when
     # ``save_logs=True``; that coupled an unrelated debug knob to collector
     # output landing in the right place (and being picked up by ``aorta
-    # bundle``). This is an absolute path-with-stem, same shape/derivation as
-    # ``_aorta_log_prefix`` (``.absolute()`` so a relative ``results_dir``
-    # still yields a usable path for a subprocess with a different cwd). Only
-    # set on rank 0 (matches the trial-JSON / log-capture write gate) and only
-    # when a collector was requested, so non-collector runs are unchanged.
+    # bundle``). This is an absolute path stem with no extension, same
+    # shape/derivation as ``_aorta_log_prefix`` (``.absolute()`` so a relative
+    # ``results_dir`` still yields a usable path for a subprocess with a
+    # different cwd). Only set on rank 0 (matches the trial-JSON / log-capture
+    # write gate) and only when a collector was requested, so non-collector
+    # runs are unchanged.
     if request.collect and should_write:
         trial_basename = (
             f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -662,6 +662,24 @@ def _run_single_trial(
             name: dict(opts) for name, opts in request.collect_options.items()
         }
 
+    # When a collector is active, thread the per-trial output directory so a
+    # workload can write collector artifacts (e.g. the layer_numerics NaN
+    # logger's summary/jsonl) into the results tree -- WITHOUT requiring
+    # ``save_logs``. Previously a subprocess wrapper had to piggy-back on
+    # ``_aorta_log_prefix``, which the dispatcher only sets when
+    # ``save_logs=True``; that coupled an unrelated debug knob to collector
+    # output landing in the right place (and being picked up by ``aorta
+    # bundle``). This is an absolute path-with-stem, same shape/derivation as
+    # ``_aorta_log_prefix`` (``.absolute()`` so a relative ``results_dir``
+    # still yields a usable path for a subprocess with a different cwd). Only
+    # set on rank 0 (matches the trial-JSON / log-capture write gate) and only
+    # when a collector was requested, so non-collector runs are unchanged.
+    if request.collect and should_write:
+        trial_basename = (
+            f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
+        )
+        config["_aorta_collect_dir"] = str((results_dir / trial_basename).absolute())
+
     # Snapshot the env BEFORE applying mitigation / extra_env so the
     # ``finally`` block can restore both the dispatcher's overlay and
     # any workload-side mutations introduced by ``setup()`` / ``run()``.

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -536,6 +536,76 @@ class TestRunTrials:
             run_trials(req)
         assert "_aorta_collect_options" not in captured_config
 
+    def test_collect_dir_injected_when_collector_active(self, tmp_path):
+        """A collector run gets ``config['_aorta_collect_dir']`` (an absolute
+        per-trial path) WITHOUT needing ``save_logs`` -- so collector artifacts
+        can land in the results tree regardless of the log-capture knob."""
+        captured_config: dict = {}
+
+        class ConfigCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_config.update(self.config)
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "collect_dir"
+        mock_ep.load.return_value = ConfigCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="collect_dir",
+                trials=1,
+                results_dir=tmp_path,
+                collect=("layer_numerics",),
+                # note: save_logs NOT set
+            )
+            run_trials(req)
+        collect_dir = captured_config["_aorta_collect_dir"]
+        assert Path(collect_dir).is_absolute()
+        assert collect_dir.endswith("trial_d0_m0_t0")
+        # No log prefix, because save_logs was not requested -- proves the two
+        # are decoupled.
+        assert "_aorta_log_prefix" not in captured_config
+
+    def test_collect_dir_absent_without_collector(self, tmp_path):
+        """No ``_aorta_collect_dir`` for a run with no collector -- back-compat
+        (the key only appears when a collector was requested)."""
+        captured_config: dict = {}
+
+        class ConfigCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_config.update(self.config)
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "nocollectdir"
+        mock_ep.load.return_value = ConfigCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(workload="nocollectdir", trials=1, results_dir=tmp_path)
+            run_trials(req)
+        assert "_aorta_collect_dir" not in captured_config
+
     def test_collect_survives_trial_json_roundtrip(self, tmp_path):
         """``_aorta_collect`` is a plain list, so the trial JSON dump needs
         no sanitizer for it (unlike ``_aorta_probe_extras``)."""

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -538,8 +538,8 @@ class TestRunTrials:
 
     def test_collect_dir_injected_when_collector_active(self, tmp_path):
         """A collector run gets ``config['_aorta_collect_dir']`` (an absolute
-        per-trial path) WITHOUT needing ``save_logs`` -- so collector artifacts
-        can land in the results tree regardless of the log-capture knob."""
+        per-trial path stem) WITHOUT needing ``save_logs`` -- so collector
+        artifacts can land in the results tree regardless of the log-capture knob."""
         captured_config: dict = {}
 
         class ConfigCapturingWorkload(Workload):


### PR DESCRIPTION
## Summary

- `collect: [layer_numerics]` in a recipe no longer requires `save_logs: true`
- The dispatcher now injects `_aorta_collect_dir` (absolute per-trial path-with-stem) whenever `collect` is non-empty, independent of `save_logs`
- Previously, subprocess wrappers had to piggy-back on `_aorta_log_prefix` which is only set when `save_logs=True` — coupling an unrelated debug knob to collector output routing

## Test plan

- [ ] `test_collect_dir_injected_when_collector_active` — verifies `_aorta_collect_dir` is set without `save_logs`
- [ ] `test_collect_dir_absent_without_save_logs_when_no_collector` — verifies non-collector runs are unchanged
- [ ] Existing collector tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)