### PR TITLE
env probe: preserve Buck context and validate customer captures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+scripts/buck2_execution_context_probe.sh text eol=lf

--- a/docs/README_aorta_env_probe.md
+++ b/docs/README_aorta_env_probe.md
@@ -1,0 +1,236 @@
+# AORTA Environment Probe — Customer Instructions
+
+Source of truth: `docs/README_aorta_env_probe.md` in the AORTA revision
+provided by your support contact. If this file is exported separately, update
+it from that source rather than editing two copies.
+
+Use this probe to record the software and hardware environment around a GPU
+workload. It launches no GPU kernels and runs no training steps. It reads
+version files, imports Python packages when available, and runs bounded
+diagnostic commands. On a multi-GPU host, collection can take tens of seconds.
+
+## What to send
+
+- Workload not built with Buck2: send one `env.host.json`.
+- Workload built with Buck2: send two files:
+  1. `env.buck-client.json` — the dependencies Buck selected for the target
+     and settings you used.
+  2. `env.workload.json` — the Python, torch, ROCm, and GPU environment seen by
+     the workload process.
+
+These files answer different questions. A host-side Buck query cannot prove
+what a workload process saw, and a workload process may not be able to run a
+nested Buck query.
+
+## Before you start
+
+Use the exact AORTA checkout, branch, release, or source archive provided by
+your support contact. AORTA requires Python 3.10 or newer. For a source
+checkout:
+
+```bash
+python -m pip install -e <AORTA_CHECKOUT>
+```
+
+If torch imports from a normal Python environment, verify that first:
+
+```bash
+python -c "import torch; print(torch.__version__, torch.version.hip)"
+```
+
+If torch exists only as a Buck target, use the Buck instructions below. Do not
+inject AORTA into an unrelated Python process with `PYTHONPATH`; that process
+will not contain the workload's torch target.
+
+## Non-Buck workload
+
+Activate the same environment and container used by the workload, then run:
+
+```bash
+aorta env probe \
+  --execution-context direct \
+  -o env.host.json
+```
+
+Send `env.host.json`. Missing optional tools appear in `partial_reasons`; they
+do not prevent the rest of the snapshot from being useful.
+
+## Buck workload — file 1: Buck dependency information
+
+Run this from the root of the real Buck checkout. Use the workload target and
+copy every mode file, `-c` override, and `-m` modifier from the workload's
+actual invocation.
+
+### When the workload uses Buck's default context
+
+```bash
+aorta env probe \
+  --execution-context direct \
+  --buck-target <WORKLOAD_TARGET> \
+  --buck-default-context \
+  -o env.buck-client.json
+```
+
+### When the workload has explicit configuration
+
+```bash
+aorta env probe \
+  --execution-context direct \
+  --buck-target <WORKLOAD_TARGET> \
+  --buck-mode-file <MODE_FILE_1> \
+  --buck-mode-file <MODE_FILE_2> \
+  --buck-config <SECTION.KEY=VALUE> \
+  --buck-modifier <MODIFIER> \
+  -o env.buck-client.json
+```
+
+Repeat each option as needed and preserve its order within that option type.
+AORTA applies mode files first, then `-c` values, then `-m` values. If the
+original command intentionally uses a different cross-option order, stop and
+ask your support contact rather than silently rearranging it. Do not paste the
+complete Buck command into one quoted string.
+
+This file should report:
+
+- `build_system.kind: "buck2"`
+- `buck_invocation.status: "success"`
+- `buck_invocation.context_source: "default_confirmed"` or `"explicit"`
+- a non-null `buck_invocation.context_fingerprint`
+- a non-empty `library_introspection` for a target that depends on recognized
+  PyTorch/ROCm/RCCL/hipBLASLt targets
+
+Only config key names are written to the JSON. Config values influence the
+fingerprint but are not stored.
+
+## Buck workload — file 2: workload process
+
+A Buck `.par` is the packaged Python executable for the application. It owns
+the application's startup code, so the AORTA CLI cannot wrap it. Add AORTA's
+`aorta_lib` to the existing `python_binary` dependencies. Keep its current
+application entrypoint, torch target, and other dependencies unchanged:
+
+```python
+python_binary(
+    name = "application_with_aorta_probe",
+    main_function = "<EXISTING_APPLICATION_MAIN_FUNCTION>",
+    deps = [
+        "<AORTA_CELL>//:aorta_lib",
+        # Keep the existing torch and application dependencies here.
+    ],
+)
+```
+
+At the beginning of the application's `main()`, after launcher environment
+variables are set but before model, optimizer, or pipeline construction:
+
+```python
+import os
+
+from aorta.instrumentation.environment import capture_to
+
+
+def main():
+    output = os.environ.get("AORTA_ENV_OUTPUT")
+    if output:
+        # Rank 0 writes the shared artifact. Every rank exits after capture so
+        # one delayed rank cannot disturb a timing-sensitive distributed run.
+        if os.environ.get("RANK", "0") == "0":
+            capture_to(
+                output,
+                probe_invocation=os.environ.get(
+                    "AORTA_PROBE_INVOCATION",
+                    "buck2_run",
+                ),
+            )
+        return
+
+    # Existing application setup follows.
+```
+
+Launch the application with:
+
+```bash
+export AORTA_ENV_OUTPUT=<SHARED_OUTPUT_DIR>/env.workload.json
+export AORTA_PROBE_INVOCATION=buck2_run
+
+buck2 run <APPLICATION_WITH_AORTA_PROBE> -- <EXISTING_APPLICATION_ARGS>
+```
+
+Treat this as a capture-only run. Importing packages and running diagnostic
+commands changes process startup timing; do not use the same run to measure a
+timing-sensitive failure rate. Unset `AORTA_ENV_OUTPUT` for normal workload
+runs.
+
+Use `buck2_run` when `buck2 run` launches the `.par` on the client host. Use
+`buck2_action` only when the probe itself runs as a declared build/test action
+and executor placement is independently known. Do not label a normal
+`buck2 run` process as a remote action.
+
+Do not pass `buck_target` to `capture_to()` inside the workload. The
+client-side file already records the dependency information, while the Buck
+command and checkout are often unavailable inside an action.
+
+If the application source cannot be changed, ask the repository owner for a
+temporary capture-only entrypoint with the same AORTA, torch, and application
+dependencies. It should call `capture_to()` and exit without starting training.
+
+## Validate both files before sending
+
+Run the validator included with the same AORTA checkout:
+
+```bash
+python3 <AORTA_CHECKOUT>/scripts/validate_buck_env_pair.py \
+  env.buck-client.json \
+  env.workload.json
+```
+
+Do not send the files until the validator prints `PASS`. If it fails, send the
+error lines to your support contact.
+
+## What to send
+
+Send:
+
+1. `env.buck-client.json`
+2. `env.workload.json`
+3. The exact workload target.
+4. The ordered mode-file and modifier names.
+5. Config key names and `buck_invocation.context_fingerprint`.
+
+If config values are sensitive, do not send them. The fingerprint lets two
+captures be compared without recording those values.
+
+## Expected limitations
+
+- `execution_context.likely_execution_platform` may be `null`. AORTA does not
+  guess the selected remote platform.
+- `probe_namespace` inequality is useful evidence; equality does not prove two
+  processes shared a namespace.
+- `system_health` may be unavailable when RDHC is not installed.
+- Optional Python packages may remain `null` when the workload does not use
+  them.
+
+## Troubleshooting
+
+### `pytorch_version` is null
+
+The probe did not run in the workload's Python process. Confirm the Buck
+`python_binary` depends on the real torch target and that `capture_to()` runs
+inside its `main()`.
+
+### `buck_invocation.context_source` is `unspecified`
+
+Rerun the client probe with either `--buck-default-context` or the exact
+mode/config/modifier options.
+
+### `library_introspection` is empty
+
+Confirm `--buck-target` names the real top-level workload target and that all
+configuration options match its normal invocation. If the graph uses library
+labels AORTA does not yet recognize, send a scrubbed list of the relevant label
+names to your support contact.
+
+### Warning says this is a client-host snapshot
+
+That is expected for a local `buck2 run`. Keep it as the client/runtime
+snapshot and do not claim it represents a remote worker.

--- a/docs/README_aorta_env_probe.md
+++ b/docs/README_aorta_env_probe.md
@@ -186,6 +186,11 @@ The validator requires the PyTorch Buck identity by default. If the workload
 also requires specific libraries, add repeatable checks such as
 `--require-library rccl` or `--require-library hipblaslt`.
 
+A file labeled `buck2_action` must contain detected isolation evidence. If
+your repository proves placement through separate `what-ran` evidence, the
+support contact may explicitly add `--allow-unisolated-action`; do not use
+that override merely to silence an error.
+
 Do not send the files until the validator prints `PASS`. If it fails, send the
 error lines to your support contact.
 

--- a/docs/README_aorta_env_probe.md
+++ b/docs/README_aorta_env_probe.md
@@ -77,18 +77,16 @@ aorta env probe \
 aorta env probe \
   --execution-context direct \
   --buck-target <WORKLOAD_TARGET> \
-  --buck-mode-file <MODE_FILE_1> \
-  --buck-mode-file <MODE_FILE_2> \
-  --buck-config <SECTION.KEY=VALUE> \
-  --buck-modifier <MODIFIER> \
+  --buck-option mode=<MODE_FILE_1> \
+  --buck-option config=<SECTION.KEY=VALUE> \
+  --buck-option mode=<MODE_FILE_2> \
+  --buck-option modifier=<MODIFIER> \
   -o env.buck-client.json
 ```
 
-Repeat each option as needed and preserve its order within that option type.
-AORTA applies mode files first, then `-c` values, then `-m` values. If the
-original command intentionally uses a different cross-option order, stop and
-ask your support contact rather than silently rearranging it. Do not paste the
-complete Buck command into one quoted string.
+Repeat `--buck-option` in the exact order used by the workload command. The
+three accepted types are `mode=...`, `config=KEY=VALUE`, and `modifier=...`.
+Do not paste the complete Buck command into one quoted string.
 
 This file should report:
 
@@ -183,6 +181,10 @@ python3 <AORTA_CHECKOUT>/scripts/validate_buck_env_pair.py \
   env.buck-client.json \
   env.workload.json
 ```
+
+The validator requires the PyTorch Buck identity by default. If the workload
+also requires specific libraries, add repeatable checks such as
+`--require-library rccl` or `--require-library hipblaslt`.
 
 Do not send the files until the validator prints `PASS`. If it fails, send the
 error lines to your support contact.

--- a/docs/buck2-env-probe-gpu-setup.md
+++ b/docs/buck2-env-probe-gpu-setup.md
@@ -127,10 +127,10 @@ input that precedes the workload target:
 ```bash
 aorta env probe \
   --buck-target //example/package:training \
-  --buck-mode-file @mode/opt \
-  --buck-mode-file @mode/inplace \
-  --buck-config example.gpu_backend=amd \
-  --buck-modifier rocm \
+  --buck-option mode=@mode/opt \
+  --buck-option mode=@mode/inplace \
+  --buck-option config=example.gpu_backend=amd \
+  --buck-option modifier=rocm \
   -o env.host.json
 ```
 
@@ -195,9 +195,9 @@ Tasks:
    `<SHARED_ROOT>/aorta-worktrees` exactly as documented above. Do not switch
    the base clone or overwrite an existing worktree. Then run the local
    `//:aorta` smoke commands from that worktree.
-5. Build the exact AORTA probe argv using repeatable --buck-mode-file,
-   --buck-config, and --buck-modifier options. Preserve order and do not use
-   shell=True, eval, or one opaque command string.
+5. Build the exact AORTA probe argv using repeatable
+   `--buck-option TYPE=VALUE` entries. Preserve cross-option order and do not
+   use shell=True, eval, or one opaque command string.
 6. Capture a host-side env.json and an in-action env.json. The in-action probe
    must be a declared Buck dependency; do not inject a host PYTHONPATH.
 7. If and only if strict local and remote execution are available, run

--- a/docs/buck2-env-probe-gpu-setup.md
+++ b/docs/buck2-env-probe-gpu-setup.md
@@ -1,0 +1,224 @@
+# Buck2 env-probe setup on a Linux GPU host
+
+This guide starts from a machine with no Buck2 installation. It has two
+separate goals:
+
+1. Run a local Buck2-built AORTA probe.
+2. Measure Buck2 remote-execution behavior in an existing RE-enabled
+   repository.
+
+The first goal is self-contained. It does **not** answer whether a remote
+worker exposes a native marker or which execution platform a real workload
+resolved to. A local Buck2 installation does not create an RE backend, CAS,
+credentials, worker image, or execution-platform registration.
+
+## 1. Machine prerequisites
+
+Confirm the host is Linux and that the GPU is visible:
+
+```bash
+uname -a
+python3 --version
+test -e /dev/kfd && echo "/dev/kfd: present" || echo "/dev/kfd: missing"
+command -v rocminfo || true
+command -v rocm_agent_enumerator || true
+```
+
+A representative GPU snapshot needs `/dev/kfd` and a working ROCm
+installation. Buck2 itself does not require a GPU.
+
+## 2. Install Buck2
+
+Download the release binary matching the host architecture from the official
+[Buck2 releases](https://github.com/facebook/buck2/releases). Keep the
+downloaded version visible in the test report; do not silently substitute a
+different repository-provided binary.
+
+If login and compute nodes use different home directories, choose a filesystem
+visible to both and set it as `SHARED_ROOT`:
+
+```bash
+SHARED_ROOT="/shared/aorta-support"
+mkdir -p "$SHARED_ROOT/bin"
+install -m 0755 /path/to/downloaded/buck2 "$SHARED_ROOT/bin/buck2"
+export PATH="$SHARED_ROOT/bin:$PATH"
+
+buck2 --version
+```
+
+Use the same shared root for the base clone, worktree, Buck binary, and result
+artifacts that must be visible on both host and compute nodes.
+
+## 3. Fetch the branch into a dedicated worktree
+
+```bash
+AORTA_BASE="$SHARED_ROOT/aorta"
+AORTA_WORKTREE="$SHARED_ROOT/aorta-worktrees/buck-invocation-context"
+AORTA_BRANCH="<branch-provided-by-aorta-support>"
+
+mkdir -p "$SHARED_ROOT/aorta-worktrees"
+if [ ! -d "$AORTA_BASE/.git" ]; then
+  git clone https://github.com/ROCm/aorta.git "$AORTA_BASE"
+fi
+
+git -C "$AORTA_BASE" fetch origin "$AORTA_BRANCH"
+if [ -e "$AORTA_WORKTREE" ]; then
+  echo "STOP: worktree path already exists: $AORTA_WORKTREE"
+  exit 1
+fi
+git -C "$AORTA_BASE" worktree add --track \
+  -b aorta-env-probe-customer-test \
+  "$AORTA_WORKTREE" \
+  "origin/$AORTA_BRANCH"
+
+cd "$AORTA_WORKTREE"
+```
+
+The public repository already contains `.buckroot`, `.buckconfig`, a bundled
+prelude declaration, toolchains, and the `//:aorta`/`//:aorta_lib` targets.
+Do not run `buck2 init` over this checkout. Keep the base clone unchanged; all
+commands and edits belong in the worktree.
+
+## 4. Local Buck2 smoke test
+
+```bash
+cd "$AORTA_WORKTREE"
+
+buck2 root
+buck2 build //:aorta --show-output
+buck2 run //:aorta -- --help
+
+buck2 run //:aorta -- env probe \
+  --execution-context buck2_run \
+  --buck-target //:aorta_lib \
+  --buck-default-context \
+  -o "$PWD/env.local-buck.json"
+
+python3 -m json.tool "$PWD/env.local-buck.json" >/dev/null
+```
+
+Check these fields:
+
+```bash
+python3 - "$PWD/env.local-buck.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    doc = json.load(fh)
+
+print("schema_version:", doc.get("schema_version"))
+print("build_system:", doc.get("build_system"))
+print("buck_invocation:", doc.get("buck_invocation"))
+print("execution_context:", doc.get("execution_context"))
+print("probe_namespace:", doc.get("probe_namespace"))
+print("partial_reasons:", doc.get("partial_reasons"))
+PY
+```
+
+This proves that AORTA builds and that target introspection runs under the
+explicitly confirmed default Buck context. It does not prove remote execution.
+
+## 5. Reproduce a real workload invocation
+
+Run the probe from the real Buck repository root. Copy every configuration
+input that precedes the workload target:
+
+```bash
+aorta env probe \
+  --buck-target //example/package:training \
+  --buck-mode-file @mode/opt \
+  --buck-mode-file @mode/inplace \
+  --buck-config example.gpu_backend=amd \
+  --buck-modifier rocm \
+  -o env.host.json
+```
+
+Mode files, config overrides, and modifiers are passed to `cquery` as atomic
+arguments. Never paste the complete workload command into one string.
+
+If torch exists only as a Buck target, define a `python_binary` that depends
+on both AORTA's `aorta_lib` and the repository's torch target, then run the
+same `env probe` arguments through that binary. A host `PYTHONPATH` is not a
+declared remote-action input and must not be used as an RE workaround.
+
+## 6. Remote-execution prerequisite
+
+The Q1/Q2 measurement requires an existing repository with:
+
+- configured execution platforms and remote workers;
+- CAS/RE credentials;
+- permission to use both `--local-only` and `--remote-only`;
+- a repository-native action that writes its environment to a declared output;
+- `buck2 log what-ran` access to prove where the action executed;
+- a representative workload target;
+- an AORTA probe target declared as a Buck dependency.
+
+If `--remote-only` cannot be proven from `what-ran`, report Q1 as **untested**.
+Do not use `--prefer-remote` or a cache hit as remote-execution evidence.
+
+## Copy-paste prompt for an agent on the GPU machine
+
+Replace every angle-bracket placeholder before sending this prompt:
+
+```text
+You are working on an authorized Linux GPU machine in a real Buck2 checkout.
+Help me set up and run AORTA's Buck-aware env probe. Do not guess remote-
+execution semantics and do not expose credentials, hostnames, internal target
+labels, environment values, or private paths in your final response.
+
+Inputs:
+- Shared filesystem root: <SHARED_ROOT>
+- AORTA base clone: <SHARED_ROOT>/aorta
+- AORTA worktree: <SHARED_ROOT>/aorta-worktrees/buck-invocation-context
+- AORTA branch: <AORTA_BRANCH>
+- Buck repository root: <REPO_ROOT>
+- Buck2 binary (or "not installed"): <BUCK2>
+- Workload target: <WORKLOAD_TARGET>
+- Repository-native env-dump target: <ENVDUMP_TARGET>
+- Buck-declared AORTA probe target: <AORTA_PROBE_TARGET>
+- Ordered mode files: <MODE_FILES_OR_NONE>
+- Ordered -c overrides: <CONFIG_OVERRIDES_OR_NONE>
+- Ordered -m modifiers: <MODIFIERS_OR_NONE>
+- Private output directory: <PRIVATE_OUT_DIR>
+
+Tasks:
+1. Read the repository instructions and make no source edits until you have
+   reported the setup state.
+2. Check Linux, Python, /dev/kfd, ROCm visibility, Buck2 version, `buck2 root`,
+   configured execution platforms, and whether the supplied targets exist.
+3. If Buck2 is absent, install an approved official release binary at
+   `<SHARED_ROOT>/bin/buck2`, prepend `<SHARED_ROOT>/bin` to PATH, and report
+   its exact version. Do not run `buck2 init` inside an existing configured
+   repository.
+4. Fetch the AORTA branch into the dedicated worktree under
+   `<SHARED_ROOT>/aorta-worktrees` exactly as documented above. Do not switch
+   the base clone or overwrite an existing worktree. Then run the local
+   `//:aorta` smoke commands from that worktree.
+5. Build the exact AORTA probe argv using repeatable --buck-mode-file,
+   --buck-config, and --buck-modifier options. Preserve order and do not use
+   shell=True, eval, or one opaque command string.
+6. Capture a host-side env.json and an in-action env.json. The in-action probe
+   must be a declared Buck dependency; do not inject a host PYTHONPATH.
+7. If and only if strict local and remote execution are available, run
+   scripts/buck2_execution_context_probe.sh with cache-busted actions. Prove
+   LocalExecute versus remote execution using `buck2 log what-ran`.
+8. Query the real workload target with `buck2 audit
+   execution-platform-resolution` and cquery attributes
+   `buck.execution_platform` and `buck.target_configuration`, carrying the same
+   mode/config/modifier context.
+9. Compare schema_version, build_system, buck_invocation, execution_context,
+   probe_namespace, ROCm/PyTorch/library identities, and partial_reasons.
+10. Keep all raw env/config/log artifacts in <PRIVATE_OUT_DIR>. Return only:
+    command success/failure, Buck2/AORTA versions, schema version, status
+    enums, redacted config keys, fingerprints, candidate marker NAMES, and
+    whether executor placement was proven.
+
+Stop conditions:
+- If remote-only execution is unavailable or `what-ran` does not prove remote
+  execution, mark Q1 untested.
+- If measured output does not name a resolved execution platform, leave
+  likely_execution_platform unset.
+- Do not invent an AORTA_RE_IMAGE convention or infer a platform from candidate
+  lists.
+```

--- a/docs/buck2.md
+++ b/docs/buck2.md
@@ -140,13 +140,43 @@ The two interesting cross-checks:
 # `python_version` is the Buck-pinned CPython (3.13.6) regardless of your venv
 buck2 run aorta -- env probe --field python_version
 
-# `--buck-target` makes the probe shell back out to `buck2 cquery` for
-# library-identity introspection (issue #163). Empty on pure-Python targets
-# like aorta_lib (no ROCm .so deps); populated when run against a
-# Buck-buildable C++/HIP target.
-buck2 run aorta -- env probe --buck-target aorta_lib --field library_introspection
+# `--buck-target` makes the probe invoke a bound `buck2 cquery 'deps(%s)'`
+# for library-identity introspection. Confirm the default context explicitly.
+# The result is empty on a pure-Python target like aorta_lib (no ROCm .so deps).
+buck2 run aorta -- env probe \
+  --buck-target aorta_lib \
+  --buck-default-context \
+  --field library_introspection
 # -> []
+
+# A configured target can instead reproduce ordered mode/config/modifier
+# inputs. These are generic examples; use the inputs from the invocation
+# being investigated.
+aorta env probe \
+  --buck-target //app:trainer \
+  --buck-mode-file root//mode/debug \
+  --buck-config build.profile=debug \
+  --buck-modifier //constraints:linux \
+  --field buck_invocation
 ```
+
+Schema 1.13 records this client-side query provenance in
+`buck_invocation`: status, target, context source, ordered mode files,
+config keys, ordered modifiers, a full-context SHA-256 fingerprint, the
+configured root target when available, and `comparison: not_compared`.
+Raw `--buck-config` values are passed to Buck and influence the fingerprint
+but are never serialized.
+
+If `--buck-target` is used without explicit context options and without
+`--buck-default-context`, the query still runs but the snapshot is partial:
+`context_source` is `unspecified`, making the unconfirmed default visible.
+Context options require `--buck-target`, and default confirmation cannot be
+combined with explicit options.
+
+`buck_invocation` describes how the configured graph was queried. It does not
+answer the execution-context design's Open Q1 or Q2, populate
+`execution_context.likely_execution_platform`, or prove whether an action
+actually ran locally, remotely, or from cache.
 
 `build_system.repo_root` is the *Buck-root* path -- meaningful even
 when you run inside a container that mounts the repo at a different
@@ -382,6 +412,9 @@ toolchain Python version.
 ## See also
 
 * [Env Probe](env-probe.md) -- the snapshot schema and `jq` cookbook.
+* [Buck2 env-probe setup on a Linux GPU host](buck2-env-probe-gpu-setup.md)
+  -- first-time Buck2 installation, local smoke test, real-RE prerequisites,
+  and a copy-paste agent prompt.
 * [`src/aorta/registry/README.md`](../src/aorta/registry/README.md) --
   mitigation / environment plugin authoring; same entry-point pattern
   as workloads.

--- a/docs/buck2.md
+++ b/docs/buck2.md
@@ -154,17 +154,17 @@ buck2 run aorta -- env probe \
 # being investigated.
 aorta env probe \
   --buck-target //app:trainer \
-  --buck-mode-file root//mode/debug \
-  --buck-config build.profile=debug \
-  --buck-modifier //constraints:linux \
+  --buck-option mode=root//mode/debug \
+  --buck-option config=build.profile=debug \
+  --buck-option modifier=//constraints:linux \
   --field buck_invocation
 ```
 
 Schema 1.13 records this client-side query provenance in
 `buck_invocation`: status, target, context source, ordered mode files,
-config keys, ordered modifiers, a full-context SHA-256 fingerprint, the
+config keys, ordered modifiers, cross-option order, a full-context SHA-256 fingerprint, the
 configured root target when available, and `comparison: not_compared`.
-Raw `--buck-config` values are passed to Buck and influence the fingerprint
+Raw config values are passed to Buck and influence the fingerprint
 but are never serialized.
 
 If `--buck-target` is used without explicit context options and without

--- a/docs/env-probe-container-execution-context.md
+++ b/docs/env-probe-container-execution-context.md
@@ -36,7 +36,27 @@ guardrail, not a data source.
   Missing boot identity, fallback use, and total failure are recorded as
   partial reasons. Additive, defaulted `null`, `from_dict()` backfill.
 
-**Still REMAINING (phase 2 — Buck2 / remote-execution, needs MI350 empirics):**
+**Landed (phase 2 — client invocation context; schema 1.13):**
+
+- Frozen `BuckInvocationContext` covers ordered mode/flag files, `-c` config
+  overrides, `-m` modifiers, and explicit default-context confirmation.
+  Repeatable CLI options reproduce those inputs as atomic argv entries; there
+  is no shell or free-form passthrough string.
+- `buck_invocation` distinguishes no request, Buck not detected, cquery
+  success, and cquery failure. It records the target, context source, ordered
+  mode files, config-key names, ordered modifiers, aggregate full-context
+  SHA-256 fingerprint, configured root target when available, and
+  `comparison: not_compared`. Raw config values are not written to `env.json`.
+- An unconfirmed default context and a target supplied outside a detected Buck
+  checkout are explicit partial states instead of plausible-looking success.
+- The target is bound through `deps(%s)` plus a separate target argument rather
+  than interpolated into Buck query syntax.
+
+This closes the target-only/configuration-loss gap for the configured graph.
+It does **not** prove where an action ran or populate
+`likely_execution_platform`; Q1 and Q2 remain unresolved.
+
+**Still REMAINING (remote-execution placement; Q1/Q2 need on-cluster empirics):**
 
 - `execution_context.likely_execution_platform` — resolved RE platform label.
   **Blocked on Open Q2** (does `buck2 audit configurations`/cquery report the
@@ -65,8 +85,8 @@ interpreter the probe process sees — trustworthy **only if the probe ran insid
 the same execution context as the workload**.
 
 For plain Docker this mostly holds (the playbook is "run the probe inside the
-container"). For **open-source Buck2 (Meta)** it breaks in a way today's schema
-cannot see:
+container"). For **remote-execution Buck2 deployments** it breaks in a way the
+process-local snapshot alone cannot see:
 
 - Buck2 is **remote-execution first**. Per action, Buck2 decides to run it
   **locally** (invoking host, *unsandboxed* — no container at all) or
@@ -112,7 +132,8 @@ Source → classification → Buck2 caveat.
 | `docker.image` / `.digest` | `$AORTA_DOCKER_IMAGE` / `$AORTA_DOCKER_DIGEST` | **externally asserted** | No Buck2 equivalent exists today (see `$AORTA_RE_IMAGE`, phase 2). |
 | `docker.container_id` | `/proc/self/cgroup` | **process** | Same host-kernel dependency; irrelevant to a remote worker. |
 | `build_system` (`kind`, `buck2_version`, `repo_root`, `revision`) | `buck2 --version`/`root`, `hg id`/`git rev-parse` on invoking host | **client-host** | Describes the developer's checkout, not the RE worker's toolchain. Two engineers get identical blocks while builds ran on different images. |
-| `library_introspection` (`buck2 cquery 'deps(target)'`) | configured target graph (labels) | **ambiguous — graph-accurate, execution-silent** | Reliable for declared deps; not for what code actually executed remotely (hybrid/racing/RE-cache). |
+| `buck_invocation` | typed CLI context + bound `buck2 cquery 'deps(%s)' <target>` | **client-host, caller-asserted** | Records which mode/config-key/modifier context configured the graph query. The fingerprint detects ordered full-value drift without exposing config values. It does not prove the workload used that context or where any action executed. |
+| `library_introspection` (`buck2 cquery 'deps(%s)' <target>`) | configured target graph (labels) | **ambiguous — graph-accurate, execution-silent** | Reliable for declared deps under the recorded invocation context; not for what code actually executed remotely (hybrid/racing/RE-cache). |
 | `pytorch_build.*` | `import torch`, `torch.__config__` | **process** | If the shell's torch ≠ the `python_binary`'s torch target, this silently describes the wrong build (the "torch is a Buck target" trap documented in `docs/env-probe.md`, schema 1.8 Buck/monorepo native-lib recovery). |
 | `host` (`kernel_release`, `glibc_version`, `machine`) | `os.uname()`, `os.confstr()` | **host-kernel** | Same wrong-machine risk. |
 | `nics` | `lspci`/`ethtool`/`ibv_devices`/`rdma link` | **host/device** | Misleading if probed off the collectives host. |
@@ -127,7 +148,8 @@ Source → classification → Buck2 caveat.
    as "no isolation," the opposite of the truth, worse than "unknown." *(Phase 1
    `container_detected` mitigates this.)*
 3. **`buck2 cquery` answers "what's declared," not "what ran."** Deterministic
-   for the label graph; blind to local/remote/RE-cache execution.
+   for the label graph. Schema 1.13 records which invocation context configured
+   that query, but remains blind to local/remote/RE-cache execution.
 4. **`build_system.revision`/`buck2_version` describe the client, not the
    executor** — false reassurance that two probes "match."
 5. **No signal at all for local-vs-remote execution** of a given action.
@@ -139,13 +161,14 @@ Source → classification → Buck2 caveat.
 ## Design — additive schema bump
 
 New fields (same additive pattern as the amdgpu_driver 1.10 change). The
-**Phase** column tracks what landed in phase 1 vs. what remains for phase 2
-(see Implementation status above):
+**Phase** column tracks landed work and what remains gated by Q1/Q2 (see
+Implementation status above):
 
 | Field | Type | Meaning | Phase |
 |---|---|---|---|
 | `container_detected` | `bool` | **Single boolean.** `true` on *any* isolation signal: a named-runtime match (`_detect_container_type() != "baremetal"`), a private mount namespace (`/proc/self/ns/mnt` != `/proc/1/ns/mnt`), or a container/k8s token in `/proc/self/cgroup` (`docker`/`containerd`/`kubepods`/`libpod`/`lxc`/`crio`). Fixes the RE-sandbox-as-baremetal false negative. No k8s-vs-containerd distinction. | **1 (done)** |
 | `execution_context.probe_invocation` | `"direct" \| "buck2_run" \| "buck2_action"` | How the probe was launched. Phase 1: **self-declared** via `--execution-context` (defaults to `direct`). Phase 2 may auto-detect via native RE env vars (**see Open Q1**). | **1 (done, self-declared)** |
+| `buck_invocation` | `dict` | Redacted provenance for the bound cquery: status, target, context source, ordered mode files/config keys/modifiers, full-context fingerprint, configured root target when available, and `comparison: not_compared`. | **client context (done, schema 1.13)** |
 | `execution_context.likely_execution_platform` | `str \| null` | Best-effort: from `buck2 audit configurations` / cquery on the target, the resolved platform label. Advisory, not guaranteed (**Open Q2**). Key present today, always `null`. | 2 (remaining) |
 | `probe_namespace` | `str \| null` | **Mismatch-only observation**: boot-scoped hash of `/proc/self/ns/mnt`, falling back to `/proc/self/ns/cgroup`: `mnt:<sha256[:16]>` / `cgroup-ns:<sha256[:16]>`; hashed `*-local:` form when `boot_id` is unavailable. Different same-kind values prove different observations; equality is advisory because namespace inode numbers can be recycled. | **2 (done)** |
 | `$AORTA_RE_IMAGE` convention | env var | Extend the existing `$AORTA_DOCKER_IMAGE` launcher pattern to Buck2: customers set this in their `remote_execution_properties` / action env (**pending Open Q1** — a native marker may exist and be preferable). Already read by the phase-1 warning. | 2 (remaining) |
@@ -166,6 +189,32 @@ Does not change what is captured (all still process-derived). It:
    Implemented in **both** the Click CLI (`aorta env probe`) and the
    dependency-free `_probe_main` entry point, since the latter is the one most
    likely used inside a Buck2 action / container.
+
+### CLI — configured-graph invocation context
+
+```bash
+# Assert that Buck's default context is intentional.
+aorta env probe \
+  --buck-target //app:trainer \
+  --buck-default-context
+
+# Or reproduce explicit inputs in order.
+aorta env probe \
+  --buck-target //app:trainer \
+  --buck-mode-file root//mode/debug \
+  --buck-config build.profile=debug \
+  --buck-modifier //constraints:linux
+```
+
+The explicit form invokes cquery with mode files first, then paired `-c`
+overrides, then paired `-m` modifiers, followed by `deps(%s)` and the target as
+separate argv entries. `--buck-config` values are passed to Buck and included
+in the aggregate fingerprint, but only config keys are serialized.
+
+Omitting both explicit inputs and `--buck-default-context` remains runnable for
+backwards compatibility, with `context_source: unspecified` and a partial
+reason. This section is about graph configuration only: neither form answers
+Q1/Q2 or proves actual execution placement.
 
 ### Durable fix — a Buck2 rule wrapper (documented, not vendored)
 

--- a/docs/env-probe-container-execution-context.md
+++ b/docs/env-probe-container-execution-context.md
@@ -44,8 +44,8 @@ guardrail, not a data source.
   is no shell or free-form passthrough string.
 - `buck_invocation` distinguishes no request, Buck not detected, cquery
   success, and cquery failure. It records the target, context source, ordered
-  mode files, config-key names, ordered modifiers, aggregate full-context
-  SHA-256 fingerprint, configured root target when available, and
+  mode files, config-key names, ordered modifiers, cross-option order,
+  aggregate full-context SHA-256 fingerprint, configured root target when available, and
   `comparison: not_compared`. Raw config values are not written to `env.json`.
 - An unconfirmed default context and a target supplied outside a detected Buck
   checkout are explicit partial states instead of plausible-looking success.
@@ -168,7 +168,7 @@ Implementation status above):
 |---|---|---|---|
 | `container_detected` | `bool` | **Single boolean.** `true` on *any* isolation signal: a named-runtime match (`_detect_container_type() != "baremetal"`), a private mount namespace (`/proc/self/ns/mnt` != `/proc/1/ns/mnt`), or a container/k8s token in `/proc/self/cgroup` (`docker`/`containerd`/`kubepods`/`libpod`/`lxc`/`crio`). Fixes the RE-sandbox-as-baremetal false negative. No k8s-vs-containerd distinction. | **1 (done)** |
 | `execution_context.probe_invocation` | `"direct" \| "buck2_run" \| "buck2_action"` | How the probe was launched. Phase 1: **self-declared** via `--execution-context` (defaults to `direct`). Phase 2 may auto-detect via native RE env vars (**see Open Q1**). | **1 (done, self-declared)** |
-| `buck_invocation` | `dict` | Redacted provenance for the bound cquery: status, target, context source, ordered mode files/config keys/modifiers, full-context fingerprint, configured root target when available, and `comparison: not_compared`. | **client context (done, schema 1.13)** |
+| `buck_invocation` | `dict` | Redacted provenance for the bound cquery: status, target, context source, ordered mode files/config keys/modifiers, cross-option order, full-context fingerprint, configured root target when available, and `comparison: not_compared`. | **client context (done, schema 1.13)** |
 | `execution_context.likely_execution_platform` | `str \| null` | Best-effort: from `buck2 audit configurations` / cquery on the target, the resolved platform label. Advisory, not guaranteed (**Open Q2**). Key present today, always `null`. | 2 (remaining) |
 | `probe_namespace` | `str \| null` | **Mismatch-only observation**: boot-scoped hash of `/proc/self/ns/mnt`, falling back to `/proc/self/ns/cgroup`: `mnt:<sha256[:16]>` / `cgroup-ns:<sha256[:16]>`; hashed `*-local:` form when `boot_id` is unavailable. Different same-kind values prove different observations; equality is advisory because namespace inode numbers can be recycled. | **2 (done)** |
 | `$AORTA_RE_IMAGE` convention | env var | Extend the existing `$AORTA_DOCKER_IMAGE` launcher pattern to Buck2: customers set this in their `remote_execution_properties` / action env (**pending Open Q1** — a native marker may exist and be preferable). Already read by the phase-1 warning. | 2 (remaining) |
@@ -201,15 +201,15 @@ aorta env probe \
 # Or reproduce explicit inputs in order.
 aorta env probe \
   --buck-target //app:trainer \
-  --buck-mode-file root//mode/debug \
-  --buck-config build.profile=debug \
-  --buck-modifier //constraints:linux
+  --buck-option mode=root//mode/debug \
+  --buck-option config=build.profile=debug \
+  --buck-option modifier=//constraints:linux
 ```
 
-The explicit form invokes cquery with mode files first, then paired `-c`
-overrides, then paired `-m` modifiers, followed by `deps(%s)` and the target as
-separate argv entries. `--buck-config` values are passed to Buck and included
-in the aggregate fingerprint, but only config keys are serialized.
+The explicit form invokes cquery in the exact `--buck-option` order, followed
+by `deps(%s)` and the target as separate argv entries. Config values are
+passed to Buck and included in the aggregate fingerprint, but only config keys
+and option kinds are serialized.
 
 Omitting both explicit inputs and `--buck-default-context` remains runnable for
 backwards compatibility, with `context_source: unspecified` and a partial

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -4,9 +4,14 @@ Capture a versioned, schema-stable snapshot of the trial environment so
 that cross-environment comparison becomes a `jq` diff instead of a
 multi-day investigation.
 
+For a short customer handoff, including Buck's required client/workload
+snapshot pair, see [Customer Instructions](README_aorta_env_probe.md).
+
 The same code path is used three ways:
 
 * **CLI**: `aorta env probe -o env.json` -- on-demand, by an operator.
+* **Application API**: `capture_to("env.json", ...)` -- in-process capture for
+  Buck `.par` applications that own `__main__`.
 * **B1 (per-trial runner)**: calls `collect_env()` once per trial; the
   snapshot is embedded in `TrialResult.env`.
 * **B2 (matrix runner)**: calls `collect_env()` once per matrix start
@@ -105,11 +110,24 @@ Options:
   --buck-target TEXT       Buck2 label to introspect for library
                            identity. When given, the snapshot's
                            library_introspection list is populated
-                           from `buck2 cquery 'deps(<label>)' --json`
+                           from a bound `buck2 cquery 'deps(%s)'
+                           <label> --json`
                            (each matched entry carries both a
                            stripped `target` and the raw
                            `configured_target`, schema 1.6). Ignored
                            if buck2 isn't on PATH.
+  --buck-mode-file PATH    Buck mode/flag file for the cquery
+                           (repeatable, ordered). A leading '@' is
+                           accepted but not required.
+  --buck-config KEY=VALUE  Buck -c config override for the cquery
+                           (repeatable, ordered). Only keys and an
+                           aggregate fingerprint are persisted.
+  --buck-modifier TEXT     Buck -m modifier for the cquery
+                           (repeatable, ordered).
+  --buck-default-context   Confirm that the target uses Buck's
+                           default invocation context. Mutually
+                           exclusive with the three explicit context
+                           options above.
   --buck-timeout INTEGER   Per-call timeout (seconds, must be >= 1)
                            for `buck2 cquery 'deps(...)'`.
                            [default: 10]
@@ -129,9 +147,10 @@ operator can act on them without `jq`'ing the JSON. A closing
 end-of-output. Sample:
 
 ```text
-Wrote env probe to /tmp/env.json (schema_version=1.12) [PARTIAL]
+Wrote env probe to /tmp/env.json (schema_version=1.13) [PARTIAL]
   runtime:   baremetal / python=venv  container_detected=no  probe=direct  ns=mnt:1a2b3c…
   build_sys: none
+  buck ctx:  status=not_requested source=none fingerprint=-
   rocm:      7.2.1 (dev: None)
   hip:       7.2.53211-e1a6bc5663 (amd)
   hipblaslt: 1.2.2 rocm_release_tweak=dabb6df2b9
@@ -184,9 +203,16 @@ who want to copy-paste without reading `env.json` from disk).
 ## Library API
 
 ```python
-from aorta.instrumentation.environment import collect_env, EnvSnapshot
+from aorta.instrumentation.environment import capture_to, collect_env, EnvSnapshot
 
 snapshot: EnvSnapshot = collect_env()   # NEVER raises
+
+# Buck .par/application path: capture this process and write env.json.
+# Filesystem errors raise; collection itself remains fail-soft.
+workload_snapshot = capture_to(
+    "env.workload.json",
+    probe_invocation="buck2_run",
+)
 
 # Embed in a trial result (B1 pattern)
 trial_result = {
@@ -210,23 +236,23 @@ if snapshot.partial:
 print(snapshot.summary())
 ```
 
-`collect_env()` is the **only** public entrypoint. It NEVER raises:
-each probe is fail-soft, and the orchestrator body has a top-level
-`try/except Exception` plus a disaster-recovery helper for any genuinely
-unexpected failure. Callers always get back a valid, fully-shaped
-`EnvSnapshot` object.
+`collect_env()` is the in-memory entrypoint and NEVER raises: each probe is
+fail-soft, and the orchestrator body has a disaster-recovery helper for any
+genuinely unexpected failure. `capture_to()` uses the same collection path and
+returns the same `EnvSnapshot`, then writes it as UTF-8 JSON. It raises only
+when the output directory/file cannot be created or validated.
 
 ## env.json schema
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | Currently `"1.12"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
+| `schema_version` | `str` | constant | Currently `"1.13"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
 | `system_health` | `dict \| null` | `rdhc --quick --json` (subprocess) | verbatim parsed JSON; `null` when rdhc absent / sudo unavailable / timeout / malformed |
 | `rocm` | `dict[str, str \| null]` | `/opt/rocm/.info/version{,_dev}`, `/sys/module/amdgpu/version` | `version`, `version_dev`, `kmd_version` |
-| `amdgpu_driver` | `dict` | `dpkg-query`/`rpm` (package), `modinfo amdgpu` (module), `/sys/module/amdgpu/version` (reused from `rocm.kmd_version`), `/dev/kfd` + `/sys/class/kfd` (existence) | Schema 1.10. `scope` (constant `"host_kernel"`), `status` (`"present"`/`"absent"`), `package_name` (stable candidate family `amdgpu-dkms`/`amdgpu-kmod`/null), `package_version`, `package_full_name` (complete canonical identity — apt `name=version` or rpm NVRA — capturing kernel-suffixed package names like `amdgpu-kmod-6.9.0-…_g9b20106afb70-6.14.14.000000-2226257.1.x86_64` that `package_name` alone drops; the single field two host snapshots diff on), `package_manager` (`"dpkg"`/`"rpm"`/null), `module_version`, `module_srcversion`, `kmd_version`, `kfd_device_present`, `kfd_sysfs_present`. **HOST-KERNEL SCOPE applies only to `kfd_device_present`/`kfd_sysfs_present`/`kmd_version`**: the amdgpu KMD + KFD live in the host kernel a container *shares*, so these three fields report the **host's** driver even from inside a container — complementary to `rocm`/`hip` which read the container's `/opt/rocm` userspace. **`package_name`/`package_version`/`package_full_name`/`package_manager` and `module_version`/`module_srcversion` are NOT host-guaranteed** — dpkg/rpm and `modinfo` read the *current filesystem's* package DB and `/lib/modules`, so from inside a container these reflect the container's own (typically driver-less) view even while the three fields above still show the host's driver as present. **Documented absence**: a GPU-less host → `status:"absent"` with NO `partial`. Only a *conflict* — amdgpu module loaded (`modinfo` metadata present) but no dpkg/rpm package resolvable — records a `partial_reason`; `/dev/kfd` alone never does, since a passthrough container legitimately has the host's KFD node without a container-local package. Package lookup is a portable, **glob-capable** dpkg-then-rpm query parsed in Python (no shell pipe), so kernel-suffixed RPM names are matched. |
+| `amdgpu_driver` | `dict` | `dpkg-query`/`rpm` (package), `modinfo amdgpu` (module), `/sys/module/amdgpu/version` (reused from `rocm.kmd_version`), `/dev/kfd` + `/sys/class/kfd` (existence) | Schema 1.10. `scope` (constant `"host_kernel"`), `status` (`"present"`/`"absent"`), `package_name` (stable candidate family `amdgpu-dkms`/`amdgpu-kmod`/null), `package_version`, `package_full_name` (complete canonical identity — apt `name=version` or rpm NVRA — capturing kernel-suffixed package names such as `amdgpu-kmod-<kernel>-<driver-version>.<arch>` that `package_name` alone drops; the single field two host snapshots diff on), `package_manager` (`"dpkg"`/`"rpm"`/null), `module_version`, `module_srcversion`, `kmd_version`, `kfd_device_present`, `kfd_sysfs_present`. **HOST-KERNEL SCOPE applies only to `kfd_device_present`/`kfd_sysfs_present`/`kmd_version`**: the amdgpu KMD + KFD live in the host kernel a container *shares*, so these three fields report the **host's** driver even from inside a container — complementary to `rocm`/`hip` which read the container's `/opt/rocm` userspace. **`package_name`/`package_version`/`package_full_name`/`package_manager` and `module_version`/`module_srcversion` are NOT host-guaranteed** — dpkg/rpm and `modinfo` read the *current filesystem's* package DB and `/lib/modules`, so from inside a container these reflect the container's own (typically driver-less) view even while the three fields above still show the host's driver as present. **Documented absence**: a GPU-less host → `status:"absent"` with NO `partial`. Only a *conflict* — amdgpu module loaded (`modinfo` metadata present) but no dpkg/rpm package resolvable — records a `partial_reason`; `/dev/kfd` alone never does, since a passthrough container legitimately has the host's KFD node without a container-local package. Package lookup is a portable, **glob-capable** dpkg-then-rpm query parsed in Python (no shell pipe), so kernel-suffixed RPM names are matched. |
 | `hip` | `dict[str, str \| null]` | `hipconfig --version/--platform/--compiler/--runtime/--cpp_config` | five subprocesses; `--version` and `--platform` cannot be combined (no delimiter) |
 | `hipblaslt` | `dict` | header parse + `sha256(libhipblaslt.so)` + sorted-filenames hash of `lib/hipblaslt/library/*` | `rocm_release_tweak` (NOT a per-hipBLASLt commit -- it's the ROCm release identifier shared across every library in a release; see note below), `package_version`, `lib_hash`, `kernel_db_revision`, `applied_prs: {}` |
 | `rocblas` | `dict` | header parse + `sha256(librocblas.so)` + sorted-filenames hash of `lib/rocblas/library/*` | Same shape as `hipblaslt`. Header lives at `include/rocblas/internal/rocblas-version.h`. |
@@ -254,7 +280,8 @@ unexpected failure. Callers always get back a valid, fully-shaped
 | `pytorch_version` | `str \| null` | optional `import torch` (no CUDA/HIP context init) | `null` when torch absent |
 | `pytorch_build` | `dict` | `torch.version.{git_version,hip,cuda,debug}` + install-kind detection + optional `git -C <src>/third_party/<sub> rev-parse HEAD` + parse of `torch.__config__.show()` + `nm -D libtorch_hip.so \| c++filt` symbol grep + scan of `<torch>/lib/` + parse of `<source>/build/CMakeCache.txt` + stream of `<source>/build/build.ninja` (modern `enable_language(HIP)` path) or walk of `<source>/build/**/<target>.dir/**/*.hip.o.cmake` (legacy `FindHIP.cmake` fallback) | `git_commit` is the linchpin -- pins every vendored submodule deterministically. Sub-blocks: `flags` (raw `build_settings`, `cxx_defines`, `cxx_flags_raw`, `cuda_flags_raw`, `gpu_arch_list`), `build_flags` (issue #170 stable 17-key parsed bool/str/None subset, with `CAFFE2_USE_MIOPEN` aliased to `USE_MIOPEN`), `binary_introspection` (`libtorch_hip_symbol_counts`, `torch_lib_bundled`, `cxx_flags_use_defines` -- pure facts, no ON/OFF inference), `cmake_cache` (source/editable installs only -- allowlisted entries from CMakeCache.txt), `ninja_hipcc` (source/editable installs only -- per-target HIPCC defines + codegen flags + offload archs; `_parser` discriminates the two parser strategies). See "PyTorch source-tree submodule probing" below. |
 | `build_system` | `dict` | `buck2 --version` + `buck2 root` + `hg id -i` / `git rev-parse HEAD` | Always present. `{"kind": "buck2", "buck2_version": str, "repo_root": str, "revision": str \| null}` when buck2 is on PATH AND we are demonstrably inside a Buck checkout (both `buck2 --version` and `buck2 root` succeed); `buck2_version` and `repo_root` are guaranteed populated, only `revision` may be `null`. `{"kind": "none"}` in every other case, including the dominant "buck2 is installed but cwd is not inside a Buck checkout" scenario. Added in schema 1.3 for issue #163 (A1.2a) so consumers can branch on Buck2 vs. system-package environments. See "Running inside a Buck environment" below. |
-| `library_introspection` | `list[dict]` | `buck2 cquery 'deps(<target>)' --json` (only when `--buck-target` is supplied) | Always present. Empty `[]` outside Buck mode. In Buck mode, one entry per matched library: `{"name", "source": "buck", "revision", "target", "configured_target"}`. `target` is the canonical Buck label (stable across daemon restarts); `configured_target` preserves the raw cquery output including its per-run configuration suffix (`(prelude//platforms:default#<hash>)`) for forensics. The matched library set lives in `KNOWN_LIBRARY_PATTERNS` in `src/aorta/instrumentation/buck_introspect.py`. Added in schema 1.4 for issue #163 (A1.2b); migrated from `buck2 audit dependencies` to `buck2 cquery` and split `target` / `configured_target` in schema 1.6 (PR #187). |
+| `buck_invocation` | `dict` | typed Buck context + bound `buck2 cquery 'deps(%s)' <target> --json` | Schema 1.13, always present. `status` distinguishes `not_requested`, `buck_not_detected`, `success`, and `failure`; `target` records the requested label. `context_source` is `none`, `unspecified`, `default_confirmed`, or `explicit`. Ordered `mode_files`, ordered `config_keys` (**never config values**), ordered `modifiers`, and `context_fingerprint` (`sha256:<hex>` over the full ordered context values) make the client-side query context comparable without disclosing raw overrides. `configured_root_target` retains the configured root label when cquery returns one; `comparison` is currently always `not_compared`. This is configured-graph invocation provenance, not execution placement: it does not answer the design note's Open Q1/Q2, populate `likely_execution_platform`, or prove where an action ran. |
+| `library_introspection` | `list[dict]` | bound `buck2 cquery 'deps(%s)' <target> --json` (only when `--buck-target` is supplied) | Always present. Empty `[]` outside Buck mode. In Buck mode, one entry per matched library: `{"name", "source": "buck", "revision", "target", "configured_target"}`. `target` is the canonical Buck label (stable across daemon restarts); `configured_target` preserves the raw cquery output including its per-run configuration suffix (`(prelude//platforms:default#<hash>)`) for forensics. The matched library set lives in `KNOWN_LIBRARY_PATTERNS` in `src/aorta/instrumentation/buck_introspect.py`. Added in schema 1.4 for issue #163 (A1.2b); migrated from `buck2 audit dependencies` to `buck2 cquery` and split `target` / `configured_target` in schema 1.6 (PR #187). Query binding replaced target interpolation in schema 1.13 without changing entry behavior. |
 | `library_introspection_alternates` | `list[dict]` | synthesised from A1's per-library blocks when a Buck match overlaps | Always present. Empty `[]` outside Buck mode and when no Buck-matched library is also captured by A1. Each entry mirrors the unified shape with `source: "package"` and pulls `revision` / `package_version` / `lib_hash` from the matching A1 block (e.g. `hipblaslt`). Added in schema 1.4 for issue #163 (A1.2b). |
 | `pytorch_sdpa` | `dict` | `torch.backends.cuda.{flash,mem_efficient,math,cudnn}_sdp_enabled()` | `backends_enabled` dict, one bool per SDPA backend + per-getter `null` when missing on older torch. Runtime state, NOT compile-time -- combine with `pytorch_build.binary_introspection.libtorch_hip_symbol_counts` for the full "compiled in AND enabled" picture. Added in schema 1.5 for issue #176 (PR #177). |
 
@@ -262,7 +289,7 @@ unexpected failure. Callers always get back a valid, fully-shaped
 probes (`composable_kernel.pytorch_bundled`, `aotriton`, and
 `pytorch_build.binary_introspection`) normally locate torch's native
 libraries at `<torch.__file__>/../lib`. When torch is a Buck target
-(e.g. `fbcode//caffe2:torch`) its Python package is materialised into a
+(e.g. `root//framework:runtime`) its Python package is materialised into a
 link-tree but the C++ runtime is `dlopen`'d from a separate
 build-artifact directory, so `<torch>/lib/libtorch_hip.so` does not
 exist and those fields previously came back `null`. Because the probe
@@ -438,7 +465,39 @@ Mirrors the in-code comment at `SCHEMA_VERSION` in
 `src/aorta/instrumentation/environment.py`. Recorded here so consumers
 tracking schema evolution don't have to read source.
 
-### `1.12` (current)
+### `1.13` (current)
+
+Buck configured-graph invocation provenance. Additive — one new top-level
+block, defaulted so older snapshots and direct constructors remain compatible.
+
+* New top-level **`buck_invocation`** block. Its `status` distinguishes no
+  request, Buck not detected, cquery success, and cquery failure. It records
+  the requested target, context source (`none` / `unspecified` /
+  `default_confirmed` / `explicit`), ordered mode files, ordered config
+  **keys only**, ordered modifiers, an aggregate `sha256:` fingerprint over
+  the full ordered context values, the configured root target when available,
+  and `comparison: "not_compared"`.
+* New repeatable CLI options `--buck-mode-file`, `--buck-config`, and
+  `--buck-modifier`, plus `--buck-default-context`. Context options require
+  `--buck-target`; default confirmation is mutually exclusive with explicit
+  options. Buck receives atomic argv entries in mode / paired `-c` / paired
+  `-m` order. There is no shell or arbitrary passthrough string.
+* Cquery now binds the target through `deps(%s)` plus a separate target argv
+  entry. Target text is never interpolated into Buck query syntax.
+* `--buck-target` without explicit context or `--buck-default-context` still
+  runs for backwards compatibility, but records `context_source:
+  "unspecified"` and a clear partial reason. A request when
+  `build_system.kind != "buck2"` is similarly partial and records
+  `status: "buck_not_detected"`.
+* Raw `--buck-config` values are never persisted. The key is visible and the
+  full value participates only in the aggregate fingerprint, so value drift
+  remains detectable without disclosure.
+* Scope remains deliberately narrow: this block describes the client-side
+  configured-graph query. It does **not** answer execution-context Open Q1 or
+  Q2, populate `execution_context.likely_execution_platform`, or prove actual
+  local/remote execution placement.
+
+### `1.12`
 
 Container & execution-context visibility, phase 2 (namespace). Additive —
 one new top-level field, defaulted so older readers don't raise. See the
@@ -523,8 +582,8 @@ don't raise.
   `kfd_device_present` / `kfd_sysfs_present` (`/dev/kfd` + `/sys/class/kfd`
   existence checks — no `open()`, no `ioctl`, no GPU compute).
 * **`package_full_name`** is the complete canonical package identity — apt
-  `name=version` on Debian, or the rpm NVRA
-  (`amdgpu-kmod-6.9.0-…_g9b20106afb70-6.14.14.000000-2226257.1.x86_64`) on
+  `name=version` on Debian, or an rpm NVRA such as
+  `amdgpu-kmod-<kernel>-<driver-version>.<arch>` on
   RHEL/SLES. Some vendors bake the kernel release into the RPM *package
   name*, which an exact `rpm -q amdgpu-kmod` misses entirely; the query
   uses a glob (`rpm -qa 'amdgpu-kmod*'`) to catch these and reconstructs
@@ -619,7 +678,7 @@ still round-trips pre-1.8 snapshots.
   `pytorch_build.binary_introspection` symbol counts / `torch_lib_bundled`)
   now locate torch's native lib dir via `/proc/self/maps` when
   `<torch>/lib` is absent, populating those fields for Buck/monorepo
-  torch targets (e.g. `fbcode//caffe2:torch`) whose C++ runtime is
+  torch targets (e.g. `root//framework:runtime`) whose C++ runtime is
   `dlopen`'d from a build-artifact dir.
 
 ### `1.7`
@@ -1200,7 +1259,9 @@ it's running inside a [Buck2](https://buck2.build/) build environment
 and records the result in the top-level `build_system` block. As of
 schema 1.4 (issue #163, A1.2b), it can additionally introspect a
 target's transitive deps to populate the `library_introspection`
-list. As of `aorta env recipe --format buck` (issue #163, A1.2c), the
+list. Schema 1.13 adds the redacted `buck_invocation` block so that
+the mode/config/modifier context used for that cquery is no longer
+implicit. As of `aorta env recipe --format buck` (issue #163, A1.2c), the
 captured `library_introspection` can be re-emitted as a best-effort
 BUCK file fragment for cross-environment handoff.
 
@@ -1241,19 +1302,36 @@ with `revision: null`.
 aorta env probe -o /tmp/env.json
 jq '.library_introspection' /tmp/env.json              # -> []
 jq '.library_introspection_alternates' /tmp/env.json   # -> []
+jq '.buck_invocation.status' /tmp/env.json              # -> "not_requested"
 
-# Inside a Buck checkout, point the probe at a top-level target. We
-# wrap `buck2 cquery 'deps(<target>)' --json` and match each
-# transitive dep label against KNOWN_LIBRARY_PATTERNS. Schema 1.6
-# emits both `target` (the canonical Buck label, stable across
-# daemon restarts) and `configured_target` (the raw cquery output
-# with its per-run configuration suffix; preserved for forensics).
-aorta env probe --buck-target //myproj:training_main -o /tmp/env.json
+# Confirm that this target needs no mode/config/modifier overrides.
+aorta env probe \
+  --buck-target //app:trainer \
+  --buck-default-context \
+  -o /tmp/env.json
+
+# Or reproduce an explicit ordered invocation context. Mode files are
+# forwarded first, followed by paired -c values, then paired -m values.
+aorta env probe \
+  --buck-target //app:trainer \
+  --buck-mode-file root//mode/debug \
+  --buck-mode-file root//mode/gpu \
+  --buck-config build.profile=debug \
+  --buck-config scheduler.policy=local \
+  --buck-modifier //constraints:linux \
+  --buck-modifier //constraints:gfx \
+  -o /tmp/env.json
+
+# The implementation binds the label as a separate query argument:
+# buck2 cquery @root//mode/debug @root//mode/gpu \
+#   -c build.profile=debug -c scheduler.policy=local \
+#   -m //constraints:linux -m //constraints:gfx \
+#   'deps(%s)' //app:trainer --json
+# No shell or free-form passthrough command is involved.
 jq '.library_introspection' /tmp/env.json
 # -> [
-#   {"name":"hipblaslt","source":"buck","revision":"<repo-sha>","target":"//.../hipblaslt_lib","configured_target":"//.../hipblaslt_lib (prelude//platforms:default#abc...)"},
-#   {"name":"rccl","source":"buck","revision":"<repo-sha>","target":"//.../rccl_lib","configured_target":"//.../rccl_lib (prelude//platforms:default#abc...)"},
-#   {"name":"pytorch","source":"buck","revision":"<repo-sha>","target":"//pytorch:torch","configured_target":"//pytorch:torch (prelude//platforms:default#abc...)"},
+#   {"name":"hipblaslt","source":"buck","revision":"<repo-sha>","target":"//libs:hipblaslt","configured_target":"root//libs:hipblaslt (prelude//platforms:default#abc...)"},
+#   {"name":"rccl","source":"buck","revision":"<repo-sha>","target":"//libs:rccl","configured_target":"root//libs:rccl (prelude//platforms:default#abc...)"},
 #   ...
 # ]
 
@@ -1263,6 +1341,19 @@ jq '.library_introspection' /tmp/env.json
 # label against the system-package version/lib_hash:
 jq '.library_introspection_alternates[] | select(.name=="hipblaslt")' /tmp/env.json
 # -> {"name":"hipblaslt","source":"package","revision":"...","package_version":"...","lib_hash":"..."}
+
+jq '.buck_invocation' /tmp/env.json
+# -> {
+#      "status": "success",
+#      "target": "//app:trainer",
+#      "context_source": "explicit",
+#      "mode_files": ["root//mode/debug", "root//mode/gpu"],
+#      "config_keys": ["build.profile", "scheduler.policy"],
+#      "modifiers": ["//constraints:linux", "//constraints:gfx"],
+#      "context_fingerprint": "sha256:<digest>",
+#      "configured_root_target": "root//app:trainer (prelude//platforms:default#...)",
+#      "comparison": "not_compared"
+#    }
 ```
 
 `--buck-timeout` (default 10 s) caps the cquery subprocess. A timeout,
@@ -1272,13 +1363,32 @@ match patterns currently cover `hipblaslt`, `rccl`, `pytorch`, and
 `rocm` runtime; new libraries are added by appending to
 `KNOWN_LIBRARY_PATTERNS` in `src/aorta/instrumentation/buck_introspect.py`.
 
+If `--buck-target` is given without any explicit context options and without
+`--buck-default-context`, the query still runs so older invocations keep
+working. The snapshot records `context_source: "unspecified"` and becomes
+partial with a reason saying the default context was not confirmed. Likewise,
+if `build_system.kind` is not `buck2`, Aorta still attempts the historical
+fail-soft cquery path but records `status: "buck_not_detected"` plus a partial
+reason; the result cannot look like a fully plausible Buck capture.
+
+Only config keys are serialized. Full `KEY=VALUE` strings are used to invoke
+Buck and compute the aggregate context fingerprint, then discarded. Changing
+a value or changing order changes the fingerprint, while the raw value never
+appears in `buck_invocation`.
+
+This metadata answers “which client-side context configured this cquery?” It
+does **not** answer execution-context Open Q1 (native remote-worker markers) or
+Open Q2 (selected execution platform), and it does not prove whether any
+workload action ran locally, remotely, or from cache. See
+[`env-probe-container-execution-context.md`](env-probe-container-execution-context.md).
+
 ### Emitting a Buck recipe (`aorta env recipe --format buck`)
 
 Issue #163 (A1.2c) ships a read-only emitter that turns an env.json
 back into a BUCK file fragment for cross-environment handoff:
 
 ```bash
-aorta env probe --buck-target //myproj:training_main -o /tmp/env.json
+aorta env probe --buck-target //app:trainer --buck-default-context -o /tmp/env.json
 aorta env recipe --format buck /tmp/env.json > BUCK.aorta-recipe
 head -n 20 BUCK.aorta-recipe
 # # ============================================================================

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -116,14 +116,12 @@ Options:
                            stripped `target` and the raw
                            `configured_target`, schema 1.6). Ignored
                            if buck2 isn't on PATH.
-  --buck-mode-file PATH    Buck mode/flag file for the cquery
-                           (repeatable, ordered). A leading '@' is
-                           accepted but not required.
-  --buck-config KEY=VALUE  Buck -c config override for the cquery
-                           (repeatable, ordered). Only keys and an
-                           aggregate fingerprint are persisted.
-  --buck-modifier TEXT     Buck -m modifier for the cquery
-                           (repeatable, ordered).
+  --buck-option TYPE=VALUE Exact ordered Buck input: mode=VALUE,
+                           config=KEY=VALUE, or modifier=VALUE.
+                           Repeat in the workload command's order.
+  --buck-mode-file PATH    Grouped convenience form for mode files.
+  --buck-config KEY=VALUE  Grouped convenience form for -c values.
+  --buck-modifier TEXT     Grouped convenience form for -m values.
   --buck-default-context   Confirm that the target uses Buck's
                            default invocation context. Mutually
                            exclusive with the three explicit context
@@ -280,7 +278,7 @@ when the output directory/file cannot be created or validated.
 | `pytorch_version` | `str \| null` | optional `import torch` (no CUDA/HIP context init) | `null` when torch absent |
 | `pytorch_build` | `dict` | `torch.version.{git_version,hip,cuda,debug}` + install-kind detection + optional `git -C <src>/third_party/<sub> rev-parse HEAD` + parse of `torch.__config__.show()` + `nm -D libtorch_hip.so \| c++filt` symbol grep + scan of `<torch>/lib/` + parse of `<source>/build/CMakeCache.txt` + stream of `<source>/build/build.ninja` (modern `enable_language(HIP)` path) or walk of `<source>/build/**/<target>.dir/**/*.hip.o.cmake` (legacy `FindHIP.cmake` fallback) | `git_commit` is the linchpin -- pins every vendored submodule deterministically. Sub-blocks: `flags` (raw `build_settings`, `cxx_defines`, `cxx_flags_raw`, `cuda_flags_raw`, `gpu_arch_list`), `build_flags` (issue #170 stable 17-key parsed bool/str/None subset, with `CAFFE2_USE_MIOPEN` aliased to `USE_MIOPEN`), `binary_introspection` (`libtorch_hip_symbol_counts`, `torch_lib_bundled`, `cxx_flags_use_defines` -- pure facts, no ON/OFF inference), `cmake_cache` (source/editable installs only -- allowlisted entries from CMakeCache.txt), `ninja_hipcc` (source/editable installs only -- per-target HIPCC defines + codegen flags + offload archs; `_parser` discriminates the two parser strategies). See "PyTorch source-tree submodule probing" below. |
 | `build_system` | `dict` | `buck2 --version` + `buck2 root` + `hg id -i` / `git rev-parse HEAD` | Always present. `{"kind": "buck2", "buck2_version": str, "repo_root": str, "revision": str \| null}` when buck2 is on PATH AND we are demonstrably inside a Buck checkout (both `buck2 --version` and `buck2 root` succeed); `buck2_version` and `repo_root` are guaranteed populated, only `revision` may be `null`. `{"kind": "none"}` in every other case, including the dominant "buck2 is installed but cwd is not inside a Buck checkout" scenario. Added in schema 1.3 for issue #163 (A1.2a) so consumers can branch on Buck2 vs. system-package environments. See "Running inside a Buck environment" below. |
-| `buck_invocation` | `dict` | typed Buck context + bound `buck2 cquery 'deps(%s)' <target> --json` | Schema 1.13, always present. `status` distinguishes `not_requested`, `buck_not_detected`, `success`, and `failure`; `target` records the requested label. `context_source` is `none`, `unspecified`, `default_confirmed`, or `explicit`. Ordered `mode_files`, ordered `config_keys` (**never config values**), ordered `modifiers`, and `context_fingerprint` (`sha256:<hex>` over the full ordered context values) make the client-side query context comparable without disclosing raw overrides. `configured_root_target` retains the configured root label when cquery returns one; `comparison` is currently always `not_compared`. This is configured-graph invocation provenance, not execution placement: it does not answer the design note's Open Q1/Q2, populate `likely_execution_platform`, or prove where an action ran. |
+| `buck_invocation` | `dict` | typed Buck context + bound `buck2 cquery 'deps(%s)' <target> --json` | Schema 1.13, always present. `status` distinguishes `not_requested`, `buck_not_detected`, `success`, and `failure`; `target` records the requested label. `context_source` is `none`, `unspecified`, `default_confirmed`, or `explicit`. Ordered `mode_files`, ordered `config_keys` (**never config values**), ordered `modifiers`, `option_order`, and `context_fingerprint` (`sha256:<hex>` over the full ordered context values) make the client-side query context comparable without disclosing raw overrides. `configured_root_target` retains the configured root label when cquery returns one; `comparison` is currently always `not_compared`. This is configured-graph invocation provenance, not execution placement: it does not answer the design note's Open Q1/Q2, populate `likely_execution_platform`, or prove where an action ran. |
 | `library_introspection` | `list[dict]` | bound `buck2 cquery 'deps(%s)' <target> --json` (only when `--buck-target` is supplied) | Always present. Empty `[]` outside Buck mode. In Buck mode, one entry per matched library: `{"name", "source": "buck", "revision", "target", "configured_target"}`. `target` is the canonical Buck label (stable across daemon restarts); `configured_target` preserves the raw cquery output including its per-run configuration suffix (`(prelude//platforms:default#<hash>)`) for forensics. The matched library set lives in `KNOWN_LIBRARY_PATTERNS` in `src/aorta/instrumentation/buck_introspect.py`. Added in schema 1.4 for issue #163 (A1.2b); migrated from `buck2 audit dependencies` to `buck2 cquery` and split `target` / `configured_target` in schema 1.6 (PR #187). Query binding replaced target interpolation in schema 1.13 without changing entry behavior. |
 | `library_introspection_alternates` | `list[dict]` | synthesised from A1's per-library blocks when a Buck match overlaps | Always present. Empty `[]` outside Buck mode and when no Buck-matched library is also captured by A1. Each entry mirrors the unified shape with `source: "package"` and pulls `revision` / `package_version` / `lib_hash` from the matching A1 block (e.g. `hipblaslt`). Added in schema 1.4 for issue #163 (A1.2b). |
 | `pytorch_sdpa` | `dict` | `torch.backends.cuda.{flash,mem_efficient,math,cudnn}_sdp_enabled()` | `backends_enabled` dict, one bool per SDPA backend + per-getter `null` when missing on older torch. Runtime state, NOT compile-time -- combine with `pytorch_build.binary_introspection.libtorch_hip_symbol_counts` for the full "compiled in AND enabled" picture. Added in schema 1.5 for issue #176 (PR #177). |
@@ -474,14 +472,15 @@ block, defaulted so older snapshots and direct constructors remain compatible.
   request, Buck not detected, cquery success, and cquery failure. It records
   the requested target, context source (`none` / `unspecified` /
   `default_confirmed` / `explicit`), ordered mode files, ordered config
-  **keys only**, ordered modifiers, an aggregate `sha256:` fingerprint over
-  the full ordered context values, the configured root target when available,
-  and `comparison: "not_compared"`.
-* New repeatable CLI options `--buck-mode-file`, `--buck-config`, and
-  `--buck-modifier`, plus `--buck-default-context`. Context options require
-  `--buck-target`; default confirmation is mutually exclusive with explicit
-  options. Buck receives atomic argv entries in mode / paired `-c` / paired
-  `-m` order. There is no shell or arbitrary passthrough string.
+  **keys only**, ordered modifiers, cross-option `option_order`, an aggregate
+  `sha256:` fingerprint over the full ordered context values, the configured
+  root target when available, and `comparison: "not_compared"`.
+* New repeatable CLI option `--buck-option TYPE=VALUE` preserves exact
+  cross-option order for `mode`, `config`, and `modifier` inputs. Grouped
+  convenience options remain available when the normal mode / `-c` / `-m`
+  order is sufficient. Context options require `--buck-target` and cannot be
+  mixed with `--buck-default-context`. There is no shell or arbitrary
+  passthrough string.
 * Cquery now binds the target through `deps(%s)` plus a separate target argv
   entry. Target text is never interpolated into Buck query syntax.
 * `--buck-target` without explicit context or `--buck-default-context` still
@@ -489,7 +488,7 @@ block, defaulted so older snapshots and direct constructors remain compatible.
   "unspecified"` and a clear partial reason. A request when
   `build_system.kind != "buck2"` is similarly partial and records
   `status: "buck_not_detected"`.
-* Raw `--buck-config` values are never persisted. The key is visible and the
+* Raw Buck config values are never persisted. The key is visible and the
   full value participates only in the aggregate fingerprint, so value drift
   remains detectable without disclosure.
 * Scope remains deliberately narrow: this block describes the client-side
@@ -1310,21 +1309,20 @@ aorta env probe \
   --buck-default-context \
   -o /tmp/env.json
 
-# Or reproduce an explicit ordered invocation context. Mode files are
-# forwarded first, followed by paired -c values, then paired -m values.
+# Or reproduce the exact cross-option order used by the workload.
 aorta env probe \
   --buck-target //app:trainer \
-  --buck-mode-file root//mode/debug \
-  --buck-mode-file root//mode/gpu \
-  --buck-config build.profile=debug \
-  --buck-config scheduler.policy=local \
-  --buck-modifier //constraints:linux \
-  --buck-modifier //constraints:gfx \
+  --buck-option mode=root//mode/debug \
+  --buck-option config=build.profile=debug \
+  --buck-option mode=root//mode/gpu \
+  --buck-option config=scheduler.policy=local \
+  --buck-option modifier=//constraints:linux \
+  --buck-option modifier=//constraints:gfx \
   -o /tmp/env.json
 
 # The implementation binds the label as a separate query argument:
-# buck2 cquery @root//mode/debug @root//mode/gpu \
-#   -c build.profile=debug -c scheduler.policy=local \
+# buck2 cquery @root//mode/debug -c build.profile=debug \
+#   @root//mode/gpu -c scheduler.policy=local \
 #   -m //constraints:linux -m //constraints:gfx \
 #   'deps(%s)' //app:trainer --json
 # No shell or free-form passthrough command is involved.
@@ -1350,6 +1348,7 @@ jq '.buck_invocation' /tmp/env.json
 #      "mode_files": ["root//mode/debug", "root//mode/gpu"],
 #      "config_keys": ["build.profile", "scheduler.policy"],
 #      "modifiers": ["//constraints:linux", "//constraints:gfx"],
+#      "option_order": ["mode", "config", "mode", "config", "modifier", "modifier"],
 #      "context_fingerprint": "sha256:<digest>",
 #      "configured_root_target": "root//app:trainer (prelude//platforms:default#...)",
 #      "comparison": "not_compared"

--- a/scripts/buck2_execution_context_probe.sh
+++ b/scripts/buck2_execution_context_probe.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+#
+# Empirical Buck2 execution-context probe for AORTA.
+#
+# This script intentionally does not create a Buck project or an RE backend.
+# It runs against an existing, configured checkout so Q1/Q2 observations use
+# the same prelude, toolchains, configuration, and execution platforms as the
+# workload under investigation.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  buck2_execution_context_probe.sh \
+    --repo-root DIR \
+    --envdump-target LABEL \
+    --workload-target LABEL \
+    --out-dir DIR \
+    [--buck2 PATH] \
+    [--aorta-probe-target LABEL] \
+    [--cache-bust-file RELATIVE_PATH] \
+    [--mode-file @MODE]... \
+    [--config KEY=VALUE]... \
+    [--modifier LABEL]...
+
+Target contracts:
+  --envdump-target
+      A repository-native action with one text output containing:
+        ---ENV---
+        sorted KEY=VALUE lines
+        ---CGROUP---
+        /proc/self/cgroup
+        ---UNAME---
+        uname output
+
+  --cache-bust-file
+      A repository-relative source declared by --envdump-target. The script
+      temporarily changes it before each build and restores it on exit so
+      local and remote measurements cannot be satisfied by the same cache hit.
+      If --aorta-probe-target is used, that target must also declare this file
+      as an input so its remote snapshot cannot be satisfied from stale cache.
+
+  --aorta-probe-target
+      Optional repository-native target whose output is an AORTA env.json.
+      AORTA must be a declared dependency; host PYTHONPATH injection is not
+      valid for a remote action.
+
+Raw environment/config/log artifacts remain in --out-dir. The generated
+q1_q2_findings.txt contains only status, hashes, and candidate variable names.
+EOF
+}
+
+REPO_ROOT=""
+ENVDUMP_TARGET=""
+WORKLOAD_TARGET=""
+OUT_DIR=""
+BUCK2="buck2"
+AORTA_PROBE_TARGET=""
+CACHE_BUST_FILE=""
+MODE_FILES=()
+CONFIG_OVERRIDES=()
+MODIFIERS=()
+
+while (($#)); do
+    case "$1" in
+        --repo-root) REPO_ROOT="${2:?missing value for --repo-root}"; shift 2 ;;
+        --envdump-target) ENVDUMP_TARGET="${2:?missing value for --envdump-target}"; shift 2 ;;
+        --workload-target) WORKLOAD_TARGET="${2:?missing value for --workload-target}"; shift 2 ;;
+        --out-dir) OUT_DIR="${2:?missing value for --out-dir}"; shift 2 ;;
+        --buck2) BUCK2="${2:?missing value for --buck2}"; shift 2 ;;
+        --aorta-probe-target) AORTA_PROBE_TARGET="${2:?missing value for --aorta-probe-target}"; shift 2 ;;
+        --cache-bust-file) CACHE_BUST_FILE="${2:?missing value for --cache-bust-file}"; shift 2 ;;
+        --mode-file) MODE_FILES+=("${2:?missing value for --mode-file}"); shift 2 ;;
+        --config) CONFIG_OVERRIDES+=("${2:?missing value for --config}"); shift 2 ;;
+        --modifier) MODIFIERS+=("${2:?missing value for --modifier}"); shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+for required in REPO_ROOT ENVDUMP_TARGET WORKLOAD_TARGET OUT_DIR; do
+    if [[ -z "${!required}" ]]; then
+        echo "ERROR: required argument is missing: $required" >&2
+        usage >&2
+        exit 2
+    fi
+done
+
+if ! command -v "$BUCK2" >/dev/null 2>&1; then
+    echo "ERROR: Buck2 not found: $BUCK2" >&2
+    exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 is required" >&2
+    exit 1
+fi
+if [[ ! -d "$REPO_ROOT" ]]; then
+    echo "ERROR: repository root does not exist: $REPO_ROOT" >&2
+    exit 1
+fi
+
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+chmod 700 "$OUT_DIR"
+FINDINGS="$OUT_DIR/q1_q2_findings.txt"
+
+CONTEXT_ARGS=()
+for mode in "${MODE_FILES[@]}"; do
+    [[ "$mode" == @* ]] || mode="@$mode"
+    CONTEXT_ARGS+=("$mode")
+done
+for config in "${CONFIG_OVERRIDES[@]}"; do
+    [[ "$config" == *=* ]] || {
+        echo "ERROR: --config requires KEY=VALUE, got: $config" >&2
+        exit 2
+    }
+    CONTEXT_ARGS+=("-c" "$config")
+done
+for modifier in "${MODIFIERS[@]}"; do
+    CONTEXT_ARGS+=("-m" "$modifier")
+done
+
+context_fingerprint="$(
+    python3 - "${MODE_FILES[@]}" -- "${CONFIG_OVERRIDES[@]}" -- "${MODIFIERS[@]}" <<'PY'
+import hashlib
+import json
+import sys
+
+parts = [[]]
+for value in sys.argv[1:]:
+    if value == "--":
+        parts.append([])
+    else:
+        parts[-1].append(value)
+payload = {"mode_files": parts[0], "config_overrides": parts[1], "modifiers": parts[2]}
+encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+print("sha256:" + hashlib.sha256(encoded).hexdigest())
+PY
+)"
+
+config_keys=()
+for config in "${CONFIG_OVERRIDES[@]}"; do
+    config_keys+=("${config%%=*}")
+done
+
+BUCK2_VERSION="$("$BUCK2" --version 2>/dev/null || true)"
+if [[ -z "$BUCK2_VERSION" ]]; then
+    echo "ERROR: could not read Buck2 version" >&2
+    exit 1
+fi
+
+(
+    cd "$REPO_ROOT"
+    "$BUCK2" root >"$OUT_DIR/buck_root.txt"
+    "$BUCK2" targets "$ENVDUMP_TARGET" >"$OUT_DIR/envdump_target.txt"
+    "$BUCK2" targets "$WORKLOAD_TARGET" >"$OUT_DIR/workload_target.txt"
+)
+for required_output in buck_root.txt envdump_target.txt workload_target.txt; do
+    [[ -s "$OUT_DIR/$required_output" ]] || {
+        echo "ERROR: preflight output is empty: $required_output" >&2
+        exit 1
+    }
+done
+
+CACHE_BUST_ABS=""
+CACHE_BUST_BACKUP=""
+CACHE_BUST_EXISTED=0
+if [[ -n "$CACHE_BUST_FILE" ]]; then
+    [[ "$CACHE_BUST_FILE" != /* ]] || {
+        echo "ERROR: --cache-bust-file must be repository-relative" >&2
+        exit 2
+    }
+    CACHE_BUST_ABS="$REPO_ROOT/$CACHE_BUST_FILE"
+    case "$(cd "$(dirname "$CACHE_BUST_ABS")" 2>/dev/null && pwd)/$(basename "$CACHE_BUST_ABS")" in
+        "$REPO_ROOT"/*) ;;
+        *) echo "ERROR: cache-bust file escapes repository root" >&2; exit 2 ;;
+    esac
+    mkdir -p "$(dirname "$CACHE_BUST_ABS")"
+    CACHE_BUST_BACKUP="$OUT_DIR/cache_bust.original"
+    if [[ -e "$CACHE_BUST_ABS" ]]; then
+        cp "$CACHE_BUST_ABS" "$CACHE_BUST_BACKUP"
+        CACHE_BUST_EXISTED=1
+    fi
+fi
+
+restore_cache_bust() {
+    if [[ -n "$CACHE_BUST_ABS" ]]; then
+        if [[ "$CACHE_BUST_EXISTED" -eq 1 ]]; then
+            cp "$CACHE_BUST_BACKUP" "$CACHE_BUST_ABS"
+        else
+            rm -f "$CACHE_BUST_ABS"
+        fi
+    fi
+}
+trap restore_cache_bust EXIT
+
+write_nonce() {
+    local label="$1"
+    [[ -n "$CACHE_BUST_ABS" ]] || return 0
+    python3 - "$label" >"$CACHE_BUST_ABS" <<'PY'
+import secrets
+import sys
+print(f"{sys.argv[1]}:{secrets.token_hex(16)}")
+PY
+}
+
+resolve_output_path() {
+    local show_output="$1"
+    local candidate
+    candidate="$(awk 'NF >= 2 {print $NF; exit}' "$show_output")"
+    [[ -n "$candidate" ]] || return 1
+    if [[ "$candidate" = /* ]]; then
+        printf '%s\n' "$candidate"
+    else
+        printf '%s\n' "$REPO_ROOT/$candidate"
+    fi
+}
+
+capture_what_ran() {
+    local label="$1"
+    (
+        cd "$REPO_ROOT"
+        "$BUCK2" log what-ran
+    ) >"$OUT_DIR/what_ran_${label}.txt" 2>"$OUT_DIR/what_ran_${label}.stderr" || true
+}
+
+placement_proven() {
+    local label="$1"
+    local expected="$2"
+    local telemetry="$OUT_DIR/what_ran_${label}.txt"
+    [[ -s "$telemetry" ]] || return 1
+    if [[ "$expected" == "local" ]]; then
+        grep -Eqi 'LocalExecute|local[_ -]?execute|"executor"[[:space:]]*:[[:space:]]*"local"' "$telemetry"
+    else
+        grep -Eqi 'RemoteExecute|remote[_ -]?execute|"executor"[[:space:]]*:[[:space:]]*"remote"' "$telemetry"
+    fi
+}
+
+build_envdump() {
+    local label="$1"
+    local placement="$2"
+    local show_output="$OUT_DIR/show_output_${label}.txt"
+    local stderr_file="$OUT_DIR/build_${label}.stderr"
+    local output_path
+
+    write_nonce "$label"
+    if ! (
+        cd "$REPO_ROOT"
+        "$BUCK2" build \
+            "${CONTEXT_ARGS[@]}" \
+            "--${placement}-only" \
+            "$ENVDUMP_TARGET" \
+            --show-output
+    ) >"$show_output" 2>"$stderr_file"; then
+        return 1
+    fi
+    capture_what_ran "$label"
+    output_path="$(resolve_output_path "$show_output")" || return 1
+    [[ -s "$output_path" ]] || return 1
+    cp "$output_path" "$OUT_DIR/envdump_${label}.txt"
+}
+
+split_envdump() {
+    local label="$1"
+    local input="$OUT_DIR/envdump_${label}.txt"
+    grep -qx -- '---ENV---' "$input"
+    grep -qx -- '---CGROUP---' "$input"
+    grep -qx -- '---UNAME---' "$input"
+    awk '
+        /^---ENV---$/ {in_env=1; next}
+        /^---CGROUP---$/ {in_env=0}
+        in_env {print}
+    ' "$input" >"$OUT_DIR/env_${label}.txt"
+    awk '
+        /^---CGROUP---$/ {in_cgroup=1; next}
+        /^---UNAME---$/ {in_cgroup=0}
+        in_cgroup {print}
+    ' "$input" >"$OUT_DIR/cgroup_${label}.txt"
+    awk '
+        /^---UNAME---$/ {in_uname=1; next}
+        in_uname {print}
+    ' "$input" >"$OUT_DIR/uname_${label}.txt"
+    [[ -s "$OUT_DIR/env_${label}.txt" ]]
+}
+
+LOCAL_CAPTURED=0
+REMOTE_CAPTURED=0
+LOCAL_PROVEN=0
+REMOTE_PROVEN=0
+
+if build_envdump local local && split_envdump local; then
+    LOCAL_CAPTURED=1
+    if placement_proven local local; then
+        LOCAL_PROVEN=1
+    fi
+fi
+
+if [[ -n "$CACHE_BUST_ABS" ]]; then
+    if build_envdump remote remote && split_envdump remote; then
+        REMOTE_CAPTURED=1
+        if placement_proven remote remote; then
+            REMOTE_PROVEN=1
+        fi
+    fi
+else
+    printf '%s\n' \
+        "Remote measurement skipped: --cache-bust-file is required to rule out a cache hit." \
+        >"$OUT_DIR/remote_skipped.txt"
+fi
+
+if [[ "$LOCAL_CAPTURED" -eq 1 && "$REMOTE_CAPTURED" -eq 1 ]]; then
+    diff -u "$OUT_DIR/env_local.txt" "$OUT_DIR/env_remote.txt" \
+        >"$OUT_DIR/env_local_vs_remote.diff" || true
+fi
+
+CANDIDATE_MARKERS="$OUT_DIR/q1_candidate_marker_names.txt"
+: >"$CANDIDATE_MARKERS"
+if [[ "$REMOTE_PROVEN" -eq 1 ]]; then
+    awk -F= '
+        /^[A-Za-z_][A-Za-z0-9_]*=/ {
+            key=toupper($1)
+            if (key ~ /^(BUCK|RE_|REMOTE_|RBE_|CAS_|BUILDBARN|BUILDBUDDY|ENGFLOW)/) {
+                print $1
+            }
+        }
+    ' "$OUT_DIR/env_remote.txt" | sort -u >"$CANDIDATE_MARKERS"
+fi
+
+(
+    cd "$REPO_ROOT"
+    "$BUCK2" audit execution-platform-resolution \
+        "${CONTEXT_ARGS[@]}" \
+        "$WORKLOAD_TARGET"
+) >"$OUT_DIR/execution_platform_resolution.txt" \
+  2>"$OUT_DIR/execution_platform_resolution.stderr" || true
+
+(
+    cd "$REPO_ROOT"
+    "$BUCK2" cquery \
+        "${CONTEXT_ARGS[@]}" \
+        "$WORKLOAD_TARGET" \
+        --output-attribute '^buck\.execution_platform$' \
+        --output-attribute '^buck\.target_configuration$' \
+        --json
+) >"$OUT_DIR/workload_configured_attributes.json" \
+  2>"$OUT_DIR/workload_configured_attributes.stderr" || true
+
+Q2_NAMED=0
+if [[ -s "$OUT_DIR/workload_configured_attributes.json" ]] &&
+   grep -q '"buck.execution_platform"' "$OUT_DIR/workload_configured_attributes.json"; then
+    Q2_NAMED=1
+fi
+
+IN_ACTION_CAPTURED=0
+if [[ -n "$AORTA_PROBE_TARGET" && "$REMOTE_PROVEN" -eq 1 ]]; then
+    write_nonce aorta_probe
+    if (
+        cd "$REPO_ROOT"
+        "$BUCK2" build \
+            "${CONTEXT_ARGS[@]}" \
+            --remote-only \
+            "$AORTA_PROBE_TARGET" \
+            --show-output
+    ) >"$OUT_DIR/show_output_aorta_probe.txt" \
+      2>"$OUT_DIR/build_aorta_probe.stderr"; then
+        capture_what_ran aorta_probe
+        aorta_output="$(resolve_output_path "$OUT_DIR/show_output_aorta_probe.txt" || true)"
+        if placement_proven aorta_probe remote &&
+           [[ -n "$aorta_output" && -s "$aorta_output" ]]; then
+            cp "$aorta_output" "$OUT_DIR/in_action_env.json"
+            if python3 -m json.tool "$OUT_DIR/in_action_env.json" >/dev/null; then
+                IN_ACTION_CAPTURED=1
+            fi
+        fi
+    fi
+fi
+
+{
+    echo "Buck2 execution-context findings"
+    echo "buck2_version=$(printf '%s' "$BUCK2_VERSION" | tr '\n' ' ')"
+    echo "context_fingerprint=$context_fingerprint"
+    echo "mode_file_count=${#MODE_FILES[@]}"
+    echo "config_keys=$(IFS=,; echo "${config_keys[*]}")"
+    echo "modifier_count=${#MODIFIERS[@]}"
+    echo "local_capture=$LOCAL_CAPTURED"
+    echo "local_placement_proven=$LOCAL_PROVEN"
+    echo "remote_capture=$REMOTE_CAPTURED"
+    echo "remote_placement_proven=$REMOTE_PROVEN"
+    if [[ "$LOCAL_PROVEN" -eq 1 && "$REMOTE_PROVEN" -eq 1 ]]; then
+        echo "q1_status=measured"
+        echo "q1_candidate_marker_names=$(paste -sd, "$CANDIDATE_MARKERS")"
+    else
+        echo "q1_status=untested"
+        echo "q1_candidate_marker_names="
+    fi
+    echo "q2_resolved_platform_named=$Q2_NAMED"
+    echo "in_action_env_captured=$IN_ACTION_CAPTURED"
+    echo "raw_artifacts_private=yes"
+} >"$FINDINGS"
+
+[[ -s "$FINDINGS" ]]
+cat "$FINDINGS"

--- a/scripts/buck2_execution_context_probe.sh
+++ b/scripts/buck2_execution_context_probe.sh
@@ -19,9 +19,7 @@ Usage:
     [--buck2 PATH] \
     [--aorta-probe-target LABEL] \
     [--cache-bust-file RELATIVE_PATH] \
-    [--mode-file @MODE]... \
-    [--config KEY=VALUE]... \
-    [--modifier LABEL]...
+    [--context-option TYPE=VALUE]...
 
 Target contracts:
   --envdump-target
@@ -60,6 +58,7 @@ CACHE_BUST_FILE=""
 MODE_FILES=()
 CONFIG_OVERRIDES=()
 MODIFIERS=()
+ORDERED_CONTEXT=()
 
 while (($#)); do
     case "$1" in
@@ -70,6 +69,7 @@ while (($#)); do
         --buck2) BUCK2="${2:?missing value for --buck2}"; shift 2 ;;
         --aorta-probe-target) AORTA_PROBE_TARGET="${2:?missing value for --aorta-probe-target}"; shift 2 ;;
         --cache-bust-file) CACHE_BUST_FILE="${2:?missing value for --cache-bust-file}"; shift 2 ;;
+        --context-option) ORDERED_CONTEXT+=("${2:?missing value for --context-option}"); shift 2 ;;
         --mode-file) MODE_FILES+=("${2:?missing value for --mode-file}"); shift 2 ;;
         --config) CONFIG_OVERRIDES+=("${2:?missing value for --config}"); shift 2 ;;
         --modifier) MODIFIERS+=("${2:?missing value for --modifier}"); shift 2 ;;
@@ -106,34 +106,69 @@ chmod 700 "$OUT_DIR"
 FINDINGS="$OUT_DIR/q1_q2_findings.txt"
 
 CONTEXT_ARGS=()
-for mode in "${MODE_FILES[@]}"; do
-    [[ "$mode" == @* ]] || mode="@$mode"
-    CONTEXT_ARGS+=("$mode")
-done
-for config in "${CONFIG_OVERRIDES[@]}"; do
-    [[ "$config" == *=* ]] || {
-        echo "ERROR: --config requires KEY=VALUE, got: $config" >&2
-        exit 2
-    }
-    CONTEXT_ARGS+=("-c" "$config")
-done
-for modifier in "${MODIFIERS[@]}"; do
-    CONTEXT_ARGS+=("-m" "$modifier")
-done
+OPTION_ORDER=()
+if ((${#ORDERED_CONTEXT[@]})) &&
+   ((${#MODE_FILES[@]} || ${#CONFIG_OVERRIDES[@]} || ${#MODIFIERS[@]})); then
+    echo "ERROR: --context-option cannot be combined with grouped context options" >&2
+    exit 2
+fi
+if ((${#ORDERED_CONTEXT[@]})); then
+    for option in "${ORDERED_CONTEXT[@]}"; do
+        kind="${option%%=*}"
+        value="${option#*=}"
+        [[ "$kind" != "$option" && -n "$value" ]] || {
+            echo "ERROR: --context-option requires TYPE=VALUE" >&2
+            exit 2
+        }
+        case "$kind" in
+            mode)
+                [[ "$value" == @* ]] || value="@$value"
+                MODE_FILES+=("${value#@}")
+                CONTEXT_ARGS+=("$value")
+                ;;
+            config)
+                [[ "$value" == *=* ]] || {
+                    echo "ERROR: config context requires config=KEY=VALUE" >&2
+                    exit 2
+                }
+                CONFIG_OVERRIDES+=("$value")
+                CONTEXT_ARGS+=("-c" "$value")
+                ;;
+            modifier)
+                MODIFIERS+=("$value")
+                CONTEXT_ARGS+=("-m" "$value")
+                ;;
+            *) echo "ERROR: unknown context type: $kind" >&2; exit 2 ;;
+        esac
+        OPTION_ORDER+=("$kind")
+    done
+else
+    for mode in "${MODE_FILES[@]}"; do
+        [[ "$mode" == @* ]] || mode="@$mode"
+        CONTEXT_ARGS+=("$mode")
+        OPTION_ORDER+=("mode")
+    done
+    for config in "${CONFIG_OVERRIDES[@]}"; do
+        [[ "$config" == *=* ]] || {
+            echo "ERROR: --config requires KEY=VALUE, got: $config" >&2
+            exit 2
+        }
+        CONTEXT_ARGS+=("-c" "$config")
+        OPTION_ORDER+=("config")
+    done
+    for modifier in "${MODIFIERS[@]}"; do
+        CONTEXT_ARGS+=("-m" "$modifier")
+        OPTION_ORDER+=("modifier")
+    done
+fi
 
 context_fingerprint="$(
-    python3 - "${MODE_FILES[@]}" -- "${CONFIG_OVERRIDES[@]}" -- "${MODIFIERS[@]}" <<'PY'
+    python3 - "${CONTEXT_ARGS[@]}" <<'PY'
 import hashlib
 import json
 import sys
 
-parts = [[]]
-for value in sys.argv[1:]:
-    if value == "--":
-        parts.append([])
-    else:
-        parts[-1].append(value)
-payload = {"mode_files": parts[0], "config_overrides": parts[1], "modifiers": parts[2]}
+payload = {"buck_argv": sys.argv[1:]}
 encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
 print("sha256:" + hashlib.sha256(encoded).hexdigest())
 PY
@@ -383,6 +418,7 @@ fi
     echo "mode_file_count=${#MODE_FILES[@]}"
     echo "config_keys=$(IFS=,; echo "${config_keys[*]}")"
     echo "modifier_count=${#MODIFIERS[@]}"
+    echo "option_order=$(IFS=,; echo "${OPTION_ORDER[*]}")"
     echo "local_capture=$LOCAL_CAPTURED"
     echo "local_placement_proven=$LOCAL_PROVEN"
     echo "remote_capture=$REMOTE_CAPTURED"

--- a/scripts/validate_buck_env_pair.py
+++ b/scripts/validate_buck_env_pair.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -28,6 +29,9 @@ def _nonempty(value: object) -> bool:
 def validate_pair(
     client: dict[str, object],
     workload: dict[str, object],
+    *,
+    required_libraries: tuple[str, ...] = ("pytorch",),
+    allow_unisolated_action: bool = False,
 ) -> list[Finding]:
     """Return actionable errors/warnings for a Buck client/workload pair."""
     findings: list[Finding] = []
@@ -52,8 +56,19 @@ def validate_pair(
         findings.append(Finding("ERROR", "Buck invocation context was not confirmed"))
     if not _nonempty(invocation.get("context_fingerprint")):
         findings.append(Finding("ERROR", "Buck invocation fingerprint is missing"))
-    if not _nonempty(client.get("library_introspection")):
+    library_entries = client.get("library_introspection")
+    if not _nonempty(library_entries):
         findings.append(Finding("ERROR", "no recognized libraries were found in the Buck graph"))
+    entry_list = library_entries if isinstance(library_entries, list) else []
+    library_names = {str(entry.get("name")) for entry in entry_list if isinstance(entry, dict)}
+    for library in required_libraries:
+        if library not in library_names:
+            findings.append(
+                Finding(
+                    "ERROR",
+                    f"required Buck library identity is missing: {library}",
+                )
+            )
 
     pytorch_build = _object(workload.get("pytorch_build"))
     runtime_rocm = (
@@ -75,6 +90,18 @@ def validate_pair(
     probe_invocation = _object(workload.get("execution_context")).get("probe_invocation")
     if probe_invocation not in {"buck2_run", "buck2_action"}:
         findings.append(Finding("ERROR", "workload snapshot was not labeled as Buck-launched"))
+    if (
+        probe_invocation == "buck2_action"
+        and workload.get("container_detected") is not True
+        and not allow_unisolated_action
+    ):
+        findings.append(
+            Finding(
+                "ERROR",
+                "buck2_action snapshot has no detected isolation evidence; "
+                "prove placement separately or relabel it buck2_run",
+            )
+        )
 
     for label, document in (("client", client), ("workload", workload)):
         reasons = document.get("partial_reasons")
@@ -99,16 +126,37 @@ def main() -> int:
     )
     parser.add_argument("client", type=Path, help="env.buck-client.json")
     parser.add_argument("workload", type=Path, help="env.workload.json")
+    parser.add_argument(
+        "--require-library",
+        action="append",
+        default=None,
+        help=(
+            "Buck library identity required in the client graph " "(repeatable; default: pytorch)"
+        ),
+    )
+    parser.add_argument(
+        "--allow-unisolated-action",
+        action="store_true",
+        help=(
+            "Allow buck2_action without container_detected=true when "
+            "placement was proven separately"
+        ),
+    )
     args = parser.parse_args()
 
     try:
-        findings = validate_pair(_load(args.client), _load(args.workload))
+        findings = validate_pair(
+            _load(args.client),
+            _load(args.workload),
+            required_libraries=tuple(args.require_library or ("pytorch",)),
+            allow_unisolated_action=args.allow_unisolated_action,
+        )
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
-        print(f"ERROR: {exc}")
+        print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
     for finding in findings:
-        print(f"{finding.severity}: {finding.message}")
+        print(f"{finding.severity}: {finding.message}", file=sys.stderr)
     if any(finding.severity == "ERROR" for finding in findings):
         return 1
     print("PASS: Buck dependency and workload runtime snapshots are usable")

--- a/scripts/validate_buck_env_pair.py
+++ b/scripts/validate_buck_env_pair.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Validate the two env-probe files required for a Buck workload handoff."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    message: str
+
+
+def _object(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): item for key, item in value.items()}
+
+
+def _nonempty(value: object) -> bool:
+    return value is not None and value != "" and value != [] and value != {}
+
+
+def validate_pair(
+    client: dict[str, object],
+    workload: dict[str, object],
+) -> list[Finding]:
+    """Return actionable errors/warnings for a Buck client/workload pair."""
+    findings: list[Finding] = []
+
+    try:
+        schema = tuple(int(part) for part in str(client["schema_version"]).split("."))
+    except (KeyError, TypeError, ValueError):
+        schema = ()
+    if schema < (1, 13):
+        findings.append(Finding("ERROR", "client schema must be 1.13 or newer"))
+
+    if _object(client.get("build_system")).get("kind") != "buck2":
+        findings.append(Finding("ERROR", "client snapshot did not detect Buck2"))
+
+    invocation = _object(client.get("buck_invocation"))
+    if invocation.get("status") != "success":
+        findings.append(Finding("ERROR", "Buck dependency lookup did not succeed"))
+    if invocation.get("context_source") not in {
+        "default_confirmed",
+        "explicit",
+    }:
+        findings.append(Finding("ERROR", "Buck invocation context was not confirmed"))
+    if not _nonempty(invocation.get("context_fingerprint")):
+        findings.append(Finding("ERROR", "Buck invocation fingerprint is missing"))
+    if not _nonempty(client.get("library_introspection")):
+        findings.append(Finding("ERROR", "no recognized libraries were found in the Buck graph"))
+
+    pytorch_build = _object(workload.get("pytorch_build"))
+    runtime_rocm = (
+        _object(workload.get("rocm")).get("version")
+        or _object(workload.get("hip")).get("version")
+        or pytorch_build.get("hip_version")
+    )
+    required_workload_fields = {
+        "python_version": workload.get("python_version"),
+        "pytorch_version": workload.get("pytorch_version"),
+        "pytorch_build.git_commit": pytorch_build.get("git_commit"),
+        "ROCm/HIP identity": runtime_rocm,
+        "gpu_arch.gfx_targets": _object(workload.get("gpu_arch")).get("gfx_targets"),
+    }
+    for name, value in required_workload_fields.items():
+        if not _nonempty(value):
+            findings.append(Finding("ERROR", f"workload snapshot is missing {name}"))
+
+    probe_invocation = _object(workload.get("execution_context")).get("probe_invocation")
+    if probe_invocation not in {"buck2_run", "buck2_action"}:
+        findings.append(Finding("ERROR", "workload snapshot was not labeled as Buck-launched"))
+
+    for label, document in (("client", client), ("workload", workload)):
+        reasons = document.get("partial_reasons")
+        if isinstance(reasons, list):
+            for reason in reasons:
+                findings.append(Finding("WARNING", f"{label}: {reason}"))
+
+    return findings
+
+
+def _load(path: Path) -> dict[str, object]:
+    with path.open(encoding="utf-8") as handle:
+        document = json.load(handle)
+    if not isinstance(document, dict):
+        raise ValueError(f"{path} is not a JSON object")
+    return {str(key): value for key, value in document.items()}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Buck client and workload env-probe snapshots."
+    )
+    parser.add_argument("client", type=Path, help="env.buck-client.json")
+    parser.add_argument("workload", type=Path, help="env.workload.json")
+    args = parser.parse_args()
+
+    try:
+        findings = validate_pair(_load(args.client), _load(args.workload))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    for finding in findings:
+        print(f"{finding.severity}: {finding.message}")
+    if any(finding.severity == "ERROR" for finding in findings):
+        return 1
+    print("PASS: Buck dependency and workload runtime snapshots are usable")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -96,12 +96,53 @@ def env() -> None:
     help=(
         "Buck2 label to introspect for library identity (issue #163, "
         "A1.2b). When given, the snapshot's library_introspection list "
-        "is populated from `buck2 cquery 'deps(<label>)' --json` (each "
+        "is populated from bound `buck2 cquery 'deps(%s)' <label> --json` (each "
         "matched entry carries both a stripped `target` and the raw "
         "`configured_target`, schema 1.6). If buck2 isn't on PATH (or "
         "the cquery otherwise fails), the library_introspection list "
         "stays empty and a human-readable reason is recorded in "
         "`partial_reasons`."
+    ),
+)
+@click.option(
+    "--buck-mode-file",
+    "buck_mode_files",
+    type=str,
+    multiple=True,
+    metavar="PATH",
+    help=(
+        "Buck mode/flag file to apply to the cquery (repeatable, ordered). "
+        "Pass a Buck cell path such as root//mode/debug; a leading '@' is "
+        "accepted but not required."
+    ),
+)
+@click.option(
+    "--buck-config",
+    "buck_configs",
+    type=str,
+    multiple=True,
+    metavar="KEY=VALUE",
+    help=(
+        "Buck -c config override for the cquery (repeatable, ordered). "
+        "Only each key and an aggregate context fingerprint are persisted; "
+        "raw values are never written to env.json."
+    ),
+)
+@click.option(
+    "--buck-modifier",
+    "buck_modifiers",
+    type=str,
+    multiple=True,
+    metavar="MODIFIER",
+    help="Buck -m configuration modifier for the cquery (repeatable, ordered).",
+)
+@click.option(
+    "--buck-default-context",
+    is_flag=True,
+    help=(
+        "Confirm that --buck-target should use Buck's default invocation "
+        "context. Mutually exclusive with --buck-mode-file, --buck-config, "
+        "and --buck-modifier."
     ),
 )
 @click.option(
@@ -138,10 +179,15 @@ def probe(
     field_path: str | None,
     extended: bool,
     buck_target: str | None,
+    buck_mode_files: tuple[str, ...],
+    buck_configs: tuple[str, ...],
+    buck_modifiers: tuple[str, ...],
+    buck_default_context: bool,
     buck_timeout: int,
     execution_context: str,
 ) -> None:
     """Capture trial-environment state to env.json (issue #147)."""
+    from aorta.instrumentation.buck_invocation import BuckInvocationContext
     from aorta.instrumentation.environment import (
         collect_env,
         execution_context_warning,
@@ -150,9 +196,32 @@ def probe(
     # --summary and --field both bypass the file write -- only one
     # output mode at a time makes sense.
     if summary and field_path is not None:
-        raise click.ClickException(
-            "--summary and --field are mutually exclusive"
+        raise click.ClickException("--summary and --field are mutually exclusive")
+
+    explicit_buck_context = bool(buck_mode_files or buck_configs or buck_modifiers)
+    if (explicit_buck_context or buck_default_context) and buck_target is None:
+        raise click.UsageError(
+            "--buck-mode-file, --buck-config, --buck-modifier, and "
+            "--buck-default-context require --buck-target"
         )
+    if buck_default_context and explicit_buck_context:
+        raise click.UsageError(
+            "--buck-default-context is mutually exclusive with "
+            "--buck-mode-file, --buck-config, and --buck-modifier"
+        )
+    try:
+        buck_context = (
+            BuckInvocationContext(
+                mode_files=buck_mode_files,
+                config_overrides=buck_configs,
+                modifiers=buck_modifiers,
+                default_context_confirmed=buck_default_context,
+            )
+            if buck_target is not None
+            else None
+        )
+    except ValueError as exc:
+        raise click.BadParameter(str(exc), param_hint="Buck context options") from exc
 
     # Capture once; both short-circuit modes and the default mode read
     # from this single snapshot. Buck-related kwargs flow through to
@@ -162,6 +231,7 @@ def probe(
     snapshot = collect_env(
         buck_target=buck_target,
         buck_timeout=buck_timeout,
+        buck_context=buck_context,
         detail="full" if extended else "compact",
         probe_invocation=execution_context,
     )
@@ -172,9 +242,7 @@ def probe(
     # launcher image env var, they may have probed the host shell instead of
     # the workload's context. Warn loudly to stderr (never a hard error --
     # the snapshot is still valid and written).
-    _ec_warning = execution_context_warning(
-        execution_context, snapshot.container_detected
-    )
+    _ec_warning = execution_context_warning(execution_context, snapshot.container_detected)
     if _ec_warning is not None:
         click.echo(_ec_warning, err=True)
 
@@ -232,14 +300,11 @@ def probe(
             encoding="utf-8",
         )
     except OSError as exc:
-        raise click.ClickException(
-            f"Failed to write env probe to {output}: {exc}"
-        ) from exc
+        raise click.ClickException(f"Failed to write env probe to {output}: {exc}") from exc
 
     partial = " [PARTIAL]" if snapshot.partial else ""
     click.echo(
-        f"Wrote env probe to {output} "
-        f"(schema_version={snapshot.schema_version}){partial}"
+        f"Wrote env probe to {output} " f"(schema_version={snapshot.schema_version}){partial}"
     )
     click.echo(snapshot.summary())
 
@@ -261,9 +326,7 @@ def probe(
     # scrolling back up. Matches the marker shown next to the "Wrote
     # env probe..." line.
     if snapshot.partial:
-        click.echo(
-            f"\n[PARTIAL, {len(snapshot.partial_reasons)} reason(s)]"
-        )
+        click.echo(f"\n[PARTIAL, {len(snapshot.partial_reasons)} reason(s)]")
     else:
         click.echo("\n[OK]")
 
@@ -292,9 +355,7 @@ def _lookup_field(snapshot_dict: dict[str, Any], dotted_path: str) -> Any:
     for i, part in enumerate(parts):
         prefix = ".".join(parts[:i]) or "<root>"
         if cur is None:
-            raise click.ClickException(
-                f"Cannot descend into '{part}' at '{prefix}': value is null"
-            )
+            raise click.ClickException(f"Cannot descend into '{part}' at '{prefix}': value is null")
         if not isinstance(cur, dict):
             raise click.ClickException(
                 f"Cannot descend into '{part}' at '{prefix}': "
@@ -305,8 +366,7 @@ def _lookup_field(snapshot_dict: dict[str, Any], dotted_path: str) -> Any:
             shown = ", ".join(available[:10])
             more = f" (+ {len(available) - 10} more)" if len(available) > 10 else ""
             raise click.ClickException(
-                f"Key '{part}' not found at '{prefix}'. "
-                f"Available keys: {shown}{more}"
+                f"Key '{part}' not found at '{prefix}'. " f"Available keys: {shown}{more}"
             )
         cur = cur[part]
     return cur
@@ -364,9 +424,7 @@ def recipe(env_json: Path, fmt: str) -> None:
         # Wrap filesystem, decode, and JSON-parse errors as a single
         # Click error so the operator sees a clean one-liner instead
         # of a Python traceback.
-        raise click.ClickException(
-            f"Failed to read env.json from {env_json}: {exc}"
-        ) from exc
+        raise click.ClickException(f"Failed to read env.json from {env_json}: {exc}") from exc
 
     if not isinstance(env_dict, dict):
         raise click.ClickException(

--- a/src/aorta/cli/env.py
+++ b/src/aorta/cli/env.py
@@ -105,6 +105,18 @@ def env() -> None:
     ),
 )
 @click.option(
+    "--buck-option",
+    "buck_options",
+    type=str,
+    multiple=True,
+    metavar="TYPE=VALUE",
+    help=(
+        "Exact ordered Buck context item (repeatable): mode=VALUE, "
+        "config=KEY=VALUE, or modifier=VALUE. Use this when order across "
+        "option types matters; do not combine it with grouped Buck options."
+    ),
+)
+@click.option(
     "--buck-mode-file",
     "buck_mode_files",
     type=str,
@@ -179,6 +191,7 @@ def probe(
     field_path: str | None,
     extended: bool,
     buck_target: str | None,
+    buck_options: tuple[str, ...],
     buck_mode_files: tuple[str, ...],
     buck_configs: tuple[str, ...],
     buck_modifiers: tuple[str, ...],
@@ -187,7 +200,10 @@ def probe(
     execution_context: str,
 ) -> None:
     """Capture trial-environment state to env.json (issue #147)."""
-    from aorta.instrumentation.buck_invocation import BuckInvocationContext
+    from aorta.instrumentation.buck_invocation import (
+        BuckInvocationContext,
+        BuckInvocationOption,
+    )
     from aorta.instrumentation.environment import (
         collect_env,
         execution_context_warning,
@@ -198,30 +214,47 @@ def probe(
     if summary and field_path is not None:
         raise click.ClickException("--summary and --field are mutually exclusive")
 
-    explicit_buck_context = bool(buck_mode_files or buck_configs or buck_modifiers)
+    grouped_buck_context = bool(buck_mode_files or buck_configs or buck_modifiers)
+    explicit_buck_context = bool(buck_options or grouped_buck_context)
     if (explicit_buck_context or buck_default_context) and buck_target is None:
         raise click.UsageError(
-            "--buck-mode-file, --buck-config, --buck-modifier, and "
-            "--buck-default-context require --buck-target"
+            "--buck-option, --buck-mode-file, --buck-config, "
+            "--buck-modifier, and --buck-default-context require "
+            "--buck-target"
+        )
+    if buck_options and grouped_buck_context:
+        raise click.UsageError(
+            "--buck-option preserves cross-option ordering and cannot be "
+            "combined with --buck-mode-file, --buck-config, or "
+            "--buck-modifier"
         )
     if buck_default_context and explicit_buck_context:
         raise click.UsageError(
             "--buck-default-context is mutually exclusive with "
-            "--buck-mode-file, --buck-config, and --buck-modifier"
+            "--buck-option, --buck-mode-file, --buck-config, and "
+            "--buck-modifier"
         )
     try:
+        ordered_options = tuple(BuckInvocationOption.parse(option) for option in buck_options)
         buck_context = (
             BuckInvocationContext(
                 mode_files=buck_mode_files,
                 config_overrides=buck_configs,
                 modifiers=buck_modifiers,
                 default_context_confirmed=buck_default_context,
+                ordered_options=ordered_options,
             )
             if buck_target is not None
             else None
         )
     except ValueError as exc:
-        raise click.BadParameter(str(exc), param_hint="Buck context options") from exc
+        raise click.BadParameter(
+            str(exc),
+            param_hint=(
+                "--buck-option/--buck-mode-file/--buck-config/"
+                "--buck-modifier/--buck-default-context"
+            ),
+        ) from exc
 
     # Capture once; both short-circuit modes and the default mode read
     # from this single snapshot. Buck-related kwargs flow through to

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -89,9 +89,9 @@ aorta env probe --buck-target //app:trainer --buck-default-context
 # Or reproduce ordered context inputs.
 aorta env probe \
   --buck-target //app:trainer \
-  --buck-mode-file root//mode/debug \
-  --buck-config build.profile=debug \
-  --buck-modifier //constraints:linux
+  --buck-option mode=root//mode/debug \
+  --buck-option config=build.profile=debug \
+  --buck-option modifier=//constraints:linux
 ```
 
 After the run, `cat env.json` reveals the same dict that

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -7,10 +7,11 @@ per-layer numerics logger. Future submodules (drift watcher, etc.) will live her
 
 | Submodule | Purpose | Public API |
 | --- | --- | --- |
-| [`environment`](environment.py) | ROCm + ML stack version snapshot + container/python env detection. See block list below. | `collect_env(buck_target: str \| None = None, buck_timeout: int = 10) -> EnvSnapshot` |
+| [`environment`](environment.py) | ROCm + ML stack version snapshot + container/python env detection. See block list below. | `collect_env(...) -> EnvSnapshot`, `capture_to(path, ...) -> EnvSnapshot` |
 | [`layer_numerics`](layer_numerics/README.md) | Per-layer / per-stage NaN, magnitude, and out-of-range logger. Runs standalone as a front-end around a training/repro script (the supported path); also a recognized `layer_numerics` sweep collector — the engine validates the name and threads it into workload config, but a workload must opt in for capture (see [`docs/layer-numerics.md`](../../../docs/layer-numerics.md)). Config via `NANLOG_SPEC` (structured, recommended) or the flat `NANLOG_*` vars. | `build_env(results_dir, overrides=None) -> dict`, `SCRIPT_PATH`, `OUTPUT_SUBDIR` |
 | [`build_system`](build_system.py) | Detects Buck2 build environments (issue #163, A1.2a). Wrapped by `collect_env()` and surfaced as the `build_system` field of `EnvSnapshot`. | `detect_build_system() -> dict` |
-| [`buck_introspect`](buck_introspect.py) | Buck-aware library introspection via `buck2 cquery 'deps(<target>)' --json` (issue #163, A1.2b). Triggered by `collect_env(buck_target=...)` (or `aorta env probe --buck-target ...`); populates the `library_introspection` and `library_introspection_alternates` fields of `EnvSnapshot`. | `introspect_libraries_via_buck(target, repo_revision, ...) -> (entries, reasons)` |
+| [`buck_invocation`](buck_invocation.py) | Frozen, ordered Buck invocation context: mode/flag files, `-c` overrides, `-m` modifiers, or explicit default confirmation. Builds atomic argv and a redacted comparison fingerprint; no shell/passthrough string. | `BuckInvocationContext` |
+| [`buck_introspect`](buck_introspect.py) | Buck-aware library introspection via bound `buck2 cquery 'deps(%s)' <target> --json` (issue #163, A1.2b; context provenance schema 1.13). Triggered by `collect_env(buck_target=...)`; populates `buck_invocation`, `library_introspection`, and `library_introspection_alternates`. | `introspect_libraries_via_buck(...) -> BuckIntrospectionResult` |
 | [`recipes/buck`](recipes/buck.py) | BUCK file-fragment emitter for `aorta env recipe --format buck` (issue #163, A1.2c). Reads `build_system` + `library_introspection` from a captured env.json dict and emits one `prebuilt_cxx_library` per `source == "buck"` entry, prefixed with a loud "BEST-EFFORT, NOT EXACT" header. Pure text generation -- never invokes `buck2 build`, never vendors Buck rules. | `emit_buck_recipe(env: dict) -> str` |
 
 **`environment` blocks** (every snapshot includes all of these; missing
@@ -35,6 +36,9 @@ values become `None` plus a `partial_reasons` line):
 * Build system: `build_system` (always present; `{"kind": "buck2",
   ...}` when Buck2 is on PATH and functional, `{"kind": "none"}`
   otherwise). Populated by `aorta.instrumentation.build_system.detect_build_system()`.
+* Buck invocation: `buck_invocation` (always present), which records the
+  redacted client-side cquery context and configured root target. It does not
+  report actual execution placement or resolve execution-context Q1/Q2.
 * Library introspection (Buck mode only): `library_introspection` and
   `library_introspection_alternates` (always present; both `[]`
   outside Buck mode). Populated only when `collect_env(buck_target=...)`
@@ -79,9 +83,15 @@ aorta env probe
 # Custom path; parent dirs are created if missing
 aorta env probe -o runs/exp1/env.json
 
-# Buck mode: also runs `buck2 cquery 'deps(<target>)' --json` and
-# populates library_introspection. The default `--buck-timeout` is 10 s.
-aorta env probe --buck-target //myproj:training_main
+# Buck mode with an explicitly confirmed default context.
+aorta env probe --buck-target //app:trainer --buck-default-context
+
+# Or reproduce ordered context inputs.
+aorta env probe \
+  --buck-target //app:trainer \
+  --buck-mode-file root//mode/debug \
+  --buck-config build.profile=debug \
+  --buck-modifier //constraints:linux
 ```
 
 After the run, `cat env.json` reveals the same dict that
@@ -135,7 +145,21 @@ Documented absences DO NOT trigger `partial`:
 * `env_vars[X] == None` for an unset env var (the documented contract).
 * `runtime_context.venv_path == None` outside a venv.
 
-### env.json schema (v1.1)
+For a Buck ``.par`` whose application owns ``__main__``, add `aorta_lib` to
+the application's dependencies and call `capture_to()` near the beginning of
+its existing `main()`:
+
+```python
+from aorta.instrumentation.environment import capture_to
+
+capture_to("env.workload.json", probe_invocation="buck2_run")
+```
+
+This captures the workload process. Keep client-side `--buck-target`
+introspection in a separate snapshot; a remote action may not have access to
+the Buck daemon or checkout needed for a nested cquery.
+
+### env.json schema (v1.13)
 
 See `EnvSnapshot` in [`environment.py`](environment.py) for the
 authoritative shape and field-by-field docstrings. Top-level keys:
@@ -148,7 +172,7 @@ tensile           triton            fbgemm          aiter
 aotriton          gpu_arch          host
 runtime_context   docker            env_vars
 python_version    pytorch_version   pytorch_build
-build_system      library_introspection
+build_system      buck_invocation       library_introspection
 library_introspection_alternates
 ```
 

--- a/src/aorta/instrumentation/buck_introspect.py
+++ b/src/aorta/instrumentation/buck_introspect.py
@@ -6,7 +6,7 @@ on disk, and parsing pkg-config / Docker image digests. Inside a
 Buck2 monorepo none of those signals exist -- libraries are Buck
 *targets*, not files at well-known FHS paths.
 
-This module wraps ``buck2 cquery 'deps(<target>)' --json`` and
+This module wraps a bound ``buck2 cquery 'deps(%s)' <target> --json`` and
 matches each transitive dep label against a small known-pattern
 list (hipblaslt, pytorch, rccl, rocm). For matches it returns one
 ``library_introspection`` entry per library with ``source: "buck"``
@@ -29,9 +29,9 @@ vendored.
 
 Per the env-probe never-raises contract: every subprocess call is
 guarded; timeouts and OS errors degrade silently. Callers receive a
-``(entries, reasons)`` tuple -- one human-readable string per
-documented failure goes into ``reasons`` so the snapshot's
-``partial_reasons`` field surfaces it for the operator.
+``BuckIntrospectionResult`` dataclass. It remains iterable as
+``(entries, reasons)`` for compatibility; each human-readable reason
+can be surfaced in the snapshot's ``partial_reasons`` field.
 """
 
 from __future__ import annotations
@@ -41,6 +41,9 @@ import logging
 import re
 import shutil
 import subprocess
+from dataclasses import dataclass
+
+from aorta.instrumentation.buck_invocation import BuckInvocationContext
 
 log = logging.getLogger(__name__)
 
@@ -90,15 +93,33 @@ KNOWN_LIBRARY_PATTERNS: dict[str, list[re.Pattern]] = {
 _CONFIG_SUFFIX_RE = re.compile(r"\s+\([^)]*\)\s*$")
 
 
+@dataclass(frozen=True)
+class BuckIntrospectionResult:
+    """Fail-soft cquery result plus configured-root metadata."""
+
+    entries: list[dict]
+    reasons: list[str]
+    succeeded: bool
+    configured_root_target: str | None
+
+    def __iter__(self):
+        """Preserve the historical ``entries, reasons = result`` API."""
+
+        yield self.entries
+        yield self.reasons
+
+
 def introspect_libraries_via_buck(
     target: str,
     repo_revision: str | None,
     timeout: int = 10,
     cwd: str | None = None,
-) -> tuple[list[dict], list[str]]:
-    """Run ``buck2 cquery 'deps(<target>)'`` and return matched library entries.
+    context: BuckInvocationContext | None = None,
+) -> BuckIntrospectionResult:
+    """Run bound ``buck2 cquery 'deps(%s)' <target>`` introspection.
 
-    Returns ``(entries, reasons)``:
+    Returns a :class:`BuckIntrospectionResult`. It remains two-value iterable
+    as ``(entries, reasons)`` for compatibility with existing callers:
 
     * ``entries`` -- one dict per matched library, in the unified
       ``library_introspection`` shape: ``{name, source: "buck",
@@ -121,26 +142,47 @@ def introspect_libraries_via_buck(
       succeeded but matched nothing (an empty match set is not a
       failure).
 
-    Never raises. Callers get a fully-shaped tuple even on failure.
+    ``succeeded`` distinguishes a clean cquery (including no library matches)
+    from every fail-soft path. ``configured_root_target`` retains the root
+    label including its cquery configuration suffix when that label can be
+    identified in the returned dependency closure.
+
+    Never raises. Callers get a fully-shaped result even on failure.
 
     The function does NOT validate ``target`` syntax; an invalid label
     will surface as a ``buck2 cquery`` non-zero exit captured in
     ``reasons``.
     """
+    invocation_context = context or BuckInvocationContext()
     buck2 = shutil.which("buck2")
     if buck2 is None:
         # Defensive: collect_env() only calls this when build_system.kind
         # == "buck2", which already implies buck2 is on PATH. If that
         # invariant is violated we still degrade cleanly.
-        return [], [
-            f"library_introspection: buck2 not on PATH; "
-            f"--buck-target {target} ignored"
-        ]
+        return BuckIntrospectionResult(
+            entries=[],
+            reasons=[
+                f"library_introspection: buck2 not on PATH; " f"--buck-target {target} ignored"
+            ],
+            succeeded=False,
+            configured_root_target=None,
+        )
 
     # Use cquery (not uquery) so the deps reflect the configured graph
     # the build would actually use, matching the semantics the prior
     # `audit dependencies --transitive` provided.
-    cmd = [buck2, "cquery", f"deps({target})", "--json"]
+    # Keep every user-controlled value in its own argv element. In particular,
+    # bind the target through Buck's multi-query ``%s`` parameter instead of
+    # interpolating it into the query language, where query syntax in a target
+    # string could alter the expression.
+    cmd = [
+        buck2,
+        "cquery",
+        *invocation_context.to_buck_args(),
+        "deps(%s)",
+        target,
+        "--json",
+    ]
     try:
         result = subprocess.run(
             cmd,
@@ -151,33 +193,56 @@ def introspect_libraries_via_buck(
             check=False,
         )
     except subprocess.TimeoutExpired:
-        return [], [
-            f"library_introspection: buck2 cquery deps({target}) "
-            f"timed out after {timeout}s (raise --buck-timeout if needed)"
-        ]
+        return BuckIntrospectionResult(
+            entries=[],
+            reasons=[
+                f"library_introspection: buck2 cquery deps({target}) "
+                f"timed out after {timeout}s (raise --buck-timeout if needed)"
+            ],
+            succeeded=False,
+            configured_root_target=None,
+        )
     except (FileNotFoundError, OSError) as exc:
-        return [], [
-            f"library_introspection: buck2 cquery deps({target}) "
-            f"failed to launch ({exc})"
-        ]
+        safe_exc = invocation_context.redact_config_overrides(str(exc))
+        return BuckIntrospectionResult(
+            entries=[],
+            reasons=[
+                f"library_introspection: buck2 cquery deps({target}) "
+                f"failed to launch ({safe_exc})"
+            ],
+            succeeded=False,
+            configured_root_target=None,
+        )
 
     if result.returncode != 0:
         # Common cause: target not found, or buck2 misconfiguration.
         # Surface the stderr (truncated) so the operator can debug
         # without re-running by hand.
-        stderr = (result.stderr or "").strip()[:300]
-        return [], [
-            f"library_introspection: buck2 cquery deps({target}) "
-            f"exited {result.returncode} (stderr: {stderr or '(empty)'})"
-        ]
+        # Redact before truncation so a config token crossing the 300-character
+        # boundary cannot leave a partial raw value in env.json.
+        stderr = invocation_context.redact_config_overrides((result.stderr or "").strip())[:300]
+        return BuckIntrospectionResult(
+            entries=[],
+            reasons=[
+                f"library_introspection: buck2 cquery deps({target}) "
+                f"exited {result.returncode} (stderr: {stderr or '(empty)'})"
+            ],
+            succeeded=False,
+            configured_root_target=None,
+        )
 
     try:
         payload = json.loads(result.stdout or "[]")
     except json.JSONDecodeError as exc:
-        return [], [
-            f"library_introspection: buck2 cquery deps({target}) "
-            f"returned non-JSON output ({exc})"
-        ]
+        return BuckIntrospectionResult(
+            entries=[],
+            reasons=[
+                f"library_introspection: buck2 cquery deps({target}) "
+                f"returned non-JSON output ({exc})"
+            ],
+            succeeded=False,
+            configured_root_target=None,
+        )
 
     # `buck2 cquery 'deps(...)' --json` returns a flat list of
     # stringified labels (with a parenthesised configuration suffix per
@@ -193,10 +258,17 @@ def introspect_libraries_via_buck(
             if isinstance(v, list):
                 dep_labels.extend(str(x) for x in v)
     else:
-        return [], [
-            f"library_introspection: buck2 cquery deps({target}) "
-            f"returned unexpected JSON shape ({type(payload).__name__})"
-        ]
+        return BuckIntrospectionResult(
+            entries=[],
+            reasons=[
+                f"library_introspection: buck2 cquery deps({target}) "
+                f"returned unexpected JSON shape ({type(payload).__name__})"
+            ],
+            succeeded=False,
+            configured_root_target=None,
+        )
+
+    configured_root_target = _find_configured_root_target(target, dep_labels)
 
     entries: list[dict] = []
     seen_names: set[str] = set()
@@ -232,12 +304,32 @@ def introspect_libraries_via_buck(
             }
         )
 
-    return entries, []
+    return BuckIntrospectionResult(
+        entries=entries,
+        reasons=[],
+        succeeded=True,
+        configured_root_target=configured_root_target,
+    )
 
 
 def _strip_config_suffix(label: str) -> str:
     """Strip the parenthesised configuration suffix buck2 cquery emits."""
     return _CONFIG_SUFFIX_RE.sub("", label).strip()
+
+
+def _find_configured_root_target(target: str, dep_labels: list[str]) -> str | None:
+    """Find the requested target in a configured ``deps(%s)`` closure."""
+
+    requested = _strip_config_suffix(target)
+    for label in dep_labels:
+        bare = _strip_config_suffix(label)
+        if bare == requested:
+            return label
+        # Cquery commonly qualifies a root-cell ``//pkg:name`` input as
+        # ``root//pkg:name`` in configured output.
+        if requested.startswith("//") and bare.endswith(requested):
+            return label
+    return None
 
 
 def _match_library(label: str) -> str | None:
@@ -248,3 +340,10 @@ def _match_library(label: str) -> str | None:
             if pat.search(bare):
                 return name
     return None
+
+
+__all__ = [
+    "BuckIntrospectionResult",
+    "KNOWN_LIBRARY_PATTERNS",
+    "introspect_libraries_via_buck",
+]

--- a/src/aorta/instrumentation/buck_introspect.py
+++ b/src/aorta/instrumentation/buck_introspect.py
@@ -43,7 +43,10 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 
-from aorta.instrumentation.buck_invocation import BuckInvocationContext
+from aorta.instrumentation.buck_invocation import (
+    BuckInvocationContext,
+    BuckInvocationOption,
+)
 
 log = logging.getLogger(__name__)
 
@@ -344,6 +347,7 @@ def _match_library(label: str) -> str | None:
 
 __all__ = [
     "BuckIntrospectionResult",
+    "BuckInvocationOption",
     "KNOWN_LIBRARY_PATTERNS",
     "introspect_libraries_via_buck",
 ]

--- a/src/aorta/instrumentation/buck_invocation.py
+++ b/src/aorta/instrumentation/buck_invocation.py
@@ -140,6 +140,16 @@ class BuckInvocationContext:
         return self.modifiers
 
     @property
+    def option_order(self) -> tuple[str, ...]:
+        if self.ordered_options:
+            return tuple(option.kind for option in self.ordered_options)
+        return (
+            ("mode",) * len(self.mode_files)
+            + ("config",) * len(self.config_overrides)
+            + ("modifier",) * len(self.modifiers)
+        )
+
+    @property
     def has_explicit_inputs(self) -> bool:
         """Whether at least one mode, config override, or modifier was supplied."""
 
@@ -173,21 +183,13 @@ class BuckInvocationContext:
         confirmation bit make the encoding unambiguous.
         """
 
-        payload: dict[str, object]
-        if self.ordered_options:
-            payload = {
-                "ordered_options": [
-                    {"kind": option.kind, "value": option.value} for option in self.ordered_options
-                ],
-                "default_context_confirmed": self.default_context_confirmed,
-            }
-        else:
-            payload = {
-                "mode_files": list(self.mode_files),
-                "config_overrides": list(self.config_overrides),
-                "modifiers": list(self.modifiers),
-                "default_context_confirmed": self.default_context_confirmed,
-            }
+        # Fingerprint the effective Buck argv, not the CLI representation.
+        # Grouped and exact-order inputs that produce the same Buck command
+        # must compare equal.
+        payload: dict[str, object] = {
+            "buck_argv": self.to_buck_args(),
+            "default_context_confirmed": self.default_context_confirmed,
+        }
         encoded = json.dumps(
             payload,
             ensure_ascii=False,

--- a/src/aorta/instrumentation/buck_invocation.py
+++ b/src/aorta/instrumentation/buck_invocation.py
@@ -1,0 +1,143 @@
+"""Typed Buck2 invocation context for environment introspection.
+
+Only configuration inputs that Buck2 understands directly are represented:
+ordered mode/flag files, ``-c`` config overrides, and ``-m`` modifiers.  The
+context deliberately has no shell-command or passthrough-string escape hatch;
+callers turn it into an argv list and invoke Buck2 without a shell.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BuckInvocationContext:
+    """Configuration inputs that must accompany a Buck2 introspection query.
+
+    ``mode_files``, ``config_overrides``, and ``modifiers`` retain caller
+    order because Buck2 configuration precedence is order-sensitive.  Config
+    override values are needed to reproduce the cquery and to fingerprint the
+    context, but must never be copied into env.json; use :attr:`config_keys`
+    for metadata.
+
+    ``default_context_confirmed`` is an explicit operator assertion that the
+    target should be queried with no additional context arguments.  It is
+    mutually exclusive with all explicit context inputs.
+    """
+
+    mode_files: tuple[str, ...] = ()
+    config_overrides: tuple[str, ...] = ()
+    modifiers: tuple[str, ...] = ()
+    default_context_confirmed: bool = False
+
+    def __post_init__(self) -> None:
+        # Coerce list-like callers to tuples so frozen=True is meaningful for
+        # the ordered collections as well as for attribute rebinding.
+        mode_files = tuple(self.mode_files)
+        config_overrides = tuple(self.config_overrides)
+        modifiers = tuple(self.modifiers)
+
+        for label, values in (
+            ("mode file", mode_files),
+            ("config override", config_overrides),
+            ("modifier", modifiers),
+        ):
+            if any(not isinstance(value, str) or not value for value in values):
+                raise ValueError(f"Buck {label} values must be non-empty strings")
+            if any("\x00" in value for value in values):
+                raise ValueError(f"Buck {label} values must not contain NUL bytes")
+
+        # Accept either the human-facing ``root//mode/debug`` form or Buck's
+        # argv spelling ``@root//mode/debug`` and retain one canonical form.
+        mode_files = tuple(value[1:] if value.startswith("@") else value for value in mode_files)
+        if any(not value for value in mode_files):
+            raise ValueError("Buck mode file values must name a file after '@'")
+
+        for override in config_overrides:
+            key, separator, _value = override.partition("=")
+            if not separator or not key.strip():
+                raise ValueError("Buck config overrides must use KEY=VALUE with a non-empty key")
+
+        has_explicit = bool(mode_files or config_overrides or modifiers)
+        if self.default_context_confirmed and has_explicit:
+            raise ValueError(
+                "default Buck context confirmation is mutually exclusive "
+                "with mode files, config overrides, and modifiers"
+            )
+
+        object.__setattr__(self, "mode_files", mode_files)
+        object.__setattr__(self, "config_overrides", config_overrides)
+        object.__setattr__(self, "modifiers", modifiers)
+
+    @property
+    def has_explicit_inputs(self) -> bool:
+        """Whether at least one mode, config override, or modifier was supplied."""
+
+        return bool(self.mode_files or self.config_overrides or self.modifiers)
+
+    @property
+    def source(self) -> str:
+        """Schema context-source label for a requested Buck target."""
+
+        if self.default_context_confirmed:
+            return "default_confirmed"
+        if self.has_explicit_inputs:
+            return "explicit"
+        return "unspecified"
+
+    @property
+    def config_keys(self) -> tuple[str, ...]:
+        """Ordered config keys, excluding values that may contain secrets."""
+
+        return tuple(override.partition("=")[0] for override in self.config_overrides)
+
+    @property
+    def fingerprint(self) -> str:
+        """SHA-256 over every full, ordered context value.
+
+        The serialized fingerprint payload includes raw config values so a
+        value-only change is detectable, while only the digest and
+        :attr:`config_keys` are persisted.  Category names and the default
+        confirmation bit make the encoding unambiguous.
+        """
+
+        payload = {
+            "mode_files": list(self.mode_files),
+            "config_overrides": list(self.config_overrides),
+            "modifiers": list(self.modifiers),
+            "default_context_confirmed": self.default_context_confirmed,
+        }
+        encoded = json.dumps(
+            payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+    def to_buck_args(self) -> list[str]:
+        """Build atomic Buck2 argv entries in precedence-preserving order."""
+
+        args = [f"@{mode_file}" for mode_file in self.mode_files]
+        for override in self.config_overrides:
+            args.extend(("-c", override))
+        for modifier in self.modifiers:
+            args.extend(("-m", modifier))
+        return args
+
+    def redact_config_overrides(self, text: str) -> str:
+        """Redact complete ``KEY=VALUE`` tokens from Buck diagnostics."""
+
+        redacted = text
+        # Longest first avoids a shorter override partially masking a longer
+        # one that shares the same prefix.
+        for override in sorted(self.config_overrides, key=len, reverse=True):
+            key = override.partition("=")[0]
+            redacted = redacted.replace(override, f"{key}=<redacted>")
+        return redacted
+
+
+__all__ = ["BuckInvocationContext"]

--- a/src/aorta/instrumentation/buck_invocation.py
+++ b/src/aorta/instrumentation/buck_invocation.py
@@ -11,6 +11,42 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class BuckInvocationOption:
+    """One ordered Buck configuration input."""
+
+    kind: Literal["mode", "config", "modifier"]
+    value: str
+
+    @classmethod
+    def parse(cls, raw: str) -> BuckInvocationOption:
+        """Parse ``TYPE=VALUE`` from the repeatable CLI option."""
+        kind, separator, value = raw.partition("=")
+        if not separator or kind not in {"mode", "config", "modifier"}:
+            raise ValueError(
+                "Buck options must use mode=VALUE, config=KEY=VALUE, " "or modifier=VALUE"
+            )
+        if not value or "\x00" in value:
+            raise ValueError("Buck option values must be non-empty and contain no NUL")
+        if kind == "mode":
+            value = value[1:] if value.startswith("@") else value
+            if not value:
+                raise ValueError("Buck mode option must name a file after '@'")
+        if kind == "config":
+            key, config_separator, _config_value = value.partition("=")
+            if not config_separator or not key.strip():
+                raise ValueError("Buck config options must use config=KEY=VALUE")
+        return cls(kind=kind, value=value)
+
+    def to_buck_args(self) -> list[str]:
+        if self.kind == "mode":
+            return [f"@{self.value}"]
+        if self.kind == "config":
+            return ["-c", self.value]
+        return ["-m", self.value]
 
 
 @dataclass(frozen=True)
@@ -32,6 +68,7 @@ class BuckInvocationContext:
     config_overrides: tuple[str, ...] = ()
     modifiers: tuple[str, ...] = ()
     default_context_confirmed: bool = False
+    ordered_options: tuple[BuckInvocationOption, ...] = ()
 
     def __post_init__(self) -> None:
         # Coerce list-like callers to tuples so frozen=True is meaningful for
@@ -39,6 +76,7 @@ class BuckInvocationContext:
         mode_files = tuple(self.mode_files)
         config_overrides = tuple(self.config_overrides)
         modifiers = tuple(self.modifiers)
+        ordered_options = tuple(self.ordered_options)
 
         for label, values in (
             ("mode file", mode_files),
@@ -62,6 +100,14 @@ class BuckInvocationContext:
                 raise ValueError("Buck config overrides must use KEY=VALUE with a non-empty key")
 
         has_explicit = bool(mode_files or config_overrides or modifiers)
+        if ordered_options and has_explicit:
+            raise ValueError(
+                "ordered Buck options cannot be combined with grouped mode, "
+                "config, or modifier inputs"
+            )
+        if any(not isinstance(option, BuckInvocationOption) for option in ordered_options):
+            raise ValueError("ordered Buck options must be BuckInvocationOption values")
+        has_explicit = has_explicit or bool(ordered_options)
         if self.default_context_confirmed and has_explicit:
             raise ValueError(
                 "default Buck context confirmation is mutually exclusive "
@@ -71,12 +117,35 @@ class BuckInvocationContext:
         object.__setattr__(self, "mode_files", mode_files)
         object.__setattr__(self, "config_overrides", config_overrides)
         object.__setattr__(self, "modifiers", modifiers)
+        object.__setattr__(self, "ordered_options", ordered_options)
+
+    @property
+    def effective_mode_files(self) -> tuple[str, ...]:
+        if self.ordered_options:
+            return tuple(option.value for option in self.ordered_options if option.kind == "mode")
+        return self.mode_files
+
+    @property
+    def effective_config_overrides(self) -> tuple[str, ...]:
+        if self.ordered_options:
+            return tuple(option.value for option in self.ordered_options if option.kind == "config")
+        return self.config_overrides
+
+    @property
+    def effective_modifiers(self) -> tuple[str, ...]:
+        if self.ordered_options:
+            return tuple(
+                option.value for option in self.ordered_options if option.kind == "modifier"
+            )
+        return self.modifiers
 
     @property
     def has_explicit_inputs(self) -> bool:
         """Whether at least one mode, config override, or modifier was supplied."""
 
-        return bool(self.mode_files or self.config_overrides or self.modifiers)
+        return bool(
+            self.ordered_options or self.mode_files or self.config_overrides or self.modifiers
+        )
 
     @property
     def source(self) -> str:
@@ -92,7 +161,7 @@ class BuckInvocationContext:
     def config_keys(self) -> tuple[str, ...]:
         """Ordered config keys, excluding values that may contain secrets."""
 
-        return tuple(override.partition("=")[0] for override in self.config_overrides)
+        return tuple(override.partition("=")[0] for override in self.effective_config_overrides)
 
     @property
     def fingerprint(self) -> str:
@@ -104,12 +173,21 @@ class BuckInvocationContext:
         confirmation bit make the encoding unambiguous.
         """
 
-        payload = {
-            "mode_files": list(self.mode_files),
-            "config_overrides": list(self.config_overrides),
-            "modifiers": list(self.modifiers),
-            "default_context_confirmed": self.default_context_confirmed,
-        }
+        payload: dict[str, object]
+        if self.ordered_options:
+            payload = {
+                "ordered_options": [
+                    {"kind": option.kind, "value": option.value} for option in self.ordered_options
+                ],
+                "default_context_confirmed": self.default_context_confirmed,
+            }
+        else:
+            payload = {
+                "mode_files": list(self.mode_files),
+                "config_overrides": list(self.config_overrides),
+                "modifiers": list(self.modifiers),
+                "default_context_confirmed": self.default_context_confirmed,
+            }
         encoded = json.dumps(
             payload,
             ensure_ascii=False,
@@ -121,6 +199,10 @@ class BuckInvocationContext:
     def to_buck_args(self) -> list[str]:
         """Build atomic Buck2 argv entries in precedence-preserving order."""
 
+        if self.ordered_options:
+            return [
+                argument for option in self.ordered_options for argument in option.to_buck_args()
+            ]
         args = [f"@{mode_file}" for mode_file in self.mode_files]
         for override in self.config_overrides:
             args.extend(("-c", override))
@@ -134,10 +216,14 @@ class BuckInvocationContext:
         redacted = text
         # Longest first avoids a shorter override partially masking a longer
         # one that shares the same prefix.
-        for override in sorted(self.config_overrides, key=len, reverse=True):
+        for override in sorted(
+            self.effective_config_overrides,
+            key=len,
+            reverse=True,
+        ):
             key = override.partition("=")[0]
             redacted = redacted.replace(override, f"{key}=<redacted>")
         return redacted
 
 
-__all__ = ["BuckInvocationContext"]
+__all__ = ["BuckInvocationContext", "BuckInvocationOption"]

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -2584,9 +2584,7 @@ def _buck_invocation_block(
         # values may be credentials or other private configuration.
         "config_keys": list(safe_context.config_keys),
         "modifiers": list(safe_context.effective_modifiers),
-        "option_order": [
-            option.kind for option in safe_context.ordered_options
-        ],
+        "option_order": list(safe_context.option_order),
         "context_fingerprint": safe_context.fingerprint,
         "configured_root_target": configured_root_target,
         "comparison": "not_compared",

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -44,6 +44,8 @@ Captured blocks:
 * ``container_detected`` / ``execution_context`` -- runtime-agnostic
   isolation signal + caller-declared probe placement.
 * ``probe_namespace`` -- mismatch-only, hashed namespace observation.
+* ``buck_invocation`` -- Buck target + redacted, fingerprinted cquery
+  invocation context when Buck introspection is requested.
 * ``docker`` -- image + digest when in a container.
 * ``env_vars`` -- canonical list of HSA / RCCL / FBGEMM / PyTorch vars.
 * ``python_version``, ``pytorch_version``.
@@ -78,10 +80,35 @@ from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any, ClassVar
 
+from aorta.instrumentation.buck_invocation import BuckInvocationContext
+
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.12"
+SCHEMA_VERSION = "1.13"
+# 1.12 -> 1.13 (Buck invocation-context provenance):
+#   - New top-level ``buck_invocation`` block, always present and defaulted
+#     via ``_empty_buck_invocation()``. It distinguishes ``not_requested``,
+#     ``buck_not_detected``, ``success``, and ``failure``; records the target,
+#     context source (``none`` / ``unspecified`` / ``default_confirmed`` /
+#     ``explicit``), ordered mode files, ordered config KEYS (never values),
+#     ordered modifiers, an aggregate SHA-256 over the full ordered context
+#     values, the configured root target when cquery exposes it, and the
+#     reserved comparison state ``not_compared``.
+#   - ``collect_env(..., buck_context=BuckInvocationContext(...))`` forwards
+#     mode/flag files, paired ``-c`` overrides, and paired ``-m`` modifiers to
+#     the same bound ``buck2 cquery 'deps(%s)' <target> --json`` invocation.
+#     The target is a query argument, never interpolated into query syntax.
+#   - A target with no explicit context and no default-context confirmation
+#     still runs, but records ``context_source="unspecified"`` plus a partial
+#     reason. A target when ``build_system.kind != "buck2"`` also still runs
+#     for backwards compatibility, but is visibly ``buck_not_detected`` and
+#     partial rather than appearing plausible.
+#   - This records client-side configured-graph invocation provenance only.
+#     It does NOT populate ``execution_context.likely_execution_platform``,
+#     answer the execution-marker/platform questions in the execution-context
+#     design note, or prove where an action actually ran.
+#
 # 1.11 -> 1.12 (container & execution-context visibility, phase 2 -- namespace):
 #   - New top-level ``probe_namespace`` (``str | None``). A mismatch-only
 #     namespace observation derived from ``/proc/self/ns/mnt`` (primary)
@@ -138,7 +165,7 @@ SCHEMA_VERSION = "1.12"
 #     candidate family) / ``package_version`` / ``package_full_name``
 #     (complete canonical identity -- apt ``name=version`` or rpm NVRA --
 #     capturing kernel-suffixed names like
-#     ``amdgpu-kmod-6.9.0-..._g9b20106afb70-...`` that a bare candidate
+#     ``amdgpu-kmod-<kernel>-<driver-version>.<arch>`` that a bare candidate
 #     name misses) / ``package_manager`` (portable, glob-capable
 #     dpkg-then-rpm query over ``amdgpu-dkms`` / ``amdgpu-kmod``),
 #     ``module_version`` / ``module_srcversion`` (``modinfo amdgpu``),
@@ -223,7 +250,7 @@ SCHEMA_VERSION = "1.12"
 #     pytorch_build.binary_introspection symbol counts / torch_lib_bundled)
 #     now locate torch's native lib dir via ``/proc/self/maps`` when
 #     ``<torch>/lib`` is absent. This populates those previously-null
-#     fields for Buck/monorepo torch targets (e.g. fbcode //caffe2:torch)
+#     fields for Buck/monorepo torch targets (e.g. cell//ml:torch)
 #     whose C++ runtime is dlopen'd from a build-artifact dir rather than
 #     laid out under the Python package. No field shapes change.
 #
@@ -435,6 +462,11 @@ SHORT_TIMEOUT_SEC = 5.0
 # would look identical to a CPU-only wheel -- so give them headroom.
 NM_TIMEOUT_SEC = 30.0
 
+# ``rocm_agent_enumerator`` can take ~16 seconds on a populated 8-GPU host
+# even when it succeeds normally. Reusing SHORT_TIMEOUT_SEC made a healthy
+# GPU node look architecture-less, so give enumeration its own bounded budget.
+GPU_ARCH_TIMEOUT_SEC = 30.0
+
 # Canonical env var list -- explicit, NOT prefix matching. Workload
 # config (AMP_DTYPE, MODEL_DTYPE, SHAMPOO_PRECONDITIONER_DTYPE) belongs
 # in the trial result emitted by ``aorta run`` (Task B1), so it is
@@ -635,7 +667,7 @@ PYTORCH_HIP_LIB_NAME = "libtorch_hip.so"
 
 # Torch's native shared libraries (libtorch_hip.so, libaotriton_v2.so*,
 # ...) normally live in ``<torch.__file__>/../lib`` -- the wheel / source
-# layout. In Buck / monorepo "par" layouts (e.g. fbcode //caffe2:torch)
+# layout. In Buck / monorepo "par" layouts (e.g. cell//ml:torch)
 # the Python package is materialised into a link-tree but the C++ runtime
 # is dlopen'd from a separate build-artifact directory, so
 # ``<torch>/lib`` does not exist on disk and the lib-on-disk probes come
@@ -1003,6 +1035,15 @@ class EnvSnapshot:
     build_system: dict = field(
         default_factory=lambda: {"kind": "none"}
     )
+    # buck_invocation: schema 1.13. Provenance for the optional Buck cquery
+    # request, distinct from ``build_system`` detection and from the
+    # process-placement ``execution_context`` block. Config override VALUES
+    # are never persisted; their keys and an aggregate full-context digest
+    # provide a redacted comparison signal. Defaulted so older constructors
+    # and pre-1.13 snapshots remain compatible.
+    buck_invocation: dict = field(
+        default_factory=lambda: _empty_buck_invocation()
+    )
     # library_introspection: A1.2b (issue #163, schema 1.4; field
     # ``configured_target`` added in schema 1.6 / PR #187 review).
     # Always present. Empty list outside buck mode. In buck mode, one
@@ -1132,6 +1173,7 @@ class EnvSnapshot:
         "aotriton",
         # build system + buck introspection
         "build_system",
+        "buck_invocation",
         "library_introspection",
         "library_introspection_alternates",
         # pytorch
@@ -1186,6 +1228,8 @@ class EnvSnapshot:
         * ``library_introspection_alternates`` -> ``[]`` (added in
           schema 1.4; empty list means "nothing was dropped in the
           Buck-vs-A1 merge").
+        * ``buck_invocation`` -> ``status="not_requested"`` (added in
+          schema 1.13; older producers did not record invocation context).
 
         Strictly-required older fields (the schema-1.0/1.1 set) are NOT
         defaulted -- a missing ``rocm`` or ``hipblaslt`` key still
@@ -1196,6 +1240,7 @@ class EnvSnapshot:
         kwargs = {k: v for k, v in d.items() if k in known}
         kwargs.setdefault("partial_reasons", [])
         kwargs.setdefault("build_system", {"kind": "none"})
+        kwargs.setdefault("buck_invocation", _empty_buck_invocation())
         kwargs.setdefault("library_introspection", [])
         kwargs.setdefault("library_introspection_alternates", [])
         kwargs.setdefault("nics", {})
@@ -1223,6 +1268,7 @@ class EnvSnapshot:
         rt = self.runtime_context or {}
         ec = self.execution_context or {}
         bs = self.build_system or {"kind": "none"}
+        buck_invocation = self.buck_invocation or _empty_buck_invocation()
         rocm = self.rocm or {}
         hip = self.hip or {}
         hipblaslt = self.hipblaslt or {}
@@ -1399,6 +1445,9 @@ class EnvSnapshot:
                 f"[AOTRITON_INSTALLED_PREFIX={aotriton.get('installed_prefix') or '(unset)'}]",
                 # build system group.
                 f"  build_sys: {self._summary_build_system_line(bs)}",
+                f"  buck ctx:  status={buck_invocation.get('status') or '?'} "
+                f"source={buck_invocation.get('context_source') or '?'} "
+                f"fingerprint={short_hash(buck_invocation.get('context_fingerprint'))}",
                 # pytorch group.
                 f"  python:    {self.python_version} | pytorch: {self.pytorch_version}",
                 f"  torch build: {self._summary_pytorch_build_line()}",
@@ -1986,6 +2035,7 @@ def collect_env(
     buck_timeout: int = 10,
     detail: str = "compact",
     probe_invocation: str = "direct",
+    buck_context: BuckInvocationContext | None = None,
 ) -> EnvSnapshot:
     """Capture the current process environment as an :class:`EnvSnapshot`.
 
@@ -2005,7 +2055,8 @@ def collect_env(
     for the version probe does NOT initialise CUDA / HIP context.
 
     Buck mode (``buck_target=...``) opts into the A1.2b path: the
-    function additionally runs ``buck2 cquery 'deps(<target>)' --json``,
+    function additionally runs a bound
+    ``buck2 cquery 'deps(%s)' <target> --json``,
     matches transitive deps against
     ``buck_introspect.KNOWN_LIBRARY_PATTERNS``, and populates
     ``library_introspection`` (plus ``library_introspection_alternates``
@@ -2016,7 +2067,11 @@ def collect_env(
     per-run configuration suffix) per schema 1.6. Outside buck mode
     both lists stay empty and the existing per-library top-level
     blocks remain authoritative. ``buck_timeout`` caps the cquery
-    subprocess (seconds; default 10).
+    subprocess (seconds; default 10). ``buck_context`` supplies only typed,
+    ordered Buck inputs (mode/flag files, config overrides, modifiers, or
+    explicit default-context confirmation); there is no shell-string
+    passthrough. Config values reach Buck and the aggregate fingerprint but
+    are never persisted in ``buck_invocation``.
 
     ``detail`` controls the size of the static kernel-catalog blocks:
 
@@ -2120,14 +2175,13 @@ def collect_env(
             "miopen": miopen,
             "rccl": rccl,
         }
-        library_introspection, library_introspection_alternates = (
-            _run_buck_introspection_safe(
-                buck_target=buck_target,
-                buck_timeout=buck_timeout,
-                build_system=build_system,
-                a1_blocks_by_lib=a1_blocks_by_lib,
-                reasons=reasons,
-            )
+        buck_capture = _run_buck_introspection_safe(
+            buck_target=buck_target,
+            buck_timeout=buck_timeout,
+            buck_context=buck_context,
+            build_system=build_system,
+            a1_blocks_by_lib=a1_blocks_by_lib,
+            reasons=reasons,
         )
 
         return EnvSnapshot(
@@ -2162,10 +2216,11 @@ def collect_env(
             pytorch_version=pytorch_version,
             pytorch_build=pytorch_build,
             build_system=build_system,
+            buck_invocation=buck_capture.invocation,
             partial=bool(reasons),
             partial_reasons=reasons,
-            library_introspection=library_introspection,
-            library_introspection_alternates=library_introspection_alternates,
+            library_introspection=buck_capture.entries,
+            library_introspection_alternates=buck_capture.alternates,
             pytorch_sdpa=pytorch_sdpa,
             nics=nics,
         )
@@ -2173,14 +2228,33 @@ def collect_env(
         # Restore stdio before logging so the disaster trace reaches the
         # operator's terminal rather than the captured (and discarded) buffer.
         _probe_stdio.stop()
-        log.info("collect_env() hit unexpected exception", exc_info=True)
+        safe_exc = (
+            buck_context.redact_config_overrides(str(exc))
+            if isinstance(buck_context, BuckInvocationContext)
+            else str(exc)
+        )
+        # An exception raised around subprocess argv construction can include
+        # the argv in its message. Avoid an unredacted traceback when config
+        # overrides are present; the sanitized reason remains actionable.
+        if isinstance(buck_context, BuckInvocationContext) and (
+            buck_context.config_overrides
+        ):
+            log.info(
+                "collect_env() hit unexpected exception (%s: %s)",
+                type(exc).__name__,
+                safe_exc,
+            )
+        else:
+            log.info("collect_env() hit unexpected exception", exc_info=True)
         return _disaster_snapshot(
             preceding_reasons=reasons,
             unexpected_reason=(
                 f"collect_env: unexpected failure "
-                f"({type(exc).__name__}: {exc})"
+                f"({type(exc).__name__}: {safe_exc})"
             ),
             probe_invocation=probe_invocation,
+            buck_target=buck_target,
+            buck_context=buck_context,
             probe_namespace=probe_namespace,
             probe_namespace_captured=probe_namespace_captured,
         )
@@ -2189,10 +2263,50 @@ def collect_env(
         _probe_stdio.stop()
 
 
+def capture_to(
+    output: Path | str,
+    *,
+    buck_target: str | None = None,
+    buck_timeout: int = 10,
+    detail: str = "compact",
+    probe_invocation: str = "direct",
+    buck_context: BuckInvocationContext | None = None,
+) -> EnvSnapshot:
+    """Capture and write an ``env.json`` artifact from application code.
+
+    This is the supported integration point for Buck ``.par`` applications
+    that own ``__main__`` and therefore cannot be wrapped by the AORTA CLI.
+    Call it before model/runtime construction so the snapshot describes the
+    same Python process and environment as the workload.
+
+    Collection remains fail-soft through :func:`collect_env`; filesystem
+    errors are raised because silently claiming that an artifact was written
+    would make a customer handoff unusable.
+    """
+    snapshot = collect_env(
+        buck_target=buck_target,
+        buck_timeout=buck_timeout,
+        detail=detail,
+        probe_invocation=probe_invocation,
+        buck_context=buck_context,
+    )
+    output_path = Path(output).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(snapshot.to_dict(), indent=2),
+        encoding="utf-8",
+    )
+    if not output_path.is_file() or output_path.stat().st_size == 0:
+        raise OSError(f"env probe output was not created or is empty: {output_path}")
+    return snapshot
+
+
 def _disaster_snapshot(
     preceding_reasons: list[str],
     unexpected_reason: str,
     probe_invocation: str = "direct",
+    buck_target: str | None = None,
+    buck_context: BuckInvocationContext | None = None,
     probe_namespace: str | None = None,
     probe_namespace_captured: bool = False,
 ) -> EnvSnapshot:
@@ -2203,6 +2317,10 @@ def _disaster_snapshot(
     snapshot from a ``buck2_action`` run must not silently rewrite itself
     to ``"direct"``, which would misdirect triage. An unrecognized value
     falls back to ``"direct"`` (same rule as the happy path).
+
+    ``buck_target`` / ``buck_context`` likewise preserve a requested Buck
+    invocation as ``status="failure"`` with redacted context metadata. A
+    crash must not rewrite a requested query as ``not_requested``.
 
     ``probe_namespace`` is preserved when the happy path captured it before
     a later helper failed. When capture was never reached, the disaster path
@@ -2386,6 +2504,12 @@ def _disaster_snapshot(
             "backends_enabled": {name: None for name in _PYTORCH_SDPA_GETTERS},
         },
         build_system={"kind": "none"},
+        buck_invocation=_buck_invocation_block(
+            status="failure" if buck_target is not None else "not_requested",
+            target=buck_target,
+            context=buck_context,
+            configured_root_target=None,
+        ),
         partial=True,
         partial_reasons=disaster_reasons,
         library_introspection=[],
@@ -2411,57 +2535,182 @@ def _detect_build_system_safe() -> dict:
         return {"kind": "none"}
 
 
+@dataclass(frozen=True)
+class _BuckCollectionResult:
+    """Buck library results and their schema-1.13 invocation provenance."""
+
+    entries: list[dict]
+    alternates: list[dict]
+    invocation: dict
+
+
+def _empty_buck_invocation() -> dict[str, Any]:
+    """Default/backfill shape for a snapshot with no Buck target request."""
+
+    return {
+        "status": "not_requested",
+        "target": None,
+        "context_source": "none",
+        "mode_files": [],
+        "config_keys": [],
+        "modifiers": [],
+        "context_fingerprint": None,
+        "configured_root_target": None,
+        "comparison": "not_compared",
+    }
+
+
+def _buck_invocation_block(
+    *,
+    status: str,
+    target: str | None,
+    context: BuckInvocationContext | None,
+    configured_root_target: str | None,
+) -> dict[str, Any]:
+    """Build the redacted, stable schema-1.13 Buck invocation block."""
+
+    if target is None:
+        return _empty_buck_invocation()
+    safe_context = (
+        context if isinstance(context, BuckInvocationContext) else BuckInvocationContext()
+    )
+    return {
+        "status": status,
+        "target": target,
+        "context_source": safe_context.source,
+        "mode_files": list(safe_context.mode_files),
+        # Deliberately never persist ``safe_context.config_overrides``:
+        # values may be credentials or other private configuration.
+        "config_keys": list(safe_context.config_keys),
+        "modifiers": list(safe_context.modifiers),
+        "context_fingerprint": safe_context.fingerprint,
+        "configured_root_target": configured_root_target,
+        "comparison": "not_compared",
+    }
+
+
 def _run_buck_introspection_safe(
     buck_target: str | None,
     buck_timeout: int,
+    buck_context: BuckInvocationContext | None,
     build_system: dict,
     a1_blocks_by_lib: dict[str, dict],
     reasons: list[str],
-) -> tuple[list[dict], list[dict]]:
+) -> _BuckCollectionResult:
     """Run the A1.2b buck-aware library introspection if requested.
 
-    Returns ``(library_introspection, library_introspection_alternates)``.
-    Both are ``[]`` when ``buck_target is None``. When a target is
-    supplied but ``build_system["kind"] != "buck2"``, we still attempt
-    the audit (so an operator can force-run from a non-Buck cwd) but
-    record a partial reason so the disconnect is visible.
+    Returns a dataclass carrying the two existing library lists plus the new
+    invocation block. Both lists are ``[]`` when ``buck_target is None``.
+    When a target is supplied but ``build_system["kind"] != "buck2"``, we
+    still attempt the cquery (so an operator can force-run from a non-Buck
+    cwd) but record a partial reason and ``status="buck_not_detected"``.
 
     Per the env-probe never-raises contract: any unexpected exception
-    is swallowed and surfaced via ``reasons``; both lists are returned
-    empty.
+    is swallowed and surfaced via ``reasons``; both library lists are
+    returned empty and the invocation status is failure-shaped.
     """
     if buck_target is None:
-        return [], []
+        if isinstance(buck_context, BuckInvocationContext) and (
+            buck_context.has_explicit_inputs
+            or buck_context.default_context_confirmed
+        ):
+            reasons.append(
+                "buck_invocation: context options were supplied without "
+                "a Buck target and were ignored"
+            )
+        return _BuckCollectionResult(
+            entries=[],
+            alternates=[],
+            invocation=_empty_buck_invocation(),
+        )
+
+    context = (
+        buck_context
+        if isinstance(buck_context, BuckInvocationContext)
+        else BuckInvocationContext()
+    )
+    if context.source == "unspecified":
+        reasons.append(
+            "buck_invocation: --buck-target was supplied without explicit "
+            "Buck context options or --buck-default-context; the default "
+            "Buck invocation context was not confirmed"
+        )
+
+    kind = build_system.get("kind") if isinstance(build_system, dict) else None
+    repo_revision = (
+        build_system.get("revision") if isinstance(build_system, dict) else None
+    )
+    cwd = build_system.get("repo_root") if isinstance(build_system, dict) else None
+    if kind != "buck2":
+        reasons.append(
+            f"library_introspection: --buck-target {buck_target} supplied but "
+            f"build_system.kind={kind!r}; running anyway"
+        )
+
     try:
         from aorta.instrumentation.buck_introspect import (
             introspect_libraries_via_buck,
         )
 
-        repo_revision = build_system.get("revision") if isinstance(build_system, dict) else None
-        cwd = build_system.get("repo_root") if isinstance(build_system, dict) else None
-        if isinstance(build_system, dict) and build_system.get("kind") != "buck2":
-            reasons.append(
-                f"library_introspection: --buck-target {buck_target} supplied but "
-                f"build_system.kind={build_system.get('kind')!r}; running anyway"
-            )
-        entries, buck_reasons = introspect_libraries_via_buck(
+        result = introspect_libraries_via_buck(
             target=buck_target,
             repo_revision=repo_revision,
             timeout=buck_timeout,
             cwd=cwd,
+            context=context,
         )
+        # Compatibility with tests/downstream monkeypatches written against
+        # the pre-1.13 two-tuple result. Production returns the typed result.
+        if hasattr(result, "entries") and hasattr(result, "reasons"):
+            entries = result.entries
+            buck_reasons = result.reasons
+            succeeded = bool(result.succeeded)
+            configured_root_target = result.configured_root_target
+        else:
+            entries, buck_reasons = result
+            succeeded = not buck_reasons
+            configured_root_target = None
         reasons.extend(buck_reasons)
         alternates = _synthesise_library_alternates(entries, a1_blocks_by_lib)
-        return entries, alternates
+        status = (
+            "buck_not_detected"
+            if kind != "buck2"
+            else ("success" if succeeded else "failure")
+        )
+        return _BuckCollectionResult(
+            entries=entries,
+            alternates=alternates,
+            invocation=_buck_invocation_block(
+                status=status,
+                target=buck_target,
+                context=context,
+                configured_root_target=configured_root_target,
+            ),
+        )
     except Exception as exc:  # noqa: BLE001 -- never-raises gate
+        safe_exc = context.redact_config_overrides(str(exc))
         log.info(
-            "library_introspection: buck introspection raised (%s)", exc, exc_info=True
+            "library_introspection: buck introspection raised (%s)",
+            safe_exc,
+            # Tracebacks can include argv containing raw config values.
+            exc_info=not context.config_overrides,
         )
         reasons.append(
             f"library_introspection: buck introspection raised "
-            f"({type(exc).__name__}: {exc})"
+            f"({type(exc).__name__}: {safe_exc})"
         )
-        return [], []
+        return _BuckCollectionResult(
+            entries=[],
+            alternates=[],
+            invocation=_buck_invocation_block(
+                status=(
+                    "buck_not_detected" if kind != "buck2" else "failure"
+                ),
+                target=buck_target,
+                context=context,
+                configured_root_target=None,
+            ),
+        )
 
 
 def _synthesise_library_alternates(
@@ -3183,11 +3432,12 @@ def execution_context_warning(
     when to warn or what to say. Stdlib-only (reads ``os.environ``), no
     Click dependency, so ``_probe_main`` can call it too.
 
-    Warns when the caller CLAIMS a non-``direct`` (container / RE) capture
-    but we saw zero isolation signal (``container_detected`` False) and the
-    launcher asserted no image via ``$AORTA_RE_IMAGE`` / ``$AORTA_DOCKER_IMAGE``
-    -- i.e. "you may be probing the host shell, not where the workload ran."
-    ``direct`` never warns.
+    A local ``buck2 run`` legitimately executes without container isolation,
+    so its warning explains that the snapshot is client-host evidence rather
+    than incorrectly saying the caller claimed remote execution. A
+    ``buck2_action`` label is stronger: without isolation or an asserted
+    image, the action may have been captured in the wrong place. ``direct``
+    never warns.
     """
     if probe_invocation == "direct":
         return None
@@ -3195,12 +3445,18 @@ def execution_context_warning(
         return None
     if os.environ.get("AORTA_RE_IMAGE") or os.environ.get("AORTA_DOCKER_IMAGE"):
         return None
+    if probe_invocation == "buck2_run":
+        return (
+            "NOTICE: --execution-context buck2_run ran without a detected "
+            "isolation boundary (container_detected=false). This is consistent "
+            "with a local `buck2 run`; treat this file as the Buck client-host "
+            "snapshot, not proof of a remote-worker environment."
+        )
     return (
-        f"WARNING: --execution-context {probe_invocation} claims a "
-        "container/remote-execution capture, but no isolation signal was "
-        "detected (container_detected=false) and neither $AORTA_RE_IMAGE "
-        "nor $AORTA_DOCKER_IMAGE is set. You may be probing the host shell "
-        "rather than where the workload actually ran."
+        "WARNING: --execution-context buck2_action claims an in-action "
+        "capture, but no isolation signal was detected "
+        "(container_detected=false) and no launcher image was identified. "
+        "You may be probing the client host rather than the workload action."
     )
 
 
@@ -4026,7 +4282,7 @@ def _torch_native_lib_dir(torch_mod: Any | None) -> Path | None:
     (via :func:`_loaded_lib_path_from_maps`) so the probe still works
     when torch is a Buck target whose C++ runtime is dlopen'd from a
     build-artifact directory rather than laid out under the Python
-    package -- the fbcode ``//caffe2:torch`` case. Returns ``None`` when
+    package -- the monorepo ``cell//ml:torch`` case. Returns ``None`` when
     neither locates a directory. Never raises.
 
     The maps-derived hit is only trusted if it still exists on disk --
@@ -7471,10 +7727,16 @@ def _capture_gpu_arch(reasons: list[str]) -> dict[str, Any]:
             [bin_path],
             capture_output=True,
             text=True,
-            timeout=SHORT_TIMEOUT_SEC,
+            timeout=GPU_ARCH_TIMEOUT_SEC,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+    except subprocess.TimeoutExpired:
+        reasons.append(
+            f"gpu_arch: {ROCM_AGENT_ENUMERATOR_BIN} exceeded "
+            f"{GPU_ARCH_TIMEOUT_SEC:.0f}s timeout"
+        )
+        return default
+    except (FileNotFoundError, OSError) as exc:
         reasons.append(f"gpu_arch: {ROCM_AGENT_ENUMERATOR_BIN} invocation failed ({exc})")
         return default
 
@@ -7528,9 +7790,9 @@ def _query_amdgpu_package() -> dict[str, str] | None:
 
     or ``None`` when no candidate is installed under any known manager.
 
-    KERNEL-SUFFIXED PACKAGE NAMES: some vendors (e.g. Meta's fbk kernels)
+    KERNEL-SUFFIXED PACKAGE NAMES: some vendor kernel packages
     ship the prebuilt kmod with the *kernel release baked into the RPM
-    name* -- ``amdgpu-kmod-6.9.0-0_fbk10_..._g9b20106afb70`` rather than a
+    name* -- ``amdgpu-kmod-<kernel>-<driver-version>`` rather than a
     plain ``amdgpu-kmod``. An exact ``rpm -q amdgpu-kmod`` misses these
     entirely. So we query with a **glob** (``rpm -qa 'amdgpu-kmod*'`` /
     ``dpkg-query -W 'amdgpu-kmod*'``) and reconstruct the complete package
@@ -7586,7 +7848,7 @@ def _query_amdgpu_package() -> dict[str, str] | None:
         # '<candidate>*': -qa + glob lists every installed package matching
         # the pattern (an exact -q would miss the kernel-suffixed names).
         # full_name is the canonical NVRA, e.g.
-        # amdgpu-kmod-6.9.0-..._g9b20106afb70-6.14.14.000000-2226257.1.x86_64
+        # amdgpu-kmod-<kernel>-<driver-version>.<arch>
         if shutil.which("rpm") is not None:
             try:
                 proc = subprocess.run(
@@ -7711,7 +7973,7 @@ def _capture_amdgpu_driver(
       dpkg-then-rpm query over ``AMDGPU_PACKAGE_CANDIDATES``).
       ``package_full_name`` is the complete canonical identity (apt
       ``name=version`` or rpm NVRA), which captures kernel-suffixed
-      package names like ``amdgpu-kmod-6.9.0-..._g9b20106afb70-...`` that
+      package names like ``amdgpu-kmod-<kernel>-<driver-version>`` that
       ``package_name`` (the stable candidate family) deliberately does not.
     * ``module_version`` / ``module_srcversion`` -- ``modinfo amdgpu``.
     * ``kmd_version`` -- reused verbatim from the already-captured ``rocm``

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -92,9 +92,9 @@ SCHEMA_VERSION = "1.13"
 #     ``buck_not_detected``, ``success``, and ``failure``; records the target,
 #     context source (``none`` / ``unspecified`` / ``default_confirmed`` /
 #     ``explicit``), ordered mode files, ordered config KEYS (never values),
-#     ordered modifiers, an aggregate SHA-256 over the full ordered context
-#     values, the configured root target when cquery exposes it, and the
-#     reserved comparison state ``not_compared``.
+#     ordered modifiers, cross-option order, an aggregate SHA-256 over the
+#     full ordered context values, the configured root target when cquery
+#     exposes it, and the reserved comparison state ``not_compared``.
 #   - ``collect_env(..., buck_context=BuckInvocationContext(...))`` forwards
 #     mode/flag files, paired ``-c`` overrides, and paired ``-m`` modifiers to
 #     the same bound ``buck2 cquery 'deps(%s)' <target> --json`` invocation.
@@ -2554,6 +2554,7 @@ def _empty_buck_invocation() -> dict[str, Any]:
         "mode_files": [],
         "config_keys": [],
         "modifiers": [],
+        "option_order": [],
         "context_fingerprint": None,
         "configured_root_target": None,
         "comparison": "not_compared",
@@ -2578,11 +2579,14 @@ def _buck_invocation_block(
         "status": status,
         "target": target,
         "context_source": safe_context.source,
-        "mode_files": list(safe_context.mode_files),
+        "mode_files": list(safe_context.effective_mode_files),
         # Deliberately never persist ``safe_context.config_overrides``:
         # values may be credentials or other private configuration.
         "config_keys": list(safe_context.config_keys),
-        "modifiers": list(safe_context.modifiers),
+        "modifiers": list(safe_context.effective_modifiers),
+        "option_order": [
+            option.kind for option in safe_context.ordered_options
+        ],
         "context_fingerprint": safe_context.fingerprint,
         "configured_root_target": configured_root_target,
         "comparison": "not_compared",

--- a/tests/instrumentation/test_buck_introspect.py
+++ b/tests/instrumentation/test_buck_introspect.py
@@ -145,6 +145,30 @@ class TestBuckInvocationContext:
         with pytest.raises(ValueError, match="name a file"):
             bi_mod.BuckInvocationContext(mode_files=("@",))
 
+    def test_ordered_options_preserve_cross_type_precedence(self):
+        context = bi_mod.BuckInvocationContext(
+            ordered_options=(
+                bi_mod.BuckInvocationOption.parse("config=build.profile=debug"),
+                bi_mod.BuckInvocationOption.parse("mode=root//mode/override"),
+                bi_mod.BuckInvocationOption.parse("modifier=//constraints:gfx"),
+            )
+        )
+        assert context.to_buck_args() == [
+            "-c",
+            "build.profile=debug",
+            "@root//mode/override",
+            "-m",
+            "//constraints:gfx",
+        ]
+        assert context.config_keys == ("build.profile",)
+
+    def test_ordered_and_grouped_options_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="cannot be combined"):
+            bi_mod.BuckInvocationContext(
+                mode_files=("root//mode/debug",),
+                ordered_options=(bi_mod.BuckInvocationOption.parse("config=build.profile=debug"),),
+            )
+
     def test_fingerprint_is_stable_and_covers_full_ordered_values(self):
         first = bi_mod.BuckInvocationContext(
             mode_files=("root//mode/debug", "root//mode/gpu"),

--- a/tests/instrumentation/test_buck_introspect.py
+++ b/tests/instrumentation/test_buck_introspect.py
@@ -28,6 +28,7 @@ import importlib.util
 import json
 import subprocess
 import sys
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import patch
 
@@ -39,9 +40,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _load_module(rel_path: str, mod_name: str):
-    spec = importlib.util.spec_from_file_location(
-        mod_name, _REPO_ROOT / rel_path
-    )
+    spec = importlib.util.spec_from_file_location(mod_name, _REPO_ROOT / rel_path)
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
@@ -62,15 +61,119 @@ env_mod = _load_module(
 )
 
 
-FIXTURE_PATH = (
-    Path(__file__).parent.parent / "fixtures" / "buck" / "audit_dependencies.json"
-)
+FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "buck" / "audit_dependencies.json"
 
 
 def _make_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
     return subprocess.CompletedProcess(
         args=["buck2"], returncode=returncode, stdout=stdout, stderr=stderr
     )
+
+
+# ---------------------------------------------------------------------------
+# BuckInvocationContext: typed, ordered, redacted invocation inputs
+# ---------------------------------------------------------------------------
+
+
+class TestBuckInvocationContext:
+    def test_builds_atomic_args_in_required_precedence_order(self):
+        context = bi_mod.BuckInvocationContext(
+            mode_files=("root//mode/debug", "@root//mode/gpu"),
+            config_overrides=(
+                "build.profile=debug",
+                "scheduler.policy=local",
+            ),
+            modifiers=("//constraints:linux", "//constraints:gfx"),
+        )
+
+        assert context.mode_files == (
+            "root//mode/debug",
+            "root//mode/gpu",
+        )
+        assert context.to_buck_args() == [
+            "@root//mode/debug",
+            "@root//mode/gpu",
+            "-c",
+            "build.profile=debug",
+            "-c",
+            "scheduler.policy=local",
+            "-m",
+            "//constraints:linux",
+            "-m",
+            "//constraints:gfx",
+        ]
+        assert context.config_keys == (
+            "build.profile",
+            "scheduler.policy",
+        )
+        assert context.source == "explicit"
+
+    def test_is_frozen_and_coerces_ordered_inputs_to_tuples(self):
+        context = bi_mod.BuckInvocationContext(
+            mode_files=["root//mode/debug"],
+            config_overrides=["build.profile=debug"],
+            modifiers=["//constraints:linux"],
+        )
+        assert isinstance(context.mode_files, tuple)
+        assert isinstance(context.config_overrides, tuple)
+        assert isinstance(context.modifiers, tuple)
+        with pytest.raises(FrozenInstanceError):
+            context.modifiers = ()  # type: ignore[misc]
+
+    def test_default_confirmation_is_distinct_and_mutually_exclusive(self):
+        confirmed = bi_mod.BuckInvocationContext(default_context_confirmed=True)
+        assert confirmed.source == "default_confirmed"
+        assert confirmed.to_buck_args() == []
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            bi_mod.BuckInvocationContext(
+                mode_files=("root//mode/debug",),
+                default_context_confirmed=True,
+            )
+
+    def test_config_override_requires_key_value_shape(self):
+        with pytest.raises(ValueError, match="KEY=VALUE"):
+            bi_mod.BuckInvocationContext(config_overrides=("build.profile",))
+
+    def test_non_string_mode_file_fails_with_validation_error(self):
+        with pytest.raises(ValueError, match="non-empty strings"):
+            bi_mod.BuckInvocationContext(
+                mode_files=(123,),  # type: ignore[arg-type]
+            )
+
+    def test_bare_at_mode_file_is_rejected(self):
+        with pytest.raises(ValueError, match="name a file"):
+            bi_mod.BuckInvocationContext(mode_files=("@",))
+
+    def test_fingerprint_is_stable_and_covers_full_ordered_values(self):
+        first = bi_mod.BuckInvocationContext(
+            mode_files=("root//mode/debug", "root//mode/gpu"),
+            config_overrides=("build.profile=debug", "scheduler.policy=local"),
+            modifiers=("//constraints:linux", "//constraints:gfx"),
+        )
+        same = bi_mod.BuckInvocationContext(
+            mode_files=("root//mode/debug", "root//mode/gpu"),
+            config_overrides=("build.profile=debug", "scheduler.policy=local"),
+            modifiers=("//constraints:linux", "//constraints:gfx"),
+        )
+        value_changed = bi_mod.BuckInvocationContext(
+            mode_files=("root//mode/debug", "root//mode/gpu"),
+            config_overrides=("build.profile=release", "scheduler.policy=local"),
+            modifiers=("//constraints:linux", "//constraints:gfx"),
+        )
+        order_changed = bi_mod.BuckInvocationContext(
+            mode_files=("root//mode/gpu", "root//mode/debug"),
+            config_overrides=("build.profile=debug", "scheduler.policy=local"),
+            modifiers=("//constraints:linux", "//constraints:gfx"),
+        )
+
+        assert first.fingerprint == same.fingerprint
+        assert first.fingerprint.startswith("sha256:")
+        assert len(first.fingerprint) == len("sha256:") + 64
+        # Same persisted config key, different hidden value -> different digest.
+        assert first.config_keys == value_changed.config_keys
+        assert first.fingerprint != value_changed.fingerprint
+        assert first.fingerprint != order_changed.fingerprint
 
 
 # ---------------------------------------------------------------------------
@@ -131,9 +234,7 @@ class TestBuck2HappyPath:
     def test_fixture_yields_expected_library_set(self, monkeypatch):
         monkeypatch.setattr(bi_mod.shutil, "which", lambda _name: "/usr/bin/buck2")
         fixture = FIXTURE_PATH.read_text()
-        with patch.object(
-            bi_mod.subprocess, "run", return_value=_make_completed(stdout=fixture)
-        ):
+        with patch.object(bi_mod.subprocess, "run", return_value=_make_completed(stdout=fixture)):
             entries, reasons = bi_mod.introspect_libraries_via_buck(
                 target="//myproj:training_main", repo_revision="cafef00d"
             )
@@ -174,9 +275,7 @@ class TestBuck2HappyPath:
             "run",
             return_value=_make_completed(stdout=json.dumps(payload)),
         ):
-            entries, _ = bi_mod.introspect_libraries_via_buck(
-                target="//foo", repo_revision=None
-            )
+            entries, _ = bi_mod.introspect_libraries_via_buck(target="//foo", repo_revision=None)
         assert entries[0]["revision"] is None
 
     def test_empty_match_set_is_not_partial(self, monkeypatch):
@@ -192,6 +291,70 @@ class TestBuck2HappyPath:
             )
         assert entries == []
         assert reasons == []  # success with no matches != failure
+
+    def test_exact_bound_cquery_argv_includes_ordered_context(self, monkeypatch):
+        monkeypatch.setattr(bi_mod.shutil, "which", lambda _name: "/usr/bin/buck2")
+        context = bi_mod.BuckInvocationContext(
+            mode_files=("root//mode/debug", "root//mode/gpu"),
+            config_overrides=("build.profile=debug", "scheduler.policy=local"),
+            modifiers=("//constraints:linux", "//constraints:gfx"),
+        )
+        configured_root = "root//app:trainer " "(prelude//platforms:default#configured)"
+        run = patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(stdout=json.dumps([configured_root])),
+        )
+        with run as mocked_run:
+            result = bi_mod.introspect_libraries_via_buck(
+                target="//app:trainer",
+                repo_revision="abc",
+                context=context,
+            )
+
+        mocked_run.assert_called_once_with(
+            [
+                "/usr/bin/buck2",
+                "cquery",
+                "@root//mode/debug",
+                "@root//mode/gpu",
+                "-c",
+                "build.profile=debug",
+                "-c",
+                "scheduler.policy=local",
+                "-m",
+                "//constraints:linux",
+                "-m",
+                "//constraints:gfx",
+                "deps(%s)",
+                "//app:trainer",
+                "--json",
+            ],
+            cwd=None,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        assert result.succeeded is True
+        assert result.configured_root_target == configured_root
+
+    def test_target_query_syntax_is_never_interpolated(self, monkeypatch):
+        monkeypatch.setattr(bi_mod.shutil, "which", lambda _name: "/usr/bin/buck2")
+        target = "//app:trainer) union deps(//other:target"
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(stdout="[]"),
+        ) as mocked_run:
+            bi_mod.introspect_libraries_via_buck(
+                target=target,
+                repo_revision=None,
+            )
+
+        argv = mocked_run.call_args.args[0]
+        assert argv[-3:] == ["deps(%s)", target, "--json"]
+        assert all(target not in arg for arg in argv if arg != target)
 
 
 class TestBuck2FailureModes:
@@ -215,9 +378,7 @@ class TestBuck2FailureModes:
         assert any("timed out after 10s" in r for r in reasons)
 
     def test_oserror_returns_reason(self):
-        with patch.object(
-            bi_mod.subprocess, "run", side_effect=OSError("permission denied")
-        ):
+        with patch.object(bi_mod.subprocess, "run", side_effect=OSError("permission denied")):
             entries, reasons = bi_mod.introspect_libraries_via_buck(
                 target="//foo", repo_revision="r"
             )
@@ -228,9 +389,7 @@ class TestBuck2FailureModes:
         with patch.object(
             bi_mod.subprocess,
             "run",
-            return_value=_make_completed(
-                stdout="", stderr="target //foo not found", returncode=2
-            ),
+            return_value=_make_completed(stdout="", stderr="target //foo not found", returncode=2),
         ):
             entries, reasons = bi_mod.introspect_libraries_via_buck(
                 target="//foo", repo_revision="r"
@@ -249,6 +408,27 @@ class TestBuck2FailureModes:
             )
         assert entries == []
         assert any("(empty)" in r for r in reasons)
+
+    def test_nonzero_exit_redacts_config_override_values(self):
+        context = bi_mod.BuckInvocationContext(
+            config_overrides=("service.token=private-placeholder",)
+        )
+        with patch.object(
+            bi_mod.subprocess,
+            "run",
+            return_value=_make_completed(
+                stderr="invalid service.token=private-placeholder",
+                returncode=1,
+            ),
+        ):
+            result = bi_mod.introspect_libraries_via_buck(
+                target="//app:trainer",
+                repo_revision="r",
+                context=context,
+            )
+
+        assert "private-placeholder" not in result.reasons[0]
+        assert "service.token=<redacted>" in result.reasons[0]
 
     def test_invalid_json_returns_reason(self):
         with patch.object(
@@ -322,9 +502,7 @@ class TestBuck2CqueryShape:
         # _strip_config_suffix is the unit doing the work; pin its
         # behaviour directly so a future change there can't silently
         # break label matching.
-        assert bi_mod._strip_config_suffix(suffixed) == (
-            "//third-party/rocm:hipblaslt-lib"
-        )
+        assert bi_mod._strip_config_suffix(suffixed) == ("//third-party/rocm:hipblaslt-lib")
 
     def test_config_suffix_absent_match_unaffected(self):
         """A label without the suffix (older buck2 audit output, or
@@ -340,10 +518,7 @@ class TestBuck2CqueryShape:
         only the suffixed form (as the schema-1.4 draft did) made
         env.json diffs unstable across repeat probes because the
         suffix hash changes between buck2 daemon restarts."""
-        suffixed = (
-            "//third-party/rocm:hipblaslt_lib "
-            "(prelude//platforms:default#abc123)"
-        )
+        suffixed = "//third-party/rocm:hipblaslt_lib " "(prelude//platforms:default#abc123)"
         payload = [suffixed]
         with patch.object(
             bi_mod.subprocess,
@@ -374,9 +549,7 @@ class TestBuck2CqueryShape:
             "run",
             return_value=_make_completed(stdout=json.dumps(payload)),
         ):
-            entries, _ = bi_mod.introspect_libraries_via_buck(
-                target="//foo", repo_revision="r"
-            )
+            entries, _ = bi_mod.introspect_libraries_via_buck(target="//foo", repo_revision="r")
         assert entries[0]["target"] == unsuffixed
         assert entries[0]["configured_target"] == unsuffixed
 
@@ -393,10 +566,156 @@ class TestCollectEnvIntegration:
     fake any of A1's per-library probes -- we only validate the wiring.
     """
 
+    @staticmethod
+    def _run_capture(
+        *,
+        target="//app:trainer",
+        context=None,
+        build_system=None,
+    ):
+        reasons = []
+        capture = env_mod._run_buck_introspection_safe(
+            buck_target=target,
+            buck_timeout=10,
+            buck_context=context,
+            build_system=build_system
+            or {
+                "kind": "buck2",
+                "revision": "abc",
+                "repo_root": "/repo",
+            },
+            a1_blocks_by_lib={},
+            reasons=reasons,
+        )
+        return capture, reasons
+
+    def test_no_request_has_complete_not_requested_block(self):
+        capture, reasons = self._run_capture(target=None)
+        assert reasons == []
+        assert capture.entries == []
+        assert capture.alternates == []
+        assert capture.invocation == env_mod._empty_buck_invocation()
+
+    def test_unspecified_context_runs_but_is_partial(self, monkeypatch):
+        monkeypatch.setattr(
+            bi_mod,
+            "introspect_libraries_via_buck",
+            lambda **_: bi_mod.BuckIntrospectionResult(
+                entries=[],
+                reasons=[],
+                succeeded=True,
+                configured_root_target=(
+                    "root//app:trainer " "(prelude//platforms:default#configured)"
+                ),
+            ),
+        )
+        capture, reasons = self._run_capture()
+
+        assert capture.invocation["status"] == "success"
+        assert capture.invocation["context_source"] == "unspecified"
+        assert capture.invocation["context_fingerprint"].startswith("sha256:")
+        assert capture.invocation["configured_root_target"].startswith("root//app:trainer ")
+        assert any("default Buck invocation context was not confirmed" in r for r in reasons)
+
+    def test_default_confirmed_context_is_not_partial(self, monkeypatch):
+        monkeypatch.setattr(
+            bi_mod,
+            "introspect_libraries_via_buck",
+            lambda **_: bi_mod.BuckIntrospectionResult(
+                entries=[],
+                reasons=[],
+                succeeded=True,
+                configured_root_target=None,
+            ),
+        )
+        context = bi_mod.BuckInvocationContext(default_context_confirmed=True)
+        capture, reasons = self._run_capture(context=context)
+
+        assert capture.invocation["status"] == "success"
+        assert capture.invocation["context_source"] == "default_confirmed"
+        assert reasons == []
+
+    def test_explicit_metadata_redacts_values_and_preserves_order(self, monkeypatch):
+        monkeypatch.setattr(
+            bi_mod,
+            "introspect_libraries_via_buck",
+            lambda **_: bi_mod.BuckIntrospectionResult(
+                entries=[],
+                reasons=[],
+                succeeded=True,
+                configured_root_target=None,
+            ),
+        )
+        hidden_value = "not-persisted-value"
+        context = bi_mod.BuckInvocationContext(
+            mode_files=("root//mode/debug", "root//mode/gpu"),
+            config_overrides=(
+                f"build.profile={hidden_value}",
+                "scheduler.policy=local",
+            ),
+            modifiers=("//constraints:linux", "//constraints:gfx"),
+        )
+        capture, reasons = self._run_capture(context=context)
+        invocation_json = json.dumps(capture.invocation)
+
+        assert capture.invocation["context_source"] == "explicit"
+        assert capture.invocation["mode_files"] == [
+            "root//mode/debug",
+            "root//mode/gpu",
+        ]
+        assert capture.invocation["config_keys"] == [
+            "build.profile",
+            "scheduler.policy",
+        ]
+        assert capture.invocation["modifiers"] == [
+            "//constraints:linux",
+            "//constraints:gfx",
+        ]
+        assert hidden_value not in invocation_json
+        assert reasons == []
+
+    def test_buck_failure_is_distinct(self, monkeypatch):
+        monkeypatch.setattr(
+            bi_mod,
+            "introspect_libraries_via_buck",
+            lambda **_: bi_mod.BuckIntrospectionResult(
+                entries=[],
+                reasons=["library_introspection: synthetic failure"],
+                succeeded=False,
+                configured_root_target=None,
+            ),
+        )
+        capture, reasons = self._run_capture(
+            context=bi_mod.BuckInvocationContext(default_context_confirmed=True)
+        )
+
+        assert capture.invocation["status"] == "failure"
+        assert "synthetic failure" in reasons[-1]
+
+    def test_buck_not_detected_is_distinct_even_when_query_runs(self, monkeypatch):
+        monkeypatch.setattr(
+            bi_mod,
+            "introspect_libraries_via_buck",
+            lambda **_: bi_mod.BuckIntrospectionResult(
+                entries=[],
+                reasons=[],
+                succeeded=True,
+                configured_root_target=None,
+            ),
+        )
+        capture, reasons = self._run_capture(
+            context=bi_mod.BuckInvocationContext(default_context_confirmed=True),
+            build_system={"kind": "none"},
+        )
+
+        assert capture.invocation["status"] == "buck_not_detected"
+        assert any("build_system.kind='none'" in reason for reason in reasons)
+
     def test_no_buck_target_yields_empty_lists(self):
         snap = env_mod.collect_env()
         assert snap.library_introspection == []
         assert snap.library_introspection_alternates == []
+        assert snap.buck_invocation == env_mod._empty_buck_invocation()
 
     def test_buck_target_populates_library_introspection(self, monkeypatch):
         fake_entries = [
@@ -413,9 +732,7 @@ class TestCollectEnvIntegration:
                 "target": "//pytorch:torch",
             },
         ]
-        monkeypatch.setattr(
-            bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, [])
-        )
+        monkeypatch.setattr(bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, []))
         snap = env_mod.collect_env(buck_target="//foo:bar")
         assert snap.library_introspection == fake_entries
 
@@ -434,9 +751,7 @@ class TestCollectEnvIntegration:
                 "target": "//pytorch:torch",
             },
         ]
-        monkeypatch.setattr(
-            bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, [])
-        )
+        monkeypatch.setattr(bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, []))
         snap = env_mod.collect_env(buck_target="//foo:bar")
         names = [a["name"] for a in snap.library_introspection_alternates]
         # hipblaslt has an A1 block, pytorch does not => only one alt
@@ -450,10 +765,7 @@ class TestCollectEnvIntegration:
             lambda **_: ([], ["library_introspection: synthetic failure"]),
         )
         snap = env_mod.collect_env(buck_target="//foo:bar")
-        assert any(
-            "library_introspection: synthetic failure" in r
-            for r in snap.partial_reasons
-        )
+        assert any("library_introspection: synthetic failure" in r for r in snap.partial_reasons)
 
     def test_unexpected_exception_in_introspection_is_swallowed(self, monkeypatch):
         def boom(**_kwargs):
@@ -463,8 +775,7 @@ class TestCollectEnvIntegration:
         snap = env_mod.collect_env(buck_target="//foo:bar")
         assert snap.library_introspection == []
         assert any(
-            "buck introspection raised" in r and "RuntimeError" in r
-            for r in snap.partial_reasons
+            "buck introspection raised" in r and "RuntimeError" in r for r in snap.partial_reasons
         )
 
     def test_round_trip_preserves_introspection_lists(self, monkeypatch):
@@ -476,32 +787,20 @@ class TestCollectEnvIntegration:
                 "target": "//rocm:rccl_lib",
             }
         ]
-        monkeypatch.setattr(
-            bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, [])
-        )
+        monkeypatch.setattr(bi_mod, "introspect_libraries_via_buck", lambda **_: (fake_entries, []))
         snap = env_mod.collect_env(buck_target="//foo:bar")
         d = snap.to_dict()
         assert d["library_introspection"] == fake_entries
         rebuilt = env_mod.EnvSnapshot.from_dict(d)
         assert rebuilt.library_introspection == fake_entries
-        assert (
-            rebuilt.library_introspection_alternates
-            == snap.library_introspection_alternates
-        )
+        assert rebuilt.library_introspection_alternates == snap.library_introspection_alternates
 
-    def test_disconnect_buck_target_without_buck2_kind_records_reason(
-        self, monkeypatch
-    ):
+    def test_disconnect_buck_target_without_buck2_kind_records_reason(self, monkeypatch):
         # Force build_system to look non-buck so the reconciliation
         # branch fires regardless of whether the host has buck2 installed.
-        monkeypatch.setattr(
-            env_mod, "_detect_build_system_safe", lambda: {"kind": "none"}
-        )
-        monkeypatch.setattr(
-            bi_mod, "introspect_libraries_via_buck", lambda **_: ([], [])
-        )
+        monkeypatch.setattr(env_mod, "_detect_build_system_safe", lambda: {"kind": "none"})
+        monkeypatch.setattr(bi_mod, "introspect_libraries_via_buck", lambda **_: ([], []))
         snap = env_mod.collect_env(buck_target="//foo:bar")
         assert any(
-            "build_system.kind=" in r and "running anyway" in r
-            for r in snap.partial_reasons
+            "build_system.kind=" in r and "running anyway" in r for r in snap.partial_reasons
         )

--- a/tests/instrumentation/test_buck_introspect.py
+++ b/tests/instrumentation/test_buck_introspect.py
@@ -106,6 +106,14 @@ class TestBuckInvocationContext:
             "build.profile",
             "scheduler.policy",
         )
+        assert context.option_order == (
+            "mode",
+            "mode",
+            "config",
+            "config",
+            "modifier",
+            "modifier",
+        )
         assert context.source == "explicit"
 
     def test_is_frozen_and_coerces_ordered_inputs_to_tuples(self):
@@ -161,6 +169,7 @@ class TestBuckInvocationContext:
             "//constraints:gfx",
         ]
         assert context.config_keys == ("build.profile",)
+        assert context.option_order == ("config", "mode", "modifier")
 
     def test_ordered_and_grouped_options_are_mutually_exclusive(self):
         with pytest.raises(ValueError, match="cannot be combined"):
@@ -168,6 +177,22 @@ class TestBuckInvocationContext:
                 mode_files=("root//mode/debug",),
                 ordered_options=(bi_mod.BuckInvocationOption.parse("config=build.profile=debug"),),
             )
+
+    def test_fingerprint_depends_on_effective_argv_not_cli_form(self):
+        grouped = bi_mod.BuckInvocationContext(
+            mode_files=("root//mode/debug",),
+            config_overrides=("build.profile=debug",),
+            modifiers=("//constraints:gfx",),
+        )
+        ordered = bi_mod.BuckInvocationContext(
+            ordered_options=(
+                bi_mod.BuckInvocationOption.parse("mode=root//mode/debug"),
+                bi_mod.BuckInvocationOption.parse("config=build.profile=debug"),
+                bi_mod.BuckInvocationOption.parse("modifier=//constraints:gfx"),
+            )
+        )
+        assert grouped.to_buck_args() == ordered.to_buck_args()
+        assert grouped.fingerprint == ordered.fingerprint
 
     def test_fingerprint_is_stable_and_covers_full_ordered_values(self):
         first = bi_mod.BuckInvocationContext(

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -293,6 +293,7 @@ REQUIRED_TOP_KEYS = {
     "pytorch_version",
     "pytorch_build",
     "build_system",
+    "buck_invocation",
     "library_introspection",
     "library_introspection_alternates",
     "pytorch_sdpa",
@@ -517,6 +518,20 @@ def _example_snapshot(**overrides) -> object:
             "ninja_hipcc": {"_source_file": None, "targets": None},
         },
         "build_system": {"kind": "none"},
+        "buck_invocation": {
+            "status": "success",
+            "target": "//app:trainer",
+            "context_source": "explicit",
+            "mode_files": ["root//mode/debug"],
+            "config_keys": ["build.profile"],
+            "modifiers": ["//constraints:linux"],
+            "context_fingerprint": "sha256:" + "a" * 64,
+            "configured_root_target": (
+                "root//app:trainer "
+                "(prelude//platforms:default#configured)"
+            ),
+            "comparison": "not_compared",
+        },
         "partial": False,
         "partial_reasons": [],
         "library_introspection": [],
@@ -604,6 +619,7 @@ class TestEnvSnapshot:
             ("rocfft_catalog", env_mod._empty_rocfft_catalog),
             ("amdgpu_driver", env_mod._empty_amdgpu_driver),
             ("execution_context", env_mod._empty_execution_context),
+            ("buck_invocation", env_mod._empty_buck_invocation),
         ],
     )
     def test_from_dict_backfills_missing_catalog_key(self, key, empty_factory):
@@ -699,6 +715,17 @@ class TestEnvSnapshot:
             if line.lstrip().startswith("runtime:")
         )
         assert "ns=mnt:012345…" in runtime_line
+
+    def test_summary_surfaces_buck_invocation_status_source_and_fingerprint(self):
+        snap = _example_snapshot()
+        buck_line = next(
+            line
+            for line in snap.summary().splitlines()
+            if line.lstrip().startswith("buck ctx:")
+        )
+        assert "status=success" in buck_line
+        assert "source=explicit" in buck_line
+        assert "fingerprint=sha256:aaaaaa…" in buck_line
 
     def test_dataclass_is_frozen(self):
         """Callers can safely embed the snapshot without mutation hazards."""
@@ -1393,6 +1420,25 @@ class TestCollectEnvContract:
         assert "collect_env: boom" in snap.partial_reasons
         # JSON-native check (no default=str needed)
         json.dumps(d)
+        assert snap.buck_invocation == env_mod._empty_buck_invocation()
+
+    def test_disaster_snapshot_preserves_redacted_buck_request(self):
+        hidden_value = "not-persisted-value"
+        context = env_mod.BuckInvocationContext(
+            config_overrides=(f"build.profile={hidden_value}",),
+        )
+        snap = env_mod._disaster_snapshot(
+            preceding_reasons=[],
+            unexpected_reason="collect_env: boom",
+            buck_target="//app:trainer",
+            buck_context=context,
+        )
+
+        assert snap.buck_invocation["status"] == "failure"
+        assert snap.buck_invocation["target"] == "//app:trainer"
+        assert snap.buck_invocation["context_source"] == "explicit"
+        assert snap.buck_invocation["config_keys"] == ["build.profile"]
+        assert hidden_value not in json.dumps(snap.buck_invocation)
 
     def test_disaster_snapshot_nics_block_is_fully_shaped(self):
         """The disaster path shapes nics like every other block (all
@@ -1544,13 +1590,16 @@ class TestCliIsThinWrapper:
         # * The --execution-context work (schema 1.11) added one more click
         #   option block plus a stderr validation-warning envelope (still
         #   pure wiring/validation -- no probing).
+        # * The Buck invocation-context work (schema 1.13) added four Click
+        #   options and their mutual-requirement validation. The typed argv
+        #   construction and fingerprinting remain in the library module.
         #
         # The real "no-probing-in-CLI" guard is
         # `test_cli_does_no_probing_imports` below -- this one is a
         # soft canary against the file ballooning beyond pure wiring.
         line_count = sum(1 for _ in cli_path.read_text().splitlines())
-        assert line_count <= 410, (
-            f"cli/env.py is {line_count} lines; soft budget is 410. "
+        assert line_count <= 500, (
+            f"cli/env.py is {line_count} lines; soft budget is 500. "
             "If you need more, check that the new code is genuinely "
             "wiring/error-handling and not probing -- "
             "test_cli_does_no_probing_imports is the strict guard."
@@ -2098,6 +2147,169 @@ class TestCliSummaryAndFieldFlags:
         assert payload["schema_version"] == env_mod.SCHEMA_VERSION
 
 
+class TestProbeBuckContextOptions:
+    @staticmethod
+    def _cli_mod():
+        cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        spec = importlib.util.spec_from_file_location(
+            "aorta.cli.env", cli_path,
+        )
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cli_mod
+        spec.loader.exec_module(cli_mod)
+        return cli_mod
+
+    @pytest.mark.parametrize(
+        "context_args",
+        [
+            ["--buck-mode-file", "root//mode/debug"],
+            ["--buck-config", "build.profile=debug"],
+            ["--buck-modifier", "//constraints:linux"],
+            ["--buck-default-context"],
+        ],
+    )
+    def test_context_options_require_buck_target(self, context_args):
+        from click.testing import CliRunner
+
+        result = CliRunner().invoke(
+            self._cli_mod().env,
+            ["probe", *context_args, "--summary"],
+        )
+        assert result.exit_code != 0
+        assert "require --buck-target" in result.output
+        assert "Traceback" not in result.output
+
+    def test_default_confirmation_rejects_explicit_context(self):
+        from click.testing import CliRunner
+
+        result = CliRunner().invoke(
+            self._cli_mod().env,
+            [
+                "probe",
+                "--buck-target",
+                "//app:trainer",
+                "--buck-default-context",
+                "--buck-modifier",
+                "//constraints:linux",
+                "--summary",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_repeatable_options_preserve_each_axis_order(self, monkeypatch):
+        from click.testing import CliRunner
+
+        captured = {}
+
+        def fake_collect_env(**kwargs):
+            captured.update(kwargs)
+            return _example_snapshot()
+
+        monkeypatch.setattr(env_mod, "collect_env", fake_collect_env)
+        result = CliRunner().invoke(
+            self._cli_mod().env,
+            [
+                "probe",
+                "--buck-target",
+                "//app:trainer",
+                "--buck-mode-file",
+                "root//mode/debug",
+                "--buck-mode-file",
+                "root//mode/gpu",
+                "--buck-config",
+                "build.profile=debug",
+                "--buck-config",
+                "scheduler.policy=local",
+                "--buck-modifier",
+                "//constraints:linux",
+                "--buck-modifier",
+                "//constraints:gfx",
+                "--summary",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        context = captured["buck_context"]
+        assert context.mode_files == (
+            "root//mode/debug",
+            "root//mode/gpu",
+        )
+        assert context.config_overrides == (
+            "build.profile=debug",
+            "scheduler.policy=local",
+        )
+        assert context.modifiers == (
+            "//constraints:linux",
+            "//constraints:gfx",
+        )
+        assert context.to_buck_args() == [
+            "@root//mode/debug",
+            "@root//mode/gpu",
+            "-c",
+            "build.profile=debug",
+            "-c",
+            "scheduler.policy=local",
+            "-m",
+            "//constraints:linux",
+            "-m",
+            "//constraints:gfx",
+        ]
+
+    def test_default_confirmation_and_unspecified_target_are_distinct(
+        self, monkeypatch
+    ):
+        from click.testing import CliRunner
+
+        contexts = []
+
+        def fake_collect_env(**kwargs):
+            contexts.append(kwargs["buck_context"])
+            return _example_snapshot()
+
+        monkeypatch.setattr(env_mod, "collect_env", fake_collect_env)
+        cli_mod = self._cli_mod()
+        runner = CliRunner()
+
+        unspecified = runner.invoke(
+            cli_mod.env,
+            ["probe", "--buck-target", "//app:trainer", "--summary"],
+        )
+        confirmed = runner.invoke(
+            cli_mod.env,
+            [
+                "probe",
+                "--buck-target",
+                "//app:trainer",
+                "--buck-default-context",
+                "--summary",
+            ],
+        )
+
+        assert unspecified.exit_code == 0, unspecified.output
+        assert confirmed.exit_code == 0, confirmed.output
+        assert contexts[0].source == "unspecified"
+        assert contexts[1].source == "default_confirmed"
+
+    def test_invalid_config_shape_is_clean_click_error(self):
+        from click.testing import CliRunner
+
+        result = CliRunner().invoke(
+            self._cli_mod().env,
+            [
+                "probe",
+                "--buck-target",
+                "//app:trainer",
+                "--buck-config",
+                "build.profile",
+                "--summary",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "KEY=VALUE" in result.output
+        assert "Traceback" not in result.output
+
+
 class TestProbeBuckTimeoutValidation:
     """Per Copilot review on PR #165: ``--buck-timeout`` must reject
     values <= 0 at arg-parse time. ``subprocess.run(timeout=...)``
@@ -2233,6 +2445,51 @@ class TestProbeWritesUtf8:
         )
         assert recipe_result.exit_code == 0, recipe_result.output
         assert "BEST-EFFORT, NOT EXACT" in recipe_result.output
+
+
+class TestCaptureTo:
+    """Programmatic writer for Buck ``.par`` applications that own __main__."""
+
+    def test_writes_complete_json_and_returns_snapshot(
+        self, all_disabled, tmp_path: Path
+    ):
+        output = tmp_path / "nested" / "env.action.json"
+        snapshot = env_mod.capture_to(
+            output,
+            probe_invocation="buck2_run",
+        )
+        assert output.is_file()
+        assert output.stat().st_size > 0
+        on_disk = json.loads(output.read_text(encoding="utf-8"))
+        assert on_disk == snapshot.to_dict()
+
+    def test_forwards_buck_context_without_persisting_config_value(
+        self, all_disabled, tmp_path: Path
+    ):
+        hidden = "private-placeholder"
+        context = env_mod.BuckInvocationContext(
+            config_overrides=(f"build.profile={hidden}",),
+        )
+        output = tmp_path / "env.action.json"
+        snapshot = env_mod.capture_to(
+            output,
+            buck_target="//app:trainer",
+            buck_context=context,
+            probe_invocation="buck2_run",
+        )
+        serialized = output.read_text(encoding="utf-8")
+        assert snapshot.buck_invocation["config_keys"] == ["build.profile"]
+        assert hidden not in serialized
+
+    def test_write_failure_is_not_silenced(
+        self, all_disabled, tmp_path: Path, monkeypatch
+    ):
+        def fail_write(*args, **kwargs):
+            raise OSError("synthetic write failure")
+
+        monkeypatch.setattr(Path, "write_text", fail_write)
+        with pytest.raises(OSError, match="synthetic write failure"):
+            env_mod.capture_to(tmp_path / "env.json")
 
 
 # ---------------------------------------------------------------------------
@@ -3073,6 +3330,14 @@ class TestExecutionContext:
     def test_warning_predicate_claim_without_isolation_warns(self, all_disabled):
         msg = env_mod.execution_context_warning("buck2_action", False)
         assert msg is not None and msg.startswith("WARNING:")
+
+    def test_buck2_run_without_isolation_is_labeled_client_host(
+        self, all_disabled
+    ):
+        msg = env_mod.execution_context_warning("buck2_run", False)
+        assert msg is not None and msg.startswith("NOTICE:")
+        assert "client-host snapshot" in msg
+        assert "remote-worker" in msg
 
     def test_warning_predicate_suppressed_by_container_detected(
         self, all_disabled
@@ -6629,6 +6894,7 @@ class TestGpuArch:
 
         def fake_run(cmd, **kwargs):
             assert cmd[0].endswith("rocm_agent_enumerator")
+            assert kwargs["timeout"] == env_mod.GPU_ARCH_TIMEOUT_SEC
             return subprocess.CompletedProcess(
                 args=cmd, returncode=0,
                 stdout="gfx942\ngfx942\ngfx942\ngfx942\n", stderr="",
@@ -6641,6 +6907,27 @@ class TestGpuArch:
         assert block["gfx_targets"] == ["gfx942"]
         assert block["agent_arch_counts"] == {"gfx942": 4}
         assert reasons == []
+
+    def test_timeout_uses_gpu_specific_budget_and_records_reason(
+        self, isolated_env, monkeypatch
+    ):
+        monkeypatch.setattr(
+            env_mod.shutil, "which",
+            lambda name: "/usr/bin/" + name,
+        )
+
+        def fake_run(cmd, **kwargs):
+            assert kwargs["timeout"] == env_mod.GPU_ARCH_TIMEOUT_SEC
+            raise subprocess.TimeoutExpired(
+                cmd=cmd,
+                timeout=kwargs["timeout"],
+            )
+
+        monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+        reasons: list[str] = []
+        block = env_mod._capture_gpu_arch(reasons)
+        assert block["agent_count"] is None
+        assert any("exceeded 30s timeout" in reason for reason in reasons)
 
     def test_filters_gfx000_placeholder(self, isolated_env, monkeypatch):
         """Some hosts include a gfx000 placeholder for the host CPU

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -525,6 +525,7 @@ def _example_snapshot(**overrides) -> object:
             "mode_files": ["root//mode/debug"],
             "config_keys": ["build.profile"],
             "modifiers": ["//constraints:linux"],
+            "option_order": ["mode", "config", "modifier"],
             "context_fingerprint": "sha256:" + "a" * 64,
             "configured_root_target": (
                 "root//app:trainer "
@@ -2148,20 +2149,30 @@ class TestCliSummaryAndFieldFlags:
 
 
 class TestProbeBuckContextOptions:
-    @staticmethod
-    def _cli_mod():
+    _module_load_count = 0
+
+    @classmethod
+    def _cli_mod(cls):
         cli_path = Path(env_mod.__file__).parent.parent / "cli" / "env.py"
+        cls._module_load_count += 1
+        module_name = f"aorta.cli.env_test_{cls._module_load_count}"
         spec = importlib.util.spec_from_file_location(
-            "aorta.cli.env", cli_path,
+            module_name,
+            cli_path,
         )
+        assert spec is not None and spec.loader is not None
         cli_mod = importlib.util.module_from_spec(spec)
-        sys.modules[spec.name] = cli_mod
-        spec.loader.exec_module(cli_mod)
+        sys.modules[module_name] = cli_mod
+        try:
+            spec.loader.exec_module(cli_mod)
+        finally:
+            sys.modules.pop(module_name, None)
         return cli_mod
 
     @pytest.mark.parametrize(
         "context_args",
         [
+            ["--buck-option", "mode=root//mode/debug"],
             ["--buck-mode-file", "root//mode/debug"],
             ["--buck-config", "build.profile=debug"],
             ["--buck-modifier", "//constraints:linux"],
@@ -2256,6 +2267,60 @@ class TestProbeBuckContextOptions:
             "//constraints:gfx",
         ]
 
+    def test_ordered_option_preserves_cross_type_order(self, monkeypatch):
+        from click.testing import CliRunner
+
+        captured = {}
+
+        def fake_collect_env(**kwargs):
+            captured.update(kwargs)
+            return _example_snapshot()
+
+        monkeypatch.setattr(env_mod, "collect_env", fake_collect_env)
+        result = CliRunner().invoke(
+            self._cli_mod().env,
+            [
+                "probe",
+                "--buck-target",
+                "//app:trainer",
+                "--buck-option",
+                "config=build.profile=debug",
+                "--buck-option",
+                "mode=root//mode/override",
+                "--buck-option",
+                "modifier=//constraints:gfx",
+                "--summary",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["buck_context"].to_buck_args() == [
+            "-c",
+            "build.profile=debug",
+            "@root//mode/override",
+            "-m",
+            "//constraints:gfx",
+        ]
+
+    def test_ordered_option_rejects_grouped_options(self):
+        from click.testing import CliRunner
+
+        result = CliRunner().invoke(
+            self._cli_mod().env,
+            [
+                "probe",
+                "--buck-target",
+                "//app:trainer",
+                "--buck-option",
+                "mode=root//mode/debug",
+                "--buck-config",
+                "build.profile=debug",
+                "--summary",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "cannot be combined" in result.output
+
     def test_default_confirmation_and_unspecified_target_are_distinct(
         self, monkeypatch
     ):
@@ -2307,6 +2372,7 @@ class TestProbeBuckContextOptions:
         )
         assert result.exit_code != 0
         assert "KEY=VALUE" in result.output
+        assert "--buck-config" in result.output
         assert "Traceback" not in result.output
 
 

--- a/tests/instrumentation/test_validate_buck_env_pair.py
+++ b/tests/instrumentation/test_validate_buck_env_pair.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -85,3 +86,55 @@ def test_pytorch_hip_version_is_valid_runtime_rocm_identity():
     workload["hip"] = {"version": None}
     findings = validator.validate_pair(_valid_client(), workload)
     assert not [finding for finding in findings if finding.severity == "ERROR"]
+
+
+def test_missing_required_library_is_an_error():
+    client = _valid_client()
+    client["library_introspection"] = [{"name": "rccl"}]
+    messages = [
+        finding.message
+        for finding in validator.validate_pair(client, _valid_workload())
+        if finding.severity == "ERROR"
+    ]
+    assert any(
+        "required Buck library identity is missing: pytorch" in message for message in messages
+    )
+
+
+def test_unisolated_action_requires_explicit_override():
+    workload = _valid_workload()
+    workload["execution_context"] = {"probe_invocation": "buck2_action"}
+    workload["container_detected"] = False
+
+    findings = validator.validate_pair(_valid_client(), workload)
+    assert any(
+        "no detected isolation evidence" in finding.message
+        for finding in findings
+        if finding.severity == "ERROR"
+    )
+
+    overridden = validator.validate_pair(
+        _valid_client(),
+        workload,
+        allow_unisolated_action=True,
+    )
+    assert not [finding for finding in overridden if finding.severity == "ERROR"]
+
+
+def test_main_writes_diagnostics_to_stderr_and_pass_to_stdout(tmp_path, monkeypatch, capsys):
+    client = _valid_client()
+    client["partial_reasons"] = ["system_health: optional tool unavailable"]
+    client_path = tmp_path / "client.json"
+    workload_path = tmp_path / "workload.json"
+    client_path.write_text(json.dumps(client), encoding="utf-8")
+    workload_path.write_text(json.dumps(_valid_workload()), encoding="utf-8")
+    monkeypatch.setattr(
+        validator.sys,
+        "argv",
+        ["validate", str(client_path), str(workload_path)],
+    )
+
+    assert validator.main() == 0
+    captured = capsys.readouterr()
+    assert "WARNING:" in captured.err
+    assert "PASS:" in captured.out

--- a/tests/instrumentation/test_validate_buck_env_pair.py
+++ b/tests/instrumentation/test_validate_buck_env_pair.py
@@ -1,0 +1,87 @@
+"""Tests for the customer-facing Buck snapshot-pair validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "validate_buck_env_pair.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "validate_buck_env_pair",
+    _SCRIPT,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+validator = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = validator
+_SPEC.loader.exec_module(validator)
+
+
+def _valid_client() -> dict[str, object]:
+    return {
+        "schema_version": "1.13",
+        "build_system": {"kind": "buck2"},
+        "buck_invocation": {
+            "status": "success",
+            "context_source": "explicit",
+            "context_fingerprint": "sha256:" + "a" * 64,
+        },
+        "library_introspection": [{"name": "pytorch"}],
+        "partial_reasons": [],
+    }
+
+
+def _valid_workload() -> dict[str, object]:
+    return {
+        "python_version": "3.12.0",
+        "pytorch_version": "2.10.0",
+        "pytorch_build": {
+            "git_commit": "a" * 40,
+            "hip_version": "7.0",
+        },
+        "gpu_arch": {"gfx_targets": ["gfx950"]},
+        "execution_context": {"probe_invocation": "buck2_run"},
+        "partial_reasons": [],
+    }
+
+
+def test_valid_pair_has_no_errors():
+    findings = validator.validate_pair(_valid_client(), _valid_workload())
+    assert not [finding for finding in findings if finding.severity == "ERROR"]
+
+
+def test_missing_client_context_and_workload_torch_are_errors():
+    client = _valid_client()
+    client["buck_invocation"] = {
+        "status": "success",
+        "context_source": "unspecified",
+        "context_fingerprint": None,
+    }
+    workload = _valid_workload()
+    workload["pytorch_version"] = None
+
+    messages = [
+        finding.message
+        for finding in validator.validate_pair(client, workload)
+        if finding.severity == "ERROR"
+    ]
+    assert any("context was not confirmed" in message for message in messages)
+    assert any("fingerprint is missing" in message for message in messages)
+    assert any("pytorch_version" in message for message in messages)
+
+
+def test_partial_reasons_are_warnings_not_errors():
+    client = _valid_client()
+    client["partial_reasons"] = ["system_health: optional tool unavailable"]
+    findings = validator.validate_pair(client, _valid_workload())
+    assert any(finding.severity == "WARNING" for finding in findings)
+    assert not [finding for finding in findings if finding.severity == "ERROR"]
+
+
+def test_pytorch_hip_version_is_valid_runtime_rocm_identity():
+    workload = _valid_workload()
+    workload["rocm"] = {"version": None}
+    workload["hip"] = {"version": None}
+    findings = validator.validate_pair(_valid_client(), workload)
+    assert not [finding for finding in findings if finding.severity == "ERROR"]


### PR DESCRIPTION
## Summary
- preserve mode files, config overrides, and modifiers when introspecting a Buck target
- record redacted schema 1.13 invocation provenance and fail visibly on unconfirmed context
- support capture from applications that own `__main__`, then validate the required client/workload snapshot pair
- add customer-safe setup, troubleshooting, and empirical RE measurement documentation

## Test plan
- [x] `tests/instrumentation/test_buck_introspect.py` + pair-validator tests: 64 passed
- [x] environment suite: 504 passed, 3 skipped, 1 Triton-dependent test deselected
- [x] focused capture/warning/validator tests: 16 passed
- [x] Bash syntax check for `scripts/buck2_execution_context_probe.sh`
- [x] local Buck2 build, CLI launch, schema 1.13 probe, and JSON validation on an 8-GPU Linux host
- [ ] pilot the in-application `capture_to()` flow in a real customer `.par`
- [ ] answer Q1/Q2 on an authorized RE-enabled Buck repository; this PR intentionally leaves platform detection unresolved

## Safety notes
- public code/docs contain no customer target labels, hostnames, paths, or environment values
- raw `-c` values are passed to Buck and fingerprinted but are never serialized
- `likely_execution_platform` remains unset until real RE evidence is available