### PR TITLE
env probe: amdgpu KMD/KFD driver identity capture (schema 1.10)

### DIFF
--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -226,6 +226,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
 | `system_health` | `dict \| null` | `rdhc --quick --json` (subprocess) | verbatim parsed JSON; `null` when rdhc absent / sudo unavailable / timeout / malformed |
 | `rocm` | `dict[str, str \| null]` | `/opt/rocm/.info/version{,_dev}`, `/sys/module/amdgpu/version` | `version`, `version_dev`, `kmd_version` |
+| `amdgpu_driver` | `dict` | `dpkg-query`/`rpm` (package), `modinfo amdgpu` (module), `/sys/module/amdgpu/version` (reused from `rocm.kmd_version`), `/dev/kfd` + `/sys/class/kfd` (existence) | Schema 1.10. `scope` (constant `"host_kernel"`), `status` (`"present"`/`"absent"`), `package_name` (`amdgpu-dkms`/`amdgpu-kmod`/null), `package_version`, `package_manager` (`"dpkg"`/`"rpm"`/null), `module_version`, `module_srcversion`, `kmd_version`, `kfd_device_present`, `kfd_sysfs_present`. **HOST-KERNEL SCOPE applies only to `kfd_device_present`/`kfd_sysfs_present`/`kmd_version`**: the amdgpu KMD + KFD live in the host kernel a container *shares*, so these three fields report the **host's** driver even from inside a container — complementary to `rocm`/`hip` which read the container's `/opt/rocm` userspace. **`package_name`/`package_version`/`package_manager` and `module_version`/`module_srcversion` are NOT host-guaranteed** — dpkg/rpm and `modinfo` read the *current filesystem's* package DB and `/lib/modules`, so from inside a container these reflect the container's own (typically driver-less) view even while the three fields above still show the host's driver as present. **Documented absence**: a GPU-less host → `status:"absent"` with NO `partial`. Only a *conflict* — KMD loaded (`/dev/kfd` or `modinfo` present) but no dpkg/rpm package resolvable — records a `partial_reason`. Package lookup is a portable dpkg-then-rpm query parsed in Python (no shell pipe). |
 | `hip` | `dict[str, str \| null]` | `hipconfig --version/--platform/--compiler/--runtime/--cpp_config` | five subprocesses; `--version` and `--platform` cannot be combined (no delimiter) |
 | `hipblaslt` | `dict` | header parse + `sha256(libhipblaslt.so)` + sorted-filenames hash of `lib/hipblaslt/library/*` | `rocm_release_tweak` (NOT a per-hipBLASLt commit -- it's the ROCm release identifier shared across every library in a release; see note below), `package_version`, `lib_hash`, `kernel_db_revision`, `applied_prs: {}` |
 | `rocblas` | `dict` | header parse + `sha256(librocblas.so)` + sorted-filenames hash of `lib/rocblas/library/*` | Same shape as `hipblaslt`. Header lives at `include/rocblas/internal/rocblas-version.h`. |
@@ -434,7 +435,50 @@ Mirrors the in-code comment at `SCHEMA_VERSION` in
 `src/aorta/instrumentation/environment.py`. Recorded here so consumers
 tracking schema evolution don't have to read source.
 
-### `1.9` (current)
+### `1.10` (current)
+
+Host/container runtime split, part 1: KFD/AMDGPU kernel-mode-driver
+identity. Additive — one new top-level block, defaulted so older readers
+don't raise.
+
+* New top-level **`amdgpu_driver`** block, always present (defaulted via
+  `_empty_amdgpu_driver()`). **Host-kernel scope — three fields only**:
+  `kfd_device_present`, `kfd_sysfs_present`, and `kmd_version` reflect the
+  host kernel a container shares, so they report the *host's* driver even
+  when the probe runs inside a container — the deliberate counterpart to
+  `rocm`/`hip`, which read the container's `/opt/rocm` userspace. This is
+  what lets a single in-process probe separate a "host runtime" signal
+  from a "container runtime" signal without a second invocation or
+  privileged access.
+* **Not host-guaranteed**: `package_name`/`package_version`/
+  `package_manager` (dpkg/rpm) and `module_version`/`module_srcversion`
+  (`modinfo`) read the *current filesystem's* package database and
+  `/lib/modules`. From inside a container these reflect the container's
+  own view — typically null, since the amdgpu driver package is normally
+  installed only on the host — even while `kfd_device_present` and
+  `kmd_version` correctly show the host driver as present. Treat these
+  two field groups as filesystem-scoped, not host-scoped.
+* Fields: `scope` (constant `"host_kernel"` — describes the block's
+  intent, not a per-field guarantee; see the two bullets above), `status`
+  (`"present"`/`"absent"`), `package_name` / `package_version` /
+  `package_manager` (portable **dpkg-then-rpm** query over `amdgpu-dkms`
+  then `amdgpu-kmod`, parsed in Python — no shell pipeline), `module_version`
+  / `module_srcversion` (`modinfo amdgpu`), `kmd_version` (reused verbatim
+  from `rocm.kmd_version` so the two blocks never disagree),
+  `kfd_device_present` / `kfd_sysfs_present` (`/dev/kfd` + `/sys/class/kfd`
+  existence checks — no `open()`, no `ioctl`, no GPU compute).
+* **Documented absence, not partial**: a GPU-less host records
+  `status:"absent"` with an empty `partial_reasons`, mirroring the `nics`
+  vendor-absent precedent. The only reason this block ever appends is a
+  *conflict*: the KMD is demonstrably loaded (`/dev/kfd` or `modinfo`
+  present) yet no dpkg/rpm package can be named — an unusual, diagnosable
+  state (out-of-band driver install, stripped package DB).
+* Backwards-compat: `EnvSnapshot.amdgpu_driver` uses a `default_factory`,
+  so a ≤1.9 snapshot round-trips via `from_dict()` (back-filled with the
+  empty/absent block). A 1.9 reader indexing `amdgpu_driver` on a pre-1.10
+  snapshot gets that back-filled block, not a `KeyError`.
+
+### `1.9`
 
 Static kernel-catalog "recipe books" for the on-disk, runtime-selected
 GPU-compute catalogs (issue #54 + follow-ups). All additive: three new
@@ -981,6 +1025,10 @@ sources are:
 | `rocm.version` | `/opt/rocm/.info/version` |
 | `rocm.version_dev` | `/opt/rocm/.info/version-dev` (often empty on developer builds) |
 | `rocm.kmd_version` | `/sys/module/amdgpu/version` (kernel module sysfs) |
+| `amdgpu_driver.package_version` / `.package_name` / `.package_manager` | `dpkg-query -W -f='${Version}' amdgpu-dkms` (Debian/Ubuntu), falling back to `rpm -q --qf '%{VERSION}-%{RELEASE}' amdgpu-dkms` then `amdgpu-kmod` (RHEL/SLES). First hit wins; `null` when no package manager names the driver. |
+| `amdgpu_driver.module_version` / `.module_srcversion` | `modinfo amdgpu` `version:` / `srcversion:` fields (module metadata; does not load the module or touch the GPU). `srcversion` is a source hash — it changes on a rebuild even when `version` doesn't. |
+| `amdgpu_driver.kmd_version` | reused verbatim from `rocm.kmd_version` (`/sys/module/amdgpu/version`) — no second read, so the two blocks can never disagree |
+| `amdgpu_driver.kfd_device_present` / `.kfd_sysfs_present` | existence of `/dev/kfd` / `/sys/class/kfd` (pure `Path.exists()`, never opened) |
 | `hip.*` | `hipconfig --version` / `--platform` / `--compiler` / `--runtime` / `--cpp_config` |
 | `hipblaslt.rocm_release_tweak` | `HIPBLASLT_VERSION_TWEAK` define in `/opt/rocm/include/hipblaslt/hipblaslt-version.h` |
 | `hipblaslt.package_version` | `HIPBLASLT_VERSION_{MAJOR,MINOR,PATCH}` defines in the same header |

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -129,7 +129,7 @@ operator can act on them without `jq`'ing the JSON. A closing
 end-of-output. Sample:
 
 ```text
-Wrote env probe to /tmp/env.json (schema_version=1.9) [PARTIAL]
+Wrote env probe to /tmp/env.json (schema_version=1.10) [PARTIAL]
   runtime:   baremetal / python=venv
   build_sys: none
   rocm:      7.2.1 (dev: None)
@@ -220,13 +220,13 @@ unexpected failure. Callers always get back a valid, fully-shaped
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | Currently `"1.9"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
+| `schema_version` | `str` | constant | Currently `"1.10"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
 | `system_health` | `dict \| null` | `rdhc --quick --json` (subprocess) | verbatim parsed JSON; `null` when rdhc absent / sudo unavailable / timeout / malformed |
 | `rocm` | `dict[str, str \| null]` | `/opt/rocm/.info/version{,_dev}`, `/sys/module/amdgpu/version` | `version`, `version_dev`, `kmd_version` |
-| `amdgpu_driver` | `dict` | `dpkg-query`/`rpm` (package), `modinfo amdgpu` (module), `/sys/module/amdgpu/version` (reused from `rocm.kmd_version`), `/dev/kfd` + `/sys/class/kfd` (existence) | Schema 1.10. `scope` (constant `"host_kernel"`), `status` (`"present"`/`"absent"`), `package_name` (`amdgpu-dkms`/`amdgpu-kmod`/null), `package_version`, `package_manager` (`"dpkg"`/`"rpm"`/null), `module_version`, `module_srcversion`, `kmd_version`, `kfd_device_present`, `kfd_sysfs_present`. **HOST-KERNEL SCOPE applies only to `kfd_device_present`/`kfd_sysfs_present`/`kmd_version`**: the amdgpu KMD + KFD live in the host kernel a container *shares*, so these three fields report the **host's** driver even from inside a container — complementary to `rocm`/`hip` which read the container's `/opt/rocm` userspace. **`package_name`/`package_version`/`package_manager` and `module_version`/`module_srcversion` are NOT host-guaranteed** — dpkg/rpm and `modinfo` read the *current filesystem's* package DB and `/lib/modules`, so from inside a container these reflect the container's own (typically driver-less) view even while the three fields above still show the host's driver as present. **Documented absence**: a GPU-less host → `status:"absent"` with NO `partial`. Only a *conflict* — KMD loaded (`/dev/kfd` or `modinfo` present) but no dpkg/rpm package resolvable — records a `partial_reason`. Package lookup is a portable dpkg-then-rpm query parsed in Python (no shell pipe). |
+| `amdgpu_driver` | `dict` | `dpkg-query`/`rpm` (package), `modinfo amdgpu` (module), `/sys/module/amdgpu/version` (reused from `rocm.kmd_version`), `/dev/kfd` + `/sys/class/kfd` (existence) | Schema 1.10. `scope` (constant `"host_kernel"`), `status` (`"present"`/`"absent"`), `package_name` (stable candidate family `amdgpu-dkms`/`amdgpu-kmod`/null), `package_version`, `package_full_name` (complete canonical identity — apt `name=version` or rpm NVRA — capturing kernel-suffixed package names like `amdgpu-kmod-6.9.0-…_g9b20106afb70-6.14.14.000000-2226257.1.x86_64` that `package_name` alone drops; the single field two host snapshots diff on), `package_manager` (`"dpkg"`/`"rpm"`/null), `module_version`, `module_srcversion`, `kmd_version`, `kfd_device_present`, `kfd_sysfs_present`. **HOST-KERNEL SCOPE applies only to `kfd_device_present`/`kfd_sysfs_present`/`kmd_version`**: the amdgpu KMD + KFD live in the host kernel a container *shares*, so these three fields report the **host's** driver even from inside a container — complementary to `rocm`/`hip` which read the container's `/opt/rocm` userspace. **`package_name`/`package_version`/`package_full_name`/`package_manager` and `module_version`/`module_srcversion` are NOT host-guaranteed** — dpkg/rpm and `modinfo` read the *current filesystem's* package DB and `/lib/modules`, so from inside a container these reflect the container's own (typically driver-less) view even while the three fields above still show the host's driver as present. **Documented absence**: a GPU-less host → `status:"absent"` with NO `partial`. Only a *conflict* — amdgpu module loaded (`modinfo` metadata present) but no dpkg/rpm package resolvable — records a `partial_reason`; `/dev/kfd` alone never does, since a passthrough container legitimately has the host's KFD node without a container-local package. Package lookup is a portable, **glob-capable** dpkg-then-rpm query parsed in Python (no shell pipe), so kernel-suffixed RPM names are matched. |
 | `hip` | `dict[str, str \| null]` | `hipconfig --version/--platform/--compiler/--runtime/--cpp_config` | five subprocesses; `--version` and `--platform` cannot be combined (no delimiter) |
 | `hipblaslt` | `dict` | header parse + `sha256(libhipblaslt.so)` + sorted-filenames hash of `lib/hipblaslt/library/*` | `rocm_release_tweak` (NOT a per-hipBLASLt commit -- it's the ROCm release identifier shared across every library in a release; see note below), `package_version`, `lib_hash`, `kernel_db_revision`, `applied_prs: {}` |
 | `rocblas` | `dict` | header parse + `sha256(librocblas.so)` + sorted-filenames hash of `lib/rocblas/library/*` | Same shape as `hipblaslt`. Header lives at `include/rocblas/internal/rocblas-version.h`. |
@@ -237,8 +237,8 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `host` | `dict` | `os.uname()` + `os.confstr("CS_GNU_LIBC_VERSION")` | `kernel_release`, `kernel_version`, `machine`, `glibc_version`. Kernel + glibc drift is the #1 confound for compiled-against-vs-runtime issues with C++ extensions. |
 | `composable_kernel` | `dict` | header at `include/ck/version.h` + `nm -D` of `libtorch_hip.so` piped through `c++filt` + `torch.__config__.show()` flag scan | Two sub-blocks (`system: {version, commit, ck_tile_present}`, `pytorch_bundled: {present, symbol_count}`) plus top-level `pytorch_use_ck_sdpa` / `pytorch_use_ck_gemm` booleans (build-time flags baked into the wheel; NOT runtime env vars). System and bundled CK can drift independently. |
 | `tensile` | `dict` | optional `import Tensile` + sorted-filenames hash over the union of hipBLASLt + rocBLAS kernel DBs | `package_version` (usually `null` outside builders), `kernel_db_combined_hash` |
-| `tensile_catalog` | `dict` | reuses the `hipblaslt`/`rocblas`/`tensile` captures + a new per-file enumeration of `lib/{hipblaslt,rocblas}/library/*` | **The "recipe book" -- installed-library identity, NOT the runtime-selected solution ID.** Top-level `doc` + `status`. Per-library `hipblaslt`/`rocblas` carry the existing `package_version`/`lib_hash`/`kernel_db_revision` (no regression) plus a `menu` sub-block: `status`, `reason`, `dir`, `logic_file_count` (`.dat`/`.yaml`), `file_count`, `gfx_arch_coverage`, `files` (per-file `{name,size,suffix,is_logic,sha256}`), and `combined_content_hash`. `combined` mirrors the `tensile` block. Partial-not-silent: a dir that can't be located/listed is `status:"partial"` (distinct from a present-but-empty menu, which is `ok` with `logic_file_count:0`). Added in schema 1.9 (issue #54). |
-| `miopen_catalog` | `dict` | reuses the `miopen` capture + a per-file enumeration of the MIOpen db dir (`share/miopen/db/`) | **Recipe book for MIOpen's convolution databases** -- same scoping as `tensile_catalog`. `doc` + `status`, the reused `package_version`/`lib_hash`/`kernel_db_revision` (no regression), `db_dir` + `db_dir_source` (`default` or `MIOPEN_SYSTEM_DB_PATH`), `env_overrides`, and a `menu`. `logic_file_count` counts the selectable DBs (`.kdb`/`.fdb.txt`/`.db.txt`/`.db`); `.ktn.model`/`.tn.model` heuristic models are catalog members but not logic. Added in schema 1.9 (issue #54 follow-up). |
+| `tensile_catalog` | `dict` | reuses the `hipblaslt`/`rocblas`/`tensile` captures + a new per-file enumeration of `lib/{hipblaslt,rocblas}/library/*` | **The "recipe book" -- installed-library identity, NOT the runtime-selected solution ID.** Top-level `doc` + `status`. Per-library `hipblaslt`/`rocblas` carry the existing `package_version`/`lib_hash`/`kernel_db_revision` (no regression) plus a `menu` sub-block: `status`, `reason`, `dir`, `logic_file_count` (`.dat`/`.yaml`), `file_count`, `gfx_arch_coverage`, `files` (per-file `{name,size,suffix,is_logic,sha256}`), and `combined_content_hash`. `combined` mirrors the `tensile` block. **`files` is `null` by default (compact mode)** — the per-file lists dominate env.json size (~25k lines on a populated host), so the default probe drops them while keeping every count and `combined_content_hash` (a diff still detects a changed catalog); run `aorta env probe --extended` to retain the full per-file list for localizing *which* file changed. Partial-not-silent: a dir that can't be located/listed is `status:"partial"` (distinct from a present-but-empty menu, which is `ok` with `logic_file_count:0`). Added in schema 1.9 (issue #54); compact default added in schema 1.10. |
+| `miopen_catalog` | `dict` | reuses the `miopen` capture + a per-file enumeration of the MIOpen db dir (`share/miopen/db/`) | **Recipe book for MIOpen's convolution databases** -- same scoping as `tensile_catalog`. `doc` + `status`, the reused `package_version`/`lib_hash`/`kernel_db_revision` (no regression), `db_dir` + `db_dir_source` (`default` or `MIOPEN_SYSTEM_DB_PATH`), `env_overrides`, and a `menu`. `logic_file_count` counts the selectable DBs (`.kdb`/`.fdb.txt`/`.db.txt`/`.db`); `.ktn.model`/`.tn.model` heuristic models are catalog members but not logic. **`menu.files` is `null` by default (compact mode)** — same size rationale as `tensile_catalog`; use `aorta env probe --extended` to retain the per-file list. Added in schema 1.9 (issue #54 follow-up); compact default added in schema 1.10. |
 | `rocfft_catalog` | `dict` | optional `rocfft_kernel_cache.db` under `$ROCFFT_RTC_SYS_CACHE_PATH` or `/opt/rocm/lib/[rocfft/]` | Fingerprint of rocFFT's **optional** AOT kernel cache -- the READ-ONLY system cache, not the read-write runtime user cache. rocFFT usually compiles at runtime, so absence is normal: a *probed* "no cache" result is `status:"absent"` with **no** partial reason. (The default/backfill/disaster shape is `status:"partial"` with a "not captured" reason instead, so a snapshot that never probed is distinguishable from one that probed and found nothing.) `doc` + `status` (`ok`/`absent`/`partial`) + `env_overrides` (both `ROCFFT_RTC_SYS_CACHE_PATH` -- the override this catalog actually resolves against -- and `ROCFFT_RTC_CACHE_PATH`, recorded for visibility only since it names the mutable, workload-dependent user cache, not installed identity; both recorded even when no cache is found so a configured-but-empty override is visible) + `kernel_cache` (`present`, `path`, `source`, `size`, `sha256`, `reason`). Added in schema 1.9 (issue #54 follow-up). |
 | `triton` | `dict` | `import triton; triton.__version__` (+ commit parse) | `package_version`, `commit` (schema 1.8). ROCm Triton fork bakes the source commit into `__version__` (e.g. `3.5.1+rocm7.2.1.gita272dfa8` -> `commit: "a272dfa8"`); fb builds versioned `+fb` carry no SHA -> `commit: null`. |
 | `fbgemm` | `dict` | optional `import fbgemm_gpu` (+ commit parse) + parse of `torch.__config__.show()` for `-DUSE_FBGEMM*` defines | `package_version`, `commit` (schema 1.8 -- best-effort git SHA from a setuptools_scm `+g<sha>` local-version segment or a `git_version`/`__commit__` module attr; `null` when fbgemm_gpu is vendored-in-torch rather than separately installed, or carries no SHA), `pytorch_use_fbgemm`, `pytorch_use_fbgemm_genai`. The two booleans capture the build-time decision baked into the PyTorch wheel even when `fbgemm_gpu` isn't a separate pip package. |
@@ -460,23 +460,56 @@ don't raise.
   two field groups as filesystem-scoped, not host-scoped.
 * Fields: `scope` (constant `"host_kernel"` — describes the block's
   intent, not a per-field guarantee; see the two bullets above), `status`
-  (`"present"`/`"absent"`), `package_name` / `package_version` /
-  `package_manager` (portable **dpkg-then-rpm** query over `amdgpu-dkms`
-  then `amdgpu-kmod`, parsed in Python — no shell pipeline), `module_version`
+  (`"present"`/`"absent"`), `package_name` (stable candidate family) /
+  `package_version` / `package_full_name` / `package_manager` (portable,
+  **glob-capable dpkg-then-rpm** query over `amdgpu-dkms` then
+  `amdgpu-kmod`, parsed in Python — no shell pipeline), `module_version`
   / `module_srcversion` (`modinfo amdgpu`), `kmd_version` (reused verbatim
   from `rocm.kmd_version` so the two blocks never disagree),
   `kfd_device_present` / `kfd_sysfs_present` (`/dev/kfd` + `/sys/class/kfd`
   existence checks — no `open()`, no `ioctl`, no GPU compute).
+* **`package_full_name`** is the complete canonical package identity — apt
+  `name=version` on Debian, or the rpm NVRA
+  (`amdgpu-kmod-6.9.0-…_g9b20106afb70-6.14.14.000000-2226257.1.x86_64`) on
+  RHEL/SLES. Some vendors bake the kernel release into the RPM *package
+  name*, which an exact `rpm -q amdgpu-kmod` misses entirely; the query
+  uses a glob (`rpm -qa 'amdgpu-kmod*'`) to catch these and reconstructs
+  the full identity so two host snapshots can be diffed on one field.
+  `package_name` stays the stable family label (`amdgpu-dkms`/`amdgpu-kmod`)
+  so it remains a clean grouping key across hosts with different suffixes.
 * **Documented absence, not partial**: a GPU-less host records
   `status:"absent"` with an empty `partial_reasons`, mirroring the `nics`
   vendor-absent precedent. The only reason this block ever appends is a
-  *conflict*: the KMD is demonstrably loaded (`/dev/kfd` or `modinfo`
-  present) yet no dpkg/rpm package can be named — an unusual, diagnosable
-  state (out-of-band driver install, stripped package DB).
+  *same-filesystem conflict*: the amdgpu module is demonstrably loaded
+  (`modinfo` metadata present) yet no dpkg/rpm package on the same
+  filesystem can be named — an unusual, diagnosable state (out-of-band
+  driver install, stripped package DB). `/dev/kfd` alone never triggers a
+  reason: it is host-kernel state passed into a container, so a container
+  with the host's KFD node but no container-local package is the normal
+  case, not a conflict.
 * Backwards-compat: `EnvSnapshot.amdgpu_driver` uses a `default_factory`,
   so a ≤1.9 snapshot round-trips via `from_dict()` (back-filled with the
   empty/absent block). A 1.9 reader indexing `amdgpu_driver` on a pre-1.10
   snapshot gets that back-filled block, not a `KeyError`.
+* **Compact catalog default + `--extended`.** The default `aorta env probe`
+  now drops the per-file `menu.files` lists from `tensile_catalog` and
+  `miopen_catalog` (setting them to `null`) — these dominated env.json
+  size (~25k lines on a populated host). Every summary field is kept:
+  `status`, `dir`, `file_count`, `logic_file_count`, `gfx_arch_coverage`,
+  and `combined_content_hash`, so a two-host diff still detects *that* a
+  catalog changed. `aorta env probe --extended` (or `collect_env(detail=
+  "full")`) restores the complete per-file lists for forensic follow-up
+  (localizing *which* recipe/db file changed). The files are hashed either
+  way — `combined_content_hash` requires it — so `--extended` only controls
+  retention of the per-file breakdown, not probe work. This is a shape
+  change to the *default output*, not a schema-field removal: the `files`
+  key is still present (as `null`), so readers indexing it are unaffected.
+* **Thematic output order.** `env.json` keys (and the CLI brief lines) are
+  now grouped by theme — host/kernel, then ROCm runtime + `amdgpu_driver`
+  driver, then GPU/fabric hardware, then compute libraries, then build,
+  then pytorch — instead of dataclass declaration order, so related
+  environment facts sit next to each other for readability and diffing.
+  Key *set* is unchanged; only ordering moved.
 
 ### `1.9`
 

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -509,7 +509,9 @@ don't raise.
   driver, then GPU/fabric hardware, then compute libraries, then build,
   then pytorch — instead of dataclass declaration order, so related
   environment facts sit next to each other for readability and diffing.
-  Key *set* is unchanged; only ordering moved.
+  `partial` / `partial_reasons` moved to the **end** of the object (a
+  probe-status trailer) so the potentially long reasons list doesn't push
+  the identity blocks down. Key *set* is unchanged; only ordering moved.
 
 ### `1.9`
 

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -71,6 +71,17 @@ def env() -> None:
     ),
 )
 @click.option(
+    "--extended",
+    is_flag=True,
+    help=(
+        "Keep the full per-file kernel-catalog lists (tensile_catalog / "
+        "miopen_catalog menu.files) in the JSON. Default (compact) drops "
+        "them -- they dominate env.json size -- but keeps every count and "
+        "content hash, so a diff still detects a changed catalog; "
+        "--extended localizes which file changed."
+    ),
+)
+@click.option(
     "--buck-target",
     type=str,
     default=None,
@@ -101,6 +112,7 @@ def probe(
     verbose: bool,
     summary: bool,
     field_path: str | None,
+    extended: bool,
     buck_target: str | None,
     buck_timeout: int,
 ) -> None:
@@ -117,8 +129,13 @@ def probe(
     # Capture once; both short-circuit modes and the default mode read
     # from this single snapshot. Buck-related kwargs flow through to
     # collect_env() regardless of output mode -- the buck audit cost
-    # is paid only when --buck-target is set.
-    snapshot = collect_env(buck_target=buck_target, buck_timeout=buck_timeout)
+    # is paid only when --buck-target is set. detail="full" only when
+    # --extended: keeps the heavy per-file catalog lists in the snapshot.
+    snapshot = collect_env(
+        buck_target=buck_target,
+        buck_timeout=buck_timeout,
+        detail="full" if extended else "compact",
+    )
     snapshot_dict = snapshot.to_dict()
 
     # --field: print one value as JSON and exit. Skips the file write

--- a/src/aorta/instrumentation/_probe_main.py
+++ b/src/aorta/instrumentation/_probe_main.py
@@ -16,6 +16,10 @@ indistinguishable from a local-env one on disk.
 
 With no argument (or ``-``) the JSON goes to stdout, so the module also
 works as ``docker exec ... > env.json`` without a bind mount.
+
+Pass ``--extended`` to retain the full per-file kernel-catalog lists
+(matching ``aorta env probe --extended``); the default is the compact
+snapshot that drops those lists to keep the artifact small.
 """
 
 from __future__ import annotations
@@ -27,11 +31,22 @@ from aorta.instrumentation.environment import collect_env
 
 
 def main(argv: list[str]) -> int:
-    """Capture the snapshot and write it to ``argv[1]`` (or stdout)."""
-    snapshot_dict = collect_env().to_dict()
+    """Capture the snapshot and write it to the output path (or stdout).
+
+    Recognizes a ``--extended`` flag (anywhere in argv) for the full
+    per-file catalog detail; the first remaining non-flag argument is the
+    output path (``-`` or absent -> stdout).
+    """
+    args = argv[1:]
+    extended = "--extended" in args
+    positional = [a for a in args if a != "--extended"]
+
+    snapshot_dict = collect_env(
+        detail="full" if extended else "compact"
+    ).to_dict()
     text = json.dumps(snapshot_dict, indent=2)
 
-    out = argv[1] if len(argv) > 1 and argv[1] != "-" else None
+    out = positional[0] if positional and positional[0] != "-" else None
     if out is None:
         sys.stdout.write(text + "\n")
         return 0

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -1021,8 +1021,6 @@ class EnvSnapshot:
         # meta
         "schema_version",
         "captured_at",
-        "partial",
-        "partial_reasons",
         # host / kernel / runtime placement
         "host",
         "runtime_context",
@@ -1060,6 +1058,12 @@ class EnvSnapshot:
         # misc / process-level
         "env_vars",
         "system_health",
+        # probe-status trailer: kept last so the (potentially long)
+        # partial_reasons list doesn't push the identity blocks down --
+        # a reader opening env.json sees the environment facts first and
+        # the fallback log at the bottom.
+        "partial",
+        "partial_reasons",
     )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -78,7 +78,36 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.9"
+SCHEMA_VERSION = "1.10"
+# 1.9 -> 1.10 (host/container runtime split, part 1): KFD/AMDGPU
+# kernel-mode-driver identity.
+#   - New top-level ``amdgpu_driver`` block, always present (defaulted via
+#     ``_empty_amdgpu_driver()``). HOST-KERNEL SCOPE for ``kfd_device_present``
+#     / ``kfd_sysfs_present`` / ``kmd_version``: the amdgpu KMD and KFD live
+#     in the host kernel a container shares, so these three fields report
+#     the *host's* driver even from inside a container -- complementary to
+#     ``rocm``/``hip`` which read the container's ``/opt/rocm`` userspace.
+#     ``package_name`` / ``package_version`` / ``package_manager`` and
+#     ``module_version`` / ``module_srcversion`` are NOT host-guaranteed:
+#     dpkg/rpm and ``modinfo`` read the *current filesystem's* package DB
+#     and ``/lib/modules``, which is the container's own view when probed
+#     from inside one, and will commonly be null there even though the
+#     three host-kernel fields above are populated. Fields: ``scope``
+#     (constant ``"host_kernel"`` -- describes the block's intent, not a
+#     per-field guarantee; see caveat above), ``status``
+#     (``"present"``/``"absent"``), ``package_name`` / ``package_version``
+#     / ``package_manager`` (portable dpkg-then-rpm query over
+#     ``amdgpu-dkms`` / ``amdgpu-kmod``), ``module_version`` /
+#     ``module_srcversion`` (``modinfo amdgpu``), ``kmd_version`` (reused
+#     verbatim from ``rocm.kmd_version``), ``kfd_device_present`` /
+#     ``kfd_sysfs_present`` (``/dev/kfd`` + ``/sys/class/kfd`` existence).
+#     A GPU-less host is a DOCUMENTED ABSENCE (``status="absent"``, no
+#     ``partial``); only a KMD-loaded-but-unpackaged conflict records a
+#     reason. Additive: ``EnvSnapshot.amdgpu_driver`` uses a
+#     ``default_factory`` so a <=1.9 snapshot still round-trips via
+#     ``from_dict``. 1.9 readers indexing ``amdgpu_driver`` on a pre-1.10
+#     snapshot get the back-filled empty block.
+#
 # 1.8 -> 1.9 (issue #54 + follow-ups): static kernel-catalog "recipe
 # books" for the on-disk, runtime-selected GPU-compute catalogs.
 #   - New top-level ``tensile_catalog`` block (issue #54), always present
@@ -462,6 +491,32 @@ ROCM_VERSION_DEV_FILE = Path("/opt/rocm/.info/version-dev")    # full build, e.g
 # Linux kernel-side AMDGPU module version (KMD = kernel-mode driver).
 # Provided by the kernel since the amdgpu module exposes a sysfs `version`.
 KMD_VERSION_FILE = Path("/sys/module/amdgpu/version")          # e.g. "6.16.13"
+
+# KFD / AMDGPU kernel-mode-driver identity (schema 1.10, host-kernel scope).
+# CRITICAL host/container semantic: the amdgpu KMD and the KFD (Kernel
+# Fusion Driver) live in the HOST kernel, which a container SHARES. So
+# these paths report the *host's* driver even when the probe runs inside
+# a container -- the opposite of /opt/rocm (userspace, reflects the
+# container filesystem). That asymmetry is exactly what makes a single
+# in-process probe able to separate a "host runtime" signal from a
+# "container runtime" signal without a second invocation.
+#
+# /dev/kfd is the compute device node the ROCm userspace opens; its
+# presence means the driver is loaded AND exposed to this
+# process/container. /sys/class/kfd is the sysfs face of the same driver.
+# Both are pure existence checks -- no open(), no ioctl, no GPU compute.
+KFD_DEVICE_NODE = Path("/dev/kfd")
+KFD_SYSFS_DIR = Path("/sys/class/kfd")
+# AMDGPU kernel module name for ``modinfo`` -- gives a package-database-
+# independent build identity (``version`` + ``srcversion``) that works
+# even in stripped containers with no dpkg/rpm metadata.
+AMDGPU_MODULE_NAME = "amdgpu"
+# Debian/Ubuntu (dpkg) is the flagship ROCm target -- every Dockerfile in
+# docker/ is Ubuntu-based. RHEL/SLES (rpm) is the secondary target. The
+# candidate package names AMD ships the KMD under, most specific first:
+# amdgpu-dkms (DKMS source build, the common case) then amdgpu-kmod
+# (prebuilt kmod, RHEL). We deliberately do NOT match amdgpu-*firmware.
+AMDGPU_PACKAGE_CANDIDATES: tuple[str, ...] = ("amdgpu-dkms", "amdgpu-kmod")
 
 # hipBLASLt build identity sources. The version header ships in the
 # hipblaslt-dev package; on hosts without it, _capture_hipblaslt's commit
@@ -924,6 +979,14 @@ class EnvSnapshot:
     rocfft_catalog: dict = field(
         default_factory=lambda: _empty_rocfft_catalog()
     )
+    # amdgpu_driver: host/container split part 1 (schema 1.10). Host-kernel
+    # scope KFD/AMDGPU driver identity. Defaulted (empty/absent block) so
+    # pre-1.10 constructors and ``from_dict()`` on older snapshots don't
+    # raise. Populated by ``_capture_amdgpu_driver()`` in collect_env() /
+    # ``_disaster_snapshot()``.
+    amdgpu_driver: dict = field(
+        default_factory=lambda: _empty_amdgpu_driver()
+    )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to the env.json shape. Round-trip pair with from_dict."""
@@ -963,6 +1026,7 @@ class EnvSnapshot:
         kwargs.setdefault("tensile_catalog", _empty_tensile_catalog())
         kwargs.setdefault("miopen_catalog", _empty_miopen_catalog())
         kwargs.setdefault("rocfft_catalog", _empty_rocfft_catalog())
+        kwargs.setdefault("amdgpu_driver", _empty_amdgpu_driver())
         return cls(**kwargs)
 
     def summary(self) -> str:
@@ -996,6 +1060,7 @@ class EnvSnapshot:
         nics = self.nics or {}
         gpu_arch = self.gpu_arch or {}
         host = self.host or {}
+        amdgpu = self.amdgpu_driver or {}
         # Use ``is not None`` -- RDHC may return an empty dict on a healthy
         # host with nothing to report, which is still a successful capture
         # and must NOT be summarised as "unavailable".
@@ -1083,6 +1148,15 @@ class EnvSnapshot:
                 f"  host:      kernel={host.get('kernel_release') or '?'} "
                 f"machine={host.get('machine') or '?'}  "
                 f"glibc={host.get('glibc_version') or '?'}",
+                # amdgpu_driver is HOST-KERNEL scope: even inside a
+                # container this reflects the shared host driver, unlike the
+                # rocm/hip lines above (container userspace). "absent" is
+                # the normal reading on a GPU-less box.
+                f"  amdgpu:    {amdgpu.get('status') or '?'} "
+                f"pkg={amdgpu.get('package_name') or '?'}={amdgpu.get('package_version') or '?'} "
+                f"({amdgpu.get('package_manager') or '?'})  "
+                f"kmd={amdgpu.get('kmd_version') or '?'}  "
+                f"kfd={'yes' if amdgpu.get('kfd_device_present') else 'no'}",
                 # CK has two layers -- system headers (composablekernel-dev
                 # apt pkg) and the copy compiled into libtorch_hip.so via
                 # PyTorch's third_party/composable_kernel submodule. Both
@@ -1760,6 +1834,10 @@ def collect_env(
         runtime_context = _detect_runtime_context()  # never partial; always populates
         system_health = _run_rdhc(reasons)
         rocm = _capture_rocm_version_files(reasons)
+        # Host-kernel scope: reuses rocm's kmd_version read (no second file
+        # read) + package/modinfo/KFD-node probes. Absent on GPU-less hosts
+        # without a partial (documented absence).
+        amdgpu_driver = _capture_amdgpu_driver(rocm, reasons)
         hip = _capture_hip_toolchain(reasons)
         hipblaslt = _capture_hipblaslt(reasons)
         rocblas = _capture_rocblas(reasons)
@@ -1827,6 +1905,7 @@ def collect_env(
             hip=hip,
             hipblaslt=hipblaslt,
             rocblas=rocblas,
+            amdgpu_driver=amdgpu_driver,
             composable_kernel=composable_kernel,
             tensile=tensile,
             tensile_catalog=tensile_catalog,
@@ -1899,6 +1978,7 @@ def _disaster_snapshot(
         captured_at=captured_at,
         system_health=None,
         rocm={"version": None, "version_dev": None, "kmd_version": None},
+        amdgpu_driver=_empty_amdgpu_driver(),
         hip={
             "version": None,
             "platform": None,
@@ -6881,6 +6961,231 @@ def _capture_gpu_arch(reasons: list[str]) -> dict[str, Any]:
         "gfx_targets": sorted(set(targets)),
         "agent_arch_counts": dict(sorted(counts.items())),
     }
+
+
+def _query_package_version(package: str) -> tuple[str, str] | None:
+    """Look up an installed system package's version, distro-portable.
+
+    Tries Debian/Ubuntu ``dpkg-query`` first (the flagship ROCm target;
+    every Dockerfile in ``docker/`` is Ubuntu-based), then RHEL/SLES
+    ``rpm``. Returns ``(version, package_manager)`` on the first hit, or
+    ``None`` when the package is not installed under any known manager.
+
+    Matches the module's subprocess contract exactly: ``shutil.which()``
+    gate, ``subprocess.run([...], check=False, timeout=SHORT_TIMEOUT_SEC)``,
+    parsing in Python -- NO shell pipeline. (The RHEL-only
+    ``rpm -qa | grep | sed`` one-liner some operators reach for is both
+    non-portable and outside this contract; a direct ``-qf`` query is the
+    portable, testable equivalent.) Never raises.
+    """
+    # dpkg-query -W -f='${Version}' <pkg>: prints the version on stdout and
+    # exits 0 when installed; exits non-zero (and prints to stderr) when
+    # not. The -f template avoids the two-column default output.
+    if shutil.which("dpkg-query") is not None:
+        try:
+            proc = subprocess.run(
+                ["dpkg-query", "-W", "-f=${Version}", package],
+                capture_output=True,
+                text=True,
+                timeout=SHORT_TIMEOUT_SEC,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            log.debug("dpkg-query failed for %s: %s", package, exc)
+        else:
+            if proc.returncode == 0:
+                ver = (proc.stdout or "").strip()
+                if ver:
+                    return (ver, "dpkg")
+
+    # rpm -q --qf '%{VERSION}-%{RELEASE}' <pkg>: same idea for RHEL/SLES.
+    # Including RELEASE captures the distro build/patch suffix that the
+    # candidate `sed 's/\.el.*//'` deliberately discarded -- we keep it,
+    # since that suffix is exactly the kind of host-to-host drift the probe
+    # exists to surface.
+    if shutil.which("rpm") is not None:
+        try:
+            proc = subprocess.run(
+                ["rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", package],
+                capture_output=True,
+                text=True,
+                timeout=SHORT_TIMEOUT_SEC,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            log.debug("rpm -q failed for %s: %s", package, exc)
+        else:
+            # rpm exits 0 and prints "<pkg> is not installed" to STDOUT for
+            # a missing package on some builds, so gate on returncode AND a
+            # non-empty version that doesn't carry the not-installed marker.
+            if proc.returncode == 0:
+                ver = (proc.stdout or "").strip()
+                if ver and "is not installed" not in ver:
+                    return (ver, "rpm")
+
+    return None
+
+
+# ``modinfo amdgpu`` prints ``field:   value`` lines; we want version and
+# srcversion. srcversion is a hash of the module source -- it changes on a
+# rebuild even when the human version string does not, so it is the finer
+# drift signal of the two.
+_MODINFO_FIELD_RE = re.compile(r"^([a-z_]+):\s*(.*)$")
+
+
+def _modinfo_field(module: str, field: str) -> str | None:
+    """Return one ``modinfo <module>`` field value, or None. Fail-soft.
+
+    ``modinfo`` reads the module file on disk (or the running kernel's
+    metadata) -- it does NOT load the module or touch the GPU. which()-gated
+    like every other subprocess here.
+    """
+    if shutil.which("modinfo") is None:
+        return None
+    try:
+        proc = subprocess.run(
+            ["modinfo", module],
+            capture_output=True,
+            text=True,
+            timeout=SHORT_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        log.debug("modinfo %s failed: %s", module, exc)
+        return None
+    if proc.returncode != 0:
+        return None
+    for line in (proc.stdout or "").splitlines():
+        m = _MODINFO_FIELD_RE.match(line)
+        if m and m.group(1) == field:
+            return m.group(2).strip() or None
+    return None
+
+
+def _empty_amdgpu_driver() -> dict[str, Any]:
+    """All-null ``amdgpu_driver`` block for the default / disaster snapshot.
+
+    Same shape ``_capture_amdgpu_driver`` returns when nothing is
+    readable, so the schema is stable across hosts and the dataclass
+    default never diverges from a real (empty) capture. ``status`` is
+    ``"absent"`` -- the honest reading of "we detected no amdgpu signal".
+    """
+    return {
+        "scope": "host_kernel",
+        "status": "absent",
+        "package_name": None,
+        "package_version": None,
+        "package_manager": None,
+        "module_version": None,
+        "module_srcversion": None,
+        "kmd_version": None,
+        "kfd_device_present": False,
+        "kfd_sysfs_present": False,
+    }
+
+
+def _capture_amdgpu_driver(
+    rocm: dict[str, str | None], reasons: list[str]
+) -> dict[str, Any]:
+    """Capture the KFD / AMDGPU kernel-mode-driver identity.
+
+    See the ``KFD_DEVICE_NODE`` constant block for the host/container
+    semantic. Only ``kfd_device_present``, ``kfd_sysfs_present``, and
+    ``kmd_version`` are HOST-KERNEL SCOPE: they reflect the kernel a
+    container shares with its host, so they report the host's driver even
+    from inside a container -- complementary to ``rocm``/``hip`` which read
+    the container's own ``/opt/rocm`` userspace.
+
+    ``package_name`` / ``package_version`` / ``package_manager`` and
+    ``module_version`` / ``module_srcversion`` are NOT host-guaranteed:
+    dpkg/rpm and ``modinfo`` read the *current filesystem's* package
+    database and ``/lib/modules``, so from inside a container these
+    reflect the container's (usually driver-less) view, not the host's,
+    even though the KFD/kmd fields above are still host-accurate.
+
+    Sources, all fail-soft and none requiring a GPU:
+
+    * ``package_version`` / ``package_manager`` / ``package_name`` --
+      ``_query_package_version`` over ``AMDGPU_PACKAGE_CANDIDATES``
+      (dpkg then rpm).
+    * ``module_version`` / ``module_srcversion`` -- ``modinfo amdgpu``.
+    * ``kmd_version`` -- reused verbatim from the already-captured ``rocm``
+      block's ``/sys/module/amdgpu/version`` read (no second file read, so
+      the two blocks can never disagree).
+    * ``kfd_device_present`` / ``kfd_sysfs_present`` -- existence of
+      ``/dev/kfd`` and ``/sys/class/kfd``.
+
+    DOCUMENTED ABSENCE, NOT partial: on a GPU-less host (this dev machine)
+    every signal is missing -> ``status="absent"`` with NO ``partial``
+    reason, mirroring the ``nics`` vendor-absent precedent. We only record
+    a reason when there is a genuine capture *conflict* (a KMD signal
+    exists but the package DB can't name it), which is worth an operator's
+    attention.
+    """
+    block = _empty_amdgpu_driver()
+
+    for candidate in AMDGPU_PACKAGE_CANDIDATES:
+        found = _query_package_version(candidate)
+        if found is not None:
+            block["package_version"], block["package_manager"] = found
+            block["package_name"] = candidate
+            break
+
+    block["module_version"] = _modinfo_field(AMDGPU_MODULE_NAME, "version")
+    block["module_srcversion"] = _modinfo_field(
+        AMDGPU_MODULE_NAME, "srcversion"
+    )
+    # Reuse the rocm block's kmd_version rather than re-reading the sysfs
+    # file, so amdgpu_driver.kmd_version == rocm.kmd_version always.
+    block["kmd_version"] = (rocm or {}).get("kmd_version")
+
+    block["kfd_device_present"] = _path_exists(KFD_DEVICE_NODE)
+    block["kfd_sysfs_present"] = _path_exists(KFD_SYSFS_DIR)
+
+    # "present" iff ANY host-kernel amdgpu signal was observed. On a
+    # GPU-less CPU box all of these are falsey -> absent (documented, no
+    # partial). /dev/kfd or a loaded module or a package hit each prove
+    # the driver stack is on this host.
+    any_signal = any(
+        (
+            block["package_version"],
+            block["module_version"],
+            block["module_srcversion"],
+            block["kmd_version"],
+            block["kfd_device_present"],
+            block["kfd_sysfs_present"],
+        )
+    )
+    block["status"] = "present" if any_signal else "absent"
+
+    # Conflict signal worth a partial: the driver is demonstrably loaded
+    # (KFD node or module metadata present) but no package manager could
+    # name the package. That is an unusual, diagnosable state (out-of-band
+    # driver install, stripped package DB) -- not the ordinary GPU-less or
+    # stripped-container absence, so it earns one reason.
+    kmd_loaded = (
+        block["kfd_device_present"]
+        or block["module_version"] is not None
+        or block["module_srcversion"] is not None
+    )
+    if kmd_loaded and block["package_version"] is None:
+        reasons.append(
+            "amdgpu_driver.package_version: amdgpu KMD is loaded "
+            "(KFD node or amdgpu module metadata present) but no dpkg/rpm "
+            f"package ({'/'.join(AMDGPU_PACKAGE_CANDIDATES)}) could be "
+            "resolved"
+        )
+
+    return block
+
+
+def _path_exists(path: Path) -> bool:
+    """``path.exists()`` that never raises (PermissionError, OSError -> False)."""
+    try:
+        return path.exists()
+    except OSError as exc:
+        log.debug("exists() check failed for %s: %s", path, exc)
+        return False
 
 
 def _capture_host(reasons: list[str]) -> dict[str, Any]:

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -73,7 +73,7 @@ import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 log = logging.getLogger(__name__)
 
@@ -87,19 +87,24 @@ SCHEMA_VERSION = "1.10"
 #     in the host kernel a container shares, so these three fields report
 #     the *host's* driver even from inside a container -- complementary to
 #     ``rocm``/``hip`` which read the container's ``/opt/rocm`` userspace.
-#     ``package_name`` / ``package_version`` / ``package_manager`` and
-#     ``module_version`` / ``module_srcversion`` are NOT host-guaranteed:
-#     dpkg/rpm and ``modinfo`` read the *current filesystem's* package DB
-#     and ``/lib/modules``, which is the container's own view when probed
-#     from inside one, and will commonly be null there even though the
-#     three host-kernel fields above are populated. Fields: ``scope``
-#     (constant ``"host_kernel"`` -- describes the block's intent, not a
-#     per-field guarantee; see caveat above), ``status``
-#     (``"present"``/``"absent"``), ``package_name`` / ``package_version``
-#     / ``package_manager`` (portable dpkg-then-rpm query over
-#     ``amdgpu-dkms`` / ``amdgpu-kmod``), ``module_version`` /
-#     ``module_srcversion`` (``modinfo amdgpu``), ``kmd_version`` (reused
-#     verbatim from ``rocm.kmd_version``), ``kfd_device_present`` /
+#     ``package_name`` / ``package_version`` / ``package_full_name`` /
+#     ``package_manager`` and ``module_version`` / ``module_srcversion``
+#     are NOT host-guaranteed: dpkg/rpm and ``modinfo`` read the *current
+#     filesystem's* package DB and ``/lib/modules``, which is the
+#     container's own view when probed from inside one, and will commonly
+#     be null there even though the three host-kernel fields above are
+#     populated. Fields: ``scope`` (constant ``"host_kernel"`` -- describes
+#     the block's intent, not a per-field guarantee; see caveat above),
+#     ``status`` (``"present"``/``"absent"``), ``package_name`` (stable
+#     candidate family) / ``package_version`` / ``package_full_name``
+#     (complete canonical identity -- apt ``name=version`` or rpm NVRA --
+#     capturing kernel-suffixed names like
+#     ``amdgpu-kmod-6.9.0-..._g9b20106afb70-...`` that a bare candidate
+#     name misses) / ``package_manager`` (portable, glob-capable
+#     dpkg-then-rpm query over ``amdgpu-dkms`` / ``amdgpu-kmod``),
+#     ``module_version`` / ``module_srcversion`` (``modinfo amdgpu``),
+#     ``kmd_version`` (reused verbatim from ``rocm.kmd_version``),
+#     ``kfd_device_present`` /
 #     ``kfd_sysfs_present`` (``/dev/kfd`` + ``/sys/class/kfd`` existence).
 #     A GPU-less host is a DOCUMENTED ABSENCE (``status="absent"``, no
 #     ``partial``); only a KMD-loaded-but-unpackaged conflict records a
@@ -107,6 +112,18 @@ SCHEMA_VERSION = "1.10"
 #     ``default_factory`` so a <=1.9 snapshot still round-trips via
 #     ``from_dict``. 1.9 readers indexing ``amdgpu_driver`` on a pre-1.10
 #     snapshot get the back-filled empty block.
+#   - Compact catalog default: ``collect_env(detail="compact")`` (the
+#     default) drops the per-file ``menu.files`` lists in
+#     ``tensile_catalog`` / ``miopen_catalog`` (set to ``None``) -- they
+#     dominated env.json size (~25k lines). All counts + the per-menu
+#     ``combined_content_hash`` are kept, so a diff still detects a changed
+#     catalog. ``detail="full"`` (CLI ``--extended``) retains the full
+#     lists. NOT a schema-field change: the ``files`` key stays present as
+#     ``None``, so ``from_dict`` and key-set readers are unaffected.
+#   - Output-order regroup: ``to_dict()`` emits keys via a curated
+#     ``_OUTPUT_KEY_ORDER`` (thematic grouping) instead of dataclass
+#     declaration order. Key SET is unchanged; only ordering moved, so it
+#     is not a compatibility-affecting change.
 #
 # 1.8 -> 1.9 (issue #54 + follow-ups): static kernel-catalog "recipe
 # books" for the on-disk, runtime-selected GPU-compute catalogs.
@@ -988,9 +1005,80 @@ class EnvSnapshot:
         default_factory=lambda: _empty_amdgpu_driver()
     )
 
+    # Curated emit order for ``to_dict()`` / ``env.json`` (JSON is written
+    # sort_keys=False, so THIS is the artifact's key order). Grouped so
+    # related environment facts sit next to each other for readability and
+    # diffing, instead of dataclass declaration order -- which is
+    # constrained by Python's "fields with defaults must come last" rule
+    # and so cannot itself express these groups (e.g. amdgpu_driver, an
+    # additive/defaulted field, must be declared near the end but belongs
+    # next to rocm semantically). Groups: meta -> host/runtime -> ROCm
+    # runtime + driver -> GPU hardware -> compute libraries -> build ->
+    # pytorch -> misc. Any field NOT listed here is still emitted (appended
+    # in declaration order) so a newly added field can never silently drop
+    # out of the JSON.
+    _OUTPUT_KEY_ORDER: ClassVar[tuple[str, ...]] = (
+        # meta
+        "schema_version",
+        "captured_at",
+        "partial",
+        "partial_reasons",
+        # host / kernel / runtime placement
+        "host",
+        "runtime_context",
+        "docker",
+        # ROCm runtime + the host-kernel driver that pairs with it
+        "rocm",
+        "amdgpu_driver",
+        "hip",
+        # GPU + fabric hardware
+        "gpu_arch",
+        "nics",
+        # compute libraries (identity + static kernel catalogs together)
+        "hipblaslt",
+        "rocblas",
+        "composable_kernel",
+        "tensile",
+        "tensile_catalog",
+        "miopen",
+        "miopen_catalog",
+        "rocfft_catalog",
+        "rccl",
+        "triton",
+        "fbgemm",
+        "aiter",
+        "aotriton",
+        # build system + buck introspection
+        "build_system",
+        "library_introspection",
+        "library_introspection_alternates",
+        # pytorch
+        "python_version",
+        "pytorch_version",
+        "pytorch_build",
+        "pytorch_sdpa",
+        # misc / process-level
+        "env_vars",
+        "system_health",
+    )
+
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to the env.json shape. Round-trip pair with from_dict."""
-        return {f.name: getattr(self, f.name) for f in fields(self)}
+        """Serialise to the env.json shape. Round-trip pair with from_dict.
+
+        Keys are emitted in ``_OUTPUT_KEY_ORDER`` (thematic grouping), then
+        any remaining dataclass field not named there (declaration order),
+        so the set of keys always equals the full field set regardless of
+        the curated list.
+        """
+        values = {f.name: getattr(self, f.name) for f in fields(self)}
+        ordered: dict[str, Any] = {}
+        for key in self._OUTPUT_KEY_ORDER:
+            if key in values:
+                ordered[key] = values.pop(key)
+        # Defensive: emit any field missing from the curated order rather
+        # than dropping it (guards against a future added field).
+        ordered.update(values)
+        return ordered
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> EnvSnapshot:
@@ -1124,39 +1212,43 @@ class EnvSnapshot:
         else:
             rf_cell = rf.get("status") or "?"
 
+        # Line order mirrors the thematic grouping of ``_OUTPUT_KEY_ORDER``
+        # / env.json: host+runtime, then the ROCm runtime and its
+        # host-kernel driver, then GPU/fabric hardware, then compute
+        # libraries, then build, then pytorch, then process-level (rdhc).
+        # Keeping the brief and the JSON in the same order means an operator
+        # reads them the same way and can diff either without re-mapping.
         return "\n".join(
             (
                 f"  runtime:   {rt.get('type', '?')} / python={rt.get('python_env', '?')}",
-                f"  build_sys: {self._summary_build_system_line(bs)}",
+                f"  host:      kernel={host.get('kernel_release') or '?'} "
+                f"machine={host.get('machine') or '?'}  "
+                f"glibc={host.get('glibc_version') or '?'}",
                 f"  rocm:      {rocm.get('version', '?')} (dev: {rocm.get('version_dev', '?')})",
+                # amdgpu_driver is HOST-KERNEL scope: even inside a
+                # container this reflects the shared host driver, unlike the
+                # rocm/hip lines around it (container userspace). Placed
+                # right after rocm so the runtime/driver split reads
+                # together. "absent" is the normal reading on a GPU-less box.
+                f"  amdgpu:    {amdgpu.get('status') or '?'} "
+                f"pkg={amdgpu.get('package_full_name') or (str(amdgpu.get('package_name') or '?') + '=' + str(amdgpu.get('package_version') or '?'))} "
+                f"({amdgpu.get('package_manager') or '?'})  "
+                f"kmd={amdgpu.get('kmd_version') or '?'}  "
+                f"kfd={'yes' if amdgpu.get('kfd_device_present') else 'no'}",
                 f"  hip:       {hip.get('version', '?')} ({hip.get('platform', '?')})",
-                # ROCm release tweak (HIPBLASLT_VERSION_TWEAK et al.)
-                # is the same string across every library in a release,
-                # not a per-library upstream commit. lib_hash is the
-                # per-binary signal (in the JSON, not the brief).
-                f"  hipblaslt: {hipblaslt.get('package_version', '?')} rocm_release_tweak={hipblaslt.get('rocm_release_tweak', '?')}",
-                f"  rocblas:   {rocblas.get('package_version', '?')} rocm_release_tweak={rocblas.get('rocm_release_tweak', '?')}",
-                f"  miopen:    {miopen.get('package_version', '?')} rocm_release_tweak={miopen.get('rocm_release_tweak', '?')}",
-                f"  rccl:      {rccl.get('version', '?')} (code={rccl.get('version_code', '?')}) net_plugin={rccl.get('net_plugin_mode', '?')}{(' [' + os.path.basename(rccl['plugin_path']) + ']') if rccl.get('plugin_path') else ''}",
-                f"  nics:      {self._summary_nics_line(nics)}",
                 # gpu_arch: dedup'd targets are the meaningful diff
                 # signal (homogeneous vs mixed-arch hosts); count tells
                 # how many GPUs were detected. Both null when the
                 # rocm_agent_enumerator probe failed.
                 f"  gpu_arch:  {gpu_arch.get('gfx_targets') or '?'} "
                 f"(counts={gpu_arch.get('agent_arch_counts') or '?'})",
-                f"  host:      kernel={host.get('kernel_release') or '?'} "
-                f"machine={host.get('machine') or '?'}  "
-                f"glibc={host.get('glibc_version') or '?'}",
-                # amdgpu_driver is HOST-KERNEL scope: even inside a
-                # container this reflects the shared host driver, unlike the
-                # rocm/hip lines above (container userspace). "absent" is
-                # the normal reading on a GPU-less box.
-                f"  amdgpu:    {amdgpu.get('status') or '?'} "
-                f"pkg={amdgpu.get('package_name') or '?'}={amdgpu.get('package_version') or '?'} "
-                f"({amdgpu.get('package_manager') or '?'})  "
-                f"kmd={amdgpu.get('kmd_version') or '?'}  "
-                f"kfd={'yes' if amdgpu.get('kfd_device_present') else 'no'}",
+                f"  nics:      {self._summary_nics_line(nics)}",
+                # ROCm release tweak (HIPBLASLT_VERSION_TWEAK et al.)
+                # is the same string across every library in a release,
+                # not a per-library upstream commit. lib_hash is the
+                # per-binary signal (in the JSON, not the brief).
+                f"  hipblaslt: {hipblaslt.get('package_version', '?')} rocm_release_tweak={hipblaslt.get('rocm_release_tweak', '?')}",
+                f"  rocblas:   {rocblas.get('package_version', '?')} rocm_release_tweak={rocblas.get('rocm_release_tweak', '?')}",
                 # CK has two layers -- system headers (composablekernel-dev
                 # apt pkg) and the copy compiled into libtorch_hip.so via
                 # PyTorch's third_party/composable_kernel submodule. Both
@@ -1172,12 +1264,14 @@ class EnvSnapshot:
                 f"  tensile:   kernel_db={short_hash(tensile.get('kernel_db_combined_hash'))}  "
                 f"[Tensile pip pkg: {pkg_state(tensile.get('package_version'))}; "
                 f"build-time tool, normal]",
+                f"  miopen:    {miopen.get('package_version', '?')} rocm_release_tweak={miopen.get('rocm_release_tweak', '?')}",
                 # Static "recipe book" identity (the installed kernel
                 # catalogs, NOT the runtime pick): per-menu content hash
                 # for hipBLASLt/rocBLAS Tensile + MIOpen, and the rocFFT
                 # AOT cache state. Full per-file detail lives in the JSON.
                 f"  catalog:   tensile[hb={short_hash(tc_hb)} rb={short_hash(tc_rb)}]  "
                 f"miopen={short_hash(mc_hash)}  rocfft={rf_cell}",
+                f"  rccl:      {rccl.get('version', '?')} (code={rccl.get('version_code', '?')}) net_plugin={rccl.get('net_plugin_mode', '?')}{(' [' + os.path.basename(rccl['plugin_path']) + ']') if rccl.get('plugin_path') else ''}",
                 f"  triton:    {pkg_state(triton.get('package_version'))}",
                 # FBGEMM has TWO surfaces and they're different artifacts:
                 #   1) FBGEMM the C++ lib is vendored inside the PyTorch
@@ -1208,7 +1302,9 @@ class EnvSnapshot:
                 f"present={aotriton.get('bundled_present')} "
                 f"images_dir={aotriton.get('bundled_images_dir_present')}  "
                 f"[AOTRITON_INSTALLED_PREFIX={aotriton.get('installed_prefix') or '(unset)'}]",
-                f"  rdhc:      {sysh}",
+                # build system group.
+                f"  build_sys: {self._summary_build_system_line(bs)}",
+                # pytorch group.
                 f"  python:    {self.python_version} | pytorch: {self.pytorch_version}",
                 f"  torch build: {self._summary_pytorch_build_line()}",
                 f"  torch flags: {self._summary_pytorch_build_flags_line()}",
@@ -1218,6 +1314,8 @@ class EnvSnapshot:
                 f"  ninja hipcc: {self._summary_pytorch_ninja_hipcc_line()}",
                 f"  aiter hsa:   {self._summary_aiter_hsa_tree_line()}",
                 f"  sdpa:        {self._summary_pytorch_sdpa_line()}",
+                # process-level health, last (misc group).
+                f"  rdhc:      {sysh}",
             )
         )
 
@@ -1791,6 +1889,7 @@ class _ProbeStdioRedirect:
 def collect_env(
     buck_target: str | None = None,
     buck_timeout: int = 10,
+    detail: str = "compact",
 ) -> EnvSnapshot:
     """Capture the current process environment as an :class:`EnvSnapshot`.
 
@@ -1822,7 +1921,26 @@ def collect_env(
     both lists stay empty and the existing per-library top-level
     blocks remain authoritative. ``buck_timeout`` caps the cquery
     subprocess (seconds; default 10).
+
+    ``detail`` controls the size of the static kernel-catalog blocks:
+
+    * ``"compact"`` (default) -- the ``tensile_catalog`` / ``miopen_catalog``
+      per-file ``menu.files`` lists are dropped (set to ``None``). These
+      lists are the dominant source of env.json size (thousands of entries
+      on a populated host -> ~25k JSON lines). Every summary/fingerprint
+      field is kept -- ``status``, ``dir``, ``file_count``,
+      ``logic_file_count``, ``gfx_arch_coverage``, ``combined_content_hash``
+      -- so a two-host diff still detects THAT a catalog differs. This is
+      the right default for the per-trial artifact.
+    * ``"full"`` -- retains the complete per-file lists for forensic
+      follow-up (localizing exactly WHICH recipe/db file changed). Selected
+      by ``aorta env probe --extended``.
+
+    Any other value is treated as ``"compact"``. Note the files are hashed
+    either way (``combined_content_hash`` requires it); ``detail`` only
+    controls whether the per-file breakdown is retained in the snapshot.
     """
+    include_files = detail == "full"
     reasons: list[str] = []
     # Capture fds 1/2 at the OS level for the probe body so that the benign
     # HIP/C-runtime device-enumeration noise the in-process ``import torch``
@@ -1857,7 +1975,7 @@ def collect_env(
         # captures above (no regression) + deepens with per-file menu
         # enumeration.
         tensile_catalog = _build_tensile_catalog(
-            hipblaslt, rocblas, tensile, reasons
+            hipblaslt, rocblas, tensile, reasons, include_files=include_files
         )
         triton = _capture_triton(reasons)
         fbgemm = _capture_fbgemm(reasons)
@@ -1866,7 +1984,9 @@ def collect_env(
         miopen = _capture_miopen(reasons)
         # Static MIOpen "recipe book" (reuses miopen capture) + rocFFT
         # optional AOT kernel cache fingerprint (absent on most installs).
-        miopen_catalog = _build_miopen_catalog(miopen, reasons)
+        miopen_catalog = _build_miopen_catalog(
+            miopen, reasons, include_files=include_files
+        )
         rocfft_catalog = _build_rocfft_catalog(reasons)
         rccl = _capture_rccl(reasons)
         nics = _capture_nics(reasons)
@@ -3835,6 +3955,7 @@ def _enumerate_catalog_dir(
     classify,
     *,
     kind: str,
+    include_files: bool = True,
 ) -> dict[str, Any]:
     """Enumerate an on-disk kernel/solution catalog directory.
 
@@ -3843,6 +3964,17 @@ def _enumerate_catalog_dir(
     and records a **content** sha256 + size, so a two-host diff localizes
     *which* file changed rather than only "the filename set differs".
     Still no GPU compute -- pure file reads in the install.
+
+    ``include_files`` controls only whether the per-file ``files`` list is
+    RETAINED in the returned menu, not whether the work happens: every
+    file is still hashed either way, because ``combined_content_hash``,
+    ``file_count``, ``logic_file_count``, and ``gfx_arch_coverage`` are all
+    derived from that pass. In compact mode (``include_files=False``) the
+    per-file list -- the dominant source of env.json bloat, thousands of
+    entries on a populated host -- is dropped to ``None`` while every
+    summary/fingerprint field is preserved, so a two-host diff still
+    detects THAT a catalog changed via ``combined_content_hash`` (only
+    localizing WHICH file needs ``--extended``).
 
     ``classify(filename) -> (include: bool, suffix_label: str | None,
     is_logic: bool)`` selects which files belong to the catalog, labels
@@ -3945,7 +4077,10 @@ def _enumerate_catalog_dir(
             "logic_file_count": logic_count,
             "file_count": len(files),
             "gfx_arch_coverage": _extract_gfx_archs(names),
-            "files": files,
+            # Compact mode drops the per-file list (the bloat) but keeps
+            # every count/coverage/fingerprint above so the menu still
+            # diffs meaningfully. --extended restores the full list.
+            "files": files if include_files else None,
             "combined_content_hash": combined_content_hash,
         }
     )
@@ -3979,17 +4114,20 @@ def _enumerate_tensile_menu(
     *,
     suffixes: tuple[str, ...] = TENSILE_MENU_SUFFIXES,
     logic_suffixes: tuple[str, ...] = TENSILE_LOGIC_SUFFIXES,
+    include_files: bool = True,
 ) -> dict[str, Any]:
     """Enumerate the frozen Tensile solution menu in ``directory``.
 
     Thin wrapper over ``_enumerate_catalog_dir`` with Tensile's suffix
     classifier. Kept as a named function so existing tests/callers keep
-    their call shape.
+    their call shape. ``include_files`` is forwarded verbatim (see
+    ``_enumerate_catalog_dir``).
     """
     return _enumerate_catalog_dir(
         directory,
         _suffix_classifier(suffixes, logic_suffixes),
         kind="Tensile library",
+        include_files=include_files,
     )
 
 
@@ -4028,6 +4166,8 @@ def _build_tensile_catalog(
     rocblas: dict[str, Any],
     tensile: dict[str, Any],
     reasons: list[str],
+    *,
+    include_files: bool = True,
 ) -> dict[str, Any]:
     """Assemble the labeled, deepened static ``tensile_catalog`` block.
 
@@ -4040,9 +4180,17 @@ def _build_tensile_catalog(
     Every partial ``menu`` threads its reason into ``partial_reasons``
     (prefixed ``tensile_catalog.<lib>.menu``) so a probe that couldn't
     read the menu is distinguishable from one that read an empty menu.
+
+    ``include_files=False`` (compact, the default probe mode) drops the
+    per-menu ``files`` lists while keeping their fingerprints; see
+    ``_enumerate_catalog_dir``.
     """
-    hipblaslt_menu = _enumerate_tensile_menu(HIPBLASLT_TENSILE_DIR)
-    rocblas_menu = _enumerate_tensile_menu(ROCBLAS_TENSILE_DIR)
+    hipblaslt_menu = _enumerate_tensile_menu(
+        HIPBLASLT_TENSILE_DIR, include_files=include_files
+    )
+    rocblas_menu = _enumerate_tensile_menu(
+        ROCBLAS_TENSILE_DIR, include_files=include_files
+    )
 
     for lib_name, menu in (("hipblaslt", hipblaslt_menu), ("rocblas", rocblas_menu)):
         if menu["status"] == "partial":
@@ -4137,18 +4285,25 @@ def _empty_miopen_catalog() -> dict[str, Any]:
 def _build_miopen_catalog(
     miopen: dict[str, Any],
     reasons: list[str],
+    *,
+    include_files: bool = True,
 ) -> dict[str, Any]:
     """Assemble the labeled, deepened static ``miopen_catalog`` block.
 
     No regression: package_version / lib_hash / kernel_db_revision are
     taken verbatim from the already-captured ``miopen`` block. The new
     work is the per-file ``menu`` enumeration of the MIOpen db dir.
+
+    ``include_files=False`` (compact, the default probe mode) drops the
+    per-file ``menu.files`` list while keeping its fingerprints; see
+    ``_enumerate_catalog_dir``.
     """
     db_dir, source = _resolve_miopen_db_dir()
     menu = _enumerate_catalog_dir(
         db_dir,
         _suffix_classifier(MIOPEN_CATALOG_SUFFIXES, MIOPEN_LOGIC_SUFFIXES),
         kind="MIOpen db",
+        include_files=include_files,
     )
     if menu["status"] == "partial":
         reasons.append(
@@ -6963,65 +7118,113 @@ def _capture_gpu_arch(reasons: list[str]) -> dict[str, Any]:
     }
 
 
-def _query_package_version(package: str) -> tuple[str, str] | None:
-    """Look up an installed system package's version, distro-portable.
+def _query_amdgpu_package() -> dict[str, str] | None:
+    """Resolve the installed amdgpu KMD package identity, distro-portable.
 
     Tries Debian/Ubuntu ``dpkg-query`` first (the flagship ROCm target;
     every Dockerfile in ``docker/`` is Ubuntu-based), then RHEL/SLES
-    ``rpm``. Returns ``(version, package_manager)`` on the first hit, or
-    ``None`` when the package is not installed under any known manager.
+    ``rpm``, over ``AMDGPU_PACKAGE_CANDIDATES`` (``amdgpu-dkms`` then
+    ``amdgpu-kmod``). Returns the first hit as::
+
+        {"name": <candidate family>, "version": <VERSION-RELEASE>,
+         "manager": "dpkg"|"rpm", "full_name": <canonical identity>}
+
+    or ``None`` when no candidate is installed under any known manager.
+
+    KERNEL-SUFFIXED PACKAGE NAMES: some vendors (e.g. Meta's fbk kernels)
+    ship the prebuilt kmod with the *kernel release baked into the RPM
+    name* -- ``amdgpu-kmod-6.9.0-0_fbk10_..._g9b20106afb70`` rather than a
+    plain ``amdgpu-kmod``. An exact ``rpm -q amdgpu-kmod`` misses these
+    entirely. So we query with a **glob** (``rpm -qa 'amdgpu-kmod*'`` /
+    ``dpkg-query -W 'amdgpu-kmod*'``) and reconstruct the complete package
+    identity in ``full_name`` -- the single field two host snapshots can be
+    diffed on (equivalent to the operator's
+    ``rpm -qa | grep amdgpu-... | sed`` one-liner, but portable and with no
+    shell pipe). ``name`` stays the stable candidate *family* label so it
+    remains a clean grouping key across hosts with different kernel suffixes.
 
     Matches the module's subprocess contract exactly: ``shutil.which()``
     gate, ``subprocess.run([...], check=False, timeout=SHORT_TIMEOUT_SEC)``,
-    parsing in Python -- NO shell pipeline. (The RHEL-only
-    ``rpm -qa | grep | sed`` one-liner some operators reach for is both
-    non-portable and outside this contract; a direct ``-qf`` query is the
-    portable, testable equivalent.) Never raises.
+    parsing in Python -- NO shell pipeline. Never raises.
     """
-    # dpkg-query -W -f='${Version}' <pkg>: prints the version on stdout and
-    # exits 0 when installed; exits non-zero (and prints to stderr) when
-    # not. The -f template avoids the two-column default output.
-    if shutil.which("dpkg-query") is not None:
-        try:
-            proc = subprocess.run(
-                ["dpkg-query", "-W", "-f=${Version}", package],
-                capture_output=True,
-                text=True,
-                timeout=SHORT_TIMEOUT_SEC,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-            log.debug("dpkg-query failed for %s: %s", package, exc)
-        else:
-            if proc.returncode == 0:
-                ver = (proc.stdout or "").strip()
-                if ver:
-                    return (ver, "dpkg")
+    for candidate in AMDGPU_PACKAGE_CANDIDATES:
+        # dpkg-query -W -f='${Package}\t${Version}\n' '<candidate>*': the
+        # glob catches kernel-suffixed names; the -f template gives us the
+        # real installed package name plus version, tab-delimited. Debian's
+        # amdgpu-dkms is arch-independent, so name=version is the canonical
+        # apt-style identity.
+        if shutil.which("dpkg-query") is not None:
+            try:
+                proc = subprocess.run(
+                    ["dpkg-query", "-W", "-f=${Package}\t${Version}\n",
+                     f"{candidate}*"],
+                    capture_output=True,
+                    text=True,
+                    timeout=SHORT_TIMEOUT_SEC,
+                    check=False,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                log.debug("dpkg-query failed for %s: %s", candidate, exc)
+            else:
+                if proc.returncode == 0:
+                    for line in (proc.stdout or "").splitlines():
+                        parts = line.split("\t")
+                        if len(parts) != 2:
+                            continue
+                        name, version = parts[0].strip(), parts[1].strip()
+                        if not name or not version or "firmware" in name:
+                            continue
+                        if name != candidate and not name.startswith(
+                            candidate + "-"
+                        ):
+                            continue
+                        return {
+                            "name": candidate,
+                            "version": version,
+                            "manager": "dpkg",
+                            "full_name": f"{name}={version}",
+                        }
 
-    # rpm -q --qf '%{VERSION}-%{RELEASE}' <pkg>: same idea for RHEL/SLES.
-    # Including RELEASE captures the distro build/patch suffix that the
-    # candidate `sed 's/\.el.*//'` deliberately discarded -- we keep it,
-    # since that suffix is exactly the kind of host-to-host drift the probe
-    # exists to surface.
-    if shutil.which("rpm") is not None:
-        try:
-            proc = subprocess.run(
-                ["rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", package],
-                capture_output=True,
-                text=True,
-                timeout=SHORT_TIMEOUT_SEC,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-            log.debug("rpm -q failed for %s: %s", package, exc)
-        else:
-            # rpm exits 0 and prints "<pkg> is not installed" to STDOUT for
-            # a missing package on some builds, so gate on returncode AND a
-            # non-empty version that doesn't carry the not-installed marker.
-            if proc.returncode == 0:
-                ver = (proc.stdout or "").strip()
-                if ver and "is not installed" not in ver:
-                    return (ver, "rpm")
+        # rpm -qa --qf '%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n'
+        # '<candidate>*': -qa + glob lists every installed package matching
+        # the pattern (an exact -q would miss the kernel-suffixed names).
+        # full_name is the canonical NVRA, e.g.
+        # amdgpu-kmod-6.9.0-..._g9b20106afb70-6.14.14.000000-2226257.1.x86_64
+        if shutil.which("rpm") is not None:
+            try:
+                proc = subprocess.run(
+                    ["rpm", "-qa", "--qf",
+                     "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n",
+                     f"{candidate}*"],
+                    capture_output=True,
+                    text=True,
+                    timeout=SHORT_TIMEOUT_SEC,
+                    check=False,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                log.debug("rpm -qa failed for %s: %s", candidate, exc)
+            else:
+                if proc.returncode == 0:
+                    for line in (proc.stdout or "").splitlines():
+                        parts = line.split("\t")
+                        if len(parts) != 3:
+                            continue
+                        name, ver_rel, arch = (p.strip() for p in parts)
+                        if not name or not ver_rel or "firmware" in name:
+                            continue
+                        if name != candidate and not name.startswith(
+                            candidate + "-"
+                        ):
+                            continue
+                        full = f"{name}-{ver_rel}"
+                        if arch:
+                            full = f"{full}.{arch}"
+                        return {
+                            "name": candidate,
+                            "version": ver_rel,
+                            "manager": "rpm",
+                            "full_name": full,
+                        }
 
     return None
 
@@ -7075,6 +7278,7 @@ def _empty_amdgpu_driver() -> dict[str, Any]:
         "status": "absent",
         "package_name": None,
         "package_version": None,
+        "package_full_name": None,
         "package_manager": None,
         "module_version": None,
         "module_srcversion": None,
@@ -7096,18 +7300,22 @@ def _capture_amdgpu_driver(
     from inside a container -- complementary to ``rocm``/``hip`` which read
     the container's own ``/opt/rocm`` userspace.
 
-    ``package_name`` / ``package_version`` / ``package_manager`` and
-    ``module_version`` / ``module_srcversion`` are NOT host-guaranteed:
-    dpkg/rpm and ``modinfo`` read the *current filesystem's* package
-    database and ``/lib/modules``, so from inside a container these
-    reflect the container's (usually driver-less) view, not the host's,
-    even though the KFD/kmd fields above are still host-accurate.
+    ``package_name`` / ``package_version`` / ``package_full_name`` /
+    ``package_manager`` and ``module_version`` / ``module_srcversion`` are
+    NOT host-guaranteed: dpkg/rpm and ``modinfo`` read the *current
+    filesystem's* package database and ``/lib/modules``, so from inside a
+    container these reflect the container's (usually driver-less) view, not
+    the host's, even though the KFD/kmd fields above are still host-accurate.
 
     Sources, all fail-soft and none requiring a GPU:
 
-    * ``package_version`` / ``package_manager`` / ``package_name`` --
-      ``_query_package_version`` over ``AMDGPU_PACKAGE_CANDIDATES``
-      (dpkg then rpm).
+    * ``package_name`` / ``package_version`` / ``package_full_name`` /
+      ``package_manager`` -- ``_query_amdgpu_package`` (glob-capable
+      dpkg-then-rpm query over ``AMDGPU_PACKAGE_CANDIDATES``).
+      ``package_full_name`` is the complete canonical identity (apt
+      ``name=version`` or rpm NVRA), which captures kernel-suffixed
+      package names like ``amdgpu-kmod-6.9.0-..._g9b20106afb70-...`` that
+      ``package_name`` (the stable candidate family) deliberately does not.
     * ``module_version`` / ``module_srcversion`` -- ``modinfo amdgpu``.
     * ``kmd_version`` -- reused verbatim from the already-captured ``rocm``
       block's ``/sys/module/amdgpu/version`` read (no second file read, so
@@ -7118,18 +7326,21 @@ def _capture_amdgpu_driver(
     DOCUMENTED ABSENCE, NOT partial: on a GPU-less host (this dev machine)
     every signal is missing -> ``status="absent"`` with NO ``partial``
     reason, mirroring the ``nics`` vendor-absent precedent. We only record
-    a reason when there is a genuine capture *conflict* (a KMD signal
-    exists but the package DB can't name it), which is worth an operator's
-    attention.
+    a reason when there is a genuine *same-filesystem* conflict: the
+    ``amdgpu`` module is loaded (``modinfo`` metadata present) but the
+    package DB on the same filesystem can't name it. A container with
+    ``/dev/kfd`` passed through but no amdgpu package installed is the
+    NORMAL case, not a conflict, so ``kfd_device_present`` alone never
+    triggers a reason.
     """
     block = _empty_amdgpu_driver()
 
-    for candidate in AMDGPU_PACKAGE_CANDIDATES:
-        found = _query_package_version(candidate)
-        if found is not None:
-            block["package_version"], block["package_manager"] = found
-            block["package_name"] = candidate
-            break
+    pkg = _query_amdgpu_package()
+    if pkg is not None:
+        block["package_name"] = pkg["name"]
+        block["package_version"] = pkg["version"]
+        block["package_manager"] = pkg["manager"]
+        block["package_full_name"] = pkg["full_name"]
 
     block["module_version"] = _modinfo_field(AMDGPU_MODULE_NAME, "version")
     block["module_srcversion"] = _modinfo_field(
@@ -7158,20 +7369,24 @@ def _capture_amdgpu_driver(
     )
     block["status"] = "present" if any_signal else "absent"
 
-    # Conflict signal worth a partial: the driver is demonstrably loaded
-    # (KFD node or module metadata present) but no package manager could
-    # name the package. That is an unusual, diagnosable state (out-of-band
-    # driver install, stripped package DB) -- not the ordinary GPU-less or
-    # stripped-container absence, so it earns one reason.
-    kmd_loaded = (
-        block["kfd_device_present"]
-        or block["module_version"] is not None
+    # Conflict signal worth a partial: the amdgpu module is demonstrably
+    # loaded on THIS filesystem (modinfo read /lib/modules) but no package
+    # manager on the SAME filesystem could name it. That is an unusual,
+    # diagnosable state (out-of-band driver install, stripped package DB)
+    # -- not the ordinary GPU-less or stripped-container absence, so it
+    # earns one reason. Deliberately does NOT key off kfd_device_present:
+    # /dev/kfd is host-kernel state (mountable into a container), so a
+    # container with /dev/kfd passed through but no amdgpu package
+    # installed is the NORMAL case, not a conflict. modinfo and dpkg/rpm
+    # both read the current filesystem, so their disagreement is real.
+    module_loaded = (
+        block["module_version"] is not None
         or block["module_srcversion"] is not None
     )
-    if kmd_loaded and block["package_version"] is None:
+    if module_loaded and block["package_version"] is None:
         reasons.append(
-            "amdgpu_driver.package_version: amdgpu KMD is loaded "
-            "(KFD node or amdgpu module metadata present) but no dpkg/rpm "
+            "amdgpu_driver.package_version: amdgpu module is loaded "
+            "(modinfo metadata present) but no dpkg/rpm "
             f"package ({'/'.join(AMDGPU_PACKAGE_CANDIDATES)}) could be "
             "resolved"
         )

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -516,6 +516,7 @@ def _example_snapshot(**overrides) -> object:
             "status": "present",
             "package_name": "amdgpu-dkms",
             "package_version": "1:6.14.14-2212064.24.04",
+            "package_full_name": "amdgpu-dkms=1:6.14.14-2212064.24.04",
             "package_manager": "dpkg",
             "module_version": "6.14.14",
             "module_srcversion": "A1B2C3D4E5F6A7B8C9D0",
@@ -1446,13 +1447,15 @@ class TestCliIsThinWrapper:
         # * PR #177 added --summary / --field output modes plus the
         #   ``_lookup_field`` helper (dotted-path resolution with
         #   friendly errors that list available keys).
+        # * The compact/--extended catalog-detail work added one more
+        #   click option block + its detail= wiring into collect_env().
         #
         # The real "no-probing-in-CLI" guard is
         # `test_cli_does_no_probing_imports` below -- this one is a
         # soft canary against the file ballooning beyond pure wiring.
         line_count = sum(1 for _ in cli_path.read_text().splitlines())
-        assert line_count <= 350, (
-            f"cli/env.py is {line_count} lines; soft budget is 350. "
+        assert line_count <= 375, (
+            f"cli/env.py is {line_count} lines; soft budget is 375. "
             "If you need more, check that the new code is genuinely "
             "wiring/error-handling and not probing -- "
             "test_cli_does_no_probing_imports is the strict guard."
@@ -1709,6 +1712,43 @@ class TestCliSummaryAndFieldFlags:
             assert "Wrote env probe to" not in result.output
             # File MUST NOT be written -- the whole point of the flag.
             assert not (Path.cwd() / "env.json").exists()
+
+    def test_default_probe_writes_compact_catalog(
+        self, all_disabled, tmp_path: Path,
+    ):
+        # Default `probe` (no --extended) writes a JSON whose catalog
+        # menus carry no per-file lists -- the size fix. all_disabled
+        # yields empty catalogs (files already None), so this asserts the
+        # key is present-and-null rather than counting entries.
+        import json as _json
+        from click.testing import CliRunner
+        cli_mod = self._cli_mod()
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            out = Path.cwd() / "env.json"
+            result = runner.invoke(cli_mod.env, ["probe", "-o", str(out)])
+            assert result.exit_code == 0, result.output
+            doc = _json.loads(out.read_text(encoding="utf-8"))
+            assert doc["tensile_catalog"]["hipblaslt"]["menu"]["files"] is None
+            assert doc["miopen_catalog"]["menu"]["files"] is None
+
+    def test_extended_flag_is_accepted(
+        self, all_disabled, tmp_path: Path,
+    ):
+        # --extended must parse and still produce a valid snapshot. (Under
+        # all_disabled the catalogs are empty so files stays None either
+        # way; this guards the flag wiring, not populated-catalog output,
+        # which TestCatalogCompactDetail covers at the library layer.)
+        from click.testing import CliRunner
+        cli_mod = self._cli_mod()
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            out = Path.cwd() / "env.json"
+            result = runner.invoke(
+                cli_mod.env, ["probe", "--extended", "-o", str(out)]
+            )
+            assert result.exit_code == 0, result.output
+            assert out.exists()
 
     def test_field_flag_returns_top_level_scalar_as_json(
         self, all_disabled, tmp_path: Path,
@@ -3575,6 +3615,92 @@ class TestTensileMenuEnumeration:
         assert menu["combined_content_hash"] is None
 
 
+class TestCatalogCompactDetail:
+    """Compact mode drops the per-file lists but keeps every fingerprint."""
+
+    def test_enumerate_compact_drops_files_keeps_summary(self, tmp_path: Path):
+        d = _make_tensile_install(tmp_path / "lib", archs=("gfx942", "gfx90a"))
+        full = env_mod._enumerate_tensile_menu(d, include_files=True)
+        compact = env_mod._enumerate_tensile_menu(d, include_files=False)
+        # The heavy per-file list is gone in compact...
+        assert full["files"] is not None and len(full["files"]) > 0
+        assert compact["files"] is None
+        # ...but every summary + fingerprint field is preserved and equal.
+        for key in (
+            "status",
+            "dir",
+            "file_count",
+            "logic_file_count",
+            "gfx_arch_coverage",
+            "combined_content_hash",
+        ):
+            assert compact[key] == full[key], key
+        # The whole point: the menu-level content hash is unchanged, so a
+        # two-host diff still detects THAT the catalog changed.
+        assert compact["combined_content_hash"] is not None
+
+    def test_tensile_catalog_compact_drops_both_menus(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            env_mod, "HIPBLASLT_TENSILE_DIR", _make_tensile_install(tmp_path / "hb")
+        )
+        monkeypatch.setattr(
+            env_mod, "ROCBLAS_TENSILE_DIR", _make_tensile_install(tmp_path / "rb")
+        )
+        empty_lib = {
+            "package_version": None,
+            "lib_hash": None,
+            "kernel_db_revision": None,
+        }
+        block = env_mod._build_tensile_catalog(
+            dict(empty_lib),
+            dict(empty_lib),
+            {"package_version": None, "kernel_db_combined_hash": None},
+            [],
+            include_files=False,
+        )
+        assert block["hipblaslt"]["menu"]["files"] is None
+        assert block["rocblas"]["menu"]["files"] is None
+        # Fingerprints survive so the compact block still diffs.
+        assert block["hipblaslt"]["menu"]["combined_content_hash"] is not None
+        assert block["hipblaslt"]["menu"]["file_count"] > 0
+
+    def test_miopen_catalog_compact_drops_menu_files(
+        self, tmp_path: Path, monkeypatch
+    ):
+        db = _make_miopen_db(tmp_path / "db")
+        monkeypatch.setattr(env_mod, "MIOPEN_KERNEL_DB_DIR", db)
+        monkeypatch.delenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, raising=False)
+        block = env_mod._build_miopen_catalog({}, [], include_files=False)
+        assert block["menu"]["files"] is None
+        assert block["menu"]["combined_content_hash"] is not None
+        assert block["menu"]["file_count"] > 0
+
+    def test_collect_env_defaults_to_compact(
+        self, tmp_path: Path, monkeypatch
+    ):
+        # The default probe (no detail arg) must not carry per-file lists.
+        monkeypatch.setattr(
+            env_mod, "HIPBLASLT_TENSILE_DIR", _make_tensile_install(tmp_path / "hb")
+        )
+        monkeypatch.setattr(
+            env_mod, "ROCBLAS_TENSILE_DIR", _make_tensile_install(tmp_path / "rb")
+        )
+        monkeypatch.setattr(
+            env_mod, "MIOPEN_KERNEL_DB_DIR", _make_miopen_db(tmp_path / "db")
+        )
+        monkeypatch.delenv(env_mod.MIOPEN_SYSTEM_DB_PATH_ENV, raising=False)
+        snap = env_mod.collect_env()
+        assert snap.tensile_catalog["hipblaslt"]["menu"]["files"] is None
+        assert snap.tensile_catalog["rocblas"]["menu"]["files"] is None
+        assert snap.miopen_catalog["menu"]["files"] is None
+        # detail="full" restores them.
+        snap_full = env_mod.collect_env(detail="full")
+        assert snap_full.tensile_catalog["hipblaslt"]["menu"]["files"] is not None
+        assert snap_full.miopen_catalog["menu"]["files"] is not None
+
+
 class TestTensileCatalogBlock:
     def test_default_and_disaster_shapes_match_built_block(self, tmp_path: Path):
         built = env_mod._build_tensile_catalog(
@@ -4656,8 +4782,8 @@ class TestHostBlock:
 # ---------------------------------------------------------------------------
 
 
-class TestQueryPackageVersion:
-    """_query_package_version(): portable dpkg-then-rpm, no shell pipe."""
+class TestQueryAmdgpuPackage:
+    """_query_amdgpu_package(): glob-capable dpkg-then-rpm, no shell pipe."""
 
     @staticmethod
     def _tools(present, outputs):
@@ -4674,85 +4800,141 @@ class TestQueryPackageVersion:
 
         return fake_which, fake_run
 
-    def test_dpkg_hit_wins_and_reports_manager(self, isolated_env, monkeypatch):
+    def test_dpkg_hit_wins_and_reports_full_name(self, isolated_env, monkeypatch):
         fw, fr = self._tools(
             {"dpkg-query", "rpm"},
             {
-                ("dpkg-query", "-W", "-f=${Version}", "amdgpu-dkms"): (
+                ("dpkg-query", "-W", "-f=${Package}\t${Version}\n",
+                 "amdgpu-dkms*"): (
                     0,
-                    "1:6.14.14-2212064.24.04\n",
+                    "amdgpu-dkms\t1:6.14.14-2212064.24.04\n",
                 ),
             },
         )
         monkeypatch.setattr(env_mod.shutil, "which", fw)
         monkeypatch.setattr(env_mod.subprocess, "run", fr)
-        assert env_mod._query_package_version("amdgpu-dkms") == (
-            "1:6.14.14-2212064.24.04",
-            "dpkg",
-        )
+        assert env_mod._query_amdgpu_package() == {
+            "name": "amdgpu-dkms",
+            "version": "1:6.14.14-2212064.24.04",
+            "manager": "dpkg",
+            "full_name": "amdgpu-dkms=1:6.14.14-2212064.24.04",
+        }
 
     def test_falls_back_to_rpm_when_dpkg_absent(self, isolated_env, monkeypatch):
-        # No dpkg-query on PATH (RHEL); rpm answers with VERSION-RELEASE.
+        # No dpkg-query on PATH (RHEL); rpm answers with NAME/VER-REL/ARCH.
         fw, fr = self._tools(
             {"rpm"},
             {
-                ("rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", "amdgpu-kmod"): (
+                ("rpm", "-qa", "--qf",
+                 "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n",
+                 "amdgpu-dkms*"): (0, ""),
+                ("rpm", "-qa", "--qf",
+                 "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n",
+                 "amdgpu-kmod*"): (
                     0,
-                    "6.14.14-2212064.el9\n",
+                    "amdgpu-kmod\t6.14.14-2212064.el9\tx86_64\n",
                 ),
             },
         )
         monkeypatch.setattr(env_mod.shutil, "which", fw)
         monkeypatch.setattr(env_mod.subprocess, "run", fr)
-        assert env_mod._query_package_version("amdgpu-kmod") == (
-            "6.14.14-2212064.el9",
-            "rpm",
+        assert env_mod._query_amdgpu_package() == {
+            "name": "amdgpu-kmod",
+            "version": "6.14.14-2212064.el9",
+            "manager": "rpm",
+            "full_name": "amdgpu-kmod-6.14.14-2212064.el9.x86_64",
+        }
+
+    def test_kernel_suffixed_rpm_name_is_matched(self, isolated_env, monkeypatch):
+        # The reported real-world case: the fbk kernel bakes the release
+        # into the RPM package NAME, so an exact `rpm -q amdgpu-kmod` finds
+        # nothing. The glob `amdgpu-kmod*` catches it, and full_name
+        # reconstructs the complete NVRA an operator would diff on.
+        real_name = (
+            "amdgpu-kmod-6.9.0-0_fbk10_brcmrdma13_141_g9b20106afb70"
+        )
+        fw, fr = self._tools(
+            {"rpm"},
+            {
+                ("rpm", "-qa", "--qf",
+                 "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n",
+                 "amdgpu-dkms*"): (0, ""),
+                ("rpm", "-qa", "--qf",
+                 "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n",
+                 "amdgpu-kmod*"): (
+                    0,
+                    f"{real_name}\t6.14.14.000000-2226257.1\tx86_64\n",
+                ),
+            },
+        )
+        monkeypatch.setattr(env_mod.shutil, "which", fw)
+        monkeypatch.setattr(env_mod.subprocess, "run", fr)
+        result = env_mod._query_amdgpu_package()
+        assert result["name"] == "amdgpu-kmod"  # stable family label
+        assert result["manager"] == "rpm"
+        assert result["version"] == "6.14.14.000000-2226257.1"
+        assert result["full_name"] == (
+            "amdgpu-kmod-6.9.0-0_fbk10_brcmrdma13_141_g9b20106afb70"
+            "-6.14.14.000000-2226257.1.x86_64"
         )
 
     def test_dpkg_present_but_package_missing_falls_to_rpm(
         self, isolated_env, monkeypatch
     ):
-        # dpkg-query runs but exits non-zero (package not installed under
-        # dpkg); rpm then finds it. Exercises the "manager present, package
-        # absent" branch rather than "manager absent".
+        # dpkg-query runs but returns no matching line (package not
+        # installed under dpkg); rpm then finds it. Exercises the "manager
+        # present, package absent" branch rather than "manager absent".
         fw, fr = self._tools(
             {"dpkg-query", "rpm"},
             {
-                ("dpkg-query", "-W", "-f=${Version}", "amdgpu-dkms"): (1, ""),
-                ("rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", "amdgpu-dkms"): (
+                ("dpkg-query", "-W", "-f=${Package}\t${Version}\n",
+                 "amdgpu-dkms*"): (1, ""),
+                ("dpkg-query", "-W", "-f=${Package}\t${Version}\n",
+                 "amdgpu-kmod*"): (1, ""),
+                ("rpm", "-qa", "--qf",
+                 "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n",
+                 "amdgpu-dkms*"): (
                     0,
-                    "6.14.14-2212064.el9\n",
+                    "amdgpu-dkms\t6.14.14-2212064.el9\tnoarch\n",
                 ),
             },
         )
         monkeypatch.setattr(env_mod.shutil, "which", fw)
         monkeypatch.setattr(env_mod.subprocess, "run", fr)
-        assert env_mod._query_package_version("amdgpu-dkms") == (
-            "6.14.14-2212064.el9",
-            "rpm",
-        )
+        assert env_mod._query_amdgpu_package() == {
+            "name": "amdgpu-dkms",
+            "version": "6.14.14-2212064.el9",
+            "manager": "rpm",
+            "full_name": "amdgpu-dkms-6.14.14-2212064.el9.noarch",
+        }
 
-    def test_rpm_not_installed_marker_is_rejected(self, isolated_env, monkeypatch):
-        # Some rpm builds exit 0 and print "<pkg> is not installed" to
-        # stdout -- must NOT be read as a version.
+    def test_firmware_package_is_ignored(self, isolated_env, monkeypatch):
+        # The glob amdgpu-dkms* / amdgpu-kmod* would never match firmware,
+        # but a defensive "firmware" filter guards against a candidate list
+        # change; assert a firmware line in the output is skipped.
         fw, fr = self._tools(
             {"rpm"},
             {
-                ("rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", "amdgpu-dkms"): (
+                ("rpm", "-qa", "--qf",
+                 "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n",
+                 "amdgpu-dkms*"): (
                     0,
-                    "package amdgpu-dkms is not installed\n",
+                    "amdgpu-dkms-firmware\t6.14.14-1\tnoarch\n",
                 ),
+                ("rpm", "-qa", "--qf",
+                 "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n",
+                 "amdgpu-kmod*"): (0, ""),
             },
         )
         monkeypatch.setattr(env_mod.shutil, "which", fw)
         monkeypatch.setattr(env_mod.subprocess, "run", fr)
-        assert env_mod._query_package_version("amdgpu-dkms") is None
+        assert env_mod._query_amdgpu_package() is None
 
     def test_no_package_manager_returns_none(self, isolated_env, monkeypatch):
         fw, fr = self._tools(set(), {})
         monkeypatch.setattr(env_mod.shutil, "which", fw)
         monkeypatch.setattr(env_mod.subprocess, "run", fr)
-        assert env_mod._query_package_version("amdgpu-dkms") is None
+        assert env_mod._query_amdgpu_package() is None
 
     def test_timeout_is_fail_soft(self, isolated_env, monkeypatch):
         def boom(cmd, **kwargs):
@@ -4762,8 +4944,8 @@ class TestQueryPackageVersion:
             env_mod.shutil, "which", lambda n: f"/usr/bin/{n}"
         )
         monkeypatch.setattr(env_mod.subprocess, "run", boom)
-        # Both managers time out -> None, no raise.
-        assert env_mod._query_package_version("amdgpu-dkms") is None
+        # Every query times out -> None, no raise.
+        assert env_mod._query_amdgpu_package() is None
 
 
 _MODINFO_AMDGPU = (
@@ -4817,6 +4999,7 @@ class TestAmdgpuDriver:
             "status",
             "package_name",
             "package_version",
+            "package_full_name",
             "package_manager",
             "module_version",
             "module_srcversion",
@@ -4844,10 +5027,13 @@ class TestAmdgpuDriver:
     def test_present_full_capture(self, isolated_env, monkeypatch):
         monkeypatch.setattr(
             env_mod,
-            "_query_package_version",
-            lambda pkg: ("1:6.14.14-2212064.24.04", "dpkg")
-            if pkg == "amdgpu-dkms"
-            else None,
+            "_query_amdgpu_package",
+            lambda: {
+                "name": "amdgpu-dkms",
+                "version": "1:6.14.14-2212064.24.04",
+                "manager": "dpkg",
+                "full_name": "amdgpu-dkms=1:6.14.14-2212064.24.04",
+            },
         )
         monkeypatch.setattr(
             env_mod,
@@ -4863,6 +5049,7 @@ class TestAmdgpuDriver:
         assert block["status"] == "present"
         assert block["package_name"] == "amdgpu-dkms"
         assert block["package_version"] == "1:6.14.14-2212064.24.04"
+        assert block["package_full_name"] == "amdgpu-dkms=1:6.14.14-2212064.24.04"
         assert block["package_manager"] == "dpkg"
         assert block["module_version"] == "6.14.14"
         assert block["module_srcversion"] == "A1B2C3D4E5F6A7B8C9D0"
@@ -4871,10 +5058,40 @@ class TestAmdgpuDriver:
         assert block["kfd_device_present"] is True
         assert reasons == []
 
+    def test_kernel_suffixed_rpm_full_name_flows_into_block(
+        self, isolated_env, monkeypatch
+    ):
+        # End-to-end at the capture layer: the resolver returns a
+        # kernel-suffixed rpm identity and the block preserves the full
+        # NVRA in package_full_name while package_name stays the family.
+        full = (
+            "amdgpu-kmod-6.9.0-0_fbk10_brcmrdma13_141_g9b20106afb70"
+            "-6.14.14.000000-2226257.1.x86_64"
+        )
+        monkeypatch.setattr(
+            env_mod,
+            "_query_amdgpu_package",
+            lambda: {
+                "name": "amdgpu-kmod",
+                "version": "6.14.14.000000-2226257.1",
+                "manager": "rpm",
+                "full_name": full,
+            },
+        )
+        monkeypatch.setattr(env_mod, "_modinfo_field", lambda mod, field: None)
+        monkeypatch.setattr(env_mod, "_path_exists", lambda p: False)
+        reasons: list[str] = []
+        block = env_mod._capture_amdgpu_driver({"kmd_version": None}, reasons)
+        assert block["package_name"] == "amdgpu-kmod"
+        assert block["package_full_name"] == full
+        assert block["status"] == "present"
+        # A resolvable package means NO conflict reason.
+        assert reasons == []
+
     def test_kmd_version_reused_from_rocm_block(self, isolated_env, monkeypatch):
         # Even with everything else absent, a kmd_version in the rocm block
         # flows through and makes the block "present".
-        monkeypatch.setattr(env_mod, "_query_package_version", lambda pkg: None)
+        monkeypatch.setattr(env_mod, "_query_amdgpu_package", lambda: None)
         monkeypatch.setattr(env_mod, "_modinfo_field", lambda mod, field: None)
         monkeypatch.setattr(env_mod, "_path_exists", lambda p: False)
         reasons: list[str] = []
@@ -4887,7 +5104,7 @@ class TestAmdgpuDriver:
     ):
         # KFD node + modinfo present, but no dpkg/rpm package resolvable:
         # an unusual, diagnosable state that DOES earn one partial reason.
-        monkeypatch.setattr(env_mod, "_query_package_version", lambda pkg: None)
+        monkeypatch.setattr(env_mod, "_query_amdgpu_package", lambda: None)
         monkeypatch.setattr(
             env_mod,
             "_modinfo_field",
@@ -4902,6 +5119,28 @@ class TestAmdgpuDriver:
             r.startswith("amdgpu_driver.package_version") for r in reasons
         )
 
+    def test_kfd_passthrough_container_is_not_a_conflict(
+        self, isolated_env, monkeypatch
+    ):
+        # The normal ROCm-container case: /dev/kfd is mounted from the host
+        # kernel, but the container filesystem has no amdgpu package and no
+        # /lib/modules entry (modinfo returns None). This is NOT a conflict
+        # -- /dev/kfd is host state while dpkg/rpm + modinfo read the
+        # container filesystem -- so it must NOT pollute partial_reasons.
+        monkeypatch.setattr(env_mod, "_query_amdgpu_package", lambda: None)
+        monkeypatch.setattr(env_mod, "_modinfo_field", lambda mod, field: None)
+        monkeypatch.setattr(
+            env_mod,
+            "_path_exists",
+            lambda p: p == env_mod.KFD_DEVICE_NODE,
+        )
+        reasons: list[str] = []
+        block = env_mod._capture_amdgpu_driver({"kmd_version": None}, reasons)
+        assert block["kfd_device_present"] is True
+        assert block["package_version"] is None
+        assert block["status"] == "present"
+        assert reasons == []
+
     def test_kfd_presence_uses_module_constants(self, isolated_env, monkeypatch):
         # kfd_device_present / kfd_sysfs_present must key off the module
         # path constants so tests (and future path moves) stay in sync.
@@ -4911,7 +5150,7 @@ class TestAmdgpuDriver:
             seen.append(p)
             return p == env_mod.KFD_DEVICE_NODE
 
-        monkeypatch.setattr(env_mod, "_query_package_version", lambda pkg: None)
+        monkeypatch.setattr(env_mod, "_query_amdgpu_package", lambda: None)
         monkeypatch.setattr(env_mod, "_modinfo_field", lambda mod, field: None)
         monkeypatch.setattr(env_mod, "_path_exists", fake_exists)
         reasons: list[str] = []
@@ -4924,7 +5163,7 @@ class TestAmdgpuDriver:
     def test_empty_matches_capture_all_absent(self, isolated_env, monkeypatch):
         # _empty_amdgpu_driver() must be byte-identical to a real all-absent
         # capture, so the dataclass default never diverges from reality.
-        monkeypatch.setattr(env_mod, "_query_package_version", lambda pkg: None)
+        monkeypatch.setattr(env_mod, "_query_amdgpu_package", lambda: None)
         monkeypatch.setattr(env_mod, "_modinfo_field", lambda mod, field: None)
         monkeypatch.setattr(env_mod, "_path_exists", lambda p: False)
         reasons: list[str] = []

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -121,6 +121,8 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
     )
     monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
     monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", tmp_path / "no_self_cgroup")
+    monkeypatch.setattr(env_mod, "KFD_DEVICE_NODE", tmp_path / "no_kfd")
+    monkeypatch.setattr(env_mod, "KFD_SYSFS_DIR", tmp_path / "no_kfd_sysfs")
     monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
     # Force pytorch import to fail so its fallback path is exercised too
     real_import = __builtins__["__import__"] if isinstance(
@@ -156,6 +158,8 @@ class TestPathConstants:
             "ROCM_VERSION_FILE",
             "ROCM_VERSION_DEV_FILE",
             "KMD_VERSION_FILE",
+            "KFD_DEVICE_NODE",
+            "KFD_SYSFS_DIR",
             "HIPBLASLT_VERSION_HEADER",
             "HIPBLASLT_LIB_DIR",
             "HIPBLASLT_TENSILE_DIR",
@@ -202,6 +206,8 @@ class TestPathConstants:
             "ROCM_VERSION_FILE",
             "ROCM_VERSION_DEV_FILE",
             "KMD_VERSION_FILE",
+            "KFD_DEVICE_NODE",
+            "KFD_SYSFS_DIR",
             "HIPBLASLT_VERSION_HEADER",
             "HIPBLASLT_LIB_DIR",
             "HIPBLASLT_TENSILE_DIR",
@@ -277,6 +283,7 @@ REQUIRED_TOP_KEYS = {
     "library_introspection_alternates",
     "pytorch_sdpa",
     "nics",
+    "amdgpu_driver",
 }
 
 
@@ -286,7 +293,7 @@ class TestSchemaCompleteness:
     ):
         snapshot = collect_env()
         assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
-        assert snapshot.schema_version == "1.9"
+        assert snapshot.schema_version == "1.10"
         assert snapshot.system_health is None
         assert snapshot.rocm == {
             "version": None,
@@ -504,6 +511,18 @@ def _example_snapshot(**overrides) -> object:
             "cx7": {"present": True, "driver_version": None, "firmware": None,
                     "rdma_devices": [], "links": []},
         },
+        "amdgpu_driver": {
+            "scope": "host_kernel",
+            "status": "present",
+            "package_name": "amdgpu-dkms",
+            "package_version": "1:6.14.14-2212064.24.04",
+            "package_manager": "dpkg",
+            "module_version": "6.14.14",
+            "module_srcversion": "A1B2C3D4E5F6A7B8C9D0",
+            "kmd_version": "6.16.13",
+            "kfd_device_present": True,
+            "kfd_sysfs_present": True,
+        },
     }
     base.update(overrides)
     return EnvSnapshot(**base)
@@ -547,6 +566,7 @@ class TestEnvSnapshot:
             ("tensile_catalog", env_mod._empty_tensile_catalog),
             ("miopen_catalog", env_mod._empty_miopen_catalog),
             ("rocfft_catalog", env_mod._empty_rocfft_catalog),
+            ("amdgpu_driver", env_mod._empty_amdgpu_driver),
         ],
     )
     def test_from_dict_backfills_missing_catalog_key(self, key, empty_factory):
@@ -1029,6 +1049,13 @@ class TestCollectEnvContract:
             env_mod, "PODMAN_CONTAINERENV_MARKER", tmp_path / "no_podmanenv"
         )
         monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
+        # Redirect KFD paths off the real filesystem: on a host that
+        # actually has an AMD GPU, /dev/kfd exists and the fake dpkg/rpm/
+        # modinfo below never resolve a package -- without this, the
+        # amdgpu_driver conflict check would fire a real partial reason
+        # and break the "clean probe -> partial is False" contract.
+        monkeypatch.setattr(env_mod, "KFD_DEVICE_NODE", tmp_path / "no_kfd")
+        monkeypatch.setattr(env_mod, "KFD_SYSFS_DIR", tmp_path / "no_kfd_sysfs")
 
         # rdhc happy path: pretend it's installed and writes valid JSON
         monkeypatch.setattr(env_mod.shutil, "which", lambda name: "/usr/bin/" + name)
@@ -4622,6 +4649,287 @@ class TestHostBlock:
         reasons: list[str] = []
         block = env_mod._capture_host(reasons)
         assert block["glibc_version"] == "2.42"
+
+
+# ---------------------------------------------------------------------------
+# amdgpu_driver (host-kernel scope KFD/AMDGPU driver identity, schema 1.10)
+# ---------------------------------------------------------------------------
+
+
+class TestQueryPackageVersion:
+    """_query_package_version(): portable dpkg-then-rpm, no shell pipe."""
+
+    @staticmethod
+    def _tools(present, outputs):
+        """(fake_which, fake_run) for the given present tools + argv->(_rc, out) map."""
+
+        def fake_which(name):
+            return f"/usr/bin/{name}" if name in present else None
+
+        def fake_run(cmd, **kwargs):
+            rc, out = outputs.get(tuple(cmd), (1, ""))
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=rc, stdout=out, stderr=""
+            )
+
+        return fake_which, fake_run
+
+    def test_dpkg_hit_wins_and_reports_manager(self, isolated_env, monkeypatch):
+        fw, fr = self._tools(
+            {"dpkg-query", "rpm"},
+            {
+                ("dpkg-query", "-W", "-f=${Version}", "amdgpu-dkms"): (
+                    0,
+                    "1:6.14.14-2212064.24.04\n",
+                ),
+            },
+        )
+        monkeypatch.setattr(env_mod.shutil, "which", fw)
+        monkeypatch.setattr(env_mod.subprocess, "run", fr)
+        assert env_mod._query_package_version("amdgpu-dkms") == (
+            "1:6.14.14-2212064.24.04",
+            "dpkg",
+        )
+
+    def test_falls_back_to_rpm_when_dpkg_absent(self, isolated_env, monkeypatch):
+        # No dpkg-query on PATH (RHEL); rpm answers with VERSION-RELEASE.
+        fw, fr = self._tools(
+            {"rpm"},
+            {
+                ("rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", "amdgpu-kmod"): (
+                    0,
+                    "6.14.14-2212064.el9\n",
+                ),
+            },
+        )
+        monkeypatch.setattr(env_mod.shutil, "which", fw)
+        monkeypatch.setattr(env_mod.subprocess, "run", fr)
+        assert env_mod._query_package_version("amdgpu-kmod") == (
+            "6.14.14-2212064.el9",
+            "rpm",
+        )
+
+    def test_dpkg_present_but_package_missing_falls_to_rpm(
+        self, isolated_env, monkeypatch
+    ):
+        # dpkg-query runs but exits non-zero (package not installed under
+        # dpkg); rpm then finds it. Exercises the "manager present, package
+        # absent" branch rather than "manager absent".
+        fw, fr = self._tools(
+            {"dpkg-query", "rpm"},
+            {
+                ("dpkg-query", "-W", "-f=${Version}", "amdgpu-dkms"): (1, ""),
+                ("rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", "amdgpu-dkms"): (
+                    0,
+                    "6.14.14-2212064.el9\n",
+                ),
+            },
+        )
+        monkeypatch.setattr(env_mod.shutil, "which", fw)
+        monkeypatch.setattr(env_mod.subprocess, "run", fr)
+        assert env_mod._query_package_version("amdgpu-dkms") == (
+            "6.14.14-2212064.el9",
+            "rpm",
+        )
+
+    def test_rpm_not_installed_marker_is_rejected(self, isolated_env, monkeypatch):
+        # Some rpm builds exit 0 and print "<pkg> is not installed" to
+        # stdout -- must NOT be read as a version.
+        fw, fr = self._tools(
+            {"rpm"},
+            {
+                ("rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", "amdgpu-dkms"): (
+                    0,
+                    "package amdgpu-dkms is not installed\n",
+                ),
+            },
+        )
+        monkeypatch.setattr(env_mod.shutil, "which", fw)
+        monkeypatch.setattr(env_mod.subprocess, "run", fr)
+        assert env_mod._query_package_version("amdgpu-dkms") is None
+
+    def test_no_package_manager_returns_none(self, isolated_env, monkeypatch):
+        fw, fr = self._tools(set(), {})
+        monkeypatch.setattr(env_mod.shutil, "which", fw)
+        monkeypatch.setattr(env_mod.subprocess, "run", fr)
+        assert env_mod._query_package_version("amdgpu-dkms") is None
+
+    def test_timeout_is_fail_soft(self, isolated_env, monkeypatch):
+        def boom(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 5)
+
+        monkeypatch.setattr(
+            env_mod.shutil, "which", lambda n: f"/usr/bin/{n}"
+        )
+        monkeypatch.setattr(env_mod.subprocess, "run", boom)
+        # Both managers time out -> None, no raise.
+        assert env_mod._query_package_version("amdgpu-dkms") is None
+
+
+_MODINFO_AMDGPU = (
+    "filename:       /lib/modules/6.8.0/updates/dkms/amdgpu.ko\n"
+    "version:        6.14.14\n"
+    "srcversion:     A1B2C3D4E5F6A7B8C9D0\n"
+    "license:        GPL and additional rights\n"
+)
+
+
+class TestModinfoField:
+    def test_parses_named_field(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda n: "/sbin/modinfo")
+        monkeypatch.setattr(
+            env_mod.subprocess,
+            "run",
+            lambda cmd, **k: subprocess.CompletedProcess(
+                cmd, 0, stdout=_MODINFO_AMDGPU, stderr=""
+            ),
+        )
+        assert env_mod._modinfo_field("amdgpu", "version") == "6.14.14"
+        assert (
+            env_mod._modinfo_field("amdgpu", "srcversion")
+            == "A1B2C3D4E5F6A7B8C9D0"
+        )
+
+    def test_absent_modinfo_returns_none(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(env_mod.shutil, "which", lambda n: None)
+        assert env_mod._modinfo_field("amdgpu", "version") is None
+
+    def test_nonzero_exit_returns_none(self, isolated_env, monkeypatch):
+        # modinfo exits non-zero when the module isn't found (GPU-less box).
+        monkeypatch.setattr(env_mod.shutil, "which", lambda n: "/sbin/modinfo")
+        monkeypatch.setattr(
+            env_mod.subprocess,
+            "run",
+            lambda cmd, **k: subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr="modinfo: ERROR: Module amdgpu not found.\n"
+            ),
+        )
+        assert env_mod._modinfo_field("amdgpu", "version") is None
+
+
+class TestAmdgpuDriver:
+    """_capture_amdgpu_driver(): host-scope, degrades cleanly with no GPU."""
+
+    def test_block_keys_stable(self, all_disabled):
+        snapshot = collect_env()
+        assert set(snapshot.amdgpu_driver.keys()) == {
+            "scope",
+            "status",
+            "package_name",
+            "package_version",
+            "package_manager",
+            "module_version",
+            "module_srcversion",
+            "kmd_version",
+            "kfd_device_present",
+            "kfd_sysfs_present",
+        }
+        assert snapshot.amdgpu_driver["scope"] == "host_kernel"
+
+    def test_no_gpu_is_documented_absence_not_partial(
+        self, isolated_env, monkeypatch
+    ):
+        # Nothing resolvable: no package manager, no modinfo, no KFD nodes,
+        # no kmd_version. This is the dev-machine / CPU-runner case.
+        monkeypatch.setattr(env_mod.shutil, "which", lambda n: None)
+        monkeypatch.setattr(env_mod, "_path_exists", lambda p: False)
+        reasons: list[str] = []
+        block = env_mod._capture_amdgpu_driver({"kmd_version": None}, reasons)
+        assert block["status"] == "absent"
+        assert block["package_version"] is None
+        assert block["kfd_device_present"] is False
+        # The whole point: a GPU-less host must NOT pollute partial_reasons.
+        assert reasons == []
+
+    def test_present_full_capture(self, isolated_env, monkeypatch):
+        monkeypatch.setattr(
+            env_mod,
+            "_query_package_version",
+            lambda pkg: ("1:6.14.14-2212064.24.04", "dpkg")
+            if pkg == "amdgpu-dkms"
+            else None,
+        )
+        monkeypatch.setattr(
+            env_mod,
+            "_modinfo_field",
+            lambda mod, field: {
+                "version": "6.14.14",
+                "srcversion": "A1B2C3D4E5F6A7B8C9D0",
+            }.get(field),
+        )
+        monkeypatch.setattr(env_mod, "_path_exists", lambda p: True)
+        reasons: list[str] = []
+        block = env_mod._capture_amdgpu_driver({"kmd_version": "6.16.13"}, reasons)
+        assert block["status"] == "present"
+        assert block["package_name"] == "amdgpu-dkms"
+        assert block["package_version"] == "1:6.14.14-2212064.24.04"
+        assert block["package_manager"] == "dpkg"
+        assert block["module_version"] == "6.14.14"
+        assert block["module_srcversion"] == "A1B2C3D4E5F6A7B8C9D0"
+        # kmd_version is REUSED from the passed rocm block (no second read).
+        assert block["kmd_version"] == "6.16.13"
+        assert block["kfd_device_present"] is True
+        assert reasons == []
+
+    def test_kmd_version_reused_from_rocm_block(self, isolated_env, monkeypatch):
+        # Even with everything else absent, a kmd_version in the rocm block
+        # flows through and makes the block "present".
+        monkeypatch.setattr(env_mod, "_query_package_version", lambda pkg: None)
+        monkeypatch.setattr(env_mod, "_modinfo_field", lambda mod, field: None)
+        monkeypatch.setattr(env_mod, "_path_exists", lambda p: False)
+        reasons: list[str] = []
+        block = env_mod._capture_amdgpu_driver({"kmd_version": "6.16.13"}, reasons)
+        assert block["kmd_version"] == "6.16.13"
+        assert block["status"] == "present"
+
+    def test_loaded_but_unpackaged_records_conflict_reason(
+        self, isolated_env, monkeypatch
+    ):
+        # KFD node + modinfo present, but no dpkg/rpm package resolvable:
+        # an unusual, diagnosable state that DOES earn one partial reason.
+        monkeypatch.setattr(env_mod, "_query_package_version", lambda pkg: None)
+        monkeypatch.setattr(
+            env_mod,
+            "_modinfo_field",
+            lambda mod, field: "6.14.14" if field == "version" else None,
+        )
+        monkeypatch.setattr(env_mod, "_path_exists", lambda p: True)
+        reasons: list[str] = []
+        block = env_mod._capture_amdgpu_driver({"kmd_version": None}, reasons)
+        assert block["status"] == "present"
+        assert block["package_version"] is None
+        assert any(
+            r.startswith("amdgpu_driver.package_version") for r in reasons
+        )
+
+    def test_kfd_presence_uses_module_constants(self, isolated_env, monkeypatch):
+        # kfd_device_present / kfd_sysfs_present must key off the module
+        # path constants so tests (and future path moves) stay in sync.
+        seen: list = []
+
+        def fake_exists(p):
+            seen.append(p)
+            return p == env_mod.KFD_DEVICE_NODE
+
+        monkeypatch.setattr(env_mod, "_query_package_version", lambda pkg: None)
+        monkeypatch.setattr(env_mod, "_modinfo_field", lambda mod, field: None)
+        monkeypatch.setattr(env_mod, "_path_exists", fake_exists)
+        reasons: list[str] = []
+        block = env_mod._capture_amdgpu_driver({"kmd_version": None}, reasons)
+        assert block["kfd_device_present"] is True
+        assert block["kfd_sysfs_present"] is False
+        assert env_mod.KFD_DEVICE_NODE in seen
+        assert env_mod.KFD_SYSFS_DIR in seen
+
+    def test_empty_matches_capture_all_absent(self, isolated_env, monkeypatch):
+        # _empty_amdgpu_driver() must be byte-identical to a real all-absent
+        # capture, so the dataclass default never diverges from reality.
+        monkeypatch.setattr(env_mod, "_query_package_version", lambda pkg: None)
+        monkeypatch.setattr(env_mod, "_modinfo_field", lambda mod, field: None)
+        monkeypatch.setattr(env_mod, "_path_exists", lambda p: False)
+        reasons: list[str] = []
+        block = env_mod._capture_amdgpu_driver({"kmd_version": None}, reasons)
+        assert block == env_mod._empty_amdgpu_driver()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `amdgpu_driver` block to `aorta env probe` (schema 1.9 → 1.10): package identity (dpkg/rpm), kernel module identity (`modinfo amdgpu`), and KFD presence (`/dev/kfd`, `/sys/class/kfd`).
- **Host-kernel scope distinction:** `kfd_device_present` / `kfd_sysfs_present` / `kmd_version` reflect the host kernel a container *shares*, so they report the host's driver even from inside a container — complementary to `rocm`/`hip` which read the container's `/opt/rocm` userspace. `package_*` / `module_*` are explicitly **not** host-guaranteed (dpkg/rpm and `modinfo` read the current filesystem's package DB and `/lib/modules`).
- Fully fail-soft; no GPU required. A GPU-less host is a documented absence (no partial reason); a KMD-loaded-but-unpackaged state is a genuine conflict that appends a partial reason.

## Test plan
- [x] `pytest -k "Amdgpu or amdgpu"` — 8 passed
- [x] Hermeticity: `all_disabled` and `test_partial_false_on_clean_full_probe` mock `KFD_DEVICE_NODE`/`KFD_SYSFS_DIR` so a real host GPU can't leak into the clean-probe contract
- [ ] Full suite on MI350 (Linux) — `test_partial_false_on_clean_full_probe` currently fails on Windows only, due to unrelated `os.uname`/`os.confstr`/`triton` noise (no `amdgpu_driver` reason in the failure list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)