### PR TITLE
recipe: allow per-cell collect override

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -24,6 +24,7 @@ workload: fsdp                       # required; resolved via aorta.workloads en
 trials: 8                            # required; per-cell trial count
 steps: 5000                          # required; per-cell step count
 save_logs: false                     # optional; when true, dispatcher writes per-trial stdout/stderr files
+collect: [layer_numerics]            # optional; default collectors for every cell
 
 confound:
   threshold: 1.15                    # default; > 1.15 -> "speed (+N%)" flag
@@ -38,6 +39,7 @@ cells:
   - name: tf32_off-local
     mitigations: [tf32_off]
     environment: local
+    collect: []                      # optional per-cell override; disables collection here
 
   - name: stack-tf32-xnack-local     # mitigation stacking (env vars unioned in list order)
     mitigations: [tf32_off, xnack]
@@ -116,6 +118,30 @@ cells:
   `results_dir`. The dispatcher already holds the
   `<prefix>.{stdout,stderr}.log` paths open, so wrappers must NOT
   write to them directly.
+- **`collect`** -- optional `list[str]` or mapping, default absent (no
+  collectors). Names one or more cross-cutting collectors to attach to every
+  cell (e.g. `[layer_numerics]` for the per-layer NaN/magnitude logger).
+  List form enables collectors with default options; mapping form passes
+  per-collector options:
+
+  ```yaml
+  # list form (default options):
+  collect: [layer_numerics]
+
+  # mapping form (per-collector options):
+  collect:
+    layer_numerics:
+      NANLOG_SAMPLE_EVERY: "10"
+  ```
+
+  Cells may also set `collect:`. An absent cell key inherits the recipe-level
+  collectors, a present value replaces the recipe-level collectors for that
+  cell, and `collect: []` disables collectors for that cell. The same mapping
+  form is accepted at cell scope. CLI `--collect` is an operator override and
+  applies to every cell, clearing any per-cell collector overrides.
+
+  Unknown collector names are rejected at load time (validated against
+  `aorta.run.collectors.KNOWN_RECIPES`).
 - **`workload_config`** -- optional `dict[str, Any]`, allowed at both
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -271,7 +271,8 @@ def execute_triage_run(
             # NAME list; validate via the same loader path the recipe uses.
             # Per-collector options are recipe-file-only (the mapping form).
             # When the CLI overrides the collector names, keep only options
-            # for collectors that are still enabled.
+            # for collectors that are still enabled and clear per-cell
+            # overrides so the operator-requested collectors apply everywhere.
             cli_collect = parse_csv(collect)
             if cli_collect:
                 collect_names, _ = _parse_collect("--collect", list(cli_collect))
@@ -284,6 +285,10 @@ def execute_triage_run(
                     r,
                     collect=collect_names,
                     collect_options=collect_options,
+                    cells=tuple(
+                        dataclasses.replace(cell, collect=None, collect_options=None)
+                        for cell in r.cells
+                    ),
                 )
         except (RecipeSchemaError, RecipeCellError, RegistryError) as exc:
             raise click.ClickException(str(exc)) from exc

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -76,6 +76,22 @@ _SAFE_RE = re.compile(r"[^A-Za-z0-9_.\-]")
 _RESERVED_SLUGS = frozenset({".", ".."})
 
 
+def _collect_doc(
+    collect: tuple[str, ...],
+    collect_options: dict[str, dict[str, str]] | None = None,
+) -> list[str] | dict[str, dict[str, str] | None]:
+    """Return the reloadable YAML shape for a ``collect:`` field.
+
+    List form keeps option-free collectors compact. Mapping form is needed when
+    any enabled collector has options; option-less collectors are emitted with
+    ``null`` so they stay enabled on reload.
+    """
+    options = collect_options or {}
+    if not options:
+        return list(collect)
+    return {name: (dict(options[name]) if name in options else None) for name in collect}
+
+
 def safe_slug(value: str) -> str:
     """Turn a ticket / workload / env name into a safe directory component.
 
@@ -993,6 +1009,12 @@ def write_resolved_recipe(
     the resolved YAML preserves the stopping behaviour rather than silently
     reverting to fixed ``trials``.
 
+    Collector settings are also re-emitted at recipe and cell scope so replay
+    preserves which collector artifacts were requested. Cell-level ``collect``
+    is omitted only when the cell inherits the recipe default; explicit
+    ``collect: []`` disables collection on reload just as it did in the
+    original run.
+
     For runs that used ``--mitigations-file``, the resolved YAML still
     references those mitigation/environment names by name -- it is **not**
     self-contained on its own. The runner snapshots the operator-supplied
@@ -1037,6 +1059,14 @@ def write_resolved_recipe(
             # YAML preserves both scopes (recipe-scope key below) so a
             # round-trip load+run produces the same effective config.
             cell_doc["workload_config"] = dict(cell.workload_config)
+        if cell.collect is not None:
+            # Preserve explicit cell-level collector intent. Omitted means
+            # inherit the recipe-level ``collect``; ``[]`` means disable for
+            # this cell.
+            cell_doc["collect"] = _collect_doc(
+                cell.collect,
+                cell.collect_options,
+            )
         resolved_cells.append(cell_doc)
 
     doc: dict[str, Any] = {
@@ -1052,6 +1082,8 @@ def write_resolved_recipe(
         # recipes that never used the field round-trip to byte-equivalent
         # YAML. Cell-scope values are written per cell above.
         doc["workload_config"] = dict(recipe.workload_config)
+    if recipe.collect:
+        doc["collect"] = _collect_doc(recipe.collect, recipe.collect_options)
     doc["confound"] = {
         "threshold": recipe.confound.threshold,
         "baseline_cell": recipe.confound.baseline_cell,

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -836,6 +836,12 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
     # We branch on key presence rather than truthiness so ``collect: []`` and
     # a missing key mean different things.
     if "collect" in raw:
+        if raw["collect"] is None:
+            raise RecipeSchemaError(
+                f"{path_hint}.collect: null is not allowed at cell scope; "
+                "omit the key to inherit recipe-level collectors or use [] "
+                "to disable collectors for this cell."
+            )
         collect, collect_options = _parse_collect(path_hint, raw["collect"])
     else:
         collect, collect_options = None, None

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -299,8 +299,8 @@ class Cell:
             as the top-level ``collect:`` key; the mapping form's per-collector
             options land in :attr:`collect_options`.
         collect_options: Per-collector option dicts parsed from the cell's
-            mapping-form ``collect:``. ``None`` when ``collect`` is inherited or
-            given in list form. Empty dict when the mapping form carried no
+            mapping-form ``collect:``. ``None`` when ``collect`` is inherited.
+            Empty dict when the cell uses list form or mapping form with no
             options.
     """
 

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -120,7 +120,16 @@ _PHASE_3_KEYS = frozenset({"condition"})
 _VALID_TOP_LEVEL = _TRIAGE_TOP_LEVEL | _PROBE_TOP_LEVEL | {"mode"}
 _VALID_CONFOUND_KEYS = frozenset({"threshold", "baseline_cell"})
 _VALID_CELL_KEYS = frozenset(
-    {"name", "mitigations", "environment", "extra_env", "trials", "steps", "workload_config"}
+    {
+        "name",
+        "mitigations",
+        "environment",
+        "extra_env",
+        "trials",
+        "steps",
+        "workload_config",
+        "collect",
+    }
 )
 _VALID_INLINE_ENV_KEYS = frozenset({"docker"})
 
@@ -281,6 +290,18 @@ class Cell:
             ``_aorta_*`` key are rejected at load time -- ``steps`` is a
             first-class field the dispatcher would silently overwrite, and
             ``_aorta_*`` is reserved for platform-supplied keys.
+        collect: Optional per-cell override of the recipe-level ``collect``.
+            ``None`` (the default, key absent) means "inherit the recipe-level
+            collectors". A present value *replaces* the recipe-level list for
+            this cell -- it is not additive. An explicit empty list disables
+            collectors for this cell entirely (e.g. a fast baseline that skips
+            ``layer_numerics`` capture). Accepts the same list or mapping form
+            as the top-level ``collect:`` key; the mapping form's per-collector
+            options land in :attr:`collect_options`.
+        collect_options: Per-collector option dicts parsed from the cell's
+            mapping-form ``collect:``. ``None`` when ``collect`` is inherited or
+            given in list form. Empty dict when the mapping form carried no
+            options.
     """
 
     name: str
@@ -290,12 +311,28 @@ class Cell:
     trials: int | None = None
     steps: int | None = None
     workload_config: dict[str, Any] = field(default_factory=dict)
+    collect: tuple[str, ...] | None = None
+    collect_options: dict[str, dict[str, str]] | None = None
 
     def effective_trials(self, recipe_trials: int) -> int:
         return self.trials if self.trials is not None else recipe_trials
 
     def effective_steps(self, recipe_steps: int) -> int:
         return self.steps if self.steps is not None else recipe_steps
+
+    def effective_collect(self, recipe_collect: tuple[str, ...]) -> tuple[str, ...]:
+        return self.collect if self.collect is not None else recipe_collect
+
+    def effective_collect_options(
+        self, recipe_collect_options: dict[str, dict[str, str]]
+    ) -> dict[str, dict[str, str]]:
+        # Options track the collect list they came from: when the cell
+        # overrides ``collect`` its own options apply (empty when none were
+        # given in the mapping form); only an inherited ``collect`` inherits
+        # the recipe-level options.
+        if self.collect is not None:
+            return self.collect_options or {}
+        return recipe_collect_options
 
 
 @dataclass(frozen=True)
@@ -794,6 +831,15 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
 
     workload_config = _parse_workload_config(path_hint, raw.get("workload_config"))
 
+    # ``collect`` absent -> None (inherit recipe-level). Present -> parse and
+    # replace, even when the value is an empty list ("disable for this cell").
+    # We branch on key presence rather than truthiness so ``collect: []`` and
+    # a missing key mean different things.
+    if "collect" in raw:
+        collect, collect_options = _parse_collect(path_hint, raw["collect"])
+    else:
+        collect, collect_options = None, None
+
     return Cell(
         name=name,
         mitigations=tuple(mitigations),
@@ -802,6 +848,8 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
         trials=trials,
         steps=steps,
         workload_config=workload_config,
+        collect=collect,
+        collect_options=collect_options,
     )
 
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -909,8 +909,8 @@ def _run_one_cell(
         subprocess_argv=subprocess_argv,
         probe_extras=probe_extras_payload,
         stop_after=stop_after,
-        collect=tuple(recipe.collect),
-        collect_options=dict(recipe.collect_options),
+        collect=tuple(cell.effective_collect(recipe.collect)),
+        collect_options=dict(cell.effective_collect_options(recipe.collect_options)),
     )
 
     try:
@@ -990,6 +990,10 @@ def _print_dry_run(
         # the workload would be constructed with -- cell-scope wins on key
         # collision, non-collision keys union with recipe-scope.
         effective_workload_config = {**recipe.workload_config, **cell.workload_config}
+        effective_collect = cell.effective_collect(recipe.collect)
+        # Flag cells whose collectors differ from the recipe default so an
+        # operator can spot per-cell on/off at a glance.
+        collect_note = " (cell override)" if cell.collect is not None else ""
         click.echo(
             f"  - {cell.name}: mitigations={list(cell.mitigations)} "
             f"environment={cell.environment} "
@@ -997,6 +1001,7 @@ def _print_dry_run(
             f"steps={cell.effective_steps(recipe.steps)}"
             + (f" extra_env={cell.extra_env}" if cell.extra_env else "")
             + (f" workload_config={effective_workload_config}" if effective_workload_config else "")
+            + (f" collect={list(effective_collect)}{collect_note}" if effective_collect or cell.collect is not None else "")
         )
     if recipe.inline_environments:
         click.echo("Inline docker environments:")

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -991,7 +991,7 @@ def _print_dry_run(
         # collision, non-collision keys union with recipe-scope.
         effective_workload_config = {**recipe.workload_config, **cell.workload_config}
         effective_collect = cell.effective_collect(recipe.collect)
-        # Flag cells whose collectors differ from the recipe default so an
+        # Flag cells that declare an explicit collector override so an
         # operator can spot per-cell on/off at a glance.
         collect_note = " (cell override)" if cell.collect is not None else ""
         click.echo(

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -13,7 +13,7 @@ import yaml
 import aorta.triage.runner as runner
 from aorta.instrumentation.environment import EnvSnapshot
 from aorta.triage.output import NO_TICKET_SLUG, resolve_run_dir, safe_slug
-from aorta.triage.recipe import Recipe, build_recipe_from_flags
+from aorta.triage.recipe import Cell, ConfoundCfg, Recipe, build_recipe_from_flags
 
 # ---- Fixtures -------------------------------------------------------------
 
@@ -483,6 +483,67 @@ def test_resolved_recipe_round_trips_workload_config(
     assert reloaded.workload_config == {"shampoo_api": "new", "warmup": 5}
     assert reloaded.cells[0].workload_config == {}
     assert reloaded.cells[1].workload_config == {"shampoo_api": "old"}
+
+
+def test_resolved_recipe_round_trips_collect(
+    tmp_path, patched_env, patched_run_trials
+):
+    """Collector settings must survive load -> run -> reload for replay."""
+    from aorta.triage.recipe import load_recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(
+            Cell(name="inherit", mitigations=("none",), environment="local"),
+            Cell(
+                name="disable",
+                mitigations=("none",),
+                environment="local",
+                collect=(),
+                collect_options={},
+            ),
+            Cell(
+                name="override",
+                mitigations=("none",),
+                environment="local",
+                collect=("layer_numerics",),
+                collect_options={"layer_numerics": {"NANLOG_SAMPLE_EVERY": "10"}},
+            ),
+        ),
+        ticket="COLLECT-RT",
+        confound=ConfoundCfg(baseline_cell="inherit"),
+        collect=("layer_numerics", "rocprof"),
+        collect_options={"layer_numerics": {"NANLOG_PRE_CONTEXT": "20"}},
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    resolved_path = run_dir / "recipe.resolved.yaml"
+    doc = yaml.safe_load(resolved_path.read_text())
+
+    assert doc["collect"] == {
+        "layer_numerics": {"NANLOG_PRE_CONTEXT": "20"},
+        "rocprof": None,
+    }
+    cells = {cell["name"]: cell for cell in doc["cells"]}
+    assert "collect" not in cells["inherit"]
+    assert cells["disable"]["collect"] == []
+    assert cells["override"]["collect"] == {
+        "layer_numerics": {"NANLOG_SAMPLE_EVERY": "10"}
+    }
+
+    reloaded = load_recipe(resolved_path)
+    assert reloaded.collect == ("layer_numerics", "rocprof")
+    assert reloaded.collect_options == {
+        "layer_numerics": {"NANLOG_PRE_CONTEXT": "20"}
+    }
+    assert reloaded.cells[0].collect is None
+    assert reloaded.cells[1].collect == ()
+    assert reloaded.cells[2].collect == ("layer_numerics",)
+    assert reloaded.cells[2].collect_options == {
+        "layer_numerics": {"NANLOG_SAMPLE_EVERY": "10"}
+    }
 
 
 def test_resolved_recipe_round_trips_stop_after(

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -241,6 +241,98 @@ def test_collect_flag_error_uses_cli_label():
         )
 
 
+def test_cell_collect_absent_inherits_recipe_collect(tmp_path):
+    text = _MINIMAL_YAML + "collect: [layer_numerics]\n"
+    r = load_recipe(_write_yaml(tmp_path, text))
+    cell = r.cells[0]
+    assert cell.collect is None
+    assert cell.collect_options is None
+    assert cell.effective_collect(r.collect) == ("layer_numerics",)
+    assert cell.effective_collect_options(r.collect_options) == {}
+
+
+def test_cell_collect_list_form_replaces_recipe_collect(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+collect: [rocprof]
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+    collect: [layer_numerics]
+"""
+    r = load_recipe(_write_yaml(tmp_path, text))
+    cell = r.cells[0]
+    assert cell.collect == ("layer_numerics",)
+    assert cell.collect_options == {}
+    assert cell.effective_collect(r.collect) == ("layer_numerics",)
+    assert cell.effective_collect_options(r.collect_options) == {}
+
+
+def test_cell_collect_empty_list_disables_recipe_collect(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+collect: [layer_numerics]
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+    collect: []
+"""
+    r = load_recipe(_write_yaml(tmp_path, text))
+    cell = r.cells[0]
+    assert cell.collect == ()
+    assert cell.effective_collect(r.collect) == ()
+    assert cell.effective_collect_options(r.collect_options) == {}
+
+
+def test_cell_collect_mapping_form_parses_names_and_options(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+collect: [rocprof]
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+    collect:
+      layer_numerics:
+        NANLOG_SAMPLE_EVERY: "10"
+"""
+    r = load_recipe(_write_yaml(tmp_path, text))
+    cell = r.cells[0]
+    assert cell.collect == ("layer_numerics",)
+    assert cell.collect_options == {"layer_numerics": {"NANLOG_SAMPLE_EVERY": "10"}}
+    assert cell.effective_collect(r.collect) == ("layer_numerics",)
+    assert cell.effective_collect_options(r.collect_options) == {
+        "layer_numerics": {"NANLOG_SAMPLE_EVERY": "10"}
+    }
+
+
+def test_cell_collect_error_uses_cell_field_label(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+    collect: not_a_list_or_mapping
+"""
+    with pytest.raises(RecipeSchemaError, match=r"^cells\[0\]\.collect:"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
 def test_unknown_top_level_key_rejected(tmp_path):
     text = _MINIMAL_YAML + "garbage: 42\n"
     with pytest.raises(RecipeSchemaError, match="unknown top-level keys"):

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -292,6 +292,23 @@ cells:
     assert cell.effective_collect_options(r.collect_options) == {}
 
 
+def test_cell_collect_null_rejected(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+collect: [layer_numerics]
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+    collect:
+"""
+    with pytest.raises(RecipeSchemaError, match=r"^cells\[0\]\.collect: null"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
 def test_cell_collect_mapping_form_parses_names_and_options(tmp_path):
     text = """\
 schema_version: 1

--- a/tests/triage/test_runner_b1_api.py
+++ b/tests/triage/test_runner_b1_api.py
@@ -430,6 +430,49 @@ cells:
     assert req.collect_options == {}
 
 
+def test_cli_collect_override_clears_cell_collect_overrides(
+    tmp_path, patched_env, patched_run_trials
+):
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        """\
+schema_version: 1
+ticket: CLI-COLLECT-2
+workload: fsdp
+trials: 1
+steps: 10
+collect: [rocprof]
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+    collect: []
+  - name: tf32-local
+    mitigations: [tf32_off]
+    environment: local
+    collect: [rocprof]
+""",
+        encoding="utf-8",
+    )
+    cli = CliRunner()
+    result = cli.invoke(
+        triage,
+        [
+            "run",
+            "--recipe",
+            str(recipe),
+            "--collect",
+            "layer_numerics",
+            "--output-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    reqs = [call.args[0] for call in patched_run_trials.call_args_list]
+    assert [req.collect for req in reqs] == [("layer_numerics",), ("layer_numerics",)]
+    assert [req.collect_options for req in reqs] == [{}, {}]
+
+
 def test_cli_exits_nonzero_when_baseline_did_not_run_but_writes_matrix(
     tmp_path, patched_env, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- Cells can now set their own `collect:` key to override the recipe-level collectors, following the same override pattern as `trials`/`steps`.
- Semantics: **absent** → inherit recipe default; **present** → replace (not additive); **empty list** → disable collectors for that cell.
- Mapping form (per-collector options) is supported per cell too.

## Example
```yaml
collect: [layer_numerics]   # recipe default
cells:
  - name: bf16_tf32
    mitigations: [shampoo_precond_bf16]
    environment: nan-repro-hipblaslt-may-drop
    # inherits layer_numerics
  - name: fp32_tf32
    mitigations: [shampoo_precond_fp32]
    environment: nan-repro-hipblaslt-may-drop
    collect: []   # skip collection for this cell
```

## Changes
- `Cell` gains `collect` / `collect_options` fields + `effective_collect` / `effective_collect_options` helpers
- `"collect"` added to `_VALID_CELL_KEYS`; `_parse_cell` branches on key presence so `collect: []` (disable) differs from an absent key (inherit)
- Runner forwards `cell.effective_collect(...)` into `RunRequest`
- Dry-run output shows per-cell collectors with a `(cell override)` marker

## Test plan
- [x] `tests/triage/test_recipe.py` — all 83 pass
- [x] Manual YAML load: inherit / override / disable / mapping-form all resolve correctly; invalid collector name rejected with cell-scoped error
- [ ] Note: the runtime consumer that reads `_aorta_collect_options` and applies `NANLOG_*` env vars is separate follow-up wiring (tracked for the workload wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)