### PR TITLE
sanitizers(ci): co-publish nightly dashboard on GitHub Pages at /sanitizers/

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,14 @@ concurrency:
 jobs:
   build-deploy:
     name: build + deploy pages
+    # Only ever deploy trusted content: a push to main, a manual dispatch, or a
+    # data-branch refresh triggered by a source workflow that itself ran on main.
+    # A workflow_run fired by a feature-branch run (e.g. a workflow_dispatch of
+    # Sanitizers Nightly off a PR branch) must NOT trigger an official Pages
+    # deploy -- that would let unreviewed branch output reach the public site.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -132,34 +140,56 @@ jobs:
       # History lives on the sanitizer-results data branch (written by
       # sanitizers-nightly's publish job); it may not exist until the first
       # sanitizer nightly runs. Same fail-closed ls-remote contract as ci-results.
+      # The /sanitizers/ route must NEVER 404: the root nav and docs link to it
+      # unconditionally, so when there is no (trusted) snapshot yet we publish the
+      # generator's own "no runs yet" empty state instead of leaving it absent.
       - name: Publish the sanitizer dashboard at /sanitizers/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          baselines="recipes/sanitizers/fixtures/expected/verdict_baselines.json"
+          mkdir -p _site/sanitizers
+          publish_placeholder() {
+            empty="$(mktemp -d)"
+            python3 scripts/sanitizers/gen_sanitizer_dashboard.py \
+              --runs-root "$empty" \
+              --baselines "$baselines" \
+              --out-dir _site/sanitizers
+          }
           repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           set +e
           git ls-remote --exit-code --heads "$repo_url" sanitizer-results >/dev/null 2>&1
           lsr=$?
           set -e
           if [ "$lsr" -eq 2 ]; then
-            echo "sanitizer-results branch absent; sub-page appears after the first sanitizer nightly"
-            echo "SANITIZER_DASHBOARD=absent" >> "$GITHUB_ENV"
+            echo "sanitizer-results branch absent; publishing the empty-state page"
+            publish_placeholder
           elif [ "$lsr" -ne 0 ]; then
             echo "::error::cannot reach sanitizer-results (git ls-remote exit ${lsr}); failing closed"
             exit 1
           else
-            echo "SANITIZER_DASHBOARD=present" >> "$GITHUB_ENV"
             tmp="$(mktemp -d)"
             git clone --depth 1 --branch sanitizer-results "$repo_url" "$tmp"
-            if [ -d "$tmp/dashboard" ] && [ -f "$tmp/dashboard/index.html" ]; then
-              mkdir -p _site/sanitizers
+            src_ref=""
+            if [ -f "$tmp/dashboard/status.json" ]; then
+              src_ref="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("ref",""))' \
+                        "$tmp/dashboard/status.json" 2>/dev/null || echo "")"
+            fi
+            if [ -f "$tmp/dashboard/status.json" ] && [ "$src_ref" != "refs/heads/main" ]; then
+              # Defence in depth for the main-only publish guard: never serve
+              # sanitizer data whose recorded source ref is not main.
+              echo "::warning::sanitizer-results recorded ref '${src_ref}' is not main; publishing empty state instead"
+              publish_placeholder
+            elif [ -d "$tmp/dashboard" ] && [ -f "$tmp/dashboard/index.html" ]; then
               cp -r "$tmp/dashboard/"* _site/sanitizers/
-              echo "sanitizer dashboard at /sanitizers/"
+              echo "sanitizer dashboard at /sanitizers/ (source ref ${src_ref:-unknown})"
             else
-              echo "sanitizer-results exists but has no dashboard yet"
+              echo "sanitizer-results exists but has no dashboard yet; publishing empty state"
+              publish_placeholder
             fi
           fi
+          test -s _site/sanitizers/index.html
 
       # The dashboard used to live at /ci/, the docs advertised that URL, and
       # /ci/data.json is a machine-readable endpoint something may already poll.
@@ -193,16 +223,16 @@ jobs:
           SITE_URL: ${{ steps.pages.outputs.base_url }}
         run: |
           set -euo pipefail
+          # /sanitizers/ is always published (a real snapshot or the empty state),
+          # so the route is required unconditionally -- it must never 404.
           routes=(
             _site/index.html
             _site/docs/index.html
             _site/ci/index.html
             _site/data.json
             _site/ci/data.json
+            _site/sanitizers/index.html
           )
-          if [ "${SANITIZER_DASHBOARD:-absent}" = "present" ]; then
-            routes+=(_site/sanitizers/index.html)
-          fi
           for f in "${routes[@]}"; do
             if [ ! -s "$f" ]; then
               echo "::error::$f is missing or empty; refusing to deploy"
@@ -217,11 +247,7 @@ jobs:
             echo "::error::/docs/ still claims the dashboard's URL as its own"
             exit 1
           fi
-          msg="routes ok: / /docs/ /ci/ /data.json /ci/data.json"
-          if [ "${SANITIZER_DASHBOARD:-absent}" = "present" ]; then
-            msg="${msg} /sanitizers/"
-          fi
-          echo "$msg"
+          echo "routes ok: / /docs/ /ci/ /data.json /ci/data.json /sanitizers/"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,13 +5,15 @@ name: Pages (landing + nightly dashboard)
 # BOTH the nightly CI dashboard (at the site root) AND the project landing page
 # (Jekyll render of README.md, under /docs/ alongside the rest of the rendered
 # docs). It runs on main pushes, after each "Nightly Evaluation" completes (pick
-# up fresh history from the ci-results branch), and on demand.
+# up fresh history from the ci-results branch), after each "Sanitizers Nightly"
+# completes (pick up fresh history from the sanitizer-results branch), and on
+# demand.
 
 on:
   push:
     branches: [main]
   workflow_run:
-    workflows: ["Nightly Evaluation"]
+    workflows: ["Nightly Evaluation", "Sanitizers Nightly"]
     types: [completed]
   workflow_dispatch:
 
@@ -127,6 +129,38 @@ jobs:
             echo "no history yet; published the dashboard's empty state at /"
           fi
 
+      # History lives on the sanitizer-results data branch (written by
+      # sanitizers-nightly's publish job); it may not exist until the first
+      # sanitizer nightly runs. Same fail-closed ls-remote contract as ci-results.
+      - name: Publish the sanitizer dashboard at /sanitizers/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          set +e
+          git ls-remote --exit-code --heads "$repo_url" sanitizer-results >/dev/null 2>&1
+          lsr=$?
+          set -e
+          if [ "$lsr" -eq 2 ]; then
+            echo "sanitizer-results branch absent; sub-page appears after the first sanitizer nightly"
+            echo "SANITIZER_DASHBOARD=absent" >> "$GITHUB_ENV"
+          elif [ "$lsr" -ne 0 ]; then
+            echo "::error::cannot reach sanitizer-results (git ls-remote exit ${lsr}); failing closed"
+            exit 1
+          else
+            echo "SANITIZER_DASHBOARD=present" >> "$GITHUB_ENV"
+            tmp="$(mktemp -d)"
+            git clone --depth 1 --branch sanitizer-results "$repo_url" "$tmp"
+            if [ -d "$tmp/dashboard" ] && [ -f "$tmp/dashboard/index.html" ]; then
+              mkdir -p _site/sanitizers
+              cp -r "$tmp/dashboard/"* _site/sanitizers/
+              echo "sanitizer dashboard at /sanitizers/"
+            else
+              echo "sanitizer-results exists but has no dashboard yet"
+            fi
+          fi
+
       # The dashboard used to live at /ci/, the docs advertised that URL, and
       # /ci/data.json is a machine-readable endpoint something may already poll.
       # A Pages deploy replaces the whole site, so moving the dashboard to the
@@ -159,8 +193,17 @@ jobs:
           SITE_URL: ${{ steps.pages.outputs.base_url }}
         run: |
           set -euo pipefail
-          for f in _site/index.html _site/docs/index.html _site/ci/index.html \
-                   _site/data.json _site/ci/data.json; do
+          routes=(
+            _site/index.html
+            _site/docs/index.html
+            _site/ci/index.html
+            _site/data.json
+            _site/ci/data.json
+          )
+          if [ "${SANITIZER_DASHBOARD:-absent}" = "present" ]; then
+            routes+=(_site/sanitizers/index.html)
+          fi
+          for f in "${routes[@]}"; do
             if [ ! -s "$f" ]; then
               echo "::error::$f is missing or empty; refusing to deploy"
               exit 1
@@ -174,7 +217,11 @@ jobs:
             echo "::error::/docs/ still claims the dashboard's URL as its own"
             exit 1
           fi
-          echo "routes ok: / /docs/ /ci/ /data.json /ci/data.json"
+          msg="routes ok: / /docs/ /ci/ /data.json /ci/data.json"
+          if [ "${SANITIZER_DASHBOARD:-absent}" = "present" ]; then
+            msg="${msg} /sanitizers/"
+          fi
+          echo "$msg"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -107,6 +107,8 @@ jobs:
     needs: sanitizers-gpu
     if: always() && needs.sanitizers-gpu.result != 'skipped'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push dashboard to the sanitizer-results branch
     steps:
       - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
@@ -122,6 +124,44 @@ jobs:
             --commit "${GITHUB_SHA}" --run-label "run ${GITHUB_RUN_ID}" \
             --out-dir dashboard
           cat dashboard/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update sanitizer-results branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          [ -d dashboard ] || { echo "no dashboard/; skipping publish"; exit 0; }
+          date="$(date -u +%Y-%m-%d)"
+          repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          tmp="$(mktemp -d)"
+          # Fail closed: distinguish a genuinely-absent sanitizer-results branch
+          # (create the orphan) from a transport/auth failure (must NOT be treated
+          # as "branch absent"). git ls-remote --exit-code: 0=present, 2=absent,
+          # else=error.
+          set +e
+          git ls-remote --exit-code --heads "$repo_url" sanitizer-results >/dev/null 2>&1
+          lsr=$?
+          set -e
+          if [ "$lsr" -eq 0 ]; then
+            git clone --depth 1 --branch sanitizer-results "$repo_url" "$tmp"
+          elif [ "$lsr" -eq 2 ]; then
+            echo "sanitizer-results branch absent; creating it"
+            git clone --depth 1 "$repo_url" "$tmp"
+            ( cd "$tmp" && git checkout --orphan sanitizer-results && git rm -rf . >/dev/null 2>&1 || true )
+          else
+            echo "::error::cannot reach sanitizer-results (git ls-remote exit ${lsr}); failing closed"
+            exit 1
+          fi
+          rm -rf "$tmp/dashboard"
+          cp -a dashboard "$tmp/dashboard"
+          ( cd "$tmp"
+            git add -A
+            if git -c user.name=aorta-ci -c user.email=aorta-ci@users.noreply.github.com \
+                 commit -m "sanitizer dashboard ${date}"; then
+              git push origin sanitizer-results   # not swallowed -- a push failure fails the job
+            else
+              echo "no changes to commit"
+            fi )
 
       - name: Upload sanitizer dashboard
         if: always()

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -24,6 +24,9 @@ env:
 jobs:
   sanitizers-gpu:
     name: gfx950 sanitizer regression
+    # Must match a real online runner: the MI350 host is labelled
+    # `self-hosted, gpu, mi350x` (same set the other GPU workflows target, e.g.
+    # gpu-tests.yml / eval-reusable.yml use `self-hosted, gpu`).
     runs-on: [self-hosted, gpu, mi350x]
     timeout-minutes: 120
     steps:
@@ -88,6 +91,9 @@ jobs:
         run: python scripts/sanitizers/compare_verdict_baselines.py "${RUNNER_TEMP}/sanitizer-out"
 
       - name: Upload sanitizer results
+        # Always upload whatever ran, even when an earlier step (e.g. the baseline
+        # comparison) failed, so the publish job can render the failure with any
+        # partial evidence instead of the run silently producing nothing.
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -105,16 +111,56 @@ jobs:
   publish:
     name: publish sanitizer dashboard
     needs: sanitizers-gpu
-    if: always() && needs.sanitizers-gpu.result != 'skipped'
+    # Run even when the GPU job failed (to publish the failure, not a stale green
+    # page) but NOT when it was skipped. Publish ONLY from main: a workflow_dispatch
+    # branch run still executes sanitizers-gpu and uploads its artifact, but must
+    # never push branch output onto the public sanitizer-results branch (that would
+    # bypass branch protection). Branch runs therefore produce artifacts only.
+    if: >-
+      always() &&
+      needs.sanitizers-gpu.result != 'skipped' &&
+      github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write   # push dashboard to the sanitizer-results branch
     steps:
       - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
+        # A failed GPU job may leave no artifact at all; don't hard-fail the
+        # publish job -- we still want to record the failure on the public page.
+        continue-on-error: true
         with:
           name: sanitizer-nightly-${{ github.run_id }}
           path: incoming
+      - name: Record run status
+        # Manifest consumed by gen_sanitizer_dashboard.py (--status) to render a
+        # stale banner, and persisted to the data branch so Pages can tell a
+        # healthy snapshot from a stale one on every subsequent deploy.
+        env:
+          GPU_RESULT: ${{ needs.sanitizers-gpu.result }}
+        run: |
+          set -euo pipefail
+          mkdir -p incoming
+          if [ "${GPU_RESULT}" = "success" ]; then healthy=true; else healthy=false; fi
+          python - "$healthy" "$GPU_RESULT" > status.json <<'PY'
+          import json, os, sys
+          healthy = sys.argv[1] == "true"
+          conclusion = sys.argv[2]
+          server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+          repo = os.environ.get("GITHUB_REPOSITORY", "")
+          run_id = os.environ.get("GITHUB_RUN_ID", "")
+          from datetime import datetime, timezone
+          print(json.dumps({
+              "healthy": healthy,
+              "conclusion": conclusion,
+              "run_id": run_id,
+              "run_url": f"{server}/{repo}/actions/runs/{run_id}",
+              "commit": os.environ.get("GITHUB_SHA", ""),
+              "ref": os.environ.get("GITHUB_REF", ""),
+              "date": datetime.now(tz=timezone.utc).isoformat(timespec="seconds"),
+          }, indent=2, sort_keys=True))
+          PY
+          cat status.json
 
       - name: Generate sanitizer dashboard
         run: |
@@ -122,6 +168,7 @@ jobs:
             --results-dir incoming \
             --baselines recipes/sanitizers/fixtures/expected/verdict_baselines.json \
             --commit "${GITHUB_SHA}" --run-label "run ${GITHUB_RUN_ID}" \
+            --status status.json \
             --out-dir dashboard
           cat dashboard/summary.md >> "$GITHUB_STEP_SUMMARY"
 

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -56,7 +56,13 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    `actions/deploy-pages`. **Repo Pages source must be "GitHub Actions"**
    (Settings -> Pages).    Nightly dashboard: `https://rocm.github.io/aorta/`;
    project docs: `https://rocm.github.io/aorta/docs/`.
-   Sanitizer nightly dashboard: `https://rocm.github.io/aorta/sanitizers/` (linked from the root nav).
+   Sanitizer nightly dashboard: `https://rocm.github.io/aorta/sanitizers/` (linked
+   from the root nav). The route is always published so it never 404s: before the
+   first successful sanitizer nightly it shows a "no sanitizer runs yet" empty
+   state, and if the latest nightly failed it shows the last data under a red
+   stale banner linking the failed run (rather than silently re-serving the
+   previous green page). Only sanitizer data produced by a `main` run is
+   published.
 
    The dashboard previously lived at `/ci/`, so that path is kept: `/ci/`
    redirects to the root and `/ci/data.json` is published alongside

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -54,8 +54,9 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    (`gen_dashboard.py`, from the `ci-results` history) to `_site/index.html`, and
    deploys the combined site via `actions/upload-pages-artifact` +
    `actions/deploy-pages`. **Repo Pages source must be "GitHub Actions"**
-   (Settings -> Pages). Nightly dashboard: `https://rocm.github.io/aorta/`;
+   (Settings -> Pages).    Nightly dashboard: `https://rocm.github.io/aorta/`;
    project docs: `https://rocm.github.io/aorta/docs/`.
+   Sanitizer nightly dashboard: `https://rocm.github.io/aorta/sanitizers/` (linked from the root nav).
 
    The dashboard previously lived at `/ci/`, so that path is kept: `/ci/`
    redirects to the root and `/ci/data.json` is published alongside

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -962,6 +962,7 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         MI350 runner and replays its workload sweep, comparing each result
         against a blessed baseline. This page is that run.</p>
       <p class="nav"><a href="docs/">AORTA documentation</a> ·
+        <a href="sanitizers/">sanitizer nightly</a> ·
         <a href="https://github.com/{_REPO}">repository</a></p>
       <div class="chips">{toolchain}</div>
       <p class="prov-line">{' · '.join(provenance)}</p>

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -345,6 +345,7 @@ def build_html(runs: list[dict[str, Any]], *, title: str = "Sanitizers Nightly")
   }}
 </style></head>
 <body><div class=wrap>
+  <p class=nav><a href="../">back to CI dashboard</a></p>
   <h1>{_esc(title)} &middot; gfx950</h1>
   <div class=meta>latest run <span class=mono>{_esc(meta.get('run', ''))}</span>
      &middot; commit <span class=mono>{_esc(meta.get('commit', ''))}</span>

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -12,6 +12,12 @@ emits, into ``--out-dir``:
 * ``summary.md`` -- a GitHub Actions job-summary fragment (append to
   ``$GITHUB_STEP_SUMMARY``) carrying the same gate, table, and kernel detail.
 * ``data.json`` -- the aggregated structure for any richer consumer.
+* ``status.json`` -- a copy of the ``--status`` run manifest, when supplied, so
+  Pages can distinguish a healthy snapshot from a stale one (a failed nightly).
+
+When ``--status`` points at an unhealthy manifest, a red "stale" banner is
+rendered at the top of both ``index.html`` and ``summary.md`` so a failed nightly
+never leaves the previous green page looking current.
 
 Two input shapes are supported:
 
@@ -227,6 +233,48 @@ def runs_from_runs_root(runs_root: Path, baselines: dict) -> list[dict[str, Any]
     return runs
 
 
+def _status_banner_html(status: dict[str, Any] | None) -> str:
+    """Red staleness banner shown when the latest nightly did not publish healthily.
+
+    A failed nightly skips its snapshot push, so Pages would otherwise republish
+    the previous green page as if it were current. When the publish job records an
+    unhealthy run status, surface it prominently with a link to the failed run.
+    """
+    if not status or status.get("healthy", True):
+        return ""
+    run_id = str(status.get("run_id", "") or "")
+    url = str(status.get("run_url", "") or "")
+    conclusion = str(status.get("conclusion", "") or "unknown")
+    when = str(status.get("date", "") or "")
+    run_txt = f" run {_esc(run_id)}" if run_id else ""
+    link = (
+        f' <a href="{_esc(url)}" style="color:#fff;text-decoration:underline">view failed run</a>'
+        if url else ""
+    )
+    when_txt = f' <span style="font-weight:400">({_esc(when)})</span>' if when else ""
+    return (
+        '<div style="color:#fff;background:#cf222e;padding:12px 16px;border-radius:8px;'
+        'font-weight:600;margin:12px 0 20px">'
+        f"&#9888; Latest sanitizer nightly{run_txt} did not complete successfully "
+        f"({_esc(conclusion)}) &mdash; the data below may be stale.{link}{when_txt}"
+        "</div>"
+    )
+
+
+def _status_banner_md(status: dict[str, Any] | None) -> str:
+    if not status or status.get("healthy", True):
+        return ""
+    run_id = str(status.get("run_id", "") or "")
+    url = str(status.get("run_url", "") or "")
+    conclusion = str(status.get("conclusion", "") or "unknown")
+    run_txt = f" run `{run_id}`" if run_id else ""
+    link = f" [view failed run]({url})" if url else ""
+    return (
+        f"> \u26a0\ufe0f **Stale** \u2014 latest sanitizer nightly{run_txt} did not "
+        f"complete successfully ({conclusion}); the data below may be stale.{link}"
+    )
+
+
 def _badge_html(verdict: str, expected: str | None) -> str:
     color = _VERDICT_COLOR.get(verdict, "#6e7781")
     mark = ""
@@ -280,9 +328,30 @@ def _kernel_detail_html(rows: dict[str, dict[str, Any]]) -> str:
     return "".join(blocks)
 
 
-def build_html(runs: list[dict[str, Any]], *, title: str = "Sanitizers Nightly") -> str:
+def build_html(
+    runs: list[dict[str, Any]],
+    *,
+    title: str = "Sanitizers Nightly",
+    status: dict[str, Any] | None = None,
+) -> str:
+    banner = _status_banner_html(status)
     if not runs:
-        return f"<!doctype html><meta charset=utf-8><title>{_esc(title)}</title><p>No runs.</p>"
+        # Rendered before the first successful nightly (empty runs-root) so the
+        # /sanitizers/ route never 404s, and whenever a run fails with no data.
+        return (
+            "<!doctype html>\n"
+            "<html lang=en><head><meta charset=utf-8>\n"
+            '<meta name=viewport content="width=device-width, initial-scale=1">\n'
+            f"<title>{_esc(title)}</title></head>\n"
+            '<body style="font:14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,'
+            'sans-serif;max-width:1000px;margin:0 auto;padding:24px">\n'
+            '<p><a href="../">back to CI dashboard</a></p>\n'
+            f"{banner}"
+            f"<h1>{_esc(title)}</h1>\n"
+            "<p>No sanitizer runs yet. This page will populate after the first "
+            "successful sanitizer nightly.</p>\n"
+            "</body></html>\n"
+        )
     latest = runs[0]
     meta = latest["meta"]
     gate_ok = latest["gate"]
@@ -346,6 +415,7 @@ def build_html(runs: list[dict[str, Any]], *, title: str = "Sanitizers Nightly")
 </style></head>
 <body><div class=wrap>
   <p class=nav><a href="../">back to CI dashboard</a></p>
+  {banner}
   <h1>{_esc(title)} &middot; gfx950</h1>
   <div class=meta>latest run <span class=mono>{_esc(meta.get('run', ''))}</span>
      &middot; commit <span class=mono>{_esc(meta.get('commit', ''))}</span>
@@ -370,17 +440,25 @@ def build_html(runs: list[dict[str, Any]], *, title: str = "Sanitizers Nightly")
 """
 
 
-def build_summary_md(runs: list[dict[str, Any]]) -> str:
+def build_summary_md(
+    runs: list[dict[str, Any]], *, status: dict[str, Any] | None = None
+) -> str:
+    banner = _status_banner_md(status)
     if not runs:
-        return "# Sanitizers Nightly\n\nNo runs found.\n"
+        head = "# Sanitizers Nightly\n\n"
+        if banner:
+            head += banner + "\n\n"
+        return head + "No runs found.\n"
     latest = runs[0]
     meta = latest["meta"]
     gate = (
         "\u2705 **PASS** \u2014 all verdicts match baselines" if latest["gate"]
         else "\u274c **FAIL** \u2014 verdict mismatch vs baselines"
     )
-    lines = [
-        "# Sanitizers Nightly \u00b7 gfx950", "",
+    lines = ["# Sanitizers Nightly \u00b7 gfx950", ""]
+    if banner:
+        lines += [banner, ""]
+    lines += [
         f"Run `{meta.get('run', '')}` \u00b7 commit `{meta.get('commit', '')}` \u00b7 "
         f"{meta.get('date', '')}",
         "", gate, "",
@@ -454,7 +532,18 @@ def main() -> int:
     ap.add_argument("--out-dir", type=Path, required=True)
     ap.add_argument("--commit", default=os.environ.get("GITHUB_SHA", ""))
     ap.add_argument("--run-label", default=os.environ.get("GITHUB_RUN_ID", ""))
+    ap.add_argument(
+        "--status",
+        type=Path,
+        help="JSON run-status manifest; renders a stale banner when it is unhealthy",
+    )
     args = ap.parse_args()
+
+    # Optional run-status manifest (see sanitizers-nightly.yml). A malformed or
+    # absent file must not crash rendering -- treat it as "no status" (no banner).
+    status = _load(args.status) if args.status is not None else None
+    if args.status is not None and not isinstance(status, dict):
+        status = None
 
     # Load baselines strictly: a missing/corrupt file would otherwise leave every
     # expected verdict as None (match=True) and paint a false-green gate.
@@ -477,11 +566,19 @@ def main() -> int:
         runs = runs_from_runs_root(args.runs_root, baselines)
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
-    (args.out_dir / "index.html").write_text(build_html(runs), encoding="utf-8")
-    (args.out_dir / "summary.md").write_text(build_summary_md(runs), encoding="utf-8")
+    (args.out_dir / "index.html").write_text(build_html(runs, status=status), encoding="utf-8")
+    (args.out_dir / "summary.md").write_text(
+        build_summary_md(runs, status=status), encoding="utf-8"
+    )
     (args.out_dir / "data.json").write_text(
         json.dumps(runs, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
+    # Persist the status manifest alongside the rendered page so Pages (and any
+    # consumer) can tell a healthy snapshot from a stale one without re-parsing HTML.
+    if status is not None:
+        (args.out_dir / "status.json").write_text(
+            json.dumps(status, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
     gate = runs[0]["gate"] if runs else False
     print(f"wrote {args.out_dir}/index.html, summary.md, data.json (gate={'green' if gate else 'red'})")
     return 0

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -58,6 +58,12 @@ def test_dashboard_empty_history():
     assert "no results yet" in html
 
 
+def test_dashboard_links_to_sanitizer_nightly():
+    html = gen_dashboard.build_dashboard_html([])
+    assert 'href="sanitizers/"' in html
+    assert "sanitizer nightly" in html
+
+
 def test_dashboard_renders_summary_metric_series():
     r = _results("2026-07-29T00:00:00Z",
                  [{"entry": "inference_offline", "cell": "baseline-local", "verdict": "pass",

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -166,6 +166,91 @@ def test_build_html_has_gate_and_kernel_names():
     assert "gemm_x" in html and "Kernel details" in html
 
 
+def test_build_html_empty_shows_placeholder_and_back_link():
+    # Rendered for the /sanitizers/ route before the first successful nightly so
+    # it never 404s. Must carry the back-link and a clear "no runs yet" message.
+    html = gen.build_html([])
+    assert "<!doctype html>" in html
+    assert 'href="../"' in html
+    assert "No sanitizer runs yet" in html
+
+
+def test_build_html_renders_stale_banner_when_unhealthy():
+    rows = {
+        "waitcheck": gen.summarize_case(_waitcheck_report(), "warn"),
+        "consan-clean": gen.summarize_case(_consan_racy_report(), "fail"),
+        "consan-racy": gen.summarize_case(_consan_racy_report(), "fail"),
+    }
+    runs = [{"meta": {"run": "r1", "commit": "abc", "date": "d", "gpu": "gfx950"}, "rows": rows, "gate": True}]
+    status = {
+        "healthy": False, "conclusion": "failure", "run_id": "42",
+        "run_url": "https://github.com/ROCm/aorta/actions/runs/42", "date": "2026-08-05",
+    }
+    html = gen.build_html(runs, status=status)
+    assert "did not complete successfully" in html
+    assert "failure" in html
+    assert "actions/runs/42" in html
+
+
+def test_build_html_no_banner_when_healthy():
+    runs = [{"meta": {"run": "r1", "commit": "abc", "date": "d", "gpu": "gfx950"},
+             "rows": {c: gen.summarize_case(_waitcheck_report(), "warn") for c, *_ in gen.CASES},
+             "gate": True}]
+    healthy = {"healthy": True, "conclusion": "success", "run_id": "42", "run_url": "", "date": "d"}
+    assert "did not complete successfully" not in gen.build_html(runs, status=healthy)
+    # An unhealthy banner also renders on the empty-state page.
+    empty = gen.build_html([], status={"healthy": False, "conclusion": "failure",
+                                       "run_id": "7", "run_url": "", "date": ""})
+    assert "did not complete successfully" in empty
+
+
+def test_build_summary_md_stale_banner():
+    status = {"healthy": False, "conclusion": "failure", "run_id": "9",
+              "run_url": "https://x/9", "date": "d"}
+    md = gen.build_summary_md([], status=status)
+    assert "Stale" in md and "https://x/9" in md
+
+
+def test_main_empty_runs_root_publishes_placeholder(tmp_path, monkeypatch):
+    # The empty-runs-root path Pages uses to guarantee /sanitizers/index.html.
+    baselines = _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+    out = tmp_path / "out"
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--runs-root", str(tmp_path / "empty"),
+        "--baselines", str(baselines),
+        "--out-dir", str(out),
+    ]
+    (tmp_path / "empty").mkdir()
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+    index = (out / "index.html").read_text(encoding="utf-8")
+    assert "No sanitizer runs yet" in index
+
+
+def test_main_writes_status_json_and_banner(tmp_path, monkeypatch):
+    baselines = _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+    status_file = tmp_path / "status.json"
+    status_file.write_text(json.dumps({
+        "healthy": False, "conclusion": "failure", "run_id": "13",
+        "run_url": "https://github.com/ROCm/aorta/actions/runs/13",
+        "ref": "refs/heads/main", "date": "2026-08-05",
+    }))
+    out = tmp_path / "out"
+    (tmp_path / "empty").mkdir()
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--runs-root", str(tmp_path / "empty"),
+        "--baselines", str(baselines),
+        "--status", str(status_file),
+        "--out-dir", str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+    assert (out / "status.json").is_file()
+    assert "did not complete successfully" in (out / "index.html").read_text(encoding="utf-8")
+
+
 def test_runs_from_results_dir_matches_baselines(tmp_path):
     baselines = {
         "waitcheck_gemm": {"overall_verdict": "warn"},


### PR DESCRIPTION
## Summary

Partially addresses #327 (Option B). Co-publishes the PR #324 sanitizer nightly dashboard (`scripts/sanitizers/gen_sanitizer_dashboard.py`) on the repo's single GitHub Pages site as a `/sanitizers/` sub-page, linked from Vivek Khandelwal's CI nightly dashboard at the site root. No report-schema or run-command changes; Pages is additive and Option A (job summary + artifact) is retained.

Based on `feat/rocjitsu-sanitizers-recipe-ux` (PR #324) because the sanitizer generator and `sanitizers-nightly.yml` do not yet exist on `main`. Retarget to `main` once #324 merges.

## Changes

- **`.github/workflows/sanitizers-nightly.yml`**: `publish` job pushes the rendered `dashboard/` to a dedicated `sanitizer-results` data branch using the fail-closed orphan pattern from `nightly-eval.yml` (`git ls-remote --exit-code`: present/absent/error); adds `contents: write` to that job only. Existing artifact upload + `$GITHUB_STEP_SUMMARY` surfacing kept.
- **`.github/workflows/pages.yml`**: rebuilds Pages after the `Sanitizers Nightly` workflow completes; clones `sanitizer-results` with the same fail-closed contract as `ci-results` and copies `dashboard/` into `_site/sanitizers/`; adds `/sanitizers/index.html` to the "Verify the published routes" gate when the branch is present. Single Pages owner preserved (`sanitizers-nightly.yml` never deploys Pages itself).
- **`scripts/ci/gen_dashboard.py`**: adds a `sanitizer nightly` nav link on the CI dashboard root.
- **`scripts/sanitizers/gen_sanitizer_dashboard.py`**: adds a `back to CI dashboard` link on the sanitizer page.
- **`docs/ci-nightly-eval.md`**: documents the `/sanitizers/` sub-page URL.
- **`tests/ci/test_dashboard_and_alert.py`**: asserts the CI dashboard links to the sanitizer sub-page.

## Issue #327 coverage

Fixed by this PR:
- [x] Sanitizer nightly persists results to a data branch, fail-closed on transport/auth errors (persists the rendered `dashboard/` snapshot).
- [x] `pages.yml` renders `/sanitizers/` from that data and gates the route (never 404s).
- [x] Public page shows the latest gate + per-kernel detail (already rendered by the PR #324 generator).
- [x] CI dashboard / docs link to `/sanitizers/`.

Deferred to a follow-up PR (kept open on #327):
- [ ] Persist raw per-night results (`sanitizer_report.json` / `data.json`) and accumulate history, replacing the `update_history.py` placeholder with real branch persistence.
- [ ] Regenerate the page from accumulated history in `pages.yml` (add a `--history` adapter to the generator if needed) instead of copying the latest pre-rendered snapshot.
- [ ] Multi-night trend view on the public page.
- [ ] Unit coverage for the history-adapter logic.
- [ ] Landing-page (`/docs/` Jekyll README) link, if desired in addition to the CI dashboard nav.

## Test plan

- [x] `pytest tests/sanitizers/test_dashboard.py tests/ci/test_dashboard_and_alert.py` (34 passed)
- [ ] After first `Sanitizers Nightly` run, confirm `sanitizer-results` branch is created and `https://rocm.github.io/aorta/sanitizers/` renders with the root-nav link and back-link working.

Made with [Cursor](https://cursor.com)