### PR TITLE
env probe: add mismatch-only namespace observations

### DIFF
--- a/docs/env-probe-container-execution-context.md
+++ b/docs/env-probe-container-execution-context.md
@@ -23,15 +23,18 @@ guardrail, not a data source.
 
 **Landed (phase 2 — namespace; schema 1.12):**
 
-- `probe_namespace` (`str | null`) — a coarse "same isolation boundary?" diff
-  key from `/proc/self/ns/mnt` (or `/proc/self/cgroup` as fallback), **salted
-  with the per-boot `boot_id` and SHA-256'd** → `mnt:<hash[:16]>` /
-  `cgroup:<hash[:16]>`. The boot salt is what makes cross-snapshot equality
-  meaningful: a raw mount-ns inode / cgroup path is only unique within one
-  kernel boot, so two unrelated hosts can collide on it; salting scopes the
-  key to (host, boot). When `boot_id` is unreadable the raw token is emitted
-  as `mnt-local:` / `cgroup-local:` and is explicitly local-only (not for
-  cross-host comparison). Additive, defaulted `null`, `from_dict()` backfill.
+- `probe_namespace` (`str | null`) — a **mismatch-only namespace
+  observation** from `/proc/self/ns/mnt` (or `/proc/self/ns/cgroup` as
+  fallback), hashed with the per-boot `boot_id` →
+  `mnt:<hash[:16]>` / `cgroup-ns:<hash[:16]>`. Different values with the
+  same prefix prove a different boot or namespace observation. Equal values
+  are advisory only: Linux may recycle non-initial namespace inode numbers
+  after teardown, so an artifact cannot prove durable identity across time.
+  When `boot_id` is unreadable, the token remains hashed and is emitted as
+  `mnt-local:` / `cgroup-ns-local:`; it is explicitly not cross-host
+  comparable. Different source prefixes are also not directly comparable.
+  Missing boot identity, fallback use, and total failure are recorded as
+  partial reasons. Additive, defaulted `null`, `from_dict()` backfill.
 
 **Still REMAINING (phase 2 — Buck2 / remote-execution, needs MI350 empirics):**
 
@@ -144,7 +147,7 @@ New fields (same additive pattern as the amdgpu_driver 1.10 change). The
 | `container_detected` | `bool` | **Single boolean.** `true` on *any* isolation signal: a named-runtime match (`_detect_container_type() != "baremetal"`), a private mount namespace (`/proc/self/ns/mnt` != `/proc/1/ns/mnt`), or a container/k8s token in `/proc/self/cgroup` (`docker`/`containerd`/`kubepods`/`libpod`/`lxc`/`crio`). Fixes the RE-sandbox-as-baremetal false negative. No k8s-vs-containerd distinction. | **1 (done)** |
 | `execution_context.probe_invocation` | `"direct" \| "buck2_run" \| "buck2_action"` | How the probe was launched. Phase 1: **self-declared** via `--execution-context` (defaults to `direct`). Phase 2 may auto-detect via native RE env vars (**see Open Q1**). | **1 (done, self-declared)** |
 | `execution_context.likely_execution_platform` | `str \| null` | Best-effort: from `buck2 audit configurations` / cquery on the target, the resolved platform label. Advisory, not guaranteed (**Open Q2**). Key present today, always `null`. | 2 (remaining) |
-| `probe_namespace` | `str \| null` | **Boot-salted** hash of the mount namespace (`/proc/self/ns/mnt`) or cgroup path fallback: `mnt:<sha256[:16]>` / `cgroup:<sha256[:16]>`, salted with `boot_id` so an inode/path that repeats across unrelated hosts can't falsely compare equal; `*-local:<raw>` when `boot_id` is unavailable (local-only). A coarse "same isolation boundary?" diff key, nothing more. | **2 (done)** |
+| `probe_namespace` | `str \| null` | **Mismatch-only observation**: boot-scoped hash of `/proc/self/ns/mnt`, falling back to `/proc/self/ns/cgroup`: `mnt:<sha256[:16]>` / `cgroup-ns:<sha256[:16]>`; hashed `*-local:` form when `boot_id` is unavailable. Different same-kind values prove different observations; equality is advisory because namespace inode numbers can be recycled. | **2 (done)** |
 | `$AORTA_RE_IMAGE` convention | env var | Extend the existing `$AORTA_DOCKER_IMAGE` launcher pattern to Buck2: customers set this in their `remote_execution_properties` / action env (**pending Open Q1** — a native marker may exist and be preferable). Already read by the phase-1 warning. | 2 (remaining) |
 
 ### CLI — a labeling+validation flag, not a behavior change
@@ -179,8 +182,11 @@ policy). *(Phase 2.)*
 2. If remote, the probe must run as a Buck2 action/genrule dependency of the
    failing target, not standalone.
 3. Always capture **both** a host-side probe and an in-action probe; diff
-   `runtime_context`, `container_detected`, and `amdgpu_driver.kfd_device_present`
-   as the first triage step.
+   `runtime_context`, `container_detected`, `probe_namespace`, and
+   `amdgpu_driver.kfd_device_present` as the first triage step. A different
+   same-kind `probe_namespace` proves different observations; equality is
+   only advisory and must not be treated as proof that both probes shared a
+   durable namespace.
 
 ### Proposed runbook wording (Residual NaN / repro)
 

--- a/docs/env-probe-container-execution-context.md
+++ b/docs/env-probe-container-execution-context.md
@@ -21,6 +21,18 @@ Phase 1 captures **nothing new about a remote worker** — it only makes the
 "probed the wrong place" failure visible. That is the whole point: it is a
 guardrail, not a data source.
 
+**Landed (phase 2 — namespace; schema 1.12):**
+
+- `probe_namespace` (`str | null`) — a coarse "same isolation boundary?" diff
+  key from `/proc/self/ns/mnt` (or `/proc/self/cgroup` as fallback), **salted
+  with the per-boot `boot_id` and SHA-256'd** → `mnt:<hash[:16]>` /
+  `cgroup:<hash[:16]>`. The boot salt is what makes cross-snapshot equality
+  meaningful: a raw mount-ns inode / cgroup path is only unique within one
+  kernel boot, so two unrelated hosts can collide on it; salting scopes the
+  key to (host, boot). When `boot_id` is unreadable the raw token is emitted
+  as `mnt-local:` / `cgroup-local:` and is explicitly local-only (not for
+  cross-host comparison). Additive, defaulted `null`, `from_dict()` backfill.
+
 **Still REMAINING (phase 2 — Buck2 / remote-execution, needs MI350 empirics):**
 
 - `execution_context.likely_execution_platform` — resolved RE platform label.
@@ -32,9 +44,6 @@ guardrail, not a data source.
   exist and be preferable; do not invent the convention until Q1 is answered.
   (The env var is already read by the `--execution-context` warning so the
   convention can be adopted without further code once Q1 is settled.)
-- `probe_namespace` (mount-ns / cgroup hash diff key) — deferred; the phase-1
-  `container_detected` boolean covers the immediate false-negative bug, and
-  the namespace hash is only useful once two-probe RE diffing exists.
 - The Buck2 `genrule`/`sh_test` rule wrapper — documentation-only per the
   external-tool policy; deferred until phase 2.
 - Open Q1, Q2, Q3 below all remain open (Q1/Q2 need a real Buck2 RE cluster;
@@ -135,7 +144,7 @@ New fields (same additive pattern as the amdgpu_driver 1.10 change). The
 | `container_detected` | `bool` | **Single boolean.** `true` on *any* isolation signal: a named-runtime match (`_detect_container_type() != "baremetal"`), a private mount namespace (`/proc/self/ns/mnt` != `/proc/1/ns/mnt`), or a container/k8s token in `/proc/self/cgroup` (`docker`/`containerd`/`kubepods`/`libpod`/`lxc`/`crio`). Fixes the RE-sandbox-as-baremetal false negative. No k8s-vs-containerd distinction. | **1 (done)** |
 | `execution_context.probe_invocation` | `"direct" \| "buck2_run" \| "buck2_action"` | How the probe was launched. Phase 1: **self-declared** via `--execution-context` (defaults to `direct`). Phase 2 may auto-detect via native RE env vars (**see Open Q1**). | **1 (done, self-declared)** |
 | `execution_context.likely_execution_platform` | `str \| null` | Best-effort: from `buck2 audit configurations` / cquery on the target, the resolved platform label. Advisory, not guaranteed (**Open Q2**). Key present today, always `null`. | 2 (remaining) |
-| `probe_namespace` | `str \| null` | Hash of the mount namespace / cgroup path (e.g. `/proc/self/ns/mnt` inode). A coarse "same isolation boundary?" diff key, nothing more. | 2 (remaining) |
+| `probe_namespace` | `str \| null` | **Boot-salted** hash of the mount namespace (`/proc/self/ns/mnt`) or cgroup path fallback: `mnt:<sha256[:16]>` / `cgroup:<sha256[:16]>`, salted with `boot_id` so an inode/path that repeats across unrelated hosts can't falsely compare equal; `*-local:<raw>` when `boot_id` is unavailable (local-only). A coarse "same isolation boundary?" diff key, nothing more. | **2 (done)** |
 | `$AORTA_RE_IMAGE` convention | env var | Extend the existing `$AORTA_DOCKER_IMAGE` launcher pattern to Buck2: customers set this in their `remote_execution_properties` / action env (**pending Open Q1** — a native marker may exist and be preferable). Already read by the phase-1 warning. | 2 (remaining) |
 
 ### CLI — a labeling+validation flag, not a behavior change

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -130,7 +130,7 @@ end-of-output. Sample:
 
 ```text
 Wrote env probe to /tmp/env.json (schema_version=1.12) [PARTIAL]
-  runtime:   baremetal / python=venv  container_detected=no  probe=direct
+  runtime:   baremetal / python=venv  container_detected=no  probe=direct  ns=mnt:1a2b3c…
   build_sys: none
   rocm:      7.2.1 (dev: None)
   hip:       7.2.53211-e1a6bc5663 (amd)
@@ -247,7 +247,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `runtime_context` | `dict` | `/.dockerenv`, `/run/.containerenv`, `$SINGULARITY_NAME`, `/proc/1/cgroup`, `sys.prefix`, `$CONDA_DEFAULT_ENV` | `type`, `python_env`, `venv_path`, `conda_env_name`. **`type` only ever returns `docker`/`podman`/`singularity`/`baremetal`** — an unnamed sandbox (RE worker, containerd k8s pod) falls through to `baremetal`; use `container_detected` (below) for the runtime-agnostic "am I isolated?" answer. |
 | `container_detected` | `bool` | named-runtime match + `/proc/self/ns/mnt` vs `/proc/1/ns/mnt` (private mount ns) + container/k8s tokens in `/proc/self/cgroup` | Schema 1.11. Runtime-**agnostic** isolation smoke test: `true` on *any* sandbox signal even when the runtime can't be named. Fixes the `runtime_context.type == "baremetal"` false negative for RE-workers / k8s pods. `container_detected:true` + `type:"baremetal"` is the honest reading of an unnamed sandbox. Fail-soft; `false` means "no isolation signal observed," not "definitely bare metal." |
 | `execution_context` | `dict` | `--execution-context` CLI flag (self-declared) | Schema 1.11. `probe_invocation` (`"direct"` \| `"buck2_run"` \| `"buck2_action"`; `"direct"` by default) records **how the probe was launched** — set `buck2_action` when running the probe as a Buck2 action so it captures the executor's env, not the invoking shell's. `likely_execution_platform` (`str \| null`) is reserved for phase-2 Buck2 work and is always `null` today. See the design note `docs/env-probe-container-execution-context.md`. The flag also **warns to stderr** when a non-`direct` context is claimed but `container_detected` is `false` and neither `$AORTA_RE_IMAGE` nor `$AORTA_DOCKER_IMAGE` is set (you may have probed the wrong place). |
-| `probe_namespace` | `str \| null` | `/proc/self/ns/mnt` (primary) or `/proc/self/cgroup` (fallback), **salted with `/proc/sys/kernel/random/boot_id`** and SHA-256'd | Schema 1.12. Coarse "were these two probes captured in the same isolation boundary?" diff key — a lightweight substitute for a full `mountinfo` comparison. Value forms: `mnt:<sha256[:16]>` (boot-salted mount-ns identity), `cgroup:<sha256[:16]>` (boot-salted cgroup-path fallback when `ns/mnt` is unreadable), or `mnt-local:<raw>` / `cgroup-local:<raw>` when `boot_id` is unavailable. **The boot salt is load-bearing**: a bare mount-ns inode (`4026531840`) or cgroup path (`0::/`) is only unique within one kernel boot, so two *unrelated* hosts routinely emit the same raw token — salting makes the key boot-scoped, so equal digests mean "same host, same boot, same namespace" rather than a cross-host coincidence. The `*-local:` forms are explicitly flagged as **not** safe to compare across snapshots from different hosts. `null` when all sources fail. Fail-soft; never raises. |
+| `probe_namespace` | `str \| null` | `/proc/self/ns/mnt` (primary) or `/proc/self/ns/cgroup` (fallback), hashed with `/proc/sys/kernel/random/boot_id` | Schema 1.12. **Mismatch-only namespace observation**, not a durable identity. Value forms: `mnt:<sha256[:16]>` or `cgroup-ns:<sha256[:16]>`; when `boot_id` is unavailable, the source token remains hashed and the prefix becomes `mnt-local:` / `cgroup-ns-local:`. Different values with the same prefix prove a different boot or namespace observation. Equal values are advisory because Linux can recycle non-initial namespace inode numbers after teardown. Different source prefixes are not directly comparable, and `*-local:` values are not cross-host comparable. Missing boot identity, fallback use, and total failure add `partial_reasons`; `null` means neither namespace handle was readable. |
 | `docker` | `dict \| null` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` env vars + `/proc/self/cgroup` | `null` on baremetal; image+digest provided by the launcher (the only reliable way from inside a container) |
 | `env_vars` | `dict[str, str \| null]` | explicit canonical list (currently 58 names; see `CANONICAL_ENV_VARS` in `environment.py` for the live set) | GPU scoping + HSA / runtime + GPU queue / codegen + NCCL/RCCL + AINIC net-plugin/fabric tuning + gfx950 fence-ordering knob + FBGEMM + MIOpen + SDPA backend selection + GEMM backend preference + hipBLASLt autotune + PyTorch / inductor. Build-time cmake flags (`USE_ROCM_CK_SDPA`, `USE_ROCM_CK_GEMM`, `USE_FBGEMM*`) are NOT in this list -- they're surfaced under their respective library blocks instead, parsed from `torch.__config__.show()`. |
 | `python_version` | `str` | `platform.python_version()` | always populated |
@@ -444,18 +444,18 @@ Container & execution-context visibility, phase 2 (namespace). Additive —
 one new top-level field, defaulted so older readers don't raise. See the
 design note `docs/env-probe-container-execution-context.md`.
 
-* New top-level **`probe_namespace`** (`str | null`). A coarse "same
-  isolation boundary?" diff key derived from `/proc/self/ns/mnt` (mount-ns
-  identity), or `/proc/self/cgroup` as a fallback, **salted with the
-  per-boot `boot_id` (`/proc/sys/kernel/random/boot_id`) and SHA-256'd** →
-  `mnt:<hash[:16]>` / `cgroup:<hash[:16]>`. The salt is essential: a bare
-  mount-ns inode or cgroup path is only unique within one kernel boot, so
-  two unrelated hosts can share it — salting makes equal values mean "same
-  host + boot + namespace" instead of a coincidence. When `boot_id` is
-  unavailable the raw token is emitted as `mnt-local:` / `cgroup-local:`,
-  explicitly flagged as local-only (never compare across hosts). `null`
-  when all sources fail. Defaulted `null` + `from_dict()` backfill so
-  pre-1.12 snapshots round-trip. Fail-soft; never raises.
+* New top-level **`probe_namespace`** (`str | null`). A mismatch-only
+  namespace observation derived from `/proc/self/ns/mnt`, or
+  `/proc/self/ns/cgroup` as a fallback, hashed with the per-boot `boot_id`
+  (`/proc/sys/kernel/random/boot_id`) → `mnt:<hash[:16]>` /
+  `cgroup-ns:<hash[:16]>`. Different same-kind values prove different
+  observations; equality is advisory because Linux can recycle namespace
+  inode numbers after teardown. When `boot_id` is unavailable the token is
+  still hashed and emitted as `mnt-local:` / `cgroup-ns-local:`; it is not
+  cross-host comparable. Missing boot identity, fallback use, and total
+  failure add partial reasons. `null` means neither namespace handle was
+  readable. Defaulted `null` + `from_dict()` backfill so pre-1.12 snapshots
+  round-trip.
 
 ### `1.11`
 
@@ -486,7 +486,7 @@ design note `docs/env-probe-container-execution-context.md`.
 * **Remaining (phase 2, Buck2 / remote-execution):**
   `likely_execution_platform` population and the `$AORTA_RE_IMAGE` launcher
   convention are deferred pending on-cluster empirics — see the design
-  note's Open Questions. (The `probe_namespace` diff key landed in schema
+  note's Open Questions. (The `probe_namespace` observation landed in schema
   1.12, above.)
 
 ### `1.10`

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -129,7 +129,7 @@ operator can act on them without `jq`'ing the JSON. A closing
 end-of-output. Sample:
 
 ```text
-Wrote env probe to /tmp/env.json (schema_version=1.11) [PARTIAL]
+Wrote env probe to /tmp/env.json (schema_version=1.12) [PARTIAL]
   runtime:   baremetal / python=venv  container_detected=no  probe=direct
   build_sys: none
   rocm:      7.2.1 (dev: None)
@@ -220,7 +220,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | Currently `"1.11"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
+| `schema_version` | `str` | constant | Currently `"1.12"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
@@ -247,6 +247,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `runtime_context` | `dict` | `/.dockerenv`, `/run/.containerenv`, `$SINGULARITY_NAME`, `/proc/1/cgroup`, `sys.prefix`, `$CONDA_DEFAULT_ENV` | `type`, `python_env`, `venv_path`, `conda_env_name`. **`type` only ever returns `docker`/`podman`/`singularity`/`baremetal`** — an unnamed sandbox (RE worker, containerd k8s pod) falls through to `baremetal`; use `container_detected` (below) for the runtime-agnostic "am I isolated?" answer. |
 | `container_detected` | `bool` | named-runtime match + `/proc/self/ns/mnt` vs `/proc/1/ns/mnt` (private mount ns) + container/k8s tokens in `/proc/self/cgroup` | Schema 1.11. Runtime-**agnostic** isolation smoke test: `true` on *any* sandbox signal even when the runtime can't be named. Fixes the `runtime_context.type == "baremetal"` false negative for RE-workers / k8s pods. `container_detected:true` + `type:"baremetal"` is the honest reading of an unnamed sandbox. Fail-soft; `false` means "no isolation signal observed," not "definitely bare metal." |
 | `execution_context` | `dict` | `--execution-context` CLI flag (self-declared) | Schema 1.11. `probe_invocation` (`"direct"` \| `"buck2_run"` \| `"buck2_action"`; `"direct"` by default) records **how the probe was launched** — set `buck2_action` when running the probe as a Buck2 action so it captures the executor's env, not the invoking shell's. `likely_execution_platform` (`str \| null`) is reserved for phase-2 Buck2 work and is always `null` today. See the design note `docs/env-probe-container-execution-context.md`. The flag also **warns to stderr** when a non-`direct` context is claimed but `container_detected` is `false` and neither `$AORTA_RE_IMAGE` nor `$AORTA_DOCKER_IMAGE` is set (you may have probed the wrong place). |
+| `probe_namespace` | `str \| null` | `/proc/self/ns/mnt` (primary) or `/proc/self/cgroup` (fallback), **salted with `/proc/sys/kernel/random/boot_id`** and SHA-256'd | Schema 1.12. Coarse "were these two probes captured in the same isolation boundary?" diff key — a lightweight substitute for a full `mountinfo` comparison. Value forms: `mnt:<sha256[:16]>` (boot-salted mount-ns identity), `cgroup:<sha256[:16]>` (boot-salted cgroup-path fallback when `ns/mnt` is unreadable), or `mnt-local:<raw>` / `cgroup-local:<raw>` when `boot_id` is unavailable. **The boot salt is load-bearing**: a bare mount-ns inode (`4026531840`) or cgroup path (`0::/`) is only unique within one kernel boot, so two *unrelated* hosts routinely emit the same raw token — salting makes the key boot-scoped, so equal digests mean "same host, same boot, same namespace" rather than a cross-host coincidence. The `*-local:` forms are explicitly flagged as **not** safe to compare across snapshots from different hosts. `null` when all sources fail. Fail-soft; never raises. |
 | `docker` | `dict \| null` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` env vars + `/proc/self/cgroup` | `null` on baremetal; image+digest provided by the launcher (the only reliable way from inside a container) |
 | `env_vars` | `dict[str, str \| null]` | explicit canonical list (currently 58 names; see `CANONICAL_ENV_VARS` in `environment.py` for the live set) | GPU scoping + HSA / runtime + GPU queue / codegen + NCCL/RCCL + AINIC net-plugin/fabric tuning + gfx950 fence-ordering knob + FBGEMM + MIOpen + SDPA backend selection + GEMM backend preference + hipBLASLt autotune + PyTorch / inductor. Build-time cmake flags (`USE_ROCM_CK_SDPA`, `USE_ROCM_CK_GEMM`, `USE_FBGEMM*`) are NOT in this list -- they're surfaced under their respective library blocks instead, parsed from `torch.__config__.show()`. |
 | `python_version` | `str` | `platform.python_version()` | always populated |
@@ -437,7 +438,26 @@ Mirrors the in-code comment at `SCHEMA_VERSION` in
 `src/aorta/instrumentation/environment.py`. Recorded here so consumers
 tracking schema evolution don't have to read source.
 
-### `1.11` (current)
+### `1.12` (current)
+
+Container & execution-context visibility, phase 2 (namespace). Additive —
+one new top-level field, defaulted so older readers don't raise. See the
+design note `docs/env-probe-container-execution-context.md`.
+
+* New top-level **`probe_namespace`** (`str | null`). A coarse "same
+  isolation boundary?" diff key derived from `/proc/self/ns/mnt` (mount-ns
+  identity), or `/proc/self/cgroup` as a fallback, **salted with the
+  per-boot `boot_id` (`/proc/sys/kernel/random/boot_id`) and SHA-256'd** →
+  `mnt:<hash[:16]>` / `cgroup:<hash[:16]>`. The salt is essential: a bare
+  mount-ns inode or cgroup path is only unique within one kernel boot, so
+  two unrelated hosts can share it — salting makes equal values mean "same
+  host + boot + namespace" instead of a coincidence. When `boot_id` is
+  unavailable the raw token is emitted as `mnt-local:` / `cgroup-local:`,
+  explicitly flagged as local-only (never compare across hosts). `null`
+  when all sources fail. Defaulted `null` + `from_dict()` backfill so
+  pre-1.12 snapshots round-trip. Fail-soft; never raises.
+
+### `1.11`
 
 Container & execution-context visibility, phase 1. Additive — two new
 top-level fields, both defaulted so older readers don't raise. See the
@@ -464,9 +484,10 @@ design note `docs/env-probe-container-execution-context.md`.
   `$AORTA_RE_IMAGE` nor `$AORTA_DOCKER_IMAGE` is set (the "you probed the
   host shell, not where the job ran" guardrail). Never a hard error.
 * **Remaining (phase 2, Buck2 / remote-execution):**
-  `likely_execution_platform` population, the `$AORTA_RE_IMAGE` launcher
-  convention, and a `probe_namespace` diff key are deferred pending
-  on-cluster empirics — see the design note's Open Questions.
+  `likely_execution_platform` population and the `$AORTA_RE_IMAGE` launcher
+  convention are deferred pending on-cluster empirics — see the design
+  note's Open Questions. (The `probe_namespace` diff key landed in schema
+  1.12, above.)
 
 ### `1.10`
 

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -41,6 +41,9 @@ Captured blocks:
   ``fbgemm`` also surfaces the ``-DUSE_FBGEMM`` / ``-DUSE_FBGEMM_GENAI``
   build-time flags from ``torch.__config__.show()``.
 * ``runtime_context`` -- container runtime + Python env detection.
+* ``container_detected`` / ``execution_context`` -- runtime-agnostic
+  isolation signal + caller-declared probe placement.
+* ``probe_namespace`` -- mismatch-only, hashed namespace observation.
 * ``docker`` -- image + digest when in a container.
 * ``env_vars`` -- canonical list of HSA / RCCL / FBGEMM / PyTorch vars.
 * ``python_version``, ``pytorch_version``.
@@ -80,20 +83,18 @@ log = logging.getLogger(__name__)
 
 SCHEMA_VERSION = "1.12"
 # 1.11 -> 1.12 (container & execution-context visibility, phase 2 -- namespace):
-#   - New top-level ``probe_namespace`` (``str | None``). A coarse
-#     "same isolation boundary?" diff key derived from
-#     ``/proc/self/ns/mnt`` (the ``mnt:[<inode>]`` token), SALTED with
-#     the per-boot ``boot_id`` and hashed -> ``mnt:<sha256[:16]>``. The
-#     salt is essential: a bare mount-ns inode is only unique within one
-#     kernel boot, so two unrelated hosts can share it; salting makes the
-#     key boot-scoped so cross-host equality is meaningful, not a
-#     coincidence. Fallback: ``cgroup:<sha256[:16]>`` over the salted
-#     ``/proc/self/cgroup`` path when ``ns/mnt`` is unreadable. When
-#     ``boot_id`` is unavailable the value is emitted as
-#     ``mnt-local:``/``cgroup-local:`` over the raw token -- explicitly
-#     local-only, not for cross-host comparison. ``None`` when all fail.
-#     Defaulted ``None`` + ``from_dict()`` backfill so pre-1.12
-#     snapshots round-trip. Never raises. See
+#   - New top-level ``probe_namespace`` (``str | None``). A mismatch-only
+#     namespace observation derived from ``/proc/self/ns/mnt`` (primary)
+#     or ``/proc/self/ns/cgroup`` (fallback), hashed with the per-boot
+#     ``boot_id`` -> ``mnt:<sha256[:16]>`` / ``cgroup-ns:<sha256[:16]>``.
+#     Different same-kind values prove that the observations came from
+#     different boots/namespaces. Equality is advisory only: Linux can
+#     recycle non-initial namespace inode numbers after namespace teardown.
+#     When ``boot_id`` is unavailable, the token is still hashed and emitted
+#     as ``mnt-local:`` / ``cgroup-ns-local:``; it is not cross-host
+#     comparable. Missing boot identity, fallback use, and total capture
+#     failure are recorded in ``partial_reasons``. Defaulted ``None`` +
+#     ``from_dict()`` backfill so pre-1.12 snapshots round-trip. See
 #     ``_capture_probe_namespace()``.
 #
 # 1.10 -> 1.11 (container & execution-context visibility, phase 1):
@@ -908,10 +909,15 @@ SELF_CGROUP_FILE = Path("/proc/self/cgroup")
 # real /proc.
 INIT_MNT_NS = Path("/proc/1/ns/mnt")
 SELF_MNT_NS = Path("/proc/self/ns/mnt")
+# Cgroup-namespace handle used only when the mount-namespace handle is
+# unavailable. Do NOT substitute /proc/self/cgroup: cgroup namespaces make
+# that membership path relative to their own root, so distinct containers
+# commonly expose the same ``0::/`` text.
+SELF_CGROUP_NS = Path("/proc/self/ns/cgroup")
 # Per-boot random identity, unique per (host, boot). Used to SALT the
-# ``probe_namespace`` diff key so a mount-ns inode / cgroup path -- both of
-# which are only unique within one kernel boot -- cannot collide across two
-# unrelated hosts and be misread as "same isolation boundary". Distinct
+# ``probe_namespace`` observation so an inode reused on another boot/host
+# cannot compare equal merely by coincidence. Namespace inode numbers can
+# still be recycled within one boot, so equality remains advisory. Distinct
 # constant so tests can monkeypatch it.
 BOOT_ID_FILE = Path("/proc/sys/kernel/random/boot_id")
 
@@ -1072,12 +1078,12 @@ class EnvSnapshot:
     execution_context: dict = field(
         default_factory=lambda: _empty_execution_context()
     )
-    # probe_namespace: coarse "same isolation boundary?" diff key (schema
-    # 1.12). Boot-salted digest of the mount-ns inode (``mnt:<sha256[:16]>``)
-    # or, as a fallback, the cgroup path (``cgroup:<sha256[:16]>``); a
-    # ``*-local:<raw>`` form when boot_id is unavailable (local-only, never
-    # compare across hosts). ``None`` when all sources fail. Defaulted so
-    # pre-1.12 snapshots round-trip. See ``_capture_probe_namespace()``.
+    # probe_namespace: mismatch-only namespace observation (schema 1.12).
+    # Boot-salted digest of the mount-ns handle (``mnt:<sha256[:16]>``) or
+    # cgroup-ns handle (``cgroup-ns:<sha256[:16]>``); a hashed ``*-local:``
+    # form when boot_id is unavailable. Equal values are advisory because
+    # Linux may recycle namespace inode numbers after teardown. ``None`` when
+    # all sources fail. Defaulted so pre-1.12 snapshots round-trip.
     probe_namespace: str | None = None
 
     # Curated emit order for ``to_dict()`` / ``env.json`` (JSON is written
@@ -1308,7 +1314,8 @@ class EnvSnapshot:
             (
                 f"  runtime:   {rt.get('type', '?')} / python={rt.get('python_env', '?')}"
                 f"  container_detected={'yes' if self.container_detected else 'no'}"
-                f"  probe={ec.get('probe_invocation', '?')}",
+                f"  probe={ec.get('probe_invocation', '?')}"
+                f"  ns={short_hash(self.probe_namespace)}",
                 f"  host:      kernel={host.get('kernel_release') or '?'} "
                 f"machine={host.get('machine') or '?'}  "
                 f"glibc={host.get('glibc_version') or '?'}",
@@ -2031,6 +2038,8 @@ def collect_env(
     """
     include_files = detail == "full"
     reasons: list[str] = []
+    probe_namespace: str | None = None
+    probe_namespace_captured = False
     # Capture fds 1/2 at the OS level for the probe body so that the benign
     # HIP/C-runtime device-enumeration noise the in-process ``import torch``
     # below emits straight to fd 2 never reaches the operator's terminal
@@ -2042,10 +2051,11 @@ def collect_env(
         # container_detected: runtime-agnostic isolation smoke test that
         # catches RE/k8s sandboxes runtime_context.type misses (schema
         # 1.11). execution_context: self-declared probe_invocation label.
-        # probe_namespace: coarse mount-ns identity diff key (schema 1.12).
+        # probe_namespace: mismatch-only namespace observation (schema 1.12).
         container_detected = _detect_container_detected()
         execution_context = _empty_execution_context()
-        probe_namespace = _capture_probe_namespace()
+        probe_namespace = _capture_probe_namespace(reasons)
+        probe_namespace_captured = True
         if probe_invocation in EXECUTION_CONTEXT_INVOCATIONS:
             execution_context["probe_invocation"] = probe_invocation
         else:
@@ -2171,6 +2181,8 @@ def collect_env(
                 f"({type(exc).__name__}: {exc})"
             ),
             probe_invocation=probe_invocation,
+            probe_namespace=probe_namespace,
+            probe_namespace_captured=probe_namespace_captured,
         )
     finally:
         # Idempotent: a no-op if the except branch already restored stdio.
@@ -2181,6 +2193,8 @@ def _disaster_snapshot(
     preceding_reasons: list[str],
     unexpected_reason: str,
     probe_invocation: str = "direct",
+    probe_namespace: str | None = None,
+    probe_namespace_captured: bool = False,
 ) -> EnvSnapshot:
     """Return a minimally-shaped EnvSnapshot when collect_env crashes.
 
@@ -2189,6 +2203,10 @@ def _disaster_snapshot(
     snapshot from a ``buck2_action`` run must not silently rewrite itself
     to ``"direct"``, which would misdirect triage. An unrecognized value
     falls back to ``"direct"`` (same rule as the happy path).
+
+    ``probe_namespace`` is preserved when the happy path captured it before
+    a later helper failed. When capture was never reached, the disaster path
+    makes one guarded best-effort attempt instead.
 
     Used by the never-raises top-level guard. Every field gets a sane
     null/empty default so downstream consumers (B1, B2, jq pipelines)
@@ -2207,6 +2225,9 @@ def _disaster_snapshot(
         python_version = platform.python_version()
     except Exception:  # noqa: BLE001
         python_version = ""
+    disaster_reasons = [*preceding_reasons, unexpected_reason]
+    if not probe_namespace_captured:
+        probe_namespace = _capture_probe_namespace_safe(disaster_reasons)
 
     return EnvSnapshot(
         schema_version=SCHEMA_VERSION,
@@ -2313,10 +2334,10 @@ def _disaster_snapshot(
         # here too, since the crash may have happened before collect_env's
         # own validation ran.
         execution_context=_disaster_execution_context(probe_invocation),
-        # probe_namespace: best-effort even in the disaster path, but the
-        # function may not have been reachable -- None is the honest answer
-        # when we don't know our namespace identity.
-        probe_namespace=None,
+        # Preserve a value captured before a later helper crashed; if the
+        # happy path never reached the namespace probe, the safe wrapper
+        # makes one best-effort attempt here.
+        probe_namespace=probe_namespace,
         host={
             "kernel_release": None,
             "kernel_version": None,
@@ -2366,7 +2387,7 @@ def _disaster_snapshot(
         },
         build_system={"kind": "none"},
         partial=True,
-        partial_reasons=[*preceding_reasons, unexpected_reason],
+        partial_reasons=disaster_reasons,
         library_introspection=[],
         library_introspection_alternates=[],
     )
@@ -3304,60 +3325,87 @@ def _mount_namespace_differs_from_init() -> bool:
     return bool(self_ns) and bool(init_ns) and self_ns != init_ns
 
 
-def _capture_probe_namespace() -> str | None:
-    """Coarse "same isolation boundary?" namespace identifier (schema 1.12).
+def _capture_probe_namespace(reasons: list[str]) -> str | None:
+    """Capture a mismatch-only namespace observation (schema 1.12).
 
     Primary source: the ``mnt:[<inode>]`` token from ``/proc/self/ns/mnt``.
-    Fallback: the ``/proc/self/cgroup`` path text when the ``ns/mnt`` symlink
-    is unreadable (``/proc`` not mounted, CAP_SYS_PTRACE denied, non-Linux).
+    Fallback: the ``cgroup:[<inode>]`` token from
+    ``/proc/self/ns/cgroup``. The cgroup *membership text* is deliberately
+    not used: separate private cgroup namespaces commonly report the same
+    relative ``0::/`` path.
 
-    **Cross-host safety.** A mount-namespace inode (``4026531840``) and a
-    cgroup path (``0::/``) are only unique within ONE kernel boot -- two
-    unrelated hosts routinely produce the *same* string. Returning the raw
-    token would let an env diff read two probes on different machines as
-    "same isolation boundary", which is false. So the token is SALTED with the
-    per-boot ``boot_id`` and hashed:
+    When the per-boot ``boot_id`` is readable, the token is boot-scoped:
 
-        ``mnt:<sha256(boot_id \\0 token)[:16]>``     (primary, boot-scoped)
-        ``cgroup:<sha256(boot_id \\0 path)[:16]>``   (fallback, boot-scoped)
+        ``mnt:<sha256(kind \\0 boot_id \\0 token)[:16]>``
+        ``cgroup-ns:<sha256(kind \\0 boot_id \\0 token)[:16]>``
 
-    Same (host, boot) -> same digest (a valid "same boundary?" key); different
-    boots/hosts -> different digests even for an identical inode. When
-    ``boot_id`` is unavailable the value is emitted with a ``-local`` kind
-    (``mnt-local:`` / ``cgroup-local:``) over the raw token, flagging that it
-    is only meaningful within the capturing host and must NOT be compared for
-    equality across snapshots from different hosts.
+    Different values with the same prefix prove a different boot or namespace
+    observation. Equal values are only advisory: Linux can recycle non-initial
+    namespace inode numbers after the old namespace is destroyed, so an
+    artifact cannot prove durable identity across time.
 
-    Returns ``None`` when both sources fail. Never raises -- all exceptions
-    are swallowed and logged at DEBUG.
+    Without ``boot_id``, the raw token is still hashed and emitted with a
+    ``-local`` prefix. This avoids leaking source text but is not cross-host
+    comparable. Missing boot identity, using the fallback source, and total
+    capture failure are all recorded in ``reasons``.
     """
-    boot_id = None
-    try:
-        boot_id = _read_text_file(BOOT_ID_FILE)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("probe_namespace: boot_id read failed: %s", exc)
+    boot_id = _read_text_file(BOOT_ID_FILE)
+    if not boot_id:
+        reasons.append(
+            "probe_namespace.boot_id: unavailable; fingerprint is local-only"
+        )
 
     def _key(kind: str, token: str) -> str:
-        # Boot-salted digest is cross-host safe; the raw-token `-local` form is
-        # explicitly marked so it is never mistaken for a portable identity.
         if boot_id:
-            digest = hashlib.sha256(f"{boot_id}\0{token}".encode()).hexdigest()[:16]
-            return f"{kind}:{digest}"
-        return f"{kind}-local:{token}"
+            material = f"{kind}\0{boot_id}\0{token}"
+            prefix = kind
+        else:
+            material = f"{kind}\0{token}"
+            prefix = f"{kind}-local"
+        digest = hashlib.sha256(material.encode()).hexdigest()[:16]
+        return f"{prefix}:{digest}"
 
     try:
-        ns = os.readlink(str(SELF_MNT_NS))
-        if ns:
-            return _key("mnt", ns)
+        mount_ns = os.readlink(str(SELF_MNT_NS))
     except OSError as exc:
-        log.debug("probe_namespace: ns/mnt readlink failed: %s", exc)
+        reasons.append(
+            "probe_namespace.mount_namespace: "
+            f"{SELF_MNT_NS} unreadable ({type(exc).__name__}: {exc}); "
+            "trying cgroup namespace"
+        )
+    else:
+        if mount_ns:
+            return _key("mnt", mount_ns)
+        reasons.append(
+            "probe_namespace.mount_namespace: empty namespace handle; "
+            "trying cgroup namespace"
+        )
+
     try:
-        cgroup = _read_text_file(SELF_CGROUP_FILE)
-        if cgroup:
-            return _key("cgroup", cgroup)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("probe_namespace: cgroup fallback failed: %s", exc)
+        cgroup_ns = os.readlink(str(SELF_CGROUP_NS))
+    except OSError as exc:
+        reasons.append(
+            "probe_namespace.cgroup_namespace: "
+            f"{SELF_CGROUP_NS} unreadable ({type(exc).__name__}: {exc})"
+        )
+    else:
+        if cgroup_ns:
+            return _key("cgroup-ns", cgroup_ns)
+        reasons.append("probe_namespace.cgroup_namespace: empty namespace handle")
     return None
+
+
+def _capture_probe_namespace_safe(reasons: list[str]) -> str | None:
+    """Disaster-path wrapper that cannot let namespace capture escape."""
+    try:
+        return _capture_probe_namespace(reasons)
+    except Exception as exc:  # noqa: BLE001 -- disaster path must not throw
+        log.debug("probe_namespace: unexpected capture failure", exc_info=True)
+        reasons.append(
+            f"probe_namespace: unexpected capture failure "
+            f"({type(exc).__name__}: {exc})"
+        )
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -78,7 +78,24 @@ from typing import Any, ClassVar
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.11"
+SCHEMA_VERSION = "1.12"
+# 1.11 -> 1.12 (container & execution-context visibility, phase 2 -- namespace):
+#   - New top-level ``probe_namespace`` (``str | None``). A coarse
+#     "same isolation boundary?" diff key derived from
+#     ``/proc/self/ns/mnt`` (the ``mnt:[<inode>]`` token), SALTED with
+#     the per-boot ``boot_id`` and hashed -> ``mnt:<sha256[:16]>``. The
+#     salt is essential: a bare mount-ns inode is only unique within one
+#     kernel boot, so two unrelated hosts can share it; salting makes the
+#     key boot-scoped so cross-host equality is meaningful, not a
+#     coincidence. Fallback: ``cgroup:<sha256[:16]>`` over the salted
+#     ``/proc/self/cgroup`` path when ``ns/mnt`` is unreadable. When
+#     ``boot_id`` is unavailable the value is emitted as
+#     ``mnt-local:``/``cgroup-local:`` over the raw token -- explicitly
+#     local-only, not for cross-host comparison. ``None`` when all fail.
+#     Defaulted ``None`` + ``from_dict()`` backfill so pre-1.12
+#     snapshots round-trip. Never raises. See
+#     ``_capture_probe_namespace()``.
+#
 # 1.10 -> 1.11 (container & execution-context visibility, phase 1):
 #   - New top-level ``container_detected`` (bool). A runtime-AGNOSTIC
 #     isolation smoke test (``_detect_container_detected()``): True on any
@@ -891,6 +908,12 @@ SELF_CGROUP_FILE = Path("/proc/self/cgroup")
 # real /proc.
 INIT_MNT_NS = Path("/proc/1/ns/mnt")
 SELF_MNT_NS = Path("/proc/self/ns/mnt")
+# Per-boot random identity, unique per (host, boot). Used to SALT the
+# ``probe_namespace`` diff key so a mount-ns inode / cgroup path -- both of
+# which are only unique within one kernel boot -- cannot collide across two
+# unrelated hosts and be misread as "same isolation boundary". Distinct
+# constant so tests can monkeypatch it.
+BOOT_ID_FILE = Path("/proc/sys/kernel/random/boot_id")
 
 
 # ---------------------------------------------------------------------------
@@ -1049,6 +1072,13 @@ class EnvSnapshot:
     execution_context: dict = field(
         default_factory=lambda: _empty_execution_context()
     )
+    # probe_namespace: coarse "same isolation boundary?" diff key (schema
+    # 1.12). Boot-salted digest of the mount-ns inode (``mnt:<sha256[:16]>``)
+    # or, as a fallback, the cgroup path (``cgroup:<sha256[:16]>``); a
+    # ``*-local:<raw>`` form when boot_id is unavailable (local-only, never
+    # compare across hosts). ``None`` when all sources fail. Defaulted so
+    # pre-1.12 snapshots round-trip. See ``_capture_probe_namespace()``.
+    probe_namespace: str | None = None
 
     # Curated emit order for ``to_dict()`` / ``env.json`` (JSON is written
     # sort_keys=False, so THIS is the artifact's key order). Grouped so
@@ -1071,6 +1101,7 @@ class EnvSnapshot:
         "runtime_context",
         "container_detected",
         "execution_context",
+        "probe_namespace",
         "docker",
         # ROCm runtime + the host-kernel driver that pairs with it
         "rocm",
@@ -1168,6 +1199,7 @@ class EnvSnapshot:
         kwargs.setdefault("amdgpu_driver", _empty_amdgpu_driver())
         kwargs.setdefault("container_detected", False)
         kwargs.setdefault("execution_context", _empty_execution_context())
+        kwargs.setdefault("probe_namespace", None)
         return cls(**kwargs)
 
     def summary(self) -> str:
@@ -2010,8 +2042,10 @@ def collect_env(
         # container_detected: runtime-agnostic isolation smoke test that
         # catches RE/k8s sandboxes runtime_context.type misses (schema
         # 1.11). execution_context: self-declared probe_invocation label.
+        # probe_namespace: coarse mount-ns identity diff key (schema 1.12).
         container_detected = _detect_container_detected()
         execution_context = _empty_execution_context()
+        probe_namespace = _capture_probe_namespace()
         if probe_invocation in EXECUTION_CONTEXT_INVOCATIONS:
             execution_context["probe_invocation"] = probe_invocation
         else:
@@ -2111,6 +2145,7 @@ def collect_env(
             runtime_context=runtime_context,
             container_detected=container_detected,
             execution_context=execution_context,
+            probe_namespace=probe_namespace,
             docker=docker,
             env_vars=env_vars,
             python_version=platform.python_version(),
@@ -2278,6 +2313,10 @@ def _disaster_snapshot(
         # here too, since the crash may have happened before collect_env's
         # own validation ran.
         execution_context=_disaster_execution_context(probe_invocation),
+        # probe_namespace: best-effort even in the disaster path, but the
+        # function may not have been reachable -- None is the honest answer
+        # when we don't know our namespace identity.
+        probe_namespace=None,
         host={
             "kernel_release": None,
             "kernel_version": None,
@@ -3263,6 +3302,62 @@ def _mount_namespace_differs_from_init() -> bool:
         log.debug("mount-ns readlink failed: %s", exc)
         return False
     return bool(self_ns) and bool(init_ns) and self_ns != init_ns
+
+
+def _capture_probe_namespace() -> str | None:
+    """Coarse "same isolation boundary?" namespace identifier (schema 1.12).
+
+    Primary source: the ``mnt:[<inode>]`` token from ``/proc/self/ns/mnt``.
+    Fallback: the ``/proc/self/cgroup`` path text when the ``ns/mnt`` symlink
+    is unreadable (``/proc`` not mounted, CAP_SYS_PTRACE denied, non-Linux).
+
+    **Cross-host safety.** A mount-namespace inode (``4026531840``) and a
+    cgroup path (``0::/``) are only unique within ONE kernel boot -- two
+    unrelated hosts routinely produce the *same* string. Returning the raw
+    token would let an env diff read two probes on different machines as
+    "same isolation boundary", which is false. So the token is SALTED with the
+    per-boot ``boot_id`` and hashed:
+
+        ``mnt:<sha256(boot_id \\0 token)[:16]>``     (primary, boot-scoped)
+        ``cgroup:<sha256(boot_id \\0 path)[:16]>``   (fallback, boot-scoped)
+
+    Same (host, boot) -> same digest (a valid "same boundary?" key); different
+    boots/hosts -> different digests even for an identical inode. When
+    ``boot_id`` is unavailable the value is emitted with a ``-local`` kind
+    (``mnt-local:`` / ``cgroup-local:``) over the raw token, flagging that it
+    is only meaningful within the capturing host and must NOT be compared for
+    equality across snapshots from different hosts.
+
+    Returns ``None`` when both sources fail. Never raises -- all exceptions
+    are swallowed and logged at DEBUG.
+    """
+    boot_id = None
+    try:
+        boot_id = _read_text_file(BOOT_ID_FILE)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("probe_namespace: boot_id read failed: %s", exc)
+
+    def _key(kind: str, token: str) -> str:
+        # Boot-salted digest is cross-host safe; the raw-token `-local` form is
+        # explicitly marked so it is never mistaken for a portable identity.
+        if boot_id:
+            digest = hashlib.sha256(f"{boot_id}\0{token}".encode()).hexdigest()[:16]
+            return f"{kind}:{digest}"
+        return f"{kind}-local:{token}"
+
+    try:
+        ns = os.readlink(str(SELF_MNT_NS))
+        if ns:
+            return _key("mnt", ns)
+    except OSError as exc:
+        log.debug("probe_namespace: ns/mnt readlink failed: %s", exc)
+    try:
+        cgroup = _read_text_file(SELF_CGROUP_FILE)
+        if cgroup:
+            return _key("cgroup", cgroup)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("probe_namespace: cgroup fallback failed: %s", exc)
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -124,6 +124,9 @@ def all_disabled(isolated_env, tmp_path: Path, monkeypatch):
     )
     monkeypatch.setattr(env_mod, "CGROUP_FILE", tmp_path / "no_cgroup")
     monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", tmp_path / "no_self_cgroup")
+    monkeypatch.setattr(env_mod, "SELF_MNT_NS", tmp_path / "no_self_mnt_ns")
+    monkeypatch.setattr(env_mod, "SELF_CGROUP_NS", tmp_path / "no_self_cgroup_ns")
+    monkeypatch.setattr(env_mod, "BOOT_ID_FILE", tmp_path / "no_boot_id")
     monkeypatch.setattr(env_mod, "KFD_DEVICE_NODE", tmp_path / "no_kfd")
     monkeypatch.setattr(env_mod, "KFD_SYSFS_DIR", tmp_path / "no_kfd_sysfs")
     monkeypatch.setattr(env_mod.shutil, "which", lambda name: None)
@@ -185,6 +188,7 @@ class TestPathConstants:
             "SELF_CGROUP_FILE",
             "INIT_MNT_NS",
             "SELF_MNT_NS",
+            "SELF_CGROUP_NS",
             "BOOT_ID_FILE",
         ],
     )
@@ -236,6 +240,7 @@ class TestPathConstants:
             "SELF_CGROUP_FILE",
             "INIT_MNT_NS",
             "SELF_MNT_NS",
+            "SELF_CGROUP_NS",
             "BOOT_ID_FILE",
         }, (
             "FS path constants set drifted; update test_path_is_absolute "
@@ -553,7 +558,7 @@ def _example_snapshot(**overrides) -> object:
             "probe_invocation": "buck2_action",
             "likely_execution_platform": None,
         },
-        "probe_namespace": "mnt:[4026531840]",
+        "probe_namespace": "mnt:0123456789abcdef",
     }
     base.update(overrides)
     return EnvSnapshot(**base)
@@ -686,6 +691,14 @@ class TestEnvSnapshot:
         assert s.count("\n") >= 4
         assert "rocm:" in s
         assert "hipblaslt:" in s
+
+    def test_summary_surfaces_probe_namespace_observation(self):
+        snap = _example_snapshot(probe_namespace="mnt:0123456789abcdef")
+        runtime_line = next(
+            line for line in snap.summary().splitlines()
+            if line.lstrip().startswith("runtime:")
+        )
+        assert "ns=mnt:012345…" in runtime_line
 
     def test_dataclass_is_frozen(self):
         """Callers can safely embed the snapshot without mutation hazards."""
@@ -1334,6 +1347,37 @@ class TestCollectEnvContract:
         assert "simulated probe failure" in recovery_reasons[0]
         # Schema must still be complete -- callers should not see missing keys
         assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
+
+    def test_disaster_snapshot_preserves_namespace_captured_before_later_failure(
+        self, all_disabled, monkeypatch
+    ):
+        observed = "mnt:0123456789abcdef"
+        monkeypatch.setattr(
+            env_mod, "_capture_probe_namespace", lambda reasons: observed
+        )
+
+        def boom(reasons):
+            raise RuntimeError("failure after namespace capture")
+
+        monkeypatch.setattr(env_mod, "_run_rdhc", boom)
+        snapshot = collect_env()
+        assert snapshot.partial is True
+        assert snapshot.probe_namespace == observed
+
+    def test_disaster_snapshot_probes_namespace_if_happy_path_never_reached(
+        self, monkeypatch
+    ):
+        observed = "cgroup-ns:0123456789abcdef"
+        monkeypatch.setattr(
+            env_mod,
+            "_capture_probe_namespace_safe",
+            lambda reasons: observed,
+        )
+        snapshot = env_mod._disaster_snapshot(
+            preceding_reasons=[],
+            unexpected_reason="collect_env: early failure",
+        )
+        assert snapshot.probe_namespace == observed
 
     def test_disaster_snapshot_emits_complete_schema(self):
         """The disaster path must still produce a full env.json shape."""
@@ -2784,7 +2828,7 @@ class TestCaptureProbeNamespace:
         boot_file.write_text(f"{value}\n")
         monkeypatch.setattr(env_mod, "BOOT_ID_FILE", boot_file)
 
-    def _mnt_link(self, tmp_path, target="mnt:[4026531840]", name="self_mnt_ns"):
+    def _ns_link(self, tmp_path, target, name):
         # os.readlink() returns the target string even for a dangling symlink,
         # so the target need not exist -- that is intentional here.
         ns_link = tmp_path / name
@@ -2795,81 +2839,146 @@ class TestCaptureProbeNamespace:
         self, monkeypatch, tmp_path
     ):
         self._set_boot_id(monkeypatch, tmp_path)
-        monkeypatch.setattr(env_mod, "SELF_MNT_NS", self._mnt_link(tmp_path))
-        result = env_mod._capture_probe_namespace()
+        mount_link = self._ns_link(
+            tmp_path, "mnt:[4026531840]", "self_mnt_ns"
+        )
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", mount_link)
+        reasons = []
+        result = env_mod._capture_probe_namespace(reasons)
         # Salted + hashed, NOT the raw inode token.
         assert result is not None
         assert result.startswith("mnt:")
         assert len(result) == len("mnt:") + 16
         assert "4026531840" not in result
+        assert reasons == []
 
     def test_same_ns_token_different_boot_ids_differ(self, monkeypatch, tmp_path):
-        """The MAJOR-finding regression guard: an identical mount-ns inode on two
-        different boots/hosts must NOT produce the same probe_namespace, so an env
-        diff cannot falsely read them as the same isolation boundary."""
-        link = self._mnt_link(tmp_path)
+        """Boot scope prevents cross-boot collisions for the same inode token."""
+        link = self._ns_link(tmp_path, "mnt:[4026531840]", "self_mnt_ns")
         monkeypatch.setattr(env_mod, "SELF_MNT_NS", link)
 
         self._set_boot_id(monkeypatch, tmp_path, "boot-host-A")
-        result_a = env_mod._capture_probe_namespace()
+        result_a = env_mod._capture_probe_namespace([])
         self._set_boot_id(monkeypatch, tmp_path, "boot-host-B")
-        result_b = env_mod._capture_probe_namespace()
+        result_b = env_mod._capture_probe_namespace([])
 
         assert result_a != result_b
-        # Same (token, boot) is stable -> a valid "same boundary?" key.
+        # Same token + boot is a stable observation, but equality remains
+        # advisory because Linux can recycle namespace inode numbers.
         self._set_boot_id(monkeypatch, tmp_path, "boot-host-A")
-        assert env_mod._capture_probe_namespace() == result_a
+        assert env_mod._capture_probe_namespace([]) == result_a
 
-    def test_local_only_marker_when_boot_id_unavailable(
+    def test_local_only_marker_hashes_token_and_records_partial_reason(
         self, monkeypatch, tmp_path
     ):
-        """No boot_id -> the value is emitted as local-only (raw token, marked)
-        so it is never mistaken for a cross-host-comparable identity."""
+        """No boot_id emits a hashed local-only value, never the raw token."""
         monkeypatch.setattr(env_mod, "BOOT_ID_FILE", tmp_path / "no_boot_id")
-        monkeypatch.setattr(env_mod, "SELF_MNT_NS", self._mnt_link(tmp_path))
-        result = env_mod._capture_probe_namespace()
-        assert result == "mnt-local:mnt:[4026531840]"
+        mount_link = self._ns_link(
+            tmp_path, "mnt:[4026531840]", "self_mnt_ns"
+        )
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", mount_link)
+        reasons = []
+        result = env_mod._capture_probe_namespace(reasons)
+        assert result is not None
+        assert result.startswith("mnt-local:")
+        assert len(result) == len("mnt-local:") + 16
+        assert "4026531840" not in result
+        assert any(r.startswith("probe_namespace.boot_id:") for r in reasons)
 
-    def test_falls_back_to_cgroup_digest_when_ns_unreadable(
+    def test_falls_back_to_cgroup_namespace_handle_when_mnt_unreadable(
         self, monkeypatch, tmp_path
     ):
         self._set_boot_id(monkeypatch, tmp_path)
         monkeypatch.setattr(env_mod, "SELF_MNT_NS", tmp_path / "nonexistent_ns")
-        cgroup_file = tmp_path / "cgroup"
-        cgroup_file.write_text("12:devices:/docker/abc123\n")
-        monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", cgroup_file)
-        result = env_mod._capture_probe_namespace()
+        cgroup_link = self._ns_link(
+            tmp_path, "cgroup:[4026533001]", "self_cgroup_ns"
+        )
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_NS", cgroup_link)
+        reasons = []
+        result = env_mod._capture_probe_namespace(reasons)
         assert result is not None
-        assert result.startswith("cgroup:")
-        assert len(result) == len("cgroup:") + 16
+        assert result.startswith("cgroup-ns:")
+        assert len(result) == len("cgroup-ns:") + 16
+        assert "4026533001" not in result
+        assert any(
+            r.startswith("probe_namespace.mount_namespace:") for r in reasons
+        )
 
-    def test_cgroup_fallback_local_only_without_boot_id(
+    def test_distinct_cgroup_namespace_handles_do_not_collapse(
+        self, monkeypatch, tmp_path
+    ):
+        """Unlike /proc/self/cgroup='0::/', namespace handles distinguish peers."""
+        self._set_boot_id(monkeypatch, tmp_path)
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", tmp_path / "nonexistent_ns")
+        cgroup_a = self._ns_link(
+            tmp_path, "cgroup:[4026533001]", "self_cgroup_ns_a"
+        )
+        cgroup_b = self._ns_link(
+            tmp_path, "cgroup:[4026533002]", "self_cgroup_ns_b"
+        )
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_NS", cgroup_a)
+        result_a = env_mod._capture_probe_namespace([])
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_NS", cgroup_b)
+        result_b = env_mod._capture_probe_namespace([])
+        assert result_a != result_b
+
+    def test_cgroup_fallback_without_boot_id_is_hashed_and_local(
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setattr(env_mod, "BOOT_ID_FILE", tmp_path / "no_boot_id")
         monkeypatch.setattr(env_mod, "SELF_MNT_NS", tmp_path / "nonexistent_ns")
-        cgroup_file = tmp_path / "cgroup"
-        cgroup_file.write_text("0::/\n")
-        monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", cgroup_file)
-        result = env_mod._capture_probe_namespace()
-        # _read_text_file strips surrounding whitespace, so the raw token is "0::/".
-        assert result == "cgroup-local:0::/"
+        cgroup_link = self._ns_link(
+            tmp_path, "cgroup:[4026533001]", "self_cgroup_ns"
+        )
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_NS", cgroup_link)
+        reasons = []
+        result = env_mod._capture_probe_namespace(reasons)
+        assert result is not None
+        assert result.startswith("cgroup-ns-local:")
+        assert len(result) == len("cgroup-ns-local:") + 16
+        assert "4026533001" not in result
+        assert any(r.startswith("probe_namespace.boot_id:") for r in reasons)
+        assert any(
+            r.startswith("probe_namespace.mount_namespace:") for r in reasons
+        )
 
     def test_returns_none_when_all_sources_fail(self, monkeypatch, tmp_path):
         self._set_boot_id(monkeypatch, tmp_path)
         monkeypatch.setattr(env_mod, "SELF_MNT_NS", tmp_path / "nonexistent_ns")
         monkeypatch.setattr(
-            env_mod, "SELF_CGROUP_FILE", tmp_path / "nonexistent_cgroup"
+            env_mod, "SELF_CGROUP_NS", tmp_path / "nonexistent_cgroup_ns"
         )
-        result = env_mod._capture_probe_namespace()
+        reasons = []
+        result = env_mod._capture_probe_namespace(reasons)
         assert result is None
+        assert any(
+            r.startswith("probe_namespace.mount_namespace:") for r in reasons
+        )
+        assert any(
+            r.startswith("probe_namespace.cgroup_namespace:") for r in reasons
+        )
+
+    def test_safe_wrapper_contains_unexpected_failure(self, monkeypatch):
+        def boom(reasons):
+            raise RuntimeError("forced namespace failure")
+
+        monkeypatch.setattr(env_mod, "_capture_probe_namespace", boom)
+        reasons = []
+        assert env_mod._capture_probe_namespace_safe(reasons) is None
+        assert any("unexpected capture failure" in r for r in reasons)
 
     def test_probe_namespace_in_collect_env_output(self, all_disabled):
         snap = collect_env()
         d = snap.to_dict()
         assert "probe_namespace" in d
-        assert d["probe_namespace"] is None or (
-            isinstance(d["probe_namespace"], str) and d["probe_namespace"]
+        assert d["probe_namespace"] is None
+        assert any(
+            r.startswith("probe_namespace.mount_namespace:")
+            for r in snap.partial_reasons
+        )
+        assert any(
+            r.startswith("probe_namespace.cgroup_namespace:")
+            for r in snap.partial_reasons
         )
 
 

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -185,6 +185,7 @@ class TestPathConstants:
             "SELF_CGROUP_FILE",
             "INIT_MNT_NS",
             "SELF_MNT_NS",
+            "BOOT_ID_FILE",
         ],
     )
     def test_path_is_absolute(self, constant_name: str):
@@ -235,6 +236,7 @@ class TestPathConstants:
             "SELF_CGROUP_FILE",
             "INIT_MNT_NS",
             "SELF_MNT_NS",
+            "BOOT_ID_FILE",
         }, (
             "FS path constants set drifted; update test_path_is_absolute "
             "parametrize list AND the provenance comments in "
@@ -293,6 +295,7 @@ REQUIRED_TOP_KEYS = {
     "amdgpu_driver",
     "container_detected",
     "execution_context",
+    "probe_namespace",
 }
 
 
@@ -302,7 +305,7 @@ class TestSchemaCompleteness:
     ):
         snapshot = collect_env()
         assert set(snapshot.to_dict().keys()) == REQUIRED_TOP_KEYS
-        assert snapshot.schema_version == "1.11"
+        assert snapshot.schema_version == SCHEMA_VERSION
         assert snapshot.system_health is None
         assert snapshot.rocm == {
             "version": None,
@@ -320,6 +323,18 @@ class TestSchemaCompleteness:
     def test_schema_version_constant_is_emitted(self, all_disabled):
         snapshot = collect_env()
         assert snapshot.schema_version == SCHEMA_VERSION
+
+    def test_public_docs_match_current_schema_version(self):
+        """The public env-probe docs must advertise the CURRENT SCHEMA_VERSION as
+        the "current" schema -- a stale doc makes operators think live env.json
+        files are wrong or that a new field shouldn't exist yet. Guards against the
+        doc/code drift that shipped probe_namespace while docs still said 1.11."""
+        docs_dir = Path(env_mod.__file__).resolve().parents[3] / "docs"
+        env_probe = (docs_dir / "env-probe.md").read_text(encoding="utf-8")
+        # The schema-version table row and the changelog "(current)" heading must
+        # both name the live constant.
+        assert f'Currently `"{SCHEMA_VERSION}"`' in env_probe
+        assert f"### `{SCHEMA_VERSION}` (current)" in env_probe
 
     def test_captured_at_is_iso8601_utc(self, all_disabled):
         snapshot = collect_env()
@@ -538,6 +553,7 @@ def _example_snapshot(**overrides) -> object:
             "probe_invocation": "buck2_action",
             "likely_execution_platform": None,
         },
+        "probe_namespace": "mnt:[4026531840]",
     }
     base.update(overrides)
     return EnvSnapshot(**base)
@@ -606,6 +622,14 @@ class TestEnvSnapshot:
         del d["container_detected"]
         rebuilt = EnvSnapshot.from_dict(d)
         assert rebuilt.container_detected is False
+
+    def test_from_dict_backfills_missing_probe_namespace(self):
+        # A pre-1.12 env.json predates probe_namespace. from_dict must
+        # default it to None rather than raising.
+        d = _example_snapshot().to_dict()
+        del d["probe_namespace"]
+        rebuilt = EnvSnapshot.from_dict(d)
+        assert rebuilt.probe_namespace is None
 
     def test_summary_does_not_duplicate_partial_marker(self):
         """The brief returned by ``summary()`` is the *body* of what the
@@ -2746,6 +2770,107 @@ class TestRuntimeContext:
         assert rt["python_env"] == "conda"
         assert rt["conda_env_name"] == "rocm-7.2"
         assert rt["venv_path"] is None
+
+
+# ---------------------------------------------------------------------------
+# probe_namespace (schema 1.12)
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureProbeNamespace:
+    @staticmethod
+    def _set_boot_id(monkeypatch, tmp_path, value="boot-aaaa-bbbb"):
+        boot_file = tmp_path / "boot_id"
+        boot_file.write_text(f"{value}\n")
+        monkeypatch.setattr(env_mod, "BOOT_ID_FILE", boot_file)
+
+    def _mnt_link(self, tmp_path, target="mnt:[4026531840]", name="self_mnt_ns"):
+        # os.readlink() returns the target string even for a dangling symlink,
+        # so the target need not exist -- that is intentional here.
+        ns_link = tmp_path / name
+        ns_link.symlink_to(target)
+        return ns_link
+
+    def test_returns_boot_salted_mnt_digest_when_proc_ns_readable(
+        self, monkeypatch, tmp_path
+    ):
+        self._set_boot_id(monkeypatch, tmp_path)
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", self._mnt_link(tmp_path))
+        result = env_mod._capture_probe_namespace()
+        # Salted + hashed, NOT the raw inode token.
+        assert result is not None
+        assert result.startswith("mnt:")
+        assert len(result) == len("mnt:") + 16
+        assert "4026531840" not in result
+
+    def test_same_ns_token_different_boot_ids_differ(self, monkeypatch, tmp_path):
+        """The MAJOR-finding regression guard: an identical mount-ns inode on two
+        different boots/hosts must NOT produce the same probe_namespace, so an env
+        diff cannot falsely read them as the same isolation boundary."""
+        link = self._mnt_link(tmp_path)
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", link)
+
+        self._set_boot_id(monkeypatch, tmp_path, "boot-host-A")
+        result_a = env_mod._capture_probe_namespace()
+        self._set_boot_id(monkeypatch, tmp_path, "boot-host-B")
+        result_b = env_mod._capture_probe_namespace()
+
+        assert result_a != result_b
+        # Same (token, boot) is stable -> a valid "same boundary?" key.
+        self._set_boot_id(monkeypatch, tmp_path, "boot-host-A")
+        assert env_mod._capture_probe_namespace() == result_a
+
+    def test_local_only_marker_when_boot_id_unavailable(
+        self, monkeypatch, tmp_path
+    ):
+        """No boot_id -> the value is emitted as local-only (raw token, marked)
+        so it is never mistaken for a cross-host-comparable identity."""
+        monkeypatch.setattr(env_mod, "BOOT_ID_FILE", tmp_path / "no_boot_id")
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", self._mnt_link(tmp_path))
+        result = env_mod._capture_probe_namespace()
+        assert result == "mnt-local:mnt:[4026531840]"
+
+    def test_falls_back_to_cgroup_digest_when_ns_unreadable(
+        self, monkeypatch, tmp_path
+    ):
+        self._set_boot_id(monkeypatch, tmp_path)
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", tmp_path / "nonexistent_ns")
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("12:devices:/docker/abc123\n")
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", cgroup_file)
+        result = env_mod._capture_probe_namespace()
+        assert result is not None
+        assert result.startswith("cgroup:")
+        assert len(result) == len("cgroup:") + 16
+
+    def test_cgroup_fallback_local_only_without_boot_id(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(env_mod, "BOOT_ID_FILE", tmp_path / "no_boot_id")
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", tmp_path / "nonexistent_ns")
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")
+        monkeypatch.setattr(env_mod, "SELF_CGROUP_FILE", cgroup_file)
+        result = env_mod._capture_probe_namespace()
+        # _read_text_file strips surrounding whitespace, so the raw token is "0::/".
+        assert result == "cgroup-local:0::/"
+
+    def test_returns_none_when_all_sources_fail(self, monkeypatch, tmp_path):
+        self._set_boot_id(monkeypatch, tmp_path)
+        monkeypatch.setattr(env_mod, "SELF_MNT_NS", tmp_path / "nonexistent_ns")
+        monkeypatch.setattr(
+            env_mod, "SELF_CGROUP_FILE", tmp_path / "nonexistent_cgroup"
+        )
+        result = env_mod._capture_probe_namespace()
+        assert result is None
+
+    def test_probe_namespace_in_collect_env_output(self, all_disabled):
+        snap = collect_env()
+        d = snap.to_dict()
+        assert "probe_namespace" in d
+        assert d["probe_namespace"] is None or (
+            isinstance(d["probe_namespace"], str) and d["probe_namespace"]
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add schema 1.12 `probe_namespace` observations for comparing direct and Buck2-action probes
- hash mount/cgroup namespace handles with boot scope while treating equality as advisory
- preserve degraded/disaster evidence, expose the value in CLI summaries, and document comparison limits

## Test plan
- [x] WSL focused namespace/schema tests: 14 passed
- [x] WSL environment suite: 488 passed, 3 skipped, 1 Triton-dependent test deselected
- [x] `python3 -m compileall -q src/aorta/instrumentation/environment.py`
- [ ] GitHub CPU CI with its installed Triton/PyTorch dependencies