### PR TITLE
layer_numerics: add follow[].pipeline:false for timing-safe block follow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ actual_outputs/
 *.sublime-workspace
 *.sublime-project
 
+# Claude Code local state (settings, permission allowlists, cache, worktrees).
+# Always local/per-developer -- never commit to the shared repo.
+.claude/
+
 # OS generated files
 .DS_Store
 Thumbs.db

--- a/docs/layer-numerics.md
+++ b/docs/layer-numerics.md
@@ -490,7 +490,7 @@ All heavy features default **OFF** and feed the same single per-step host transf
 | `NANLOG_BOUNDS` | Per-tensor in-range check `substr:lo:hi;...` (→ `kind="oob"`) | (empty) | `follow[].bounds` |
 | `NANLOG_SPARSE` | Cheap host-side KJT metadata at the sparse stage | `0` (off) | — |
 | `NANLOG_TRACK_EVERY_LAYER` | Re-scan tracked tensors at each scoped block. Rides an **active follow** — with `NANLOG_PIPELINE=1` (stage+block). **Setting this flat var alone (no `NANLOG_PIPELINE`, no spec) is a warned no-op**, so a legacy run is never silently switched into forward-capture mode; the wrapper-free block follow is opt-in via a `pipeline:false` spec. | `0` (off) | `follow[].scope` (+ `stride`) |
-| `NANLOG_PIPELINE_OFF_FOLLOW` | **Spec-internal, not a public flat knob.** Set only by a validated `follow[].pipeline:false`; enables the forward+block follow without the stage wrappers. Documented for artifact readers, not for direct use. | `0` (off) | `follow[].pipeline: false` |
+| `NANLOG_PIPELINE_OFF_FOLLOW` | **Spec-internal, not a supported public flat knob.** The engine does read it from the environment (so it *can* be set by hand), but it is **intended to be set only** by a validated `follow[].pipeline:false`; enables the forward+block follow without the stage wrappers. Documented for artifact readers — prefer the `pipeline:false` spec over setting it directly. | `0` (off) | `follow[].pipeline: false` |
 | `NANLOG_TRACK_LAYER_STRIDE` | Re-scan every Kth layer when re-scan is on | `1` | `follow[].stride` |
 
 Channel notes:

--- a/docs/layer-numerics.md
+++ b/docs/layer-numerics.md
@@ -101,6 +101,7 @@ observation kinds:
 | `tensors` | which of a module's tensors | `input, output, weight, bias, igrad, grad` |
 | `stages` | (follow) check at the pipeline stage boundaries | `true` (`copy`/`sparse_start`/`sparse_wait`/`forward`) |
 | `stride` | (follow) also check every Nth module in `scope` | `N` (default `1`; requires `scope`). Set `stages`, `scope`, or both; neither ⇒ stages only |
+| `pipeline` | (follow) install the copy/sparse stage wrappers | `true` (default) / `false` — `false` follows at forward entry + `scope` blocks only, **without** the stage wrappers (timing-safe; see below). Requires a `scope`; incompatible with `stages: true` |
 | `stride` | (watch) hook only every Nth matched module | `N` (integer `>= 1`, default `1`); thins a broad watch whose per-module reduction volume is too high |
 | `diagnostics` | (top-level) how-much-detail toggles applied to **every** captured record | `addr, locate, bad_values, dump_tensor, alloc_snapshot` (see below) |
 
@@ -125,6 +126,7 @@ Common patterns (each cell is a complete, copy-paste `NANLOG_SPEC` value):
 | Follow a tensor through the pipeline | `{"follow":[{"tensor":"embedding_features","stages":true}]}` |
 | Follow a tensor every N layers | `{"follow":[{"tensor":"embedding_features","scope":{"names":["emb_proj"]},"stride":8}]}` |
 | Follow a tensor at named layers only | `{"follow":[{"tensor":"embedding_features","scope":{"names":["emb_proj.projections.0"]}}]}` |
+| Follow through blocks WITHOUT the stage wrappers (timing-safe) | `{"follow":[{"tensor":"embedding_features","pipeline":false,"scope":{"names":["emb_proj"]},"bounds":[0,60]}]}` |
 
 When `NANLOG_SPEC` is set it **wins**; when it is unset, the flat `NANLOG_*`
 vars below are read directly (still fully supported). A malformed spec logs a
@@ -198,10 +200,40 @@ Everything the logger does is one of two kinds — the `watch` and `follow` keys
   Each record is tagged with its `phase` and a `batch_id` so one batch's records
   line up across steps. This catches corruption that arrives *upstream* of the
   layers, which watching alone cannot see.
-  > Note: a scoped re-scan rides the pipeline hook, so it **also** emits the
-  > stage-boundary records even when `stages` is omitted or `false` — you will see
-  > `phase` records at the stages regardless. Stage records can't be suppressed
-  > independently of a scoped re-scan today.
+  > Note: by default a scoped re-scan rides the pipeline stage wrappers, so it
+  > **also** emits the stage-boundary records even when `stages` is omitted or
+  > `false` — you will see `phase` records at the stages regardless. To drop the
+  > stage wrappers entirely, set `pipeline: false` (next).
+
+#### `pipeline: false` — follow through blocks without the stage wrappers
+
+By default any `follow` installs the TorchRec stage-method wrappers
+(`copy_batch_to_gpu` / `start_sparse_data_dist` / `wait_sparse_data_dist`) — that
+is what produces the `copy`/`sparse_start`/`sparse_wait` records. Those wrappers
+**serialize the overlapped copy/compute** the batch pipeline runs, which can
+**suppress a timing-sensitive cross-stream race** (the buffer never gets corrupted
+because the overlap the race needs is gone). If a `follow`/`stages` sweep comes
+back with **0 NaN on a bug you can otherwise reproduce**, this is the likely cause.
+
+Set `"pipeline": false` on the follow entry to keep the per-block re-scan (at each
+module in `scope`) and the forward-entry checkpoint, but **not** install the stage
+wrappers. The re-scan rides the ordinary forward hooks — the same timing-safe
+mechanism `watch` uses — so the copy/compute overlap is preserved and the race
+still fires:
+
+```bash
+NANLOG_DIR=/output/layer_numerics \
+NANLOG_SPEC='{"follow":[{"tensor":"embedding_features","pipeline":false,"scope":{"names":["emb_proj"]},"bounds":[0,60]}],"pre_context":10}' \
+  python -m aorta.instrumentation.layer_numerics /path/to/your_script.py
+```
+
+Constraints: `pipeline: false` **requires a `scope`** (there are no stages left to
+capture at, so a block scope is what it checks) and is **incompatible with
+`stages: true`** (stage capture *is* the wrappers) — either combination rolls the
+spec back. What you give up vs. the default: the `copy` / `sparse_start` /
+`sparse_wait` stage records (the upstream-of-forward checkpoints). What you keep:
+the block-by-block trajectory of the followed tensor. The summary records
+`follow_mode` (`stage_wrappers` / `forward_blocks` / `off`) so a run is auditable.
 
 Add a `bounds: [lo, hi]` to a `follow` entry to flag out-of-range values
 (`kind="oob"`) — a two-sided check the one-sided "huge" threshold misses.
@@ -302,9 +334,26 @@ Written under `NANLOG_DIR`:
 - `summary_rank<N>.json` — the headline: the `first_bad` fingerprint
   (step / layer / direction / kind / `matmul_calls_so_far`), and when bounds are
   set `first_oob` / `oob_records` / `peak_finite_min` / `peak_finite_max`, plus
-  totals.
+  totals. For a `follow`, it also records **how** the tensor was tracked so a run
+  is auditable:
+  - `follow_mode` — `"stage_wrappers"` (stage boundaries + any blocks, the
+    default), `"forward_blocks"` (a `pipeline:false` follow: forward entry + blocks,
+    **no** stage wrappers), or `"off"` (no follow).
+  - `pipeline` / `pipeline_installed` — whether the copy/sparse stage wrappers were
+    requested / actually installed. Both `false` in a `pipeline:false` run.
+  - `pipeline_checkpoints` — count of **stage-wrapper** checkpoints
+    (`copy`/`sparse_start`/`sparse_wait`) that captured the tensor. Always `0` in a
+    `pipeline:false` run (no wrappers ran) — so a nonzero value here is proof the
+    stage instrumentation was active.
+  - `forward_checkpoints` — count of **forward-entry** checkpoints (the read of the
+    tensor at the top of the forward pass, which rides the root pre-hook, not the
+    stage wrappers). This is the "yes, the pipeline-off follow captured something"
+    signal for a `forward_blocks` run, kept separate from `pipeline_checkpoints` so
+    a timing-safe run never looks like it used stage instrumentation.
 - `layers_rank<N>.jsonl` — the full per-(layer, step, channel) trajectory. Each
-  record carries `phase` and `batch_id` when pipeline tracking is on.
+  record carries `phase` and `batch_id` when a follow is active (`phase="forward"`
+  for the forward-entry checkpoint; `checkpoint=<block name>` for a per-block
+  re-scan).
 - `bad_tensor_step*_rank<N>.pt` — the full bad tensor (only with
   `NANLOG_DUMP_TENSOR=1`, on first detection).
 - `alloc_snapshot_step*_rank<N>.pickle` — caching-allocator event trace (only
@@ -436,11 +485,12 @@ All heavy features default **OFF** and feed the same single per-step host transf
 | `NANLOG_LOCATE` | Record how many rows hold a bad value | `0` (off) | `diagnostics:[locate]` |
 | `NANLOG_DUMP_TENSOR` | Save the full bad tensor to a `.pt` on first detection | `0` (off) | `diagnostics:[dump_tensor]` |
 | `NANLOG_ALLOC_SNAPSHOT` | Dump a caching-allocator event trace on first bad (~10% overhead) | `0` (off) | `diagnostics:[alloc_snapshot]` |
-| `NANLOG_PIPELINE` | Track tensors at the TorchRec stage boundaries | `0` (off) | `follow[].stages: true` |
+| `NANLOG_PIPELINE` | Install the TorchRec stage-method wrappers (copy/sparse checkpoints) | `0` (off) | `follow[].stages: true`; suppressed by `follow[].pipeline: false` |
 | `NANLOG_TRACK_ATTR` | Batch attribute(s) to follow as tracked tensors | `embedding_features` | `follow[].tensor` |
 | `NANLOG_BOUNDS` | Per-tensor in-range check `substr:lo:hi;...` (→ `kind="oob"`) | (empty) | `follow[].bounds` |
 | `NANLOG_SPARSE` | Cheap host-side KJT metadata at the sparse stage | `0` (off) | — |
-| `NANLOG_TRACK_EVERY_LAYER` | Re-scan tracked tensors at each layer | `0` (off) | `follow[].scope` (+ `stride`) |
+| `NANLOG_TRACK_EVERY_LAYER` | Re-scan tracked tensors at each scoped block. Rides an **active follow** — with `NANLOG_PIPELINE=1` (stage+block). **Setting this flat var alone (no `NANLOG_PIPELINE`, no spec) is a warned no-op**, so a legacy run is never silently switched into forward-capture mode; the wrapper-free block follow is opt-in via a `pipeline:false` spec. | `0` (off) | `follow[].scope` (+ `stride`) |
+| `NANLOG_PIPELINE_OFF_FOLLOW` | **Spec-internal, not a public flat knob.** Set only by a validated `follow[].pipeline:false`; enables the forward+block follow without the stage wrappers. Documented for artifact readers, not for direct use. | `0` (off) | `follow[].pipeline: false` |
 | `NANLOG_TRACK_LAYER_STRIDE` | Re-scan every Kth layer when re-scan is on | `1` | `follow[].stride` |
 
 Channel notes:

--- a/src/aorta/instrumentation/layer_numerics/README.md
+++ b/src/aorta/instrumentation/layer_numerics/README.md
@@ -85,9 +85,13 @@ back). Keeping the engine flat-var-only is what preserves the standalone contrac
 Recent schema additions (full how-to in [`docs/layer-numerics.md`](../../../../docs/layer-numerics.md)):
 a `watch` entry's `tensors` list also accepts `igrad` (the activation-input grad
 alone, vs. `grad` which is all gradients); a `watch` entry may set `"stride": N`
-(`>= 1`, default `1`) to hook only every Nth matched module; and a top-level
+(`>= 1`, default `1`) to hook only every Nth matched module; a top-level
 `"diagnostics": [...]` list (`addr`, `locate`, `bad_values`, `dump_tensor`,
-`alloc_snapshot`) toggles per-record detail across every captured record.
+`alloc_snapshot`) toggles per-record detail across every captured record; and a
+`follow` entry may set `"pipeline": false` to follow the tensor through its `scope`
+blocks (and at forward entry) **without** installing the copy/sparse stage wrappers
+— the timing-safe mode for a cross-stream race the wrappers would otherwise suppress
+(requires a `scope`, incompatible with `stages: true`; summary records `follow_mode`).
 
 Collector defaults (applied by [`build_env`](__init__.py)): all seven channels,
 `NANLOG_PRE_CONTEXT=10`, `NANLOG_SAMPLE_EVERY=50`. `NANLOG_DIR` is filled per-cell

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -418,8 +418,9 @@ def _resolve_follow_cadence(f: dict) -> tuple:
     # that rides the forward hook, not the stage wrappers.
     if not pipeline and stages:
         raise ValueError("follow[].pipeline false is incompatible with stages: true "
-                         "(stage capture requires the pipeline wrappers); drop stages "
-                         "or set a `scope` for a forward/block-only follow")
+                         "(stage capture requires the pipeline wrappers); to follow at "
+                         "blocks only, drop `stages` and give a `scope`, or keep "
+                         "`stages` and use the default pipeline: true")
     return stages, stride, pipeline
 
 

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -1792,12 +1792,15 @@ def _resolve_batch_id(batch, phase: str):
     existing = _batch_id_by_obj.get(id(batch))
     if existing is not None:
         return existing
-    # Which phase is allowed to MINT a fresh id (the batch's first sighting)? With the
-    # stage wrappers on, that is `copy` -- a non-copy first sighting means we started
-    # mid-pipeline and must not fabricate an id. With the wrappers off (pipeline-off
-    # follow), `copy` never fires, so `forward` IS the first sighting and mints the id;
-    # otherwise every record would carry batch_id=null.
-    _mint_phase = "copy" if _PIPELINE else "forward"
+    # Which phase is allowed to MINT a fresh id (the batch's first sighting)? Key off
+    # whether the stage wrappers were ACTUALLY installed (_pipeline_installed), not
+    # merely requested (_PIPELINE): when the wrappers run, `copy` is the first sighting
+    # (a non-copy first sighting means we started mid-pipeline and must not fabricate an
+    # id). When they are NOT installed -- a pipeline-off follow, OR a degraded run where
+    # NANLOG_PIPELINE=1 was requested but torchrec was unavailable / its API changed so
+    # `copy` never fires -- `forward` IS the first sighting and mints the id; otherwise
+    # every record would carry batch_id=null.
+    _mint_phase = "copy" if _pipeline_installed else "forward"
     if phase != _mint_phase:
         # A non-minting phase with no id: either a mid-pipeline start, or (wrappers off)
         # a stray non-forward phase. Don't fabricate an id; leave it null.
@@ -1970,11 +1973,16 @@ def _checkpoint(batch, phase: str) -> None:
         _log(f"WARNING: pipeline checkpoint ({phase}) failed: {e!r}")
         return
     if n:
-        # Count the stage-wrapper checkpoints (copy/sparse/forward with the wrappers
-        # installed) separately from the forward-entry-only checkpoint of a
-        # pipeline-off follow, so a `pipeline: false` summary never reports nonzero
-        # pipeline_checkpoints (which would imply stage instrumentation ran).
-        if _PIPELINE:
+        # Split the counters by what ACTUALLY produced this checkpoint, so each is a
+        # truthful signal:
+        #   pipeline_checkpoints -> a real stage-wrapper checkpoint: the wrappers were
+        #     installed AND this is a stage phase (copy/sparse_*), NOT the forward-entry
+        #     capture. Gating on _pipeline_installed (not the requested _PIPELINE) means
+        #     a degraded run (NANLOG_PIPELINE=1 but torchrec absent -> wrappers no-op)
+        #     never reports phantom stage checkpoints.
+        #   forward_checkpoints -> the forward-entry capture (rides the root pre-hook,
+        #     not the wrappers), in BOTH the pipeline-off follow and the wrapper-on case.
+        if _pipeline_installed and phase != "forward":
             _pipeline_checkpoints += 1
         else:
             _forward_checkpoints += 1

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -1625,6 +1625,13 @@ def _install_optimizer_autohook() -> None:
 # tensor-flow tracker — EF is only the default target (NANLOG_TRACK_ATTR).
 # ---------------------------------------------------------------------------
 _pipeline_installed = False
+# The EARLIEST pipeline stage whose wrapper was actually installed, in execution
+# order (copy -> sparse_start -> sparse_wait). That wrapper is the first to see each
+# batch, so it -- not a hardcoded "copy" -- is the phase allowed to MINT a batch_id.
+# None until _install_pipeline_hook patches at least one method. Guards the case
+# where a torchrec API change drops copy_batch_to_gpu but keeps sparse_*: minting
+# must then happen at sparse_start, or every stage record would carry batch_id=null.
+_pipeline_mint_phase = None
 _pipeline_checkpoints = 0     # stage-wrapper checkpoints that stashed something (_PIPELINE only)
 _forward_checkpoints = 0      # forward-entry checkpoints that stashed something (pipeline-off follow)
 _pipeline_warned = False
@@ -1793,14 +1800,16 @@ def _resolve_batch_id(batch, phase: str):
     if existing is not None:
         return existing
     # Which phase is allowed to MINT a fresh id (the batch's first sighting)? Key off
-    # whether the stage wrappers were ACTUALLY installed (_pipeline_installed), not
-    # merely requested (_PIPELINE): when the wrappers run, `copy` is the first sighting
-    # (a non-copy first sighting means we started mid-pipeline and must not fabricate an
-    # id). When they are NOT installed -- a pipeline-off follow, OR a degraded run where
-    # NANLOG_PIPELINE=1 was requested but torchrec was unavailable / its API changed so
-    # `copy` never fires -- `forward` IS the first sighting and mints the id; otherwise
-    # every record would carry batch_id=null.
-    _mint_phase = "copy" if _pipeline_installed else "forward"
+    # what the wrappers ACTUALLY installed, not what was requested (_PIPELINE):
+    #   - Wrappers installed -> the EARLIEST patched stage (_pipeline_mint_phase, in
+    #     copy/sparse_start/sparse_wait execution order) is the first to see each batch.
+    #     Using it -- not a hardcoded "copy" -- handles a torchrec API change that drops
+    #     copy_batch_to_gpu but keeps sparse_*, where "copy" never fires and hardcoding
+    #     it would leave every stage record's batch_id null.
+    #   - Wrappers NOT installed (pipeline-off follow, OR a degraded NANLOG_PIPELINE=1
+    #     run where torchrec was unavailable) -> `forward` is the first sighting.
+    # A first sighting at any OTHER phase means we started mid-pipeline; don't fabricate.
+    _mint_phase = _pipeline_mint_phase if _pipeline_installed else "forward"
     if phase != _mint_phase:
         # A non-minting phase with no id: either a mid-pipeline start, or (wrappers off)
         # a stray non-forward phase. Don't fabricate an id; leave it null.
@@ -1993,7 +2002,7 @@ def _install_pipeline_hook() -> None:
     checkpoint of the tracked flow objects with the right `phase`. Defensive: if the
     installed torchrec exposes none of the known stage methods, warn once and leave
     the layer hooks untouched. Same auto-attach philosophy as the DMP __init__ patch."""
-    global _pipeline_installed, _pipeline_warned
+    global _pipeline_installed, _pipeline_warned, _pipeline_mint_phase
     if not _PIPELINE or _pipeline_installed:
         return
     try:
@@ -2015,6 +2024,7 @@ def _install_pipeline_hook() -> None:
         ("wait_sparse_data_dist", "sparse_wait", False),
     ]
     patched = []
+    patched_phases = []   # in execution order; first entry = earliest stage that fires
     for meth_name, phase, from_return in specs:
         orig = getattr(_TP, meth_name, None)
         if orig is None or not callable(orig):
@@ -2042,6 +2052,7 @@ def _install_pipeline_hook() -> None:
 
         setattr(_TP, meth_name, make(orig, phase, from_return))
         patched.append(meth_name)
+        patched_phases.append(phase)
 
     if not patched:
         _pipeline_warned = True
@@ -2050,6 +2061,10 @@ def _install_pipeline_hook() -> None:
              f"wait_sparse_data_dist); checkpoints inactive. torchrec API changed?")
         return
     _pipeline_installed = True
+    # The earliest patched stage (specs is in execution order) is the first to see
+    # each batch, so it is the batch_id-minting phase -- NOT a hardcoded "copy",
+    # which may not have been patched if torchrec dropped copy_batch_to_gpu.
+    _pipeline_mint_phase = patched_phases[0]
     _log(f"pipeline tracking armed: patched {patched}; track_attr={list(_TRACK_ATTR)}; "
          f"track_max={_TRACK_MAX}; sparse={_SPARSE}; sparse_heavy={_SPARSE_HEAVY}; "
          f"track_every_layer={_TRACK_EVERY_LAYER}; track_layer_stride={_TRACK_LAYER_STRIDE}")
@@ -2086,6 +2101,7 @@ def _write_summary() -> None:
         "alloc_snapshot_dumped": _snapshot_dumped,
         "pipeline": _PIPELINE,
         "pipeline_installed": _pipeline_installed,
+        "pipeline_mint_phase": _pipeline_mint_phase,
         "pipeline_checkpoints": _pipeline_checkpoints,
         "forward_checkpoints": _forward_checkpoints,
         "follow_fwd": _FOLLOW_FWD,

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -172,7 +172,8 @@ Settings (environment variables):
                          tensors (default "embedding_features"); a name may resolve
                          to a Tensor, list/tuple/dict of Tensors, or a KJT (its
                          values() is tracked). Falls back to a bounded auto-discovery
-                         walk if none are found. Only with NANLOG_PIPELINE=1.
+                         walk if none are found. Active only when a follow is armed
+                         (NANLOG_PIPELINE=1, or a `pipeline: false` follow spec).
   NANLOG_TRACK_MAX       hard cap on how many tensor objects the tracker follows
                          (default 64).
   NANLOG_SPARSE          "1" -> at the pipeline stages, capture cheap host-side
@@ -187,7 +188,13 @@ Settings (environment variables):
                          layer's forward hook (record carries checkpoint=<layer_name>),
                          bracketing the corruption to a layer interval within forward.
                          Multiplies the per-step reduction count; can perturb a
-                         timing-sensitive bug. Requires NANLOG_PIPELINE=1 (default 0).
+                         timing-sensitive bug. Rides an active follow: with
+                         NANLOG_PIPELINE=1 it is the stage+block follow. The
+                         wrapper-free forward+block follow is NOT reachable by setting
+                         this flat var alone (that stays a warned no-op, to avoid
+                         silently changing a legacy run's timing profile) -- request it
+                         explicitly via a `pipeline: false` follow spec, which sets
+                         NANLOG_PIPELINE_OFF_FOLLOW. (default 0).
   NANLOG_TRACK_LAYER_STRIDE  re-scan every Kth watched layer (default 1). Only with
                          NANLOG_TRACK_EVERY_LAYER=1.
   NANLOG_BOUNDS          per-tensor in-range check "substr:lo:hi;substr:lo:hi": a
@@ -274,7 +281,7 @@ import torch  # noqa: E402
 # ---------------------------------------------------------------------------
 # One JSON env var, two observation kinds:
 #   watch   [{scope, tensors, stride?}, ...]      -- a module's OWN tensors
-#   follow  [{tensor, stages?, scope?, stride?, bounds?}, ...]
+#   follow  [{tensor, stages?, scope?, stride?, bounds?, pipeline?}, ...]
 #                                                 -- trace ONE named tensor across positions
 # building blocks:
 #   scope   {names:[substr,...], types:[ClassName,...]}  -- which modules
@@ -282,6 +289,11 @@ import torch  # noqa: E402
 #   stages  bool  -- (follow) check at the pipeline stage boundaries
 #   stride  int   -- every Nth matched module (default 1); watch: thin the hooks,
 #                    follow: re-scan cadence at scoped modules
+#   pipeline bool -- (follow, default true) install the copy/sparse stage wrappers.
+#                    false -> follow at forward entry + scoped blocks ONLY, no stage
+#                    wrappers, so the copy/compute overlap is never serialized (the
+#                    mode for a timing-sensitive race the wrappers would suppress);
+#                    incompatible with stages:true, requires a scope for block capture
 # plus cross-cutting: sample_every, pre_context, diagnostics[]. (Output dir is the
 # separate NANLOG_DIR env var, never a spec key.)
 #
@@ -354,8 +366,8 @@ def _spec_int(spec: dict, key: str, minimum: int) -> int | None:
 
 
 def _resolve_follow_cadence(f: dict) -> tuple:
-    """Normalize a follow entry's cadence into (stages: bool, stride: int|None),
-    where stride is the "also re-scan every Nth watched module" cadence (None = don't
+    """Normalize a follow entry's cadence into (stages, stride, pipeline), where
+    stride is the "also re-scan every Nth watched module" cadence (None = don't
     re-scan at modules). WHERE to check the followed tensor is two independent knobs:
 
         "stages": true   -> capture at the pipeline stage boundaries (copy/sparse/fwd)
@@ -363,11 +375,18 @@ def _resolve_follow_cadence(f: dict) -> tuple:
         "stride": N       -> every Nth matched module (default 1; requires `scope`)
 
     Set either or both. Default (neither key) is stages-only, the common case.
+
+    `pipeline` (default true) controls whether the TorchRec stage-method wrappers
+    (copy/sparse) are installed. `pipeline: false` keeps the follow at forward entry
+    + scoped blocks ONLY, so the copy/compute overlap is never serialized -- the mode
+    for a timing-sensitive race the stage wrappers would suppress. `stages: true`
+    REQUIRES the wrappers, so `pipeline: false` + `stages: true` is contradictory.
+
     Raises ValueError on a malformed/contradictory entry so the whole spec rolls back.
     """
     # Reject unknown keys so a typo or a leftover `at` from the old schema fails loudly
     # instead of silently falling through to the stages-only default.
-    _FOLLOW_KEYS = {"tensor", "stages", "scope", "stride", "bounds"}
+    _FOLLOW_KEYS = {"tensor", "stages", "scope", "stride", "bounds", "pipeline"}
     unknown = [k for k in f if k not in _FOLLOW_KEYS]
     if unknown:
         raise ValueError(f"unknown follow[] key(s) {sorted(unknown)}; "
@@ -377,6 +396,9 @@ def _resolve_follow_cadence(f: dict) -> tuple:
     stages = f.get("stages", "scope" not in f)
     if not isinstance(stages, bool):
         raise ValueError(f"follow[].stages must be true/false, got {stages!r}")
+    pipeline = f.get("pipeline", True)
+    if not isinstance(pipeline, bool):
+        raise ValueError(f"follow[].pipeline must be true/false, got {pipeline!r}")
     stride = None
     if "stride" in f:
         v = f["stride"]
@@ -391,7 +413,14 @@ def _resolve_follow_cadence(f: dict) -> tuple:
     if not stages and stride is None:
         raise ValueError("follow[] captures nothing: set `stages: true` and/or a "
                          "`scope` to re-scan at modules")
-    return stages, stride
+    # `pipeline: false` disables the stage wrappers, so it cannot coexist with a
+    # `stages` capture (which IS the wrappers). A scoped/strided follow is fine --
+    # that rides the forward hook, not the stage wrappers.
+    if not pipeline and stages:
+        raise ValueError("follow[].pipeline false is incompatible with stages: true "
+                         "(stage capture requires the pipeline wrappers); drop stages "
+                         "or set a `scope` for a forward/block-only follow")
+    return stages, stride, pipeline
 
 
 def _spec_optional_mapping(container: dict, key: str, path: str) -> dict:
@@ -458,7 +487,8 @@ def _apply_spec(spec_json: str) -> tuple:
 _SPEC_OWNED_VARS = {
     "NANLOG_WATCH_NAMES": "", "NANLOG_WATCH_TYPES": "", "NANLOG_CHANNELS": "",
     "NANLOG_WATCH_STRIDE": "1",
-    "NANLOG_PIPELINE": "0", "NANLOG_TRACK_ATTR": "", "NANLOG_TRACK_EVERY_LAYER": "0",
+    "NANLOG_PIPELINE": "0", "NANLOG_PIPELINE_OFF_FOLLOW": "0",
+    "NANLOG_TRACK_ATTR": "", "NANLOG_TRACK_EVERY_LAYER": "0",
     "NANLOG_TRACK_LAYER_STRIDE": "1", "NANLOG_BOUNDS": "",
     "NANLOG_SAMPLE_EVERY": "", "NANLOG_PRE_CONTEXT": "",
     # diagnostics block (see _SPEC_DIAG_KEYS)
@@ -557,17 +587,31 @@ def _translate_spec(spec: dict) -> None:
                    "(engine has one follow path); tensors are unioned into TRACK_ATTR")
     if follow:
         f0 = follow[0]
-        stages, stride = _resolve_follow_cadence(f0)
-        # `stages` -> the pipeline stage scan (NANLOG_PIPELINE). Also required as the
-        # engine's transport for the per-module re-scan, so it is on whenever a stride
-        # is requested too. Consequence: a scoped follow still emits stage records even
-        # when `stages` is false/omitted -- warn (worded for both cases) rather than
-        # silently over-capture.
-        if stride is not None and not stages:
+        stages, stride, pipeline = _resolve_follow_cadence(f0)
+        # `stages` -> the pipeline stage-method wrappers (NANLOG_PIPELINE). Historically
+        # these were also the transport for the per-module re-scan, so any scoped follow
+        # armed them too -- which serializes the copy/compute overlap and can suppress a
+        # timing-sensitive race. `pipeline: false` opts out: the re-scan rides the forward
+        # hook (installed via TRACK_EVERY_LAYER) and the forward-entry checkpoint rides the
+        # root pre-hook, neither of which needs the stage wrappers. When the wrappers ARE
+        # on for a scoped follow (the default), warn that stage records still appear.
+        arm_wrappers = pipeline and (stages or stride is not None)
+        if stride is not None and not stages and arm_wrappers:
             _spec_warn("a scoped `follow` still emits pipeline-stage records even with "
-                       "`stages` false or omitted (the per-module re-scan rides the same "
-                       "pipeline hook); stage records cannot be suppressed independently today")
-        _spec_set("NANLOG_PIPELINE", "1" if (stages or stride is not None) else "0")
+                       "`stages` false or omitted (the per-module re-scan shares the "
+                       "pipeline wrappers); pass `pipeline: false` to drop the stage "
+                       "wrappers and follow at forward entry + blocks only (timing-safe "
+                       "for a race the wrappers would suppress)")
+        _spec_set("NANLOG_PIPELINE", "1" if arm_wrappers else "0")
+        # Pipeline-OFF follow: a valid follow that deliberately does NOT arm the stage
+        # wrappers (pipeline:false). This is an EXPLICIT, spec-derived state -- it is
+        # what enables the forward-entry + block capture (_FOLLOW_FWD) without the
+        # wrappers. Deriving it here (not inferring it from TRACK_EVERY_LAYER at the
+        # engine) is deliberate: a flat NANLOG_TRACK_EVERY_LAYER=1 without
+        # NANLOG_PIPELINE=1 must stay a warned no-op, so a legacy flat-var run is never
+        # silently opted into this timing-sensitive mode. Only a validated
+        # `pipeline: false` follow sets it.
+        _spec_set("NANLOG_PIPELINE_OFF_FOLLOW", "1" if (not arm_wrappers) else "0")
         track_attrs = [f["tensor"].strip() for f in follow]
         _spec_set("NANLOG_TRACK_ATTR", ",".join(track_attrs))
         if stride is not None:
@@ -761,6 +805,14 @@ _DUMP_TENSOR = os.environ.get("NANLOG_DUMP_TENSOR", "0") == "1"
 # Pipeline-stage tracking: scan the NANLOG_TRACK_ATTR tensors at the TorchRec stage
 # boundaries (copy/sparse/forward), tagging each record with its `phase`.
 _PIPELINE = os.environ.get("NANLOG_PIPELINE", "0") == "1"
+# Pipeline-OFF follow: an EXPLICIT, spec-derived opt-in (set only by a validated
+# follow[].pipeline == false in NANLOG_SPEC) to follow the tracked tensor at forward
+# entry + scoped blocks WITHOUT the stage wrappers. It is NOT inferred from
+# TRACK_EVERY_LAYER: doing so would silently opt a legacy flat-var run
+# (NANLOG_TRACK_EVERY_LAYER=1 without NANLOG_PIPELINE=1) into this timing-sensitive
+# mode, which historically warned and no-op'd. Keep that contract -- only the spec
+# turns this on.
+_PIPELINE_OFF_FOLLOW = os.environ.get("NANLOG_PIPELINE_OFF_FOLLOW", "0") == "1"
 _TRACK_ATTR = tuple(
     s.strip() for s in os.environ.get("NANLOG_TRACK_ATTR", "embedding_features").split(",")
     if s.strip()
@@ -773,6 +825,15 @@ _SPARSE_HEAVY = os.environ.get("NANLOG_SPARSE_HEAVY", "0") == "1"
 # to a within-forward layer interval. Multiplies the per-step reduction count.
 _TRACK_EVERY_LAYER = os.environ.get("NANLOG_TRACK_EVERY_LAYER", "0") == "1"
 _TRACK_LAYER_STRIDE = max(1, int(os.environ.get("NANLOG_TRACK_LAYER_STRIDE", "1")))
+# Follow the tracked tensor at forward entry (and, with TRACK_EVERY_LAYER, at each
+# scoped block) via the root pre-hook + forward hooks. This is the gate for the
+# forward-entry checkpoint. It is on in exactly two cases, BOTH explicit: the
+# stage-wrapper follow (_PIPELINE) implies it, and the spec-derived pipeline-off
+# follow (_PIPELINE_OFF_FOLLOW) requests it without the wrappers. It is deliberately
+# NOT gated on _TRACK_EVERY_LAYER: a flat NANLOG_TRACK_EVERY_LAYER=1 without a follow
+# stays a warned no-op (see the warning below) so a legacy flat-var run is never
+# silently switched into forward-capture mode.
+_FOLLOW_FWD = _PIPELINE or _PIPELINE_OFF_FOLLOW
 # Two-sided in-range check: per-tensor [lo,hi] via "substr:lo:hi;..." patterns (first
 # substring match wins); out-of-range elements are `bad` with kind="oob". Bare
 # NANLOG_BOUND_LO/HI is the match-all fallback. Catches small OOB the huge threshold
@@ -863,19 +924,23 @@ if _unknown_channels:
          f"valid: {list(_ALL_CHANNELS)}")
 
 if not _WATCH_TYPES and not _WATCH_NAMES:
-    # Empty watch scope is EXPECTED for a pipeline stage-only follow (it captures at
+    # Empty watch scope is EXPECTED for a stage-only follow (it captures at
     # copy/sparse/forward stage boundaries, not via layer hooks), so don't cry
-    # "misconfigured" there. A stride follow (_TRACK_EVERY_LAYER) DOES need a scope
-    # to know which layers to re-scan, so still warn in that case.
-    if not (_PIPELINE and not _TRACK_EVERY_LAYER):
+    # "misconfigured" there. A per-block re-scan (_TRACK_EVERY_LAYER) DOES need a
+    # scope to know which layers to re-scan, so still warn in that case. (A
+    # pipeline-off follow always carries a scope by construction -- validation
+    # requires one -- so it never reaches this warning with an empty scope.)
+    if not (_FOLLOW_FWD and not _TRACK_EVERY_LAYER):
         _log("WARNING: both NANLOG_WATCH_TYPES and NANLOG_WATCH_NAMES are empty; "
              "no modules will be watched")
 
-# Warn once when a scope knob silently no-ops without its prerequisite.
-if _TRACK_EVERY_LAYER and not _PIPELINE:
-    _log("WARNING: NANLOG_TRACK_EVERY_LAYER=1 has no effect without NANLOG_PIPELINE=1 "
-         "(the per-layer re-scan targets are captured by the pipeline hook); set "
-         "NANLOG_PIPELINE=1 to enable per-layer tracking.")
+# Warn once when a scope knob silently no-ops without its prerequisite. The per-layer
+# re-scan rides the forward hook, so it needs a follow to be active (stage-wrapper OR
+# pipeline-off) -- i.e. _FOLLOW_FWD -- not the stage wrappers specifically.
+if _TRACK_EVERY_LAYER and not _FOLLOW_FWD:
+    _log("WARNING: NANLOG_TRACK_EVERY_LAYER=1 has no effect without an active follow "
+         "(NANLOG_PIPELINE=1 or a pipeline-off follow spec); the per-layer re-scan "
+         "targets are captured at forward entry.")
 if os.environ.get("NANLOG_TRACK_LAYER_STRIDE") is not None and not _TRACK_EVERY_LAYER:
     _log("WARNING: NANLOG_TRACK_LAYER_STRIDE is set but NANLOG_TRACK_EVERY_LAYER is "
          "off, so the stride is ignored; set NANLOG_TRACK_EVERY_LAYER=1 to use it.")
@@ -1560,7 +1625,8 @@ def _install_optimizer_autohook() -> None:
 # tensor-flow tracker — EF is only the default target (NANLOG_TRACK_ATTR).
 # ---------------------------------------------------------------------------
 _pipeline_installed = False
-_pipeline_checkpoints = 0     # count of stage checkpoints that stashed something
+_pipeline_checkpoints = 0     # stage-wrapper checkpoints that stashed something (_PIPELINE only)
+_forward_checkpoints = 0      # forward-entry checkpoints that stashed something (pipeline-off follow)
 _pipeline_warned = False
 
 
@@ -1726,9 +1792,15 @@ def _resolve_batch_id(batch, phase: str):
     existing = _batch_id_by_obj.get(id(batch))
     if existing is not None:
         return existing
-    if phase != "copy":
-        # A non-copy phase with no id means we started mid-pipeline (missed this
-        # batch's copy). Don't fabricate an id; leave it null.
+    # Which phase is allowed to MINT a fresh id (the batch's first sighting)? With the
+    # stage wrappers on, that is `copy` -- a non-copy first sighting means we started
+    # mid-pipeline and must not fabricate an id. With the wrappers off (pipeline-off
+    # follow), `copy` never fires, so `forward` IS the first sighting and mints the id;
+    # otherwise every record would carry batch_id=null.
+    _mint_phase = "copy" if _PIPELINE else "forward"
+    if phase != _mint_phase:
+        # A non-minting phase with no id: either a mid-pipeline start, or (wrappers off)
+        # a stray non-forward phase. Don't fabricate an id; leave it null.
         return None
     _batch_counter += 1
     bid = _batch_counter
@@ -1829,15 +1901,21 @@ def _capture_forward_batch(inp) -> None:
     re-scan IS on, also hold the tracked objects in _layer_scan_targets so each layer
     hook can re-scan the SAME objects. Host-side only; the reductions join the drain.
 
+    Gated on _FOLLOW_FWD, not _PIPELINE: in the pipeline-off follow mode the stage
+    wrappers are absent but the forward-entry checkpoint (and the per-block re-scan it
+    arms) is exactly the capture we want, so it must still run here.
+
     The forward-entry _checkpoint resolves _batch_id to batch N. This is REQUIRED
-    whenever pipeline tracking is on: otherwise the forward/layer records inherit the
+    whenever a follow is active: otherwise the forward/layer records inherit the
     stale _batch_id the LAST stage wrapper left set (start_sparse_data_dist for batch
     N+1 in the standard prefetch order), tagging the emb_proj input record where
-    first_bad fires with the WRONG batch. _batch_id ends up batch N (or None on a
-    mid-pipeline start / re-wrapped batch), never a stale stage value."""
+    first_bad fires with the WRONG batch. With the wrappers off there is no stale
+    stage value, and this forward-entry checkpoint is what mints the id (see
+    _resolve_batch_id). _batch_id ends up batch N (or None on a mid-pipeline start /
+    re-wrapped batch), never a stale stage value."""
     global _layer_scan_targets, _batch_id
     _layer_scan_targets = []
-    if not _PIPELINE:
+    if not _FOLLOW_FWD:
         return
     # The batch is usually the first positional arg to the root forward.
     batch = inp[0] if isinstance(inp, (tuple, list)) and inp else inp
@@ -1862,8 +1940,10 @@ def _capture_forward_batch(inp) -> None:
 def _checkpoint(batch, phase: str) -> None:
     """Set the phase + batch_id, discover the tracked flow objects on `batch`, and
     stash a re-scan of each. Sync-free (reductions join the per-step drain). Called
-    from the wrapped pipeline stage methods. Never raises into the training run."""
-    global _phase, _batch_id, _pipeline_checkpoints
+    from the wrapped pipeline stage methods (all phases) AND from the forward-entry
+    capture (phase='forward' only, which is the sole caller when the stage wrappers
+    are off in a pipeline-off follow). Never raises into the training run."""
+    global _phase, _batch_id, _pipeline_checkpoints, _forward_checkpoints
     if batch is None:
         return
     _phase = phase
@@ -1890,7 +1970,14 @@ def _checkpoint(batch, phase: str) -> None:
         _log(f"WARNING: pipeline checkpoint ({phase}) failed: {e!r}")
         return
     if n:
-        _pipeline_checkpoints += 1
+        # Count the stage-wrapper checkpoints (copy/sparse/forward with the wrappers
+        # installed) separately from the forward-entry-only checkpoint of a
+        # pipeline-off follow, so a `pipeline: false` summary never reports nonzero
+        # pipeline_checkpoints (which would imply stage instrumentation ran).
+        if _PIPELINE:
+            _pipeline_checkpoints += 1
+        else:
+            _forward_checkpoints += 1
 
 
 def _install_pipeline_hook() -> None:
@@ -1992,6 +2079,13 @@ def _write_summary() -> None:
         "pipeline": _PIPELINE,
         "pipeline_installed": _pipeline_installed,
         "pipeline_checkpoints": _pipeline_checkpoints,
+        "forward_checkpoints": _forward_checkpoints,
+        "follow_fwd": _FOLLOW_FWD,
+        "follow_mode": (
+            "stage_wrappers" if _PIPELINE
+            else "forward_blocks" if _FOLLOW_FWD
+            else "off"
+        ),
         "track_attr": list(_TRACK_ATTR),
         "track_max": _TRACK_MAX,
         "sparse": _SPARSE,

--- a/tests/instrumentation/test_layer_numerics_runtime.py
+++ b/tests/instrumentation/test_layer_numerics_runtime.py
@@ -191,6 +191,11 @@ def test_pipeline_forward_stage_and_batch_id(monkeypatch, tmp_path_factory):
         {"NANLOG_PIPELINE": "1", "NANLOG_TRACK_ATTR": "embedding_features",
          "NANLOG_BOUNDS": "embedding_features:0:60", "NANLOG_SAMPLE_EVERY": "1"},
         monkeypatch, tmp_path_factory)
+    # This test drives the stage checkpoints (copy/sparse_*) by hand instead of
+    # installing the real TorchRec wrappers, so mark them installed -- batch-id
+    # minting keys off _pipeline_installed (what actually ran), not the requested
+    # _PIPELINE, so `copy` is the id-minting first sighting here.
+    nl._pipeline_installed = True
 
     class Batch:
         def __init__(self):
@@ -217,6 +222,46 @@ def test_pipeline_forward_stage_and_batch_id(monkeypatch, tmp_path_factory):
     # a single copy checkpoint's records share one non-null batch_id
     copy_recs = [r for r in track if r["phase"] == "copy"]
     assert copy_recs and all(r["batch_id"] is not None for r in copy_recs)
+
+
+def test_pipeline_requested_but_wrappers_not_installed_mints_at_forward(
+    monkeypatch, tmp_path_factory
+):
+    """Degraded case (Copilot PR #296 review): NANLOG_PIPELINE=1 was requested but the
+    stage wrappers never installed (torchrec absent / API changed), so `copy` never
+    fires. Batch-id minting and the checkpoint counters must key off what ACTUALLY ran
+    (_pipeline_installed), not the request (_PIPELINE): the forward-entry checkpoint
+    must still mint a non-null batch_id, and it must count as a forward checkpoint, not
+    a phantom stage (pipeline) checkpoint."""
+    nl = _load_logger(
+        {"NANLOG_PIPELINE": "1", "NANLOG_TRACK_ATTR": "embedding_features",
+         "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is True             # requested
+    assert nl._pipeline_installed is False  # but wrappers never installed (no torchrec)
+
+    class Batch:
+        def __init__(self):
+            self.embedding_features = [torch.rand(4, 8) for _ in range(3)]
+
+    # Only the forward-entry path runs (the stage wrappers that would call
+    # _checkpoint(b, "copy") were never installed).
+    for _ in range(2):
+        nl._root_pre_hook(None, (Batch(),))
+    nl._root_pre_hook(None, (Batch(),))     # drain the last step
+    nl._write_summary()
+
+    recs = _records(nl)
+    fwd = [r for r in recs if r["role"] == "track" and r["phase"] == "forward"]
+    assert fwd, "forward-entry follow wrote no track records in the degraded run"
+    # batch_id is minted at forward (not left null just because `copy` never came).
+    assert all(r["batch_id"] is not None for r in fwd)
+
+    smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
+    # No phantom stage checkpoints; the forward-entry capture is counted honestly.
+    assert smy["pipeline_installed"] is False
+    assert smy["pipeline_checkpoints"] == 0
+    assert smy["forward_checkpoints"] > 0
 
 
 def test_pipeline_off_produces_no_track_records(monkeypatch, tmp_path_factory):

--- a/tests/instrumentation/test_layer_numerics_runtime.py
+++ b/tests/instrumentation/test_layer_numerics_runtime.py
@@ -192,10 +192,12 @@ def test_pipeline_forward_stage_and_batch_id(monkeypatch, tmp_path_factory):
          "NANLOG_BOUNDS": "embedding_features:0:60", "NANLOG_SAMPLE_EVERY": "1"},
         monkeypatch, tmp_path_factory)
     # This test drives the stage checkpoints (copy/sparse_*) by hand instead of
-    # installing the real TorchRec wrappers, so mark them installed -- batch-id
-    # minting keys off _pipeline_installed (what actually ran), not the requested
-    # _PIPELINE, so `copy` is the id-minting first sighting here.
+    # installing the real TorchRec wrappers, so simulate that install: mark them
+    # installed and set the mint phase to the earliest stage this test fires (`copy`).
+    # Batch-id minting keys off _pipeline_installed + _pipeline_mint_phase (what
+    # actually ran), not the requested _PIPELINE.
     nl._pipeline_installed = True
+    nl._pipeline_mint_phase = "copy"
 
     class Batch:
         def __init__(self):
@@ -262,6 +264,45 @@ def test_pipeline_requested_but_wrappers_not_installed_mints_at_forward(
     assert smy["pipeline_installed"] is False
     assert smy["pipeline_checkpoints"] == 0
     assert smy["forward_checkpoints"] > 0
+
+
+def test_pipeline_mints_at_earliest_installed_stage_when_copy_absent(
+    monkeypatch, tmp_path_factory
+):
+    """Copilot PR #296 follow-up: _pipeline_installed can be true even when
+    copy_batch_to_gpu was NOT patched (a torchrec API change that keeps only sparse_*).
+    Then `copy` never fires, so minting must happen at the EARLIEST stage that WAS
+    installed (here sparse_start), not a hardcoded `copy` -- otherwise every stage
+    record's batch_id stays null."""
+    nl = _load_logger(
+        {"NANLOG_PIPELINE": "1", "NANLOG_TRACK_ATTR": "embedding_features",
+         "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    # Simulate an install where copy_batch_to_gpu was absent: only sparse_* patched,
+    # so the earliest firing stage -- and thus the mint phase -- is sparse_start.
+    nl._pipeline_installed = True
+    nl._pipeline_mint_phase = "sparse_start"
+
+    class Batch:
+        def __init__(self):
+            self.embedding_features = [torch.rand(4, 8) for _ in range(3)]
+
+    for _ in range(2):
+        b = Batch()
+        # No `copy` checkpoint -- that wrapper was never installed.
+        nl._checkpoint(b, "sparse_start")
+        nl._checkpoint(b, "sparse_wait")
+        nl._root_pre_hook(None, (b,))       # forward-entry checkpoint
+    nl._root_pre_hook(None, (Batch(),))     # drain the last step
+    nl._write_summary()
+
+    track = [r for r in _records(nl) if r["role"] in ("track", "sparse")]
+    # sparse_start (the earliest installed stage) mints a non-null batch_id.
+    start_recs = [r for r in track if r["phase"] == "sparse_start"]
+    assert start_recs and all(r["batch_id"] is not None for r in start_recs)
+    # and the later same-batch stages share it (they read the minted id back).
+    wait_recs = [r for r in track if r["phase"] == "sparse_wait"]
+    assert wait_recs and all(r["batch_id"] is not None for r in wait_recs)
 
 
 def test_pipeline_off_produces_no_track_records(monkeypatch, tmp_path_factory):

--- a/tests/instrumentation/test_layer_numerics_spec.py
+++ b/tests/instrumentation/test_layer_numerics_spec.py
@@ -235,6 +235,160 @@ def test_follow_scope_with_stride(monkeypatch, tmp_path_factory):
     assert nl._WATCH_NAMES == ("emb",)
 
 
+# ---------------------------------------------------------------------------
+# follow pipeline:false -> forward/block follow WITHOUT the stage wrappers
+# (timing-safe mode for a race the copy/sparse wrappers would suppress)
+# ---------------------------------------------------------------------------
+def test_follow_pipeline_false_scope_no_stage_wrappers(monkeypatch, tmp_path_factory):
+    """`pipeline:false` + scope -> per-block re-scan armed, stage wrappers OFF."""
+    spec = {"follow": [{"tensor": "embedding_features", "pipeline": False,
+                        "scope": {"names": ["emb_proj"]}, "bounds": [0, 60]}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is True
+    assert nl._PIPELINE is False              # no copy/sparse stage wrappers
+    assert nl._PIPELINE_OFF_FOLLOW is True    # explicit spec-derived opt-in
+    assert nl._TRACK_EVERY_LAYER is True      # per-block re-scan still armed
+    assert nl._FOLLOW_FWD is True             # forward-entry checkpoint still runs
+    assert nl._WATCH_NAMES == ("emb_proj",)
+    assert nl._bound_for("embedding_features") == (0.0, 60.0)
+
+
+def test_flat_track_every_layer_without_pipeline_is_noop(monkeypatch, tmp_path_factory):
+    """REGRESSION GUARD: a legacy flat-var run with NANLOG_TRACK_EVERY_LAYER=1 and
+    NANLOG_PIPELINE=0 (no NANLOG_SPEC) must NOT silently activate the pipeline-off
+    forward/block follow. That combination historically warned and no-op'd; keeping
+    it a no-op is what prevents a legacy run from being switched into a different,
+    timing-sensitive capture profile without an explicit opt-in. Only a validated
+    `pipeline: false` follow spec (which sets NANLOG_PIPELINE_OFF_FOLLOW) turns the
+    forward capture on."""
+    nl = _load_logger(
+        {"NANLOG_TRACK_EVERY_LAYER": "1", "NANLOG_PIPELINE": "0"},
+        monkeypatch, tmp_path_factory)
+    assert nl._SPEC_PRESENT is False           # pure flat-var run
+    assert nl._TRACK_EVERY_LAYER is True        # the flat var is read...
+    assert nl._PIPELINE is False
+    assert nl._PIPELINE_OFF_FOLLOW is False     # ...but the new mode is NOT inferred
+    assert nl._FOLLOW_FWD is False              # so forward capture stays OFF (no-op)
+
+
+def test_flat_pipeline_off_follow_var_alone_is_not_honored(monkeypatch, tmp_path_factory):
+    """NANLOG_PIPELINE_OFF_FOLLOW is a spec-INTERNAL derived var, not a public flat
+    knob. Setting it directly in a no-spec run is reset to its baseline by the
+    spec-owned-vars machinery only when a spec applies; with no spec it is read as-is,
+    so this test documents that it is not part of the supported flat surface. (The
+    supported entry point is a `pipeline: false` follow spec.)"""
+    # No NANLOG_SPEC -> the flat var is read directly; we assert the plumbing exists
+    # (the attribute is defined) rather than encouraging this as a public path.
+    nl = _load_logger({}, monkeypatch, tmp_path_factory)
+    assert hasattr(nl, "_PIPELINE_OFF_FOLLOW")
+    assert nl._PIPELINE_OFF_FOLLOW is False     # default off when unset
+
+
+def test_follow_pipeline_false_default_stride_is_one(monkeypatch, tmp_path_factory):
+    """A scope with no stride means every matched block, wrappers still off."""
+    spec = {"follow": [{"tensor": "ef", "pipeline": False, "scope": {"types": ["MLP"]}}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is False
+    assert nl._TRACK_EVERY_LAYER is True
+    assert nl._TRACK_LAYER_STRIDE == 1
+    assert nl._WATCH_TYPES == ("MLP",)
+
+
+def test_follow_pipeline_true_is_default_and_unchanged(monkeypatch, tmp_path_factory):
+    """Omitting `pipeline` keeps the historical behavior: stage wrappers ON."""
+    spec = {"follow": [{"tensor": "ef", "scope": {"types": ["MLP"]}, "stride": 5}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is True
+    assert nl._TRACK_EVERY_LAYER is True
+
+
+@pytest.mark.parametrize("follow_entry", [
+    {"tensor": "ef", "pipeline": False, "stages": True},   # stages needs wrappers
+    {"tensor": "ef", "pipeline": False},                   # no scope -> captures nothing
+    {"tensor": "ef", "pipeline": "no", "scope": {"types": ["MLP"]}},  # non-bool
+])
+def test_follow_pipeline_false_invalid_rolls_back(follow_entry, monkeypatch, tmp_path_factory):
+    """pipeline:false with stages:true (contradiction), with no scope (captures
+    nothing), or a non-bool value rejects the whole spec (flat fallback)."""
+    nl = _load_logger(
+        {"NANLOG_SPEC": json.dumps({"follow": [follow_entry]}),
+         "NANLOG_CHANNELS": "act,igrad"},
+        monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is False
+    assert nl._CHANNELS == frozenset({"act", "igrad"})
+    assert nl._PIPELINE is False
+
+
+def test_follow_pipeline_false_summary_mode(monkeypatch, tmp_path_factory):
+    """The summary records follow_mode=forward_blocks so a pipeline-off run is
+    auditable (distinct from stage_wrappers and off)."""
+    spec = {"follow": [{"tensor": "ef", "pipeline": False, "scope": {"types": ["MLP"]}}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    nl._write_summary()
+    smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
+    assert smy["pipeline"] is False
+    assert smy["follow_fwd"] is True
+    assert smy["follow_mode"] == "forward_blocks"
+
+
+def test_follow_stage_summary_mode(monkeypatch, tmp_path_factory):
+    """A stage-wrapper follow records follow_mode=stage_wrappers."""
+    spec = {"follow": [{"tensor": "ef", "stages": True}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    nl._write_summary()
+    smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
+    assert smy["follow_mode"] == "stage_wrappers"
+
+
+def test_follow_pipeline_false_runtime_capture(monkeypatch, tmp_path_factory):
+    """End-to-end: a pipeline-off follow re-scans the tracked tensor at each scoped
+    block via the forward hook, with NO pipeline hook installed. The track records
+    carry checkpoint=<block name> and a resolved (non-null) batch_id."""
+    class Batch:
+        def __init__(self, ef):
+            self.embedding_features = ef
+
+    class Net(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.blocks = torch.nn.ModuleList(
+                [torch.nn.Linear(4, 4) for _ in range(3)])
+
+        def forward(self, batch):
+            x = batch.embedding_features
+            for b in self.blocks:
+                x = b(x)
+            return x
+
+    spec = {"follow": [{"tensor": "embedding_features", "pipeline": False,
+                        "scope": {"types": ["Linear"]}}],
+            "sample_every": 1}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    model = Net()
+    assert nl._attach(model) == 3     # forward hooks installed despite no channels
+    for _ in range(2):
+        batch = Batch(torch.randn(4, 4))
+        nl._root_pre_hook(None, (batch,))   # forward-entry checkpoint mints batch_id
+        model(batch)
+    nl._write_summary()
+    recs = _records(nl)
+    track = [r for r in recs if r.get("role") == "track"]
+    assert track, "pipeline-off follow wrote no track records"
+    # re-scanned at the scoped blocks (checkpoint = block name), not a stage phase
+    assert any("blocks" in (r.get("checkpoint") or "") for r in track)
+    # batch_id is resolved at forward entry (not null) even with the wrappers off
+    assert any(r.get("batch_id") is not None for r in track)
+    # A pipeline-off run must NOT report stage-wrapper checkpoints -- that would
+    # imply stage instrumentation ran on a timing-safe capture. The forward-entry
+    # checkpoints are counted separately.
+    smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
+    assert smy["follow_mode"] == "forward_blocks"
+    assert smy["pipeline"] is False
+    assert smy["pipeline_installed"] is False
+    assert smy["pipeline_checkpoints"] == 0
+    assert smy["forward_checkpoints"] > 0
+
+
 def test_follow_at_key_is_rejected(monkeypatch, tmp_path_factory):
     """The old `at` key was removed: it is now an unknown follow key and rolls the
     whole spec back (no silent back-compat)."""
@@ -535,6 +689,18 @@ def test_spec_clears_stale_flat_pipeline(monkeypatch, tmp_path_factory):
          "NANLOG_SPEC": json.dumps({"watch": [{"scope": {"types": ["MLP"]}, "tensors": ["input"]}]})},
         monkeypatch, tmp_path_factory)
     assert nl._PIPELINE is False
+
+
+def test_spec_clears_stale_flat_pipeline_off_follow(monkeypatch, tmp_path_factory):
+    """A watch-only spec must not inherit a lingering flat NANLOG_PIPELINE_OFF_FOLLOW=1
+    (the spec-owned reset covers the new var too), so a stale value can't switch a
+    watch run into forward-capture mode."""
+    nl = _load_logger(
+        {"NANLOG_PIPELINE_OFF_FOLLOW": "1",
+         "NANLOG_SPEC": json.dumps({"watch": [{"scope": {"types": ["MLP"]}, "tensors": ["input"]}]})},
+        monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE_OFF_FOLLOW is False
+    assert nl._FOLLOW_FWD is False
 
 
 def test_spec_stage_clears_stale_flat_track_every_layer(monkeypatch, tmp_path_factory):


### PR DESCRIPTION
## Summary

- Adds an opt-out `follow[].pipeline: false` to the `NANLOG_SPEC` follow schema. A follow historically **always** installed the TorchRec copy/sparse stage wrappers, which serialize the pipeline's copy/compute overlap and can **suppress a timing-sensitive cross-stream race** — the requested follow/stages capture caught **0 NaN in 478 trials** on a residual-NaN bug that reproduced bare (customer handoff, hipBLASLt `4940ccbb57` / MI350X).
- `pipeline: false` keeps the **forward-entry + scoped-block** re-scan (riding ordinary forward hooks — the same timing-safe mechanism `watch` uses) but does **not** install the stage wrappers. Requires a `scope`; incompatible with `stages: true`.
- The pipeline-off state is **spec-derived** (`NANLOG_PIPELINE_OFF_FOLLOW`), not inferred from `TRACK_EVERY_LAYER`, so a legacy flat `NANLOG_TRACK_EVERY_LAYER=1` without `NANLOG_PIPELINE=1` stays a **warned no-op** and is never silently switched into the new timing profile.
- Summary now records `follow_mode` (`stage_wrappers` / `forward_blocks` / `off`) and splits `forward_checkpoints` from `pipeline_checkpoints`, so a timing-safe run never looks like stage instrumentation ran.
- Docs (`docs/layer-numerics.md`, package README) updated with the new key, a runnable example, constraints, and the summary fields. Also ignores local `.claude/` state.

## What you give up vs. keep

`pipeline: false` drops the `copy` / `sparse_start` / `sparse_wait` stage checkpoints (upstream-of-forward visibility) in exchange for **timing safety** + the block-by-block trajectory. Use it when a `follow`/`stages` sweep comes back 0-NaN on an otherwise-reproducible race.

## Test plan

- [x] `test_layer_numerics_spec.py` — pipeline:false schema, contradiction rollback (`pipeline:false`+`stages:true`, no-scope), stale-flat-var clearing, legacy flat no-op guard, summary `follow_mode`, and an end-to-end runtime capture asserting `role="track"` records at block checkpoints with `pipeline_checkpoints == 0` / `forward_checkpoints > 0`.
- [x] Full local suite: **129 passed** (`test_layer_numerics_spec / _docs / _runtime / .py`) in the `ort_312` env.
- [ ] GPU smoke test (see `docs/aorta-workspace/recipes/` smoke recipe) — run on an MI-class box to confirm the follow binds and writes `follow_mode: forward_blocks` with no stage wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)