### PR TITLE
ci(gpu): gate GPU tests in-workflow so the required check always reports

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -62,6 +62,26 @@ jobs:
             exit 0
           fi
 
+          # Fail open. This gate decides a required status check, so an
+          # indeterminate answer must never be read as "no GPU work needed":
+          # that would hand a GPU-touching PR a green check without testing it.
+          # On any retrieval problem, claim relevance and run the suite.
+          # Assigning inside `if !` keeps `set -e` from aborting on failure.
+          if ! files="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+                          --paginate --jq '.[].filename' 2>&1)"; then
+            echo "::warning::Could not list the PR's files, so running the GPU" \
+                 "suite rather than guessing. gh said: ${files}"
+            echo "gpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "$files" ]; then
+            echo "::warning::The PR file list came back empty, which should not" \
+                 "happen for a real PR; running the GPU suite."
+            echo "gpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # One-to-one with the `paths:` filter this replaced. Trailing `*` is a
           # `case` glob, which matches `/` too, so it covers whole subtrees.
           # Single-quoted and expanded via "${patterns[@]}" so the shell never
@@ -95,8 +115,7 @@ jobs:
                   ;;
               esac
             done
-          done < <(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-                     --paginate --jq '.[].filename')
+          done <<< "$files"
 
           if [ "$gpu" = false ]; then
             echo "No GPU-relevant paths changed; the GPU jobs will be skipped."

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -5,8 +5,13 @@ name: GPU Tests
 # Complements cpu-tests.yml (`not gpu and not rocm`) with no overlap -- see
 # docs/ci-testing-plan.md and issue #268.
 #
-# After a stable soak period, mark `pytest (GPU, MI350)` as a required status
-# check on `main` (branch protection) so GPU-touching PRs cannot merge red.
+# `pytest (GPU, MI350)` is a required status check on `main`. Path filtering
+# therefore must NOT live on the `pull_request` trigger: a workflow skipped by
+# path filtering leaves its checks Pending forever rather than reporting, so any
+# PR outside those paths would be permanently unmergeable. A job skipped by a
+# conditional, by contrast, reports Success. So this workflow always starts and
+# the `changes` job below decides whether the GPU work is relevant.
+# See https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks
 
 on:
   workflow_dispatch:
@@ -14,26 +19,14 @@ on:
     # Nightly full GPU run (offset from nightly.yml at 11:00 UTC).
     - cron: "0 8 * * *"
   pull_request:
-    paths:
-      - "src/aorta/race/**"
-      - "src/aorta/ebpf/**"
-      - "src/aorta/hw_queue_eval/**"
-      - "src/aorta/workloads/**"
-      - "src/aorta/utils/gpu_control.py"
-      - "tests/hw_queue_eval/**"
-      - "tests/instrumentation/test_environment.py"
-      - "tests/test_marker_partition.py"
-      - "config/ci/**"
-      - "recipes/ci/**"
-      - "scripts/ci/**"
-      - "docker/**"
-      - ".github/workflows/gpu-tests.yml"
 
 # contents: read to check out; actions: read for artifact upload (matches the
-# other artifact-uploading workflows in this repo).
+# other artifact-uploading workflows in this repo); pull-requests: read so the
+# `changes` gate can list the files a PR touches.
 permissions:
   contents: read
   actions: read
+  pull-requests: read
 
 # Protect the single GPU runner: one workflow run at a time per ref; newer PR
 # pushes cancel the superseded run.
@@ -45,15 +38,86 @@ env:
   CONTAINER_NAME: aorta-ci-gpu
 
 jobs:
+  # Cheap gate on a GitHub-hosted runner, replacing the trigger-level `paths:`
+  # filter. Non-PR triggers always report true so scheduled and dispatched runs
+  # exercise the full suite.
+  changes:
+    name: detect GPU-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      gpu: ${{ steps.filter.outputs.gpu }}
+    steps:
+      - name: Decide whether the GPU suite applies
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "$EVENT_NAME is not a pull request; running the full GPU suite."
+            echo "gpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # One-to-one with the `paths:` filter this replaced. Trailing `*` is a
+          # `case` glob, which matches `/` too, so it covers whole subtrees.
+          # Single-quoted and expanded via "${patterns[@]}" so the shell never
+          # filename-expands them -- they must reach `case` as literal patterns.
+          patterns=(
+            'src/aorta/race/*'
+            'src/aorta/ebpf/*'
+            'src/aorta/hw_queue_eval/*'
+            'src/aorta/workloads/*'
+            'src/aorta/utils/gpu_control.py'
+            'tests/hw_queue_eval/*'
+            'tests/instrumentation/test_environment.py'
+            'tests/test_marker_partition.py'
+            'config/ci/*'
+            'recipes/ci/*'
+            'scripts/ci/*'
+            'docker/*'
+            '.github/workflows/gpu-tests.yml'
+          )
+
+          gpu=false
+          while read -r file; do
+            [ -n "$file" ] || continue
+            for pattern in "${patterns[@]}"; do
+              # shellcheck disable=SC2254  # unquoted glob match is intentional
+              case "$file" in
+                $pattern)
+                  echo "GPU-relevant change: $file (matched $pattern)"
+                  gpu=true
+                  break 2
+                  ;;
+              esac
+            done
+          done < <(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+                     --paginate --jq '.[].filename')
+
+          if [ "$gpu" = false ]; then
+            echo "No GPU-relevant paths changed; the GPU jobs will be skipped."
+            echo "A skipped job reports Success, satisfying the required check."
+          fi
+          echo "gpu=$gpu" >> "$GITHUB_OUTPUT"
+
   gpu-tests:
     name: pytest (GPU, MI350)
     runs-on: [self-hosted, gpu]
+    needs: changes
+    # Skipped (and therefore reported as Success) when no GPU-relevant path
+    # changed, which keeps the single MI350 runner free on docs-only PRs.
+    #
     # Security: never run untrusted fork-PR code on the self-hosted GPU runner.
     # Only same-repo PRs (plus schedule / dispatch) reach the runner. Fork PRs
     # also lack the ROCM_SHARED_KEY secret, so they could not authenticate anyway.
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      needs.changes.outputs.gpu == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     timeout-minutes: 60
 
     steps:
@@ -119,9 +183,11 @@ jobs:
     name: workload regression (GPU, MI350)
     runs-on: [self-hosted, gpu]
     needs: gpu-tests
-    # Runs on every trigger. PRs run the fast, single-GPU "pr" tier; nightly /
-    # dispatch run the full manifest (AORTA_CI_TIER below). Same fork-PR guard
-    # as gpu-tests: no untrusted fork code on the self-hosted runner.
+    # Skipped along with gpu-tests when no GPU-relevant path changed, since a
+    # dependency that did not succeed skips this job too. Otherwise PRs run the
+    # fast, single-GPU "pr" tier and nightly / dispatch run the full manifest
+    # (AORTA_CI_TIER below). Same fork-PR guard as gpu-tests: no untrusted fork
+    # code on the self-hosted runner.
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## The problem

`pytest (GPU, MI350)` is a required status check in the active `main protection` ruleset (`strict_required_status_checks_policy: true`). But `gpu-tests.yml` filtered its `pull_request` trigger with a `paths:` list.

Per [GitHub's docs on required status checks](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks), those two settings are incompatible:

| Cause | Result |
|---|---|
| A workflow is skipped by path filtering | Associated checks stay **Pending** and block merging |
| A job is skipped by a conditional | The job reports **Success** |

So a PR touching none of the filtered paths never produces a `pytest (GPU, MI350)` result at all, and the merge gate waits forever on a check that will never arrive. This is not theoretical — five of the seven currently open PRs are blocked by it:

| PR | Files | GPU checks |
|---|---|---|
| #307 | `docs/**` | none |
| #313 | `.github/workflows/{lock-requirements,refresh-baselines}.yml` | none |
| #314 | `.github/workflows/*` (setup-python bump) | none |
| #315 | `nightly-eval.yml`, `pages.yml`, `docs/` | none |
| #317 | `src/aorta/cli/**`, `src/aorta/tools/**`, `pyproject.toml` | none |
| #318 | `tests/instrumentation/test_environment.py` | 2 |
| #320 | `scripts/ci/gen_dashboard.py` | 2 |

Note the workflow's own header comment anticipated making this check required, but marking it so didn't account for the paths filter.

## The fix

Move the path decision from the trigger into the workflow:

- `pull_request:` no longer carries `paths:`, so the workflow always starts and always reports.
- A new `changes` job on `ubuntu-latest` lists the PR's files via `gh api .../pulls/N/files` and sets a `gpu` output. Non-PR events (schedule, `workflow_dispatch`) always return `true`.
- `gpu-tests` gains `needs: changes` and gates on `needs.changes.outputs.gpu == 'true'`, keeping its existing fork-PR guard. `gpu-regression` skips along with it, since a dependency that did not succeed skips the dependent job.

A skipped job reports Success, so docs-only PRs satisfy the required check in seconds without ever touching the MI350 runner. `permissions:` gains `pull-requests: read` for the file listing.

**Job names are unchanged**, so the ruleset needs no edit.

## Behaviour is preserved

The pattern list is one-to-one with the `paths:` filter it replaces. I replayed the gate logic against the actual file lists of all seven open PRs and it reproduces the old decisions exactly — `gpu=true` for #318 and #320, `gpu=false` for the other five.

Edge cases also checked: a brand-new file under `scripts/ci/`, a deep subtree under `src/aorta/workloads/`, `gpu-tests.yml` itself, an unrelated workflow, docs-only, and near-miss lookalikes (`scripts/other/x.py`, `docker.md`, `src/aorta/racecar/x.py`) all classify correctly.

One implementation note worth flagging for review: the patterns are single-quoted in a bash array and iterated as `"${patterns[@]}"`. An earlier draft used an unquoted string list, which the shell filename-expanded against the working directory — that silently turned `scripts/ci/*` into whatever happened to exist locally and would have missed newly added files. The array form keeps them literal so they reach `case` as patterns.

## Verification

This PR touches `.github/workflows/gpu-tests.yml`, which is in the pattern list, so GPU jobs should run here and prove the positive path still works. The skip path is proven by updating #315 with `main` afterwards and confirming `pytest (GPU, MI350)` reports as skipped/Success.

Made with [Cursor](https://cursor.com)