### PR TITLE
env probe: capture torchrec + recom-NaN GEMM/loader env vars (schema …

### DIFF
--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -244,7 +244,7 @@ when the output directory/file cannot be created or validated.
 
 | Top-level key | Type | Source | Notes |
 | --- | --- | --- | --- |
-| `schema_version` | `str` | constant | Currently `"1.13"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
+| `schema_version` | `str` | constant | Currently `"1.14"`. See the changelog comment in `src/aorta/instrumentation/environment.py` next to the `SCHEMA_VERSION` constant for the field-by-field history. |
 | `captured_at` | `str` | `datetime` | ISO-8601 UTC with trailing `Z` |
 | `partial` | `bool` | computed | `True` if any probe fell back |
 | `partial_reasons` | `list[str]` | per-probe | one human-readable line per fallback |
@@ -265,6 +265,7 @@ when the output directory/file cannot be created or validated.
 | `miopen_catalog` | `dict` | reuses the `miopen` capture + a per-file enumeration of the MIOpen db dir (`share/miopen/db/`) | **Recipe book for MIOpen's convolution databases** -- same scoping as `tensile_catalog`. `doc` + `status`, the reused `package_version`/`lib_hash`/`kernel_db_revision` (no regression), `db_dir` + `db_dir_source` (`default` or `MIOPEN_SYSTEM_DB_PATH`), `env_overrides`, and a `menu`. `logic_file_count` counts the selectable DBs (`.kdb`/`.fdb.txt`/`.db.txt`/`.db`); `.ktn.model`/`.tn.model` heuristic models are catalog members but not logic. **`menu.files` is `null` by default (compact mode)** — same size rationale as `tensile_catalog`; use `aorta env probe --extended` to retain the per-file list. Added in schema 1.9 (issue #54 follow-up); compact default added in schema 1.10. |
 | `rocfft_catalog` | `dict` | optional `rocfft_kernel_cache.db` under `$ROCFFT_RTC_SYS_CACHE_PATH` or `/opt/rocm/lib/[rocfft/]` | Fingerprint of rocFFT's **optional** AOT kernel cache -- the READ-ONLY system cache, not the read-write runtime user cache. rocFFT usually compiles at runtime, so absence is normal: a *probed* "no cache" result is `status:"absent"` with **no** partial reason. (The default/backfill/disaster shape is `status:"partial"` with a "not captured" reason instead, so a snapshot that never probed is distinguishable from one that probed and found nothing.) `doc` + `status` (`ok`/`absent`/`partial`) + `env_overrides` (both `ROCFFT_RTC_SYS_CACHE_PATH` -- the override this catalog actually resolves against -- and `ROCFFT_RTC_CACHE_PATH`, recorded for visibility only since it names the mutable, workload-dependent user cache, not installed identity; both recorded even when no cache is found so a configured-but-empty override is visible) + `kernel_cache` (`present`, `path`, `source`, `size`, `sha256`, `reason`). Added in schema 1.9 (issue #54 follow-up). |
 | `triton` | `dict` | `import triton; triton.__version__` (+ commit parse) | `package_version`, `commit` (schema 1.8). ROCm Triton fork bakes the source commit into `__version__` (e.g. `3.5.1+rocm7.2.1.gita272dfa8` -> `commit: "a272dfa8"`); fb builds versioned `+fb` carry no SHA -> `commit: null`. |
+| `torchrec` | `dict` | `importlib.metadata.version("torchrec")` (+ commit parse from the version string) | `package_version`, `commit` (schema 1.14). TorchRec is the sharded-embedding / training-pipeline library layered on top of fbgemm and is the core library of the recom-repro workload; release wheels (e.g. `1.4.0`) carry no SHA so `commit` is usually `null`. Read from distribution metadata (NOT `import torchrec`, which would pull in torch/fbgemm and can touch CUDA on import). Absence is suppressed like `fbgemm_gpu`/`aiter`. |
 | `fbgemm` | `dict` | optional `import fbgemm_gpu` (+ commit parse) + parse of `torch.__config__.show()` for `-DUSE_FBGEMM*` defines | `package_version`, `commit` (schema 1.8 -- best-effort git SHA from a setuptools_scm `+g<sha>` local-version segment or a `git_version`/`__commit__` module attr; `null` when fbgemm_gpu is vendored-in-torch rather than separately installed, or carries no SHA), `pytorch_use_fbgemm`, `pytorch_use_fbgemm_genai`. The two booleans capture the build-time decision baked into the PyTorch wheel even when `fbgemm_gpu` isn't a separate pip package. |
 | `aiter` | `dict` | `import aiter; aiter.__version__` + `importlib.metadata.version("amd_aiter" \| "aiter")` + scan of `aiter_meta/hsa/<gfx>/` (or `$AORTA_PYTORCH_SRC/third_party/aiter/hsa/`) | `package_version`, `package_dist_name` (which PyPI dist matched: `amd_aiter` is the canonical AMD-internal ROCm/PyTorch image dist; `aiter` is the upstream name), `commit` (parsed from the setuptools_scm `+g<sha>` local-version segment, matches the image tag's `aiter-<sha>` label), `hsa_tree` (issue #176 -- per-arch fingerprint of pre-built `.co` kernel binaries: file_count, co_count, deterministic combined_sha256). Most installs record `null` for everything; absence is silent. |
 | `aotriton` | `dict` | scan of `<torch>/lib/libaotriton_v2.so*` filenames + `sha256` of the resolved file + presence of `<torch>/lib/aotriton.images/` + `$AOTRITON_INSTALLED_PREFIX` | Default ROCm Flash Attention backend. Bundled in the wheel via `cmake/External/aotriton.cmake` (NOT a `third_party/` git submodule). Fields: `bundled_present`, `bundled_version`, `bundled_lib_hash`, `bundled_images_dir_present`, `installed_prefix`. CK is the alternative backend (toggled via `TORCH_ROCM_FA_PREFER_CK=1`). |
@@ -463,7 +464,31 @@ Mirrors the in-code comment at `SCHEMA_VERSION` in
 `src/aorta/instrumentation/environment.py`. Recorded here so consumers
 tracking schema evolution don't have to read source.
 
-### `1.13` (current)
+### `1.14` (current)
+
+Recsys-stack package identity + recom-NaN environment knobs. Additive — one
+new top-level block plus new `env_vars` entries; older snapshots and direct
+constructors remain compatible.
+
+* New top-level **`torchrec`** block `{package_version, commit}`, defaulted so
+  older snapshots round-trip. TorchRec is the sharded-embedding / training-
+  pipeline library layered on the already-captured fbgemm and is the core
+  library of the MI350X recom-repro workload, so its version is load-bearing
+  for that escalation. Same shape and fail-soft contract as `triton`.
+* Expanded **`CANONICAL_ENV_VARS`** with the hipBLASLt / rocBLAS / Tensile GEMM
+  numeric + kernel-path knobs that flip *which* library, *which* kernels, and
+  (for xf32/TF32) the numeric path itself run the GEMMs:
+  `HIPBLASLT_OVERRIDE_COMPUTE_TYPE_XF32`, `ROCBLAS_USE_HIPBLASLT`,
+  `HIPBLASLT_TENSILE_LIBPATH`, `ROCBLAS_TENSILE_LIBPATH`,
+  `HIPBLASLT_USE_ROCROLLER` (+ `HIPBLASLT_ROCROLLER_NO_CUSTOM_KERNEL`),
+  `HIPBLASLT_TUNING_OVERRIDE_FILE`, `ROCBLAS_DEFAULT_ATOMICS_MODE`,
+  `ROCBLAS_INTERNAL_FP16_ALT_IMPL` (+ `_RNZ`), `ROCBLAS_STREAM_ORDER_ALLOC`,
+  and `TENSILE_SOLUTION_INDEX`; plus `HSA_TOOLS_DISABLE_REGISTER` and
+  `LD_LIBRARY_PATH` (which `.so` actually loads). Logging-only knobs
+  (`HIPBLASLT_LOG_*`, `ROCBLAS_LAYER`, `TENSILE_DB`, `*_CHECK_NUMERICS`) were
+  deliberately excluded — they don't change the computed result.
+
+### `1.13`
 
 Buck configured-graph invocation provenance. Additive — one new top-level
 block, defaulted so older snapshots and direct constructors remain compatible.

--- a/src/aorta/instrumentation/environment.py
+++ b/src/aorta/instrumentation/environment.py
@@ -85,7 +85,22 @@ from aorta.instrumentation.buck_invocation import BuckInvocationContext
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = "1.13"
+SCHEMA_VERSION = "1.14"
+# 1.13 -> 1.14 (recsys-stack package identity + recom-NaN env vars):
+#   - New top-level ``torchrec`` block ``{package_version, commit}``, always
+#     present and defaulted so older snapshots / direct constructors remain
+#     compatible. TorchRec is the core library of the MI350X recom-repro
+#     workload (layered on the already-captured fbgemm); its version is
+#     load-bearing for that escalation. Populated by ``_capture_torchrec()``.
+#   - Expanded ``CANONICAL_ENV_VARS`` with the hipBLASLt/rocBLAS/Tensile GEMM
+#     numeric + kernel-path knobs that flip which library / kernels / numeric
+#     path actually run (HIPBLASLT_OVERRIDE_COMPUTE_TYPE_XF32, ROCBLAS_USE_
+#     HIPBLASLT, {HIPBLASLT,ROCBLAS}_TENSILE_LIBPATH, HIPBLASLT_USE_ROCROLLER
+#     [+NO_CUSTOM_KERNEL], HIPBLASLT_TUNING_OVERRIDE_FILE, ROCBLAS_DEFAULT_
+#     ATOMICS_MODE, ROCBLAS_INTERNAL_FP16_ALT_IMPL[_RNZ], ROCBLAS_STREAM_
+#     ORDER_ALLOC, TENSILE_SOLUTION_INDEX), plus HSA_TOOLS_DISABLE_REGISTER
+#     and LD_LIBRARY_PATH (which .so actually loads). env_vars is an existing
+#     dict field, so these are additive to its contents, not a new key.
 # 1.12 -> 1.13 (Buck invocation-context provenance):
 #   - New top-level ``buck_invocation`` block, always present and defaulted
 #     via ``_empty_buck_invocation()``. It distinguishes ``not_requested``,
@@ -480,6 +495,7 @@ CANONICAL_ENV_VARS: tuple[str, ...] = (
     "HSA_KERNARG_POOL_SIZE",
     "HSA_NO_SCRATCH_RECLAIM",
     "HSA_OVERRIDE_GFX_VERSION",  # forces a different gfx target than the silicon
+    "HSA_TOOLS_DISABLE_REGISTER",  # disables HSA tool (profiler/sanitizer) registration
     # GPU queue / codegen / build target
     "GPU_MAX_HW_QUEUES",
     "AMDGCN_USE_BUFFER_OPS",
@@ -551,6 +567,31 @@ CANONICAL_ENV_VARS: tuple[str, ...] = (
     # PyTorch / inductor
     "TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE",
     "PYTORCH_CUDA_ALLOC_CONF",
+    # Dynamic loader -- which shared object actually loads. LD_LIBRARY_PATH
+    # can silently point hipBLASLt/rocBLAS/RCCL at a different .so than the
+    # installed one ("the version running wasn't the version we thought" --
+    # the failure this tool exists to catch). Verbose and not ROCm-specific,
+    # but load-bearing for a library-identity diff.
+    "LD_LIBRARY_PATH",
+    # hipBLASLt / rocBLAS / Tensile GEMM numeric + kernel-path selection.
+    # These flip WHICH library and WHICH kernels actually run the GEMMs, and
+    # in the xf32/TF32 case the numeric path itself -- the load-bearing knobs
+    # in the MI350X recom-repro NaN escalation. All verified present in the
+    # libhipblaslt.so / librocblas.so string tables. Logging-only knobs
+    # (HIPBLASLT_LOG_*, ROCBLAS_LAYER, TENSILE_DB, *_CHECK_NUMERICS) are
+    # deliberately excluded: they don't change the computed result.
+    "HIPBLASLT_OVERRIDE_COMPUTE_TYPE_XF32",  # forces xf32/TF32 emulation compute path
+    "HIPBLASLT_TENSILE_LIBPATH",  # overrides the Tensile kernel-DB dir (bypasses tensile_catalog)
+    "HIPBLASLT_USE_ROCROLLER",  # switches to the rocRoller kernel generator
+    "HIPBLASLT_ROCROLLER_NO_CUSTOM_KERNEL",  # rocRoller sub-knob (disables custom kernels)
+    "HIPBLASLT_TUNING_OVERRIDE_FILE",  # native pin (distinct from TORCH_HIPBLASLT_TUNING_OVERRIDE_FILE)
+    "ROCBLAS_USE_HIPBLASLT",  # routes rocBLAS GEMMs through hipBLASLt vs Tensile
+    "ROCBLAS_TENSILE_LIBPATH",  # overrides rocBLAS's Tensile kernel-DB dir
+    "ROCBLAS_DEFAULT_ATOMICS_MODE",  # atomic reductions on/off -> numeric determinism
+    "ROCBLAS_INTERNAL_FP16_ALT_IMPL",  # alternate fp16 implementation
+    "ROCBLAS_INTERNAL_FP16_ALT_IMPL_RNZ",  # alternate fp16 impl, round-nearest-zero variant
+    "ROCBLAS_STREAM_ORDER_ALLOC",  # stream-ordered allocation (interacts w/ cross-stream reuse)
+    "TENSILE_SOLUTION_INDEX",  # pins a specific Tensile solution (forces a kernel)
 )
 
 # Filesystem locations -- collected here so tests can monkeypatch them.
@@ -1126,6 +1167,14 @@ class EnvSnapshot:
     # Linux may recycle namespace inode numbers after teardown. ``None`` when
     # all sources fail. Defaulted so pre-1.12 snapshots round-trip.
     probe_namespace: str | None = None
+    # torchrec: recsys-stack package identity (schema 1.14). TorchRec is the
+    # sharded-embedding / training-pipeline library that sits ON TOP of fbgemm
+    # (which we already capture) -- and it is the core library of the MI350X
+    # recom-repro workload, so its version is load-bearing for that escalation.
+    # Same shape as ``triton`` (``{package_version, commit}``). Defaulted so
+    # pre-1.14 snapshots round-trip via ``from_dict()`` and older direct
+    # constructors don't raise. Populated by ``_capture_torchrec()``.
+    torchrec: dict = field(default_factory=lambda: {"package_version": None, "commit": None})
 
     # Curated emit order for ``to_dict()`` / ``env.json`` (JSON is written
     # sort_keys=False, so THIS is the artifact's key order). Grouped so
@@ -1169,6 +1218,7 @@ class EnvSnapshot:
         "rccl",
         "triton",
         "fbgemm",
+        "torchrec",
         "aiter",
         "aotriton",
         # build system + buck introspection
@@ -1230,6 +1280,9 @@ class EnvSnapshot:
           Buck-vs-A1 merge").
         * ``buck_invocation`` -> ``status="not_requested"`` (added in
           schema 1.13; older producers did not record invocation context).
+        * ``torchrec`` -> ``{"package_version": None, "commit": None}``
+          (added in schema 1.14; older snapshots predate the recsys-stack
+          package block).
 
         Strictly-required older fields (the schema-1.0/1.1 set) are NOT
         defaulted -- a missing ``rocm`` or ``hipblaslt`` key still
@@ -1251,6 +1304,7 @@ class EnvSnapshot:
         kwargs.setdefault("container_detected", False)
         kwargs.setdefault("execution_context", _empty_execution_context())
         kwargs.setdefault("probe_namespace", None)
+        kwargs.setdefault("torchrec", {"package_version": None, "commit": None})
         return cls(**kwargs)
 
     def summary(self) -> str:
@@ -2147,6 +2201,7 @@ def collect_env(
         )
         triton = _capture_triton(reasons)
         fbgemm = _capture_fbgemm(reasons)
+        torchrec = _capture_torchrec(reasons)
         aiter = _capture_aiter(reasons)
         aotriton = _capture_aotriton(reasons)
         miopen = _capture_miopen(reasons)
@@ -2200,6 +2255,7 @@ def collect_env(
             rocfft_catalog=rocfft_catalog,
             triton=triton,
             fbgemm=fbgemm,
+            torchrec=torchrec,
             aiter=aiter,
             aotriton=aotriton,
             miopen=miopen,
@@ -2395,6 +2451,7 @@ def _disaster_snapshot(
             "pytorch_use_fbgemm": None,
             "pytorch_use_fbgemm_genai": None,
         },
+        torchrec={"package_version": None, "commit": None},
         aiter={
             "package_version": None,
             "package_dist_name": None,
@@ -5162,6 +5219,44 @@ def _capture_triton(reasons: list[str]) -> dict[str, str | None]:
         # (e.g. "3.5.1+rocm7.2.1.gita272dfa8"); fb builds (e.g. "3.5.0+fb")
         # carry none -> commit stays None.
         "commit": _capture_python_package_commit("triton", version),
+    }
+
+
+def _capture_torchrec(reasons: list[str]) -> dict[str, str | None]:
+    """Capture TorchRec package version (+ best-effort commit from version).
+
+    TorchRec is the sharded-embedding / training-pipeline library layered on
+    top of fbgemm (already captured separately) and is the core library of
+    the MI350X recom-repro workload, so pinning its version matters for that
+    escalation.
+
+    Deliberately reads the version from DISTRIBUTION METADATA
+    (``importlib.metadata.version``) rather than importing torchrec the way
+    ``_capture_triton`` imports triton: importing torchrec eagerly pulls in
+    torch + fbgemm and can touch CUDA on import, which would violate the
+    probe's "no GPU compute" guarantee. Metadata lookup reads
+    ``*.dist-info`` off disk with no import side effects.
+
+    Fail-soft like the other optional-package probes: a *missing* torchrec is
+    the documented common case (most non-recsys installs lack it), so it
+    records NO partial reason -- mirroring the ``suppress_missing`` contract
+    used for fbgemm_gpu / aiter. Only an unexpected metadata error records a
+    reason. Commit is parsed from the version string (pure string work, no
+    import); release wheels (e.g. ``"1.4.0"``) carry no SHA -> ``None``.
+    """
+    import importlib.metadata as importlib_metadata
+
+    try:
+        version = importlib_metadata.version("torchrec")
+    except importlib_metadata.PackageNotFoundError:
+        return {"package_version": None, "commit": None}
+    except Exception as exc:  # noqa: BLE001 -- never let env probe fail
+        log.debug("torchrec metadata lookup failed: %s", exc)
+        reasons.append(f"torchrec.package_version: metadata lookup raised ({type(exc).__name__})")
+        return {"package_version": None, "commit": None}
+    return {
+        "package_version": version,
+        "commit": _extract_commit_from_version(version),
     }
 
 

--- a/tests/instrumentation/test_environment.py
+++ b/tests/instrumentation/test_environment.py
@@ -280,6 +280,7 @@ REQUIRED_TOP_KEYS = {
     "rocfft_catalog",
     "triton",
     "fbgemm",
+    "torchrec",
     "aiter",
     "aotriton",
     "miopen",
@@ -429,6 +430,10 @@ def _example_snapshot(**overrides) -> object:
             "commit": None,
             "pytorch_use_fbgemm": True,
             "pytorch_use_fbgemm_genai": True,
+        },
+        "torchrec": {
+            "package_version": "1.4.0",
+            "commit": None,
         },
         "aiter": {
             "package_version": None,
@@ -3651,6 +3656,7 @@ class TestEnvVars:
             "HSA_KERNARG_POOL_SIZE",
             "HSA_NO_SCRATCH_RECLAIM",
             "HSA_OVERRIDE_GFX_VERSION",
+            "HSA_TOOLS_DISABLE_REGISTER",
             # GPU queue / codegen / build target
             "GPU_MAX_HW_QUEUES",
             "AMDGCN_USE_BUFFER_OPS",
@@ -3715,6 +3721,22 @@ class TestEnvVars:
             # PyTorch / inductor
             "TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE",
             "PYTORCH_CUDA_ALLOC_CONF",
+            # Dynamic loader
+            "LD_LIBRARY_PATH",
+            # hipBLASLt / rocBLAS / Tensile GEMM numeric + kernel-path selection
+            # (MI350X recom-repro NaN escalation). Logging-only knobs excluded.
+            "HIPBLASLT_OVERRIDE_COMPUTE_TYPE_XF32",
+            "HIPBLASLT_TENSILE_LIBPATH",
+            "HIPBLASLT_USE_ROCROLLER",
+            "HIPBLASLT_ROCROLLER_NO_CUSTOM_KERNEL",
+            "HIPBLASLT_TUNING_OVERRIDE_FILE",
+            "ROCBLAS_USE_HIPBLASLT",
+            "ROCBLAS_TENSILE_LIBPATH",
+            "ROCBLAS_DEFAULT_ATOMICS_MODE",
+            "ROCBLAS_INTERNAL_FP16_ALT_IMPL",
+            "ROCBLAS_INTERNAL_FP16_ALT_IMPL_RNZ",
+            "ROCBLAS_STREAM_ORDER_ALLOC",
+            "TENSILE_SOLUTION_INDEX",
         }
 
 
@@ -5097,6 +5119,57 @@ class TestTritonBlock:
             "commit": "a272dfa8",
         }
         assert reasons == []
+
+
+# ---------------------------------------------------------------------------
+# TorchRec package identity (schema 1.14)
+# ---------------------------------------------------------------------------
+
+
+class TestTorchrec:
+    def test_torchrec_absent_is_suppressed_no_reason(self, monkeypatch):
+        """A missing torchrec is the documented common case (non-recsys
+        installs lack it) -> no partial reason, mirroring fbgemm_gpu/aiter."""
+        import importlib.metadata as md
+
+        def fake_version(name):
+            raise md.PackageNotFoundError(name)
+
+        monkeypatch.setattr(md, "version", fake_version)
+        reasons: list[str] = []
+        block = env_mod._capture_torchrec(reasons)
+        assert block == {"package_version": None, "commit": None}
+        assert reasons == []
+
+    def test_torchrec_release_wheel_has_no_commit(self, monkeypatch):
+        import importlib.metadata as md
+
+        monkeypatch.setattr(md, "version", lambda name: "1.4.0")
+        reasons: list[str] = []
+        block = env_mod._capture_torchrec(reasons)
+        assert block == {"package_version": "1.4.0", "commit": None}
+        assert reasons == []
+
+    def test_torchrec_dev_build_extracts_commit(self, monkeypatch):
+        import importlib.metadata as md
+
+        monkeypatch.setattr(md, "version", lambda name: "1.5.0.dev0+g0123abc")
+        reasons: list[str] = []
+        block = env_mod._capture_torchrec(reasons)
+        assert block == {"package_version": "1.5.0.dev0+g0123abc", "commit": "0123abc"}
+        assert reasons == []
+
+    def test_torchrec_metadata_error_records_reason(self, monkeypatch):
+        import importlib.metadata as md
+
+        def boom(name):
+            raise RuntimeError("broken dist-info")
+
+        monkeypatch.setattr(md, "version", boom)
+        reasons: list[str] = []
+        block = env_mod._capture_torchrec(reasons)
+        assert block == {"package_version": None, "commit": None}
+        assert any("torchrec" in r for r in reasons)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…1.14)

Add a top-level `torchrec` block (`package_version`, `commit`) read via importlib.metadata so it does not import torchrec (which pulls in torch/fbgemm and calls torch.cuda.is_available on import, violating the probe's no-GPU-compute guard). TorchRec is the core library of the MI350X recom-repro workload; its version is load-bearing for that escalation.

Expand CANONICAL_ENV_VARS with the hipBLASLt/rocBLAS/Tensile GEMM numeric and kernel-path knobs that flip which library / kernels / numeric path actually run (HIPBLASLT_OVERRIDE_COMPUTE_TYPE_XF32, ROCBLAS_USE_HIPBLASLT, {HIPBLASLT,ROCBLAS}_TENSILE_LIBPATH, HIPBLASLT_USE_ROCROLLER [+NO_CUSTOM_KERNEL], HIPBLASLT_TUNING_OVERRIDE_FILE, ROCBLAS_DEFAULT_ATOMICS_MODE, ROCBLAS_INTERNAL_FP16_ALT_IMPL[_RNZ], ROCBLAS_STREAM_ORDER_ALLOC, TENSILE_SOLUTION_INDEX), plus HSA_TOOLS_DISABLE_REGISTER and LD_LIBRARY_PATH (which .so actually loads). All verified present in the libhipblaslt.so / librocblas.so string tables; logging-only knobs (LOG_*, ROCBLAS_LAYER, TENSILE_DB, CHECK_NUMERICS) are excluded since they do not change the computed result.

Bumps SCHEMA_VERSION 1.13 -> 1.14 (additive, backward-compatible via from_dict) with in-code changelog and docs/env-probe.md updates. Adds TorchRec unit tests and updates the canonical env-var / schema guards.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
