### PR TITLE
Generic trial-environment contract across host and Docker workloads

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,56 @@
 
 All configuration knobs can be adjusted via `config/default.yaml` or dotted `--override` arguments when invoking `train.py` or the launch scripts.
 
+## Trial environment variables
+
+AORTA uses one controlled environment-variable overlay for host workloads and
+workload-owned isolation backends. Its precedence, from lowest to highest, is:
+
+```text
+Environment.env
+< named mitigations
+< recipe-level extra_env
+< cell-level extra_env or direct aorta run --extra-env
+```
+
+| Surface | Purpose |
+| --- | --- |
+| `Environment.env` | Baseline variables intrinsic to a registered or inline environment. |
+| Mitigations | Named runtime or diagnostic variable bundles. |
+| Recipe `extra_env` | Variables applied to every cell in a matrix recipe. |
+| Cell `extra_env` | Per-cell overrides; wins over recipe-level values. |
+| `workload_config` | Workload-specific configuration, not environment variables. It is passed to the workload constructor and does not enter the environment overlay. |
+
+All environment mappings are `dict[str, str]`; numeric and boolean YAML/JSON
+values are rejected rather than coerced. For host workloads, the dispatcher
+applies the effective overlay before environment capture and workload
+`setup()`/`run()`, then restores the process environment after each trial.
+Unrelated variables inherited through `os.environ` are never added to the
+controlled overlay.
+
+### Workload-owned Docker launches
+
+The dispatcher records the effective controlled overlay in
+`config["_aorta_trial_env"]`. The key is always present as a plain
+`dict[str, str]`, including `{}` when no controlled source contributed. A
+Docker-aware workload wrapper can forward it with the public helper:
+
+```python
+from aorta.run import docker_env_flags
+
+trial_env = config.get("_aorta_trial_env", {})
+argv = ["docker", "run", *docker_env_flags(trial_env), image, *inner_command]
+```
+
+`docker_env_flags()` emits deterministic, key-sorted `-e KEY=VALUE` tokens,
+validates names and string values, and never reads `os.environ`. Treat values
+as potentially sensitive and do not log `_aorta_trial_env`.
+
+The dispatcher does not launch Docker. Workload wrappers continue to own image
+selection, mounts, devices, IPC/shared-memory settings, entrypoints, and inner
+commands. Top-level recipe `extra_env` is a matrix/triage feature; probe-mode
+recipes retain their separate environment-passthrough contract.
+
 ## Configuration Reference
 
 | Category | Knob | Expected Behaviour |

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -38,6 +38,8 @@ workload: fsdp                       # required; resolved via aorta.workloads en
 trials: 8                            # required; per-cell trial count
 steps: 5000                          # required; per-cell step count
 save_logs: false                     # optional; when true, dispatcher writes per-trial stdout/stderr files
+extra_env:                           # optional; applies to every cell
+  GLOBAL_DEBUG_FLAG: "1"             # values must be strings
 
 confound:
   threshold: 1.15                    # default; > 1.15 -> "speed (+N%)" flag
@@ -62,7 +64,10 @@ cells:
 
   - name: try-nightly                # inline docker shorthand
     mitigations: [none]
-    environment: { docker: "rocm/pytorch:nightly" }
+    environment:
+      docker: "rocm/pytorch:nightly"
+      env:                            # optional baseline intrinsic to this environment
+        TORCH_ROCM_FA_PREFER_CK: "1"
 
   - name: custom-env-override        # one-off env var override for this cell only
     mitigations: [tf32_off]
@@ -101,15 +106,21 @@ cells:
   intentionally override.
 - **`cells[*].environment`** -- required. Either:
   - a registered environment name (resolved via `aorta.registry.get_environment()`), OR
-  - a mapping `{ docker: "<image-ref>" }` -- inline docker shorthand.
-    Auto-named `_inline_<hash>` where `<hash>` is the first 8 hex chars of
-    `blake2b(image-ref)`. Deterministic: two cells with the same ref share
-    the same auto-name and the same per-environment env-probe. No other
-    keys accepted.
+  - a mapping `{docker: "<image-ref>", env: {KEY: "VALUE"}}` -- inline
+    docker shorthand with optional baseline environment variables.
+    Auto-named `_inline_<hash>`. For legacy mappings with no `env` (or an
+    empty mapping), the hash remains the first 8 hex chars of
+    `blake2b(image-ref)`. Non-empty `env` content is included canonically in
+    the identity, so the same image with different baseline variables cannot
+    silently collapse into one environment. No other keys are accepted.
+- **Top-level `extra_env`** -- optional `dict[str, str]`. Applied to every
+  cell after `Environment.env` and mitigations. Probe-mode recipes reject this
+  triage-only key and retain their separate environment-passthrough contract.
 - **`cells[*].extra_env`** -- optional `dict[str, str]`. Applied AFTER the
-  mitigation bundle, so it can override a registered mitigation's env var
-  for one-off experiments without polluting the registry. Recorded in
-  `matrix.json` for audit.
+  recipe-level mapping, so it can override a recipe default or registered
+  mitigation for one-off experiments without polluting the registry. Recorded
+  in `matrix.json` for audit. All environment mappings require string keys and
+  values; quote YAML numbers and booleans.
 - **`save_logs`** -- optional `bool`, default `false`. When `true`, the
   dispatcher captures the workload's in-process `stdout` / `stderr`
   writes into `trial_d{d}_m{m}_t{t}.{stdout,stderr}.log` files alongside
@@ -174,7 +185,8 @@ cells:
 - **`workload_config`** -- optional `dict[str, Any]`, allowed at both
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use
-  this for workload-specific knobs that aren't env vars -- e.g.
+  this for workload-specific knobs that aren't env vars; it does not enter
+  `os.environ` or `_aorta_trial_env`. For example,
   `shampoo_api: old` on the `recom_repro` workload to select the V1
   flat-kwarg SHAMPOO entry script (both `new` and `old` import from the
   OSS `distributed_shampoo` package; they differ in constructor shape).
@@ -202,6 +214,23 @@ cells:
 
 Every validation error reports a path like `cells[2].mitigations` so the
 failure is localisable without reading the loader source.
+
+The complete environment-variable precedence is:
+
+```text
+Environment.env
+< mitigations
+< recipe-level extra_env
+< cell-level extra_env
+```
+
+Direct `aorta run --extra-env` occupies the same highest-precedence request
+layer as the recipe runner's merged recipe/cell values. The dispatcher applies
+the controlled overlay to host workloads and injects the exact same mapping as
+`config["_aorta_trial_env"]` for self-isolating wrappers. It never adds
+unrelated ambient host variables, and it does not launch Docker. Docker-aware
+wrappers can use `aorta.run.docker_env_flags`; see
+[`docs/configuration.md`](../docs/configuration.md#workload-owned-docker-launches).
 
 ## Workloads
 
@@ -331,8 +360,9 @@ A green run proves: `compute_type=transformer`, `layers_verified > 0`, `layer_ch
   rows are marked `n/a` in `matrix.md` -- so a workload that only exposes
   wall-clock can't be silently compared against one that emits per-step
   timing.
-- `resolved_env_vars` -- the env-var bundle as actually applied (mitigation
-  union + `extra_env`).
+- `resolved_env_vars` -- the controlled env-var bundle as actually applied
+  (`Environment.env`, mitigation union, and merged recipe/cell `extra_env` in
+  precedence order).
 - `resolved_environment` -- the resolved `Environment` descriptor.
 - `workload_config` -- the merged per-cell `workload_config` dict (recipe
   scope union cell scope, cell wins on collision). Empty `{}` when neither

--- a/src/aorta/_env_rules.py
+++ b/src/aorta/_env_rules.py
@@ -1,0 +1,45 @@
+"""Shared environment-variable name/value rules (dependency-free leaf module).
+
+An env var declared in a recipe, a registry environment, a sidecar file, a
+mitigation bundle, or a direct ``--extra-env`` flag must satisfy the SAME two
+rules before it can be applied to ``os.environ`` or forwarded into a container:
+
+1. The NAME must be a POSIX env-var name (``[A-Za-z_][A-Za-z0-9_]*``).
+2. The VALUE must not contain a NUL byte -- a valid Python ``str`` character
+   that cannot be stored in an OS environment variable (``os.environ.update``
+   and ``execve`` both reject it).
+
+These rules were previously duplicated (and drifted) across the dispatcher,
+the Docker helper, the recipe parser, and the registry loaders -- and two
+declaration boundaries enforced neither, so a bad entry could pass recipe
+loading / ``--dry-run`` and only fail per-cell at run time (a "green command,
+zero work" outcome). This module is the single source of truth for the two
+predicates. It deliberately has NO aorta imports so every layer -- registry,
+triage, run -- can use it without an import cycle, and each caller raises its
+own public exception type (``RegistryError`` / ``RecipeSchemaError`` /
+``ValueError``) rather than a shared one.
+
+The predicates never accept or echo the value's content, so callers can build
+value-redacting error messages (env values may be secrets).
+"""
+
+from __future__ import annotations
+
+import re
+
+# POSIX env-var name shape. The single definition; every layer imports this
+# rather than re-compiling its own copy.
+ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def is_valid_env_name(key: str) -> bool:
+    """True if ``key`` is a valid POSIX env-var name (``[A-Za-z_][A-Za-z0-9_]*``)."""
+    return ENV_KEY_RE.fullmatch(key) is not None
+
+
+def value_has_nul(value: str) -> bool:
+    """True if ``value`` contains a NUL byte (cannot live in an env var)."""
+    return "\x00" in value
+
+
+__all__ = ["ENV_KEY_RE", "is_valid_env_name", "value_has_nul"]

--- a/src/aorta/cli/_env_display.py
+++ b/src/aorta/cli/_env_display.py
@@ -1,0 +1,24 @@
+"""Safe, compact rendering for environment-variable bundles in CLI output."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+_SAFE_VALUE_RE = re.compile(r"[A-Za-z0-9_@%+=:,./-]+")
+
+
+def format_env_bundle(env: Mapping[str, str], *, empty: str = "(none)") -> str:
+    """Render sorted ``KEY=VALUE`` tokens without emitting unsafe characters.
+
+    Simple values stay unquoted for readable listings. Values containing
+    whitespace, terminal control characters, or characters outside the
+    conservative token-safe set use ``repr`` so each pair remains one visible
+    token and cannot alter the surrounding terminal output.
+    """
+
+    pairs = []
+    for key, value in sorted(env.items()):
+        rendered_value = value if _SAFE_VALUE_RE.fullmatch(value) else repr(value)
+        pairs.append(f"{key}={rendered_value}")
+    return " ".join(pairs) or empty

--- a/src/aorta/cli/environments.py
+++ b/src/aorta/cli/environments.py
@@ -21,19 +21,22 @@ def environments() -> None:
     help="JSON file with extra environment entries to merge into the listing (repeatable).",
 )
 def list_(files: tuple[Path, ...]) -> None:
-    """List every registered environment, its source package, and its docker/venv."""
+    """List every registered environment and its baseline recipe."""
     registry = load_environments(extra_files=list(files) or None)
     name_w = max(len("NAME"), *(len(n) for n in registry))
     src_w = max(len("SOURCE"), *(len(e.source_package) for e in registry.values()))
     docker_w = max(len("DOCKER"), *(len(e.docker or "-") for e in registry.values()))
+    venv_w = max(len("VENV"), *(len(e.venv or "-") for e in registry.values()))
 
     click.echo(
         f"{'NAME'.ljust(name_w)}  {'SOURCE'.ljust(src_w)}  "
-        f"{'DOCKER'.ljust(docker_w)}  VENV"
+        f"{'DOCKER'.ljust(docker_w)}  {'VENV'.ljust(venv_w)}  ENV"
     )
     for name in sorted(registry):
         e = registry[name]
+        env_str = " ".join(f"{k}={v}" for k, v in sorted(e.env.items())) or "(none)"
         click.echo(
             f"{name.ljust(name_w)}  {e.source_package.ljust(src_w)}  "
-            f"{(e.docker or '-').ljust(docker_w)}  {e.venv or '-'}"
+            f"{(e.docker or '-').ljust(docker_w)}  "
+            f"{(e.venv or '-').ljust(venv_w)}  {env_str}"
         )

--- a/src/aorta/cli/environments.py
+++ b/src/aorta/cli/environments.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import click
 
+from aorta.cli._env_display import format_env_bundle
 from aorta.registry import load_environments
 
 
@@ -34,7 +35,7 @@ def list_(files: tuple[Path, ...]) -> None:
     )
     for name in sorted(registry):
         e = registry[name]
-        env_str = " ".join(f"{k}={v}" for k, v in sorted(e.env.items())) or "(none)"
+        env_str = format_env_bundle(e.env)
         click.echo(
             f"{name.ljust(name_w)}  {e.source_package.ljust(src_w)}  "
             f"{(e.docker or '-').ljust(docker_w)}  "

--- a/src/aorta/cli/mitigations.py
+++ b/src/aorta/cli/mitigations.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import click
 
+from aorta.cli._env_display import format_env_bundle
 from aorta.registry import load_mitigations
 
 
@@ -29,5 +30,5 @@ def list_(files: tuple[Path, ...]) -> None:
     click.echo(f"{'NAME'.ljust(name_w)}  {'SOURCE'.ljust(src_w)}  ENV")
     for name in sorted(registry):
         m = registry[name]
-        env_str = " ".join(f"{k}={v}" for k, v in sorted(m.env.items())) or "(none)"
+        env_str = format_env_bundle(m.env)
         click.echo(f"{name.ljust(name_w)}  {m.source_package.ljust(src_w)}  {env_str}")

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -618,7 +618,7 @@ def sweep_list_mitigations(files: tuple[Path, ...]) -> None:
     help="JSON sidecar to merge into the listing (repeatable).",
 )
 def sweep_list_environments(files: tuple[Path, ...]) -> None:
-    """List every registered environment with its source_package and docker/venv."""
+    """List every registered environment and its baseline recipe."""
     execute_list_environments(files)
 
 

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import click
 
 from aorta.cli._deprecation import emit_deprecation
+from aorta.cli._env_display import format_env_bundle
 from aorta.registry import (
     RegistryError,
     load_environments,
@@ -448,7 +449,7 @@ def execute_list_mitigations(files: tuple[Path, ...]) -> None:
     click.echo(f"{'NAME'.ljust(name_w)}  {'SOURCE'.ljust(src_w)}  ENV")
     for name in sorted(registry):
         m = registry[name]
-        env_str = " ".join(f"{k}={v}" for k, v in sorted(m.env.items())) or "(none)"
+        env_str = format_env_bundle(m.env)
         click.echo(f"{name.ljust(name_w)}  {m.source_package.ljust(src_w)}  {env_str}")
 
 
@@ -482,7 +483,7 @@ def execute_list_environments(files: tuple[Path, ...]) -> None:
     )
     for name in sorted(registry):
         e = registry[name]
-        env_str = " ".join(f"{k}={v}" for k, v in sorted(e.env.items())) or "(none)"
+        env_str = format_env_bundle(e.env)
         click.echo(
             f"{name.ljust(name_w)}  {e.source_package.ljust(src_w)}  "
             f"{(e.docker or '-').ljust(docker_w)}  "

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -461,7 +461,7 @@ def execute_list_mitigations(files: tuple[Path, ...]) -> None:
     help="JSON sidecar to merge into the listing (repeatable).",
 )
 def list_environments(files: tuple[Path, ...]) -> None:
-    """List every registered environment with its source_package and docker/venv."""
+    """List every registered environment and its baseline recipe."""
     emit_deprecation("aorta triage list-environments", "aorta sweep list-environments")
     execute_list_environments(files)
 
@@ -475,10 +475,16 @@ def execute_list_environments(files: tuple[Path, ...]) -> None:
     name_w = max(len("NAME"), *(len(n) for n in registry))
     src_w = max(len("SOURCE"), *(len(e.source_package) for e in registry.values()))
     docker_w = max(len("DOCKER"), *(len(e.docker or "-") for e in registry.values()))
-    click.echo(f"{'NAME'.ljust(name_w)}  {'SOURCE'.ljust(src_w)}  {'DOCKER'.ljust(docker_w)}  VENV")
+    venv_w = max(len("VENV"), *(len(e.venv or "-") for e in registry.values()))
+    click.echo(
+        f"{'NAME'.ljust(name_w)}  {'SOURCE'.ljust(src_w)}  "
+        f"{'DOCKER'.ljust(docker_w)}  {'VENV'.ljust(venv_w)}  ENV"
+    )
     for name in sorted(registry):
         e = registry[name]
+        env_str = " ".join(f"{k}={v}" for k, v in sorted(e.env.items())) or "(none)"
         click.echo(
             f"{name.ljust(name_w)}  {e.source_package.ljust(src_w)}  "
-            f"{(e.docker or '-').ljust(docker_w)}  {e.venv or '-'}"
+            f"{(e.docker or '-').ljust(docker_w)}  "
+            f"{(e.venv or '-').ljust(venv_w)}  {env_str}"
         )

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -4,9 +4,11 @@ Two small registries that ship with aorta:
 
 - **Mitigations** (`name → env vars`) — process-level flags applied just before
   the workload subprocess launches. Examples: `tf32_off`, `xnack`.
-- **Environments** (`name → docker / venv / buck_target recipe`) — baseline
+- **Environments** (`name → launch hints + baseline env vars`) — baseline
   state of the process, container, or Buck-built binary the workload runs in.
-  Examples: `local`, `default`.
+  Launch hints include `docker`, `venv`, and `buck_target`; `env` is an
+  optional `dict[str, str]` intrinsic to that environment. Examples: `local`,
+  `default`.
 
 Both follow the same shape: built-ins ship from this package; external
 contributions arrive via Python entry-points and are merged at runtime.
@@ -124,7 +126,10 @@ the same collision rule.
     "amp_bf16": { "AMP_DTYPE": "bfloat16" }
   },
   "environments": {
-    "my_local_image": { "docker": "myorg/private:test@sha256:..." },
+    "my_local_image": {
+      "docker": "myorg/private:test@sha256:...",
+      "env": { "TORCH_ROCM_FA_PREFER_CK": "1" }
+    },
     "host_venv_3_12": { "venv":   "/home/me/.venvs/aorta-3.12" }
   }
 }
@@ -198,12 +203,36 @@ workloads via the `aorta.workloads` entry-point group.
 
 ## Adding an environment
 
-Same two paths, with `aorta.environments` as the entry-point group. Plugin
-payloads must use only the keys `docker`, `venv`, or `buck_target`; anything
-else (e.g. `rocm`) raises `RegistryError` at load time. ROCm version is
-implicit in the docker image digest, the host the venv runs on, or the Buck
-checkout's captured revision — capture it from `aorta env probe` at runtime,
-not via static declaration.
+Same two paths, with `aorta.environments` as the entry-point group. Plugin and
+sidecar payloads may use `docker`, `venv`, `buck_target`, `emulator`,
+`mirage_profile`, and `env`. The launch-hint values are `str | None`; `env`
+must be a `dict[str, str]`. Numeric and boolean values are rejected rather than
+coerced. Omitting `env` remains compatible and produces an empty mapping.
+Anything outside this allow-list (for example `rocm`) raises `RegistryError`
+at load time. ROCm version is implicit in the docker image digest, the host the
+venv runs on, or the Buck checkout's captured revision — capture it from
+`aorta env probe` at runtime, not via static declaration.
+
+Entry-point example:
+
+```toml
+[project.entry-points."aorta.environments"]
+nightly = "my_package.environments:NIGHTLY"
+```
+
+```python
+# my_package/environments.py
+NIGHTLY = {
+    "docker": "myorg/pytorch@sha256:...",
+    "env": {
+        "TORCH_ROCM_FA_PREFER_CK": "1",
+    },
+}
+```
+
+`Environment.env` is the lowest-precedence layer. Mitigations override it,
+recipe-level `extra_env` overrides mitigations, and cell-level or direct-CLI
+`extra_env` wins last.
 
 ### Tier hints: how the workload consumes the resolved environment
 
@@ -216,7 +245,10 @@ config["_aorta_environment"] = {
     "docker": "...",         # or None
     "venv": "...",           # or None
     "buck_target": "...",    # or None
+    "emulator": "...",        # or None
+    "mirage_profile": "...",  # or None
     "source_package": "...",
+    "env": {"KEY": "VALUE"},
 }
 ```
 
@@ -240,6 +272,27 @@ elif image:
 else:
     argv = [sys.executable, str(entry)]
 ```
+
+The dispatcher separately injects the fully resolved controlled overlay as
+`config["_aorta_trial_env"]`. Docker-aware plugin wrappers should forward that
+mapping with the shared helper rather than reading the complete host
+environment:
+
+```python
+from aorta.run import docker_env_flags
+
+trial_env = self.config.get("_aorta_trial_env", {})
+argv = [
+    "docker",
+    "run",
+    *docker_env_flags(trial_env),
+    # wrapper-owned mounts, devices, IPC, entrypoint, image, and command...
+]
+```
+
+The helper sorts keys, validates `dict[str, str]`, and never reads
+`os.environ`. Do not log `_aorta_trial_env` values. AORTA's dispatcher does not
+launch Docker; wrappers retain ownership of the complete launch command.
 
 Adding a fourth tier later (e.g. Bazel) follows the same pattern: extend
 `Environment`, extend `_VALID_ENV_KEYS`, document the read pattern here.

--- a/src/aorta/registry/environments.py
+++ b/src/aorta/registry/environments.py
@@ -1,19 +1,22 @@
 """Environments registry: built-ins + entry-point discovery + collision detection.
 
 Mirrors the mitigations registry. Plugin payloads are validated against
-`_VALID_ENV_KEYS` — `docker`, `venv`, `buck_target`, `emulator`, and
-`mirage_profile` are accepted. ROCm version is intentionally not a valid key
-(see `Environment` docstring).
+`_ALLOWED_ENV_TOP_LEVEL` — `docker`, `venv`, `buck_target`, `emulator`,
+`mirage_profile` (each `str | None`) and `env` (a nested `dict[str, str]` of
+baseline environment variables) are accepted. ROCm version is intentionally not
+a valid key (see `Environment` docstring).
 
 Plugin authors register one entry-point per environment in their `pyproject.toml`
 under the `aorta.environments` group. The entry-point name IS the environment
-name; the loaded object is the recipe (`dict[str, str | None]` with any of the
-keys `docker`, `venv`, `buck_target`, `emulator`, `mirage_profile`). Mirrors
-the `aorta.workloads` extension-point pattern.
+name; the loaded object is the recipe (`dict` with any of the keys `docker`,
+`venv`, `buck_target`, `emulator`, `mirage_profile` mapping to `str | None`,
+plus an optional `env` mapping to `dict[str, str]`). Mirrors the
+`aorta.workloads` extension-point pattern.
 """
 
 from importlib.metadata import entry_points
 from pathlib import Path
+from typing import TypedDict
 
 from aorta.registry.errors import (
     RegistryCollisionError,
@@ -28,13 +31,57 @@ _GROUP = "aorta.environments"
 # `emulator` / `mirage_profile` add a GPU-emulated baseline axis (mirage +
 # rocjitsu) so workloads can run with no physical GPU. Order in the frozenset
 # is irrelevant; spelled this way for grep-ability.
+#
+# NOTE: `env` (baseline env-var mapping) is a valid top-level key too, but it
+# is validated separately (`_validate_env_mapping`) because its value is a
+# nested `dict[str, str]`, not the `str | None` shape the recipe keys share.
+# `_VALID_ENV_KEYS` therefore lists only the `str | None` recipe keys; the
+# allowed-key check unions in `env` explicitly.
 _VALID_ENV_KEYS = frozenset({"docker", "venv", "buck_target", "emulator", "mirage_profile"})
+_ALLOWED_ENV_TOP_LEVEL = _VALID_ENV_KEYS | {"env"}
+
+
+class _EnvironmentPayload(TypedDict, total=False):
+    docker: str | None
+    venv: str | None
+    buck_target: str | None
+    emulator: str | None
+    mirage_profile: str | None
+    env: dict[str, str]
+
+
+def _validate_env_mapping(source_hint: str, name: str, raw: object) -> dict[str, str]:
+    """Validate an environment payload's ``env`` mapping into ``dict[str, str]``.
+
+    ``env`` is the baseline env-var overlay for an environment (lowest layer of
+    the platform env contract). Keys AND values must be strings -- numbers /
+    booleans are rejected rather than silently ``str()``-coerced, mirroring the
+    mitigation-sidecar and recipe ``extra_env`` rules so the same value in a
+    YAML/JSON number position fails everywhere consistently. Returns a fresh
+    ``dict`` (the ``Environment`` constructor deep-copies again defensively).
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RegistryError(
+            f"{source_hint} environment '{name}': 'env' must be a mapping of "
+            f"str -> str, got {type(raw).__name__}"
+        )
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise RegistryError(
+                f"{source_hint} environment '{name}': 'env' keys and values must "
+                f"be strings, got {type(k).__name__} -> {type(v).__name__}"
+            )
+        out[k] = v
+    return out
 
 # Built-in environments. `local` and `default` are both "current process, no
 # overrides" — `default` is reserved as a site-configurable alias. Customer
 # docker recipes ship from downstream private packages via the
 # `aorta.environments` entry-point group, NOT here.
-BUILTIN_ENVIRONMENTS: dict[str, dict[str, str | None]] = {
+BUILTIN_ENVIRONMENTS: dict[str, _EnvironmentPayload] = {
     "local":   {},
     "default": {},
     # GPU-emulated baseline: run the workload under the mirage control plane +
@@ -70,8 +117,9 @@ def load_environments(
         RegistryCollisionError: two contributors registered the same environment name.
         RegistryError: a plugin's payload was not a dict, contained keys outside
             ``_VALID_ENV_KEYS`` (``docker``, ``venv``, ``buck_target``,
-            ``emulator``, ``mirage_profile``), or had non-``str | None`` values;
-            or a sidecar file failed schema validation.
+            ``emulator``, ``mirage_profile``, ``env``), had non-``str | None``
+            launch-hint values, had a malformed ``dict[str, str]`` ``env``
+            mapping, or a sidecar file failed schema validation.
     """
     registry: dict[str, Environment] = {
         name: Environment(
@@ -82,6 +130,7 @@ def load_environments(
             emulator=spec.get("emulator"),
             mirage_profile=spec.get("mirage_profile"),
             source_package="aorta",
+            env=_validate_env_mapping("built-in", name, spec.get("env")),
         )
         for name, spec in BUILTIN_ENVIRONMENTS.items()
     }
@@ -99,21 +148,29 @@ def load_environments(
             raise RegistryError(
                 f"plugin '{plugin_name}' environment '{ep.name}' has non-string "
                 f"keys {[repr(k) for k in non_string_keys]}; allowed keys: "
-                f"{sorted(_VALID_ENV_KEYS)}"
+                f"{sorted(_ALLOWED_ENV_TOP_LEVEL)}"
             )
-        invalid = set(spec) - _VALID_ENV_KEYS
+        invalid = set(spec) - _ALLOWED_ENV_TOP_LEVEL
         if invalid:
             raise RegistryError(
                 f"plugin '{plugin_name}' environment '{ep.name}' has invalid "
-                f"keys {sorted(invalid)}; allowed keys: {sorted(_VALID_ENV_KEYS)}"
+                f"keys {sorted(invalid)}; allowed keys: {sorted(_ALLOWED_ENV_TOP_LEVEL)}"
             )
-        bad_values = {k: v for k, v in spec.items() if v is not None and not isinstance(v, str)}
+        # ``env`` is validated separately (nested mapping); exclude it from the
+        # ``str | None`` recipe-key value check so a valid ``env`` dict doesn't
+        # trip the "non-string values" guard.
+        bad_values = {
+            k: v
+            for k, v in spec.items()
+            if k != "env" and v is not None and not isinstance(v, str)
+        }
         if bad_values:
             raise RegistryError(
                 f"plugin '{plugin_name}' environment '{ep.name}' has non-string values "
                 f"{ {k: type(v).__name__ for k, v in bad_values.items()} }; "
                 f"each value must be `str | None`"
             )
+        env_mapping = _validate_env_mapping(f"plugin '{plugin_name}'", ep.name, spec.get("env"))
         if ep.name in registry:
             existing = registry[ep.name].source_package
             raise RegistryCollisionError(
@@ -128,6 +185,7 @@ def load_environments(
             emulator=spec.get("emulator"),
             mirage_profile=spec.get("mirage_profile"),
             source_package=plugin_name,
+            env=env_mapping,
         )
 
     check_sidecar_basenames(extra_files)

--- a/src/aorta/registry/environments.py
+++ b/src/aorta/registry/environments.py
@@ -18,6 +18,7 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from typing import TypedDict
 
+from aorta._env_rules import is_valid_env_name, value_has_nul
 from aorta.registry.errors import (
     RegistryCollisionError,
     RegistryError,
@@ -57,8 +58,12 @@ def _validate_env_mapping(source_hint: str, name: str, raw: object) -> dict[str,
     the platform env contract). Keys AND values must be strings -- numbers /
     booleans are rejected rather than silently ``str()``-coerced, mirroring the
     mitigation-sidecar and recipe ``extra_env`` rules so the same value in a
-    YAML/JSON number position fails everywhere consistently. Returns a fresh
-    ``dict`` (the ``Environment`` constructor deep-copies again defensively).
+    YAML/JSON number position fails everywhere consistently. Env-var NAME shape
+    and NUL-in-VALUE are enforced here too (via the shared ``aorta._env_rules``
+    predicates): a NAMED environment bypasses the recipe parser entirely, so
+    without this a malformed name or NUL value would pass loading / ``--dry-run``
+    and only fail per-cell at run time. Returns a fresh ``dict`` (the
+    ``Environment`` constructor deep-copies again defensively).
     """
     if raw is None:
         return {}
@@ -73,6 +78,19 @@ def _validate_env_mapping(source_hint: str, name: str, raw: object) -> dict[str,
             raise RegistryError(
                 f"{source_hint} environment '{name}': 'env' keys and values must "
                 f"be strings, got {type(k).__name__} -> {type(v).__name__}"
+            )
+        if not is_valid_env_name(k):
+            raise RegistryError(
+                f"{source_hint} environment '{name}': 'env' has invalid "
+                f"environment-variable name {k!r}; expected "
+                "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
+            )
+        if value_has_nul(v):
+            # Value NOT echoed -- it may be a secret.
+            raise RegistryError(
+                f"{source_hint} environment '{name}': 'env' value for key {k!r} "
+                "contains a NUL byte and cannot be stored in an environment "
+                "variable."
             )
         out[k] = v
     return out

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -126,13 +126,27 @@ def load_mitigations(
     for ep in entry_points(group=_GROUP):
         env = ep.load()
         plugin_name = ep.dist.name
-        if not isinstance(env, dict) or not all(
-            isinstance(k, str) and isinstance(v, str) for k, v in env.items()
-        ):
+        if not isinstance(env, dict):
             raise RegistryError(
                 f"plugin '{plugin_name}' mitigation '{ep.name}' must resolve to "
                 f"dict[str, str]; got {type(env).__name__}"
-                + (f" with non-string entries {dict(env)!r}" if isinstance(env, dict) else "")
+            )
+        invalid_entries = [
+            (
+                key if isinstance(key, str) else f"<{type(key).__name__} key>",
+                type(key).__name__,
+                type(value).__name__,
+            )
+            for key, value in env.items()
+            if not isinstance(key, str) or not isinstance(value, str)
+        ]
+        if invalid_entries:
+            # Values may be credentials. Report only the key (or key type) and
+            # key/value types; never repr the payload or an offending value.
+            raise RegistryError(
+                f"plugin '{plugin_name}' mitigation '{ep.name}' must resolve to "
+                "dict[str, str]; invalid entries "
+                f"(key, key type, value type): {invalid_entries!r}"
             )
         # Enforce the env-var name/NUL rules at this declaration boundary too --
         # a plugin mitigation bundle otherwise reaches ``os.environ.update`` in

--- a/src/aorta/registry/mitigations.py
+++ b/src/aorta/registry/mitigations.py
@@ -13,6 +13,7 @@ the existing `aorta.workloads` extension-point pattern.
 from importlib.metadata import entry_points
 from pathlib import Path
 
+from aorta._env_rules import is_valid_env_name, value_has_nul
 from aorta.registry.errors import (
     RegistryCollisionError,
     RegistryError,
@@ -133,6 +134,22 @@ def load_mitigations(
                 f"dict[str, str]; got {type(env).__name__}"
                 + (f" with non-string entries {dict(env)!r}" if isinstance(env, dict) else "")
             )
+        # Enforce the env-var name/NUL rules at this declaration boundary too --
+        # a plugin mitigation bundle otherwise reaches ``os.environ.update`` in
+        # the dispatcher and only fails there. Values are NOT echoed.
+        for k, v in env.items():
+            if not is_valid_env_name(k):
+                raise RegistryError(
+                    f"plugin '{plugin_name}' mitigation '{ep.name}': invalid "
+                    f"environment-variable name {k!r}; expected "
+                    "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
+                )
+            if value_has_nul(v):
+                raise RegistryError(
+                    f"plugin '{plugin_name}' mitigation '{ep.name}': value for "
+                    f"key {k!r} contains a NUL byte and cannot be stored in an "
+                    "environment variable."
+                )
         if ep.name in registry:
             existing = registry[ep.name].source_package
             raise RegistryCollisionError(

--- a/src/aorta/registry/sidecar.py
+++ b/src/aorta/registry/sidecar.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from aorta._env_rules import is_valid_env_name, value_has_nul
 from aorta.registry.errors import RegistryError
 from aorta.registry.types import Environment, Mitigation
 
@@ -163,7 +164,11 @@ def _validate_sidecar_env_mapping(path: Path, name: str, raw: object) -> dict[st
 
     Keys AND values must be strings (no number/boolean coercion), matching the
     entry-point loader and recipe ``extra_env`` rules so the same YAML/JSON
-    value fails everywhere consistently.
+    value fails everywhere consistently. Env-var NAME shape and NUL-in-VALUE are
+    enforced too (via the shared ``aorta._env_rules`` predicates): a named
+    sidecar environment bypasses the recipe parser, so without this a malformed
+    name or NUL value would pass loading / ``--dry-run`` and only fail per-cell
+    at run time.
     """
     if raw is None:
         return {}
@@ -186,6 +191,18 @@ def _validate_sidecar_env_mapping(path: Path, name: str, raw: object) -> dict[st
             raise RegistryError(
                 f"sidecar {path}: environments.{name}.env.{k}: env var value must "
                 f"be string, got {type(v).__name__}"
+            )
+        if not is_valid_env_name(k):
+            raise RegistryError(
+                f"sidecar {path}: environments.{name}.env: invalid "
+                f"environment-variable name {k!r}; expected "
+                "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
+            )
+        if value_has_nul(v):
+            # Value NOT echoed -- it may be a secret.
+            raise RegistryError(
+                f"sidecar {path}: environments.{name}.env.{k}: value contains a "
+                "NUL byte and cannot be stored in an environment variable."
             )
         out[k] = v
     return out

--- a/src/aorta/registry/sidecar.py
+++ b/src/aorta/registry/sidecar.py
@@ -123,6 +123,18 @@ def _validate_mitigation_payload(path: Path, name: str, payload: object) -> dict
                 f"sidecar {path}: mitigations.{name}.{k}: env var value must "
                 f"be string, got {type(v).__name__}"
             )
+        if not is_valid_env_name(k):
+            raise RegistryError(
+                f"sidecar {path}: mitigations.{name}: invalid "
+                f"environment-variable name {k!r}; expected "
+                "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
+            )
+        if value_has_nul(v):
+            # Value NOT echoed -- it may be a secret.
+            raise RegistryError(
+                f"sidecar {path}: mitigations.{name}.{k}: value contains a "
+                "NUL byte and cannot be stored in an environment variable."
+            )
     return dict(payload)
 
 

--- a/src/aorta/registry/sidecar.py
+++ b/src/aorta/registry/sidecar.py
@@ -24,7 +24,11 @@ _VALID_TOP_LEVEL = frozenset({"version", "mitigations", "environments"})
 # allow-lists are intentionally identical so sidecar payloads and entry-point
 # payloads accept the same schema. `buck_target` peers `docker` / `venv` per #182;
 # `emulator` / `mirage_profile` add the GPU-emulated (mirage) baseline axis.
+# `env` (a nested `dict[str, str]` baseline env-var overlay) is a valid top-level
+# key too, validated separately because its value shape differs from the
+# `str | None` recipe keys; `_ALLOWED_ENV_TOP_LEVEL` is the full allow-list.
 _VALID_ENV_KEYS = frozenset({"docker", "venv", "buck_target", "emulator", "mirage_profile"})
+_ALLOWED_ENV_TOP_LEVEL = _VALID_ENV_KEYS | {"env"}
 
 
 def _source_tag(path: Path) -> str:
@@ -111,14 +115,17 @@ def _validate_mitigation_payload(path: Path, name: str, payload: object) -> dict
                 f"string, got {type(k).__name__} ({k!r})"
             )
         if not isinstance(v, str):
+            # Do NOT echo the value -- env-var values may carry secrets
+            # (tokens, endpoints). Report only the offending key + type,
+            # matching the dispatcher / recipe env validators.
             raise RegistryError(
                 f"sidecar {path}: mitigations.{name}.{k}: env var value must "
-                f"be string, got {type(v).__name__} ({v!r})"
+                f"be string, got {type(v).__name__}"
             )
     return dict(payload)
 
 
-def _validate_environment_payload(path: Path, name: str, payload: object) -> dict[str, str | None]:
+def _validate_environment_payload(path: Path, name: str, payload: object) -> dict[str, object]:
     if not isinstance(payload, dict):
         raise RegistryError(
             f"sidecar {path}: environments.{name}: must be an object, "
@@ -128,21 +135,60 @@ def _validate_environment_payload(path: Path, name: str, payload: object) -> dic
     if non_string_keys:
         raise RegistryError(
             f"sidecar {path}: environments.{name}: non-string keys "
-            f"{[repr(k) for k in non_string_keys]}; allowed: {sorted(_VALID_ENV_KEYS)}"
+            f"{[repr(k) for k in non_string_keys]}; allowed: {sorted(_ALLOWED_ENV_TOP_LEVEL)}"
         )
-    invalid = set(payload) - _VALID_ENV_KEYS
+    invalid = set(payload) - _ALLOWED_ENV_TOP_LEVEL
     if invalid:
         raise RegistryError(
             f"sidecar {path}: environments.{name}: invalid keys "
-            f"{sorted(invalid)}; allowed: {sorted(_VALID_ENV_KEYS)}"
+            f"{sorted(invalid)}; allowed: {sorted(_ALLOWED_ENV_TOP_LEVEL)}"
         )
     for k, v in payload.items():
+        # ``env`` is a nested mapping validated below; the other keys are the
+        # ``str | None`` recipe slots.
+        if k == "env":
+            continue
         if v is not None and not isinstance(v, str):
             raise RegistryError(
                 f"sidecar {path}: environments.{name}.{k}: value must be "
                 f"string or null, got {type(v).__name__} ({v!r})"
             )
+    if "env" in payload:
+        payload = {**payload, "env": _validate_sidecar_env_mapping(path, name, payload["env"])}
     return dict(payload)
+
+
+def _validate_sidecar_env_mapping(path: Path, name: str, raw: object) -> dict[str, str]:
+    """Validate an ``env`` baseline mapping in a sidecar environment payload.
+
+    Keys AND values must be strings (no number/boolean coercion), matching the
+    entry-point loader and recipe ``extra_env`` rules so the same YAML/JSON
+    value fails everywhere consistently.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RegistryError(
+            f"sidecar {path}: environments.{name}.env: must be an object of "
+            f"env vars, got {type(raw).__name__}"
+        )
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        if not isinstance(k, str):
+            raise RegistryError(
+                f"sidecar {path}: environments.{name}.env: env var name must be "
+                f"string, got {type(k).__name__} ({k!r})"
+            )
+        if not isinstance(v, str):
+            # Do NOT echo the value -- env-var values may carry secrets
+            # (tokens, endpoints). Report only the offending key + type,
+            # matching the dispatcher / recipe env validators.
+            raise RegistryError(
+                f"sidecar {path}: environments.{name}.env.{k}: env var value must "
+                f"be string, got {type(v).__name__}"
+            )
+        out[k] = v
+    return out
 
 
 def load_sidecar_mitigations(path: Path) -> dict[str, Mitigation]:
@@ -198,11 +244,12 @@ def load_sidecar_environments(path: Path) -> dict[str, Environment]:
         spec = _validate_environment_payload(path, name, payload)
         out[name] = Environment(
             name=name,
-            docker=spec.get("docker"),
-            venv=spec.get("venv"),
-            buck_target=spec.get("buck_target"),
-            emulator=spec.get("emulator"),
-            mirage_profile=spec.get("mirage_profile"),
+            docker=spec.get("docker"),  # type: ignore[arg-type]
+            venv=spec.get("venv"),  # type: ignore[arg-type]
+            buck_target=spec.get("buck_target"),  # type: ignore[arg-type]
+            emulator=spec.get("emulator"),  # type: ignore[arg-type]
+            mirage_profile=spec.get("mirage_profile"),  # type: ignore[arg-type]
             source_package=src,
+            env=spec.get("env") or {},  # type: ignore[arg-type]
         )
     return out

--- a/src/aorta/registry/types.py
+++ b/src/aorta/registry/types.py
@@ -1,6 +1,7 @@
 """Data types for the mitigations + environments registry."""
 
-from dataclasses import dataclass
+import copy
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -48,6 +49,15 @@ class Environment:
     `_aorta_environment`; an emulation-aware launch backend decides how to
     launch (e.g. `mirage run --profile <p> -- <argv>`, or an `LD_PRELOAD` env
     overlay). The platform itself launches nothing.
+
+    `env` is a mapping of baseline environment variables intrinsic to this
+    environment -- the lowest layer of the platform-wide env contract
+    (`Environment.env < mitigations < recipe extra_env < cell/CLI extra_env`;
+    see the dispatcher). Empty by default so every plugin / sidecar that omits
+    it round-trips unchanged. Values are kept strictly `str`; the loaders do
+    NOT coerce YAML/JSON numbers or booleans. Defensively deep-copied on
+    construction (`frozen=True` blocks attribute reassignment but not mutation
+    of the mapping in place), mirroring the `RunRequest` pattern.
     """
 
     name: str
@@ -57,3 +67,11 @@ class Environment:
     emulator: str | None = None
     mirage_profile: str | None = None
     source_package: str = "aorta"
+    env: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # ``frozen=True`` blocks reassigning ``self.env`` but not mutating the
+        # passed-in dict in place. Deep-copy via ``object.__setattr__`` so a
+        # caller cannot mutate an environment's baseline env after construction
+        # (same defensive pattern as ``RunRequest.__post_init__``).
+        object.__setattr__(self, "env", copy.deepcopy(self.env))

--- a/src/aorta/run/__init__.py
+++ b/src/aorta/run/__init__.py
@@ -8,6 +8,8 @@ Public API:
     run_trials(request: RunRequest) -> list[TrialResult]
     RunRequest: Configuration for a run
     TrialResult: Per-trial result wrapper
+    docker_env_flags(env): Deterministic Docker ``-e KEY=VALUE`` tokens for
+        the controlled ``config["_aorta_trial_env"]`` overlay
 
 Example:
     from aorta.run import run_trials, RunRequest
@@ -23,6 +25,7 @@ Example:
 """
 
 from aorta.run.dispatcher import RunRequest, run_trials
+from aorta.run.docker import docker_env_flags
 from aorta.run.results import TrialResult
 
-__all__ = ["RunRequest", "TrialResult", "run_trials"]
+__all__ = ["RunRequest", "TrialResult", "docker_env_flags", "run_trials"]

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -52,6 +52,18 @@ def _validate_env_mapping(label: str, env: object) -> None:
                 f"{label} value for key {key!r} must be str, "
                 f"got {type(value).__name__}"
             )
+        if "\x00" in value:
+            # A NUL byte is a valid Python str character but cannot be stored
+            # in an OS environment variable. ``os.environ.update`` applies the
+            # overlay entry-by-entry, so a NUL value part-way through would
+            # raise AFTER earlier entries are already set -- and the overlay is
+            # applied via a single ``update`` that lives OUTSIDE the try/finally
+            # restore block, so those earlier entries would leak into later
+            # matrix cells. Reject before any mutation. Value is NOT echoed.
+            raise ValueError(
+                f"{label} value for key {key!r} contains a NUL byte and cannot "
+                "be stored in an environment variable."
+            )
         if not _ENV_KEY_RE.fullmatch(key):
             raise ValueError(
                 f"Invalid {label} keys [{key!r}]: each key must match "

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -446,12 +446,13 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     # 7-env. Validate the resolved environment's baseline ``env`` mapping.
     #     ``Environment.env`` is the lowest layer of the platform env
     #     contract and is applied to ``os.environ`` before the workload runs
-    #     (see ``_run_single_trial``). The registry loaders already enforce
-    #     ``str`` keys/values, but not POSIX env-var *name shape* -- so a
-    #     malformed key (e.g. ``"1BAD"`` or ``"has space"``) would otherwise
-    #     only surface deep inside ``os.environ.update`` with the opaque
-    #     ``ValueError: illegal environment variable name``. Re-validate here,
-    #     before any trial runs, for parity with the ``extra_env`` check above.
+    #     (see ``_run_single_trial``). The registry loaders already validate
+    #     name shape + NUL for env declared through them; this re-check is
+    #     defense-in-depth for ``Environment`` objects constructed
+    #     programmatically (which bypass the loaders), so a malformed key or
+    #     value never reaches ``os.environ.update`` with the opaque
+    #     ``ValueError: illegal environment variable name``. Same rule set as
+    #     the ``extra_env`` check above.
     _validate_env_mapping("Environment.env", env_descriptor.env)
 
     # 7a. Apply the per-axis runtime overrides (if any) AFTER

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -13,12 +13,12 @@ import copy
 import json
 import logging
 import os
-import re
 import time
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
+from aorta._env_rules import is_valid_env_name, value_has_nul
 from aorta.instrumentation.environment import collect_env
 from aorta.registry import Environment, get_environment, get_mitigation
 from aorta.run.collectors import KNOWN_RECIPES
@@ -29,15 +29,15 @@ from aorta.workloads import Workload, WorkloadResult
 
 logger = logging.getLogger(__name__)
 
-# Conservative POSIX env-var name shape: must start with a letter or
-# underscore and contain only [A-Za-z0-9_].  The CLI also enforces this
-# at parse time; library callers pass ``extra_env`` directly so we
-# re-validate here for parity.
-_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
 
 def _validate_env_mapping(label: str, env: object) -> None:
-    """Validate a controlled environment overlay without exposing values."""
+    """Validate a controlled environment overlay without exposing values.
+
+    Name shape and NUL-in-value rules come from the shared ``aorta._env_rules``
+    predicates (the single source of truth also used by the recipe parser and
+    the registry loaders). The CLI enforces the same at parse time; library
+    callers pass ``extra_env`` directly so we re-validate here for parity.
+    """
     if not isinstance(env, dict):
         raise ValueError(
             f"{label} must be a dict[str, str], got {type(env).__name__}"
@@ -52,7 +52,7 @@ def _validate_env_mapping(label: str, env: object) -> None:
                 f"{label} value for key {key!r} must be str, "
                 f"got {type(value).__name__}"
             )
-        if "\x00" in value:
+        if value_has_nul(value):
             # A NUL byte is a valid Python str character but cannot be stored
             # in an OS environment variable. ``os.environ.update`` applies the
             # overlay entry-by-entry, so a NUL value part-way through would
@@ -64,7 +64,7 @@ def _validate_env_mapping(label: str, env: object) -> None:
                 f"{label} value for key {key!r} contains a NUL byte and cannot "
                 "be stored in an environment variable."
             )
-        if not _ENV_KEY_RE.fullmatch(key):
+        if not is_valid_env_name(key):
             raise ValueError(
                 f"Invalid {label} keys [{key!r}]: each key must match "
                 "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -803,11 +803,12 @@ def _run_single_trial(
     # introduced by ``setup()`` / ``run()``.
     pre_trial_env = dict(os.environ)
 
-    # Apply the effective overlay BEFORE the env snapshot.  The snapshot is
-    # supposed to describe the actual environment the workload ran under --
-    # including the environment's baseline vars, operator overrides like
-    # ``HSA_XNACK=1`` from a mitigation, and one-off ``DISABLE_TF32=1`` from
-    # ``--extra-env``.  Capturing pre-override loses that signal for
+    # Apply the effective overlay BEFORE collecting ``env_snapshot`` below.
+    # Unlike ``pre_trial_env`` above (the pre-overlay restore point), that
+    # snapshot is supposed to describe the actual environment the workload ran
+    # under -- including the environment's baseline vars, operator overrides
+    # like ``HSA_XNACK=1`` from a mitigation, and one-off ``DISABLE_TF32=1``
+    # from ``--extra-env``. Capturing it pre-override loses that signal for
     # reproducibility / debugging. A single ``update`` from the pre-merged
     # overlay applies all three layers in their resolved precedence.
     os.environ.update(effective_overlay)

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -36,6 +36,29 @@ logger = logging.getLogger(__name__)
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+def _validate_env_mapping(label: str, env: object) -> None:
+    """Validate a controlled environment overlay without exposing values."""
+    if not isinstance(env, dict):
+        raise ValueError(
+            f"{label} must be a dict[str, str], got {type(env).__name__}"
+        )
+    for key, value in env.items():
+        if not isinstance(key, str):
+            raise ValueError(
+                f"{label} keys must be str, got {type(key).__name__}"
+            )
+        if not isinstance(value, str):
+            raise ValueError(
+                f"{label} value for key {key!r} must be str, "
+                f"got {type(value).__name__}"
+            )
+        if not _ENV_KEY_RE.fullmatch(key):
+            raise ValueError(
+                f"Invalid {label} keys [{key!r}]: each key must match "
+                "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
+            )
+
+
 @dataclass(frozen=True)
 class RunRequest:
     """Configuration for a run_trials() invocation.
@@ -359,17 +382,10 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
             f"{bad_collect_options}"
         )
 
-    # 3. Validate ``extra_env`` keys.  The CLI validates this at parse
-    #    time, but library callers (B2, future programmatic users) pass
-    #    ``extra_env`` directly -- without parity here, a bad key would
-    #    only fail mid-trial inside ``os.environ.update`` with the much
-    #    less friendly ``ValueError: illegal environment variable name``.
-    bad_keys = [k for k in request.extra_env if not _ENV_KEY_RE.match(k)]
-    if bad_keys:
-        raise ValueError(
-            f"Invalid extra_env keys {bad_keys}: each key must match "
-            "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
-        )
+    # 3. Validate ``extra_env``. The CLI and recipe loader validate their
+    #    inputs, but library callers can construct ``RunRequest`` directly.
+    #    Fail before mutating ``os.environ`` and never include values in errors.
+    _validate_env_mapping("extra_env", request.extra_env)
 
     # Validate ``env_probe`` shape early.  The triage runner is the only
     # in-tree producer and always passes ``{"src": str, "out": str}``, but
@@ -415,6 +431,17 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     sidecar_files = list(request.sidecar_files) or None
     env_descriptor = get_environment(request.environment, extra_files=sidecar_files)
 
+    # 7-env. Validate the resolved environment's baseline ``env`` mapping.
+    #     ``Environment.env`` is the lowest layer of the platform env
+    #     contract and is applied to ``os.environ`` before the workload runs
+    #     (see ``_run_single_trial``). The registry loaders already enforce
+    #     ``str`` keys/values, but not POSIX env-var *name shape* -- so a
+    #     malformed key (e.g. ``"1BAD"`` or ``"has space"``) would otherwise
+    #     only surface deep inside ``os.environ.update`` with the opaque
+    #     ``ValueError: illegal environment variable name``. Re-validate here,
+    #     before any trial runs, for parity with the ``extra_env`` check above.
+    _validate_env_mapping("Environment.env", env_descriptor.env)
+
     # 7a. Apply the per-axis runtime overrides (if any) AFTER
     #     resolving the named environment, so the named env's other
     #     fields (``venv`` / ``source_package`` / the axes not being
@@ -450,6 +477,7 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     mitigation_env: dict[str, str] = {}
     for name in request.mitigations:
         mitigation_env.update(get_mitigation(name, extra_files=sidecar_files))
+    _validate_env_mapping("mitigation environment", mitigation_env)
 
     # 9. Determine if we should write (rank 0 only for distributed).
     #    Only rank 0 needs the output directory; creating it on every
@@ -728,19 +756,48 @@ def _run_single_trial(
         )
         config["_aorta_collect_dir"] = str((results_dir / trial_basename).absolute())
 
-    # Snapshot the env BEFORE applying mitigation / extra_env so the
-    # ``finally`` block can restore both the dispatcher's overlay and
-    # any workload-side mutations introduced by ``setup()`` / ``run()``.
+    # Compute the effective controlled overlay in the platform env-precedence
+    # order (lowest to highest):
+    #
+    #     Environment.env  <  mitigations  <  request.extra_env
+    #
+    # ``request.extra_env`` already carries the recipe-level + cell-level (or
+    # direct-CLI ``--extra-env``) merge -- the runner unions those before
+    # constructing the request, and direct ``aorta run --extra-env`` lands here
+    # too -- so this single mapping is the top layer. The overlay contains ONLY
+    # variables contributed by these three controlled sources; it is NEVER
+    # populated from the ambient ``os.environ``. This is the exact bundle
+    # threaded to workloads as ``config['_aorta_trial_env']`` (below) so a
+    # Docker-aware wrapper can forward precisely these vars into its container.
+    effective_overlay: dict[str, str] = {}
+    effective_overlay.update(env_descriptor.env)
+    effective_overlay.update(mitigation_env)
+    effective_overlay.update(request.extra_env)
+
+    # Thread the controlled overlay into the workload config under a reserved
+    # key so a self-isolating wrapper (docker/venv/buck) can forward exactly
+    # these vars -- and only these -- across the isolation boundary via the
+    # shared ``aorta.run.docker_env_flags`` helper. Injected AFTER the
+    # ``config_overrides`` spread (like the other ``_aorta_*`` keys) so the
+    # reserved-key rejection at the top of ``run_trials`` guards the slot.
+    # Always a plain ``dict[str, str]`` (JSON-safe; recorded verbatim in the
+    # trial-JSON ``config``). Empty when no controlled source contributed --
+    # back-compat with every existing run. Values are deliberately NOT logged.
+    config["_aorta_trial_env"] = dict(effective_overlay)
+
+    # Snapshot the env BEFORE applying the overlay so the ``finally`` block can
+    # restore both the dispatcher's overlay and any workload-side mutations
+    # introduced by ``setup()`` / ``run()``.
     pre_trial_env = dict(os.environ)
 
-    # Apply mitigation env + extra_env BEFORE the env snapshot.  The
-    # snapshot is supposed to describe the actual environment the
-    # workload ran under -- including operator overrides like
-    # ``HSA_XNACK=1`` from a mitigation or one-off ``DISABLE_TF32=1``
-    # from ``--extra-env``.  Capturing pre-override loses that signal
-    # for reproducibility / debugging.
-    os.environ.update(mitigation_env)
-    os.environ.update(request.extra_env)
+    # Apply the effective overlay BEFORE the env snapshot.  The snapshot is
+    # supposed to describe the actual environment the workload ran under --
+    # including the environment's baseline vars, operator overrides like
+    # ``HSA_XNACK=1`` from a mitigation, and one-off ``DISABLE_TF32=1`` from
+    # ``--extra-env``.  Capturing pre-override loses that signal for
+    # reproducibility / debugging. A single ``update`` from the pre-merged
+    # overlay applies all three layers in their resolved precedence.
+    os.environ.update(effective_overlay)
 
     # Capture environment snapshot AFTER env-var application.
     # ``collect_env`` is fail-soft and never raises (see A1 docs).

--- a/src/aorta/run/docker.py
+++ b/src/aorta/run/docker.py
@@ -1,0 +1,84 @@
+"""Shared Docker env-forwarding helper for workload wrappers.
+
+The platform does NOT launch Docker -- workload wrappers own their ``docker
+run`` invocation (mounts, devices, entrypoints, shared memory, inner command).
+This module provides the one piece those wrappers should share: turning a
+controlled env-var mapping into ``-e KEY=VALUE`` flags, so every wrapper
+forwards the platform's ``config['_aorta_trial_env']`` overlay the same way.
+
+Deliberately narrow: it accepts an explicit mapping, never reads ``os.environ``,
+and returns a flat ``list[str]`` the wrapper splices into its argv. Keeping the
+launch logic (image selection, mounts, `--device`, `--ipc`, `--shm-size`, the
+inner command) in the wrapper preserves the platform's no-Docker-launching
+policy -- this helper is env-forwarding only.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Same POSIX env-var name shape the dispatcher enforces on ``extra_env`` /
+# ``Environment.env`` (``aorta.run.dispatcher._ENV_KEY_RE``). Duplicated here
+# (rather than imported) so this leaf helper has no dependency on the
+# dispatcher module -- a wrapper can import ``docker_env_flags`` without pulling
+# in the whole run-orchestration graph.
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def docker_env_flags(env: dict[str, str]) -> list[str]:
+    """Turn a controlled env mapping into ``docker run`` ``-e KEY=VALUE`` flags.
+
+    Args:
+        env: An explicit ``dict[str, str]`` of environment variables to forward
+            -- typically the platform-supplied ``config['_aorta_trial_env']``
+            overlay. Only these vars are forwarded; the helper NEVER reads
+            ``os.environ``, so a wrapper cannot accidentally leak the ambient
+            host environment into the container.
+
+    Returns:
+        A flat ``list[str]`` of alternating ``"-e"`` / ``"KEY=VALUE"`` tokens,
+        ready to splice into a ``docker run`` argv. Deterministic: keys are
+        emitted in sorted order so the same mapping always yields byte-identical
+        output (stable argv for logging, diffing, and test assertions).
+
+    Raises:
+        TypeError: ``env`` is not a mapping, or any key/value is not a ``str``.
+        ValueError: a key is not a valid POSIX env-var name
+            (``[A-Za-z_][A-Za-z0-9_]*``). The offending key is named; VALUES
+            are never echoed in the error (they may be secrets).
+    """
+    if not isinstance(env, dict):
+        raise TypeError(
+            f"docker_env_flags() expects a dict[str, str], got {type(env).__name__}"
+        )
+    # Validate before sorting. A mixed-type key set such as
+    # ``{"GOOD": "1", 2: "bad"}`` otherwise fails inside ``sorted`` with an
+    # implementation-level comparison error instead of this API's clear,
+    # value-redacting validation error.
+    for key, value in env.items():
+        if not isinstance(key, str):
+            raise TypeError(
+                f"docker_env_flags() env keys must be str, got {type(key).__name__}"
+            )
+        if not isinstance(value, str):
+            # Do NOT include the value in the message -- only its type. Values
+            # may carry secrets (tokens, endpoints).
+            raise TypeError(
+                f"docker_env_flags() env value for key {key!r} must be str, "
+                f"got {type(value).__name__}"
+            )
+        if not _ENV_KEY_RE.fullmatch(key):
+            raise ValueError(
+                f"docker_env_flags() invalid env-var name {key!r}: must match "
+                "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
+            )
+
+    flags: list[str] = []
+    for key in sorted(env):
+        value = env[key]
+        flags.append("-e")
+        flags.append(f"{key}={value}")
+    return flags
+
+
+__all__ = ["docker_env_flags"]

--- a/src/aorta/run/docker.py
+++ b/src/aorta/run/docker.py
@@ -15,14 +15,11 @@ policy -- this helper is env-forwarding only.
 
 from __future__ import annotations
 
-import re
-
-# Same POSIX env-var name shape the dispatcher enforces on ``extra_env`` /
-# ``Environment.env`` (``aorta.run.dispatcher._ENV_KEY_RE``). Duplicated here
-# (rather than imported) so this leaf helper has no dependency on the
-# dispatcher module -- a wrapper can import ``docker_env_flags`` without pulling
-# in the whole run-orchestration graph.
-_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Name-shape and NUL rules come from the shared ``aorta._env_rules`` leaf module
+# -- the single source of truth also used by the dispatcher, the recipe parser,
+# and the registry loaders. ``_env_rules`` has NO aorta imports, so a wrapper can
+# import ``docker_env_flags`` without pulling in the run-orchestration graph.
+from aorta._env_rules import is_valid_env_name, value_has_nul
 
 
 def docker_env_flags(env: dict[str, str]) -> list[str]:
@@ -74,7 +71,7 @@ def docker_env_flags(env: dict[str, str]) -> list[str]:
                 f"docker_env_flags() env value for key {key!r} must be str, "
                 f"got {type(value).__name__}"
             )
-        if "\x00" in value:
+        if value_has_nul(value):
             # A NUL byte cannot round-trip through a ``docker run -e`` argument
             # (execve rejects it), so reject it here for parity with the
             # dispatcher's ``os.environ`` validation. Value is NOT echoed.
@@ -82,7 +79,7 @@ def docker_env_flags(env: dict[str, str]) -> list[str]:
                 f"docker_env_flags() env value for key {key!r} contains a NUL "
                 "byte and cannot be passed as an environment variable."
             )
-        if not _ENV_KEY_RE.fullmatch(key):
+        if not is_valid_env_name(key):
             raise ValueError(
                 f"docker_env_flags() invalid env-var name {key!r}: must match "
                 "[A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."

--- a/src/aorta/run/docker.py
+++ b/src/aorta/run/docker.py
@@ -39,13 +39,20 @@ def docker_env_flags(env: dict[str, str]) -> list[str]:
         A flat ``list[str]`` of alternating ``"-e"`` / ``"KEY=VALUE"`` tokens,
         ready to splice into a ``docker run`` argv. Deterministic: keys are
         emitted in sorted order so the same mapping always yields byte-identical
-        output (stable argv for logging, diffing, and test assertions).
+        output (stable for diffing and test assertions).
+
+        SECURITY: the ``KEY=VALUE`` tokens contain the RAW environment values,
+        which may be secrets (tokens, endpoints). Do NOT log the returned list
+        or any completed ``docker run`` argv built from it, and do not persist
+        it to run artifacts unless those artifacts are already treated as
+        sensitive.
 
     Raises:
         TypeError: ``env`` is not a mapping, or any key/value is not a ``str``.
         ValueError: a key is not a valid POSIX env-var name
-            (``[A-Za-z_][A-Za-z0-9_]*``). The offending key is named; VALUES
-            are never echoed in the error (they may be secrets).
+            (``[A-Za-z_][A-Za-z0-9_]*``), or a value contains a NUL byte. The
+            offending key is named; VALUES are never echoed in the error (they
+            may be secrets).
     """
     if not isinstance(env, dict):
         raise TypeError(
@@ -66,6 +73,14 @@ def docker_env_flags(env: dict[str, str]) -> list[str]:
             raise TypeError(
                 f"docker_env_flags() env value for key {key!r} must be str, "
                 f"got {type(value).__name__}"
+            )
+        if "\x00" in value:
+            # A NUL byte cannot round-trip through a ``docker run -e`` argument
+            # (execve rejects it), so reject it here for parity with the
+            # dispatcher's ``os.environ`` validation. Value is NOT echoed.
+            raise ValueError(
+                f"docker_env_flags() env value for key {key!r} contains a NUL "
+                "byte and cannot be passed as an environment variable."
             )
         if not _ENV_KEY_RE.fullmatch(key):
             raise ValueError(

--- a/src/aorta/triage/output.py
+++ b/src/aorta/triage/output.py
@@ -1348,12 +1348,17 @@ def write_resolved_recipe(
     """
     del sidecar_files  # see docstring; kept for caller-stable signature
 
-    inline_docker = {e.name: e.docker for e in recipe.inline_environments}
+    inline_by_name = {e.name: e for e in recipe.inline_environments}
 
     resolved_cells: list[dict[str, Any]] = []
     for cell in recipe.cells:
-        if cell.environment in inline_docker:
-            cell_env: Any = {"docker": inline_docker[cell.environment]}
+        if cell.environment in inline_by_name:
+            inline = inline_by_name[cell.environment]
+            cell_env: Any = {"docker": inline.docker}
+            # Re-emit inline baseline env only when non-empty so a legacy
+            # ``{docker: <ref>}`` cell round-trips to the identical shorthand.
+            if inline.env:
+                cell_env["env"] = dict(inline.env)
         else:
             cell_env = cell.environment
         cell_doc: dict[str, Any] = {
@@ -1396,6 +1401,13 @@ def write_resolved_recipe(
         # recipes that never used the field round-trip to byte-equivalent
         # YAML. Cell-scope values are written per cell above.
         doc["workload_config"] = dict(recipe.workload_config)
+    if recipe.extra_env:
+        # Recipe-scope env-var overlay -- emitted only when non-empty so
+        # recipes that never used the field round-trip to byte-equivalent YAML.
+        # Cell-scope extra_env is written per cell above; the runner merges
+        # recipe-scope under cell-scope at execution time, so preserving both
+        # scopes here keeps a round-trip load+run's effective env identical.
+        doc["extra_env"] = dict(recipe.extra_env)
     if recipe.collect:
         doc["collect"] = _collect_doc(recipe.collect, recipe.collect_options)
     doc["confound"] = {
@@ -1429,12 +1441,14 @@ def resolved_cell_environment(
     the shorthand needed to re-derive the same ``_inline_<hash>``.
     """
     extra = list(sidecar_files) if sidecar_files else None
-    inline_docker = {e.name: e.docker for e in inline_environments}
-    if cell_environment in inline_docker:
+    inline_by_name = {e.name: e for e in inline_environments}
+    if cell_environment in inline_by_name:
+        inline = inline_by_name[cell_environment]
         return {
             "name": cell_environment,
-            "docker": inline_docker[cell_environment],
+            "docker": inline.docker,
             "venv": None,
+            "env": dict(inline.env),
             "source_package": "_inline_",
             "inline": True,
         }
@@ -1443,6 +1457,7 @@ def resolved_cell_environment(
         "name": env_desc.name,
         "docker": env_desc.docker,
         "venv": env_desc.venv,
+        "env": dict(env_desc.env),
         "source_package": env_desc.source_package,
         "inline": False,
     }

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -56,6 +56,10 @@ _TRIAGE_TOP_LEVEL = frozenset(
         # Cross-cutting collector names attached to every cell (e.g.
         # layer_numerics). Not a matrix axis.
         "collect",
+        # Recipe-level env-var overlay applied to every cell, BELOW cell-level
+        # ``extra_env`` in precedence (see the dispatcher's effective-overlay
+        # contract). Not a matrix axis.
+        "extra_env",
         # Issue #232: collect-until-N stopping rule (valid in both modes).
         "stop_after",
     }
@@ -131,7 +135,7 @@ _VALID_CELL_KEYS = frozenset(
         "collect",
     }
 )
-_VALID_INLINE_ENV_KEYS = frozenset({"docker"})
+_VALID_INLINE_ENV_KEYS = frozenset({"docker", "env"})
 
 # Keys that workload_config (recipe- or cell-scope) is NOT allowed to set.
 # - "steps" is a first-class recipe/cell field; the dispatcher writes
@@ -167,16 +171,23 @@ class RecipeCellError(ValueError):
 
 @dataclass(frozen=True)
 class InlineEnv:
-    """An environment declared inline in a recipe as ``{docker: <ref>}``.
+    """An environment declared inline in a recipe as ``{docker: <ref>}`` (with
+    an optional ``{env: {...}}`` baseline env-var mapping).
 
     Auto-named ``_inline_<hash>`` where ``<hash>`` is the first 8 chars of
-    blake2b over the image ref. Two cells that reference the same image ref
-    produce the same auto-name (deterministic), so the environment probe for
-    that ref is captured exactly once.
+    blake2b over the image ref AND any non-empty inline ``env`` content. Two
+    cells that reference the same image ref (and same ``env``) produce the same
+    auto-name (deterministic), so the environment probe for that ref is captured
+    exactly once. When ``env`` is absent or empty the hash is over the image ref
+    alone -- so legacy ``{docker: <ref>}`` cells keep their historical
+    auto-name. Two cells with the same image but *different* ``env`` mappings
+    therefore hash to different auto-names and cannot silently collapse into one
+    environment.
     """
 
     name: str
     docker: str
+    env: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -440,6 +451,15 @@ class Recipe:
     # ``{"layer_numerics": {"NANLOG_SAMPLE_EVERY": "1"}}``. Empty dict
     # (default) is identical to today's recipes.
     collect_options: dict[str, dict[str, str]] = field(default_factory=dict)
+    # Recipe-level env-var overlay applied to every cell. Sits ABOVE mitigations
+    # and Environment.env but BELOW each cell's own ``extra_env`` in the
+    # platform env-precedence contract (see the dispatcher). The runner merges
+    # ``{**recipe.extra_env, **cell.extra_env}`` into the single
+    # ``RunRequest.extra_env`` so a cell can override a recipe-wide value.
+    # Empty dict (default) is behaviourally identical to today's recipes. Kept
+    # as a distinct field (rather than pre-merged into each cell) so the
+    # resolved recipe can re-emit both scopes for faithful replay.
+    extra_env: dict[str, str] = field(default_factory=dict)
     # Issue #232: collect-until-N stopping rule applied per cell. ``None``
     # preserves the legacy fixed-``trials`` behaviour. When set, the cell
     # runs up to ``stop_after.max_trials`` trials, stopping early once
@@ -454,15 +474,30 @@ class Recipe:
     probe_extras: Any | None = None
 
 
-def inline_env_name(docker_ref: str) -> str:
+def inline_env_name(docker_ref: str, env: dict[str, str] | None = None) -> str:
     """Deterministic auto-name for an inline docker environment.
 
-    The first 8 hex chars of blake2b(image-ref). Matches the spec in issue
-    #151 so two cells with the same ``docker_ref`` share a single
-    auto-registered environment and therefore a single env-probe.
+    The first 8 hex chars of blake2b over the image ref and any non-empty
+    inline ``env`` mapping. Matches the spec in issue #151 so two cells with
+    the same ``docker_ref`` (and same ``env``) share a single auto-registered
+    environment and therefore a single env-probe.
+
+    Backward-compatibility: when ``env`` is ``None`` or empty the digest is
+    taken over the image ref ALONE -- byte-for-byte the legacy pre-``env``
+    hash -- so every existing ``{docker: <ref>}`` cell keeps its historical
+    ``_inline_<hash>`` name. A non-empty ``env`` folds a canonical
+    (sorted-key) JSON encoding of the mapping into the hash, so the same image
+    with two different ``env`` mappings produces two distinct auto-names and
+    cannot silently collapse into one environment.
     """
-    digest = hashlib.blake2b(docker_ref.encode("utf-8"), digest_size=4).hexdigest()
-    return f"_inline_{digest}"
+    h = hashlib.blake2b(docker_ref.encode("utf-8"), digest_size=4)
+    if env:
+        # Canonical encoding: sorted keys, no incidental whitespace, so the
+        # hash depends only on the mapping's content, not dict ordering.
+        canonical = json.dumps(env, sort_keys=True, separators=(",", ":"))
+        h.update(b"\x00")  # domain separator between ref and env
+        h.update(canonical.encode("utf-8"))
+    return f"_inline_{h.hexdigest()}"
 
 
 def _ensure_type(path_hint: str, value: Any, expected: type, label: str) -> None:
@@ -644,17 +679,50 @@ def _parse_environment(path_hint: str, raw: Any, inline_envs: dict[str, InlineEn
             f"{path_hint}.environment.docker: must be a non-empty string, "
             f"got {type(ref).__name__} ({ref!r})"
         )
-    auto_name = inline_env_name(ref)
+    env_mapping = _parse_str_str_mapping(
+        f"{path_hint}.environment.env", raw.get("env")
+    )
+    auto_name = inline_env_name(ref, env_mapping)
     existing = inline_envs.get(auto_name)
     if existing is None:
-        inline_envs[auto_name] = InlineEnv(name=auto_name, docker=ref)
-    elif existing.docker != ref:
+        inline_envs[auto_name] = InlineEnv(name=auto_name, docker=ref, env=env_mapping)
+    elif existing.docker != ref or existing.env != env_mapping:
+        # Hash collision on distinct content -- ``env`` folds into the hash, so
+        # this can only fire on a genuine blake2b collision (astronomically
+        # unlikely), but surface it rather than silently coalescing two
+        # different environments into one.
         raise RecipeSchemaError(
             f"{path_hint}.environment: inline-env hash collision for "
-            f"{auto_name!r}: {existing.docker!r} vs {ref!r}. "
+            f"{auto_name!r}: ({existing.docker!r}, env={existing.env!r}) vs "
+            f"({ref!r}, env={env_mapping!r}). "
             "Rename one ref or register a named environment explicitly."
         )
     return auto_name
+
+
+def _parse_str_str_mapping(path_hint: str, raw: Any) -> dict[str, str]:
+    """Validate a ``dict[str, str]`` mapping (recipe/inline ``env`` / ``extra_env``).
+
+    ``None`` / missing -> ``{}`` so callers can pass ``data.get(key)`` without
+    branching. Keys and values must both be strings -- YAML/JSON numbers and
+    booleans are rejected rather than silently coerced, matching the registry
+    loaders so the same value fails everywhere consistently.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RecipeSchemaError(
+            f"{path_hint}: must be a mapping of str -> str, got {type(raw).__name__}"
+        )
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise RecipeSchemaError(
+                f"{path_hint}[{k!r}]: keys and values must be strings, "
+                f"got {type(k).__name__} -> {type(v).__name__}"
+            )
+        out[k] = v
+    return out
 
 
 def _parse_workload_config(path_hint: str, raw: Any) -> dict[str, Any]:
@@ -803,22 +871,7 @@ def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:
 
     environment = _parse_environment(path_hint, raw["environment"], inline_envs)
 
-    extra_env_raw = raw.get("extra_env", {})
-    if extra_env_raw is None:
-        extra_env_raw = {}
-    if not isinstance(extra_env_raw, dict):
-        raise RecipeSchemaError(
-            f"{path_hint}.extra_env: must be a mapping of str -> str, got "
-            f"{type(extra_env_raw).__name__}"
-        )
-    extra_env: dict[str, str] = {}
-    for k, v in extra_env_raw.items():
-        if not isinstance(k, str) or not isinstance(v, str):
-            raise RecipeSchemaError(
-                f"{path_hint}.extra_env[{k!r}]: keys and values must be strings, "
-                f"got {type(k).__name__} -> {type(v).__name__}"
-            )
-        extra_env[k] = v
+    extra_env = _parse_str_str_mapping(f"{path_hint}.extra_env", raw.get("extra_env"))
 
     trials = raw.get("trials")
     if trials is not None and (
@@ -1186,6 +1239,7 @@ def _build_recipe(
 
     confound = _parse_confound("recipe", data.get("confound"))
     workload_config = _parse_workload_config("recipe", data.get("workload_config"))
+    recipe_extra_env = _parse_str_str_mapping("recipe.extra_env", data.get("extra_env"))
     stop_after = _parse_stop_after("recipe", data.get("stop_after"))
 
     raw_save_logs = data.get("save_logs", False)
@@ -1249,6 +1303,7 @@ def _build_recipe(
         save_logs=raw_save_logs,
         collect=collect,
         collect_options=collect_options,
+        extra_env=recipe_extra_env,
         stop_after=stop_after,
     )
 

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import yaml
 
+from aorta._env_rules import is_valid_env_name, value_has_nul
 from aorta.registry import (
     get_environment,
     get_mitigation,
@@ -159,11 +160,6 @@ _RESERVED_WORKLOAD_CONFIG_PREFIX = "_aorta_"
 # without an extra layer of slugging that would silently rename cells.
 _CELL_NAME_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*$")
 _RESERVED_CELL_NAMES = frozenset({".", "..", "matrix.md", "matrix.json"})
-# POSIX env-var name shape -- kept byte-identical to the dispatcher's
-# ``aorta.run.dispatcher._ENV_KEY_RE`` so a name that fails at run time also
-# fails at recipe-load time. Duplicated (not imported) to keep this module's
-# import graph free of the run-orchestration package.
-_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class RecipeSchemaError(ValueError):
@@ -719,6 +715,13 @@ def _parse_str_str_mapping(path_hint: str, raw: Any) -> dict[str, str]:
     branching. Keys and values must both be strings -- YAML/JSON numbers and
     booleans are rejected rather than silently coerced, matching the registry
     loaders so the same value fails everywhere consistently.
+
+    Env-var NAME shape and NUL-in-VALUE are validated here too (via the shared
+    ``aorta._env_rules`` predicates), so a malformed name (e.g. ``"BAD KEY"``)
+    or an unusable value (a NUL byte) fails at recipe-load time / ``--dry-run``
+    instead of slipping through to a per-cell failure at run time -- the
+    "green command, zero work" outcome, where a non-strict sweep still writes a
+    matrix and exits zero while every cell errored.
     """
     if raw is None:
         return {}
@@ -733,17 +736,16 @@ def _parse_str_str_mapping(path_hint: str, raw: Any) -> dict[str, str]:
                 f"{path_hint}[{k!r}]: keys and values must be strings, "
                 f"got {type(k).__name__} -> {type(v).__name__}"
             )
-        # Validate the env-var *name shape* at recipe-load time, using the same
-        # rule the dispatcher enforces (``_ENV_KEY_RE``). Without this a
-        # malformed name (e.g. ``"BAD KEY"``) passes loading and ``--dry-run``
-        # and only fails per-cell inside ``os.environ.update`` at run time --
-        # after the default CLI has already exited zero and printed
-        # "Wrote matrix". Fail early so a bad global/cell/inline env name is
-        # caught before any artifact is written.
-        if not _ENV_KEY_RE.fullmatch(k):
+        if not is_valid_env_name(k):
             raise RecipeSchemaError(
                 f"{path_hint}[{k!r}]: invalid environment-variable name; "
                 "expected [A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
+            )
+        if value_has_nul(v):
+            # Value NOT echoed -- it may be a secret.
+            raise RecipeSchemaError(
+                f"{path_hint}[{k!r}]: value contains a NUL byte and cannot "
+                "be stored in an environment variable."
             )
         out[k] = v
     return out

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -159,6 +159,11 @@ _RESERVED_WORKLOAD_CONFIG_PREFIX = "_aorta_"
 # without an extra layer of slugging that would silently rename cells.
 _CELL_NAME_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*$")
 _RESERVED_CELL_NAMES = frozenset({".", "..", "matrix.md", "matrix.json"})
+# POSIX env-var name shape -- kept byte-identical to the dispatcher's
+# ``aorta.run.dispatcher._ENV_KEY_RE`` so a name that fails at run time also
+# fails at recipe-load time. Duplicated (not imported) to keep this module's
+# import graph free of the run-orchestration package.
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class RecipeSchemaError(ValueError):
@@ -459,7 +464,14 @@ class Recipe:
     # Empty dict (default) is behaviourally identical to today's recipes. Kept
     # as a distinct field (rather than pre-merged into each cell) so the
     # resolved recipe can re-emit both scopes for faithful replay.
-    extra_env: dict[str, str] = field(default_factory=dict)
+    #
+    # ``kw_only=True``: ``Recipe`` is public through ``aorta.triage``, and this
+    # field is inserted BEFORE the pre-existing ``stop_after`` / ``probe_extras``
+    # fields. A positional insert would silently rebind existing positional
+    # callers (a ``StopAfter`` would land in ``extra_env`` and fail the dict
+    # merge). Keyword-only keeps every existing positional constructor call
+    # binding to the same fields it did before.
+    extra_env: dict[str, str] = field(default_factory=dict, kw_only=True)
     # Issue #232: collect-until-N stopping rule applied per cell. ``None``
     # preserves the legacy fixed-``trials`` behaviour. When set, the cell
     # runs up to ``stop_after.max_trials`` trials, stopping early once
@@ -720,6 +732,18 @@ def _parse_str_str_mapping(path_hint: str, raw: Any) -> dict[str, str]:
             raise RecipeSchemaError(
                 f"{path_hint}[{k!r}]: keys and values must be strings, "
                 f"got {type(k).__name__} -> {type(v).__name__}"
+            )
+        # Validate the env-var *name shape* at recipe-load time, using the same
+        # rule the dispatcher enforces (``_ENV_KEY_RE``). Without this a
+        # malformed name (e.g. ``"BAD KEY"``) passes loading and ``--dry-run``
+        # and only fails per-cell inside ``os.environ.update`` at run time --
+        # after the default CLI has already exited zero and printed
+        # "Wrote matrix". Fail early so a bad global/cell/inline env name is
+        # caught before any artifact is written.
+        if not _ENV_KEY_RE.fullmatch(k):
+            raise RecipeSchemaError(
+                f"{path_hint}[{k!r}]: invalid environment-variable name; "
+                "expected [A-Za-z_][A-Za-z0-9_]* (POSIX env-var name shape)."
             )
         out[k] = v
     return out

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -732,8 +732,12 @@ def _parse_str_str_mapping(path_hint: str, raw: Any) -> dict[str, str]:
     out: dict[str, str] = {}
     for k, v in raw.items():
         if not isinstance(k, str) or not isinstance(v, str):
+            # String keys are safe to identify, but a malformed non-string YAML
+            # key can itself carry sensitive content (for example ``!!binary``).
+            # Report only its type, never its repr.
+            key_hint = repr(k) if isinstance(k, str) else f"<{type(k).__name__} key>"
             raise RecipeSchemaError(
-                f"{path_hint}[{k!r}]: keys and values must be strings, "
+                f"{path_hint}[{key_hint}]: keys and values must be strings, "
                 f"got {type(k).__name__} -> {type(v).__name__}"
             )
         if not is_valid_env_name(k):

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -222,7 +222,16 @@ def _write_inline_sidecar(run_dir: Path, inline_envs: tuple[InlineEnv, ...]) -> 
     path = run_dir / _INLINE_SIDECAR_NAME
     doc = {
         "version": 1,
-        "environments": {env.name: {"docker": env.docker} for env in inline_envs},
+        "environments": {
+            env.name: (
+                # Only emit ``env`` when non-empty so a legacy inline docker
+                # env round-trips to the same sidecar payload as before.
+                {"docker": env.docker, "env": dict(env.env)}
+                if env.env
+                else {"docker": env.docker}
+            )
+            for env in inline_envs
+        },
     }
     path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
     return path
@@ -503,16 +512,33 @@ def _resolve_cell_env_vars(
     cell_mitigations: tuple[str, ...],
     cell_extra_env: dict[str, str],
     sidecar_files: tuple[Path, ...] | None,
+    environment: str | None = None,
 ) -> dict[str, str]:
-    """Compute the unioned env-var bundle B1 will apply for a cell.
+    """Compute the unioned env-var bundle the dispatcher will apply for a cell.
 
-    B1 also unions internally; we duplicate the computation here so
+    The dispatcher also unions internally; we duplicate the computation here so
     matrix.json can record the resolved env-var set alongside the aggregated
-    stats, without having to rely on B1 threading them through
+    stats, without having to rely on the dispatcher threading them through
     TrialResult.
+
+    Precedence (lowest to highest) matches the platform env contract:
+    ``Environment.env < mitigations < extra_env`` (``cell_extra_env`` here is
+    already the recipe-level + cell-level merge). ``environment`` is optional so
+    legacy callers that only care about the mitigation+extra_env layers still
+    work; when provided, the named environment's baseline ``env`` seeds the
+    bundle so the recorded set matches what the workload actually observes.
     """
     extra = list(sidecar_files) if sidecar_files else None
     env: dict[str, str] = {}
+    if environment is not None:
+        try:
+            env.update(get_environment(environment, extra_files=extra).env)
+        except RegistryError:
+            # Unknown envs are caught earlier by _validate_names_resolve; a
+            # lookup failure here (e.g. an inline env not in the sidecar yet)
+            # falls back to omitting the baseline layer rather than aborting
+            # the audit computation.
+            pass
     for name in cell_mitigations:
         env.update(get_mitigation(name, extra_files=extra))
     env.update(cell_extra_env)
@@ -933,7 +959,13 @@ def _run_one_cell(
         cell_dir = _cells_dir(run_dir) / safe_slug(cell.name)
     cell_dir.mkdir(parents=True, exist_ok=True)
 
-    resolved_env_vars = _resolve_cell_env_vars(cell.mitigations, cell.extra_env, sidecar_files)
+    # Recipe-level extra_env is the base; cell-level merges over it (cell wins
+    # on key collision). This single merged mapping is the request ``extra_env``
+    # layer the dispatcher applies above mitigations / Environment.env.
+    merged_extra_env = {**recipe.extra_env, **cell.extra_env}
+    resolved_env_vars = _resolve_cell_env_vars(
+        cell.mitigations, merged_extra_env, sidecar_files, environment=cell.environment
+    )
     effective_trials = cell.effective_trials(recipe.trials)
     # Issue #232: a ``stop_after`` rule turns ``max_trials`` into the hard
     # cap and lets the dispatcher break early once the event target is met.
@@ -1086,7 +1118,7 @@ def _run_one_cell(
         trials=cap,
         environment=cell.environment,
         mitigations=tuple(cell.mitigations),
-        extra_env=dict(cell.extra_env),
+        extra_env=merged_extra_env,
         steps=cell.effective_steps(recipe.steps),
         config_overrides=merged_workload_config,
         results_dir=cell_dir,

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -346,6 +346,11 @@ def _write_isolated_env_placeholder(
     descriptor: dict[str, Any] = {"name": env_name}
     if inline_match is not None:
         descriptor["docker"] = inline_match.docker
+        # Record the inline baseline ``env`` too -- it is part of what the
+        # isolated env would actually apply, so an operator debugging a failed
+        # isolated probe from this placeholder sees the complete descriptor
+        # (a missing ``BASELINE_FLAG`` may be exactly what explains the failure).
+        descriptor["env"] = dict(inline_match.env)
         descriptor["source"] = "inline"
     else:
         extra = list(sidecar_files) if sidecar_files else None
@@ -353,6 +358,7 @@ def _write_isolated_env_placeholder(
             env_desc = get_environment(env_name, extra_files=extra)
             descriptor["docker"] = env_desc.docker
             descriptor["venv"] = env_desc.venv
+            descriptor["env"] = dict(env_desc.env)
             descriptor["source_package"] = env_desc.source_package
         except RegistryError as exc:  # pragma: no cover - guarded by predicate
             descriptor["_lookup_error"] = f"{type(exc).__name__}: {exc}"

--- a/src/aorta/triage/runner.py
+++ b/src/aorta/triage/runner.py
@@ -539,12 +539,19 @@ def _resolve_cell_env_vars(
     if environment is not None:
         try:
             env.update(get_environment(environment, extra_files=extra).env)
-        except RegistryError:
+        except RegistryError as exc:
             # Unknown envs are caught earlier by _validate_names_resolve; a
             # lookup failure here (e.g. an inline env not in the sidecar yet)
             # falls back to omitting the baseline layer rather than aborting
-            # the audit computation.
-            pass
+            # the audit computation. Keep the warning value-redacted: registry
+            # payloads may contain credentials, so report only the environment
+            # name and exception type rather than the exception text.
+            log.warning(
+                "environment %r could not be resolved while computing "
+                "resolved_env_vars (%s); omitting its baseline Environment.env layer",
+                environment,
+                type(exc).__name__,
+            )
     for name in cell_mitigations:
         env.update(get_mitigation(name, extra_files=extra))
     env.update(cell_extra_env)

--- a/tests/registry/test_environments.py
+++ b/tests/registry/test_environments.py
@@ -211,6 +211,30 @@ def test_env_field_rejects_non_mapping_and_non_string_entries(fake_env_eps):
             load_environments()
 
 
+def test_env_field_rejects_invalid_name_from_plugin(fake_env_eps):
+    """An entry-point Environment.env with a malformed NAME fails loading.
+
+    Named environments bypass the recipe parser, so the name-shape rule must be
+    enforced in the registry loader to avoid a per-cell-only run-time failure.
+    """
+    fake_env_eps([
+        ("bad-name", {"docker": "img@sha256:abc", "env": {"BAD KEY": "1"}}, "plugin_x"),
+    ])
+    with pytest.raises(RegistryError, match="invalid environment-variable name"):
+        load_environments()
+
+
+def test_env_field_rejects_nul_value_from_plugin(fake_env_eps):
+    """An entry-point Environment.env with a NUL VALUE fails loading, without
+    echoing the (possibly secret) value."""
+    fake_env_eps([
+        ("nul-env", {"docker": "img@sha256:abc", "env": {"TOKEN": "a\x00b"}}, "plugin_x"),
+    ])
+    with pytest.raises(RegistryError, match="NUL") as exc:
+        load_environments()
+    assert "a\x00b" not in str(exc.value)
+
+
 def test_environment_defensively_copies_env_mapping():
     source = {"FOO": "original"}
     env = Environment(name="copy-test", env=source)

--- a/tests/registry/test_environments.py
+++ b/tests/registry/test_environments.py
@@ -2,12 +2,12 @@
 
 import pytest
 
+from aorta.registry.environments import get_environment, load_environments
 from aorta.registry.errors import (
     RegistryCollisionError,
     RegistryError,
     UnknownEnvironmentError,
 )
-from aorta.registry.environments import get_environment, load_environments
 from aorta.registry.types import Environment
 
 
@@ -149,6 +149,7 @@ def test_environment_constructs_with_buck_target_only():
         "emulator": None,
         "mirage_profile": None,
         "source_package": "aorta",
+        "env": {},
     }
 
 
@@ -160,3 +161,61 @@ def test_buck_target_with_non_string_value_raises(fake_env_eps):
     fake_env_eps([("bad", {"buck_target": 123}, "plugin_x")])
     with pytest.raises(RegistryError, match="plugin_x.*bad.*non-string"):
         load_environments()
+
+
+# ---- env field (per-environment baseline vars) ----------------------------
+#
+# ``Environment.env`` is the lowest layer of the platform env-precedence
+# contract.  These tests pin that the field round-trips faithfully through
+# the plugin loader and defaults to an empty dict when absent in the plugin
+# payload.
+
+
+def test_env_field_round_trips_from_plugin(fake_env_eps):
+    """A plugin that declares ``env: {FOO: "1"}`` must produce an
+    ``Environment`` with ``env["FOO"] == "1"``.
+
+    This is the primary seam that lets a private plugin (e.g. recom_repro)
+    declare baseline env vars without hard-coding them in a wrapper.
+    """
+    fake_env_eps([
+        ("with-env", {"docker": "img@sha256:abc", "env": {"FOO": "1", "BAR": "2"}}, "plugin_x"),
+    ])
+    result = load_environments()
+    env = result["with-env"]
+    assert env.env == {"FOO": "1", "BAR": "2"}
+
+
+def test_env_field_absent_defaults_to_empty_dict(fake_env_eps):
+    """A plugin that omits ``env`` must produce ``Environment.env == {}``.
+
+    Back-compat: every existing plugin payload has no ``env`` key; the
+    loader must not inject a ``None`` or raise -- the field must default
+    to an empty dict so the dispatcher's ``effective_overlay.update(env_descriptor.env)``
+    is a no-op for these environments.
+    """
+    fake_env_eps([
+        ("no-env", {"docker": "img@sha256:abc"}, "plugin_x"),
+    ])
+    result = load_environments()
+    env = result["no-env"]
+    assert env.env == {}
+
+
+def test_env_field_rejects_non_mapping_and_non_string_entries(fake_env_eps):
+    for bad_env in (["FOO=1"], {"FOO": 1}, {1: "value"}):
+        fake_env_eps([
+            ("bad-env", {"docker": "img@sha256:abc", "env": bad_env}, "plugin_x"),
+        ])
+        with pytest.raises(RegistryError, match=r"plugin_x.*bad-env.*env"):
+            load_environments()
+
+
+def test_environment_defensively_copies_env_mapping():
+    source = {"FOO": "original"}
+    env = Environment(name="copy-test", env=source)
+
+    source["FOO"] = "mutated"
+    source["NEW"] = "added"
+
+    assert env.env == {"FOO": "original"}

--- a/tests/registry/test_mitigations.py
+++ b/tests/registry/test_mitigations.py
@@ -90,10 +90,24 @@ def test_collision_plugin_vs_builtin_raises(fake_eps):
         load_mitigations()
 
 
-def test_non_string_env_value_raises(fake_eps):
-    fake_eps([("bad", {"K": 123}, "plugin_x")])
-    with pytest.raises(RegistryError, match="plugin_x.*bad.*dict\\[str, str\\]"):
+def test_invalid_env_entry_types_raise_without_echoing_values(fake_eps):
+    secret = "super-secret-token"
+    fake_eps(
+        [
+            (
+                "bad",
+                {"TOKEN": secret, "K": {"credential": secret}, 7: secret},
+                "plugin_x",
+            )
+        ]
+    )
+    with pytest.raises(RegistryError, match="plugin_x.*bad.*dict\\[str, str\\]") as exc:
         load_mitigations()
+    message = str(exc.value)
+    assert "K" in message
+    assert "dict" in message
+    assert "<int key>" in message
+    assert secret not in message
 
 
 def test_non_dict_payload_raises(fake_eps):

--- a/tests/registry/test_mitigations.py
+++ b/tests/registry/test_mitigations.py
@@ -102,6 +102,26 @@ def test_non_dict_payload_raises(fake_eps):
         load_mitigations()
 
 
+def test_plugin_mitigation_rejects_invalid_name(fake_eps):
+    """An entry-point mitigation with a malformed env-var NAME fails loading.
+
+    Mitigation bundles are a declaration boundary too -- without this the bad
+    name only fails later inside the dispatcher's os.environ.update.
+    """
+    fake_eps([("bad", {"BAD KEY": "1"}, "plugin_x")])
+    with pytest.raises(RegistryError, match="invalid environment-variable name"):
+        load_mitigations()
+
+
+def test_plugin_mitigation_rejects_nul_value(fake_eps):
+    """An entry-point mitigation with a NUL VALUE fails loading, without echoing
+    the (possibly secret) value."""
+    fake_eps([("bad", {"TOKEN": "a\x00b"}, "plugin_x")])
+    with pytest.raises(RegistryError, match="NUL") as exc:
+        load_mitigations()
+    assert "a\x00b" not in str(exc.value)
+
+
 @pytest.mark.parametrize(
     ("name", "expected_env"),
     sorted(PROBE_FLAG_BUILTIN_EXPECTED.items()),

--- a/tests/registry/test_sidecar.py
+++ b/tests/registry/test_sidecar.py
@@ -13,7 +13,6 @@ from aorta.registry import (
     load_sidecar_mitigations,
 )
 
-
 # ---------- mitigations: merge into resolver ----------
 
 
@@ -247,3 +246,75 @@ def test_missing_file_reports_path(tmp_path):
     p = tmp_path / "nonexistent.json"
     with pytest.raises(RegistryError, match="cannot read file"):
         load_sidecar_mitigations(p)
+
+
+# ---- sidecar environment env field ----------------------------------------
+#
+# ``Environment.env`` is the lowest layer of the platform env-precedence
+# contract. These tests confirm the sidecar loader round-trips the field and
+# defaults gracefully when it is absent -- mirroring the plugin EP loader
+# tests in test_environments.py.
+
+
+def test_sidecar_environment_with_env_field_round_trips(tmp_sidecar, fake_env_eps):
+    """A sidecar environment that declares ``env`` must produce the correct
+    ``Environment.env`` mapping after loading.
+
+    The sidecar loader validates ``env`` independently of the ``str | None``
+    recipe slots -- this test pins that the validated mapping reaches the
+    ``Environment`` dataclass intact.
+    """
+    fake_env_eps([])
+    p = tmp_sidecar({
+        "version": 1,
+        "environments": {
+            "sidecar-with-env": {
+                "docker": "img@sha256:abc",
+                "env": {"FOO": "1", "BAR": "val"},
+            },
+        },
+    })
+    envs = load_environments(extra_files=[p])
+    assert envs["sidecar-with-env"].env == {"FOO": "1", "BAR": "val"}
+
+
+def test_sidecar_environment_env_field_absent_defaults_empty(tmp_sidecar, fake_env_eps):
+    """A sidecar environment that omits ``env`` must produce
+    ``Environment.env == {}``.
+
+    Back-compat: every existing sidecar payload has no ``env`` key; the
+    loader must not raise and must produce an empty dict so the dispatcher's
+    overlay merge is a no-op for these environments.
+    """
+    fake_env_eps([])
+    p = tmp_sidecar({
+        "version": 1,
+        "environments": {
+            "sidecar-no-env": {"docker": "img@sha256:abc"},
+        },
+    })
+    envs = load_environments(extra_files=[p])
+    assert envs["sidecar-no-env"].env == {}
+
+
+@pytest.mark.parametrize(
+    "bad_env",
+    [
+        ["FOO=1"],
+        {"FOO": 1},
+    ],
+)
+def test_sidecar_environment_env_field_rejects_malformed_values(
+    tmp_sidecar, bad_env
+):
+    p = tmp_sidecar({
+        "version": 1,
+        "environments": {
+            "bad-env": {
+                "docker": "img@sha256:abc",
+                "env": bad_env,
+            },
+        },
+    })
+    with pytest.raises(RegistryError, match=r"environments\.bad-env\.env"):
+        load_sidecar_environments(p)

--- a/tests/registry/test_sidecar.py
+++ b/tests/registry/test_sidecar.py
@@ -318,3 +318,39 @@ def test_sidecar_environment_env_field_rejects_malformed_values(
     })
     with pytest.raises(RegistryError, match=r"environments\.bad-env\.env"):
         load_sidecar_environments(p)
+
+
+def test_sidecar_environment_env_field_rejects_invalid_name(tmp_sidecar):
+    """A named sidecar Environment.env with a malformed NAME must fail loading.
+
+    A named environment bypasses the recipe parser entirely, so this is the
+    only place the name-shape rule can be enforced before run time.
+    """
+    p = tmp_sidecar({
+        "version": 1,
+        "environments": {
+            "bad-name-env": {
+                "docker": "img@sha256:abc",
+                "env": {"BAD KEY": "1"},
+            },
+        },
+    })
+    with pytest.raises(RegistryError, match="invalid environment-variable name"):
+        load_sidecar_environments(p)
+
+
+def test_sidecar_environment_env_field_rejects_nul_value(tmp_sidecar):
+    """A named sidecar Environment.env with a NUL VALUE must fail loading,
+    without echoing the (possibly secret) value."""
+    p = tmp_sidecar({
+        "version": 1,
+        "environments": {
+            "nul-env": {
+                "docker": "img@sha256:abc",
+                "env": {"TOKEN": "before\x00after"},
+            },
+        },
+    })
+    with pytest.raises(RegistryError, match="NUL") as exc:
+        load_sidecar_environments(p)
+    assert "before" not in str(exc.value) and "after" not in str(exc.value)

--- a/tests/registry/test_sidecar.py
+++ b/tests/registry/test_sidecar.py
@@ -220,6 +220,26 @@ def test_mitigation_payload_must_be_object(tmp_sidecar):
         load_sidecar_mitigations(p)
 
 
+def test_sidecar_mitigation_rejects_invalid_name(tmp_sidecar):
+    """A sidecar mitigation bundle with a malformed env-var NAME must fail load.
+
+    Mitigation bundles are a declaration boundary too: without this the bad
+    name only fails later in the dispatcher's os.environ.update.
+    """
+    p = tmp_sidecar({"version": 1, "mitigations": {"foo": {"BAD KEY": "1"}}})
+    with pytest.raises(RegistryError, match="invalid environment-variable name"):
+        load_sidecar_mitigations(p)
+
+
+def test_sidecar_mitigation_rejects_nul_value(tmp_sidecar):
+    """A sidecar mitigation bundle with a NUL VALUE must fail load, without
+    echoing the (possibly secret) value."""
+    p = tmp_sidecar({"version": 1, "mitigations": {"foo": {"TOKEN": "a\x00b"}}})
+    with pytest.raises(RegistryError, match="NUL") as exc:
+        load_sidecar_mitigations(p)
+    assert "a\x00b" not in str(exc.value)
+
+
 def test_environment_value_must_be_string_or_null(tmp_sidecar):
     p = tmp_sidecar({"version": 1, "environments": {"e": {"docker": 123}}})
     with pytest.raises(

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -2752,3 +2752,30 @@ class TestAortaTrialEnv:
                 ) as exc:
                     run_trials(req)
         assert "123456789" not in str(exc.value)
+
+    def test_nul_value_rejected_before_os_environ_mutated(self, tmp_path):
+        """A NUL-containing overlay value fails BEFORE any var is applied.
+
+        ``os.environ.update`` applies the overlay entry-by-entry and lives
+        outside the try/finally restore block, so a NUL value part-way through
+        would raise AFTER earlier entries were already set -- leaking them into
+        later matrix cells. The dispatcher rejects NUL up front, so a valid
+        canary declared alongside a NUL value must NEVER reach ``os.environ``.
+        """
+        canary = "AORTA_NUL_CANARY_SHOULD_NOT_BE_SET"
+        assert canary not in os.environ  # pre-condition
+
+        mock_eps = self._make_ep(PassingWorkload, name="nul_reject")
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="nul_reject",
+                trials=1,
+                extra_env={canary: "ok", "BAD": "has\x00nul"},
+                results_dir=tmp_path,
+            )
+            with pytest.raises(ValueError, match="NUL") as exc:
+                run_trials(req)
+
+        # Value never echoed, and the canary never leaked into the process env.
+        assert "has\x00nul" not in str(exc.value)
+        assert canary not in os.environ

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -213,6 +213,17 @@ class TestRunTrials:
             with pytest.raises(ValueError, match="Invalid extra_env keys"):
                 run_trials(req)
 
+    def test_rejects_non_string_extra_env_without_echoing_value(self, tmp_path):
+        req = RunRequest(
+            workload="anything",
+            trials=1,
+            extra_env={"TOKEN": 123456789},  # type: ignore[dict-item]
+            results_dir=tmp_path,
+        )
+        with pytest.raises(ValueError, match="extra_env value for key 'TOKEN'") as exc:
+            run_trials(req)
+        assert "123456789" not in str(exc.value)
+
     def test_rejects_malformed_env_probe(self, tmp_path):
         """``env_probe`` must be {'src', 'out'} with str values.
 
@@ -1349,6 +1360,7 @@ class TestConfigOverrides:
             "emulator": None,
             "mirage_profile": None,
             "source_package": "test",
+            "env": {},
         }
         assert captured_config["_aorta_environment"] == expected
         assert results[0].execution_env == expected
@@ -1416,6 +1428,7 @@ class TestConfigOverrides:
             "emulator": None,
             "mirage_profile": None,
             "source_package": "test",
+            "env": {},
         }
         assert captured_config["_aorta_environment"] == expected
         assert results[0].execution_env == expected
@@ -1746,6 +1759,7 @@ class TestBuckTargetOverride:
             "mirage_profile": None,
             # source_package survived
             "source_package": "custom_pkg",
+            "env": {},
         }
         assert captured_config["_aorta_environment"] == expected
         assert results[0].execution_env == expected
@@ -2055,6 +2069,7 @@ class TestImageOverride:
             "mirage_profile": None,
             # source_package survived
             "source_package": "custom_pkg",
+            "env": {},
         }
         assert captured_config["_aorta_environment"] == expected
         assert results[0].execution_env == expected
@@ -2239,6 +2254,58 @@ class TestEnvironmentRestoration:
             else:
                 os.environ["TEST_RESTORE_VAR"] = original_value
 
+    def test_environment_restored_after_workload_crash(self, tmp_path):
+        """Environment vars applied before a trial must be restored even when
+        the workload raises in ``run()``.
+
+        The dispatcher applies the controlled overlay to ``os.environ`` before
+        each trial, so a workload crash must not leave those vars in place for
+        subsequent trials or other code that shares the process environment.
+        """
+        original_value = os.environ.get("AORTA_CRASH_RESTORE_CANARY")
+
+        class CrashingEnvWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                pass
+
+            def run(self):
+                raise RuntimeError("intentional workload crash")
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "crashing_env"
+        mock_ep.load.return_value = CrashingEnvWorkload
+
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        try:
+            with patch("importlib.metadata.entry_points", return_value=mock_eps):
+                req = RunRequest(
+                    workload="crashing_env",
+                    trials=1,
+                    extra_env={"AORTA_CRASH_RESTORE_CANARY": "injected"},
+                    results_dir=tmp_path,
+                )
+                # run_trials catches workload exceptions and records them as
+                # infrastructure_failed -- it must not propagate the RuntimeError.
+                results = run_trials(req)
+
+            assert len(results) == 1
+            assert results[0].exit_status == "infrastructure_failed"
+            # The injected var must be gone from the process environment.
+            assert os.environ.get("AORTA_CRASH_RESTORE_CANARY") == original_value
+        finally:
+            if original_value is None:
+                os.environ.pop("AORTA_CRASH_RESTORE_CANARY", None)
+            else:
+                os.environ["AORTA_CRASH_RESTORE_CANARY"] = original_value
+
 
 class NoisyWorkload(Workload):
     """Workload that writes a marker to stdout + stderr and records the
@@ -2387,3 +2454,301 @@ class TestSaveLogs:
         assert "AORTA_LEAK_PROBE" not in os.environ, "env overlay leaked when log-open failed"
         assert "_aorta_save_logs" not in NoisyWorkload.seen_config
         assert "_aorta_log_prefix" not in NoisyWorkload.seen_config
+
+
+class TestAortaTrialEnv:
+    """Tests for the ``_aorta_trial_env`` config key and the 3-layer env-precedence contract.
+
+    The platform env contract (from lowest to highest precedence):
+
+        Environment.env  <  mitigations  <  request.extra_env
+
+    ``_aorta_trial_env`` is the effective controlled overlay injected into
+    ``config`` so Docker-aware wrappers can forward ONLY these vars across
+    isolation boundaries without reading ``os.environ``.
+    """
+
+    def _make_ep(self, workload_cls, name="env_probe"):
+        mock_ep = MagicMock()
+        mock_ep.name = name
+        mock_ep.load.return_value = workload_cls
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+        return mock_eps
+
+    def test_aorta_trial_env_injected_into_config(self, tmp_path):
+        """``config['_aorta_trial_env']`` carries the merged controlled overlay.
+
+        When a mitigation and an extra_env var are both active, both must
+        appear in ``_aorta_trial_env``.  This pins the injection seam that
+        Docker-aware wrappers read to build their ``-e`` flags.
+        """
+        captured_config: dict = {}
+
+        class CaptureWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def __init__(self, config):
+                super().__init__(config)
+                captured_config.update(config)
+
+            def setup(self):
+                pass
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_eps = self._make_ep(CaptureWorkload, name="trial_env_inject")
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="trial_env_inject",
+                trials=1,
+                mitigations=("tf32_off",),
+                extra_env={"CUSTOM_AORTA_VAR": "hello"},
+                results_dir=tmp_path,
+            )
+            run_trials(req)
+
+        trial_env = captured_config.get("_aorta_trial_env")
+        assert trial_env is not None, "_aorta_trial_env must always be present in config"
+        # tf32_off contributes DISABLE_TF32=1
+        assert trial_env.get("DISABLE_TF32") == "1"
+        # extra_env contributes CUSTOM_AORTA_VAR=hello
+        assert trial_env.get("CUSTOM_AORTA_VAR") == "hello"
+
+    def test_aorta_trial_env_contains_only_controlled_overlay(self, tmp_path):
+        """Ambient ``os.environ`` vars must NOT appear in ``_aorta_trial_env``.
+
+        The overlay is built exclusively from the three controlled sources.
+        An ambient var that was already present in the process environment
+        before the trial ran must be invisible to ``_aorta_trial_env`` --
+        otherwise the Docker wrapper would forward variables it didn't own.
+        """
+        captured_config: dict = {}
+
+        class CaptureWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def __init__(self, config):
+                super().__init__(config)
+                captured_config.update(config)
+
+            def setup(self):
+                pass
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_eps = self._make_ep(CaptureWorkload, name="ambient_exclusion")
+        # Inject an ambient variable that no controlled source owns.
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with patch.dict(os.environ, {"AORTA_AMBIENT_ONLY": "ambient"}):
+                req = RunRequest(
+                    workload="ambient_exclusion",
+                    trials=1,
+                    results_dir=tmp_path,
+                )
+                run_trials(req)
+
+        trial_env = captured_config["_aorta_trial_env"]
+        assert "AORTA_AMBIENT_ONLY" not in trial_env, (
+            "ambient os.environ var must not bleed into _aorta_trial_env"
+        )
+
+    def test_aorta_trial_env_empty_when_no_controlled_sources(self, tmp_path):
+        """``_aorta_trial_env`` is an empty dict (not absent) when no controlled
+        source contributes any var.
+
+        Back-compat: every existing run with the default ``none`` mitigation,
+        no ``extra_env``, and the built-in ``local`` environment (no ``env``
+        field) must see ``_aorta_trial_env == {}`` in the trial JSON.
+        """
+        captured_config: dict = {}
+
+        class CaptureWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def __init__(self, config):
+                super().__init__(config)
+                captured_config.update(config)
+
+            def setup(self):
+                pass
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_eps = self._make_ep(CaptureWorkload, name="empty_overlay")
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="empty_overlay",
+                trials=1,
+                results_dir=tmp_path,
+                # No mitigations override, no extra_env, default "local" env
+            )
+            run_trials(req)
+
+        trial_env = captured_config.get("_aorta_trial_env")
+        assert trial_env is not None, "_aorta_trial_env must be present even when empty"
+        assert trial_env == {}, f"expected empty overlay, got {trial_env!r}"
+
+    def test_environment_env_applied_to_os_environ(self, tmp_path):
+        """``Environment.env`` vars appear in ``os.environ`` during workload execution.
+
+        ``Environment.env`` is the lowest layer: it is applied to the process
+        environment before ``setup()`` runs, so workloads that read
+        ``os.environ`` directly (rather than the config slot) still receive
+        the baseline vars.
+        """
+        captured_env: dict = {}
+
+        class EnvCaptureWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_env.update(dict(os.environ))
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        from aorta.registry import Environment
+
+        patched_env = Environment(
+            name="local",
+            env={"AORTA_TEST_ENV_LAYER": "from_environment_env"},
+        )
+
+        mock_eps = self._make_ep(EnvCaptureWorkload, name="env_env_applied")
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with patch("aorta.run.dispatcher.get_environment", return_value=patched_env):
+                req = RunRequest(
+                    workload="env_env_applied",
+                    trials=1,
+                    results_dir=tmp_path,
+                )
+                run_trials(req)
+
+        assert captured_env.get("AORTA_TEST_ENV_LAYER") == "from_environment_env", (
+            "Environment.env must be applied to os.environ before workload runs"
+        )
+
+    def test_full_precedence_env_env_lowest(self, tmp_path):
+        """Mitigation wins over ``Environment.env`` when both set the same var.
+
+        Precedence: Environment.env (lowest) < mitigations < extra_env (highest).
+        When ``Environment.env`` sets ``DISABLE_TF32=env_layer`` and the
+        ``tf32_off`` mitigation sets ``DISABLE_TF32=1``, the workload must
+        see ``1`` (the mitigation value).
+        """
+        captured_env: dict = {}
+
+        class EnvCaptureWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_env.update(dict(os.environ))
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        from aorta.registry import Environment
+
+        # Environment.env sets the lowest-precedence value.
+        patched_env = Environment(
+            name="local",
+            env={"DISABLE_TF32": "env_layer"},
+        )
+
+        mock_eps = self._make_ep(EnvCaptureWorkload, name="precedence_probe")
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with patch("aorta.run.dispatcher.get_environment", return_value=patched_env):
+                req = RunRequest(
+                    workload="precedence_probe",
+                    trials=1,
+                    # tf32_off sets DISABLE_TF32=1 -- must override env_layer.
+                    mitigations=("tf32_off",),
+                    results_dir=tmp_path,
+                )
+                run_trials(req)
+
+        assert captured_env.get("DISABLE_TF32") == "1", (
+            "mitigation must take precedence over Environment.env for the same key"
+        )
+
+    def test_invalid_environment_env_key_rejected(self, tmp_path):
+        """A malformed key in ``Environment.env`` raises ``ValueError`` before
+        any trial runs.
+
+        ``Environment.env`` keys are validated at ``run_trials()`` entry, not
+        deep inside ``os.environ.update`` -- so the caller sees a clear
+        platform error instead of the opaque OS-level exception.
+        """
+        from aorta.registry import Environment
+
+        patched_env = Environment(
+            name="local",
+            # Keys are NOT validated by the dataclass itself (it's just a dict
+            # field) -- the dispatcher catches them at run_trials() time.
+            env={"1BADKEY": "val"},
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "invalid_env_key"
+        mock_ep.load.return_value = PassingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with patch("aorta.run.dispatcher.get_environment", return_value=patched_env):
+                req = RunRequest(
+                    workload="invalid_env_key",
+                    trials=1,
+                    results_dir=tmp_path,
+                )
+                with pytest.raises(ValueError, match="Invalid Environment.env keys"):
+                    run_trials(req)
+
+    def test_non_string_environment_env_value_rejected_without_echoing_value(
+        self, tmp_path
+    ):
+        """Direct library callers get the same strict value validation as loaders."""
+        from aorta.registry import Environment
+
+        patched_env = Environment(
+            name="local",
+            env={"TOKEN": 123456789},  # type: ignore[dict-item]
+        )
+        mock_eps = self._make_ep(PassingWorkload, name="invalid_env_value")
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with patch("aorta.run.dispatcher.get_environment", return_value=patched_env):
+                req = RunRequest(
+                    workload="invalid_env_value",
+                    trials=1,
+                    results_dir=tmp_path,
+                )
+                with pytest.raises(
+                    ValueError, match="Environment.env value for key 'TOKEN'"
+                ) as exc:
+                    run_trials(req)
+        assert "123456789" not in str(exc.value)

--- a/tests/run/test_docker.py
+++ b/tests/run/test_docker.py
@@ -1,0 +1,73 @@
+"""Tests for the shared ``docker_env_flags`` helper (env-forwarding only)."""
+
+import os
+
+import pytest
+
+from aorta.run import docker_env_flags
+
+
+def test_empty_mapping_yields_no_flags():
+    assert docker_env_flags({}) == []
+
+
+def test_single_pair():
+    assert docker_env_flags({"FOO": "bar"}) == ["-e", "FOO=bar"]
+
+
+def test_output_is_deterministic_sorted_by_key():
+    # Insertion order deliberately not sorted; output must be key-sorted so the
+    # same mapping always renders byte-identical argv.
+    env = {"ZED": "3", "ALPHA": "1", "MIKE": "2"}
+    assert docker_env_flags(env) == [
+        "-e",
+        "ALPHA=1",
+        "-e",
+        "MIKE=2",
+        "-e",
+        "ZED=3",
+    ]
+    # Same content, different insertion order -> identical output.
+    assert docker_env_flags({"MIKE": "2", "ZED": "3", "ALPHA": "1"}) == docker_env_flags(env)
+
+
+def test_value_with_equals_and_spaces_preserved():
+    # Only the FIRST '=' delimits key/value for docker; the value may itself
+    # contain '=' and spaces. The helper emits a single KEY=VALUE token.
+    flags = docker_env_flags({"CONN": "a=b c=d"})
+    assert flags == ["-e", "CONN=a=b c=d"]
+
+
+def test_never_reads_os_environ(monkeypatch):
+    # A var present in the ambient environment but NOT in the explicit mapping
+    # must never appear in the output -- the helper cannot leak host env.
+    monkeypatch.setenv("AORTA_TEST_LEAK_CANARY", "leaked")
+    assert "AORTA_TEST_LEAK_CANARY" in os.environ
+    flags = docker_env_flags({"SAFE": "1"})
+    assert flags == ["-e", "SAFE=1"]
+    assert not any("LEAK_CANARY" in tok for tok in flags)
+
+
+def test_non_mapping_raises_type_error():
+    with pytest.raises(TypeError, match="dict"):
+        docker_env_flags(["FOO=bar"])  # type: ignore[arg-type]
+
+
+def test_non_string_value_raises_without_echoing_value():
+    with pytest.raises(TypeError) as exc:
+        docker_env_flags({"TOKEN": 12345})  # type: ignore[dict-item]
+    # The (possibly secret) value must not appear in the error text.
+    assert "12345" not in str(exc.value)
+    assert "TOKEN" in str(exc.value)
+
+
+def test_non_string_key_is_rejected_before_sorting():
+    with pytest.raises(TypeError, match="keys must be str"):
+        docker_env_flags({"GOOD": "1", 2: "bad"})  # type: ignore[dict-item]
+
+
+def test_invalid_key_name_raises_value_error():
+    with pytest.raises(ValueError, match="POSIX"):
+        docker_env_flags({"1BAD": "x"})
+    with pytest.raises(ValueError, match="POSIX"):
+        docker_env_flags({"has space": "x"})

--- a/tests/run/test_docker.py
+++ b/tests/run/test_docker.py
@@ -71,3 +71,13 @@ def test_invalid_key_name_raises_value_error():
         docker_env_flags({"1BAD": "x"})
     with pytest.raises(ValueError, match="POSIX"):
         docker_env_flags({"has space": "x"})
+
+
+def test_nul_value_rejected_without_echoing_value():
+    # A NUL byte cannot survive an execve'd ``docker run -e`` argument; reject
+    # it for parity with the dispatcher's os.environ validation. The value must
+    # not be echoed in the error (it may be a secret).
+    with pytest.raises(ValueError, match="NUL") as exc:
+        docker_env_flags({"TOKEN": "abc\x00def"})
+    assert "abc" not in str(exc.value) and "def" not in str(exc.value)
+    assert "TOKEN" in str(exc.value)

--- a/tests/test_cli_env_display.py
+++ b/tests/test_cli_env_display.py
@@ -1,0 +1,68 @@
+"""Tests for safe environment-bundle rendering in registry listings."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from aorta.cli._env_display import format_env_bundle
+from aorta.cli.environments import environments
+from aorta.cli.mitigations import mitigations
+from aorta.cli.triage import triage
+
+_VALUES = {
+    "SAFE": "a=b",
+    "SPACED": "two words",
+    "EMPTY": "",
+    "NEWLINE": "first\nsecond",
+    "CONTROL": "\x1b[31m",
+}
+
+
+def test_format_env_bundle_keeps_simple_values_and_escapes_unsafe_values():
+    assert format_env_bundle(_VALUES) == (
+        r"CONTROL='\x1b[31m' EMPTY='' NEWLINE='first\nsecond' " r"SAFE=a=b SPACED='two words'"
+    )
+    assert format_env_bundle({}) == "(none)"
+
+
+@pytest.mark.parametrize(
+    ("command", "args"),
+    [
+        pytest.param(environments, ("list", "--file"), id="environments"),
+        pytest.param(
+            triage,
+            ("list-environments", "--mitigations-file"),
+            id="triage-environments",
+        ),
+        pytest.param(mitigations, ("list", "--file"), id="mitigations"),
+        pytest.param(
+            triage,
+            ("list-mitigations", "--mitigations-file"),
+            id="triage-mitigations",
+        ),
+    ],
+)
+def test_registry_listings_escape_ambiguous_and_control_values(tmp_path, command, args):
+    sidecar = tmp_path / "registry.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "environments": {"display-env": {"env": _VALUES}},
+                "mitigations": {"display-mitigation": _VALUES},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(command, [*args, str(sidecar)])
+
+    assert result.exit_code == 0, result.output
+    assert "SAFE=a=b" in result.output
+    assert "SPACED='two words'" in result.output
+    assert r"NEWLINE='first\nsecond'" in result.output
+    assert r"CONTROL='\x1b[31m'" in result.output
+    assert "\x1b" not in result.output

--- a/tests/test_env_rules.py
+++ b/tests/test_env_rules.py
@@ -1,0 +1,39 @@
+"""Unit tests for the shared env-rule predicates (``aorta._env_rules``)."""
+
+from aorta._env_rules import ENV_KEY_RE, is_valid_env_name, value_has_nul
+
+
+def test_valid_env_names():
+    for name in ("FOO", "_bar", "A1", "HIP_LAUNCH_BLOCKING", "_"):
+        assert is_valid_env_name(name) is True
+
+
+def test_invalid_env_names():
+    for name in ("1BAD", "has space", "BAD-KEY", "a.b", "", "FOO=BAR", "é"):
+        assert is_valid_env_name(name) is False
+
+
+def test_env_key_re_is_fullmatch_anchored():
+    # A trailing newline must NOT sneak through -- fullmatch semantics.
+    assert ENV_KEY_RE.fullmatch("FOO\n") is None
+    assert ENV_KEY_RE.fullmatch("FOO") is not None
+
+
+def test_value_has_nul():
+    assert value_has_nul("plain") is False
+    assert value_has_nul("") is False
+    assert value_has_nul("a\x00b") is True
+    assert value_has_nul("\x00") is True
+
+
+def test_module_is_dependency_free():
+    # The whole point of this leaf module is that any layer can import it
+    # without pulling in aorta subpackages. Its own imports must be stdlib only.
+    import aorta._env_rules as mod
+
+    src = mod.__file__
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    # No ``import aorta`` / ``from aorta`` inside the leaf module.
+    assert "import aorta" not in text
+    assert "from aorta" not in text

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -1714,6 +1714,47 @@ def test_dry_run_rejects_unresolvable_baseline():
         runner.run_recipe(r, output_dir="ignored", dry_run=True)
 
 
+def test_dry_run_rejects_named_sidecar_env_with_bad_name(tmp_path):
+    """A named sidecar Environment.env with an invalid name must fail --dry-run
+    without creating artifacts.
+
+    This is the boundary the recipe parser can't cover: the cell references a
+    NAMED environment, so the bad ``env`` only surfaces when the registry loads
+    the sidecar. That happens as early as recipe construction (name-resolution
+    preflight), before ``run_recipe`` / dry-run can print a summary -- so the
+    "green command, zero work" matrix can never be produced. No artifacts are
+    created under the ticket.
+    """
+    from aorta.registry import RegistryError as _RegErr
+
+    sidecar = tmp_path / "envs.sidecar.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "environments": {
+                    "cust_img": {
+                        "docker": "myorg/img@sha256:abc",
+                        "env": {"BAD KEY": "1"},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(_RegErr, match="invalid environment-variable name"):
+        build_recipe_from_flags(
+            workload="fsdp",
+            mitigation_axis="none",
+            environment_axis="cust_img",
+            trials=1,
+            steps=10,
+            ticket="T-1",
+            sidecar_files=(sidecar,),
+        )
+    assert not (tmp_path / "T-1").exists()
+
+
 def test_dry_run_rejects_env_slug_collision(tmp_path):
     """Dry-run must surface env-slug collisions before printing the summary."""
     from aorta.registry import RegistryError as _RegErr

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -1024,6 +1024,54 @@ def test_resolved_recipe_round_trips_stop_after(
     assert reloaded.stop_after == StopAfter(events=2, max_trials=5, event_verdict="fail")
 
 
+def test_resolved_recipe_round_trips_extra_env(
+    tmp_path, patched_env, patched_run_trials
+):
+    """Both recipe-scope and cell-scope ``extra_env`` must survive
+    load → run → reload so a replay from ``recipe.resolved.yaml`` applies the
+    same env-var overrides as the original run.
+
+    Mirrors ``test_resolved_recipe_round_trips_workload_config`` for the
+    env-precedence contract (A6 checklist item).
+    """
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe, load_recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(
+            Cell(name="a", mitigations=("none",), environment="local"),
+            Cell(
+                name="b",
+                mitigations=("tf32_off",),
+                environment="local",
+                extra_env={"CELL_KEY": "cell_value"},
+            ),
+        ),
+        ticket="EE-RT",
+        confound=ConfoundCfg(baseline_cell="a"),
+        extra_env={"GLOBAL_KEY": "global_value", "SHARED_KEY": "recipe"},
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    resolved_path = run_dir / "recipe.resolved.yaml"
+
+    # Verify the YAML doc contains both scopes before reloading.
+    import yaml as _yaml
+    doc = _yaml.safe_load(resolved_path.read_text())
+    assert doc["extra_env"] == {"GLOBAL_KEY": "global_value", "SHARED_KEY": "recipe"}
+    cells_by_name = {c["name"]: c for c in doc["cells"]}
+    assert "extra_env" not in cells_by_name["a"]
+    assert cells_by_name["b"]["extra_env"] == {"CELL_KEY": "cell_value"}
+
+    # Reload and verify the Recipe dataclass fields are intact.
+    reloaded = load_recipe(resolved_path)
+    assert reloaded.extra_env == {"GLOBAL_KEY": "global_value", "SHARED_KEY": "recipe"}
+    assert reloaded.cells[0].extra_env == {}
+    assert reloaded.cells[1].extra_env == {"CELL_KEY": "cell_value"}
+
+
 # ---- Config column (diffs-only workload_config) --------------------------
 #
 # The column surfaces per-cell workload_config keys whose value varies

--- a/tests/triage/test_output_layout.py
+++ b/tests/triage/test_output_layout.py
@@ -309,6 +309,73 @@ def test_isolated_env_writes_placeholder_not_runner_snapshot(
     assert "no in-container snapshot captured" in md.lower()
 
 
+def test_isolated_inline_env_placeholder_records_baseline_env(
+    tmp_path, patched_env, patched_run_trials
+):
+    """The inline-env placeholder descriptor must include its baseline ``env``.
+
+    An operator debugging a failed isolated probe is pointed at this env.json;
+    dropping ``Environment.env`` would hide baseline vars (e.g. a required
+    ``BASELINE_FLAG``) that may be exactly what explains the failure.
+    """
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 10
+cells:
+  - name: inline-with-baseline
+    mitigations: [none]
+    environment:
+      docker: "rocm/pytorch:nightly"
+      env: { BASELINE_FLAG: "required" }
+"""
+    from aorta.triage.recipe import load_recipe
+
+    p = tmp_path / "recipe.yaml"
+    p.write_text(text, encoding="utf-8")
+    r = load_recipe(p)
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    env_json = run_dir / "environments" / r.cells[0].environment / "env.json"
+    placeholder = json.loads(env_json.read_text())
+    assert placeholder["descriptor"]["docker"] == "rocm/pytorch:nightly"
+    assert placeholder["descriptor"]["env"] == {"BASELINE_FLAG": "required"}
+
+
+def test_isolated_registered_env_placeholder_records_baseline_env(
+    tmp_path, patched_env, patched_run_trials
+):
+    """A registered (sidecar) docker env's placeholder also records its ``env``."""
+    sidecar = tmp_path / "envs.sidecar.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "environments": {
+                    "cust_img": {
+                        "docker": "myorg/img@sha256:abc",
+                        "env": {"REG_BASELINE": "on"},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    r = build_recipe_from_flags(
+        workload="fsdp",
+        mitigation_axis="none",
+        environment_axis="cust_img",
+        trials=1,
+        steps=10,
+        sidecar_files=(sidecar,),
+    )
+    run_dir = runner.run_recipe(r, output_dir=tmp_path)
+    env_json = run_dir / "environments" / "cust_img" / "env.json"
+    placeholder = json.loads(env_json.read_text())
+    assert placeholder["descriptor"]["docker"] == "myorg/img@sha256:abc"
+    assert placeholder["descriptor"]["env"] == {"REG_BASELINE": "on"}
+
+
 def test_isolated_env_promotes_in_container_snapshot(
     tmp_path, patched_env, monkeypatch
 ):

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -575,6 +575,112 @@ cells:
     assert r.cells[0].environment != r.cells[2].environment
 
 
+# ---- inline docker env field (#A6) ----------------------------------------
+#
+# An inline environment may include an ``env`` dict alongside ``docker``.
+# The hash covers both the ref and the env content, so two cells with the
+# same image but different ``env`` mappings are distinct environments.
+
+
+def test_inline_docker_env_field_preserved(tmp_path):
+    """Env vars declared in an inline environment reach the ``InlineEnv.env``
+    field and are not silently dropped."""
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 10
+cells:
+  - name: baseline
+    mitigations: [none]
+    environment: local
+  - name: with-env
+    mitigations: [none]
+    environment:
+      docker: "rocm/pytorch:nightly"
+      env:
+        TORCH_LOGS: "+recompiles"
+        TORCHDYNAMO_VERBOSE: "1"
+"""
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert len(r.inline_environments) == 1
+    inline = r.inline_environments[0]
+    assert inline.docker == "rocm/pytorch:nightly"
+    assert inline.env == {"TORCH_LOGS": "+recompiles", "TORCHDYNAMO_VERBOSE": "1"}
+
+
+def test_inline_docker_env_changes_auto_name(tmp_path):
+    """Two cells with the same docker ref but different ``env`` dicts must
+    produce different auto-names and register as separate environments.
+
+    Without this, a cell that declares ``env: {A: 1}`` could silently collapse
+    into another cell's environment that had ``env: {A: 99}``, applying the
+    wrong baseline vars at runtime.
+    """
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 10
+cells:
+  - name: no-env
+    mitigations: [none]
+    environment: { docker: "x/y:1" }
+  - name: with-env
+    mitigations: [none]
+    environment:
+      docker: "x/y:1"
+      env: { EXTRA_FLAG: "1" }
+"""
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert len(r.inline_environments) == 2
+    names = {e.name for e in r.inline_environments}
+    assert len(names) == 2
+    assert r.cells[0].environment != r.cells[1].environment
+
+
+def test_inline_docker_same_env_deduplicates(tmp_path):
+    """Two cells with identical docker ref AND identical env dict must share a
+    single auto-name (dedup) so the environment probe is captured only once."""
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 10
+cells:
+  - name: a
+    mitigations: [none]
+    environment:
+      docker: "x/y:1"
+      env: { FOO: "bar" }
+  - name: b
+    mitigations: [tf32_off]
+    environment:
+      docker: "x/y:1"
+      env: { FOO: "bar" }
+"""
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert len(r.inline_environments) == 1
+    assert r.cells[0].environment == r.cells[1].environment
+
+
+def test_inline_docker_env_requires_string_values(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 10
+cells:
+  - name: bad-env
+    mitigations: [none]
+    environment:
+      docker: "x/y:1"
+      env: { FOO: 1 }
+"""
+    with pytest.raises(RecipeSchemaError, match=r"environment\.env"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
 # ---- extra_env ------------------------------------------------------------
 
 
@@ -592,6 +698,50 @@ def test_extra_env_must_be_strings(tmp_path):
         "    environment: local\n",
         "    environment: local\n    extra_env:\n      MY_FLAG: 1\n",
     )
+    with pytest.raises(RecipeSchemaError, match="extra_env"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+# ---- recipe-level extra_env -----------------------------------------------
+#
+# ``Recipe.extra_env`` is a top-level overlay applied to EVERY cell, sitting
+# ABOVE mitigations but BELOW each cell's own ``extra_env``.  The runner
+# merges ``{**recipe.extra_env, **cell.extra_env}`` into the single
+# ``RunRequest.extra_env`` so a recipe can provide a global baseline without
+# repeating it on every cell.
+
+
+def test_recipe_level_extra_env_parsed(tmp_path):
+    """A top-level ``extra_env`` key on the recipe is loaded into ``Recipe.extra_env``.
+
+    This is distinct from the cell-level ``extra_env``: it lives at the recipe
+    root and applies to all cells.  The runner merges them; the loader's job
+    is to faithfully parse the key and expose it on the ``Recipe`` dataclass.
+    """
+    text = _MINIMAL_YAML + 'extra_env:\n  GLOBAL_FLAG: "1"\n  NANLOG_TRACE: "on"\n'
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.extra_env == {"GLOBAL_FLAG": "1", "NANLOG_TRACE": "on"}
+
+
+def test_recipe_level_extra_env_defaults_empty(tmp_path):
+    """A recipe with no top-level ``extra_env`` key has ``Recipe.extra_env == {}``.
+
+    Back-compat: every existing recipe has no ``extra_env`` key at the root;
+    the loader must not raise and must produce an empty dict, so the runner's
+    ``{**recipe.extra_env, **cell.extra_env}`` merge is a no-op for these recipes.
+    """
+    r = load_recipe(_write_yaml(tmp_path, _MINIMAL_YAML))
+    assert r.extra_env == {}
+
+
+def test_recipe_level_extra_env_non_string_value_rejected(tmp_path):
+    """A non-string value in the top-level ``extra_env`` raises ``RecipeSchemaError``.
+
+    Mirrors the cell-level validation: ``extra_env`` is a ``dict[str, str]``
+    contract; an integer or list value must be caught at load time with a
+    clear error rather than silently propagating a bad type into the runner.
+    """
+    text = _MINIMAL_YAML + "extra_env:\n  MY_FLAG: 1\n"
     with pytest.raises(RecipeSchemaError, match="extra_env"):
         load_recipe(_write_yaml(tmp_path, text))
 

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -746,6 +746,16 @@ def test_recipe_level_extra_env_non_string_value_rejected(tmp_path):
         load_recipe(_write_yaml(tmp_path, text))
 
 
+def test_recipe_level_extra_env_non_string_key_is_redacted(tmp_path):
+    """A secret-bearing YAML key reports only its type, not its decoded content."""
+    text = _MINIMAL_YAML + """extra_env:
+  !!binary c3VwZXItc2VjcmV0LWtleQ==: "value"
+"""
+    with pytest.raises(RecipeSchemaError, match="<bytes key>") as exc:
+        load_recipe(_write_yaml(tmp_path, text))
+    assert "super-secret-key" not in str(exc.value)
+
+
 # ---- env-var NAME validation at load time ---------------------------------
 #
 # An invalid env-var NAME (e.g. ``"BAD KEY"``) must fail recipe loading, not

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -787,6 +787,49 @@ cells:
         load_recipe(_write_yaml(tmp_path, text))
 
 
+# ---- env-var VALUE (NUL) validation at load time --------------------------
+#
+# A NUL byte is a valid Python str character but cannot be stored in an OS
+# environment variable. Like an invalid name, it must fail at load time (and
+# thus ``--dry-run``) instead of only failing per-cell at run time while a
+# non-strict sweep still writes a matrix and exits zero. The NUL is written via
+# YAML's ``\0`` double-quoted escape.
+
+
+def test_recipe_level_extra_env_nul_value_rejected(tmp_path):
+    text = _MINIMAL_YAML + 'extra_env:\n  TOKEN: "before\\0after"\n'
+    with pytest.raises(RecipeSchemaError, match="NUL") as exc:
+        load_recipe(_write_yaml(tmp_path, text))
+    # Value must not be echoed (it may be a secret).
+    assert "before" not in str(exc.value) and "after" not in str(exc.value)
+
+
+def test_cell_level_extra_env_nul_value_rejected(tmp_path):
+    text = _MINIMAL_YAML.replace(
+        "    environment: local\n",
+        '    environment: local\n    extra_env:\n      TOKEN: "a\\0b"\n',
+    )
+    with pytest.raises(RecipeSchemaError, match="NUL"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_inline_env_nul_value_rejected(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 10
+cells:
+  - name: nul-inline-env
+    mitigations: [none]
+    environment:
+      docker: "x/y:1"
+      env: { TOKEN: "a\\0b" }
+"""
+    with pytest.raises(RecipeSchemaError, match="NUL"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
 # ---- Recipe.extra_env is keyword-only (public-API back-compat) ------------
 #
 # ``Recipe`` is public through ``aorta.triage``. ``extra_env`` was inserted

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -746,6 +746,95 @@ def test_recipe_level_extra_env_non_string_value_rejected(tmp_path):
         load_recipe(_write_yaml(tmp_path, text))
 
 
+# ---- env-var NAME validation at load time ---------------------------------
+#
+# An invalid env-var NAME (e.g. ``"BAD KEY"``) must fail recipe loading, not
+# slip through to run time. Before this, a malformed name passed loading and
+# ``--dry-run``; the real run then set no vars per cell while the default CLI
+# still exited zero and printed "Wrote matrix". The recipe parser now enforces
+# the same ``_ENV_KEY_RE`` shape the dispatcher does, at all three env surfaces.
+
+
+def test_recipe_level_extra_env_invalid_name_rejected(tmp_path):
+    text = _MINIMAL_YAML + 'extra_env:\n  "BAD KEY": "1"\n'
+    with pytest.raises(RecipeSchemaError, match="invalid environment-variable name"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_cell_level_extra_env_invalid_name_rejected(tmp_path):
+    text = _MINIMAL_YAML.replace(
+        "    environment: local\n",
+        '    environment: local\n    extra_env:\n      "BAD KEY": "1"\n',
+    )
+    with pytest.raises(RecipeSchemaError, match="invalid environment-variable name"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_inline_env_invalid_name_rejected(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 1
+steps: 10
+cells:
+  - name: bad-inline-env
+    mitigations: [none]
+    environment:
+      docker: "x/y:1"
+      env: { "BAD KEY": "1" }
+"""
+    with pytest.raises(RecipeSchemaError, match="invalid environment-variable name"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+# ---- Recipe.extra_env is keyword-only (public-API back-compat) ------------
+#
+# ``Recipe`` is public through ``aorta.triage``. ``extra_env`` was inserted
+# before the pre-existing ``stop_after`` / ``probe_extras`` fields, so it MUST
+# be keyword-only -- otherwise existing positional callers would silently
+# rebind a ``StopAfter`` into ``extra_env``.
+
+
+def test_recipe_extra_env_is_keyword_only():
+    import dataclasses
+
+    fld = next(f for f in dataclasses.fields(Recipe) if f.name == "extra_env")
+    assert fld.kw_only is True
+
+
+def test_recipe_positional_stop_after_still_binds_to_stop_after():
+    """A positional call that previously set ``stop_after`` must still do so.
+
+    Reproduces a pre-existing positional constructor shape: everything through
+    ``collect_options`` positionally, then ``stop_after`` positionally. Because
+    ``extra_env`` is keyword-only it is skipped by position, so the positional
+    ``StopAfter`` binds to ``stop_after`` (not ``extra_env``) as before.
+    """
+    from aorta.triage.recipe import StopAfter
+
+    sa = StopAfter(events=1, max_trials=3)
+    r = Recipe(
+        1,              # schema_version
+        "fsdp",         # workload
+        2,              # trials
+        100,            # steps
+        (),             # cells
+        None,           # ticket
+        ConfoundCfg(),  # confound
+        (),             # inline_environments
+        (),             # sidecar_files
+        None,           # source_path
+        "abc",          # source_sha256
+        {},             # workload_config
+        False,          # save_logs
+        (),             # collect
+        {},             # collect_options
+        sa,             # stop_after  <-- positional, MUST NOT land in extra_env
+    )
+    assert r.stop_after is sa
+    assert r.extra_env == {}
+
+
 # ---- workload_config ------------------------------------------------------
 
 

--- a/tests/triage/test_runner_b1_api.py
+++ b/tests/triage/test_runner_b1_api.py
@@ -903,6 +903,26 @@ def test_cli_list_environments():
     assert "local" in result.output
 
 
+def test_cli_list_environments_shows_baseline_env(tmp_path):
+    sidecar = tmp_path / "environment-env.json"
+    sidecar.write_text(
+        '{"version": 1, "environments": {'
+        '"env-list-test": {"env": {"BASELINE_FLAG": "enabled"}}'
+        "}}",
+        encoding="utf-8",
+    )
+
+    cli = CliRunner()
+    result = cli.invoke(
+        triage,
+        ["list-environments", "--mitigations-file", str(sidecar)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "ENV" in result.output
+    assert "BASELINE_FLAG=enabled" in result.output
+
+
 def test_cli_list_mitigations_wraps_registry_error_in_click_exception(tmp_path):
     """Malformed --mitigations-file -> clean ClickException, not a Python traceback.
 
@@ -1067,3 +1087,104 @@ def test_nonzero_rank_does_not_collide_with_rank_zero(
     leaves = list((out / "RANK-1" / "fsdp").iterdir())
     assert len(leaves) == 1
     assert leaves[0].name == "2026-01-01T00-00-00"
+
+
+# ---- extra_env recipe-level + cell-level merge ----------------------------
+#
+# The runner merges ``{**recipe.extra_env, **cell.extra_env}`` into
+# ``RunRequest.extra_env``, giving the cell-scope the win on key collision.
+# This merge is the lowest-level seam of the env-precedence contract that
+# the runner owns (above it: the dispatcher's mitigation and Environment.env
+# layers; below it: nothing).  Pin all three observable behaviours: recipe
+# only, cell only, and collision (cell wins).
+
+
+def test_extra_env_recipe_scope_reaches_run_request(
+    tmp_path, patched_env, patched_run_trials
+):
+    """A recipe-level ``extra_env`` with no per-cell override reaches every
+    cell's ``RunRequest.extra_env`` unchanged."""
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(Cell(name="a", mitigations=("none",), environment="local"),),
+        ticket="EE-1",
+        confound=ConfoundCfg(baseline_cell="a"),
+        extra_env={"GLOBAL_FLAG": "1", "NANLOG_TRACE": "on"},
+    )
+    runner.run_recipe(r, output_dir=tmp_path)
+    req: RunRequest = patched_run_trials.call_args_list[0].args[0]
+    assert req.extra_env == {"GLOBAL_FLAG": "1", "NANLOG_TRACE": "on"}
+
+
+def test_extra_env_cell_scope_only_reaches_run_request(
+    tmp_path, patched_env, patched_run_trials
+):
+    """A cell-level ``extra_env`` with no recipe-level extra_env reaches only
+    that cell's ``RunRequest.extra_env``."""
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(
+            Cell(name="a", mitigations=("none",), environment="local"),
+            Cell(
+                name="b",
+                mitigations=("tf32_off",),
+                environment="local",
+                extra_env={"CELL_FLAG": "cell_only"},
+            ),
+        ),
+        ticket="EE-2",
+        confound=ConfoundCfg(baseline_cell="a"),
+    )
+    runner.run_recipe(r, output_dir=tmp_path)
+    reqs = [c.args[0] for c in patched_run_trials.call_args_list]
+    assert reqs[0].extra_env == {}
+    assert reqs[1].extra_env == {"CELL_FLAG": "cell_only"}
+
+
+def test_extra_env_cell_wins_on_collision_with_recipe(
+    tmp_path, patched_env, patched_run_trials
+):
+    """Cell-scope wins on key collision; non-collision keys union (mirrors
+    ``test_workload_config_cell_overrides_recipe_and_merges``)."""
+    from aorta.triage.recipe import Cell, ConfoundCfg, Recipe
+
+    r = Recipe(
+        schema_version=1,
+        workload="fsdp",
+        trials=1,
+        steps=10,
+        cells=(
+            Cell(name="a", mitigations=("none",), environment="local"),
+            Cell(
+                name="b",
+                mitigations=("tf32_off",),
+                environment="local",
+                # SHARED_KEY collides; CELL_ONLY is new.
+                extra_env={"SHARED_KEY": "cell_wins", "CELL_ONLY": "yes"},
+            ),
+        ),
+        ticket="EE-3",
+        confound=ConfoundCfg(baseline_cell="a"),
+        # Recipe-level: SHARED_KEY also set, RECIPE_ONLY not in cell.
+        extra_env={"SHARED_KEY": "recipe_value", "RECIPE_ONLY": "always"},
+    )
+    runner.run_recipe(r, output_dir=tmp_path)
+    reqs = [c.args[0] for c in patched_run_trials.call_args_list]
+    # Cell a has no extra_env; inherits recipe only.
+    assert reqs[0].extra_env == {"SHARED_KEY": "recipe_value", "RECIPE_ONLY": "always"}
+    # Cell b: SHARED_KEY -> cell wins; RECIPE_ONLY unions in; CELL_ONLY unions in.
+    assert reqs[1].extra_env == {
+        "SHARED_KEY": "cell_wins",
+        "RECIPE_ONLY": "always",
+        "CELL_ONLY": "yes",
+    }

--- a/tests/triage/test_runner_b1_api.py
+++ b/tests/triage/test_runner_b1_api.py
@@ -1188,3 +1188,28 @@ def test_extra_env_cell_wins_on_collision_with_recipe(
         "RECIPE_ONLY": "always",
         "CELL_ONLY": "yes",
     }
+
+
+def test_resolved_env_lookup_failure_warns_without_echoing_error_text(monkeypatch, caplog):
+    """A fail-soft baseline lookup must not silently weaken the audit bundle."""
+    from aorta.registry import RegistryError
+
+    def fail_lookup(*args, **kwargs):
+        raise RegistryError("secret-value-must-not-be-logged")
+
+    monkeypatch.setattr(runner, "get_environment", fail_lookup)
+
+    with caplog.at_level("WARNING", logger="aorta.triage.runner"):
+        resolved = runner._resolve_cell_env_vars(
+            (),
+            {"EXTRA": "kept"},
+            None,
+            environment="broken-env",
+        )
+
+    assert resolved == {"EXTRA": "kept"}
+    warning = "\n".join(record.getMessage() for record in caplog.records)
+    assert "broken-env" in warning
+    assert "RegistryError" in warning
+    assert "omitting its baseline Environment.env layer" in warning
+    assert "secret-value-must-not-be-logged" not in warning


### PR DESCRIPTION
## Summary

Makes environment variables a **platform-level contract** shared by all workloads and execution backends, so a recipe author uses one concept — `extra_env` — without needing to know whether a workload runs in-process or launches Docker. This is **Part A** (public `aorta`); private Docker-wrapper migration is Part B and is intentionally out of scope here.

**Precedence contract (lowest → highest):**
```
Environment.env < mitigations < recipe extra_env < cell/CLI extra_env
```

- `Environment.env` — baseline env vars intrinsic to a registered / inline / sidecar environment (str-only; no numeric/bool coercion).
- Recipe-level `extra_env` — top-level key applied to every cell; cell-level `extra_env` still wins.
- The dispatcher computes one **effective overlay**, applies it to `os.environ` before env capture / `setup()` / `run()` (host path), and exposes it as `config["_aorta_trial_env"]` — built **only** from the three controlled sources, never from ambient `os.environ`.
- New public helper `aorta.run.docker_env_flags(env)` turns that controlled overlay into deterministic `-e KEY=VALUE` flags for Docker-aware wrappers.

**The platform still does not launch Docker** — wrappers keep ownership of image selection, mounts, devices, IPC/shm, entrypoints, and the inner command. This PR only gives them a shared helper + a reserved config key to read.

## Validation hardening

Env-var **name shape** and **NUL-in-value** are enforced at *every* declaration boundary — recipe parser, registry (built-in + entry-point), sidecar loader, dispatcher, and the Docker helper — via a single dependency-free source of truth (`aorta._env_rules`). This closes the "green command, zero work" class where a malformed entry passed `--dry-run` and only failed per-cell at run time while a non-strict sweep still wrote a matrix and exited zero. Validation errors never echo values (they may be secrets).

## Test plan

- [x] Registry: `Environment.env` round-trip (entry-point + sidecar), name/NUL/type rejection
- [x] Recipe: recipe-level + cell + inline `extra_env` parse, merge, replay; invalid-name and NUL rejection at load
- [x] Dispatcher: full precedence, `_aorta_trial_env` composition, ambient-var exclusion, env restoration on success + crash, NUL-before-mutation
- [x] Docker helper: deterministic output, never reads `os.environ`, name/NUL/type validation
- [x] `aorta._env_rules` unit tests (incl. dependency-free guard)
- [x] Focused suite green (361 passed); broad suite green except 2 pre-existing Windows-only failures unrelated to this change
- [ ] mypy — not available in the dev environment used; run in CI
- [ ] Full suite on Linux CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)