### PR TITLE
triage: capture in-container env snapshots for isolated envs

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -380,10 +380,12 @@ with no `pip install`. It writes exactly the same `env.json` shape as
 `aorta env probe -o`, so a promoted in-container snapshot is
 indistinguishable on disk from a local-env one.
 
-Probing is **per unique environment**, not per cell: only the first cell of
-each isolated env requests a probe. If that cell's container fails to start,
-the next cell reusing the same env retries; an env that never produces a
-snapshot gets the placeholder at the end of the run.
+Probing is **per unique environment**, not per cell: the first cell of each
+isolated env requests a probe, and subsequent cells reusing that env keep
+requesting one until a valid snapshot is captured (so a cell whose container
+fails to start doesn't permanently lose the snapshot). Once captured, later
+cells stop requesting it. An env that never produces a valid snapshot gets the
+placeholder at the end of the run.
 
 ## Re-running a past matrix
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -332,10 +332,13 @@ Every run records the environment each cell ran in under
 - **Isolated envs** (a registry `Environment` with a `docker:` or `venv:`
   field, or an inline-docker cell) cannot be probed from the runner
   process -- that would record the *host's* Python / ROCm / hipBLASLt
-  state under a docker label. Instead the **workload wrapper** captures a
-  snapshot from *inside* the container, and the runner promotes it. If the
-  wrapper produces nothing, the runner writes a placeholder with
-  `"snapshot_captured": false` and the image descriptor.
+  state, not the isolated env's. Instead the **workload wrapper** captures a
+  snapshot from *inside the isolated env* (the container, or the activated
+  venv), and the runner promotes it. If the wrapper produces nothing, the
+  runner writes a placeholder with `"snapshot_captured": false` and the env
+  descriptor. The docker example below is the common case; a venv wrapper
+  runs the same probe command in its activated venv using the host
+  `src`/`out` paths directly (no bind-mount).
 
 ### Wrapper contract for in-container snapshots
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -273,7 +273,7 @@ A green run proves: `compute_type=transformer`, `layers_verified > 0`, `layer_ch
         matrix.json
         recipe.resolved.yaml                    # post-resolution snapshot
         host_env.json                           # collect_env() once per run
-        environments/<env-name>/env.json        # once per unique environment
+        environments/<env-name>/env.json        # once per unique environment (see "Environment snapshots")
         inline_environments.sidecar.json        # only when inline docker is used
         sidecars/<basename>                     # one copy per --mitigations-file
         cells/<cell-name>/<workload>/trial_*.json
@@ -320,6 +320,70 @@ write to `cells/<cell-name>/`, and B1 ends up writing
 `cells/<cell-name>/<workload>/trial_N.json`. `matrix.json` records the
 real paths; a future B1 follow-up can drop this level of nesting via a
 `skip_workload_subdir` kwarg on `RunRequest`.
+
+## Environment snapshots
+
+Every run records the environment each cell ran in under
+`environments/<env-name>/env.json`, once per unique environment:
+
+- **Local (non-isolated) envs** are probed in-process: the runner calls
+  `collect_env()` directly, because the runner process *is* the trial
+  environment. The snapshot is written before the env's first cell runs.
+- **Isolated envs** (a registry `Environment` with a `docker:` or `venv:`
+  field, or an inline-docker cell) cannot be probed from the runner
+  process -- that would record the *host's* Python / ROCm / hipBLASLt
+  state under a docker label. Instead the **workload wrapper** captures a
+  snapshot from *inside* the container, and the runner promotes it. If the
+  wrapper produces nothing, the runner writes a placeholder with
+  `"snapshot_captured": false` and the image descriptor.
+
+### Wrapper contract for in-container snapshots
+
+For isolated envs the dispatcher injects a reserved
+`config["_aorta_env_probe"]` dict with two keys:
+
+- `src` -- absolute path to the aorta `src` tree on the runner host. Bind-mount
+  this into the container so the dependency-free probe entry resolves without
+  installing aorta in the image.
+- `out` -- absolute host path (`environments/<env-name>/env.json`) the runner
+  will read after the cell runs. Bind-mount its parent and write there.
+
+A self-isolating wrapper (e.g. `recom_repro` invoking `docker run`) opts in
+by reading the reserved config key and running the probe as the first step
+inside the container. There are no `AORTA_PROBE_SRC` / `AORTA_ENV_OUT`
+environment variables -- the paths arrive only through
+`config["_aorta_env_probe"]`, and the wrapper is responsible for turning them
+into bind-mounts on the `docker run` it builds:
+
+```python
+# inside the wrapper's run(), before building argv:
+probe = self.config.get("_aorta_env_probe")   # None for non-isolated envs
+mounts, probe_prefix = [], ""
+if probe is not None:
+    src, out = probe["src"], probe["out"]      # host paths from the runner
+    out_dir = os.path.dirname(out)
+    mounts = ["-v", f"{src}:/opt/aorta_src:ro", "-v", f"{out_dir}:/aorta_out"]
+    probe_prefix = (
+        "PYTHONPATH=/opt/aorta_src python -m aorta.instrumentation._probe_main "
+        f"/aorta_out/{os.path.basename(out)} && "
+    )
+
+argv = [
+    "docker", "run", *mounts, image,
+    "bash", "-c", f"{probe_prefix}{workload_cmd}",
+]
+```
+
+`aorta.instrumentation._probe_main` imports only stdlib plus the
+`collect_env()` module (no Click), so it runs under a bare container Python
+with no `pip install`. It writes exactly the same `env.json` shape as
+`aorta env probe -o`, so a promoted in-container snapshot is
+indistinguishable on disk from a local-env one.
+
+Probing is **per unique environment**, not per cell: only the first cell of
+each isolated env requests a probe. If that cell's container fails to start,
+the next cell reusing the same env retries; an env that never produces a
+snapshot gets the placeholder at the end of the run.
 
 ## Re-running a past matrix
 

--- a/src/aorta/instrumentation/_probe_main.py
+++ b/src/aorta/instrumentation/_probe_main.py
@@ -1,0 +1,52 @@
+"""Dependency-free ``collect_env`` entry point for in-container probing.
+
+The regular CLI (``aorta env probe``) imports Click and the entry-point
+machinery, which need not exist inside a workload's docker image. This
+module is the minimal alternative: it imports only stdlib plus
+:mod:`aorta.instrumentation.environment` (itself stdlib-only), so a
+container can produce a byte-identical ``env.json`` by bind-mounting the
+aorta ``src`` tree and running::
+
+    PYTHONPATH=/opt/aorta_src python -m aorta.instrumentation._probe_main /out/env.json
+
+The output format is exactly ``EnvSnapshot.to_dict()`` serialised with
+``json.dumps(..., indent=2)`` -- identical to what ``aorta env probe -o``
+writes -- so the isolated-env snapshot the triage runner promotes is
+indistinguishable from a local-env one on disk.
+
+With no argument (or ``-``) the JSON goes to stdout, so the module also
+works as ``docker exec ... > env.json`` without a bind mount.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from aorta.instrumentation.environment import collect_env
+
+
+def main(argv: list[str]) -> int:
+    """Capture the snapshot and write it to ``argv[1]`` (or stdout)."""
+    snapshot_dict = collect_env().to_dict()
+    text = json.dumps(snapshot_dict, indent=2)
+
+    out = argv[1] if len(argv) > 1 and argv[1] != "-" else None
+    if out is None:
+        sys.stdout.write(text + "\n")
+        return 0
+
+    # collect_env() never raises, but the write can (unwritable mount,
+    # full disk). Surface it as a non-zero exit + stderr line rather than
+    # a traceback so the wrapper's ``&& <workload>`` chain stops cleanly.
+    try:
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(text)
+    except OSError as exc:
+        sys.stderr.write(f"aorta probe: failed to write {out}: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/aorta/instrumentation/_probe_main.py
+++ b/src/aorta/instrumentation/_probe_main.py
@@ -43,7 +43,7 @@ def main(argv: list[str]) -> int:
         with open(out, "w", encoding="utf-8") as fh:
             fh.write(text)
     except OSError as exc:
-        sys.stderr.write(f"aorta probe: failed to write {out}: {exc}\n")
+        sys.stderr.write(f"aorta env probe: failed to write {out}: {exc}\n")
         return 1
     return 0
 

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -379,8 +379,10 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     # JSON-serialized, with a confusing ``TypeError``.  Fail fast with an
     # actionable message instead.
     if request.env_probe is not None:
-        if set(request.env_probe) != {"src", "out"} or not all(
-            isinstance(v, str) for v in request.env_probe.values()
+        if (
+            not isinstance(request.env_probe, dict)
+            or set(request.env_probe) != {"src", "out"}
+            or not all(isinstance(v, str) for v in request.env_probe.values())
         ):
             raise ValueError(
                 "env_probe must be a dict with exactly {'src', 'out'} string "

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -636,7 +636,7 @@ def _run_single_trial(
     # appears, else falls back to the placeholder. Same reserved-``_aorta_*``
     # convention + non-None-only injection as the keys above; the platform
     # launches nothing, the wrapper acts. Non-isolated envs and every
-    # pre-#(env-probe) caller leave this None so the key stays absent.
+    # pre-existing caller leave this None so the key stays absent.
     if request.env_probe is not None:
         config["_aorta_env_probe"] = dict(request.env_probe)
 

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -265,6 +265,16 @@ class RunRequest:
     # ``Recipe.probe_extras``); the loop only duck-types ``.events`` /
     # ``.event_verdict``. ``kw_only`` so positional callers are unaffected.
     stop_after: Any | None = field(default=None, kw_only=True)
+    # In-container env-probe contract for isolated (docker/venv) envs.
+    # The triage runner sets this to ``{"src": <host aorta src>, "out":
+    # <environments/<env>/env.json>}`` so a self-isolating wrapper can
+    # bind-mount the aorta source and drop a real snapshot the runner
+    # then promotes (else it falls back to a placeholder). ``None`` (the
+    # default) means "no in-container probe requested" -- every
+    # pre-existing caller and every non-isolated env round-trips with the
+    # ``_aorta_env_probe`` key absent. ``kw_only`` so positional callers
+    # are unaffected, matching ``stop_after`` above.
+    env_probe: dict[str, str] | None = field(default=None, kw_only=True)
 
     def __post_init__(self) -> None:
         # Defensively deep-copy mutable dict fields.  ``frozen=True``
@@ -610,6 +620,20 @@ def _run_single_trial(
     # in ``config_overrides`` so this assignment can't silently clobber
     # a caller-supplied value.
     config["_aorta_environment"] = asdict(env_descriptor)
+
+    # In-container env-probe contract (isolated docker/venv envs only).
+    # The triage runner supplies ``{"src": ..., "out": ...}`` so a
+    # self-isolating wrapper can bind-mount the aorta source at ``src``
+    # and, as the first step inside its ``docker run``, write a real
+    # ``env.json`` to the host path ``out`` -- captured INSIDE the
+    # container, so ``sys.prefix`` / ROCm / hipBLASLt reflect the image
+    # rather than the runner's venv. The runner promotes that file if it
+    # appears, else falls back to the placeholder. Same reserved-``_aorta_*``
+    # convention + non-None-only injection as the keys above; the platform
+    # launches nothing, the wrapper acts. Non-isolated envs and every
+    # pre-#(env-probe) caller leave this None so the key stays absent.
+    if request.env_probe is not None:
+        config["_aorta_env_probe"] = dict(request.env_probe)
 
     # Subprocess-shaped workloads (currently SubprocessWorkload, wired
     # by ``aorta probe``) receive their opaque user argv via a typed

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -371,6 +371,22 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
             "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
         )
 
+    # Validate ``env_probe`` shape early.  The triage runner is the only
+    # in-tree producer and always passes ``{"src": str, "out": str}``, but
+    # ``RunRequest`` is a public library API -- a programmatic caller passing
+    # a bad shape (missing keys, Path values) would otherwise only fail much
+    # later when the value is injected into ``TrialResult.config`` and
+    # JSON-serialized, with a confusing ``TypeError``.  Fail fast with an
+    # actionable message instead.
+    if request.env_probe is not None:
+        if set(request.env_probe) != {"src", "out"} or not all(
+            isinstance(v, str) for v in request.env_probe.values()
+        ):
+            raise ValueError(
+                "env_probe must be a dict with exactly {'src', 'out'} string "
+                f"values; got {request.env_probe!r}."
+            )
+
     # 4. Reject reserved ``_aorta_*`` keys in ``config_overrides``.
     #    The dispatcher writes platform-supplied values (currently
     #    ``_aorta_environment``) into ``config`` after merging

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -289,6 +289,11 @@ class RunRequest:
         # out from under the dispatcher. ``None`` short-circuits.
         if self.probe_extras is not None:
             object.__setattr__(self, "probe_extras", copy.deepcopy(self.probe_extras))
+        # ``env_probe`` is the same optional-dict pattern as ``probe_extras``:
+        # deep-copy so a caller cannot mutate the {src, out} paths after
+        # construction and steer an in-flight probe. ``None`` short-circuits.
+        if self.env_probe is not None:
+            object.__setattr__(self, "env_probe", copy.deepcopy(self.env_probe))
 
 
 def run_trials(request: RunRequest) -> list[TrialResult]:

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -309,11 +309,13 @@ def _write_isolated_env_placeholder(
         "capture the real environment, have the workload wrapper read the "
         "reserved config['_aorta_env_probe'] {'src', 'out'} HOST paths, "
         "bind-mount 'src' and the parent of 'out' into the container, and run "
-        "'python -m aorta.instrumentation._probe_main <container-visible out>' "
-        "as the first step inside its docker run -- note 'out' is a host path, "
-        "so pass the mounted container path, not 'out' verbatim. The runner "
-        "then promotes that file in place of this placeholder. host_env.json "
-        "next to this file captures the runner's view."
+        "'PYTHONPATH=<mounted src> python -m aorta.instrumentation._probe_main "
+        "<container-visible out>' as the first step inside its docker run -- "
+        "PYTHONPATH is required unless aorta is installed in the image, and "
+        "'out' is a host path so pass the mounted container path, not 'out' "
+        "verbatim. The runner then promotes that file in place of this "
+        "placeholder. host_env.json next to this file captures the runner's "
+        "view."
     )
     placeholder = {
         "name": env_name,
@@ -348,14 +350,19 @@ def _is_real_env_snapshot(target: Path, env_name: str, warnings: list[str]) -> b
     """True iff ``target`` holds a wrapper-produced in-container snapshot.
 
     Called AFTER an isolated env's cell has run. A real snapshot is a JSON
-    *object* (matching ``EnvSnapshot.to_dict()``) that is NOT one of our own
+    *object* carrying a non-empty ``schema_version`` string (the shape
+    ``EnvSnapshot.to_dict()`` always produces) that is NOT one of our own
     placeholders -- the placeholder carries ``"snapshot_captured": false``, so
     a later retry reading it back would otherwise mistake it for a genuine
-    capture. Non-object JSON (arrays, strings, numbers) is rejected: promoting
-    it would hand downstream consumers a shape they don't expect. A file that
-    fails to parse is reported (once) and treated as "not yet captured" so the
+    capture. Non-object JSON (arrays, strings, numbers) and objects missing
+    ``schema_version`` (``{}``, partial/buggy writes) are rejected: promoting
+    them would hand downstream consumers a shape they don't expect.
+
+    A file that is missing, unreadable, or the wrong shape returns False so the
     env keeps retrying on later cells and, failing that, gets a placeholder at
-    the end.
+    the end. Each rejection appends a warning; on retry across N cells for the
+    same still-broken env this can log N times, which is acceptable -- the
+    signal is per-cell and points at a real, unresolved problem.
     """
     if not target.is_file():
         return False
@@ -374,6 +381,13 @@ def _is_real_env_snapshot(target: Path, env_name: str, warnings: list[str]) -> b
         )
         return False
     if doc.get("snapshot_captured") is False:
+        return False
+    if not isinstance(doc.get("schema_version"), str) or not doc["schema_version"]:
+        warnings.append(
+            f"environment {env_name!r}: in-container snapshot at {target} "
+            "lacks a non-empty schema_version (not an EnvSnapshot shape); "
+            "will retry / fall back to placeholder."
+        )
         return False
     return True
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -33,6 +33,7 @@ Per the acceptance criteria in issue #151, this module MUST NOT use
 from __future__ import annotations
 
 import contextlib
+import errno
 import json
 import logging
 import os
@@ -368,6 +369,27 @@ def _write_json_atomic_replace(target: Path, payload: dict[str, Any]) -> None:
                 tmp_path.unlink()
 
 
+def _read_json_no_follow(target: Path) -> Any:
+    """Read JSON without following a final-path symlink when supported."""
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        fd = os.open(target, os.O_RDONLY | nofollow)
+        try:
+            fh = os.fdopen(fd, "r", encoding="utf-8")
+        except Exception:
+            os.close(fd)
+            raise
+        with fh:
+            return json.load(fh)
+
+    # Windows does not expose O_NOFOLLOW. Keep the explicit symlink rejection
+    # there; POSIX runners use the atomic open path above.
+    if target.is_symlink():
+        raise OSError(errno.ELOOP, "symlink not allowed", str(target))
+    with target.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
 def _aorta_src_root() -> Path:
     """Absolute path to the aorta ``src`` tree on the runner host.
 
@@ -404,17 +426,17 @@ def _is_real_env_snapshot(target: Path, env_name: str, warnings: list[str]) -> b
     written, or a prior placeholder read back -- return False silently, since
     they are the expected "not captured yet" states, not errors.
     """
-    if target.is_symlink():
-        warnings.append(
-            f"environment {env_name!r}: in-container snapshot at {target} "
-            "is a symlink; will retry / fall back to placeholder."
-        )
-        return False
-    if not target.is_file():
-        return False
     try:
-        doc = json.loads(target.read_text(encoding="utf-8"))
+        doc = _read_json_no_follow(target)
+    except FileNotFoundError:
+        return False
     except (OSError, json.JSONDecodeError) as exc:
+        if isinstance(exc, OSError) and exc.errno == errno.ELOOP:
+            warnings.append(
+                f"environment {env_name!r}: in-container snapshot at {target} "
+                "is a symlink; will retry / fall back to placeholder."
+            )
+            return False
         warnings.append(
             f"environment {env_name!r}: in-container snapshot at {target} "
             f"is unreadable ({type(exc).__name__}); will retry / fall back to placeholder."

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -9,9 +9,13 @@ the flag-mode CLI funnel into. Given a validated :class:`Recipe`, it:
    ``_inline_<hash>`` envs) so B1's registry resolver picks them up.
 3. Captures the host :func:`aorta.instrumentation.environment.collect_env`
    snapshot once -> ``host_env.json``.
-4. For each unique environment in ``recipe.cells``, captures a
-   per-environment ``collect_env`` snapshot once, *right before that env's
-   first cell runs* -> ``environments/<name>/env.json``.
+4. Captures a per-environment snapshot once per unique env ->
+   ``environments/<name>/env.json``. Local (non-isolated) envs are probed
+   in-process *right before* that env's first cell runs. Isolated
+   (docker/venv) envs are probed by the workload wrapper *inside the
+   container* via the ``_aorta_env_probe`` contract; the runner promotes
+   that snapshot *after* the cell runs (retrying on later cells of the same
+   env) and falls back to a placeholder if none is produced.
 5. Builds a :class:`aorta.run.RunRequest` per cell and calls
    :func:`aorta.run.run_trials` **in-process**. Per-cell exceptions are
    caught and surfaced as an ``error`` row so other cells still run.

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -314,8 +314,8 @@ def _write_isolated_env_placeholder(
         "PYTHONPATH is required unless aorta is installed in the image, and "
         "'out' is a host path so pass the mounted container path, not 'out' "
         "verbatim. The runner then promotes that file in place of this "
-        "placeholder. host_env.json next to this file captures the runner's "
-        "view."
+        "placeholder. The run root's host_env.json (../../host_env.json "
+        "relative to this file) captures the runner's view."
     )
     placeholder = {
         "name": env_name,
@@ -1265,11 +1265,18 @@ def _run_recipe_locked(
         recipe.steps,
         run_dir,
     )
+    # Isolation status is per-environment (a registry lookup), so cache it by
+    # env name: matrices where many cells share one env would otherwise repeat
+    # the resolution once per cell.
+    isolation_cache: dict[str, bool] = {}
+
     for cell_idx, cell in enumerate(recipe.cells, start=1):
         env_json_path = env_dir / safe_slug(cell.environment) / "env.json"
-        is_isolated = _is_isolated_environment(
-            cell.environment, recipe.inline_environments, sidecar_files
-        )
+        if cell.environment not in isolation_cache:
+            isolation_cache[cell.environment] = _is_isolated_environment(
+                cell.environment, recipe.inline_environments, sidecar_files
+            )
+        is_isolated = isolation_cache[cell.environment]
         # Local envs: probe in-process once, before the env's first cell.
         # Isolated envs: defer to the wrapper (post-cell promotion below).
         if cell.environment not in seen_envs:

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -313,15 +313,17 @@ def _write_isolated_env_placeholder(
         "the host's state instead of the isolated env's, so it is "
         "intentionally not written. To capture the real environment, have the "
         "workload wrapper read the reserved config['_aorta_env_probe'] "
-        "{'src', 'out'} HOST paths and run 'PYTHONPATH=<src> python -m "
-        "aorta.instrumentation._probe_main <out>' as the first step inside the "
-        "isolated env. For docker: bind-mount 'src' and the parent of 'out' "
-        "into the container, and pass the container-visible paths ('out' is a "
-        "host path, not valid inside the container). For venv: run it in the "
-        "activated venv with the host 'src'/'out' paths directly. PYTHONPATH "
-        "is required unless aorta is installed in the isolated env. The runner "
-        "then promotes that file in place of this placeholder. The run root's "
-        "host_env.json (../../host_env.json relative to this file) captures "
+        "{'src', 'out'} HOST paths and, as the first step inside the isolated "
+        "env, run 'PYTHONPATH=SRC python -m aorta.instrumentation._probe_main "
+        "OUT' where SRC/OUT are the paths as seen FROM INSIDE that env. "
+        "For docker: bind-mount 'src' and the parent of 'out', then set "
+        "SRC/OUT to the container mount points -- NOT the host 'src'/'out' "
+        "values, which do not exist inside the container. For venv: SRC/OUT "
+        "are the host 'src'/'out' values directly (same filesystem, no mount). "
+        "PYTHONPATH is required unless aorta is installed in the isolated env. "
+        "The runner then promotes that file in place of this placeholder. The "
+        "run root's host_env.json (../../host_env.json relative to this file) "
+        "captures "
         "the runner's view."
     )
     placeholder = {
@@ -367,9 +369,12 @@ def _is_real_env_snapshot(target: Path, env_name: str, warnings: list[str]) -> b
 
     A file that is missing, unreadable, or the wrong shape returns False so the
     env keeps retrying on later cells and, failing that, gets a placeholder at
-    the end. Each rejection appends a warning; on retry across N cells for the
-    same still-broken env this can log N times, which is acceptable -- the
-    signal is per-cell and points at a real, unresolved problem.
+    the end. A *malformed* file (unreadable, non-object, or missing
+    schema_version) appends a warning -- and on retry across N cells for the
+    same still-broken env this can log N times, which is acceptable (the signal
+    is per-cell and points at a real problem). The benign cases -- file not yet
+    written, or a prior placeholder read back -- return False silently, since
+    they are the expected "not captured yet" states, not errors.
     """
     if not target.is_file():
         return False

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -12,10 +12,11 @@ the flag-mode CLI funnel into. Given a validated :class:`Recipe`, it:
 4. Captures a per-environment snapshot once per unique env ->
    ``environments/<name>/env.json``. Local (non-isolated) envs are probed
    in-process *right before* that env's first cell runs. Isolated
-   (docker/venv) envs are probed by the workload wrapper *inside the
-   container* via the ``_aorta_env_probe`` contract; the runner promotes
-   that snapshot *after* the cell runs (retrying on later cells of the same
-   env) and falls back to a placeholder if none is produced.
+   (docker/venv) envs are probed by the workload wrapper *inside the isolated
+   environment* (the container, or the activated venv) via the
+   ``_aorta_env_probe`` contract; the runner promotes that snapshot *after*
+   the cell runs (retrying on later cells of the same env) and falls back to
+   a placeholder if none is produced.
 5. Builds a :class:`aorta.run.RunRequest` per cell and calls
    :func:`aorta.run.run_trials` **in-process**. Per-cell exceptions are
    caught and surfaced as an ``error`` row so other cells still run.
@@ -307,19 +308,21 @@ def _write_isolated_env_placeholder(
         except RegistryError as exc:  # pragma: no cover - guarded by predicate
             descriptor["_lookup_error"] = f"{type(exc).__name__}: {exc}"
     skip_reason = (
-        "No in-container snapshot was produced for this isolated docker/venv "
-        "environment. A runner-process collect_env() would record the host's "
-        "state instead of the image's, so it is intentionally not written. To "
-        "capture the real environment, have the workload wrapper read the "
-        "reserved config['_aorta_env_probe'] {'src', 'out'} HOST paths, "
-        "bind-mount 'src' and the parent of 'out' into the container, and run "
-        "'PYTHONPATH=<mounted src> python -m aorta.instrumentation._probe_main "
-        "<container-visible out>' as the first step inside its docker run -- "
-        "PYTHONPATH is required unless aorta is installed in the image, and "
-        "'out' is a host path so pass the mounted container path, not 'out' "
-        "verbatim. The runner then promotes that file in place of this "
-        "placeholder. The run root's host_env.json (../../host_env.json "
-        "relative to this file) captures the runner's view."
+        "No in-isolated-env snapshot was produced for this isolated "
+        "docker/venv environment. A runner-process collect_env() would record "
+        "the host's state instead of the isolated env's, so it is "
+        "intentionally not written. To capture the real environment, have the "
+        "workload wrapper read the reserved config['_aorta_env_probe'] "
+        "{'src', 'out'} HOST paths and run 'PYTHONPATH=<src> python -m "
+        "aorta.instrumentation._probe_main <out>' as the first step inside the "
+        "isolated env. For docker: bind-mount 'src' and the parent of 'out' "
+        "into the container, and pass the container-visible paths ('out' is a "
+        "host path, not valid inside the container). For venv: run it in the "
+        "activated venv with the host 'src'/'out' paths directly. PYTHONPATH "
+        "is required unless aorta is installed in the isolated env. The runner "
+        "then promotes that file in place of this placeholder. The run root's "
+        "host_env.json (../../host_env.json relative to this file) captures "
+        "the runner's view."
     )
     placeholder = {
         "name": env_name,

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -307,12 +307,13 @@ def _write_isolated_env_placeholder(
         "environment. A runner-process collect_env() would record the host's "
         "state instead of the image's, so it is intentionally not written. To "
         "capture the real environment, have the workload wrapper read the "
-        "reserved config['_aorta_env_probe'] {'src', 'out'} paths, bind-mount "
-        "'src' into the container, and run "
-        "'python -m aorta.instrumentation._probe_main <out>' as the first step "
-        "inside its docker run; the runner then promotes that file in place of "
-        "this placeholder. host_env.json next to this file captures the "
-        "runner's view."
+        "reserved config['_aorta_env_probe'] {'src', 'out'} HOST paths, "
+        "bind-mount 'src' and the parent of 'out' into the container, and run "
+        "'python -m aorta.instrumentation._probe_main <container-visible out>' "
+        "as the first step inside its docker run -- note 'out' is a host path, "
+        "so pass the mounted container path, not 'out' verbatim. The runner "
+        "then promotes that file in place of this placeholder. host_env.json "
+        "next to this file captures the runner's view."
     )
     placeholder = {
         "name": env_name,
@@ -346,12 +347,15 @@ def _aorta_src_root() -> Path:
 def _is_real_env_snapshot(target: Path, env_name: str, warnings: list[str]) -> bool:
     """True iff ``target`` holds a wrapper-produced in-container snapshot.
 
-    Called AFTER an isolated env's cell has run. A real snapshot is valid
-    JSON that is NOT one of our own placeholders -- the placeholder carries
-    ``"snapshot_captured": false``, so a later retry reading it back would
-    otherwise mistake it for a genuine capture. A file that fails to parse
-    is reported (once) and treated as "not yet captured" so the env keeps
-    retrying on later cells and, failing that, gets a placeholder at the end.
+    Called AFTER an isolated env's cell has run. A real snapshot is a JSON
+    *object* (matching ``EnvSnapshot.to_dict()``) that is NOT one of our own
+    placeholders -- the placeholder carries ``"snapshot_captured": false``, so
+    a later retry reading it back would otherwise mistake it for a genuine
+    capture. Non-object JSON (arrays, strings, numbers) is rejected: promoting
+    it would hand downstream consumers a shape they don't expect. A file that
+    fails to parse is reported (once) and treated as "not yet captured" so the
+    env keeps retrying on later cells and, failing that, gets a placeholder at
+    the end.
     """
     if not target.is_file():
         return False
@@ -363,7 +367,13 @@ def _is_real_env_snapshot(target: Path, env_name: str, warnings: list[str]) -> b
             f"is unreadable ({type(exc).__name__}); will retry / fall back to placeholder."
         )
         return False
-    if isinstance(doc, dict) and doc.get("snapshot_captured") is False:
+    if not isinstance(doc, dict):
+        warnings.append(
+            f"environment {env_name!r}: in-container snapshot at {target} "
+            f"is not a JSON object ({type(doc).__name__}); will retry / fall back to placeholder."
+        )
+        return False
+    if doc.get("snapshot_captured") is False:
         return False
     return True
 
@@ -1267,6 +1277,11 @@ def _run_recipe_locked(
         # in-container probe to rank 0 to avoid N redundant collect_env calls.
         env_probe_arg: dict[str, str] | None = None
         if is_isolated and cell.environment not in captured_envs:
+            # Create the parent now so the wrapper bind-mounts an existing
+            # host dir. Otherwise ``docker run -v <out_dir>:...`` would have
+            # the daemon create it as root, and the probe (or a later
+            # placeholder write) could fail on permissions.
+            env_json_path.parent.mkdir(parents=True, exist_ok=True)
             env_probe_arg = {"src": aorta_src, "out": str(env_json_path)}
             pending_envs[cell.environment] = (env_json_path, cell.environment)
 

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -332,12 +332,40 @@ def _write_isolated_env_placeholder(
         "skip_reason": skip_reason,
         "descriptor": descriptor,
     }
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(placeholder, indent=2), encoding="utf-8")
+    _write_json_atomic_replace(target, placeholder)
     warnings.append(
         f"environment {env_name!r}: no in-container snapshot captured (isolated env). "
         "See the env's env.json for the descriptor and the host-level snapshot in host_env.json."
     )
+
+
+def _write_json_atomic_replace(target: Path, payload: dict[str, Any]) -> None:
+    """Write JSON by replacing ``target`` instead of following it.
+
+    Isolated-env wrappers write into a host-mounted output directory. If a
+    wrapper leaves ``env.json`` as a symlink, a direct ``write_text`` fallback
+    would follow the link and overwrite whatever host path it points at. A
+    random temp file plus ``os.replace`` replaces the directory entry itself.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as fh:
+            tmp_path = Path(fh.name)
+            fh.write(json.dumps(payload, indent=2))
+        os.replace(tmp_path, target)
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink()
 
 
 def _aorta_src_root() -> Path:
@@ -376,6 +404,12 @@ def _is_real_env_snapshot(target: Path, env_name: str, warnings: list[str]) -> b
     written, or a prior placeholder read back -- return False silently, since
     they are the expected "not captured yet" states, not errors.
     """
+    if target.is_symlink():
+        warnings.append(
+            f"environment {env_name!r}: in-container snapshot at {target} "
+            "is a symlink; will retry / fall back to placeholder."
+        )
+        return False
     if not target.is_file():
         return False
     try:

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -243,10 +243,12 @@ def _is_isolated_environment(
     their :class:`aorta.registry.Environment` descriptor sets ``docker`` or
     ``venv`` -- in either case, a runner-process ``collect_env()`` call would
     record the host's state, not the trial's, and therefore the resulting
-    ``environments/<name>/env.json`` would be misleading. B1 doesn't actually
-    perform docker / venv isolation today (in-process execution); the fix
-    when it does is to capture inside the isolated env. Until then, gate the
-    runner-process probe on this predicate.
+    ``environments/<name>/env.json`` would be misleading. Isolated envs
+    instead rely on the workload wrapper to capture an in-container snapshot
+    via the ``_aorta_env_probe`` contract, which the runner promotes after
+    the cell runs (falling back to a placeholder if none appears). This
+    predicate gates that path: True routes the env to wrapper-driven probing,
+    False to the in-process ``collect_env()``.
 
     ``sidecar_files`` MUST be threaded through so envs defined only in a
     ``--mitigations-file`` JSON are visible to the registry resolver. Without
@@ -301,11 +303,16 @@ def _write_isolated_env_placeholder(
         except RegistryError as exc:  # pragma: no cover - guarded by predicate
             descriptor["_lookup_error"] = f"{type(exc).__name__}: {exc}"
     skip_reason = (
-        "B1 currently runs trials in the runner process, so a runner-time "
-        "collect_env() snapshot would record the host's state instead of the "
-        "isolated docker/venv environment the descriptor advertises. The "
-        "snapshot is intentionally skipped to avoid a misleading artifact; "
-        "host_env.json next to this file captures the runner's view."
+        "No in-container snapshot was produced for this isolated docker/venv "
+        "environment. A runner-process collect_env() would record the host's "
+        "state instead of the image's, so it is intentionally not written. To "
+        "capture the real environment, have the workload wrapper read the "
+        "reserved config['_aorta_env_probe'] {'src', 'out'} paths, bind-mount "
+        "'src' into the container, and run "
+        "'python -m aorta.instrumentation._probe_main <out>' as the first step "
+        "inside its docker run; the runner then promotes that file in place of "
+        "this placeholder. host_env.json next to this file captures the "
+        "runner's view."
     )
     placeholder = {
         "name": env_name,
@@ -316,9 +323,49 @@ def _write_isolated_env_placeholder(
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(json.dumps(placeholder, indent=2), encoding="utf-8")
     warnings.append(
-        f"environment {env_name!r}: per-env probe skipped (isolated env, B1 in-process). "
+        f"environment {env_name!r}: no in-container snapshot captured (isolated env). "
         "See the env's env.json for the descriptor and the host-level snapshot in host_env.json."
     )
+
+
+def _aorta_src_root() -> Path:
+    """Absolute path to the aorta ``src`` tree on the runner host.
+
+    A self-isolating wrapper bind-mounts this into its container so the
+    dependency-free ``python -m aorta.instrumentation._probe_main`` entry
+    resolves without installing aorta in the image. Derived from the
+    installed package location (``.../src/aorta/__init__.py`` -> ``.../src``)
+    so it works for an editable install; a non-editable install returns the
+    site-packages root, which is equally mountable.
+    """
+    import aorta
+
+    return Path(aorta.__file__).resolve().parent.parent
+
+
+def _is_real_env_snapshot(target: Path, env_name: str, warnings: list[str]) -> bool:
+    """True iff ``target`` holds a wrapper-produced in-container snapshot.
+
+    Called AFTER an isolated env's cell has run. A real snapshot is valid
+    JSON that is NOT one of our own placeholders -- the placeholder carries
+    ``"snapshot_captured": false``, so a later retry reading it back would
+    otherwise mistake it for a genuine capture. A file that fails to parse
+    is reported (once) and treated as "not yet captured" so the env keeps
+    retrying on later cells and, failing that, gets a placeholder at the end.
+    """
+    if not target.is_file():
+        return False
+    try:
+        doc = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        warnings.append(
+            f"environment {env_name!r}: in-container snapshot at {target} "
+            f"is unreadable ({type(exc).__name__}); will retry / fall back to placeholder."
+        )
+        return False
+    if isinstance(doc, dict) and doc.get("snapshot_captured") is False:
+        return False
+    return True
 
 
 def _resolve_cell_env_vars(
@@ -715,6 +762,7 @@ def _run_one_cell(
     layout: Literal["timestamped", "flat_resume"] = "timestamped",
     resume_existing: bool = False,
     subprocess_argv: tuple[str, ...] | None = None,
+    env_probe: dict[str, str] | None = None,
 ) -> tuple[list[TrialResult], str | None, dict[str, str], list[str]]:
     """Execute a single cell through B1 and return (trials, error, env_vars, trial_paths).
 
@@ -911,6 +959,7 @@ def _run_one_cell(
         stop_after=stop_after,
         collect=tuple(cell.effective_collect(recipe.collect)),
         collect_options=dict(cell.effective_collect_options(recipe.collect_options)),
+        env_probe=env_probe,
     )
 
     try:
@@ -1157,13 +1206,25 @@ def _run_recipe_locked(
     _capture_env(run_dir / "host_env.json", scope="host", warnings=warnings)
 
     # Per-environment probes, captured once per unique env in the order
-    # cells reference them. ``seen`` preserves first-use ordering so the
-    # probe lands right before the env's first cell runs (matches the
-    # "captured once per unique --environment-axis value" acceptance
-    # criterion).
+    # cells reference them. Non-isolated (local) envs are probed in-process
+    # right before their first cell -- the runner process IS the trial env,
+    # so its snapshot is truthful and needs no container.
+    #
+    # Isolated (docker/venv) envs cannot be probed from the runner process
+    # (that would record host state under a docker label). Instead the
+    # wrapper writes an in-container snapshot to ``environments/<env>/env.json``
+    # via the ``_aorta_env_probe`` contract, and we promote it AFTER the
+    # cell runs. ``captured_envs`` tracks which isolated envs already have a
+    # real snapshot so later cells reusing the same env don't re-probe;
+    # ``pending_envs`` tracks isolated envs still awaiting one (retried on
+    # each subsequent cell of that env until success), and any left pending
+    # at the end get a placeholder.
     seen_envs: set[str] = set()
+    captured_envs: set[str] = set()
+    pending_envs: dict[str, tuple[Path, str]] = {}
 
     env_dir = run_dir / "environments"
+    aorta_src = str(_aorta_src_root())
 
     # Env-slug collision + baseline resolution were already enforced by
     # _preflight_validate at the very top of run_recipe (so dry-run sees the
@@ -1181,25 +1242,33 @@ def _run_recipe_locked(
         run_dir,
     )
     for cell_idx, cell in enumerate(recipe.cells, start=1):
+        env_json_path = env_dir / safe_slug(cell.environment) / "env.json"
+        is_isolated = _is_isolated_environment(
+            cell.environment, recipe.inline_environments, sidecar_files
+        )
+        # Local envs: probe in-process once, before the env's first cell.
+        # Isolated envs: defer to the wrapper (post-cell promotion below).
         if cell.environment not in seen_envs:
-            env_json_path = env_dir / safe_slug(cell.environment) / "env.json"
-            if _is_isolated_environment(
-                cell.environment, recipe.inline_environments, sidecar_files
-            ):
-                _write_isolated_env_placeholder(
-                    env_json_path,
-                    cell.environment,
-                    recipe.inline_environments,
-                    warnings,
-                    sidecar_files,
-                )
-            else:
+            if not is_isolated:
                 _capture_env(
                     env_json_path,
                     scope=f"environment:{cell.environment}",
                     warnings=warnings,
                 )
             seen_envs.add(cell.environment)
+
+        # Hand the wrapper the probe contract while this isolated env still
+        # lacks a real snapshot. Once captured, stop requesting it so later
+        # cells (same image, different mitigations) don't overwrite it.
+        # Not separately rank-gated: on non-rank-0 ``env_json_path`` is rooted
+        # in the discarded scratch ``run_dir`` (see run_recipe), so a promoted
+        # snapshot there is thrown away with the tempdir like every other
+        # artifact. Wrappers that fan out per rank should themselves gate the
+        # in-container probe to rank 0 to avoid N redundant collect_env calls.
+        env_probe_arg: dict[str, str] | None = None
+        if is_isolated and cell.environment not in captured_envs:
+            env_probe_arg = {"src": aorta_src, "out": str(env_json_path)}
+            pending_envs[cell.environment] = (env_json_path, cell.environment)
 
         log.info(
             "cell %d/%d: %s (mitigations=%s environment=%s) -- starting %d trial(s)",
@@ -1219,8 +1288,19 @@ def _run_recipe_locked(
             layout=layout,
             resume_existing=resume_existing,
             subprocess_argv=subprocess_argv,
+            env_probe=env_probe_arg,
         )
         cell_elapsed = time.perf_counter() - cell_t0
+
+        # Promote the wrapper's in-container snapshot if this cell produced
+        # one. Retries across cells reusing the env: only cells still in
+        # ``pending_envs`` requested a probe, so a container that failed to
+        # start on cell N gets another chance on cell N+1 of the same env.
+        if cell.environment in pending_envs:
+            probe_target, probe_env = pending_envs[cell.environment]
+            if _is_real_env_snapshot(probe_target, probe_env, warnings):
+                captured_envs.add(cell.environment)
+                del pending_envs[cell.environment]
         if error is not None:
             log.info(
                 "cell %d/%d: %s -- ERROR (%s) in %.1fs",
@@ -1279,6 +1359,19 @@ def _run_recipe_locked(
             stop_after_note=stop_after_note,
         )
         cell_stats.append(stats)
+
+    # Isolated envs whose containers never produced an in-container snapshot
+    # (wrapper didn't opt in, or every cell of that env failed to start the
+    # container) get an honest placeholder now -- one per env, matching the
+    # per-unique-environment artifact contract.
+    for probe_target, probe_env in pending_envs.values():
+        _write_isolated_env_placeholder(
+            probe_target,
+            probe_env,
+            recipe.inline_environments,
+            warnings,
+            sidecar_files,
+        )
 
     # Did-not-run baseline disqualification (issue #173). Three cases,
     # all of them produce matrix.md / matrix.json so the operator can

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -213,6 +213,27 @@ class TestRunTrials:
             with pytest.raises(ValueError, match="Invalid extra_env keys"):
                 run_trials(req)
 
+    def test_rejects_malformed_env_probe(self, tmp_path):
+        """``env_probe`` must be {'src', 'out'} with str values.
+
+        The triage runner always passes the right shape, but RunRequest is a
+        public API -- a bad shape must fail fast here, not later at JSON
+        serialization of TrialResult.config.
+        """
+        for bad in (
+            {"src": "/a"},                       # missing 'out'
+            {"src": "/a", "out": "/b", "x": 1},  # extra key
+            {"src": "/a", "out": Path("/b")},    # non-str value
+        ):
+            req = RunRequest(
+                workload="anything",
+                trials=1,
+                env_probe=bad,
+                results_dir=tmp_path,
+            )
+            with pytest.raises(ValueError, match="env_probe must be a dict"):
+                run_trials(req)
+
     def test_rejects_collect_options_without_enabled_collector(self, tmp_path):
         req = RunRequest(
             workload="anything",

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -224,6 +224,8 @@ class TestRunTrials:
             {"src": "/a"},                       # missing 'out'
             {"src": "/a", "out": "/b", "x": 1},  # extra key
             {"src": "/a", "out": Path("/b")},    # non-str value
+            ["src", "out"],                      # not a dict (would AttributeError)
+            42,                                  # not even iterable (would TypeError)
         ):
             req = RunRequest(
                 workload="anything",

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -380,6 +380,33 @@ def test_isolated_env_probe_retries_on_next_cell(tmp_path, patched_env, monkeypa
     assert snap["python_version"] == "late"
 
 
+def test_isolated_env_rejects_non_object_snapshot(tmp_path, patched_env, monkeypatch):
+    """A syntactically-valid but non-object env.json is not promoted.
+
+    The wrapper writes a JSON array (wrong shape); the runner must reject it
+    and fall back to the placeholder rather than hand downstream a bad shape.
+    """
+
+    def fake_run_trials(request):
+        out = Path(request.env_probe["out"])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+        return [_fake_trial(), _fake_trial()]
+
+    monkeypatch.setattr(runner, "run_trials", fake_run_trials)
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none",
+        environment_axis="image:rocm/pytorch:nightly",
+        trials=1,
+        steps=10,
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    env_json = run_dir / "environments" / r.cells[0].environment / "env.json"
+    placeholder = json.loads(env_json.read_text())
+    assert placeholder["snapshot_captured"] is False
+
+
 def test_isolated_env_falls_back_to_placeholder_when_no_snapshot(
     tmp_path, patched_env, patched_run_trials
 ):

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -363,7 +363,10 @@ def test_isolated_env_probe_retries_on_next_cell(tmp_path, patched_env, monkeypa
         if calls["n"] == 2 and request.env_probe is not None:
             out = Path(request.env_probe["out"])
             out.parent.mkdir(parents=True, exist_ok=True)
-            out.write_text(json.dumps({"python_version": "late"}), encoding="utf-8")
+            out.write_text(
+                json.dumps({"schema_version": "1.7", "python_version": "late"}),
+                encoding="utf-8",
+            )
         return [_fake_trial(), _fake_trial()]
 
     monkeypatch.setattr(runner, "run_trials", fake_run_trials)
@@ -391,6 +394,35 @@ def test_isolated_env_rejects_non_object_snapshot(tmp_path, patched_env, monkeyp
         out = Path(request.env_probe["out"])
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+        return [_fake_trial(), _fake_trial()]
+
+    monkeypatch.setattr(runner, "run_trials", fake_run_trials)
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none",
+        environment_axis="image:rocm/pytorch:nightly",
+        trials=1,
+        steps=10,
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    env_json = run_dir / "environments" / r.cells[0].environment / "env.json"
+    placeholder = json.loads(env_json.read_text())
+    assert placeholder["snapshot_captured"] is False
+
+
+def test_isolated_env_rejects_snapshot_without_schema_version(
+    tmp_path, patched_env, monkeypatch
+):
+    """A JSON object lacking schema_version is not a valid snapshot.
+
+    Guards against a partial/buggy wrapper write (e.g. ``{}`` or a
+    half-populated dict) being promoted as if it were a real EnvSnapshot.
+    """
+
+    def fake_run_trials(request):
+        out = Path(request.env_probe["out"])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps({"python_version": "3.12"}), encoding="utf-8")
         return [_fake_trial(), _fake_trial()]
 
     monkeypatch.setattr(runner, "run_trials", fake_run_trials)

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -302,10 +302,99 @@ def test_isolated_env_writes_placeholder_not_runner_snapshot(
     assert env_json.exists()
     placeholder = json.loads(env_json.read_text())
     assert placeholder["snapshot_captured"] is False
-    assert "B1" in placeholder["skip_reason"]
+    assert "in-container" in placeholder["skip_reason"]
     assert placeholder["descriptor"]["docker"] == "rocm/pytorch:nightly"
     md = (run_dir / "matrix.md").read_text()
-    assert "skipped" in md.lower()
+    assert "no in-container snapshot captured" in md.lower()
+
+
+def test_isolated_env_promotes_in_container_snapshot(
+    tmp_path, patched_env, monkeypatch
+):
+    """A wrapper-written in-container env.json is promoted over the placeholder.
+
+    Simulates the ``_aorta_env_probe`` contract: the runner hands the cell
+    ``{"src", "out"}`` via ``RunRequest.env_probe``; a real wrapper would
+    bind-mount ``src`` and write a snapshot to ``out`` from inside the
+    container. Here the stubbed ``run_trials`` plays the wrapper by writing
+    a real snapshot to the requested ``out`` path.
+    """
+
+    def fake_run_trials(request):
+        assert request.env_probe is not None
+        src = Path(request.env_probe["src"])
+        assert src.is_absolute() and src.is_dir()
+        out = Path(request.env_probe["out"])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps({"schema_version": "1.7", "python_version": "3.12-in-container"}),
+            encoding="utf-8",
+        )
+        return [_fake_trial(), _fake_trial()]
+
+    monkeypatch.setattr(runner, "run_trials", fake_run_trials)
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none",
+        environment_axis="image:rocm/pytorch:nightly",
+        trials=1,
+        steps=10,
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    env_json = run_dir / "environments" / r.cells[0].environment / "env.json"
+    snap = json.loads(env_json.read_text())
+    # Promoted, not the placeholder.
+    assert "snapshot_captured" not in snap
+    assert snap["python_version"] == "3.12-in-container"
+
+
+def test_isolated_env_probe_retries_on_next_cell(tmp_path, patched_env, monkeypatch):
+    """If the first cell's container never writes a snapshot, the next cell retries.
+
+    The env is probed once successfully across the two cells that share it;
+    the first cell's ``run_trials`` writes nothing (container failed to
+    start), the second writes the real snapshot.
+    """
+    calls = {"n": 0}
+
+    def fake_run_trials(request):
+        calls["n"] += 1
+        # Only the second cell (same env) produces the snapshot.
+        if calls["n"] == 2 and request.env_probe is not None:
+            out = Path(request.env_probe["out"])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(json.dumps({"python_version": "late"}), encoding="utf-8")
+        return [_fake_trial(), _fake_trial()]
+
+    monkeypatch.setattr(runner, "run_trials", fake_run_trials)
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none,tf32_off",
+        environment_axis="image:rocm/pytorch:nightly",
+        trials=1,
+        steps=10,
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    env_json = run_dir / "environments" / r.cells[0].environment / "env.json"
+    snap = json.loads(env_json.read_text())
+    assert snap["python_version"] == "late"
+
+
+def test_isolated_env_falls_back_to_placeholder_when_no_snapshot(
+    tmp_path, patched_env, patched_run_trials
+):
+    """Wrapper never writes a snapshot -> honest placeholder at the end."""
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none",
+        environment_axis="image:rocm/pytorch:nightly",
+        trials=1,
+        steps=10,
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    env_json = run_dir / "environments" / r.cells[0].environment / "env.json"
+    placeholder = json.loads(env_json.read_text())
+    assert placeholder["snapshot_captured"] is False
 
 
 def test_per_env_probe_once_per_unique_env(tmp_path, patched_env, patched_run_trials):

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -302,7 +302,7 @@ def test_isolated_env_writes_placeholder_not_runner_snapshot(
     assert env_json.exists()
     placeholder = json.loads(env_json.read_text())
     assert placeholder["snapshot_captured"] is False
-    assert "in-container" in placeholder["skip_reason"]
+    assert "_probe_main" in placeholder["skip_reason"]
     assert placeholder["descriptor"]["docker"] == "rocm/pytorch:nightly"
     md = (run_dir / "matrix.md").read_text()
     assert "no in-container snapshot captured" in md.lower()

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -473,6 +474,30 @@ def test_isolated_env_rejects_symlink_snapshot_and_preserves_target(
 
     doc = json.loads((run_dir / "matrix.json").read_text())
     assert any("symlink" in warning.lower() for warning in doc["warnings"])
+
+
+def test_isolated_env_snapshot_rejects_symlink_at_open_time(
+    tmp_path, monkeypatch
+):
+    """O_NOFOLLOW closes the race between checking and opening env.json."""
+    if not hasattr(os, "O_NOFOLLOW"):
+        pytest.skip("os.O_NOFOLLOW is unavailable on this platform")
+
+    victim = tmp_path / "host_victim.json"
+    victim.write_text(json.dumps({"schema_version": "1.7"}), encoding="utf-8")
+    link = tmp_path / "env.json"
+    try:
+        link.symlink_to(victim)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+    # Simulate the old check-then-read race: the pre-read symlink check sees
+    # "not a symlink", but the open-time no-follow guard must still reject it.
+    monkeypatch.setattr(Path, "is_symlink", lambda self: False)
+
+    warnings: list[str] = []
+    assert runner._is_real_env_snapshot(link, "container-env", warnings) is False
+    assert any("symlink" in warning.lower() for warning in warnings)
 
 
 def test_isolated_env_falls_back_to_placeholder_when_no_snapshot(

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -439,6 +439,42 @@ def test_isolated_env_rejects_snapshot_without_schema_version(
     assert placeholder["snapshot_captured"] is False
 
 
+def test_isolated_env_rejects_symlink_snapshot_and_preserves_target(
+    tmp_path, patched_env, monkeypatch
+):
+    """A container-controlled env.json symlink must not be read or overwritten."""
+    victim = tmp_path / "host_victim.txt"
+    victim.write_text("do not clobber", encoding="utf-8")
+
+    def fake_run_trials(request):
+        out = Path(request.env_probe["out"])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            out.symlink_to(victim)
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+        return [_fake_trial(), _fake_trial()]
+
+    monkeypatch.setattr(runner, "run_trials", fake_run_trials)
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none",
+        environment_axis="image:rocm/pytorch:nightly",
+        trials=1,
+        steps=10,
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    env_json = run_dir / "environments" / r.cells[0].environment / "env.json"
+
+    assert not env_json.is_symlink()
+    placeholder = json.loads(env_json.read_text())
+    assert placeholder["snapshot_captured"] is False
+    assert victim.read_text(encoding="utf-8") == "do not clobber"
+
+    doc = json.loads((run_dir / "matrix.json").read_text())
+    assert any("symlink" in warning.lower() for warning in doc["warnings"])
+
+
 def test_isolated_env_falls_back_to_placeholder_when_no_snapshot(
     tmp_path, patched_env, patched_run_trials
 ):


### PR DESCRIPTION
Isolated (docker/venv) environments previously got only a placeholder env.json because a runner-process collect_env() would record host state, not the container's. Add a wrapper-driven probe contract so the real image environment is captured.

Changes:
- Add dependency-free aorta.instrumentation._probe_main entry point that calls collect_env() and writes env.json (stdlib + environment.py only, no Click) so a container can probe itself off a bind-mounted src tree with no pip install.
- Add RunRequest.env_probe, threaded to the reserved config ["_aorta_env_probe"] {src, out} key for self-isolating wrappers.
- Runner now probes isolated envs after the cell runs: promote the wrapper-written snapshot if present, else fall back to placeholder; retry across cells reusing the same env. Local envs unchanged.
- Document the wrapper contract in recipes/README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
