### PR TITLE
feat(sweep): print a concise end-of-run pass/fail/error summary (#280)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ aorta bench hw_queue_eval sweep hetero_kernels --streams 2,4,8,16
 
 Both flows write `matrix.md` + `matrix.json`, embed a per-environment `env.json`
 snapshot, and emit a replayable `recipe.resolved.yaml`. See
-[`docs/probe-188/usage.md`](docs/probe-188/usage.md).
+[`docs/probe/usage.md`](docs/probe/usage.md).
 
 At the end of every run `aorta sweep run` prints a concise summary to stdout —
 which cells failed vs. errored, the workload's own failure hint, and the path to
@@ -244,7 +244,7 @@ The standalone `aorta mitigations list` and `aorta environments list` groups are
 | [`aorta sweep`](docs/probe/usage.md) | Unified matrix runner — built-in workloads **or** opaque launch commands |
 | [LLM Determinism](docs/llm-determinism.md) | Bit-exact double-run nondeterminism probe |
 | [`aorta agent`](docs/agent/agentic-testing-guide.md) | Closed-loop mitigation search (optional LLM proposer) |
-| [`aorta bundle`](docs/probe-188/bundle.md) | Package sweep artifacts with recipe-driven redaction |
+| [`aorta bundle`](docs/probe/bundle.md) | Package sweep artifacts with recipe-driven redaction |
 | [Recipes](recipes/README.md) | Recipe schema and running recipes |
 | [Buck2](docs/buck2.md) | Build / run the AORTA CLI via Buck2 |
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Both flows write `matrix.md` + `matrix.json`, embed a per-environment `env.json`
 snapshot, and emit a replayable `recipe.resolved.yaml`. See
 [`docs/probe-188/usage.md`](docs/probe-188/usage.md).
 
+At the end of every run `aorta sweep run` prints a concise summary to stdout —
+which cells failed vs. errored, the workload's own failure hint, and the path to
+each failing cell's artifact directory (logs + per-trial JSON) — so you don't
+have to open `matrix.md` to find what broke. Pass `-v` (`-vv`) to also stream
+live per-cell progress to stderr while a long matrix runs.
+
 ### Environment snapshot / reproducibility
 
 `aorta env probe` captures a versioned, schema-stable `env.json`. Diff two

--- a/docs/probe/usage.md
+++ b/docs/probe/usage.md
@@ -263,6 +263,16 @@ of the three built-ins above) when copy-pasting this template.
   target nor reached the cap (or a trial in it is missing/malformed), the
   **whole cell** re-runs from `trial_0`; the re-run is bounded because the
   dispatcher applies the same early-stop.
+* A resumed (cache-served) cell is no longer silent (issue #282). Each
+  cell records a `resumed` boolean in `matrix.json` (`cells[*].resumed`,
+  `false` for freshly-run cells and for every timestamped-triage cell,
+  which never resumes), and the end-of-run summary printed on stdout
+  suffixes its totals line with the resumed count, tags each non-clean
+  resumed cell with `[resumed]`, and prints a note explaining how to force
+  a fresh run (delete `<output>/<ticket>/` or use a new `--ticket` /
+  `--output`). This is why an intentionally-failing command can still show
+  a green cell on a re-run against the same `--output`/`--ticket`: the cell
+  was served from cache and the new command never executed.
 
 ## 5. CLI / recipe interaction
 

--- a/recipes/README-running-recipes.md
+++ b/recipes/README-running-recipes.md
@@ -75,8 +75,11 @@ cat triage_results/<TICKET>/<workload>/<timestamp>/matrix.md
 The run directory `triage_results/<TICKET>/<workload>/<timestamp>/` contains
 `matrix.md` (summary table), `matrix.json` (full per-cell stats),
 `recipe.resolved.yaml`, and `cells/<cell>/.../trial_*.json` (per-trial detail).
-The `<TICKET>` comes from the recipe's `ticket:` field; the CLI prints
-`Wrote matrix to <run_dir>` on rank 0 when finished.
+The `<TICKET>` comes from the recipe's `ticket:` field. On rank 0 when
+finished the CLI prints a concise pass/fail/error summary of the cells
+(pointing at each non-clean cell's artifacts) followed by the
+`Wrote matrix to <run_dir>` line; pass `-v` to also stream per-trial
+progress to stderr while the matrix runs.
 
 ## Tip: smoke-test a recipe before the full matrix
 

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -359,7 +359,12 @@ def sweep() -> None:
     "-v",
     "--verbose",
     count=True,
-    help="Stream per-cell progress to stderr. -v = INFO, -vv = DEBUG (aorta.* logger).",
+    help=(
+        "Stream live per-cell progress to stderr while the matrix runs. "
+        "-v = INFO, -vv = DEBUG (aorta.* logger). A concise end-of-run "
+        "summary (which cells failed + where their artifacts are) prints "
+        "to stdout regardless of this flag."
+    ),
 )
 @click.argument("argv", nargs=-1, type=click.UNPROCESSED)
 def sweep_run(

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -169,14 +169,14 @@ def triage() -> None:
     "--verbose",
     count=True,
     help=(
-        "Stream per-cell progress to stderr while the matrix runs. "
+        "Stream live per-cell progress to stderr while the matrix runs. "
         "-v = INFO (matrix preamble, per-cell start/finish, timings, "
         "trials passed). -vv = DEBUG (aorta platform internals). "
         "Scope is the aorta.* logger hierarchy; workload code in "
-        "sibling packages is unaffected. Default is silent: only "
-        "the final 'Wrote matrix to ...' line prints. Useful for "
-        "long matrix runs where you'd otherwise have no signal that "
-        "anything is happening."
+        "sibling packages is unaffected. A concise end-of-run summary "
+        "(which cells failed + where their artifacts are) and the final "
+        "'Wrote matrix to ...' line print to stdout regardless of this "
+        "flag; -v adds the live blow-by-blow for long runs."
     ),
 )
 def triage_run(

--- a/src/aorta/run/cli_helpers.py
+++ b/src/aorta/run/cli_helpers.py
@@ -31,13 +31,22 @@ from aorta.run.results import TrialResult
 def configure_verbose_logging(verbose_count: int) -> None:
     """Wire a stderr StreamHandler onto the ``aorta`` logger when -v is set.
 
-    Both ``aorta run`` and ``aorta triage run`` emit no *live* progress by
-    default -- the ``aorta.*`` loggers exist but have no handlers, so
-    INFO-level progress calls are dropped. Without this, a long matrix run
-    prints nothing *while it runs*; the shared engine still prints a concise
-    end-of-run summary (issue #280) and the final ``Wrote matrix to ...``
-    line at the end, but ``-v`` is what surfaces the per-cell blow-by-blow
-    as the matrix executes.
+    Both ``aorta run`` and ``aorta triage run`` / ``aorta sweep run`` emit no
+    *live* progress by default -- the ``aorta.*`` loggers exist but have no
+    handlers, so INFO-level progress calls are dropped, and ``-v`` is what
+    surfaces the per-trial / per-cell blow-by-blow while work executes.
+
+    Each command's *own* final stdout is separate from this handler and is
+    unaffected by the verbosity level:
+
+    * ``aorta triage run`` / ``aorta sweep run`` (the shared triage/sweep
+      engine, :func:`aorta.triage.runner.run_recipe`) print a concise
+      end-of-run matrix summary (issue #280) followed by the
+      ``Wrote matrix to ...`` line.
+    * ``aorta run`` (single-workload :func:`aorta.run.run_trials`, which does
+      NOT go through that engine) prints its own one-line pass/fail result
+      (``All N trial(s) passed. Results in: ...`` / ``Failed trials: ...``)
+      and never emits ``Wrote matrix to ...``.
 
     Scope: only the ``aorta.*`` logger hierarchy. Workloads registered
     via the ``aorta.workloads`` entry-point group from sibling packages

--- a/src/aorta/run/cli_helpers.py
+++ b/src/aorta/run/cli_helpers.py
@@ -31,11 +31,13 @@ from aorta.run.results import TrialResult
 def configure_verbose_logging(verbose_count: int) -> None:
     """Wire a stderr StreamHandler onto the ``aorta`` logger when -v is set.
 
-    Both ``aorta run`` and ``aorta triage run`` are silent by default --
-    the ``aorta.*`` loggers exist but have no handlers, so INFO-level
-    progress calls are dropped. Without this, a long matrix run prints
-    nothing until the final ``Wrote matrix to ...`` line, leaving
-    operators with no signal that anything is happening.
+    Both ``aorta run`` and ``aorta triage run`` emit no *live* progress by
+    default -- the ``aorta.*`` loggers exist but have no handlers, so
+    INFO-level progress calls are dropped. Without this, a long matrix run
+    prints nothing *while it runs*; the shared engine still prints a concise
+    end-of-run summary (issue #280) and the final ``Wrote matrix to ...``
+    line at the end, but ``-v`` is what surfaces the per-cell blow-by-blow
+    as the matrix executes.
 
     Scope: only the ``aorta.*`` logger hierarchy. Workloads registered
     via the ``aorta.workloads`` entry-point group from sibling packages

--- a/src/aorta/triage/matrix.py
+++ b/src/aorta/triage/matrix.py
@@ -209,6 +209,15 @@ class CellStats:
     # ``error`` verdict). Excluded from the ``failure_rate`` denominator;
     # surfaced via ``error_rate`` and the matrix.md "Errors" column.
     error_count: int = 0
+    # Issue #282: True when this cell's trials were hydrated from a prior
+    # run's on-disk artifacts (probe ``flat_resume`` layout) instead of
+    # being re-executed -- the resume short-circuit in
+    # :func:`aorta.triage.runner._run_one_cell`. Always False for the
+    # timestamped triage layout (which never resumes) and for freshly-run
+    # cells. Surfaced in matrix.json and the end-of-run summary so an
+    # operator can tell a cached result from a fresh one without opening
+    # the per-trial logs.
+    resumed: bool = False
 
     @property
     def failure_rate(self) -> float:
@@ -536,6 +545,7 @@ def aggregate_cell(
     error: str | None = None,
     workload_config: dict[str, Any] | None = None,
     stop_after_note: str | None = None,
+    resumed: bool = False,
 ) -> CellStats:
     """Aggregate a list of TrialResult-shaped objects into a :class:`CellStats`.
 
@@ -563,6 +573,10 @@ def aggregate_cell(
             the returned :class:`CellStats` so matrix.md and matrix.json
             can surface workload-knob differences across cells. ``None``
             and ``{}`` both collapse to an empty dict on the result.
+        resumed: True when the cell's trials were hydrated from a prior
+            run's on-disk artifacts (probe ``flat_resume`` resume
+            short-circuit) rather than re-executed. Recorded on the
+            returned :class:`CellStats` (issue #282).
 
     Returns:
         :class:`CellStats` populated from the trials.
@@ -602,6 +616,7 @@ def aggregate_cell(
             top_warn_detector_id=None,
             stop_after_note=stop_after_note,
             error_count=0,
+            resumed=resumed,
         )
 
     trial_count = len(trials)
@@ -698,6 +713,7 @@ def aggregate_cell(
         top_warn_detector_id=top_warn_id,
         stop_after_note=stop_after_note,
         error_count=errored,
+        resumed=resumed,
     )
 
 

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -677,9 +677,21 @@ def format_run_summary(
             lines.append(resumed_note)
         return lines
 
+    # The three buckets PARTITION the cells (clean + with_failures + with_errors
+    # == total): each non-clean cell falls in exactly one, mirroring its per-cell
+    # tag below. A cell with any genuine failing trial is counted "with failing
+    # trials" ([fail]) even if it also has errored trials; a cell is counted
+    # "with errors" only when the whole cell errored (``error`` set) or it has
+    # errored trials and NO failing trial ([error]). Without the
+    # ``failed_count == 0`` guard a mixed fail+error cell would be counted twice
+    # and the buckets could sum past ``total`` (Copilot, #281).
     clean_count = total - len(non_clean)
     with_failures = sum(1 for c in cell_stats if c.error is None and c.failed_count > 0)
-    with_errors = sum(1 for c in cell_stats if c.error is not None or c.error_count > 0)
+    with_errors = sum(
+        1
+        for c in cell_stats
+        if c.error is not None or (c.error_count > 0 and c.failed_count == 0)
+    )
 
     lines = [
         f"Sweep summary: {total} cell(s) -- {clean_count} clean, "

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -591,6 +591,100 @@ def _cell_directory(name: str, layout: Literal["timestamped", "flat_resume"]) ->
     return f"cells/{slug}/"
 
 
+def _cell_is_clean(cell: CellStats) -> bool:
+    """True when a cell has no whole-cell error and no failing/erroring trials.
+
+    A "clean" cell is one an operator never needs to open: it ran, and every
+    trial passed. Anything else (a whole-cell ``error``, at least one failing
+    trial, or at least one infra-``error`` trial) is worth a line in the
+    end-of-run summary so the failure and its artifacts are one glance away.
+    """
+    return cell.error is None and cell.failed_count == 0 and cell.error_count == 0
+
+
+def _oneline(text: str) -> str:
+    """Collapse a possibly multi-line message into a single summary line.
+
+    Cell-level ``error`` strings are ``f"{type(exc).__name__}: {exc}"`` and an
+    exception message can carry newlines; the summary is one line per cell, so
+    fold internal whitespace to single spaces.
+    """
+    return " ".join(text.split())
+
+
+def format_run_summary(
+    cell_stats: list[CellStats],
+    run_dir: Path,
+    *,
+    layout: Literal["timestamped", "flat_resume"] = "timestamped",
+    verbose_active: bool = False,
+) -> list[str]:
+    """Build the concise end-of-run sweep summary (issue #280).
+
+    ``aorta sweep run`` is otherwise silent during a run and prints only a
+    single ``Wrote matrix to ...`` line at the end, so an operator has no way
+    to see which cells failed or where their captured output landed without
+    opening ``matrix.md`` and digging through per-cell log files. This renders
+    a short, always-on report the runner echoes to stdout:
+
+    * one totals line (cells, how many clean / with failing trials / with
+      errors);
+    * one line per **non-clean** cell -- ``cell did not run (...)`` when the
+      whole cell errored before any trial (``cell.error`` set), otherwise its
+      failed/errored trial counts out of the cell's trial budget -- plus the
+      workload's own one-line failure ``hint`` when it emitted one, and the
+      cell's artifact directory (relative to ``run_dir``, correct for both the
+      timestamped triage layout and the flat-resume probe layout) so the logs
+      and per-trial JSON are one ``cd`` away; and
+    * a footer pointing at ``matrix.md`` for the full table, plus a ``-v`` tip
+      when the run was not already verbose.
+
+    Scales with the number of cells, not trials, so a long sweep still ends in
+    a scannable report; an all-passing run collapses to the single totals line.
+    Returns the lines (no trailing newline); the caller joins + echoes them.
+    """
+    total = len(cell_stats)
+    non_clean = [c for c in cell_stats if not _cell_is_clean(c)]
+
+    if not non_clean:
+        # Happy path: exactly one line so a clean sweep isn't noisy.
+        return [f"Sweep summary: all {total} cell(s) passed."]
+
+    clean_count = total - len(non_clean)
+    with_failures = sum(1 for c in cell_stats if c.error is None and c.failed_count > 0)
+    with_errors = sum(1 for c in cell_stats if c.error is not None or c.error_count > 0)
+
+    lines = [
+        f"Sweep summary: {total} cell(s) -- {clean_count} clean, "
+        f"{with_failures} with failing trials, {with_errors} with errors."
+    ]
+    for cell in non_clean:
+        rel_dir = _cell_directory(cell.name, layout)
+        hint = cell.failure_hints[0][0] if cell.failure_hints else None
+        if cell.error is not None:
+            # Whole cell never ran (unknown mitigation, docker pull failure, ...).
+            detail = f"cell did not run ({_oneline(cell.error)})"
+            tag = "[error]"
+        else:
+            parts = []
+            if cell.failed_count:
+                parts.append(f"{cell.failed_count} failed")
+            if cell.error_count:
+                parts.append(f"{cell.error_count} errored")
+            detail = f"{', '.join(parts)} of {cell.trials} trial(s)"
+            # A cell with any genuine failure is a [fail]; one with only infra
+            # errors (no failing trial) is an [error] -- the bug never got a
+            # valid observation there.
+            tag = "[fail]" if cell.failed_count else "[error]"
+        hint_str = f" ({_oneline(hint)})" if hint else ""
+        lines.append(f"  {tag} {cell.name}: {detail}{hint_str} -> {rel_dir}")
+
+    lines.append(f"Full matrix: {run_dir / 'matrix.md'}")
+    if not verbose_active:
+        lines.append("Tip: re-run with -v to stream per-cell progress live.")
+    return lines
+
+
 def write_matrix_md(
     path: Path,
     recipe: Recipe,
@@ -1136,6 +1230,7 @@ def resolved_cell_environment(
 
 __all__ = [
     "NO_TICKET_SLUG",
+    "format_run_summary",
     "format_timestamp",
     "resolve_run_dir",
     "resolved_cell_environment",

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -628,27 +628,54 @@ def format_run_summary(
     a short, always-on report the runner echoes to stdout:
 
     * one totals line (cells, how many clean / with failing trials / with
-      errors);
+      errors), suffixed with the count of cells that were **resumed** from a
+      prior run's cached artifacts when any were (issue #282);
     * one line per **non-clean** cell -- ``cell did not run (...)`` when the
       whole cell errored before any trial (``cell.error`` set), otherwise its
       failed/errored trial counts out of the cell's trial budget -- plus the
-      workload's own one-line failure ``hint`` when it emitted one, and the
+      workload's own one-line failure ``hint`` when it emitted one, a
+      ``[resumed]`` marker when the cell's trials came from cache, and the
       cell's artifact directory (relative to ``run_dir``, correct for both the
       timestamped triage layout and the flat-resume probe layout) so the logs
       and per-trial JSON are one ``cd`` away; and
-    * a footer pointing at ``matrix.md`` for the full table, plus a ``-v`` tip
-      when the run was not already verbose.
+    * a footer pointing at ``matrix.md`` for the full table, a "how to force a
+      fresh run" note when any cell was resumed, plus a ``-v`` tip when the run
+      was not already verbose.
+
+    Resume is why an ``exit 1`` command can still report a green cell: the
+    ``flat_resume`` layout reuses ``<output>/<ticket>/`` across invocations, so
+    a cell whose trials are already complete on disk is served from cache and
+    the new command never runs. Calling that out here means an operator does
+    not have to open the per-trial logs to tell a cached pass from a fresh one.
 
     Scales with the number of cells, not trials, so a long sweep still ends in
-    a scannable report; an all-passing run collapses to the single totals line.
-    Returns the lines (no trailing newline); the caller joins + echoes them.
+    a scannable report; an all-passing run with nothing resumed collapses to
+    the single totals line. Returns the lines (no trailing newline); the caller
+    joins + echoes them.
     """
     total = len(cell_stats)
     non_clean = [c for c in cell_stats if not _cell_is_clean(c)]
+    resumed_count = sum(1 for c in cell_stats if c.resumed)
+    resumed_suffix = (
+        f" {resumed_count} resumed from a prior run (no trials re-executed)."
+        if resumed_count
+        else ""
+    )
+    # Actionable when a cache hit surprised the operator: how to force fresh.
+    resumed_note = (
+        f"Note: resumed cells reused cached artifacts under {run_dir}; delete "
+        "that directory or use a new --ticket/--output to force a fresh run."
+        if resumed_count
+        else None
+    )
 
     if not non_clean:
-        # Happy path: exactly one line so a clean sweep isn't noisy.
-        return [f"Sweep summary: all {total} cell(s) passed."]
+        # Happy path: one totals line (plus the resume note only when a cache
+        # hit means "passed" might not mean "freshly re-verified").
+        lines = [f"Sweep summary: all {total} cell(s) passed.{resumed_suffix}"]
+        if resumed_note is not None:
+            lines.append(resumed_note)
+        return lines
 
     clean_count = total - len(non_clean)
     with_failures = sum(1 for c in cell_stats if c.error is None and c.failed_count > 0)
@@ -657,6 +684,7 @@ def format_run_summary(
     lines = [
         f"Sweep summary: {total} cell(s) -- {clean_count} clean, "
         f"{with_failures} with failing trials, {with_errors} with errors."
+        f"{resumed_suffix}"
     ]
     for cell in non_clean:
         rel_dir = _cell_directory(cell.name, layout)
@@ -677,9 +705,12 @@ def format_run_summary(
             # valid observation there.
             tag = "[fail]" if cell.failed_count else "[error]"
         hint_str = f" ({_oneline(hint)})" if hint else ""
-        lines.append(f"  {tag} {cell.name}: {detail}{hint_str} -> {rel_dir}")
+        resumed_mark = " [resumed]" if cell.resumed else ""
+        lines.append(f"  {tag} {cell.name}: {detail}{hint_str}{resumed_mark} -> {rel_dir}")
 
     lines.append(f"Full matrix: {run_dir / 'matrix.md'}")
+    if resumed_note is not None:
+        lines.append(resumed_note)
     if not verbose_active:
         lines.append("Tip: re-run with -v to stream per-cell progress live.")
     return lines

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -60,6 +60,7 @@ from aorta.triage.matrix import (
 )
 from aorta.triage.output import (
     acquire_flat_resume_lock,
+    format_run_summary,
     format_timestamp,
     resolve_run_dir,
     safe_slug,
@@ -91,6 +92,21 @@ def _is_rank_zero() -> bool:
     except ValueError:
         log.warning("Ignoring non-integer RANK=%r; treating this process as rank 0.", raw_rank)
         return True
+
+
+def _verbose_active() -> bool:
+    """True when ``-v`` / ``-vv`` installed the aorta stderr progress handler.
+
+    Lets the end-of-run summary (issue #280) suppress its "re-run with -v"
+    tip when the operator already streamed live progress. Mirrors the marker
+    attribute :func:`aorta.run.cli_helpers.configure_verbose_logging` stamps
+    on the handler it installs, so the two stay in lockstep without importing
+    the CLI layer.
+    """
+    return any(
+        getattr(handler, "_aorta_verbose", False)
+        for handler in logging.getLogger("aorta").handlers
+    )
 
 
 class MatrixIncompleteError(Exception):
@@ -1112,6 +1128,7 @@ def run_recipe(
             layout=layout,
             resume_existing=resume_existing,
             subprocess_argv=subprocess_argv,
+            should_write=should_write,
         )
 
 
@@ -1124,6 +1141,7 @@ def _run_recipe_locked(
     layout: Literal["timestamped", "flat_resume"],
     resume_existing: bool,
     subprocess_argv: tuple[str, ...] | None,
+    should_write: bool = True,
 ) -> Path:
     """Body of :func:`run_recipe` after the flat_resume lock is held.
 
@@ -1131,6 +1149,10 @@ def _run_recipe_locked(
     ``contextlib.ExitStack`` block at the top of :func:`run_recipe` and
     the matrix-loop body doesn't need to be re-indented inside a ``with``.
     Not part of the public API -- callers go through :func:`run_recipe`.
+
+    ``should_write`` mirrors :func:`run_recipe`'s rank-0 gate: only rank 0
+    owns the real output tree, so only rank 0 prints the end-of-run summary
+    (a ``torchrun`` launch otherwise emits one copy per rank).
     """
     # Operator sidecars come from two places: ones the Recipe was built
     # against (``recipe.sidecar_files``, populated by ``load_recipe`` /
@@ -1399,6 +1421,25 @@ def _run_recipe_locked(
         click.echo(
             f"to rerun: cd {run_dir} && aorta triage run --recipe recipe.resolved.yaml {flags}"
         )
+
+    # Concise end-of-run summary (issue #280): otherwise ``aorta sweep run`` is
+    # silent during the run and prints only ``Wrote matrix to ...`` at the end,
+    # leaving operators with no signal of which cells failed or where the
+    # captured output landed. Rank-0 only (same gate as the artifact writes),
+    # and printed before the ``MatrixIncompleteError`` raise so a degraded run
+    # -- exactly when the operator most needs to know what failed -- still
+    # reports. Best-effort: a formatting bug must never mask the run's outcome.
+    if should_write:
+        try:
+            for line in format_run_summary(
+                cell_stats,
+                run_dir,
+                layout=layout,
+                verbose_active=_verbose_active(),
+            ):
+                click.echo(line)
+        except Exception:  # pragma: no cover - defensive; summary is advisory
+            log.warning("failed to render end-of-run summary", exc_info=True)
 
     if incomplete_reason is not None:
         # Artifacts are written; raise so the CLI can print the failure

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -431,11 +431,11 @@ def _resume_stop_after_cell(
     cap: int,
     stop_after: Any,
     resolved_env_vars: dict[str, str],
-) -> tuple[list[TrialResult], None, dict[str, str], list[str]] | None:
+) -> tuple[list[TrialResult], None, dict[str, str], list[str], bool] | None:
     """Resume short-circuit for a ``stop_after`` cell (issue #232).
 
-    Returns the hydrated ``(trials, error, env, paths)`` tuple iff the
-    on-disk trial prefix ALREADY satisfies the stopping rule -- i.e. the
+    Returns the hydrated ``(trials, error, env, paths, resumed)`` tuple iff
+    the on-disk trial prefix ALREADY satisfies the stopping rule -- i.e. the
     contiguous run of complete ``trial_<i>`` directories from index 0
     either hit the event target or reached the cap. Otherwise returns
     ``None`` so the caller re-runs the cell from scratch (re-running is
@@ -475,7 +475,7 @@ def _resume_stop_after_cell(
             stop_after.events,
             cap,
         )
-        return hydrated, None, resolved_env_vars, trial_paths
+        return hydrated, None, resolved_env_vars, trial_paths, True
     return None
 
 
@@ -731,8 +731,13 @@ def _run_one_cell(
     layout: Literal["timestamped", "flat_resume"] = "timestamped",
     resume_existing: bool = False,
     subprocess_argv: tuple[str, ...] | None = None,
-) -> tuple[list[TrialResult], str | None, dict[str, str], list[str]]:
-    """Execute a single cell through B1 and return (trials, error, env_vars, trial_paths).
+) -> tuple[list[TrialResult], str | None, dict[str, str], list[str], bool]:
+    """Execute a single cell through B1 and return (trials, error, env_vars, trial_paths, resumed).
+
+    ``resumed`` is True only when the whole cell was hydrated from a prior
+    run's on-disk artifacts via the ``flat_resume`` resume short-circuit
+    (no trials re-executed); False for freshly-run cells and for every
+    timestamped-layout cell (which never resumes).
 
     Exception handling scope is deliberately wide: any failure originating
     from B1 (unknown mitigation, workload crash in ``setup``, docker pull
@@ -795,9 +800,11 @@ def _run_one_cell(
         # on-disk prefix already satisfies the stopping rule; otherwise
         # fall through to a full re-run (the dispatcher will itself stop
         # early, so re-running is bounded by ``cap``).
-        resumed = _resume_stop_after_cell(cell, cell_dir, cap, stop_after, resolved_env_vars)
-        if resumed is not None:
-            return resumed
+        resumed_result = _resume_stop_after_cell(
+            cell, cell_dir, cap, stop_after, resolved_env_vars
+        )
+        if resumed_result is not None:
+            return resumed_result
     elif resume_existing and layout == "flat_resume":
         from aorta.probe.resume import is_trial_complete
 
@@ -836,7 +843,7 @@ def _run_one_cell(
                     cell.name,
                     effective_trials,
                 )
-                return hydrated, None, resolved_env_vars, trial_paths
+                return hydrated, None, resolved_env_vars, trial_paths, True
             # Subset check failed -> at least one required index is missing.
             # The single-branch log subsumes the previous two-branch shape
             # (separate "indices missing" vs "count short" cases): with the
@@ -933,10 +940,10 @@ def _run_one_cell(
         trials = run_trials(request)
     except Exception as exc:
         log.warning("cell %r failed with %s: %s", cell.name, type(exc).__name__, exc, exc_info=True)
-        return [], f"{type(exc).__name__}: {exc}", resolved_env_vars, []
+        return [], f"{type(exc).__name__}: {exc}", resolved_env_vars, [], False
 
     trial_paths = _collect_trial_paths(cell_dir)
-    return trials, None, resolved_env_vars, trial_paths
+    return trials, None, resolved_env_vars, trial_paths, False
 
 
 def _preflight_validate(recipe: Recipe) -> None:
@@ -1233,7 +1240,7 @@ def _run_recipe_locked(
             cell.effective_trials(recipe.trials),
         )
         cell_t0 = time.perf_counter()
-        trials, error, resolved_env_vars, trial_paths = _run_one_cell(
+        trials, error, resolved_env_vars, trial_paths, resumed = _run_one_cell(
             cell,
             recipe,
             run_dir,
@@ -1263,11 +1270,13 @@ def _run_recipe_locked(
             # both halves of the predicate are needed.
             passed = sum(1 for t in trials if _trial_passed_for_log(t))
             summary, suffix = _format_cell_summary(trials, passed)
+            done_verb = "resumed (cached, no re-run) in" if resumed else "done in"
             log.info(
-                "cell %d/%d: %s -- done in %.1fs %s%s",
+                "cell %d/%d: %s -- %s %.1fs %s%s",
                 cell_idx,
                 total_cells,
                 cell.name,
+                done_verb,
                 cell_elapsed,
                 summary,
                 suffix,
@@ -1299,6 +1308,7 @@ def _run_recipe_locked(
             error=error,
             workload_config={**recipe.workload_config, **cell.workload_config},
             stop_after_note=stop_after_note,
+            resumed=resumed,
         )
         cell_stats.append(stats)
 

--- a/tests/triage/test_run_summary.py
+++ b/tests/triage/test_run_summary.py
@@ -1,0 +1,234 @@
+"""Tests for the concise end-of-run sweep summary (issue #280).
+
+``aorta sweep run`` is otherwise silent during a run and prints only a single
+``Wrote matrix to ...`` line at the end, so an operator has no way to see which
+cells failed or where their captured output landed. These tests pin:
+
+* the pure :func:`aorta.triage.output.format_run_summary` formatter -- totals
+  line, per-cell fail/error lines, artifact-directory pointers (both layouts),
+  failure hints, and the ``-v`` tip suppression; and
+* that a real ``aorta sweep run`` (through the shared engine) actually emits the
+  summary to stdout -- including on a degraded (``MatrixIncompleteError``) run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+import aorta.triage.runner as runner
+from aorta.cli import main
+from aorta.triage.matrix import aggregate_cell
+from aorta.triage.output import format_run_summary
+
+# ---- trial stand-ins ------------------------------------------------------
+
+
+def _pass_trial() -> SimpleNamespace:
+    return SimpleNamespace(
+        exit_status="ok",
+        wall_clock_sec=1.0,
+        result={"passed": True, "step_times_ms": [100.0]},
+    )
+
+
+def _fail_trial(hint: str | None = None) -> SimpleNamespace:
+    result: dict = {"passed": False, "step_times_ms": [100.0]}
+    if hint is not None:
+        result["failure_details"] = [{"hint": hint}]
+    return SimpleNamespace(exit_status="workload_failed", wall_clock_sec=1.0, result=result)
+
+
+def _error_trial() -> SimpleNamespace:
+    # setup() raised -> infra error verdict, no valid observation.
+    return SimpleNamespace(
+        exit_status="workload_setup_failed",
+        wall_clock_sec=0.0,
+        result={"passed": False, "step_times_ms": [], "elapsed_sec": 0.0},
+    )
+
+
+def _cell(name, mitigation, trials, error=None):
+    return aggregate_cell(
+        name=name,
+        mitigations=(mitigation,),
+        environment="local",
+        extra_env={},
+        resolved_env_vars={},
+        trials=trials,
+        effective_steps=50,
+        error=error,
+    )
+
+
+# ---- format_run_summary: unit --------------------------------------------
+
+
+def test_all_clean_is_a_single_line():
+    clean = _cell("baseline-local", "none", [_pass_trial(), _pass_trial()])
+    lines = format_run_summary([clean], Path("/tmp/run"))
+    assert lines == ["Sweep summary: all 1 cell(s) passed."]
+
+
+def test_totals_line_counts_clean_failing_and_errored_cells():
+    stats = [
+        _cell("baseline-local", "none", [_pass_trial(), _pass_trial()]),
+        _cell("tf32-local", "tf32_off", [_fail_trial(), _pass_trial()]),
+        _cell("hsa-local", "hsa_xnack", [_error_trial(), _error_trial()]),
+        _cell("bad-local", "bad", [], error="UnknownMitigationError: bad"),
+    ]
+    lines = format_run_summary(stats, Path("/tmp/run"))
+    assert lines[0] == (
+        "Sweep summary: 4 cell(s) -- 1 clean, 1 with failing trials, 2 with errors."
+    )
+
+
+def test_failing_cell_line_has_counts_hint_and_relative_dir():
+    stats = [
+        _cell("baseline-local", "none", [_pass_trial(), _pass_trial()]),
+        _cell("tf32-local", "tf32_off", [_fail_trial("NaN at layer 3"), _pass_trial()]),
+    ]
+    lines = format_run_summary(stats, Path("/tmp/run"))
+    # Clean cells never get their own line.
+    assert not any("baseline-local" in ln for ln in lines[1:])
+    fail_line = next(ln for ln in lines if "tf32-local" in ln)
+    assert fail_line.startswith("  [fail] tf32-local:")
+    assert "1 failed of 2 trial(s)" in fail_line
+    assert "(NaN at layer 3)" in fail_line
+    # Timestamped (triage) layout nests cells under cells/.
+    assert fail_line.rstrip().endswith("-> cells/tf32-local/")
+
+
+def test_error_only_cell_is_tagged_error_not_fail():
+    stats = [
+        _cell("baseline-local", "none", [_pass_trial()]),
+        _cell("hsa-local", "hsa_xnack", [_error_trial(), _error_trial()]),
+    ]
+    lines = format_run_summary(stats, Path("/tmp/run"))
+    err_line = next(ln for ln in lines if "hsa-local" in ln)
+    assert err_line.startswith("  [error] hsa-local:")
+    assert "2 errored of 2 trial(s)" in err_line
+
+
+def test_whole_cell_error_line_and_message_is_single_line():
+    stats = [
+        _cell("baseline-local", "none", [_pass_trial()]),
+        _cell("bad-local", "bad", [], error="UnknownMitigationError: no\nsuch\nname"),
+    ]
+    lines = format_run_summary(stats, Path("/tmp/run"))
+    err_line = next(ln for ln in lines if "bad-local" in ln)
+    assert err_line.startswith("  [error] bad-local: cell did not run (")
+    # Newlines in the error message are folded so each cell stays one line.
+    assert "\n" not in err_line
+    assert "UnknownMitigationError: no such name" in err_line
+
+
+def test_flat_resume_layout_points_at_sibling_dirs():
+    stats = [
+        _cell("none-smoke", "none", [_pass_trial()]),
+        _cell("tf32-smoke", "tf32_off", [_fail_trial()]),
+    ]
+    lines = format_run_summary(stats, Path("/tmp/run"), layout="flat_resume")
+    fail_line = next(ln for ln in lines if "tf32-smoke" in ln)
+    # flat_resume puts cell artifacts directly under the run dir (no cells/).
+    assert fail_line.rstrip().endswith("-> tf32-smoke/")
+
+
+def test_footer_points_at_matrix_and_offers_verbose_tip():
+    stats = [_cell("tf32-local", "tf32_off", [_fail_trial()])]
+    lines = format_run_summary(stats, Path("/tmp/run"))
+    assert f"Full matrix: {Path('/tmp/run') / 'matrix.md'}" in lines
+    assert any(ln.startswith("Tip: re-run with -v") for ln in lines)
+
+
+def test_verbose_run_suppresses_the_verbose_tip():
+    stats = [_cell("tf32-local", "tf32_off", [_fail_trial()])]
+    lines = format_run_summary(stats, Path("/tmp/run"), verbose_active=True)
+    assert not any("re-run with -v" in ln for ln in lines)
+    # The matrix pointer is still there -- it's useful regardless of verbosity.
+    assert any(ln.startswith("Full matrix:") for ln in lines)
+
+
+# ---- aorta sweep run: end-to-end -----------------------------------------
+
+_TRIAGE_RECIPE = """\
+schema_version: 1
+ticket: SUM-1
+workload: fsdp
+trials: 2
+steps: 5
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+  - name: tf32-local
+    mitigations: [tf32_off]
+    environment: local
+"""
+
+
+@pytest.fixture
+def _hermetic_engine(monkeypatch):
+    """Patch the runner's env probe so the summary tests don't touch host state."""
+    monkeypatch.setattr(
+        runner,
+        "collect_env",
+        lambda: SimpleNamespace(to_dict=lambda: {}, partial=False, partial_reasons=[]),
+    )
+
+
+def test_sweep_run_prints_summary_with_failing_cell(tmp_path, monkeypatch, _hermetic_engine):
+    def fake_run_trials(request):
+        if "tf32_off" in request.mitigations:
+            return [_fail_trial("NaN at layer 3"), _pass_trial()]
+        return [_pass_trial(), _pass_trial()]
+
+    monkeypatch.setattr(runner, "run_trials", fake_run_trials)
+
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(_TRIAGE_RECIPE, encoding="utf-8")
+    result = CliRunner().invoke(
+        main,
+        ["sweep", "run", "--recipe", str(recipe), "--output", str(tmp_path / "out")],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Sweep summary: 2 cell(s) -- 1 clean, 1 with failing trials" in result.output
+    assert "[fail] tf32-local:" in result.output
+    assert "(NaN at layer 3)" in result.output
+    assert "cells/tf32-local/" in result.output
+    # The pre-existing final line is preserved.
+    assert "Wrote matrix to" in result.output
+
+
+def test_sweep_run_all_pass_is_one_summary_line(tmp_path, monkeypatch, _hermetic_engine):
+    monkeypatch.setattr(runner, "run_trials", lambda request: [_pass_trial(), _pass_trial()])
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(_TRIAGE_RECIPE, encoding="utf-8")
+    result = CliRunner().invoke(
+        main,
+        ["sweep", "run", "--recipe", str(recipe), "--output", str(tmp_path / "out")],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Sweep summary: all 2 cell(s) passed." in result.output
+    assert "[fail]" not in result.output
+
+
+def test_summary_prints_even_on_degraded_run(tmp_path, monkeypatch, _hermetic_engine):
+    """A run whose explicit baseline never ran still gets a summary + exit!=0."""
+    monkeypatch.setattr(runner, "run_trials", lambda request: [_error_trial(), _error_trial()])
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        _TRIAGE_RECIPE + "confound:\n  baseline_cell: baseline-local\n",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        main,
+        ["sweep", "run", "--recipe", str(recipe), "--output", str(tmp_path / "out")],
+    )
+    # Degraded: the baseline produced only errored trials.
+    assert result.exit_code != 0, result.output
+    assert "Sweep summary:" in result.output
+    assert "[error] baseline-local:" in result.output

--- a/tests/triage/test_run_summary.py
+++ b/tests/triage/test_run_summary.py
@@ -318,11 +318,14 @@ diagnostic_axis: [none]
 """
 
 
-def test_probe_rerun_surfaces_resumed_cell_in_summary_and_matrix(tmp_path):
+def test_probe_rerun_surfaces_resumed_cell_in_summary_and_matrix(tmp_path, _hermetic_engine):
     """Reproduce the reported confusion: a second run against the same
     ``--output``/``--ticket`` serves the cell from cache, so an ``exit 1``
     command still shows a green cell. The summary must now say so, and
     ``matrix.json`` must record ``resumed: true``.
+
+    Uses ``_hermetic_engine`` to stub ``runner.collect_env`` so the test does
+    not probe host state; the real subprocess + resume short-circuit still run.
     """
     recipe = tmp_path / "probe.yaml"
     recipe.write_text(_PROBE_RECIPE, encoding="utf-8")

--- a/tests/triage/test_run_summary.py
+++ b/tests/triage/test_run_summary.py
@@ -13,6 +13,7 @@ cells failed or where their captured output landed. These tests pin:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -51,7 +52,7 @@ def _error_trial() -> SimpleNamespace:
     )
 
 
-def _cell(name, mitigation, trials, error=None):
+def _cell(name, mitigation, trials, error=None, resumed=False):
     return aggregate_cell(
         name=name,
         mitigations=(mitigation,),
@@ -61,6 +62,7 @@ def _cell(name, mitigation, trials, error=None):
         trials=trials,
         effective_steps=50,
         error=error,
+        resumed=resumed,
     )
 
 
@@ -152,6 +154,51 @@ def test_verbose_run_suppresses_the_verbose_tip():
     assert any(ln.startswith("Full matrix:") for ln in lines)
 
 
+# ---- format_run_summary: resumed (cached) cells (issue #282) --------------
+
+
+def test_no_resumed_cells_leaves_summary_unchanged():
+    """The resume wording only appears when a cell was actually resumed."""
+    stats = [_cell("baseline-local", "none", [_pass_trial(), _pass_trial()])]
+    lines = format_run_summary(stats, Path("/tmp/run"))
+    assert lines == ["Sweep summary: all 1 cell(s) passed."]
+    assert not any("resumed" in ln.lower() for ln in lines)
+
+
+def test_all_clean_resumed_run_reports_resume_and_how_to_force_fresh():
+    stats = [
+        _cell("none-none", "none", [_pass_trial()], resumed=True),
+        _cell("tf32-none", "tf32_off", [_pass_trial()], resumed=True),
+    ]
+    lines = format_run_summary(stats, Path("/tmp/run"), layout="flat_resume")
+    assert lines[0] == (
+        "Sweep summary: all 2 cell(s) passed. "
+        "2 resumed from a prior run (no trials re-executed)."
+    )
+    # The actionable "force a fresh run" note points at the run dir.
+    note = next(ln for ln in lines if ln.startswith("Note:"))
+    assert "/tmp/run" in note
+    assert "--ticket" in note
+
+
+def test_resumed_failing_cell_is_marked_and_counted():
+    stats = [
+        _cell("none-none", "none", [_fail_trial("NaN at layer 3")], resumed=True),
+        _cell("tf32-none", "tf32_off", [_pass_trial()], resumed=False),
+    ]
+    lines = format_run_summary(stats, Path("/tmp/run"), layout="flat_resume")
+    # Totals line carries the resumed count.
+    assert "1 resumed from a prior run" in lines[0]
+    # The resumed non-clean cell is tagged; the marker sits before the arrow.
+    fail_line = next(ln for ln in lines if "none-none" in ln)
+    assert "[resumed]" in fail_line
+    assert "(NaN at layer 3)" in fail_line
+    assert fail_line.rstrip().endswith("-> none-none/")
+    # A fresh (non-resumed) cell that passed never gets a line at all.
+    assert not any("tf32-none" in ln for ln in lines)
+    assert any(ln.startswith("Note:") for ln in lines)
+
+
 # ---- aorta sweep run: end-to-end -----------------------------------------
 
 _TRIAGE_RECIPE = """\
@@ -232,3 +279,54 @@ def test_summary_prints_even_on_degraded_run(tmp_path, monkeypatch, _hermetic_en
     assert result.exit_code != 0, result.output
     assert "Sweep summary:" in result.output
     assert "[error] baseline-local:" in result.output
+
+
+# ---- aorta sweep run: end-to-end resume visibility (issue #282) -----------
+
+_PROBE_RECIPE = """\
+schema_version: 1
+mode: probe
+ticket: RESUME-VIS
+trials: 1
+mitigation_axis: [none]
+diagnostic_axis: [none]
+"""
+
+
+def test_probe_rerun_surfaces_resumed_cell_in_summary_and_matrix(tmp_path):
+    """Reproduce the reported confusion: a second run against the same
+    ``--output``/``--ticket`` serves the cell from cache, so an ``exit 1``
+    command still shows a green cell. The summary must now say so, and
+    ``matrix.json`` must record ``resumed: true``.
+    """
+    recipe = tmp_path / "probe.yaml"
+    recipe.write_text(_PROBE_RECIPE, encoding="utf-8")
+    output = tmp_path / "out"
+
+    # First run: fresh, the command actually executes and passes.
+    first = CliRunner().invoke(
+        main,
+        ["sweep", "run", "--recipe", str(recipe), "--output", str(output),
+         "--ticket", "RESUME-VIS", "--", "sh", "-c", "exit 0"],
+    )
+    assert first.exit_code == 0, first.output
+    assert "resumed from a prior run" not in first.output
+
+    # Second run: SAME output/ticket, but a failing command. The cell is
+    # already complete on disk -> served from cache, the exit-1 never runs.
+    second = CliRunner().invoke(
+        main,
+        ["sweep", "run", "--recipe", str(recipe), "--output", str(output),
+         "--ticket", "RESUME-VIS", "--", "sh", "-c", "exit 1"],
+    )
+    assert second.exit_code == 0, second.output
+    # The cache hit is now visible on stdout, with the count and how to
+    # force a fresh run -- no need to open the per-trial logs.
+    assert "1 resumed from a prior run (no trials re-executed)." in second.output
+    assert "Note:" in second.output
+    assert "--ticket" in second.output
+
+    # And it is persisted so tooling can tell cached from fresh.
+    matrix = json.loads((output / "RESUME-VIS" / "matrix.json").read_text(encoding="utf-8"))
+    cells = {c["name"]: c for c in matrix["cells"]}
+    assert cells.get("none-none", {}).get("resumed") is True

--- a/tests/triage/test_run_summary.py
+++ b/tests/triage/test_run_summary.py
@@ -115,6 +115,31 @@ def test_error_only_cell_is_tagged_error_not_fail():
     assert "2 errored of 2 trial(s)" in err_line
 
 
+def test_mixed_fail_and_error_cell_counted_once_as_failing():
+    """A cell with BOTH failing and errored trials is a single [fail] cell.
+
+    Regression for a Copilot review on #281: ``with_errors`` also counted a
+    cell that had failing trials, so the buckets could sum past ``total`` and
+    disagreed with the per-cell ``[fail]`` tag. The three buckets must
+    partition the cells.
+    """
+    stats = [
+        _cell("baseline-local", "none", [_pass_trial(), _pass_trial()]),
+        _cell("mixed-local", "tf32_off", [_fail_trial(), _error_trial()]),
+    ]
+    lines = format_run_summary(stats, Path("/tmp/run"))
+    # The mixed cell is counted with the failing bucket, not both.
+    assert lines[0] == (
+        "Sweep summary: 2 cell(s) -- 1 clean, 1 with failing trials, 0 with errors."
+    )
+    # clean + with_failures + with_errors must equal total (2).
+    mixed_line = next(ln for ln in lines if "mixed-local" in ln)
+    assert mixed_line.startswith("  [fail] mixed-local:")
+    # Both counts still surface on the per-cell detail line.
+    assert "1 failed" in mixed_line
+    assert "1 errored" in mixed_line
+
+
 def test_whole_cell_error_line_and_message_is_single_line():
     stats = [
         _cell("baseline-local", "none", [_pass_trial()]),


### PR DESCRIPTION
## Summary

Closes #280. Also closes #282 (follow-up commit — see "Follow-up" section below).

`aorta sweep run` (and its `triage run` alias / the `torchrun … aorta triage run` matrix path) is silent while a matrix runs and prints only a single `Wrote matrix to <run_dir>` line at the end. An operator has no signal of **which cells failed vs. errored** or **where the captured output landed** without opening `matrix.md` and digging through per-cell logs. The existing `-v`/`-vv` flag streams live progress but is off by default and gives no final rollup.

This adds an always-on, concise end-of-run summary printed to stdout by the shared engine, so every front door gets it:

- a totals line — `Sweep summary: N cell(s) -- C clean, F with failing trials, E with errors.`
- one line per **non-clean** cell — `[fail]`/`[error]` tag, failed/errored counts out of the cell's trial budget (or `cell did not run (<reason>)` when the whole cell errored before any trial), the workload's own one-line failure `hint` when it emitted one, and the cell's artifact directory **relative to the run dir** (correct for both the timestamped triage layout, `cells/<cell>/`, and the flat-resume probe layout, `<cell>/`).
- a footer pointing at `matrix.md`, plus a `-v` tip (suppressed when live progress was already streamed).

An all-passing run collapses to a single line; the report scales with the number of **cells**, not trials, so a long sweep still ends in something scannable.

Example on a failing run:

```
Sweep summary: 2 cell(s) -- 1 clean, 1 with failing trials, 0 with errors.
  [fail] tf32-local: 1 failed of 2 trial(s) (NaN at layer 3) -> cells/tf32-local/
Full matrix: results/SUM-1/fsdp/2026-.../matrix.md
Tip: re-run with -v to stream per-cell progress live.
Wrote matrix to results/SUM-1/fsdp/2026-.../
```

## Implementation notes / deliberate choices

- **Single integration point.** The summary is rendered by a new pure helper `format_run_summary()` in `aorta/triage/output.py` and wired into `_run_recipe_locked` (the shared engine), so `aorta sweep run`, the deprecated `aorta triage run` alias, and the distributed `torchrun` path all get it with no per-front-door code.
- **Rank-0 gated.** Printed only when `should_write` is true — the same gate as the artifact writes — so a `torchrun` launch doesn't emit one copy per rank.
- **Prints on degraded runs too.** Emitted *before* the `MatrixIncompleteError` raise, so a run whose baseline never anchored — exactly when you most need to know what failed — still reports, then exits non-zero.
- **Best-effort / advisory.** The render is wrapped so a formatting bug can never mask the run's real outcome; a failure logs a WARNING and is otherwise swallowed. The summary is derived entirely from data already persisted in `matrix.json`/`matrix.md`, so nothing new needs persisting (KB #6 n/a here).
- **`-v` tip suppression** reuses the `_aorta_verbose` handler marker that `configure_verbose_logging` already stamps, so the two stay in lockstep without importing the CLI layer.
- Byte-for-byte behavior of `matrix.md`/`matrix.json`/`recipe.resolved.yaml` is unchanged; this is additive stdout only.
- No cross-platform concern (this is the Linux-only triage/probe path).

## Docs

Updated `aorta sweep`/`aorta triage run` `--help`, the `configure_verbose_logging` docstring, the top-level `README.md`, and `recipes/README-running-recipes.md` to describe the always-on summary vs. the `-v` live stream. `aorta run` (single-workload `run_trials` path) is intentionally untouched — it doesn't go through `run_recipe`.

## Test plan

- [x] New unit tests for `format_run_summary`: all-clean single line, totals counting, failing-cell line (counts + hint + relative dir), error-only vs. fail tagging, whole-cell-error one-line folding, flat-resume vs. timestamped layout, footer + `-v` tip suppression.
- [x] New end-to-end `CliRunner` tests through `aorta sweep run`: summary appears with a failing cell, all-pass collapses to one line, and the summary still prints on a **degraded** (`MatrixIncompleteError`, exit != 0) run.
- [x] `ruff check` clean on changed files.
- [x] Existing triage/sweep/probe suites pass (no regressions; artifacts unchanged).

Made with [Cursor](https://cursor.com)

---

## Follow-up: surface resumed (cached) cells (closes #282)

A second commit on this branch closes the sibling gap #282. In probe mode
(`flat_resume`) a re-run against the same `--output`/`--ticket` serves an
already-complete cell **from cache** — the new command never executes. That was
silent, so an intentionally-failing command could still report a green cell with
no signal it was resumed (the operator had to diff each `trial_*/result.json` to
tell a cached pass from a fresh one — exactly the log-digging this PR's summary
set out to remove).

- `CellStats` gains a `resumed` bool, threaded from both resume short-circuits
  in `_run_one_cell` (fixed-trials + `stop_after`) through `aggregate_cell`.
  It auto-persists to `matrix.json` (`cells[*].resumed`) via the existing
  `asdict` serialization. `false` for freshly-run cells and every
  timestamped-triage cell (which never resumes).
- The end-of-run summary suffixes its totals line with the resumed count, tags
  each non-clean resumed cell with `[resumed]`, and prints an actionable note
  (delete the run dir or use a new `--ticket`/`--output` to force a fresh run).
  A run with nothing resumed is byte-identical to before.
- The per-cell `-v` log line reads `resumed (cached, no re-run)` for a resumed
  cell; `docs/probe/usage.md` "Resume semantics" documents the new visibility.
- `matrix.md`'s table format is intentionally unchanged.

Example (run 2 of the same `--ticket`, with a now-failing command):

```
Sweep summary: 2 cell(s) -- 0 clean, 2 with failing trials, 0 with errors. 2 resumed from a prior run (no trials re-executed).
  [fail] none-none: 2 failed of 2 trial(s) [resumed] -> none-none/
  [fail] tf32_off-none: 2 failed of 2 trial(s) [resumed] -> tf32_off-none/
Full matrix: probe_results/DEMO/matrix.md
Note: resumed cells reused cached artifacts under probe_results/DEMO; delete that directory or use a new --ticket/--output to force a fresh run.
Tip: re-run with -v to stream per-cell progress live.
```

Adds unit tests for the resumed wording/marker/note plus an end-to-end test that
reproduces the report (a fresh run then a resumed run against the same ticket,
asserting the summary calls it out and `matrix.json` records `resumed: true`).
