### PR TITLE
layer_numerics: add follow[].stage_reads for timing-safe copy/sparse stage brackets

### DIFF
--- a/docs/layer-numerics.md
+++ b/docs/layer-numerics.md
@@ -102,6 +102,7 @@ observation kinds:
 | `stages` | (follow) check at the pipeline stage boundaries | `true` (`copy`/`sparse_start`/`sparse_wait`/`forward`) |
 | `stride` | (follow) also check every Nth module in `scope` | `N` (default `1`; requires `scope`). Set `stages`, `scope`, or both; neither ⇒ stages only |
 | `pipeline` | (follow) install the copy/sparse stage wrappers | `true` (default) / `false` — `false` follows at forward entry + `scope` blocks only, **without** the stage wrappers (timing-safe; see below). Requires a `scope`; incompatible with `stages: true` |
+| `stage_reads` | (follow) run the copy/sparse/forward stage read on a **side stream** | `true` / `false` (default). Keeps the wrappers but moves each stage read off the pipeline stream so it no longer serializes the copy/compute overlap — timing-safe **stage** brackets. Requires `pipeline: true` (see below) |
 | `stride` | (watch) hook only every Nth matched module | `N` (integer `>= 1`, default `1`); thins a broad watch whose per-module reduction volume is too high |
 | `diagnostics` | (top-level) how-much-detail toggles applied to **every** captured record | `addr, locate, bad_values, dump_tensor, alloc_snapshot` (see below) |
 
@@ -234,6 +235,55 @@ spec back. What you give up vs. the default: the `copy` / `sparse_start` /
 `sparse_wait` stage records (the upstream-of-forward checkpoints). What you keep:
 the block-by-block trajectory of the followed tensor. The summary records
 `follow_mode` (`stage_wrappers` / `forward_blocks` / `off`) so a run is auditable.
+
+#### `stage_reads: true` — timing-safe copy/sparse **stage** brackets
+
+`pipeline: false` gives up the copy/sparse stage records — so it can bracket *which
+block* inside forward, but not *which stage* (copy vs sparse vs "arrived before
+forward"). When you need to know **which stage** first corrupts the tensor — e.g. a
+wild write from a kernel with a bad index/offset that lands in the buffer's memory —
+you need reads at the stage boundaries, but the default stage read is exactly what
+serializes the overlap and hides the race.
+
+`"stage_reads": true` resolves this: it **keeps** the stage wrappers (so the
+`copy`/`sparse_start`/`sparse_wait`/`forward` timing points still fire) but runs each
+stage read of the tracked tensor on a **dedicated side CUDA stream**. The side stream
+waits on the current stream's already-enqueued work; the pipeline stream **never waits
+back**, so no ordering dependency is inserted into the overlap and the race still fires.
+The reductions ride the existing per-step drain (one host sync; the drain inserts a
+device-side wait so the side-stream results are ready before the read-back).
+
+> **Assumption (why this is customer-validated).** The side read waits on the *current*
+> stream at the wrapper. That reads valid post-stage bytes only if the stage's work is
+> ordered on the current stream when the wrapper fires — TorchRec runs stages on its own
+> internal streams, and which stream is current at that point can vary by version. We
+> can't verify torchrec's stream layout in-house, so treat the bracket as best-effort
+> and confirm it via the NaN-rate check below rather than assuming it's exact.
+
+```bash
+NANLOG_DIR=/output/layer_numerics \
+NANLOG_SPEC='{"follow":[{"tensor":"embedding_features","stages":true,"stage_reads":true,"bounds":[0,60]}],"pre_context":10}' \
+  python -m aorta.instrumentation.layer_numerics /path/to/your_script.py
+```
+
+Then the first bad read's `phase` (in `first_bad` / `first_oob`) names the bracketing
+stage: `copy` → a copy-stage kernel; `sparse_start`/`sparse_wait` → a sparse-stage
+kernel; `forward` → between sparse and forward.
+
+Constraints and caveats:
+- **Requires `pipeline: true`** (the wrappers must exist to have a stage read to move).
+  `stage_reads: true` + `pipeline: false` rolls the spec back.
+- A **torn read** (reading while a wild kernel is mid-write) is possible and acceptable
+  here — you only need clean-vs-corrupt to bracket, not exact boundary values.
+- The side stream removes the *serialization* but still shares SMs/HBM bandwidth, so it
+  is much lighter than the inline read but **not zero-overhead**. On a marginal race it
+  *may* still perturb the window. **Validate it:** compare its NaN capture rate against a
+  known-good baseline (`watch` or `pipeline:false`); if the rate holds, the stage
+  bracket is trustworthy; if it collapses, the read is still too heavy on that build.
+- Auditability: the summary records `stage_reads` (requested), `stage_reads_active`
+  (whether the side stream was actually created — `false` means it **fell back to the
+  serializing inline read** and may have hidden the race), `stage_read_count`, and
+  `follow_mode: "stage_wrappers_side_read"` when active.
 
 Add a `bounds: [lo, hi]` to a `follow` entry to flag out-of-range values
 (`kind="oob"`) — a two-sided check the one-sided "huge" threshold misses.
@@ -491,6 +541,7 @@ All heavy features default **OFF** and feed the same single per-step host transf
 | `NANLOG_SPARSE` | Cheap host-side KJT metadata at the sparse stage | `0` (off) | — |
 | `NANLOG_TRACK_EVERY_LAYER` | Re-scan tracked tensors at each scoped block. Rides an **active follow** — with `NANLOG_PIPELINE=1` (stage+block). **Setting this flat var alone (no `NANLOG_PIPELINE`, no spec) is a warned no-op**, so a legacy run is never silently switched into forward-capture mode; the wrapper-free block follow is opt-in via a `pipeline:false` spec. | `0` (off) | `follow[].scope` (+ `stride`) |
 | `NANLOG_PIPELINE_OFF_FOLLOW` | **Spec-internal, not a supported public flat knob.** The engine does read it from the environment (so it *can* be set by hand), but it is **intended to be set only** by a validated `follow[].pipeline:false`; enables the forward+block follow without the stage wrappers. Documented for artifact readers — prefer the `pipeline:false` spec over setting it directly. | `0` (off) | `follow[].pipeline: false` |
+| `NANLOG_STAGE_READS` | With `NANLOG_PIPELINE=1`, run the copy/sparse/forward stage read on a side CUDA stream (one-way event dependency) so it doesn't serialize the copy/compute overlap — timing-safe **stage** brackets. Falls back to the inline (serializing) read + warns if the side stream can't be created; the summary's `stage_reads_active` reports which happened. | `0` (off) | `follow[].stage_reads` |
 | `NANLOG_TRACK_LAYER_STRIDE` | Re-scan every Kth layer when re-scan is on | `1` | `follow[].stride` |
 
 Channel notes:

--- a/src/aorta/instrumentation/layer_numerics/README.md
+++ b/src/aorta/instrumentation/layer_numerics/README.md
@@ -91,7 +91,11 @@ alone, vs. `grad` which is all gradients); a `watch` entry may set `"stride": N`
 `follow` entry may set `"pipeline": false` to follow the tensor through its `scope`
 blocks (and at forward entry) **without** installing the copy/sparse stage wrappers
 — the timing-safe mode for a cross-stream race the wrappers would otherwise suppress
-(requires a `scope`, incompatible with `stages: true`; summary records `follow_mode`).
+(requires a `scope`, incompatible with `stages: true`; summary records `follow_mode`);
+and a `follow` entry may set `"stage_reads": true` (with `pipeline: true`) to KEEP the
+stage wrappers but run each copy/sparse/forward stage read on a side CUDA stream, so
+the stage reads give timing-safe **stage** brackets without serializing the overlap
+(summary records `stage_reads_active` — `false` means it fell back to the inline read).
 
 Collector defaults (applied by [`build_env`](__init__.py)): all seven channels,
 `NANLOG_PRE_CONTEXT=10`, `NANLOG_SAMPLE_EVERY=50`. `NANLOG_DIR` is filled per-cell

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -168,6 +168,16 @@ Settings (environment variables):
                          re-scan the tracked flow objects at each stage, before the
                          forward reads them. Warns once and stays inactive if the
                          stage methods are absent. Same per-step drain (default 0).
+  NANLOG_STAGE_READS     "1" (with NANLOG_PIPELINE=1) -> run each copy/sparse/forward
+                         stage read on a dedicated side CUDA stream with a one-way
+                         event dependency, so the stage read does NOT serialize the
+                         copy/compute overlap (which the default inline read does, and
+                         which hides a timing-sensitive cross-stream race). Gives
+                         timing-safe copy/sparse STAGE brackets. Falls back to the
+                         inline read + warns once if the side stream can't be created;
+                         the summary's stage_reads_active records which happened. The
+                         side stream is synchronized once per step in the drain, so the
+                         single batched host transfer stays the only host sync (def 0).
   NANLOG_TRACK_ATTR      comma list of batch attribute/key names to follow as flow
                          tensors (default "embedding_features"); a name may resolve
                          to a Tensor, list/tuple/dict of Tensors, or a KJT (its
@@ -213,6 +223,7 @@ Settings (environment variables):
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import math
 import os
@@ -281,7 +292,7 @@ import torch  # noqa: E402
 # ---------------------------------------------------------------------------
 # One JSON env var, two observation kinds:
 #   watch   [{scope, tensors, stride?}, ...]      -- a module's OWN tensors
-#   follow  [{tensor, stages?, scope?, stride?, bounds?, pipeline?}, ...]
+#   follow  [{tensor, stages?, scope?, stride?, bounds?, pipeline?, stage_reads?}, ...]
 #                                                 -- trace ONE named tensor across positions
 # building blocks:
 #   scope   {names:[substr,...], types:[ClassName,...]}  -- which modules
@@ -294,6 +305,10 @@ import torch  # noqa: E402
 #                    wrappers, so the copy/compute overlap is never serialized (the
 #                    mode for a timing-sensitive race the wrappers would suppress);
 #                    incompatible with stages:true, requires a scope for block capture
+#   stage_reads bool -- (follow, default false) keep the stage wrappers but run each
+#                    copy/sparse/forward stage read on a side CUDA stream (one-way event
+#                    dependency), so the stage read no longer serializes the overlap ->
+#                    timing-safe copy/sparse STAGE brackets. Requires pipeline:true.
 # plus cross-cutting: sample_every, pre_context, diagnostics[]. (Output dir is the
 # separate NANLOG_DIR env var, never a spec key.)
 #
@@ -366,8 +381,8 @@ def _spec_int(spec: dict, key: str, minimum: int) -> int | None:
 
 
 def _resolve_follow_cadence(f: dict) -> tuple:
-    """Normalize a follow entry's cadence into (stages, stride, pipeline), where
-    stride is the "also re-scan every Nth watched module" cadence (None = don't
+    """Normalize a follow entry's cadence into (stages, stride, pipeline, stage_reads),
+    where stride is the "also re-scan every Nth watched module" cadence (None = don't
     re-scan at modules). WHERE to check the followed tensor is two independent knobs:
 
         "stages": true   -> capture at the pipeline stage boundaries (copy/sparse/fwd)
@@ -382,11 +397,19 @@ def _resolve_follow_cadence(f: dict) -> tuple:
     for a timing-sensitive race the stage wrappers would suppress. `stages: true`
     REQUIRES the wrappers, so `pipeline: false` + `stages: true` is contradictory.
 
+    `stage_reads` (default false) keeps the stage wrappers BUT moves each stage read of
+    the tracked tensor off the pipeline's stream onto a dedicated side stream, so the
+    copy/sparse checkpoints no longer serialize the copy/compute overlap. It exists to
+    get timing-safe copy/sparse stage brackets on a race the default (inline) stage read
+    hides. It REQUIRES the wrappers (pipeline: true) -- it is meaningless with
+    pipeline: false (there are no stage wrappers to move the read off of).
+
     Raises ValueError on a malformed/contradictory entry so the whole spec rolls back.
     """
     # Reject unknown keys so a typo or a leftover `at` from the old schema fails loudly
     # instead of silently falling through to the stages-only default.
-    _FOLLOW_KEYS = {"tensor", "stages", "scope", "stride", "bounds", "pipeline"}
+    _FOLLOW_KEYS = {"tensor", "stages", "scope", "stride", "bounds", "pipeline",
+                    "stage_reads"}
     unknown = [k for k in f if k not in _FOLLOW_KEYS]
     if unknown:
         raise ValueError(f"unknown follow[] key(s) {sorted(unknown)}; "
@@ -399,6 +422,9 @@ def _resolve_follow_cadence(f: dict) -> tuple:
     pipeline = f.get("pipeline", True)
     if not isinstance(pipeline, bool):
         raise ValueError(f"follow[].pipeline must be true/false, got {pipeline!r}")
+    stage_reads = f.get("stage_reads", False)
+    if not isinstance(stage_reads, bool):
+        raise ValueError(f"follow[].stage_reads must be true/false, got {stage_reads!r}")
     stride = None
     if "stride" in f:
         v = f["stride"]
@@ -421,7 +447,14 @@ def _resolve_follow_cadence(f: dict) -> tuple:
                          "(stage capture requires the pipeline wrappers); to follow at "
                          "blocks only, drop `stages` and give a `scope`, or keep "
                          "`stages` and use the default pipeline: true")
-    return stages, stride, pipeline
+    # `stage_reads` only changes HOW the stage wrappers read; with pipeline: false there
+    # are no wrappers, so it is meaningless there. Require the wrappers explicitly.
+    if stage_reads and not pipeline:
+        raise ValueError("follow[].stage_reads true needs the pipeline wrappers "
+                         "(pipeline must be true); it moves the copy/sparse stage read "
+                         "off the pipeline stream, so there is nothing to move with "
+                         "pipeline: false")
+    return stages, stride, pipeline, stage_reads
 
 
 def _spec_optional_mapping(container: dict, key: str, path: str) -> dict:
@@ -489,6 +522,7 @@ _SPEC_OWNED_VARS = {
     "NANLOG_WATCH_NAMES": "", "NANLOG_WATCH_TYPES": "", "NANLOG_CHANNELS": "",
     "NANLOG_WATCH_STRIDE": "1",
     "NANLOG_PIPELINE": "0", "NANLOG_PIPELINE_OFF_FOLLOW": "0",
+    "NANLOG_STAGE_READS": "0",
     "NANLOG_TRACK_ATTR": "", "NANLOG_TRACK_EVERY_LAYER": "0",
     "NANLOG_TRACK_LAYER_STRIDE": "1", "NANLOG_BOUNDS": "",
     "NANLOG_SAMPLE_EVERY": "", "NANLOG_PRE_CONTEXT": "",
@@ -588,7 +622,7 @@ def _translate_spec(spec: dict) -> None:
                    "(engine has one follow path); tensors are unioned into TRACK_ATTR")
     if follow:
         f0 = follow[0]
-        stages, stride, pipeline = _resolve_follow_cadence(f0)
+        stages, stride, pipeline, stage_reads = _resolve_follow_cadence(f0)
         # `stages` -> the pipeline stage-method wrappers (NANLOG_PIPELINE). Historically
         # these were also the transport for the per-module re-scan, so any scoped follow
         # armed them too -- which serializes the copy/compute overlap and can suppress a
@@ -613,6 +647,11 @@ def _translate_spec(spec: dict) -> None:
         # silently opted into this timing-sensitive mode. Only a validated
         # `pipeline: false` follow sets it.
         _spec_set("NANLOG_PIPELINE_OFF_FOLLOW", "1" if (not arm_wrappers) else "0")
+        # Stage-reads: move the copy/sparse stage reads off the pipeline stream onto a
+        # side stream so they don't serialize the overlap. Only meaningful when the
+        # wrappers are actually armed (validation already rejects stage_reads without
+        # pipeline; guard on arm_wrappers too so it can't leak on with no wrappers).
+        _spec_set("NANLOG_STAGE_READS", "1" if (stage_reads and arm_wrappers) else "0")
         track_attrs = [f["tensor"].strip() for f in follow]
         _spec_set("NANLOG_TRACK_ATTR", ",".join(track_attrs))
         if stride is not None:
@@ -814,6 +853,13 @@ _PIPELINE = os.environ.get("NANLOG_PIPELINE", "0") == "1"
 # mode, which historically warned and no-op'd. Keep that contract -- only the spec
 # turns this on.
 _PIPELINE_OFF_FOLLOW = os.environ.get("NANLOG_PIPELINE_OFF_FOLLOW", "0") == "1"
+# Stage-reads: keep the stage wrappers, but run the copy/sparse/forward stage read of
+# the tracked tensor on a DEDICATED side stream with a one-way event dependency, so the
+# read does not serialize the copy/compute overlap the way the default inline read does.
+# The wrappers still fire (we need the timing point + batch handle); only the reduction
+# moves off the pipeline stream. Purpose: timing-safe copy/sparse stage brackets for a
+# race the inline stage read hides. Requires NANLOG_PIPELINE=1 (spec enforces this).
+_STAGE_READS = os.environ.get("NANLOG_STAGE_READS", "0") == "1"
 _TRACK_ATTR = tuple(
     s.strip() for s in os.environ.get("NANLOG_TRACK_ATTR", "embedding_features").split(",")
     if s.strip()
@@ -1173,7 +1219,26 @@ def _stash(layer_name: str, direction: str, t: torch.Tensor, role: str = "act",
     # For the one-shot dump, hold a DETACHED ref so we don't keep the autograd graph
     # alive across the step (memory / allocator-reuse perturbation).
     held = t.detach() if (_DUMP_TENSOR and not _tensor_dumped) else None
-    _pending.append((rec, _device_stats(t, bound), held))
+    # Stage-reads: run this reduction on the side stream (created on t's OWN device) so
+    # it doesn't serialize the copy/compute overlap. _stage_read_stream applies the
+    # one-way dependency (side waits for the current stream, current never waits back);
+    # record_stream tells the caching allocator not to hand t's block to another op on
+    # the training stream while the side-stream read is in flight (which would reduce a
+    # DIFFERENT tensor's data -> a false clean/NaN). Off / non-CUDA / no side stream ->
+    # the context is a no-op and the read runs inline (historical behavior).
+    # _checkpoint is the sole writer of _stage_read_in_progress; here we only read it.
+    use_side = _stage_read_in_progress and t.is_cuda
+    if use_side:
+        with _stage_read_stream(t.device):
+            if _stage_stream is not None:
+                try:
+                    t.record_stream(_stage_stream)
+                except Exception:
+                    pass
+            stats = _device_stats(t, bound)
+    else:
+        stats = _device_stats(t, bound)
+    _pending.append((rec, stats, held))
 
 
 # ---------------------------------------------------------------------------
@@ -1206,6 +1271,16 @@ def _drain_step() -> None:
         keys = keys + ["bad_rows"]
     if _BAD_VALUES:
         keys = keys + ["first_bad_flat", "first_bad_val", "first_bad_row", "first_bad_col"]
+    # With stage reads, some of this step's reductions (stats[k]) were produced on the
+    # side stream. Everything below -- the .to(float64) casts, the stack, the .cpu()
+    # copy -- runs on the current stream. Insert a DEVICE-SIDE dependency FIRST so those
+    # casts wait for the side stream: a host .synchronize() AFTER enqueuing the casts is
+    # too late (the cast kernels are already queued on the current stream with no
+    # ordering vs. the side stream and could read not-yet-written scalars). wait_stream
+    # is enqueue-time and one-way, so it costs no host sync of its own -- the single
+    # .cpu().tolist() below stays the only host transfer. No-op when stage reads are off.
+    if _stage_reads_active and _stage_stream is not None:
+        torch.cuda.current_stream().wait_stream(_stage_stream)
     flat = []
     for _rec, stats, _held_t in pending:
         for k in keys:
@@ -1637,6 +1712,93 @@ _pipeline_checkpoints = 0     # stage-wrapper checkpoints that stashed something
 _forward_checkpoints = 0      # forward-entry checkpoints that stashed something (pipeline-off follow)
 _pipeline_warned = False
 
+# Side stream for NANLOG_STAGE_READS: the stage read runs here, not on the pipeline
+# stream, so it doesn't serialize the copy/compute overlap. Created lazily on first
+# use (CUDA must be initialized); None if unavailable / creation failed (then we fall
+# back to the inline read and warn once). _stage_reads_active reflects what ACTUALLY
+# happened, for the summary. _stage_read_in_progress is set by _checkpoint (SOLE writer)
+# around its emit loop and READ by _stash to decide whether to route the reduction to
+# the side stream; the context manager must not touch it (see _stage_read_stream).
+_stage_stream = None
+_stage_reads_active = False
+# Count of side-stream reads performed (one per tracked tensor per stage, i.e. it
+# increments per _stash, NOT per stage checkpoint -- a 31-tensor batch adds 31 per
+# copy/sparse/forward). An audit signal that the side path actually ran.
+_stage_read_count = 0
+_stage_stream_warned = False
+_stage_read_in_progress = False
+
+
+def _get_stage_stream(device=None):
+    """Lazily create the side CUDA stream for stage reads, on `device` (the tracked
+    tensor's device -- NOT whatever the current device happens to be, which on a
+    multi-GPU rank may differ). Returns the stream, or None if stage reads are off /
+    CUDA is unavailable / creation failed (caller falls back to an inline read). Never
+    raises."""
+    global _stage_stream, _stage_reads_active, _stage_stream_warned
+    if not _STAGE_READS:
+        return None
+    if _stage_stream is not None:
+        return _stage_stream
+    try:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA not available")
+        # Pin the stream to the tensor's device so the wait/reduction never cross GPUs.
+        with torch.cuda.device(device) if device is not None else contextlib.nullcontext():
+            _stage_stream = torch.cuda.Stream()
+        _stage_reads_active = True
+        _log("stage_reads: side stream created; copy/sparse/forward stage reads run "
+             "off the pipeline stream (one-way dependency). NOTE: this assumes the "
+             "current stream at the stage wrapper carries the stage's work -- validate "
+             "the NaN capture rate against a baseline (see docs).")
+        return _stage_stream
+    except Exception as e:  # noqa: BLE001 -- a sidecar must never take the run down
+        if not _stage_stream_warned:
+            _stage_stream_warned = True
+            _log(f"WARNING: stage_reads requested but the side stream could not be "
+                 f"created ({e!r}); falling back to inline stage reads (these DO "
+                 f"serialize the pipeline and can hide a timing race).")
+        return None
+
+
+@contextlib.contextmanager
+def _stage_read_stream(device=None):
+    """Context manager: run the enclosed reduction on the side stream with a one-way
+    dependency on the CURRENT stream. The side stream waits for the current stream's
+    already-enqueued work; the current stream never waits back (so no ordering
+    dependency is inserted into the overlap). Falls back to a no-op (inline read on the
+    current stream) when the side stream is unavailable.
+
+    IMPORTANT / assumption: this waits on `torch.cuda.current_stream()` at the moment
+    the stage wrapper fires. That is correct ONLY if the stage's work (the H2D copy /
+    sparse dist) is ordered on the current stream by the time _checkpoint runs. TorchRec
+    runs stages on its own internal streams, so on some versions the current stream may
+    NOT be the stage's stream -- in which case the side read can execute before the
+    stage's writes land and mis-report "clean" at that stage. We cannot verify torchrec's
+    stream layout in-house; this is why the mode ships as CUSTOMER-VALIDATED (compare the
+    NaN rate to a baseline). The reduction is best-effort, not a guaranteed post-stage
+    snapshot.
+
+    _drain_step synchronizes the side stream before the host read-back, so the scalars
+    are ready without inserting a per-stage host sync.
+
+    Ownership: `_stage_read_in_progress` is set/reset by `_checkpoint` (the sole writer)
+    around the whole emit loop; this context ONLY reads the side stream. It must not
+    touch that flag -- doing so previously reset it after the first tensor, so only one
+    of a batch's N tracked tensors got the side stream and the rest silently serialized.
+    """
+    global _stage_read_count
+    stream = _get_stage_stream(device)
+    if stream is None:
+        yield
+        return
+    cur = torch.cuda.current_stream()
+    stream.wait_stream(cur)          # side waits for the current stream's enqueued work
+    with torch.cuda.stream(stream):  # reductions enqueue on the side stream
+        yield
+    _stage_read_count += 1
+    # NOTE: cur does NOT wait on `stream` -- that one-way dependency is the whole point.
+
 
 _kjt_types_cache = None
 
@@ -1957,6 +2119,7 @@ def _checkpoint(batch, phase: str) -> None:
     capture (phase='forward' only, which is the sole caller when the stage wrappers
     are off in a pipeline-off follow). Never raises into the training run."""
     global _phase, _batch_id, _pipeline_checkpoints, _forward_checkpoints
+    global _stage_read_in_progress
     if batch is None:
         return
     _phase = phase
@@ -1966,6 +2129,14 @@ def _checkpoint(batch, phase: str) -> None:
         _batch_id = None
     seen: set = set()
     n = 0
+    # With NANLOG_STAGE_READS, mark that the emits below are a stage read: _stash then
+    # routes each tensor's reduction onto the side stream (on the tensor's own device,
+    # with a one-way dependency + record_stream), so the read doesn't serialize the
+    # copy/compute overlap. Off -> the flag stays False and reads run inline (historical
+    # behavior). Doing it per-tensor in _stash (not around the whole loop here) keeps the
+    # stream pinned to each tensor's device and the record_stream call co-located.
+    prev_flag = _stage_read_in_progress
+    _stage_read_in_progress = _STAGE_READS
     try:
         found_named = False
         for name in _TRACK_ATTR:
@@ -1982,6 +2153,8 @@ def _checkpoint(batch, phase: str) -> None:
     except Exception as e:
         _log(f"WARNING: pipeline checkpoint ({phase}) failed: {e!r}")
         return
+    finally:
+        _stage_read_in_progress = prev_flag
     if n:
         # Split the counters by what ACTUALLY produced this checkpoint, so each is a
         # truthful signal:
@@ -2105,9 +2278,18 @@ def _write_summary() -> None:
         "pipeline_mint_phase": _pipeline_mint_phase,
         "pipeline_checkpoints": _pipeline_checkpoints,
         "forward_checkpoints": _forward_checkpoints,
+        # Stage-reads auditability: whether the timing-safe side-stream stage read was
+        # requested, whether the side stream was actually created (falls back to inline +
+        # warns if not), and how many stage reads ran on it. A run that requested it but
+        # shows stage_reads_active=false read INLINE and may have hidden the race -- the
+        # whole reason this is surfaced.
+        "stage_reads": _STAGE_READS,
+        "stage_reads_active": _stage_reads_active,
+        "stage_read_count": _stage_read_count,
         "follow_fwd": _FOLLOW_FWD,
         "follow_mode": (
-            "stage_wrappers" if _PIPELINE
+            "stage_wrappers_side_read" if (_PIPELINE and _stage_reads_active)
+            else "stage_wrappers" if _PIPELINE
             else "forward_blocks" if _FOLLOW_FWD
             else "off"
         ),

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -1280,7 +1280,11 @@ def _drain_step() -> None:
     # is enqueue-time and one-way, so it costs no host sync of its own -- the single
     # .cpu().tolist() below stays the only host transfer. No-op when stage reads are off.
     if _stage_reads_active and _stage_stream is not None:
-        torch.cuda.current_stream().wait_stream(_stage_stream)
+        # Under the side stream's OWN device: the casts/stack/.cpu() below run on that
+        # device's current stream, and the wait must be issued there too (an unpinned
+        # wait on a multi-GPU rank could target the wrong device's stream or raise).
+        with torch.cuda.device(_stage_stream_device):
+            torch.cuda.current_stream().wait_stream(_stage_stream)
     flat = []
     for _rec, stats, _held_t in pending:
         for k in keys:
@@ -1720,6 +1724,12 @@ _pipeline_warned = False
 # around its emit loop and READ by _stash to decide whether to route the reduction to
 # the side stream; the context manager must not touch it (see _stage_read_stream).
 _stage_stream = None
+# The device _stage_stream lives on (the tracked tensor's device at creation). Every
+# wait_stream against the side stream must be issued under this device -- on a
+# multi-GPU ROCm rank the ambient current device can differ, and an unpinned
+# current_stream()/wait_stream would order against the WRONG device's stream or raise
+# a cross-device error. Set alongside _stage_stream.
+_stage_stream_device = None
 _stage_reads_active = False
 # Count of side-stream reads performed (one per tracked tensor per stage, i.e. it
 # increments per _stash, NOT per stage checkpoint -- a 31-tensor batch adds 31 per
@@ -1735,7 +1745,7 @@ def _get_stage_stream(device=None):
     multi-GPU rank may differ). Returns the stream, or None if stage reads are off /
     CUDA is unavailable / creation failed (caller falls back to an inline read). Never
     raises."""
-    global _stage_stream, _stage_reads_active, _stage_stream_warned
+    global _stage_stream, _stage_stream_device, _stage_reads_active, _stage_stream_warned
     if not _STAGE_READS:
         return None
     if _stage_stream is not None:
@@ -1746,6 +1756,7 @@ def _get_stage_stream(device=None):
         # Pin the stream to the tensor's device so the wait/reduction never cross GPUs.
         with torch.cuda.device(device) if device is not None else contextlib.nullcontext():
             _stage_stream = torch.cuda.Stream()
+        _stage_stream_device = device if device is not None else torch.cuda.current_device()
         _stage_reads_active = True
         _log("stage_reads: side stream created; copy/sparse/forward stage reads run "
              "off the pipeline stream (one-way dependency). NOTE: this assumes the "
@@ -1792,10 +1803,14 @@ def _stage_read_stream(device=None):
     if stream is None:
         yield
         return
-    cur = torch.cuda.current_stream()
-    stream.wait_stream(cur)          # side waits for the current stream's enqueued work
-    with torch.cuda.stream(stream):  # reductions enqueue on the side stream
-        yield
+    # Issue the wait + enqueue under the side stream's OWN device: on a multi-GPU rank
+    # the ambient device can differ, and an unpinned current_stream()/wait_stream would
+    # order against the wrong device's stream or raise cross-device.
+    with torch.cuda.device(_stage_stream_device):
+        cur = torch.cuda.current_stream()
+        stream.wait_stream(cur)          # side waits for the current stream's enqueued work
+        with torch.cuda.stream(stream):  # reductions enqueue on the side stream
+            yield
     _stage_read_count += 1
     # NOTE: cur does NOT wait on `stream` -- that one-way dependency is the whole point.
 

--- a/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
+++ b/src/aorta/instrumentation/layer_numerics/instrument_nan_logger.py
@@ -1753,10 +1753,18 @@ def _get_stage_stream(device=None):
     try:
         if not torch.cuda.is_available():
             raise RuntimeError("CUDA not available")
-        # Pin the stream to the tensor's device so the wait/reduction never cross GPUs.
-        with torch.cuda.device(device) if device is not None else contextlib.nullcontext():
+        # Normalize to an integer device INDEX (not a torch.device): torch.cuda.device()
+        # accepts an int, downstream code / the summary compare it numerically, and a
+        # torch.device with .index=None (e.g. "cuda") would otherwise leak through.
+        if device is None:
+            dev_idx = torch.cuda.current_device()
+        else:
+            d = torch.device(device)
+            dev_idx = d.index if d.index is not None else torch.cuda.current_device()
+        # Pin the stream to that device so the wait/reduction never cross GPUs.
+        with torch.cuda.device(dev_idx):
             _stage_stream = torch.cuda.Stream()
-        _stage_stream_device = device if device is not None else torch.cuda.current_device()
+        _stage_stream_device = dev_idx
         _stage_reads_active = True
         _log("stage_reads: side stream created; copy/sparse/forward stage reads run "
              "off the pipeline stream (one-way dependency). NOTE: this assumes the "
@@ -2302,9 +2310,13 @@ def _write_summary() -> None:
         "stage_reads_active": _stage_reads_active,
         "stage_read_count": _stage_read_count,
         "follow_fwd": _FOLLOW_FWD,
+        # Keyed on what ACTUALLY ran (_pipeline_installed), not what was requested
+        # (_PIPELINE): a degraded run (NANLOG_PIPELINE=1 but torchrec absent -> wrappers
+        # no-op) has no stage brackets, so it must NOT claim stage_wrappers*. It still
+        # captures at forward entry via the root pre-hook, so it reads as forward_blocks.
         "follow_mode": (
-            "stage_wrappers_side_read" if (_PIPELINE and _stage_reads_active)
-            else "stage_wrappers" if _PIPELINE
+            "stage_wrappers_side_read" if (_pipeline_installed and _stage_reads_active)
+            else "stage_wrappers" if _pipeline_installed
             else "forward_blocks" if _FOLLOW_FWD
             else "off"
         ),

--- a/tests/instrumentation/test_layer_numerics_runtime.py
+++ b/tests/instrumentation/test_layer_numerics_runtime.py
@@ -229,8 +229,13 @@ def test_pipeline_forward_stage_and_batch_id(monkeypatch, tmp_path_factory):
 def test_stage_reads_still_capture_all_stages(monkeypatch, tmp_path_factory):
     """With NANLOG_STAGE_READS=1 the copy/sparse/forward stage reads still produce the
     same records (the side stream only changes WHERE the reduction runs, not WHAT is
-    captured). On a CPU box the side stream is unavailable, so this also exercises the
-    inline fallback: capture must be identical either way, and the run must not crash."""
+    captured). The tracked tensors are put on the SAME device the side stream needs
+    (cuda when available, else cpu), so the summary assertions below actually reflect
+    which path ran -- the side stream only engages for a CUDA tensor (t.is_cuda), so a
+    CPU tensor on a CUDA box would (correctly) fall back to inline, not exercise the
+    feature. On a CPU box this exercises the inline fallback: capture must be identical
+    either way and the run must not crash."""
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
     nl = _load_logger(
         {"NANLOG_PIPELINE": "1", "NANLOG_STAGE_READS": "1",
          "NANLOG_TRACK_ATTR": "embedding_features",
@@ -242,7 +247,8 @@ def test_stage_reads_still_capture_all_stages(monkeypatch, tmp_path_factory):
 
     class Batch:
         def __init__(self):
-            self.embedding_features = [torch.rand(4, 8) * 60.0 for _ in range(3)]
+            self.embedding_features = [
+                (torch.rand(4, 8, device=dev) * 60.0) for _ in range(3)]
 
     for _ in range(2):
         b = Batch()
@@ -261,9 +267,8 @@ def test_stage_reads_still_capture_all_stages(monkeypatch, tmp_path_factory):
 
     smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
     assert smy["stage_reads"] is True
-    # follow_mode reflects whether the side stream actually engaged on this box:
-    # "stage_wrappers_side_read" when CUDA is present, plain "stage_wrappers" on CPU
-    # (inline fallback). Either is a valid, honestly-reported outcome.
+    # With CUDA tensors on a CUDA box the side stream engages; on CPU it falls back to
+    # inline. Both are honestly reported.
     if torch.cuda.is_available():
         assert smy["stage_reads_active"] is True
         assert smy["follow_mode"] == "stage_wrappers_side_read"
@@ -308,6 +313,52 @@ def test_stage_reads_drain_reads_side_stream_values_correctly(
     assert r["nan_count"] == 2       # exact -- proves the drain waited for the side stream
     assert r["oob_count"] == 1
     assert nl._stage_reads_active is True
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs >=2 GPUs")
+def test_stage_reads_cross_device_ambient_differs_from_stream(
+    monkeypatch, tmp_path_factory
+):
+    """Copilot #297 review (#1/#2): the side stream is created on the tracked tensor's
+    device, but the wait_stream calls (context manager + drain) previously used an
+    UNPINNED current_stream(). On a multi-GPU rank where the ambient current device
+    differs from the stream's device, that orders against the wrong device's stream or
+    raises cross-device. This is the real ROCm case (8x MI350X ranks on non-zero
+    devices).
+
+    Put the tracked tensor on cuda:1 while the AMBIENT device is cuda:0, run a stage
+    read + drain, and assert it neither raises nor mis-reports -- i.e. the device-pinned
+    waits ordered correctly across the device mismatch."""
+    nl = _load_logger(
+        {"NANLOG_PIPELINE": "1", "NANLOG_STAGE_READS": "1",
+         "NANLOG_TRACK_ATTR": "embedding_features",
+         "NANLOG_BOUNDS": "embedding_features:0:60", "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    nl._pipeline_installed = True
+    nl._pipeline_mint_phase = "copy"
+
+    # Tensor on device 1; known content (2 NaN, 1 oob).
+    ef = torch.tensor([[float("nan"), float("nan"), 100.0, 5.0]], device="cuda:1")
+
+    class Batch:
+        def __init__(self):
+            self.embedding_features = ef
+
+    # Ambient device deliberately 0 (!= the tensor's device 1) for the whole flow.
+    with torch.cuda.device(0):
+        nl._checkpoint(Batch(), "copy")
+        nl._root_pre_hook(None, (Batch(),))
+    nl._write_summary()
+
+    recs = [r for r in _records(nl) if r["role"] == "track" and r["phase"] == "copy"]
+    assert recs, "no copy-stage track record"
+    r = recs[0]
+    assert r["nan_count"] == 2       # correct across the device mismatch -> pin worked
+    assert r["oob_count"] == 1
+    smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
+    assert smy["stage_reads_active"] is True
+    # the side stream lives on the tensor's device, not the ambient device
+    assert nl._stage_stream_device == 1
 
 
 def test_pipeline_requested_but_wrappers_not_installed_mints_at_forward(

--- a/tests/instrumentation/test_layer_numerics_runtime.py
+++ b/tests/instrumentation/test_layer_numerics_runtime.py
@@ -226,6 +226,90 @@ def test_pipeline_forward_stage_and_batch_id(monkeypatch, tmp_path_factory):
     assert copy_recs and all(r["batch_id"] is not None for r in copy_recs)
 
 
+def test_stage_reads_still_capture_all_stages(monkeypatch, tmp_path_factory):
+    """With NANLOG_STAGE_READS=1 the copy/sparse/forward stage reads still produce the
+    same records (the side stream only changes WHERE the reduction runs, not WHAT is
+    captured). On a CPU box the side stream is unavailable, so this also exercises the
+    inline fallback: capture must be identical either way, and the run must not crash."""
+    nl = _load_logger(
+        {"NANLOG_PIPELINE": "1", "NANLOG_STAGE_READS": "1",
+         "NANLOG_TRACK_ATTR": "embedding_features",
+         "NANLOG_BOUNDS": "embedding_features:0:60", "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    assert nl._STAGE_READS is True
+    nl._pipeline_installed = True
+    nl._pipeline_mint_phase = "copy"
+
+    class Batch:
+        def __init__(self):
+            self.embedding_features = [torch.rand(4, 8) * 60.0 for _ in range(3)]
+
+    for _ in range(2):
+        b = Batch()
+        nl._checkpoint(b, "copy")
+        nl._checkpoint(b, "sparse_start")
+        nl._checkpoint(b, "sparse_wait")
+        nl._root_pre_hook(None, (b,))
+    nl._root_pre_hook(None, (Batch(),))
+    nl._write_summary()
+
+    track = [r for r in _records(nl) if r["role"] in ("track", "sparse")]
+    phases = {r["phase"] for r in track}
+    assert {"copy", "sparse_start", "sparse_wait", "forward"} <= phases
+    # stats came through regardless of which stream the reduction ran on
+    assert all("nan_count" in r for r in track)
+
+    smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
+    assert smy["stage_reads"] is True
+    # follow_mode reflects whether the side stream actually engaged on this box:
+    # "stage_wrappers_side_read" when CUDA is present, plain "stage_wrappers" on CPU
+    # (inline fallback). Either is a valid, honestly-reported outcome.
+    if torch.cuda.is_available():
+        assert smy["stage_reads_active"] is True
+        assert smy["follow_mode"] == "stage_wrappers_side_read"
+        assert smy["stage_read_count"] > 0
+    else:
+        assert smy["stage_reads_active"] is False   # fell back to inline, honestly
+        assert smy["follow_mode"] == "stage_wrappers"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for side stream")
+def test_stage_reads_drain_reads_side_stream_values_correctly(
+    monkeypatch, tmp_path_factory
+):
+    """BLOCKER regression: the drain must not read the side-stream reduction outputs
+    before they are computed. Feed a tensor with a KNOWN nan/oob content, run the stage
+    read on the side stream, drain, and assert the emitted counts match the tensor
+    exactly -- i.e. the drain's device-side wait_stream ordered the casts after the
+    side-stream reductions (a missing/late wait would give wrong or stale counts)."""
+    nl = _load_logger(
+        {"NANLOG_PIPELINE": "1", "NANLOG_STAGE_READS": "1",
+         "NANLOG_TRACK_ATTR": "embedding_features",
+         "NANLOG_BOUNDS": "embedding_features:0:60", "NANLOG_SAMPLE_EVERY": "1"},
+        monkeypatch, tmp_path_factory)
+    assert nl._STAGE_READS is True
+    nl._pipeline_installed = True
+    nl._pipeline_mint_phase = "copy"
+
+    # Known content: 2 NaNs and 1 out-of-range (100 > 60) among finite values.
+    ef = torch.tensor([[float("nan"), float("nan"), 100.0, 5.0]], device="cuda")
+
+    class Batch:
+        def __init__(self):
+            self.embedding_features = ef
+
+    nl._checkpoint(Batch(), "copy")     # reduction runs on the side stream
+    nl._root_pre_hook(None, (Batch(),))  # drain the step (device-side wait then read-back)
+    nl._write_summary()
+
+    recs = [r for r in _records(nl) if r["role"] == "track" and r["phase"] == "copy"]
+    assert recs, "no copy-stage track record"
+    r = recs[0]
+    assert r["nan_count"] == 2       # exact -- proves the drain waited for the side stream
+    assert r["oob_count"] == 1
+    assert nl._stage_reads_active is True
+
+
 def test_pipeline_requested_but_wrappers_not_installed_mints_at_forward(
     monkeypatch, tmp_path_factory
 ):

--- a/tests/instrumentation/test_layer_numerics_spec.py
+++ b/tests/instrumentation/test_layer_numerics_spec.py
@@ -294,6 +294,69 @@ def test_follow_pipeline_false_default_stride_is_one(monkeypatch, tmp_path_facto
     assert nl._WATCH_TYPES == ("MLP",)
 
 
+# ---------------------------------------------------------------------------
+# follow stage_reads -> timing-safe copy/sparse stage reads on a side stream
+# ---------------------------------------------------------------------------
+def test_follow_stage_reads_arms_pipeline_and_side_read(monkeypatch, tmp_path_factory):
+    """`stages:true` + `stage_reads:true` keeps the pipeline wrappers ON (we need the
+    copy/sparse timing points) but flags the reads to run off the pipeline stream."""
+    spec = {"follow": [{"tensor": "embedding_features", "stages": True,
+                        "stage_reads": True, "bounds": [0, 60]}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is True
+    assert nl._PIPELINE is True           # wrappers armed -- stage reads need them
+    assert nl._STAGE_READS is True        # reads flagged for the side stream
+    assert nl._PIPELINE_OFF_FOLLOW is False
+
+
+def test_follow_stage_reads_defaults_false(monkeypatch, tmp_path_factory):
+    """A plain stages follow does not flag stage_reads (historical inline behavior)."""
+    spec = {"follow": [{"tensor": "ef", "stages": True}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is True
+    assert nl._STAGE_READS is False
+
+
+def test_follow_stage_reads_with_scope_keeps_wrappers(monkeypatch, tmp_path_factory):
+    """stage_reads + a scoped follow (pipeline defaults true, wrappers armed via scope)
+    is valid: the stage reads move to the side stream AND the per-block re-scan runs."""
+    spec = {"follow": [{"tensor": "ef", "stage_reads": True,
+                        "scope": {"types": ["MLP"]}}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is True
+    assert nl._PIPELINE is True
+    assert nl._STAGE_READS is True
+    assert nl._TRACK_EVERY_LAYER is True
+
+
+@pytest.mark.parametrize("follow_entry", [
+    {"tensor": "ef", "pipeline": False, "scope": {"types": ["MLP"]}, "stage_reads": True},
+    {"tensor": "ef", "stage_reads": "yes", "stages": True},   # non-bool
+])
+def test_follow_stage_reads_invalid_rolls_back(follow_entry, monkeypatch, tmp_path_factory):
+    """stage_reads needs the pipeline wrappers (pipeline:true). With pipeline:false it is
+    meaningless and rejected; a non-bool value is rejected too. Both roll the whole spec
+    back to the flat vars. (Note: stages:false + scope keeps pipeline:true by default, so
+    the wrappers ARE armed via the scope -- that combination is valid, not a rejection.)"""
+    nl = _load_logger(
+        {"NANLOG_SPEC": json.dumps({"follow": [follow_entry]}),
+         "NANLOG_CHANNELS": "act,igrad"},
+        monkeypatch, tmp_path_factory)
+    assert nl._SPEC_APPLIED is False
+    assert nl._STAGE_READS is False
+    assert nl._CHANNELS == frozenset({"act", "igrad"})
+
+
+def test_spec_clears_stale_flat_stage_reads(monkeypatch, tmp_path_factory):
+    """A spec that doesn't ask for stage_reads must clear a lingering flat
+    NANLOG_STAGE_READS=1, so it can't leak on."""
+    nl = _load_logger(
+        {"NANLOG_STAGE_READS": "1",
+         "NANLOG_SPEC": json.dumps({"follow": [{"tensor": "ef", "stages": True}]})},
+        monkeypatch, tmp_path_factory)
+    assert nl._STAGE_READS is False
+
+
 def test_follow_pipeline_true_is_default_and_unchanged(monkeypatch, tmp_path_factory):
     """Omitting `pipeline` keeps the historical behavior: stage wrappers ON."""
     spec = {"follow": [{"tensor": "ef", "scope": {"types": ["MLP"]}, "stride": 5}]}

--- a/tests/instrumentation/test_layer_numerics_spec.py
+++ b/tests/instrumentation/test_layer_numerics_spec.py
@@ -395,12 +395,32 @@ def test_follow_pipeline_false_summary_mode(monkeypatch, tmp_path_factory):
 
 
 def test_follow_stage_summary_mode(monkeypatch, tmp_path_factory):
-    """A stage-wrapper follow records follow_mode=stage_wrappers."""
+    """A stage-wrapper follow records follow_mode=stage_wrappers -- but only when the
+    wrappers were ACTUALLY installed. follow_mode keys on _pipeline_installed (what ran),
+    not the requested _PIPELINE, so simulate the install (no torchrec in this env)."""
     spec = {"follow": [{"tensor": "ef", "stages": True}]}
     nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is True
+    nl._pipeline_installed = True   # torchrec would set this; forced here
     nl._write_summary()
     smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
     assert smy["follow_mode"] == "stage_wrappers"
+
+
+def test_follow_stage_requested_but_not_installed_is_forward_blocks(
+    monkeypatch, tmp_path_factory
+):
+    """Copilot #297 review: a stages follow REQUESTED (pipeline true) but where the
+    wrappers never installed (torchrec absent -> _pipeline_installed false) must NOT
+    claim stage bracketing. follow_mode falls to forward_blocks (it still captures at
+    forward entry), never stage_wrappers*."""
+    spec = {"follow": [{"tensor": "ef", "stages": True}]}
+    nl = _load_logger({"NANLOG_SPEC": json.dumps(spec)}, monkeypatch, tmp_path_factory)
+    assert nl._PIPELINE is True
+    assert nl._pipeline_installed is False   # wrappers never installed
+    nl._write_summary()
+    smy = json.loads((nl._OUT_DIR / "summary_rank0.json").read_text())
+    assert smy["follow_mode"] == "forward_blocks"
 
 
 def test_follow_pipeline_false_runtime_capture(monkeypatch, tmp_path_factory):


### PR DESCRIPTION
## Summary

- Adds `follow[].stage_reads: true` — a mode that brackets **which pipeline stage** (copy vs sparse vs "arrived before forward") first corrupts the followed tensor, without serializing the copy/compute overlap that hides a timing-sensitive cross-stream race.
- Builds on `pipeline:false` (#296): that mode brackets *which block* inside forward but gives up the copy/sparse stage checkpoints. `stage_reads` restores those checkpoints **timing-safe**.
- Motivating case: residual-NaN on hipBLASLt `4940ccbb57` (MI350X) — a **wild write** (kernel with a bad index/bias stores into `embedding_features`' memory), ruled out as aliasing via `NANLOG_ADDR`. Goal is stage/block localization, not the exact kernel.

## How it works

Keeps the TorchRec stage wrappers (so `copy`/`sparse_start`/`sparse_wait`/`forward` timing points still fire) but runs each stage read of the tracked tensor on a **dedicated side CUDA stream** with a one-way dependency: the side stream waits on the current stream's enqueued work; the pipeline stream **never waits back**, so no ordering dependency is inserted into the overlap and the race still fires. `first_bad.phase` / `first_oob.phase` then names the bracketing stage.

## Correctness

- **Drain ordering:** a device-side `current_stream().wait_stream(side)` is inserted **before** the scalar casts, so the read-back can't consume not-yet-computed side-stream outputs (a host `synchronize()` after enqueue would be too late).
- **Allocator safety:** `t.record_stream(side)` so the caching allocator can't reuse the source block on the training stream mid-read.
- **Device correctness:** the side stream is created on the tracked tensor's own device (no cross-GPU on a multi-GPU rank).
- **Flag ownership:** `_checkpoint` is the sole writer of the in-progress flag; the context manager only reads the side stream. (A prior draft reset the flag after the first tensor, silently serializing the rest — fixed + commented.)

## Constraints / honesty

- **Requires `pipeline: true`** (rejected with `pipeline:false` — nothing to move off the stream).
- **Fail-soft:** if the side stream can't be created, warns once and falls back to the inline read. Summary records `stage_reads` / `stage_reads_active` / `stage_read_count` / `follow_mode: stage_wrappers_side_read`, so a fallback is never mistaken for a validated capture.
- **Customer-validated:** the side read waits on the *current* stream at the wrapper, which is correct only if the stage's work is ordered there — unverifiable against torchrec in-house. So the mode ships with the NaN-rate-vs-baseline check as the validation step (documented).

## Test plan

- [x] `test_layer_numerics_spec.py` — schema parse, `pipeline:true` requirement, non-bool rejection, stale-flat clearing, valid scope+stage_reads combo.
- [x] `test_layer_numerics_runtime.py` — capture parity + honest `stage_reads_active` on CPU fallback; **CUDA-gated** drain-ordering regression test (feeds known nan/oob content, asserts exact drained counts).
- [x] Full local suite: **138 passed, 1 skipped** (CUDA test) in the `ort_312` env.
- [ ] GPU smoke test on an MI-class box (see `docs/aorta-workspace/recipes/`): confirm `follow_mode: stage_wrappers_side_read`, copy/sparse stage records present, and NaN rate holds vs. baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)