### PR TITLE
ci(cpu-tests): skip CPU matrix on PRs that can't affect the suite

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -1,12 +1,21 @@
 name: CPU Tests
 
-# PR merge gate: run the CPU-runnable slice of the pytest suite on every pull
-# request (and on pushes to main). GPU-only tests (markers `gpu` / `rocm`) are
-# deselected here and will get their own workflow once a GPU/self-hosted runner
-# is available -- see docs/ci-testing-plan.md.
+# PR merge gate: run the CPU-runnable slice of the pytest suite on pull
+# requests that touch code (and on pushes to main). GPU-only tests (markers
+# `gpu` / `rocm`) are deselected here and run in gpu-tests.yml -- see
+# docs/ci-testing-plan.md.
 #
 # Mark the `tests` jobs as required status checks on `main` so a red suite
 # blocks merge.
+#
+# `pytest (CPU, py3.x)` is a required status check on `main`. Path filtering
+# therefore must NOT live on the `pull_request` trigger: a workflow skipped by
+# path filtering leaves its checks Pending forever rather than reporting, so any
+# PR outside those paths would be permanently unmergeable. A job skipped by a
+# conditional, by contrast, reports Success. So this workflow always starts and
+# the `changes` job below decides whether the CPU suite is relevant -- the same
+# pattern gpu-tests.yml uses.
+# See https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks
 
 on:
   pull_request:
@@ -14,9 +23,11 @@ on:
     branches:
       - main
 
-# Least privilege: this gate only checks out code and runs tests.
+# contents: read to check out; pull-requests: read so the `changes` gate can
+# list the files a PR touches.
 permissions:
   contents: read
+  pull-requests: read
 
 # A newer push to the same PR/branch cancels the older, still-running gate:
 # the only thing that matters is whether the tip commit is green.
@@ -25,9 +36,118 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Cheap gate on a GitHub-hosted runner, replacing a trigger-level `paths:`
+  # filter (which would strand the required check as Pending on skipped PRs).
+  # Non-PR triggers always report true so pushes to main run the full suite.
+  #
+  # Unlike gpu-tests.yml -- which allow-lists a small set of GPU-relevant paths
+  # -- the CPU suite is the catch-all gate and is affected by almost the entire
+  # tree (all of src/**, tests/**, packaging metadata, and even a few docs:
+  # tests/instrumentation/test_layer_numerics_docs.py reads docs/layer-numerics.md).
+  # So this gate is fail-open with a *deny*-list: it runs the suite unless every
+  # changed file matches a path that provably never feeds `pytest -m "not gpu
+  # and not rocm"`. Getting the list wrong only ever runs the fast CPU suite
+  # unnecessarily; it never skips a code change. New/unknown paths run the suite.
+  changes:
+    name: detect CPU-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      cpu: ${{ steps.filter.outputs.cpu }}
+    steps:
+      - name: Decide whether the CPU suite applies
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "$EVENT_NAME is not a pull request; running the full CPU suite."
+            echo "cpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fail open. This gate decides a required status check, so an
+          # indeterminate answer must never be read as "no CPU work needed":
+          # that would hand a code-touching PR a green check without testing it.
+          # On any retrieval problem, claim relevance and run the suite.
+          # Assigning inside `if !` keeps `set -e` from aborting on failure.
+          if ! files="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+                          --paginate --jq '.[].filename' 2>&1)"; then
+            echo "::warning::Could not list the PR's files, so running the CPU" \
+                 "suite rather than guessing. gh said: ${files}"
+            echo "cpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "$files" ]; then
+            echo "::warning::The PR file list came back empty, which should not" \
+                 "happen for a real PR; running the CPU suite."
+            echo "cpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Deny-list: paths that provably never affect the CPU pytest suite.
+          # Kept intentionally narrow -- only entries we are certain are inert
+          # belong here, since a wrong entry silently skips real tests. Trailing
+          # `*` is a `case` glob that matches `/` too, so it covers whole
+          # subtrees. Single-quoted and expanded via "${ignore[@]}" so the shell
+          # never filename-expands them -- they must reach `case` as literal
+          # patterns.
+          #
+          # `.github/*` (CI workflows, composite actions, templates, CODEOWNERS)
+          # is inert for CPU tests -- no test imports or reads anything under it
+          # -- with one exception: a change to this workflow itself must re-run
+          # it, so cpu-tests.yml is special-cased as relevant below.
+          ignore=(
+            '.github/*'
+          )
+
+          cpu=false
+          while read -r file; do
+            [ -n "$file" ] || continue
+
+            # A change to the CPU gate itself must exercise the CPU gate.
+            if [ "$file" = ".github/workflows/cpu-tests.yml" ]; then
+              echo "CPU-relevant change: $file (the CPU workflow itself)"
+              cpu=true
+              break
+            fi
+
+            ignorable=false
+            for pattern in "${ignore[@]}"; do
+              # shellcheck disable=SC2254  # unquoted glob match is intentional
+              case "$file" in
+                $pattern)
+                  ignorable=true
+                  break
+                  ;;
+              esac
+            done
+
+            if [ "$ignorable" = false ]; then
+              echo "CPU-relevant change: $file"
+              cpu=true
+              break
+            fi
+          done <<< "$files"
+
+          if [ "$cpu" = false ]; then
+            echo "No CPU-relevant paths changed; the CPU jobs will be skipped."
+            echo "A skipped job reports Success, satisfying the required check."
+          fi
+          echo "cpu=$cpu" >> "$GITHUB_OUTPUT"
+
   tests:
     name: pytest (CPU, py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    needs: changes
+    # Skipped (and therefore reported as Success) when no CPU-relevant path
+    # changed, so CI-only / other-workflow PRs don't spin up three Python
+    # matrix jobs for nothing.
+    if: needs.changes.outputs.cpu == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -8,14 +8,26 @@ name: CPU Tests
 # Mark the `tests` jobs as required status checks on `main` so a red suite
 # blocks merge.
 #
-# `pytest (CPU, py3.x)` is a required status check on `main`. Path filtering
-# therefore must NOT live on the `pull_request` trigger: a workflow skipped by
-# path filtering leaves its checks Pending forever rather than reporting, so any
-# PR outside those paths would be permanently unmergeable. A job skipped by a
-# conditional, by contrast, reports Success. So this workflow always starts and
-# the `changes` job below decides whether the CPU suite is relevant -- the same
-# pattern gpu-tests.yml uses.
+# Making this skippable-yet-required needs care on two fronts:
+#
+#   1. Path filtering must NOT live on the `pull_request` trigger. A workflow
+#      skipped by trigger-level path filtering leaves its checks Pending forever
+#      rather than reporting, so any PR outside those paths would be permanently
+#      unmergeable. Instead the `changes` job below always runs and decides
+#      whether the CPU suite is relevant (same pattern as gpu-tests.yml).
+#
+#   2. The per-version `pytest (CPU, py3.x)` legs must NOT be the required
+#      status checks. GitHub evaluates a job-level `if` *before* expanding a
+#      matrix, so when the `tests` job is skipped the three matrix contexts are
+#      never created -- and a required check pinned to a context that never
+#      reports hangs the PR forever (actions/runner#952). gpu-tests.yml dodges
+#      this only because its gated job is a single, non-matrix job whose one
+#      static context still reports "skipped" (== success). A matrix cannot rely
+#      on that. So the stable, always-running `required` aggregator job at the
+#      bottom is what `main` requires; it collapses the matrix result into one
+#      fixed check name that reports on every PR.
 # See https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks
+# and https://github.com/actions/runner/issues/952
 
 on:
   pull_request:
@@ -46,8 +58,11 @@ jobs:
   # tests/instrumentation/test_layer_numerics_docs.py reads docs/layer-numerics.md).
   # So this gate is fail-open with a *deny*-list: it runs the suite unless every
   # changed file matches a path that provably never feeds `pytest -m "not gpu
-  # and not rocm"`. Getting the list wrong only ever runs the fast CPU suite
-  # unnecessarily; it never skips a code change. New/unknown paths run the suite.
+  # and not rocm"`. The safety here is asymmetric, so mind the direction: an
+  # *omitted* deny entry only costs an unnecessary (fast) run, but an *overbroad
+  # or wrong* entry misclassifies a relevant change as ignorable and silently
+  # skips real tests. New/unknown paths therefore run the suite, and every deny
+  # entry below must be proven inert before it is added.
   changes:
     name: detect CPU-relevant changes
     runs-on: ubuntu-latest
@@ -74,17 +89,63 @@ jobs:
           # that would hand a code-touching PR a green check without testing it.
           # On any retrieval problem, claim relevance and run the suite.
           # Assigning inside `if !` keeps `set -e` from aborting on failure.
-          if ! files="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-                          --paginate --jq '.[].filename' 2>&1)"; then
+
+          # The true changed-file count, read first so we can detect the API cap
+          # below. The /files listing returns at most 3000 files; comparing its
+          # record count against this catches a truncated list.
+          if ! changed_files="$(gh api \
+                  "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+                  --jq '.changed_files' 2>&1)"; then
+            echo "::warning::Could not read PR metadata, so running the CPU" \
+                 "suite rather than guessing. gh said: ${changed_files}"
+            echo "cpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          case "$changed_files" in
+            ''|*[!0-9]*)
+              echo "::warning::PR changed_files was not a number" \
+                   "(${changed_files:-empty}); running the CPU suite."
+              echo "cpu=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          if ! resp="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+                          --paginate 2>&1)"; then
             echo "::warning::Could not list the PR's files, so running the CPU" \
-                 "suite rather than guessing. gh said: ${files}"
+                 "suite rather than guessing. gh said: ${resp}"
             echo "cpu=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [ -z "$files" ]; then
+          # Evaluate *both* sides of a rename. A file moved out of a
+          # CPU-relevant path (its previous_filename) still deleted source and
+          # must count as relevant even when the new path is ignorable, so the
+          # deny-list must see the old path too. `// empty` drops it for
+          # non-renames. jq handles a merged array or a stream of per-page
+          # arrays identically, so this is robust to how gh emits --paginate.
+          if ! paths="$(printf '%s' "$resp" \
+                  | jq -r '.[] | .filename, (.previous_filename // empty)' 2>&1)"; then
+            echo "::warning::Could not parse the PR file list, so running the" \
+                 "CPU suite. jq said: ${paths}"
+            echo "cpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "$paths" ]; then
             echo "::warning::The PR file list came back empty, which should not" \
                  "happen for a real PR; running the CPU suite."
+            echo "cpu=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # One record per changed file (renames counted once, unlike $paths).
+          record_count="$(printf '%s' "$resp" | jq -r '.[].filename' 2>/dev/null \
+                            | grep -c . || true)"
+          if [ "${record_count:-0}" -lt "$changed_files" ]; then
+            echo "::warning::Only ${record_count:-0}/${changed_files} changed" \
+                 "files were returned (3000-file API cap); running the CPU" \
+                 "suite rather than trusting a truncated list."
             echo "cpu=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -132,11 +193,12 @@ jobs:
               cpu=true
               break
             fi
-          done <<< "$files"
+          done <<< "$paths"
 
           if [ "$cpu" = false ]; then
-            echo "No CPU-relevant paths changed; the CPU jobs will be skipped."
-            echo "A skipped job reports Success, satisfying the required check."
+            echo "No CPU-relevant paths changed; the CPU matrix will be skipped."
+            echo "The 'required' aggregator still reports and stays green, so the"
+            echo "required check is satisfied without running the matrix."
           fi
           echo "cpu=$cpu" >> "$GITHUB_OUTPUT"
 
@@ -144,9 +206,10 @@ jobs:
     name: pytest (CPU, py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: changes
-    # Skipped (and therefore reported as Success) when no CPU-relevant path
-    # changed, so CI-only / other-workflow PRs don't spin up three Python
-    # matrix jobs for nothing.
+    # Skipped when no CPU-relevant path changed, so CI-only / other-workflow PRs
+    # don't spin up three Python matrix jobs for nothing. These per-version legs
+    # are deliberately NOT the required checks (a skipped matrix never emits
+    # their contexts -- actions/runner#952); the `required` job below is.
     if: needs.changes.outputs.cpu == 'true'
     strategy:
       fail-fast: false
@@ -206,3 +269,39 @@ jobs:
       # longer needed for correctness -- and dropping it makes the gate faster.
       - name: Run CPU test suite
         run: pytest -m "not gpu and not rocm" -n auto
+
+  # Stable required-status-check aggregator. Branch protection on `main` must
+  # require THIS job ("CPU tests"), not the per-version `pytest (CPU, py3.x)`
+  # legs: a matrix skipped by a job-level `if` never emits those contexts, so a
+  # required check pinned to them would hang the PR forever (actions/runner#952).
+  # This job has no matrix and `if: always()`, so its single context reports on
+  # every PR. It passes when the matrix ran green OR was legitimately skipped
+  # (no CPU-relevant change), and fails if any leg failed/was cancelled or the
+  # gate itself did not succeed.
+  required:
+    name: CPU tests
+    runs-on: ubuntu-latest
+    needs: [changes, tests]
+    if: always()
+    steps:
+      - name: Collapse the CPU matrix result into one required check
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
+        run: |
+          set -euo pipefail
+          echo "changes=${CHANGES_RESULT} tests=${TESTS_RESULT}"
+
+          # The relevance gate must have completed; a broken gate is not a pass.
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "The CPU relevance gate did not succeed (${CHANGES_RESULT})."
+            exit 1
+          fi
+
+          # 'skipped' == no CPU-relevant path changed (a pass); 'success' == the
+          # matrix ran green. Anything else (failure/cancelled) fails the check.
+          case "$TESTS_RESULT" in
+            success)  echo "CPU matrix passed." ;;
+            skipped)  echo "CPU matrix skipped (no CPU-relevant change)." ;;
+            *)        echo "CPU matrix did not pass (${TESTS_RESULT})."; exit 1 ;;
+          esac

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -18,7 +18,7 @@ runners; Phase 2 runs the GPU complement on a self-hosted MI350 runner
 | Workflow | Trigger | What it does |
 | --- | --- | --- |
 | `pre-commit.yml` | PR + push to `main` | Runs `pre-commit` hooks (whitespace, EOF, YAML) |
-| `cpu-tests.yml` | PR + push to `main` | CPU pytest gate (`not gpu and not rocm`) on `ubuntu-latest` |
+| `cpu-tests.yml` | PR (code-touching paths) + push to `main` | CPU pytest gate (`not gpu and not rocm`) on `ubuntu-latest` |
 | `gpu-tests.yml` | PR (GPU paths) + nightly + dispatch | GPU pytest gate + nightly workload regression on `[self-hosted, gpu]` |
 | `nightly.yml` | cron + dispatch | Builds/publishes rolling dev wheels |
 | `release.yml` / `cleanup_releases.yml` | tags / cron | Release packaging + asset pruning |
@@ -33,7 +33,9 @@ it never executes pytest. A PR could break ~2,000 tests and still merge.
 
 Workflow: [`.github/workflows/cpu-tests.yml`](../.github/workflows/cpu-tests.yml)
 
-- **Triggers:** `pull_request` (every PR) and `push` to `main`.
+- **Triggers:** `pull_request` and `push` to `main`. On PRs a cheap `changes`
+  job first decides whether the suite is relevant (see "Path gate" below); it
+  always runs on pushes to `main`.
 - **Runner / matrix:** `ubuntu-latest`, Python `3.10`, `3.11`, `3.12` (the
   versions declared in `pyproject.toml`). `fail-fast: false` so one version's
   failure still reports the others.
@@ -123,6 +125,31 @@ That pollution came from two culprits, both fixed in
 
 The suite is now deterministic in one interpreter (verified across randomized
 orderings), so `--forked` is dropped and only `-n auto` is kept, for speed.
+
+### Path gate (fail-open deny-list)
+
+`pytest (CPU, py3.x)` is a required status check, so the workflow can't use a
+trigger-level `paths:` filter: GitHub leaves a path-skipped required check
+Pending forever, making the PR unmergeable. Instead a cheap `changes` job runs
+first and a job-level `if` decides whether the matrix runs (a *skipped* job
+reports Success and satisfies the required check) -- the same pattern
+[`gpu-tests.yml`](../.github/workflows/gpu-tests.yml) uses.
+
+The GPU gate allow-lists a small set of GPU-relevant paths. The CPU gate is the
+opposite shape: it's the catch-all suite touched by nearly the whole tree
+(`src/**`, `tests/**`, packaging metadata, and even a few docs -- e.g.
+`test_layer_numerics_docs.py` reads `docs/layer-numerics.md`), so an allow-list
+would be huge and dangerous to get wrong. It instead uses a small **deny-list**
+and **fails open**: the suite runs unless *every* changed file matches a path
+that provably never feeds `pytest -m "not gpu and not rocm"`. A wrong or missing
+deny entry only ever runs the fast CPU suite unnecessarily; it can never skip a
+real code change. On any error listing the PR's files, it runs the suite.
+
+Currently the deny-list is just `.github/*` (CI workflows, composite actions,
+templates, CODEOWNERS -- none of which any test imports), with a special case so
+that a change to `cpu-tests.yml` itself still exercises the gate. This is why a
+CI-only PR such as [#337](https://github.com/ROCm/aorta/pull/337) (which only
+edited `sanitizers-nightly.yml`) no longer spins up the three-Python CPU matrix.
 
 ### Making it a required check
 

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -128,22 +128,41 @@ orderings), so `--forked` is dropped and only `-n auto` is kept, for speed.
 
 ### Path gate (fail-open deny-list)
 
-`pytest (CPU, py3.x)` is a required status check, so the workflow can't use a
+The CPU suite is a required status check, so the workflow can't use a
 trigger-level `paths:` filter: GitHub leaves a path-skipped required check
 Pending forever, making the PR unmergeable. Instead a cheap `changes` job runs
-first and a job-level `if` decides whether the matrix runs (a *skipped* job
-reports Success and satisfies the required check) -- the same pattern
+first and a job-level `if` decides whether the matrix runs -- the same pattern
 [`gpu-tests.yml`](../.github/workflows/gpu-tests.yml) uses.
 
-The GPU gate allow-lists a small set of GPU-relevant paths. The CPU gate is the
-opposite shape: it's the catch-all suite touched by nearly the whole tree
-(`src/**`, `tests/**`, packaging metadata, and even a few docs -- e.g.
-`test_layer_numerics_docs.py` reads `docs/layer-numerics.md`), so an allow-list
-would be huge and dangerous to get wrong. It instead uses a small **deny-list**
-and **fails open**: the suite runs unless *every* changed file matches a path
-that provably never feeds `pytest -m "not gpu and not rocm"`. A wrong or missing
-deny entry only ever runs the fast CPU suite unnecessarily; it can never skip a
-real code change. On any error listing the PR's files, it runs the suite.
+There is one crucial difference from the GPU gate, though. GPU's gated job is a
+single, non-matrix job (`pytest (GPU, MI350)`): when skipped, its one static
+check context still reports (as *skipped* == success), so it can be the required
+check directly. The CPU job is a **matrix** (py3.10/3.11/3.12). GitHub evaluates
+a job-level `if` *before* expanding the matrix, so a skipped `tests` job never
+creates the `pytest (CPU, py3.x)` contexts at all -- and a required check pinned
+to a context that never reports hangs the PR forever
+([actions/runner#952](https://github.com/actions/runner/issues/952)). So the CPU
+workflow adds a stable, non-matrix `required` job (check name **`CPU tests`**,
+`if: always()`) that collapses the matrix result into one context that reports
+on every PR: it passes when the matrix ran green or was legitimately skipped,
+and fails if any leg failed. **That** aggregator is the required check, not the
+per-version legs.
+
+The relevance decision itself: the GPU gate allow-lists a small set of
+GPU-relevant paths. The CPU gate is the opposite shape -- it's the catch-all
+suite touched by nearly the whole tree (`src/**`, `tests/**`, packaging
+metadata, and even a few docs -- e.g. `test_layer_numerics_docs.py` reads
+`docs/layer-numerics.md`), so an allow-list would be huge and dangerous to get
+wrong. It instead uses a small **deny-list** and **fails open**: the suite runs
+unless *every* changed file matches a path that provably never feeds
+`pytest -m "not gpu and not rocm"`. The safety is **asymmetric**: an *omitted*
+deny entry only costs an unnecessary (fast) run, but an *overbroad or wrong*
+entry misclassifies a relevant change as ignorable and silently skips real
+tests. So new/unknown paths run the suite, and every deny entry must be proven
+inert before it is added. On any error listing the PR's files -- including a
+truncated listing past the 3000-file API cap -- it runs the suite. Renames are
+evaluated on both sides, so moving a source file *into* an ignored path still
+counts as a relevant (source-removing) change.
 
 Currently the deny-list is just `.github/*` (CI workflows, composite actions,
 templates, CODEOWNERS -- none of which any test imports), with a special case so
@@ -153,15 +172,20 @@ edited `sanitizers-nightly.yml`) no longer spins up the three-Python CPU matrix.
 
 ### Making it a required check
 
-To actually block merges, add the `tests` jobs as **required status checks** on
+To actually block merges, add the aggregator as a **required status check** on
 the `main` branch:
 
 `Settings -> Branches -> Branch protection rules -> main -> Require status
 checks to pass before merging`, then select:
 
-- `pytest (CPU, py3.10)`
-- `pytest (CPU, py3.11)`
-- `pytest (CPU, py3.12)`
+- `CPU tests`
+
+Do **not** require the per-version `pytest (CPU, py3.10/3.11/3.12)` legs: because
+the matrix is skipped by a job-level `if` on irrelevant PRs, those contexts are
+not emitted and a required check pinned to them would hang the PR forever
+([actions/runner#952](https://github.com/actions/runner/issues/952)). The `CPU
+tests` aggregator reports on every PR and already fails if any matrix leg fails,
+so it is the correct single required check.
 
 (The workflow runs on PRs regardless; branch protection is what makes a red run
 *block* the merge.)

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -359,10 +359,11 @@ issues so each can be picked up independently:
 Done: [#269](https://github.com/ROCm/aorta/issues/269) modernized
 `test_sweep_cli.py` for `click>=8.2` and removed the `click<8.2` CI pin.
 
-Not an issue: making the `pytest (CPU, py3.x)` and **`pytest (GPU, MI350)`**
+Not an issue: making the **`CPU tests`** aggregator and **`pytest (GPU, MI350)`**
 jobs **required status checks** on `main` is a repo/admin setting (see
 "Making it a required check" / "Making the GPU gate a required check" above),
-not a code change.
+not a code change. (For CPU, require the `CPU tests` aggregator, not the
+per-version `pytest (CPU, py3.x)` legs -- see "Making it a required check".)
 
 ## Summary
 


### PR DESCRIPTION
## Summary

`cpu-tests.yml` triggered on every `pull_request` with no path filtering, so the three-Python `pytest (CPU, py3.x)` matrix ran on **every** PR — including ones that cannot change the outcome of `pytest -m "not gpu and not rocm"`. For example [#337](https://github.com/ROCm/aorta/pull/337) only edited `.github/workflows/sanitizers-nightly.yml`, yet all three CPU jobs ran.

This adds a `changes` gate to `cpu-tests.yml`, following the same required-check-safe pattern `gpu-tests.yml` already uses:

- The relevance decision lives in a `changes` job + a job-level `if`, **not** a trigger-level `paths:` filter — a path-skipped *required* check stays Pending forever and blocks merge, whereas a conditionally-skipped job reports Success.
- **Fails open:** non-PR events (push to `main`) and any error listing the PR's files run the full suite.

### Why a deny-list (not the GPU gate's allow-list)

The GPU gate allow-lists a few GPU-relevant paths. The CPU suite is the opposite shape — the catch-all gate touched by nearly the whole tree (`src/**`, `tests/**`, packaging metadata, and even a few docs, e.g. `tests/instrumentation/test_layer_numerics_docs.py` reads `docs/layer-numerics.md`). An allow-list there would be huge and unsafe: a forgotten code path would silently skip real tests.

So this gate uses a small **deny-list** and runs the suite unless *every* changed file matches a path proven inert for the pytest suite. A wrong/missing deny entry only ever runs the fast CPU suite unnecessarily; it can never skip a real code change. Initial deny-list is `.github/*` (workflows, composite actions, templates, CODEOWNERS — none imported by any test), with `cpu-tests.yml` itself special-cased as relevant.

## Behavior (dry-run of the gate logic)

| Changed files | Result |
| --- | --- |
| `sanitizers-nightly.yml` only (like #337) | skip |
| composite action only | skip |
| `cpu-tests.yml` itself | run |
| any `src/**` change | run |
| `docs/layer-numerics.md` | run (a test reads it) |
| CI file + `src/**` mixed | run |
| top-level `README.md` | run (fail-open) |

## Test plan

- [ ] Open/observe a CI-only PR and confirm `pytest (CPU, py3.x)` report **Success** (skipped), not Pending.
- [ ] Confirm a PR touching `src/**` or `tests/**` still runs the full matrix.
- [ ] Confirm the `changes` job logs its per-file decision.

Docs updated in `docs/ci-testing-plan.md` (new "Path gate" section).

Closes #338

Made with Cursor

Made with [Cursor](https://cursor.com)