### PR TITLE
ci(dashboard): serve the dashboard at the site root and rebuild its layout

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,10 +2,10 @@ name: Pages (landing + nightly dashboard)
 
 # Single owner of the GitHub Pages deployment (repo Pages source must be set to
 # "GitHub Actions"). A repo has exactly one Pages site, so this one build serves
-# BOTH the existing project landing page (Jekyll render of README.md at the site
-# root) AND the nightly CI dashboard mounted at /ci/. It runs on main pushes
-# (refresh the landing page), after each "Nightly Evaluation" completes (pick up
-# fresh history from the ci-results branch), and on demand.
+# BOTH the nightly CI dashboard (at the site root) AND the project landing page
+# (Jekyll render of README.md, under /docs/ alongside the rest of the rendered
+# docs). It runs on main pushes, after each "Nightly Evaluation" completes (pick
+# up fresh history from the ci-results branch), and on demand.
 
 on:
   push:
@@ -44,9 +44,8 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
-      # Renders README.md (+ any repo docs) to ./_site exactly like the previous
-      # legacy Pages build (same github-pages gem), so the landing page is
-      # preserved.
+      # Renders README.md (+ any repo docs) to ./_site with the same github-pages
+      # gem the legacy Pages build used, so the rendered docs are unchanged.
       - name: Build landing page (Jekyll)
         uses: actions/jekyll-build-pages@v1
         with:
@@ -55,16 +54,32 @@ jobs:
 
       # jekyll-build-pages is a container action running as root, so ./_site comes
       # back root-owned and the later steps (which run as the unprivileged runner
-      # user) cannot mount the dashboard inside it.
+      # user) cannot write inside it.
       - name: Take ownership of the Jekyll output
         run: sudo chown -R "$(id -u):$(id -g)" _site
 
+      # Jekyll renders README.md to _site/index.html and docs/*.md to _site/docs/*.
+      # Move that landing page under /docs/ (which had no index of its own) so the
+      # CI dashboard can own the site root. The rendered README mixes root-absolute
+      # links with relative ones; going one directory deeper breaks only the
+      # relative ones, so they are re-pointed with a ../ prefix. Fragments (#x),
+      # root-absolute (/x) and absolute (https://x) links are left alone.
+      - name: Move the landing page to /docs/
+        run: |
+          set -euo pipefail
+          test -f _site/index.html
+          mkdir -p _site/docs
+          sed -E 's%(href|src)="([^":#/][^":]*)"%\1="../\2"%g' \
+            _site/index.html > _site/docs/index.html
+          rm _site/index.html
+          echo "landing page -> /docs/ ($(wc -c < _site/docs/index.html) bytes)"
+
       # History lives on the ci-results data branch (written by nightly-eval's
       # publish job); it may not exist until the first nightly runs. Fail closed:
-      # a genuinely-absent branch (ls-remote exit 2) deploys the landing page
-      # only, but a transport/auth error must NOT be swallowed into "no dashboard"
-      # -- that would silently drop the dashboard while history exists.
-      - name: Generate nightly dashboard at /ci/
+      # a genuinely-absent branch (ls-remote exit 2) deploys the docs only, but a
+      # transport/auth error must NOT be swallowed into "no dashboard" -- that
+      # would silently drop the dashboard while history exists.
+      - name: Generate the nightly dashboard at the site root
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -75,21 +90,29 @@ jobs:
           lsr=$?
           set -e
           if [ "$lsr" -eq 2 ]; then
-            echo "ci-results branch absent; deploying landing page only (dashboard appears after the first nightly)"
-            exit 0
+            echo "ci-results branch absent; dashboard appears after the first nightly"
           elif [ "$lsr" -ne 0 ]; then
             echo "::error::cannot reach ci-results (git ls-remote exit ${lsr}); failing closed"
             exit 1
-          fi
-          tmp="$(mktemp -d)"
-          git clone --depth 1 --branch ci-results "$repo_url" "$tmp"
-          if ls "$tmp"/results/*.json >/dev/null 2>&1; then
-            mkdir -p _site/ci
-            python3 scripts/ci/gen_dashboard.py \
-              --results-dir "$tmp/results" --out-dir _site/ci --max-builds 180
-            echo "mounted dashboard at /ci/ ($(ls -1 "$tmp"/results/*.json | wc -l) build(s))"
           else
-            echo "ci-results exists but has no results yet; deploying landing page only"
+            tmp="$(mktemp -d)"
+            git clone --depth 1 --branch ci-results "$repo_url" "$tmp"
+            if ls "$tmp"/results/*.json >/dev/null 2>&1; then
+              python3 scripts/ci/gen_dashboard.py \
+                --results-dir "$tmp/results" --out-dir _site --max-builds 180
+              echo "dashboard at / ($(ls -1 "$tmp"/results/*.json | wc -l) build(s))"
+            else
+              echo "ci-results exists but has no results yet"
+            fi
+          fi
+
+          # The root must never 404: without results, publish the dashboard's own
+          # empty state rather than leaving the site with no index at all.
+          if [ ! -f _site/index.html ]; then
+            mkdir -p "${RUNNER_TEMP}/empty-results"
+            python3 scripts/ci/gen_dashboard.py \
+              --results-dir "${RUNNER_TEMP}/empty-results" --out-dir _site
+            echo "no history yet; published the dashboard's empty state at /"
           fi
 
       - name: Upload Pages artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,7 @@ jobs:
           ref: main
 
       - name: Configure Pages
+        id: pages
         uses: actions/configure-pages@v5
 
       # Renders README.md (+ any repo docs) to ./_site with the same github-pages
@@ -60,16 +61,27 @@ jobs:
 
       # Jekyll renders README.md to _site/index.html and docs/*.md to _site/docs/*.
       # Move that landing page under /docs/ (which had no index of its own) so the
-      # CI dashboard can own the site root. The rendered README mixes root-absolute
-      # links with relative ones; going one directory deeper breaks only the
-      # relative ones, so they are re-pointed with a ../ prefix. Fragments (#x),
-      # root-absolute (/x) and absolute (https://x) links are left alone.
+      # CI dashboard can own the site root. Two rewrites are needed:
+      #
+      #  1. The rendered README mixes root-absolute links with relative ones;
+      #     going one directory deeper breaks only the relative ones, so they are
+      #     re-pointed with a ../ prefix. Fragments (#x), root-absolute (/x) and
+      #     absolute (https://x, which all contain a colon) are left alone.
+      #  2. Jekyll's SEO tags hard-code the page's own URL, which was the site
+      #     root. Left alone they would tell crawlers and link unfurlers that this
+      #     page lives at the dashboard's URL, so they are re-pointed at /docs/.
       - name: Move the landing page to /docs/
+        env:
+          DOCS_URL: ${{ steps.pages.outputs.base_url }}/docs/
         run: |
           set -euo pipefail
           test -f _site/index.html
           mkdir -p _site/docs
-          sed -E 's%(href|src)="([^":#/][^":]*)"%\1="../\2"%g' \
+          sed -E \
+            -e 's%(href|src)="([^":#/][^":]*)"%\1="../\2"%g' \
+            -e "s%(<link rel=\"canonical\" href=\")[^\"]*\"%\1${DOCS_URL}\"%" \
+            -e "s%(<meta property=\"og:url\" content=\")[^\"]*\"%\1${DOCS_URL}\"%" \
+            -e "s%(\"url\":\")[^\"]*\"%\1${DOCS_URL}\"%" \
             _site/index.html > _site/docs/index.html
           rm _site/index.html
           echo "landing page -> /docs/ ($(wc -c < _site/docs/index.html) bytes)"
@@ -114,6 +126,55 @@ jobs:
               --results-dir "${RUNNER_TEMP}/empty-results" --out-dir _site
             echo "no history yet; published the dashboard's empty state at /"
           fi
+
+      # The dashboard used to live at /ci/, the docs advertised that URL, and
+      # /ci/data.json is a machine-readable endpoint something may already poll.
+      # A Pages deploy replaces the whole site, so moving the dashboard to the
+      # root would 404 both the moment it ships. Keep the data endpoint where it
+      # was and redirect the page to its new home.
+      - name: Keep the old /ci/ routes working
+        env:
+          SITE_URL: ${{ steps.pages.outputs.base_url }}
+        run: |
+          set -euo pipefail
+          site="${SITE_URL%/}"
+          mkdir -p _site/ci
+          cp _site/data.json _site/ci/data.json
+          printf '%s\n' \
+            '<!doctype html>' \
+            '<html lang="en"><head><meta charset="utf-8">' \
+            '<title>Moved — aorta nightly CI</title>' \
+            '<meta http-equiv="refresh" content="0; url=../">' \
+            "<link rel=\"canonical\" href=\"${site}/\">" \
+            '</head><body>' \
+            '<p>The nightly CI dashboard moved to <a href="../">the site root</a>.' \
+            'The history feed is unchanged at <a href="data.json">/ci/data.json</a>.</p>' \
+            '</body></html>' \
+            > _site/ci/index.html
+
+      # Fail before deploying rather than publishing a site that 404s a route we
+      # promised. Every path below is one an existing bookmark or consumer uses.
+      - name: Verify the published routes
+        env:
+          SITE_URL: ${{ steps.pages.outputs.base_url }}
+        run: |
+          set -euo pipefail
+          for f in _site/index.html _site/docs/index.html _site/ci/index.html \
+                   _site/data.json _site/ci/data.json; do
+            if [ ! -s "$f" ]; then
+              echo "::error::$f is missing or empty; refusing to deploy"
+              exit 1
+            fi
+          done
+          cmp _site/data.json _site/ci/data.json
+          # The moved docs page must not still identify itself as the site root.
+          site="${SITE_URL%/}"
+          if grep -E 'rel="canonical"|property="og:url"|"url":"' \
+               _site/docs/index.html | grep -qF "${site}/\""; then
+            echo "::error::/docs/ still claims the dashboard's URL as its own"
+            exit 1
+          fi
+          echo "routes ok: / /docs/ /ci/ /data.json /ci/data.json"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ reproduces workload-specific issues (numerics, races, nondeterminism) that
 micro-benchmarks miss. It ships a single `aorta` CLI plus a plugin system so
 downstream packages can register their own workloads.
 
+Every night AORTA's own workload sweep runs on an MI350 runner; the results are
+published to the [nightly CI dashboard](https://rocm.github.io/aorta/).
+
 ## What It Does
 
 - **Unified sweep.** Run a built-in workload — or your own opaque launch

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -57,6 +57,12 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    (Settings -> Pages). Nightly dashboard: `https://rocm.github.io/aorta/`;
    project docs: `https://rocm.github.io/aorta/docs/`.
 
+   The dashboard previously lived at `/ci/`, so that path is kept: `/ci/`
+   redirects to the root and `/ci/data.json` is published alongside
+   `/data.json` for anything already polling it. A verification step fails the
+   deploy if any of those routes would be missing, since a Pages deploy
+   replaces the whole site and a dropped route 404s immediately.
+
 ## Correctness vs performance
 
 - **Correctness** is gated: a cell that should pass but errored/failed => `fail`.

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -47,14 +47,15 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
 5. **Publish** (`publish` job on `ubuntu-latest`): appends
    `results/<date>.json` to the **`ci-results`** data branch (history only).
 6. **Deploy** (`pages.yml`): a repo has a single Pages site, shared with the
-   project landing page, so one workflow owns the deploy. On main pushes, after
-   each Nightly Evaluation completes, and on demand, `pages.yml` builds the
-   README landing page (Jekyll) into `_site/`, mounts the self-contained
-   dashboard (`gen_dashboard.py`, from the `ci-results` history) at **`_site/ci/`**,
-   and deploys the combined site via `actions/upload-pages-artifact` +
+   project docs, so one workflow owns the deploy. On main pushes, after each
+   Nightly Evaluation completes, and on demand, `pages.yml` builds the Jekyll
+   site into `_site/`, relocates the rendered README from `_site/index.html` to
+   `_site/docs/index.html`, writes the self-contained dashboard
+   (`gen_dashboard.py`, from the `ci-results` history) to `_site/index.html`, and
+   deploys the combined site via `actions/upload-pages-artifact` +
    `actions/deploy-pages`. **Repo Pages source must be "GitHub Actions"**
-   (Settings -> Pages). Landing page: `https://rocm.github.io/aorta/`; nightly
-   dashboard: `https://rocm.github.io/aorta/ci/`.
+   (Settings -> Pages). Nightly dashboard: `https://rocm.github.io/aorta/`;
+   project docs: `https://rocm.github.io/aorta/docs/`.
 
 ## Correctness vs performance
 
@@ -112,10 +113,12 @@ the cap in `nightly-eval.yml` / the flag if a longer window is wanted.
 
 1. Set GitHub Pages **source = "GitHub Actions"** (Settings -> Pages). This
    switches the site from the legacy branch build to `pages.yml`, which serves
-   the README landing page **and** the dashboard at `/ci/` from one deploy. Run
-   the **Pages (landing + nightly dashboard)** workflow once to publish
-   immediately (the landing page is served even before any nightly results).
+   the dashboard at `/` **and** the project docs under `/docs/` from one deploy.
+   Run the **Pages (landing + nightly dashboard)** workflow once to publish
+   immediately (the docs are served even before any nightly results, and the
+   root shows the dashboard's empty state).
 2. First nightly runs **record-only**; then run **Refresh baselines** to bless.
-   The dashboard at `/aorta/ci/` appears after the first Nightly Evaluation.
+   Until then the dashboard reports `recording` rather than `passing`, because
+   nothing has been graded against a baseline yet.
 3. (Optional) Run **Lock requirements** to pin the CI dependency set.
 4. (Later) Enable perf gating via `refresh_baselines.py --perf-gate`.

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -82,6 +82,17 @@ def _isnum(v: Any) -> bool:
         return False
 
 
+def _count(v: Any) -> int:
+    """A summary count as an int; anything unusable counts as 0.
+
+    Counts drive branching and division, so a string in a malformed summary
+    would crash generation outright ("4" + 0 raises) instead of rendering badly.
+    Display still goes through ``_fmt_num``, which shows "—" rather than a 0 it
+    cannot vouch for.
+    """
+    return int(v) if _isnum(v) else 0
+
+
 def load_results(results_dir: Path) -> list[dict[str, Any]]:
     """Load and sort all result docs by generated_at (oldest first)."""
     docs: list[dict[str, Any]] = []
@@ -145,13 +156,13 @@ def _latest_status(results: list[dict[str, Any]]) -> tuple[str, str]:
     if not results:
         return "unknown", "#57606a"
     s = results[-1].get("summary", {}) or {}
-    if s.get("fail", 0):
+    if _count(s.get("fail")):
         return "failing", _VERDICT_COLOR["fail"]
-    if (s.get("total", 0) or 0) == 0:
+    if _count(s.get("total")) == 0:
         return "empty", "#57606a"
-    if s.get("pass", 0) or 0:
+    if _count(s.get("pass")):
         return "passing", _VERDICT_COLOR["pass"]
-    if s.get("record", 0) or 0:
+    if _count(s.get("record")):
         return "recording", _VERDICT_COLOR["record"]
     return "skipping", _VERDICT_COLOR["skip"]
 
@@ -276,13 +287,14 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     passrate = []
     for doc in results:
         ds = doc.get("summary", {}) or {}
-        graded = (ds.get("pass", 0) + ds.get("fail", 0)) or 0
-        passrate.append((ds.get("pass", 0) / graded) if graded else None)
+        passed, failed = _count(ds.get("pass")), _count(ds.get("fail"))
+        graded = passed + failed
+        passrate.append((passed / graded) if graded else None)
 
-    total = s.get("total", 0) or 0
-    graded_now = (s.get("pass", 0) or 0) + (s.get("fail", 0) or 0)
-    record_now = s.get("record", 0) or 0
-    skip_now = s.get("skip", 0) or 0
+    total = _count(s.get("total"))
+    graded_now = _count(s.get("pass")) + _count(s.get("fail"))
+    record_now = _count(s.get("record"))
+    skip_now = _count(s.get("skip"))
     # "Nothing was graded" splits three ways and they must not be described
     # identically: every cell recorded a baseline, some recorded while others
     # were skipped, or nothing ran at all. The last of those is unreachable for
@@ -474,7 +486,7 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     # Counts go through _fmt_num so a malformed summary shows "—" rather than
     # printing whatever str() makes of it ("nan", "True").
     cards = [
-        ("results", _fmt_num(total), ""),
+        ("results", _fmt_num(s.get("total", 0)), ""),
         ("pass", _fmt_num(s.get("pass", 0)), "#3fb950"),
         ("fail", _fmt_num(s.get("fail", 0)), "#f85149"),
         ("record", _fmt_num(s.get("record", 0)), "#d29922"),

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -112,8 +112,9 @@ def _has_trend(series: list[list[float | None]]) -> bool:
 def _latest_status(results: list[dict[str, Any]]) -> tuple[str, str]:
     """Headline verdict for the newest build.
 
-    ``recording`` is distinct from ``passing``: with no blessed baselines
-    nothing was actually graded, and calling that "passing" overstates it.
+    Only a graded pass earns ``passing``. A build with no blessed baselines is
+    ``recording``, and one where every cell was skipped is ``skipping``:
+    reporting either as "passing" would claim a result nothing established.
     """
     if not results:
         return "unknown", "#57606a"
@@ -122,9 +123,11 @@ def _latest_status(results: list[dict[str, Any]]) -> tuple[str, str]:
         return "failing", _VERDICT_COLOR["fail"]
     if (s.get("total", 0) or 0) == 0:
         return "empty", "#57606a"
-    if not (s.get("pass", 0) or 0) and (s.get("record", 0) or 0):
+    if s.get("pass", 0) or 0:
+        return "passing", _VERDICT_COLOR["pass"]
+    if s.get("record", 0) or 0:
         return "recording", _VERDICT_COLOR["record"]
-    return "passing", _VERDICT_COLOR["pass"]
+    return "skipping", _VERDICT_COLOR["skip"]
 
 
 def _fmt_num(v: Any) -> str:
@@ -250,7 +253,12 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
 
     total = s.get("total", 0) or 0
     graded_now = (s.get("pass", 0) or 0) + (s.get("fail", 0) or 0)
-    record_only = bool(total) and not graded_now
+    record_now = s.get("record", 0) or 0
+    skip_now = s.get("skip", 0) or 0
+    # "Nothing was graded" splits three ways and they must not be described
+    # identically: every cell recorded a baseline, some recorded while others
+    # were skipped, or nothing ran at all.
+    nothing_graded = bool(total) and not graded_now
 
     # Columns that would be uniformly empty are dropped rather than rendered as
     # a wall of "n/a" -- with one night of history that was three of five.
@@ -385,12 +393,22 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
             "<div class='notice'>No nightly results have been published yet. "
             "This page fills in after the first Nightly Evaluation run.</div>"
         )
-    elif record_only:
+    elif nothing_graded and record_now:
+        scope = (
+            f"all {total} cells" if record_now == total
+            else f"{record_now} of {total} cells ({skip_now} skipped)"
+        )
         extra = f" Every cell reports: {_esc(shared_reason)}." if shared_reason else ""
         notices.append(
             f"<div class='notice'>No baselines are blessed yet, so nothing was graded "
-            f"pass or fail — this run <strong>recorded</strong> metrics for all {total} "
-            f"cells to become the reference.{extra}</div>"
+            f"pass or fail — this run <strong>recorded</strong> metrics for {scope} "
+            f"to become the reference.{extra}</div>"
+        )
+    elif nothing_graded:
+        notices.append(
+            f"<div class='notice'>Nothing ran: all {total} cells were "
+            f"<strong>skipped</strong>, so this build establishes nothing. Check that "
+            f"the runner exposes as many GPUs as the matrix asks for.</div>"
         )
     elif shared_reason:
         notices.append(

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from html import escape as _esc
 from pathlib import Path
@@ -64,13 +65,21 @@ _VERDICT_ORDER = ("fail", "record", "skip", "pass")
 
 
 def _isnum(v: Any) -> bool:
-    """Numeric for display purposes.
+    """Numeric, finite, and representable as a float — i.e. safe to render.
 
-    ``bool`` is a subclass of ``int``, so a stray ``true`` in the (untrusted)
-    results JSON would otherwise format as a step time, scale a bar, or count
-    towards a trend.
+    Three things in the (untrusted) results JSON pass a bare isinstance check
+    and should not: ``bool``, which is a subclass of ``int`` and would format as
+    a step time or count towards a trend; ``NaN``/``Infinity``, which
+    ``json.loads`` accepts and which plot as ``nan`` coordinates and a bar that
+    silently reads full-width; and an integer too large to convert to a float,
+    which raises ``OverflowError`` in every formatter below.
     """
-    return isinstance(v, (int, float)) and not isinstance(v, bool)
+    if not isinstance(v, (int, float)) or isinstance(v, bool):
+        return False
+    try:
+        return math.isfinite(v)
+    except OverflowError:  # int beyond the float range
+        return False
 
 
 def load_results(results_dir: Path) -> list[dict[str, Any]]:
@@ -85,8 +94,10 @@ def load_results(results_dir: Path) -> list[dict[str, Any]]:
     return docs
 
 
-def _svg_sparkline(values: list[float], width: int = 160, height: int = 32) -> str:
-    """Tiny inline SVG line chart for a metric's history (ignores None)."""
+def _svg_sparkline(
+    values: list[float | None], width: int = 160, height: int = 32
+) -> str:
+    """Tiny inline SVG line chart for a metric's history (ignores non-numbers)."""
     pts = [v for v in values if _isnum(v)]
     if len(pts) < 2:
         return '<span class="muted">n/a</span>'
@@ -444,16 +455,18 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
             "runs; they appear automatically once more history accumulates.</div>"
         )
 
+    # Counts go through _fmt_num so a malformed summary shows "—" rather than
+    # printing whatever str() makes of it ("nan", "True").
     cards = [
-        ("cells", total, ""),
-        ("pass", s.get("pass", 0), "#3fb950"),
-        ("fail", s.get("fail", 0), "#f85149"),
-        ("record", s.get("record", 0), "#d29922"),
-        ("skip", s.get("skip", 0), "#8b949e"),
+        ("cells", _fmt_num(total), ""),
+        ("pass", _fmt_num(s.get("pass", 0)), "#3fb950"),
+        ("fail", _fmt_num(s.get("fail", 0)), "#f85149"),
+        ("record", _fmt_num(s.get("record", 0)), "#d29922"),
+        ("skip", _fmt_num(s.get("skip", 0)), "#8b949e"),
     ]
     # Only worth a card when something was actually graded; otherwise it would
     # sit next to the trend card reading "n/a" twice.
-    if passrate and isinstance(passrate[-1], float):
+    if passrate and _isnum(passrate[-1]):
         cards.append(("pass rate", f"{passrate[-1] * 100:.0f}%", ""))
     cards_html = "".join(
         f'<div class="card"><div class="k">{_esc(k)}</div>'

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -332,12 +332,23 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         tally_txt = " · ".join(
             f"{tally[v]} {v}" for v in _VERDICT_ORDER if tally.get(v)
         )
-        cell_word = "cell" if len(cell_keys) == 1 else "cells"
+        n = len(cell_keys)
+        head = f"{n} result{'' if n == 1 else 's'} · {tally_txt}"
+        # duration_sec is measured once around the whole recipe invocation and
+        # copied onto every record it produced, so it belongs to the workload and
+        # is stated here once -- repeated in each cell it reads as per-cell time.
+        durs = {
+            d for d in (latest_by_key[k].get("duration_sec") for k in cell_keys)
+            if _isnum(d)
+        }
+        # A skipped workload reports 0.0 -- it never ran, so it has no duration.
+        if len(durs) == 1 and max(durs) > 0:
+            head += f" · workload run {max(durs):,.0f}s"
 
         rows = [
             f"<tr class='grp'><th colspan='{ncols}' scope='rowgroup'>"
             f"<span class='wl'>{_esc(entry_name)}</span>"
-            f"<span class='muted'> {len(cell_keys)} {cell_word} · {_esc(tally_txt)}</span>"
+            f"<span class='muted'> {_esc(head)}</span>"
             f"</th></tr>"
         ]
         for k in cell_keys:
@@ -345,8 +356,16 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
             verdict = e.get("verdict", "skip")
             color = _VERDICT_COLOR.get(verdict, "#57606a")
             st = (e.get("metrics") or {}).get("mean_step_time_ms")
+            # A record for a workload that never reached its cells (skipped for
+            # want of GPUs, or the synthetic zero-work entry) carries cell=None;
+            # printing that as "None" invites reading it as a cell's name.
+            cell_name = e.get("cell")
+            label = (
+                f"<span class='mono'>{_esc(str(cell_name))}</span>"
+                if cell_name else "<span class='muted'>whole workload</span>"
+            )
             cells = [
-                f"<td class='cell mono'>{_esc(str(e.get('cell')))}</td>",
+                f"<td class='cell'>{label}</td>",
                 f"<td class='center'><span class='badge' "
                 f"style='background:{color}'>{_esc(verdict)}</span></td>",
                 f"<td class='num'>{_esc(_fmt_ms(st))}{_bar(st, group_max)}</td>",
@@ -363,12 +382,9 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
             if mrows:
                 n_metrics = len((e.get("metrics") or {}).get("summary") or {})
                 recipe = e.get("recipe") or ""
-                dur = e.get("duration_sec")
                 prov = []
                 if recipe:
                     prov.append(f"recipe <span class='mono'>{_esc(str(recipe))}</span>")
-                if _isnum(dur):
-                    prov.append(f"ran in {dur:,.0f}s")
                 trials = e.get("trials")
                 if _isnum(trials):
                     n_trials = int(trials)
@@ -430,10 +446,10 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         )
     elif nothing_graded and record_now:
         scope = (
-            f"all {total} cells" if record_now == total
-            else f"{record_now} of {total} cells ({skip_now} skipped)"
+            f"all {total} results" if record_now == total
+            else f"{record_now} of {total} results ({skip_now} skipped)"
         )
-        extra = f" Every cell reports: {_esc(shared_reason)}." if shared_reason else ""
+        extra = f" Every result reports: {_esc(shared_reason)}." if shared_reason else ""
         notices.append(
             f"<div class='notice'>No baselines are blessed yet, so nothing was graded "
             f"pass or fail — this run <strong>recorded</strong> metrics for {scope} "
@@ -441,13 +457,13 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         )
     elif nothing_graded:
         notices.append(
-            f"<div class='notice'>Nothing ran: all {total} cells were "
+            f"<div class='notice'>Nothing ran: all {total} results were "
             f"<strong>skipped</strong>, so this build establishes nothing. Check that "
             f"the runner exposes as many GPUs as the matrix asks for.</div>"
         )
     elif shared_reason:
         notices.append(
-            f"<div class='notice'>Every cell reports: {_esc(shared_reason)}.</div>"
+            f"<div class='notice'>Every result reports: {_esc(shared_reason)}.</div>"
         )
     if results and not (show_trend or show_metric_trend):
         notices.append(
@@ -458,7 +474,7 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     # Counts go through _fmt_num so a malformed summary shows "—" rather than
     # printing whatever str() makes of it ("nan", "True").
     cards = [
-        ("cells", _fmt_num(total), ""),
+        ("results", _fmt_num(total), ""),
         ("pass", _fmt_num(s.get("pass", 0)), "#3fb950"),
         ("fail", _fmt_num(s.get("fail", 0)), "#f85149"),
         ("record", _fmt_num(s.get("record", 0)), "#d29922"),
@@ -592,8 +608,9 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     <p class="legend">Verdicts: <strong>pass</strong>/<strong>fail</strong> = compared
       against a blessed baseline · <strong>record</strong> = no baseline yet, metrics
       captured as the future reference · <strong>skip</strong> = not enough GPUs on the
-      runner. Expand a cell to see its captured metrics and the recipe that produced
-      them.</p>
+      runner. One row is one recorded result: a workload skipped before it reached
+      its cells yields a single row for the whole workload, so a count of rows is
+      not a count of configured cells. Expand a row for its metrics and recipe.</p>
   </div>
 </body></html>
 """

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -63,6 +63,16 @@ _VERDICT_COLOR = {
 _VERDICT_ORDER = ("fail", "record", "skip", "pass")
 
 
+def _isnum(v: Any) -> bool:
+    """Numeric for display purposes.
+
+    ``bool`` is a subclass of ``int``, so a stray ``true`` in the (untrusted)
+    results JSON would otherwise format as a step time, scale a bar, or count
+    towards a trend.
+    """
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
 def load_results(results_dir: Path) -> list[dict[str, Any]]:
     """Load and sort all result docs by generated_at (oldest first)."""
     docs: list[dict[str, Any]] = []
@@ -77,7 +87,7 @@ def load_results(results_dir: Path) -> list[dict[str, Any]]:
 
 def _svg_sparkline(values: list[float], width: int = 160, height: int = 32) -> str:
     """Tiny inline SVG line chart for a metric's history (ignores None)."""
-    pts = [v for v in values if isinstance(v, (int, float))]
+    pts = [v for v in values if _isnum(v)]
     if len(pts) < 2:
         return '<span class="muted">n/a</span>'
     lo, hi = min(pts), max(pts)
@@ -85,7 +95,7 @@ def _svg_sparkline(values: list[float], width: int = 160, height: int = 32) -> s
     n = len(values)
     coords = []
     for i, v in enumerate(values):
-        if not isinstance(v, (int, float)):
+        if not _isnum(v):
             continue
         x = (i / (n - 1)) * (width - 4) + 2
         y = height - 2 - ((v - lo) / span) * (height - 4)
@@ -104,9 +114,7 @@ def _svg_sparkline(values: list[float], width: int = 160, height: int = 32) -> s
 
 def _has_trend(series: list[list[float | None]]) -> bool:
     """True when at least one series has enough numeric points to draw."""
-    return any(
-        len([v for v in vals if isinstance(v, (int, float))]) >= 2 for vals in series
-    )
+    return any(len([v for v in vals if _isnum(v)]) >= 2 for vals in series)
 
 
 def _latest_status(results: list[dict[str, Any]]) -> tuple[str, str]:
@@ -132,7 +140,7 @@ def _latest_status(results: list[dict[str, Any]]) -> tuple[str, str]:
 
 def _fmt_num(v: Any) -> str:
     """Compact number for display; keeps large integer counts readable."""
-    if not isinstance(v, (int, float)) or isinstance(v, bool):
+    if not _isnum(v):
         return "—"
     if float(v).is_integer() and abs(v) < 1e12:
         return f"{int(v):,}"
@@ -140,7 +148,7 @@ def _fmt_num(v: Any) -> str:
 
 
 def _fmt_ms(v: Any) -> str:
-    return f"{v:,.1f} ms" if isinstance(v, (int, float)) else "—"
+    return f"{v:,.1f} ms" if _isnum(v) else "—"
 
 
 def _fmt_timestamp(iso: str) -> str:
@@ -175,7 +183,7 @@ def _bar(value: Any, group_max: float) -> str:
     pass ``group_max`` of 0 for single-cell groups, where a bar would only ever
     compare a value against itself and read as a full-width bar.
     """
-    if not isinstance(value, (int, float)) or not group_max:
+    if not _isnum(value) or not group_max:
         return ""
     pct = max(2.0, min(100.0, value / group_max * 100.0))
     return f'<div class="bartrack"><div class="bar" style="width:{pct:.1f}%"></div></div>'
@@ -296,7 +304,7 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
             v = latest_by_key[k].get("verdict", "skip")
             tally[v] = tally.get(v, 0) + 1
             st = (latest_by_key[k].get("metrics") or {}).get("mean_step_time_ms")
-            if isinstance(st, (int, float)):
+            if _isnum(st):
                 step_times.append(st)
         group_max = max(step_times) if len(step_times) > 1 else 0.0
         tally_txt = " · ".join(
@@ -337,11 +345,12 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
                 prov = []
                 if recipe:
                     prov.append(f"recipe <span class='mono'>{_esc(str(recipe))}</span>")
-                if isinstance(dur, (int, float)):
+                if _isnum(dur):
                     prov.append(f"ran in {dur:,.0f}s")
                 trials = e.get("trials")
-                if isinstance(trials, int):
-                    prov.append(f"{trials} trial{'s' if trials != 1 else ''}")
+                if _isnum(trials):
+                    n_trials = int(trials)
+                    prov.append(f"{n_trials} trial{'s' if n_trials != 1 else ''}")
                 rows.append(
                     f"<tr class='mrow'><td colspan='{ncols}'><details>"
                     f"<summary>{n_metrics} metric{'s' if n_metrics != 1 else ''}</summary>"

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -262,7 +262,11 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
 
     # Columns that would be uniformly empty are dropped rather than rendered as
     # a wall of "n/a" -- with one night of history that was three of five.
+    # Step-time and per-metric history are judged separately: a workload can
+    # report metrics.summary without a mean_step_time_ms, and gating its metric
+    # sparklines on step time would discard trends that do exist.
     show_trend = _has_trend([history[k] for k in keys])
+    show_metric_trend = _has_trend(list(mhist.values()))
     reason_texts = ["; ".join(e.get("reasons") or []) for e in latest_entries]
     distinct_reasons = sorted({r for r in reason_texts if r})
     # Collapse the notes column ONLY when every cell says the same thing, so it
@@ -325,7 +329,7 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
                 )
             rows.append(f"<tr>{''.join(cells)}</tr>")
 
-            mrows = _metric_rows(k, e, mhist, show_trend)
+            mrows = _metric_rows(k, e, mhist, show_metric_trend)
             if mrows:
                 n_metrics = len((e.get("metrics") or {}).get("summary") or {})
                 recipe = e.get("recipe") or ""
@@ -344,7 +348,7 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
                     f"<p class='prov'>{' · '.join(prov)}</p>"
                     f"<table class='inner'><thead><tr><th>metric</th>"
                     f"<th class='center'>policy</th><th class='num'>latest</th>"
-                    f"{'<th>trend</th>' if show_trend else ''}</tr></thead>"
+                    f"{'<th>trend</th>' if show_metric_trend else ''}</tr></thead>"
                     f"<tbody>{mrows}</tbody></table>"
                     f"</details></td></tr>"
                 )
@@ -414,7 +418,7 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         notices.append(
             f"<div class='notice'>Every cell reports: {_esc(shared_reason)}.</div>"
         )
-    if results and not show_trend:
+    if results and not (show_trend or show_metric_trend):
         notices.append(
             "<div class='notice muted-notice'>Trend charts need at least two nightly "
             "runs; they appear automatically once more history accumulates.</div>"

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -2,8 +2,9 @@
 """Generate the nightly CI dashboard from the results history.
 
 Reads ``results/*.json`` (each written by nightly_eval.py) and emits a
-self-contained ``index.html`` (no external CDN): latest per-entry status table
-plus inline-SVG performance trend sparklines and a pass-rate-over-time chart.
+self-contained ``index.html`` (no external CDN): a run header with the
+toolchain identity, headline counts, and one workload-grouped status table
+whose per-cell metrics are nested in collapsible rows.
 Also writes ``data.json`` (the aggregated history) for any richer consumer.
 
 Pure rendering lives in ``build_dashboard_html`` so it can be unit tested.
@@ -29,6 +30,10 @@ except Exception:  # pragma: no cover - dashboard must render even if import fai
     def _metric_policy(_name: str):  # type: ignore
         return None
 
+# Links back to the source of truth. This dashboard only ever describes this
+# repo's nightly run, so the slug is fixed rather than plumbed through.
+_REPO = "ROCm/aorta"
+
 # Display units keyed by metric name (suffix-independent). Unknown -> no unit.
 _METRIC_UNITS = {
     "gflops": "GFLOP/s",
@@ -39,6 +44,9 @@ _METRIC_UNITS = {
     "prefill_latency_ms": "ms",
     "decode_latency_ms": "ms",
     "latency_ms": "ms",
+    "step_time_p50": "ms",
+    "step_time_p99": "ms",
+    "mean_wall_clock_sec": "s",
     "logits_checksum": "",
     "output_checksum": "",
     "checksum": "",
@@ -50,6 +58,9 @@ _VERDICT_COLOR = {
     "record": "#9a6700",
     "skip": "#57606a",
 }
+
+# Worst-first, so a group's tally leads with whatever needs attention.
+_VERDICT_ORDER = ("fail", "record", "skip", "pass")
 
 
 def load_results(results_dir: Path) -> list[dict[str, Any]]:
@@ -91,15 +102,104 @@ def _svg_sparkline(values: list[float], width: int = 160, height: int = 32) -> s
     )
 
 
+def _has_trend(series: list[list[float | None]]) -> bool:
+    """True when at least one series has enough numeric points to draw."""
+    return any(
+        len([v for v in vals if isinstance(v, (int, float))]) >= 2 for vals in series
+    )
+
+
 def _latest_status(results: list[dict[str, Any]]) -> tuple[str, str]:
+    """Headline verdict for the newest build.
+
+    ``recording`` is distinct from ``passing``: with no blessed baselines
+    nothing was actually graded, and calling that "passing" overstates it.
+    """
     if not results:
         return "unknown", "#57606a"
-    s = results[-1].get("summary", {})
+    s = results[-1].get("summary", {}) or {}
     if s.get("fail", 0):
         return "failing", _VERDICT_COLOR["fail"]
-    if s.get("total", 0) == 0:
+    if (s.get("total", 0) or 0) == 0:
         return "empty", "#57606a"
+    if not (s.get("pass", 0) or 0) and (s.get("record", 0) or 0):
+        return "recording", _VERDICT_COLOR["record"]
     return "passing", _VERDICT_COLOR["pass"]
+
+
+def _fmt_num(v: Any) -> str:
+    """Compact number for display; keeps large integer counts readable."""
+    if not isinstance(v, (int, float)) or isinstance(v, bool):
+        return "—"
+    if float(v).is_integer() and abs(v) < 1e12:
+        return f"{int(v):,}"
+    return f"{v:.4g}"
+
+
+def _fmt_ms(v: Any) -> str:
+    return f"{v:,.1f} ms" if isinstance(v, (int, float)) else "—"
+
+
+def _fmt_timestamp(iso: str) -> str:
+    """``2026-08-03T12:15:51.105587+00:00`` -> ``2026-08-03 12:15 UTC``.
+
+    Deliberately absolute: the page is static between nightly runs, so a
+    relative age ("2 hours ago") would freeze at generation time and lie.
+    """
+    if not iso:
+        return ""
+    try:
+        date, _, rest = iso.partition("T")
+        hh, mm = rest.split(":")[:2]
+        return f"{date} {hh}:{mm} UTC"
+    except Exception:
+        return iso
+
+
+def _chip(label: str, value: Any) -> str:
+    return (
+        f'<div class="chip"><div class="k">{_esc(label)}</div>'
+        f'<div class="v mono">{_esc(str(value) if value else "unknown")}</div></div>'
+    )
+
+
+def _bar(value: Any, group_max: float) -> str:
+    """Relative bar, scaled within the workload group.
+
+    Scaling per group rather than globally is deliberate: comparing a smoke
+    test's step time against an 8-GPU training loop's is meaningless, whereas
+    comparing cells of the same workload is exactly the useful signal. Callers
+    pass ``group_max`` of 0 for single-cell groups, where a bar would only ever
+    compare a value against itself and read as a full-width bar.
+    """
+    if not isinstance(value, (int, float)) or not group_max:
+        return ""
+    pct = max(2.0, min(100.0, value / group_max * 100.0))
+    return f'<div class="bartrack"><div class="bar" style="width:{pct:.1f}%"></div></div>'
+
+
+def _metric_rows(
+    cell_key: str,
+    entry: dict[str, Any],
+    mhist: dict[tuple[str, str], list[float | None]],
+    show_trend: bool,
+) -> str:
+    summary = ((entry.get("metrics") or {}).get("summary") or {})
+    out = []
+    for m in sorted(summary):
+        unit = _METRIC_UNITS.get(m, "")
+        val = f"{_fmt_num(summary.get(m))} {unit}".strip()
+        policy = _metric_policy(m) or "trend only"
+        trend = (
+            f"<td class='spark'>{_svg_sparkline(mhist.get((cell_key, m), []))}</td>"
+            if show_trend else ""
+        )
+        out.append(
+            f"<tr><td class='mono'>{_esc(m)}</td>"
+            f"<td class='center muted'>{_esc(policy)}</td>"
+            f"<td class='num'>{_esc(val)}</td>{trend}</tr>"
+        )
+    return "".join(out)
 
 
 def build_dashboard_html(results: list[dict[str, Any]]) -> str:
@@ -107,8 +207,9 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     status, status_color = _latest_status(results)
     latest = results[-1] if results else {"build": {}, "summary": {}, "entries": []}
     build = latest.get("build", {}) or {}
+    s = latest.get("summary", {}) or {}
 
-    # The "Latest" table reflects ONLY the newest build's entries -- a cell that
+    # The status table reflects ONLY the newest build's entries -- a cell that
     # disappeared from the current matrix must not linger as a stale pass/fail.
     latest_entries = latest.get("entries", []) or []
     latest_by_key: dict[str, dict[str, Any]] = {
@@ -126,71 +227,196 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         for k in keys:
             history[k].append(seen.get(k))
 
-    passrate = []
-    for doc in results:
-        s = doc.get("summary", {})
-        graded = (s.get("pass", 0) + s.get("fail", 0)) or 0
-        passrate.append((s.get("pass", 0) / graded) if graded else None)
-
-    # All values below originate from results/*.json (untrusted: error strings,
-    # reasons, version strings) and are HTML-escaped before interpolation.
-    rows = []
-    for k in sorted(keys):
-        e = latest_by_key.get(k, {})
-        verdict = e.get("verdict", "skip")
-        color = _VERDICT_COLOR.get(verdict, "#57606a")
-        st = (e.get("metrics") or {}).get("mean_step_time_ms")
-        st_txt = f"{st:.3f} ms" if isinstance(st, (int, float)) else "—"
-        reasons = "; ".join(e.get("reasons", []) or [])
-        rows.append(
-            f"<tr><td class='mono'>{_esc(k)}</td>"
-            f"<td class='center'><span class='badge' style='background:{color}'>{_esc(verdict)}</span></td>"
-            f"<td class='num'>{_esc(st_txt)}</td>"
-            f"<td class='spark'>{_svg_sparkline(history.get(k, []))}</td>"
-            f"<td class='muted'>{_esc(reasons)}</td></tr>"
-        )
-
-    # Per-metric trends from metrics.summary (the newest build defines the set).
+    # Per-metric history from metrics.summary (the newest build defines the set).
     metric_pairs: list[tuple[str, str]] = []
     for k, e in latest_by_key.items():
         for m in ((e.get("metrics") or {}).get("summary") or {}):
             metric_pairs.append((k, m))
     mhist: dict[tuple[str, str], list[float | None]] = {p: [] for p in metric_pairs}
     for doc in results:
-        seen: dict[tuple[str, str], float | None] = {}
+        seen_m: dict[tuple[str, str], float | None] = {}
         for e in doc.get("entries", []) or []:
             kk = f"{e.get('entry')}::{e.get('cell')}"
             for mm, val in ((e.get("metrics") or {}).get("summary") or {}).items():
-                seen[(kk, mm)] = val
+                seen_m[(kk, mm)] = val
         for p in metric_pairs:
-            mhist[p].append(seen.get(p))
-    metric_rows = []
-    for k, m in sorted(metric_pairs):
-        latest_val = ((latest_by_key[k].get("metrics") or {}).get("summary") or {}).get(m)
-        unit = _METRIC_UNITS.get(m, "")
-        val_txt = (
-            f"{latest_val:.4g} {unit}".strip()
-            if isinstance(latest_val, (int, float)) else "—"
+            mhist[p].append(seen_m.get(p))
+
+    passrate = []
+    for doc in results:
+        ds = doc.get("summary", {}) or {}
+        graded = (ds.get("pass", 0) + ds.get("fail", 0)) or 0
+        passrate.append((ds.get("pass", 0) / graded) if graded else None)
+
+    total = s.get("total", 0) or 0
+    graded_now = (s.get("pass", 0) or 0) + (s.get("fail", 0) or 0)
+    record_only = bool(total) and not graded_now
+
+    # Columns that would be uniformly empty are dropped rather than rendered as
+    # a wall of "n/a" -- with one night of history that was three of five.
+    show_trend = _has_trend([history[k] for k in keys])
+    reason_texts = ["; ".join(e.get("reasons") or []) for e in latest_entries]
+    distinct_reasons = sorted({r for r in reason_texts if r})
+    # Collapse the notes column ONLY when every cell says the same thing, so it
+    # can be stated once in a banner. Any variation keeps the column: a cell's
+    # explanation -- above all a failure's -- must stay next to the cell.
+    collapse_note = (
+        len(distinct_reasons) == 1
+        and len(reason_texts) > 1
+        and all(r == distinct_reasons[0] for r in reason_texts)
+    )
+    show_notes = bool(distinct_reasons) and not collapse_note
+    shared_reason = distinct_reasons[0] if collapse_note else ""
+
+    ncols = 3 + int(show_trend) + int(show_notes)
+
+    # Group cells under their workload so the sweep matrix stays visible.
+    groups: dict[str, list[str]] = {}
+    for k in keys:
+        groups.setdefault(str(latest_by_key[k].get("entry")), []).append(k)
+
+    body_parts = []
+    for entry_name in sorted(groups):
+        cell_keys = sorted(groups[entry_name])
+        tally: dict[str, int] = {}
+        step_times = []
+        for k in cell_keys:
+            v = latest_by_key[k].get("verdict", "skip")
+            tally[v] = tally.get(v, 0) + 1
+            st = (latest_by_key[k].get("metrics") or {}).get("mean_step_time_ms")
+            if isinstance(st, (int, float)):
+                step_times.append(st)
+        group_max = max(step_times) if len(step_times) > 1 else 0.0
+        tally_txt = " · ".join(
+            f"{tally[v]} {v}" for v in _VERDICT_ORDER if tally.get(v)
         )
-        policy = _metric_policy(m) or "(trend)"
-        metric_rows.append(
-            f"<tr><td class='mono'>{_esc(k)}</td>"
-            f"<td class='mono'>{_esc(m)}</td>"
-            f"<td class='center'>{_esc(policy)}</td>"
-            f"<td class='num'>{_esc(val_txt)}</td>"
-            f"<td class='spark'>{_svg_sparkline(mhist[(k, m)])}</td></tr>"
+        cell_word = "cell" if len(cell_keys) == 1 else "cells"
+
+        rows = [
+            f"<tr class='grp'><th colspan='{ncols}' scope='rowgroup'>"
+            f"<span class='wl'>{_esc(entry_name)}</span>"
+            f"<span class='muted'> {len(cell_keys)} {cell_word} · {_esc(tally_txt)}</span>"
+            f"</th></tr>"
+        ]
+        for k in cell_keys:
+            e = latest_by_key[k]
+            verdict = e.get("verdict", "skip")
+            color = _VERDICT_COLOR.get(verdict, "#57606a")
+            st = (e.get("metrics") or {}).get("mean_step_time_ms")
+            cells = [
+                f"<td class='cell mono'>{_esc(str(e.get('cell')))}</td>",
+                f"<td class='center'><span class='badge' "
+                f"style='background:{color}'>{_esc(verdict)}</span></td>",
+                f"<td class='num'>{_esc(_fmt_ms(st))}{_bar(st, group_max)}</td>",
+            ]
+            if show_trend:
+                cells.append(f"<td class='spark'>{_svg_sparkline(history.get(k, []))}</td>")
+            if show_notes:
+                cells.append(
+                    f"<td class='muted'>{_esc('; '.join(e.get('reasons') or []))}</td>"
+                )
+            rows.append(f"<tr>{''.join(cells)}</tr>")
+
+            mrows = _metric_rows(k, e, mhist, show_trend)
+            if mrows:
+                n_metrics = len((e.get("metrics") or {}).get("summary") or {})
+                recipe = e.get("recipe") or ""
+                dur = e.get("duration_sec")
+                prov = []
+                if recipe:
+                    prov.append(f"recipe <span class='mono'>{_esc(str(recipe))}</span>")
+                if isinstance(dur, (int, float)):
+                    prov.append(f"ran in {dur:,.0f}s")
+                trials = e.get("trials")
+                if isinstance(trials, int):
+                    prov.append(f"{trials} trial{'s' if trials != 1 else ''}")
+                rows.append(
+                    f"<tr class='mrow'><td colspan='{ncols}'><details>"
+                    f"<summary>{n_metrics} metric{'s' if n_metrics != 1 else ''}</summary>"
+                    f"<p class='prov'>{' · '.join(prov)}</p>"
+                    f"<table class='inner'><thead><tr><th>metric</th>"
+                    f"<th class='center'>policy</th><th class='num'>latest</th>"
+                    f"{'<th>trend</th>' if show_trend else ''}</tr></thead>"
+                    f"<tbody>{mrows}</tbody></table>"
+                    f"</details></td></tr>"
+                )
+        body_parts.append(f"<tbody>{''.join(rows)}</tbody>")
+
+    table_body = "".join(body_parts) or (
+        f"<tbody><tr><td colspan='{ncols}' class='muted'>no results yet</td></tr></tbody>"
+    )
+
+    head = [
+        "<th scope='col'>cell</th>",
+        "<th scope='col' class='center'>status</th>",
+        "<th scope='col' class='num'>step time</th>",
+    ]
+    if show_trend:
+        head.append("<th scope='col'>trend (step ms)</th>")
+    if show_notes:
+        head.append("<th scope='col'>notes</th>")
+
+    toolchain = "".join([
+        _chip("aorta", build.get("amd_aorta_version")),
+        _chip("PyTorch", build.get("torch")),
+        _chip("ROCm", build.get("rocm")),
+        _chip("HIP", build.get("hip")),
+    ])
+
+    provenance = [f"Run of {_esc(_fmt_timestamp(latest.get('generated_at', '')))}"]
+    sha = str(build.get("head_sha") or "")
+    if sha:
+        provenance.append(
+            f"commit <a class='mono' href='https://github.com/{_REPO}/commit/{_esc(sha)}'>"
+            f"{_esc(sha[:7])}</a>"
+        )
+    run_id = str(build.get("upstream_run_id") or "")
+    if run_id:
+        provenance.append(
+            f"<a href='https://github.com/{_REPO}/actions/runs/{_esc(run_id)}'>workflow run</a>"
+        )
+    wheel = str(build.get("wheel_file") or "")
+    if wheel:
+        provenance.append(f"<span class='mono'>{_esc(wheel)}</span>")
+
+    notices = []
+    if not results:
+        notices.append(
+            "<div class='notice'>No nightly results have been published yet. "
+            "This page fills in after the first Nightly Evaluation run.</div>"
+        )
+    elif record_only:
+        extra = f" Every cell reports: {_esc(shared_reason)}." if shared_reason else ""
+        notices.append(
+            f"<div class='notice'>No baselines are blessed yet, so nothing was graded "
+            f"pass or fail — this run <strong>recorded</strong> metrics for all {total} "
+            f"cells to become the reference.{extra}</div>"
+        )
+    elif shared_reason:
+        notices.append(
+            f"<div class='notice'>Every cell reports: {_esc(shared_reason)}.</div>"
+        )
+    if results and not show_trend:
+        notices.append(
+            "<div class='notice muted-notice'>Trend charts need at least two nightly "
+            "runs; they appear automatically once more history accumulates.</div>"
         )
 
-    s = latest.get("summary", {})
-    meta = _esc(
-        f"aorta {build.get('amd_aorta_version') or '?'} · "
-        f"torch {build.get('torch') or '?'} · ROCm {build.get('rocm') or '?'} · "
-        f"HIP {build.get('hip') or '?'}"
-    )
-    generated = _esc(latest.get("generated_at", ""))
-    metric_table = (
-        "".join(metric_rows) if metric_rows
-        else "<tr><td colspan=5 class=muted>no workload metrics captured yet</td></tr>"
+    cards = [
+        ("cells", total, ""),
+        ("pass", s.get("pass", 0), "#3fb950"),
+        ("fail", s.get("fail", 0), "#f85149"),
+        ("record", s.get("record", 0), "#d29922"),
+        ("skip", s.get("skip", 0), "#8b949e"),
+    ]
+    # Only worth a card when something was actually graded; otherwise it would
+    # sit next to the trend card reading "n/a" twice.
+    if passrate and isinstance(passrate[-1], float):
+        cards.append(("pass rate", f"{passrate[-1] * 100:.0f}%", ""))
+    cards_html = "".join(
+        f'<div class="card"><div class="k">{_esc(k)}</div>'
+        f'<div class="v"{f" style=color:{c}" if c else ""}>{_esc(str(v))}</div></div>'
+        for k, v, c in cards
     )
 
     return f"""<!doctype html>
@@ -198,80 +424,121 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>aorta nightly CI</title>
 <style>
-  :root {{ --bg:#0d1117; --panel:#161b22; --border:#21262d; --fg:#c9d1d9; --muted:#8b949e; }}
+  :root {{ --bg:#0d1117; --panel:#161b22; --border:#21262d; --fg:#c9d1d9;
+           --muted:#8b949e; --accent:#539bf5; }}
   * {{ box-sizing:border-box; }}
   body {{ font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-          margin:0; background:var(--bg); color:var(--fg); line-height:1.45; }}
-  .wrap {{ max-width:1060px; margin:0 auto; padding:2rem 1.25rem 3rem; }}
-  header {{ border-bottom:1px solid var(--border); padding-bottom:1rem; margin-bottom:.5rem; }}
-  h1 {{ font-size:1.5rem; margin:0 0 .5rem; }}
-  h2 {{ font-size:1.05rem; margin:2rem 0 .25rem; color:#e6edf3; }}
+          margin:0; background:var(--bg); color:var(--fg); line-height:1.5; }}
+  a {{ color:var(--accent); }}
+  .wrap {{ max-width:1100px; margin:0 auto; padding:2rem 1.25rem 4rem; }}
+  header {{ border-bottom:1px solid var(--border); padding-bottom:1.25rem; }}
+  .titlebar {{ display:flex; align-items:center; gap:.7rem; flex-wrap:wrap; }}
+  h1 {{ font-size:1.5rem; margin:0; }}
+  h2 {{ font-size:1.1rem; margin:2.25rem 0 .35rem; color:#e6edf3; }}
   .status-pill {{ display:inline-block; color:#fff; font-weight:600; font-size:.78rem;
-                  padding:3px 11px; border-radius:999px; background:{status_color}; vertical-align:middle; }}
-  .meta {{ color:var(--muted); font-size:.82rem; margin:.55rem 0 0; }}
-  .cards {{ display:flex; flex-wrap:wrap; gap:.6rem; align-items:stretch; margin:1.1rem 0 .25rem; }}
-  .card {{ background:var(--panel); border:1px solid var(--border); border-radius:8px;
-           padding:.5rem .85rem; min-width:80px; }}
-  .card .k {{ font-size:.68rem; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; }}
-  .card .v {{ font-size:1.3rem; font-weight:600; line-height:1.3; }}
-  .card.trend {{ flex:1; min-width:220px; }}
+                  padding:3px 11px; border-radius:999px; background:{status_color}; }}
+  .lede {{ color:var(--muted); font-size:.9rem; margin:.5rem 0 0; max-width:70ch; }}
+  .nav {{ font-size:.85rem; margin:.5rem 0 0; }}
+  /* Toolchain identity: a labelled grid, so each version is readable on its
+     own instead of one dot-separated run of small grey text. */
+  .chips {{ display:grid; gap:.5rem; margin:1.1rem 0 0;
+            grid-template-columns:repeat(auto-fit, minmax(190px, 1fr)); }}
+  .chip {{ background:var(--panel); border:1px solid var(--border);
+           border-radius:8px; padding:.45rem .7rem; min-width:0; }}
+  .chip .k {{ font-size:.65rem; color:var(--muted); text-transform:uppercase;
+              letter-spacing:.06em; }}
+  .chip .v {{ font-size:.82rem; overflow-wrap:anywhere; }}
+  .prov-line {{ color:var(--muted); font-size:.8rem; margin:.8rem 0 0; }}
+  .notice {{ background:#1c2128; border:1px solid var(--border);
+             border-left:3px solid var(--record, #9a6700); border-radius:6px;
+             padding:.6rem .85rem; margin:1.1rem 0 0; font-size:.86rem; }}
+  .notice.muted-notice {{ border-left-color:var(--border); color:var(--muted); }}
+  .cards {{ display:grid; gap:.6rem; margin:1.25rem 0 0;
+            grid-template-columns:repeat(auto-fit, minmax(96px, 1fr)); }}
+  .card {{ background:var(--panel); border:1px solid var(--border);
+           border-radius:8px; padding:.5rem .85rem; }}
+  .card .k {{ font-size:.65rem; color:var(--muted); text-transform:uppercase;
+              letter-spacing:.06em; }}
+  .card .v {{ font-size:1.35rem; font-weight:600; line-height:1.3; }}
+  .card.trend {{ grid-column:span 2; min-width:0; }}
   /* Block-level SVG avoids inline baseline spacing without zeroing the font
      size, which would also hide the "n/a" fallback for short histories. */
   .card.trend svg {{ display:block; }}
-  table {{ border-collapse:collapse; width:100%; margin-top:.5rem; background:var(--panel);
-           border:1px solid var(--border); border-radius:8px; overflow:hidden; }}
-  th, td {{ padding:.5rem .8rem; border-bottom:1px solid var(--border); font-size:.88rem; vertical-align:middle; }}
-  thead th {{ text-align:left; color:var(--muted); font-weight:600; font-size:.7rem;
-              text-transform:uppercase; letter-spacing:.05em; background:#12161b; }}
-  tbody tr:last-child td {{ border-bottom:0; }}
+  .tablewrap {{ overflow-x:auto; }}
+  table {{ border-collapse:collapse; width:100%; margin-top:.5rem;
+           background:var(--panel); border:1px solid var(--border);
+           border-radius:8px; overflow:hidden; }}
+  th, td {{ padding:.5rem .8rem; border-bottom:1px solid var(--border);
+            font-size:.88rem; vertical-align:middle; text-align:left; }}
+  thead th {{ color:var(--muted); font-weight:600; font-size:.68rem;
+              text-transform:uppercase; letter-spacing:.06em; background:#12161b;
+              position:sticky; top:0; z-index:1; }}
+  tr.grp th {{ background:#12171e; font-size:.9rem; font-weight:600;
+               border-top:1px solid var(--border); }}
+  tr.grp .wl {{ font-family:ui-monospace, SFMono-Regular, Menlo, monospace;
+                color:#e6edf3; }}
+  tr.grp .muted {{ font-weight:400; }}
+  td.cell {{ padding-left:1.6rem; }}
   tbody tr:hover {{ background:#1b2129; }}
-  td.num, th.num {{ text-align:right; font-variant-numeric:tabular-nums; }}
+  tbody tr.grp:hover, tbody tr.mrow:hover {{ background:transparent; }}
+  td.num, th.num {{ text-align:right; font-variant-numeric:tabular-nums;
+                    white-space:nowrap; }}
   td.center, th.center {{ text-align:center; }}
   td.spark {{ width:180px; }}
   td.spark svg {{ display:block; }}
-  .badge {{ display:inline-block; min-width:60px; text-align:center; color:#fff;
+  /* Step time is compared within its workload group, where the ratio means
+     something; the number stays the primary read and the bar is a hint. */
+  .bartrack {{ height:3px; background:#21262d; border-radius:2px; margin-top:4px; }}
+  .bar {{ height:3px; background:var(--accent); border-radius:2px; opacity:.75; }}
+  tr.mrow > td {{ padding:0 .8rem .4rem 1.6rem; }}
+  tr.mrow summary {{ cursor:pointer; color:var(--muted); font-size:.78rem;
+                     padding:.15rem 0; }}
+  tr.mrow .prov {{ color:var(--muted); font-size:.75rem; margin:.3rem 0 .1rem; }}
+  table.inner {{ margin:.3rem 0 .6rem; background:#12161b; }}
+  table.inner th, table.inner td {{ font-size:.8rem; padding:.35rem .6rem; }}
+  table.inner thead th {{ position:static; }}
+  .badge {{ display:inline-block; min-width:62px; text-align:center; color:#fff;
             padding:2px 8px; border-radius:999px; font-size:.75rem; font-weight:600; }}
-  .mono {{ font-family:ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.82rem; word-break:break-word; }}
+  .mono {{ font-family:ui-monospace, SFMono-Regular, Menlo, monospace;
+           font-size:.82rem; overflow-wrap:anywhere; }}
   .muted {{ color:var(--muted); font-size:.8rem; }}
-  .legend {{ color:var(--muted); font-size:.78rem; margin:.65rem 0 0; }}
+  .legend {{ color:var(--muted); font-size:.78rem; margin:.7rem 0 0; }}
 </style></head>
 <body>
   <div class="wrap">
     <header>
-      <h1>aorta nightly CI dashboard</h1>
-      <div>Latest: <span class="status-pill">{status}</span></div>
-      <p class="meta">{meta}<br>generated {generated}</p>
+      <div class="titlebar">
+        <h1>aorta nightly CI</h1>
+        <span class="status-pill">{status}</span>
+      </div>
+      <p class="lede">Every night AORTA installs the freshly built wheel on an
+        MI350 runner and replays its workload sweep, comparing each result
+        against a blessed baseline. This page is that run.</p>
+      <p class="nav"><a href="docs/">AORTA documentation</a> ·
+        <a href="https://github.com/{_REPO}">repository</a></p>
+      <div class="chips">{toolchain}</div>
+      <p class="prov-line">{' · '.join(provenance)}</p>
     </header>
 
+    {''.join(notices)}
+
     <div class="cards">
-      <div class="card"><div class="k">total</div><div class="v">{s.get('total', 0)}</div></div>
-      <div class="card"><div class="k">pass</div><div class="v" style="color:#3fb950">{s.get('pass', 0)}</div></div>
-      <div class="card"><div class="k">fail</div><div class="v" style="color:#f85149">{s.get('fail', 0)}</div></div>
-      <div class="card"><div class="k">record</div><div class="v" style="color:#d29922">{s.get('record', 0)}</div></div>
-      <div class="card"><div class="k">skip</div><div class="v" style="color:#8b949e">{s.get('skip', 0)}</div></div>
+      {cards_html}
       <div class="card trend"><div class="k">pass-rate trend</div><div class="v">{_svg_sparkline(passrate, width=240)}</div></div>
     </div>
 
-    <h2>Latest status</h2>
-    <table>
-      <colgroup><col style="width:38%"><col style="width:12%"><col style="width:13%"><col style="width:17%"><col style="width:20%"></colgroup>
-      <thead><tr><th>workload::cell</th><th class="center">status</th><th class="num">step time</th>
-        <th>trend (step ms)</th><th>notes</th></tr></thead>
-      <tbody>
-        {''.join(rows) if rows else '<tr><td colspan=5 class=muted>no results yet</td></tr>'}
-      </tbody>
-    </table>
-    <p class="legend">Verdicts: pass/fail = vs blessed baseline · record = no baseline yet (metrics captured) · skip = insufficient GPUs.</p>
-
-    <h2>Performance / metric trends</h2>
-    <table>
-      <colgroup><col style="width:34%"><col style="width:20%"><col style="width:10%"><col style="width:18%"><col style="width:18%"></colgroup>
-      <thead><tr><th>workload::cell</th><th>metric</th><th class="center">policy</th>
-        <th class="num">latest</th><th>trend</th></tr></thead>
-      <tbody>
-        {metric_table}
-      </tbody>
-    </table>
+    <h2>Workloads</h2>
+    <div class="tablewrap">
+      <table>
+        <thead><tr>{''.join(head)}</tr></thead>
+        {table_body}
+      </table>
+    </div>
+    <p class="legend">Verdicts: <strong>pass</strong>/<strong>fail</strong> = compared
+      against a blessed baseline · <strong>record</strong> = no baseline yet, metrics
+      captured as the future reference · <strong>skip</strong> = not enough GPUs on the
+      runner. Expand a cell to see its captured metrics and the recipe that produced
+      them.</p>
   </div>
 </body></html>
 """

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -120,9 +120,16 @@ def _has_trend(series: list[list[float | None]]) -> bool:
 def _latest_status(results: list[dict[str, Any]]) -> tuple[str, str]:
     """Headline verdict for the newest build.
 
-    Only a graded pass earns ``passing``. A build with no blessed baselines is
-    ``recording``, and one where every cell was skipped is ``skipping``:
-    reporting either as "passing" would claim a result nothing established.
+    Only a graded pass earns ``passing``; a build with no blessed baselines is
+    ``recording``, since reporting either as "passing" would claim a result
+    nothing established.
+
+    ``skipping`` is the terminal branch of that classification and not a state
+    today's pipeline can reach: ``nightly_eval`` appends a synthetic ``fail``
+    entry when every cell skips, so a real zero-work build carries ``fail >= 1``
+    and stops at ``failing`` above. It stays because this function must classify
+    whatever summary it is handed, and for an all-skip one every other label
+    would be a lie.
     """
     if not results:
         return "unknown", "#57606a"
@@ -198,8 +205,10 @@ def _metric_rows(
     summary = ((entry.get("metrics") or {}).get("summary") or {})
     out = []
     for m in sorted(summary):
+        raw = summary.get(m)
         unit = _METRIC_UNITS.get(m, "")
-        val = f"{_fmt_num(summary.get(m))} {unit}".strip()
+        # A unit on an unknown value ("— ms") reads as a measurement of nothing.
+        val = f"{_fmt_num(raw)} {unit}".strip() if _isnum(raw) else _fmt_num(raw)
         policy = _metric_policy(m) or "trend only"
         trend = (
             f"<td class='spark'>{_svg_sparkline(mhist.get((cell_key, m), []))}</td>"
@@ -265,7 +274,9 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     skip_now = s.get("skip", 0) or 0
     # "Nothing was graded" splits three ways and they must not be described
     # identically: every cell recorded a baseline, some recorded while others
-    # were skipped, or nothing ran at all.
+    # were skipped, or nothing ran at all. The last of those is unreachable for
+    # this pipeline's own output (see _latest_status) and only guards a summary
+    # from some other producer.
     nothing_graded = bool(total) and not graded_now
 
     # Columns that would be uniformly empty are dropped rather than rendered as

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -184,6 +184,34 @@ def test_dashboard_record_only_run_is_not_reported_as_passing():
     assert ">passing<" not in html
 
 
+def test_dashboard_skip_only_run_is_neither_passing_nor_recording():
+    # Every cell skipped for want of GPUs establishes nothing, so neither
+    # "passing" nor the record-only baseline story applies.
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "w", "cell": "c", "verdict": "skip",
+                   "reasons": ["needs 8 GPUs, runner exposes 2"], "metrics": {}}],
+                 total=1, skip=1)
+    html = gen_dashboard.build_dashboard_html([r])
+    assert "skipping" in html
+    assert ">passing<" not in html
+    assert "No baselines are blessed yet" not in html
+    assert "all 1 cells were" in html
+
+
+def test_dashboard_partial_record_does_not_claim_every_cell_recorded():
+    # record + skip must not be described as "recorded all N cells".
+    entries = [{"entry": "w", "cell": f"r{i}", "verdict": "record",
+                "reasons": ["no baseline (record-only)"],
+                "metrics": {"mean_step_time_ms": 1.0}} for i in range(3)]
+    entries.append({"entry": "w", "cell": "s0", "verdict": "skip",
+                    "reasons": ["needs 8 GPUs, runner exposes 2"], "metrics": {}})
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-07-30T00:00:00Z", entries, total=4, record=3, skip=1)])
+    assert "recording" in html
+    assert "3 of 4 cells (1 skipped)" in html
+    assert "all 4 cells" not in html
+
+
 def test_dashboard_groups_cells_under_their_workload():
     entries = [
         {"entry": "llm_determinism", "cell": c, "verdict": "record",

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -184,9 +184,34 @@ def test_dashboard_record_only_run_is_not_reported_as_passing():
     assert ">passing<" not in html
 
 
-def test_dashboard_skip_only_run_is_neither_passing_nor_recording():
-    # Every cell skipped for want of GPUs establishes nothing, so neither
-    # "passing" nor the record-only baseline story applies.
+def test_dashboard_zero_work_run_reports_the_failure_the_pipeline_records():
+    # This is what a real all-skip nightly looks like: nightly_eval appends a
+    # synthetic _nightly_eval "fail" entry when every cell skips, so the build
+    # carries fail>=1 and the honest headline is "failing", not "skipping".
+    # Asserting the shape without that entry would test a document this
+    # pipeline never emits.
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "w", "cell": "c", "verdict": "skip",
+                   "reasons": ["needs 8 GPUs, runner exposes 2"], "metrics": {}},
+                  {"entry": "_nightly_eval", "cell": None, "verdict": "fail",
+                   "reasons": ["no matrix entry ran (empty matrix or all skipped -- check GPUs)"],
+                   "metrics": {}}],
+                 total=2, fail=1, skip=1)
+    html = gen_dashboard.build_dashboard_html([r])
+    assert "failing" in html
+    assert ">passing<" not in html
+    assert "skipping" not in html
+    # The reason a zero-work build failed must be on the page, not just a badge.
+    assert "no matrix entry ran" in html
+    assert "No baselines are blessed yet" not in html
+
+
+def test_dashboard_all_skip_summary_is_labelled_skipping_not_passing():
+    # Defensive branch: unreachable for nightly_eval's own output (the test
+    # above covers that), but _latest_status must still classify an all-skip
+    # summary from any other producer, and every label but "skipping" would
+    # overclaim. Kept so a future relaxation of that invariant cannot silently
+    # resurrect the "skip-only reads as passing" bug.
     r = _results("2026-07-30T00:00:00Z",
                  [{"entry": "w", "cell": "c", "verdict": "skip",
                    "reasons": ["needs 8 GPUs, runner exposes 2"], "metrics": {}}],
@@ -285,3 +310,16 @@ def test_dashboard_does_not_treat_a_boolean_as_a_measurement():
         [doc("2026-07-30T00:00:00Z", True), doc("2026-07-31T00:00:00Z", False)])
     assert "1.0 ms" not in html
     assert "trend (step ms)" not in html
+
+
+def test_dashboard_omits_the_unit_when_the_value_is_unknown():
+    # "— ms" reads as a measurement of nothing; a missing value gets no unit.
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "w", "cell": "c", "verdict": "record", "reasons": [],
+                   "metrics": {"mean_step_time_ms": 1.0,
+                               "summary": {"decode_latency_ms": None,
+                                           "latency_ms": 12.5}}}],
+                 total=1, record=1)
+    html = gen_dashboard.build_dashboard_html([r])
+    assert "— ms" not in html
+    assert "12.5 ms" in html  # a real value keeps its unit

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -212,6 +212,26 @@ def test_dashboard_partial_record_does_not_claim_every_cell_recorded():
     assert "all 4 cells" not in html
 
 
+def test_dashboard_metric_trends_survive_a_missing_step_time():
+    # A cell can report metrics.summary with no mean_step_time_ms (harvest
+    # leaves it None). Its metric history is real, so the per-metric sparkline
+    # must still draw and the "needs two runs" notice must not claim otherwise,
+    # even though there is no step-time history to chart.
+    def doc(when, latency):
+        return _results(when,
+                        [{"entry": "w", "cell": "c", "verdict": "record", "reasons": [],
+                          "metrics": {"mean_step_time_ms": None,
+                                      "summary": {"decode_latency_ms": latency}}}],
+                        total=1, record=1)
+
+    html = gen_dashboard.build_dashboard_html(
+        [doc("2026-07-30T00:00:00Z", 12.5), doc("2026-07-31T00:00:00Z", 13.5)])
+    assert "<svg" in html
+    assert "Trend charts need at least two nightly runs" not in html
+    # The step-time column still has nothing to chart, so it stays collapsed.
+    assert "trend (step ms)" not in html
+
+
 def test_dashboard_groups_cells_under_their_workload():
     entries = [
         {"entry": "llm_determinism", "cell": c, "verdict": "record",

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -312,6 +312,38 @@ def test_dashboard_does_not_treat_a_boolean_as_a_measurement():
     assert "trend (step ms)" not in html
 
 
+def test_dashboard_rejects_values_it_cannot_render():
+    # json.loads accepts NaN/Infinity, and a metric mean can genuinely come out
+    # NaN. Unfiltered, NaN plots as "nan" coordinates and -- worse -- draws a
+    # full-width bar, since min(100.0, nan) returns 100.0. An int past the float
+    # range is rejected too: it raises OverflowError in every formatter here,
+    # including math.isfinite itself.
+    huge = int("9" * 400)
+    for bad in (float("nan"), float("inf"), float("-inf"), huge, True, None, "4"):
+        assert not gen_dashboard._isnum(bad), bad
+        assert gen_dashboard._fmt_num(bad) == "—", bad
+        assert gen_dashboard._fmt_ms(bad) == "—", bad
+        assert gen_dashboard._bar(bad, 10.0) == "", bad
+    assert gen_dashboard._isnum(0) and gen_dashboard._isnum(-1.5)
+
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "w", "cell": "c", "verdict": "record", "reasons": [],
+                   "metrics": {"mean_step_time_ms": float("nan"),
+                               "summary": {"decode_latency_ms": huge}}}],
+                 total=1, record=1)
+    html = gen_dashboard.build_dashboard_html([r])  # must not raise
+    assert "nan" not in html.lower()
+    assert 'class="bar"' not in html
+
+    # The pass-rate card divides summary counts, so a non-finite count would
+    # reach it as "nan%" rather than being withheld.
+    bad_counts = _results("2026-07-30T00:00:00Z",
+                          [{"entry": "w", "cell": "c", "verdict": "pass",
+                            "reasons": [], "metrics": {}}],
+                          total=1, **{"pass": float("nan")})
+    assert "nan" not in gen_dashboard.build_dashboard_html([bad_counts]).lower()
+
+
 def test_dashboard_omits_the_unit_when_the_value_is_unknown():
     # "— ms" reads as a measurement of nothing; a missing value gets no unit.
     r = _results("2026-07-30T00:00:00Z",

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -44,7 +44,9 @@ def test_dashboard_renders_status_and_rows():
     html = gen_dashboard.build_dashboard_html([r1, r2])
     assert "aorta nightly CI" in html
     assert "failing" in html  # latest run failed
-    assert "inference_offline::baseline-local" in html
+    # Cells are grouped under their workload, so the two names render separately.
+    assert "inference_offline" in html
+    assert "baseline-local" in html
     assert "0.2.1rc" in html
 
 
@@ -60,7 +62,7 @@ def test_dashboard_renders_summary_metric_series():
                                               "summary": {"decode_latency_ms": 12.5}}}],
                  total=1, **{"pass": 1})
     html = gen_dashboard.build_dashboard_html([r])
-    assert "Performance / metric trends" in html
+    assert "Workloads" in html
     assert "decode_latency_ms" in html
     assert "ms" in html  # unit rendered
 
@@ -136,3 +138,80 @@ def test_dashboard_escapes_untrusted_reason():
     html = gen_dashboard.build_dashboard_html([r])
     assert "<script>alert(1)</script>" not in html
     assert "&lt;script&gt;" in html
+
+
+def test_dashboard_always_explains_a_failure():
+    # Uninformative columns get collapsed, but a failing cell's reason must
+    # never be one of them -- a bare "fail" badge with no explanation anywhere
+    # is worse than a redundant column.
+    entries = [
+        {"entry": "w", "cell": f"c{i}", "verdict": "pass", "reasons": [],
+         "metrics": {"mean_step_time_ms": 1.0}}
+        for i in range(4)
+    ]
+    entries.append({"entry": "w", "cell": "bad", "verdict": "fail",
+                    "reasons": ["mean_step_time_ms 9 > max 5"],
+                    "metrics": {"mean_step_time_ms": 9.0}})
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-07-30T00:00:00Z", entries, total=5, fail=1, **{"pass": 4})])
+    assert "mean_step_time_ms 9 &gt; max 5" in html
+
+
+def test_dashboard_collapses_a_note_shared_by_every_cell():
+    # When every cell says the same thing, say it once instead of repeating it
+    # down a column -- but it still has to appear somewhere.
+    entries = [
+        {"entry": "w", "cell": f"c{i}", "verdict": "record",
+         "reasons": ["no baseline (record-only)"],
+         "metrics": {"mean_step_time_ms": 1.0}}
+        for i in range(3)
+    ]
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-07-30T00:00:00Z", entries, total=3, record=3)])
+    assert "no baseline (record-only)" in html
+    assert "<th scope='col'>notes</th>" not in html
+
+
+def test_dashboard_record_only_run_is_not_reported_as_passing():
+    # Nothing was graded, so "passing" would overstate the result.
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "w", "cell": "c", "verdict": "record",
+                   "reasons": ["no baseline (record-only)"],
+                   "metrics": {"mean_step_time_ms": 1.0}}],
+                 total=1, record=1)
+    html = gen_dashboard.build_dashboard_html([r])
+    assert "recording" in html
+    assert ">passing<" not in html
+
+
+def test_dashboard_groups_cells_under_their_workload():
+    entries = [
+        {"entry": "llm_determinism", "cell": c, "verdict": "record",
+         "reasons": [], "metrics": {"mean_step_time_ms": 10.0}}
+        for c in ("bf16-12L", "tf32-24L")
+    ]
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-07-30T00:00:00Z", entries, total=2, record=2)])
+    # One group header for the workload, and each cell listed beneath it.
+    assert html.count("llm_determinism") == 1
+    assert "bf16-12L" in html and "tf32-24L" in html
+
+
+def test_dashboard_omits_trend_column_without_history():
+    # A single build cannot draw a trend; the column is dropped rather than
+    # rendered as a full column of "n/a".
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "w", "cell": "c", "verdict": "record", "reasons": [],
+                   "metrics": {"mean_step_time_ms": 1.0,
+                               "summary": {"decode_latency_ms": 12.5}}}],
+                 total=1, record=1)
+    one = gen_dashboard.build_dashboard_html([r])
+    assert "trend (step ms)" not in one
+
+    r2 = _results("2026-07-31T00:00:00Z",
+                  [{"entry": "w", "cell": "c", "verdict": "record", "reasons": [],
+                    "metrics": {"mean_step_time_ms": 2.0,
+                                "summary": {"decode_latency_ms": 13.5}}}],
+                  total=1, record=1)
+    two = gen_dashboard.build_dashboard_html([r, r2])
+    assert "trend (step ms)" in two

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -263,3 +263,25 @@ def test_dashboard_omits_trend_column_without_history():
                   total=1, record=1)
     two = gen_dashboard.build_dashboard_html([r, r2])
     assert "trend (step ms)" in two
+
+
+def test_dashboard_does_not_treat_a_boolean_as_a_measurement():
+    # bool is a subclass of int, so a stray `true` in the results JSON would
+    # otherwise format as "1.0 ms", scale a bar, and count towards a trend.
+    assert gen_dashboard._fmt_ms(True) == "—"
+    assert gen_dashboard._fmt_num(True) == "—"
+    assert gen_dashboard._bar(True, 10.0) == ""
+    assert not gen_dashboard._has_trend([[True, False]])
+    assert "n/a" in gen_dashboard._svg_sparkline([True, True, True])
+
+    def doc(when, step):
+        return _results(when,
+                        [{"entry": "w", "cell": "c", "verdict": "record", "reasons": [],
+                          "metrics": {"mean_step_time_ms": step,
+                                      "summary": {"decode_latency_ms": step}}}],
+                        total=1, record=1)
+
+    html = gen_dashboard.build_dashboard_html(
+        [doc("2026-07-30T00:00:00Z", True), doc("2026-07-31T00:00:00Z", False)])
+    assert "1.0 ms" not in html
+    assert "trend (step ms)" not in html

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -18,6 +18,7 @@ def _load(name: str):
 
 gen_dashboard = _load("gen_dashboard")
 alert_issue = _load("alert_issue")
+eval_lib = _load("eval_lib")
 
 
 def _results(generated, entries, **summary):
@@ -220,11 +221,11 @@ def test_dashboard_all_skip_summary_is_labelled_skipping_not_passing():
     assert "skipping" in html
     assert ">passing<" not in html
     assert "No baselines are blessed yet" not in html
-    assert "all 1 cells were" in html
+    assert "all 1 results were" in html
 
 
-def test_dashboard_partial_record_does_not_claim_every_cell_recorded():
-    # record + skip must not be described as "recorded all N cells".
+def test_dashboard_partial_record_does_not_claim_every_result_recorded():
+    # record + skip must not be described as "recorded all N results".
     entries = [{"entry": "w", "cell": f"r{i}", "verdict": "record",
                 "reasons": ["no baseline (record-only)"],
                 "metrics": {"mean_step_time_ms": 1.0}} for i in range(3)]
@@ -233,8 +234,8 @@ def test_dashboard_partial_record_does_not_claim_every_cell_recorded():
     html = gen_dashboard.build_dashboard_html(
         [_results("2026-07-30T00:00:00Z", entries, total=4, record=3, skip=1)])
     assert "recording" in html
-    assert "3 of 4 cells (1 skipped)" in html
-    assert "all 4 cells" not in html
+    assert "3 of 4 results (1 skipped)" in html
+    assert "all 4 results" not in html
 
 
 def test_dashboard_metric_trends_survive_a_missing_step_time():
@@ -342,6 +343,55 @@ def test_dashboard_rejects_values_it_cannot_render():
                             "reasons": [], "metrics": {}}],
                           total=1, **{"pass": float("nan")})
     assert "nan" not in gen_dashboard.build_dashboard_html([bad_counts]).lower()
+
+
+def test_dashboard_does_not_count_records_as_configured_cells():
+    # summary.total is len(entries), not the size of the matrix: a workload
+    # skipped for want of GPUs emits ONE record with cell=None however many
+    # cells its recipe defines. Counting those as "cells" overstates coverage
+    # exactly when coverage is worst, so the page says "results" instead.
+    entries = [
+        {"entry": "llm_determinism", "cell": c, "verdict": "record",
+         "reasons": ["no baseline (record-only)"],
+         "metrics": {"mean_step_time_ms": 10.0}} for c in ("bf16-12L", "tf32-24L")
+    ]
+    entries.append({"entry": "training_ddp_8gpu", "cell": None, "verdict": "skip",
+                    "reasons": ["needs 8 GPU(s), have 2"], "metrics": {}})
+    # Summarised by the harness's own summarizer, so the document under test
+    # cannot drift into a shape nightly_eval would never produce.
+    doc = _results("2026-07-30T00:00:00Z", entries, **eval_lib.summarize(entries))
+    assert doc["summary"]["total"] == 3  # three records, though the matrix is wider
+    html = gen_dashboard.build_dashboard_html([doc])
+
+    assert "2 of 3 results (1 skipped)" in html
+    assert ">results<" in html and ">cells<" not in html  # count card label
+    for wrong in ("2 of 3 cells", "3 cells", "2 cells ·", "1 cell ·"):
+        assert wrong not in html, wrong
+    assert "2 results ·" in html and "1 result ·" in html  # group tallies
+    # A skipped workload reports duration_sec 0.0; it never ran, so claiming a
+    # "workload run 0s" would be a measurement of something that did not happen.
+    assert "workload run 0s" not in html
+    # The skipped workload's single record is not presented as a cell name.
+    assert ">None<" not in html
+    assert "whole workload" in html
+
+
+def test_dashboard_states_duration_once_per_workload_not_per_cell():
+    # nightly_eval measures duration_sec once around the whole recipe and copies
+    # it onto every record, so repeating it inside each cell's details reads as
+    # per-cell time. It belongs to the workload and is stated there once.
+    entries = [
+        {"entry": "llm_determinism", "cell": c, "verdict": "record", "reasons": [],
+         "duration_sec": 105.96, "trials": 2,
+         "metrics": {"mean_step_time_ms": 10.0, "summary": {"latency_ms": 1.5}}}
+        for c in ("bf16-12L", "tf32-24L", "moe4-bf16-12L", "baseline-bf16-24L")
+    ]
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-07-30T00:00:00Z", entries, **eval_lib.summarize(entries))])
+
+    assert html.count("workload run 106s") == 1
+    assert "ran in 106s" not in html  # never restated as if it were per cell
+    assert html.count("2 trials") == 4  # genuinely per-record detail stays
 
 
 def test_dashboard_omits_the_unit_when_the_value_is_unknown():

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -336,13 +336,16 @@ def test_dashboard_rejects_values_it_cannot_render():
     assert "nan" not in html.lower()
     assert 'class="bar"' not in html
 
-    # The pass-rate card divides summary counts, so a non-finite count would
-    # reach it as "nan%" rather than being withheld.
-    bad_counts = _results("2026-07-30T00:00:00Z",
-                          [{"entry": "w", "cell": "c", "verdict": "pass",
-                            "reasons": [], "metrics": {}}],
-                          total=1, **{"pass": float("nan")})
-    assert "nan" not in gen_dashboard.build_dashboard_html([bad_counts]).lower()
+    # Summary counts drive branching, division and the pass-rate card, so a
+    # malformed one must not crash generation ("4" + 0 raises TypeError) nor
+    # surface as "nan%". They render as "—" rather than a 0 we cannot vouch for.
+    entry = [{"entry": "w", "cell": "c", "verdict": "pass", "reasons": [],
+              "metrics": {}}]
+    for count in (float("nan"), "4", huge, True, None):
+        doc = _results("2026-07-30T00:00:00Z", entry, total=1, **{"pass": count})
+        out = gen_dashboard.build_dashboard_html([doc])  # must not raise
+        assert "nan" not in out.lower(), count
+        assert "—" in out, count
 
 
 def test_dashboard_does_not_count_records_as_configured_cells():


### PR DESCRIPTION
## Why

Two problems, both about the nightly results being unusable in practice.

**Nobody could find the dashboard.** It was served at `/ci/`, and the landing page at the site root never linked to it — the word "dashboard" did not appear anywhere in the README. Anyone visiting https://rocm.github.io/aorta/ saw an unchanged project README and reasonably concluded nothing had shipped.

**The page itself was unreadable for a newcomer.** It was two long tables. On the live data, three of the five columns in the first table carried no information at all: `status` said `record` 16 times, `trend` said `n/a` 16 times, and `notes` repeated "no baseline (record-only)" 16 times — and those were the widest columns. Step times spanning 39 ms to 19,125 ms sat in a plain column with no sense of scale, and `llm_determinism`'s eight cells were flat rows with no grouping, so the sweep matrix was invisible.

## What changed

### Site layout

The dashboard now owns the site root; the Jekyll-rendered README moves to `/docs/`, which had no index of its own (it 404s today, so nothing is overwritten). The README gains a link to the dashboard.

The rendered README mixes root-absolute links with relative ones, and moving it one directory deeper breaks only the relative ones, so those are re-pointed with a `../` prefix. On the real page this rewrites exactly one link, `recipes/` → `../recipes/`, which resolves to a live 200; fragment, root-absolute and absolute links are untouched and the result is still well-formed.

The no-history path also changed: rather than deploying docs only, the root publishes the dashboard's own empty state, so the site root can never 404.

### The dashboard

- **Grouped by workload**, with a per-group verdict tally, so the matrix structure is visible.
- **Uninformative columns are dropped** instead of rendered as a wall of `n/a`; the record-only page went from 117 `n/a` strings to 3. A note shared by *every* cell collapses into a single banner — but any variation keeps the column, because a failing cell's reason must never be dropped.
- **The metric-trends table is folded into collapsible per-cell rows**, which also carry the recipe, duration and trial count.
- **Step time gets a bar scaled within its workload group**, where the ratio is meaningful; single-cell groups get no bar, since that would only compare a value to itself.
- **Rebuilt header**: the toolchain identity is a labelled grid rather than one cramped dot-separated line, with links to the commit, the workflow run and the docs, plus a plain-English description of what the page shows.
- **Honest status**: a run with no blessed baselines reports `recording`, not `passing`, and a banner explains why there are no verdicts.

## Verification

Rendered four history shapes — the real published history, plus synthetic empty, multi-build-with-a-failure, and mixed-verdict-with-skips:

- All four are well-formed HTML (zero unclosed tags, zero nesting errors).
- The multi-build render draws sparklines and surfaces the failing cell's reason.
- The link rewrite was checked against the live landing page: 1 of 25 links changed, and it resolves to a 200.

Test suite goes from 11 to 16 tests. New coverage for: a failure's reason always rendering, a shared note collapsing to a banner, record-only not reporting as passing, workload grouping, and the trend column appearing only once there is history. Two existing tests were updated for the restructured markup (`workload::cell` is now a group row plus a cell row, and the "Performance / metric trends" heading is gone).

## Note for the reviewer

While building this I introduced and then fixed a bug worth flagging, since the column-collapsing logic is the subtle part: the first version dropped the notes column whenever there was only one *distinct* reason string, which meant a graded failure rendered a bare `fail` badge with its explanation nowhere on the page. `test_dashboard_always_explains_a_failure` now guards it.

Made with [Cursor](https://cursor.com)