### PR TITLE
ci(pages): serve nightly dashboard alongside the README landing page

### DIFF
--- a/.github/workflows/nightly-eval.yml
+++ b/.github/workflows/nightly-eval.yml
@@ -4,7 +4,8 @@ name: Nightly Evaluation
 # exact wheel and evaluate the workloads against committed expected-outcome
 # baselines, capturing perf metrics as trend data. Runs inside the pinned ROCm
 # docker image on the self-hosted MI350 runner; a separate ubuntu-latest job
-# stores history (ci-results branch) and deploys the GitHub Pages dashboard.
+# stores history on the ci-results branch. The dashboard is built + deployed to
+# GitHub Pages by pages.yml (triggered on this workflow's completion).
 #
 # Correctness fails the job on any failed/errored cell, a missing matrix, a
 # per-entry timeout, a blessed-baseline breach, or a run that did zero work.
@@ -36,37 +37,29 @@ jobs:
       do_alert: true
     secrets: inherit
 
-  # Store history + deploy the dashboard via the official Pages actions. A
-  # GITHUB_TOKEN push to a branch does NOT trigger a branch-sourced Pages build,
-  # so we keep history on a data branch (ci-results) and deploy the generated
-  # site through actions/deploy-pages (repo Pages source must be "GitHub Actions").
+  # Append today's results to the ci-results data branch. The dashboard itself is
+  # built + deployed to GitHub Pages by the separate pages.yml workflow (a repo
+  # has a single Pages site, shared with the project landing page), which triggers
+  # on this workflow's completion and reads the history from ci-results.
   publish:
-    name: publish dashboard
+    name: publish results history
     needs: nightly-eval
-    # Run even when the eval failed (to publish the failure), but NOT when it was
+    # Run even when the eval failed (to record the failure), but NOT when it was
     # skipped (upstream "Nightly wheels" failed/cancelled) -- there'd be no
     # results artifact and publish would fail misleadingly.
     if: always() && needs.nightly-eval.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
       contents: write   # push results history to the ci-results branch
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v5
-
       - name: Download results
         uses: actions/download-artifact@v6
         with:
           name: nightly-results-${{ github.run_id }}
           path: incoming
 
-      - name: Update history + build site
+      - name: Update history branch (ci-results)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -77,8 +70,8 @@ jobs:
           tmp="$(mktemp -d)"
           # Fail closed: distinguish a genuinely-absent ci-results branch (create
           # the orphan) from a transport/auth failure (must NOT be treated as
-          # "branch absent" -- that would truncate history to one day and still
-          # deploy). git ls-remote --exit-code: 0=present, 2=absent, else=error.
+          # "branch absent" -- that would truncate history to one day). git
+          # ls-remote --exit-code: 0=present, 2=absent, else=error.
           set +e
           git ls-remote --exit-code --heads "$repo_url" ci-results >/dev/null 2>&1
           lsr=$?
@@ -105,17 +98,3 @@ jobs:
             else
               echo "no changes to commit"
             fi )
-          mkdir -p site
-          python3 scripts/ci/gen_dashboard.py --results-dir "$tmp/results" --out-dir site --max-builds 180
-          touch site/.nojekyll
-
-      - name: Upload Pages artifact
-        if: hashFiles('site/index.html') != ''
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: site
-
-      - name: Deploy to GitHub Pages
-        id: deploy
-        if: hashFiles('site/index.html') != ''
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,8 +34,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
+      # Always deploy the landing page + dashboard generator from main, even for a
+      # manual workflow_dispatch off another ref, so Pages content is deterministic.
       - name: Check out main
         uses: actions/checkout@v5
+        with:
+          ref: main
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
@@ -50,24 +54,36 @@ jobs:
           destination: ./_site
 
       # History lives on the ci-results data branch (written by nightly-eval's
-      # publish job). It may not exist until the first nightly runs.
-      - name: Check out results history (ci-results)
-        uses: actions/checkout@v5
-        with:
-          ref: ci-results
-          path: ci-results
-        continue-on-error: true
-
+      # publish job); it may not exist until the first nightly runs. Fail closed:
+      # a genuinely-absent branch (ls-remote exit 2) deploys the landing page
+      # only, but a transport/auth error must NOT be swallowed into "no dashboard"
+      # -- that would silently drop the dashboard while history exists.
       - name: Generate nightly dashboard at /ci/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if ls ci-results/results/*.json >/dev/null 2>&1; then
+          repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          set +e
+          git ls-remote --exit-code --heads "$repo_url" ci-results >/dev/null 2>&1
+          lsr=$?
+          set -e
+          if [ "$lsr" -eq 2 ]; then
+            echo "ci-results branch absent; deploying landing page only (dashboard appears after the first nightly)"
+            exit 0
+          elif [ "$lsr" -ne 0 ]; then
+            echo "::error::cannot reach ci-results (git ls-remote exit ${lsr}); failing closed"
+            exit 1
+          fi
+          tmp="$(mktemp -d)"
+          git clone --depth 1 --branch ci-results "$repo_url" "$tmp"
+          if ls "$tmp"/results/*.json >/dev/null 2>&1; then
             mkdir -p _site/ci
             python3 scripts/ci/gen_dashboard.py \
-              --results-dir ci-results/results --out-dir _site/ci --max-builds 180
-            echo "mounted dashboard at /ci/ ($(ls -1 ci-results/results/*.json | wc -l) build(s))"
+              --results-dir "$tmp/results" --out-dir _site/ci --max-builds 180
+            echo "mounted dashboard at /ci/ ($(ls -1 "$tmp"/results/*.json | wc -l) build(s))"
           else
-            echo "no nightly results yet; deploying landing page only (dashboard appears after the first nightly)"
+            echo "ci-results exists but has no results yet; deploying landing page only"
           fi
 
       - name: Upload Pages artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,80 @@
+name: Pages (landing + nightly dashboard)
+
+# Single owner of the GitHub Pages deployment (repo Pages source must be set to
+# "GitHub Actions"). A repo has exactly one Pages site, so this one build serves
+# BOTH the existing project landing page (Jekyll render of README.md at the site
+# root) AND the nightly CI dashboard mounted at /ci/. It runs on main pushes
+# (refresh the landing page), after each "Nightly Evaluation" completes (pick up
+# fresh history from the ci-results branch), and on demand.
+
+on:
+  push:
+    branches: [main]
+  workflow_run:
+    workflows: ["Nightly Evaluation"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never cancel an in-progress deploy; queue them so a landing-page push and a
+# nightly refresh don't race to publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-deploy:
+    name: build + deploy pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v5
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      # Renders README.md (+ any repo docs) to ./_site exactly like the previous
+      # legacy Pages build (same github-pages gem), so the landing page is
+      # preserved.
+      - name: Build landing page (Jekyll)
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+
+      # History lives on the ci-results data branch (written by nightly-eval's
+      # publish job). It may not exist until the first nightly runs.
+      - name: Check out results history (ci-results)
+        uses: actions/checkout@v5
+        with:
+          ref: ci-results
+          path: ci-results
+        continue-on-error: true
+
+      - name: Generate nightly dashboard at /ci/
+        run: |
+          set -euo pipefail
+          if ls ci-results/results/*.json >/dev/null 2>&1; then
+            mkdir -p _site/ci
+            python3 scripts/ci/gen_dashboard.py \
+              --results-dir ci-results/results --out-dir _site/ci --max-builds 180
+            echo "mounted dashboard at /ci/ ($(ls -1 ci-results/results/*.json | wc -l) build(s))"
+          else
+            echo "no nightly results yet; deploying landing page only (dashboard appears after the first nightly)"
+          fi
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -19,6 +19,7 @@ nightly evaluation, dashboard, alerting, baselines, and automated bumps.
 | Dashboard generator | `scripts/ci/gen_dashboard.py` |
 | Regression alerter | `scripts/ci/alert_issue.py` |
 | Nightly workflow | `.github/workflows/nightly-eval.yml` |
+| Pages build + deploy (landing + dashboard) | `.github/workflows/pages.yml` |
 | Baseline refresh workflow | `.github/workflows/refresh-baselines.yml` |
 | Lock refresh workflow | `.github/workflows/lock-requirements.yml` |
 | Automated bumps | `.github/dependabot.yml` |
@@ -44,12 +45,16 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
 4. **Alert** (`alert_issue.py`): opens/updates one `nightly-regression` issue on
    failure; comments + closes it when green.
 5. **Publish** (`publish` job on `ubuntu-latest`): appends
-   `results/<date>.json` to the **`ci-results`** data branch (history),
-   regenerates the self-contained dashboard (`gen_dashboard.py`), and deploys it
-   via `actions/upload-pages-artifact` + `actions/deploy-pages`. A GITHUB_TOKEN
-   push to a branch does not trigger a branch-sourced Pages build, so the branch
-   is data-only and the site is deployed through the Pages actions.
-   **Repo Pages source must be "GitHub Actions"** (Settings -> Pages).
+   `results/<date>.json` to the **`ci-results`** data branch (history only).
+6. **Deploy** (`pages.yml`): a repo has a single Pages site, shared with the
+   project landing page, so one workflow owns the deploy. On main pushes, after
+   each Nightly Evaluation completes, and on demand, `pages.yml` builds the
+   README landing page (Jekyll) into `_site/`, mounts the self-contained
+   dashboard (`gen_dashboard.py`, from the `ci-results` history) at **`_site/ci/`**,
+   and deploys the combined site via `actions/upload-pages-artifact` +
+   `actions/deploy-pages`. **Repo Pages source must be "GitHub Actions"**
+   (Settings -> Pages). Landing page: `https://rocm.github.io/aorta/`; nightly
+   dashboard: `https://rocm.github.io/aorta/ci/`.
 
 ## Correctness vs performance
 
@@ -105,8 +110,12 @@ the cap in `nightly-eval.yml` / the flag if a longer window is wanted.
 
 ## Operating checklist
 
-1. Enable GitHub Pages with **source = "GitHub Actions"** (Settings -> Pages) so
-   `deploy-pages` can serve the dashboard.
+1. Set GitHub Pages **source = "GitHub Actions"** (Settings -> Pages). This
+   switches the site from the legacy branch build to `pages.yml`, which serves
+   the README landing page **and** the dashboard at `/ci/` from one deploy. Run
+   the **Pages (landing + nightly dashboard)** workflow once to publish
+   immediately (the landing page is served even before any nightly results).
 2. First nightly runs **record-only**; then run **Refresh baselines** to bless.
+   The dashboard at `/aorta/ci/` appears after the first Nightly Evaluation.
 3. (Optional) Run **Lock requirements** to pin the CI dependency set.
 4. (Later) Enable perf gating via `refresh_baselines.py --perf-gate`.


### PR DESCRIPTION
## Summary
Follow-up to the nightly-eval harness (#303). Makes the CI dashboard actually deployable **without clobbering the existing project landing page**.

- The repo already serves its `README.md` as the GitHub Pages landing page (legacy build from `main`). A repo has **one** Pages deployment, so `nightly-eval.yml`'s `publish` job couldn't deploy the dashboard via `deploy-pages` without replacing that landing page.
- New **`pages.yml`** is the single owner of the Pages deploy: it builds the README landing page (Jekyll) into `_site/`, mounts the self-contained nightly dashboard at `_site/ci/` (from the `ci-results` history), and deploys the combined site. Triggers on `main` pushes, after each **Nightly Evaluation** completes, and on demand.
- **`nightly-eval.yml`**'s `publish` job is reduced to maintaining the `ci-results` history branch only.

Result: landing page at `https://rocm.github.io/aorta/`, nightly dashboard at `https://rocm.github.io/aorta/ci/`.

## Required manual step (after merge)
Set **Settings → Pages → Source = "GitHub Actions"** (currently "Deploy from a branch"). This switches from the legacy build to `pages.yml`. The landing page is preserved (same `github-pages` Jekyll gem); the dashboard appears at `/ci/` after the first Nightly Evaluation. Running the **Pages (landing + nightly dashboard)** workflow once publishes the landing page immediately.

## Test plan
- [ ] Merge, then flip Pages source to "GitHub Actions".
- [ ] Dispatch **Pages (landing + nightly dashboard)** → landing page still renders at `/aorta/`.
- [ ] Dispatch **Nightly Evaluation** → `ci-results` branch gets `results/<date>.json`; `pages.yml` re-runs on completion; dashboard renders at `/aorta/ci/`.

Made with [Cursor](https://cursor.com)