### PR TITLE
build: derive version from git tags via setuptools_scm (tag-driven releases)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,12 +67,24 @@ jobs:
             exit 1
           fi
           echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMD_AORTA=${rc_version}" >> "$GITHUB_ENV"
+          echo "RC_VERSION=${rc_version}" >> "$GITHUB_ENV"
           echo "Building nightly ${rc_version}."
 
       - name: Build wheel and sdist
         run: |
           python -m pip install --upgrade build
           python -m build
+
+      # Fail fast if the built wheel doesn't carry the stamped rc version (e.g. a
+      # setuptools_scm/PRETEND_VERSION misconfiguration), so a mis-versioned
+      # artifact is never uploaded to the shared dev-wheels release.
+      - name: Verify built version matches
+        run: |
+          if [ ! -f "dist/amd_aorta-${RC_VERSION}-py3-none-any.whl" ]; then
+            echo "::error::Built wheel does not match stamped version ${RC_VERSION}. dist/ contains:"
+            ls -1 dist/
+            exit 1
+          fi
 
       # softprops/action-gh-release creates the dev-wheels tag on the first run
       # but does NOT move it on subsequent runs, so the rolling tag (and the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,14 +77,11 @@ jobs:
 
       # Fail fast if the built wheel doesn't carry the stamped rc version (e.g. a
       # setuptools_scm/PRETEND_VERSION misconfiguration), so a mis-versioned
-      # artifact is never uploaded to the shared dev-wheels release.
+      # artifact is never uploaded to the shared dev-wheels release. Validate the
+      # wheel's embedded METADATA version (what pip installs) rather than a single
+      # filename, so a future build/platform tag or extra wheel can't skew it.
       - name: Verify built version matches
-        run: |
-          if [ ! -f "dist/amd_aorta-${RC_VERSION}-py3-none-any.whl" ]; then
-            echo "::error::Built wheel does not match stamped version ${RC_VERSION}. dist/ contains:"
-            ls -1 dist/
-            exit 1
-          fi
+        run: python scripts/check_wheel_version.py "${RC_VERSION}"
 
       # softprops/action-gh-release creates the dev-wheels tag on the first run
       # but does NOT move it on subsequent runs, so the rolling tag (and the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,8 +7,9 @@ name: Nightly wheels
 #   pip install "amd-aorta==X.Y.ZrcYYYYMMDD" \
 #     -f https://github.com/ROCm/aorta/releases/expanded_assets/dev-wheels
 #
-# The rc version is stamped at build time (scripts/bump_version.py --suffix) and
-# is NOT committed back to the repo. Old assets are pruned by cleanup_releases.yml.
+# The rc version is derived at build time from the latest release tag
+# (scripts/bump_version.py + setuptools_scm's PRETEND_VERSION) and is NOT
+# committed anywhere. Old assets are pruned by cleanup_releases.yml.
 on:
   schedule:
     - cron: "0 11 * * *"  # 11:00 UTC daily
@@ -45,6 +46,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # full history + tags so setuptools_scm / bump_version see the latest release
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -53,11 +56,17 @@ jobs:
 
       - name: Stamp release-candidate version
         run: |
+          # rc of the NEXT release above the latest tag (e.g. latest v0.2.0 ->
+          # 0.2.1rcYYYYMMDD), so the nightly sorts as a pre-release of the version
+          # it will become -- not an rc of an already-released version. The value
+          # is fed to setuptools_scm via PRETEND_VERSION for this build only; it is
+          # never written to any file.
           suffix="rc$(date -u +%Y%m%d)"
-          if ! rc_version="$(python scripts/bump_version.py --suffix "${suffix}")"; then
+          if ! rc_version="$(python scripts/bump_version.py patch --suffix "${suffix}")"; then
             echo "::error::Failed to stamp release-candidate version."
             exit 1
           fi
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMD_AORTA=${rc_version}" >> "$GITHUB_ENV"
           echo "Building nightly ${rc_version}."
 
       - name: Build wheel and sdist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,10 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      # Only vMAJOR.MINOR.PATCH tags (same semver shape as setuptools_scm /
+      # bump_version.py), so stray tags like v1 / v1beta / v0.2.0rc1 don't
+      # trigger noisy Release runs that just fail the stable-version gate.
+      - "v[0-9]*.[0-9]*.[0-9]*"
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,12 @@ name: Release
 on:
   push:
     tags:
-      # Only vMAJOR.MINOR.PATCH tags (same semver shape as setuptools_scm /
-      # bump_version.py), so stray tags like v1 / v1beta / v0.2.0rc1 don't
-      # trigger noisy Release runs that just fail the stable-version gate.
+      # Coarse first-pass filter for vMAJOR.MINOR.PATCH tags. This is a glob,
+      # not a regex: the `*`s aren't end-anchored, so it rejects shapes like
+      # v1 / v1beta but still admits rc-style / 4-segment tags such as
+      # v0.2.0rc1 / v1.2.3.4. Those are caught (and the run failed) by the
+      # stable-version gate in "Resolve release version" below, which is the
+      # real safety net; this filter just trims the most obvious noise.
       - "v[0-9]*.[0-9]*.[0-9]*"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,14 @@ jobs:
               echo "::error::A manual release must run on a branch, not a tag ref (${GITHUB_REF_NAME}). Re-run from the default branch, or push a vX.Y.Z tag instead."
               exit 1
             fi
+            # release.yml is the STABLE channel (marks the GitHub Release
+            # "Latest" and publishes to PyPI), so a manual run must originate
+            # from the default branch -- never an unmerged feature branch.
+            # Tag-push releases are unaffected: they take the else branch below.
+            if [ "${GITHUB_REF}" != "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+              echo "::error::Manual releases must run from the default branch (${{ github.event.repository.default_branch }}), not ${GITHUB_REF_NAME}."
+              exit 1
+            fi
             if [ -n "${EXPLICIT_VERSION}" ]; then
               pkg_version="$(python scripts/bump_version.py --set "${EXPLICIT_VERSION}")" \
                 || { echo "::error::Could not resolve explicit version '${EXPLICIT_VERSION}' (see log)."; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,11 @@ jobs:
           # release.yml is the STABLE channel: it marks the GitHub Release
           # "Latest" and publishes to PyPI. Pre-release / rc builds
           # (X.Y.ZrcYYYYMMDD) belong to nightly.yml's rolling dev-wheels channel.
-          # Reject any suffixed / non-MAJOR.MINOR.PATCH version so an rc value can
-          # never ship as a stable release.
-          if ! printf '%s' "${pkg_version}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          # Reject any suffixed / non-MAJOR.MINOR.PATCH version (and leading-zero
+          # segments like 01.02.003, which normalize away and wouldn't match the
+          # built wheel's version) so an rc or ambiguous value can never ship as a
+          # stable release.
+          if ! printf '%s' "${pkg_version}" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
             echo "::error::Release version '${pkg_version}' is not a stable MAJOR.MINOR.PATCH release; use nightly.yml for pre-release rc builds."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,15 +143,14 @@ jobs:
 
       # Fail fast if the built artifacts don't carry the resolved version (e.g. a
       # setuptools_scm misconfiguration), so a release can never disagree with the
-      # metadata customers install.
+      # metadata customers install. Read the version from the wheel's embedded
+      # METADATA (the source of truth pip installs) rather than pattern-matching a
+      # single filename, so a future build/platform tag or extra wheel can't make
+      # this pass/fail on the wrong signal.
       - name: Verify built version matches
-        run: |
-          version="${{ steps.version.outputs.version }}"
-          if [ ! -f "dist/amd_aorta-${version}-py3-none-any.whl" ]; then
-            echo "::error::Built wheel does not match resolved version ${version}. dist/ contains:"
-            ls -1 dist/
-            exit 1
-          fi
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+        run: python scripts/check_wheel_version.py "${EXPECTED_VERSION}"
 
       # Only now that the build has succeeded do we create and push the tag, so
       # a build failure on a manual run leaves nothing to clean up before retry.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,18 @@ name: Release
 
 # Build the wheel + sdist once, attach them to a GitHub Release, and publish the
 # same artifacts to PyPI (so customers can `pip install amd-aorta`). The release
-# version is always read from pyproject.toml (never hard-coded here).
+# version is derived from the git tag by setuptools_scm (see
+# [tool.setuptools_scm] in pyproject.toml) -- it is never hard-coded here and is
+# never committed back to a branch, so there is a single source of truth (the
+# vX.Y.Z tag) and this workflow never has to push to a protected branch.
 #
 # Two ways to cut a release:
 #   * push a version tag:  git tag vX.Y.Z && git push origin vX.Y.Z
-#     (releases the current pyproject.toml version; tag must match it)
+#     (builds X.Y.Z straight from the tag)
 #   * run this workflow manually (Actions -> Release -> Run workflow):
 #       - bump = patch/minor/major (or an explicit version) -> the workflow
-#         bumps pyproject.toml, commits the bump back to the branch, then tags;
-#       - bump = none -> releases the current pyproject.toml version as-is.
+#         computes the next version from the latest tag, builds it, and (only
+#         after a successful build) creates and pushes the new vX.Y.Z tag.
 on:
   push:
     tags:
@@ -18,21 +21,20 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: "Version bump for a manual release ('none' releases the current pyproject.toml version)."
+        description: "Version bump above the latest release tag (ignored if 'version' is set)."
         type: choice
         options:
-          - none
           - patch
           - minor
           - major
-        default: none
+        default: patch
       version:
         description: "Explicit MAJOR.MINOR.PATCH to release (overrides 'bump'; leave blank to use 'bump')."
         required: false
         default: ""
 
 permissions:
-  contents: write  # required to push the version bump + tag and create the release
+  contents: write  # required to create the release and push the new tag (manual runs)
 
 jobs:
   build-and-release:
@@ -41,103 +43,68 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0  # full history so a manual run can push the bump + tag
+          fetch-depth: 0  # full history + tags so setuptools_scm can derive the version
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"  # 3.11+ for stdlib tomllib to read the version
+          python-version: "3.11"
 
-      # Manual runs may bump pyproject.toml and commit the bump back to the
-      # branch before tagging, so the released version is never hard-coded.
-      - name: Bump version
-        if: github.event_name == 'workflow_dispatch' && (github.event.inputs.bump != 'none' || github.event.inputs.version != '')
+      - name: Resolve release version
+        id: version
         env:
           # Bind inputs to env vars rather than interpolating them straight into
           # the shell, to avoid script injection (bump_version.py also validates).
           BUMP: ${{ github.event.inputs.bump }}
           EXPLICIT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          # The bump path commits + pushes back to a branch. If a manual run is
-          # launched against a tag ref, GITHUB_REF_NAME is the tag, so the push
-          # below would create a stray branch named after the tag. Reject it.
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "::error::A manual release with a version bump must run on a branch, not a tag ref (${GITHUB_REF_NAME}). Re-run from the default branch."
-            exit 1
-          fi
-          if [ -n "${EXPLICIT_VERSION}" ]; then
-            new_version="$(python scripts/bump_version.py --set "${EXPLICIT_VERSION}")" \
-              || { echo "::error::Version bump failed for explicit version '${EXPLICIT_VERSION}' (see log)."; exit 1; }
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            # A manual run creates a NEW tag, so it must run on a branch: a tag
+            # ref has no "next version" to bump toward and can't own a new tag.
+            if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+              echo "::error::A manual release must run on a branch, not a tag ref (${GITHUB_REF_NAME}). Re-run from the default branch, or push a vX.Y.Z tag instead."
+              exit 1
+            fi
+            if [ -n "${EXPLICIT_VERSION}" ]; then
+              pkg_version="$(python scripts/bump_version.py --set "${EXPLICIT_VERSION}")" \
+                || { echo "::error::Could not resolve explicit version '${EXPLICIT_VERSION}' (see log)."; exit 1; }
+            else
+              pkg_version="$(python scripts/bump_version.py "${BUMP}")" \
+                || { echo "::error::Could not compute a '${BUMP}' bump from the latest tag (see log)."; exit 1; }
+            fi
           else
-            new_version="$(python scripts/bump_version.py "${BUMP}")" \
-              || { echo "::error::Version bump failed for bump '${BUMP}' (see log)."; exit 1; }
+            # Tag push: the tag IS the version.
+            pkg_version="${GITHUB_REF_NAME#v}"
           fi
-          echo "Bumped version to ${new_version}."
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          # A manual run with `version` set to the current value (or a bump that
-          # resolves to it) leaves pyproject.toml unchanged; commit then fails
-          # with a confusing "nothing to commit". Fail early with a clear hint.
-          if git diff --cached --quiet; then
-            echo "::error::pyproject.toml is already at ${new_version}; nothing to bump. Use bump='none' to release the current version, or pick a different version."
-            exit 1
-          fi
-          git commit -m "Release v${new_version}: bump version"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
 
-      - name: Resolve release version from pyproject.toml
-        id: version
-        run: |
-          # On a parse failure (invalid TOML / missing project.version) add a
-          # GitHub Actions annotation so the cause is easy to spot; the Python
-          # traceback may still appear in the step log for deeper debugging.
-          if ! pkg_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"; then
-            echo "::error::Could not read project.version from pyproject.toml (invalid TOML or missing project.version)."
-            exit 1
-          fi
-          if [ -z "${pkg_version}" ]; then
-            echo "::error::project.version in pyproject.toml is empty."
-            exit 1
-          fi
           # release.yml is the STABLE channel: it marks the GitHub Release
           # "Latest" and publishes to PyPI. Pre-release / rc builds
           # (X.Y.ZrcYYYYMMDD) belong to nightly.yml's rolling dev-wheels channel.
-          # Reject any suffixed / non-MAJOR.MINOR.PATCH version up front --
-          # otherwise an rc value would pass validation here and ship as a stable
-          # release, collapsing the stable-vs-nightly split this automation adds.
+          # Reject any suffixed / non-MAJOR.MINOR.PATCH version so an rc value can
+          # never ship as a stable release.
           if ! printf '%s' "${pkg_version}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::project.version '${pkg_version}' is not a stable MAJOR.MINOR.PATCH release; use nightly.yml for pre-release rc builds."
+            echo "::error::Release version '${pkg_version}' is not a stable MAJOR.MINOR.PATCH release; use nightly.yml for pre-release rc builds."
             exit 1
           fi
           tag="v${pkg_version}"
-          # Defensive backstop: a MAJOR.MINOR.PATCH value always yields a valid
-          # git ref, but let git be the source of truth so the tag is rejected
-          # here rather than later at tag creation/push if the check above is ever
-          # loosened.
           if ! git check-ref-format "refs/tags/${tag}"; then
-            echo "::error::project.version '${pkg_version}' yields an invalid git tag '${tag}' (rejected by git check-ref-format); choose a tag-safe version."
+            echo "::error::Version '${pkg_version}' yields an invalid git tag '${tag}'; choose a tag-safe version."
             exit 1
           fi
           echo "version=${pkg_version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          # Pin the version setuptools_scm stamps into the build. On a tag push
+          # this equals the tag; on a manual run it pins the not-yet-created tag's
+          # version (the tag is pushed only after the build succeeds, below) and
+          # also strips any dirty/local segment so the wheel version is exactly
+          # X.Y.Z.
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMD_AORTA=${pkg_version}" >> "$GITHUB_ENV"
           echo "Resolved release version ${pkg_version} (tag ${tag})."
 
-      # Fail fast BEFORE building: a pushed tag must match the package version so
-      # a release can never disagree with the metadata customers install.
-      - name: Verify pushed tag matches version
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          tag_version="${GITHUB_REF_NAME#v}"
-          if [ "${{ steps.version.outputs.version }}" != "${tag_version}" ]; then
-            echo "::error::Pushed tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${{ steps.version.outputs.version }}. Bump 'version' in pyproject.toml and retag."
-            exit 1
-          fi
-
-      # Manual runs create the tag from the resolved version. Fail fast here if
-      # it already exists so an already-released version is never re-released --
-      # but defer the actual tag push until after the build succeeds (below) so
-      # a failed build never leaves an orphaned remote tag that blocks reruns.
+      # Manual runs mint a NEW tag, so fail fast here if it already exists (an
+      # already-released version must never be re-released) -- but defer the tag
+      # push until after the build succeeds (below) so a failed build never
+      # leaves an orphaned remote tag that blocks reruns.
       - name: Verify tag is available for manual release
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -159,6 +126,18 @@ jobs:
         run: |
           python -m pip install --upgrade build
           python -m build
+
+      # Fail fast if the built artifacts don't carry the resolved version (e.g. a
+      # setuptools_scm misconfiguration), so a release can never disagree with the
+      # metadata customers install.
+      - name: Verify built version matches
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          if [ ! -f "dist/amd_aorta-${version}-py3-none-any.whl" ]; then
+            echo "::error::Built wheel does not match resolved version ${version}. dist/ contains:"
+            ls -1 dist/
+            exit 1
+          fi
 
       # Only now that the build has succeeded do we create and push the tag, so
       # a build failure on a manual run leaves nothing to clean up before retry.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,54 +8,63 @@ AORTA is a pure-Python package, so a single `py3-none-any` wheel installs on
 every platform; PyTorch is intentionally **not** bundled (customers install it
 from the ROCm index — see below).
 
-The release version is always read from `version` in `pyproject.toml` — it is
-never hard-coded in the workflow — so cutting a new release is just a version
-bump plus a trigger.
+The version is **derived from git tags** by
+[`setuptools_scm`](https://setuptools-scm.readthedocs.io/) (see
+`[tool.setuptools_scm]` in `pyproject.toml`) — it is not stored in
+`pyproject.toml` or `src/aorta/__init__.py`, so there is a single source of
+truth (the `vX.Y.Z` tag). A build sitting on a tag becomes `X.Y.Z`; a checkout
+ahead of the latest tag becomes `X.Y.(Z+1).devN+g<sha>`, so a local
+`pip install .` / `pip install git+...` always reports the most recent release
+(plus how far past it the tree is) rather than a stale hard-coded value.
+`aorta.__version__` reads this same value back from the installed package
+metadata. Cutting a release is therefore just creating a tag.
 
 ## Maintainer release flow
 
 Releases are automated by [`.github/workflows/release.yml`](../.github/workflows/release.yml).
-Each run builds the artifacts for the resolved `pyproject.toml` version and
-publishes them as a new GitHub Release marked **Latest**. Each release needs a
-new version: on a **manual run** the workflow refuses to release a version whose
-tag already exists, and on a **tag push** Git itself rejects a tag that already
-exists (force-updating an existing tag would re-release it).
+Each run builds the artifacts for the resolved version and publishes them as a
+new GitHub Release marked **Latest**. Each release needs a new version: on a
+**manual run** the workflow refuses to release a version whose tag already
+exists, and on a **tag push** Git itself rejects a tag that already exists
+(force-updating an existing tag would re-release it). The release is entirely
+**tag-driven** — the workflow never pushes to a protected branch.
 
 Pick whichever trigger fits:
 
-- **Manual run with a version bump (recommended).** From the GitHub UI
+- **Manual run (recommended).** From the GitHub UI
   (*Actions -> Release -> Run workflow*), choose a `bump` of `patch`, `minor`,
   or `major` (or type an explicit version in the `version` field). The workflow
-  bumps `version` in `pyproject.toml`, commits that bump back to the branch it
-  ran from, then tags and releases — so you never edit the version by hand. The
-  bump is computed by [`scripts/bump_version.py`](../scripts/bump_version.py),
-  which you can also run locally:
+  computes the next version above the latest tag, builds it (via
+  `setuptools_scm`'s pretend-version), and — only after the build succeeds —
+  creates and pushes the new `vX.Y.Z` tag. You never edit a version by hand. The
+  next version is computed by [`scripts/bump_version.py`](../scripts/bump_version.py),
+  which reads the latest release tag and prints the next version (it writes no
+  files); you can run it locally to preview:
 
   ```bash
-  python scripts/bump_version.py patch        # 0.2.0 -> 0.2.1
-  python scripts/bump_version.py minor        # 0.2.0 -> 0.3.0
-  python scripts/bump_version.py --set 1.4.2  # set an explicit version
+  python scripts/bump_version.py patch        # latest v0.2.0 -> 0.2.1
+  python scripts/bump_version.py minor        # latest v0.2.0 -> 0.3.0
+  python scripts/bump_version.py --set 1.4.2  # an explicit version
   ```
 
-- **Manual run without a bump.** Choose `bump = none` to release the current
-  `pyproject.toml` version as-is (the workflow creates and pushes the matching
-  `vX.Y.Z` tag for you).
-
-- **Push a version tag** matching the current version, for a fully manual flow:
+- **Push a version tag**, for a fully manual flow (the tag *is* the version):
 
   ```bash
   git checkout main && git pull
-  git tag vX.Y.Z      # X.Y.Z must equal the pyproject.toml version
+  git tag vX.Y.Z
   git push origin vX.Y.Z
   ```
 
 The workflow then:
 
-- (manual bump only) bumps `pyproject.toml` and pushes the bump commit,
-- reads the version from `pyproject.toml`,
-- **before building**, fails fast if a pushed tag does not match that version
-  (so a release can never disagree with the package metadata),
+- resolves the version (from the pushed tag, or the computed next version on a
+  manual run) and pins it for the build via
+  `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMD_AORTA`,
 - builds the wheel + sdist with `python -m build`,
+- **after building**, fails fast if the built wheel does not carry the resolved
+  version (so a release can never disagree with the package metadata),
+- on a manual run, creates and pushes the `vX.Y.Z` tag (only after a successful
+  build, so a failed build leaves no orphaned tag),
 - creates the GitHub Release named `AORTA X.Y.Z`, marks it **Latest**, and
   uploads the wheel + sdist as release assets with auto-generated notes,
 - publishes the **same** wheel + sdist to PyPI (the `publish-pypi` job reuses the
@@ -76,11 +85,10 @@ release, a PyPI owner must register this repo as a trusted publisher once:
 Until this is configured the `publish-pypi` job will fail; the GitHub Release
 (with installable assets) is still created by the preceding job.
 
-> **Branch protection note.** A manual bump run pushes the version-bump commit
-> to the branch it ran from. If you run it against a protected branch (e.g.
-> `main`) whose rules block the `GITHUB_TOKEN`, either allow the
-> `github-actions` bot to push, or bump the version in a normal PR and use the
-> tag-push trigger instead.
+> **No branch pushes.** Because the version lives in git tags (not in a tracked
+> file), the release workflow only ever *creates a tag* — it never pushes a
+> commit to `main`, so branch-protection rules on `main` don't block it. Ensure
+> your tag protection / rulesets allow the release actor to push `v*` tags.
 
 After the workflow finishes, confirm the [latest release](https://github.com/ROCm/aorta/releases/latest)
 shows `amd_aorta-X.Y.Z-py3-none-any.whl` plus the sdist, and run the customer
@@ -118,8 +126,10 @@ pip install "amd-aorta @ https://github.com/ROCm/aorta/releases/download/vX.Y.Z/
 release candidate from `main` every night and uploads it to a single rolling
 [`dev-wheels`](https://github.com/ROCm/aorta/releases/tag/dev-wheels)
 pre-release (it is never marked **Latest**). The version is stamped as
-`X.Y.ZrcYYYYMMDD` at build time (via `scripts/bump_version.py --suffix`) and is
-not committed back to the repo.
+`X.Y.ZrcYYYYMMDD` at build time — where `X.Y.Z` is the **next** release above
+the latest tag (e.g. latest `v0.2.0` → `0.2.1rcYYYYMMDD`, so the rc sorts as a
+pre-release of the version it will become) — via `setuptools_scm`'s
+pretend-version and is not committed anywhere.
 
 Customers who need a fix before the next stable release install a specific
 nightly by pointing pip at the release's asset index:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,11 +144,13 @@ Repository = "https://github.com/ROCm/aorta"
 # ``*`` also spans dots, so it alone still admits ``v0.2.0rc1`` and
 # ``v1.2.3.4``); ``--exclude`` drops any tag carrying a non-digit/non-dot
 # character or a fourth numeric segment, and ``tag_regex`` then anchors the
-# extracted version to exactly three numeric components. A tree with no git
+# extracted version to exactly three numeric components with no leading zeros
+# (so it round-trips through the integer parsing in ``bump_version.py`` and the
+# release gate unchanged). A tree with no git
 # metadata (e.g. an unpacked sdist without .git) falls back to the literal below;
 # built sdists/wheels embed the resolved version in their metadata, so installing
 # from those still reports the correct version.
-tag_regex = "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$"
+tag_regex = "^v(?P<version>(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*))$"
 git_describe_command = [
     "git",
     "describe",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,14 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=64", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "amd-aorta"
-version = "0.2.0"
+# The version is not hard-coded here: it is derived from git tags at build time
+# by setuptools_scm (see [tool.setuptools_scm]). ``dynamic`` tells setuptools the
+# version is supplied by the build backend, so there is a single source of truth
+# (the ``vX.Y.Z`` tag) that both released wheels and local/editable installs read.
+dynamic = ["version"]
 description = "PyTorch compute-communication overlap debugging toolkit with GPU hardware queue evaluation"
 readme = "README.md"
 license = {text = "MIT"}
@@ -126,6 +130,28 @@ all = [
 Homepage = "https://github.com/ROCm/aorta"
 Documentation = "https://github.com/ROCm/aorta#readme"
 Repository = "https://github.com/ROCm/aorta"
+
+[tool.setuptools_scm]
+# Single source of truth for the version: the ``vX.Y.Z`` git tags.
+#   * a checkout sitting exactly on a tag builds a clean ``X.Y.Z``;
+#   * a checkout ahead of the latest tag builds ``X.Y.(Z+1).devN+g<sha>`` so a
+#     local ``pip install .`` / ``pip install git+...`` always reflects the most
+#     recent release (plus how far past it the tree is), never a stale literal.
+# Only version-like tags (``v`` + a digit) are matched, so the rolling
+# ``dev-wheels`` nightly tag is never mistaken for a release. A tree with no git
+# metadata (e.g. an unpacked sdist without .git) falls back to the literal below;
+# built sdists/wheels embed the resolved version in their metadata, so installing
+# from those still reports the correct version.
+git_describe_command = [
+    "git",
+    "describe",
+    "--dirty",
+    "--tags",
+    "--long",
+    "--match",
+    "v[0-9]*",
+]
+fallback_version = "0.0.0+unknown"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,11 +137,12 @@ Repository = "https://github.com/ROCm/aorta"
 #   * a checkout ahead of the latest tag builds ``X.Y.(Z+1).devN+g<sha>`` so a
 #     local ``pip install .`` / ``pip install git+...`` always reflects the most
 #     recent release (plus how far past it the tree is), never a stale literal.
-# Only version-like tags (``v`` + a digit) are matched, so the rolling
-# ``dev-wheels`` nightly tag is never mistaken for a release. A tree with no git
-# metadata (e.g. an unpacked sdist without .git) falls back to the literal below;
-# built sdists/wheels embed the resolved version in their metadata, so installing
-# from those still reports the correct version.
+# Only ``vMAJOR.MINOR.PATCH`` tags are matched (same shape as
+# ``scripts/bump_version.py``), so neither the rolling ``dev-wheels`` nightly tag
+# nor a stray ``v1`` / ``v1beta`` tag can be mistaken for a release. A tree with
+# no git metadata (e.g. an unpacked sdist without .git) falls back to the literal
+# below; built sdists/wheels embed the resolved version in their metadata, so
+# installing from those still reports the correct version.
 git_describe_command = [
     "git",
     "describe",
@@ -149,7 +150,7 @@ git_describe_command = [
     "--tags",
     "--long",
     "--match",
-    "v[0-9]*",
+    "v[0-9]*.[0-9]*.[0-9]*",
 ]
 fallback_version = "0.0.0+unknown"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,12 +137,18 @@ Repository = "https://github.com/ROCm/aorta"
 #   * a checkout ahead of the latest tag builds ``X.Y.(Z+1).devN+g<sha>`` so a
 #     local ``pip install .`` / ``pip install git+...`` always reflects the most
 #     recent release (plus how far past it the tree is), never a stale literal.
-# Only ``vMAJOR.MINOR.PATCH`` tags are matched (same shape as
+# Only exact ``vMAJOR.MINOR.PATCH`` tags are matched (same shape as
 # ``scripts/bump_version.py``), so neither the rolling ``dev-wheels`` nightly tag
-# nor a stray ``v1`` / ``v1beta`` tag can be mistaken for a release. A tree with
-# no git metadata (e.g. an unpacked sdist without .git) falls back to the literal
-# below; built sdists/wheels embed the resolved version in their metadata, so
-# installing from those still reports the correct version.
+# nor a stray ``v1`` / ``v1beta`` / ``v0.2.0rc1`` / ``v1.2.3.4`` tag can be
+# mistaken for a release. The ``--match`` glob is only a coarse first pass (glob
+# ``*`` also spans dots, so it alone still admits ``v0.2.0rc1`` and
+# ``v1.2.3.4``); ``--exclude`` drops any tag carrying a non-digit/non-dot
+# character or a fourth numeric segment, and ``tag_regex`` then anchors the
+# extracted version to exactly three numeric components. A tree with no git
+# metadata (e.g. an unpacked sdist without .git) falls back to the literal below;
+# built sdists/wheels embed the resolved version in their metadata, so installing
+# from those still reports the correct version.
+tag_regex = "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$"
 git_describe_command = [
     "git",
     "describe",
@@ -151,6 +157,10 @@ git_describe_command = [
     "--long",
     "--match",
     "v[0-9]*.[0-9]*.[0-9]*",
+    "--exclude",
+    "v*[!0-9.]*",
+    "--exclude",
+    "v*.*.*.*",
 ]
 fallback_version = "0.0.0+unknown"
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,27 +1,31 @@
 #!/usr/bin/env python3
-"""Bump the project version in ``pyproject.toml``.
+"""Compute the next release version from the project's git tags.
 
-Used by the release workflow (and runnable locally) to compute the next version
-without hard-coding it anywhere. Supports semantic-version bumps
-(``major``/``minor``/``patch``) or setting an explicit version, and rewrites
-only the single ``version = "..."`` line inside the ``[project]`` table so the
-rest of the file is left byte-for-byte untouched.
+The version is no longer stored in ``pyproject.toml``; it is derived from the
+``vX.Y.Z`` git tags by ``setuptools_scm`` at build time (see
+``[tool.setuptools_scm]`` in ``pyproject.toml``). This script computes the *next*
+version to release/stamp from the latest such tag, without writing any file --
+the release/nightly workflows capture its stdout and feed it to
+``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMD_AORTA`` (release) or use it to create the
+new tag. Keeping the math here (rather than inline in YAML) keeps it unit-tested.
 
 Examples:
-    python scripts/bump_version.py patch                 # 0.2.0 -> 0.2.1
-    python scripts/bump_version.py minor                 # 0.2.0 -> 0.3.0
-    python scripts/bump_version.py --set 1.4.2           # set an explicit version
-    python scripts/bump_version.py --suffix rc20260619   # 0.2.0 -> 0.2.0rc20260619
+    python scripts/bump_version.py patch                 # latest v0.2.0 -> 0.2.1
+    python scripts/bump_version.py minor                 # latest v0.2.0 -> 0.3.0
+    python scripts/bump_version.py --set 1.4.2           # an explicit version
+    python scripts/bump_version.py patch --suffix rc20260619
+                                                         # 0.2.0 -> 0.2.1rc20260619
+    python scripts/bump_version.py patch --current 0.2.0 # override git lookup (tests/CI)
 
-Prints the new version to stdout so callers (e.g. CI) can capture it.
+Prints the resolved version to stdout so callers (e.g. CI) can capture it.
 """
 
 from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
-from pathlib import Path
 
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 # Match a MAJOR.MINOR.PATCH base, but only when the patch is not followed by
@@ -29,28 +33,14 @@ _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 # rejected instead of being silently truncated to "0.2.0". A trailing
 # pre-release part (e.g. "0.2.0rc20260101") is still allowed for re-stamping.
 _SEMVER_PREFIX_RE = re.compile(r"^(\d+\.\d+\.\d+)(?![\d.])")
-_VERSION_LINE_RE = re.compile(r'^(\s*version\s*=\s*")([^"]*)(".*)$')
-# A suffix is concatenated straight into the quoted TOML version string, so it
-# must be a single PEP 440-style token: non-empty and limited to alphanumerics
-# plus . + - (no quotes, whitespace, or newlines that could break the TOML or
-# inject extra content).
+# A suffix is concatenated straight onto the base version, so it must be a
+# single PEP 440-style token: non-empty and limited to alphanumerics plus . + -
+# (no quotes, whitespace, or newlines that could corrupt the emitted version).
 _SUFFIX_RE = re.compile(r"^[A-Za-z0-9.+-]+$")
 
-
-def _table_header(line: str) -> str | None:
-    """Return the bracketed TOML table name on ``line``, or ``None``.
-
-    Tolerates a trailing inline comment so a valid header like
-    ``[project]  # note`` is still recognized (TOML allows comments after a
-    table header). Only the comment is dropped; nothing else is rewritten.
-    """
-    stripped = line.strip()
-    if not stripped.startswith("["):
-        return None
-    without_comment = stripped.split("#", 1)[0].strip()
-    if without_comment.endswith("]"):
-        return without_comment
-    return None
+# When no version tag exists yet, releases start from this base (so a first
+# ``patch`` release resolves to 0.0.1, ``minor`` to 0.1.0, ``major`` to 1.0.0).
+_INITIAL_VERSION = "0.0.0"
 
 
 def bump_version(current: str, level: str) -> str:
@@ -79,9 +69,8 @@ def apply_suffix(current: str, suffix: str) -> str:
     ``0.2.0rc20260101`` -> ``0.2.0rc20260619`` is idempotent on the base.
     Inputs whose extra part is dot-prefixed (PEP 440 ``.dev0`` / ``.post1``)
     or extends the release number (``0.2.0.1``) are intentionally rejected
-    with ``ValueError`` rather than silently truncated -- not every existing
-    pre-release/local form is dropped. Used to mint nightly
-    release-candidate versions such as ``0.2.0rc20260619``.
+    with ``ValueError`` rather than silently truncated. Used to mint nightly
+    release-candidate versions such as ``0.2.1rc20260619``.
     """
     if _SUFFIX_RE.match(suffix) is None:
         raise ValueError(
@@ -96,49 +85,35 @@ def apply_suffix(current: str, suffix: str) -> str:
     return f"{match.group(1)}{suffix}"
 
 
-def read_version(text: str) -> str:
-    """Return the version declared in the ``[project]`` table of ``text``."""
-    in_project = False
-    for line in text.splitlines():
-        header = _table_header(line)
-        if header is not None:
-            in_project = header == "[project]"
-            continue
-        if in_project:
-            match = _VERSION_LINE_RE.match(line)
-            if match is not None:
-                return match.group(2)
-    raise ValueError("no project.version found in pyproject text")
+def current_version_from_git() -> str:
+    """Return the latest ``vX.Y.Z`` release tag as ``X.Y.Z`` (or ``0.0.0``).
 
+    Only annotated/lightweight tags of the form ``v<MAJOR>.<MINOR>.<PATCH>`` are
+    considered, so the rolling ``dev-wheels`` nightly tag (and any other
+    non-release tag) is ignored. When the repository has no release tag yet, the
+    initial ``0.0.0`` base is returned so a first ``patch`` release resolves to
+    ``0.0.1``.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:  # pragma: no cover - env-specific
+        raise RuntimeError(f"could not list git tags: {exc}") from exc
 
-def set_version(text: str, new_version: str) -> str:
-    """Return ``text`` with the ``[project]`` version line set to ``new_version``."""
-    out: list[str] = []
-    in_project = False
-    replaced = False
-    for line in text.splitlines(keepends=True):
-        header = _table_header(line)
-        if header is not None:
-            in_project = header == "[project]"
-            out.append(line)
-            continue
-        if in_project and not replaced:
-            # Split off the exact trailing newline sequence ("\r\n", "\r",
-            # "\n" or "") and match against the bare content, so a CRLF/CR
-            # checkout keeps its line endings byte-for-byte (the "untouched"
-            # guarantee) instead of relying on the regex's "." swallowing the
-            # stray "\r".
-            content = line.rstrip("\r\n")
-            terminator = line[len(content):]
-            match = _VERSION_LINE_RE.match(content)
-            if match is not None:
-                out.append(f"{match.group(1)}{new_version}{match.group(3)}{terminator}")
-                replaced = True
-                continue
-        out.append(line)
-    if not replaced:
-        raise ValueError("no project.version line to replace in pyproject text")
-    return "".join(out)
+    versions: list[tuple[int, int, int]] = []
+    for line in out.splitlines():
+        tag = line.strip()
+        match = _SEMVER_RE.match(tag[1:] if tag.startswith("v") else tag)
+        if match is not None:
+            versions.append(tuple(int(p) for p in match.groups()))  # type: ignore[arg-type]
+    if not versions:
+        return _INITIAL_VERSION
+    major, minor, patch = max(versions)
+    return f"{major}.{minor}.{patch}"
 
 
 def resolve_new_version(
@@ -147,21 +122,29 @@ def resolve_new_version(
     explicit: str | None,
     suffix: str | None = None,
 ) -> str:
-    """Resolve the target version from an ``explicit`` value, a ``suffix``, or a bump ``level``.
+    """Resolve the target version from ``current`` plus a bump/explicit/suffix.
 
-    Precedence: ``explicit`` (``--set``) > ``suffix`` > ``level``.
+    The base is chosen by precedence ``explicit`` (``--set``) > ``level`` bump >
+    ``current`` as-is. A ``suffix`` (e.g. ``rc20260619``) is then appended to that
+    base, so ``level='patch'`` + ``suffix='rc...'`` yields the *next* release's rc
+    (``0.2.0`` -> ``0.2.1rc...``) rather than an rc of the already-released base.
     """
     if explicit is not None:
         if _SEMVER_RE.match(explicit) is None:
             raise ValueError(f"explicit version {explicit!r} is not MAJOR.MINOR.PATCH")
-        return explicit
+        base = explicit
+    elif level is not None:
+        base = bump_version(current, level)
+    else:
+        if _SEMVER_RE.match(current) is None:
+            raise ValueError(
+                f"current version {current!r} is not MAJOR.MINOR.PATCH; "
+                "pass a bump level or --set VERSION"
+            )
+        base = current
     if suffix is not None:
-        return apply_suffix(current, suffix)
-    if level is not None:
-        return bump_version(current, level)
-    raise ValueError(
-        "one of a bump level (major/minor/patch), --set VERSION, or --suffix SUFFIX is required"
-    )
+        return apply_suffix(base, suffix)
+    return base
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -170,7 +153,7 @@ def main(argv: list[str] | None = None) -> int:
         "level",
         nargs="?",
         choices=("major", "minor", "patch"),
-        help="semantic-version component to bump",
+        help="semantic-version component to bump above the latest release tag",
     )
     parser.add_argument(
         "--set",
@@ -179,32 +162,18 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--suffix",
-        help="append SUFFIX to the base MAJOR.MINOR.PATCH version, e.g. 'rc20260619' "
-        "(used for nightly release candidates; overrides the bump level)",
+        help="append SUFFIX to the resolved base version, e.g. 'rc20260619' "
+        "(used for nightly release candidates)",
     )
     parser.add_argument(
-        "--pyproject",
-        type=Path,
-        default=Path("pyproject.toml"),
-        help="path to pyproject.toml (default: ./pyproject.toml)",
+        "--current",
+        help="override the latest-release base instead of reading it from git "
+        "tags (mainly for tests/CI)",
     )
     args = parser.parse_args(argv)
 
-    # newline="" disables universal-newline translation on both read and write
-    # so a CRLF/CR pyproject.toml round-trips byte-for-byte (Path.read_text /
-    # write_text would normalize "\r\n" -> "\n" on read and back to os.linesep
-    # on write, defeating set_version's line-ending preservation). encoding is
-    # pinned so the result doesn't depend on the platform default.
-    with open(args.pyproject, encoding="utf-8", newline="") as fh:
-        text = fh.read()
-    current = read_version(text)
+    current = args.current if args.current is not None else current_version_from_git()
     new_version = resolve_new_version(current, args.level, args.explicit, args.suffix)
-    # Render the full updated text BEFORE opening for write: open(..., "w")
-    # truncates immediately, so if set_version raised here (e.g. malformed
-    # [project]) an in-place write would leave pyproject.toml emptied.
-    new_text = set_version(text, new_version)
-    with open(args.pyproject, "w", encoding="utf-8", newline="") as fh:
-        fh.write(new_text)
     print(new_version)
     return 0
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -27,12 +27,16 @@ import re
 import subprocess
 import sys
 
-_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+# Each segment is 0 or a non-zero-leading run of digits: leading-zero segments
+# (e.g. "01.02.003") are rejected so a version round-trips through int() parsing
+# and re-rendering unchanged, matching SemVer and the tag/gate validation.
+_SEGMENT = r"(?:0|[1-9]\d*)"
+_SEMVER_RE = re.compile(rf"^({_SEGMENT})\.({_SEGMENT})\.({_SEGMENT})$")
 # Match a MAJOR.MINOR.PATCH base, but only when the patch is not followed by
 # another dot or digit -- so a malformed 4-segment value like "0.2.0.1" is
 # rejected instead of being silently truncated to "0.2.0". A trailing
 # pre-release part (e.g. "0.2.0rc20260101") is still allowed for re-stamping.
-_SEMVER_PREFIX_RE = re.compile(r"^(\d+\.\d+\.\d+)(?![\d.])")
+_SEMVER_PREFIX_RE = re.compile(rf"^({_SEGMENT}\.{_SEGMENT}\.{_SEGMENT})(?![\d.])")
 # A suffix is concatenated straight onto the base version, so it must be a
 # single PEP 440-style token: non-empty and limited to alphanumerics plus . + -
 # (no quotes, whitespace, or newlines that could corrupt the emitted version).

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -149,7 +149,10 @@ def resolve_new_version(
     elif level is not None:
         base = bump_version(current, level)
     elif suffix is not None:
-        # suffix-only: stamp onto the current base (e.g. re-stamping an rc date).
+        # suffix-only: append the suffix to the current release base as-is
+        # (e.g. stamp today's rc onto the latest vX.Y.Z tag). `current` must be
+        # a plain MAJOR.MINOR.PATCH here -- the guard below rejects an already
+        # suffixed value, so this mints a fresh rc rather than re-dating one.
         if _SEMVER_RE.match(current) is None:
             raise ValueError(
                 f"current version {current!r} is not MAJOR.MINOR.PATCH; "

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -124,10 +124,14 @@ def resolve_new_version(
 ) -> str:
     """Resolve the target version from ``current`` plus a bump/explicit/suffix.
 
-    The base is chosen by precedence ``explicit`` (``--set``) > ``level`` bump >
-    ``current`` as-is. A ``suffix`` (e.g. ``rc20260619``) is then appended to that
-    base, so ``level='patch'`` + ``suffix='rc...'`` yields the *next* release's rc
-    (``0.2.0`` -> ``0.2.1rc...``) rather than an rc of the already-released base.
+    At least one of ``level``, ``explicit``, or ``suffix`` is required: this tool
+    computes the *next* version, so returning ``current`` unchanged on empty input
+    would be a misleading "success" (e.g. a blank bump input in CI). The base is
+    chosen by precedence ``explicit`` (``--set``) > ``level`` bump > ``current``
+    as-is (suffix-only). A ``suffix`` (e.g. ``rc20260619``) is then appended to
+    that base, so ``level='patch'`` + ``suffix='rc...'`` yields the *next*
+    release's rc (``0.2.0`` -> ``0.2.1rc...``) rather than an rc of the
+    already-released base.
     """
     if explicit is not None:
         if _SEMVER_RE.match(explicit) is None:
@@ -135,13 +139,18 @@ def resolve_new_version(
         base = explicit
     elif level is not None:
         base = bump_version(current, level)
-    else:
+    elif suffix is not None:
+        # suffix-only: stamp onto the current base (e.g. re-stamping an rc date).
         if _SEMVER_RE.match(current) is None:
             raise ValueError(
                 f"current version {current!r} is not MAJOR.MINOR.PATCH; "
                 "pass a bump level or --set VERSION"
             )
         base = current
+    else:
+        raise ValueError(
+            "one of a bump level (major/minor/patch), --set VERSION, or --suffix SUFFIX is required"
+        )
     if suffix is not None:
         return apply_suffix(base, suffix)
     return base

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -118,7 +118,8 @@ def current_version_from_git() -> str:
         tag = line.strip()
         match = _SEMVER_RE.match(tag[1:] if tag.startswith("v") else tag)
         if match is not None:
-            versions.append(tuple(int(p) for p in match.groups()))  # type: ignore[arg-type]
+            major, minor, patch = match.groups()
+            versions.append((int(major), int(minor), int(patch)))
     if not versions:
         return _INITIAL_VERSION
     major, minor, patch = max(versions)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -101,8 +101,17 @@ def current_version_from_git() -> str:
             capture_output=True,
             text=True,
         ).stdout
-    except (OSError, subprocess.CalledProcessError) as exc:  # pragma: no cover - env-specific
-        raise RuntimeError(f"could not list git tags: {exc}") from exc
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - env-specific
+        # Surface git's own stderr (captured above), e.g. "not a git
+        # repository", so the failure is actionable in CI and local runs --
+        # str(exc) alone only reports the non-zero exit code.
+        stderr = (exc.stderr or "").strip()
+        detail = f": {stderr}" if stderr else ""
+        raise RuntimeError(
+            f"could not list git tags (git exited {exc.returncode}){detail}"
+        ) from exc
+    except OSError as exc:  # pragma: no cover - env-specific (e.g. git not installed)
+        raise RuntimeError(f"could not run git to list tags: {exc}") from exc
 
     versions: list[tuple[int, int, int]] = []
     for line in out.splitlines():

--- a/scripts/check_wheel_version.py
+++ b/scripts/check_wheel_version.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Verify the built wheel in ``dist/`` carries an expected version.
+
+The release/nightly workflows build a wheel whose version is pinned via
+``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMD_AORTA`` and must fail fast if the
+artifact does not actually carry that version (e.g. a setuptools_scm
+misconfiguration), so a mis-versioned wheel is never released or uploaded.
+
+The version is read from the wheel's embedded ``*.dist-info/METADATA`` -- the
+same metadata ``pip`` installs -- rather than by pattern-matching a single
+filename, so a future build/platform tag (or an unexpected extra wheel) can't
+make the check pass or fail on the wrong signal. Comparison is on the PEP
+440-normalized version (via ``packaging`` when available) so cosmetic spelling
+differences (e.g. a ``-``/``_`` separator before a pre-release) don't cause a
+false mismatch; without ``packaging`` it falls back to exact string equality.
+
+Usage:
+    python scripts/check_wheel_version.py <expected-version> [dist-dir]
+
+Exits non-zero with a ``::error::`` line (GitHub Actions annotation) on any
+mismatch or ambiguity; prints a confirmation and exits 0 on success.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+from email.parser import BytesParser
+from zipfile import BadZipFile, ZipFile
+
+_METADATA_RE = re.compile(r"[^/]+\.dist-info/METADATA$")
+
+
+def _versions_match(built: str, expected: str) -> bool:
+    """Return whether two version strings are equal under PEP 440.
+
+    Uses ``packaging`` for a proper PEP 440 comparison (so ``0.2.1-rc1`` and
+    ``0.2.1rc1`` are equal) when it is importable -- it is a dependency of
+    ``build``, so it is present in the workflows after ``pip install build``.
+    Without it (or on an unparseable value), fall back to exact, stripped string
+    equality, which still matches for the already-normalized versions these
+    workflows produce.
+    """
+    a, b = built.strip(), expected.strip()
+    try:
+        from packaging.version import InvalidVersion, Version
+    except ImportError:  # pragma: no cover - packaging is present in CI
+        return a == b
+    try:
+        return Version(a) == Version(b)
+    except InvalidVersion:
+        return a == b
+
+
+def wheel_metadata_version(wheel_path: str) -> str:
+    """Return the ``Version`` field from a wheel's ``dist-info/METADATA``."""
+    with ZipFile(wheel_path) as zf:
+        names = [n for n in zf.namelist() if _METADATA_RE.match(n)]
+        if len(names) != 1:
+            raise ValueError(
+                f"expected exactly one dist-info/METADATA in {wheel_path}, found {names or 'none'}"
+            )
+        version = BytesParser().parsebytes(zf.read(names[0])).get("Version")
+    if not version:
+        raise ValueError(f"no Version field in {wheel_path} METADATA")
+    return version
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if not 1 <= len(args) <= 2:
+        print(f"::error::usage: {os.path.basename(__file__)} <expected-version> [dist-dir]")
+        return 2
+    expected = args[0]
+    dist_dir = args[1] if len(args) == 2 else "dist"
+
+    wheels = sorted(glob.glob(os.path.join(dist_dir, "*.whl")))
+    if len(wheels) != 1:
+        listing = ", ".join(wheels) if wheels else "none"
+        print(f"::error::expected exactly one built wheel in {dist_dir}/, found: {listing}")
+        return 1
+
+    try:
+        built = wheel_metadata_version(wheels[0])
+    except (OSError, BadZipFile, ValueError) as exc:
+        print(f"::error::could not read version from {wheels[0]}: {exc}")
+        return 1
+
+    if not _versions_match(built, expected):
+        print(
+            f"::error::built wheel version {built!r} does not match resolved "
+            f"version {expected!r} (wheel: {wheels[0]})"
+        )
+        return 1
+
+    print(f"Verified built wheel version {built} matches resolved {expected}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/aorta/__init__.py
+++ b/src/aorta/__init__.py
@@ -5,10 +5,20 @@ This package provides:
 - GPU hardware queue evaluation framework (hw_queue_eval subpackage)
 """
 
-__version__ = "0.2.0"
-
 from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
+
+# Single source of truth for the version is the distribution metadata, which is
+# generated from ``pyproject.toml`` at build/install time. This keeps
+# ``aorta.__version__`` in lockstep with whatever was actually installed (wheel,
+# ``pip install .``, editable, or ``pip install git+...``) instead of a hard-coded
+# literal that silently drifts from the released version. The fallback only
+# triggers when running against an uninstalled source tree with no metadata.
+try:
+    __version__ = version("amd-aorta")
+except PackageNotFoundError:  # pragma: no cover - source tree without dist-info
+    __version__ = "0.0.0+unknown"
 
 
 def load_training_entrypoint() -> Any:

--- a/src/aorta/__init__.py
+++ b/src/aorta/__init__.py
@@ -13,11 +13,15 @@ from typing import Any
 # generated from ``pyproject.toml`` at build/install time. This keeps
 # ``aorta.__version__`` in lockstep with whatever was actually installed (wheel,
 # ``pip install .``, editable, or ``pip install git+...``) instead of a hard-coded
-# literal that silently drifts from the released version. The fallback only
-# triggers when running against an uninstalled source tree with no metadata.
+# literal that silently drifts from the released version. This runs at import
+# time, so the fallback is best-effort and defensive: besides the expected
+# missing-metadata case (uninstalled source tree), any unexpected metadata error
+# (e.g. unreadable/corrupted dist-info) must not break ``import aorta``.
 try:
     __version__ = version("amd-aorta")
-except PackageNotFoundError:  # pragma: no cover - source tree without dist-info
+except PackageNotFoundError:  # source tree without dist-info
+    __version__ = "0.0.0+unknown"
+except Exception:  # pragma: no cover - defensive: never break import on metadata errors
     __version__ = "0.0.0+unknown"
 
 

--- a/src/aorta/__init__.py
+++ b/src/aorta/__init__.py
@@ -24,7 +24,7 @@ except PackageNotFoundError:  # pragma: no cover - source tree without dist-info
 def load_training_entrypoint() -> Any:
     """Lazily import and return the default training entry point."""
     module = import_module("aorta.training.fsdp_trainer")
-    return getattr(module, "main")
+    return module.main
 
 
 def load_hw_queue_eval():

--- a/src/aorta/bundle/writer.py
+++ b/src/aorta/bundle/writer.py
@@ -58,9 +58,14 @@ _TRIAL_RESULT_GLOB = "*/trial_*/result.json"
 
 
 def _aorta_version() -> str:
-    """Return the installed ``aorta`` package version (best-effort)."""
+    """Return the installed ``amd-aorta`` package version (best-effort).
+
+    Queries the canonical *distribution* name (``amd-aorta``), not the import
+    package name (``aorta``), so it resolves from installed dist metadata rather
+    than downgrading to ``"unknown"`` on a real install.
+    """
     try:
-        return _pkg_version("aorta")
+        return _pkg_version("amd-aorta")
     except PackageNotFoundError:
         return "unknown"
     except Exception:  # pragma: no cover - defensive

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -74,8 +74,10 @@ def _aorta_package_version() -> str:
 
     Queries the canonical *distribution* name (``amd-aorta``), not the import
     package name (``aorta``). ``importlib.metadata.version`` is the supported
-    API; falls back to ``"unknown"`` only when the package metadata is missing
-    (editable install on a Python that doesn't expose dist-info, very rare).
+    API; falls back to ``"unknown"`` when the package metadata is missing
+    (``PackageNotFoundError`` -- e.g. an editable install on a Python that
+    doesn't expose dist-info) and, defensively, on any other unexpected
+    metadata error, since a version banner must never crash the probe.
     """
     try:
         from importlib.metadata import PackageNotFoundError, version

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -70,12 +70,12 @@ from aorta.triage.runner import run_recipe
 
 
 def _aorta_package_version() -> str:
-    """Return the installed ``aorta`` package version (best-effort).
+    """Return the installed ``amd-aorta`` package version (best-effort).
 
-    ``importlib.metadata.version`` is the supported API; falls back
-    to ``"unknown"`` only when the package metadata is missing
-    (editable install on a Python that doesn't expose dist-info,
-    very rare).
+    Queries the canonical *distribution* name (``amd-aorta``), not the import
+    package name (``aorta``). ``importlib.metadata.version`` is the supported
+    API; falls back to ``"unknown"`` only when the package metadata is missing
+    (editable install on a Python that doesn't expose dist-info, very rare).
     """
     try:
         from importlib.metadata import PackageNotFoundError, version

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -80,7 +80,10 @@ def _aorta_package_version() -> str:
     try:
         from importlib.metadata import PackageNotFoundError, version
 
-        return version("aorta")
+        # Query the canonical distribution name from pyproject.toml (``amd-aorta``),
+        # not the import package name (``aorta``), so this resolves reliably from
+        # installed dist metadata rather than falling back to "unknown".
+        return version("amd-aorta")
     except PackageNotFoundError:
         return "unknown"
     except Exception:  # pragma: no cover - defensive

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -113,9 +113,16 @@ def test_resolve_new_version_rejects_bad_explicit():
         resolve_new_version("0.2.0", None, "not-a-version")
 
 
-def test_resolve_new_version_rejects_non_semver_current_without_bump():
+def test_resolve_new_version_requires_input():
+    # Empty input must fail loudly rather than silently return the current
+    # version unchanged (this tool computes the *next* version).
     with pytest.raises(ValueError):
-        resolve_new_version("0.2.0rc1", None, None)
+        resolve_new_version("0.2.0", None, None)
+
+
+def test_resolve_new_version_suffix_only_rejects_non_semver_current():
+    with pytest.raises(ValueError):
+        resolve_new_version("0.2.0rc1", None, None, "rc20260620")
 
 
 def test_main_bump_uses_current_override(capsys):

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,5 +1,6 @@
-"""Tests for scripts/bump_version.py (the release version bumper)."""
+"""Tests for scripts/bump_version.py (computes the next release version from git tags)."""
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -11,27 +12,15 @@ try:
     from bump_version import (  # noqa: E402
         apply_suffix,
         bump_version,
+        current_version_from_git,
         main,
-        read_version,
         resolve_new_version,
-        set_version,
     )
 finally:
     # Keep the import-time path change local to bump_version so the rest of the
     # pytest session can't accidentally import the many top-level modules under
     # scripts/.
     sys.path.remove(_SCRIPTS_DIR)
-
-SAMPLE = """\
-[build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
-
-[project]
-name = "aorta"
-version = "0.2.0"
-requires-python = ">=3.10"
-"""
 
 
 @pytest.mark.parametrize(
@@ -45,24 +34,6 @@ def test_bump_version_levels(level, expected):
 def test_bump_version_rejects_non_semver():
     with pytest.raises(ValueError):
         bump_version("0.2", "patch")
-
-
-def test_read_version_reads_project_table():
-    assert read_version(SAMPLE) == "0.2.0"
-
-
-def test_set_version_replaces_only_project_version():
-    updated = set_version(SAMPLE, "0.3.0")
-    assert read_version(updated) == "0.3.0"
-    # Unrelated lines (including the build-system table) stay byte-for-byte intact.
-    assert 'requires = ["setuptools>=61.0", "wheel"]' in updated
-    assert 'build-backend = "setuptools.build_meta"' in updated
-    assert updated.count('version = "') == 1
-
-
-def test_set_version_preserves_trailing_content():
-    text = '[project]\nversion = "0.2.0"  # keep me\n'
-    assert set_version(text, "0.2.1") == '[project]\nversion = "0.2.1"  # keep me\n'
 
 
 def test_apply_suffix_appends_to_base():
@@ -89,8 +60,7 @@ def test_apply_suffix_rejects_four_segment_version():
 @pytest.mark.parametrize("current", ["0.2.0.dev0", "0.2.0.post1"])
 def test_apply_suffix_rejects_dot_prefixed_prerelease(current):
     # The anchored prefix only strips a non-dot-prefixed suffix (e.g. rcN);
-    # dot-prefixed PEP 440 segments are rejected, not silently dropped --
-    # matches the documented contract (and the four-segment guard above).
+    # dot-prefixed PEP 440 segments are rejected, not silently dropped.
     with pytest.raises(ValueError):
         apply_suffix(current, "rc20260619")
 
@@ -98,105 +68,37 @@ def test_apply_suffix_rejects_dot_prefixed_prerelease(current):
 @pytest.mark.parametrize(
     "suffix",
     [
-        "",  # empty -> would emit version = "0.2.0" unchanged / meaningless
-        'rc"20260619',  # embedded quote would break/inject the TOML version line
+        "",  # empty -> meaningless (base unchanged)
+        'rc"20260619',  # embedded quote
         "rc 20260619",  # whitespace is not a valid version token
-        "rc\n20260619",  # newline would inject extra TOML content
+        "rc\n20260619",  # newline would inject extra content
         "rc;rm -rf",  # arbitrary punctuation outside the safe charset
     ],
 )
 def test_apply_suffix_rejects_unsafe_suffix(suffix):
-    # The suffix is concatenated straight into the quoted TOML version string,
-    # so anything that isn't a clean PEP 440-style token must be rejected before
-    # it can corrupt pyproject.toml.
+    # The suffix is concatenated straight onto the version string, so anything
+    # that isn't a clean PEP 440-style token must be rejected.
     with pytest.raises(ValueError):
         apply_suffix("0.2.0", suffix)
-
-
-
-@pytest.mark.parametrize("nl", ["\r\n", "\r", "\n"])
-def test_set_version_preserves_line_endings(nl):
-    """The "byte-for-byte untouched" promise must hold on CRLF/CR checkouts
-    (e.g. a Windows ``pyproject.toml``), not just LF — only the version value
-    changes, every line ending is preserved exactly.
-    """
-    text = nl.join(["[project]", 'name = "aorta"', 'version = "0.2.0"', ""])
-    expected = nl.join(["[project]", 'name = "aorta"', 'version = "0.3.0"', ""])
-    updated = set_version(text, "0.3.0")
-    assert read_version(text) == "0.2.0"
-    assert updated == expected
-
-
-@pytest.mark.parametrize("nl", ["\r\n", "\r", "\n"])
-def test_main_preserves_line_endings_end_to_end(tmp_path, capsys, nl):
-    """End-to-end: running the CLI on a CRLF/CR file must not normalize line
-    endings. ``read_text``/``write_text`` would translate newlines and silently
-    rewrite the whole file; main() reads + writes with ``newline=""`` so only
-    the version value changes on disk (compared as raw bytes).
-    """
-    raw = nl.join(["[project]", 'name = "aorta"', 'version = "0.2.0"', ""]).encode("utf-8")
-    expected = nl.join(["[project]", 'name = "aorta"', 'version = "0.3.0"', ""]).encode("utf-8")
-    p = tmp_path / "pyproject.toml"
-    p.write_bytes(raw)
-    rc = main(["--set", "0.3.0", "--pyproject", str(p)])
-    assert rc == 0
-    assert capsys.readouterr().out.strip() == "0.3.0"
-    assert p.read_bytes() == expected
-
-
-def test_main_suffix_end_to_end(tmp_path, capsys):
-    """End-to-end CLI coverage for ``--suffix``: it stamps the suffix onto the
-    base version, writes it back, and prints the new version (guards the
-    argparse wiring + apply_suffix precedence, not just the helper in isolation).
-    """
-    p = tmp_path / "pyproject.toml"
-    p.write_text('[project]\nname = "aorta"\nversion = "0.2.0"\n')
-    rc = main(["--suffix", "rc20260620", "--pyproject", str(p)])
-    assert rc == 0
-    assert capsys.readouterr().out.strip() == "0.2.0rc20260620"
-    assert 'version = "0.2.0rc20260620"' in p.read_text()
-
-
-def test_main_set_takes_precedence_over_suffix(tmp_path, capsys):
-    """``--set`` outranks ``--suffix`` (documented precedence: explicit > suffix
-    > level); passing both must yield the explicit version verbatim.
-    """
-    p = tmp_path / "pyproject.toml"
-    p.write_text('[project]\nname = "aorta"\nversion = "0.2.0"\n')
-    rc = main(["--set", "1.4.2", "--suffix", "rc20260620", "--pyproject", str(p)])
-    assert rc == 0
-    assert capsys.readouterr().out.strip() == "1.4.2"
-    assert 'version = "1.4.2"' in p.read_text()
-
-
-
-# A trailing inline comment on the table header is valid TOML; the bumper must
-# still recognize the [project] table (regression for the header parse).
-COMMENTED_HEADER = '[project]  # the package\nname = "aorta"\nversion = "0.2.0"\n'
-
-
-def test_read_version_handles_commented_table_header():
-    assert read_version(COMMENTED_HEADER) == "0.2.0"
-
-
-def test_set_version_handles_commented_table_header():
-    updated = set_version(COMMENTED_HEADER, "0.3.0")
-    assert read_version(updated) == "0.3.0"
-    # The header (comment and all) is preserved verbatim.
-    assert updated.startswith("[project]  # the package\n")
 
 
 def test_resolve_new_version_explicit_overrides_level():
     assert resolve_new_version("0.2.0", "patch", "5.6.7") == "5.6.7"
 
 
-def test_resolve_new_version_suffix_overrides_level():
-    assert resolve_new_version("0.2.0", "patch", None, "rc20260619") == "0.2.0rc20260619"
+def test_resolve_new_version_suffix_stamps_onto_bumped_base():
+    # suffix combines WITH the bump: patch bumps 0.2.0 -> 0.2.1, then the rc
+    # suffix is stamped onto that next base (so the rc precedes the eventual
+    # 0.2.1 stable), rather than an rc of the already-released 0.2.0.
+    assert resolve_new_version("0.2.0", "patch", None, "rc20260619") == "0.2.1rc20260619"
 
 
-def test_resolve_new_version_explicit_overrides_suffix():
-    assert resolve_new_version("0.2.0", None, "5.6.7", "rc20260619") == "5.6.7"
+def test_resolve_new_version_suffix_without_level_uses_current_base():
+    assert resolve_new_version("0.2.0", None, None, "rc20260619") == "0.2.0rc20260619"
 
+
+def test_resolve_new_version_explicit_overrides_level_with_suffix():
+    assert resolve_new_version("0.2.0", "patch", "5.6.7", "rc20260619") == "5.6.7rc20260619"
 
 
 def test_resolve_new_version_rejects_bad_explicit():
@@ -204,6 +106,52 @@ def test_resolve_new_version_rejects_bad_explicit():
         resolve_new_version("0.2.0", None, "not-a-version")
 
 
-def test_resolve_new_version_requires_input():
+def test_resolve_new_version_rejects_non_semver_current_without_bump():
     with pytest.raises(ValueError):
-        resolve_new_version("0.2.0", None, None)
+        resolve_new_version("0.2.0rc1", None, None)
+
+
+def test_main_bump_uses_current_override(capsys):
+    assert main(["patch", "--current", "0.2.0"]) == 0
+    assert capsys.readouterr().out.strip() == "0.2.1"
+
+
+def test_main_set_takes_precedence_over_level(capsys):
+    assert main(["patch", "--set", "1.4.2", "--current", "0.2.0"]) == 0
+    assert capsys.readouterr().out.strip() == "1.4.2"
+
+
+def test_main_nightly_suffix_on_next_base(capsys):
+    # Mirrors nightly.yml: bump to the next patch base, then stamp the rc date.
+    assert main(["patch", "--suffix", "rc20260620", "--current", "0.2.0"]) == 0
+    assert capsys.readouterr().out.strip() == "0.2.1rc20260620"
+
+
+def test_current_version_from_git_picks_highest_release_tag(tmp_path, monkeypatch):
+    """The helper returns the highest ``vX.Y.Z`` tag and ignores non-release
+    tags such as the rolling ``dev-wheels`` nightly tag."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (repo / "f").write_text("x")
+    git("add", "f")
+    git("commit", "-qm", "c1")
+    git("tag", "v0.2.0")
+    git("tag", "dev-wheels")  # non-release tag must be ignored
+    git("tag", "v0.10.0")  # highest by semver, not lexical
+    monkeypatch.chdir(repo)
+    assert current_version_from_git() == "0.10.0"
+
+
+def test_current_version_from_git_defaults_to_initial(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, capture_output=True)
+    monkeypatch.chdir(repo)
+    assert current_version_from_git() == "0.0.0"

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,10 +1,17 @@
 """Tests for scripts/bump_version.py (computes the next release version from git tags)."""
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+# The two tests below shell out to the real ``git`` executable; skip (rather than
+# error with FileNotFoundError) on minimal environments that lack it.
+requires_git = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git executable not available"
+)
 
 _SCRIPTS_DIR = str(Path(__file__).parent.parent / "scripts")
 sys.path.insert(0, _SCRIPTS_DIR)
@@ -127,6 +134,7 @@ def test_main_nightly_suffix_on_next_base(capsys):
     assert capsys.readouterr().out.strip() == "0.2.1rc20260620"
 
 
+@requires_git
 def test_current_version_from_git_picks_highest_release_tag(tmp_path, monkeypatch):
     """The helper returns the highest ``vX.Y.Z`` tag and ignores non-release
     tags such as the rolling ``dev-wheels`` nightly tag."""
@@ -149,6 +157,7 @@ def test_current_version_from_git_picks_highest_release_tag(tmp_path, monkeypatc
     assert current_version_from_git() == "0.10.0"
 
 
+@requires_git
 def test_current_version_from_git_defaults_to_initial(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -113,6 +113,21 @@ def test_resolve_new_version_rejects_bad_explicit():
         resolve_new_version("0.2.0", None, "not-a-version")
 
 
+@pytest.mark.parametrize("explicit", ["01.2.3", "1.02.3", "1.2.03"])
+def test_resolve_new_version_rejects_leading_zero_explicit(explicit):
+    # Leading-zero segments normalize away under int() parsing (01 -> 1), so a
+    # tag/version like v01.02.003 wouldn't round-trip or match the built wheel;
+    # reject them up front to keep versions unambiguous (SemVer alignment).
+    with pytest.raises(ValueError):
+        resolve_new_version("0.2.0", None, explicit)
+
+
+@pytest.mark.parametrize("level", ["patch", "minor", "major"])
+def test_bump_version_rejects_leading_zero_current(level):
+    with pytest.raises(ValueError):
+        bump_version("01.02.003", level)
+
+
 def test_resolve_new_version_requires_input():
     # Empty input must fail loudly rather than silently return the current
     # version unchanged (this tool computes the *next* version).

--- a/tests/test_check_wheel_version.py
+++ b/tests/test_check_wheel_version.py
@@ -57,6 +57,10 @@ def test_main_matches_build_tagged_wheel(tmp_path):
 
 def test_main_normalizes_rc_separator(tmp_path):
     # setuptools may spell an rc with a separator; normalized compare still matches.
+    # This relies on PEP 440 normalization via ``packaging``; without it the script
+    # falls back to exact string equality (by design), so skip rather than fail in
+    # environments where ``packaging`` isn't installed (it's not in the tests extra).
+    pytest.importorskip("packaging.version")
     _make_wheel(tmp_path, "amd_aorta-0.2.1rc20260708-py3-none-any.whl", "0.2.1rc20260708")
     assert main(["0.2.1-rc20260708", str(tmp_path)]) == 0
 

--- a/tests/test_check_wheel_version.py
+++ b/tests/test_check_wheel_version.py
@@ -1,0 +1,79 @@
+"""Tests for scripts/check_wheel_version.py (verifies a built wheel's version)."""
+
+import sys
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+_SCRIPTS_DIR = str(Path(__file__).parent.parent / "scripts")
+sys.path.insert(0, _SCRIPTS_DIR)
+try:
+    from check_wheel_version import main, wheel_metadata_version  # noqa: E402
+finally:
+    sys.path.remove(_SCRIPTS_DIR)
+
+
+def _make_wheel(directory: Path, name: str, version: str) -> Path:
+    """Write a minimal wheel (zip with a ``*.dist-info/METADATA``) and return it."""
+    wheel = directory / name
+    with ZipFile(wheel, "w") as zf:
+        zf.writestr(
+            f"amd_aorta-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.1\nName: amd-aorta\nVersion: {version}\n",
+        )
+    return wheel
+
+
+def test_wheel_metadata_version_reads_embedded_version(tmp_path):
+    wheel = _make_wheel(tmp_path, "amd_aorta-1.2.3-py3-none-any.whl", "1.2.3")
+    assert wheel_metadata_version(str(wheel)) == "1.2.3"
+
+
+def test_main_passes_on_matching_version(tmp_path, capsys):
+    _make_wheel(tmp_path, "amd_aorta-1.2.3-py3-none-any.whl", "1.2.3")
+    assert main(["1.2.3", str(tmp_path)]) == 0
+    assert "matches" in capsys.readouterr().out
+
+
+def test_main_fails_on_version_mismatch(tmp_path, capsys):
+    _make_wheel(tmp_path, "amd_aorta-1.2.3-py3-none-any.whl", "1.2.3")
+    assert main(["9.9.9", str(tmp_path)]) == 1
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_main_matches_regardless_of_filename(tmp_path):
+    # The check reads METADATA, not the filename: a wheel whose name disagrees
+    # with its embedded version still validates against the embedded version.
+    _make_wheel(tmp_path, "amd_aorta-0.0.0-py3-none-any.whl", "2.5.0")
+    assert main(["2.5.0", str(tmp_path)]) == 0
+
+
+def test_main_matches_build_tagged_wheel(tmp_path):
+    # A future build tag in the filename must not break the check.
+    _make_wheel(tmp_path, "amd_aorta-1.2.3-1-py3-none-any.whl", "1.2.3")
+    assert main(["1.2.3", str(tmp_path)]) == 0
+
+
+def test_main_normalizes_rc_separator(tmp_path):
+    # setuptools may spell an rc with a separator; normalized compare still matches.
+    _make_wheel(tmp_path, "amd_aorta-0.2.1rc20260708-py3-none-any.whl", "0.2.1rc20260708")
+    assert main(["0.2.1-rc20260708", str(tmp_path)]) == 0
+
+
+def test_main_fails_when_no_wheel(tmp_path, capsys):
+    assert main(["1.2.3", str(tmp_path)]) == 1
+    assert "found: none" in capsys.readouterr().out
+
+
+def test_main_fails_on_multiple_wheels(tmp_path, capsys):
+    _make_wheel(tmp_path, "amd_aorta-1.2.3-py3-none-any.whl", "1.2.3")
+    _make_wheel(tmp_path, "amd_aorta-1.2.4-py3-none-any.whl", "1.2.4")
+    assert main(["1.2.3", str(tmp_path)]) == 1
+    assert "exactly one built wheel" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("argc", [0, 3])
+def test_main_bad_arg_count_returns_usage(argc, capsys):
+    assert main(["x"] * argc) == 2
+    assert "usage:" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Makes **git tags the single source of truth** for the package version via [`setuptools_scm`](https://setuptools-scm.readthedocs.io/), which fixes the failed `Release` workflow and stops local installs from reporting a stale hard-coded version.

Closes #283.

### Why

- **Release workflow failed** ([run](https://github.com/ROCm/aorta/actions/runs/28850964644)): the *Bump version* step committed the `pyproject.toml` bump and pushed it back to `main`, which `main`'s ruleset rejects (`GH013`: PR + status checks required).
- **Stale version**: the version was hard-coded in two places (`pyproject.toml` and `src/aorta/__init__.py`), so `aorta.__version__` / the `aorta probe --version` banner drifted from the released version on any repo/editable install.

### Changes

- `pyproject.toml`: `dynamic = ["version"]`, `setuptools_scm` build dep, and `[tool.setuptools_scm]` — matches only `v[0-9]*` tags (so the rolling `dev-wheels` tag is ignored) with a `fallback_version` for treeless installs.
- `src/aorta/__init__.py`: `__version__` now reads from installed package metadata (single source of truth); also replaced a `getattr(module, "main")` with attribute access (ruff `B009`).
- `src/aorta/cli/probe.py`: version banner queries the canonical dist name `amd-aorta`.
- `.github/workflows/release.yml`: **tag-driven** — no push to `main`. Manual runs compute the next version, build via `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMD_AORTA`, verify the built wheel carries that version, then push the `vX.Y.Z` tag only after a successful build (no orphan tags on failure). Kept the strict `^[0-9]+\.[0-9]+\.[0-9]+$` stable gate (rc builds stay on nightly), the tag-ref guard, and env-bound inputs.
- `.github/workflows/nightly.yml`: rc stamps onto the **next** base above the latest tag (`v0.2.0` -> `0.2.1rcYYYYMMDD`, correct PEP 440 pre-release ordering); `fetch-depth: 0` so tags are visible.
- `scripts/bump_version.py`: repurposed to compute the next version from git tags (no file writes); tests updated.
- `docs/releasing.md`: documents the tag-driven flow; removes the obsolete branch-protection caveat.

### Result

- The release workflow only ever *creates a tag* — it never touches a protected branch, so `GH013` cannot happen. (Ensure tag rulesets allow the release actor to push `v*` tags.)
- Local/editable installs report the version derived from the latest tag (`X.Y.Z`, or `X.Y.(Z+1).devN+g<sha>` when ahead) — never a stale literal.

## Test plan

- [x] `setuptools_scm` resolves `0.2.1.dev52+g...` from the `v0.2.0` tag (ignores `dev-wheels`).
- [x] `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMD_AORTA=0.2.1 python -m build` produces `amd_aorta-0.2.1-py3-none-any.whl`; a fresh install reports `0.2.1` via `importlib.metadata`, `aorta.__version__`, and the probe banner.
- [x] `python scripts/bump_version.py patch --suffix rcYYYYMMDD` -> `0.2.1rcYYYYMMDD`.
- [x] `pytest tests/test_bump_version.py tests/test_distribution_name.py` -> 29 passed.
- [x] `ruff check` clean on changed files.
- [ ] CI green (cpu-tests / pre-commit).
- [ ] Dry-run the manual `Release` workflow on this branch (or a fork) to confirm the tag-driven path builds and tags without touching `main`.
