### PR TITLE
ci(copilot): add Copilot custom instructions for public-disclosure review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,101 @@
+# Copilot instructions -- ROCm/aorta
+
+## This repository is public
+
+`ROCm/aorta` is a public repository. Everything that reaches `main` -- source,
+docs, recipes, test fixtures, sample logs, commit messages -- is world-readable
+and permanent in git history. Reverting a leak does not unpublish it.
+
+AORTA's private counterpart, `ROCm/aorta-internal`, owns the customer-escalation
+workloads, NDA'd reproducer sources, and the mitigation harness. The two sides
+meet only through the public `aorta.workloads` entry-point group, and this
+repository's plugin system exists precisely so downstream and private workloads
+can register from outside. **Customer-specific material is therefore never
+required here for the platform to work.** If a diff seems to need it, that is the
+signal that the change belongs on the private side.
+
+Treat every pull request as a disclosure review as well as a code review. When
+something in a diff looks like it belongs on the private side, raise it
+explicitly, name the category below that it falls under, and say whether the fix
+is to relocate it to `aorta-internal` or to redact it in place. Prefer raising a
+borderline case over staying silent: a false positive costs a review comment, a
+false negative is public forever.
+
+## What must not land in this repository
+
+1. **Customer and partner identity.** Names, codenames, abbreviations, ticket
+   IDs, or logos of external customers and partners -- in code, comments,
+   docstrings, docs, recipe names, cell names, fixture filenames, or test data.
+   This includes indirect identification: a workload named after the customer's
+   product, or a model/config combination unique enough to identify them.
+
+2. **Customer workload material.** Reproducer sources, model definitions,
+   training or inference scripts, hyperparameters, dataset names or paths, and
+   model architecture details that arrived from a customer escalation. These live
+   in the owning workload directory on the private side.
+
+3. **Real captured environments and logs.** Verbatim environment-variable dumps,
+   `aorta env probe` snapshots, training logs, loss curves, step timings, or
+   profiler output taken from a real customer or partner run. Fixtures and
+   examples in this repository should be synthetic or drawn from AMD's own
+   hardware. Watch for these arriving as large `.json` / `.log` / `.txt`
+   additions under `tests/`, `examples/`, or `docs/`.
+
+4. **Internal infrastructure identifiers.** Lab, dev, and CI machine hostnames;
+   internal IP addresses and subnets; cluster, partition, or queue names;
+   internal dashboard, wiki, or document-store URLs; and absolute paths that
+   embed a user's home directory or an internal mount. A setup guide or example
+   command that only works on one specific machine is the usual way these arrive
+   -- rewrite it against a placeholder.
+
+5. **Non-public container images.** Image tags or digests from AMD-internal or
+   customer-gated registries. Only images a member of the public can actually
+   pull belong in committed Dockerfiles, recipes, and docs.
+
+6. **Internal-only planning material.** Design documents, roadmaps, escalation
+   post-mortems, and status reports written for an internal audience. Public
+   planning documents are welcome (see the "expected here" list below); the test
+   is the intended audience and the content, not the file's location.
+
+## This file is public too
+
+Do not add real customer names, codenames, hostnames, or internal URLs to this
+file or to any other instructions file, whether as a deny-list, an example, or a
+"do not use this string" note. Doing so publishes the exact value the rule exists
+to protect. Describing the *shape* of a sensitive value is the most any file in
+this repository can carry. The authoritative list lives on the private side.
+
+## What is expected here, and should not be flagged
+
+These are all normal in this repository. Flagging them produces noise and trains
+reviewers to ignore disclosure comments.
+
+- **AMD product and architecture names** -- `MI300X`, `MI350X`, `MI355X`,
+  `MI450X`, `gfx942`, `gfx1250`, ROCm and HIP version numbers. Public.
+- **Links to public repositories and docs**, including `ROCm/rocm-systems`,
+  `mirage`, `rocjitsu`, and `rocm.docs.amd.com`.
+- **Cross-references to `aorta-internal` issue numbers.** Pointing at a private
+  issue by number is established practice here (see
+  `tests/probe/test_recurring_issue_regression.py`). The pointer is fine; what
+  must not follow it across is the customer-identifying content behind it.
+- **`docs/plans/`.** A legitimate home for planning documents written for a
+  public audience, such as feature rubrics tied to public issues.
+- **Public mitigation and environment-variable names** -- `tf32_off`,
+  `hsa_xnack`, `HSA_NO_SCRATCH_RECLAIM`, and the rest of the built-in registry.
+  These are published debugging knobs, not customer information.
+- **Contributor names, emails, and GitHub handles** in git metadata, CODEOWNERS,
+  and changelogs.
+- **`docker/` package URLs on `artifactory-cdn.amd.com`.** These predate these
+  instructions and are already on `main`; do not raise them as new findings.
+  Newly added credentials, tokens, or auth headers alongside them are in scope.
+
+## How to raise a finding
+
+Comment on the specific line, name the category number, and state the remedy.
+For example: "Category 4 -- this example command hardcodes a lab hostname, so it
+only works on one machine and publishes its name. Suggest a placeholder such as
+`<your-host>` with the requirement described in prose."
+
+If a diff mixes platform work with customer-specific material, say which files
+are safe to merge and which need to move, so the author can split the pull
+request rather than rework it wholesale.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,53 @@
+---
+applyTo: "docs/**,**/README.md"
+---
+
+# Disclosure review for prose
+
+Narrative files are where private material has actually reached public `main` in
+this repository, because prose carries the incidental detail that code does not:
+the machine someone ran it on, the internal document that explains why, the
+customer the investigation was really about. Apply the categories in
+`.github/copilot-instructions.md`, and additionally check the following.
+
+## Is this document written for a public reader?
+
+A page belongs here only if a ROCm user outside AMD could act on it. Ask who the
+audience is:
+
+- **Reproducible by anyone** -- flag nothing. Setup guides, CLI walkthroughs,
+  schema references, and design notes for published features are the point of
+  `docs/`.
+- **Reproducible only by the author** -- flag it. A walkthrough pinned to one
+  developer's host, container name, absolute home-directory path, or scratch
+  mount is a private artifact even when nothing in it is formally confidential.
+  The remedy is usually to parameterise the specifics, not to delete the page.
+- **Written for an internal audience** -- flag it. Escalation narratives, status
+  updates addressed to an internal team, and design documents for unpublished
+  work belong in `aorta-internal`. Public planning documents tied to public
+  issues are fine and live in `docs/plans/`.
+
+## Checks specific to prose
+
+- **Example commands and shell blocks.** Every host, path, container name,
+  registry, and image tag in a fenced block is published. Prefer a placeholder
+  (`<your-host>`, `$HOME`, `<output-dir>`) with the requirement stated in prose
+  over a literal value that happened to work on one machine.
+- **Pasted output.** Sample terminal output, `env probe` snapshots, and log
+  excerpts should be synthetic or from AMD hardware, and trimmed to the lines
+  that illustrate the point. A full paste tends to carry hostnames, absolute
+  paths, and environment details nobody reviewed.
+- **Cross-links.** Links must resolve for an anonymous reader. A link to a
+  private repository path, an internal wiki, or a document store is both a broken
+  link and a disclosure of the internal structure. Naming a private issue by
+  number is fine; linking into private content is not.
+- **Deletions that leave dangling references.** When a page is removed because it
+  should not have been public, the same pull request has to drop every reference
+  to it -- other docs, README links, and module docstrings. A stale link tells a
+  reader exactly what was withdrawn and invites them to go looking for it.
+
+## Do not rewrite technical substance
+
+These instructions cover what is safe to publish, not how the documentation
+should read. Do not use a disclosure review to argue for restructuring a page,
+changing its tone, or expanding its coverage.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -13,11 +13,15 @@ customer the investigation was really about. Apply the categories in
 ## Is this document written for a public reader?
 
 A page belongs here only if a ROCm user outside AMD could act on it. Ask who the
-audience is:
+audience is. This test decides whether the *page* belongs in a public repository;
+it never waives the line-level checks. A broadly useful document can still leak a
+hostname, an absolute path, or an internal image tag in a single example, so apply
+the categories to the contents either way.
 
-- **Reproducible by anyone** -- flag nothing. Setup guides, CLI walkthroughs,
-  schema references, and design notes for published features are the point of
-  `docs/`.
+- **Reproducible by anyone** -- the page itself is in scope for `docs/`, so raise
+  no objection to its presence. Setup guides, CLI walkthroughs, schema
+  references, and design notes for published features are the point of this
+  directory. Still review its individual lines.
 - **Reproducible only by the author** -- flag it. A walkthrough pinned to one
   developer's host, container name, absolute home-directory path, or scratch
   mount is a private artifact even when nothing in it is formally confidential.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -50,6 +50,14 @@ the categories to the contents either way.
   to it -- other docs, README links, and module docstrings. A stale link tells a
   reader exactly what was withdrawn and invites them to go looking for it.
 
+## This file is public too
+
+Every rule above applies to this file. When illustrating a check, describe the
+shape of the offending value rather than quoting a real hostname, path, image
+tag, or customer name -- pasting one here publishes the exact value the rule
+exists to protect. See the same section in
+`.github/copilot-instructions.md`.
+
 ## Do not rewrite technical substance
 
 These instructions cover what is safe to publish, not how the documentation


### PR DESCRIPTION
## Summary

Copilot code review already runs on every PR and push in this repository (the
`CoPilot Review` ruleset, with `review_on_push` and `review_draft_pull_requests`
both enabled), but we ship no custom instructions. So Copilot reviews every diff
without knowing that `ROCm/aorta` is the public half of a public/private split.
Its own review footer has been asking for these files on each PR: *"Add Copilot
custom instructions for smarter, more guided reviews."*

This adds them, aimed at one job: catching customer-specific and internal-only
material before it reaches public `main`.

The motivating case is #285, which deleted an internal design doc and a
contributor-specific demo guide (including a lab machine hostname) *after* they
had already landed on `main`. Reverting does not unpublish anything, so the check
has to happen pre-merge. `aorta-internal`'s `CLAUDE.md` rule 4 already states the
policy; nothing on the public side could see it until now.

- **`.github/copilot-instructions.md`** — repository-wide. States the boundary,
  notes that the `aorta.workloads` entry-point group means customer-specific
  material is never *required* here, then enumerates six categories to flag:
  customer identity, customer workload material, real captured environments and
  logs, internal infrastructure identifiers, non-public container images, and
  internal-only planning material.
- **`.github/instructions/docs.instructions.md`** — scoped to `docs/**` and
  `**/README.md` via `applyTo`, because prose is where this has actually gone
  wrong. Adds an audience test ("could a ROCm user outside AMD act on this?")
  plus checks for example commands, pasted output, cross-links, and deletions
  that leave dangling references.

Both files include an allow-list of things that are already public and must
**not** be flagged — AMD product and arch names, public ROCm links,
`aorta-internal` issue pointers, `docs/plans/`, built-in mitigation names, and
the existing `artifactory-cdn.amd.com` URLs in `docker/`. A reviewer that flags
established practice teaches people to ignore it, so the noise floor matters as
much as the coverage.

Both also carry an explicit rule that **the instructions files are public too**,
so no one later adds real customer names or hostnames as a deny-list and
publishes the exact values the rules exist to protect.

## Limits — please read before treating this as a control

This is a guardrail, not enforcement. Three specific gaps:

1. **Copilot cannot block a merge.** Its reviews land as `COMMENTED`, never a
   blocking `REQUEST_CHANGES`, and it is not a status check.
2. **Instructions are read from the PR head branch**, so a branch that edits or
   deletes these files changes the rules of its own review.
3. **`main protection` currently has `required_approving_review_count: 0`**, with
   `require_code_owner_review: false` and
   `required_review_thread_resolution: false` — a PR can merge with no human
   approval and with Copilot's comments unread.

Follow-ups worth deciding on separately, not included here:

- A `leak-scan` workflow as a **required status check** — the only layer that
  actually prevents a merge. Note the deny-list of customer names cannot live in
  plaintext in a public repo; it would need an Actions variable or org-level
  secret scanning custom patterns.
- **Secret scanning push protection is currently disabled** on this repo
  (scanning itself is on). Enabling it rejects content at `git push`, before a PR
  exists.
- Raising `required_approving_review_count` to 1 and/or enabling CODEOWNERS
  review, so a human signs off on public-facing diffs.

## Open question for reviewers

`docker/` Dockerfiles fetch `amdgpu-install-internal` packages from
`artifactory-cdn.amd.com`. That predates this PR and is on `main`, so the
instructions explicitly tell Copilot not to raise it as a new finding. Flagging
it here in case that was never a deliberate decision — if it should be treated as
in-scope, the allow-list entry should come out.

## Test plan

No code changes; nothing executable is added.

- [x] `pre-commit` passes on both files (trailing-whitespace, end-of-file-fixer, check-yaml); full CI green.
- [x] `applyTo` frontmatter parses as valid YAML.
- [x] Every identifier in the allow-list verified to already exist publicly in the repo, so the examples are real rather than invented.
- [x] **Confirmed Copilot picks the instructions up from the head branch, so this PR reviewed itself.** Its overview now describes the disclosure purpose and the `aorta-internal` split — information available only from these files — and the "Add Copilot custom instructions" footer nag is gone from the latest review.
- [x] **The self-review found two real defects, both fixed here:**
  - `9042a3d` — the "reproducible by anyone" bullet said *"flag nothing"*, which read as a blanket waiver on a whole page rather than on its audience. That would have suppressed exactly the findings this file exists to produce. The audience test is now explicitly scoped to whether a page belongs in a public repo, and never waives the line-level category checks.
  - `5a4476f` — the "this file is public too" rule lived only in the repo-wide file, while the docs-scoped file is the one that will be edited to add a worked example of a check. That is precisely when a real hostname gets pasted in to illustrate the point, so the rule is now repeated there.
- [ ] Watch the next few PRs for false positives, and tighten the allow-list if the noise floor is too high.