### PR TITLE
ci(gpu): make an errored workload fail the regression gate (strict exit codes)

### DIFF
--- a/config/ci/gpu_regression_smokes.yaml
+++ b/config/ci/gpu_regression_smokes.yaml
@@ -13,10 +13,10 @@
 #                 GPU-touching PRs stay protected without starving the runner.
 #                 Nightly / workflow_dispatch (AORTA_CI_TIER=full) run everything.
 #
-# Exit codes: every `aorta sweep run` smoke passes ``--strict``. Without it the
+# Exit codes: every ``aorta sweep run`` smoke passes ``--strict``. Without it the
 # matrix flow tolerates per-cell failures and exits 0, so a workload that errors
 # or never runs would leave this gate green -- the one thing it exists to catch.
-# `aorta run` needs no flag: it already exits non-zero on a failed trial.
+# ``aorta run`` needs no flag: it already exits non-zero on a failed trial.
 # ``--strict`` deliberately does NOT trip on a cell that ran and reported
 # passed=False, which is an expected A/B "bug reproduced" outcome; these smokes
 # are all expected to pass cleanly, so an errored workload is the target here.
@@ -35,7 +35,7 @@ smokes:
   - name: gpu_smoke_cli
     pr: true
     command:
-      # No --strict: `aorta run` derives its exit code from trial results.
+      # No ``--strict``: ``aorta run`` derives its exit code from trial results.
       - aorta
       - run
       - --workload

--- a/config/ci/gpu_regression_smokes.yaml
+++ b/config/ci/gpu_regression_smokes.yaml
@@ -12,6 +12,14 @@
 #                 (AORTA_CI_TIER=pr). Keep the PR set fast and single-GPU so
 #                 GPU-touching PRs stay protected without starving the runner.
 #                 Nightly / workflow_dispatch (AORTA_CI_TIER=full) run everything.
+#
+# Exit codes: every `aorta sweep run` smoke passes ``--strict``. Without it the
+# matrix flow tolerates per-cell failures and exits 0, so a workload that errors
+# or never runs would leave this gate green -- the one thing it exists to catch.
+# `aorta run` needs no flag: it already exits non-zero on a failed trial.
+# ``--strict`` deliberately does NOT trip on a cell that ran and reported
+# passed=False, which is an expected A/B "bug reproduced" outcome; these smokes
+# are all expected to pass cleanly, so an errored workload is the target here.
 
 smokes:
   - name: gpu_smoke_recipe
@@ -22,10 +30,12 @@ smokes:
       - run
       - --recipe
       - recipes/ci/gpu-smoke.yaml
+      - --strict
 
   - name: gpu_smoke_cli
     pr: true
     command:
+      # No --strict: `aorta run` derives its exit code from trial results.
       - aorta
       - run
       - --workload
@@ -43,6 +53,7 @@ smokes:
       - run
       - --recipe
       - recipes/inference/example-inference-smoke.yaml
+      - --strict
 
   # Distributed (2-GPU) reproducer: nightly / dispatch only -- too heavy for the
   # per-PR path and needs a second GPU.
@@ -57,3 +68,4 @@ smokes:
       - run
       - --recipe
       - recipes/race/race_smoke.yaml
+      - --strict

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -246,6 +246,19 @@ group and add a smoke recipe/command to the manifest.
 Current smokes: `gpu_smoke` (recipe + CLI, PR tier), `inference` smoke (PR
 tier), `race` smoke (nightly only, requires 2 GPUs).
 
+**Exit codes.** New `aorta sweep run` smokes must pass `--strict`, so the sweep
+exits non-zero when a cell errors or never runs; the matrix flow otherwise
+tolerates per-cell failures and exits 0, leaving this gate green on a broken
+workload. `aorta run` needs no flag -- it already exits non-zero on a failed
+trial. Note that `--strict` does not trip on a cell that ran but reported
+`passed=False` (an expected A/B "bug reproduced" outcome); every smoke here is
+expected to pass cleanly, so an errored workload is what this guards against.
+
+Broader per-workload coverage (dtype and GPU-count axes, metric regressions
+against blessed baselines) lives in the nightly eval matrix instead -- see
+[`ci-nightly-eval.md`](ci-nightly-eval.md). Keep this manifest focused on fast
+crash-level protection, with the PR tier the part that gates merges.
+
 ### Making the GPU gate a required check
 
 After a stable soak on the runner, add the GPU jobs as **required status


### PR DESCRIPTION
Follow-up to #268 / #295 (GPU CI Phase 2). **Rescoped** — see "What changed since the original PR" below.

## The problem

`aorta sweep run` exits 0 even when a cell ERRORS or never runs (`did_not_run`) — the matrix flow tolerates per-cell failures by design. Every recipe smoke in `config/ci/gpu_regression_smokes.yaml` runs that way, so `workload regression (GPU, MI350)` stays **green** on a workload that crashed or never started. That is the one failure mode this gate exists to catch, on both the PR tier and nightly.

## The fix

Pass `--strict` on the three `aorta sweep run` smokes (`gpu_smoke_recipe`, `inference_smoke`, `race_smoke`). `gpu_smoke_cli` needs no flag: `aorta run` already derives its exit code from trial results.

`--strict` intentionally does **not** trip on a cell that ran and reported `passed=False` — that is an expected A/B "bug reproduced" outcome. All smokes here are expected to pass cleanly, so an errored/crashed workload is what we are guarding against.

## What changed since the original PR

The original version of this PR also expanded the manifest to sweep every runnable workload (8 new entries, +113 lines). That half is now **dropped as superseded**: `config/ci/nightly_eval_matrix.yaml` landed afterwards and already runs every runnable workload under `--strict`, across the GPU-count axis (2- **and** 8-GPU variants), with metric regressions graded against blessed baselines.

The two things the old version added beyond that matrix are the very entries the matrix documents as deliberately excluded, and both reasons still hold:

- **continuous-batch inference** — `recipes/inference/example-inference-continuous-smoke.yaml` fails on the MI350 runner ("1 failed of 1 trial") while the offline smoke passes; a genuine workload issue to fix separately.
- **HRX (3 entries)** — the shipped `recipes/hrx/*.yaml` hard-code `/path/to/hrx-root` preload paths and build for `gfx942`, while the runner is `gfx950` with no HRX runtime provisioned. Verified still true on `main` today.

Wiring those under `--strict` would turn the nightly red on known-broken recipes. This manifest now stays focused on fast crash-level protection, which is also the part that gates PRs; broader coverage belongs to the nightly eval matrix, and `docs/ci-testing-plan.md` now says so and points there.

Net diff is +25/-0 instead of +113/-4, rebased on current `main`.

## Test plan

- [ ] `workload regression (GPU, MI350)` PR tier passes (unchanged set: 2 sweep smokes + 1 CLI smoke, all single-GPU).
- [ ] Nightly / dispatch `full` tier passes, adding the 2-GPU `race` smoke.
- Verified locally that the manifest parses under the runner's exact validation and tier logic, that all three sweep smokes carry `--strict` and the CLI smoke does not, and that both tiers select the same entries as before.

Made with [Cursor](https://cursor.com)