### PR TITLE
ci(sanitizers): use shared gpu runner label and cancel stale runs

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: sanitizers-nightly-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   CONTAINER_NAME: aorta-ci-gpu
@@ -25,10 +25,10 @@ env:
 jobs:
   sanitizers-gpu:
     name: gfx950 sanitizer regression
-    # Must match a real online runner: the MI350 host is labelled
-    # `self-hosted, gpu, mi350x` (same set the other GPU workflows target, e.g.
-    # gpu-tests.yml / eval-reusable.yml use `self-hosted, gpu`).
-    runs-on: [self-hosted, gpu, mi350x]
+    # Target the same online MI350 runner pool as gpu-tests.yml /
+    # eval-reusable.yml (`self-hosted, gpu`). Avoid the extra `mi350x` label: it
+    # can route to a stale/offline runner and leave the job wedged in "Set up job".
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 120
     steps:
       # Sibling GPU jobs (gpu-tests.yml et al.) run aorta in a root ROCm CI


### PR DESCRIPTION
## Summary
- Change Sanitizers Nightly `runs-on` from `[self-hosted, gpu, mi350x]` to `[self-hosted, gpu]` (same pool as gpu-tests / eval-reusable).
- Set `cancel-in-progress: true` so stale scheduled reruns (e.g. 31102697357) do not block fresh dispatches.

## Why
[Run 31116518267](https://github.com/ROCm/aorta/actions/runs/31116518267) wedged indefinitely in **Set up job** on the `mi350x`-labelled runner while other GPU workflows use the shared `gpu` label successfully.