### PR TITLE
layer_numerics: pipeline-stage tracking, bounds/OOB, address & snapshot capture

### DIFF
--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -11,6 +11,8 @@ What it records, per watched layer, per step:
   - tf32_path: whether this layer ran on the fp32 + allow_tf32 (TF32) path
   - matmul_calls_so_far: a running counter (no GPU sync) that can be used to
     cross-reference a matmul-level "call #N" from a separate GEMM-output tool
+  - t: time.monotonic() at record time; subtract two records for elapsed seconds
+    (per-process clock, not comparable across ranks)
   - identity: layer name, direction (fwd/bwd), rank/gpu/host/pid
 
 How it stays out of the way (important):
@@ -105,10 +107,72 @@ Settings (environment variables):
   NANLOG_STOP_ON_FIRST   "1" -> stop writing clean records after the first bad
                          layer is seen (default 0)
   NANLOG_VERBOSE         "1" -> print one line per step       (default 0)
+  NANLOG_ADDR            "1" -> record each watched tensor's GPU address (data_ptr)
+                         + backing-storage extent (storage_ptr, storage_offset_bytes,
+                         storage_nbytes). Host-side metadata, no GPU sync. Default 0
+                         (off) so the base record schema stays minimal; enable to
+                         trace memory aliasing. For a sparse (KJT) record the address
+                         is that of the KJT's .values() tensor, not the KJT object.
+  NANLOG_LOCATE          "1" -> also record bad_rows: how many rows (dim 0) hold a
+                         NaN/Inf/huge element. Extra on-GPU reduction, same drain,
+                         no host sync (default 0).
+  NANLOG_BAD_VALUES      "1" -> for each BAD tensor, record first_bad_flat_idx,
+                         first_bad_row, first_bad_col, first_bad_value (first
+                         NaN/Inf/huge element). GPU reductions, same drain (default 0).
+  NANLOG_DUMP_TENSOR     "1" -> on the first bad record (NaN/Inf/huge/oob), save the
+                         full bad tensor to a .pt file (one-shot; the input is saved
+                         before the output when both are bad). May delay allocator
+                         reuse (default 0).
+  NANLOG_ALLOC_SNAPSHOT  "1" -> enable the caching-allocator event recorder and dump
+                         a snapshot pickle on the first bad record (NaN/Inf/huge/oob;
+                         alloc/free events with address, size, stream, Python stack).
+                         ~10% step overhead; GPU kernel timing unaffected (default 0).
+  NANLOG_PIPELINE        "1" -> monkeypatch TrainPipelineSparseDist stage methods
+                         (copy_batch_to_gpu / start_sparse_data_dist /
+                         wait_sparse_data_dist) to tag records with a `phase` and
+                         re-scan the tracked flow objects at each stage, before the
+                         forward reads them. Warns once and stays inactive if the
+                         stage methods are absent. Same per-step drain (default 0).
+  NANLOG_TRACK_ATTR      comma list of batch attribute/key names to follow as flow
+                         tensors (default "embedding_features"); a name may resolve
+                         to a Tensor, list/tuple/dict of Tensors, or a KJT (its
+                         values() is tracked). Falls back to a bounded auto-discovery
+                         walk if none are found. Only with NANLOG_PIPELINE=1.
+  NANLOG_TRACK_MAX       hard cap on how many tensor objects the tracker follows
+                         (default 64).
+  NANLOG_SPARSE          "1" -> at the pipeline stages, capture cheap host-side
+                         KJT/JaggedTensor metadata (num keys, lengths/offsets shape,
+                         num_bags = count of length entries, values shape/dtype/device)
+                         and route the index values through the normal sync-free
+                         reduction. Requires NANLOG_PIPELINE=1 (default 0).
+  NANLOG_SPARSE_HEAVY    "1" -> add sparse stats needing a host readback (empty_bags,
+                         max_bag_len, index value min/max). The one sparse path that
+                         syncs; gated separately. Requires NANLOG_SPARSE=1 (default 0).
+  NANLOG_TRACK_EVERY_LAYER "1" -> also re-scan the tracked flow objects at EACH watched
+                         layer's forward hook (record carries checkpoint=<layer_name>),
+                         bracketing the corruption to a layer interval within forward.
+                         Multiplies the per-step reduction count; can perturb a
+                         timing-sensitive bug. Requires NANLOG_PIPELINE=1 (default 0).
+  NANLOG_TRACK_LAYER_STRIDE  re-scan every Kth watched layer (default 1). Only with
+                         NANLOG_TRACK_EVERY_LAYER=1.
+  NANLOG_BOUNDS          per-tensor in-range check "substr:lo:hi;substr:lo:hi": a
+                         watched tensor takes the first entry whose substring is in
+                         its layer_name; elements outside [lo,hi] count as oob and
+                         mark the record bad (kind="oob"). Two-sided, unlike the
+                         one-sided huge threshold. One reduction, same drain, no host
+                         sync. Unmatched tensors are unbounded (default off).
+  NANLOG_BOUND_LO / NANLOG_BOUND_HI  match-all fallback range applied to EVERY tensor
+                         (degenerate single-range form of NANLOG_BOUNDS; sensible only
+                         when watching one well-bounded target).
+
+  Every record carries a `batch_id`, assigned when a batch enters at
+  copy_batch_to_gpu and re-read at each later checkpoint, so one batch's
+  copy/sparse/forward records can be grouped across steps (null before its copy).
 """
 from __future__ import annotations
 
 import json
+import math
 import os
 import runpy
 import socket
@@ -117,12 +181,13 @@ import time
 from collections import deque
 from pathlib import Path
 
+# Keep the no-arg usage path dependency-light: print usage and exit before importing
+# torch, so `python instrument_nan_logger.py` works in a minimal env without torch.
 if __name__ == "__main__" and len(sys.argv) < 2:
-    sys.stderr.write("nanlog: usage: python instrument_nan_logger.py <target_script.py> [args...]\n")
-    sys.stderr.flush()
+    sys.stderr.write("usage: python instrument_nan_logger.py <target_script.py> [args...]\n")
     sys.exit(2)
 
-import torch  # noqa: E402 - keep no-arg usage path dependency-light.
+import torch  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -132,19 +197,9 @@ _HUGE = float(os.environ.get("NANLOG_HUGE_THRESHOLD", "1e10"))
 _SAMPLE_EVERY = int(os.environ.get("NANLOG_SAMPLE_EVERY", "50"))
 _PRE_CONTEXT = int(os.environ.get("NANLOG_PRE_CONTEXT", "0"))
 _MAX_RECORDS = int(os.environ.get("NANLOG_MAX_RECORDS", "200000"))
-# A module is watched if its CLASS NAME is in _WATCH_TYPES, OR its fully-qualified
-# module path CONTAINS any substring in _WATCH_NAMES (union, not intersection — so
-# you can target one specific layer AND a whole type at once). An unset axis
-# contributes no matches.
-#
-# The type filter defaults to "Linear", BUT only when no name filter is given.
-# This makes the common targeted case intuitive: setting NANLOG_WATCH_NAMES alone
-# watches exactly those named layers — the "Linear" default does NOT silently
-# union in every Linear, so you never have to write NANLOG_WATCH_TYPES= to clear
-# it. To watch named layers AND a type, set both explicitly:
-#   NANLOG_WATCH_NAMES=encoder.blocks.3                   -> only that block
-#   NANLOG_WATCH_NAMES=...  NANLOG_WATCH_TYPES=MoELayer   -> that block + all MoE
-# The bare default (neither var set) stays types=Linear -> original behavior.
+# Watched = class name in _WATCH_TYPES OR module path contains a _WATCH_NAMES
+# substring (union). The "Linear" type default applies only when no name filter is
+# given, so naming a layer targets exactly it without pulling in every Linear.
 _WATCH_NAMES = tuple(
     s.strip() for s in os.environ.get("NANLOG_WATCH_NAMES", "").split(",") if s.strip()
 )
@@ -152,16 +207,9 @@ _types_default = "" if _WATCH_NAMES else "Linear"
 _WATCH_TYPES = tuple(
     s.strip() for s in os.environ.get("NANLOG_WATCH_TYPES", _types_default).split(",") if s.strip()
 )
-# Capture channels (comma list). Each channel is one independently switchable
-# observation; each adds its own on-GPU reductions, so default to the cheap pair
-# that reproduces the original (activation + grad_input) timing profile exactly.
-#   act    forward output activation       (fwd hook)
-#   input  forward input activation        (fwd hook)
-#   igrad  grad w.r.t. inputs (grad_input) (bwd hook)   -- old NANLOG_BWD
-#   weight param values,  ndim >= 2        (root pre-hook, PREV step, sync-free)
-#   bias   param values,  ndim == 1        (root pre-hook, PREV step, sync-free)
-#   wgrad  param.grad,    ndim >= 2        (opt step_pre_hook, CURRENT step, sync-free)
-#   bgrad  param.grad,    ndim == 1        (opt step_pre_hook, CURRENT step, sync-free)
+# Capture channels (comma list). Each is an independently switchable observation
+# adding its own on-GPU reductions; default to the cheap act+igrad pair. See the
+# module docstring for the per-channel semantics.
 _ALL_CHANNELS = ("act", "input", "igrad", "weight", "bias", "wgrad", "bgrad")
 _CHANNELS = frozenset(
     s.strip() for s in os.environ.get("NANLOG_CHANNELS", "act,igrad").split(",") if s.strip()
@@ -191,6 +239,91 @@ _EMBEDDING_TYPES = ("Embedding", "EmbeddingBag", "EmbeddingBagCollection",
                     "ShardedEmbeddingCollection")
 _STOP_ON_FIRST = os.environ.get("NANLOG_STOP_ON_FIRST", "0") == "1"
 _VERBOSE = os.environ.get("NANLOG_VERBOSE", "0") == "1"
+# All flags below default OFF and feed the one per-step drain (no added host sync).
+# See the module docstring for each var's full semantics.
+# Address + backing-storage extent per tensor (host-side; for aliasing analysis).
+_CAPTURE_ADDR = os.environ.get("NANLOG_ADDR", "0") == "1"
+# bad_rows: how many dim-0 rows hold a NaN/Inf/huge element (extra on-GPU reduction).
+_LOCATE = os.environ.get("NANLOG_LOCATE", "0") == "1"
+# First bad element's flat idx / row / col / value.
+_BAD_VALUES = os.environ.get("NANLOG_BAD_VALUES", "0") == "1"
+# Dump the caching-allocator event history to a pickle on first bad (~10% overhead).
+_ALLOC_SNAPSHOT = os.environ.get("NANLOG_ALLOC_SNAPSHOT", "0") == "1"
+# Save the full bad tensor to a .pt on first detection (one-shot; see docstring risk).
+_DUMP_TENSOR = os.environ.get("NANLOG_DUMP_TENSOR", "0") == "1"
+# Pipeline-stage tracking: scan the NANLOG_TRACK_ATTR tensors at the TorchRec stage
+# boundaries (copy/sparse/forward), tagging each record with its `phase`.
+_PIPELINE = os.environ.get("NANLOG_PIPELINE", "0") == "1"
+_TRACK_ATTR = tuple(
+    s.strip() for s in os.environ.get("NANLOG_TRACK_ATTR", "embedding_features").split(",")
+    if s.strip()
+)
+_TRACK_MAX = int(os.environ.get("NANLOG_TRACK_MAX", "64"))
+# Cheap host-side KJT metadata; _SPARSE_HEAVY adds the one readback (sync) path.
+_SPARSE = os.environ.get("NANLOG_SPARSE", "0") == "1"
+_SPARSE_HEAVY = os.environ.get("NANLOG_SPARSE_HEAVY", "0") == "1"
+# Re-scan the tracked tensors at each watched layer (strided) to bracket corruption
+# to a within-forward layer interval. Multiplies the per-step reduction count.
+_TRACK_EVERY_LAYER = os.environ.get("NANLOG_TRACK_EVERY_LAYER", "0") == "1"
+_TRACK_LAYER_STRIDE = max(1, int(os.environ.get("NANLOG_TRACK_LAYER_STRIDE", "1")))
+# Two-sided in-range check: per-tensor [lo,hi] via "substr:lo:hi;..." patterns (first
+# substring match wins); out-of-range elements are `bad` with kind="oob". Bare
+# NANLOG_BOUND_LO/HI is the match-all fallback. Catches small OOB the huge threshold
+# (|x|>T) misses.
+def _parse_bounds(spec: str):
+    """Parse "substr:lo:hi;substr:lo:hi" into [(substr, lo, hi), ...]. Malformed
+    entries are skipped with a warning rather than crashing the sidecar."""
+    out = []
+    for entry in spec.split(";"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        parts = entry.rsplit(":", 2)
+        if len(parts) != 3:
+            sys.stderr.write(f"nanlog: WARNING: ignoring malformed NANLOG_BOUNDS entry {entry!r} "
+                             "(expected substring:lo:hi)\n")
+            continue
+        substr, lo_s, hi_s = parts
+        try:
+            out.append((substr, float(lo_s), float(hi_s)))
+        except ValueError:
+            sys.stderr.write(f"nanlog: WARNING: ignoring NANLOG_BOUNDS entry {entry!r} "
+                             "(lo/hi not numeric)\n")
+    return out
+
+
+_BOUNDS = _parse_bounds(os.environ.get("NANLOG_BOUNDS", ""))
+def _parse_bound_env(name: str):
+    """Parse a NANLOG_BOUND_LO/HI value; treat unset/empty as None, warn on non-numeric
+    (never crash the sidecar at import)."""
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        sys.stderr.write(f"nanlog: WARNING: ignoring {name}={raw!r} (not numeric)\n")
+        return None
+
+
+_BOUND_LO = _parse_bound_env("NANLOG_BOUND_LO")
+_BOUND_HI = _parse_bound_env("NANLOG_BOUND_HI")
+# Match-all fallback (applies to every tensor) when the bare LO/HI form is used.
+_BOUND_GLOBAL = (
+    (_BOUND_LO if _BOUND_LO is not None else float("-inf"),
+     _BOUND_HI if _BOUND_HI is not None else float("inf"))
+    if (_BOUND_LO is not None or _BOUND_HI is not None) else None
+)
+_BOUNDS_ACTIVE = bool(_BOUNDS) or _BOUND_GLOBAL is not None
+
+
+def _bound_for(layer_name: str):
+    """Return (lo, hi) for this tensor: first matching NANLOG_BOUNDS pattern, else
+    the global LO/HI fallback, else None (unbounded)."""
+    for substr, lo, hi in _BOUNDS:
+        if substr in layer_name:
+            return (lo, hi)
+    return _BOUND_GLOBAL
 
 # Create the output dir. If it is not writable (e.g. the default lands in a
 # read-only working dir), fall back to a temp dir rather than crashing the
@@ -226,6 +359,15 @@ if not _WATCH_TYPES and not _WATCH_NAMES:
     _log("WARNING: both NANLOG_WATCH_TYPES and NANLOG_WATCH_NAMES are empty; "
          "no modules will be watched")
 
+# Warn once when a scope knob silently no-ops without its prerequisite.
+if _TRACK_EVERY_LAYER and not _PIPELINE:
+    _log("WARNING: NANLOG_TRACK_EVERY_LAYER=1 has no effect without NANLOG_PIPELINE=1 "
+         "(the per-layer re-scan targets are captured by the pipeline hook); set "
+         "NANLOG_PIPELINE=1 to enable per-layer tracking.")
+if os.environ.get("NANLOG_TRACK_LAYER_STRIDE") is not None and not _TRACK_EVERY_LAYER:
+    _log("WARNING: NANLOG_TRACK_LAYER_STRIDE is set but NANLOG_TRACK_EVERY_LAYER is "
+         "off, so the stride is ignored; set NANLOG_TRACK_EVERY_LAYER=1 to use it.")
+
 
 # ---------------------------------------------------------------------------
 # State
@@ -235,8 +377,30 @@ if not _WATCH_TYPES and not _WATCH_NAMES:
 _pending: list = []
 _step = 0
 _records_written = 0
+# Current pipeline phase (copy/sparse_start/sparse_wait/forward); every record stamps
+# it so a corruption can be bracketed to a stage. Default "forward" (layer hooks).
+_phase = "forward"
+# batch_id: cross-step/phase join key. The 3-in-flight pipeline scans copy(N+2),
+# sparse(N+1), forward(N) in one tick — so step and the recycled data_ptr can't line
+# up one batch's records; batch_id can. Assigned at copy_batch_to_gpu, carried on the
+# batch object, re-read at each later checkpoint. None until the first copy.
+_batch_id = None
+_batch_counter = 0           # monotonic source for batch_id (host-side, no sync)
+# id(batch) -> batch_id fallback when the object can't take an attribute (bounded).
+_batch_id_by_obj: dict = {}
+_BATCH_ID_ATTR = "_nanlog_batch_id"
+# Tracked ef objects for this step's forward batch, so each layer hook re-scans the
+# SAME objects (per-layer re-scan). Rebuilt each step; empty when that mode is off.
+_layer_scan_targets: list = []
+_layer_scan_idx = 0          # watched-layer fwd hook counter, for striding
 _matmul_calls = 0          # running count of watched layer tensors (no GPU sync)
 _first_bad = None          # first layer to go bad: {"step","layer","direction","kind"}
+# OOB summary aggregates (surface out-of-bound status without grepping the JSONL):
+# first violation, count, and widest range seen on bounded tensors.
+_first_oob = None
+_oob_records = 0
+_peak_finite_max = None
+_peak_finite_min = None
 _root_installed = False
 # Ring buffer of the last _PRE_CONTEXT steps of records that were NOT otherwise
 # written (clean + unsampled). Dumped to the JSONL when the first bad is seen so
@@ -273,23 +437,38 @@ _grad_warned = False
 # ---------------------------------------------------------------------------
 # On-device reductions (NO .item() here — that is the whole point)
 # ---------------------------------------------------------------------------
-def _device_stats(t: torch.Tensor) -> dict:
+def _device_stats(t: torch.Tensor, bound=None) -> dict:
     """Return a dict of GPU scalar tensors. No host sync; read back later.
 
     finite_abs_max masks non-finite values to 0 first, so it stays meaningful
     even when some elements are already NaN/Inf (lets us see the magnitude
-    trend leading up to a NaN)."""
+    trend leading up to a NaN).
+
+    bound: optional (lo, hi) for this tensor. When bound tracking is active
+    (_BOUNDS_ACTIVE), oob_count is ALWAYS emitted (0 when bound is None) so the
+    fixed per-step drain stack stays uniform across records."""
     fin = torch.isfinite(t)
-    # Mask non-finite values out per reduction with an identity that can never
-    # win: 0 for abs-max (no real magnitude loses to 0), -inf for max, +inf for
-    # min. Using 0 for max/min would be a BUG -- e.g. all-negative finite values
-    # plus one NaN would report finite_max=0 instead of the true (negative) max.
-    abs_safe = torch.where(fin, t.abs(), torch.zeros((), dtype=t.dtype, device=t.device))
-    neg_inf = torch.full((), float("-inf"), dtype=t.dtype, device=t.device)
-    pos_inf = torch.full((), float("inf"), dtype=t.dtype, device=t.device)
-    safe_max = torch.where(fin, t, neg_inf)
-    safe_min = torch.where(fin, t, pos_inf)
-    return {
+    # Integer/bool tensors (e.g. KJT indices) have no non-finite values and cannot
+    # hold ±inf, so the masking below is only needed — and only valid — for float
+    # dtypes. For non-float, every element is finite: reduce directly.
+    if t.is_floating_point():
+        # Mask non-finite values out per reduction with an identity that can never
+        # win: 0 for abs-max (no real magnitude loses to 0), -inf for max, +inf for
+        # min. Using 0 for max/min would be a BUG -- e.g. all-negative finite values
+        # plus one NaN would report finite_max=0 instead of the true (negative) max.
+        abs_safe = torch.where(fin, t.abs(), torch.zeros((), dtype=t.dtype, device=t.device))
+        neg_inf = torch.full((), float("-inf"), dtype=t.dtype, device=t.device)
+        pos_inf = torch.full((), float("inf"), dtype=t.dtype, device=t.device)
+        safe_max = torch.where(fin, t, neg_inf)
+        safe_min = torch.where(fin, t, pos_inf)
+    else:
+        # bool has no .abs(); promote to int so magnitude/compare reductions work.
+        t = t.to(torch.int64) if t.dtype is torch.bool else t
+        fin = torch.ones_like(t, dtype=torch.bool)
+        abs_safe = t.abs()
+        safe_max = t
+        safe_min = t
+    stats = {
         "nan_count": torch.isnan(t).sum(),
         "inf_count": torch.isinf(t).sum(),
         "finite_count": fin.sum(),
@@ -299,6 +478,41 @@ def _device_stats(t: torch.Tensor) -> dict:
         "finite_min": safe_min.min(),
         "numel": torch.tensor(t.numel(), device=t.device),
     }
+    # Out-of-range count: finite elements outside [lo, hi]. Emitted for EVERY record
+    # once bound tracking is active (0 when this tensor has no bound) so the drain's
+    # fixed key stack is uniform. One extra reduction, same drain, no host sync.
+    if _BOUNDS_ACTIVE:
+        if bound is not None:
+            lo, hi = bound
+            stats["oob_count"] = (fin & ((t < lo) | (t > hi))).sum()
+        else:
+            stats["oob_count"] = torch.zeros((), dtype=torch.int64, device=t.device)
+    # Bad mask includes out-of-range so NANLOG_LOCATE/BAD_VALUES point at the OOB
+    # element too, not only NaN/Inf/huge.
+    if _LOCATE or _BAD_VALUES:
+        bad = (~fin) | (fin & (t.abs() > _HUGE))
+        if _BOUNDS_ACTIVE and bound is not None:
+            lo, hi = bound
+            bad = bad | (fin & ((t < lo) | (t > hi)))
+    if _LOCATE:
+        rows = t.shape[0] if t.dim() >= 1 else 1
+        stats["bad_rows"] = bad.reshape(rows, -1).any(dim=1).sum()
+    if _BAD_VALUES:
+        flat_bad = bad.reshape(-1).to(torch.int64)
+        first_idx = flat_bad.argmax()          # GPU scalar: flat index of first bad
+        stats["first_bad_flat"] = first_idx
+        stats["first_bad_val"] = t.reshape(-1)[first_idx]  # GPU scalar via GPU-scalar indexing
+        if t.dim() >= 2:
+            # Elements per dim-0 slice — consistent with bad_rows (which reshapes
+            # to (shape[0], -1)). For a [256,8192] tensor this is 8192; for a
+            # [B,C,H,W] tensor this is C*H*W.
+            elems_per_row = t.numel() // t.shape[0]
+            stats["first_bad_row"] = first_idx // elems_per_row
+            stats["first_bad_col"] = first_idx % elems_per_row
+        else:
+            stats["first_bad_row"] = torch.zeros((), dtype=torch.int64, device=t.device)
+            stats["first_bad_col"] = first_idx
+    return stats
 
 
 def _is_tf32_path(t: torch.Tensor) -> bool:
@@ -313,16 +527,17 @@ _FLOW_ROLES = frozenset({"act", "igrad"})
 
 
 def _stash(layer_name: str, direction: str, t: torch.Tensor, role: str = "act",
-           param_name: str = "", from_prev_step: bool = False) -> None:
+           param_name: str = "", from_prev_step: bool = False,
+           extra: dict = None) -> None:
     """Queue one tensor's on-GPU reduction for this step. No host sync.
 
     Args:
         layer_name:     fully-qualified module name the tensor belongs to.
-        direction:      "fwd" | "bwd" | "param" | "grad" — coarse origin of the
-                        tensor (see ``role`` for the precise channel).
+        direction:      "fwd" | "bwd" | "param" | "grad" | "pipeline" — coarse
+                        origin of the tensor (see ``role`` for the precise channel).
         t:              the tensor to reduce (skipped if empty / non-tensor).
         role:           the channel that produced this record
-                        (act/input/igrad/weight/bias/wgrad/bgrad).
+                        (act/input/igrad/weight/bias/wgrad/bgrad/track/sparse).
         param_name:     exact owned-parameter name (e.g. "w", "scale") for the
                         param/grad channels; "" for activation channels.
         from_prev_step: True for the weight/bias value channels, which are read in
@@ -331,6 +546,8 @@ def _stash(layer_name: str, direction: str, t: torch.Tensor, role: str = "act",
                         False for activations and for the wgrad/bgrad channels,
                         which are read at the optimizer step boundary (current
                         step). Flagged so the JSONL is never misread.
+        extra:          optional dict of host-side metadata merged into the record
+                        (e.g. sparse KJT stats). No GPU sync — caller's job.
     """
     global _matmul_calls
     if not torch.is_tensor(t) or t.numel() == 0:
@@ -340,6 +557,8 @@ def _stash(layer_name: str, direction: str, t: torch.Tensor, role: str = "act",
     rec = {
         "type": "layer_step",
         "step": _step,
+        "phase": _phase,
+        "batch_id": _batch_id,
         "rank": _RANK, "gpu": _RANK, "host": _HOST, "pid": _PID,
         "layer_name": layer_name,
         "direction": direction,
@@ -350,8 +569,30 @@ def _stash(layer_name: str, direction: str, t: torch.Tensor, role: str = "act",
         "dtype": str(t.dtype),
         "tf32_path": _is_tf32_path(t),
         "matmul_calls_so_far": _matmul_calls,
+        "t": time.monotonic(),
     }
-    _pending.append((rec, _device_stats(t)))
+    if extra:
+        rec.update(extra)
+    if _CAPTURE_ADDR:
+        # Host-side address + backing-block extent (no GPU sync). Overlapping
+        # [storage_ptr, storage_ptr+storage_nbytes) ranges across records identify
+        # an aliasing producer/writer.
+        try:
+            st = t.untyped_storage()
+            rec["data_ptr"] = hex(t.data_ptr())
+            rec["storage_ptr"] = hex(st.data_ptr())
+            rec["storage_offset_bytes"] = int(t.storage_offset() * t.element_size())
+            rec["storage_nbytes"] = int(st.nbytes())
+        except Exception:
+            try:
+                rec["data_ptr"] = hex(t.data_ptr())
+            except Exception:
+                pass  # e.g. meta tensor — omit address fields, never crash
+    bound = _bound_for(layer_name) if _BOUNDS_ACTIVE else None
+    # For the one-shot dump, hold a DETACHED ref so we don't keep the autograd graph
+    # alive across the step (memory / allocator-reuse perturbation).
+    held = t.detach() if (_DUMP_TENSOR and not _tensor_dumped) else None
+    _pending.append((rec, _device_stats(t, bound), held))
 
 
 # ---------------------------------------------------------------------------
@@ -369,7 +610,8 @@ def _write_rec(rec: dict) -> None:
 
 def _drain_step() -> None:
     """Flush last step's pending reductions with a single batched sync."""
-    global _records_written, _first_bad, _pre_flushed
+    global _records_written, _first_bad, _pre_flushed, _tensor_dumped
+    global _first_oob, _oob_records, _peak_finite_max, _peak_finite_min
     if not _pending:
         return
     pending, _pending[:] = list(_pending), []
@@ -377,8 +619,14 @@ def _drain_step() -> None:
     # Batch every scalar into one stacked tensor -> ONE .tolist() host transfer.
     keys = ["nan_count", "inf_count", "finite_count", "huge_count",
             "finite_abs_max", "finite_max", "finite_min", "numel"]
+    if _BOUNDS_ACTIVE:
+        keys = keys + ["oob_count"]
+    if _LOCATE:
+        keys = keys + ["bad_rows"]
+    if _BAD_VALUES:
+        keys = keys + ["first_bad_flat", "first_bad_val", "first_bad_row", "first_bad_col"]
     flat = []
-    for _rec, stats in pending:
+    for _rec, stats, _held_t in pending:
         for k in keys:
             flat.append(stats[k].to(torch.float64).reshape(()))
     try:
@@ -391,7 +639,7 @@ def _drain_step() -> None:
     worst = None
     bad_this_step = False        # did first_bad trigger during THIS drain?
     step_records = []            # all records this step, in order, for buffering
-    for i, (rec, _stats) in enumerate(pending):
+    for i, (rec, _stats, held_t) in enumerate(pending):
         base = i * len(keys)
         d = dict(zip(keys, vals[base:base + len(keys)]))
         rec["nan_count"] = int(d["nan_count"])
@@ -408,13 +656,43 @@ def _drain_step() -> None:
         rec["finite_max"] = d["finite_max"] if has_finite else None
         rec["finite_min"] = d["finite_min"] if has_finite else None
         rec["numel"] = int(d["numel"])
-        bad = rec["nan_count"] or rec["inf_count"] or rec["huge_count"]
+        if _BOUNDS_ACTIVE:
+            rec["oob_count"] = int(d["oob_count"])
+            # Summary aggregates. Peak range is tracked only for tensors that
+            # actually carry a bound, so "how close to the limit" reflects the
+            # bounded targets, not unrelated activations.
+            if _bound_for(rec["layer_name"]) is not None and has_finite:
+                if _peak_finite_max is None or rec["finite_max"] > _peak_finite_max:
+                    _peak_finite_max = rec["finite_max"]
+                if _peak_finite_min is None or rec["finite_min"] < _peak_finite_min:
+                    _peak_finite_min = rec["finite_min"]
+            if rec["oob_count"] > 0:
+                _oob_records += 1
+                if _first_oob is None:
+                    _first_oob = {"step": rec["step"], "layer": rec["layer_name"],
+                                  "phase": rec.get("phase"), "oob_count": rec["oob_count"]}
+        if _LOCATE:
+            rec["bad_rows"] = int(d["bad_rows"])
+        bad = (rec["nan_count"] or rec["inf_count"] or rec["huge_count"]
+               or rec.get("oob_count", 0))
         rec["bad"] = bool(bad)
+        if _BAD_VALUES and bad:
+            rec["first_bad_flat_idx"] = int(d["first_bad_flat"])
+            rec["first_bad_row"] = int(d["first_bad_row"])
+            rec["first_bad_col"] = int(d["first_bad_col"])
+            val = d["first_bad_val"]
+            if math.isnan(val):
+                rec["first_bad_value"] = "NaN"
+            elif math.isinf(val):
+                rec["first_bad_value"] = "Inf" if val > 0 else "-Inf"
+            else:
+                rec["first_bad_value"] = val
         step_records.append(rec)
 
         if bad and _first_bad is None:
             kind = ("nan" if rec["nan_count"] else
-                    "inf" if rec["inf_count"] else "huge")
+                    "inf" if rec["inf_count"] else
+                    "huge" if rec["huge_count"] else "oob")
             _first_bad = {"step": rec["step"], "layer": rec["layer_name"],
                           "direction": rec["direction"], "kind": kind,
                           "matmul_calls_so_far": rec["matmul_calls_so_far"]}
@@ -422,6 +700,10 @@ def _drain_step() -> None:
             _log(f"FIRST BAD: step={rec['step']} layer={rec['layer_name']} "
                  f"dir={rec['direction']} kind={kind} "
                  f"call#~{rec['matmul_calls_so_far']} tf32={rec['tf32_path']}")
+            _dump_alloc_snapshot(rec["step"])
+
+        if bad and not _tensor_dumped and held_t is not None:
+            _dump_bad_tensor(rec, held_t)
 
         if bad and rec["finite_abs_max"] is not None and rec["finite_abs_max"] > worst_abs:
             worst_abs, worst = rec["finite_abs_max"], rec
@@ -472,16 +754,47 @@ def _first_tensor(x):
     return x
 
 
+def _rescan_tracked_at_layer(layer_name: str) -> None:
+    """Re-scan the forward batch's tracked ef objects AT this layer boundary, so the
+    JSONL shows each ef object clean->corrupt across the forward layer sequence
+    (diagram-3 step B). Strided by NANLOG_TRACK_LAYER_STRIDE. Each record carries
+    role='track', direction='pipeline', phase='forward', checkpoint=<layer_name> so
+    it is distinct from the layer's own input/act. Reductions join the per-step
+    drain (no extra host sync); the GPU-kernel cost is the striding tradeoff."""
+    global _layer_scan_idx
+    if not _layer_scan_targets:
+        return
+    do_scan = (_layer_scan_idx % _TRACK_LAYER_STRIDE == 0)
+    _layer_scan_idx += 1
+    if not do_scan:
+        return
+    for tname, t in _layer_scan_targets:
+        _stash(tname, "pipeline", t, role="track", extra={"checkpoint": layer_name})
+
+
 def _fwd_hook(name):
     def hook(_module, inp, out):
-        if "act" in _CHANNELS:
-            t = _first_tensor(out)
-            if torch.is_tensor(t):
-                _stash(name, "fwd", t, role="act")
+        # Stash the INPUT before the output (act). When an aliasing corruption
+        # makes BOTH a layer's input and its resulting output bad in the same
+        # step, the one-shot NANLOG_DUMP_TENSOR then captures the INPUT (the
+        # corrupt origin / 8 MiB block) rather than the output (a downstream
+        # consequence of feeding that garbage through the GEMM). This is the
+        # whole point of the emb_proj aliasing workflow; it also matches the
+        # natural input->output order. Layers where only the output is bad still
+        # dump the output (the input isn't a bad candidate), so nothing is lost.
         if "input" in _CHANNELS:
             t = _first_tensor(inp)
             if torch.is_tensor(t):
                 _stash(name, "fwd", t, role="input")
+        if "act" in _CHANNELS:
+            t = _first_tensor(out)
+            if torch.is_tensor(t):
+                _stash(name, "fwd", t, role="act")
+        # Per-layer re-scan of the tracked ef objects (gated). Runs AFTER this
+        # layer's own capture so the JSONL order reads: layer input/act, then the
+        # ef snapshot as of this layer boundary.
+        if _TRACK_EVERY_LAYER:
+            _rescan_tracked_at_layer(name)
     return hook
 
 
@@ -598,9 +911,16 @@ def _root_pre_hook(_module, _inp):
     step's pending reductions (all GPU work from last step is already queued),
     advances the step counter, then queues this step's param scan (prev-step
     values). The single host sync per step lives in the drain."""
-    global _step
+    global _step, _phase, _layer_scan_idx
     _drain_step()
     _step += 1
+    _phase = "forward"   # stage wrappers set copy/sparse phases outside forward
+    _layer_scan_idx = 0
+    # Scan the batch forward is about to read (batch N) at forward entry: emits the
+    # phase='forward' embedding checkpoint (making forward a stage like copy/sparse)
+    # and tags forward records with batch N's id. Also arms the per-layer re-scan
+    # targets when NANLOG_TRACK_EVERY_LAYER is on. No-op unless NANLOG_PIPELINE.
+    _capture_forward_batch(_inp)
     _scan_params()
     _maybe_warn_grad()
 
@@ -652,12 +972,16 @@ def _install_autohook() -> None:
         global _root_installed
         if _root_installed:
             return
+        _start_alloc_recording()
         n = _attach(self)
         # Drive one drain+step per training iteration off the root forward.
         self.register_forward_pre_hook(_root_pre_hook)
         _root_installed = True
         _log(f"attached layer hooks to {n} module(s) (types={list(_WATCH_TYPES)}, "
              f"names={list(_WATCH_NAMES)}); channels={sorted(_CHANNELS)}; "
+             f"capture_addr={_CAPTURE_ADDR}; locate={_LOCATE}; "
+             f"bad_values={_BAD_VALUES}; dump_tensor={_DUMP_TENSOR}; "
+             f"alloc_snapshot={_ALLOC_SNAPSHOT}; "
              f"params_scanned={len(_scan_plan)}; params_skipped={len(_skipped_params)}; "
              f"per-step drain installed on DMP root")
         if 0 < n <= 10:
@@ -701,6 +1025,411 @@ def _install_optimizer_autohook() -> None:
          "the optimizer step boundary")
 
 
+# ---------------------------------------------------------------------------
+# Pipeline-stage tracking (NANLOG_PIPELINE): checkpoint tracked flow objects at
+# the TorchRec pipeline stage boundaries, BEFORE forward reads them. General
+# tensor-flow tracker — EF is only the default target (NANLOG_TRACK_ATTR).
+# ---------------------------------------------------------------------------
+_pipeline_installed = False
+_pipeline_checkpoints = 0     # count of stage checkpoints that stashed something
+_pipeline_warned = False
+
+
+_kjt_types_cache = None
+
+
+def _kjt_types():
+    """Lazily resolve (KeyedJaggedTensor, JaggedTensor) classes; () if unavailable.
+    Kept out of module import so a torchrec-less environment imports cleanly; the
+    result is memoized so the hot path (every checkpoint) doesn't re-run the import."""
+    global _kjt_types_cache
+    if _kjt_types_cache is None:
+        try:
+            from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+            _kjt_types_cache = (KeyedJaggedTensor, JaggedTensor)
+        except Exception:
+            _kjt_types_cache = ()
+    return _kjt_types_cache
+
+
+def _sparse_extra(obj) -> dict:
+    """Cheap, host-side-only sparse distribution metadata for a KJT/JaggedTensor.
+    No GPU sync unless NANLOG_SPARSE_HEAVY (empty_bags/max_bag_len/index min-max).
+    Returns {} for non-sparse objects."""
+    kjt_types = _kjt_types()
+    if not kjt_types or not isinstance(obj, kjt_types):
+        return {}
+    extra = {"sparse": True}
+    try:
+        keys = obj.keys()
+        extra["sparse_num_keys"] = len(keys)
+    except Exception:
+        pass
+    for meth, tag in (("lengths", "lengths"), ("offsets", "offsets"), ("values", "values")):
+        try:
+            t = getattr(obj, meth)()
+        except Exception:
+            continue
+        if not torch.is_tensor(t):
+            continue
+        extra[f"sparse_{tag}_shape"] = list(t.shape)
+        extra[f"sparse_{tag}_dtype"] = str(t.dtype)
+        if tag == "lengths":
+            extra["sparse_num_bags"] = int(t.numel())  # count of length entries (bags), not sum
+        if tag == "values":
+            extra["sparse_values_device"] = str(t.device)
+    if _SPARSE_HEAVY:
+        # The ONE sparse path that reads back from device (explicit .item() sync).
+        # Gated so it can never fire on a timing-sensitive repro run.
+        try:
+            lengths = obj.lengths()
+            if torch.is_tensor(lengths) and lengths.numel():
+                extra["sparse_empty_bags"] = int((lengths == 0).sum().item())
+                extra["sparse_max_bag_len"] = int(lengths.max().item())
+        except Exception:
+            pass
+        try:
+            vals = obj.values()
+            if torch.is_tensor(vals) and vals.numel():
+                extra["sparse_index_min"] = int(vals.min().item())
+                extra["sparse_index_max"] = int(vals.max().item())
+        except Exception:
+            pass
+    return extra
+
+
+def _emit_tracked(name: str, obj, seen: set) -> int:
+    """Stash one tracked object (or its tensor members) with role track/sparse and
+    the current phase. Recurses one level into list/tuple/dict. De-dupes by id so a
+    tensor shared across containers is scanned once per checkpoint. Returns count."""
+    if len(seen) >= _TRACK_MAX:
+        return 0
+    kjt_types = _kjt_types()
+    n = 0
+    if kjt_types and isinstance(obj, kjt_types):
+        if id(obj) in seen:
+            return 0
+        seen.add(id(obj))
+        try:
+            vals = obj.values()
+        except Exception:
+            vals = None
+        role = "sparse" if _SPARSE else "track"
+        extra = _sparse_extra(obj) if _SPARSE else None
+        if torch.is_tensor(vals):
+            _stash(name, "pipeline", vals, role=role, extra=extra)
+            n += 1
+        return n
+    if torch.is_tensor(obj):
+        if id(obj) in seen:
+            return 0
+        seen.add(id(obj))
+        _stash(name, "pipeline", obj, role="track")
+        return 1
+    if isinstance(obj, (list, tuple)):
+        for i, item in enumerate(obj):
+            if len(seen) >= _TRACK_MAX:
+                break
+            n += _emit_tracked(f"{name}[{i}]", item, seen)
+        return n
+    if isinstance(obj, dict):
+        for k, item in obj.items():
+            if len(seen) >= _TRACK_MAX:
+                break
+            n += _emit_tracked(f"{name}[{k}]", item, seen)
+        return n
+    return n
+
+
+def _auto_discover(batch, seen: set) -> int:
+    """Fallback when no NANLOG_TRACK_ATTR name is found on the batch: bounded walk
+    (depth<=2) over attributes / container members collecting Tensors and KJTs."""
+    n = 0
+    kjt_types = _kjt_types()
+
+    def visit(name, obj, depth):
+        nonlocal n
+        if len(seen) >= _TRACK_MAX:
+            return
+        if torch.is_tensor(obj) or (kjt_types and isinstance(obj, kjt_types)):
+            n += _emit_tracked(name, obj, seen)
+            return
+        if depth <= 0:
+            return
+        if isinstance(obj, (list, tuple)):
+            for i, item in enumerate(obj):
+                visit(f"{name}[{i}]", item, depth - 1)
+        elif isinstance(obj, dict):
+            for k, item in obj.items():
+                visit(f"{name}[{k}]", item, depth - 1)
+        else:
+            for attr in getattr(obj, "__dict__", {}):
+                if attr.startswith("_"):
+                    continue
+                try:
+                    visit(f"{name}.{attr}", getattr(obj, attr), depth - 1)
+                except Exception:
+                    continue
+
+    visit("batch", batch, 2)
+    return n
+
+
+def _resolve_batch_id(batch, phase: str):
+    """Return the batch_id for this batch, host-side and sync-free.
+
+    At the COPY phase a batch is entering the pipeline for the first time -> assign
+    a fresh monotonic id and stamp it on the batch object (best effort) plus an
+    id()-keyed fallback map for objects that reject attributes. At later phases the
+    SAME batch is seen again -> read the id back so copy/sparse/forward of one batch
+    share a key. Returns None if the batch can neither be tagged nor found (records
+    then carry batch_id=null rather than a wrong guess)."""
+    global _batch_counter
+    is_dict = isinstance(batch, dict)
+    # Prefer an id already carried on the batch (set at its copy checkpoint). Dict
+    # batches carry it as a key; other objects as an attribute.
+    if is_dict:
+        existing = batch.get(_BATCH_ID_ATTR)
+    else:
+        existing = getattr(batch, _BATCH_ID_ATTR, None)
+    if existing is not None:
+        return existing
+    existing = _batch_id_by_obj.get(id(batch))
+    if existing is not None:
+        return existing
+    if phase != "copy":
+        # A non-copy phase with no id means we started mid-pipeline (missed this
+        # batch's copy). Don't fabricate an id; leave it null.
+        return None
+    _batch_counter += 1
+    bid = _batch_counter
+    if is_dict:
+        batch[_BATCH_ID_ATTR] = bid
+        return bid
+    try:
+        setattr(batch, _BATCH_ID_ATTR, bid)   # respects custom __setattr__ / frozen
+    except Exception:
+        # Object rejects attributes (e.g. __slots__, frozen). Fall back to the id()
+        # map, bounded so a long run cannot grow it without limit. (id() reuse after
+        # GC is a theoretical mis-join risk; only truly untaggable objects land here.)
+        if len(_batch_id_by_obj) > 4096:
+            _batch_id_by_obj.clear()
+        _batch_id_by_obj[id(batch)] = bid
+    return bid
+
+
+def _collect_tracked(batch, seen: set, out: list) -> None:
+    """Collect the tracked flow objects on `batch` as (name, tensor) pairs into
+    `out`, resolving a KJT to its .values() tensor. Same discovery order as
+    _checkpoint (named NANLOG_TRACK_ATTR first, else bounded auto-discovery) but it
+    RETURNS the tensors instead of stashing them, so the per-layer re-scan can hold
+    the object references and re-emit them at each layer. Host-side, no reduction."""
+    kjt_types = _kjt_types()
+
+    def take(name, obj):
+        if len(seen) >= _TRACK_MAX:
+            return
+        if kjt_types and isinstance(obj, kjt_types):
+            if id(obj) in seen:
+                return
+            seen.add(id(obj))
+            try:
+                v = obj.values()
+            except Exception:
+                v = None
+            if torch.is_tensor(v):
+                out.append((name, v))
+            return
+        if torch.is_tensor(obj):
+            if id(obj) in seen:
+                return
+            seen.add(id(obj))
+            out.append((name, obj))
+            return
+        if isinstance(obj, (list, tuple)):
+            for i, item in enumerate(obj):
+                take(f"{name}[{i}]", item)
+        elif isinstance(obj, dict):
+            for k, item in obj.items():
+                take(f"{name}[{k}]", item)
+
+    found_named = False
+    for name in _TRACK_ATTR:
+        obj = None
+        if hasattr(batch, name):
+            obj = getattr(batch, name)
+        elif isinstance(batch, dict) and name in batch:
+            obj = batch[name]
+        if obj is not None:
+            found_named = True
+            take(name, obj)
+    if not found_named:
+        # Reuse the checkpoint auto-discovery, but collect into `out`. Cheapest to
+        # just walk attributes here rather than thread a callback through.
+        def visit(name, obj, depth):
+            if len(seen) >= _TRACK_MAX:
+                return
+            if torch.is_tensor(obj) or (kjt_types and isinstance(obj, kjt_types)):
+                take(name, obj)
+                return
+            if depth <= 0:
+                return
+            if isinstance(obj, (list, tuple)):
+                for i, item in enumerate(obj):
+                    visit(f"{name}[{i}]", item, depth - 1)
+            elif isinstance(obj, dict):
+                for k, item in obj.items():
+                    visit(f"{name}[{k}]", item, depth - 1)
+            else:
+                for attr in getattr(obj, "__dict__", {}):
+                    if attr.startswith("_"):
+                        continue
+                    try:
+                        visit(f"{name}.{attr}", getattr(obj, attr), depth - 1)
+                    except Exception:
+                        continue
+        visit("batch", batch, 2)
+
+
+def _capture_forward_batch(inp) -> None:
+    """From the root forward's positional args, find the batch being processed
+    (batch N, the one forward actually reads — distinct from the copy(N+2)/
+    sparse(N+1) batches the stage wrappers just saw) and scan its tracked ef objects
+    at forward ENTRY (phase='forward'), so forward is a first-class stage alongside
+    copy/sparse — no watched module or per-layer re-scan required. When per-layer
+    re-scan IS on, also hold the tracked objects in _layer_scan_targets so each layer
+    hook can re-scan the SAME objects. Host-side only; the reductions join the drain.
+
+    The forward-entry _checkpoint resolves _batch_id to batch N. This is REQUIRED
+    whenever pipeline tracking is on: otherwise the forward/layer records inherit the
+    stale _batch_id the LAST stage wrapper left set (start_sparse_data_dist for batch
+    N+1 in the standard prefetch order), tagging the emb_proj input record where
+    first_bad fires with the WRONG batch. _batch_id ends up batch N (or None on a
+    mid-pipeline start / re-wrapped batch), never a stale stage value."""
+    global _layer_scan_targets, _batch_id
+    _layer_scan_targets = []
+    if not _PIPELINE:
+        return
+    # The batch is usually the first positional arg to the root forward.
+    batch = inp[0] if isinstance(inp, (tuple, list)) and inp else inp
+    if batch is None:
+        _batch_id = None   # don't let forward records inherit a stale stage batch_id
+        return
+    try:
+        # Forward-entry checkpoint: scan the 31 ef objects once here (sets _batch_id
+        # to batch N and _phase='forward'). Makes 'forward' a stage like copy/sparse
+        # without needing NANLOG_WATCH_NAMES or NANLOG_TRACK_EVERY_LAYER.
+        _checkpoint(batch, "forward")
+        if _TRACK_EVERY_LAYER:
+            seen: set = set()
+            targets: list = []
+            _collect_tracked(batch, seen, targets)
+            _layer_scan_targets = targets
+    except Exception as e:
+        _log(f"WARNING: forward-batch capture failed: {e!r}")
+
+
+def _checkpoint(batch, phase: str) -> None:
+    """Set the phase + batch_id, discover the tracked flow objects on `batch`, and
+    stash a re-scan of each. Sync-free (reductions join the per-step drain). Called
+    from the wrapped pipeline stage methods. Never raises into the training run."""
+    global _phase, _batch_id, _pipeline_checkpoints
+    if batch is None:
+        return
+    _phase = phase
+    try:
+        _batch_id = _resolve_batch_id(batch, phase)
+    except Exception:
+        _batch_id = None
+    seen: set = set()
+    n = 0
+    try:
+        found_named = False
+        for name in _TRACK_ATTR:
+            obj = None
+            if hasattr(batch, name):
+                obj = getattr(batch, name)
+            elif isinstance(batch, dict) and name in batch:
+                obj = batch[name]
+            if obj is not None:
+                found_named = True
+                n += _emit_tracked(name, obj, seen)
+        if not found_named:
+            n += _auto_discover(batch, seen)
+    except Exception as e:
+        _log(f"WARNING: pipeline checkpoint ({phase}) failed: {e!r}")
+        return
+    if n:
+        _pipeline_checkpoints += 1
+
+
+def _install_pipeline_hook() -> None:
+    """Monkeypatch TrainPipelineSparseDist stage methods so each fires a sync-free
+    checkpoint of the tracked flow objects with the right `phase`. Defensive: if the
+    installed torchrec exposes none of the known stage methods, warn once and leave
+    the layer hooks untouched. Same auto-attach philosophy as the DMP __init__ patch."""
+    global _pipeline_installed, _pipeline_warned
+    if not _PIPELINE or _pipeline_installed:
+        return
+    try:
+        from torchrec.distributed.train_pipeline import TrainPipelineSparseDist as _TP
+    except Exception as e:
+        _pipeline_warned = True
+        _log(f"WARNING: NANLOG_PIPELINE=1 but TrainPipelineSparseDist could not be "
+             f"imported ({e!r}); pipeline checkpoints inactive. Layer hooks unaffected.")
+        return
+
+    # (method name on the pipeline, phase, index of the batch arg in *a, whether
+    # the batch is the RETURN value instead of an argument).
+    #   copy_batch_to_gpu(self, dataloader_iter) -> batch      (batch = return)
+    #   start_sparse_data_dist(self, batch, ...)               (batch = a[0])
+    #   wait_sparse_data_dist(self, batch, ...) OR (self)       (a[0] if present)
+    specs = [
+        ("copy_batch_to_gpu", "copy", True),
+        ("start_sparse_data_dist", "sparse_start", False),
+        ("wait_sparse_data_dist", "sparse_wait", False),
+    ]
+    patched = []
+    for meth_name, phase, from_return in specs:
+        orig = getattr(_TP, meth_name, None)
+        if orig is None or not callable(orig):
+            continue
+
+        def make(orig, phase, from_return):
+            def wrapper(self, *a, **k):
+                result = orig(self, *a, **k)
+                try:
+                    if from_return:
+                        # copy_batch_to_gpu returns the batch, or a (batch, context)
+                        # tuple across torchrec versions; unwrap the first element
+                        # only when the named track attr is not on the tuple itself.
+                        batch = result
+                        if (isinstance(batch, tuple) and batch
+                                and not any(hasattr(batch, nm) for nm in _TRACK_ATTR)):
+                            batch = batch[0]
+                    else:
+                        batch = a[0] if a else None
+                    _checkpoint(batch, phase)
+                except Exception as e:
+                    _log(f"WARNING: pipeline wrapper ({phase}) error: {e!r}")
+                return result
+            return wrapper
+
+        setattr(_TP, meth_name, make(orig, phase, from_return))
+        patched.append(meth_name)
+
+    if not patched:
+        _pipeline_warned = True
+        _log(f"WARNING: NANLOG_PIPELINE=1 but TrainPipelineSparseDist has none of the "
+             f"known stage methods (copy_batch_to_gpu/start_sparse_data_dist/"
+             f"wait_sparse_data_dist); checkpoints inactive. torchrec API changed?")
+        return
+    _pipeline_installed = True
+    _log(f"pipeline tracking armed: patched {patched}; track_attr={list(_TRACK_ATTR)}; "
+         f"track_max={_TRACK_MAX}; sparse={_SPARSE}; sparse_heavy={_SPARSE_HEAVY}; "
+         f"track_every_layer={_TRACK_EVERY_LAYER}; track_layer_stride={_TRACK_LAYER_STRIDE}")
+
+
 def _write_summary() -> None:
     """Write the end-of-run summary (first bad layer + totals)."""
     _drain_step()  # flush the final step
@@ -716,7 +1445,31 @@ def _write_summary() -> None:
         "watch_types": list(_WATCH_TYPES),
         "watch_names": list(_WATCH_NAMES),
         "watched_count": len(_watched_names),
+        "watched_names": list(_watched_names),
         "channels": sorted(_CHANNELS),
+        "capture_addr": _CAPTURE_ADDR,
+        "locate": _LOCATE,
+        "bad_values": _BAD_VALUES,
+        "dump_tensor": _DUMP_TENSOR,
+        "dump_tensor_dumped": _tensor_dumped,
+        "alloc_snapshot": _ALLOC_SNAPSHOT,
+        "alloc_snapshot_dumped": _snapshot_dumped,
+        "pipeline": _PIPELINE,
+        "pipeline_installed": _pipeline_installed,
+        "pipeline_checkpoints": _pipeline_checkpoints,
+        "track_attr": list(_TRACK_ATTR),
+        "track_max": _TRACK_MAX,
+        "sparse": _SPARSE,
+        "sparse_heavy": _SPARSE_HEAVY,
+        "track_every_layer": _TRACK_EVERY_LAYER,
+        "track_layer_stride": _TRACK_LAYER_STRIDE,
+        "bounds": [{"pattern": s, "lo": lo, "hi": hi} for s, lo, hi in _BOUNDS],
+        "bound_global": (list(_BOUND_GLOBAL) if _BOUND_GLOBAL is not None else None),
+        "first_oob": _first_oob,
+        "oob_records": _oob_records,
+        "peak_finite_max": _peak_finite_max,
+        "peak_finite_min": _peak_finite_min,
+        "batches_seen": _batch_counter,
         "max_param_numel": _MAX_PARAM_NUMEL,
         "params_scanned": len(_scan_plan),
         "grad_params_planned": len(_grad_plan),
@@ -726,7 +1479,7 @@ def _write_summary() -> None:
         "tf32_allowed": bool(torch.backends.cuda.matmul.allow_tf32),
         "jsonl": str(_JSONL),
         "notes": (
-            "first_bad is the first layer/step that went NaN/Inf/huge, or null if "
+            "first_bad is the first layer/step that went NaN/Inf/huge/oob, or null if "
             "none was seen. matmul_calls_so_far counts watched layer tensors (not "
             "raw GEMMs); it can be lined up with a separate GEMM-output tool's "
             "'call #N' if one is also running."
@@ -741,6 +1494,73 @@ def _write_summary() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Allocator snapshot (NANLOG_ALLOC_SNAPSHOT)
+# ---------------------------------------------------------------------------
+_snapshot_dumped = False
+_tensor_dumped = False
+
+
+_alloc_recording_started = False
+
+
+def _start_alloc_recording() -> None:
+    """Enable allocator event recording. Safe to call multiple times (idempotent).
+
+    Deferred to the DMP __init__ hook so CUDA is guaranteed to be initialized.
+    Calling at import time would fail with 'No CUDA GPUs available' because
+    torch.cuda is not yet set up."""
+    global _alloc_recording_started
+    if not _ALLOC_SNAPSHOT or _alloc_recording_started:
+        return
+    try:
+        torch.cuda.memory._record_memory_history(
+            enabled="all", stacks="python", max_entries=500000)
+        _alloc_recording_started = True
+        _log("allocator snapshot: recording enabled (stacks=python, "
+             "max_entries=500000). Overhead: ~10% per step from stack capture; "
+             "GPU kernel timing unchanged.")
+    except Exception as e:
+        _log(f"WARNING: allocator snapshot: could not enable recording: {e!r}. "
+             "NANLOG_ALLOC_SNAPSHOT will be inactive.")
+
+
+def _dump_bad_tensor(rec: dict, t: torch.Tensor) -> None:
+    """Save the full bad tensor to disk on first detection. One-shot."""
+    global _tensor_dumped
+    if _tensor_dumped or not _DUMP_TENSOR:
+        return
+    _tensor_dumped = True
+    layer_safe = rec["layer_name"].replace(".", "_").replace("/", "_")
+    pt_path = _DIR / f"bad_tensor_step{rec['step']}_{layer_safe}_{rec['role']}_rank{_RANK}.pt"
+    try:
+        torch.save(t.detach().cpu(), pt_path)
+        _log(f"dump_tensor -> {pt_path} (shape={list(t.shape)}, dtype={t.dtype}, "
+             f"{t.numel() * t.element_size() / 1024:.0f} KB)")
+    except Exception as e:
+        _log(f"WARNING: dump_tensor failed: {e!r}")
+
+
+def _dump_alloc_snapshot(step: int) -> None:
+    """Dump the allocator snapshot on the first bad record (nan/inf/huge/oob), then
+    stop recording."""
+    global _snapshot_dumped
+    if _snapshot_dumped or not _ALLOC_SNAPSHOT:
+        return
+    _snapshot_dumped = True
+    snap_path = _DIR / f"alloc_snapshot_step{step}_rank{_RANK}.pickle"
+    try:
+        torch.cuda.memory._dump_snapshot(str(snap_path))
+        _log(f"allocator snapshot -> {snap_path}")
+    except Exception as e:
+        _log(f"WARNING: allocator snapshot dump failed: {e!r}")
+    try:
+        torch.cuda.memory._record_memory_history(enabled=None)
+        _log("allocator snapshot: recording stopped after dump")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Install + run target
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
@@ -752,6 +1572,7 @@ if __name__ == "__main__":
         sys.exit(2)
     _install_autohook()
     _install_optimizer_autohook()
+    _install_pipeline_hook()
     target = Path(sys.argv[1]).resolve()
     sys.argv = [str(target)] + sys.argv[2:]
     _log(f"running target {target}")

--- a/tests/instrumentation/test_layer_numerics_runtime.py
+++ b/tests/instrumentation/test_layer_numerics_runtime.py
@@ -1,0 +1,226 @@
+"""CPU runtime tests for the ``instrument_nan_logger`` script itself.
+
+Unlike ``test_layer_numerics.py`` (which covers only the ``build_env`` collector
+plumbing), this exercises the logger's actual hook/drain behavior on CPU tensors —
+no GPU and no torchrec required. It drives the same entry points the auto-hook would
+call (``_attach`` / ``_root_pre_hook`` / ``_checkpoint``) on tiny eager models.
+
+The logger reads all config from ``NANLOG_*`` env vars AT IMPORT, so each test loads
+a FRESH copy of the module by path with its own env + throwaway output dir.
+
+Skipped cleanly when torch is unavailable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+
+import pytest
+
+from aorta.instrumentation.layer_numerics import SCRIPT_PATH
+
+torch = pytest.importorskip("torch")
+
+
+def _load_logger(env: dict, monkeypatch, tmp_path_factory) -> object:
+    """Import a fresh instance of the logger with the given NANLOG_* env applied.
+
+    A unique module name per load avoids sys.modules caching so env changes take
+    effect; a per-load output dir keeps the JSONL/summary isolated.
+    """
+    out = tmp_path_factory.mktemp("nanlog")
+    monkeypatch.setenv("NANLOG_DIR", str(out))
+    monkeypatch.setenv("RANK", "0")
+    for key, val in env.items():
+        monkeypatch.setenv(key, val)
+    # Load by path under a unique name so repeated loads don't collide in sys.modules.
+    name = f"_nanlog_{out.name}"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod._OUT_DIR = out  # attach for the test to read back
+    return mod
+
+
+def _records(mod) -> list:
+    jsonl = mod._OUT_DIR / "layers_rank0.jsonl"
+    if not jsonl.exists():
+        return []
+    return [json.loads(line) for line in jsonl.read_text().splitlines() if line.strip()]
+
+
+def _summary(mod) -> dict:
+    return json.loads((mod._OUT_DIR / "summary_rank0.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# Channels: independently selectable, off unless named
+# ---------------------------------------------------------------------------
+def test_channels_are_independently_selectable(monkeypatch, tmp_path_factory):
+    """NANLOG_CHANNELS=act,input must emit act+input records and NOT igrad/weight."""
+    nl = _load_logger(
+        {"NANLOG_CHANNELS": "act,input", "NANLOG_WATCH_TYPES": "Linear",
+         "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    model = torch.nn.Sequential(torch.nn.Linear(8, 8), torch.nn.ReLU(), torch.nn.Linear(8, 4))
+    assert nl._attach(model) > 0
+    opt = torch.optim.SGD(model.parameters(), lr=1e-3)
+    for _ in range(2):
+        nl._root_pre_hook(None, None)
+        opt.zero_grad()
+        model(torch.randn(4, 8)).sum().backward()
+        opt.step()
+    nl._write_summary()
+    roles = {r["role"] for r in _records(nl)}
+    assert "act" in roles and "input" in roles
+    assert "igrad" not in roles and "weight" not in roles and "wgrad" not in roles
+
+
+def test_default_channels_do_not_include_new_ones(monkeypatch, tmp_path_factory):
+    """Bare default channels are act,igrad only — new channels off by default."""
+    nl = _load_logger(
+        {"NANLOG_WATCH_TYPES": "Linear", "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    assert nl._CHANNELS == frozenset({"act", "igrad"})
+
+
+# ---------------------------------------------------------------------------
+# Default-off paths: heavy features stay off with a bare config
+# ---------------------------------------------------------------------------
+def test_heavy_features_default_off(monkeypatch, tmp_path_factory):
+    nl = _load_logger({"NANLOG_WATCH_TYPES": "Linear"}, monkeypatch, tmp_path_factory)
+    assert nl._CAPTURE_ADDR is False        # NANLOG_ADDR now defaults off
+    assert nl._PIPELINE is False
+    assert nl._TRACK_EVERY_LAYER is False
+    assert nl._SPARSE is False and nl._SPARSE_HEAVY is False
+    assert nl._LOCATE is False and nl._BAD_VALUES is False
+    assert nl._BOUNDS_ACTIVE is False
+
+
+def test_device_stats_handles_non_float_tensors(monkeypatch, tmp_path_factory):
+    """Integer/bool tensors (e.g. KJT indices) must not crash _device_stats — it
+    cannot fill +/-inf into an int dtype. Reduces directly for non-float."""
+    nl = _load_logger({"NANLOG_WATCH_TYPES": "Linear"}, monkeypatch, tmp_path_factory)
+    for t in (torch.tensor([1, 2, 3], dtype=torch.int64),
+              torch.tensor([True, False, True]),
+              torch.tensor([0.0, 1.0, float("nan")])):
+        stats = nl._device_stats(t)
+        assert int(stats["numel"]) == 3          # no exception, sane result
+
+
+def test_addr_off_omits_address_fields(monkeypatch, tmp_path_factory):
+    nl = _load_logger(
+        {"NANLOG_CHANNELS": "act", "NANLOG_WATCH_TYPES": "Linear",
+         "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    model = torch.nn.Linear(8, 8)
+    nl._attach(model)
+    nl._root_pre_hook(None, None)
+    model(torch.randn(4, 8))
+    nl._write_summary()
+    recs = _records(nl)
+    assert recs and all("data_ptr" not in r for r in recs)
+
+
+# ---------------------------------------------------------------------------
+# Bounds / OOB detection + summary
+# ---------------------------------------------------------------------------
+def test_bounds_flag_out_of_range_and_summary(monkeypatch, tmp_path_factory):
+    """A value outside [0,60] on a bounded tensor is bad with kind=oob, and the
+    summary surfaces first_oob / oob_records / peak range."""
+    nl = _load_logger(
+        {"NANLOG_CHANNELS": "input", "NANLOG_WATCH_TYPES": "Linear",
+         "NANLOG_SAMPLE_EVERY": "1", "NANLOG_BOUNDS": "proj:0:60",
+         "NANLOG_BAD_VALUES": "1"},
+        monkeypatch, tmp_path_factory)
+
+    class M(torch.nn.Module):
+        def __init__(s):
+            super().__init__()
+            s.proj = torch.nn.Linear(4, 4)
+
+        def forward(s, x):
+            return s.proj(x)
+
+    m = M()
+    nl._attach(m)
+    for _ in range(2):
+        nl._root_pre_hook(None, None)
+        m(torch.rand(3, 4) * 50.0)          # in-range
+    nl._root_pre_hook(None, None)            # advances _step; the model runs at this step
+    bad_step = nl._step
+    x = torch.rand(3, 4) * 50.0
+    x[0, 0] = -9.0                           # small NEGATIVE: huge threshold can't catch it
+    m(x)
+    nl._root_pre_hook(None, None)            # drain the bad step
+    nl._write_summary()
+
+    smy = _summary(nl)
+    assert smy["oob_records"] >= 1
+    assert smy["first_oob"] is not None and smy["first_oob"]["step"] == bad_step
+    assert smy["first_bad"] and smy["first_bad"]["kind"] == "oob"
+    assert smy["peak_finite_min"] == pytest.approx(-9.0)
+
+
+def test_bounds_are_scoped_per_pattern(monkeypatch, tmp_path_factory):
+    """A bound on 'proj' must not flag an unrelated 'other' layer."""
+    nl = _load_logger(
+        {"NANLOG_CHANNELS": "input", "NANLOG_WATCH_TYPES": "Linear",
+         "NANLOG_SAMPLE_EVERY": "1", "NANLOG_BOUNDS": "proj:0:60"},
+        monkeypatch, tmp_path_factory)
+    assert nl._bound_for("emb.proj.layers.0") == (0.0, 60.0)
+    assert nl._bound_for("other.dense") is None
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: forward-stage checkpoint + batch_id, no watched layer needed
+# ---------------------------------------------------------------------------
+def test_pipeline_forward_stage_and_batch_id(monkeypatch, tmp_path_factory):
+    """With NANLOG_PIPELINE=1 (no WATCH_NAMES, no TRACK_EVERY_LAYER), the tracked
+    tensors are scanned at copy/sparse_start/sparse_wait AND forward, and one batch's
+    records share a batch_id."""
+    nl = _load_logger(
+        {"NANLOG_PIPELINE": "1", "NANLOG_TRACK_ATTR": "embedding_features",
+         "NANLOG_BOUNDS": "embedding_features:0:60", "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+
+    class Batch:
+        def __init__(self):
+            self.embedding_features = [torch.rand(4, 8) * 60.0 for _ in range(3)]
+
+    for _ in range(2):
+        b = Batch()
+        nl._checkpoint(b, "copy")
+        nl._checkpoint(b, "sparse_start")
+        nl._checkpoint(b, "sparse_wait")
+        nl._root_pre_hook(None, (b,))        # forward-stage checkpoint
+    nl._root_pre_hook(None, (Batch(),))      # drain the last step
+    nl._write_summary()
+
+    recs = _records(nl)
+    track = [r for r in recs if r["role"] in ("track", "sparse")]
+    phases = {r["phase"] for r in track}
+    assert {"copy", "sparse_start", "sparse_wait", "forward"} <= phases
+    # forward records must be STAGE records (no per-layer checkpoint field)
+    fwd = [r for r in track if r["phase"] == "forward"]
+    assert fwd and all("checkpoint" not in r for r in fwd)
+    # all 3 tracked tensors present by name
+    assert len({r["layer_name"] for r in fwd}) == 3
+    # a single copy checkpoint's records share one non-null batch_id
+    copy_recs = [r for r in track if r["phase"] == "copy"]
+    assert copy_recs and all(r["batch_id"] is not None for r in copy_recs)
+
+
+def test_pipeline_off_produces_no_track_records(monkeypatch, tmp_path_factory):
+    nl = _load_logger(
+        {"NANLOG_CHANNELS": "act", "NANLOG_WATCH_TYPES": "Linear",
+         "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is False
+    m = torch.nn.Linear(4, 4)
+    nl._attach(m)
+    nl._root_pre_hook(None, (torch.rand(3, 4),))   # must be a no-op for the pipeline path
+    m(torch.rand(3, 4))
+    nl._write_summary()
+    assert all(r["role"] != "track" for r in _records(nl))


### PR DESCRIPTION
## Summary
- Extend `instrument_nan_logger.py` with pipeline-stage tracking (`NANLOG_PIPELINE`), per-tensor in-range bound checks (`NANLOG_BOUNDS`) with OOB surfaced in the summary, forward as a first-class embedding checkpoint, GPU address / allocator-snapshot capture, a per-record `t = time.monotonic()` timestamp, and non-float tensor handling in `_device_stats`.
- All heavy features default **off** and feed the single per-step host transfer (no per-GEMM sync), preserving the original timing profile.
- Add `tests/instrumentation/test_layer_numerics_runtime.py` covering CPU-runnable paths (heavy features off by default, non-float tensors, address fields gated by `NANLOG_ADDR`).

## Scope
- Touches exactly two files: `instrument_nan_logger.py` and its runtime test. No docs, recipes, or other subsystems.
- Docs for these knobs land in a separate stacked PR (`docs/layer-numerics-recipes`).

## Test plan
- [ ] `pytest tests/instrumentation/test_layer_numerics_runtime.py` (CPU, no GPU needed)
- [ ] `python -m aorta.instrumentation.layer_numerics` prints the usage line

🤖 Generated with [Claude Code](https://claude.com/claude-code)