### PR TITLE
docs: clarify installation and Docker execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ use paths from the AORTA repository root.
 There is no global rule that AORTA must run on the host or inside a container:
 
 - Run `aorta env probe` in the environment you want to inspect, including
-  inside a container when appropriate.
+  inside a container when appropriate. To inspect an image without installing
+  AORTA in it, use the [package-mount workflow](docs/env-probe.md#probe-a-docker-image-without-aorta-installed).
 - Some workloads run in the same environment as the CLI.
 - Some workload plugins own a `docker run` launch. For those workloads, follow
   the plugin's instructions; the CLI normally runs on a Docker-capable host,

--- a/README.md
+++ b/README.md
@@ -29,57 +29,84 @@ downstream packages can register their own workloads.
 
 ## Installation
 
-PyTorch for ROCm is **installed separately** from the ROCm PyTorch index (it is
-not bundled in the wheel). Install it first, then AORTA.
-
-Install the published release with `pip install amd-aorta` (below). For the
-latest unreleased changes, clone the repo and do an editable install from source
-(see [From source](#from-source-for-contributors)).
+Install AORTA in the Python environment from which you will invoke `aorta`.
+The core install provides the CLI, recipe support, and environment probe. It
+does not install or require PyTorch. AORTA requires Python 3.10 or newer.
 
 ### From PyPI (recommended for users)
 
 ```bash
-# 1. PyTorch for your ROCm version — see https://pytorch.org/get-started/locally/
-#    for the index URL matching your ROCm release.
-pip install --pre torch torchvision torchaudio \
-  --index-url https://download.pytorch.org/whl/nightly/rocm<YOUR_ROCM_VERSION>/
-
-# 2. AORTA (distribution: amd-aorta; import package + CLI: aorta)
-pip install amd-aorta
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install amd-aorta
+aorta --help
 ```
 
-Optional extras:
-
-```bash
-pip install "amd-aorta[hw-queue]"   # hardware-queue evaluation (numpy/pandas/tabulate)
-```
-
-> `[hw-queue]` requires PyTorch — install torch from the ROCm index (step 1
-> above) before installing this extra.
-
-Other extras: `analysis` (matplotlib only), `hw-queue-profiling` (hw-queue +
-profiling plots), `ebpf` (no extra Python deps; needs the `bpftrace` binary and
-`CAP_BPF`/`CAP_PERFMON` or sudo at runtime).
+The distribution name is `amd-aorta`; the import package and command are
+`aorta`.
 
 ### From source (for contributors)
 
-We recommend [uv](https://github.com/astral-sh/uv) for fast environment management.
+Use [uv](https://github.com/astral-sh/uv) for a fast editable setup:
 
 ```bash
 git clone https://github.com/ROCm/aorta.git
 cd aorta
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+aorta --help
+```
 
-uv venv && source .venv/bin/activate
+Plain `pip` also works: `python -m pip install -e .`. Contributors who need
+the test and lint tools can use `uv pip install -e ".[dev]"`.
 
-# PyTorch for your ROCm version — see https://pytorch.org/get-started/locally/
-uv pip install --pre torch torchvision torchaudio \
-  --index-url https://download.pytorch.org/whl/nightly/rocm<YOUR_ROCM_VERSION>/
+### Optional dependencies
 
-# Editable install with the extras you need
+An **extra** adds dependencies for a specific feature; it is not part of the
+minimal install. Install only the extras you need. For example:
+
+```bash
+# Published package:
+python -m pip install "amd-aorta[hw-queue]"
+
+# Editable source checkout:
 uv pip install -e ".[hw-queue]"
 ```
 
-Plain `pip` works too: `pip install -e ".[hw-queue]"`.
+Hardware-queue evaluation and most GPU training or inference workloads also
+require PyTorch. AORTA does not bundle it. When the selected workload requires
+PyTorch, install a build matching that environment's ROCm version:
+
+```bash
+# Set this to the index URL for your ROCm release from
+# https://pytorch.org/get-started/locally/
+PYTORCH_ROCM_INDEX=https://download.pytorch.org/whl/nightly/rocmX.Y/
+python -m pip install --pre torch \
+  --index-url "$PYTORCH_ROCM_INDEX"
+```
+
+Other optional extras include `analysis`, `report`, `hw-queue-profiling`,
+`agent`, and `ebpf`. The `ebpf` extra has no additional Python packages; its
+runtime needs `bpftrace` and the required permissions.
+
+## Where commands run
+
+`aorta` runs in the active Python environment, and relative recipe, command,
+and output paths are resolved from the current directory. The examples below
+use paths from the AORTA repository root.
+
+There is no global rule that AORTA must run on the host or inside a container:
+
+- Run `aorta env probe` in the environment you want to inspect, including
+  inside a container when appropriate.
+- Some workloads run in the same environment as the CLI.
+- Some workload plugins own a `docker run` launch. For those workloads, follow
+  the plugin's instructions; the CLI normally runs on a Docker-capable host,
+  while the workload image supplies its runtime dependencies.
+
+The core dispatcher does not execute `docker run`; Docker-aware workload
+plugins may do so and own the launch.
 
 ## Quick Start
 
@@ -242,7 +269,7 @@ The standalone `aorta mitigations list` and `aorta environments list` groups are
 
 | Guide | Description |
 | --- | --- |
-| [Getting Started](docs/getting-started.md) | Prerequisites, Docker setup, installation |
+| [Getting Started](docs/getting-started.md) | Installation, command location, and workload-specific prerequisites |
 | [Hardware Queue Eval](docs/hw-queue-eval.md) | Workloads, CLI usage, metrics |
 | [Environment Probe](docs/env-probe.md) | Capture / diff / query a versioned environment snapshot; jq cookbook |
 | [`aorta sweep`](docs/probe/usage.md) | Unified matrix runner — built-in workloads **or** opaque launch commands |

--- a/docs/buck2.md
+++ b/docs/buck2.md
@@ -220,7 +220,7 @@ buck2 run aorta -- sweep list-environments
 
 # Validate a recipe without executing it
 buck2 run aorta -- sweep run --recipe recipes/training/example-fsdp-smoke.yaml --dry-run
-# Dry run: fsdp / ticket=EXAMPLE-151
+# Dry run: race (mode=fsdp) / ticket=EXAMPLE-151
 # Cells (3):
 #   - baseline-local: mitigations=['none'] environment=local trials=2 steps=100
 #   - tf32_off-local: mitigations=['tf32_off'] environment=local trials=2 steps=100
@@ -233,16 +233,16 @@ The public `aorta` build ships no `aorta.workloads` plugins (workloads
 register via a separate package's entry-points; see
 [Extending: adding workloads via plugins](#extending-adding-workloads-via-plugins)
 below).
-The example recipe targets `workload: fsdp`, so each cell will error
-with `Workload 'fsdp' not found. Available: []`. That's intentional --
-the recipe's own header documents it -- and `aorta sweep` is built to
-keep going:
+The example recipe targets `workload: race`, so each cell will error with
+`Workload 'race' not found. Available: []`. That's intentional for this Buck
+target, which does not include workload plugin metadata, and `aorta sweep` is
+built to keep going:
 
 ```bash
 buck2 run aorta -- sweep run --recipe recipes/training/example-fsdp-smoke.yaml -v
 ```
 
-What you get back (under `triage_results/EXAMPLE-151/fsdp/<timestamp>/`):
+What you get back (under `triage_results/EXAMPLE-151/race/<timestamp>/`):
 
 | Artifact | What's in it |
 |---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,12 @@ as silent corruption. Trial metrics record both the workload dtype and
 
 ### Workload-owned Docker launches
 
-The dispatcher records the effective controlled overlay in
+Docker is not a universal AORTA execution backend. The core dispatcher does
+not execute `docker run`; a Docker-aware workload plugin may own the container
+launch. Operators should follow that workload's guide and normally invoke the
+CLI from a Docker-capable host.
+
+For plugin authors, the dispatcher records the effective controlled overlay in
 `config["_aorta_trial_env"]`. The key is always present as a plain
 `dict[str, str]`, including `{}` when no controlled source contributed. A
 Docker-aware workload wrapper can forward it with the public helper:
@@ -96,10 +101,10 @@ argv = ["docker", "run", *docker_env_flags(trial_env), image, *inner_command]
 validates names and string values, and never reads `os.environ`. Treat values
 as potentially sensitive and do not log `_aorta_trial_env`.
 
-The dispatcher does not launch Docker. Workload wrappers continue to own image
-selection, mounts, devices, IPC/shared-memory settings, entrypoints, and inner
-commands. Top-level recipe `extra_env` is a matrix/triage feature; probe-mode
-recipes retain their separate environment-passthrough contract.
+The dispatcher does not launch Docker itself. Workload wrappers continue to
+own image selection, mounts, devices, IPC/shared-memory settings, entrypoints,
+and inner commands. Top-level recipe `extra_env` is a matrix/triage feature;
+probe-mode recipes retain their separate environment-passthrough contract.
 
 ## Configuration Reference
 
@@ -131,8 +136,6 @@ In-process runs must set import/process-static values before launching Python.
 
 ## Tuning Scenarios
 
-![GEMM Communication CU Contention](../analysis/figures/GEMM_Comm_CU_Contention.png)
-
 ### Kernel Chunking / Occupancy Capping
 
 Split large GEMMs or reduce active waves so the hardware scheduler has chances to issue communication kernels between compute launches.
@@ -144,10 +147,6 @@ Enqueue SDMA copies immediately after compute and inject a lightweight wait kern
 ### Stream Isolation and Priorities
 
 Ensure collectives execute on dedicated HIP streams created with `torch.cuda.Stream(priority=...)`. This prevents default-stream enqueueing and allows experimentation with priority hints.
-
-## Parameter Sweep
-
-![Parameter Sweep Results](param_sweep.png)
 
 ## Next Steps
 

--- a/docs/env-probe-container-execution-context.md
+++ b/docs/env-probe-container-execution-context.md
@@ -70,7 +70,7 @@ It does **not** prove where an action ran or populate
 - The Buck2 `genrule`/`sh_test` rule wrapper — documentation-only per the
   external-tool policy; deferred until phase 2.
 - Open Q1, Q2, Q3 below all remain open (Q1/Q2 need a real Buck2 RE cluster;
-  Q3 is "where does the NaN-repro runbook live").
+  Q3 is "where does the workload runbook live").
 
 The **field classification, risks, and runbook** sections below are the
 enduring rationale and apply to both phases.

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -1470,12 +1470,49 @@ jq '.partial_reasons' /tmp/env.json
 PATH= aorta env probe -o /tmp/env_no_rdhc.json
 jq '.system_health' /tmp/env_no_rdhc.json    # null
 jq '.hipblaslt.rocm_release_tweak' /tmp/env_no_rdhc.json # still populated
-
-# Compare across docker images (manual until `aorta env matrix` lands)
-docker run --rm <image-A> aorta env probe -o /workspace/env_a.json
-docker run --rm <image-B> aorta env probe -o /workspace/env_b.json
-diff <(jq -S . env_a.json) <(jq -S . env_b.json)
 ```
+
+### Probe a Docker image without AORTA installed
+
+The probe must run inside the environment it describes. Use this manual path
+for a standalone image capture when AORTA is installed on the host but not in
+the image. It is not the execution model for every sweep: a Docker-aware
+workload that implements the
+[in-container snapshot contract](../recipes/README.md#wrapper-contract-for-in-container-snapshots)
+performs the equivalent mount and probe automatically.
+
+Do not mount the host's entire virtual-environment `site-packages` directory.
+Putting it first on `PYTHONPATH` can make host PyTorch or TorchRec shadow the
+versions in the image, producing a snapshot of the wrong frameworks. Mount
+only the `aorta` package and use the dependency-free `_probe_main` entry point.
+The image must provide Python 3.10 or newer.
+
+```bash
+IMAGE_REF=registry.example/image:tag
+IMAGE_ID=$(docker image inspect --format '{{.Id}}' "$IMAGE_REF")
+OUTPUT_DIR=$(pwd)
+AORTA_PACKAGE=$(
+  python -c \
+    'from pathlib import Path; import aorta; print(Path(aorta.__file__).resolve().parent)'
+)
+
+docker run --rm \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --group-add render \
+  -v "$AORTA_PACKAGE":/opt/aorta_src/aorta:ro \
+  -v "$OUTPUT_DIR":/out \
+  -e AORTA_DOCKER_IMAGE="$IMAGE_REF" \
+  -e AORTA_DOCKER_DIGEST="$IMAGE_ID" \
+  "$IMAGE_ID" \
+  env PYTHONPATH=/opt/aorta_src \
+  python3 -m aorta.instrumentation._probe_main /out/env.json
+```
+
+`AORTA_PACKAGE` resolves only the public package from the active host
+environment, so framework imports still come from the image. The command runs
+the resolved immutable image ID while recording both the requested image
+reference and that ID in `env.json`. Repeat with another image and compare the
+two output files with `diff <(jq -S . env_a.json) <(jq -S . env_b.json)`.
 
 ## Output modes
 

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -14,9 +14,11 @@ The same code path is used three ways:
   Buck `.par` applications that own `__main__`.
 * **B1 (per-trial runner)**: calls `collect_env()` once per trial; the
   snapshot is embedded in `TrialResult.env`.
-* **B2 (matrix runner)**: calls `collect_env()` once per matrix start
-  (host scope) and once per `--environment-axis` value (container
-  scope).
+* **B2 (matrix runner)**: captures the host environment once per matrix. For
+  an isolated environment, it asks the workload wrapper to run the probe
+  inside that environment and promotes the resulting snapshot; the core
+  dispatcher does not launch the container. See
+  [Environment snapshots](../recipes/README.md#environment-snapshots).
 
 ## Why
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,159 +1,85 @@
 # Getting Started
 
-This guide covers prerequisites, installation, and initial setup for AORTA.
+Start with the core CLI, then add only the dependencies required by the command
+or workload you plan to run.
 
-## Prerequisites
+## 1. Install AORTA
 
-- PyTorch >= 2.2 with FSDP2 APIs (ROCm 7/RCCL)
-- ROCm tooling (`rocm-smi`, `rocminfo`)
-- PyYAML, matplotlib
-- GPU nodes with RCCL capable interconnects
-- Sufficient GPU memory for the configured model (see `config/default.yaml`)
-
-## Key Assumptions
-
-- TorchTitan components required by your wider stack are pre-installed (the synthetic workload does not import TorchTitan directly).
-- The code gracefully degrades when optional dependencies are absent.
-- All processes run under a job launcher that sets `LOCAL_RANK` (e.g., `torchrun`, Slurm, or similar).
-- The synthetic dataset is intended for profiling and does not reflect production data distributions.
-
-## Docker Setup (Recommended for Training)
-
-Training runs in Docker containers with all dependencies pre-installed.
-
-### Quick Start
-
-#### Option 1: Using the Setup Script (Recommended for First-Time Users)
-
-The interactive setup script guides you through creating your personal `.env` configuration:
+Follow the canonical [installation instructions](../README.md#installation) for
+a published or editable install. Verify that the active environment provides
+the command:
 
 ```bash
-cd docker
-bash setup-env.sh
-docker compose -f docker-compose.build.yaml up -d
+aorta --help
 ```
 
-The script will prompt you to:
-- Select a Dockerfile (ROCm version, with/without Shampoo optimizer, etc.)
-- Choose a container name (defaults to `${USER}-${variant}-${date}`)
-- Configure workspace and RCCL paths
-- Set up optional volume mounts
+The core install does not require a GPU, ROCm, Docker, or PyTorch. Those are
+runtime requirements for particular workloads and features.
 
-#### Option 2: Manual .env Configuration
+## 2. Choose where to invoke the CLI
 
-For more control, manually create your `.env` file:
+`aorta` runs in the environment where it is installed. Relative recipe,
+command, and output paths are resolved from your current directory.
+
+- Run `aorta env probe` in the environment you want to describe. That can be a
+  host environment or a container.
+- A workload that runs in the CLI process needs its runtime dependencies in
+  that same environment.
+- A Docker-launching workload plugin normally expects the CLI on a host with a
+  working Docker CLI and daemon. The plugin owns the container launch; follow
+  its guide for host mounts, image access, and dependencies inside the image.
+
+AORTA does not apply one host-or-container rule to every command. The core
+dispatcher does not execute `docker run`; Docker-aware workload plugins may do
+so and own the launch.
+
+### Repository-relative examples
+
+Commands that name `recipes/...`, `config/...`, or scripts in this repository
+assume the repository root as the current directory:
 
 ```bash
-cd docker
-cp .env.example .env
-# Edit .env with your preferred editor
-nano .env  # or vim, code, etc.
-docker compose -f docker-compose.build.yaml up -d
+cd /path/to/aorta
+aorta sweep run \
+  --recipe recipes/llm-determinism/example-llm-determinism.yaml \
+  --dry-run
 ```
 
-**Available Dockerfiles:**
-- `Dockerfile.rocm70_9-1` - Standard ROCm 7.0.9.1 build
-- `Dockerfile.rocm70_9-1-shampoo` - ROCm 7.0.9.1 with Shampoo optimizer
-- `Dockerfile.rocm70_2-ubuntu-pytorch` - ROCm 7.0.2 Ubuntu PyTorch build
-- `Dockerfile.rocm70_2-ubuntu-nan` - ROCm 7.0.2 with NaN debugging tools
-- `Dockerfile.rocm-ubuntu-ebpf` - ROCm 7.2 with eBPF tracing tools (bpftrace, bcc)
+From another directory, pass a path that is valid from that location.
 
-**Example `.env` configurations:**
+## 3. Add workload requirements
 
-For standard ROCm development:
-```bash
-DOCKERFILE=Dockerfile.rocm70_9-1
-CONTAINER_NAME=myuser-rocm70-dev
-AORTA_WORKSPACE=..
-RCCL_PATH=/tmp/rccl_placeholder
-```
+Read the selected workload's guide before installing its runtime:
 
-For Shampoo optimizer testing with custom RCCL:
-```bash
-DOCKERFILE=Dockerfile.rocm70_9-1-shampoo
-CONTAINER_NAME=myuser-shampoo-exp1
-AORTA_WORKSPACE=/apps/username/aorta_work/aorta_1
-RCCL_PATH=/apps/username/rccl
-```
+- Install a matching PyTorch build only for workloads or features that require
+  it. AORTA does not bundle PyTorch.
+- Install optional AORTA extras such as `hw-queue` only when you use that
+  feature; see [Optional dependencies](../README.md#optional-dependencies).
+- Provide ROCm tools, GPUs, launchers such as `torchrun`, and Docker only where
+  the workload instructions require them.
 
-#### Option 3: Pre-built Image (Alternative)
+For the repository's Docker Compose development images for in-tree training
+workloads, see [`docker/README.md`](../docker/README.md). That setup is optional,
+not the general AORTA installation path.
 
-If you prefer using a pre-built image instead of building from a Dockerfile:
+## 4. Check the installation
+
+The environment probe is a useful first command:
 
 ```bash
-cd docker
-docker compose up -d
+aorta env probe --summary
 ```
 
-This uses the default `docker-compose.yaml` with a pre-configured image.
-
-### Connecting to Your Container
-
-Connect to the running container via CLI or VSCode:
+Unavailable optional components are reported as such. For a recipe, validate
+its syntax and workload name before starting GPU work:
 
 ```bash
-# Via Docker CLI
-docker exec -it <your-container-name> bash
-
-# Or use VSCode's "Attach to Running Container" feature
+aorta sweep run --recipe /path/to/recipe.yaml --dry-run
 ```
-
-### Running TorchRec Benchmark
-
-```bash
-python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
-  --yaml_config=$ROOT/config/torchrec_dist/sparse_data_dist_base.yaml \
-  --name="sparse_data_dist_q_contend$(git rev-parse --short HEAD || echo $USER)"
-```
-
-This captures a profiler trace file locally.
-
-**What runs in Docker:**
-- `train.py` - Model training
-- Distributed workloads
-- GPU profiling
-
-## Local Installation (Analysis & Processing)
-
-For running analysis scripts and processing traces locally.
-
-We recommend using [uv](https://github.com/astral-sh/uv) for fast, reliable Python environment management.
-
-```bash
-# Install uv (if not already installed)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Clone the repository
-git clone https://github.com/ROCm/aorta.git
-cd aorta
-
-# Create and activate a virtual environment
-uv venv && source .venv/bin/activate
-
-# Install PyTorch nightly for ROCm 7.1
-uv pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1/
-
-# Install dependencies for analysis scripts
-uv pip install -r requirements.txt
-
-# For contributors: install development tools (pytest, pre-commit, etc.)
-uv pip install -r requirements-dev.txt
-pre-commit install
-```
-
-**What runs locally:**
-- `scripts/utils/merge_gpu_trace_ranks.py` - Merge distributed traces
-- `analysis/overlap_report.py` - Generate analysis reports
-- `scripts/analyze_*.py` - Analysis utilities
-- Test suite (`pytest tests/`)
-
-## Additional Notes
-
-- On ROCm systems, verify `rocm-smi` and `rocminfo` are in `$PATH`.
-- Run scripts from the repository root so path bootstrapping works correctly.
 
 ## Next Steps
 
-- [Running the Benchmark](running-benchmark.md) - Launch your first training run
-- [Configuration Guide](configuration.md) - Customize model and training parameters
-- [eBPF Usage Guide](ebpf-usage-guide.md) - Kernel-level GPU queue and memory tracing
+- [Recipes](../recipes/README.md) - Understand recipe fields and execution
+- [Running the Benchmark](running-benchmark.md) - Launch an in-tree training run
+- [Configuration Guide](configuration.md) - Customize trial and workload settings
+- [Environment Probe](env-probe.md) - Capture and compare environments

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,20 +18,10 @@ runtime requirements for particular workloads and features.
 
 ## 2. Choose where to invoke the CLI
 
-`aorta` runs in the environment where it is installed. Relative recipe,
-command, and output paths are resolved from your current directory.
-
-- Run `aorta env probe` in the environment you want to describe. That can be a
-  host environment or a container.
-- A workload that runs in the CLI process needs its runtime dependencies in
-  that same environment.
-- A Docker-launching workload plugin normally expects the CLI on a host with a
-  working Docker CLI and daemon. The plugin owns the container launch; follow
-  its guide for host mounts, image access, and dependencies inside the image.
-
-AORTA does not apply one host-or-container rule to every command. The core
-dispatcher does not execute `docker run`; Docker-aware workload plugins may do
-so and own the launch.
+Use the canonical [command-location guidance](../README.md#where-commands-run)
+to decide whether the CLI and runtime dependencies belong on the host or in a
+container. Relative recipe, command, and output paths are resolved from your
+current directory.
 
 ### Repository-relative examples
 

--- a/docs/plans/aorta-probe-188-rubric.md
+++ b/docs/plans/aorta-probe-188-rubric.md
@@ -620,7 +620,7 @@ Every file path cited in the rubric was read or grep'd; the audit list:
 | `tests/triage/test_runner_b1_api.py` (header) | Existing mock-`run_trials` pattern that probe-mode's shared-engine test mirrors. |
 | `tests/run/test_cli_parsing.py` (header) | Thin-shell-handler test pattern (anchor for FR 1.15). |
 | `tests/conftest.py` | Shared fixtures (none relevant to probe). |
-| `recipes/example-fsdp-smoke.yaml` | Existing recipe shape (triage-mode) for back-compat assertion. |
+| `recipes/training/example-fsdp-smoke.yaml` | Existing recipe shape (triage-mode) for back-compat assertion. |
 | `pyproject.toml` | Project metadata, optional-deps, `[project.entry-points."aorta.workloads"]` (commented out), `[project.scripts] aorta=aorta.cli:main`, lint/format config. |
 | `.pre-commit-config.yaml` | Active hooks (trailing-whitespace, end-of-file-fixer, check-yaml). |
 | `BUCK` | Top-level `python_library` + `python_binary` definitions; `src/aorta/**/*.py` glob (confirms no per-file BUCK changes needed for new modules). |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,8 +5,8 @@ Stable releases are published to **PyPI** (`pip install amd-aorta`) and also
 attached to a [GitHub Release](https://github.com/ROCm/aorta/releases);
 pre-release nightlies are published to a rolling **`dev-wheels`** pre-release.
 AORTA is a pure-Python package, so a single `py3-none-any` wheel installs on
-every platform; PyTorch is intentionally **not** bundled (customers install it
-from the ROCm index — see below).
+every platform; PyTorch is intentionally **not** bundled. Workloads that need
+PyTorch install a matching build separately.
 
 The version is **derived from git tags** by
 [`setuptools_scm`](https://setuptools-scm.readthedocs.io/) (see
@@ -96,13 +96,8 @@ install command below in a clean virtualenv as a smoke test.
 
 ## Customer install flow
 
-PyTorch is installed separately from the ROCm index (it is not part of the
-wheel), so customers always install it first:
-
-```bash
-pip install --pre torch torchvision torchaudio \
-    --index-url https://download.pytorch.org/whl/nightly/rocm7.1/
-```
+Install the core package first. Add only the extras and workload dependencies
+the customer needs.
 
 **Stable (recommended) — from PyPI:**
 
@@ -111,6 +106,14 @@ pip install --pre torch torchvision torchaudio \
 pip install amd-aorta                  # latest stable
 pip install "amd-aorta==X.Y.Z"         # a specific version
 pip install "amd-aorta[hw-queue]"      # with optional extras
+```
+
+PyTorch is not part of the AORTA wheel. Install it only when the selected
+workload or feature requires it, using the PyTorch index for that ROCm release:
+
+```bash
+PYTORCH_ROCM_INDEX=https://download.pytorch.org/whl/nightly/rocmX.Y/
+pip install --pre torch --index-url "$PYTORCH_ROCM_INDEX"
 ```
 
 **Stable — from the GitHub Release** (no PyPI; pin to the version you want, the

--- a/recipes/README-running-recipes.md
+++ b/recipes/README-running-recipes.md
@@ -9,21 +9,27 @@ Throughout, `<recipe>` is the path to any recipe YAML, e.g.
 
 ## 1. Install
 
-In an environment that already has a working PyTorch (ROCm or CUDA) build:
+Install AORTA in the environment from which your launcher will invoke the CLI:
 
 ```bash
 pip install -e .
-aorta --version
+aorta --help
 ```
 
 Workloads register via the `aorta.workloads` entry point — no extra wiring.
+PyTorch is workload-specific: install it in this environment only when the
+selected workload runs here and requires it. A workload plugin that launches
+Docker may instead rely on PyTorch and other runtime dependencies in its image;
+follow that workload's instructions.
 
 ## 2. CPU smoke test (no GPU needed)
 
-Confirm the code is intact on any machine, including a laptop:
+Validate the CLI and a subprocess recipe on any machine, including a laptop:
 
 ```bash
-python -m pytest tests/ -q
+aorta sweep run \
+  --recipe recipes/probe/probe-template-bash.yaml \
+  --dry-run -- echo hi
 ```
 
 ## 3. Validate a recipe without running it

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -15,6 +15,19 @@ Recipes are the primary interface. The `--mode matrix` flag shim is kept as
 an escape hatch for ad-hoc one-shots; internally it constructs an in-memory
 `Recipe` and reuses the same execution path.
 
+## Before you run
+
+Install AORTA in the environment from which you will invoke `aorta`. Relative
+recipe and output paths are resolved from the current directory; commands in
+this repository assume the repository root unless stated otherwise.
+
+Execution is workload-specific. Some workloads run in the CLI environment,
+while a Docker-aware workload plugin may launch its own container. The core
+dispatcher does not execute `docker run`; the plugin owns that launch. For such
+a plugin, use a Docker-capable host and follow the workload's instructions for
+host and image requirements. See
+[`README.md#where-commands-run`](../README.md#where-commands-run).
+
 ## Layout
 
 Recipes are grouped by workload:
@@ -34,7 +47,7 @@ Recipes are grouped by workload:
 ```yaml
 schema_version: 1                    # required; loader rejects unknown versions
 ticket: EXAMPLE-001                  # optional; drives output dir grouping
-workload: fsdp                       # required; resolved via aorta.workloads entry-point group
+workload: training                   # required; resolved via aorta.workloads entry-point group
 trials: 8                            # required; per-cell trial count
 steps: 5000                          # required; per-cell step count
 trial_isolation: auto                # optional: auto | in_process | process
@@ -62,13 +75,6 @@ cells:
     environment: local
     trials: 16                       # optional per-cell override
     steps: 8000                      # optional per-cell override
-
-  - name: try-nightly                # inline docker shorthand
-    mitigations: [none]
-    environment:
-      docker: "rocm/pytorch:nightly"
-      env:                            # optional baseline intrinsic to this environment
-        TORCH_ROCM_FA_PREFER_CK: "1"
 
   - name: custom-env-override        # one-off env var override for this cell only
     mitigations: [tf32_off]
@@ -114,6 +120,8 @@ cells:
     `blake2b(image-ref)`. Non-empty `env` content is included canonically in
     the identity, so the same image with different baseline variables cannot
     silently collapse into one environment. No other keys are accepted.
+    This is metadata passed to the workload; it does not make the core
+    dispatcher launch a container. A Docker-aware plugin must consume it.
 - **Top-level `extra_env`** -- optional `dict[str, str]`. Applied to every
   cell after `Environment.env` and mitigations. Probe-mode recipes reject this
   triage-only key and retain their separate environment-passthrough contract.
@@ -157,8 +165,8 @@ not how it is merged. For distributed details, see
   guarantee); wrappers running on non-rank-0 won't see the keys and
   should treat capture as off there.
   `contextlib.redirect_*` only catches Python-level writes; workloads
-  that spawn subprocesses (e.g. `recom_repro` invoking `docker run`)
-  don't have their subprocess output captured automatically. Those
+  that spawn subprocesses don't have their subprocess output captured
+  automatically. Those
   wrappers can opt in by reading the platform-supplied
   `_aorta_save_logs` / `_aorta_log_prefix` config keys the dispatcher
   injects, and writing their own capture to a sibling path derived from
@@ -214,10 +222,8 @@ not how it is merged. For distributed details, see
   recipe scope (top level) and per cell. Forwarded to the workload
   constructor through the dispatcher's `Request.config_overrides`. Use
   this for workload-specific knobs that aren't env vars; it does not enter
-  `os.environ` or `_aorta_trial_env`. For example,
-  `shampoo_api: old` on the `recom_repro` workload to select the V1
-  flat-kwarg SHAMPOO entry script (both `new` and `old` import from the
-  OSS `distributed_shampoo` package; they differ in constructor shape).
+  `os.environ` or `_aorta_trial_env`. For example, a plugin may use
+  `algorithm: alternate` to select one implementation.
   Cell-scope merges over recipe-scope on a per-key basis (cell wins on
   collision; non-collision keys union),
   so a recipe can set a workload-wide default and opt one cell out.
@@ -226,18 +232,18 @@ not how it is merged. For distributed details, see
   (platform-supplied) are rejected at load time. Example:
 
   ```yaml
-  workload: recom_repro
+  workload: my_workload
   workload_config:
-    shampoo_api: new          # recipe default
+    algorithm: standard       # recipe default
   cells:
-    - name: v3-baseline
+    - name: baseline-local
       mitigations: [none]
-      environment: nan-repro-v3
-    - name: v2-baseline
+      environment: local
+    - name: alternate-local
       mitigations: [none]
-      environment: nan-repro-v2-image
+      environment: local
       workload_config:
-        shampoo_api: old      # cell override
+        algorithm: alternate  # cell override
   ```
 
 Every validation error reports a path like `cells[2].mitigations` so the
@@ -256,8 +262,8 @@ Direct `aorta run --extra-env` occupies the same highest-precedence request
 layer as the recipe runner's merged recipe/cell values. The dispatcher applies
 the controlled overlay to host workloads and injects the exact same mapping as
 `config["_aorta_trial_env"]` for self-isolating wrappers. It never adds
-unrelated ambient host variables, and it does not launch Docker. Docker-aware
-wrappers can use `aorta.run.docker_env_flags`; see
+unrelated ambient host variables, and the core dispatcher does not execute
+`docker run`. Docker-aware wrappers can use `aorta.run.docker_env_flags`; see
 [`docs/configuration.md`](../docs/configuration.md#workload-owned-docker-launches).
 
 ## Workloads
@@ -343,9 +349,6 @@ Confirmed working on a single node with 8 GPUs (one rank per GPU):
 # single node, 8 GPUs:
 torchrun --standalone --nproc_per_node=8 $(which aorta) sweep run \
   --recipe recipes/race/race_smoke.yaml
-
-# AINIC cluster, multi-node (1 rank per host via Slurm):
-# see rccl_ainic/run-cell.sbatch
 ```
 
 A green run proves: `compute_type=transformer`, `layers_verified > 0`, `layer_checksum_mismatches == 0`, `passed=true`. Use `recipes/race/ainic-gdr-flush-sdc.yaml` for the full SDC triage matrix.
@@ -440,10 +443,10 @@ For isolated envs the dispatcher injects a reserved
 - `out` -- absolute host path (`environments/<env-name>/env.json`) the runner
   will read after the cell runs. Bind-mount its parent and write there.
 
-A self-isolating wrapper (e.g. `recom_repro` invoking `docker run`) opts in
-by reading the reserved config key and running the probe as the first step
-inside the container. There are no `AORTA_PROBE_SRC` / `AORTA_ENV_OUT`
-environment variables -- the paths arrive only through
+A self-isolating wrapper that invokes `docker run` opts in by reading the
+reserved config key and running the probe as the first step inside the
+container. There are no `AORTA_PROBE_SRC` / `AORTA_ENV_OUT` environment
+variables -- the paths arrive only through
 `config["_aorta_env_probe"]`, and the wrapper is responsible for turning them
 into bind-mounts on the `docker run` it builds:
 
@@ -516,11 +519,11 @@ audit data is still preserved next to the run.
 
 ## Flag mode (escape hatch)
 
-The equivalent of `recipes/training/example-fsdp-smoke.yaml` as flag-mode CLI:
+Example flag-mode CLI:
 
 ```
 aorta sweep run --mode matrix \
-  --workload fsdp \
+  --workload training \
   --mitigation-axis none,tf32_off,xnack \
   --environment-axis local \
   --trials 2 --steps 100 \
@@ -531,7 +534,8 @@ Inline docker still works in flag mode via the `image:` prefix on the
 axis, e.g. `--environment-axis local,image:rocm/pytorch:nightly`. Each
 comma-separated item is parsed independently; bare names go through the
 registry, `image:<ref>` maps to the same `{ docker: <ref> }` shorthand as
-recipe mode.
+recipe mode. The value remains workload metadata; a Docker-aware plugin must
+consume it.
 
 ## Probe handout templates (issue #188 Phase 3)
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -17,16 +17,10 @@ an escape hatch for ad-hoc one-shots; internally it constructs an in-memory
 
 ## Before you run
 
-Install AORTA in the environment from which you will invoke `aorta`. Relative
-recipe and output paths are resolved from the current directory; commands in
-this repository assume the repository root unless stated otherwise.
-
-Execution is workload-specific. Some workloads run in the CLI environment,
-while a Docker-aware workload plugin may launch its own container. The core
-dispatcher does not execute `docker run`; the plugin owns that launch. For such
-a plugin, use a Docker-capable host and follow the workload's instructions for
-host and image requirements. See
-[`README.md#where-commands-run`](../README.md#where-commands-run).
+Commands in this repository assume the repository root unless stated
+otherwise. For installation and host/container ownership, see
+[Where commands run](../README.md#where-commands-run) and the selected
+workload's guide.
 
 ## Layout
 

--- a/recipes/training/example-fsdp-smoke.yaml
+++ b/recipes/training/example-fsdp-smoke.yaml
@@ -7,16 +7,16 @@
 # module):
 #
 #   # validate only (no GPUs / no launcher needed):
-#   aorta sweep run --recipe recipes/example-fsdp-smoke.yaml --dry-run
+#   aorta sweep run --recipe recipes/training/example-fsdp-smoke.yaml --dry-run
 #
 #   # single node, 2 ranks (CX-7 / RCCL smoke; bump to your GPU count):
 #   torchrun --standalone --nproc_per_node=2 $(which aorta) sweep run \
-#     --recipe recipes/example-fsdp-smoke.yaml
+#     --recipe recipes/training/example-fsdp-smoke.yaml
 #
 #   # multi-node (e.g. 1 rank/host x 40 hosts -- the AINIC topology):
 #   torchrun --nnodes=40 --nproc_per_node=1 --rdzv-backend=c10d \
 #     --rdzv-endpoint=$MASTER_ADDR:29500 $(which aorta) sweep run \
-#     --recipe recipes/example-fsdp-smoke.yaml
+#     --recipe recipes/training/example-fsdp-smoke.yaml
 #
 # Results are written by rank 0 only (dispatcher gates on RANK), so multi-rank
 # launches don't clobber each other.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-# Local development dependencies for AORTA
-# (Training runs in Docker - these are for local development only)
+# Legacy requirements-file setup for local development with analysis tools.
+# The canonical package development install is `pip install -e ".[dev]"`.
 # Install with: pip install -r requirements-dev.txt
 
 # Include base requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,16 @@
-# Dependencies for local analysis and processing scripts
-# (Training dependencies are managed in Docker - see docker/Dockerfile.*)
+# Optional dependencies for local analysis and processing scripts.
+# This is not the core AORTA install; use `pip install -e .` for that.
 #
-# Install with uv (two steps to avoid pulling nvidia packages):
-#   uv pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1/
-#   uv pip install -r requirements.txt
+# PyTorch is workload-specific and is not listed here. Install a matching build
+# separately only when the selected workload or feature requires it.
 #
-# For full installation including hw_queue_eval:
+# For hardware-queue evaluation:
 #   uv pip install -e ".[hw-queue]"
 #
 # For development:
 #   uv pip install -e ".[all]"
 
-# Base dependencies (PyTorch installed separately - see above)
+# Base dependency used by these scripts
 pyyaml>=6.0
 
 # For analysis scripts

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -213,9 +213,8 @@ that what we capture stays auditable and reviewable.
 
 What does **not** belong here:
 
-* **Workload config** like `AMP_DTYPE`, `MODEL_DTYPE`,
-  `SHAMPOO_PRECONDITIONER_DTYPE`, model precision, optimizer
-  hyperparameters. Those are training-script arguments
+* **Workload config** like `AMP_DTYPE`, `MODEL_DTYPE`, model precision, or
+  optimizer hyperparameters. Those are training-script arguments
   (Hydra/argparse), captured by `aorta run` in the trial result
   (Task B1). Some workloads forward them as env vars to subprocesses --
   the env probe still does NOT capture them, since they are workload

--- a/src/aorta/registry/README.md
+++ b/src/aorta/registry/README.md
@@ -32,7 +32,7 @@ candidate — it's a plugin candidate (Path 2).
 | Qualifies as built-in | Does NOT qualify (use Path 2) |
 |---|---|
 | `DISABLE_TF32` (hipBLASLt reads it) | `AMP_DTYPE` (only the workload's Python reads it) |
-| `HSA_XNACK` (ROCm runtime reads it) | `SHAMPOO_PRECONDITIONER_DTYPE` (only recom_repro reads it) |
+| `HSA_XNACK` (ROCm runtime reads it) | `MY_MODEL_DTYPE` (only a plugin workload reads it) |
 | `CUDA_LAUNCH_BLOCKING` (PyTorch reads it) | Any custom flag your workload introspects |
 | `NCCL_DEBUG`, `OMP_NUM_THREADS`, `LD_PRELOAD` | Anything that's a silent no-op on workloads that don't read it |
 
@@ -107,8 +107,8 @@ are not yet consumed. Today the commands raise "not yet implemented" before
 reaching the loader:
 
 ```bash
-aorta run    --workload fsdp --mitigations-file ./my-experiments.json --mitigations my_flag
-aorta triage run --workload fsdp --mitigations-file ./my-experiments.json ...
+aorta run    --workload training --mitigations-file ./my-experiments.json --mitigations my_flag
+aorta triage run --workload training --mitigations-file ./my-experiments.json ...
 ```
 
 `--mitigations-file` is repeatable. Each file may declare mitigations,
@@ -154,7 +154,7 @@ PR or publishing a package. Two options:
 For "is this even worth pursuing" experiments:
 
 ```bash
-aorta run --workload fsdp --env HSA_ENABLE_SDMA=0
+aorta run --workload training --env HSA_ENABLE_SDMA=0
 ```
 
 No registry involvement. The flag isn't named, isn't tracked, doesn't appear
@@ -253,11 +253,10 @@ config["_aorta_environment"] = {
 ```
 
 Workloads that can isolate themselves read this dict and branch their
-subprocess invocation accordingly. The platform itself launches no docker
-images, activates no venvs, and invokes no `buck2 run` — it threads the
-metadata; the wrapper decides. Today's `recom_repro` wrapper consumes
-`docker`; a Buck-aware wrapper consumes `buck_target` with the same
-pattern:
+subprocess invocation accordingly. The core platform does not execute
+`docker run`, activate a venv, or invoke `buck2 run`; it threads the metadata
+and the wrapper decides. A Docker-aware wrapper consumes `docker`; a Buck-aware
+wrapper consumes `buck_target` with the same pattern:
 
 ```python
 # Inside a workload's run() method:


### PR DESCRIPTION
## Summary
- make the core install the default and keep PyTorch and feature extras optional
- define where the CLI runs and distinguish core dispatch from workload-owned Docker launches
- document dependency-free image probing and replace duplicated or stale onboarding examples with canonical links

## Test plan
- [x] Validate changed relative links, image links, and heading anchors
- [x] Run `aorta --help`, `aorta env probe --summary`, and a subprocess recipe dry-run
- [x] Syntax-check documented Bash commands
- [x] Run `git diff --check` and changed-file whitespace/EOF checks