### PR TITLE
ci(dashboard): cleaner, better-aligned dashboard layout

### DIFF
--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -80,9 +80,13 @@ def _svg_sparkline(values: list[float], width: int = 160, height: int = 32) -> s
         y = height - 2 - ((v - lo) / span) * (height - 4)
         coords.append(f"{x:.1f},{y:.1f}")
     poly = " ".join(coords)
+    last_x, last_y = coords[-1].split(",")
     return (
-        f'<svg width="{width}" height="{height}" viewBox="0 0 {width} {height}">'
-        f'<polyline fill="none" stroke="#539bf5" stroke-width="1.5" points="{poly}"/>'
+        f'<svg width="{width}" height="{height}" viewBox="0 0 {width} {height}" '
+        f'preserveAspectRatio="none" style="vertical-align:middle">'
+        f'<polyline fill="none" stroke="#539bf5" stroke-width="1.5" '
+        f'stroke-linejoin="round" stroke-linecap="round" points="{poly}"/>'
+        f'<circle cx="{last_x}" cy="{last_y}" r="2" fill="#539bf5"/>'
         f"</svg>"
     )
 
@@ -140,9 +144,9 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         reasons = "; ".join(e.get("reasons", []) or [])
         rows.append(
             f"<tr><td class='mono'>{_esc(k)}</td>"
-            f"<td><span class='badge' style='background:{color}'>{_esc(verdict)}</span></td>"
-            f"<td>{_esc(st_txt)}</td>"
-            f"<td>{_svg_sparkline(history.get(k, []))}</td>"
+            f"<td class='center'><span class='badge' style='background:{color}'>{_esc(verdict)}</span></td>"
+            f"<td class='num'>{_esc(st_txt)}</td>"
+            f"<td class='spark'>{_svg_sparkline(history.get(k, []))}</td>"
             f"<td class='muted'>{_esc(reasons)}</td></tr>"
         )
 
@@ -172,9 +176,9 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         metric_rows.append(
             f"<tr><td class='mono'>{_esc(k)}</td>"
             f"<td class='mono'>{_esc(m)}</td>"
-            f"<td>{_esc(policy)}</td>"
-            f"<td>{_esc(val_txt)}</td>"
-            f"<td>{_svg_sparkline(mhist[(k, m)])}</td></tr>"
+            f"<td class='center'>{_esc(policy)}</td>"
+            f"<td class='num'>{_esc(val_txt)}</td>"
+            f"<td class='spark'>{_svg_sparkline(mhist[(k, m)])}</td></tr>"
         )
 
     s = latest.get("summary", {})
@@ -194,40 +198,79 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>aorta nightly CI</title>
 <style>
-  body {{ font-family: -apple-system, Segoe UI, Roboto, sans-serif; margin: 2rem; background:#0d1117; color:#c9d1d9; }}
-  h1 {{ font-size: 1.4rem; }}
-  .badge {{ color:#fff; padding:2px 8px; border-radius:10px; font-size:.8rem; }}
-  .status {{ font-size:1.1rem; font-weight:600; color:{status_color}; }}
-  table {{ border-collapse: collapse; width:100%; margin-top:1rem; }}
-  th, td {{ text-align:left; padding:.4rem .6rem; border-bottom:1px solid #21262d; font-size:.9rem; vertical-align:middle; }}
-  th {{ color:#8b949e; font-weight:600; }}
-  .mono {{ font-family: ui-monospace, monospace; }}
-  .muted {{ color:#8b949e; font-size:.8rem; }}
+  :root {{ --bg:#0d1117; --panel:#161b22; --border:#21262d; --fg:#c9d1d9; --muted:#8b949e; }}
+  * {{ box-sizing:border-box; }}
+  body {{ font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+          margin:0; background:var(--bg); color:var(--fg); line-height:1.45; }}
+  .wrap {{ max-width:1060px; margin:0 auto; padding:2rem 1.25rem 3rem; }}
+  header {{ border-bottom:1px solid var(--border); padding-bottom:1rem; margin-bottom:.5rem; }}
+  h1 {{ font-size:1.5rem; margin:0 0 .5rem; }}
+  h2 {{ font-size:1.05rem; margin:2rem 0 .25rem; color:#e6edf3; }}
+  .status-pill {{ display:inline-block; color:#fff; font-weight:600; font-size:.78rem;
+                  padding:3px 11px; border-radius:999px; background:{status_color}; vertical-align:middle; }}
+  .meta {{ color:var(--muted); font-size:.82rem; margin:.55rem 0 0; }}
+  .cards {{ display:flex; flex-wrap:wrap; gap:.6rem; align-items:stretch; margin:1.1rem 0 .25rem; }}
+  .card {{ background:var(--panel); border:1px solid var(--border); border-radius:8px;
+           padding:.5rem .85rem; min-width:80px; }}
+  .card .k {{ font-size:.68rem; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; }}
+  .card .v {{ font-size:1.3rem; font-weight:600; line-height:1.3; }}
+  .card.trend {{ flex:1; min-width:220px; }}
+  .card.trend .v {{ font-size:0; }}
+  table {{ border-collapse:collapse; width:100%; margin-top:.5rem; background:var(--panel);
+           border:1px solid var(--border); border-radius:8px; overflow:hidden; }}
+  th, td {{ padding:.5rem .8rem; border-bottom:1px solid var(--border); font-size:.88rem; vertical-align:middle; }}
+  thead th {{ text-align:left; color:var(--muted); font-weight:600; font-size:.7rem;
+              text-transform:uppercase; letter-spacing:.05em; background:#12161b; }}
+  tbody tr:last-child td {{ border-bottom:0; }}
+  tbody tr:hover {{ background:#1b2129; }}
+  td.num, th.num {{ text-align:right; font-variant-numeric:tabular-nums; }}
+  td.center, th.center {{ text-align:center; }}
+  td.spark {{ width:180px; }}
+  td.spark svg {{ display:block; }}
+  .badge {{ display:inline-block; min-width:60px; text-align:center; color:#fff;
+            padding:2px 8px; border-radius:999px; font-size:.75rem; font-weight:600; }}
+  .mono {{ font-family:ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.82rem; word-break:break-word; }}
+  .muted {{ color:var(--muted); font-size:.8rem; }}
+  .legend {{ color:var(--muted); font-size:.78rem; margin:.65rem 0 0; }}
 </style></head>
 <body>
-  <h1>aorta nightly CI dashboard</h1>
-  <p class="status">Latest: {status}</p>
-  <p class="muted">{meta}<br>generated {generated}</p>
-  <p>Summary — total {s.get('total', 0)}, pass {s.get('pass', 0)},
-     fail {s.get('fail', 0)}, record {s.get('record', 0)}, skip {s.get('skip', 0)}
-     &nbsp;|&nbsp; pass-rate trend: {_svg_sparkline(passrate)}</p>
-  <table>
-    <thead><tr><th>workload::cell</th><th>status</th><th>step time</th>
-      <th>trend (step ms)</th><th>notes</th></tr></thead>
-    <tbody>
-      {''.join(rows) if rows else '<tr><td colspan=5 class=muted>no results yet</td></tr>'}
-    </tbody>
-  </table>
-  <p class="muted">Verdicts: pass/fail = vs blessed baseline · record = no baseline yet (metrics captured) · skip = insufficient GPUs.</p>
+  <div class="wrap">
+    <header>
+      <h1>aorta nightly CI dashboard</h1>
+      <div>Latest: <span class="status-pill">{status}</span></div>
+      <p class="meta">{meta}<br>generated {generated}</p>
+    </header>
 
-  <h2 style="font-size:1.1rem;margin-top:2rem;">Performance / metric trends</h2>
-  <table>
-    <thead><tr><th>workload::cell</th><th>metric</th><th>policy</th>
-      <th>latest</th><th>trend</th></tr></thead>
-    <tbody>
-      {metric_table}
-    </tbody>
-  </table>
+    <div class="cards">
+      <div class="card"><div class="k">total</div><div class="v">{s.get('total', 0)}</div></div>
+      <div class="card"><div class="k">pass</div><div class="v" style="color:#3fb950">{s.get('pass', 0)}</div></div>
+      <div class="card"><div class="k">fail</div><div class="v" style="color:#f85149">{s.get('fail', 0)}</div></div>
+      <div class="card"><div class="k">record</div><div class="v" style="color:#d29922">{s.get('record', 0)}</div></div>
+      <div class="card"><div class="k">skip</div><div class="v" style="color:#8b949e">{s.get('skip', 0)}</div></div>
+      <div class="card trend"><div class="k">pass-rate trend</div><div class="v">{_svg_sparkline(passrate, width=240)}</div></div>
+    </div>
+
+    <h2>Latest status</h2>
+    <table>
+      <colgroup><col style="width:38%"><col style="width:12%"><col style="width:13%"><col style="width:17%"><col style="width:20%"></colgroup>
+      <thead><tr><th>workload::cell</th><th class="center">status</th><th class="num">step time</th>
+        <th>trend (step ms)</th><th>notes</th></tr></thead>
+      <tbody>
+        {''.join(rows) if rows else '<tr><td colspan=5 class=muted>no results yet</td></tr>'}
+      </tbody>
+    </table>
+    <p class="legend">Verdicts: pass/fail = vs blessed baseline · record = no baseline yet (metrics captured) · skip = insufficient GPUs.</p>
+
+    <h2>Performance / metric trends</h2>
+    <table>
+      <colgroup><col style="width:34%"><col style="width:20%"><col style="width:10%"><col style="width:18%"><col style="width:18%"></colgroup>
+      <thead><tr><th>workload::cell</th><th>metric</th><th class="center">policy</th>
+        <th class="num">latest</th><th>trend</th></tr></thead>
+      <tbody>
+        {metric_table}
+      </tbody>
+    </table>
+  </div>
 </body></html>
 """
 


### PR DESCRIPTION
## Summary
The live nightly dashboard (https://rocm.github.io/aorta/) looked cramped/misaligned. This restyles the generated page (pure `gen_dashboard.py` render change) for readability:

- Centered max-width container; header with a status **pill**.
- Summary shown as colored **count cards** (total/pass/fail/record/skip) + a pass-rate trend card, instead of a run-on sentence with an inline sparkline.
- Tables get panel styling, uppercase headers, row hover, and `colgroup` widths; **numeric columns right-aligned** with tabular figures; **status badges centered + uniform width**.
- Sparklines vertically centered, rounded stroke, with an end-point marker for the latest value.

No behavior/schema change; all fields remain HTML-escaped. Independent of the root-vs-`/ci/` hosting decision (#315) — this improves the dashboard wherever it's served.

## Before / after
Rendered locally with mock history; the "after" is this branch's output.

## Test plan
- [x] `tests/ci/test_dashboard_and_alert.py` passes (10/10).
- [ ] After merge, the live dashboard reflects the new layout on the next publish.

Made with [Cursor](https://cursor.com)