### PR TITLE
test: fix cross-file state pollution so the CPU suite runs without --forked (closes #270)

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -79,9 +79,17 @@ jobs:
           pip install -e ".[tests,hw-queue]"
           pip install triton
 
-      # Per-test process isolation (--forked) is deliberate: the suite has
-      # pre-existing cross-file state pollution that only appears when the whole
-      # suite shares one interpreter (every affected file passes on its own).
-      # Forking each test keeps the gate deterministic; -n auto keeps it fast.
+      # -n auto (pytest-xdist) parallelizes across cores for speed. --forked is
+      # intentionally NOT used: the two cross-file state leaks that made
+      # single-interpreter runs order-dependent were fixed in #270 --
+      #   1. the aorta.ebpf runner tests leaked a patched `subprocess.Popen`
+      #      (hand-entered mock.patch that never restored when start() raised);
+      #      now restored via monkeypatch.
+      #   2. the dispatcher/discovery tests patch `importlib.metadata.entry_points`
+      #      with a mock; if Triton's first import happened under that mock its
+      #      backend discovery corrupted `sys.modules`; tests/conftest.py now
+      #      pre-imports Triton so the mock can't poison it.
+      # The suite is deterministic in one interpreter, so per-test forking is no
+      # longer needed for correctness -- and dropping it makes the gate faster.
       - name: Run CPU test suite
-        run: pytest -m "not gpu and not rocm" -n auto --forked
+        run: pytest -m "not gpu and not rocm" -n auto

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -78,37 +78,55 @@ export PIP_CONSTRAINT=.github/ci-constraints.txt
 pip install -e ".[tests,hw-queue]"
 pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install triton
-pytest -m "not gpu and not rocm" -n auto --forked
+pytest -m "not gpu and not rocm" -n auto
 ```
 
 (`bpftrace` still needs to be on the box for the `aorta.ebpf` tests; on Ubuntu
 that's `sudo apt-get install -y bpftrace`. Or just `pip install "click<8.2"`
 into the venv if you'd rather not set the env var -- the pin is temporary.)
 
-### Why per-test process isolation (`--forked`)
+### Parallelism (`-n auto`, no `--forked`)
 
 The command is:
 
 ```
-pytest -m "not gpu and not rocm" -n auto --forked
+pytest -m "not gpu and not rocm" -n auto
 ```
 
-Running the whole suite in a single interpreter produces ~100 failures whose
-membership shifts with test ordering. Every affected file passes cleanly when
-run on its own, which is the signature of **cross-file global-state pollution**
-(leaked env vars, patched module globals, cached imports), not real breakage.
+`-n auto` (`pytest-xdist`) parallelizes across cores to keep wall-clock time
+down (~1-2 min). Per-test process isolation (`--forked`) is **not** used.
 
-Rather than couple the gate to that latent pollution (which would make it flaky
-and order-dependent), each test runs in its own forked subprocess
-(`pytest-forked`), and `-n auto` (`pytest-xdist`) parallelizes across cores to
-keep wall-clock time down (~1-2 min). This is deterministic today and stays
-green as the offending fixtures are cleaned up over time.
+Historically the suite could not run pollution-free in a single interpreter:
+running everything together produced ~100 failures whose membership shifted
+with test ordering, while every affected file passed on its own -- the
+signature of cross-file global-state pollution. The gate leaned on `--forked`
+as a safety net while the leak was tracked down.
 
-> Follow-up (out of scope for the gate): track down and fix the specific
-> fixtures that leak global state so the suite can eventually run pollution-free
-> in a single process. Until then, `--forked` is the safety net, not a crutch to
-> hide new pollution behind. Tracked in
-> [#270](https://github.com/ROCm/aorta/issues/270).
+That pollution came from two culprits, both fixed in
+[#270](https://github.com/ROCm/aorta/issues/270):
+
+1. **Leaked `subprocess.Popen`.** The `aorta.ebpf` runner tests patched the
+   shared stdlib `subprocess.Popen` with a hand-entered `mock.patch`
+   (`ctx.__enter__()`), relying on the test body's `finally` to undo it. When
+   `start()` raised before that `finally` was established (e.g. a missing
+   `bpftrace` binary rejected in `_build_command`), the patch leaked, so every
+   later `subprocess.run` in the interpreter hit the fake `Popen`. Fixed by
+   restoring the patch via the `monkeypatch` fixture, which tears down
+   regardless of whether `start()` raised.
+
+2. **Corrupted `triton` in `sys.modules`.** Many dispatcher/discovery tests
+   patch `importlib.metadata.entry_points` with a `MagicMock` to fake
+   `aorta.workloads` discovery. Triton discovers its compiler backends lazily on
+   first import via that same `entry_points` API, so if Triton's first import
+   happened under the mock (e.g. `run_trials` -> `collect_env` probes the Triton
+   version), backend discovery raised and left `sys.modules` half-initialized
+   (`triton.backends.compiler` cached but `triton` gone). That then broke
+   `torch.use_deterministic_algorithms` in every later workload test. Fixed by
+   pre-importing Triton once in `tests/conftest.py`, against the real
+   `entry_points`, so later mocked imports are harmless cache hits.
+
+The suite is now deterministic in one interpreter (verified across randomized
+orderings), so `--forked` is dropped and only `-n auto` is kept, for speed.
 
 ### Making it a required check
 
@@ -165,7 +183,7 @@ issues so each can be picked up independently:
 | --- | --- |
 | Phase 2 GPU test gate on a self-hosted runner | [#268](https://github.com/ROCm/aorta/issues/268) |
 | Modernize `test_sweep_cli.py` for `click>=8.2` and drop the `click<8.2` pin | [#269](https://github.com/ROCm/aorta/issues/269) |
-| Fix cross-file state pollution so the suite runs without `--forked` | [#270](https://github.com/ROCm/aorta/issues/270) |
+| ~~Fix cross-file state pollution so the suite runs without `--forked`~~ (done: [#270](https://github.com/ROCm/aorta/issues/270)) | [#270](https://github.com/ROCm/aorta/issues/270) |
 
 Not an issue: making the `pytest (CPU, py3.x)` jobs **required status checks** on
 `main` is a repo/admin setting (see "Making it a required check" above), not a
@@ -176,5 +194,5 @@ the repository's branch-protection settings.
 
 | Phase | Runner | Selection | Status |
 | --- | --- | --- | --- |
-| 1 - CPU gate | `ubuntu-latest` (3.10-3.12) | `not gpu and not rocm`, `--forked` | Implemented (`cpu-tests.yml`) |
+| 1 - CPU gate | `ubuntu-latest` (3.10-3.12) | `not gpu and not rocm`, `-n auto` | Implemented (`cpu-tests.yml`) |
 | 2 - GPU gate | `[self-hosted, gpu]` | `gpu or rocm` + real-hw + regression | Planned (needs runner) |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,31 @@ Shared pytest fixtures and configuration for all tests.
 
 import pytest
 
+# Pre-import Triton once, up front, against the *real* importlib.metadata
+# entry-points before any test can replace them with a mock.
+#
+# Triton discovers its compiler backends lazily on first import via
+# ``importlib.metadata.entry_points`` (``triton.backends._discover_backends``).
+# Many dispatcher/discovery tests patch ``importlib.metadata.entry_points`` with
+# a ``MagicMock`` to fake ``aorta.workloads`` discovery. If Triton's very first
+# import happens while that patch is active (e.g. ``run_trials`` -> ``collect_env``
+# probes the ``triton`` version), backend discovery raises ``ModuleNotFoundError``
+# on the mock, the ``import triton`` fails, and Python drops ``triton`` /
+# ``triton.backends`` from ``sys.modules`` while leaving the already-loaded
+# ``triton.backends.compiler`` cached. That half-initialized state then makes
+# ``torch.use_deterministic_algorithms`` (which does ``import
+# triton.backends.compiler``) raise ``AttributeError`` in every later workload
+# test -- order-dependent cross-file pollution (issue #270).
+#
+# Importing Triton here makes it a cache hit everywhere else, so a mocked
+# ``entry_points`` never triggers a fresh (failing) Triton import. Best-effort:
+# Triton is an optional dependency and absent on CPU-only stacks, where no
+# ``triton.backends.compiler`` exists to orphan, so there is nothing to guard.
+try:  # noqa: SIM105 -- contextlib.suppress would hide an unexpected import error type
+    import triton  # noqa: F401
+except Exception:  # noqa: BLE001 -- optional dep; any import failure is a clean no-op
+    pass
+
 
 @pytest.fixture
 def sample_trace_event():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,11 +25,17 @@ import pytest
 # Triton is an optional dependency and absent on CPU-only stacks, where no
 # ``triton.backends.compiler`` exists to orphan, so there is nothing to guard.
 # Catch ``Exception`` (not just ``ImportError``): a broken Triton/native install
-# can fail with OSError/RuntimeError, and any such failure is a clean no-op here.
+# can fail with OSError/RuntimeError. On any failure, purge partially-imported
+# ``triton.*`` modules so the failure leaves a clean slate instead of seeding
+# the very half-state (an orphaned ``triton.backends.compiler`` with ``triton``
+# gone) that this pre-import exists to prevent.
 try:
     import triton  # noqa: F401
 except Exception:
-    pass
+    import sys
+
+    for _mod in [m for m in sys.modules if m == "triton" or m.startswith("triton.")]:
+        del sys.modules[_mod]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,11 @@ import pytest
 # ``entry_points`` never triggers a fresh (failing) Triton import. Best-effort:
 # Triton is an optional dependency and absent on CPU-only stacks, where no
 # ``triton.backends.compiler`` exists to orphan, so there is nothing to guard.
-try:  # noqa: SIM105 -- contextlib.suppress would hide an unexpected import error type
+# Catch ``Exception`` (not just ``ImportError``): a broken Triton/native install
+# can fail with OSError/RuntimeError, and any such failure is a clean no-op here.
+try:
     import triton  # noqa: F401
-except Exception:  # noqa: BLE001 -- optional dep; any import failure is a clean no-op
+except Exception:
     pass
 
 

--- a/tests/ebpf/test_runner.py
+++ b/tests/ebpf/test_runner.py
@@ -546,7 +546,7 @@ class TestStopNeverReRaises:
     rank, leaking the rendezvous backend and hanging every other rank.
     """
 
-    def _start_runner(self, fake_kwargs):
+    def _start_runner(self, monkeypatch, fake_kwargs):
         captured: dict = {}
 
         def factory(*args, **kwargs):
@@ -557,46 +557,47 @@ class TestStopNeverReRaises:
             return captured["popen"]
 
         runner = _make_runner()
-        ctx = _patch_popen(factory)
-        ctx.__enter__()
+        # ``monkeypatch`` (not a hand-entered ``mock.patch``) so the patch on
+        # the *shared* stdlib ``subprocess.Popen`` is always torn down at test
+        # end -- even if ``start()`` raises before this helper returns (e.g.
+        # ``_build_command`` rejecting a missing bpftrace binary). A leaked
+        # ``FakePopen`` would otherwise poison every later ``subprocess.run``
+        # in the same interpreter, which is the cross-file pollution in #270.
+        monkeypatch.setattr("aorta.ebpf.runner.subprocess.Popen", factory)
         runner.start()
-        return runner, captured["popen"], ctx
+        return runner, captured["popen"]
 
-    def test_stop_swallows_terminate_process_lookup_error(self, caplog):
-        runner, _fake, ctx = self._start_runner(
+    def test_stop_swallows_terminate_process_lookup_error(self, caplog, monkeypatch):
+        runner, _fake = self._start_runner(
+            monkeypatch,
             {
                 "script_lines": [],
                 "terminate_raises": ProcessLookupError(3, "No such process"),
-            }
+            },
         )
-        try:
-            import logging
+        import logging
 
-            with caplog.at_level(logging.DEBUG, logger="aorta.ebpf.runner"):
-                events = runner.stop()
-        finally:
-            ctx.__exit__(None, None, None)
+        with caplog.at_level(logging.DEBUG, logger="aorta.ebpf.runner"):
+            events = runner.stop()
         # No exception propagated, return type is still the events list.
         assert isinstance(events, list)
         assert runner.is_running is False
 
-    def test_stop_swallows_kill_process_lookup_error(self):
+    def test_stop_swallows_kill_process_lookup_error(self, monkeypatch):
         # ``terminate()`` succeeds, but ``wait()`` times out so the code
         # path falls through to ``kill()``, which races. Pre-fix this
         # would re-raise ``ProcessLookupError`` from ``stop()``.
         import subprocess as _sp
 
-        runner, _fake, ctx = self._start_runner(
+        runner, _fake = self._start_runner(
+            monkeypatch,
             {
                 "script_lines": [],
                 "wait_raises": _sp.TimeoutExpired(cmd="bpftrace", timeout=0.1),
                 "kill_raises": ProcessLookupError(3, "No such process"),
-            }
+            },
         )
-        try:
-            events = runner.stop()
-        finally:
-            ctx.__exit__(None, None, None)
+        events = runner.stop()
         assert isinstance(events, list)
 
     def test_stop_short_circuits_on_already_exited(self):
@@ -635,23 +636,21 @@ class TestStopNeverReRaises:
             events = runner.stop()
         assert isinstance(events, list)
 
-    def test_stop_swallows_unexpected_exception(self, caplog):
+    def test_stop_swallows_unexpected_exception(self, caplog, monkeypatch):
         # Defensive: any unexpected exception type must still be
         # logged-and-swallowed, not propagated. The docstring promises
         # this without qualifying on exception class.
-        runner, _fake, ctx = self._start_runner(
+        runner, _fake = self._start_runner(
+            monkeypatch,
             {
                 "script_lines": [],
                 "terminate_raises": OSError(1, "Operation not permitted"),
-            }
+            },
         )
-        try:
-            import logging
+        import logging
 
-            with caplog.at_level(logging.ERROR, logger="aorta.ebpf.runner"):
-                events = runner.stop()
-        finally:
-            ctx.__exit__(None, None, None)
+        with caplog.at_level(logging.ERROR, logger="aorta.ebpf.runner"):
+            events = runner.stop()
         assert isinstance(events, list)
 
 


### PR DESCRIPTION
## Summary

The CPU gate ran every test in its own forked subprocess (`--forked`) to paper over cross-file global-state pollution: a single-interpreter run produced ~100 order-dependent failures even though each affected file passed in isolation. This isolates and fixes the **two independent leaks** responsible, so the suite is deterministic in a single interpreter and `--forked` can be dropped (keeping only `-n auto` for speed). Closes #270.

### Root cause 1 — leaked `subprocess.Popen`
`TestStopNeverReRaises._start_runner` in `tests/ebpf/test_runner.py` patched the **shared stdlib** `subprocess.Popen` via a hand-entered `mock.patch` (`ctx.__enter__()`), relying on the test body's `finally` to undo it. When `start()` raised *before* that `finally` was established (e.g. `_build_command` rejecting a missing `bpftrace` binary), the patch leaked and every later `subprocess.run` in the interpreter hit the fake `Popen`.
**Fix:** restore via the `monkeypatch` fixture, which tears down regardless of whether `start()` raised.

### Root cause 2 — corrupted `triton` in `sys.modules`
Many dispatcher/discovery tests patch `importlib.metadata.entry_points` with a `MagicMock` to fake `aorta.workloads` discovery. Triton discovers its compiler backends lazily on first import via that **same** `entry_points` API, so when Triton's first import happened under the mock (a workload trial probing the Triton version), backend discovery raised and left `sys.modules` half-initialized (`triton.backends.compiler` cached but `triton` gone). That then broke `torch.use_deterministic_algorithms` in every later workload test.
**Fix:** pre-import Triton once in `tests/conftest.py`, against the real `entry_points`, so later mocked imports are harmless cache hits.

## Changes
- `tests/ebpf/test_runner.py` — `_start_runner` uses `monkeypatch` instead of a manually-entered `mock.patch`.
- `tests/conftest.py` — best-effort pre-import of Triton at session start (catches `Exception`; Triton is optional/absent on CPU-only stacks).
- `.github/workflows/cpu-tests.yml` — drop `--forked`, keep `-n auto`.
- `docs/ci-testing-plan.md` — document both root causes and the invocation change; mark #270 done.

## Test plan
- [x] `ruff check` clean on changed files.
- [x] `pytest -m "not gpu and not rocm"` green in a **single interpreter** (no `--forked`) in default order.
- [x] Order-independence verified across random seeds (`pytest-randomly` seeds 777 / 12345 / 2 / 314 / 99999 / 5).
- [x] eBPF runner tests still pass with `bpftrace` installed.

## Notes for review
- The `monkeypatch.setattr("aorta.ebpf.runner.subprocess.Popen", ...)` call intentionally omits `raising=False`: `subprocess.Popen` is a universal stdlib attribute, so a missing target should fail loudly (unlike the POSIX-only `os.killpg`/`getpgid` precedent).

Made with [Cursor](https://cursor.com)