### PR TITLE
ci: weekly grouped pip auto-bump-and-merge (docker OS/base image excluded)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,16 @@ updates:
     directory: "/"
     schedule:
       interval: weekly           # weekly bump PR (revisit cadence later)
-    open-pull-requests-limit: 1  # a still-open/failing bump PR blocks a new one
+    # Caps version-update PRs so a still-open/failing bump blocks the next one.
+    # NOTE: Dependabot exempts security-update PRs from this limit and from the
+    # version-update group below, so more than one pip PR can be open at once
+    # (see docs/ci-nightly-eval.md).
+    open-pull-requests-limit: 1
     labels: ["dependencies", "python"]
     groups:
       python-deps:
-        patterns: ["*"]          # one combined PR for all pip updates
+        applies-to: version-updates
+        patterns: ["*"]          # one combined PR for all pip version updates
 
   # (docker ecosystem intentionally omitted -- OS/base image is bumped manually)
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # Automated dependency bumps (Phase 4 of docs/ci-plan.md).
 #
-# pip: Dependabot opens one grouped, auto-merging PR nightly (see
+# pip: Dependabot opens one grouped, auto-merging PR weekly (see
 # .github/workflows/dependabot-auto-merge.yml). The docker base image is NOT
 # tracked here -- the ROCm/Ubuntu OS image is bumped manually so an OS change
 # never lands unreviewed. github-actions bumps are weekly and human-merged.
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: daily            # ~nightly (Dependabot's finest cadence)
+      interval: weekly           # weekly bump PR (revisit cadence later)
     open-pull-requests-limit: 1  # a still-open/failing bump PR blocks a new one
     labels: ["dependencies", "python"]
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,23 @@
 # Automated dependency bumps (Phase 4 of docs/ci-plan.md).
 #
-# Dependabot opens PRs for newer versions; a human reviews (and, for stack-moving
-# bumps, runs the Refresh baselines workflow so the baseline diff shows the
-# numeric/perf impact). No auto-merge.
+# pip: Dependabot opens one grouped, auto-merging PR nightly (see
+# .github/workflows/dependabot-auto-merge.yml). The docker base image is NOT
+# tracked here -- the ROCm/Ubuntu OS image is bumped manually so an OS change
+# never lands unreviewed. github-actions bumps are weekly and human-merged.
 version: 2
 updates:
-  # Python deps (pyproject.toml extras + requirements*.txt).
+  # Python deps (requirements*.txt; pyproject.toml extras stay as >= floors).
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+      interval: daily            # ~nightly (Dependabot's finest cadence)
+    open-pull-requests-limit: 1  # a still-open/failing bump PR blocks a new one
     labels: ["dependencies", "python"]
+    groups:
+      python-deps:
+        patterns: ["*"]          # one combined PR for all pip updates
 
-  # ROCm base image + other pinned images (bumps the FROM ... @sha256 digests).
-  - package-ecosystem: docker
-    directory: "/docker"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    labels: ["dependencies", "docker", "rocm"]
+  # (docker ecosystem intentionally omitted -- OS/base image is bumped manually)
 
   # GitHub Actions used by the workflows.
   - package-ecosystem: github-actions

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,19 @@
+name: Dependabot auto-merge
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - if: steps.meta.outputs.package-ecosystem == 'pip'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,7 +6,10 @@ name: Dependabot auto-merge
 #      requirements-dev.txt across the supported Pythons -- no other required
 #      check exercises those files (the CPU gate installs pyproject extras, not
 #      the requirements files; pre-commit only installs pre-commit), so an
-#      incompatible exact pin could otherwise merge green.
+#      incompatible exact pin could otherwise merge green. The stable
+#      `Requirements validation` aggregate must be a *required* status check on
+#      `main` so this is enforced on the current head SHA (a `needs:` edge only
+#      gates enabling auto-merge, not the merge itself across a rebase).
 #   2. `gh pr merge --auto` still waits on any other required checks before the
 #      merge completes.
 # Scoped to Dependabot pip PRs only.
@@ -60,6 +63,47 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
+
+  # Stable required-status-check aggregator, same pattern as cpu-tests.yml's
+  # `required` job. Branch protection on `main` must require THIS check
+  # ("Requirements validation"), not the per-version `validate-requirements`
+  # matrix legs: a matrix skipped by a job-level `if` never emits their contexts,
+  # so a required check pinned to them hangs the PR forever (actions/runner#952).
+  # Requiring the aggregate also closes the auto-merge rebase race -- `gh pr
+  # merge --auto` merges once the *required* checks pass on the current head SHA,
+  # so a rebased Dependabot PR is re-validated on its merge commit rather than
+  # only when auto-merge was first enabled. Non-pip / non-Dependabot PRs skip the
+  # matrix and this reports a pass.
+  requirements-validated:
+    name: Requirements validation
+    runs-on: ubuntu-latest
+    needs: [meta, validate-requirements]
+    if: always()
+    permissions: {}
+    steps:
+      - name: Collapse the requirements matrix result into one required check
+        env:
+          META_RESULT: ${{ needs.meta.result }}
+          VALIDATE_RESULT: ${{ needs.validate-requirements.result }}
+        run: |
+          set -euo pipefail
+          echo "meta=${META_RESULT} validate-requirements=${VALIDATE_RESULT}"
+
+          # meta ran (dependabot) or was not applicable (non-dependabot,
+          # skipped); a broken meta must not read as a pass.
+          case "$META_RESULT" in
+            success|skipped) ;;
+            *) echo "meta job did not succeed (${META_RESULT})."; exit 1 ;;
+          esac
+
+          # 'success' == the pinned files installed across every supported
+          # Python; 'skipped' == not a pip bump, nothing to validate (a pass).
+          # Anything else (failure/cancelled) fails the required check.
+          case "$VALIDATE_RESULT" in
+            success)  echo "Pinned requirements installed on all supported Pythons." ;;
+            skipped)  echo "Not a Dependabot pip bump; nothing to validate." ;;
+            *)        echo "Requirements validation did not pass (${VALIDATE_RESULT})."; exit 1 ;;
+          esac
 
   auto-merge:
     needs: [meta, validate-requirements]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,15 @@ permissions: {}
 
 jobs:
   meta:
-    if: github.actor == 'dependabot[bot]'
+    # Guard on the PR *author*, not `github.actor` (the event actor). A
+    # Dependabot-authored PR can emit synchronize/reopened events triggered by a
+    # maintainer or another automation after auto-merge is enabled; keying on
+    # `github.actor` would skip meta + the matrix on those, and the always-on
+    # `Requirements validation` aggregate would treat both skips as a pass --
+    # letting an unvalidated head merge. The author is stable across every
+    # revision, so validation covers them all (and fetch-metadata still rejects a
+    # PR that isn't genuinely Dependabot's).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,18 +1,62 @@
 name: Dependabot auto-merge
+
+# Auto-merge grouped pip version bumps once they are green. Two guards keep an
+# unattended merge safe:
+#   1. `validate-requirements` actually installs requirements.txt +
+#      requirements-dev.txt across the supported Pythons -- no other required
+#      check exercises those files (the CPU gate installs pyproject extras, not
+#      the requirements files; pre-commit only installs pre-commit), so an
+#      incompatible exact pin could otherwise merge green.
+#   2. `gh pr merge --auto` still waits on any other required checks before the
+#      merge completes.
+# Scoped to Dependabot pip PRs only.
+
 on: pull_request
+
 permissions:
   contents: write
   pull-requests: write
+
 jobs:
-  auto-merge:
+  meta:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    outputs:
+      ecosystem: ${{ steps.meta.outputs.package-ecosystem }}
     steps:
+      # Pinned to a commit SHA rather than the mutable `v2` tag: this workflow
+      # runs with contents/pull-requests write and gates an auto-merge, so an
+      # upstream tag move must not silently change what runs with that token.
+      # The github-actions Dependabot ecosystem keeps this SHA updated.
       - id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: steps.meta.outputs.package-ecosystem == 'pip'
+
+  validate-requirements:
+    needs: meta
+    if: needs.meta.outputs.ecosystem == 'pip'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pinned requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+  auto-merge:
+    needs: [meta, validate-requirements]
+    if: needs.meta.outputs.ecosystem == 'pip'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,23 +10,29 @@ name: Dependabot auto-merge
 #   2. `gh pr merge --auto` still waits on any other required checks before the
 #      merge completes.
 # Scoped to Dependabot pip PRs only.
+#
+# Permissions are per-job, not workflow-wide: `validate-requirements` checks out
+# the PR and installs newly published packages *before* human review, so it must
+# never hold a write-capable token (and it checks out with
+# `persist-credentials: false` so no token is left in the Git config for that
+# package code to recover). Only `auto-merge` gets contents/pull-requests write.
 
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   meta:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       ecosystem: ${{ steps.meta.outputs.package-ecosystem }}
     steps:
-      # Pinned to a commit SHA rather than the mutable `v2` tag: this workflow
-      # runs with contents/pull-requests write and gates an auto-merge, so an
-      # upstream tag move must not silently change what runs with that token.
+      # Pinned to a commit SHA rather than the mutable `v2` tag: this action's
+      # output is the sole gate on the write-capable `auto-merge` job, so an
+      # upstream tag move must not silently change what decides the merge.
       # The github-actions Dependabot ecosystem keeps this SHA updated.
       - id: meta
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
@@ -37,12 +43,16 @@ jobs:
     needs: meta
     if: needs.meta.outputs.ecosystem == 'pip'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -55,6 +65,9 @@ jobs:
     needs: [meta, validate-requirements]
     if: needs.meta.outputs.ecosystem == 'pip'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Enable auto-merge (squash)
         env:

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -57,9 +57,10 @@
 #
 # Pinned as tag@digest (not digest-only): the tag records which ROCm stream the
 # digest is meant to come from, so a bump proposal that silently changes streams
-# is visible in review (and anchors the docker Dependabot ecosystem to that
-# stream for as long as .github/dependabot.yml enables it); the digest keeps the
-# build reproducible. Resolved via:
+# is visible in review; the digest keeps the build reproducible. This OS/base
+# image is bumped MANUALLY -- it is intentionally NOT tracked by Dependabot (see
+# .github/dependabot.yml) so an OS change never lands unreviewed. Resolve a new
+# digest via:
 #   docker buildx imagetools inspect rocm/pytorch:rocm10.0_ubuntu26.04_py3.14_pytorch_release_2.13.0
 FROM rocm/pytorch:rocm10.0_ubuntu26.04_py3.14_pytorch_release_2.13.0@sha256:3174cb7061d94c427da96c0edef4adea28046fa3f3b2ff3948dc4e995665ff8c
 

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -212,8 +212,8 @@ multi-GPU entries on an 8-GPU box.
 
 ## Automated ROCm + dependency bumps
 
-- **pip (nightly, auto-merged).** Dependabot (`.github/dependabot.yml`, `pip`
-  ecosystem) runs **daily** and opens **one grouped PR** (`python-deps`,
+- **pip (weekly, auto-merged).** Dependabot (`.github/dependabot.yml`, `pip`
+  ecosystem) runs **weekly** and opens **one grouped PR** (`python-deps`,
   `patterns: ["*"]`) that raises the `==` pins in the requirements files.
   `.github/workflows/dependabot-auto-merge.yml` turns on GitHub **auto-merge
   (squash)** for these PRs, so a bump lands **with no human review** once the
@@ -221,7 +221,7 @@ multi-GPU entries on an 8-GPU box.
   GPU checks auto-skip to Success for a requirements-only change). Only
   **one bump PR is open at a time** (`open-pull-requests-limit: 1`): a red or
   still-open bump PR blocks the next one instead of piling up, and Dependabot
-  rebases the open PR upward each night.
+  rebases the open PR upward each week.
   - A bump PR **edits exactly**: `requirements.txt` (`pyyaml`, `matplotlib`,
     `numpy`, `pandas`, `openpyxl`, `seaborn`, `beautifulsoup4`, `click`) and
     `requirements-dev.txt` (`pytest`, `pytest-cov`, `pre-commit`,

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -215,13 +215,24 @@ multi-GPU entries on an 8-GPU box.
 - **pip (weekly, auto-merged).** Dependabot (`.github/dependabot.yml`, `pip`
   ecosystem) runs **weekly** and opens **one grouped PR** (`python-deps`,
   version updates, `patterns: ["*"]`) that raises the `==` pins in the
-  requirements files. `.github/workflows/dependabot-auto-merge.yml` first
+  requirements files.   `.github/workflows/dependabot-auto-merge.yml` first
   installs `requirements.txt` + `requirements-dev.txt` across Python
   3.10/3.11/3.12 (no other gate exercises those files -- the CPU gate installs
   `pyproject.toml` extras, not the requirements files), then turns on GitHub
   **auto-merge (squash)**, so a bump lands **with no human review** once that
   install job and the repo's other required checks (the aggregate `CPU tests`
-  check and `pre-commit`) are green. Only **one bump PR is open at a time**
+  check and `pre-commit`) are green. **`Requirements validation` must be a
+  required status check on `main`** (branch protection): it is the stable
+  aggregate over the `validate-requirements` matrix (the per-version legs can't
+  be required — a skipped matrix never emits their contexts, actions/runner#952),
+  and requiring it is what enforces the install gate on the *current head SHA*.
+  A bare `needs:` edge only gates enabling auto-merge; since Dependabot rebases
+  the open PR weekly, without the required aggregate a later revision could merge
+  as soon as the other required checks pass while its re-validation is still
+  pending. The permissions are per-job: only the `auto-merge` job holds
+  `contents`/`pull-requests: write`, while `validate-requirements` checks out and
+  installs the newly published packages with a read-only token and
+  `persist-credentials: false`. Only **one bump PR is open at a time**
   (`open-pull-requests-limit: 1`): a red or still-open bump PR blocks the next
   one instead of piling up, and Dependabot rebases the open PR upward each week.
   - **Security updates are the exception.** Dependabot opens security-update PRs

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -212,13 +212,38 @@ multi-GPU entries on an 8-GPU box.
 
 ## Automated ROCm + dependency bumps
 
-- **Dependabot** (`.github/dependabot.yml`) opens weekly PRs for pip / docker
-  (ROCm base image digest) / github-actions updates.
-- After a stack-moving bump, run **Refresh baselines** (numerics/perf move with
-  ROCm/hipBLASLt — the baseline diff is the bump's impact) and **Lock
-  requirements** to refresh `config/ci/ci-constraints.txt` (partial pip
-  constraints, not a hash-pinned lock). Both open PRs; a human blesses.
-  No auto-merge.
+- **pip (nightly, auto-merged).** Dependabot (`.github/dependabot.yml`, `pip`
+  ecosystem) runs **daily** and opens **one grouped PR** (`python-deps`,
+  `patterns: ["*"]`) that raises the `==` pins in the requirements files.
+  `.github/workflows/dependabot-auto-merge.yml` turns on GitHub **auto-merge
+  (squash)** for these PRs, so a bump lands **with no human review** once the
+  required checks are green (`pytest (CPU, py3.10/3.11/3.12)` and `pre-commit`;
+  GPU checks auto-skip to Success for a requirements-only change). Only
+  **one bump PR is open at a time** (`open-pull-requests-limit: 1`): a red or
+  still-open bump PR blocks the next one instead of piling up, and Dependabot
+  rebases the open PR upward each night.
+  - A bump PR **edits exactly**: `requirements.txt` (`pyyaml`, `matplotlib`,
+    `numpy`, `pandas`, `openpyxl`, `seaborn`, `beautifulsoup4`, `click`) and
+    `requirements-dev.txt` (`pytest`, `pytest-cov`, `pre-commit`,
+    `pytest-timeout`, `pytest-xdist`, `pytest-forked`).
+  - It **never** edits: `pyproject.toml` (kept as `>=` library floors on
+    purpose — a library shouldn't hard-pin), `docker/**`, or
+    `config/ci/ci-constraints.txt` (that file is refreshed by the separate
+    **Lock requirements** dispatch, not by a bump PR). The
+    `git+https://github.com/AMD-AGI/TraceLens.git` VCS line is not
+    Dependabot-managed and is left alone.
+- **docker base image (manual, NOT auto-bumped).** The ROCm/Ubuntu OS/base
+  image is intentionally **not** tracked by Dependabot, so an OS change never
+  lands unreviewed. Bump it by hand: resolve the new digest with
+  `docker buildx imagetools inspect rocm/pytorch:<tag>`, update the
+  `FROM rocm/pytorch:...@sha256:...` line in `docker/Dockerfile.ci-gpu`, then run
+  **Refresh baselines** (numerics/perf move with ROCm/hipBLASLt — the baseline
+  diff is the bump's impact).
+- **github-actions (weekly, human-merged).** Action version bumps stay on the
+  **weekly** schedule and are reviewed/merged by a human — no auto-merge.
+- After any stack-moving bump, run **Lock requirements** to refresh
+  `config/ci/ci-constraints.txt` (partial pip constraints, not a hash-pinned
+  lock). It opens a PR that a human blesses.
 
 ## Results retention
 

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -214,14 +214,27 @@ multi-GPU entries on an 8-GPU box.
 
 - **pip (weekly, auto-merged).** Dependabot (`.github/dependabot.yml`, `pip`
   ecosystem) runs **weekly** and opens **one grouped PR** (`python-deps`,
-  `patterns: ["*"]`) that raises the `==` pins in the requirements files.
-  `.github/workflows/dependabot-auto-merge.yml` turns on GitHub **auto-merge
-  (squash)** for these PRs, so a bump lands **with no human review** once the
-  required checks are green (`pytest (CPU, py3.10/3.11/3.12)` and `pre-commit`;
-  GPU checks auto-skip to Success for a requirements-only change). Only
-  **one bump PR is open at a time** (`open-pull-requests-limit: 1`): a red or
-  still-open bump PR blocks the next one instead of piling up, and Dependabot
-  rebases the open PR upward each week.
+  version updates, `patterns: ["*"]`) that raises the `==` pins in the
+  requirements files. `.github/workflows/dependabot-auto-merge.yml` first
+  installs `requirements.txt` + `requirements-dev.txt` across Python
+  3.10/3.11/3.12 (no other gate exercises those files -- the CPU gate installs
+  `pyproject.toml` extras, not the requirements files), then turns on GitHub
+  **auto-merge (squash)**, so a bump lands **with no human review** once that
+  install job and the repo's other required checks (the aggregate `CPU tests`
+  check and `pre-commit`) are green. Only **one bump PR is open at a time**
+  (`open-pull-requests-limit: 1`): a red or still-open bump PR blocks the next
+  one instead of piling up, and Dependabot rebases the open PR upward each week.
+  - **Security updates are the exception.** Dependabot opens security-update PRs
+    regardless of `open-pull-requests-limit` and outside the version-update
+    group, so more than one pip PR can be open at once; those also auto-merge on
+    green via the same workflow. Only version updates obey the one-PR/grouped
+    contract.
+  - **`bump-validate.yml` must be absent for a clean pip merge.** If that
+    workflow is present, a pip PR that edits `requirements*.txt` also triggers
+    its self-hosted GPU eval, which cannot run on a Dependabot PR (no
+    `ROCM_SHARED_KEY`) and would block the merge. It is removed in #345, so
+    ensure that has landed. (`gpu-tests.yml` itself skips to Success, since
+    `requirements*.txt` is not one of its GPU-relevant paths.)
   - A bump PR **edits exactly**: `requirements.txt` (`pyyaml`, `matplotlib`,
     `numpy`, `pandas`, `openpyxl`, `seaborn`, `beautifulsoup4`, `click`) and
     `requirements-dev.txt` (`pytest`, `pytest-cov`, `pre-commit`,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,13 +6,13 @@
 -r requirements.txt
 
 # Testing
-pytest>=8.0.0
-pytest-cov>=4.1.0
+pytest==9.1.1
+pytest-cov==7.1.0
 
 # Code quality
-pre-commit>=3.0.0
+pre-commit==4.6.1
 
 # Optional: useful testing utilities
-pytest-timeout>=2.1.0
-pytest-xdist>=3.3.0  # For parallel test execution
-pytest-forked>=1.6.0  # Per-test process isolation (used by the CPU CI gate; see docs/ci-testing-plan.md)
+pytest-timeout==2.4.0
+pytest-xdist==3.8.0  # For parallel test execution
+pytest-forked==1.6.0  # Per-test process isolation (used by the CPU CI gate; see docs/ci-testing-plan.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,13 @@
 # Base dependency used by these scripts
 pyyaml==6.0.3
 
-# For analysis scripts
-matplotlib==3.11.1
-numpy==2.5.1
-pandas==3.0.5
+# For analysis scripts.
+# Pins are the latest releases that still support the project's minimum Python
+# (3.10); matplotlib 3.11 / numpy 2.3+ / pandas 3.0 require >=3.11. Dependabot
+# respects requires-python, so it keeps these on the 3.10-compatible line.
+matplotlib==3.10.9
+numpy==2.2.6
+pandas==2.3.3
 openpyxl==3.1.5
 seaborn==0.13.2
 beautifulsoup4==4.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,21 +11,21 @@
 #   uv pip install -e ".[all]"
 
 # Base dependency used by these scripts
-pyyaml>=6.0
+pyyaml==6.0.3
 
 # For analysis scripts
-matplotlib>=3.7.0
-numpy>=1.20.0
-pandas>=1.3.0
-openpyxl>=3.0.0
-seaborn>=0.12.0
-beautifulsoup4>=4.12.0
+matplotlib==3.11.1
+numpy==2.5.1
+pandas==3.0.5
+openpyxl==3.1.5
+seaborn==0.13.2
+beautifulsoup4==4.15.0
 
 # For GEMM analysis (scripts/gemm_analysis/)
 git+https://github.com/AMD-AGI/TraceLens.git
 
 # For aorta-report CLI (src/aorta/report/)
-click>=8.0.0
+click==8.4.2
 
 # For hw_queue_eval (optional - install with: pip install -e ".[hw-queue]")
 # numpy>=1.20.0  # Already included above


### PR DESCRIPTION
## Summary

Set up a **weekly, grouped, `==`-pinned pip auto-bump-and-merge** so Python
dependencies are raised to their latest releases every week and land without
human review once required checks are green — while the **docker OS/base image is
never auto-bumped**.

- **Pin `requirements*.txt` to `==`** at the latest release that still supports
  the project's minimum Python (3.10) so Dependabot's weekly pip run produces a
  real diff (`>=` floors never move). `pyproject.toml` keeps its `>=` library
  floors; the TraceLens `git+` VCS dep is left untouched.
- **`.github/dependabot.yml`**: pip → `interval: weekly`,
  `open-pull-requests-limit: 1`, grouped `python-deps`
  (`applies-to: version-updates`, `patterns: ["*"]`); **remove the `docker`
  package-ecosystem block** so the ROCm/Ubuntu OS/base image is never
  auto-bumped; `github-actions` stays weekly + human-merged.
- **`.github/workflows/dependabot-auto-merge.yml`**: for `dependabot[bot]` pip
  PRs, a `validate-requirements` matrix job installs `requirements.txt` +
  `requirements-dev.txt` across Python 3.10/3.11/3.12, then the merge step
  (`needs:` that job) enables GitHub **auto-merge (squash)**. `fetch-metadata`
  is pinned to a commit SHA (this workflow has write perms + merges).
- **`docs/ci-nightly-eval.md`** / **`docker/Dockerfile.ci-gpu`**: document the
  weekly grouped pip auto-merge, the one-open-PR rule, the security-update
  exception, the files a bump PR touches / never touches, and the manual docker
  OS/base-image bump flow.

## Behavior

- One grouped pip PR weekly; auto-merges (squash) after the requirements
  install job passes on 3.10/3.11/3.12 and the repo's other required checks
  (the aggregate `CPU tests` check and `pre-commit`) are green. No human review.
- **Why the extra install job:** no existing gate exercises `requirements*.txt`
  (the CPU gate installs `pyproject.toml` extras, pre-commit installs only
  pre-commit), so an incompatible exact pin could otherwise merge green.
- **Security updates are the exception:** Dependabot opens security-update PRs
  outside `open-pull-requests-limit` and the version-update group, so more than
  one pip PR can be open; those also auto-merge on green. Only version updates
  obey the one-PR/grouped contract.
- Only one version-update bump PR open at a time; Dependabot rebases it upward
  each week.
- A bump PR **edits exactly** `requirements.txt` (`pyyaml`, `matplotlib`,
  `numpy`, `pandas`, `openpyxl`, `seaborn`, `beautifulsoup4`, `click`) and
  `requirements-dev.txt` (`pytest`, `pytest-cov`, `pre-commit`,
  `pytest-timeout`, `pytest-xdist`, `pytest-forked`). It **never** edits
  `pyproject.toml` floors, `docker/**`, or `config/ci/ci-constraints.txt`.
- docker OS/base image: bump **manually** via
  `docker buildx imagetools inspect rocm/pytorch:<tag>` → update the `FROM
  ...@sha256:...` in `docker/Dockerfile.ci-gpu` → run **Refresh baselines**.

## Relationship to #345

Not fully independent: `bump-validate.yml` (deleted by #345) triggers the
self-hosted GPU eval on any `requirements*.txt` change for same-repo PRs —
including Dependabot's — and can't run on a Dependabot PR (no `ROCM_SHARED_KEY`),
which would block auto-merge. **Merge #345 first** (or together). `gpu-tests.yml`
itself skips to Success since `requirements*.txt` isn't a GPU-relevant path.

## Required repo settings (prerequisites)

- **Allow auto-merge** (Settings → General → Pull Requests).
- **Actions: Read and write permissions** + **Allow GitHub Actions to create
  and approve pull requests** (Settings → Actions → General).
- **Branch protection** on `main`: required status checks configured (`CPU
  tests`, `pre-commit`) with **no blocking human review** for pip bump PRs (or a
  Ruleset bypass for Dependabot). If approvals are still required with no bypass,
  auto-merge waits.

## Review updates (f092769, addressing Copilot)

- Added the `validate-requirements` matrix job gating auto-merge.
- Fixed pins that broke Python 3.10: `matplotlib 3.11.1`→`3.10.9`,
  `numpy 2.5.1`→`2.2.6`, `pandas 3.0.5`→`2.3.3` (3.11/2.3+/3.0 require ≥3.11).
- SHA-pinned `dependabot/fetch-metadata`; explicit `applies-to: version-updates`
  + documented the security-update exception; refreshed the `Dockerfile.ci-gpu`
  comment; corrected the required-check names and the #345 relationship.

Closes #346
Refs #303
