### PR TITLE
docs: clarify Buck guide file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The standalone `aorta mitigations list` and `aorta environments list` groups are
 | [`aorta agent`](docs/agent/agentic-testing-guide.md) | Closed-loop mitigation search (optional LLM proposer) |
 | [`aorta bundle`](docs/probe/bundle.md) | Package sweep artifacts with recipe-driven redaction |
 | [Recipes](recipes/README.md) | Recipe schema and running recipes |
-| [Buck2](docs/buck2.md) | Build / run the AORTA CLI via Buck2 |
+| [Buck2 Build Reference](docs/buck2-build-reference.md) | Build / run the AORTA CLI via Buck2 |
 
 
 ## Repository Layout

--- a/docs/buck2-build-reference.md
+++ b/docs/buck2-build-reference.md
@@ -1,9 +1,9 @@
-# Buck2
+# Buck2 Build Reference
 
 Build and run the AORTA CLI with [Buck2](https://buck2.build/) -- a
 fast, hermetic, multi-language build system. The repo already ships a
-working Buck2 setup (added in [#187]); this doc is the user-facing
-walkthrough.
+working Buck2 setup (added in [#187]); this document is the build and
+command reference.
 
 > The repo's current Buck2 scaffold defines `python_library` /
 > `python_binary` targets only -- no `python_test` targets yet, so
@@ -412,9 +412,9 @@ toolchain Python version.
 ## See also
 
 * [Env Probe](env-probe.md) -- the snapshot schema and `jq` cookbook.
-* [Buck2 env probe](buck2-env-probe.md) -- workload integration,
+* [Buck2 env-probe workflow](buck2-env-probe-workflow.md) -- workload integration,
   client/workload snapshots, and validation.
-* [Buck2 env-probe setup on a Linux GPU host](buck2-env-probe-gpu-setup.md)
+* [Buck2 GPU and remote-execution setup](buck2-gpu-re-setup.md)
   -- first-time Buck2 installation, local smoke test, real-RE prerequisites,
   and a copy-paste agent prompt.
 * [`src/aorta/registry/README.md`](../src/aorta/registry/README.md) --

--- a/docs/buck2-env-probe-workflow.md
+++ b/docs/buck2-env-probe-workflow.md
@@ -1,6 +1,6 @@
-# AORTA Env Probe for Buck2 Workloads
+# Buck2 Env-Probe Workflow
 
-Canonical source: `docs/buck2-env-probe.md` in the selected AORTA revision.
+Canonical source: `docs/buck2-env-probe-workflow.md` in the selected AORTA revision.
 Refresh exported copies from this file rather than editing two copies.
 
 This guide is only for workloads built or launched with Buck2. The probe

--- a/docs/buck2-gpu-re-setup.md
+++ b/docs/buck2-gpu-re-setup.md
@@ -1,4 +1,4 @@
-# Buck2 env-probe setup on a Linux GPU host
+# Buck2 GPU and Remote-Execution Setup
 
 This guide starts from a machine with no Buck2 installation. It has two
 separate goals:

--- a/docs/env-probe.md
+++ b/docs/env-probe.md
@@ -5,7 +5,7 @@ that cross-environment comparison becomes a `jq` diff instead of a
 multi-day investigation.
 
 For Buck2 workloads, including the required client/workload snapshot pair, see
-[Buck2 Env Probe](buck2-env-probe.md).
+[Buck2 Env-Probe Workflow](buck2-env-probe-workflow.md).
 
 The same code path is used three ways:
 


### PR DESCRIPTION
## Summary
- rename the three Buck2 guides so each filename states its scope
- update headings and cross-links for the build reference, env-probe workflow, and GPU/RE setup guide

## Test plan
- [x] `git diff --check`
- [x] verified no references to the old Buck2 documentation filenames remain