### PR TITLE
layer_numerics: follow stages/scope/stride, igrad token, watch stride, diagnostics

### DIFF
--- a/docs/layer-numerics.md
+++ b/docs/layer-numerics.md
@@ -89,7 +89,7 @@ before the logger armed, or it is not reachable through the hook path (see
 ## Configuration (`NANLOG_SPEC`, recommended)
 
 The clearest way to configure the logger is a single structured JSON value,
-`NANLOG_SPEC`. It unifies the many flat flags onto three axes and two
+`NANLOG_SPEC`. It unifies the many flat flags onto a small set of axes and two
 observation kinds:
 
 - **`watch`** — observe a module's **own** tensors.
@@ -98,13 +98,16 @@ observation kinds:
 | Axis | Question | Values |
 |---|---|---|
 | `scope` | which modules | `names: [substr,…]` and/or `types: [ClassName,…]` |
-| `tensors` | which of a module's tensors | `input, output, weight, bias, grad` |
-| `at` | when / how often | `stride:N` (every Nth module in scope; `1`=every) · `stage` (pipeline stages) |
+| `tensors` | which of a module's tensors | `input, output, weight, bias, igrad, grad` |
+| `stages` | (follow) check at the pipeline stage boundaries | `true` (`copy`/`sparse_start`/`sparse_wait`/`forward`) |
+| `stride` | (follow) also check every Nth module in `scope` | `N` (default `1`; requires `scope`). Set `stages`, `scope`, or both; neither ⇒ stages only |
+| `stride` | (watch) hook only every Nth matched module | `N` (integer `>= 1`, default `1`); thins a broad watch whose per-module reduction volume is too high |
+| `diagnostics` | (top-level) how-much-detail toggles applied to **every** captured record | `addr, locate, bad_values, dump_tensor, alloc_snapshot` (see below) |
 
 ```bash
 NANLOG_SPEC='{
   "watch":  [{"scope": {"types": ["MLP","AttentionBlock"]}, "tensors": ["input","output"]}],
-  "follow": [{"tensor": "embedding_features", "at": "stage", "bounds": [0,60]}],
+  "follow": [{"tensor": "embedding_features", "stages": true, "bounds": [0,60]}],
   "sample_every": 50, "pre_context": 10
 }' \
   python -m aorta.instrumentation.layer_numerics /path/to/your_script.py
@@ -116,9 +119,12 @@ Common patterns (each cell is a complete, copy-paste `NANLOG_SPEC` value):
 |---|---|
 | Standard tensors by block | `{"watch":[{"scope":{"types":["AttentionBlock","MLP"]},"tensors":["input","output","weight","bias","grad"]}]}` |
 | Selected tensors from one scope | `{"watch":[{"scope":{"names":["emb_proj"]},"tensors":["input","output"]}]}` |
-| Follow a tensor through the pipeline | `{"follow":[{"tensor":"embedding_features","at":"stage"}]}` |
-| Follow a tensor every N layers | `{"follow":[{"tensor":"embedding_features","at":"stride:8","scope":{"names":["emb_proj"]}}]}` |
-| Follow a tensor at named layers only | `{"follow":[{"tensor":"embedding_features","at":"stride:1","scope":{"names":["emb_proj.projections.0"]}}]}` |
+| Activation-input grad only (no param grads) | `{"watch":[{"scope":{"types":["Linear"]},"tensors":["igrad"]}]}` |
+| Thin a broad watch to every 4th Linear | `{"watch":[{"scope":{"types":["Linear"]},"tensors":["output"],"stride":4}]}` |
+| Extra per-record detail via diagnostics | `{"watch":[{"scope":{"types":["MLP"]},"tensors":["output"]}],"diagnostics":["addr","bad_values"]}` |
+| Follow a tensor through the pipeline | `{"follow":[{"tensor":"embedding_features","stages":true}]}` |
+| Follow a tensor every N layers | `{"follow":[{"tensor":"embedding_features","scope":{"names":["emb_proj"]},"stride":8}]}` |
+| Follow a tensor at named layers only | `{"follow":[{"tensor":"embedding_features","scope":{"names":["emb_proj.projections.0"]}}]}` |
 
 When `NANLOG_SPEC` is set it **wins**; when it is unset, the flat `NANLOG_*`
 vars below are read directly (still fully supported). A malformed spec logs a
@@ -138,7 +144,7 @@ Put the spec in `spec.json`:
 
 ```json
 {
-  "follow": [{"tensor": "embedding_features", "at": "stage", "bounds": [0, 60]}],
+  "follow": [{"tensor": "embedding_features", "stages": true, "bounds": [0, 60]}],
   "pre_context": 10,
   "sample_every": 50
 }
@@ -173,16 +179,52 @@ Everything the logger does is one of two kinds — the `watch` and `follow` keys
 
 - **`watch` — a module's own tensors.** Hooks the modules you name (by class
   `types` or path `names`) and records their `input` / `output` / `weight` /
-  `bias` / `grad`. This is the "which layer went bad" view.
+  `bias` / `igrad` / `grad`. This is the "which layer went bad" view. `grad` is
+  the umbrella for **all** gradients (input-grad + both param grads); `igrad` is
+  the input-grad piece alone, for when you want the activation-input gradient
+  without the weight/bias grads. Add `"stride": N` (integer `>= 1`, default `1`)
+  to hook only every Nth matched module in traversal order — a way to thin a
+  broad watch whose per-module reduction volume is too high (e.g.
+  `{"scope":{"types":["Linear"]},"tensors":["output"],"stride":4}` hooks every
+  4th `Linear`). This watch `stride` is separate from a `follow` entry's own
+  `stride`. If the same spec also uses a scoped `follow`, the logger **ignores**
+  `watch[].stride` and warns, because the follow re-scan runs inside those module
+  hooks and thinning them would drop follow evidence.
 - **`follow` — one named tensor across positions.** Follows a batch tensor
-  (default `embedding_features`) and re-checks it at each TorchRec pipeline stage
-  (`at: stage` → `copy`, `sparse_start`, `sparse_wait`, `forward`) or at each
-  module (`at: stride:N`). Each record is tagged with its `phase` and a `batch_id`
-  so one batch's records line up across steps. This catches corruption that
-  arrives *upstream* of the layers, which watching alone cannot see.
+  (default `embedding_features`) and re-checks it at the TorchRec pipeline stage
+  boundaries (`stages: true` → `copy`, `sparse_start`, `sparse_wait`, `forward`)
+  and/or at each module in a `scope` (`stride: N` for every Nth match, default
+  `1`). Set `stages`, `scope`, or both — with neither, it checks stages only.
+  Each record is tagged with its `phase` and a `batch_id` so one batch's records
+  line up across steps. This catches corruption that arrives *upstream* of the
+  layers, which watching alone cannot see.
 
 Add a `bounds: [lo, hi]` to a `follow` entry to flag out-of-range values
 (`kind="oob"`) — a two-sided check the one-sided "huge" threshold misses.
+
+### Diagnostics — how much detail per record
+
+A top-level `"diagnostics": [...]` list adds "how much detail" toggles that
+apply to **every** captured record, independent of `watch` / `follow`. Valid
+names:
+
+- `addr` — GPU `data_ptr` + backing-storage extent per tensor.
+- `locate` — how many rows hold a bad value.
+- `bad_values` — the first bad element's flat idx / row / col / value.
+- `dump_tensor` — save the full bad tensor to a `.pt` file (one-shot, on first
+  detection).
+- `alloc_snapshot` — caching-allocator event trace on first bad (~10% overhead).
+
+These correspond one-to-one to the flat `NANLOG_ADDR` / `NANLOG_LOCATE` /
+`NANLOG_BAD_VALUES` / `NANLOG_DUMP_TENSOR` / `NANLOG_ALLOC_SNAPSHOT` vars. The
+output dir stays env-only (`NANLOG_DIR`) — it is **not** a diagnostic.
+
+```json
+{
+  "watch": [{"scope": {"types": ["MLP"]}, "tensors": ["output"]}],
+  "diagnostics": ["addr", "bad_values"]
+}
+```
 
 ## Stage 1 / Stage 2 workflow
 
@@ -197,7 +239,7 @@ check and pre-context buffer, so it is safe to run on a timing-sensitive repro:
 
 ```bash
 NANLOG_DIR=/output/layer_numerics \
-NANLOG_SPEC='{"follow":[{"tensor":"embedding_features","at":"stage","bounds":[0,60]}],"pre_context":10,"sample_every":50}' \
+NANLOG_SPEC='{"follow":[{"tensor":"embedding_features","stages":true,"bounds":[0,60]}],"pre_context":10,"sample_every":50}' \
   python -m aorta.instrumentation.layer_numerics /path/to/your_script.py
 ```
 
@@ -217,12 +259,12 @@ add heavier GPU work or a host sync that can **hide** a timing-sensitive bug, so
 never enable them alongside the Stage 1 scan.
 
 If the first hit was at `phase=forward`, re-scan per layer to bracket the layer
-(coarse stride first — `stride:5` re-checks every 5th module in the suspect
+(coarse stride first — `"stride":5` re-checks every 5th module in the suspect
 block):
 
 ```bash
 NANLOG_DIR=/output/layer_numerics_stage2 \
-NANLOG_SPEC='{"follow":[{"tensor":"embedding_features","at":"stride:5","scope":{"names":["<suspect.block>"]},"bounds":[0,60]}],"pre_context":10}' \
+NANLOG_SPEC='{"follow":[{"tensor":"embedding_features","scope":{"names":["<suspect.block>"]},"stride":5,"bounds":[0,60]}],"pre_context":10}' \
   python -m aorta.instrumentation.layer_numerics /path/to/your_script.py
 ```
 
@@ -231,7 +273,7 @@ Or as a `collect:` block in a recipe:
 ```yaml
 collect:
   layer_numerics:
-    NANLOG_SPEC: '{"follow":[{"tensor":"embedding_features","at":"stride:5","scope":{"names":["<suspect.block>"]},"bounds":[0,60]}],"pre_context":10}'
+    NANLOG_SPEC: '{"follow":[{"tensor":"embedding_features","scope":{"names":["<suspect.block>"]},"stride":5,"bounds":[0,60]}],"pre_context":10}'
 ```
 
 If the first hit was at a sparse stage, watch the sparse modules' own tensors and
@@ -240,7 +282,7 @@ add it as a flat var alongside the spec):
 
 ```bash
 NANLOG_DIR=/output/layer_numerics_stage2 \
-NANLOG_SPEC='{"watch":[{"scope":{"names":["<sparse.module.names>"]},"tensors":["input","output"]}],"follow":[{"tensor":"embedding_features","at":"stage","bounds":[0,60]}],"pre_context":10}' \
+NANLOG_SPEC='{"watch":[{"scope":{"names":["<sparse.module.names>"]},"tensors":["input","output"]}],"follow":[{"tensor":"embedding_features","stages":true,"bounds":[0,60]}],"pre_context":10}' \
 NANLOG_SPARSE=1 \
   python -m aorta.instrumentation.layer_numerics /path/to/your_script.py
 ```
@@ -349,7 +391,7 @@ or per-recipe / per-cell via the `collect:` mapping (see
 ```yaml
 collect:
   layer_numerics:
-    NANLOG_SPEC: '{"follow":[{"tensor":"embedding_features","at":"stage","bounds":[0,60]}],"pre_context":10,"sample_every":50}'
+    NANLOG_SPEC: '{"follow":[{"tensor":"embedding_features","stages":true,"bounds":[0,60]}],"pre_context":10,"sample_every":50}'
 ```
 
 > **Important — opt-in required.** The sweep engine validates the collector name
@@ -385,16 +427,17 @@ All heavy features default **OFF** and feed the same single per-step host transf
 | `NANLOG_PRE_CONTEXT` | Buffer the last K clean steps; dump on first-bad | `0` (off) | `pre_context` |
 | `NANLOG_SAMPLE_EVERY` | Write a clean record 1 step in N (bad always written) | `50` | `sample_every` |
 | `NANLOG_HUGE_THRESHOLD` | `\|x\| > T` counts as "huge" | `1e10` | — |
-| `NANLOG_BAD_VALUES` | Record the first bad element's flat idx / row / col / value | `0` (off) | — |
-| `NANLOG_ADDR` | Record `data_ptr` + backing-storage extent per tensor | `0` (off) | — |
-| `NANLOG_DUMP_TENSOR` | Save the full bad tensor to a `.pt` on first detection | `0` (off) | — |
-| `NANLOG_ALLOC_SNAPSHOT` | Dump a caching-allocator event trace on first bad (~10% overhead) | `0` (off) | — |
-| `NANLOG_PIPELINE` | Track tensors at the TorchRec stage boundaries | `0` (off) | `follow[].at: stage` |
+| `NANLOG_BAD_VALUES` | Record the first bad element's flat idx / row / col / value | `0` (off) | `diagnostics:[bad_values]` |
+| `NANLOG_ADDR` | Record `data_ptr` + backing-storage extent per tensor | `0` (off) | `diagnostics:[addr]` |
+| `NANLOG_LOCATE` | Record how many rows hold a bad value | `0` (off) | `diagnostics:[locate]` |
+| `NANLOG_DUMP_TENSOR` | Save the full bad tensor to a `.pt` on first detection | `0` (off) | `diagnostics:[dump_tensor]` |
+| `NANLOG_ALLOC_SNAPSHOT` | Dump a caching-allocator event trace on first bad (~10% overhead) | `0` (off) | `diagnostics:[alloc_snapshot]` |
+| `NANLOG_PIPELINE` | Track tensors at the TorchRec stage boundaries | `0` (off) | `follow[].stages: true` |
 | `NANLOG_TRACK_ATTR` | Batch attribute(s) to follow as tracked tensors | `embedding_features` | `follow[].tensor` |
 | `NANLOG_BOUNDS` | Per-tensor in-range check `substr:lo:hi;...` (→ `kind="oob"`) | (empty) | `follow[].bounds` |
 | `NANLOG_SPARSE` | Cheap host-side KJT metadata at the sparse stage | `0` (off) | — |
-| `NANLOG_TRACK_EVERY_LAYER` | Re-scan tracked tensors at each layer | `0` (off) | `follow[].at: stride:N` |
-| `NANLOG_TRACK_LAYER_STRIDE` | Re-scan every Kth layer when re-scan is on | `1` | `follow[].at: stride:N` |
+| `NANLOG_TRACK_EVERY_LAYER` | Re-scan tracked tensors at each layer | `0` (off) | `follow[].scope` (+ `stride`) |
+| `NANLOG_TRACK_LAYER_STRIDE` | Re-scan every Kth layer when re-scan is on | `1` | `follow[].stride` |
 
 Channel notes:
 

--- a/docs/layer-numerics.md
+++ b/docs/layer-numerics.md
@@ -198,6 +198,10 @@ Everything the logger does is one of two kinds — the `watch` and `follow` keys
   Each record is tagged with its `phase` and a `batch_id` so one batch's records
   line up across steps. This catches corruption that arrives *upstream* of the
   layers, which watching alone cannot see.
+  > Note: a scoped re-scan rides the pipeline hook, so it **also** emits the
+  > stage-boundary records even when `stages` is omitted or `false` — you will see
+  > `phase` records at the stages regardless. Stage records can't be suppressed
+  > independently of a scoped re-scan today.
 
 Add a `bounds: [lo, hi]` to a `follow` entry to flag out-of-range values
 (`kind="oob"`) — a two-sided check the one-sided "huge" threshold misses.

--- a/src/aorta/instrumentation/layer_numerics/README.md
+++ b/src/aorta/instrumentation/layer_numerics/README.md
@@ -82,6 +82,13 @@ See [`docs/layer-numerics.md`](../../../../docs/layer-numerics.md) for the how-t
 it into the flat vars the engine already reads (a malformed spec warns and falls
 back). Keeping the engine flat-var-only is what preserves the standalone contract.
 
+Recent schema additions (full how-to in [`docs/layer-numerics.md`](../../../../docs/layer-numerics.md)):
+a `watch` entry's `tensors` list also accepts `igrad` (the activation-input grad
+alone, vs. `grad` which is all gradients); a `watch` entry may set `"stride": N`
+(`>= 1`, default `1`) to hook only every Nth matched module; and a top-level
+`"diagnostics": [...]` list (`addr`, `locate`, `bad_values`, `dump_tensor`,
+`alloc_snapshot`) toggles per-record detail across every captured record.
+
 Collector defaults (applied by [`build_env`](__init__.py)): all seven channels,
 `NANLOG_PRE_CONTEXT=10`, `NANLOG_SAMPLE_EVERY=50`. `NANLOG_DIR` is filled per-cell
 so `aorta bundle` picks up the output; recipe/CLI overrides win.

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -518,12 +518,14 @@ def _translate_spec(spec: dict) -> None:
         for t in tensor_names:
             channels += _SPEC_TENSOR_TO_CHANNEL[t]
         per_group_tensors.append(tuple(sorted(tensor_names)))
-        # Optional per-group `stride`: hook only every Nth matched module.
-        if "stride" in g:
-            sv = g["stride"]
-            if isinstance(sv, bool) or not isinstance(sv, int) or sv < 1:
-                raise ValueError(f"watch[].stride must be an integer >= 1, got {sv!r}")
-            watch_strides.append(sv)
+        # Per-group `stride` (hook only every Nth matched module). An omitted stride
+        # means 1 (every module) -- record that explicitly so the merge below always
+        # picks the FINEST requested; otherwise a group asking for the default 1 would
+        # be ignored and a larger stride from a sibling group would thin it.
+        sv = g.get("stride", 1)
+        if isinstance(sv, bool) or not isinstance(sv, int) or sv < 1:
+            raise ValueError(f"watch[].stride must be an integer >= 1, got {sv!r}")
+        watch_strides.append(sv)
     if len(per_group_tensors) > 1 and len(set(per_group_tensors)) > 1:
         _spec_warn("multiple watch groups with different `tensors` are merged into one "
                    "global set (engine limitation); split into separate runs for exact per-group capture")
@@ -558,13 +560,13 @@ def _translate_spec(spec: dict) -> None:
         stages, stride = _resolve_follow_cadence(f0)
         # `stages` -> the pipeline stage scan (NANLOG_PIPELINE). Also required as the
         # engine's transport for the per-module re-scan, so it is on whenever a stride
-        # is requested too. Consequence: a scoped follow with stages:false still emits
-        # the stage records (the engine can't separate the two today) -- warn rather
-        # than silently over-capture.
+        # is requested too. Consequence: a scoped follow still emits stage records even
+        # when `stages` is false/omitted -- warn (worded for both cases) rather than
+        # silently over-capture.
         if stride is not None and not stages:
-            _spec_warn("follow with stages:false + a scope still emits pipeline-stage "
-                       "records (the per-module re-scan rides the same pipeline hook); "
-                       "stage records cannot be suppressed independently today")
+            _spec_warn("a scoped `follow` still emits pipeline-stage records even with "
+                       "`stages` false or omitted (the per-module re-scan rides the same "
+                       "pipeline hook); stage records cannot be suppressed independently today")
         _spec_set("NANLOG_PIPELINE", "1" if (stages or stride is not None) else "0")
         track_attrs = [f["tensor"].strip() for f in follow]
         _spec_set("NANLOG_TRACK_ATTR", ",".join(track_attrs))
@@ -588,13 +590,16 @@ def _translate_spec(spec: dict) -> None:
         if bounds_entries:
             _spec_set("NANLOG_BOUNDS", ";".join(bounds_entries))
 
-    # Deferred watch[].stride. The follow per-module re-scan runs INSIDE the forward
-    # hook, and _attach installs that hook only on modules that survive the watch
-    # stride -- so a watch stride would silently thin a scoped follow's capture and
-    # could hide the layer where corruption starts. When a scoped follow needs every
-    # matched module's hook, IGNORE the watch stride (with a warning) rather than lose
-    # follow evidence; otherwise apply it (finest, if groups disagree).
-    if watch_strides:
+    # Deferred watch[].stride. Every group contributes a stride (1 when omitted), so
+    # the finest requested is min(watch_strides); this is only meaningful when some
+    # group asked for >1. The follow per-module re-scan runs INSIDE the forward hook,
+    # and _attach installs that hook only on modules that survive the watch stride --
+    # so a watch stride would silently thin a scoped follow's capture and could hide
+    # the layer where corruption starts. When a scoped follow needs every matched
+    # module's hook, IGNORE the watch stride (with a warning) rather than lose follow
+    # evidence; otherwise apply the finest.
+    effective_watch_stride = min(watch_strides) if watch_strides else 1
+    if effective_watch_stride > 1:
         follow_needs_all_hooks = bool(
             follow and _resolve_follow_cadence(follow[0])[1] is not None)
         if follow_needs_all_hooks:
@@ -605,7 +610,7 @@ def _translate_spec(spec: dict) -> None:
             if len(set(watch_strides)) > 1:
                 _spec_warn("multiple watch groups set different `stride`s; the engine has "
                            "one global watch stride, so the smallest (finest) is used")
-            _spec_set("NANLOG_WATCH_STRIDE", str(min(watch_strides)))
+            _spec_set("NANLOG_WATCH_STRIDE", str(effective_watch_stride))
 
     if names:
         _spec_set("NANLOG_WATCH_NAMES", ",".join(names))

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -45,20 +45,28 @@ How to run:
 
 Settings (environment variables):
   NANLOG_SPEC            structured JSON config (recommended). When set, it WINS and
-                         is translated into the flat NANLOG_* vars below. Unifies the
-                         flat flags onto three axes -- scope (which modules), tensors
-                         (which of a module's tensors), at (when/how often) -- and two
+                         is translated into the flat NANLOG_* vars below. Two
                          observation kinds: `watch` (a module's OWN tensors) and
                          `follow` (trace ONE named tensor across positions). Example:
                            NANLOG_SPEC='{
                              "watch":  [{"scope": {"types": ["MLP","AttentionBlock"]},
                                          "tensors": ["input","output"]}],
                              "follow": [{"tensor": "embedding_features",
-                                         "at": "stage", "bounds": [0,60]}],
+                                         "stages": true, "bounds": [0,60]}],
                              "sample_every": 50, "pre_context": 10}'
-                         tensors: input,output,weight,bias,grad ("grad" = all of
-                         igrad+wgrad+bgrad). at: "stride:N" (every Nth module in
-                         scope; 1=every) or "stage" (pipeline stages).
+                         watch: scope {names/types} + tensors + optional stride.
+                           tensors: input,output,weight,bias,igrad,grad
+                             ("igrad" = activation-input grad only; "grad" =
+                             igrad+wgrad+bgrad). "stride": N hooks every Nth matched
+                             module (default 1 = all), to thin a broad watch.
+                         follow: `tensor` + WHERE to check it, as two independent knobs:
+                           "stages": true  -> at the pipeline stage boundaries
+                           "scope": {...}  -> ALSO at those modules; "stride": N picks
+                                              every Nth matched module (default 1).
+                           Set either or both (default: stages only).
+                         diagnostics: optional list of "how much detail" toggles
+                           applied to every record: addr, locate, bad_values,
+                           dump_tensor, alloc_snapshot.
                          The same JSON can instead come from a file, by precedence:
                          `--config <file>` CLI flag > NANLOG_SPEC_FILE=<file> env >
                          inline NANLOG_SPEC. NANLOG_DIR stays a separate var either
@@ -264,15 +272,18 @@ import torch  # noqa: E402
 # ---------------------------------------------------------------------------
 # NANLOG_SPEC front-end (structured config)
 # ---------------------------------------------------------------------------
-# One JSON env var that unifies the flat NANLOG_* flags onto three axes:
+# One JSON env var, two observation kinds:
+#   watch   [{scope, tensors, stride?}, ...]      -- a module's OWN tensors
+#   follow  [{tensor, stages?, scope?, stride?, bounds?}, ...]
+#                                                 -- trace ONE named tensor across positions
+# building blocks:
 #   scope   {names:[substr,...], types:[ClassName,...]}  -- which modules
-#   tensors [input,output,weight,bias,grad]              -- which of a module's tensors
-#   at      "stride:N" | "stage"                         -- when/how often
-# and two observation kinds:
-#   watch   [{scope, tensors, at?}, ...]   -- a module's OWN tensors
-#   follow  [{tensor, at, scope?, bounds?}, ...] -- trace ONE named tensor across positions
-# plus cross-cutting: sample_every, pre_context. (Output dir is the separate
-# NANLOG_DIR env var, never a spec key.)
+#   tensors [input,output,weight,bias,igrad,grad]        -- which of a module's tensors
+#   stages  bool  -- (follow) check at the pipeline stage boundaries
+#   stride  int   -- every Nth matched module (default 1); watch: thin the hooks,
+#                    follow: re-scan cadence at scoped modules
+# plus cross-cutting: sample_every, pre_context, diagnostics[]. (Output dir is the
+# separate NANLOG_DIR env var, never a spec key.)
 #
 # When set, NANLOG_SPEC WINS: it is translated into the flat NANLOG_* vars the
 # engine below already reads (the engine is unchanged). Standalone-safe: no aorta
@@ -282,13 +293,27 @@ import torch  # noqa: E402
 # scopes are merged with a warning (see _apply_spec).
 # Each spec `tensors` token maps to one or more flat channels. "grad" is the
 # umbrella for ALL gradients — activation-input grad (igrad) AND parameter grads
-# (wgrad/bgrad) — so asking for "grad" gets everything a NaN hunt wants.
+# (wgrad/bgrad) — so asking for "grad" gets everything a NaN hunt wants. "igrad"
+# selects ONLY the activation-input gradient, for when the param grads aren't wanted.
 _SPEC_TENSOR_TO_CHANNEL = {
     "input": ("input",),
     "output": ("act",),
     "weight": ("weight",),
     "bias": ("bias",),
+    "igrad": ("igrad",),
     "grad": ("igrad", "wgrad", "bgrad"),
+}
+
+# Optional `diagnostics` block: "how much detail" toggles that apply to every
+# captured record, independent of watch/follow. Spec name -> flat env var it sets.
+# These are cross-cutting (not per-entry), so they live in a top-level list rather
+# than on a watch/follow entry.
+_SPEC_DIAG_KEYS = {
+    "addr": "NANLOG_ADDR",                    # GPU data_ptr + storage extent per tensor
+    "locate": "NANLOG_LOCATE",                # how many rows hold a bad value
+    "bad_values": "NANLOG_BAD_VALUES",        # first bad element idx/row/col/value
+    "dump_tensor": "NANLOG_DUMP_TENSOR",      # save the full bad tensor to .pt (one-shot)
+    "alloc_snapshot": "NANLOG_ALLOC_SNAPSHOT",  # allocator event trace on first bad
 }
 
 
@@ -300,19 +325,6 @@ def _spec_warn(msg: str) -> None:
 def _spec_set(env_key: str, value: str) -> None:
     """Set a derived flat var (NANLOG_SPEC wins, so overwrite)."""
     os.environ[env_key] = value
-
-
-def _parse_stride(at: str) -> str | None:
-    """Return the N of a well-formed "stride:N" (N a positive int) as a string, else
-    None (warned by the caller). Guards the engine's `int(NANLOG_TRACK_LAYER_STRIDE)`
-    against a malformed spec value crashing the logger at import."""
-    n_str = at.split(":", 1)[1].strip()
-    try:
-        if int(n_str) >= 1:
-            return n_str
-    except ValueError:
-        pass
-    return None
 
 
 # --- Spec validation helpers -------------------------------------------------
@@ -341,13 +353,45 @@ def _spec_int(spec: dict, key: str, minimum: int) -> int | None:
     return v
 
 
-def _validate_follow_at(at) -> None:
-    """A follow `at` must be 'stage' or 'stride:N' (N>=1). Raises otherwise."""
-    if at == "stage":
-        return
-    if isinstance(at, str) and at.startswith("stride:") and _parse_stride(at) is not None:
-        return
-    raise ValueError(f"follow[].at {at!r} must be 'stage' or 'stride:N' with N>=1")
+def _resolve_follow_cadence(f: dict) -> tuple:
+    """Normalize a follow entry's cadence into (stages: bool, stride: int|None),
+    where stride is the "also re-scan every Nth watched module" cadence (None = don't
+    re-scan at modules). WHERE to check the followed tensor is two independent knobs:
+
+        "stages": true   -> capture at the pipeline stage boundaries (copy/sparse/fwd)
+        "scope":  {...}   -> ALSO capture at those modules (names/types)
+        "stride": N       -> every Nth matched module (default 1; requires `scope`)
+
+    Set either or both. Default (neither key) is stages-only, the common case.
+    Raises ValueError on a malformed/contradictory entry so the whole spec rolls back.
+    """
+    # Reject unknown keys so a typo or a leftover `at` from the old schema fails loudly
+    # instead of silently falling through to the stages-only default.
+    _FOLLOW_KEYS = {"tensor", "stages", "scope", "stride", "bounds"}
+    unknown = [k for k in f if k not in _FOLLOW_KEYS]
+    if unknown:
+        raise ValueError(f"unknown follow[] key(s) {sorted(unknown)}; "
+                         f"valid: {sorted(_FOLLOW_KEYS)}")
+    # `stages` defaults to True unless a `scope` is given without it (then the intent
+    # is module-capture; the caller opts into stages explicitly with stages:true).
+    stages = f.get("stages", "scope" not in f)
+    if not isinstance(stages, bool):
+        raise ValueError(f"follow[].stages must be true/false, got {stages!r}")
+    stride = None
+    if "stride" in f:
+        v = f["stride"]
+        if isinstance(v, bool) or not isinstance(v, int) or v < 1:
+            raise ValueError(f"follow[].stride must be an integer >= 1, got {v!r}")
+        stride = v
+    if "scope" in f and stride is None:
+        stride = 1   # a scope with no stride means "every matched module"
+    if stride is not None and "scope" not in f:
+        raise ValueError("follow[].stride needs a `scope` naming which modules to "
+                         "re-scan (types/names)")
+    if not stages and stride is None:
+        raise ValueError("follow[] captures nothing: set `stages: true` and/or a "
+                         "`scope` to re-scan at modules")
+    return stages, stride
 
 
 def _spec_optional_mapping(container: dict, key: str, path: str) -> dict:
@@ -413,9 +457,13 @@ def _apply_spec(spec_json: str) -> tuple:
 # the wrapper owns output routing and sets it independently of the spec.
 _SPEC_OWNED_VARS = {
     "NANLOG_WATCH_NAMES": "", "NANLOG_WATCH_TYPES": "", "NANLOG_CHANNELS": "",
+    "NANLOG_WATCH_STRIDE": "1",
     "NANLOG_PIPELINE": "0", "NANLOG_TRACK_ATTR": "", "NANLOG_TRACK_EVERY_LAYER": "0",
     "NANLOG_TRACK_LAYER_STRIDE": "1", "NANLOG_BOUNDS": "",
     "NANLOG_SAMPLE_EVERY": "", "NANLOG_PRE_CONTEXT": "",
+    # diagnostics block (see _SPEC_DIAG_KEYS)
+    "NANLOG_ADDR": "0", "NANLOG_LOCATE": "0", "NANLOG_BAD_VALUES": "0",
+    "NANLOG_DUMP_TENSOR": "0", "NANLOG_ALLOC_SNAPSHOT": "0",
 }
 
 
@@ -446,7 +494,13 @@ def _translate_spec(spec: dict) -> None:
     if not all(isinstance(g, dict) for g in watch):
         raise ValueError("each `watch` entry must be a mapping")
     per_group_tensors = []   # validated tensor lists, for the multi-group merge warning
+    watch_strides = []       # validated per-group strides, for the merge check below
+    _WATCH_KEYS = {"scope", "tensors", "stride"}
     for g in watch:
+        unknown_k = [k for k in g if k not in _WATCH_KEYS]
+        if unknown_k:
+            raise ValueError(f"unknown watch[] key(s) {sorted(unknown_k)}; "
+                             f"valid: {sorted(_WATCH_KEYS)}")
         sc = _spec_optional_mapping(g, "scope", "watch[].scope")
         names += _spec_string_list(sc.get("names"), "watch[].scope.names")
         types += _spec_string_list(sc.get("types"), "watch[].scope.types")
@@ -464,9 +518,19 @@ def _translate_spec(spec: dict) -> None:
         for t in tensor_names:
             channels += _SPEC_TENSOR_TO_CHANNEL[t]
         per_group_tensors.append(tuple(sorted(tensor_names)))
+        # Optional per-group `stride`: hook only every Nth matched module.
+        if "stride" in g:
+            sv = g["stride"]
+            if isinstance(sv, bool) or not isinstance(sv, int) or sv < 1:
+                raise ValueError(f"watch[].stride must be an integer >= 1, got {sv!r}")
+            watch_strides.append(sv)
     if len(per_group_tensors) > 1 and len(set(per_group_tensors)) > 1:
         _spec_warn("multiple watch groups with different `tensors` are merged into one "
                    "global set (engine limitation); split into separate runs for exact per-group capture")
+    # NOTE: watch[].stride is NOT applied here -- it is deferred until after the follow
+    # cadence is known, because a scoped follow re-scans INSIDE the forward hook and a
+    # watch stride that skips hook registration would silently thin that follow's
+    # per-module capture. See the deferred application after the follow block below.
 
     raw_follow = spec["follow"] if "follow" in spec else []
     if not isinstance(raw_follow, list):
@@ -474,15 +538,15 @@ def _translate_spec(spec: dict) -> None:
     if not all(isinstance(f, dict) for f in raw_follow):
         raise ValueError("each `follow` entry must be a mapping")
     # Validate EVERY follow entry up front, not just the first -- otherwise a
-    # malformed `at`/`scope` on a non-first entry would be silently accepted while
-    # the spec still applies, contradicting the atomic-validation contract. (Only the
-    # first entry's cadence/scope is *honored* by the single-follow engine, but a
-    # malformed later entry still signals a user mistake and must roll back.)
+    # malformed field on a non-first entry would be silently accepted while the spec
+    # still applies, contradicting the atomic-validation contract. (Only the first
+    # entry's cadence/scope is *honored* by the single-follow engine, but a malformed
+    # later entry still signals a user mistake and must roll back.)
     for f in raw_follow:
         tensor = f.get("tensor")
         if not isinstance(tensor, str) or not tensor.strip():
             raise ValueError(f"follow[].tensor must be a non-empty string, got {tensor!r}")
-        _validate_follow_at(f.get("at", "stage"))
+        _resolve_follow_cadence(f)                             # validates stages/stride/at
         _spec_optional_mapping(f, "scope", "follow[].scope")   # rejects non-dict scope
         _spec_bounds(f.get("bounds"), "follow[].bounds")       # rejects malformed bounds
     follow = raw_follow
@@ -490,27 +554,30 @@ def _translate_spec(spec: dict) -> None:
         _spec_warn("multiple `follow` entries: only the first cadence/scope is honored "
                    "(engine has one follow path); tensors are unioned into TRACK_ATTR")
     if follow:
-        _spec_set("NANLOG_PIPELINE", "1")
+        f0 = follow[0]
+        stages, stride = _resolve_follow_cadence(f0)
+        # `stages` -> the pipeline stage scan (NANLOG_PIPELINE). Also required as the
+        # engine's transport for the per-module re-scan, so it is on whenever a stride
+        # is requested too. Consequence: a scoped follow with stages:false still emits
+        # the stage records (the engine can't separate the two today) -- warn rather
+        # than silently over-capture.
+        if stride is not None and not stages:
+            _spec_warn("follow with stages:false + a scope still emits pipeline-stage "
+                       "records (the per-module re-scan rides the same pipeline hook); "
+                       "stage records cannot be suppressed independently today")
+        _spec_set("NANLOG_PIPELINE", "1" if (stages or stride is not None) else "0")
         track_attrs = [f["tensor"].strip() for f in follow]
         _spec_set("NANLOG_TRACK_ATTR", ",".join(track_attrs))
-        f0 = follow[0]
-        at = f0.get("at", "stage")
-        if at == "stage":
-            pass  # pipeline stage scan; scope does not apply to stages
-        elif isinstance(at, str) and at.startswith("stride:"):
-            n_str = _parse_stride(at)
-            if n_str is None:
-                raise ValueError(f"follow[].at {at!r} must be 'stride:N' with N>=1")
+        if stride is not None:
+            # Re-scan the followed tensor at every Nth module in the follow's scope.
             _spec_set("NANLOG_TRACK_EVERY_LAYER", "1")
-            _spec_set("NANLOG_TRACK_LAYER_STRIDE", n_str)
+            _spec_set("NANLOG_TRACK_LAYER_STRIDE", str(stride))
             fsc = _spec_optional_mapping(f0, "scope", "follow[].scope")
             if (names or types) and (fsc.get("names") or fsc.get("types")):
-                _spec_warn("both watch scope and follow-stride scope set; they share the "
+                _spec_warn("both watch scope and follow scope set; they share the "
                            "engine's single module filter and are merged")
             names += _spec_string_list(fsc.get("names"), "follow[].scope.names")
             types += _spec_string_list(fsc.get("types"), "follow[].scope.types")
-        else:
-            raise ValueError(f"follow[].at {at!r} must be 'stage' or 'stride:N'")
         # Bounds are PER-ENTRY: each tensor takes its OWN [lo,hi]. A present-but-malformed
         # bounds raises (silently dropping it would leave a requested OOB check un-run).
         bounds_entries = []
@@ -520,6 +587,25 @@ def _translate_spec(spec: dict) -> None:
                 bounds_entries.append(f"{f['tensor'].strip()}:{b[0]}:{b[1]}")
         if bounds_entries:
             _spec_set("NANLOG_BOUNDS", ";".join(bounds_entries))
+
+    # Deferred watch[].stride. The follow per-module re-scan runs INSIDE the forward
+    # hook, and _attach installs that hook only on modules that survive the watch
+    # stride -- so a watch stride would silently thin a scoped follow's capture and
+    # could hide the layer where corruption starts. When a scoped follow needs every
+    # matched module's hook, IGNORE the watch stride (with a warning) rather than lose
+    # follow evidence; otherwise apply it (finest, if groups disagree).
+    if watch_strides:
+        follow_needs_all_hooks = bool(
+            follow and _resolve_follow_cadence(follow[0])[1] is not None)
+        if follow_needs_all_hooks:
+            _spec_warn("watch[].stride ignored: a scoped `follow` re-scans inside the "
+                       "forward hook, so every matched module must keep its hook; "
+                       "thinning it would drop follow evidence")
+        else:
+            if len(set(watch_strides)) > 1:
+                _spec_warn("multiple watch groups set different `stride`s; the engine has "
+                           "one global watch stride, so the smallest (finest) is used")
+            _spec_set("NANLOG_WATCH_STRIDE", str(min(watch_strides)))
 
     if names:
         _spec_set("NANLOG_WATCH_NAMES", ",".join(names))
@@ -546,6 +632,18 @@ def _translate_spec(spec: dict) -> None:
     pre_context = _spec_int(spec, "pre_context", minimum=0)
     if pre_context is not None:
         _spec_set("NANLOG_PRE_CONTEXT", str(pre_context))
+    # Optional `diagnostics`: a list of "how much detail" toggles that apply to every
+    # captured record (independent of watch/follow). Each name maps to a flat var.
+    if "diagnostics" in spec:
+        diag = spec["diagnostics"]
+        if not isinstance(diag, list) or not all(isinstance(d, str) for d in diag):
+            raise ValueError("`diagnostics` must be a list of strings")
+        unknown_d = [d for d in diag if d not in _SPEC_DIAG_KEYS]
+        if unknown_d:
+            raise ValueError(f"unknown diagnostics {sorted(unknown_d)}; "
+                             f"valid: {sorted(_SPEC_DIAG_KEYS)}")
+        for d in diag:
+            _spec_set(_SPEC_DIAG_KEYS[d], "1")
     # `dir` is intentionally NOT honored: the output location is always the separate
     # NANLOG_DIR env var (the sweep/collector wrapper owns it and routes artifacts
     # into the trial result tree). A spec `dir` would let a recipe redirect output
@@ -608,6 +706,9 @@ _types_default = "" if _WATCH_NAMES else "Linear"
 _WATCH_TYPES = tuple(
     s.strip() for s in os.environ.get("NANLOG_WATCH_TYPES", _types_default).split(",") if s.strip()
 )
+# Hook only every Nth matched module (1 = every, the default). Thins a broad watch
+# whose per-module reduction volume is too high; applied in _attach.
+_WATCH_STRIDE = max(1, int(os.environ.get("NANLOG_WATCH_STRIDE", "1")))
 # Capture channels (comma list). Each is an independently switchable observation
 # adding its own on-GPU reductions; default to the cheap act+igrad pair. See the
 # module docstring for the per-channel semantics.
@@ -1353,8 +1454,14 @@ def _attach(root: torch.nn.Module) -> int:
     # re-scan silently never fires.
     want_fwd = bool(_CHANNELS & {"act", "input"}) or _TRACK_EVERY_LAYER
     want_bwd = "igrad" in _CHANNELS
+    match_idx = 0   # counts modules matching the scope, for NANLOG_WATCH_STRIDE
     for layer_name, module in root.named_modules():
         if not _is_watched(layer_name, module):
+            continue
+        # Watch stride: hook only every Nth matched module (in traversal order).
+        take = (match_idx % _WATCH_STRIDE == 0)
+        match_idx += 1
+        if not take:
             continue
         if want_fwd:
             module.register_forward_hook(_fwd_hook(layer_name))
@@ -1866,6 +1973,7 @@ def _write_summary() -> None:
         "pre_context_flushed": _pre_flushed,
         "watch_types": list(_WATCH_TYPES),
         "watch_names": list(_WATCH_NAMES),
+        "watch_stride": _WATCH_STRIDE,
         "watched_count": len(_watched_names),
         "watched_names": list(_watched_names),
         "channels": sorted(_CHANNELS),

--- a/tests/instrumentation/test_layer_numerics_spec.py
+++ b/tests/instrumentation/test_layer_numerics_spec.py
@@ -63,6 +63,82 @@ def test_watch_spec_maps_tensors_to_channels(monkeypatch, tmp_path_factory):
     assert nl._CHANNELS == frozenset({"input", "act", "weight"})
 
 
+def test_igrad_token_is_activation_input_grad_only(monkeypatch, tmp_path_factory):
+    """`igrad` selects ONLY the activation-input grad; `grad` is the wider umbrella."""
+    nl = _load_logger(
+        {"NANLOG_SPEC": json.dumps(
+            {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output", "igrad"]}]})},
+        monkeypatch, tmp_path_factory)
+    assert nl._CHANNELS == frozenset({"act", "igrad"})   # no wgrad/bgrad
+    assert nl._GRAD_CHANNELS == frozenset()              # no param-grad channels
+
+
+def test_watch_stride(monkeypatch, tmp_path_factory):
+    """`watch[].stride: N` -> NANLOG_WATCH_STRIDE=N; _attach hooks every Nth match."""
+    nl = _load_logger(
+        {"NANLOG_SPEC": json.dumps(
+            {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"], "stride": 3}]})},
+        monkeypatch, tmp_path_factory)
+    assert nl._WATCH_STRIDE == 3
+    model = torch.nn.Sequential(*[torch.nn.Linear(4, 4) for _ in range(7)])
+    assert nl._attach(model) == 3   # ceil(7/3): modules 0,3,6
+    # the resolved stride is recorded in the summary so a thinned run is auditable
+    nl._write_summary()
+    smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
+    assert smy["watch_stride"] == 3
+
+
+def test_watch_stride_ignored_when_scoped_follow_needs_all_hooks(monkeypatch, tmp_path_factory):
+    """A scoped follow re-scans inside the forward hook, so watch[].stride must NOT
+    thin the hooks (that would drop follow evidence). The watch stride is ignored
+    (falls back to 1) with a warning; the follow re-scan is preserved."""
+    spec = {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"], "stride": 4}],
+            "follow": [{"tensor": "ef", "scope": {"types": ["MLP"]}, "stride": 1}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is True
+    assert nl._WATCH_STRIDE == 1          # watch stride dropped, not honored
+    assert nl._TRACK_EVERY_LAYER is True  # follow re-scan still armed
+
+
+def test_watch_stride_applied_with_stages_only_follow(monkeypatch, tmp_path_factory):
+    """A stages-only follow uses no forward hooks, so watch[].stride is safe to apply."""
+    spec = {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"], "stride": 4}],
+            "follow": [{"tensor": "ef", "stages": True}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._WATCH_STRIDE == 4          # applied: no module-hook follow to protect
+    assert nl._TRACK_EVERY_LAYER is False
+
+
+def test_diagnostics_block(monkeypatch, tmp_path_factory):
+    """`diagnostics: [...]` enables the matching flat toggles; unlisted ones stay off."""
+    nl = _load_logger(
+        {"NANLOG_SPEC": json.dumps(
+            {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"]}],
+             "diagnostics": ["addr", "bad_values", "alloc_snapshot"]})},
+        monkeypatch, tmp_path_factory)
+    assert nl._CAPTURE_ADDR is True
+    assert nl._BAD_VALUES is True
+    assert nl._ALLOC_SNAPSHOT is True
+    assert nl._LOCATE is False          # not listed
+    assert nl._DUMP_TENSOR is False     # not listed
+
+
+@pytest.mark.parametrize("spec", [
+    {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"], "stride": 0}]},   # <1
+    {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"], "stride": "3"}]}, # non-int
+    {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"], "bogus": 1}]},    # unknown key
+    {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"]}], "diagnostics": ["bogus"]},
+    {"watch": [{"scope": {"types": ["Linear"]}, "tensors": ["output"]}], "diagnostics": "addr"},  # not a list
+])
+def test_new_watch_diag_invalid_rolls_back(spec, monkeypatch, tmp_path_factory):
+    """Malformed watch stride / unknown watch key / bad diagnostics roll the spec back."""
+    nl = _load_logger(
+        {"NANLOG_SPEC": json.dumps(spec), "NANLOG_CHANNELS": "act,igrad"},
+        monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is False
+    assert nl._CHANNELS == frozenset({"act", "igrad"})
+
+
 def test_watch_spec_names_scope(monkeypatch, tmp_path_factory):
     spec = {"watch": [{"scope": {"names": ["emb_proj"]}, "tensors": ["input", "output"]}]}
     nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
@@ -99,7 +175,7 @@ def test_watch_spec_runtime_capture(monkeypatch, tmp_path_factory):
 # follow: at:stage -> PIPELINE, bounds -> BOUNDS
 # ---------------------------------------------------------------------------
 def test_follow_stage_spec(monkeypatch, tmp_path_factory):
-    spec = {"follow": [{"tensor": "embedding_features", "at": "stage", "bounds": [0, 60]}]}
+    spec = {"follow": [{"tensor": "embedding_features", "stages": True, "bounds": [0, 60]}]}
     nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
     assert nl._PIPELINE is True
     assert nl._TRACK_ATTR == ("embedding_features",)
@@ -109,14 +185,82 @@ def test_follow_stage_spec(monkeypatch, tmp_path_factory):
 
 
 def test_follow_stride_spec(monkeypatch, tmp_path_factory):
-    """`at:stride:8` -> TRACK_EVERY_LAYER + stride 8; follow scope merges into WATCH_*."""
-    spec = {"follow": [{"tensor": "embedding_features", "at": "stride:8",
-                        "scope": {"names": ["emb_proj"]}}]}
+    """follow `scope` + `stride:8` -> TRACK_EVERY_LAYER + stride 8; scope -> WATCH_*."""
+    spec = {"follow": [{"tensor": "embedding_features", "scope": {"names": ["emb_proj"]}, "stride": 8}]}
     nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
     assert nl._PIPELINE is True
     assert nl._TRACK_EVERY_LAYER is True
     assert nl._TRACK_LAYER_STRIDE == 8
     assert nl._WATCH_NAMES == ("emb_proj",)
+
+
+# ---------------------------------------------------------------------------
+# follow cadence: explicit `stages` + `scope`/`stride` (replaces the `at` overload)
+# ---------------------------------------------------------------------------
+def test_follow_stages_only(monkeypatch, tmp_path_factory):
+    """`stages: true` alone -> pipeline stage scan, no per-module re-scan."""
+    spec = {"follow": [{"tensor": "ef", "stages": True, "bounds": [0, 60]}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is True
+    assert nl._TRACK_EVERY_LAYER is False
+    assert nl._BOUNDS_ACTIVE is True
+
+
+def test_follow_default_is_stages_only(monkeypatch, tmp_path_factory):
+    """A follow entry with neither `stages` nor `scope` defaults to stages-only."""
+    spec = {"follow": [{"tensor": "ef"}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is True
+    assert nl._TRACK_EVERY_LAYER is False
+
+
+def test_follow_stages_and_scope(monkeypatch, tmp_path_factory):
+    """`stages:true` + `scope` -> BOTH the pipeline stages AND a per-module re-scan
+    at every module in scope (stride defaults to 1)."""
+    spec = {"follow": [{"tensor": "ef", "stages": True,
+                        "scope": {"types": ["MLP"]}, "bounds": [0, 60]}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is True
+    assert nl._TRACK_EVERY_LAYER is True
+    assert nl._TRACK_LAYER_STRIDE == 1
+    assert nl._WATCH_TYPES == ("MLP",)
+
+
+def test_follow_scope_with_stride(monkeypatch, tmp_path_factory):
+    """`scope` + `stride:N` -> re-scan every Nth module in scope."""
+    spec = {"follow": [{"tensor": "ef", "scope": {"names": ["emb"]}, "stride": 8}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._TRACK_EVERY_LAYER is True
+    assert nl._TRACK_LAYER_STRIDE == 8
+    assert nl._WATCH_NAMES == ("emb",)
+
+
+def test_follow_at_key_is_rejected(monkeypatch, tmp_path_factory):
+    """The old `at` key was removed: it is now an unknown follow key and rolls the
+    whole spec back (no silent back-compat)."""
+    spec = {"follow": [{"tensor": "ef", "at": "stage"}]}
+    nl = _load_logger(
+        {"NANLOG_SPEC": json.dumps(spec), "NANLOG_CHANNELS": "act,igrad"},
+        monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is False
+    assert nl._CHANNELS == frozenset({"act", "igrad"})
+
+
+@pytest.mark.parametrize("follow_entry", [
+    {"tensor": "ef", "at": "stage"},                        # removed `at` key -> unknown
+    {"tensor": "ef", "stride": 4},                          # stride without scope
+    {"tensor": "ef", "stages": False},                      # captures nothing
+    {"tensor": "ef", "stages": "yes"},                      # non-bool stages
+    {"tensor": "ef", "scope": {"types": ["MLP"]}, "stride": 0},   # stride < 1
+])
+def test_follow_cadence_invalid_rolls_back(follow_entry, monkeypatch, tmp_path_factory):
+    """Malformed / contradictory follow cadence rejects the whole spec (flat fallback)."""
+    nl = _load_logger(
+        {"NANLOG_SPEC": json.dumps({"follow": [follow_entry]}),
+         "NANLOG_CHANNELS": "act,igrad"},
+        monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is False
+    assert nl._CHANNELS == frozenset({"act", "igrad"})
 
 
 @pytest.mark.parametrize("watch_scope", [
@@ -128,16 +272,16 @@ def test_watch_plus_follow_stride_warns_on_merged_scope(watch_scope, monkeypatch
     filter, so the merge warning must fire for BOTH names-only and types-only watch
     scopes (PR #292 review: types-only was silently missed)."""
     spec = {"watch": [{"scope": watch_scope, "tensors": ["input"]}],
-            "follow": [{"tensor": "ef", "at": "stride:4", "scope": {"names": ["emb"]}}]}
+            "follow": [{"tensor": "ef", "scope": {"names": ["emb"]}, "stride": 4}]}
     _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
-    assert "both watch scope and follow-stride scope set" in capsys.readouterr().err
+    assert "both watch scope and follow scope set" in capsys.readouterr().err
 
 
 def test_follow_entry_without_tensor_does_not_capture_default(monkeypatch, tmp_path_factory):
     """A follow entry with no `tensor` is malformed; it must NOT silently fall through
     to the engine default (embedding_features). With no valid follow entry and no flat
     vars asking for pipeline, the run rolls back to flat defaults (pipeline off)."""
-    spec = {"follow": [{"at": "stage"}]}   # no tensor
+    spec = {"follow": [{"stages": True}]}   # no tensor
     nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
     assert nl._PIPELINE is False           # rolled back; not a real capture
     assert nl._TRACK_ATTR == ("embedding_features",)  # the flat DEFAULT, not spec-driven
@@ -146,7 +290,7 @@ def test_follow_entry_without_tensor_does_not_capture_default(monkeypatch, tmp_p
 def test_follow_mixed_valid_and_tensorless_rolls_back(monkeypatch, tmp_path_factory):
     """A tensorless entry makes the WHOLE spec invalid (atomic validation): the run
     rolls back to flat vars rather than silently applying only the valid entry."""
-    spec = {"follow": [{"at": "stage"}, {"tensor": "ef", "at": "stage"}]}
+    spec = {"follow": [{"stages": True}, {"tensor": "ef", "stages": True}]}
     nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
     assert nl._PIPELINE is False           # rolled back; not a partial apply
     assert nl._TRACK_ATTR == ("embedding_features",)  # flat default, not "ef"
@@ -164,7 +308,7 @@ def test_follow_per_entry_bounds(monkeypatch, tmp_path_factory):
 def test_follow_stage_no_watch_warning(monkeypatch, tmp_path_factory, capsys):
     """A follow-stage spec (empty watch scope by design) must NOT print the
     'no modules will be watched' warning; a stride follow with no scope still does."""
-    stage = {"follow": [{"tensor": "ef", "at": "stage"}]}
+    stage = {"follow": [{"tensor": "ef", "stages": True}]}
     _load_logger({"NANLOG_SPEC": json.dumps(stage)}, monkeypatch, tmp_path_factory)
     assert "no modules will be watched" not in capsys.readouterr().err
 
@@ -176,7 +320,7 @@ def test_follow_only_clears_inherited_layer_defaults(monkeypatch, tmp_path_facto
     """With the collector's 7-channel + Linear defaults already in env, a follow-only
     stage spec must clear the layer channels AND the Linear watch default, so it does
     not silently hook Linear layers the user never asked to watch."""
-    spec = {"follow": [{"tensor": "embedding_features", "at": "stage"}]}
+    spec = {"follow": [{"tensor": "embedding_features", "stages": True}]}
     nl = _load_logger(
         {"NANLOG_SPEC": json.dumps(spec),
          "NANLOG_CHANNELS": "act,input,igrad,weight,bias,wgrad,bgrad"},
@@ -189,7 +333,7 @@ def test_follow_only_clears_inherited_layer_defaults(monkeypatch, tmp_path_facto
 def test_follow_stride_clears_channels_but_keeps_scope(monkeypatch, tmp_path_factory):
     """A stride follow clears inherited layer channels but keeps its own scope, and
     the engine still installs forward hooks (the re-scan runs inside the fwd hook)."""
-    spec = {"follow": [{"tensor": "ef", "at": "stride:2", "scope": {"types": ["Linear"]}}]}
+    spec = {"follow": [{"tensor": "ef", "scope": {"types": ["Linear"]}, "stride": 2}]}
     nl = _load_logger(
         {"NANLOG_SPEC": json.dumps(spec), "NANLOG_CHANNELS": "act,igrad"},
         monkeypatch, tmp_path_factory)
@@ -206,7 +350,7 @@ def test_watch_plus_follow_does_not_clear_watch_channels(monkeypatch, tmp_path_f
     """The clear only applies to follow-ONLY specs: a watch group present means its
     channels are honored, not wiped."""
     spec = {"watch": [{"scope": {"types": ["MLP"]}, "tensors": ["input"]}],
-            "follow": [{"tensor": "ef", "at": "stage"}]}
+            "follow": [{"tensor": "ef", "stages": True}]}
     nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
     assert nl._CHANNELS == frozenset({"input"})
     assert nl._WATCH_TYPES == ("MLP",)
@@ -243,11 +387,11 @@ def test_no_spec_uses_flat_vars(monkeypatch, tmp_path_factory):
 # ---------------------------------------------------------------------------
 # malformed spec must never crash import (sidecar contract)
 # ---------------------------------------------------------------------------
-@pytest.mark.parametrize("at", ["stride:", "stride:abc", "stride:0", "stride:-3"])
-def test_malformed_stride_rolls_back(at, monkeypatch, tmp_path_factory):
-    """A bad stride value must not crash the int() at config time; it rolls back to
-    flat vars (stride 1, no per-layer re-scan armed)."""
-    spec = {"follow": [{"tensor": "ef", "at": at}]}
+@pytest.mark.parametrize("stride", [0, -3, "8", 1.5, True])
+def test_malformed_stride_rolls_back(stride, monkeypatch, tmp_path_factory):
+    """A bad `stride` value (non-int, <1, bool) rolls back to flat vars rather than
+    crashing the int() at config time or arming a bogus re-scan."""
+    spec = {"follow": [{"tensor": "ef", "scope": {"names": ["x"]}, "stride": stride}]}
     nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
     assert nl._TRACK_LAYER_STRIDE == 1
     assert nl._TRACK_EVERY_LAYER is False
@@ -285,9 +429,9 @@ def test_malformed_entry_shapes_do_not_crash(spec, monkeypatch, tmp_path_factory
     {"sample_every": "abc"},                                              # non-int
     {"sample_every": 0},                                                  # < 1 (div-by-zero risk)
     {"pre_context": -1},                                                  # < 0
-    {"follow": [{"tensor": "ef", "at": "stage", "bounds": {"lo": 0, "hi": 1}}]},  # bounds dict
-    {"follow": [{"tensor": "ef", "at": "stage", "bounds": [0]}]},         # bounds wrong length
-    {"follow": [{"tensor": "ef", "at": "stage", "bounds": ["x", "y"]}]},  # bounds non-numeric
+    {"follow": [{"tensor": "ef", "stages": True, "bounds": {"lo": 0, "hi": 1}}]},  # bounds dict
+    {"follow": [{"tensor": "ef", "stages": True, "bounds": [0]}]},         # bounds wrong length
+    {"follow": [{"tensor": "ef", "stages": True, "bounds": ["x", "y"]}]},  # bounds non-numeric
     # a 2nd watch group with a non-list `tensors` must give the clean tensors error,
     # not a TypeError from the multi-group merge check (regression, PR #292 review).
     {"watch": [{"scope": {"types": ["MLP"]}, "tensors": ["input"]},
@@ -296,20 +440,20 @@ def test_malformed_entry_shapes_do_not_crash(spec, monkeypatch, tmp_path_factory
     # default -- it is malformed and must roll back (PR #292 review).
     {"watch": [{"scope": [], "tensors": ["input"]}]},           # falsy list scope
     {"watch": [{"scope": "", "tensors": ["input"]}]},           # falsy str scope
-    {"follow": [{"tensor": "ef", "at": "stride:1", "scope": ""}]},   # falsy follow scope
+    {"follow": [{"tensor": "ef", "scope": "", "stride": 1}]},   # falsy follow scope
     {"watch": None},                                            # explicit null
     {"follow": None},
     # non-finite bounds would make the OOB check meaningless while looking applied.
-    {"follow": [{"tensor": "ef", "at": "stage", "bounds": [float("nan"), 60]}]},
-    {"follow": [{"tensor": "ef", "at": "stage", "bounds": [0, float("inf")]}]},
-    {"follow": [{"tensor": "ef", "at": "stage", "bounds": [float("-inf"), 60]}]},
+    {"follow": [{"tensor": "ef", "stages": True, "bounds": [float("nan"), 60]}]},
+    {"follow": [{"tensor": "ef", "stages": True, "bounds": [0, float("inf")]}]},
+    {"follow": [{"tensor": "ef", "stages": True, "bounds": [float("-inf"), 60]}]},
     # a malformed field on a NON-FIRST follow entry must still reject the whole spec
     # (atomic validation), even though only the first entry's cadence is honored
     # (PR #292 review).
-    {"follow": [{"tensor": "a", "at": "stage"}, {"tensor": "b", "at": "bogus"}]},
-    {"follow": [{"tensor": "a", "at": "stage"}, {"tensor": "b", "at": "stride:0"}]},
-    {"follow": [{"tensor": "a", "at": "stage"}, {"tensor": "b", "at": "stage", "scope": []}]},
-    {"follow": [{"tensor": "a", "at": "stage"}, {"tensor": "b", "at": "stage", "bounds": [1, 2, 3]}]},
+    {"follow": [{"tensor": "a", "stages": True}, {"tensor": "b", "at": "bogus"}]},  # leftover `at` key
+    {"follow": [{"tensor": "a", "stages": True}, {"tensor": "b", "scope": {"names": ["x"]}, "stride": 0}]},
+    {"follow": [{"tensor": "a", "stages": True}, {"tensor": "b", "stages": True, "scope": []}]},
+    {"follow": [{"tensor": "a", "stages": True}, {"tensor": "b", "stages": True, "bounds": [1, 2, 3]}]},
 ])
 def test_invalid_spec_rolls_back_to_flat_vars(spec, monkeypatch, tmp_path_factory):
     """Every malformed shape/value rejects the WHOLE spec and falls back to the flat
@@ -343,7 +487,7 @@ def test_mid_translation_crash_rolls_back_to_flat_vars(monkeypatch, tmp_path_fac
     """A spec that derives some flat vars and THEN crashes (scope is a string, not a
     mapping) must roll back fully to the original flat vars — no half-applied
     NANLOG_PIPELINE / TRACK_ATTR / stride survives."""
-    spec = {"follow": [{"tensor": "ef", "at": "stride:8", "scope": "bad"}]}
+    spec = {"follow": [{"tensor": "ef", "scope": "bad", "stride": 8}]}
     nl = _load_logger(
         {"NANLOG_SPEC": json.dumps(spec),
          "NANLOG_CHANNELS": "act,igrad", "NANLOG_PIPELINE": "0"},
@@ -397,7 +541,7 @@ def test_spec_stage_clears_stale_flat_track_every_layer(monkeypatch, tmp_path_fa
     """A stage follow must not keep a lingering flat NANLOG_TRACK_EVERY_LAYER=1."""
     nl = _load_logger(
         {"NANLOG_TRACK_EVERY_LAYER": "1",
-         "NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "at": "stage"}]})},
+         "NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "stages": True}]})},
         monkeypatch, tmp_path_factory)
     assert nl._TRACK_EVERY_LAYER is False
 
@@ -406,7 +550,7 @@ def test_spec_without_bounds_clears_stale_flat_bounds(monkeypatch, tmp_path_fact
     """A follow spec with no bounds must not keep a lingering flat NANLOG_BOUNDS."""
     nl = _load_logger(
         {"NANLOG_BOUNDS": "ef:0:60",
-         "NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "at": "stage"}]})},
+         "NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "stages": True}]})},
         monkeypatch, tmp_path_factory)
     assert nl._BOUNDS_ACTIVE is False
 
@@ -415,7 +559,7 @@ def test_follow_only_spec_clears_stale_flat_watch_names(monkeypatch, tmp_path_fa
     """A follow-only spec must not keep a lingering flat NANLOG_WATCH_NAMES."""
     nl = _load_logger(
         {"NANLOG_WATCH_NAMES": "emb_proj",
-         "NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "at": "stage"}]})},
+         "NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "stages": True}]})},
         monkeypatch, tmp_path_factory)
     assert nl._WATCH_NAMES == ()
     assert nl._WATCH_TYPES == ()   # and the Linear default does not re-arm
@@ -465,7 +609,7 @@ def test_spec_dir_key_is_rejected(monkeypatch, tmp_path_factory):
     """`dir` is not a valid spec key -- output location is the separate NANLOG_DIR env
     var. A spec `dir` must roll back (not silently redirect artifacts)."""
     nl = _load_logger(
-        {"NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "at": "stage"}], "dir": "/tmp/x"})},
+        {"NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "stages": True}], "dir": "/tmp/x"})},
         monkeypatch, tmp_path_factory)
     assert nl._SPEC_APPLIED is False
     assert "dir" in (nl._SPEC_ERROR or "")
@@ -475,7 +619,7 @@ def test_spec_dir_key_is_rejected(monkeypatch, tmp_path_factory):
 def test_inline_spec_still_works(monkeypatch, tmp_path_factory):
     """The original inline NANLOG_SPEC path is unchanged (lowest precedence)."""
     nl = _load_logger(
-        {"NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "at": "stage"}]})},
+        {"NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "stages": True}]})},
         monkeypatch, tmp_path_factory)
     assert nl._SPEC_APPLIED is True
     assert nl._SPEC_SOURCE == "NANLOG_SPEC"


### PR DESCRIPTION
## Summary
Builds on the merged `NANLOG_SPEC` front-end (#292) with a clearer follow cadence and three new capture capabilities.

- **Follow cadence is now two explicit knobs** instead of the overloaded `at`:
  - `"stages": true` — check the followed tensor at the pipeline stage boundaries (copy/sparse/forward).
  - `"scope": {...}` + optional `"stride": N` — also re-scan at those modules (every Nth, default 1).
  - Set either or both (default: stages only). The old `at` key is **removed** (unknown key → the spec rolls back), so "capture at stages AND at blocks" reads clearly instead of hiding behind `at:"stride:1"`.
- **New `igrad` tensors token** — activation-input gradient only (vs `grad` = igrad+wgrad+bgrad), for when param grads aren't wanted.
- **`watch[].stride`** — hook only every Nth matched module, to thin a broad watch. Ignored **with a warning** when a scoped `follow` is present (the follow re-scan rides those forward hooks; thinning them would drop follow evidence). The resolved stride is recorded in the summary (`watch_stride`).
- **Top-level `diagnostics: [...]`** block (`addr`, `locate`, `bad_values`, `dump_tensor`, `alloc_snapshot`) for cross-cutting per-record detail. `NANLOG_DIR` stays env-only (never a spec key).

All malformed shapes roll back atomically; unknown watch/follow/diagnostics keys are rejected. Docs (`docs/layer-numerics.md`) and the dev README updated to match.

## Test plan
- [x] `pytest tests/instrumentation/test_layer_numerics_spec.py tests/instrumentation/test_layer_numerics_runtime.py tests/instrumentation/test_layer_numerics.py tests/instrumentation/test_layer_numerics_docs.py` — 117 pass, 3 skip (GPU-smoke self-skips on CPU).
- [ ] GPU box: standalone smoke for igrad / watch-stride / diagnostics / watch-stride+scoped-follow (see workspace `run_layer_numerics_standalone_smoke.sh --spec ...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)