### PR TITLE
ci: make the reusable GPU eval refuse fork PRs itself

### DIFF
--- a/.github/workflows/eval-reusable.yml
+++ b/.github/workflows/eval-reusable.yml
@@ -33,6 +33,18 @@ jobs:
   eval:
     name: gpu eval (MI350)
     runs-on: [self-hosted, gpu]
+    # Defence in depth: today's only pull_request caller (bump-validate.yml)
+    # already refuses forks, so this closes no live hole. It makes the callee
+    # safe by default instead of relying on every future caller to remember,
+    # which matters more here than usual -- this job runs on the self-hosted
+    # MI350 and builds a container as root from the PR's own docker/**, so the
+    # cost of one forgetful caller is the host rather than a bad test run.
+    #
+    # In a called workflow these refer to the caller's event, so the nightly
+    # (workflow_run / workflow_dispatch) is unaffected.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 150
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

`eval-reusable.yml`'s job runs on the self-hosted MI350 and builds a container as root from the pull request's own `docker/**`. If a fork PR ever reaches it, the cost is the host, not a red check.

**This closes no live hole.** The only `pull_request` caller, `bump-validate.yml`, already gates on `head.repo.full_name`, and the org's fork-PR policy is set to `all_external_contributors`. The point is to make the callee safe by default instead of depending on every future caller to remember — an easy thing to miss when adding a PR trigger to a workflow that reads as nightly-only.

It's the same guard `gpu-tests.yml` already carries, so the pattern is consistent across everything that touches the self-hosted runner.

## Why the callee and not just the callers

`bump-validate.yml`'s trigger paths are `docker/**` and the requirements files — exactly the inputs that decide what gets built and executed as root in the container. That makes a forgotten guard on some future caller unusually expensive, and the callee is the one place that can't be forgotten.

## Test plan

- [x] YAML parses; guard resolves to the same expression `gpu-tests.yml` uses
- [x] Nightly paths unaffected: in a called workflow these expressions see the caller's event, which is `workflow_run` / `workflow_dispatch` for `nightly-eval.yml`, so `github.event_name != 'pull_request'` short-circuits true
- [x] `bump-validate.yml` has a single job with no dependents, so a skip on fork PRs cannot strand downstream work
- [ ] CI green