### PR TITLE
feat(tools): add aorta.tools plugin surface + rocjitsu_sanitizers guardrail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ overlap_debug*/
 *.logs
 # Exception: example sidecar files that ship with the repo
 !examples/*.json
+!**/examples/*.json
 *_merged_enhanced.json
 nccl_thread_sweep_*.log
 nccl_thread_sweep_summary_*.txt

--- a/docs/tools_rocjitsu_sanitizers.md
+++ b/docs/tools_rocjitsu_sanitizers.md
@@ -1,0 +1,111 @@
+# `rocjitsu_sanitizers` tool
+
+A built-in `aorta.tools` plugin that runs the two rocjitsu sanitizers over the
+**top kernels a workload launches** and folds the findings into one
+`pass` / `warn` / `fail` guardrail verdict:
+
+- **waitcheck** (static) — `rj_waitcheck` inspects a *saved* code object
+  (`.hsaco`, HIP fat binary, executable, shared lib, directory corpus) and
+  reports missing AMDGPU waits. No GPU required.
+- **ConSan** (dynamic) — the combined HSA-tools hook
+  (`librocjitsu_dbi_hooks.so`, loaded via `HSA_TOOLS_LIB`) instruments the code
+  object during a real run and reports races. Needs hardware or the RocJITsu
+  simulator.
+
+Reconciled against `rocm-systems/emulation/rocjitsu/docs/sanitizers.md` (branch
+`shared/rocjitsu/sanitizers`).
+
+## The rocjitsu build (not vendored)
+
+The tool locates the two artifacts at runtime; it never builds or ships them:
+
+| Env var | Points at |
+|---|---|
+| `ROCJITSU_BUILD` | a rocjitsu build dir (resolves both artifacts) |
+| `RJ_WAITCHECK_BIN` | just `rj_waitcheck` |
+| `ROCJITSU_SANITIZER_HOOK` | just `librocjitsu_dbi_hooks.so` |
+
+Build only the two targets (not the whole repo):
+
+```sh
+cmake -S emulation/rocjitsu -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target rocjitsu_dbi_hooks rj_waitcheck
+export ROCJITSU_BUILD="$PWD/build"
+```
+
+When the artifacts are absent, every check records `skipped` and the verdict is
+`not_checked` — so the tool is safe to discover/import on any machine.
+
+## Target support (from the doc's table)
+
+| Target | waitcheck | ConSan |
+|---|---|---|
+| `gfx942`, `gfx950` (MI350X/MI355X), `gfx1100`, `gfx1201`, `gfx1250` | full | full |
+| `gfx1150`, `gfx1151`, `gfx1200` | full | unsupported (waitcheck-only) |
+
+ConSan on `gfx950` needs real hardware (no gfx950 simulator). The per-conflict
+diagnostic lines that make a race **fail** the gate are only emitted when
+`RJ_CONSAN_LOG=1` — pass `consan_log` when you want races caught.
+
+## Bring your own kernels
+
+The tool consumes a **kernel worklist** (`rocjitsu_sanitizers.kernels/1`). Any
+workload can produce one; two built-in producers are provided:
+
+- a **Magpie** `benchmark_report.json` (`kernel_summary` / `top_bottlenecks`), and
+- a **hipBLASLt GEMM dispatch CSV** (ranked by launch count).
+
+Or hand it a pre-built worklist JSON directly (`kernels=...`), so a workload in
+any package can feed its own top kernels in.
+
+## CLI
+
+```sh
+# discover tools
+aorta tools list
+
+# static waitcheck over saved code objects (no GPU)
+aorta tools run rocjitsu_sanitizers \
+    --input gemm_csv=gemm_shapes.csv --input isa_dir=./kernel_isa \
+    --input target=gfx950 --input checks=waitcheck \
+    --output-dir ./san-out
+
+# dynamic ConSan around a real app (on gfx950 hardware)
+aorta tools run rocjitsu_sanitizers \
+    --input kernels=kernels.json --input target=gfx950 \
+    --input checks=consan --input consan_command="python my_repro.py" \
+    --input consan_log=1 --output-dir ./san-out
+```
+
+## Python
+
+```python
+from pathlib import Path
+from aorta.tools import get_tool
+
+tool = get_tool("rocjitsu_sanitizers")()
+result = tool.invoke(
+    inputs={
+        "gemm_csv": Path("gemm_shapes.csv"),
+        "isa_dir": Path("./kernel_isa"),
+        "target": "gfx950",
+        "checks": ["waitcheck", "consan"],
+        "consan_command": "python my_repro.py",
+        "consan_log": True,
+    },
+    output_dir=Path("./san-out"),
+)
+print(result["overall_verdict"])   # pass | warn | fail | not_checked
+```
+
+## Verdicts
+
+| Verdict | Meaning | Exit code (`aorta tools run`) |
+|---|---|---|
+| `pass` | check ran, no findings | 0 |
+| `warn` | waitcheck found advisory missing-wait(s) | 0 |
+| `fail` | ConSan found a race/hazard | 1 |
+| `not_checked` | no check ran (all skipped) | 0 |
+
+A **skip is not a pass**: each skipped check records a `reason` and its
+`support` block.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,12 @@ race = "aorta.run.validation:PROCESS_REQUIRED_POLICY"
 [project.entry-points."aorta.workload_startup_env"]
 race = "aorta.run.validation:race_startup_env"
 
+# Analysis tools register here via the aorta.tools entry-point group (see
+# aorta.tools.Tool). Built-in tools live in aorta.tools.*; private tools
+# register the same group from a downstream package's pyproject.toml.
+[project.entry-points."aorta.tools"]
+rocjitsu_sanitizers = "aorta.tools.rocjitsu_sanitizers:RocjitsuSanitizersTool"
+
 [project.optional-dependencies]
 # For analysis/visualization scripts
 analysis = [

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -2,7 +2,19 @@
 
 import click
 
-from aorta.cli import agent, bench, bundle, env, environments, mitigations, probe, run, sweep, triage
+from aorta.cli import (
+    agent,
+    bench,
+    bundle,
+    env,
+    environments,
+    mitigations,
+    probe,
+    run,
+    sweep,
+    tools,
+    triage,
+)
 
 
 @click.group()
@@ -18,6 +30,7 @@ main.add_command(env.env)
 main.add_command(environments.environments)
 main.add_command(mitigations.mitigations)
 main.add_command(sweep.sweep)
+main.add_command(tools.tools)
 # Deprecated aliases (issue #248): keep working, delegate to the same engine.
 main.add_command(probe.probe)
 main.add_command(run.run)

--- a/src/aorta/cli/tools.py
+++ b/src/aorta/cli/tools.py
@@ -1,0 +1,69 @@
+"""`aorta tools` -- discover and invoke registered analysis tools.
+
+Tools register under the ``aorta.tools`` entry-point group (built-ins in
+``aorta.tools.*``; private tools from downstream packages). ``aorta tools
+list`` shows the merged registry; ``aorta tools run`` invokes one over
+key=value inputs and prints its verdict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from aorta.tools import get_tool, load_tools
+
+
+@click.group()
+def tools() -> None:
+    """Discover and invoke AORTA analysis tools (emulators, sanitizers, ...)."""
+
+
+@tools.command(name="list")
+def list_() -> None:
+    """List every registered tool and its source package."""
+    registry = load_tools()
+    if not registry:
+        click.echo("no tools registered under the 'aorta.tools' entry-point group")
+        return
+    name_w = max(len("NAME"), *(len(n) for n in registry))
+    click.echo(f"{'NAME'.ljust(name_w)}  CLASS")
+    for name in sorted(registry):
+        cls = registry[name]
+        click.echo(f"{name.ljust(name_w)}  {cls.__module__}.{cls.__qualname__}")
+
+
+@tools.command()
+@click.argument("name")
+@click.option("--input", "inputs", metavar="KEY=VALUE", multiple=True,
+              help="Tool input (repeatable). Comma-joined values become a list "
+                   "(e.g. --input checks=waitcheck,consan).")
+@click.option("--output-dir", type=click.Path(file_okay=False, path_type=Path),
+              default=None, help="Directory to write the tool's report into.")
+def run(name: str, inputs: tuple[str, ...], output_dir: Path | None) -> None:
+    """Invoke tool NAME over the given --input KEY=VALUE pairs."""
+    tool = get_tool(name)()
+    parsed = _parse_inputs(inputs)
+    result = tool.invoke(inputs=parsed, output_dir=output_dir)
+    verdict = result.get("overall_verdict")
+    if verdict is not None:
+        click.echo(f"overall_verdict: {verdict}")
+    else:
+        click.echo(json.dumps(result.get("report"), indent=2))
+    # Non-zero exit only on an explicit fail verdict (mirrors the runner).
+    if verdict == "fail":
+        raise SystemExit(1)
+
+
+def _parse_inputs(pairs: tuple[str, ...]) -> dict[str, Any]:
+    """Parse ``KEY=VALUE`` pairs; comma-joined values become a list."""
+    out: dict[str, Any] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise click.BadParameter(f"expected KEY=VALUE, got {pair!r}")
+        key, _, value = pair.partition("=")
+        out[key.strip()] = value.split(",") if "," in value else value
+    return out

--- a/src/aorta/tools/__init__.py
+++ b/src/aorta/tools/__init__.py
@@ -1,0 +1,100 @@
+"""AORTA tools: analysis utilities discovered via the ``aorta.tools`` group.
+
+A **tool** wraps a utility (emulator, profiler, validator, sanitizer) that
+consumes structured inputs (kernel shapes, an exported graph, a saved code
+object) and returns structured analysis output. A tool is:
+
+  * **not a workload** -- it does not reproduce a customer training loop on
+    real hardware and has no ``setup -> run -> cleanup`` trial lifecycle; and
+  * **not a mitigation** -- it ships no environment-variable bundle.
+
+Tools register one entry point each under the ``aorta.tools`` group (mirroring
+the ``aorta.workloads`` / ``aorta.mitigations`` extension points). Public
+tools live in ``aorta.tools.*``; private tools register the same way from a
+downstream package's ``pyproject.toml``. ``load_tools()`` returns the merged
+registry keyed by name, each entry tagged with its ``source_package`` so
+collisions can name both sides.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from aorta.registry.errors import RegistryCollisionError, RegistryError
+
+_GROUP = "aorta.tools"
+
+
+@runtime_checkable
+class Tool(Protocol):
+    """The shape every ``aorta.tools`` plugin implements.
+
+    Implementations expose a ``name`` (matching their entry-point key) and a
+    single ``invoke()`` that runs the tool once over ``inputs`` and returns a
+    result dict. ``inputs`` is tool-specific; ``invoke`` should return at least
+    a ``report`` (structured result, or ``None`` when nothing was produced) and
+    an ``overall_verdict`` when the tool is a guardrail. Other keys are
+    tool-specific.
+    """
+
+    name: str
+
+    def invoke(
+        self, *, inputs: dict[str, Any], output_dir: Path | None = None
+    ) -> dict[str, Any]:
+        """Run the tool once over ``inputs`` and return a result dict."""
+        ...
+
+
+def load_tools() -> dict[str, type[Tool]]:
+    """Discover and merge all tools registered under ``aorta.tools``.
+
+    Returns a dict of ``name -> Tool class``. No caching -- re-reads
+    entry-points each call (cheap; mirrors ``load_mitigations``).
+
+    Raises:
+        RegistryError: a plugin entry point did not resolve to a ``Tool``.
+        RegistryCollisionError: two packages registered the same tool name.
+    """
+    registry: dict[str, type[Tool]] = {}
+    source: dict[str, str] = {}
+    for ep in entry_points(group=_GROUP):
+        obj = ep.load()
+        plugin_name = ep.dist.name if ep.dist is not None else "unknown"
+        if not (isinstance(obj, type) and _looks_like_tool(obj)):
+            raise RegistryError(
+                f"plugin '{plugin_name}' tool '{ep.name}' must resolve to a Tool "
+                f"class (with a 'name' attribute and an 'invoke' method); got "
+                f"{type(obj).__name__}"
+            )
+        if ep.name in registry:
+            raise RegistryCollisionError(
+                f"tool '{ep.name}' registered by both '{source[ep.name]}' and "
+                f"'{plugin_name}' -- rename one or remove the duplicate"
+            )
+        registry[ep.name] = obj
+        source[ep.name] = plugin_name
+    return registry
+
+
+def get_tool(name: str) -> type[Tool]:
+    """Return the ``Tool`` class registered under ``name``.
+
+    Raises ``RegistryError`` if the name is unknown.
+    """
+    registry = load_tools()
+    if name not in registry:
+        raise RegistryError(
+            f"unknown tool '{name}'; available: {sorted(registry)}; if you "
+            f"expected a plugin-contributed tool, ensure the plugin is installed"
+        )
+    return registry[name]
+
+
+def _looks_like_tool(obj: type) -> bool:
+    return hasattr(obj, "name") and callable(getattr(obj, "invoke", None))
+
+
+__all__ = ["Tool", "load_tools", "get_tool"]

--- a/src/aorta/tools/rocjitsu_sanitizers/__init__.py
+++ b/src/aorta/tools/rocjitsu_sanitizers/__init__.py
@@ -1,0 +1,5 @@
+"""rocjitsu waitcheck (static) + ConSan (dynamic) kernel guardrail tool."""
+
+from aorta.tools.rocjitsu_sanitizers.tool import RocjitsuSanitizersTool
+
+__all__ = ["RocjitsuSanitizersTool"]

--- a/src/aorta/tools/rocjitsu_sanitizers/backends.py
+++ b/src/aorta/tools/rocjitsu_sanitizers/backends.py
@@ -1,0 +1,331 @@
+"""rocjitsu sanitizer backends: waitcheck (static) + ConSan (dynamic).
+
+This is the ONE place that encodes how we invoke the rocjitsu sanitizers
+and how we read their output. It is reconciled against
+``rocm-systems/emulation/rocjitsu/docs/sanitizers.md`` (branch
+``shared/rocjitsu/sanitizers``). If that doc changes, update only this
+module -- everything else consumes the normalised structures here.
+
+How the two checks actually ship (per the doc):
+
+  * **waitcheck** -- STATIC. The standalone ``rj_waitcheck`` tool inspects a
+    saved code object (``.hsaco``, HIP fat binary, executable, shared lib,
+    or a directory corpus) WITHOUT running it, and reports missing AMDGPU
+    waits. Diagnostics are non-fatal and print with a
+    ``rocjitsu-waitcheck:`` prefix. Needs no GPU.
+
+  * **ConSan** -- DYNAMIC. There is no separate ``consan`` binary. ConSan
+    is the second stage of the combined HSA-tools hook
+    (``librocjitsu_dbi_hooks.so``): you load it via ``HSA_TOOLS_LIB`` and
+    run the real application (on hardware, or a native ISA in the RocJITsu
+    simulator). The hook runs an exhaustive load-time waitcheck first, then
+    instruments the code object for ConSan. Diagnostics print with a
+    ``[rocjitsu-dbi-hooks] ConSan`` prefix.
+
+Target support (verbatim from the doc's table; ``support()`` below):
+``gfx950`` (MI350X/MI355X) and ``gfx1100`` are **waitcheck: Yes, ConSan:
+Yes** -- full supported-form coverage, as of the ``shared/rocjitsu/sanitizers``
+update that graduated them from Partial/dash to full. There is no gfx950
+simulator, so a dynamic ConSan run on that target needs real hardware.
+Neither tool translates between ISAs; support is for native code objects only.
+
+Nothing here assumes a GPU: argv/env builders are pure; the orchestrator
+decides whether a check can actually execute.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from typing import Any
+
+# --- binary / artifact resolution ----------------------------------------
+# The build produces two artifacts (see the doc's Build section):
+#   build/tools/rj_waitcheck                                  (static tool)
+#   build/lib/rocjitsu/src/rocjitsu/hooks/librocjitsu_dbi_hooks.so  (hook)
+# We resolve them from an explicit override, then $ROCJITSU_BUILD, then PATH.
+ENV_ROCJITSU_BUILD = "ROCJITSU_BUILD"
+ENV_WAITCHECK_BIN = "RJ_WAITCHECK_BIN"
+ENV_SANITIZER_HOOK = "ROCJITSU_SANITIZER_HOOK"
+DEFAULT_WAITCHECK_BIN = "rj_waitcheck"
+_WAITCHECK_RELPATH = "tools/rj_waitcheck"
+_HOOK_RELPATH = "lib/rocjitsu/src/rocjitsu/hooks/librocjitsu_dbi_hooks.so"
+
+# ConSan analysis engines (RJ_CONSAN_MODE); record/replay is the default.
+CONSAN_MODES = frozenset({"record-replay", "inline-shadow", "sampled", "supercollider"})
+
+
+def resolve_waitcheck() -> str | None:
+    """Absolute path to ``rj_waitcheck``, or ``None`` if not locatable."""
+    override = os.environ.get(ENV_WAITCHECK_BIN)
+    if override:
+        return override if os.path.isabs(override) else (shutil.which(override) or override)
+    build = os.environ.get(ENV_ROCJITSU_BUILD)
+    if build:
+        candidate = os.path.join(build, _WAITCHECK_RELPATH)
+        if os.path.isfile(candidate):
+            return candidate
+    return shutil.which(DEFAULT_WAITCHECK_BIN)
+
+
+def resolve_hook() -> str | None:
+    """Absolute path to the combined DBI hook ``.so``, or ``None``."""
+    override = os.environ.get(ENV_SANITIZER_HOOK)
+    if override:
+        return override
+    build = os.environ.get(ENV_ROCJITSU_BUILD)
+    if build:
+        candidate = os.path.join(build, _HOOK_RELPATH)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+# --- support / validation policy -----------------------------------------
+# Verbatim from the doc's target-support table. "Yes" == supported-form
+# coverage (not every ISA memory op); "Partial" == native instrumentation
+# for a subset of ConSan forms; a dash == waitcheck-only target (ConSan
+# leaves the object uninstrumented).
+_WAITCHECK_TARGETS = frozenset({
+    "gfx942", "gfx950", "gfx1100", "gfx1150", "gfx1151", "gfx1200", "gfx1201", "gfx1250",
+})
+# ConSan "Yes" targets per the doc's table. gfx950 (MI350X/MI355X) and gfx1100
+# graduated from Partial/dash to full on the shared/rocjitsu/sanitizers update.
+_CONSAN_FULL = frozenset({"gfx942", "gfx950", "gfx1100", "gfx1201", "gfx1250"})
+# No target is ConSan-"partial" in the current matrix; kept so re-adding one is
+# a one-line change and the "partial" level below stays a documented outcome.
+_CONSAN_PARTIAL: frozenset[str] = frozenset()
+
+
+def support(check: str, target: str) -> dict[str, Any]:
+    """Describe how well ``check`` is supported on ``target``.
+
+    Returns ``{level, runnable, requires, note}``:
+      * ``level``    -- ``full`` / ``partial`` / ``unsupported`` / ``unknown``
+      * ``runnable`` -- whether we should attempt the check on this target
+                        (static waitcheck is always attemptable; ConSan is
+                        gated on the target being in the support table)
+      * ``requires`` -- ``none`` (static) or ``hardware-or-simulator``
+      * ``note``     -- caveat surfaced in the report
+    """
+    if check == "waitcheck":
+        if target in _WAITCHECK_TARGETS:
+            return _s("full", True, "none",
+                      "waitcheck supported (native code objects; supported-form "
+                      "coverage, not every ISA memory op)")
+        return _s("unknown", True, "none",
+                  f"{target} not in the rocjitsu support table; static waitcheck "
+                  "may still run on a native code object")
+    if check == "consan":
+        if target in _CONSAN_FULL:
+            return _s("full", True, "hardware-or-simulator",
+                      "ConSan supported-form coverage on this target")
+        if target in _CONSAN_PARTIAL:
+            return _s("partial", True, "hardware-or-simulator",
+                      f"{target} ConSan is PARTIAL: native instrumentation for "
+                      "a subset of ConSan forms only")
+        if target in _WAITCHECK_TARGETS:
+            return _s("unsupported", False, "hardware-or-simulator",
+                      f"{target} is a waitcheck-only target; ConSan leaves the "
+                      "code object uninstrumented")
+        return _s("unknown", False, "hardware-or-simulator",
+                  f"{target} not in the rocjitsu support table")
+    raise ValueError(f"unknown check {check!r}")
+
+
+def _s(level: str, runnable: bool, requires: str, note: str) -> dict[str, Any]:
+    return {"level": level, "runnable": runnable, "requires": requires, "note": note}
+
+
+# --- invocation builders --------------------------------------------------
+
+def waitcheck_argv(binary: str, artifact_path: str,
+                   extra_args: list[str] | None = None) -> list[str]:
+    """argv for a static ``rj_waitcheck`` run over one saved code object.
+
+    ``extra_args`` passes through target-selection / kernel-filtering /
+    corpus flags documented in the waitcheck guide without hard-coding them.
+    """
+    return [binary, *(extra_args or []), artifact_path]
+
+
+def consan_env(hook_path: str, *, base_env: dict[str, str] | None = None,
+               mode: str | None = None, policy: str | None = None,
+               log: bool = False) -> dict[str, str]:
+    """Environment for a dynamic ConSan run via the combined hook.
+
+    Mirrors the doc's "Run waitcheck and ConSan together" recipe:
+    ``HSA_TOOLS_DISABLE_REGISTER=1`` + ``HSA_TOOLS_LIB=<hook>``, plus the
+    optional ``RJ_CONSAN_*`` knobs. Do NOT also set ``ROCJITSU_WAITCHECK*``
+    -- the combined hook always runs an exhaustive load-time waitcheck.
+
+    Note: the per-conflict ConSan diagnostic lines the guardrail keys on are
+    only emitted when ``RJ_CONSAN_LOG=1`` (``log=True``); pass it when you want
+    a race to fail the gate rather than pass silently.
+    """
+    if mode is not None and mode not in CONSAN_MODES:
+        raise ValueError(f"invalid RJ_CONSAN_MODE {mode!r}; pick from {sorted(CONSAN_MODES)}")
+    env = dict(base_env or {})
+    env["HSA_TOOLS_DISABLE_REGISTER"] = "1"
+    env["HSA_TOOLS_LIB"] = hook_path
+    if mode is not None:
+        env["RJ_CONSAN_MODE"] = mode
+    if policy is not None:
+        env["RJ_CONSAN_POLICY"] = policy
+    if log:
+        env["RJ_CONSAN_LOG"] = "1"
+    return env
+
+
+def consan_argv(command: list[str], *, simulator: str | None = None,
+                config: str | None = None) -> list[str]:
+    """argv for the instrumented application ConSan wraps.
+
+    On real hardware this is just the application command. For a native-ISA
+    simulator run (e.g. gfx1250), route it through the RocJITsu binary:
+    ``rocjitsu --config <cfg>.json -- <app>``.
+    """
+    if simulator:
+        return [simulator, *(["--config", config] if config else []), "--", *command]
+    return list(command)
+
+
+# --- output parsers -------------------------------------------------------
+
+_WAITCHECK_PREFIX = "rocjitsu-waitcheck:"
+# A missing-wait diagnostic in either output shape:
+#   * combined hook (doc): "rocjitsu-waitcheck: .text+0x..: missing s_wait..."
+#   * standalone rj_waitcheck: "<obj>:gfx950[0]:.text+0x..: missing s_waitcnt lgkmcnt(0) ..."
+_WAITCHECK_MISS = re.compile(r"missing\s+s_wait|hazard", re.IGNORECASE)
+# Producer/consumer context lines (hook uses "consumer:", tool uses "  producer ..").
+_WAITCHECK_CTX = re.compile(r"^(producer|consumer)\b", re.IGNORECASE)
+_CONSAN_PREFIX = "[rocjitsu-dbi-hooks] ConSan"
+_KV_RE = re.compile(r"(\w+)=(\S+)")
+
+
+def parse_waitcheck(stdout: str) -> dict[str, Any]:
+    """Normalise ``rj_waitcheck`` output into ``{findings, counts}``.
+
+    Handles both output shapes -- the combined hook's ``rocjitsu-waitcheck:``
+    lines (doc) and the standalone ``rj_waitcheck`` tool's
+    ``<obj>:<target>[i]:.text+0x..: missing s_waitcnt ..`` lines -- by keying
+    on the ``missing s_wait`` / ``hazard`` text rather than a fixed prefix.
+    The following indented ``producer``/``consumer`` context lines are
+    attached to the finding. waitcheck diagnostics are non-fatal, so we
+    classify them as ``warning`` (advisory) severity.
+    """
+    findings: list[dict[str, Any]] = []
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if line.startswith(_WAITCHECK_PREFIX):
+            line = line[len(_WAITCHECK_PREFIX):].strip()
+        if _WAITCHECK_CTX.match(line):
+            if findings:
+                findings[-1].setdefault("context", []).append(line)
+            continue
+        if _WAITCHECK_MISS.search(line):
+            findings.append({"severity": "warning", "message": line})
+    return _summarise(findings)
+
+
+def parse_consan(output: str) -> dict[str, Any]:
+    """Normalise combined-hook ConSan output into ``{findings, counts, verdict}``.
+
+    Keys ONLY on real conflict markers, verified against live gfx950 output:
+      * a per-conflict ``... ConSan MOI auto replay diagnostic ...`` line
+        (the doc's race emission, with ``first_kind`` / ``second_kind``);
+      * an ``... auto replay ...`` summary line reporting ``conflict=true`` or
+        a nonzero ``diagnostics=N``.
+    Each becomes a ``race`` finding (-> fail). The ``analysis verdict`` line
+    is captured as completeness metadata. Crucially, the many benign
+    inventory / report / plan lines that merely contain the substring
+    ``diagnostics=N`` (capacity, not a finding) are NOT counted.
+    """
+    findings: list[dict[str, Any]] = []
+    verdict: dict[str, str] = {}
+    for raw in output.splitlines():
+        line = raw.strip()
+        if _CONSAN_PREFIX not in line:
+            continue
+        low = line.lower()
+        if "analysis verdict" in low:
+            verdict = dict(_KV_RE.findall(line))
+        elif "auto replay diagnostic" in low:
+            findings.append({"severity": "race", "message": line,
+                             **dict(_KV_RE.findall(line))})
+        elif "auto replay" in low:
+            kv = dict(_KV_RE.findall(line))
+            try:
+                ndiag = int(kv.get("diagnostics", "0"))
+            except ValueError:
+                ndiag = 0
+            if kv.get("conflict", "false").lower() == "true" or ndiag > 0:
+                findings.append({"severity": "race", "message": line, **kv})
+    summary = _summarise(findings)
+    summary["verdict"] = verdict
+    return summary
+
+
+def _summarise(findings: list[dict[str, Any]]) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    for finding in findings:
+        sev = finding.get("severity", "info")
+        counts[sev] = counts.get(sev, 0) + 1
+    return {"findings": findings, "counts": counts}
+
+
+def consan_effective(verdict: dict[str, str]) -> dict[str, Any]:
+    """Summarise what ConSan ACTUALLY achieved this run, straight from its
+    ``analysis verdict`` line -- as opposed to the static per-target
+    ``support()`` policy label. This is the underlying layer's own answer:
+    even where the static table is conservative, a given kernel's run may
+    still yield complete coverage. Returns ``{complete, analysis_complete,
+    dynamic_complete, unsupported, incomplete_code_objects, access, note}``;
+    ``complete`` is ``None`` when the hook emitted no verdict line.
+    """
+    if not verdict:
+        return {"complete": None,
+                "note": "no ConSan verdict line (hook produced no analysis)"}
+
+    def _b(key: str) -> bool:
+        return str(verdict.get(key, "")).lower() == "true"
+
+    def _i(key: str) -> int:
+        try:
+            return int(verdict.get(key, "0"))
+        except ValueError:
+            return 0
+
+    unsupported = (_i("replay_unsupported_access") + _i("replay_unsupported_atomics")
+                   + _i("replay_unsupported_fences"))
+    incomplete = _i("incomplete_code_objects")
+    complete = (_b("analysis_complete") and _b("dynamic_complete")
+                and incomplete == 0 and unsupported == 0)
+    return {
+        "complete": complete,
+        "analysis_complete": _b("analysis_complete"),
+        "dynamic_complete": _b("dynamic_complete"),
+        "unsupported": unsupported,
+        "incomplete_code_objects": incomplete,
+        "access": verdict.get("access"),
+        "note": ("ConSan achieved complete coverage on this run"
+                 if complete else
+                 "ConSan coverage was incomplete on this run "
+                 "(some forms unsupported on this target)"),
+    }
+
+
+# Guardrail policy layered on top of the tools' own (non-fatal) diagnostics:
+# a ConSan race fails the gate; an advisory missing-wait warns.
+FAIL_SEVERITIES = frozenset({"error", "hazard", "race", "violation"})
+WARN_SEVERITIES = frozenset({"warning"})
+
+
+def verdict_for_counts(counts: dict[str, int]) -> str:
+    """Reduce severity counts to ``pass`` / ``warn`` / ``fail``."""
+    if any(counts.get(s, 0) for s in FAIL_SEVERITIES):
+        return "fail"
+    if any(counts.get(s, 0) for s in WARN_SEVERITIES):
+        return "warn"
+    return "pass"

--- a/src/aorta/tools/rocjitsu_sanitizers/examples/example_kernels.json
+++ b/src/aorta/tools/rocjitsu_sanitizers/examples/example_kernels.json
@@ -1,0 +1,11 @@
+{
+  "schema": "rocjitsu_sanitizers.kernels/1",
+  "top_n": 3,
+  "sources": ["synthetic"],
+  "kernel_count": 3,
+  "kernels": [
+    {"source": "gemm_csv", "rank": 1, "name": "gemm_NT_M256_N256_K256", "top_solution_idx": 100001},
+    {"source": "gemm_csv", "rank": 2, "name": "gemm_NN_M512_N512_K128", "top_solution_idx": 100002},
+    {"source": "gemm_csv", "rank": 3, "name": "gemm_TN_M128_N1024_K256", "top_solution_idx": 100003}
+  ]
+}

--- a/src/aorta/tools/rocjitsu_sanitizers/examples/synthetic_gemm_shapes.csv
+++ b/src/aorta/tools/rocjitsu_sanitizers/examples/synthetic_gemm_shapes.csv
@@ -1,0 +1,4 @@
+rank,count,transA,transB,M,N,K,batch_count,compute_type,top_solution_idx
+1,1000,N,T,256,256,256,1,f32_r,100001
+2,900,N,N,512,512,128,1,f32_r,100002
+3,800,T,N,128,1024,256,1,f32_r,100003

--- a/src/aorta/tools/rocjitsu_sanitizers/runner.py
+++ b/src/aorta/tools/rocjitsu_sanitizers/runner.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Run the rocjitsu sanitizers (waitcheck + ConSan) over a kernel worklist.
+
+Orchestrates the tool end to end for an AMDGPU target:
+
+    top kernels ->  waitcheck  (static; rj_waitcheck on saved objects)  -\
+                                                                          >-- verdict
+                    ConSan     (dynamic; combined hook around a run)     -/
+
+The worklist comes from ``select.py`` (Magpie kernel summary + hipBLASLt GEMM
+CSV) or any producer that emits the ``rocjitsu_sanitizers.kernels/1`` schema.
+waitcheck runs ``rj_waitcheck`` per-kernel over ISA artifacts in ``--isa-dir``;
+ConSan loads the combined DBI hook (``librocjitsu_dbi_hooks.so``) via
+``HSA_TOOLS_LIB`` around a real application (``--consan-command``) on hardware
+or the RocJITsu simulator. Any check that cannot run (missing artifact,
+unsupported target, no command, ``--dry-run``) is recorded *skipped* with a
+reason -- a skip is "not checked", not "clean".
+
+Standalone usage::
+
+    python -m aorta.tools.rocjitsu_sanitizers.runner \
+        --gemm-csv gemm_shapes_unique.csv \
+        --isa-dir ./kernel_isa \
+        --target gfx950 \
+        --checks waitcheck,consan \
+        --consan-command "python my_repro.py" \
+        --output-dir ./sanitizer-out
+
+Exit code is non-zero only when a runnable check returns a ``fail`` verdict;
+``warn`` and all-skipped runs exit 0 (the JSON report has detail).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import backends
+from .select import select_kernels
+
+_ISA_SUFFIXES = (".s", ".isa", ".asm", ".hsaco", ".txt", ".co")
+_VERDICT_RANK = {"pass": 0, "warn": 1, "fail": 2}
+
+
+def _resolve_isa(kernel: dict[str, Any], isa_dir: Path | None) -> Path | None:
+    """Best-effort map a worklist kernel to an ISA artifact in ``isa_dir``.
+
+    Matches on the Tensile solution index (GEMM kernels) or a sanitised
+    substring of the kernel name. Returns ``None`` when nothing matches --
+    the caller records that as ``isa_not_found`` rather than guessing.
+    """
+    if isa_dir is None or not isa_dir.is_dir():
+        return None
+    candidates = [p for p in sorted(isa_dir.iterdir())
+                  if p.suffix.lower() in _ISA_SUFFIXES]
+    sol = kernel.get("top_solution_idx")
+    if sol is not None:
+        for path in candidates:
+            if str(sol) in path.stem:
+                return path
+    token = "".join(c for c in kernel.get("name", "") if c.isalnum()).lower()
+    for path in candidates:
+        stem = "".join(c for c in path.stem if c.isalnum()).lower()
+        if token and (token in stem or stem in token):
+            return path
+    return None
+
+
+def _exec(argv: list[str], timeout: int,
+          env: dict[str, str] | None = None) -> tuple[int | None, str, str]:
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, env=env)
+        return p.returncode, p.stdout, p.stderr
+    except subprocess.TimeoutExpired as e:
+        out = e.stdout if isinstance(e.stdout, str) else ""
+        err = (e.stderr if isinstance(e.stderr, str) else "") + "\n[TIMEOUT]"
+        return None, out, err
+
+
+def _skip(check: str, target: str, reason: str, **extra: Any) -> dict[str, Any]:
+    return {"check": check, "target": target, "status": "skipped",
+            "verdict": "skipped", "reason": reason,
+            "support": backends.support(check, target), **extra}
+
+
+def run_waitcheck(worklist: dict[str, Any], target: str, isa_dir: Path | None,
+                  *, dry_run: bool, timeout: int,
+                  extra_args: list[str] | None = None) -> dict[str, Any]:
+    """Static per-kernel ``rj_waitcheck`` pass; never needs a GPU."""
+    sup = backends.support("waitcheck", target)
+    binary = backends.resolve_waitcheck()
+    if binary is None:
+        return _skip("waitcheck", target,
+                     f"rj_waitcheck not found (set {backends.ENV_WAITCHECK_BIN} or "
+                     f"{backends.ENV_ROCJITSU_BUILD})")
+
+    per_kernel: list[dict[str, Any]] = []
+    worst = "pass"
+    for kernel in worklist["kernels"]:
+        isa = _resolve_isa(kernel, isa_dir)
+        if isa is None:
+            per_kernel.append({"kernel": kernel["name"], "status": "skipped",
+                               "reason": "isa_not_found"})
+            continue
+        if dry_run:
+            per_kernel.append({"kernel": kernel["name"], "status": "skipped",
+                               "reason": "dry_run", "isa": str(isa)})
+            continue
+        argv = backends.waitcheck_argv(binary, str(isa), extra_args)
+        rc, out, err = _exec(argv, timeout)
+        result = backends.parse_waitcheck(out + "\n" + err)
+        verdict = backends.verdict_for_counts(result["counts"])
+        worst = _worse(worst, verdict)
+        per_kernel.append({"kernel": kernel["name"], "status": "ran",
+                           "isa": str(isa), "returncode": rc,
+                           "verdict": verdict, "counts": result["counts"],
+                           "findings": result["findings"],
+                           "stderr_tail": err[-500:]})
+
+    ran = [k for k in per_kernel if k["status"] == "ran"]
+    return {"check": "waitcheck", "target": target, "mode": "static",
+            "status": "ran" if ran else "skipped",
+            "verdict": worst if ran else "skipped",
+            "support": sup, "kernels_checked": len(ran),
+            "kernels_total": len(per_kernel), "results": per_kernel}
+
+
+def run_consan(worklist: dict[str, Any], target: str, command: list[str] | None,
+               *, dry_run: bool, timeout: int, base_env: dict[str, str] | None = None,
+               mode: str | None = None, policy: str | None = None, log: bool = False,
+               simulator: str | None = None, config: str | None = None) -> dict[str, Any]:
+    """Dynamic ConSan pass via the combined hook; needs hardware or a simulator."""
+    sup = backends.support("consan", target)
+    total = worklist["kernel_count"]
+    if not sup["runnable"]:
+        return _skip("consan", target, sup["note"], kernels_total=total)
+    hook = backends.resolve_hook()
+    if hook is None:
+        return _skip("consan", target,
+                     f"DBI hook .so not found (set {backends.ENV_SANITIZER_HOOK} or "
+                     f"{backends.ENV_ROCJITSU_BUILD})", kernels_total=total)
+    if not command:
+        return _skip("consan", target,
+                     "no --consan-command given (ConSan wraps a real application run "
+                     "via HSA_TOOLS_LIB)", kernels_total=total)
+    if dry_run:
+        return _skip("consan", target, "dry_run", kernels_total=total, command=command)
+
+    env = backends.consan_env(hook, base_env=base_env, mode=mode, policy=policy, log=log)
+    argv = backends.consan_argv(command, simulator=simulator, config=config)
+    rc, out, err = _exec(argv, timeout, env=env)
+    result = backends.parse_consan(out + "\n" + err)
+    verdict = backends.verdict_for_counts(result["counts"])
+    return {"check": "consan", "target": target, "mode": "dynamic",
+            "status": "ran", "verdict": verdict, "support": sup,
+            "returncode": rc, "command": command, "hook": hook,
+            "consan_mode": mode or "record-replay", "policy": policy,
+            "kernels_total": total, "counts": result["counts"],
+            "consan_verdict": result.get("verdict", {}),
+            # Live coverage the hook actually achieved this run (not the static
+            # per-target policy label) -- this is "how the layer responded".
+            "consan_effective": backends.consan_effective(result.get("verdict", {})),
+            "findings": result["findings"], "stderr_tail": err[-500:]}
+
+
+def _worse(a: str, b: str) -> str:
+    return a if _VERDICT_RANK[a] >= _VERDICT_RANK[b] else b
+
+
+def run_sanitizers(*, worklist: dict[str, Any], target: str, checks: list[str],
+                   isa_dir: Path | None = None,
+                   consan_command: list[str] | None = None,
+                   dry_run: bool = False, timeout: int = 900,
+                   waitcheck_args: list[str] | None = None,
+                   base_env: dict[str, str] | None = None,
+                   consan_mode: str | None = None, consan_policy: str | None = None,
+                   consan_log: bool = False, simulator: str | None = None,
+                   simulator_config: str | None = None) -> dict[str, Any]:
+    """Run the requested checks and fold them into one guardrail report."""
+    check_reports: list[dict[str, Any]] = []
+    if "waitcheck" in checks:
+        check_reports.append(run_waitcheck(worklist, target, isa_dir,
+                                           dry_run=dry_run, timeout=timeout,
+                                           extra_args=waitcheck_args))
+    if "consan" in checks:
+        check_reports.append(run_consan(worklist, target, consan_command,
+                                        dry_run=dry_run, timeout=timeout,
+                                        base_env=base_env, mode=consan_mode,
+                                        policy=consan_policy, log=consan_log,
+                                        simulator=simulator, config=simulator_config))
+
+    ran = [c["verdict"] for c in check_reports if c["status"] == "ran"]
+    overall = "not_checked" if not ran else max(ran, key=lambda v: _VERDICT_RANK[v])
+    return {
+        "schema": "rocjitsu_sanitizers.report/1",
+        "target": target,
+        "checks_requested": checks,
+        "overall_verdict": overall,
+        "kernel_count": worklist["kernel_count"],
+        "kernel_sources": worklist["sources"],
+        "checks": check_reports,
+    }
+
+
+def _print_summary(report: dict[str, Any]) -> None:
+    print(f"target           : {report['target']}")
+    print(f"kernels          : {report['kernel_count']} "
+          f"from {', '.join(report['kernel_sources'])}")
+    for check in report["checks"]:
+        print(f"  {check['check']:<10} [{check.get('mode', '-')}]"
+              f" status={check['status']} verdict={check['verdict']}")
+        eff = check.get("consan_effective")
+        if check["status"] == "ran" and eff and eff.get("complete") is not None:
+            # A check that ACTUALLY ran: lead with the live rocjitsu verdict;
+            # the static per-target policy label is only a parenthetical.
+            print(f"      live (rocjitsu): analysis_complete={eff['analysis_complete']} "
+                  f"dynamic_complete={eff['dynamic_complete']} access={eff.get('access')} "
+                  f"unsupported={eff['unsupported']} -> "
+                  f"{'complete' if eff['complete'] else 'incomplete'} for this run "
+                  f"(target policy: {check['support']['level']})")
+        else:
+            print(f"      support: {check['support']['level']} -- {check['support']['note']}")
+        if check.get("reason"):
+            print(f"      skipped: {check['reason']}")
+    print(f"OVERALL VERDICT  : {report['overall_verdict'].upper()}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    import os
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kernels", type=Path, default=None,
+                        help="pre-built worklist JSON (rocjitsu_sanitizers.kernels/1)")
+    parser.add_argument("--magpie-report", type=Path, default=None)
+    parser.add_argument("--gemm-csv", type=Path, default=None)
+    parser.add_argument("--top-n", type=int, default=20)
+    parser.add_argument("--isa-dir", type=Path, default=None,
+                        help="directory of kernel ISA / .s / .hsaco / .co artifacts")
+    parser.add_argument("--target", default="gfx950",
+                        help="GPU target (gfx950 = MI350X/MI355X)")
+    parser.add_argument("--checks", default="waitcheck,consan",
+                        help="comma-separated subset of waitcheck,consan")
+    parser.add_argument("--consan-command", default=None,
+                        help="application command the ConSan hook wraps")
+    parser.add_argument("--consan-mode", default=None,
+                        help=f"RJ_CONSAN_MODE ({', '.join(sorted(backends.CONSAN_MODES))})")
+    parser.add_argument("--consan-policy", default=None,
+                        help="RJ_CONSAN_POLICY (e.g. 'strict')")
+    parser.add_argument("--consan-log", action="store_true", help="RJ_CONSAN_LOG=1")
+    parser.add_argument("--simulator", default=None,
+                        help="RocJITsu simulator binary (native-ISA run, e.g. gfx1250)")
+    parser.add_argument("--simulator-config", default=None,
+                        help="RocJITsu --config JSON for the simulator")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="plan only: resolve kernels/backends, run nothing")
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    if args.kernels is not None:
+        worklist = json.loads(args.kernels.read_text())
+    else:
+        worklist = select_kernels(magpie_report=args.magpie_report,
+                                  gemm_csv=args.gemm_csv, top_n=args.top_n)
+
+    checks = [c.strip() for c in args.checks.split(",") if c.strip()]
+    unknown = set(checks) - {"waitcheck", "consan"}
+    if unknown:
+        parser.error(f"unknown checks: {sorted(unknown)}")
+
+    consan_command = args.consan_command.split() if args.consan_command else None
+    report = run_sanitizers(worklist=worklist, target=args.target, checks=checks,
+                            isa_dir=args.isa_dir, consan_command=consan_command,
+                            dry_run=args.dry_run, timeout=args.timeout,
+                            base_env=dict(os.environ), consan_mode=args.consan_mode,
+                            consan_policy=args.consan_policy, consan_log=args.consan_log,
+                            simulator=args.simulator, simulator_config=args.simulator_config)
+
+    if args.output_dir is not None:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        out = args.output_dir / "sanitizer_report.json"
+        out.write_text(json.dumps(report, indent=2) + "\n")
+        print(f"wrote report -> {out}")
+    _print_summary(report)
+    return 1 if report["overall_verdict"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/aorta/tools/rocjitsu_sanitizers/select.py
+++ b/src/aorta/tools/rocjitsu_sanitizers/select.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Select the "top kernels" a workload actually launches, for sanitizing.
+
+This is the front of the ``rocjitsu_sanitizers`` pipeline: before we can
+run waitcheck (static) or consan (dynamic) on anything, we need a ranked
+worklist of *which* kernels matter. Two complementary sources feed it:
+
+  1. **Magpie kernel summary** -- a Magpie benchmark workspace's
+     ``benchmark_report.json`` carries ``kernel_summary`` (one entry per
+     kernel: ``name``, ``time_ms``, ``percent``, ``calls``) and
+     ``top_bottlenecks`` (surfaced via ``aorta.report.magpie_adapter``).
+     Ranked by wall time, it answers "which kernels dominate this model's
+     runtime".
+
+  2. **hipBLASLt GEMM dispatch CSV** -- ``gemm_shapes_unique.csv``
+     (columns ``rank,count,...,transA,transB,M,N,K,...``) exported from a
+     GEMM dispatch trace. Ranked by dispatch count, it answers "which GEMM
+     shapes are launched the most".
+
+Any producer that emits the ``rocjitsu_sanitizers.kernels/1`` worklist schema
+below can feed the sanitizers directly (see ``runner.py --kernels``); the two
+loaders here are conveniences, not the only entry points.
+
+The output is a JSON worklist consumed by ``runner.py``. Kernel selection is
+host-only, needs no GPU, and is deterministic, so it is the fully
+unit-testable core of the tool.
+
+Usage::
+
+    python -m aorta.tools.rocjitsu_sanitizers.select \
+        --magpie-report benchmark_report.json \
+        --gemm-csv gemm_shapes_unique.csv \
+        --top-n 20 \
+        --output kernels.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_magpie_kernels(report_path: Path, top_n: int) -> list[dict[str, Any]]:
+    """Read ``kernel_summary`` from a Magpie ``benchmark_report.json``.
+
+    Accepts either the raw Magpie report or the normalised dict emitted by
+    ``aorta.report.magpie_adapter.read_magpie_report`` -- both expose the
+    same ``kernel_summary`` list. Ranks by ``percent`` (falling back to
+    ``time_ms``) so the hottest kernels come first.
+    """
+    with open(report_path) as fh:
+        report = json.load(fh)
+    summary = report.get("kernel_summary") or []
+    bottlenecks = set(report.get("top_bottlenecks") or [])
+
+    def sort_key(entry: dict[str, Any]) -> tuple[float, float]:
+        return (float(entry.get("percent") or 0.0), float(entry.get("time_ms") or 0.0))
+
+    ranked = sorted(summary, key=sort_key, reverse=True)[:top_n]
+    kernels: list[dict[str, Any]] = []
+    for rank, entry in enumerate(ranked, start=1):
+        name = entry.get("name", "")
+        kernels.append(
+            {
+                "source": "magpie",
+                "rank": rank,
+                "name": name,
+                "percent": entry.get("percent"),
+                "time_ms": entry.get("time_ms"),
+                "calls": entry.get("calls"),
+                "is_bottleneck": name in bottlenecks,
+            }
+        )
+    return kernels
+
+
+def _load_gemm_kernels(csv_path: Path, top_n: int) -> list[dict[str, Any]]:
+    """Read the top GEMM shapes from a ``gemm_shapes_unique.csv``.
+
+    The CSV is pre-sorted by dispatch ``count`` (rank 1 = most-launched). We
+    read the shape tuple and carry the Tensile ``top_solution_idx`` so a later
+    stage can map a shape back to the concrete ``.co`` variant it selects.
+    """
+    kernels: list[dict[str, Any]] = []
+    with open(csv_path, newline="") as fh:
+        for row in csv.DictReader(fh):
+            if len(kernels) >= top_n:
+                break
+            m, n, k = row.get("M"), row.get("N"), row.get("K")
+            trans = f"{row.get('transA', '?')}{row.get('transB', '?')}"
+            kernels.append(
+                {
+                    "source": "gemm_csv",
+                    "rank": int(row.get("rank", len(kernels) + 1)),
+                    "name": f"gemm_{trans}_M{m}_N{n}_K{k}",
+                    "shape": {
+                        "transA": row.get("transA"),
+                        "transB": row.get("transB"),
+                        "M": _int_or_none(m),
+                        "N": _int_or_none(n),
+                        "K": _int_or_none(k),
+                        "batch_count": _int_or_none(row.get("batch_count")),
+                    },
+                    "count": _int_or_none(row.get("count")),
+                    "compute_type": row.get("compute_type"),
+                    "top_solution_idx": _int_or_none(row.get("top_solution_idx")),
+                }
+            )
+    return kernels
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def select_kernels(
+    *,
+    magpie_report: Path | None,
+    gemm_csv: Path | None,
+    top_n: int,
+) -> dict[str, Any]:
+    """Build the ranked kernel worklist from whichever sources are given."""
+    if magpie_report is None and gemm_csv is None:
+        raise ValueError("provide at least one of --magpie-report / --gemm-csv")
+
+    kernels: list[dict[str, Any]] = []
+    sources: list[str] = []
+    if magpie_report is not None:
+        kernels += _load_magpie_kernels(magpie_report, top_n)
+        sources.append(f"magpie:{magpie_report.name}")
+    if gemm_csv is not None:
+        kernels += _load_gemm_kernels(gemm_csv, top_n)
+        sources.append(f"gemm_csv:{gemm_csv.name}")
+
+    return {
+        "schema": "rocjitsu_sanitizers.kernels/1",
+        "top_n": top_n,
+        "sources": sources,
+        "kernel_count": len(kernels),
+        "kernels": kernels,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--magpie-report", type=Path, default=None,
+                        help="Magpie benchmark_report.json with kernel_summary")
+    parser.add_argument("--gemm-csv", type=Path, default=None,
+                        help="gemm_shapes_unique.csv (ranked by dispatch count)")
+    parser.add_argument("--top-n", type=int, default=20,
+                        help="keep the top N kernels from each source")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="write worklist JSON here (default: stdout)")
+    args = parser.parse_args(argv)
+
+    worklist = select_kernels(
+        magpie_report=args.magpie_report,
+        gemm_csv=args.gemm_csv,
+        top_n=args.top_n,
+    )
+    text = json.dumps(worklist, indent=2)
+    if args.output is not None:
+        args.output.write_text(text + "\n")
+        print(f"wrote {worklist['kernel_count']} kernels -> {args.output}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/aorta/tools/rocjitsu_sanitizers/tool.py
+++ b/src/aorta/tools/rocjitsu_sanitizers/tool.py
@@ -1,0 +1,103 @@
+"""``rocjitsu_sanitizers`` -- waitcheck (static) + ConSan (dynamic) guardrail.
+
+Runs the two rocjitsu sanitizers over the top kernels a workload launches and
+folds the findings into one ``pass`` / ``warn`` / ``fail`` verdict. The tool
+locates the rocjitsu artifacts (``rj_waitcheck`` + ``librocjitsu_dbi_hooks.so``)
+at runtime via ``ROCJITSU_BUILD`` / ``RJ_WAITCHECK_BIN`` /
+``ROCJITSU_SANITIZER_HOOK``; it does not build or vendor them. When the
+artifacts are absent every check records ``skipped`` and the verdict is
+``not_checked`` -- so the tool is safe to import/discover on any machine.
+
+``invoke`` runs in-process (no subprocess wrapper); the engine lives in
+``select.py`` / ``runner.py`` / ``backends.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from . import runner
+from .select import select_kernels
+
+# rocjitsu + ROCm env worth pinning next to a run for reproducibility.
+_ENV_KEYS = ("ROCM_PATH", "HIP_VISIBLE_DEVICES", "ROCJITSU_BUILD",
+             "ROCJITSU_SANITIZER_HOOK", "RJ_WAITCHECK_BIN", "HSA_TOOLS_LIB",
+             "RJ_CONSAN_MODE", "RJ_CONSAN_POLICY")
+
+
+def _as_path(value: Any) -> Path | None:
+    return Path(value) if value is not None else None
+
+
+def _as_command(value: Any) -> list[str] | None:
+    if value is None:
+        return None
+    return value if isinstance(value, list) else str(value).split()
+
+
+class RocjitsuSanitizersTool:
+    """``aorta.tools`` plugin for the rocjitsu waitcheck + ConSan guardrail."""
+
+    name = "rocjitsu_sanitizers"
+
+    def invoke(self, *, inputs: dict[str, Any],
+               output_dir: Path | None = None) -> dict[str, Any]:
+        """Run the requested checks over a kernel worklist; return the report.
+
+        Recognised ``inputs`` keys:
+          * ``kernels`` -- path to a pre-built ``rocjitsu_sanitizers.kernels/1``
+            worklist (any workload can emit one), OR
+          * ``magpie_report`` / ``gemm_csv`` -- sources to build one, with
+            ``top_n`` (default 20);
+          * ``isa_dir`` -- directory of saved code objects for waitcheck;
+          * ``target`` -- GPU target (default ``gfx950``);
+          * ``checks`` -- list or comma string, subset of ``waitcheck,consan``;
+          * ``consan_command`` -- app the ConSan hook wraps (str or list);
+          * ``consan_mode`` / ``consan_policy`` / ``consan_log`` -- ConSan knobs;
+          * ``simulator`` / ``simulator_config`` -- native-ISA simulator run;
+          * ``dry_run`` / ``timeout``.
+        """
+        kernels_path = _as_path(inputs.get("kernels"))
+        if kernels_path is not None:
+            worklist = json.loads(kernels_path.read_text())
+        else:
+            worklist = select_kernels(
+                magpie_report=_as_path(inputs.get("magpie_report")),
+                gemm_csv=_as_path(inputs.get("gemm_csv")),
+                top_n=int(inputs.get("top_n", 20)),
+            )
+
+        checks = inputs.get("checks", ["waitcheck", "consan"])
+        if isinstance(checks, str):
+            checks = [c.strip() for c in checks.split(",") if c.strip()]
+
+        report = runner.run_sanitizers(
+            worklist=worklist,
+            target=str(inputs.get("target", "gfx950")),
+            checks=checks,
+            isa_dir=_as_path(inputs.get("isa_dir")),
+            consan_command=_as_command(inputs.get("consan_command")),
+            dry_run=bool(inputs.get("dry_run", False)),
+            timeout=int(inputs.get("timeout", 1800)),
+            base_env=dict(os.environ),
+            consan_mode=inputs.get("consan_mode"),
+            consan_policy=inputs.get("consan_policy"),
+            consan_log=bool(inputs.get("consan_log", False)),
+            simulator=inputs.get("simulator"),
+            simulator_config=inputs.get("simulator_config"),
+        )
+
+        if output_dir is not None:
+            output_dir = Path(output_dir)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            (output_dir / "sanitizer_report.json").write_text(
+                json.dumps(report, indent=2) + "\n")
+
+        return {
+            "report": report,
+            "overall_verdict": report["overall_verdict"],
+            "env": {k: os.environ[k] for k in _ENV_KEYS if k in os.environ},
+        }

--- a/tests/tools/test_rocjitsu_sanitizers.py
+++ b/tests/tools/test_rocjitsu_sanitizers.py
@@ -1,0 +1,236 @@
+"""Tests for the built-in rocjitsu_sanitizers tool.
+
+None of these need a GPU, a rocjitsu build, or the sanitizer artifacts: the
+backends are exercised with monkeypatched subprocess results, kernel selection
+is pure host code, and the tool-level runs use ``dry_run`` or mocked binaries.
+
+The invocation model and support table are reconciled against
+``rocm-systems/emulation/rocjitsu/docs/sanitizers.md`` (combined HSA-tools
+hook: ``rj_waitcheck`` static tool + ``librocjitsu_dbi_hooks.so`` dynamic hook;
+gfx950 = waitcheck Yes / ConSan Yes).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import aorta.tools.rocjitsu_sanitizers as _pkg
+from aorta.tools import Tool, get_tool, load_tools
+from aorta.tools.rocjitsu_sanitizers import RocjitsuSanitizersTool, backends, runner
+from aorta.tools.rocjitsu_sanitizers.select import select_kernels
+
+_EXAMPLES = Path(_pkg.__file__).parent / "examples"
+_GEMM_CSV = _EXAMPLES / "synthetic_gemm_shapes.csv"
+_KERNELS_JSON = _EXAMPLES / "example_kernels.json"
+
+# Doc example lines (verbatim shapes) the parsers must handle.
+_WAITCHECK_OUT = (
+    "rocjitsu-waitcheck: .text+0x40: missing s_wait_loadcnt <= 0 ... global_load_b32 ...\n"
+    "rocjitsu-waitcheck:   consumer: v_mov_b32_e32 ...\n"
+)
+_CONSAN_OUT = (
+    "[rocjitsu-dbi-hooks] ConSan MOI auto replay diagnostic ... kind=1 ... "
+    "first_lds=[0,4) second_lds=[0,4) first_kind=2 second_kind=1 ...\n"
+    "[rocjitsu-dbi-hooks] ConSan analysis verdict applicable=true "
+    "analysis_complete=true static_complete=true dynamic_complete=true\n"
+)
+
+
+# --- discovery / registry ------------------------------------------------
+
+def test_tool_discovered_via_entry_point() -> None:
+    registry = load_tools()
+    assert "rocjitsu_sanitizers" in registry
+    assert registry["rocjitsu_sanitizers"] is RocjitsuSanitizersTool
+
+
+def test_get_tool_returns_class_and_unknown_raises() -> None:
+    assert get_tool("rocjitsu_sanitizers") is RocjitsuSanitizersTool
+    with pytest.raises(Exception, match="unknown tool"):
+        get_tool("does_not_exist")
+
+
+def test_tool_conforms_to_protocol_and_name() -> None:
+    assert isinstance(RocjitsuSanitizersTool(), Tool)
+    assert RocjitsuSanitizersTool.name == "rocjitsu_sanitizers"
+
+
+# --- backends: support policy matches the doc's target table -------------
+
+def test_waitcheck_supported_on_gfx950_and_gfx1250() -> None:
+    assert backends.support("waitcheck", "gfx950")["level"] == "full"
+    assert backends.support("waitcheck", "gfx1250")["level"] == "full"
+
+
+def test_consan_full_on_gfx950_gfx1100_gfx1250() -> None:
+    sup = backends.support("consan", "gfx950")
+    assert sup["level"] == "full"
+    assert sup["runnable"] is True
+    assert sup["requires"] == "hardware-or-simulator"
+    assert backends.support("consan", "gfx1100")["level"] == "full"
+    assert backends.support("consan", "gfx1250")["level"] == "full"
+
+
+def test_consan_unsupported_on_waitcheck_only_target() -> None:
+    sup = backends.support("consan", "gfx1200")
+    assert sup["level"] == "unsupported"
+    assert sup["runnable"] is False
+
+
+def test_resolve_waitcheck_honours_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(backends.ENV_WAITCHECK_BIN, "/opt/rocjitsu/build/tools/rj_waitcheck")
+    assert backends.resolve_waitcheck() == "/opt/rocjitsu/build/tools/rj_waitcheck"
+
+
+# --- backends: output parsers --------------------------------------------
+
+def test_parse_waitcheck_flags_missing_wait_with_context() -> None:
+    result = backends.parse_waitcheck(
+        "/tmp/k0.hsaco:gfx950[0]:.text+0x458: missing s_waitcnt lgkmcnt(0) before def of s45\n"
+        "  producer .text+0x448: s_load_dwordx8 s[40:47], s[0:1], 0x50\n"
+        "  consumer .text+0x458: s_load_dword s45, s[0:1], 0x8c\n"
+    )
+    assert result["counts"] == {"warning": 1}
+    assert result["findings"][0]["context"]
+
+
+def test_parse_consan_ignores_benign_capacity_lines() -> None:
+    out = ("[rocjitsu-dbi-hooks] ConSan patch plan diagnostics=32768 capacity\n"
+           "[rocjitsu-dbi-hooks] ConSan analysis verdict applicable=true "
+           "analysis_complete=true dynamic_complete=true\n")
+    result = backends.parse_consan(out)
+    assert result["counts"] == {}
+    assert backends.verdict_for_counts(result["counts"]) == "pass"
+
+
+def test_parse_consan_conflict_true_is_race() -> None:
+    out = ("[rocjitsu-dbi-hooks] ConSan MOI auto replay reader=1 processed_access=2 "
+           "diagnostics=1 conflict=true\n")
+    result = backends.parse_consan(out)
+    assert result["counts"].get("race") == 1
+    assert backends.verdict_for_counts(result["counts"]) == "fail"
+
+
+def test_consan_effective_complete_and_incomplete() -> None:
+    complete = backends.consan_effective(
+        {"analysis_complete": "true", "dynamic_complete": "true",
+         "incomplete_code_objects": "0", "access": "2/2",
+         "replay_unsupported_access": "0"})
+    assert complete["complete"] is True
+    incomplete = backends.consan_effective(
+        {"analysis_complete": "true", "dynamic_complete": "false",
+         "incomplete_code_objects": "1"})
+    assert incomplete["complete"] is False
+    assert backends.consan_effective({})["complete"] is None
+
+
+def test_consan_env_recipe_and_bad_mode() -> None:
+    env = backends.consan_env("/build/hook.so", mode="record-replay", log=True)
+    assert env["HSA_TOOLS_LIB"] == "/build/hook.so"
+    assert env["HSA_TOOLS_DISABLE_REGISTER"] == "1"
+    assert env["RJ_CONSAN_LOG"] == "1"
+    with pytest.raises(ValueError, match="RJ_CONSAN_MODE"):
+        backends.consan_env("/build/hook.so", mode="bogus")
+
+
+def test_consan_argv_simulator_wrapper() -> None:
+    argv = backends.consan_argv(["./app", "-x"], simulator="rocjitsu", config="gfx1250.json")
+    assert argv == ["rocjitsu", "--config", "gfx1250.json", "--", "./app", "-x"]
+
+
+# --- select_kernels ------------------------------------------------------
+
+def test_select_kernels_requires_a_source() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        select_kernels(magpie_report=None, gemm_csv=None, top_n=5)
+
+
+def test_select_kernels_gemm_csv_carries_shape_and_solution() -> None:
+    worklist = select_kernels(magpie_report=None, gemm_csv=_GEMM_CSV, top_n=5)
+    assert worklist["schema"] == "rocjitsu_sanitizers.kernels/1"
+    top = worklist["kernels"][0]
+    assert top["source"] == "gemm_csv"
+    assert top["shape"]["M"] and top["shape"]["K"]
+    assert top["top_solution_idx"] == 100001
+
+
+# --- runner: static waitcheck (mocked binary + exec) ---------------------
+
+def _gemm_worklist() -> dict[str, Any]:
+    return {"schema": "x", "top_n": 1, "sources": ["test"], "kernel_count": 1,
+            "kernels": [{"source": "gemm_csv", "rank": 1, "name": "gemm_NT",
+                         "top_solution_idx": 100001}]}
+
+
+def test_run_waitcheck_reports_missing_wait_as_warn(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    (tmp_path / "sol_100001.hsaco").write_text("...")
+    monkeypatch.setattr(backends, "resolve_waitcheck", lambda: "/fake/rj_waitcheck")
+    monkeypatch.setattr(runner, "_exec",
+                        lambda argv, timeout, env=None: (0, _WAITCHECK_OUT, ""))
+    report = runner.run_waitcheck(
+        _gemm_worklist(), "gfx950", tmp_path, dry_run=False, timeout=10)
+    assert report["status"] == "ran"
+    assert report["verdict"] == "warn"
+    assert report["support"]["level"] == "full"
+
+
+def test_run_waitcheck_skips_without_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(backends, "resolve_waitcheck", lambda: None)
+    report = runner.run_waitcheck(
+        _gemm_worklist(), "gfx950", None, dry_run=False, timeout=10)
+    assert report["status"] == "skipped"
+    assert "rj_waitcheck not found" in report["reason"]
+
+
+# --- runner: dynamic ConSan gating ---------------------------------------
+
+def test_run_consan_skips_on_unsupported_target() -> None:
+    report = runner.run_consan(
+        _gemm_worklist(), "gfx1200", ["python", "repro.py"], dry_run=False, timeout=10)
+    assert report["verdict"] == "skipped"
+    assert report["support"]["level"] == "unsupported"
+
+
+def test_run_consan_skips_without_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(backends, "resolve_hook", lambda: "/fake/hook.so")
+    report = runner.run_consan(
+        _gemm_worklist(), "gfx950", None, dry_run=False, timeout=10)
+    assert report["verdict"] == "skipped"
+    assert "consan-command" in report["reason"]
+    assert report["support"]["level"] == "full"
+
+
+def test_run_consan_flags_race_with_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(backends, "resolve_hook", lambda: "/fake/hook.so")
+    monkeypatch.setattr(runner, "_exec",
+                        lambda argv, timeout, env=None: (0, _CONSAN_OUT, ""))
+    report = runner.run_consan(
+        _gemm_worklist(), "gfx950", ["python", "repro.py"], dry_run=False, timeout=10)
+    assert report["status"] == "ran"
+    assert report["verdict"] == "fail"
+
+
+# --- runner + tool: orchestration ----------------------------------------
+
+def test_run_sanitizers_dry_run_is_not_checked() -> None:
+    report = runner.run_sanitizers(
+        worklist=_gemm_worklist(), target="gfx950",
+        checks=["waitcheck", "consan"], dry_run=True)
+    assert report["overall_verdict"] == "not_checked"
+    assert {c["check"] for c in report["checks"]} == {"waitcheck", "consan"}
+
+
+def test_tool_invoke_from_worklist_dry_run(tmp_path: Path) -> None:
+    result = RocjitsuSanitizersTool().invoke(
+        inputs={"kernels": _KERNELS_JSON, "target": "gfx950",
+                "checks": ["waitcheck", "consan"], "dry_run": True},
+        output_dir=tmp_path,
+    )
+    assert result["overall_verdict"] == "not_checked"
+    assert (tmp_path / "sanitizer_report.json").exists()
+    assert result["report"]["kernel_count"] == 3


### PR DESCRIPTION
Closes #316.

## Summary

Adds a generic **`aorta.tools`** plugin category (alongside workloads /
mitigations / environments) and the first built-in tool: a rocjitsu
**waitcheck (static) + ConSan (dynamic)** kernel-correctness guardrail.

- **`aorta.tools`** — a `Tool` Protocol (the canonical interface tools
  implement) and `load_tools()` / `get_tool()` entry-point discovery over the
  new `aorta.tools` group, with collision detection (mirrors `load_mitigations`).
- **`aorta.tools.rocjitsu_sanitizers`** — engine (`backends` / `select` /
  `runner`) + a `RocjitsuSanitizersTool` adapter. Runs the two rocjitsu
  sanitizers over the **top kernels a workload launches** and folds findings
  into one `pass` / `warn` / `fail` verdict.
- **Bring-your-own kernels** — the tool consumes a versioned worklist
  (`rocjitsu_sanitizers.kernels/1`) that any workload can emit; built-in
  producers read a Magpie `kernel_summary` or a hipBLASLt GEMM dispatch CSV.
- **No build coupling** — `rj_waitcheck` + `librocjitsu_dbi_hooks.so` are
  resolved at runtime via `ROCJITSU_BUILD` / `RJ_WAITCHECK_BIN` /
  `ROCJITSU_SANITIZER_HOOK`; absent artifacts → every check `skipped`, verdict
  `not_checked`, so discovery is safe on any machine.
- **CLI** — `aorta tools list` / `aorta tools run <name> --input k=v`.

Target support tracks `rocm-systems` `emulation/rocjitsu/docs/sanitizers.md`
(gfx942 / gfx950 / gfx1100 / gfx1201 / gfx1250 ConSan full; gfx1150 / gfx1151 /
gfx1200 waitcheck-only). Note: ConSan's per-conflict diagnostics are emitted
only under `RJ_CONSAN_LOG=1`, so the tool exposes a `consan_log` input for races
to fail the gate.

## Test plan

- [x] `pytest tests/tools/test_rocjitsu_sanitizers.py` → 22 passed (no GPU, no
      rocjitsu build; backends exercised with mocked subprocess output)
- [x] `ruff check` clean on new files
- [x] `aorta tools list` shows `rocjitsu_sanitizers`; `aorta tools run ... --input dry_run=1` → `not_checked`
- [ ] End-to-end on real gfx950 hardware with a rocjitsu build (waitcheck WARN
      on real kernels; ConSan PASS/FAIL) — validated separately; artifacts not
      required for CI.

## Notes

- New plugin category, so no existing behavior changes. `Tool` is a `Protocol`
  to keep the contract minimal; downstream packages register their own tools
  under the same `aorta.tools` group.

Made with [Cursor](https://cursor.com)