### PR TITLE
docs: add general Buck2 env-probe workflow

### DIFF
--- a/docs/README_aorta_env_probe.md
+++ b/docs/README_aorta_env_probe.md
@@ -15,8 +15,8 @@ diagnostic commands. On a multi-GPU host, collection can take tens of seconds.
 - Workload built with Buck2: send two files:
   1. `env.buck-client.json` — the dependencies Buck selected for the target
      and settings you used.
-  2. `env.workload.json` — the Python, torch, ROCm, and GPU environment seen by
-     the workload process.
+  2. `env.workload.rank<RANK>.json` — the Python, torch, ROCm, and GPU
+     environment seen by one node-local rank 0 process.
 
 These files answer different questions. A host-side Buck query cannot prove
 what a workload process saw, and a workload process may not be able to run a
@@ -103,19 +103,28 @@ fingerprint but are not stored.
 ## Buck workload — file 2: workload process
 
 A Buck `.par` is the packaged Python executable for the application. It owns
-the application's startup code, so the AORTA CLI cannot wrap it. Add AORTA's
-`aorta_lib` to the existing `python_binary` dependencies. Keep its current
-application entrypoint, torch target, and other dependencies unchanged:
+the application's startup code, so the AORTA CLI cannot wrap it.
+
+First, ask the repository owner to expose the provided AORTA revision as a
+Buck cell or vendored source target. Confirm this command lists `aorta_lib`:
+
+```bash
+buck2 targets <AORTA_CELL>//:
+```
+
+If that target is unavailable, stop and contact support. Do not substitute a
+different AORTA revision.
+
+Add only AORTA's library to the existing application rule. Keep its current
+rule macro, name, `main`/`main_function`, torch target, and all other
+dependencies unchanged:
 
 ```python
-python_binary(
-    name = "application_with_aorta_probe",
-    main_function = "<EXISTING_APPLICATION_MAIN_FUNCTION>",
-    deps = [
-        "<AORTA_CELL>//:aorta_lib",
-        # Keep the existing torch and application dependencies here.
-    ],
-)
+# Inside the existing python_binary(...) or repository-specific Python macro:
+deps = [
+    # Keep every existing dependency.
+    "<AORTA_CELL>//:aorta_lib",
+]
 ```
 
 At the beginning of the application's `main()`, after launcher environment
@@ -130,11 +139,12 @@ from aorta.instrumentation.environment import capture_to
 def main():
     output = os.environ.get("AORTA_ENV_OUTPUT")
     if output:
-        # Rank 0 writes the shared artifact. Every rank exits after capture so
-        # one delayed rank cannot disturb a timing-sensitive distributed run.
-        if os.environ.get("RANK", "0") == "0":
+        # One local-rank-0 process writes per node. {rank} makes filenames
+        # unique across nodes; on a single process it resolves to rank 0.
+        rank = os.environ.get("RANK", "0")
+        if os.environ.get("LOCAL_RANK", "0") == "0":
             capture_to(
-                output,
+                output.format(rank=rank),
                 probe_invocation=os.environ.get(
                     "AORTA_PROBE_INVOCATION",
                     "buck2_run",
@@ -145,10 +155,10 @@ def main():
     # Existing application setup follows.
 ```
 
-Launch the application with:
+### Local workload process launched by `buck2 run`
 
 ```bash
-export AORTA_ENV_OUTPUT=<SHARED_OUTPUT_DIR>/env.workload.json
+export AORTA_ENV_OUTPUT='<SHARED_OUTPUT_DIR>/env.workload.rank{rank}.json'
 export AORTA_PROBE_INVOCATION=buck2_run
 
 buck2 run <APPLICATION_WITH_AORTA_PROBE> -- <EXISTING_APPLICATION_ARGS>
@@ -157,12 +167,24 @@ buck2 run <APPLICATION_WITH_AORTA_PROBE> -- <EXISTING_APPLICATION_ARGS>
 Treat this as a capture-only run. Importing packages and running diagnostic
 commands changes process startup timing; do not use the same run to measure a
 timing-sensitive failure rate. Unset `AORTA_ENV_OUTPUT` for normal workload
-runs.
+runs. On a single node, validate `env.workload.rank0.json`. On a multi-node
+job, validate and send one file per node-local rank 0.
 
-Use `buck2_run` when `buck2 run` launches the `.par` on the client host. Use
-`buck2_action` only when the probe itself runs as a declared build/test action
-and executor placement is independently known. Do not label a normal
-`buck2 run` process as a remote action.
+`buck2 run` starts the packaged executable on the client host after Buck builds
+it. This does not capture a remote build/test worker.
+
+### Remote build/test action
+
+To capture a remote worker, the repository owner must run the same
+capture-enabled binary as a declared build/test action, pass a declared output
+path as `AORTA_ENV_OUTPUT`, and set:
+
+```bash
+export AORTA_PROBE_INVOCATION=buck2_action
+```
+
+Do not use `buck2_action` for a normal `buck2 run`. Executor placement must be
+confirmed separately using the repository's Buck execution evidence.
 
 Do not pass `buck_target` to `capture_to()` inside the workload. The
 client-side file already records the dependency information, while the Buck
@@ -178,13 +200,15 @@ Run the validator included with the same AORTA checkout:
 
 ```bash
 python3 <AORTA_CHECKOUT>/scripts/validate_buck_env_pair.py \
+  --require-library rccl \
+  --require-library hipblaslt \
   env.buck-client.json \
-  env.workload.json
+  env.workload.rank0.json
 ```
 
-The validator requires the PyTorch Buck identity by default. If the workload
-also requires specific libraries, add repeatable checks such as
-`--require-library rccl` or `--require-library hipblaslt`.
+The validator always requires the PyTorch Buck identity. Keep only the
+additional `--require-library` lines for libraries the workload is expected to
+use. For a multi-node capture, rerun the validator for every workload file.
 
 A file labeled `buck2_action` must contain detected isolation evidence. If
 your repository proves placement through separate `what-ran` evidence, the
@@ -199,10 +223,11 @@ error lines to your support contact.
 Send:
 
 1. `env.buck-client.json`
-2. `env.workload.json`
+2. Each `env.workload.rank<RANK>.json` produced by a node-local rank 0.
 3. The exact workload target.
 4. The ordered mode-file and modifier names.
-5. Config key names and `buck_invocation.context_fingerprint`.
+5. Config key names, `buck_invocation.option_order`, and
+   `buck_invocation.context_fingerprint`.
 
 If config values are sensitive, do not send them. The fingerprint lets two
 captures be compared without recording those values.

--- a/docs/buck2-env-probe-customer.md
+++ b/docs/buck2-env-probe-customer.md
@@ -1,22 +1,22 @@
-# AORTA Environment Probe — Customer Instructions
+# AORTA Env Probe for Buck2 Workloads — Customer Instructions
 
-Source of truth: `docs/README_aorta_env_probe.md` in the AORTA revision
+Source of truth: `docs/buck2-env-probe-customer.md` in the AORTA revision
 provided by your support contact. If this file is exported separately, update
 it from that source rather than editing two copies.
 
-Use this probe to record the software and hardware environment around a GPU
-workload. It launches no GPU kernels and runs no training steps. It reads
-version files, imports Python packages when available, and runs bounded
-diagnostic commands. On a multi-GPU host, collection can take tens of seconds.
+This guide is only for workloads built or launched with Buck2. The probe
+records the Buck dependency selection and the software/hardware environment
+seen by the packaged Python workload. It launches no GPU kernels and runs no
+training steps. On a multi-GPU host, collection can take tens of seconds.
 
 ## What to send
 
-- Workload not built with Buck2: send one `env.host.json`.
-- Workload built with Buck2: send two files:
-  1. `env.buck-client.json` — the dependencies Buck selected for the target
-     and settings you used.
-  2. `env.workload.rank<RANK>.json` — the Python, torch, ROCm, and GPU
-     environment seen by one node-local rank 0 process.
+Send two files:
+
+1. `env.buck-client.json` — the dependencies Buck selected for the target and
+   settings you used.
+2. `env.workload.rank<RANK>.json` — the Python, torch, ROCm, and GPU
+   environment seen by one node-local rank 0 process.
 
 These files answer different questions. A host-side Buck query cannot prove
 what a workload process saw, and a workload process may not be able to run a
@@ -38,22 +38,9 @@ If torch imports from a normal Python environment, verify that first:
 python -c "import torch; print(torch.__version__, torch.version.hip)"
 ```
 
-If torch exists only as a Buck target, use the Buck instructions below. Do not
-inject AORTA into an unrelated Python process with `PYTHONPATH`; that process
-will not contain the workload's torch target.
-
-## Non-Buck workload
-
-Activate the same environment and container used by the workload, then run:
-
-```bash
-aorta env probe \
-  --execution-context direct \
-  -o env.host.json
-```
-
-Send `env.host.json`. Missing optional tools appear in `partial_reasons`; they
-do not prevent the rest of the snapshot from being useful.
+If torch exists only as a Buck target, do not inject AORTA into an unrelated
+Python process with `PYTHONPATH`; that process will not contain the workload's
+torch target.
 
 ## Buck workload — file 1: Buck dependency information
 

--- a/docs/buck2-env-probe-gpu-setup.md
+++ b/docs/buck2-env-probe-gpu-setup.md
@@ -34,13 +34,22 @@ Download the release binary matching the host architecture from the official
 downloaded version visible in the test report; do not silently substitute a
 different repository-provided binary.
 
+Official Linux assets are commonly Zstandard-compressed (`.zst`). Decompress
+the downloaded asset before installing it.
+
 If login and compute nodes use different home directories, choose a filesystem
 visible to both and set it as `SHARED_ROOT`:
 
 ```bash
 SHARED_ROOT="/shared/aorta-support"
 mkdir -p "$SHARED_ROOT/bin"
-install -m 0755 /path/to/downloaded/buck2 "$SHARED_ROOT/bin/buck2"
+command -v zstd >/dev/null || {
+  echo "Install the zstd package before continuing."
+  exit 1
+}
+zstd -d /path/to/downloaded/buck2-<target>.zst \
+  -o "$SHARED_ROOT/bin/buck2"
+chmod 0755 "$SHARED_ROOT/bin/buck2"
 export PATH="$SHARED_ROOT/bin:$PATH"
 
 buck2 --version
@@ -54,7 +63,7 @@ artifacts that must be visible on both host and compute nodes.
 ```bash
 AORTA_BASE="$SHARED_ROOT/aorta"
 AORTA_WORKTREE="$SHARED_ROOT/aorta-worktrees/buck-invocation-context"
-AORTA_BRANCH="<branch-provided-by-aorta-support>"
+AORTA_BRANCH="<aorta-branch-to-test>"
 
 mkdir -p "$SHARED_ROOT/aorta-worktrees"
 if [ ! -d "$AORTA_BASE/.git" ]; then
@@ -67,7 +76,7 @@ if [ -e "$AORTA_WORKTREE" ]; then
   exit 1
 fi
 git -C "$AORTA_BASE" worktree add --track \
-  -b aorta-env-probe-customer-test \
+  -b aorta-env-probe-test \
   "$AORTA_WORKTREE" \
   "origin/$AORTA_BRANCH"
 

--- a/docs/buck2-env-probe-gpu-setup.md
+++ b/docs/buck2-env-probe-gpu-setup.md
@@ -43,12 +43,19 @@ visible to both and set it as `SHARED_ROOT`:
 ```bash
 SHARED_ROOT="/shared/aorta-support"
 mkdir -p "$SHARED_ROOT/bin"
-command -v zstd >/dev/null || {
-  echo "Install the zstd package before continuing."
-  exit 1
-}
-zstd -d /path/to/downloaded/buck2-<target>.zst \
-  -o "$SHARED_ROOT/bin/buck2"
+BUCK2_DOWNLOAD="/path/to/downloaded/buck2-or-buck2.zst"
+case "$BUCK2_DOWNLOAD" in
+  *.zst)
+    command -v zstd >/dev/null || {
+      echo "Install the zstd package before continuing."
+      exit 1
+    }
+    zstd -d "$BUCK2_DOWNLOAD" -o "$SHARED_ROOT/bin/buck2"
+    ;;
+  *)
+    install -m 0755 "$BUCK2_DOWNLOAD" "$SHARED_ROOT/bin/buck2"
+    ;;
+esac
 chmod 0755 "$SHARED_ROOT/bin/buck2"
 export PATH="$SHARED_ROOT/bin:$PATH"
 

--- a/docs/buck2-env-probe.md
+++ b/docs/buck2-env-probe.md
@@ -8,9 +8,9 @@ records the Buck dependency selection and the software/hardware environment
 seen by the packaged Python workload. It launches no GPU kernels and runs no
 training steps. On a multi-GPU host, collection can take tens of seconds.
 
-## What to send
+## Capture outputs
 
-Send two files:
+Buck workloads use two complementary snapshots:
 
 1. `env.buck-client.json` — the dependencies Buck selected for the target and
    settings you used.
@@ -97,8 +97,8 @@ Buck cell or vendored source target. Confirm this command lists `aorta_lib`:
 buck2 targets <AORTA_CELL>//:
 ```
 
-If that target is unavailable, stop and contact support. Do not substitute a
-different AORTA revision.
+If that target is unavailable, stop and configure the intended AORTA Buck cell
+before continuing. Do not substitute a different AORTA revision.
 
 Add only AORTA's library to the existing application rule. Keep its current
 rule macro, name, `main`/`main_function`, torch target, and all other
@@ -153,7 +153,7 @@ Treat this as a capture-only run. Importing packages and running diagnostic
 commands changes process startup timing; do not use the same run to measure a
 timing-sensitive failure rate. Unset `AORTA_ENV_OUTPUT` for normal workload
 runs. On a single node, validate `env.workload.rank0.json`. On a multi-node
-job, validate and send one file per node-local rank 0.
+job, validate one file per node-local rank 0.
 
 `buck2 run` builds the target and then launches its `RunInfo` command. Its
 build actions may run locally, remotely, or from cache, but this workload
@@ -180,7 +180,7 @@ If the application source cannot be changed, ask the repository owner for a
 temporary capture-only entrypoint with the same AORTA, torch, and application
 dependencies. It should call `capture_to()` and exit without starting training.
 
-## Validate both files before sending
+## Validate the snapshot pair
 
 Run the validator included with the same AORTA checkout:
 
@@ -197,16 +197,16 @@ additional `--require-library` lines for libraries the workload is expected to
 use. For a multi-node capture, rerun the validator for every workload file.
 
 A file labeled `buck2_action` must contain detected isolation evidence. If
-your repository proves placement through separate `what-ran` evidence, an
-AORTA maintainer may explicitly add `--allow-unisolated-action`; do not use
-that override merely to silence an error.
+your repository proves placement through separate `what-ran` evidence, add
+`--allow-unisolated-action`; do not use that override merely to silence an
+error.
 
-Do not use the files until the validator prints `PASS`. If it fails, give the
-error lines to the AORTA maintainer.
+Do not use the files until the validator prints `PASS`. If it fails, correct
+the reported setup or capture error and rerun the probe.
 
-## What to send
+## Generated artifacts
 
-Send:
+Keep these artifacts together for comparison or later analysis:
 
 1. `env.buck-client.json`
 2. Each `env.workload.rank<RANK>.json` produced by a node-local rank 0.
@@ -215,8 +215,8 @@ Send:
 5. Config key names, `buck_invocation.option_order`, and
    `buck_invocation.context_fingerprint`.
 
-If config values are sensitive, do not send them. The fingerprint lets two
-captures be compared without recording those values.
+Raw config values are intentionally omitted. The fingerprint lets two captures
+be compared without recording those values.
 
 ## Expected limitations
 
@@ -245,8 +245,8 @@ mode/config/modifier options.
 
 Confirm `--buck-target` names the real top-level workload target and that all
 configuration options match its normal invocation. If the graph uses library
-labels AORTA does not yet recognize, give the AORTA maintainer a scrubbed list
-of the relevant label names.
+labels AORTA does not yet recognize, update AORTA's recognized-library patterns
+before relying on this validation.
 
 ### Warning says this is a client-host snapshot
 

--- a/docs/buck2-env-probe.md
+++ b/docs/buck2-env-probe.md
@@ -155,8 +155,9 @@ timing-sensitive failure rate. Unset `AORTA_ENV_OUTPUT` for normal workload
 runs. On a single node, validate `env.workload.rank0.json`. On a multi-node
 job, validate and send one file per node-local rank 0.
 
-`buck2 run` starts the packaged executable on the client host after Buck builds
-it. This does not capture a remote build/test worker.
+`buck2 run` builds the target and then launches its `RunInfo` command. Its
+build actions may run locally, remotely, or from cache, but this workload
+capture does not by itself prove it ran inside a remote build/test action.
 
 ### Remote build/test action
 
@@ -251,3 +252,10 @@ of the relevant label names.
 
 That is expected for a local `buck2 run`. Keep it as the client/runtime
 snapshot and do not claim it represents a remote worker.
+
+## Buck2 references
+
+- [Python binary dependencies and entrypoints](https://buck2.build/docs/prelude/rules/python/python_binary/)
+- [Command-line config and flag-file precedence](https://buck2.build/docs/concepts/buckconfig/)
+- [`buck2 run` and execution policy flags](https://buck2.build/docs/users/commands/run/)
+- [Configured queries and exact attributes](https://buck2.build/docs/users/commands/cquery/)

--- a/docs/buck2-env-probe.md
+++ b/docs/buck2-env-probe.md
@@ -1,8 +1,7 @@
-# AORTA Env Probe for Buck2 Workloads — Customer Instructions
+# AORTA Env Probe for Buck2 Workloads
 
-Source of truth: `docs/buck2-env-probe-customer.md` in the AORTA revision
-provided by your support contact. If this file is exported separately, update
-it from that source rather than editing two copies.
+Canonical source: `docs/buck2-env-probe.md` in the selected AORTA revision.
+Refresh exported copies from this file rather than editing two copies.
 
 This guide is only for workloads built or launched with Buck2. The probe
 records the Buck dependency selection and the software/hardware environment
@@ -24,9 +23,8 @@ nested Buck query.
 
 ## Before you start
 
-Use the exact AORTA checkout, branch, release, or source archive provided by
-your support contact. AORTA requires Python 3.10 or newer. For a source
-checkout:
+Use one pinned AORTA checkout, branch, release, or source archive for both
+captures. AORTA requires Python 3.10 or newer. For a source checkout:
 
 ```bash
 python -m pip install -e <AORTA_CHECKOUT>
@@ -198,12 +196,12 @@ additional `--require-library` lines for libraries the workload is expected to
 use. For a multi-node capture, rerun the validator for every workload file.
 
 A file labeled `buck2_action` must contain detected isolation evidence. If
-your repository proves placement through separate `what-ran` evidence, the
-support contact may explicitly add `--allow-unisolated-action`; do not use
+your repository proves placement through separate `what-ran` evidence, an
+AORTA maintainer may explicitly add `--allow-unisolated-action`; do not use
 that override merely to silence an error.
 
-Do not send the files until the validator prints `PASS`. If it fails, send the
-error lines to your support contact.
+Do not use the files until the validator prints `PASS`. If it fails, give the
+error lines to the AORTA maintainer.
 
 ## What to send
 
@@ -246,8 +244,8 @@ mode/config/modifier options.
 
 Confirm `--buck-target` names the real top-level workload target and that all
 configuration options match its normal invocation. If the graph uses library
-labels AORTA does not yet recognize, send a scrubbed list of the relevant label
-names to your support contact.
+labels AORTA does not yet recognize, give the AORTA maintainer a scrubbed list
+of the relevant label names.
 
 ### Warning says this is a client-host snapshot
 

--- a/docs/buck2-env-probe.md
+++ b/docs/buck2-env-probe.md
@@ -104,11 +104,12 @@ Add only AORTA's library to the existing application rule. Keep its current
 rule macro, name, `main`/`main_function`, torch target, and all other
 dependencies unchanged:
 
-```python
+```diff
 # Inside the existing python_binary(...) or repository-specific Python macro:
 deps = [
-    # Keep every existing dependency.
-    "<AORTA_CELL>//:aorta_lib",
+    "<EXISTING_APPLICATION_DEPENDENCY>",
+    "<EXISTING_TORCH_TARGET>",
++   "<AORTA_CELL>//:aorta_lib",
 ]
 ```
 
@@ -127,7 +128,11 @@ def main():
         # One local-rank-0 process writes per node. {rank} makes filenames
         # unique across nodes; on a single process it resolves to rank 0.
         rank = os.environ.get("RANK", "0")
-        if os.environ.get("LOCAL_RANK", "0") == "0":
+        local_rank = os.environ.get("LOCAL_RANK")
+        is_node_writer = (
+            local_rank == "0" if local_rank is not None else rank == "0"
+        )
+        if is_node_writer:
             capture_to(
                 output.format(rank=rank),
                 probe_invocation=os.environ.get(
@@ -186,15 +191,14 @@ Run the validator included with the same AORTA checkout:
 
 ```bash
 python3 <AORTA_CHECKOUT>/scripts/validate_buck_env_pair.py \
-  --require-library rccl \
-  --require-library hipblaslt \
   env.buck-client.json \
   env.workload.rank0.json
 ```
 
-The validator always requires the PyTorch Buck identity. Keep only the
-additional `--require-library` lines for libraries the workload is expected to
-use. For a multi-node capture, rerun the validator for every workload file.
+The validator always requires the PyTorch Buck identity. For libraries the
+workload is expected to use, add optional checks before the two filenames, for
+example `--require-library rccl` or `--require-library hipblaslt`. For a
+multi-node capture, rerun the validator for every workload file.
 
 A file labeled `buck2_action` must contain detected isolation evidence. If
 your repository proves placement through separate `what-ran` evidence, add

--- a/docs/buck2-env-probe.md
+++ b/docs/buck2-env-probe.md
@@ -145,6 +145,11 @@ def main():
     # Existing application setup follows.
 ```
 
+`capture_to()` uses compact detail by default. Compact capture still includes
+every canonical `env_vars` key and the complete TorchRec identity block.
+`detail="full"` (CLI `--extended`) only retains verbose per-file
+Tensile/MIOpen catalog inventories.
+
 ### Local workload process launched by `buck2 run`
 
 ```bash
@@ -195,9 +200,12 @@ python3 <AORTA_CHECKOUT>/scripts/validate_buck_env_pair.py \
   env.workload.rank0.json
 ```
 
-The validator always requires the PyTorch Buck identity. For libraries the
-workload is expected to use, add optional checks before the two filenames, for
-example `--require-library rccl` or `--require-library hipblaslt`. For a
+No library is mandatory by default. Missing Buck or workload library
+identities are reported as warnings and remain unknown/`null`; they do not
+discard an otherwise usable snapshot. To make a Buck-graph identity mandatory,
+add `--require-library <NAME>` before the two filenames, for example
+`--require-library rccl` or `--require-library hipblaslt`. Only names supplied
+with this option are strict requirements, and the option is repeatable. For a
 multi-node capture, rerun the validator for every workload file.
 
 A file labeled `buck2_action` must contain detected isolation evidence. If
@@ -205,8 +213,11 @@ your repository proves placement through separate `what-ran` evidence, add
 `--allow-unisolated-action`; do not use that override merely to silence an
 error.
 
-Do not use the files until the validator prints `PASS`. If it fails, correct
-the reported setup or capture error and rerun the probe.
+`PASS` means the snapshot structure and every explicitly requested requirement
+passed. Warnings about unavailable optional identities are allowed; preserve
+the corresponding `null` values and warnings with the artifacts. If validation
+returns an error, correct the reported setup or capture problem and rerun the
+probe.
 
 ## Generated artifacts
 

--- a/docs/buck2.md
+++ b/docs/buck2.md
@@ -412,6 +412,8 @@ toolchain Python version.
 ## See also
 
 * [Env Probe](env-probe.md) -- the snapshot schema and `jq` cookbook.
+* [Buck2 env-probe customer instructions](buck2-env-probe-customer.md) --
+  customer-safe workload integration, two-file capture, and validation.
 * [Buck2 env-probe setup on a Linux GPU host](buck2-env-probe-gpu-setup.md)
   -- first-time Buck2 installation, local smoke test, real-RE prerequisites,
   and a copy-paste agent prompt.

--- a/docs/buck2.md
+++ b/docs/buck2.md
@@ -412,8 +412,8 @@ toolchain Python version.
 ## See also
 
 * [Env Probe](env-probe.md) -- the snapshot schema and `jq` cookbook.
-* [Buck2 env-probe customer instructions](buck2-env-probe-customer.md) --
-  customer-safe workload integration, two-file capture, and validation.
+* [Buck2 env probe](buck2-env-probe.md) -- workload integration, two-file
+  capture, and validation.
 * [Buck2 env-probe setup on a Linux GPU host](buck2-env-probe-gpu-setup.md)
   -- first-time Buck2 installation, local smoke test, real-RE prerequisites,
   and a copy-paste agent prompt.

--- a/docs/buck2.md
+++ b/docs/buck2.md
@@ -412,8 +412,8 @@ toolchain Python version.
 ## See also
 
 * [Env Probe](env-probe.md) -- the snapshot schema and `jq` cookbook.
-* [Buck2 env probe](buck2-env-probe.md) -- workload integration, two-file
-  capture, and validation.
+* [Buck2 env probe](buck2-env-probe.md) -- workload integration,
+  client/workload snapshots, and validation.
 * [Buck2 env-probe setup on a Linux GPU host](buck2-env-probe-gpu-setup.md)
   -- first-time Buck2 installation, local smoke test, real-RE prerequisites,
   and a copy-paste agent prompt.

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -4,8 +4,8 @@ Capture a versioned, schema-stable snapshot of the trial environment so
 that cross-environment comparison becomes a `jq` diff instead of a
 multi-day investigation.
 
-For a short customer handoff, including Buck's required client/workload
-snapshot pair, see [Customer Instructions](README_aorta_env_probe.md).
+For a Buck2 customer handoff, including the required client/workload snapshot
+pair, see [Buck2 Customer Instructions](buck2-env-probe-customer.md).
 
 The same code path is used three ways:
 

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -4,8 +4,8 @@ Capture a versioned, schema-stable snapshot of the trial environment so
 that cross-environment comparison becomes a `jq` diff instead of a
 multi-day investigation.
 
-For a Buck2 customer handoff, including the required client/workload snapshot
-pair, see [Buck2 Customer Instructions](buck2-env-probe-customer.md).
+For Buck2 workloads, including the required client/workload snapshot pair, see
+[Buck2 Env Probe](buck2-env-probe.md).
 
 The same code path is used three ways:
 

--- a/scripts/validate_buck_env_pair.py
+++ b/scripts/validate_buck_env_pair.py
@@ -30,7 +30,7 @@ def validate_pair(
     client: dict[str, object],
     workload: dict[str, object],
     *,
-    required_libraries: tuple[str, ...] = ("pytorch",),
+    required_libraries: tuple[str, ...] = (),
     allow_unisolated_action: bool = False,
 ) -> list[Finding]:
     """Return actionable errors/warnings for a Buck client/workload pair."""
@@ -58,9 +58,17 @@ def validate_pair(
         findings.append(Finding("ERROR", "Buck invocation fingerprint is missing"))
     library_entries = client.get("library_introspection")
     if not _nonempty(library_entries):
-        findings.append(Finding("ERROR", "no recognized libraries were found in the Buck graph"))
+        findings.append(Finding("WARNING", "no recognized libraries were found in the Buck graph"))
     entry_list = library_entries if isinstance(library_entries, list) else []
     library_names = {str(entry.get("name")) for entry in entry_list if isinstance(entry, dict)}
+    if "pytorch" not in library_names and "pytorch" not in required_libraries:
+        findings.append(
+            Finding(
+                "WARNING",
+                "PyTorch Buck identity is unavailable; retaining the snapshot "
+                "with that identity unknown",
+            )
+        )
     for library in required_libraries:
         if library not in library_names:
             findings.append(
@@ -76,16 +84,23 @@ def validate_pair(
         or _object(workload.get("hip")).get("version")
         or pytorch_build.get("hip_version")
     )
-    required_workload_fields = {
-        "python_version": workload.get("python_version"),
+    if not _nonempty(workload.get("python_version")):
+        findings.append(Finding("ERROR", "workload snapshot is missing python_version"))
+
+    workload_identity_fields = {
         "pytorch_version": workload.get("pytorch_version"),
         "pytorch_build.git_commit": pytorch_build.get("git_commit"),
         "ROCm/HIP identity": runtime_rocm,
         "gpu_arch.gfx_targets": _object(workload.get("gpu_arch")).get("gfx_targets"),
     }
-    for name, value in required_workload_fields.items():
+    for name, value in workload_identity_fields.items():
         if not _nonempty(value):
-            findings.append(Finding("ERROR", f"workload snapshot is missing {name}"))
+            findings.append(
+                Finding(
+                    "WARNING",
+                    f"workload snapshot is missing {name}; retaining it as unknown",
+                )
+            )
 
     probe_invocation = _object(workload.get("execution_context")).get("probe_invocation")
     if probe_invocation not in {"buck2_run", "buck2_action"}:
@@ -131,7 +146,8 @@ def main() -> int:
         action="append",
         default=None,
         help=(
-            "Buck library identity required in the client graph " "(repeatable; default: pytorch)"
+            "Buck library identity required in the client graph "
+            "(repeatable; default: none; missing requested identities are errors)"
         ),
     )
     parser.add_argument(
@@ -148,7 +164,7 @@ def main() -> int:
         findings = validate_pair(
             _load(args.client),
             _load(args.workload),
-            required_libraries=tuple(args.require_library or ("pytorch",)),
+            required_libraries=tuple(args.require_library or ()),
             allow_unisolated_action=args.allow_unisolated_action,
         )
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
@@ -159,7 +175,7 @@ def main() -> int:
         print(f"{finding.severity}: {finding.message}", file=sys.stderr)
     if any(finding.severity == "ERROR" for finding in findings):
         return 1
-    print("PASS: Buck dependency and workload runtime snapshots are usable")
+    print("PASS: snapshot structure and explicitly requested requirements are usable")
     return 0
 
 

--- a/tests/instrumentation/test_validate_buck_env_pair.py
+++ b/tests/instrumentation/test_validate_buck_env_pair.py
@@ -52,7 +52,7 @@ def test_valid_pair_has_no_errors():
     assert not [finding for finding in findings if finding.severity == "ERROR"]
 
 
-def test_missing_client_context_and_workload_torch_are_errors():
+def test_missing_client_context_is_error_and_workload_torch_is_warning():
     client = _valid_client()
     client["buck_invocation"] = {
         "status": "success",
@@ -62,14 +62,19 @@ def test_missing_client_context_and_workload_torch_are_errors():
     workload = _valid_workload()
     workload["pytorch_version"] = None
 
-    messages = [
+    error_messages = [
         finding.message
         for finding in validator.validate_pair(client, workload)
         if finding.severity == "ERROR"
     ]
-    assert any("context was not confirmed" in message for message in messages)
-    assert any("fingerprint is missing" in message for message in messages)
-    assert any("pytorch_version" in message for message in messages)
+    warning_messages = [
+        finding.message
+        for finding in validator.validate_pair(client, workload)
+        if finding.severity == "WARNING"
+    ]
+    assert any("context was not confirmed" in message for message in error_messages)
+    assert any("fingerprint is missing" in message for message in error_messages)
+    assert any("pytorch_version" in message for message in warning_messages)
 
 
 def test_partial_reasons_are_warnings_not_errors():
@@ -88,16 +93,67 @@ def test_pytorch_hip_version_is_valid_runtime_rocm_identity():
     assert not [finding for finding in findings if finding.severity == "ERROR"]
 
 
-def test_missing_required_library_is_an_error():
+def test_no_recognized_libraries_is_warning_not_error():
+    client = _valid_client()
+    client["library_introspection"] = []
+    findings = validator.validate_pair(client, _valid_workload())
+
+    assert not [finding for finding in findings if finding.severity == "ERROR"]
+    assert any(
+        "no recognized libraries" in finding.message
+        for finding in findings
+        if finding.severity == "WARNING"
+    )
+
+
+def test_missing_pytorch_buck_identity_is_warning_by_default():
     client = _valid_client()
     client["library_introspection"] = [{"name": "rccl"}]
+    findings = validator.validate_pair(client, _valid_workload())
+
+    assert not [finding for finding in findings if finding.severity == "ERROR"]
+    assert any(
+        "PyTorch Buck identity is unavailable" in finding.message
+        for finding in findings
+        if finding.severity == "WARNING"
+    )
+
+
+def test_missing_explicitly_required_library_is_an_error():
     messages = [
         finding.message
-        for finding in validator.validate_pair(client, _valid_workload())
+        for finding in validator.validate_pair(
+            _valid_client(),
+            _valid_workload(),
+            required_libraries=("rccl",),
+        )
         if finding.severity == "ERROR"
     ]
+    assert any("required Buck library identity is missing: rccl" in message for message in messages)
+
+
+def test_only_explicit_library_is_strict():
+    client = _valid_client()
+    client["library_introspection"] = [{"name": "rccl"}]
+    workload = _valid_workload()
+    workload["pytorch_version"] = None
+
+    findings = validator.validate_pair(
+        client,
+        workload,
+        required_libraries=("rccl",),
+    )
+
+    assert not [finding for finding in findings if finding.severity == "ERROR"]
     assert any(
-        "required Buck library identity is missing: pytorch" in message for message in messages
+        "PyTorch Buck identity is unavailable" in finding.message
+        for finding in findings
+        if finding.severity == "WARNING"
+    )
+    assert any(
+        "pytorch_version" in finding.message
+        for finding in findings
+        if finding.severity == "WARNING"
     )
 
 
@@ -123,6 +179,7 @@ def test_unisolated_action_requires_explicit_override():
 
 def test_main_writes_diagnostics_to_stderr_and_pass_to_stdout(tmp_path, monkeypatch, capsys):
     client = _valid_client()
+    client["library_introspection"] = [{"name": "rccl"}]
     client["partial_reasons"] = ["system_health: optional tool unavailable"]
     client_path = tmp_path / "client.json"
     workload_path = tmp_path / "workload.json"


### PR DESCRIPTION
## Summary
- make the env-probe workload integration guide audience-neutral and Buck2-specific
- explain how to expose AORTA in an existing Buck repository without replacing the application entrypoint
- separate local `buck2 run` capture from proven remote actions
- capture one uniquely named runtime snapshot per node and validate required library identities

## Test plan
- [x] exported README is byte-identical to `docs/buck2-env-probe.md`
- [x] no customer names, hostnames, internal paths, or private target labels
- [x] Markdown fence, link, and whitespace checks pass

## Context
Documentation follow-up to merged #306.