### PR TITLE
env probe: container & execution-context visibility (schema 1.11, phase 1)

### DIFF
--- a/docs/env-probe-container-execution-context.md
+++ b/docs/env-probe-container-execution-context.md
@@ -1,0 +1,212 @@
+# env probe — container & Buck2 execution context (design note)
+
+Status: partially implemented · Scope: `src/aorta/instrumentation/environment.py`, `src/aorta/cli/env.py`, `src/aorta/instrumentation/_probe_main.py`, `docs/env-probe.md`
+
+## Implementation status
+
+**Landed (phase 1 — container-context, no Buck2 dependency; schema 1.11):**
+
+- `container_detected` (bool) — the generic-isolation smoke detector that
+  fixes the RE/k8s-sandbox-as-`baremetal` false negative. Additive schema bump.
+- `execution_context.probe_invocation` — a self-declared label
+  (`direct` / `buck2_run` / `buck2_action`) stamped from the new
+  `--execution-context` flag.
+- `--execution-context` flag on both `aorta env probe` and
+  `python -m aorta.instrumentation._probe_main` — labels the snapshot and
+  **warns loudly to stderr** when a container/RE capture is claimed but
+  `container_detected` is `false` and neither `$AORTA_RE_IMAGE` nor
+  `$AORTA_DOCKER_IMAGE` is set.
+
+Phase 1 captures **nothing new about a remote worker** — it only makes the
+"probed the wrong place" failure visible. That is the whole point: it is a
+guardrail, not a data source.
+
+**Still REMAINING (phase 2 — Buck2 / remote-execution, needs MI350 empirics):**
+
+- `execution_context.likely_execution_platform` — resolved RE platform label.
+  **Blocked on Open Q2** (does `buck2 audit configurations`/cquery report the
+  *selected* platform, or only candidates?). The key exists today and is
+  always `null`.
+- `$AORTA_RE_IMAGE` launcher convention — **blocked on Open Q1**: a native RE
+  marker (`BUCK2_RE_*` / `RE_PLATFORM` / sandbox rootfs path) may already
+  exist and be preferable; do not invent the convention until Q1 is answered.
+  (The env var is already read by the `--execution-context` warning so the
+  convention can be adopted without further code once Q1 is settled.)
+- `probe_namespace` (mount-ns / cgroup hash diff key) — deferred; the phase-1
+  `container_detected` boolean covers the immediate false-negative bug, and
+  the namespace hash is only useful once two-probe RE diffing exists.
+- The Buck2 `genrule`/`sh_test` rule wrapper — documentation-only per the
+  external-tool policy; deferred until phase 2.
+- Open Q1, Q2, Q3 below all remain open (Q1/Q2 need a real Buck2 RE cluster;
+  Q3 is "where does the NaN-repro runbook live").
+
+The **field classification, risks, and runbook** sections below are the
+enduring rationale and apply to both phases.
+
+## Problem
+
+`aorta env probe` captures state from **the process that runs it**. There is no
+host-vs-container distinction beyond a small `runtime_context` / `docker` block.
+Nearly every field (ROCm, HIP, hipBLASLt/rocBLAS/MIOpen/RCCL, GPU arch, PyTorch
+build, env vars) is read from whatever filesystem, `/proc`, and Python
+interpreter the probe process sees — trustworthy **only if the probe ran inside
+the same execution context as the workload**.
+
+For plain Docker this mostly holds (the playbook is "run the probe inside the
+container"). For **open-source Buck2 (Meta)** it breaks in a way today's schema
+cannot see:
+
+- Buck2 is **remote-execution first**. Per action, Buck2 decides to run it
+  **locally** (invoking host, *unsandboxed* — no container at all) or
+  **remotely** on an RE worker inside whatever image the chosen execution
+  platform's `remote_execution_properties` specifies (BuildBarn / BuildBuddy /
+  EngFlow).
+- The local-vs-remote decision is **per action** and can **race both** (hybrid
+  execution). There is no single "the build ran in container X" answer to
+  capture.
+- `aorta env probe --buck-target …` runs `buck2 cquery`, `buck2 root`,
+  `buck2 --version`, `hg id -i` **on the invoking host**, not the RE worker. It
+  returns configured-target-**graph labels**, not the worker's filesystem /
+  driver / ROCm state.
+- `_detect_container_type()` recognizes only `/.dockerenv`,
+  `/run/.containerenv`, and `SINGULARITY_NAME`/cgroup tokens. An RE worker's
+  bare `runc`/containerd sandbox has none of these and silently falls through to
+  `"baremetal"` — actively misleading. **Phase 1's `container_detected`
+  addresses exactly this false negative.**
+
+**Bottom line:** "did I probe the container the workload ran in?" is not
+answerable from the artifact today, because Buck2 has no fixed "the container" —
+it has a per-action execution-platform decision the probe has no visibility into.
+
+Sources: Buck2 Remote Execution docs (buck2.build/docs/users/remote_execution/),
+Buck2 Architectural Model (buck2.build/docs/developers/architecture/buck2/),
+Buck2 Glossary, Tweag "A Tour Around Buck2."
+
+## Field classification
+
+Source → classification → Buck2 caveat.
+
+| Field(s) | Source | Class | Buck2 caveat |
+|---|---|---|---|
+| `rocm`, `hip`, `hipblaslt`, `rocblas`, `miopen`, `rccl`, `composable_kernel`, `tensile`, catalogs | `/opt/rocm` reads, `nm`/`c++filt`, `hipconfig` | **process** | If actions run remotely while the probe runs on the host, these describe the **wrong machine** — not host/container drift, an unrelated box. |
+| `amdgpu_driver.kfd_device_present` / `.kfd_sysfs_present` / `.kmd_version` | `/dev/kfd`, `/sys/class/kfd`, `/sys/module/amdgpu/version` | **host-kernel** | Valid only if the probe runs on the **same physical/VM host** as the workload. An RE worker on another machine has its own driver. |
+| `amdgpu_driver.package_*` / `.module_*` | `dpkg`/`rpm`, `modinfo` | **filesystem/process** | Same, one level down (see schema 1.10 scope narrowing). |
+| `gpu_arch` | `rocm_agent_enumerator` | **host/device** | Needs `/dev/kfd` passthrough; a passthrough gap reads as "no GPU." |
+| `env_vars` | `os.environ` of probe | **process** | Buck2 actions set env per-rule; the invoking shell's env is often not what the action saw. |
+| `runtime_context.type` | `/.dockerenv`, `/run/.containerenv`, cgroup | **process, narrow** | RE sandbox → `"baremetal"` false negative. Use `container_detected` for the runtime-agnostic answer. |
+| `container_detected` | named-runtime match, `/proc/self/ns/mnt` vs `/proc/1/ns/mnt`, container/k8s cgroup tokens | **process, runtime-agnostic** | `true` when *any* isolation signal fires even if the runtime can't be named. Still describes the probe's OWN process — it does not prove the probe ran where the workload ran. |
+| `execution_context.probe_invocation` | `--execution-context` flag (self-declared) | **caller-asserted** | Honest record of the caller's claim, not an auto-detected fact (phase 1). |
+| `runtime_context.python_env` / `.venv_path` / `.conda_env_name` | `sys.prefix`, `$CONDA_DEFAULT_ENV` | **process** | May not match the interpreter Buck2 packages into a `python_binary`. |
+| `docker.image` / `.digest` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` | **externally asserted** | No Buck2 equivalent exists today (see `$AORTA_RE_IMAGE`, phase 2). |
+| `docker.container_id` | `/proc/self/cgroup` | **process** | Same host-kernel dependency; irrelevant to a remote worker. |
+| `build_system` (`kind`, `buck2_version`, `repo_root`, `revision`) | `buck2 --version`/`root`, `hg id`/`git rev-parse` on invoking host | **client-host** | Describes the developer's checkout, not the RE worker's toolchain. Two engineers get identical blocks while builds ran on different images. |
+| `library_introspection` (`buck2 cquery 'deps(target)'`) | configured target graph (labels) | **ambiguous — graph-accurate, execution-silent** | Reliable for declared deps; not for what code actually executed remotely (hybrid/racing/RE-cache). |
+| `pytorch_build.*` | `import torch`, `torch.__config__` | **process** | If the shell's torch ≠ the `python_binary`'s torch target, this silently describes the wrong build (the "torch is a Buck target" trap documented in `docs/env-probe.md`, schema 1.8 Buck/monorepo native-lib recovery). |
+| `host` (`kernel_release`, `glibc_version`, `machine`) | `os.uname()`, `os.confstr()` | **host-kernel** | Same wrong-machine risk. |
+| `nics` | `lspci`/`ethtool`/`ibv_devices`/`rdma link` | **host/device** | Misleading if probed off the collectives host. |
+| `system_health` | `rdhc --quick --json` | **host** | Same. |
+
+## Risks for Buck2
+
+1. **False confidence from a clean snapshot.** Every field degrades gracefully,
+   so a probe run on the wrong machine still produces a full, `partial:false`
+   artifact. Nothing says "captured somewhere unrelated to where your job ran."
+2. **`runtime_context.type` misclassifies RE sandboxes as `"baremetal"`** — reads
+   as "no isolation," the opposite of the truth, worse than "unknown." *(Phase 1
+   `container_detected` mitigates this.)*
+3. **`buck2 cquery` answers "what's declared," not "what ran."** Deterministic
+   for the label graph; blind to local/remote/RE-cache execution.
+4. **`build_system.revision`/`buck2_version` describe the client, not the
+   executor** — false reassurance that two probes "match."
+5. **No signal at all for local-vs-remote execution** of a given action.
+6. **The "torch is a Buck target" workaround already exists for exactly this
+   gap** (documented in `docs/env-probe.md`, schema 1.8) — it generalizes to
+   `env_vars`, `gpu_arch`, ROCm/HIP, and `amdgpu_driver` whenever an RE
+   action's env differs from the invoking shell.
+
+## Design — additive schema bump
+
+New fields (same additive pattern as the amdgpu_driver 1.10 change). The
+**Phase** column tracks what landed in phase 1 vs. what remains for phase 2
+(see Implementation status above):
+
+| Field | Type | Meaning | Phase |
+|---|---|---|---|
+| `container_detected` | `bool` | **Single boolean.** `true` on *any* isolation signal: a named-runtime match (`_detect_container_type() != "baremetal"`), a private mount namespace (`/proc/self/ns/mnt` != `/proc/1/ns/mnt`), or a container/k8s token in `/proc/self/cgroup` (`docker`/`containerd`/`kubepods`/`libpod`/`lxc`/`crio`). Fixes the RE-sandbox-as-baremetal false negative. No k8s-vs-containerd distinction. | **1 (done)** |
+| `execution_context.probe_invocation` | `"direct" \| "buck2_run" \| "buck2_action"` | How the probe was launched. Phase 1: **self-declared** via `--execution-context` (defaults to `direct`). Phase 2 may auto-detect via native RE env vars (**see Open Q1**). | **1 (done, self-declared)** |
+| `execution_context.likely_execution_platform` | `str \| null` | Best-effort: from `buck2 audit configurations` / cquery on the target, the resolved platform label. Advisory, not guaranteed (**Open Q2**). Key present today, always `null`. | 2 (remaining) |
+| `probe_namespace` | `str \| null` | Hash of the mount namespace / cgroup path (e.g. `/proc/self/ns/mnt` inode). A coarse "same isolation boundary?" diff key, nothing more. | 2 (remaining) |
+| `$AORTA_RE_IMAGE` convention | env var | Extend the existing `$AORTA_DOCKER_IMAGE` launcher pattern to Buck2: customers set this in their `remote_execution_properties` / action env (**pending Open Q1** — a native marker may exist and be preferable). Already read by the phase-1 warning. | 2 (remaining) |
+
+### CLI — a labeling+validation flag, not a behavior change
+
+```
+aorta env probe --execution-context buck2_action
+python -m aorta.instrumentation._probe_main --execution-context buck2_action /out/env.json
+```
+
+Does not change what is captured (all still process-derived). It:
+1. stamps `execution_context.probe_invocation`, and
+2. **warns loudly to stderr** (fail-soft, never a hard error) if
+   `container_detected` is `false` **and** neither `$AORTA_RE_IMAGE` nor
+   `$AORTA_DOCKER_IMAGE` is set — i.e. "you claimed a container/RE capture but I
+   see zero isolation signal." This single check catches the core misdiagnosis.
+   Implemented in **both** the Click CLI (`aorta env probe`) and the
+   dependency-free `_probe_main` entry point, since the latter is the one most
+   likely used inside a Buck2 action / container.
+
+### Durable fix — a Buck2 rule wrapper (documented, not vendored)
+
+A `genrule`/`sh_test` that runs `aorta env probe` **as part of the action**, so
+it executes wherever Buck2 actually placed that action. This is the direct RE
+analogue of the README's existing "put AORTA and torch in one `python_binary`"
+pattern. Documented in `docs/`, not shipped as vendored Buck code (external-tool
+policy). *(Phase 2.)*
+
+## Recipes / runbook guidance
+
+1. Never accept a bare host-shell probe as sufficient for a Buck2-driven job
+   without first asking: **local or remote execution?**
+2. If remote, the probe must run as a Buck2 action/genrule dependency of the
+   failing target, not standalone.
+3. Always capture **both** a host-side probe and an in-action probe; diff
+   `runtime_context`, `container_detected`, and `amdgpu_driver.kfd_device_present`
+   as the first triage step.
+
+### Proposed runbook wording (Residual NaN / repro)
+
+> **⚠️ If your job runs under Buck2, a host-shell `aorta env probe` is not
+> enough.** Buck2 may execute your build/test locally or on a remote executor,
+> and the two can have completely different ROCm/driver/GPU environments. A
+> host-shell probe only tells us about your shell — not what your job saw if it
+> executed remotely.
+>
+> Before filing a repro, tell us: **did this job run locally or via remote
+> execution?** If unsure, assume remote for anything routed through a shared
+> Buck2 RE cluster.
+>
+> - **Local** Buck2 build (`--local-only`, or RE disabled in `.buckconfig`): a
+>   host-shell probe is representative — `aorta env probe -o env.json`.
+> - **Can run remotely:** add
+>   `aorta env probe --execution-context buck2_action -o env_workload.json` as a
+>   dependency/step of the failing target so it captures the RE worker's actual
+>   environment; submit **that** file.
+> - **When in doubt, submit both.** If they disagree on `runtime_context`,
+>   `container_detected`, `amdgpu_driver`, or ROCm versions, that mismatch is
+>   itself diagnostic — send it as-is.
+
+## Open questions (empirically testable on MI350)
+
+1. **Is there already a native "I'm on an RE worker" env var?** Test: a trivial
+   `genrule`/`sh_test` that runs `env | sort > $OUT` both locally and
+   forced-remote, then diff. If Buck2/the RE backend injects a stable marker
+   (`BUCK2_RE_*`, `RE_PLATFORM`, a sandbox rootfs path), read *that* instead of
+   inventing `$AORTA_RE_IMAGE`. If not, the customer-set convention is confirmed
+   necessary.
+2. **Can `buck2 audit configurations` / cquery name the *resolved* execution
+   platform, not just the available ones?** Test on a real target. If it reports
+   the selected platform, `likely_execution_platform` becomes confident; if only
+   candidates, it stays advisory.
+3. Where does the "Residual NaN repro" runbook actually live? Not found in the
+   `aorta` repo — likely customer-facing docs, or a doc to be created under
+   `docs/`.

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -129,8 +129,8 @@ operator can act on them without `jq`'ing the JSON. A closing
 end-of-output. Sample:
 
 ```text
-Wrote env probe to /tmp/env.json (schema_version=1.10) [PARTIAL]
-  runtime:   baremetal / python=venv
+Wrote env probe to /tmp/env.json (schema_version=1.11) [PARTIAL]
+  runtime:   baremetal / python=venv  container_detected=no  probe=direct
   build_sys: none
   rocm:      7.2.1 (dev: None)
   hip:       7.2.53211-e1a6bc5663 (amd)
@@ -220,7 +220,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | Currently `"1.10"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
+| `schema_version` | `str` | constant | Currently `"1.11"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
@@ -244,7 +244,9 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `fbgemm` | `dict` | optional `import fbgemm_gpu` (+ commit parse) + parse of `torch.__config__.show()` for `-DUSE_FBGEMM*` defines | `package_version`, `commit` (schema 1.8 -- best-effort git SHA from a setuptools_scm `+g<sha>` local-version segment or a `git_version`/`__commit__` module attr; `null` when fbgemm_gpu is vendored-in-torch rather than separately installed, or carries no SHA), `pytorch_use_fbgemm`, `pytorch_use_fbgemm_genai`. The two booleans capture the build-time decision baked into the PyTorch wheel even when `fbgemm_gpu` isn't a separate pip package. |
 | `aiter` | `dict` | `import aiter; aiter.__version__` + `importlib.metadata.version("amd_aiter" \| "aiter")` + scan of `aiter_meta/hsa/<gfx>/` (or `$AORTA_PYTORCH_SRC/third_party/aiter/hsa/`) | `package_version`, `package_dist_name` (which PyPI dist matched: `amd_aiter` is the canonical AMD-internal ROCm/PyTorch image dist; `aiter` is the upstream name), `commit` (parsed from the setuptools_scm `+g<sha>` local-version segment, matches the image tag's `aiter-<sha>` label), `hsa_tree` (issue #176 -- per-arch fingerprint of pre-built `.co` kernel binaries: file_count, co_count, deterministic combined_sha256). Most installs record `null` for everything; absence is silent. |
 | `aotriton` | `dict` | scan of `<torch>/lib/libaotriton_v2.so*` filenames + `sha256` of the resolved file + presence of `<torch>/lib/aotriton.images/` + `$AOTRITON_INSTALLED_PREFIX` | Default ROCm Flash Attention backend. Bundled in the wheel via `cmake/External/aotriton.cmake` (NOT a `third_party/` git submodule). Fields: `bundled_present`, `bundled_version`, `bundled_lib_hash`, `bundled_images_dir_present`, `installed_prefix`. CK is the alternative backend (toggled via `TORCH_ROCM_FA_PREFER_CK=1`). |
-| `runtime_context` | `dict` | `/.dockerenv`, `/run/.containerenv`, `$SINGULARITY_NAME`, `/proc/1/cgroup`, `sys.prefix`, `$CONDA_DEFAULT_ENV` | `type`, `python_env`, `venv_path`, `conda_env_name` |
+| `runtime_context` | `dict` | `/.dockerenv`, `/run/.containerenv`, `$SINGULARITY_NAME`, `/proc/1/cgroup`, `sys.prefix`, `$CONDA_DEFAULT_ENV` | `type`, `python_env`, `venv_path`, `conda_env_name`. **`type` only ever returns `docker`/`podman`/`singularity`/`baremetal`** — an unnamed sandbox (RE worker, containerd k8s pod) falls through to `baremetal`; use `container_detected` (below) for the runtime-agnostic "am I isolated?" answer. |
+| `container_detected` | `bool` | named-runtime match + `/proc/self/ns/mnt` vs `/proc/1/ns/mnt` (private mount ns) + container/k8s tokens in `/proc/self/cgroup` | Schema 1.11. Runtime-**agnostic** isolation smoke test: `true` on *any* sandbox signal even when the runtime can't be named. Fixes the `runtime_context.type == "baremetal"` false negative for RE-workers / k8s pods. `container_detected:true` + `type:"baremetal"` is the honest reading of an unnamed sandbox. Fail-soft; `false` means "no isolation signal observed," not "definitely bare metal." |
+| `execution_context` | `dict` | `--execution-context` CLI flag (self-declared) | Schema 1.11. `probe_invocation` (`"direct"` \| `"buck2_run"` \| `"buck2_action"`; `"direct"` by default) records **how the probe was launched** — set `buck2_action` when running the probe as a Buck2 action so it captures the executor's env, not the invoking shell's. `likely_execution_platform` (`str \| null`) is reserved for phase-2 Buck2 work and is always `null` today. See the design note `docs/env-probe-container-execution-context.md`. The flag also **warns to stderr** when a non-`direct` context is claimed but `container_detected` is `false` and neither `$AORTA_RE_IMAGE` nor `$AORTA_DOCKER_IMAGE` is set (you may have probed the wrong place). |
 | `docker` | `dict \| null` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` env vars + `/proc/self/cgroup` | `null` on baremetal; image+digest provided by the launcher (the only reliable way from inside a container) |
 | `env_vars` | `dict[str, str \| null]` | explicit canonical list (currently 58 names; see `CANONICAL_ENV_VARS` in `environment.py` for the live set) | GPU scoping + HSA / runtime + GPU queue / codegen + NCCL/RCCL + AINIC net-plugin/fabric tuning + gfx950 fence-ordering knob + FBGEMM + MIOpen + SDPA backend selection + GEMM backend preference + hipBLASLt autotune + PyTorch / inductor. Build-time cmake flags (`USE_ROCM_CK_SDPA`, `USE_ROCM_CK_GEMM`, `USE_FBGEMM*`) are NOT in this list -- they're surfaced under their respective library blocks instead, parsed from `torch.__config__.show()`. |
 | `python_version` | `str` | `platform.python_version()` | always populated |
@@ -435,7 +437,38 @@ Mirrors the in-code comment at `SCHEMA_VERSION` in
 `src/aorta/instrumentation/environment.py`. Recorded here so consumers
 tracking schema evolution don't have to read source.
 
-### `1.10` (current)
+### `1.11` (current)
+
+Container & execution-context visibility, phase 1. Additive — two new
+top-level fields, both defaulted so older readers don't raise. See the
+design note `docs/env-probe-container-execution-context.md`.
+
+* New top-level **`container_detected`** (`bool`). A runtime-**agnostic**
+  isolation smoke test: `true` on any generic sandbox signal (a named
+  runtime match, a private mount namespace via `/proc/self/ns/mnt` vs
+  `/proc/1/ns/mnt`, or a container/k8s token in `/proc/self/cgroup`).
+  Fixes the long-standing false negative where an RE worker or containerd
+  k8s pod — which have none of the `docker`/`podman`/`singularity` markers
+  `runtime_context.type` knows — reported as `"baremetal"`, the opposite of
+  the truth. `container_detected:true` + `type:"baremetal"` is the honest
+  reading of an unnamed sandbox. Fail-soft; defaulted `false`.
+* New top-level **`execution_context`** block: `probe_invocation`
+  (`"direct"`/`"buck2_run"`/`"buck2_action"`, **self-declared** via the new
+  `aorta env probe --execution-context` flag; `"direct"` by default) and
+  `likely_execution_platform` (`null` today; reserved for phase-2 Buck2
+  work). Defaulted via `_empty_execution_context()`.
+* New CLI flag **`--execution-context`** (also accepted by
+  `python -m aorta.instrumentation._probe_main`). Captures nothing new — it
+  labels the snapshot and **warns to stderr** when a non-`direct` context
+  is claimed but `container_detected` is `false` and neither
+  `$AORTA_RE_IMAGE` nor `$AORTA_DOCKER_IMAGE` is set (the "you probed the
+  host shell, not where the job ran" guardrail). Never a hard error.
+* **Remaining (phase 2, Buck2 / remote-execution):**
+  `likely_execution_platform` population, the `$AORTA_RE_IMAGE` launcher
+  convention, and a `probe_namespace` diff key are deferred pending
+  on-cluster empirics — see the design note's Open Questions.
+
+### `1.10`
 
 Host/container runtime split, part 1: KFD/AMDGPU kernel-mode-driver
 identity. Additive — one new top-level block, defaulted so older readers

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -24,6 +24,11 @@ from typing import Any
 
 import click
 
+# Single source of truth for the --execution-context choices, shared with
+# the dependency-free _probe_main entry point so the two never drift. This
+# is a stdlib-only constant tuple (no probing side effects at import).
+from aorta.instrumentation.environment import EXECUTION_CONTEXT_INVOCATIONS
+
 
 @click.group()
 def env() -> None:
@@ -107,6 +112,22 @@ def env() -> None:
     show_default=True,
     help="Per-call timeout (seconds, must be >= 1) for `buck2 cquery 'deps(...)'`.",
 )
+@click.option(
+    "--execution-context",
+    type=click.Choice(list(EXECUTION_CONTEXT_INVOCATIONS)),
+    default="direct",
+    show_default=True,
+    help=(
+        "Self-declared label for HOW the probe was launched, stamped into "
+        "execution_context.probe_invocation. Use buck2_action when running "
+        "the probe as a Buck2 action/genrule so it captures the executor's "
+        "environment. Captures nothing new -- but if you claim a "
+        "container/RE capture (non-'direct') and no isolation is detected "
+        "AND neither $AORTA_RE_IMAGE nor $AORTA_DOCKER_IMAGE is set, a "
+        "loud warning is printed to stderr (you may have probed the wrong "
+        "place)."
+    ),
+)
 def probe(
     output: Path,
     verbose: bool,
@@ -115,9 +136,13 @@ def probe(
     extended: bool,
     buck_target: str | None,
     buck_timeout: int,
+    execution_context: str,
 ) -> None:
     """Capture trial-environment state to env.json (issue #147)."""
-    from aorta.instrumentation.environment import collect_env
+    from aorta.instrumentation.environment import (
+        collect_env,
+        execution_context_warning,
+    )
 
     # --summary and --field both bypass the file write -- only one
     # output mode at a time makes sense.
@@ -135,8 +160,20 @@ def probe(
         buck_target=buck_target,
         buck_timeout=buck_timeout,
         detail="full" if extended else "compact",
+        probe_invocation=execution_context,
     )
     snapshot_dict = snapshot.to_dict()
+
+    # Validation guardrail (shared predicate with _probe_main): if the caller
+    # claims a container/RE capture but we saw zero isolation signal and no
+    # launcher image env var, they may have probed the host shell instead of
+    # the workload's context. Warn loudly to stderr (never a hard error --
+    # the snapshot is still valid and written).
+    _ec_warning = execution_context_warning(
+        execution_context, snapshot.container_detected
+    )
+    if _ec_warning is not None:
+        click.echo(_ec_warning, err=True)
 
     # --field: print one value as JSON and exit. Skips the file write
     # entirely; pair with `jq` / `xargs` for scripting.

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -24,10 +24,13 @@ from typing import Any
 
 import click
 
-# Single source of truth for the --execution-context choices, shared with
-# the dependency-free _probe_main entry point so the two never drift. This
-# is a stdlib-only constant tuple (no probing side effects at import).
-from aorta.instrumentation.environment import EXECUTION_CONTEXT_INVOCATIONS
+# --execution-context choices. Mirrors EXECUTION_CONTEXT_INVOCATIONS in
+# aorta.instrumentation.environment (the canonical source). We hard-code the
+# literal here rather than importing it, so that `aorta env --help` / CLI
+# startup does NOT eagerly import the large environment probing module (it
+# is imported lazily inside probe() only when the command actually runs).
+# tests/instrumentation/test_environment.py asserts these stay in sync.
+_EXECUTION_CONTEXT_CHOICES = ["direct", "buck2_run", "buck2_action"]
 
 
 @click.group()
@@ -114,7 +117,7 @@ def env() -> None:
 )
 @click.option(
     "--execution-context",
-    type=click.Choice(list(EXECUTION_CONTEXT_INVOCATIONS)),
+    type=click.Choice(_EXECUTION_CONTEXT_CHOICES),
     default="direct",
     show_default=True,
     help=(

--- a/src/aorta/instrumentation/_probe_main.py
+++ b/src/aorta/instrumentation/_probe_main.py
@@ -20,6 +20,11 @@ works as ``docker exec ... > env.json`` without a bind mount.
 Pass ``--extended`` to retain the full per-file kernel-catalog lists
 (matching ``aorta env probe --extended``); the default is the compact
 snapshot that drops those lists to keep the artifact small.
+
+Pass ``--execution-context <direct|buck2_run|buck2_action>`` to stamp
+``execution_context.probe_invocation`` (matching the CLI flag). Since this
+entry point is the in-container / in-action probe, ``buck2_action`` is the
+common value here.
 """
 
 from __future__ import annotations
@@ -27,23 +32,76 @@ from __future__ import annotations
 import json
 import sys
 
-from aorta.instrumentation.environment import collect_env
+from aorta.instrumentation.environment import (
+    EXECUTION_CONTEXT_INVOCATIONS,
+    collect_env,
+    execution_context_warning,
+)
 
 
 def main(argv: list[str]) -> int:
     """Capture the snapshot and write it to the output path (or stdout).
 
-    Recognizes a ``--extended`` flag (anywhere in argv) for the full
-    per-file catalog detail; the first remaining non-flag argument is the
-    output path (``-`` or absent -> stdout).
+    Recognizes ``--extended`` (full per-file catalog detail) and
+    ``--execution-context <label>`` anywhere in argv; the first remaining
+    non-flag argument is the output path (``-`` or absent -> stdout).
     """
     args = argv[1:]
     extended = "--extended" in args
-    positional = [a for a in args if a != "--extended"]
+    probe_invocation = "direct"
+    positional: list[str] = []
+    i = 0
+    rest = [a for a in args if a != "--extended"]
+    allowed = ", ".join(EXECUTION_CONTEXT_INVOCATIONS)
+    while i < len(rest):
+        a = rest[i]
+        if a == "--execution-context":
+            # Strict, matching Click's Choice: a missing or unknown value
+            # must be a hard error, NOT a silent fall-through. Otherwise
+            # `--execution-context /out/env.json` (forgotten value) would
+            # eat the output path as the label, leave positional empty, and
+            # dump JSON to stdout while exiting 0 -- silently failing to
+            # write the very artifact this entry point exists to produce.
+            if i + 1 >= len(rest) or rest[i + 1] not in EXECUTION_CONTEXT_INVOCATIONS:
+                got = rest[i + 1] if i + 1 < len(rest) else "(missing)"
+                sys.stderr.write(
+                    f"aorta env probe: --execution-context requires one of: "
+                    f"{allowed} (got {got!r})\n"
+                )
+                return 2
+            probe_invocation = rest[i + 1]
+            i += 2
+            continue
+        if a.startswith("--execution-context="):
+            probe_invocation = a.split("=", 1)[1]
+            if probe_invocation not in EXECUTION_CONTEXT_INVOCATIONS:
+                sys.stderr.write(
+                    f"aorta env probe: --execution-context requires one of: "
+                    f"{allowed} (got {probe_invocation!r})\n"
+                )
+                return 2
+            i += 1
+            continue
+        positional.append(a)
+        i += 1
 
-    snapshot_dict = collect_env(
-        detail="full" if extended else "compact"
-    ).to_dict()
+    snapshot = collect_env(
+        detail="full" if extended else "compact",
+        probe_invocation=probe_invocation,
+    )
+
+    # Same claim-vs-reality guardrail as the Click CLI (aorta env probe),
+    # via the SHARED predicate so the two entry points never drift. This
+    # dependency-free entry point is the one most likely used inside a Buck2
+    # action / container, so it needs the warning even more. Fail-soft:
+    # stderr only, never a non-zero exit.
+    _ec_warning = execution_context_warning(
+        probe_invocation, snapshot.container_detected
+    )
+    if _ec_warning is not None:
+        sys.stderr.write(_ec_warning + "\n")
+
+    snapshot_dict = snapshot.to_dict()
     text = json.dumps(snapshot_dict, indent=2)
 
     out = positional[0] if positional and positional[0] != "-" else None

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -78,7 +78,28 @@ from typing import Any, ClassVar
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.10"
+SCHEMA_VERSION = "1.11"
+# 1.10 -> 1.11 (container & execution-context visibility, phase 1):
+#   - New top-level ``container_detected`` (bool). A runtime-AGNOSTIC
+#     isolation smoke test (``_detect_container_detected()``): True on any
+#     generic sandbox signal -- a named runtime match, a private mount
+#     namespace (``/proc/self/ns/mnt`` != ``/proc/1/ns/mnt``), or a
+#     container/k8s token in ``/proc/self/cgroup``. Fixes the
+#     RE-worker / k8s-pod false negative where ``runtime_context.type``
+#     falls through to ``"baremetal"`` (it only knows docker/podman/
+#     singularity). ``container_detected=True`` + ``type="baremetal"`` is
+#     the honest reading of an unnamed sandbox. Defaulted ``False``.
+#   - New top-level ``execution_context`` block (defaulted via
+#     ``_empty_execution_context()``): ``probe_invocation`` (``direct`` /
+#     ``buck2_run`` / ``buck2_action``, SELF-DECLARED via the new
+#     ``aorta env probe --execution-context`` flag; ``direct`` by default)
+#     and ``likely_execution_platform`` (reserved for phase-2 Buck2 work;
+#     always ``None`` today). Additive: both fields use ``default_factory``
+#     so <=1.10 snapshots round-trip via ``from_dict()``.
+#   - See docs/env-probe-container-execution-context.md (design note). The
+#     Buck2 / remote-execution pieces (likely_execution_platform,
+#     $AORTA_RE_IMAGE, probe_namespace) remain phase-2 follow-ups.
+#
 # 1.9 -> 1.10 (host/container runtime split, part 1): KFD/AMDGPU
 # kernel-mode-driver identity.
 #   - New top-level ``amdgpu_driver`` block, always present (defaulted via
@@ -859,6 +880,17 @@ DOCKERENV_MARKER = Path("/.dockerenv")
 PODMAN_CONTAINERENV_MARKER = Path("/run/.containerenv")
 CGROUP_FILE = Path("/proc/1/cgroup")
 SELF_CGROUP_FILE = Path("/proc/self/cgroup")
+# Generic isolation signals for ``container_detected`` (schema 1.11). These
+# are RUNTIME-AGNOSTIC -- they fire on any mount/cgroup isolation, not just
+# the named docker/podman/singularity runtimes ``_detect_container_type()``
+# knows -- so an RE worker or k8s pod (which have none of the named markers
+# and would otherwise read as "baremetal") is still flagged. The ns/mnt
+# magic symlinks resolve to ``mnt:[<inode>]``; a different inode from PID
+# 1's means a private mount namespace (the defining trait of an OCI
+# sandbox). Distinct constants so tests can monkeypatch without touching
+# real /proc.
+INIT_MNT_NS = Path("/proc/1/ns/mnt")
+SELF_MNT_NS = Path("/proc/self/ns/mnt")
 
 
 # ---------------------------------------------------------------------------
@@ -1004,6 +1036,19 @@ class EnvSnapshot:
     amdgpu_driver: dict = field(
         default_factory=lambda: _empty_amdgpu_driver()
     )
+    # container_detected / execution_context: container & execution-context
+    # visibility (schema 1.11). ``container_detected`` is a single boolean
+    # smoke-detector that is True on ANY generic isolation signal, catching
+    # the RE-worker / k8s-pod sandboxes that ``runtime_context.type`` misses
+    # (they fall through to ``"baremetal"``). ``execution_context`` carries
+    # the self-declared ``probe_invocation`` label set by
+    # ``--execution-context`` (``direct`` by default). Both defaulted so
+    # pre-1.11 snapshots round-trip via ``from_dict()``. See
+    # ``_detect_container_detected()`` and ``_empty_execution_context()``.
+    container_detected: bool = False
+    execution_context: dict = field(
+        default_factory=lambda: _empty_execution_context()
+    )
 
     # Curated emit order for ``to_dict()`` / ``env.json`` (JSON is written
     # sort_keys=False, so THIS is the artifact's key order). Grouped so
@@ -1024,6 +1069,8 @@ class EnvSnapshot:
         # host / kernel / runtime placement
         "host",
         "runtime_context",
+        "container_detected",
+        "execution_context",
         "docker",
         # ROCm runtime + the host-kernel driver that pairs with it
         "rocm",
@@ -1119,6 +1166,8 @@ class EnvSnapshot:
         kwargs.setdefault("miopen_catalog", _empty_miopen_catalog())
         kwargs.setdefault("rocfft_catalog", _empty_rocfft_catalog())
         kwargs.setdefault("amdgpu_driver", _empty_amdgpu_driver())
+        kwargs.setdefault("container_detected", False)
+        kwargs.setdefault("execution_context", _empty_execution_context())
         return cls(**kwargs)
 
     def summary(self) -> str:
@@ -1134,6 +1183,7 @@ class EnvSnapshot:
         for line-width; the full values live in the JSON.
         """
         rt = self.runtime_context or {}
+        ec = self.execution_context or {}
         bs = self.build_system or {"kind": "none"}
         rocm = self.rocm or {}
         hip = self.hip or {}
@@ -1224,7 +1274,9 @@ class EnvSnapshot:
         # reads them the same way and can diff either without re-mapping.
         return "\n".join(
             (
-                f"  runtime:   {rt.get('type', '?')} / python={rt.get('python_env', '?')}",
+                f"  runtime:   {rt.get('type', '?')} / python={rt.get('python_env', '?')}"
+                f"  container_detected={'yes' if self.container_detected else 'no'}"
+                f"  probe={ec.get('probe_invocation', '?')}",
                 f"  host:      kernel={host.get('kernel_release') or '?'} "
                 f"machine={host.get('machine') or '?'}  "
                 f"glibc={host.get('glibc_version') or '?'}",
@@ -1894,6 +1946,7 @@ def collect_env(
     buck_target: str | None = None,
     buck_timeout: int = 10,
     detail: str = "compact",
+    probe_invocation: str = "direct",
 ) -> EnvSnapshot:
     """Capture the current process environment as an :class:`EnvSnapshot`.
 
@@ -1954,6 +2007,18 @@ def collect_env(
     _probe_stdio.start()
     try:
         runtime_context = _detect_runtime_context()  # never partial; always populates
+        # container_detected: runtime-agnostic isolation smoke test that
+        # catches RE/k8s sandboxes runtime_context.type misses (schema
+        # 1.11). execution_context: self-declared probe_invocation label.
+        container_detected = _detect_container_detected()
+        execution_context = _empty_execution_context()
+        if probe_invocation in EXECUTION_CONTEXT_INVOCATIONS:
+            execution_context["probe_invocation"] = probe_invocation
+        else:
+            reasons.append(
+                f"execution_context.probe_invocation: unknown value "
+                f"{probe_invocation!r}; recorded as 'direct'"
+            )
         system_health = _run_rdhc(reasons)
         rocm = _capture_rocm_version_files(reasons)
         # Host-kernel scope: reuses rocm's kmd_version read (no second file
@@ -2044,6 +2109,8 @@ def collect_env(
             gpu_arch=gpu_arch,
             host=host,
             runtime_context=runtime_context,
+            container_detected=container_detected,
+            execution_context=execution_context,
             docker=docker,
             env_vars=env_vars,
             python_version=platform.python_version(),
@@ -2068,6 +2135,7 @@ def collect_env(
                 f"collect_env: unexpected failure "
                 f"({type(exc).__name__}: {exc})"
             ),
+            probe_invocation=probe_invocation,
         )
     finally:
         # Idempotent: a no-op if the except branch already restored stdio.
@@ -2075,9 +2143,17 @@ def collect_env(
 
 
 def _disaster_snapshot(
-    preceding_reasons: list[str], unexpected_reason: str
+    preceding_reasons: list[str],
+    unexpected_reason: str,
+    probe_invocation: str = "direct",
 ) -> EnvSnapshot:
     """Return a minimally-shaped EnvSnapshot when collect_env crashes.
+
+    ``probe_invocation`` is threaded through from ``collect_env`` so a
+    crash artifact still records HOW the probe was launched -- a disaster
+    snapshot from a ``buck2_action`` run must not silently rewrite itself
+    to ``"direct"``, which would misdirect triage. An unrecognized value
+    falls back to ``"direct"`` (same rule as the happy path).
 
     Used by the never-raises top-level guard. Every field gets a sane
     null/empty default so downstream consumers (B1, B2, jq pipelines)
@@ -2194,6 +2270,14 @@ def _disaster_snapshot(
             "venv_path": None,
             "conda_env_name": None,
         },
+        # Best-effort even in the disaster path (the detector is fail-soft
+        # and cheap); falls back to False if it too raises.
+        container_detected=_detect_container_detected_safe(),
+        # Preserve the caller's probe_invocation so a crashed buck2_action
+        # probe isn't relabelled "direct" (misleading triage). Validate
+        # here too, since the crash may have happened before collect_env's
+        # own validation ran.
+        execution_context=_disaster_execution_context(probe_invocation),
         host={
             "kernel_release": None,
             "kernel_version": None,
@@ -3013,6 +3097,172 @@ def _detect_python_env() -> str:
     if getattr(sys, "base_prefix", sys.prefix) != sys.prefix:
         return "venv"
     return "system"
+
+
+# Valid probe-invocation labels for ``--execution-context`` /
+# ``execution_context.probe_invocation`` (schema 1.11). ``direct`` is the
+# default (a plain ``aorta env probe``). The two ``buck2_*`` values are
+# SELF-DECLARED by the caller -- phase 1 does not auto-detect them (see the
+# design note's Open Q1); they exist so a Buck2 wrapper can label its
+# snapshot and the CLI can validate the claim.
+EXECUTION_CONTEXT_INVOCATIONS: tuple[str, ...] = (
+    "direct",
+    "buck2_run",
+    "buck2_action",
+)
+
+
+def execution_context_warning(
+    probe_invocation: str, container_detected: bool
+) -> str | None:
+    """Return the claim-vs-reality warning string, or ``None`` if no warning.
+
+    Single source of truth for BOTH probe entry points -- the Click CLI
+    (``aorta env probe``) and the dependency-free
+    ``aorta.instrumentation._probe_main`` -- so the two can never drift on
+    when to warn or what to say. Stdlib-only (reads ``os.environ``), no
+    Click dependency, so ``_probe_main`` can call it too.
+
+    Warns when the caller CLAIMS a non-``direct`` (container / RE) capture
+    but we saw zero isolation signal (``container_detected`` False) and the
+    launcher asserted no image via ``$AORTA_RE_IMAGE`` / ``$AORTA_DOCKER_IMAGE``
+    -- i.e. "you may be probing the host shell, not where the workload ran."
+    ``direct`` never warns.
+    """
+    if probe_invocation == "direct":
+        return None
+    if container_detected:
+        return None
+    if os.environ.get("AORTA_RE_IMAGE") or os.environ.get("AORTA_DOCKER_IMAGE"):
+        return None
+    return (
+        f"WARNING: --execution-context {probe_invocation} claims a "
+        "container/remote-execution capture, but no isolation signal was "
+        "detected (container_detected=false) and neither $AORTA_RE_IMAGE "
+        "nor $AORTA_DOCKER_IMAGE is set. You may be probing the host shell "
+        "rather than where the workload actually ran."
+    )
+
+
+def _empty_execution_context() -> dict[str, Any]:
+    """Default ``execution_context`` block (schema 1.11).
+
+    ``probe_invocation`` defaults to ``"direct"`` -- a plain, unlabelled
+    ``aorta env probe``. ``likely_execution_platform`` is reserved for the
+    phase-2 Buck2 work (resolved RE platform label) and is always ``None``
+    today. Shaped like every other block so the default and a real capture
+    never diverge and pre-1.11 ``from_dict()`` round-trips cleanly.
+    """
+    return {
+        "probe_invocation": "direct",
+        "likely_execution_platform": None,
+    }
+
+
+def _disaster_execution_context(probe_invocation: str) -> dict[str, Any]:
+    """``execution_context`` for the disaster path, preserving the label.
+
+    Same shape as ``_empty_execution_context()`` but keeps the caller's
+    ``probe_invocation`` (validated; unknown -> ``"direct"``) so a crash
+    artifact from a Buck2 action is not silently relabelled.
+    """
+    block = _empty_execution_context()
+    if probe_invocation in EXECUTION_CONTEXT_INVOCATIONS:
+        block["probe_invocation"] = probe_invocation
+    return block
+
+
+def _detect_container_detected() -> bool:
+    """Runtime-agnostic "am I inside *any* isolation boundary?" smoke test.
+
+    Complements ``_detect_container_type()``: that function names the
+    runtime but only knows docker/podman/singularity and falls through to
+    ``"baremetal"`` for everything else -- so a remote-execution worker or
+    a containerd-managed k8s pod (which have none of those markers) reads
+    as bare metal, the OPPOSITE of the truth. This returns ``True`` on ANY
+    of several generic isolation signals, even when the runtime can't be
+    named, so ``container_detected=True`` + ``runtime_context.type=
+    "baremetal"`` is the honest reading of such a sandbox.
+
+    Signals (any one is sufficient; each is fail-soft):
+
+    * A named runtime already matched (``_detect_container_type() !=
+      "baremetal"``) -- docker/podman/singularity are containers by
+      definition, so never report less than that function does.
+    * ``/.dockerenv`` / ``/run/.containerenv`` markers (belt-and-braces;
+      subsumed by the above but cheap and explicit).
+    * The current process's mount namespace differs from PID 1's
+      (``/proc/self/ns/mnt`` resolves to a different ``mnt:[<inode>]``
+      than ``/proc/1/ns/mnt``). NOTE: this only fires when PID 1 is
+      OUTSIDE the probe's namespace -- e.g. an RE worker or ``unshare -m``
+      sandbox that shares the HOST pid namespace so ``/proc/1`` is host
+      init. A STANDARD container (docker/podman/OCI) has its own pid
+      namespace where PID 1 IS the container's init, so it shares the
+      probe's mount namespace and this signal does NOT fire -- that case
+      is caught by the marker files and cgroup tokens instead. So this is
+      an extra signal for the shared-pid-namespace sandbox, not the
+      primary container check.
+    * A container/sandbox token in the process cgroup path
+      (``/proc/self/cgroup``): ``docker`` / ``containerd`` / ``kubepods``
+      / ``libpod`` / ``lxc`` / ``crio`` -- the cgroup-v2 shapes RE and
+      k8s runtimes leave behind.
+
+    Never raises; a signal that can't be read simply doesn't fire. False
+    only means "no isolation signal observed," never "definitely bare
+    metal" -- but a false negative here is strictly less misleading than
+    the ``"baremetal"`` type string it backstops.
+    """
+    if _detect_container_type() != "baremetal":
+        return True
+    if DOCKERENV_MARKER.exists() or PODMAN_CONTAINERENV_MARKER.exists():
+        return True
+    if _mount_namespace_differs_from_init():
+        return True
+    cgroup = _read_text_file(SELF_CGROUP_FILE) or ""
+    tokens = ("docker", "containerd", "kubepods", "libpod", "lxc", "crio")
+    if any(tok in cgroup for tok in tokens):
+        return True
+    return False
+
+
+def _detect_container_detected_safe() -> bool:
+    """``_detect_container_detected()`` that never raises (disaster path)."""
+    try:
+        return _detect_container_detected()
+    except Exception as exc:  # noqa: BLE001 -- disaster path must not throw
+        log.debug("container_detected probe failed: %s", exc)
+        return False
+
+
+def _mount_namespace_differs_from_init() -> bool:
+    """True iff this process has a different mount namespace than PID 1.
+
+    Compares the ``/proc/<pid>/ns/mnt`` magic symlinks, which resolve to
+    ``mnt:[<inode>]``: same inode => same namespace; different inode =>
+    this process is in a different mount namespace than ``/proc/1``.
+    (Raw ``mountinfo`` text can differ between two processes in the SAME
+    namespace, so the inode comparison, not the text, is used here.)
+
+    IMPORTANT scope: this returns True only when PID 1 is OUTSIDE the
+    probe's mount namespace. That happens for a sandbox sharing the HOST
+    pid namespace (some RE workers, ``unshare -m``), where ``/proc/1`` is
+    host init. A STANDARD container has its OWN pid namespace, so PID 1 is
+    the container's init and shares the probe's mount namespace -> this
+    returns False for the common container case (which the marker/cgroup
+    signals catch instead). It is a supplementary signal, not the primary
+    container detector.
+
+    Fail-soft: on non-Linux, or when either symlink is unreadable
+    (permission, PID 1 not inspectable), returns ``False`` -- we do not
+    claim isolation we can't observe.
+    """
+    try:
+        self_ns = os.readlink(str(SELF_MNT_NS))
+        init_ns = os.readlink(str(INIT_MNT_NS))
+    except OSError as exc:
+        log.debug("mount-ns readlink failed: %s", exc)
+        return False
+    return bool(self_ns) and bool(init_ns) and self_ns != init_ns
 
 
 # ---------------------------------------------------------------------------

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -72,6 +72,9 @@ def isolated_env(monkeypatch):
     monkeypatch.delenv("SINGULARITY_NAME", raising=False)
     monkeypatch.delenv("AORTA_DOCKER_IMAGE", raising=False)
     monkeypatch.delenv("AORTA_DOCKER_DIGEST", raising=False)
+    # AORTA_RE_IMAGE also suppresses the --execution-context warning, so a
+    # host/CI that sets it must not silently defuse the warning tests.
+    monkeypatch.delenv("AORTA_RE_IMAGE", raising=False)
     return monkeypatch
 
 
@@ -180,6 +183,8 @@ class TestPathConstants:
             "PODMAN_CONTAINERENV_MARKER",
             "CGROUP_FILE",
             "SELF_CGROUP_FILE",
+            "INIT_MNT_NS",
+            "SELF_MNT_NS",
         ],
     )
     def test_path_is_absolute(self, constant_name: str):
@@ -228,6 +233,8 @@ class TestPathConstants:
             "PODMAN_CONTAINERENV_MARKER",
             "CGROUP_FILE",
             "SELF_CGROUP_FILE",
+            "INIT_MNT_NS",
+            "SELF_MNT_NS",
         }, (
             "FS path constants set drifted; update test_path_is_absolute "
             "parametrize list AND the provenance comments in "
@@ -284,6 +291,8 @@ REQUIRED_TOP_KEYS = {
     "pytorch_sdpa",
     "nics",
     "amdgpu_driver",
+    "container_detected",
+    "execution_context",
 }
 
 
@@ -293,7 +302,7 @@ class TestSchemaCompleteness:
     ):
         snapshot = collect_env()
         assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
-        assert snapshot.schema_version == "1.10"
+        assert snapshot.schema_version == "1.11"
         assert snapshot.system_health is None
         assert snapshot.rocm == {
             "version": None,
@@ -524,6 +533,11 @@ def _example_snapshot(**overrides) -> object:
             "kfd_device_present": True,
             "kfd_sysfs_present": True,
         },
+        "container_detected": True,
+        "execution_context": {
+            "probe_invocation": "buck2_action",
+            "likely_execution_platform": None,
+        },
     }
     base.update(overrides)
     return EnvSnapshot(**base)
@@ -568,6 +582,7 @@ class TestEnvSnapshot:
             ("miopen_catalog", env_mod._empty_miopen_catalog),
             ("rocfft_catalog", env_mod._empty_rocfft_catalog),
             ("amdgpu_driver", env_mod._empty_amdgpu_driver),
+            ("execution_context", env_mod._empty_execution_context),
         ],
     )
     def test_from_dict_backfills_missing_catalog_key(self, key, empty_factory):
@@ -582,6 +597,15 @@ class TestEnvSnapshot:
         del d[key]
         rebuilt = EnvSnapshot.from_dict(d)
         assert getattr(rebuilt, key) == empty_factory()
+
+    def test_from_dict_backfills_missing_container_detected(self):
+        # A pre-1.11 env.json predates container_detected (a bare bool, so
+        # it isn't in the factory-parametrized test above). from_dict must
+        # default it to False rather than raising.
+        d = _example_snapshot().to_dict()
+        del d["container_detected"]
+        rebuilt = EnvSnapshot.from_dict(d)
+        assert rebuilt.container_detected is False
 
     def test_summary_does_not_duplicate_partial_marker(self):
         """The brief returned by ``summary()`` is the *body* of what the
@@ -1449,13 +1473,16 @@ class TestCliIsThinWrapper:
         #   friendly errors that list available keys).
         # * The compact/--extended catalog-detail work added one more
         #   click option block + its detail= wiring into collect_env().
+        # * The --execution-context work (schema 1.11) added one more click
+        #   option block plus a stderr validation-warning envelope (still
+        #   pure wiring/validation -- no probing).
         #
         # The real "no-probing-in-CLI" guard is
         # `test_cli_does_no_probing_imports` below -- this one is a
         # soft canary against the file ballooning beyond pure wiring.
         line_count = sum(1 for _ in cli_path.read_text().splitlines())
-        assert line_count <= 375, (
-            f"cli/env.py is {line_count} lines; soft budget is 375. "
+        assert line_count <= 410, (
+            f"cli/env.py is {line_count} lines; soft budget is 410. "
             "If you need more, check that the new code is genuinely "
             "wiring/error-handling and not probing -- "
             "test_cli_does_no_probing_imports is the strict guard."
@@ -1712,6 +1739,68 @@ class TestCliSummaryAndFieldFlags:
             assert "Wrote env probe to" not in result.output
             # File MUST NOT be written -- the whole point of the flag.
             assert not (Path.cwd() / "env.json").exists()
+
+    def test_execution_context_claim_without_isolation_warns(
+        self, all_disabled, tmp_path: Path, monkeypatch,
+    ):
+        # Claiming buck2_action on a host with no isolation signal and no
+        # launcher image env var must warn loudly (the core misdiagnosis
+        # guardrail) -- but still exit 0 and write the file. The warning
+        # must land on STDERR so it never corrupts stdout scripting; use
+        # mix_stderr=False to assert the stream explicitly.
+        from click.testing import CliRunner
+        cli_mod = self._cli_mod()
+        # Force container_detected False regardless of the test host.
+        monkeypatch.setattr(
+            env_mod, "_detect_container_detected", lambda: False
+        )
+        runner = CliRunner(mix_stderr=False)
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            out = Path.cwd() / "env.json"
+            result = runner.invoke(
+                cli_mod.env,
+                ["probe", "--execution-context", "buck2_action", "-o", str(out)],
+            )
+            assert result.exit_code == 0, result.stdout
+            assert "WARNING" in result.stderr
+            assert "WARNING" not in result.stdout
+            assert out.exists()
+
+    def test_execution_context_claim_with_image_does_not_warn(
+        self, all_disabled, tmp_path: Path, monkeypatch,
+    ):
+        # Same claim, but $AORTA_DOCKER_IMAGE is set -> no warning (the
+        # launcher asserted the context, which is the sanctioned pattern).
+        from click.testing import CliRunner
+        cli_mod = self._cli_mod()
+        monkeypatch.setattr(
+            env_mod, "_detect_container_detected", lambda: False
+        )
+        monkeypatch.setenv("AORTA_DOCKER_IMAGE", "rocm/pytorch:tag")
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            out = Path.cwd() / "env.json"
+            result = runner.invoke(
+                cli_mod.env,
+                ["probe", "--execution-context", "buck2_action", "-o", str(out)],
+            )
+            assert result.exit_code == 0, result.output
+            assert "WARNING" not in result.output
+
+    def test_direct_execution_context_never_warns(
+        self, all_disabled, tmp_path: Path, monkeypatch,
+    ):
+        from click.testing import CliRunner
+        cli_mod = self._cli_mod()
+        monkeypatch.setattr(
+            env_mod, "_detect_container_detected", lambda: False
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            out = Path.cwd() / "env.json"
+            result = runner.invoke(cli_mod.env, ["probe", "-o", str(out)])
+            assert result.exit_code == 0, result.output
+            assert "WARNING" not in result.output
 
     def test_default_probe_writes_compact_catalog(
         self, all_disabled, tmp_path: Path,
@@ -2598,6 +2687,246 @@ class TestRuntimeContext:
         assert rt["python_env"] == "conda"
         assert rt["conda_env_name"] == "rocm-7.2"
         assert rt["venv_path"] is None
+
+
+# ---------------------------------------------------------------------------
+# container_detected + execution_context (schema 1.11)
+# ---------------------------------------------------------------------------
+
+
+class TestContainerDetected:
+    """_detect_container_detected(): runtime-agnostic isolation smoke test."""
+
+    def test_baremetal_no_signal_is_false(self, all_disabled, monkeypatch):
+        # No named runtime, no markers, and mount-ns check disabled ->
+        # the honest "no isolation observed" answer.
+        monkeypatch.setattr(
+            env_mod, "_mount_namespace_differs_from_init", lambda: False
+        )
+        assert env_mod._detect_container_detected() is False
+
+    def test_named_runtime_implies_true(self, all_disabled, tmp_path, monkeypatch):
+        # docker marker -> _detect_container_type() != baremetal -> True.
+        marker = tmp_path / ".dockerenv"
+        marker.write_text("")
+        monkeypatch.setattr(env_mod, "DOCKERENV_MARKER", marker)
+        monkeypatch.setattr(
+            env_mod, "_mount_namespace_differs_from_init", lambda: False
+        )
+        assert env_mod._detect_container_detected() is True
+
+    def test_private_mount_namespace_implies_true(
+        self, all_disabled, monkeypatch
+    ):
+        # No named runtime, but a private mount namespace -> True. This is
+        # the RE-worker / stripped-sandbox case runtime_context.type misses.
+        monkeypatch.setattr(
+            env_mod, "_mount_namespace_differs_from_init", lambda: True
+        )
+        assert env_mod._detect_container_detected() is True
+
+    def test_kubepods_cgroup_token_implies_true(
+        self, all_disabled, tmp_path, monkeypatch
+    ):
+        # A k8s pod: runtime_context.type falls through to baremetal (no
+        # docker/podman/singularity), but the cgroup carries a kubepods
+        # token -> container_detected True. The core false-negative fix.
+        self_cgroup = tmp_path / "self_cgroup"
+        self_cgroup.write_text("0::/kubepods.slice/kubepods-besteffort-pod123.slice\n")
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", self_cgroup)
+        monkeypatch.setattr(
+            env_mod, "_mount_namespace_differs_from_init", lambda: False
+        )
+        # type still reads baremetal (no named runtime)...
+        assert env_mod._detect_container_type() == "baremetal"
+        # ...but the isolation smoke test correctly fires.
+        assert env_mod._detect_container_detected() is True
+
+    def test_safe_wrapper_swallows_exceptions(self, monkeypatch):
+        def boom():
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(env_mod, "_detect_container_detected", boom)
+        # The disaster-path wrapper must never raise.
+        assert env_mod._detect_container_detected_safe() is False
+
+
+class TestExecutionContext:
+    """execution_context.probe_invocation stamping via collect_env()."""
+
+    def test_default_is_direct(self, all_disabled):
+        snap = collect_env()
+        assert snap.execution_context["probe_invocation"] == "direct"
+        assert snap.execution_context["likely_execution_platform"] is None
+
+    def test_valid_label_is_stamped(self, all_disabled):
+        snap = collect_env(probe_invocation="buck2_action")
+        assert snap.execution_context["probe_invocation"] == "buck2_action"
+
+    def test_unknown_label_falls_back_to_direct_with_reason(self, all_disabled):
+        snap = collect_env(probe_invocation="nonsense")
+        assert snap.execution_context["probe_invocation"] == "direct"
+        assert snap.partial is True
+        assert any(
+            r.startswith("execution_context.probe_invocation")
+            for r in snap.partial_reasons
+        )
+
+    def test_warning_predicate_direct_never_warns(self, all_disabled):
+        # Shared helper used by BOTH the CLI and _probe_main.
+        assert env_mod.execution_context_warning("direct", False) is None
+        assert env_mod.execution_context_warning("direct", True) is None
+
+    def test_warning_predicate_claim_without_isolation_warns(self, all_disabled):
+        msg = env_mod.execution_context_warning("buck2_action", False)
+        assert msg is not None and msg.startswith("WARNING:")
+
+    def test_warning_predicate_suppressed_by_container_detected(
+        self, all_disabled
+    ):
+        assert env_mod.execution_context_warning("buck2_action", True) is None
+
+    def test_warning_predicate_suppressed_by_image_env(
+        self, all_disabled, monkeypatch
+    ):
+        monkeypatch.setenv("AORTA_DOCKER_IMAGE", "img:tag")
+        assert env_mod.execution_context_warning("buck2_action", False) is None
+        monkeypatch.delenv("AORTA_DOCKER_IMAGE", raising=False)
+        monkeypatch.setenv("AORTA_RE_IMAGE", "re:tag")
+        assert env_mod.execution_context_warning("buck2_action", False) is None
+
+    def test_disaster_snapshot_preserves_probe_invocation(
+        self, all_disabled, monkeypatch
+    ):
+        # If an internal probe crashes, collect_env falls back to the
+        # disaster snapshot -- which must still record the caller's
+        # probe_invocation rather than silently relabelling it "direct".
+        def boom(*args, **kwargs):
+            raise RuntimeError("forced probe crash")
+
+        # _run_rdhc runs early in the probe body; make it explode so the
+        # top-level guard builds a disaster snapshot.
+        monkeypatch.setattr(env_mod, "_run_rdhc", boom)
+        snap = collect_env(probe_invocation="buck2_action")
+        assert snap.partial is True
+        assert snap.execution_context["probe_invocation"] == "buck2_action"
+        # And a garbage label in the crash path still normalizes to direct.
+        snap2 = collect_env(probe_invocation="nonsense")
+        assert snap2.execution_context["probe_invocation"] == "direct"
+
+
+class TestProbeMainExecutionContext:
+    """_probe_main mirrors the CLI --execution-context flag + warning."""
+
+    @staticmethod
+    def _probe_main_mod():
+        # Load by file path (like _cli_mod above) so these tests pass from a
+        # clean checkout without aorta installed / PYTHONPATH set -- the rest
+        # of this module deliberately loads environment.py by path too.
+        probe_main_path = Path(env_mod.__file__).parent / "_probe_main.py"
+        spec = importlib.util.spec_from_file_location(
+            "aorta.instrumentation._probe_main", probe_main_path
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    def _write(self, tmp_path, argv_extra, monkeypatch, container=False):
+        monkeypatch.setattr(
+            env_mod, "_detect_container_detected", lambda: container
+        )
+        probe_main = self._probe_main_mod()
+        out = str(tmp_path / "env.json")
+        rc = probe_main.main(["_probe_main", *argv_extra, out])
+        return rc, out
+
+    def test_stamps_probe_invocation(self, all_disabled, tmp_path, monkeypatch):
+        rc, out = self._write(
+            tmp_path, ["--execution-context", "buck2_action"], monkeypatch
+        )
+        assert rc == 0
+        doc = json.loads(Path(out).read_text(encoding="utf-8"))
+        assert doc["execution_context"]["probe_invocation"] == "buck2_action"
+
+    def test_warns_on_claim_without_isolation(
+        self, all_disabled, tmp_path, monkeypatch, capsys
+    ):
+        # The dependency-free entry point must emit the same claim-vs-reality
+        # warning as the Click CLI -- it is the one most likely used inside a
+        # Buck2 action / container.
+        rc, _ = self._write(
+            tmp_path, ["--execution-context", "buck2_action"], monkeypatch,
+            container=False,
+        )
+        assert rc == 0
+        assert "WARNING" in capsys.readouterr().err
+
+    def test_no_warning_when_container_detected(
+        self, all_disabled, tmp_path, monkeypatch, capsys
+    ):
+        rc, _ = self._write(
+            tmp_path, ["--execution-context", "buck2_action"], monkeypatch,
+            container=True,
+        )
+        assert rc == 0
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_no_warning_for_direct(
+        self, all_disabled, tmp_path, monkeypatch, capsys
+    ):
+        rc, _ = self._write(tmp_path, [], monkeypatch, container=False)
+        assert rc == 0
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_no_warning_when_re_image_set(
+        self, all_disabled, tmp_path, monkeypatch, capsys
+    ):
+        # $AORTA_RE_IMAGE (the phase-2 launcher convention) suppresses the
+        # warning the same way $AORTA_DOCKER_IMAGE does.
+        monkeypatch.setenv("AORTA_RE_IMAGE", "re-worker-image:tag")
+        rc, _ = self._write(
+            tmp_path, ["--execution-context", "buck2_action"], monkeypatch,
+            container=False,
+        )
+        assert rc == 0
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_missing_flag_value_is_hard_error_not_silent_stdout(
+        self, all_disabled, tmp_path, monkeypatch, capsys
+    ):
+        # Forgotten value: `--execution-context <outpath>` must NOT eat the
+        # output path as the label and dump JSON to stdout while exiting 0.
+        monkeypatch.setattr(
+            env_mod, "_detect_container_detected", lambda: False
+        )
+        probe_main = self._probe_main_mod()
+        out = tmp_path / "env.json"
+        # Only the flag + the intended output path; the path is not a valid
+        # label, so the parser must reject rather than consume it.
+        rc = probe_main.main(["_probe_main", "--execution-context", str(out)])
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "--execution-context requires one of" in captured.err
+        # The artifact must NOT have been written, and JSON must NOT have
+        # been dumped to stdout under the guise of success.
+        assert not out.exists()
+        assert "schema_version" not in captured.out
+
+    def test_invalid_flag_value_is_hard_error(
+        self, all_disabled, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(
+            env_mod, "_detect_container_detected", lambda: False
+        )
+        probe_main = self._probe_main_mod()
+        out = tmp_path / "env.json"
+        rc = probe_main.main(
+            ["_probe_main", "--execution-context", "nonsense", str(out)]
+        )
+        assert rc == 2
+        assert "--execution-context requires one of" in capsys.readouterr().err
+        assert not out.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -1502,6 +1502,53 @@ class TestCliIsThinWrapper:
         text = cli_path.read_text()
         assert "collect_env" in text
 
+    def test_cli_does_not_eager_import_environment(self, cli_path: Path):
+        """The CLI must NOT import the heavy environment probing module at
+        module top level -- that would pull subprocess/hashlib/platform into
+        every ``aorta env --help`` / startup and defeat the thin-wrapper
+        goal. ``environment`` may only be imported lazily inside handlers.
+
+        Parse the AST and check only module-level ``import`` nodes, so a
+        mere mention of the module in a docstring or comment does not trip.
+        """
+        import ast
+
+        tree = ast.parse(cli_path.read_text())
+        for node in tree.body:  # module-level statements only
+            if isinstance(node, ast.ImportFrom) and node.module and (
+                "aorta.instrumentation.environment" in node.module
+            ):
+                raise AssertionError(
+                    f"cli/env.py imports environment at module top "
+                    f"(from {node.module}); import it lazily inside the handler."
+                )
+            if isinstance(node, ast.Import) and any(
+                "aorta.instrumentation.environment" in alias.name
+                for alias in node.names
+            ):
+                raise AssertionError(
+                    "cli/env.py imports environment at module top; "
+                    "import it lazily inside the handler."
+                )
+
+    def test_cli_execution_context_choices_match_canonical(self, cli_path: Path):
+        """The hard-coded --execution-context choices in the CLI must stay in
+        sync with the canonical EXECUTION_CONTEXT_INVOCATIONS. The CLI
+        hard-codes (rather than imports) the list to avoid the eager
+        environment import guarded above, so this is the drift guard.
+        """
+        spec = importlib.util.spec_from_file_location("aorta.cli.env", cli_path)
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+        assert (
+            cli_mod._EXECUTION_CONTEXT_CHOICES
+            == list(env_mod.EXECUTION_CONTEXT_INVOCATIONS)
+        ), (
+            "cli/env.py _EXECUTION_CONTEXT_CHOICES drifted from "
+            "EXECUTION_CONTEXT_INVOCATIONS; keep them identical."
+        )
+
     def test_cli_creates_missing_parent_directory(self, all_disabled, tmp_path: Path):
         """Regression guard: ``-o newdir/env.json`` must work for a non-existent
         parent. With ``click.Path(writable=True)`` Click would reject that

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -1710,6 +1710,19 @@ class TestCliSummaryAndFieldFlags:
     """
 
     @staticmethod
+    def _split_stderr_runner():
+        """A CliRunner whose result exposes stderr separately, across Click
+        versions. Click < 8.2 combines the streams unless given
+        ``mix_stderr=False``; Click >= 8.2 removed that kwarg (streams are
+        always separate). Pass it only when the running Click accepts it."""
+        from click.testing import CliRunner
+
+        try:
+            return CliRunner(mix_stderr=False)
+        except TypeError:
+            return CliRunner()
+
+    @staticmethod
     def _cli_mod():
         cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
         spec = importlib.util.spec_from_file_location(
@@ -1746,15 +1759,14 @@ class TestCliSummaryAndFieldFlags:
         # Claiming buck2_action on a host with no isolation signal and no
         # launcher image env var must warn loudly (the core misdiagnosis
         # guardrail) -- but still exit 0 and write the file. The warning
-        # must land on STDERR so it never corrupts stdout scripting; use
-        # mix_stderr=False to assert the stream explicitly.
-        from click.testing import CliRunner
+        # must land on STDERR so it never corrupts stdout scripting; use a
+        # split-stderr runner to assert the stream explicitly.
         cli_mod = self._cli_mod()
         # Force container_detected False regardless of the test host.
         monkeypatch.setattr(
             env_mod, "_detect_container_detected", lambda: False
         )
-        runner = CliRunner(mix_stderr=False)
+        runner = self._split_stderr_runner()
         with runner.isolated_filesystem(temp_dir=tmp_path):
             out = Path.cwd() / "env.json"
             result = runner.invoke(


### PR DESCRIPTION
## Summary

Phase 1 of the env-probe container/execution-context work. Adds two **additive** schema fields so a snapshot can say *whether it was captured inside an isolated environment* and *how the probe was launched* — making "probed the wrong place" failures visible **without changing what the probe captures**.

- **`container_detected`** (bool) — runtime-agnostic isolation smoke test: `true` on any of a named-runtime match, a private mount namespace (`/proc/self/ns/mnt` != `/proc/1/ns/mnt`), or a container/k8s token in `/proc/self/cgroup`. Fixes the long-standing false negative where an RE worker or containerd k8s pod reported `runtime_context.type == "baremetal"` (the opposite of the truth).
- **`execution_context.probe_invocation`** — self-declared `direct`/`buck2_run`/`buck2_action` label via a new `--execution-context` flag on both `aorta env probe` and `python -m aorta.instrumentation._probe_main`. `likely_execution_platform` is reserved (`null`) for phase-2 Buck2 work.
- **`--execution-context` warning** — warns to stderr when a non-`direct` capture is claimed but no isolation is detected and neither `$AORTA_RE_IMAGE` nor `$AORTA_DOCKER_IMAGE` is set. The enum and the warning predicate live in a single stdlib-only helper (`execution_context_warning`) shared by both entry points so they cannot drift.

### Robustness
- Disaster snapshots preserve the caller's `probe_invocation` (a crashed `buck2_action` probe is not relabelled `direct`).
- `_probe_main` rejects a missing/invalid `--execution-context` value (exit 2) rather than silently consuming the output path.

### Schema / compatibility
- Bumped `1.10` → `1.11`. Both fields are defaulted and `from_dict()` backfills them, so pre-1.11 snapshots round-trip. Key *set* changes (two new keys); ordering places them in the host/runtime group.

### Scope / non-goals
- Design note added at `docs/env-probe-container-execution-context.md`. **Buck2 remote-execution discovery is explicitly deferred to phase 2** (`likely_execution_platform`, `$AORTA_RE_IMAGE` convention, `probe_namespace`, the genrule wrapper) — those need on-cluster empirics (Open Q1/Q2). This PR tells you *when a probe may be in the wrong place*; it does not yet *prove* the probe ran in the same Buck action / RE worker as the workload.

## Test plan

- [ ] Linux CI is the merge signal (see note below).
- [x] New unit tests: `TestContainerDetected`, `TestExecutionContext` (incl. shared-helper predicate + disaster-path preservation), `TestProbeMainExecutionContext` (stamping, warning parity, strict arg parsing).
- [x] CLI warning asserted on **stderr** specifically (`mix_stderr=False`); no-warning coverage for `container_detected`, `$AORTA_DOCKER_IMAGE`, and `$AORTA_RE_IMAGE`.
- [x] `from_dict` backfill for both new fields; `to_dict` key-set + round-trip tests updated.
- [x] `_probe_main` tests load the module by file path (pass without the package installed / no `PYTHONPATH`).
- [x] Local run: focused execution-context tests pass; full `tests/instrumentation/test_environment.py` passes except pre-existing POSIX-only assertions on the Windows dev host (`/opt`, `/proc`, `os.uname`, `os.confstr`) — unrelated to this change.

> **Reviewer note:** the full suite was validated on a Windows dev host, where a set of pre-existing Linux-only tests fail for platform reasons (paths under `/opt` and `/proc`, `os.uname`, `os.confstr`). Please treat **Linux CI** as the merge signal, not local results. No GPU tests were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)