### PR TITLE
ci(sanitizers): fix nightly checkout perms + Ninja-less build

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -52,8 +52,16 @@ jobs:
           git clone --filter=blob:none https://github.com/ROCm/rocm-systems.git "${ROCJITSU_SRC}"
           git -C "${ROCJITSU_SRC}" checkout "${ROCJITSU_REF}"
           echo "ROCJITSU checkout: $(git -C "${ROCJITSU_SRC}" rev-parse HEAD)"
-          cmake -S "${ROCJITSU_SRC}/emulation/rocjitsu" -B "${ROCJITSU_BUILD}" -GNinja
-          ninja -C "${ROCJITSU_BUILD}" rj_waitcheck rocjitsu_dbi_hooks
+          # Prefer Ninja when the runner has it, but fall back to CMake's default
+          # generator so the gate doesn't hard-fail on hosts without Ninja
+          # installed. `cmake --build` drives whichever generator was selected.
+          if command -v ninja >/dev/null 2>&1; then
+            cmake -S "${ROCJITSU_SRC}/emulation/rocjitsu" -B "${ROCJITSU_BUILD}" -GNinja
+          else
+            cmake -S "${ROCJITSU_SRC}/emulation/rocjitsu" -B "${ROCJITSU_BUILD}"
+          fi
+          cmake --build "${ROCJITSU_BUILD}" --parallel \
+            --target rj_waitcheck rocjitsu_dbi_hooks
           echo "ROCJITSU_BUILD=${ROCJITSU_BUILD}" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
Two independent failures were blocking the **Sanitizers Nightly** gfx950 job on the shared self-hosted MI350 runner:

1. **`Check out code` — `EACCES: permission denied, rmdir '.../results/gpu_smoke'`.** Sibling GPU jobs (`gpu-tests.yml` et al.) run `aorta` inside a **root** ROCm CI container that leaves root-owned artifacts in the mounted checkout; `actions/checkout`'s `git clean` runs as the runner user and can't delete them. Added the same **Reclaim workspace ownership** step already used by `gpu-tests.yml` / `eval-reusable.yml` / `refresh-baselines.yml` (throwaway root `busybox` container `chown`, with `sudo docker` / host `sudo` fallbacks) before checkout. `sanitizers-nightly.yml` was the only GPU workflow missing it.
2. **`Build rocjitsu sanitizer binaries` — `CMake was unable to find a build program corresponding to "Ninja"`.** The runner has no Ninja on PATH. Now prefers Ninja only when present, otherwise falls back to CMake's default generator, and builds via `cmake --build --target ...`.

See failing [run 31102697357](https://github.com/ROCm/aorta/actions/runs/31102697357).

## Test plan
- [ ] Re-run **Sanitizers Nightly** via `workflow_dispatch` and confirm checkout succeeds and the rocjitsu build + downstream ConSan/waitcheck steps run.