### PR TITLE
ci(sanitizers): install cmake/ninja in the container for the rocjitsu build

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -81,6 +81,12 @@ jobs:
 
             python -m pip install --upgrade pip
             pip install -e ".[tests]"
+            # The pinned ROCm CI container ships hipcc but not cmake/ninja, so
+            # the rocjitsu build below hit `cmake: command not found` (exit 127
+            # on run 31152762604). Provision both from PyPI (real prebuilt
+            # binaries, no image change needed); the `command -v ninja` check
+            # below then selects the faster Ninja generator.
+            pip install cmake ninja
 
             rm -rf "${ROCJITSU_SRC}" "${ROCJITSU_BUILD}"
             git clone --filter=blob:none https://github.com/ROCm/rocm-systems.git "${ROCJITSU_SRC}"


### PR DESCRIPTION
## Summary

The nightly **Sanitizers** gate builds the rocjitsu sanitizer binaries. Since #335 that build runs inside the pinned ROCm CI container (`aorta-ci-gpu`). That image ships `hipcc` but **not** `cmake`/`ninja`, so the build failed with:

```
bash: line 18: cmake: command not found
Error: Process completed with exit code 127.
```

(see [run 31152762604](https://github.com/ROCm/aorta/actions/runs/31152762604/job/92785696247), commit `667b1a6`).

This installs `cmake` and `ninja` from PyPI (real prebuilt binaries) right after the editable aorta install, so the rocjitsu build no longer depends on the base image carrying them. The existing `command -v ninja` guard (from #333) then selects the faster Ninja generator instead of falling back to Make.

- No image/digest change required.
- Keeps the container-based design from #335 and the Ninja-optional defensiveness from #333.

## Test plan

- [ ] `workflow_dispatch` the **Sanitizers Nightly** workflow on this branch and confirm the "Run sanitizer regression" step gets past the `cmake`/`ninja` invocation and builds `rj_waitcheck` / `rocjitsu_dbi_hooks`.

> Note: [run 31152762604](https://github.com/ROCm/aorta/actions/runs/31152762604/job/92785696247) also logged a warning that the Docker Hub login failed (`ROCM_SHARED_KEY` may be expired) and it continued with anonymous pulls. That's a separate runner-secret issue and is not addressed here.

Made with [Cursor](https://cursor.com)