### PR TITLE
ci(sanitizers): match consan_racy verdict baseline to current ConSan diagnostic (fixes #341)

### DIFF
--- a/recipes/sanitizers/fixtures/expected/verdict_baselines.json
+++ b/recipes/sanitizers/fixtures/expected/verdict_baselines.json
@@ -23,7 +23,7 @@
       "consan": "fail"
     },
     "finding_shape": {
-      "consan": "conflict=true"
+      "consan": "auto replay diagnostic"
     }
   }
 }

--- a/tests/sanitizers/test_compare_baselines.py
+++ b/tests/sanitizers/test_compare_baselines.py
@@ -67,10 +67,17 @@ def _write_case(root: Path, case_dir: str, check: CheckResult) -> None:
     write_report(report, root / case_dir / "sanitizer_report.json")
 
 
+_RACY_CONFLICT_MESSAGE = (
+    "[rocjitsu-dbi-hooks] ConSan MOI auto replay diagnostic reader=1 index=0 kind=1 "
+    "first_owner=0 second_owner=1 first_lds=[0,4) second_lds=[0,4) "
+    "first_kind=2 second_kind=1"
+)
+
+
 def _write_all_matching(root: Path) -> None:
     _write_case(root, "waitcheck", _check("waitcheck", Verdict.WARN, message="missing s_waitcnt"))
     _write_case(root, "consan-clean", _check("consan", Verdict.PASS))
-    _write_case(root, "consan-racy", _check("consan", Verdict.FAIL, message="conflict=true"))
+    _write_case(root, "consan-racy", _check("consan", Verdict.FAIL, message=_RACY_CONFLICT_MESSAGE))
 
 
 def test_comparator_passes_when_all_cases_match(tmp_path, monkeypatch) -> None:
@@ -102,8 +109,8 @@ def test_comparator_rejects_incomplete_execution(tmp_path, monkeypatch) -> None:
 def test_comparator_rejects_missing_finding_shape(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(_REPO_ROOT)
     _write_all_matching(tmp_path)
-    # FAIL verdict is correct, but the expected finding shape ("conflict=true")
-    # is absent -> the gate must not accept it.
+    # FAIL verdict is correct, but the expected finding shape ("auto replay
+    # diagnostic") is absent -> the gate must not accept it.
     _write_case(tmp_path, "consan-racy", _check("consan", Verdict.FAIL, message="something else"))
     assert comparator.main(["prog", str(tmp_path)]) == 1
 


### PR DESCRIPTION
## Summary

Fixes #341. The nightly sanitizer gate's `consan_racy` `finding_shape` asserted the literal token `conflict=true`, but the current RocJITsu ConSan output no longer emits it. Per-conflict lines are now:

```
[rocjitsu-dbi-hooks] ConSan MOI auto replay diagnostic reader=... index=... kind=1
  ... first_owner=0 second_owner=1 first_lds=[188,192) second_lds=[188,192)
  first_kind=2 second_kind=1 ...
```

i.e. the conflict is encoded via fields (two owners, overlapping LDS ranges, write-vs-read kinds) instead of a `conflict=true` flag. The race is still detected — [run 31162084250](https://github.com/ROCm/aorta/actions/runs/31162084250) produced 64 `severity=race` findings — but the stale substring made the fail-closed gate reject a correct result. This is drift from the unpinned mutable `shared/rocjitsu/sanitizers` ref (#330).

## Change

- `recipes/sanitizers/fixtures/expected/verdict_baselines.json`: `consan_racy.finding_shape.consan` → `"auto replay diagnostic"`.
- `tests/sanitizers/test_compare_baselines.py`: use a realistic diagnostic message + refresh the shape reference.

`auto replay diagnostic` is the exact token `consan.py` (`_AUTO_REPLAY_DIAGNOSTIC`) keys on to classify a line as a RACE conflict finding, and the finding stores the raw line as its message — so it is guaranteed present in every detected-conflict message and stays coupled to the parser's own contract (if upstream renames it, the parser stops producing findings and the gate fails on verdict, not on a silently-wrong shape).

## Verification

- Ran the comparator against the **real** nightly artifact from run 31162084250 → `consan_racy: ok (fail)`, exit 0 (previously `findings do not contain expected shape 'conflict=true'`).
- `tests/sanitizers/test_compare_baselines.py`: 5/5 pass, including the `rejects_missing_finding_shape` negative case now keyed on the new shape.

## Notes

- Complements #340 (which fixes the build/run deps so the nightly reaches this gate). Independent change; based on `main`.
- Does not address the underlying drift risk — pinning the RocJITsu ref (#330) remains the durable fix so the expected shape and emitted format move together.

Made with [Cursor](https://cursor.com)