### PR TITLE
ci: keep the pass-rate trend fallback visible and unblock the Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,6 +53,12 @@ jobs:
           source: ./
           destination: ./_site
 
+      # jekyll-build-pages is a container action running as root, so ./_site comes
+      # back root-owned and the later steps (which run as the unprivileged runner
+      # user) cannot mount the dashboard inside it.
+      - name: Take ownership of the Jekyll output
+        run: sudo chown -R "$(id -u):$(id -g)" _site
+
       # History lives on the ci-results data branch (written by nightly-eval's
       # publish job); it may not exist until the first nightly runs. Fail closed:
       # a genuinely-absent branch (ls-remote exit 2) deploys the landing page

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -215,7 +215,9 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
   .card .k {{ font-size:.68rem; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; }}
   .card .v {{ font-size:1.3rem; font-weight:600; line-height:1.3; }}
   .card.trend {{ flex:1; min-width:220px; }}
-  .card.trend .v {{ font-size:0; }}
+  /* Block-level SVG avoids inline baseline spacing without zeroing the font
+     size, which would also hide the "n/a" fallback for short histories. */
+  .card.trend svg {{ display:block; }}
   table {{ border-collapse:collapse; width:100%; margin-top:.5rem; background:var(--panel);
            border:1px solid var(--border); border-radius:8px; overflow:hidden; }}
   th, td {{ padding:.5rem .8rem; border-bottom:1px solid var(--border); font-size:.88rem; vertical-align:middle; }}

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -65,6 +65,25 @@ def test_dashboard_renders_summary_metric_series():
     assert "ms" in html  # unit rendered
 
 
+def test_dashboard_record_only_history_keeps_trend_fallback_visible():
+    # A record-only build has no graded cells, so pass-rate is None for every
+    # build and the sparkline falls back to "n/a". That fallback must stay
+    # legible: styling the trend card with font-size:0 would blank it out.
+    r = _results("2026-08-03T00:00:00Z",
+                 [{"entry": "gpu_smoke", "cell": "baseline-local", "verdict": "record",
+                   "reasons": ["no baseline (record-only)"],
+                   "metrics": {"mean_step_time_ms": 254.0}}],
+                 total=1, record=1)
+    html = gen_dashboard.build_dashboard_html([r])
+
+    trend_card = html.split('<div class="card trend">', 1)[1].split("</div></div>", 1)[0]
+    assert "n/a" in trend_card
+    assert "<svg" not in trend_card
+
+    assert ".card.trend svg { display:block; }" in html
+    assert "font-size:0" not in html
+
+
 def test_alert_render_lists_failures():
     results = _results("2026-07-29T00:00:00Z",
                        [{"entry": "race", "cell": "smoke", "verdict": "fail",


### PR DESCRIPTION
Two small CI fixes, both needed before the next nightly publishes the dashboard.

### 1. The pass-rate trend card rendered blank

`.card.trend .v { font-size:0; }` existed to collapse the line box under the
inline sparkline SVG, but it also inherited into the `n/a` fallback that
`_svg_sparkline()` returns when there are fewer than two numeric samples.

A record-only build has no graded cells, so pass-rate is `None` for every
build in the history and the fallback is what actually gets rendered today --
invisibly. Replaced with `.card.trend svg { display:block; }`, which removes
the baseline spacing without zeroing the font size. Added a regression test
that renders a record-only history and asserts the fallback is present, no
`<svg>` is emitted, and no `font-size:0` rule survives.

### 2. The Pages workflow could never mount the dashboard

The workflow added in #315 failed on its first run on main:

```
mkdir: cannot create directory '_site/ci': Permission denied
```

`actions/jekyll-build-pages` is a Docker container action that runs as root,
so `./_site` is created owned by `0:0` mode 755. The next step runs as the
unprivileged runner user and cannot create `_site/ci` inside it, so the
dashboard was never mounted and the deploy was skipped.

Take ownership of `_site` after the Jekyll build so later steps can write
into it. Reproduced locally against the same image
(`ghcr.io/actions/jekyll-build-pages:v1.0.13`): the container leaves `_site`
as `0:0`, a non-root `mkdir _site/ci` fails with the identical error, and
after chowning to the unprivileged uid the mkdir and write both succeed.

Note the fail-closed `ci-results` probe from #315's review worked correctly
in that run -- the branch was found and cloned; only the mount failed.