### PR TITLE
feat(docker): ROCm ASAN nan-repro image (hipBLASLt 1.4.0)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -15,6 +15,7 @@
 # - Dockerfile.rocm70_9-1-shampoo      ROCm 7.0.9.1 with Shampoo optimizer
 # - Dockerfile.rocm70_2-ubuntu-pytorch ROCm 7.0.2 Ubuntu PyTorch build
 # - Dockerfile.rocm70_2-ubuntu-nan     ROCm 7.0.2 with NaN debugging tools
+# - Dockerfile.rocm70_2-nan-asan       ROCm 7.0.2 nan-repro (hipBLASLt 1.4.0) + AddressSanitizer
 # - Dockerfile.rocm-ubuntu-ebpf        ROCm 7.2 with eBPF tracing tools (bpftrace, bcc)
 #
 DOCKERFILE=Dockerfile.rocm70_9-1

--- a/docker/Dockerfile.rocm70_2-nan-asan
+++ b/docker/Dockerfile.rocm70_2-nan-asan
@@ -1,0 +1,86 @@
+# ROCm 7.0.2 residual-NaN repro image, instrumented with AddressSanitizer.
+#
+# Base: the customer-aligned nan-repro image that ships the custom
+#       hipBLASLt 1.4.0 build. It is Ubuntu 24.04 (noble) with ROCm 7.0.2
+#       build 56 from the internal OSDB apt pool.
+#
+# WHY WE EXTRACT INSTEAD OF apt install
+# -------------------------------------
+# ROCm only publishes ASAN-instrumented libraries (`*-asan`) for jammy
+# (Ubuntu 22.04); the noble (24.04) apt tree has none, and the `rocm-asan`
+# metapackage would drag the whole *jammy* ROCm stack onto the noble base
+# and clash with the custom build. So we DOWNLOAD only the jammy `*-asan`
+# leaf packages and unpack their `.so` files into /opt/rocm/lib/asan with
+# `dpkg-deb -x` -- no dpkg DB changes, no maintainer scripts, no dependency
+# resolution. The custom noble ROCm 7.0.2 build-56 stack in the base is left
+# byte-for-byte untouched. The ASAN build number (70002-56) matches the base
+# ROCm build exactly, and noble's libstdc++ is forward-compatible with the
+# jammy-built instrumented libraries.
+#
+# BUILD (host networking is required -- the default docker bridge has no
+# outbound network on this host):
+#   docker build --network=host -f Dockerfile.rocm70_2-nan-asan \
+#     -t aorta:nan-repro-hipblaslt-1.4.0-asan .
+#
+# Override the apt source if the base ROCm build is bumped:
+#   --build-arg ASAN_APT_URL=https://repo.radeon.com/rocm/apt/7.0.2 \
+#   --build-arg ASAN_APT_DIST=jammy
+
+ARG BASE_IMAGE=rocm/pytorch-private:nan-repro-production-aligned-hipblaslt-1.4.0
+FROM ${BASE_IMAGE}
+
+ARG ASAN_APT_URL=https://repo.radeon.com/rocm/apt/7.0.2
+ARG ASAN_APT_DIST=jammy
+
+# The compute-relevant subset of the `*-asan` closure for a hipBLASLt/rocBLAS
+# residual-NaN repro (Distributed Shampoo -> GEMM + linear-algebra + RCCL).
+# Vision/graph/conv/FFT/sparse asan packages are intentionally omitted to
+# bound image size; add them here if a run needs them.
+ARG ASAN_PACKAGES="comgr-asan hsa-rocr-asan hsa-amd-aqlprofile-asan hip-runtime-amd-asan rocblas-asan hipblas-asan hipblaslt-asan rocsolver-asan hipsolver-asan rocrand-asan hiprand-asan rccl-asan roctracer-asan rocprofiler-asan"
+
+USER root
+
+RUN set -eux; \
+    mkdir -p /tmp/asan-debs; cd /tmp/asan-debs; \
+    # Swap in ONLY the jammy asan source so we never touch the base's apt
+    # config or hit the (flaky) internal OSDB repo during the download.
+    mv /etc/apt/sources.list.d /etc/apt/sources.list.d.aorta-bak 2>/dev/null || true; \
+    mkdir -p /etc/apt/sources.list.d; \
+    if [ -f /etc/apt/sources.list ]; then mv /etc/apt/sources.list /etc/apt/sources.list.aorta-bak; fi; \
+    : > /etc/apt/sources.list; \
+    echo "deb [arch=amd64 trusted=yes] ${ASAN_APT_URL} ${ASAN_APT_DIST} main" \
+      > /etc/apt/sources.list.d/rocm-asan.list; \
+    apt-get update -o Acquire::AllowInsecureRepositories=true; \
+    apt-get download -o Acquire::AllowInsecureRepositories=true --allow-unauthenticated ${ASAN_PACKAGES}; \
+    for d in *.deb; do echo "unpacking $d"; dpkg-deb -x "$d" /; done; \
+    # Restore the base apt configuration exactly as it was.
+    rm -f /etc/apt/sources.list.d/rocm-asan.list; rmdir /etc/apt/sources.list.d 2>/dev/null || rm -rf /etc/apt/sources.list.d; \
+    mv /etc/apt/sources.list.d.aorta-bak /etc/apt/sources.list.d 2>/dev/null || true; \
+    rm -f /etc/apt/sources.list; \
+    mv /etc/apt/sources.list.aorta-bak /etc/apt/sources.list 2>/dev/null || true; \
+    rm -rf /tmp/asan-debs /var/lib/apt/lists/*; \
+    ls /opt/rocm/lib/asan/libhipblaslt.so.* >/dev/null; \
+    ls /opt/rocm/lib/asan/librocblas.so.* >/dev/null; \
+    echo "asan libs installed: $(ls /opt/rocm/lib/asan | wc -l) files"; \
+    ls /opt/rocm/lib/asan | head
+
+# Make the instrumented libraries win at load time. run_docker.sh (the
+# recom_repro launcher) overrides LD_LIBRARY_PATH inside the container, so we
+# cannot rely on it alone: register the asan dir with the dynamic linker at
+# high priority (00- prefix => searched before the base /opt/rocm/lib entry)
+# and rebuild the cache.
+RUN echo "/opt/rocm/lib/asan" > /etc/ld.so.conf.d/00-rocm-asan.conf && ldconfig
+
+# ASAN runtime environment. LD_PRELOAD forces the host ASAN runtime
+# (shipped in the base's rocm-llvm) to initialise first even when
+# LD_LIBRARY_PATH is overridden -- this is the "ASan runtime does not come
+# first in initial library list" workaround. HSA_XNACK requests GPU-side
+# (device) ASAN; on an xnack- target it degrades gracefully to host-side
+# coverage only.
+ENV LD_LIBRARY_PATH=/opt/rocm/lib/asan:/opt/rocm/lib
+ENV LD_PRELOAD=/opt/rocm/lib/llvm/lib/clang/20/lib/linux/libclang_rt.asan-x86_64.so
+ENV HSA_XNACK=1
+ENV ASAN_OPTIONS=detect_leaks=0:halt_on_error=0:abort_on_error=0:exitcode=0:print_stats=0:handle_segv=1:protect_shadow_gap=0:new_delete_type_mismatch=0:detect_odr_violation=0
+ENV HSA_TOOLS_LIB=
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.rocm70_2-nan-asan
+++ b/docker/Dockerfile.rocm70_2-nan-asan
@@ -17,6 +17,33 @@
 # ROCm build exactly, and noble's libstdc++ is forward-compatible with the
 # jammy-built instrumented libraries.
 #
+# hipBLASLt ASAN BUILD (AMD-confirmed by Sahil, 2026-07-16)
+# ---------------------------------------------------------
+# The only published ASAN hipBLASLt lives at
+#   https://repo.radeon.com/rocm/apt/7.0.2/pool/main/h/hipblaslt-asan/
+# and is exactly ONE deb: `hipblaslt-asan_1.0.0.70002-56~22.04_amd64.deb`
+# (version 1.0.0, jammy). There is NO 24.04 build "on any of the builds"
+# (Sahil), which is why we extract the jammy .so. `apt-get download
+# hipblaslt-asan` from the 7.0.2/jammy pool resolves to exactly this deb.
+#
+# TWO CAVEATS THIS BUILD DOES NOT SOLVE (both verified on an MI350 box):
+#  1. SONAME SHADOW: the asan hipBLASLt is `libhipblaslt.so.1 ->
+#     libhipblaslt.so.1.0.70002` with SONAME `libhipblaslt.so.1` -- the SAME
+#     soname as the base's custom `libhipblaslt.so.1 -> .so.1.4.70002`. With
+#     /opt/rocm/lib/asan searched first, the loader resolves the GEMM library
+#     to the STOCK 1.0.0 asan build, shadowing the custom 1.4.0 that actually
+#     produces the residual NaN. So this deb instruments a *different* library
+#     than the one under investigation (see INCLUDE_HIPBLASLT_ASAN below).
+#  2. HIP-INIT ABORT: engaging the ASAN runtime at all (LD_PRELOAD of
+#     libclang_rt.asan, required for any instrumented lib) crashes at HIP init
+#     -- OOM in the asan HIP runtime, or a null-deref SEGV in the stock HIP
+#     runtime -- because the base PyTorch/HIP stack is NOT ASAN-instrumented.
+#     Sahil (2026-07-16): "PyTorch was not instrumented with ASAN on ROCm
+#     7.0.2. We did that recently for Fremont but is not fully productionized."
+#     So a real GPU run under ASAN stays BLOCKED until a device-ASAN PyTorch
+#     (the Fremont build, or a 7.0.2 rebuild of it) is available. The asan
+#     hipBLASLt here cannot be exercised on-GPU with this base.
+#
 # BUILD (host networking is required -- the default docker bridge has no
 # outbound network on this host):
 #   docker build --network=host -f Dockerfile.rocm70_2-nan-asan \
@@ -38,6 +65,14 @@ ARG ASAN_APT_DIST=jammy
 # bound image size; add them here if a run needs them.
 ARG ASAN_PACKAGES="comgr-asan hsa-rocr-asan hsa-amd-aqlprofile-asan hip-runtime-amd-asan rocblas-asan hipblas-asan hipblaslt-asan rocsolver-asan hipsolver-asan rocrand-asan hiprand-asan rccl-asan roctracer-asan rocprofiler-asan"
 
+# Include the mentioned stock hipBLASLt ASAN build (caveat #1 above: it
+# SHADOWS the custom 1.4.0). Default 1 = include it (per the request to wire
+# in the mentioned build). Set to 0 to drop `hipblaslt-asan` from the overlay
+# so the base's custom `libhipblaslt.so.1.4.70002` stays the resolved GEMM
+# library -- do this once an ASAN build of the *custom 1.4.0* exists, or when
+# you want the NaN to reproduce against the real library.
+ARG INCLUDE_HIPBLASLT_ASAN=1
+
 USER root
 
 RUN set -eux; \
@@ -51,7 +86,13 @@ RUN set -eux; \
     echo "deb [arch=amd64 trusted=yes] ${ASAN_APT_URL} ${ASAN_APT_DIST} main" \
       > /etc/apt/sources.list.d/rocm-asan.list; \
     apt-get update -o Acquire::AllowInsecureRepositories=true; \
-    apt-get download -o Acquire::AllowInsecureRepositories=true --allow-unauthenticated ${ASAN_PACKAGES}; \
+    pkgs="${ASAN_PACKAGES}"; \
+    if [ "${INCLUDE_HIPBLASLT_ASAN}" != "1" ]; then \
+      echo "INCLUDE_HIPBLASLT_ASAN=${INCLUDE_HIPBLASLT_ASAN}: dropping hipblaslt-asan (custom 1.4.0 stays authoritative)"; \
+      pkgs="$(echo "$pkgs" | sed 's/hipblaslt-asan//')"; \
+    fi; \
+    apt-get download -o Acquire::AllowInsecureRepositories=true --allow-unauthenticated ${pkgs}; \
+    echo "resolved hipBLASLt asan deb: $(ls hipblaslt-asan_*.deb 2>/dev/null || echo '<excluded>')"; \
     for d in *.deb; do echo "unpacking $d"; dpkg-deb -x "$d" /; done; \
     # Restore the base apt configuration exactly as it was.
     rm -f /etc/apt/sources.list.d/rocm-asan.list; rmdir /etc/apt/sources.list.d 2>/dev/null || rm -rf /etc/apt/sources.list.d; \
@@ -59,7 +100,7 @@ RUN set -eux; \
     rm -f /etc/apt/sources.list; \
     mv /etc/apt/sources.list.aorta-bak /etc/apt/sources.list 2>/dev/null || true; \
     rm -rf /tmp/asan-debs /var/lib/apt/lists/*; \
-    ls /opt/rocm/lib/asan/libhipblaslt.so.* >/dev/null; \
+    if [ "${INCLUDE_HIPBLASLT_ASAN}" = "1" ]; then ls /opt/rocm/lib/asan/libhipblaslt.so.* >/dev/null; fi; \
     ls /opt/rocm/lib/asan/librocblas.so.* >/dev/null; \
     echo "asan libs installed: $(ls /opt/rocm/lib/asan | wc -l) files"; \
     ls /opt/rocm/lib/asan | head

--- a/docker/README.md
+++ b/docker/README.md
@@ -41,6 +41,7 @@ docker compose -f docker-compose.build.yaml up -d
 | `Dockerfile.rocm70_9-1-shampoo` | ROCm 7.0.9.1 + Shampoo optimizer | Shampoo optimizer experiments |
 | `Dockerfile.rocm70_2-ubuntu-pytorch` | ROCm 7.0.2 Ubuntu PyTorch | Legacy ROCm 7.0.2 support |
 | `Dockerfile.rocm70_2-ubuntu-nan` | ROCm 7.0.2 + NaN debugging | Debugging NaN issues |
+| `Dockerfile.rocm70_2-nan-asan` | ROCm 7.0.2 nan-repro (hipBLASLt 1.4.0) + AddressSanitizer | Running the residual-NaN repro under ASAN |
 | `Dockerfile.rocm-ubuntu-ebpf` | ROCm 7.2 + eBPF tracing (bpftrace, bcc) | eBPF-based GPU queue/memory tracing |
 
 ## Configuration Variables
@@ -108,6 +109,32 @@ AORTA_WORKSPACE=..
 Inside the container, verify eBPF readiness with `aorta ebpf-info`, then run
 workloads with `--ebpf-trace` and/or `--ebpf-memory-trace` flags.
 
+### Example 5: Residual-NaN Repro under AddressSanitizer
+
+```bash
+# .env
+DOCKERFILE=Dockerfile.rocm70_2-nan-asan
+CONTAINER_NAME=myuser-nan-asan
+AORTA_WORKSPACE=..
+```
+
+This image layers ROCm ASAN-instrumented libraries onto the customer-aligned
+`nan-repro` hipBLASLt 1.4.0 base. The base is Ubuntu 24.04 (noble) but ROCm
+only ships `*-asan` packages for jammy (22.04), so the Dockerfile *extracts*
+the jammy asan `.so` files into `/opt/rocm/lib/asan` without disturbing the
+noble ROCm stack (see the header of `Dockerfile.rocm70_2-nan-asan`).
+
+Build requires host networking (the default bridge has no outbound net):
+
+```bash
+docker build --network=host -f Dockerfile.rocm70_2-nan-asan \
+  -t aorta:nan-repro-hipblaslt-1.4.0-asan .
+```
+
+Then drive the residual-NaN matrix under ASAN via the sidecar in the internal
+repo (`recipes/recom_repro_residual_nan_asan_side_car.json`); see the
+"run under ROCm ASAN" section of `docs/Residual-NaN-Repro-runbook.md`.
+
 ## Using custom RCCL
 
 By default, the container uses the RCCL bundled in the image. You do not need to set or remove any RCCL path in the YAML.
@@ -136,6 +163,7 @@ docker/
 ├── Dockerfile.rocm70_9-1         # Standard ROCm build
 ├── Dockerfile.rocm70_9-1-shampoo # Shampoo variant
 ├── Dockerfile.rocm70_2-ubuntu-*  # Legacy ROCm 7.0.2 builds
+├── Dockerfile.rocm70_2-nan-asan  # nan-repro hipBLASLt 1.4.0 + AddressSanitizer
 ├── Dockerfile.rocm-ubuntu-ebpf   # ROCm 7.2 + eBPF tracing tools
 └── rccl_test/                    # Separate RCCL testing setup
 ```

--- a/docker/setup-env.sh
+++ b/docker/setup-env.sh
@@ -45,10 +45,11 @@ echo "  2) Dockerfile.rocm70_9-1-shampoo      - ROCm 7.0.9.1 with Shampoo optimi
 echo "  3) Dockerfile.rocm70_2-ubuntu-pytorch - ROCm 7.0.2 Ubuntu PyTorch build"
 echo "  4) Dockerfile.rocm70_2-ubuntu-nan     - ROCm 7.0.2 with NaN debugging tools"
 echo "  5) Dockerfile.rocm-ubuntu-ebpf        - ROCm 7.2 with eBPF tracing tools (bpftrace, bcc)"
+echo "  6) Dockerfile.rocm70_2-nan-asan       - ROCm 7.0.2 nan-repro (hipBLASLt 1.4.0) + AddressSanitizer"
 echo ""
 
 while true; do
-    read -p "Enter choice [1-5]: " dockerfile_choice
+    read -p "Enter choice [1-6]: " dockerfile_choice
     case $dockerfile_choice in
         1)
             DOCKERFILE="Dockerfile.rocm70_9-1"
@@ -75,8 +76,13 @@ while true; do
             VARIANT="rocm-ubuntu-ebpf"
             break
             ;;
+        6)
+            DOCKERFILE="Dockerfile.rocm70_2-nan-asan"
+            VARIANT="nan-repro-hipblaslt-1.4.0-asan"
+            break
+            ;;
         *)
-            echo -e "${RED}Invalid choice. Please enter 1-5.${NC}"
+            echo -e "${RED}Invalid choice. Please enter 1-6.${NC}"
             ;;
     esac
 done


### PR DESCRIPTION
## Summary
- Adds `docker/Dockerfile.rocm70_2-nan-asan`: layers ROCm's ASAN-instrumented libraries onto the customer-aligned nan-repro **hipBLASLt 1.4.0** base, for running the residual-NaN repro under AddressSanitizer.
- The base is **Ubuntu 24.04 (noble)**, but ROCm only publishes `*-asan` packages for **jammy (22.04)**. So the Dockerfile **downloads only the jammy `*-asan` leaf packages and `dpkg-deb -x` extracts their `.so`s into `/opt/rocm/lib/asan`** — no dpkg DB changes, no dependency resolution — leaving the custom noble ROCm 7.0.2 build-56 stack (incl. the custom `libhipblaslt.so.1.4.70002`) untouched. Build number `70002-56` matches the base exactly.
- Wires the variant into `.env.example`, `README.md` (variant row, Example 5, file structure) and `setup-env.sh` (menu option 6).

## Build
Host networking is required (default docker bridge has no outbound net on the build box):
```bash
docker build --network=host -f docker/Dockerfile.rocm70_2-nan-asan \
  -t aorta:nan-repro-hipblaslt-1.4.0-asan docker/
```

## Test plan
- [x] Image builds on the MI350 host and verifies: 52 asan libs in `/opt/rocm/lib/asan`, ASAN env vars set (`HSA_XNACK=1`, `LD_PRELOAD`→clang_rt.asan, `ASAN_OPTIONS`), base ROCm + custom hipBLASLt 1.4.0 intact.
- [x] `import torch` under the preloaded ASAN runtime does not hit "ASan runtime does not come first".
- [ ] Full GPU repro run under ASAN — **known limitation**: device-memory alloc aborts at HIP init (`AddressSanitizer: out of memory` in `libamdhip64.so.7`) because the stock jammy asan libs over a non-instrumented PyTorch aren't device-ASAN-capable on this host. Needs an ASAN-instrumented PyTorch/HIP stack (tracked separately). Documented in the internal runbook.

Companion internal PR adds the sidecar + runbook section.

Made with [Cursor](https://cursor.com)