### PR TITLE
feat(consan): drive ConSan over arbitrary command / code objects

### DIFF
--- a/recipes/sanitizers/consan-code-objects.yaml
+++ b/recipes/sanitizers/consan-code-objects.yaml
@@ -1,0 +1,37 @@
+schema_version: 1
+mode: sanitizer
+ticket: CONSAN-CODE-OBJECTS
+description: >
+  Drive ConSan over caller-selected/extracted code objects on gfx950. A run
+  area extracts the top-N f32 GEMM .hsaco objects from a customer report and a
+  small HIP loader (consan_app.py) loads exactly those objects on-device so
+  ConSan instruments precisely them. Point one selected identity (top_n: 1) at
+  that loader via source.consan_command; the command is resolved relative to
+  this recipe file. Fail-closed: a missing hook/loader yields not_checked, never
+  a false pass.
+
+sanitizer_plan:
+  target: gfx950
+  source:
+    kind: kernel
+    kernel:
+      name: gemm_NT_M128_N128_K128
+      code_object: fixtures/isa/sol_0.hsaco
+      code_object_index: 0
+    # Loader that mmaps/loads the extracted .hsaco objects on-device (see the
+    # consan_app.py HIP-loader pattern) so ConSan runs against exactly the
+    # selected identity. Resolved relative to this recipe file.
+    consan_command: fixtures/bin/consan_app
+    consan_log: true
+  scope:
+    kind: kernel
+  selection:
+    requirement: top_dispatch_count
+    top_n: 1
+  sanitizers:
+    - consan
+  policy:
+    consan_policy: strict
+    on_missing_backend: fail
+  output:
+    report: sanitizer_report.json

--- a/recipes/sanitizers/consan-code-objects.yaml
+++ b/recipes/sanitizers/consan-code-objects.yaml
@@ -33,5 +33,9 @@ sanitizer_plan:
   policy:
     consan_policy: strict
     on_missing_backend: fail
+    # Optional per-sanitizer subprocess wall-clock ceiling in seconds (default
+    # 900). ConSan's MOI transform of large production code objects can exceed
+    # the default and fail closed with combined_hook_timeout; raise it here.
+    # timeout_seconds: 3600
   output:
     report: sanitizer_report.json

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/pipeline.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/pipeline.py
@@ -12,6 +12,11 @@ from .waitcheck import run_waitcheck
 
 _KNOWN_SANITIZERS = frozenset({"waitcheck", "consan"})
 
+# Default wall-clock ceiling for a single sanitizer subprocess (waitcheck or
+# consan). ConSan's MOI transform of large production code objects can be heavy,
+# so a recipe may raise this via ``sanitizer_plan.policy.timeout_seconds``.
+DEFAULT_TIMEOUT_SECONDS = 900.0
+
 
 def run_sanitizers(
     worklist: KernelWorklist,
@@ -25,7 +30,7 @@ def run_sanitizers(
     consan_log: bool = True,
     consan_policy: str = "strict",
     on_missing_backend: str = "fail",
-    timeout_seconds: float = 900.0,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     report_name: str = "sanitizer_report.json",
     consan_target: KernelIdentity | None = None,
 ) -> SanitizerReport:

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py
@@ -260,6 +260,14 @@ def load_sanitizer_recipe(path: Path) -> SanitizerRecipe:
         kernel = _require_mapping(source.get("kernel"), name="sanitizer_plan.source.kernel")
         kernel_specs = (_parse_kernel_spec(kernel, context="sanitizer_plan.source.kernel"),)
 
+    # For every resolvable (non-repro) source kind an optional
+    # ``source.consan_command`` points ConSan at a caller-supplied command or
+    # code-object loader (e.g. the consan_app.py HIP loader), resolved relative
+    # to the recipe file. Absent, the non-repro kinds keep today's
+    # ``not_checked`` behavior; the ``consan_repro`` kind uses ``command``.
+    if source_kind != "consan_repro" and "consan_command" in source:
+        consan_command = _resolve_path(_require_str(source, "consan_command"), recipe_path=path)
+
     if "isa_dir" in source:
         isa_dir = _resolve_path(_require_str(source, "isa_dir"), recipe_path=path)
     if source_kind == "gemm_csv" and isa_dir is None:

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py
@@ -11,7 +11,7 @@ from aorta.triage.recipe import RecipeSchemaError, load_recipe_mapping
 
 from .consan import resolve_consan_hook
 from .models import CheckResult, ExecutionState, SelectionRequirement, Verdict
-from .pipeline import run_sanitizers
+from .pipeline import DEFAULT_TIMEOUT_SECONDS, run_sanitizers
 from .report import build_report, write_report
 from .selection import (
     observations_from_consan_repro,
@@ -144,6 +144,7 @@ class SanitizerRecipe:
     report_name: str
     repro_variant: str | None = None
     kernel_specs: tuple[KernelSourceSpec, ...] = ()
+    timeout_seconds: float | None = None
 
     @property
     def recipe_dir(self) -> Path | None:
@@ -170,6 +171,28 @@ def _resolve_path(raw: str, *, recipe_path: Path) -> Path:
     if candidate.is_absolute():
         return candidate
     return (recipe_path.parent / candidate).resolve()
+
+
+def _optional_timeout_seconds(block: Mapping[str, object]) -> float | None:
+    """Parse an optional positive ``timeout_seconds`` (seconds) from a block.
+
+    Absent keeps the pipeline default. A bool, non-number, or non-positive value
+    is rejected so a malformed knob fails at load rather than silently disabling
+    the ceiling.
+    """
+
+    if "timeout_seconds" not in block:
+        return None
+    value = block.get("timeout_seconds")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RecipeSchemaError(
+            "sanitizer_plan.policy.timeout_seconds must be a positive number"
+        )
+    if value <= 0:
+        raise RecipeSchemaError(
+            "sanitizer_plan.policy.timeout_seconds must be a positive number"
+        )
+    return float(value)
 
 
 def load_sanitizer_recipe(path: Path) -> SanitizerRecipe:
@@ -228,6 +251,7 @@ def load_sanitizer_recipe(path: Path) -> SanitizerRecipe:
         raise RecipeSchemaError(
             f"unsupported sanitizer_plan.policy.on_missing_backend={on_missing_backend!r}"
         )
+    timeout_seconds = _optional_timeout_seconds(policy)
     output = _require_mapping(plan.get("output"), name="sanitizer_plan.output")
     report_name = _require_str(output, "report")
 
@@ -291,6 +315,7 @@ def load_sanitizer_recipe(path: Path) -> SanitizerRecipe:
         report_name=report_name,
         repro_variant=repro_variant,
         kernel_specs=kernel_specs,
+        timeout_seconds=timeout_seconds,
     )
 
 
@@ -407,5 +432,10 @@ def execute_sanitizer_run(
         on_missing_backend=recipe.on_missing_backend,
         consan_target=consan_target,
         report_name=recipe.report_name,
+        timeout_seconds=(
+            recipe.timeout_seconds
+            if recipe.timeout_seconds is not None
+            else DEFAULT_TIMEOUT_SECONDS
+        ),
     )
     return report_path

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
@@ -404,16 +404,32 @@ def observations_from_consan_repro(
     variant: str,
     *,
     target: str,
+    label: str | None = None,
 ) -> tuple[KernelObservation, ...]:
-    label = {"clean": "consan_lds_race", "racy": "consan_lds_race_2wave"}.get(variant)
-    if label is None:
+    """Build the single kernel identity for a ConSan repro variant.
+
+    The two built-in variants ("clean"/"racy") keep their historical kernel
+    labels for backward compatibility. Any other non-empty variant is accepted
+    so a recipe can drive ConSan over a user-supplied command/code object: its
+    kernel label is either the explicit ``label`` or a stable ``consan_{variant}``
+    derived from the variant. An empty/invalid variant still fails closed.
+    """
+
+    normalized = _optional_str(variant)
+    if normalized is None:
         raise ValueError(f"unsupported consan repro variant {variant!r}")
+    builtin = {"clean": "consan_lds_race", "racy": "consan_lds_race_2wave"}.get(normalized)
+    if builtin is not None:
+        resolved_label = builtin
+    else:
+        explicit = _optional_str(label)
+        resolved_label = explicit if explicit is not None else f"consan_{normalized}"
     return (
         KernelObservation(
-            identity=KernelIdentity(name=label, target=target),
+            identity=KernelIdentity(name=resolved_label, target=target),
             total_time_ms=0.0,
             dispatch_count=1,
-            sources=(f"consan_repro:{variant}",),
+            sources=(f"consan_repro:{normalized}",),
         ),
     )
 

--- a/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
@@ -9,12 +9,14 @@ from pathlib import Path
 import pytest
 
 from aorta.instrumentation.rocjitsu_sanitizers.backends import support
-from aorta.instrumentation.rocjitsu_sanitizers.models import SelectionRequirement
+from aorta.instrumentation.rocjitsu_sanitizers.models import SelectionRequirement, Verdict
 from aorta.instrumentation.rocjitsu_sanitizers.recipe import (
     execute_sanitizer_run,
     load_sanitizer_recipe,
 )
+from aorta.instrumentation.rocjitsu_sanitizers.report import read_report
 from aorta.instrumentation.rocjitsu_sanitizers.selection import (
+    observations_from_consan_repro,
     observations_from_gemm_csv,
     observations_from_rocprof_trace,
     select_kernels,
@@ -198,6 +200,167 @@ def test_recipe_rejects_non_boolean_consan_log(tmp_path: Path) -> None:
     )
     with pytest.raises(RecipeSchemaError, match="consan_log"):
         load_sanitizer_recipe(recipe)
+
+
+def _write_kernel_consan_recipe(
+    tmp_path: Path,
+    *,
+    consan_command: str = "loaders/consan_app",
+    ticket: str = "TEST-CONSAN-CMD",
+) -> Path:
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        "schema_version: 1\n"
+        "mode: sanitizer\n"
+        f"ticket: {ticket}\n"
+        "sanitizer_plan:\n"
+        "  target: gfx950\n"
+        "  source:\n"
+        "    kind: kernel\n"
+        "    kernel:\n"
+        "      name: gemm_NT_M128_N128_K128\n"
+        "      code_object: fixtures/isa/sol_0.hsaco\n"
+        "      code_object_index: 0\n"
+        f"    consan_command: {consan_command}\n"
+        "  scope:\n"
+        "    kind: kernel\n"
+        "  selection:\n"
+        "    requirement: top_dispatch_count\n"
+        "    top_n: 1\n"
+        "  sanitizers:\n"
+        "    - consan\n"
+        "  policy:\n"
+        "    consan_policy: strict\n"
+        "    on_missing_backend: fail\n"
+        "  output:\n"
+        "    report: sanitizer_report.json\n",
+        encoding="utf-8",
+    )
+    return recipe
+
+
+def test_loader_resolves_consan_command_for_kernel_source(tmp_path: Path) -> None:
+    recipe = _write_kernel_consan_recipe(tmp_path)
+    loaded = load_sanitizer_recipe(recipe)
+    assert loaded.source_kind == "kernel"
+    assert loaded.consan_command is not None
+    assert loaded.consan_command.is_absolute()
+    assert loaded.consan_command == (tmp_path / "loaders" / "consan_app").resolve()
+
+
+def test_loader_resolves_consan_command_for_kernel_list_source(tmp_path: Path) -> None:
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        "schema_version: 1\n"
+        "mode: sanitizer\n"
+        "ticket: TEST-CONSAN-LIST\n"
+        "sanitizer_plan:\n"
+        "  target: gfx950\n"
+        "  source:\n"
+        "    kind: kernel_list\n"
+        "    kernels:\n"
+        "      - gemm_a\n"
+        "    consan_command: bin/loader\n"
+        "  scope:\n"
+        "    kind: kernel\n"
+        "  selection:\n"
+        "    requirement: top_dispatch_count\n"
+        "    top_n: 1\n"
+        "  sanitizers:\n"
+        "    - consan\n"
+        "  policy:\n"
+        "    consan_policy: strict\n"
+        "    on_missing_backend: fail\n"
+        "  output:\n"
+        "    report: sanitizer_report.json\n",
+        encoding="utf-8",
+    )
+    loaded = load_sanitizer_recipe(recipe)
+    assert loaded.source_kind == "kernel_list"
+    assert loaded.consan_command == (tmp_path / "bin" / "loader").resolve()
+
+
+def test_loader_resolves_consan_command_for_gemm_csv_source(tmp_path: Path) -> None:
+    recipe = _write_gemm_recipe(
+        tmp_path,
+        scope="kernel",
+        policy_lines=_GOOD_POLICY,
+        source_extra="    consan_command: loaders/consan_app\n",
+    )
+    loaded = load_sanitizer_recipe(recipe)
+    assert loaded.source_kind == "gemm_csv"
+    assert loaded.consan_command == (tmp_path / "loaders" / "consan_app").resolve()
+
+
+def test_loader_accepts_custom_consan_repro_variant(tmp_path: Path) -> None:
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        "schema_version: 1\n"
+        "mode: sanitizer\n"
+        "ticket: TEST-CONSAN-VARIANT\n"
+        "sanitizer_plan:\n"
+        "  target: gfx950\n"
+        "  source:\n"
+        "    kind: consan_repro\n"
+        "    variant: custom_race\n"
+        "    hip: repro/custom.hip\n"
+        "    command: bin/custom_repro\n"
+        "  scope:\n"
+        "    kind: kernel\n"
+        "  selection:\n"
+        "    requirement: top_dispatch_count\n"
+        "    top_n: 1\n"
+        "  sanitizers:\n"
+        "    - consan\n"
+        "  policy:\n"
+        "    consan_policy: strict\n"
+        "    on_missing_backend: fail\n"
+        "  output:\n"
+        "    report: sanitizer_report.json\n",
+        encoding="utf-8",
+    )
+    loaded = load_sanitizer_recipe(recipe)
+    assert loaded.repro_variant == "custom_race"
+    assert loaded.consan_command == (tmp_path / "bin" / "custom_repro").resolve()
+    observations = observations_from_consan_repro("custom_race", target="gfx950")
+    assert len(observations) == 1
+    assert observations[0].identity.name == "consan_custom_race"
+
+
+def test_observations_from_consan_repro_keeps_builtin_labels() -> None:
+    clean = observations_from_consan_repro("clean", target="gfx950")
+    racy = observations_from_consan_repro("racy", target="gfx950")
+    assert clean[0].identity.name == "consan_lds_race"
+    assert racy[0].identity.name == "consan_lds_race_2wave"
+
+
+def test_observations_from_consan_repro_rejects_empty_variant() -> None:
+    with pytest.raises(ValueError):
+        observations_from_consan_repro("  ", target="gfx950")
+
+
+def test_loader_rejects_empty_consan_command(tmp_path: Path) -> None:
+    recipe = _write_kernel_consan_recipe(tmp_path, consan_command='""')
+    with pytest.raises(RecipeSchemaError, match="consan_command"):
+        load_sanitizer_recipe(recipe)
+
+
+def test_consan_command_run_is_fail_closed_when_command_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A kernel source + top_n: 1 with a consan_command that does not exist on
+    # disk must fail closed: the ConSan check is not_checked, never pass. Without
+    # ROCJITSU_BUILD the hook also fails to resolve; either is an acceptable
+    # fail-closed outcome, so we assert the verdict is never pass.
+    monkeypatch.delenv("ROCJITSU_BUILD", raising=False)
+    recipe = _write_kernel_consan_recipe(tmp_path, consan_command="loaders/does_not_exist")
+    report_path = execute_sanitizer_run(recipe, output_dir=tmp_path / "out")
+    report = read_report(report_path)
+    assert report.overall_verdict is not Verdict.PASS
+    consan_checks = [check for check in report.checks if check.sanitizer == "consan"]
+    assert consan_checks
+    for check in consan_checks:
+        assert check.verdict is Verdict.NOT_CHECKED
 
 
 def test_verdict_baselines_fixture_present() -> None:

--- a/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
@@ -8,8 +8,15 @@ from pathlib import Path
 
 import pytest
 
+from aorta.instrumentation.rocjitsu_sanitizers import pipeline
 from aorta.instrumentation.rocjitsu_sanitizers.backends import support
-from aorta.instrumentation.rocjitsu_sanitizers.models import SelectionRequirement, Verdict
+from aorta.instrumentation.rocjitsu_sanitizers.consan import ConSanRunResult
+from aorta.instrumentation.rocjitsu_sanitizers.models import (
+    CheckResult,
+    ExecutionState,
+    SelectionRequirement,
+    Verdict,
+)
 from aorta.instrumentation.rocjitsu_sanitizers.recipe import (
     execute_sanitizer_run,
     load_sanitizer_recipe,
@@ -377,6 +384,50 @@ def test_consan_command_run_is_fail_closed_when_command_missing(
     for check in consan_checks:
         assert check.verdict is Verdict.NOT_CHECKED
         assert check.reason == "consan_command_not_found"
+
+
+@pytest.mark.parametrize("consan_verdict", [Verdict.PASS, Verdict.FAIL])
+def test_consan_command_positive_path_surfaces_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, consan_verdict: Verdict
+) -> None:
+    # Positive execution coverage for the new custom-source command path. run_consan
+    # needs a gfx950 host + provisioned hook, so it is stubbed here; the point is the
+    # adapter wiring, not the ConSan verdict logic. Asserts that a present
+    # consan_command reaches run_consan (guarding a regression that drops it before
+    # the call), that the single selected identity is threaded as the target, and
+    # that a healthy/failing hook verdict surfaces as PASS/FAIL through the report.
+    loader = tmp_path / "loaders" / "consan_app"
+    loader.parent.mkdir(parents=True, exist_ok=True)
+    loader.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    def _fake_run_consan(worklist, *, command, target, **_kwargs) -> ConSanRunResult:
+        captured["command"] = command
+        captured["target"] = target
+        return ConSanRunResult(
+            consan=CheckResult(
+                sanitizer="consan", state=ExecutionState.RAN, verdict=consan_verdict
+            ),
+            waitcheck_preflight=CheckResult(
+                sanitizer="waitcheck_preflight",
+                state=ExecutionState.RAN,
+                verdict=Verdict.PASS,
+            ),
+        )
+
+    monkeypatch.setattr(pipeline, "run_consan", _fake_run_consan)
+    recipe = _write_kernel_consan_recipe(tmp_path)
+    report_path = execute_sanitizer_run(recipe, output_dir=tmp_path / "out")
+    report = read_report(report_path)
+
+    assert captured.get("command") == (tmp_path / "loaders" / "consan_app").resolve()
+    target = captured.get("target")
+    assert target is not None
+    assert target.name == "gemm_NT_M128_N128_K128"
+    consan_checks = [check for check in report.checks if check.sanitizer == "consan"]
+    assert consan_checks and consan_checks[0].verdict is consan_verdict
+    assert report.overall_verdict is consan_verdict
 
 
 def test_verdict_baselines_fixture_present() -> None:

--- a/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
@@ -17,6 +17,7 @@ from aorta.instrumentation.rocjitsu_sanitizers.models import (
     SelectionRequirement,
     Verdict,
 )
+from aorta.instrumentation.rocjitsu_sanitizers.pipeline import DEFAULT_TIMEOUT_SECONDS
 from aorta.instrumentation.rocjitsu_sanitizers.recipe import (
     execute_sanitizer_run,
     load_sanitizer_recipe,
@@ -214,7 +215,11 @@ def _write_kernel_consan_recipe(
     *,
     consan_command: str = "loaders/consan_app",
     ticket: str = "TEST-CONSAN-CMD",
+    timeout_seconds: str | None = None,
 ) -> Path:
+    timeout_line = (
+        f"    timeout_seconds: {timeout_seconds}\n" if timeout_seconds is not None else ""
+    )
     recipe = tmp_path / "recipe.yaml"
     recipe.write_text(
         "schema_version: 1\n"
@@ -239,6 +244,7 @@ def _write_kernel_consan_recipe(
         "  policy:\n"
         "    consan_policy: strict\n"
         "    on_missing_backend: fail\n"
+        f"{timeout_line}"
         "  output:\n"
         "    report: sanitizer_report.json\n",
         encoding="utf-8",
@@ -428,6 +434,61 @@ def test_consan_command_positive_path_surfaces_verdict(
     consan_checks = [check for check in report.checks if check.sanitizer == "consan"]
     assert consan_checks and consan_checks[0].verdict is consan_verdict
     assert report.overall_verdict is consan_verdict
+
+
+def test_loader_parses_policy_timeout_seconds(tmp_path: Path) -> None:
+    recipe = _write_kernel_consan_recipe(tmp_path, timeout_seconds="1800")
+    loaded = load_sanitizer_recipe(recipe)
+    assert loaded.timeout_seconds == 1800.0
+
+
+def test_loader_defaults_timeout_seconds_to_none_when_absent(tmp_path: Path) -> None:
+    loaded = load_sanitizer_recipe(_write_kernel_consan_recipe(tmp_path))
+    assert loaded.timeout_seconds is None
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-5", '"fast"', "true"])
+def test_loader_rejects_invalid_timeout_seconds(tmp_path: Path, bad_value: str) -> None:
+    recipe = _write_kernel_consan_recipe(tmp_path, timeout_seconds=bad_value)
+    with pytest.raises(RecipeSchemaError, match="timeout_seconds"):
+        load_sanitizer_recipe(recipe)
+
+
+@pytest.mark.parametrize(
+    ("timeout_seconds", "expected"),
+    [("2400", 2400.0), (None, DEFAULT_TIMEOUT_SECONDS)],
+)
+def test_execute_threads_timeout_seconds_into_run_sanitizers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    timeout_seconds: str | None,
+    expected: float,
+) -> None:
+    # The recipe knob (or its pipeline default when absent) must reach run_consan
+    # as the per-subprocess wall-clock ceiling, so a heavy ConSan transform can be
+    # given more time without editing code.
+    captured: dict[str, object] = {}
+
+    def _fake_run_consan(worklist, *, timeout_seconds, **_kwargs) -> ConSanRunResult:
+        captured["timeout_seconds"] = timeout_seconds
+        return ConSanRunResult(
+            consan=CheckResult(
+                sanitizer="consan", state=ExecutionState.RAN, verdict=Verdict.PASS
+            ),
+            waitcheck_preflight=CheckResult(
+                sanitizer="waitcheck_preflight",
+                state=ExecutionState.RAN,
+                verdict=Verdict.PASS,
+            ),
+        )
+
+    monkeypatch.setattr(pipeline, "run_consan", _fake_run_consan)
+    loader = tmp_path / "loaders" / "consan_app"
+    loader.parent.mkdir(parents=True, exist_ok=True)
+    loader.write_text("#!/bin/sh\n", encoding="utf-8")
+    recipe = _write_kernel_consan_recipe(tmp_path, timeout_seconds=timeout_seconds)
+    execute_sanitizer_run(recipe, output_dir=tmp_path / "out")
+    assert captured.get("timeout_seconds") == expected
 
 
 def test_verdict_baselines_fixture_present() -> None:

--- a/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
@@ -348,11 +348,26 @@ def test_loader_rejects_empty_consan_command(tmp_path: Path) -> None:
 def test_consan_command_run_is_fail_closed_when_command_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A kernel source + top_n: 1 with a consan_command that does not exist on
-    # disk must fail closed: the ConSan check is not_checked, never pass. Without
-    # ROCJITSU_BUILD the hook also fails to resolve; either is an acceptable
-    # fail-closed outcome, so we assert the verdict is never pass.
-    monkeypatch.delenv("ROCJITSU_BUILD", raising=False)
+    # A kernel source + top_n: 1 whose consan_command does not exist on disk must
+    # fail closed on command resolution: the ConSan check is not_checked with the
+    # specific consan_command_not_found reason, never pass. Provision a dummy hook
+    # so hook resolution succeeds and the run actually reaches the command check --
+    # deleting ROCJITSU_BUILD would short-circuit on consan_hook_not_found first and
+    # never exercise the command-resolution path this test is meant to cover.
+    hook = (
+        tmp_path
+        / "rocjitsu-build"
+        / "lib"
+        / "rocjitsu"
+        / "src"
+        / "rocjitsu"
+        / "hooks"
+        / "librocjitsu_dbi_hooks.so"
+    )
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    # Never dlopen'd: run_consan returns on the missing command before it launches.
+    hook.write_bytes(b"")
+    monkeypatch.setenv("ROCJITSU_BUILD", str(tmp_path / "rocjitsu-build"))
     recipe = _write_kernel_consan_recipe(tmp_path, consan_command="loaders/does_not_exist")
     report_path = execute_sanitizer_run(recipe, output_dir=tmp_path / "out")
     report = read_report(report_path)
@@ -361,6 +376,7 @@ def test_consan_command_run_is_fail_closed_when_command_missing(
     assert consan_checks
     for check in consan_checks:
         assert check.verdict is Verdict.NOT_CHECKED
+        assert check.reason == "consan_command_not_found"
 
 
 def test_verdict_baselines_fixture_present() -> None:


### PR DESCRIPTION
## Summary

`mode: sanitizer` recipes could previously only run ConSan through `kind: consan_repro`, hard-wired to the two built-in fixture variants (`clean`/`racy`). There was no recipe-expressible way to point ConSan at user-supplied / extracted code objects (`.hsaco`) or an arbitrary application command (the real guardrail use case: extract the top-N f32 GEMM code objects and load exactly those via a small HIP loader so ConSan instruments precisely those objects — the old private model used `--consan-command`).

This is a **schema + adapter** change only; no new plugin surface and no changes to the ConSan execution/verdict logic:

- `recipe.py`: accept an optional `source.consan_command` on every resolvable (non-repro) source kind (`kernel`, `kernel_list`, `gemm_csv`, ...). It is resolved relative to the recipe file and stored on the existing `SanitizerRecipe.consan_command` field that `execute_sanitizer_run` already threads into `run_consan`. Absent, non-repro kinds keep today's `not_checked` behavior. The `consan_repro` kind continues to use its `command` key.
- `selection.py`: `observations_from_consan_repro` no longer gates on the two known variants. The built-in `clean`/`racy` variants keep their historical kernel labels for backward compatibility; any other non-empty variant is accepted and gets a stable `consan_<variant>` label (or an explicit `label`), so a recipe can drive ConSan over a user-supplied command/code object. An empty/whitespace variant still raises (fail-closed).
- `recipes/sanitizers/consan-code-objects.yaml`: new example recipe demonstrating a `kind: kernel` source with a selected identity (`top_n: 1`) pointed at a `.hsaco` loader via `source.consan_command`.
- `tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py`: new unit coverage mirroring the existing daily-consan tests.

## How each acceptance criterion is met

1. **Point ConSan at a user-supplied command / extracted code object and get a real pass/fail on gfx950.** A `consan_command` on `kernel`/`kernel_list`/`gemm_csv`, or an arbitrary `command` + user `variant` on `consan_repro`, is resolved relative to the recipe and handed to `run_consan`, which launches it under the RocJITsu combined hook and returns a real `pass`/`fail` from `evaluate_record_replay` (record/replay conflict + coverage decision).
2. **`not_checked`, never a false `pass`, when the hook/binary/command cannot be resolved (fail-closed, per #324).** No logic was added here — the existing `run_consan` path already returns `not_checked` for `consan_hook_not_found` / `consan_command_not_found`, and single-identity targeting is enforced. A new test (`test_consan_command_run_is_fail_closed_when_command_missing`) asserts the ConSan verdict is `NOT_CHECKED` (and never `PASS`) when the command is unresolvable and no hook is provisioned.
3. **Unit coverage for the new source/command shape, mirroring the daily-consan tests.** Added tests cover: `consan_command` resolution for `kernel`, `kernel_list`, and `gemm_csv` sources; acceptance of a custom `consan_repro` variant with a resolved `command` and its derived `consan_<variant>` label; preservation of the built-in `clean`/`racy` labels; rejection of an empty variant; rejection of an empty `consan_command`; and the fail-closed run above.

## Test plan

Isolated Python 3.13 venv, editable install (`pip install -e ".[tests,hw-queue]"`):

- `python -m pytest tests/instrumentation/rocjitsu_sanitizers/ -q -m "not gpu and not rocm"` → **95 passed, 3 deselected** (the 3 deselected are `gpu`/`rocm`-marked, not runnable on this CPU host).
- `ruff check src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py src/aorta/instrumentation/rocjitsu_sanitizers/selection.py tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py` → **All checks passed**.

Note: criteria (1)/(2)'s real gfx950 `pass`/`fail` path requires a gfx950 host with `ROCJITSU_BUILD` provisioned (nightly `sanitizers-nightly` gate); on a CPU host the covered behavior is the fail-closed `not_checked` outcome, asserted by the new test.

Closes #332

Made with [Cursor](https://cursor.com)