### PR TITLE
Sanitizer dashboard: publish per-run results and link them from the page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -153,7 +153,7 @@ jobs:
           publish_placeholder() {
             empty="$(mktemp -d)"
             python3 scripts/sanitizers/gen_sanitizer_dashboard.py \
-              --runs-root "$empty" \
+              --history-root "$empty" \
               --baselines "$baselines" \
               --out-dir _site/sanitizers
           }

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -219,23 +219,20 @@ jobs:
           PY
           cat status.json
 
-      - name: Generate sanitizer dashboard
-        run: |
-          python scripts/sanitizers/gen_sanitizer_dashboard.py \
-            --results-dir incoming \
-            --baselines recipes/sanitizers/fixtures/expected/verdict_baselines.json \
-            --commit "${GITHUB_SHA}" --run-label "run ${GITHUB_RUN_ID}" \
-            --status status.json \
-            --out-dir dashboard
-          cat dashboard/summary.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Update sanitizer-results branch
+      - name: Publish sanitizer dashboard to sanitizer-results branch
+        # Preserve the accumulated per-run history on the data branch: clone it,
+        # co-locate THIS run's raw reports under dashboard/runs/<date>-<run_id>/,
+        # prune to a rolling window, then regenerate the rendered dashboard from
+        # the merged history and push. The old "wipe dashboard/ and re-copy" flow
+        # destroyed every prior run's raw reports, so it is deliberately gone.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPU_RESULT: ${{ needs.sanitizers-gpu.result }}
         run: |
           set -euo pipefail
-          [ -d dashboard ] || { echo "no dashboard/; skipping publish"; exit 0; }
+          keep=30
           date="$(date -u +%Y-%m-%d)"
+          run_dir_id="${date}-${GITHUB_RUN_ID}"   # <YYYY-MM-DD>-<run_id>: date-sortable + unique
           repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           tmp="$(mktemp -d)"
           # Fail closed: distinguish a genuinely-absent sanitizer-results branch
@@ -256,12 +253,68 @@ jobs:
             echo "::error::cannot reach sanitizer-results (git ls-remote exit ${lsr}); failing closed"
             exit 1
           fi
-          rm -rf "$tmp/dashboard"
-          cp -a dashboard "$tmp/dashboard"
+
+          # Stage this run's raw reports next to the preserved history (never wipe
+          # dashboard/runs/). A failed/absent report is simply not copied; the
+          # generator then renders that case as missing -> a red per-run gate.
+          runs_dir="$tmp/dashboard/runs"
+          dest="$runs_dir/${run_dir_id}"
+          mkdir -p "$dest"
+          for case in waitcheck consan-clean consan-racy; do
+            report="incoming/${case}/sanitizer_report.json"
+            if [ -f "$report" ]; then
+              mkdir -p "$dest/${case}"
+              cp -a "$report" "$dest/${case}/sanitizer_report.json"
+            fi
+          done
+
+          # Per-run manifest read back by gen_sanitizer_dashboard.py --history-root.
+          # gate mirrors the GPU job result (its comparator step is the gate); the
+          # rendered history recomputes it from the reports + baselines regardless.
+          if [ "${GPU_RESULT}" = "success" ]; then gate=true; else gate=false; fi
+          python - "$run_dir_id" "$date" "$gate" > "$dest/meta.json" <<'PY'
+          import json, os, sys
+          run_id, date, gate = sys.argv[1], sys.argv[2], sys.argv[3] == "true"
+          server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+          repo = os.environ.get("GITHUB_REPOSITORY", "")
+          gh_run = os.environ.get("GITHUB_RUN_ID", "")
+          print(json.dumps({
+              "run": run_id,
+              "commit": os.environ.get("GITHUB_SHA", ""),
+              "date": date,
+              "gpu": "gfx950",
+              "run_url": f"{server}/{repo}/actions/runs/{gh_run}",
+              "gate": gate,
+          }, indent=2, sort_keys=True))
+          PY
+
+          # Rolling window: drop all but the newest N run directories (ids sort
+          # lexically because of the <YYYY-MM-DD>-<run_id> prefix).
+          if [ -d "$runs_dir" ]; then
+            ls -1 "$runs_dir" | sort -r | tail -n +"$((keep + 1))" | while IFS= read -r old; do
+              [ -n "$old" ] && rm -rf "${runs_dir:?}/${old}"
+            done
+          fi
+
+          # Regenerate the rendered dashboard from the merged, pruned history. This
+          # also writes each retained run's tiny runs/<id>/index.html landing page.
+          python scripts/sanitizers/gen_sanitizer_dashboard.py \
+            --history-root "$runs_dir" --keep "$keep" \
+            --baselines recipes/sanitizers/fixtures/expected/verdict_baselines.json \
+            --commit "${GITHUB_SHA}" --run-label "run ${GITHUB_RUN_ID}" \
+            --status status.json \
+            --out-dir "$tmp/dashboard"
+
+          # Mirror the rendered dashboard to the workspace and append the job
+          # summary BEFORE pushing, so both survive even if the push later fails.
+          rm -rf dashboard
+          cp -a "$tmp/dashboard" dashboard
+          cat dashboard/summary.md >> "$GITHUB_STEP_SUMMARY"
+
           ( cd "$tmp"
             git add -A
             if git -c user.name=aorta-ci -c user.email=aorta-ci@users.noreply.github.com \
-                 commit -m "sanitizer dashboard ${date}"; then
+                 commit -m "sanitizer dashboard ${date} (run ${GITHUB_RUN_ID})"; then
               git push origin sanitizer-results   # not swallowed -- a push failure fails the job
             else
               echo "no changes to commit"

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -259,6 +259,11 @@ jobs:
           # generator then renders that case as missing -> a red per-run gate.
           runs_dir="$tmp/dashboard/runs"
           dest="$runs_dir/${run_dir_id}"
+          # A same-day Actions re-run reuses GITHUB_RUN_ID (only GITHUB_RUN_ATTEMPT
+          # changes), so it targets this same directory. Clear it first so a report
+          # absent from the current attempt cannot survive from a prior one and mask
+          # a now-missing case (the generator fails such a case closed).
+          rm -rf "$dest"
           mkdir -p "$dest"
           for case in waitcheck consan-clean consan-racy; do
             report="incoming/${case}/sanitizer_report.json"

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -293,10 +293,14 @@ jobs:
           }, indent=2, sort_keys=True))
           PY
 
-          # Rolling window: drop all but the newest N run directories (ids sort
-          # lexically because of the <YYYY-MM-DD>-<run_id> prefix).
+          # Rolling window: drop all but the newest N run directories. Sort by the
+          # date fields then the run-id numerically (-t- splits <YYYY-MM-DD>-<run_id>
+          # into fields 1-4), so a variable-width run id (...-9 vs ...-10) still
+          # orders newest-first -- a plain lexical sort would prune the wrong dir.
           if [ -d "$runs_dir" ]; then
-            ls -1 "$runs_dir" | sort -r | tail -n +"$((keep + 1))" | while IFS= read -r old; do
+            ls -1 "$runs_dir" \
+              | sort -t- -k1,1nr -k2,2nr -k3,3nr -k4,4nr \
+              | tail -n +"$((keep + 1))" | while IFS= read -r old; do
               [ -n "$old" ] && rm -rf "${runs_dir:?}/${old}"
             done
           fi

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -64,6 +64,22 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    previous green page). Only sanitizer data produced by a `main` run is
    published.
 
+   Each nightly's raw per-case `sanitizer_report.json` files are co-located on the
+   `sanitizer-results` data branch under `dashboard/runs/<YYYY-MM-DD>-<run_id>/`
+   (one `<case>/sanitizer_report.json` per recipe plus a `meta.json` with commit /
+   date / gpu / run_url / gate), and the rendered page links to them: the latest
+   run table has a per-recipe **Report** link, the kernel-detail sections carry a
+   "view raw report" link, and each **Run** row in the history table links to its
+   `runs/<id>/` area. A tiny `runs/<id>/index.html` landing page lists that run's
+   three reports. Because `pages.yml` copies `dashboard/*` recursively into
+   `_site/sanitizers/`, everything under `runs/` is served at
+   `/sanitizers/runs/...` with relative links and no change to `pages.yml`. The
+   publish job keeps a rolling window of the newest **30** run directories
+   (`gen_sanitizer_dashboard.py --history-root <dir> --keep 30`); older ones are
+   pruned. Previously these raw reports lived only in an expiring Actions
+   artifact and were never linked; the rolling window makes them durable and
+   reachable from the page.
+
    The dashboard previously lived at `/ci/`, so that path is kept: `/ci/`
    redirects to the root and `/ci/data.json` is published alongside
    `/data.json` for anything already polling it. A verification step fails the
@@ -146,6 +162,14 @@ The publish step keeps only the **most recent 180** `results/<date>.json` files 
 the `ci-results` data branch (older ones are pruned), and the dashboard renders at
 most the last 180 builds (`gen_dashboard.py --max-builds`). Files are tiny; adjust
 the cap in `nightly-eval.yml` / the flag if a longer window is wanted.
+
+The **sanitizer** nightly keeps a separate rolling window on the
+`sanitizer-results` data branch: the newest **30** `dashboard/runs/<id>/`
+directories (each holding that run's three raw `sanitizer_report.json` files and a
+`meta.json`). The publish job prunes older ones and re-renders with
+`gen_sanitizer_dashboard.py --history-root dashboard/runs --keep 30`; adjust
+`keep` in `sanitizers-nightly.yml` (and the matching `--keep`) to change the
+window.
 
 ## Operating checklist
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -268,20 +268,37 @@ def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
     return meta
 
 
+def _history_sort_key(name: str) -> tuple[str, int]:
+    """Order key for a published run id (``<YYYY-MM-DD>-<run_id>``).
+
+    The ISO date prefix sorts correctly as a string, but the trailing run id is a
+    variable-width integer, so a plain name sort mis-orders ``...-9`` after
+    ``...-10`` and would pick the wrong latest run (and prune the wrong dir).
+    Split the numeric suffix off and compare it as an int. Names that don't match
+    the scheme fall back to ``(name, -1)`` so enumeration never crashes.
+    """
+    head, sep, tail = name.rpartition("-")
+    if sep and tail.isdigit():
+        return (head, int(tail))
+    return (name, -1)
+
+
 def runs_from_history_root(
     history_root: Path, baselines: dict, *, keep: int = 30
 ) -> list[dict[str, Any]]:
     """Enumerate the PUBLISHED ``DIR/<id>/<case>/sanitizer_report.json`` layout.
 
-    Runs are ordered newest-first by the ``<id>`` directory name (the
-    ``<YYYY-MM-DD>-<run_id>`` format is monotonic) and capped to the newest
-    ``keep``. Each summarized row is tagged with a ``report_rel`` pointing at its
-    raw JSON relative to the dashboard root, and each record with the run's
-    ``rel`` area, so ``build_html`` can emit relative links that work under
-    ``/sanitizers/``.
+    Runs are ordered newest-first by ``<id>`` (``<YYYY-MM-DD>-<run_id>``) using a
+    date-then-numeric key (see ``_history_sort_key``; a plain string sort would
+    put ``...-9`` after ``...-10``) and capped to the newest ``keep``. Each
+    summarized row is tagged with a ``report_rel`` pointing at its raw JSON
+    relative to the dashboard root, and each record with the run's ``rel`` area,
+    so ``build_html`` can emit relative links that work under ``/sanitizers/``.
     """
     run_dirs = sorted(
-        (p for p in history_root.iterdir() if p.is_dir()), key=lambda p: p.name, reverse=True
+        (p for p in history_root.iterdir() if p.is_dir()),
+        key=lambda p: _history_sort_key(p.name),
+        reverse=True,
     ) if history_root.is_dir() else []
     runs: list[dict[str, Any]] = []
     for run_dir in run_dirs[: max(keep, 0)]:
@@ -874,6 +891,15 @@ def main() -> int:
     # to its co-located raw reports (out_dir/runs/<id>/index.html). Bounded by
     # --keep, so pruned runs stop getting a page.
     if args.history_root is not None:
+        # When the raw reports live in a separate tree from the output (the copy
+        # branch below), a reused --out-dir would keep run dirs dropped by --keep
+        # (or reports since removed from a retained run) as stale published output.
+        # Clear the output runs/ tree first so the published set matches `runs`
+        # exactly. Skipped when both resolve to the same tree (CI), where clearing
+        # would delete the very reports we are about to render.
+        runs_out = args.out_dir / "runs"
+        if runs_out.exists() and args.history_root.resolve() != runs_out.resolve():
+            shutil.rmtree(runs_out)
         for run in runs:
             rel = run.get("rel")
             if not rel:

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import sys
 from datetime import datetime, timezone
 from html import escape as _esc
@@ -242,22 +243,28 @@ def runs_from_runs_root(runs_root: Path, baselines: dict) -> list[dict[str, Any]
     return runs
 
 
-def _run_meta_from_history(run_dir: Path) -> dict[str, str]:
+def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
     """Read a published run's ``meta.json`` (commit, date, gpu, run_url, gate).
 
     The run id (``<YYYY-MM-DD>-<run_id>``) is authoritative from the directory
     name; ``meta.json`` supplies the rest. A missing/corrupt manifest degrades to
     an id-only record rather than crashing the whole dashboard render.
     """
-    meta: dict[str, str] = {"run": run_dir.name, "commit": "", "date": "", "gpu": "gfx950"}
+    meta: dict[str, Any] = {"run": run_dir.name, "commit": "", "date": "", "gpu": "gfx950"}
     data = _load(run_dir / "meta.json")
     if isinstance(data, dict):
         if data.get("commit"):
             meta["commit"] = _short(str(data["commit"]), 12)
-        for key in ("date", "gpu", "run_url", "gate"):
+        for key in ("date", "gpu", "run_url"):
             value = data.get(key)
             if value not in (None, ""):
                 meta[key] = str(value)
+        # Preserve the manifest's recorded gate with its JSON type. Coercing it to
+        # str would emit "True"/"False" into data.json, where "False" is truthy
+        # for machine consumers and the documented boolean type is lost.
+        gate = data.get("gate")
+        if gate is not None:
+            meta["gate"] = gate
     return meta
 
 
@@ -647,9 +654,11 @@ def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightl
     """
     meta = run["meta"]
     rows = run["rows"]
-    gate_ok = run["gate"]
-    gate_color = "#1a7f37" if gate_ok else "#cf222e"
-    gate_text = "PASS \u2014 verdicts match baselines" if gate_ok else "FAIL \u2014 verdict mismatch"
+    # Reuse the shared aggregate classifier so a missing report reads as
+    # INCOMPLETE rather than a misleading "verdict mismatch" (mirrors build_html).
+    summary = _gate_summary(rows)
+    gate_color = "#1a7f37" if summary["ok"] else "#cf222e"
+    gate_text = f"{summary['label']} \u2014 {summary['detail']}"
     run_url = meta.get("run_url", "")
     run_link = (
         f' &middot; <a href="{_esc(run_url)}">workflow run</a>' if run_url else ""
@@ -871,6 +880,17 @@ def main() -> int:
                 continue
             run_out = args.out_dir / rel
             run_out.mkdir(parents=True, exist_ok=True)
+            # Co-locate each retained run's raw reports under the output tree so the
+            # emitted runs/<id>/<case>/sanitizer_report.json links resolve even when
+            # --history-root is not already <out-dir>/runs. In CI both resolve to the
+            # same path, so the copy is skipped and this is a no-op.
+            src_run = args.history_root / run["meta"].get("run", "")
+            if src_run.is_dir() and src_run.resolve() != run_out.resolve():
+                for case, _key, _label, _backend in CASES:
+                    src_report = src_run / case / "sanitizer_report.json"
+                    if src_report.is_file():
+                        (run_out / case).mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(src_report, run_out / case / "sanitizer_report.json")
             (run_out / "index.html").write_text(
                 build_run_index_html(run), encoding="utf-8"
             )

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -187,7 +187,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
 
 
 def _run_record(
-    meta: dict[str, str],
+    meta: dict[str, Any],
     rows: dict[str, dict[str, Any]],
     *,
     rel: str | None = None,
@@ -195,6 +195,13 @@ def _run_record(
     # Fail closed: a missing report (present=False -> match=False) turns the gate
     # unhealthy, mirroring compare_verdict_baselines.py which errors on absent reports.
     gate = all(r["match"] for r in rows.values())
+    # The authoritative comparator gate recorded in the run manifest (meta.gate)
+    # is stricter than a row-level overall_verdict match (it also checks schema,
+    # execution status, per-check verdicts, and finding shape). Honor a recorded
+    # failure so a comparator-failed run whose verdicts happen to match baselines
+    # is never rendered healthy, and run.gate agrees with meta.gate in data.json.
+    if meta.get("gate") is False:
+        gate = False
     # ``rel`` is the run's relative area under the published dashboard (e.g.
     # ``runs/<id>``); None for the results-dir / runs-root modes, which do not
     # publish co-located raw reports and therefore render no per-run links.
@@ -408,7 +415,9 @@ def _execution_md(execution: Any) -> str:
     return f"\u274c **{text}**"
 
 
-def _gate_summary(rows: dict[str, dict[str, Any]]) -> dict[str, Any]:
+def _gate_summary(
+    rows: dict[str, dict[str, Any]], *, recorded_gate: bool | None = None
+) -> dict[str, Any]:
     """Classify the aggregate run health for the top banner and history gate.
 
     A missing report and an observed verdict mismatch both fail the gate, but
@@ -416,12 +425,23 @@ def _gate_summary(rows: dict[str, dict[str, Any]]) -> dict[str, Any]:
     with its baseline is a regression. Absent reports are surfaced separately so
     an infrastructure failure is not mislabeled as a verdict regression, and a
     run with both is reported as a combined ``UNHEALTHY`` state.
+
+    ``recorded_gate`` is the authoritative comparator result persisted in the run
+    manifest (``meta.gate``). It is stricter than the row-level ``overall_verdict``
+    match, so when it is explicitly ``False`` the run fails closed even if every
+    reduced row matches its baseline -- otherwise a comparator-failed run would
+    render ``HEALTHY``.
     """
     total = len(rows)
     matched = sum(1 for r in rows.values() if r["match"])
     mismatches = sum(1 for r in rows.values() if r["present"] and not r["match"])
     missing = sum(1 for r in rows.values() if not r["present"])
-    if matched == total:
+    rows_ok = matched == total
+    if rows_ok and recorded_gate is False:
+        # Rows match their baselines but the stricter comparator gate failed.
+        label = "FAILED"
+        detail = "run gate failed its comparator check"
+    elif rows_ok:
         label = "HEALTHY"
         detail = f"{matched}/{total} sanitizer outcomes match their baselines"
     elif mismatches and missing:
@@ -439,7 +459,8 @@ def _gate_summary(rows: dict[str, dict[str, Any]]) -> dict[str, Any]:
     else:
         label = "INCOMPLETE"
         detail = f"{missing}/{total} sanitizer report(s) are missing"
-    return {"ok": matched == total, "label": label, "detail": detail, "short": label.capitalize()}
+    ok = rows_ok and recorded_gate is not False
+    return {"ok": ok, "label": label, "detail": detail, "short": label.capitalize()}
 
 
 def _history_case_html(row: dict[str, Any]) -> str:
@@ -453,7 +474,7 @@ def _history_case_html(row: dict[str, Any]) -> str:
 
 
 def _history_gate_html(run: dict[str, Any]) -> str:
-    summary = _gate_summary(run["rows"])
+    summary = _gate_summary(run["rows"], recorded_gate=run["meta"].get("gate"))
     emphasis = "pass" if run["gate"] else "fail"
     return f'<td><span class="pill {emphasis}">{_esc(summary["short"])}</span></td>'
 
@@ -575,7 +596,7 @@ def build_html(
         )
     latest = runs[0]
     meta = latest["meta"]
-    summary = _gate_summary(latest["rows"])
+    summary = _gate_summary(latest["rows"], recorded_gate=latest["meta"].get("gate"))
     gate_color = "#2c7d3b" if summary["ok"] else "#c92c35"
     gate_text = f"{summary['label']} \u2014 {summary['detail']}"
 
@@ -686,7 +707,7 @@ def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightl
     rows = run["rows"]
     # Reuse the shared aggregate classifier so a missing report reads as
     # INCOMPLETE rather than a misleading "verdict mismatch" (mirrors build_html).
-    summary = _gate_summary(rows)
+    summary = _gate_summary(rows, recorded_gate=run["meta"].get("gate"))
     gate_color = "#1a7f37" if summary["ok"] else "#cf222e"
     gate_text = f"{summary['label']} \u2014 {summary['detail']}"
     run_url = meta.get("run_url", "")
@@ -754,7 +775,7 @@ def build_summary_md(
         return head + "No runs found.\n"
     latest = runs[0]
     meta = latest["meta"]
-    summary = _gate_summary(latest["rows"])
+    summary = _gate_summary(latest["rows"], recorded_gate=latest["meta"].get("gate"))
     icon = "\u2705" if summary["ok"] else "\u274c"
     gate = f"{icon} **{summary['label']}** \u2014 {summary['detail']}"
     lines = ["# Sanitizers Nightly \u00b7 gfx950", ""]
@@ -837,7 +858,7 @@ def build_summary_md(
         cells = " | ".join(_history_case_md(run["rows"][c]) for c, _k, _l, _b in CASES)
         lines.append(
             f"| {run['meta'].get('run', '')} | `{run['meta'].get('commit', '')}` | {cells} | "
-            f"{_gate_summary(run['rows'])['short']} |"
+            f"{_gate_summary(run['rows'], recorded_gate=run['meta'].get('gate'))['short']} |"
         )
     lines.append("")
     return "\n".join(lines)
@@ -956,7 +977,10 @@ def main() -> int:
         (args.out_dir / "status.json").write_text(
             json.dumps(status, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
-    gate_label = _gate_summary(runs[0]["rows"])["short"].lower() if runs else "no-data"
+    gate_label = (
+        _gate_summary(runs[0]["rows"], recorded_gate=runs[0]["meta"].get("gate"))["short"].lower()
+        if runs else "no-data"
+    )
     print(f"wrote {args.out_dir}/index.html, summary.md, data.json (gate={gate_label})")
     return 0
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -895,10 +895,16 @@ def main() -> int:
         # branch below), a reused --out-dir would keep run dirs dropped by --keep
         # (or reports since removed from a retained run) as stale published output.
         # Clear the output runs/ tree first so the published set matches `runs`
-        # exactly. Skipped when both resolve to the same tree (CI), where clearing
-        # would delete the very reports we are about to render.
+        # exactly. Skip when history_root IS runs_out (CI) or nests beneath it
+        # (e.g. --history-root out/runs/source --out-dir out) -- removing runs_out
+        # would delete the very reports we are about to copy.
         runs_out = args.out_dir / "runs"
-        if runs_out.exists() and args.history_root.resolve() != runs_out.resolve():
+        runs_out_res = runs_out.resolve()
+        history_res = args.history_root.resolve()
+        history_within_runs_out = (
+            history_res == runs_out_res or runs_out_res in history_res.parents
+        )
+        if runs_out.exists() and not history_within_runs_out:
             shutil.rmtree(runs_out)
         for run in runs:
             rel = run.get("rel")
@@ -917,6 +923,11 @@ def main() -> int:
                     if src_report.is_file():
                         (run_out / case).mkdir(parents=True, exist_ok=True)
                         shutil.copy2(src_report, run_out / case / "sanitizer_report.json")
+                # Carry the run manifest too so the published layout
+                # (runs/<id>/meta.json) is complete, not just the reports.
+                src_meta = src_run / "meta.json"
+                if src_meta.is_file():
+                    shutil.copy2(src_meta, run_out / "meta.json")
             (run_out / "index.html").write_text(
                 build_run_index_html(run), encoding="utf-8"
             )

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -19,22 +19,32 @@ When ``--status`` points at an unhealthy manifest, an error-colored "stale" bann
 rendered at the top of both ``index.html`` and ``summary.md`` so a failed nightly
 never leaves the previous healthy page looking current.
 
-Two input shapes are supported:
+Three input shapes are supported:
 
 * ``--results-dir DIR`` -- a single run laid out as
   ``DIR/{waitcheck,consan-clean,consan-racy}/sanitizer_report.json`` (the same
   layout ``compare_verdict_baselines.py`` consumes). This is the CI shape.
 * ``--runs-root DIR`` -- a directory of ``run_*`` folders, each with an
   ``out/<case>/sanitizer_report.json``; used locally to render a history/trend.
+* ``--history-root DIR`` -- the PUBLISHED data-branch layout
+  ``DIR/<id>/<case>/sanitizer_report.json`` plus a per-run ``DIR/<id>/meta.json``
+  (keys: commit, date, gpu, run_url, gate). ``<id>`` is ``<YYYY-MM-DD>-<run_id>``
+  (date-sortable, unique), enumerated newest-first and capped by ``--keep N``
+  (default 30). This is the shape the nightly publishes and Pages serves under
+  ``/sanitizers/``: each run's raw reports are co-located under ``runs/<id>/`` and
+  linked from the rendered page, and a tiny ``runs/<id>/index.html`` landing page
+  is written for each retained run.
 
-Pure rendering lives in ``build_html`` / ``build_summary_md`` and pure
-aggregation in ``summarize_case`` so they are unit testable without the FS.
+Pure rendering lives in ``build_html`` / ``build_summary_md`` /
+``build_run_index_html`` and pure aggregation in ``summarize_case`` so they are
+unit testable without the FS.
 
-Usage (CI):
+Usage (CI, published-history mode):
     python scripts/sanitizers/gen_sanitizer_dashboard.py \
-        --results-dir incoming \
+        --history-root dashboard/runs --keep 30 \
         --baselines recipes/sanitizers/fixtures/expected/verdict_baselines.json \
         --commit "$GITHUB_SHA" --run-label "run $GITHUB_RUN_ID" \
+        --status status.json \
         --out-dir dashboard
 """
 
@@ -174,11 +184,19 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     }
 
 
-def _run_record(meta: dict[str, str], rows: dict[str, dict[str, Any]]) -> dict[str, Any]:
+def _run_record(
+    meta: dict[str, str],
+    rows: dict[str, dict[str, Any]],
+    *,
+    rel: str | None = None,
+) -> dict[str, Any]:
     # Fail closed: a missing report (present=False -> match=False) turns the gate
     # unhealthy, mirroring compare_verdict_baselines.py which errors on absent reports.
     gate = all(r["match"] for r in rows.values())
-    return {"meta": meta, "rows": rows, "gate": gate}
+    # ``rel`` is the run's relative area under the published dashboard (e.g.
+    # ``runs/<id>``); None for the results-dir / runs-root modes, which do not
+    # publish co-located raw reports and therefore render no per-run links.
+    return {"meta": meta, "rows": rows, "gate": gate, "rel": rel}
 
 
 def runs_from_results_dir(
@@ -221,6 +239,57 @@ def runs_from_runs_root(runs_root: Path, baselines: dict) -> list[dict[str, Any]
         }
         if any(r["present"] for r in rows.values()):
             runs.append(_run_record(_run_meta_from_env(run_dir), rows))
+    return runs
+
+
+def _run_meta_from_history(run_dir: Path) -> dict[str, str]:
+    """Read a published run's ``meta.json`` (commit, date, gpu, run_url, gate).
+
+    The run id (``<YYYY-MM-DD>-<run_id>``) is authoritative from the directory
+    name; ``meta.json`` supplies the rest. A missing/corrupt manifest degrades to
+    an id-only record rather than crashing the whole dashboard render.
+    """
+    meta: dict[str, str] = {"run": run_dir.name, "commit": "", "date": "", "gpu": "gfx950"}
+    data = _load(run_dir / "meta.json")
+    if isinstance(data, dict):
+        if data.get("commit"):
+            meta["commit"] = _short(str(data["commit"]), 12)
+        for key in ("date", "gpu", "run_url", "gate"):
+            value = data.get(key)
+            if value not in (None, ""):
+                meta[key] = str(value)
+    return meta
+
+
+def runs_from_history_root(
+    history_root: Path, baselines: dict, *, keep: int = 30
+) -> list[dict[str, Any]]:
+    """Enumerate the PUBLISHED ``DIR/<id>/<case>/sanitizer_report.json`` layout.
+
+    Runs are ordered newest-first by the ``<id>`` directory name (the
+    ``<YYYY-MM-DD>-<run_id>`` format is monotonic) and capped to the newest
+    ``keep``. Each summarized row is tagged with a ``report_rel`` pointing at its
+    raw JSON relative to the dashboard root, and each record with the run's
+    ``rel`` area, so ``build_html`` can emit relative links that work under
+    ``/sanitizers/``.
+    """
+    run_dirs = sorted(
+        (p for p in history_root.iterdir() if p.is_dir()), key=lambda p: p.name, reverse=True
+    ) if history_root.is_dir() else []
+    runs: list[dict[str, Any]] = []
+    for run_dir in run_dirs[: max(keep, 0)]:
+        rel = f"runs/{run_dir.name}"
+        rows: dict[str, dict[str, Any]] = {}
+        for case, key, _label, _backend in CASES:
+            row = summarize_case(
+                _load(run_dir / case / "sanitizer_report.json"),
+                baselines.get(key, {}).get("overall_verdict"),
+            )
+            # Only link reports that are actually present, so the page never
+            # points at a 404. Relative to the dashboard root (runs/<id>/...).
+            row["report_rel"] = f"{rel}/{case}/sanitizer_report.json" if row["present"] else None
+            rows[case] = row
+        runs.append(_run_record(_run_meta_from_history(run_dir), rows, rel=rel))
     return runs
 
 
@@ -367,10 +436,30 @@ def _history_case_md(row: dict[str, Any]) -> str:
     return f"{_baseline_status_md(row, history=True)}<br>" f"Observed: `{row['verdict']}`{expected}"
 
 
+def _report_link_html(report_rel: str | None) -> str:
+    """A relative link to a case's raw ``sanitizer_report.json``, or an em dash."""
+    if not report_rel:
+        return "&mdash;"
+    return f'<a href="{_esc(report_rel)}">report</a>'
+
+
+def _run_cell_html(run: dict[str, Any]) -> str:
+    """History "Run" cell: link the run id to its published ``runs/<id>/`` area."""
+    label = run["meta"].get("run", "")
+    rel = run.get("rel")
+    if rel:
+        return f'<a href="{_esc(rel)}/">{_esc(label)}</a>'
+    return _esc(label)
+
+
 def _kernel_detail_html(rows: dict[str, dict[str, Any]]) -> str:
     blocks: list[str] = []
     for case, _key, label, _backend_label in CASES:
         row = rows[case]
+        report_rel = row.get("report_rel")
+        raw_link = (
+            f' <a class=raw href="{_esc(report_rel)}">view raw report</a>' if report_rel else ""
+        )
         if not row["present"]:
             blocks.append(
                 f"<h3>{_esc(label)} &middot; {_baseline_status_html(row)}</h3>"
@@ -406,7 +495,7 @@ def _kernel_detail_html(rows: dict[str, dict[str, Any]]) -> str:
             or "<tr><td colspan=5>no findings</td></tr>"
         )
         blocks.append(
-            f"<h3>{_esc(label)} &middot; {_baseline_status_html(row)}</h3>"
+            f"<h3>{_esc(label)} &middot; {_baseline_status_html(row)}{raw_link}</h3>"
             f'<div class="secondary">Observed sanitizer verdict '
             f"{_observed_html(row['verdict'])} &middot; expected "
             f"{_observed_html(row['expected'] or _DASH)}</div>"
@@ -460,13 +549,19 @@ def build_html(
         f"<td>{_observed_html(latest['rows'][case]['expected'] or _DASH)}</td>"
         f"<td>{_execution_html(latest['rows'][case]['execution'])}</td>"
         f"<td class=num>{latest['rows'][case]['findings']}</td>"
-        f"<td>{_esc(latest['rows'][case]['coverage']) or '&mdash;'}</td></tr>"
+        f"<td>{_esc(latest['rows'][case]['coverage']) or '&mdash;'}</td>"
+        f"<td>{_report_link_html(latest['rows'][case].get('report_rel'))}</td></tr>"
         for case, _key, label, backend in CASES
+    )
+    # Link to the whole run area (co-located raw reports) when published there.
+    latest_rel = latest.get("rel")
+    run_area_link = (
+        f' &middot; <a href="{_esc(latest_rel)}/">raw reports</a>' if latest_rel else ""
     )
 
     hist_head = "".join(f"<th>{_esc(label)}</th>" for _c, _k, label, _b in CASES)
     hist_rows = "".join(
-        f"<tr><td class=mono>{_esc(run['meta'].get('run', ''))}</td>"
+        f"<tr><td class=mono>{_run_cell_html(run)}</td>"
         f"<td class=mono>{_esc(run['meta'].get('commit', ''))}</td>"
         f"<td>{_esc(run['meta'].get('date', ''))}</td>"
         + "".join(f"<td>{_history_case_html(run['rows'][c])}</td>" for c, _k, _l, _b in CASES)
@@ -489,6 +584,7 @@ def build_html(
   h3 {{ font-size:14px; margin:18px 0 4px; }}
   .meta {{ color:#57606a; font-size:12px; margin-bottom:12px; }}
   .secondary {{ color:#57606a; font-size:12px; margin:4px 0 8px; }}
+  a.raw {{ font-size:12px; font-weight:400; margin-left:8px; }}
   .mono {{ font-family: ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; }}
   .gate {{ color:#fff; background:{gate_color}; padding:12px 16px; border-radius:8px;
           font-weight:600; margin:12px 0 20px; }}
@@ -517,7 +613,7 @@ def build_html(
   <h1>{_esc(title)} &middot; gfx950</h1>
   <div class=meta>latest run <span class=mono>{_esc(meta.get('run', ''))}</span>
      &middot; commit <span class=mono>{_esc(meta.get('commit', ''))}</span>
-     &middot; {_esc(meta.get('date', ''))} &middot; target {_esc(meta.get('gpu', 'gfx950'))}</div>
+     &middot; {_esc(meta.get('date', ''))} &middot; target {_esc(meta.get('gpu', 'gfx950'))}{run_area_link}</div>
   <div class=gate>{_esc(gate_text)}</div>
   <p class=secondary>Observed <span class=mono>WARN</span> or <span class=mono>FAIL</span>
      verdicts may be expected positive-control outcomes. Baseline status is the
@@ -526,7 +622,7 @@ def build_html(
   <h2>Latest run</h2>
   <table>
     <tr><th>Recipe</th><th>Backend</th><th>Baseline status</th><th>Observed</th>
-        <th>Expected</th><th>Execution</th><th>Findings</th><th>Coverage</th></tr>
+        <th>Expected</th><th>Execution</th><th>Findings</th><th>Coverage</th><th>Report</th></tr>
     {latest_rows}
   </table>
 
@@ -540,6 +636,72 @@ def build_html(
   </table>
 </div></body></html>
 """
+
+
+def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightly") -> str:
+    """A tiny, self-contained landing page for one published run (pure).
+
+    Lives at ``runs/<id>/index.html`` alongside the run's raw reports, so the
+    report links are case-local (``<case>/sanitizer_report.json``) rather than
+    dashboard-root-relative.
+    """
+    meta = run["meta"]
+    rows = run["rows"]
+    gate_ok = run["gate"]
+    gate_color = "#1a7f37" if gate_ok else "#cf222e"
+    gate_text = "PASS \u2014 verdicts match baselines" if gate_ok else "FAIL \u2014 verdict mismatch"
+    run_url = meta.get("run_url", "")
+    run_link = (
+        f' &middot; <a href="{_esc(run_url)}">workflow run</a>' if run_url else ""
+    )
+
+    def _cell(case: str, present: bool) -> str:
+        if not present:
+            return "report missing"
+        href = _esc(f"{case}/sanitizer_report.json")
+        return f'<a href="{href}">sanitizer_report.json</a>'
+
+    report_rows = "".join(
+        f"<tr><td>{_esc(label)}</td>"
+        f"<td>{_baseline_status_html(rows[case])}"
+        f'<div class="secondary">Observed {_observed_html(rows[case]["verdict"])}</div></td>'
+        f"<td>{_cell(case, rows[case]['present'])}</td></tr>"
+        for case, _key, label, _backend in CASES
+    )
+    return (
+        "<!doctype html>\n"
+        "<html lang=en><head><meta charset=utf-8>\n"
+        '<meta name=viewport content="width=device-width, initial-scale=1">\n'
+        f"<title>{_esc(title)} &middot; {_esc(meta.get('run', ''))}</title>\n"
+        "<style>\n"
+        "  body { font: 14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;\n"
+        "         max-width:900px; margin:0 auto; padding:24px; color:#1f2328; }\n"
+        "  h1 { font-size:18px; margin:0 0 4px; }\n"
+        "  .meta { color:#57606a; font-size:12px; margin-bottom:12px; }\n"
+        "  .mono { font-family: ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; }\n"
+        f"  .gate {{ color:#fff; background:{gate_color}; padding:10px 14px; border-radius:8px;\n"
+        "          font-weight:600; margin:12px 0 18px; }\n"
+        "  table { width:100%; border-collapse:collapse; }\n"
+        "  th,td { text-align:left; padding:7px 10px; border-bottom:1px solid #d0d7de; }\n"
+        "  .secondary { color:#57606a; font-size:12px; margin:4px 0 0; }\n"
+        "  .pill { padding:2px 8px; border-radius:999px; font-size:12px; font-weight:600; }\n"
+        "  .pill.ok { background:#1a7f3722; color:#1a7f37; } .pill.bad { background:#cf222e22; color:#cf222e; }\n"
+        "  .observed { display:inline-block; color:#57606a; background:#afb8c133; border:1px solid #afb8c1;\n"
+        "              padding:1px 7px; border-radius:999px; font:600 12px ui-monospace,SFMono-Regular,Menlo,monospace; }\n"
+        "</style></head>\n"
+        "<body>\n"
+        '<p><a href="../../">back to sanitizer dashboard</a></p>\n'
+        f"<h1>{_esc(title)} &middot; run <span class=mono>{_esc(meta.get('run', ''))}</span></h1>\n"
+        f"<div class=meta>commit <span class=mono>{_esc(meta.get('commit', ''))}</span>"
+        f" &middot; {_esc(meta.get('date', ''))} &middot; target {_esc(meta.get('gpu', 'gfx950'))}"
+        f"{run_link}</div>\n"
+        f"<div class=gate>{_esc(gate_text)}</div>\n"
+        "<table>\n"
+        "<tr><th>Recipe</th><th>Baseline status</th><th>Raw report</th></tr>\n"
+        f"{report_rows}\n"
+        "</table>\n"
+        "</body></html>\n"
+    )
 
 
 def build_summary_md(
@@ -647,6 +809,17 @@ def main() -> int:
     src = ap.add_mutually_exclusive_group(required=True)
     src.add_argument("--results-dir", type=Path, help="DIR/<case>/sanitizer_report.json (one run)")
     src.add_argument("--runs-root", type=Path, help="dir of run_* folders (local history)")
+    src.add_argument(
+        "--history-root",
+        type=Path,
+        help="published DIR/<id>/<case>/sanitizer_report.json layout (data branch)",
+    )
+    ap.add_argument(
+        "--keep",
+        type=int,
+        default=30,
+        help="in --history-root mode, render only the newest N runs (default 30)",
+    )
     ap.add_argument("--baselines", type=Path, required=True)
     ap.add_argument("--out-dir", type=Path, required=True)
     ap.add_argument("--commit", default=os.environ.get("GITHUB_SHA", ""))
@@ -681,11 +854,26 @@ def main() -> int:
             "gpu": "gfx950",
         }
         runs = runs_from_results_dir(args.results_dir, baselines, meta=meta)
-    else:
+    elif args.runs_root is not None:
         runs = runs_from_runs_root(args.runs_root, baselines)
+    else:
+        runs = runs_from_history_root(args.history_root, baselines, keep=args.keep)
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     (args.out_dir / "index.html").write_text(build_html(runs, status=status), encoding="utf-8")
+    # In published-history mode, write each retained run's tiny landing page next
+    # to its co-located raw reports (out_dir/runs/<id>/index.html). Bounded by
+    # --keep, so pruned runs stop getting a page.
+    if args.history_root is not None:
+        for run in runs:
+            rel = run.get("rel")
+            if not rel:
+                continue
+            run_out = args.out_dir / rel
+            run_out.mkdir(parents=True, exist_ok=True)
+            (run_out / "index.html").write_text(
+                build_run_index_html(run), encoding="utf-8"
+            )
     (args.out_dir / "summary.md").write_text(
         build_summary_md(runs, status=status), encoding="utf-8"
     )

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -268,14 +269,23 @@ def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
     return meta
 
 
+# A published run directory is ``<YYYY-MM-DD>-<run_id>`` (run_id an integer).
+_RUN_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d+$")
+
+
+def _is_run_id(name: str) -> bool:
+    """Whether a directory name is a well-formed ``<YYYY-MM-DD>-<run_id>`` id."""
+    return _RUN_ID_RE.match(name) is not None
+
+
 def _history_sort_key(name: str) -> tuple[str, int]:
     """Order key for a published run id (``<YYYY-MM-DD>-<run_id>``).
 
-    The ISO date prefix sorts correctly as a string, but the trailing run id is a
-    variable-width integer, so a plain name sort mis-orders ``...-9`` after
-    ``...-10`` and would pick the wrong latest run (and prune the wrong dir).
-    Split the numeric suffix off and compare it as an int. Names that don't match
-    the scheme fall back to ``(name, -1)`` so enumeration never crashes.
+    Enumeration is already filtered to well-formed ids (``_is_run_id``); this key
+    exists because the trailing run id is a *variable-width* integer, so a plain
+    name sort mis-orders ``...-9`` after ``...-10`` and would pick the wrong
+    latest run (and prune the wrong dir). Split the numeric suffix off and compare
+    it as an int. The malformed fallback ``(name, -1)`` is defensive only.
     """
     head, sep, tail = name.rpartition("-")
     if sep and tail.isdigit():
@@ -295,8 +305,11 @@ def runs_from_history_root(
     relative to the dashboard root, and each record with the run's ``rel`` area,
     so ``build_html`` can emit relative links that work under ``/sanitizers/``.
     """
+    # Only enumerate well-formed <YYYY-MM-DD>-<run_id> dirs: a stray child (e.g. a
+    # leftover `source/` from a nested --history-root layout) must not become a
+    # phantom "latest" pseudo-run or consume a --keep slot.
     run_dirs = sorted(
-        (p for p in history_root.iterdir() if p.is_dir()),
+        (p for p in history_root.iterdir() if p.is_dir() and _is_run_id(p.name)),
         key=lambda p: _history_sort_key(p.name),
         reverse=True,
     ) if history_root.is_dir() else []

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -563,6 +563,20 @@ def test_history_root_orders_variable_width_run_ids_numerically(tmp_path):
     ]
 
 
+def test_history_root_ignores_malformed_run_dirs(tmp_path):
+    root = tmp_path / "runs"
+    _write_history_run(root, "2026-08-05-33")
+    # A stray non-conforming child (e.g. a leftover `source/` from a nested
+    # --history-root layout) must not be enumerated as a run: without filtering it
+    # would sort ahead of every dated id under reverse=True and show as "latest".
+    (root / "source" / "waitcheck").mkdir(parents=True)
+    (root / "not-a-run").mkdir()
+
+    runs = gen.runs_from_history_root(root, _baselines())
+
+    assert [r["meta"]["run"] for r in runs] == ["2026-08-05-33"]
+
+
 def test_history_root_missing_report_has_no_report_rel(tmp_path):
     root = tmp_path / "runs"
     run_dir = _write_history_run(root, "2026-08-05-33")

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -563,6 +563,27 @@ def test_history_root_orders_variable_width_run_ids_numerically(tmp_path):
     ]
 
 
+def test_history_root_preserves_recorded_comparator_gate_failure(tmp_path):
+    root = tmp_path / "runs"
+    # Every overall_verdict matches its baseline, but the authoritative comparator
+    # gate (meta.gate, the strict compare_verdict_baselines.py result) recorded a
+    # failure. The dashboard must fail closed, not render the run HEALTHY.
+    _write_history_run(root, "2026-08-05-33", meta={"gate": False})
+
+    run = gen.runs_from_history_root(root, _baselines())[0]
+
+    # run.gate agrees with meta.gate (no contradiction in data.json).
+    assert run["gate"] is False
+    assert run["meta"]["gate"] is False
+    summary = gen._gate_summary(run["rows"], recorded_gate=run["meta"].get("gate"))
+    assert summary["ok"] is False
+    assert summary["short"] == "Failed"
+    # The per-run landing page and the history gate pill reflect the failure.
+    page = gen.build_run_index_html(run)
+    assert "FAILED" in page and "HEALTHY" not in page
+    assert 'class="pill fail"' in gen._history_gate_html(run)
+
+
 def test_history_root_ignores_malformed_run_dirs(tmp_path):
     root = tmp_path / "runs"
     _write_history_run(root, "2026-08-05-33")

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -615,6 +615,19 @@ def test_build_run_index_html_lists_reports(tmp_path):
     assert 'href="../../"' in page
 
 
+def test_build_run_index_html_missing_report_reads_incomplete(tmp_path):
+    root = tmp_path / "runs"
+    run_dir = _write_history_run(root, "2026-08-05-33")
+    (run_dir / "consan-clean" / "sanitizer_report.json").unlink()
+    run = gen.runs_from_history_root(root, _baselines())[0]
+
+    page = gen.build_run_index_html(run)
+
+    # A missing report must read as INCOMPLETE, not a misleading verdict mismatch.
+    assert "INCOMPLETE \u2014 1/3 sanitizer report(s) are missing" in page
+    assert "verdict mismatch" not in page
+
+
 def test_main_history_root_writes_per_run_landing_pages(tmp_path, monkeypatch):
     baselines = _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
     root = tmp_path / "runs"
@@ -635,6 +648,11 @@ def test_main_history_root_writes_per_run_landing_pages(tmp_path, monkeypatch):
     # A per-run landing page is written next to each retained run's reports.
     assert (out / "runs" / "2026-08-05-33" / "index.html").is_file()
     assert (out / "runs" / "2026-08-04-22" / "index.html").is_file()
+    # The raw reports are co-located under the output tree so every emitted
+    # runs/<id>/<case>/sanitizer_report.json link resolves even though the
+    # history-root here is a separate directory from <out-dir>/runs.
+    assert (out / "runs" / "2026-08-05-33" / "waitcheck" / "sanitizer_report.json").is_file()
+    assert (out / "runs" / "2026-08-04-22" / "consan-racy" / "sanitizer_report.json").is_file()
     # data.json mirrors the rel / report_rel fields for machine consumers.
     data = json.loads((out / "data.json").read_text(encoding="utf-8"))
     assert data[0]["rel"] == "runs/2026-08-05-33"
@@ -642,6 +660,8 @@ def test_main_history_root_writes_per_run_landing_pages(tmp_path, monkeypatch):
         data[0]["rows"]["waitcheck"]["report_rel"]
         == "runs/2026-08-05-33/waitcheck/sanitizer_report.json"
     )
+    # gate stays a JSON boolean (not coerced to the string "True") for consumers.
+    assert data[0]["meta"]["gate"] is True
 
 
 def test_main_empty_history_root_publishes_placeholder(tmp_path, monkeypatch):

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -465,6 +465,201 @@ def test_runs_from_results_dir_matches_baselines(tmp_path):
     assert runs[0]["gate"] is False
 
 
+def _consan_clean_report() -> dict:
+    return {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "pass", "execution_status": "complete",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 1, "kernel_count": 1,
+            "kernels": [{
+                "identity": {
+                    "name": "consan_lds_clean", "target": "gfx950", "code_object": None,
+                    "code_object_sha256": None, "code_object_index": None, "entry_offset": None,
+                },
+                "total_time_ms": 0.0, "dispatch_count": 1, "sources": ["consan_repro"],
+            }],
+        },
+        "checks": [{
+            "sanitizer": "consan", "state": "ran", "verdict": "pass",
+            "reason": None, "returncode": 0, "findings": [], "kernel_results": [],
+            "coverage": [{"object_id": "reader=1,load=1", "access": "1/1"}], "backend": {},
+        }],
+    }
+
+
+def _baselines() -> dict:
+    return {
+        "waitcheck_gemm": {"overall_verdict": "warn"},
+        "consan_clean": {"overall_verdict": "pass"},
+        "consan_racy": {"overall_verdict": "fail"},
+    }
+
+
+def _write_history_run(root: Path, run_id: str, *, meta: dict | None = None) -> Path:
+    """Lay out one published run: root/<id>/<case>/sanitizer_report.json + meta.json."""
+    run_dir = root / run_id
+    for case, report in (
+        ("waitcheck", _waitcheck_report()),
+        ("consan-clean", _consan_clean_report()),
+        ("consan-racy", _consan_racy_report()),
+    ):
+        (run_dir / case).mkdir(parents=True)
+        (run_dir / case / "sanitizer_report.json").write_text(json.dumps(report))
+    manifest = {
+        "run": run_id, "commit": "0123456789abcdef", "date": "2026-08-05",
+        "gpu": "gfx950", "run_url": "https://github.com/ROCm/aorta/actions/runs/99",
+        "gate": True,
+    }
+    if meta:
+        manifest.update(meta)
+    (run_dir / "meta.json").write_text(json.dumps(manifest))
+    return run_dir
+
+
+def test_history_root_enumerates_newest_first(tmp_path):
+    root = tmp_path / "runs"
+    for run_id in ("2026-08-03-11", "2026-08-05-33", "2026-08-04-22"):
+        _write_history_run(root, run_id)
+
+    runs = gen.runs_from_history_root(root, _baselines())
+
+    ids = [r["meta"]["run"] for r in runs]
+    assert ids == ["2026-08-05-33", "2026-08-04-22", "2026-08-03-11"]
+    # rel + report_rel are threaded through, relative to the dashboard root.
+    latest = runs[0]
+    assert latest["rel"] == "runs/2026-08-05-33"
+    assert (
+        latest["rows"]["waitcheck"]["report_rel"]
+        == "runs/2026-08-05-33/waitcheck/sanitizer_report.json"
+    )
+    # meta.json is read back (commit is shortened to 12 chars for display).
+    assert latest["meta"]["commit"] == "0123456789ab"
+    assert latest["meta"]["gpu"] == "gfx950"
+    assert latest["meta"]["run_url"].endswith("/runs/99")
+
+
+def test_history_root_keep_caps_to_newest_n(tmp_path):
+    root = tmp_path / "runs"
+    for i in range(5):
+        _write_history_run(root, f"2026-08-0{i + 1}-{i + 1}")
+
+    runs = gen.runs_from_history_root(root, _baselines(), keep=2)
+
+    assert [r["meta"]["run"] for r in runs] == ["2026-08-05-5", "2026-08-04-4"]
+
+
+def test_history_root_missing_report_has_no_report_rel(tmp_path):
+    root = tmp_path / "runs"
+    run_dir = _write_history_run(root, "2026-08-05-33")
+    # Remove one case's report -> present False, and no dead link is emitted.
+    (run_dir / "consan-clean" / "sanitizer_report.json").unlink()
+
+    runs = gen.runs_from_history_root(root, _baselines())
+    rows = runs[0]["rows"]
+    assert rows["consan-clean"]["present"] is False
+    assert rows["consan-clean"]["report_rel"] is None
+    assert runs[0]["gate"] is False  # a missing report fails the gate closed
+
+
+def test_build_html_emits_relative_report_links(tmp_path):
+    root = tmp_path / "runs"
+    _write_history_run(root, "2026-08-05-33")
+    _write_history_run(root, "2026-08-04-22")
+    runs = gen.runs_from_history_root(root, _baselines())
+
+    html = gen.build_html(runs)
+
+    # Latest-run table links each case to its raw JSON, relative to /sanitizers/.
+    assert 'href="runs/2026-08-05-33/waitcheck/sanitizer_report.json"' in html
+    # A "view raw report" link appears in the kernel-detail section.
+    assert "view raw report" in html
+    # The run area is linked from the latest-run header and the history table.
+    assert 'href="runs/2026-08-05-33/"' in html
+    assert 'href="runs/2026-08-04-22/"' in html
+    # All emitted links are relative (no site-absolute or protocol-absolute hrefs
+    # to the run area / reports).
+    assert 'href="/runs/' not in html
+    assert "https://runs/" not in html
+
+
+def test_build_html_no_report_column_links_without_history():
+    # results-dir / runs-root modes carry no rel/report_rel: the Report column is
+    # present but renders an em dash, and no run-area links are emitted.
+    rows = {
+        "waitcheck": gen.summarize_case(_waitcheck_report(), "warn"),
+        "consan-clean": gen.summarize_case(_waitcheck_report(), "warn"),
+        "consan-racy": gen.summarize_case(_consan_racy_report(), "fail"),
+    }
+    runs = [gen._run_record({"run": "r1", "commit": "abc", "date": "d"}, rows)]
+    html = gen.build_html(runs)
+    assert "<th>Report</th>" in html
+    assert "sanitizer_report.json" not in html
+    assert "runs/" not in html
+
+
+def test_build_run_index_html_lists_reports(tmp_path):
+    root = tmp_path / "runs"
+    _write_history_run(root, "2026-08-05-33")
+    run = gen.runs_from_history_root(root, _baselines())[0]
+
+    page = gen.build_run_index_html(run)
+
+    assert "<!doctype html>" in page
+    assert "2026-08-05-33" in page
+    # Report links are case-local (the page lives inside runs/<id>/).
+    assert 'href="waitcheck/sanitizer_report.json"' in page
+    assert 'href="consan-racy/sanitizer_report.json"' in page
+    # Links back to the workflow run and up to the dashboard.
+    assert "/runs/99" in page
+    assert 'href="../../"' in page
+
+
+def test_main_history_root_writes_per_run_landing_pages(tmp_path, monkeypatch):
+    baselines = _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+    root = tmp_path / "runs"
+    _write_history_run(root, "2026-08-05-33")
+    _write_history_run(root, "2026-08-04-22")
+    out = tmp_path / "dashboard"
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(root),
+        "--keep", "30",
+        "--baselines", str(baselines),
+        "--out-dir", str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+
+    assert (out / "index.html").is_file()
+    # A per-run landing page is written next to each retained run's reports.
+    assert (out / "runs" / "2026-08-05-33" / "index.html").is_file()
+    assert (out / "runs" / "2026-08-04-22" / "index.html").is_file()
+    # data.json mirrors the rel / report_rel fields for machine consumers.
+    data = json.loads((out / "data.json").read_text(encoding="utf-8"))
+    assert data[0]["rel"] == "runs/2026-08-05-33"
+    assert (
+        data[0]["rows"]["waitcheck"]["report_rel"]
+        == "runs/2026-08-05-33/waitcheck/sanitizer_report.json"
+    )
+
+
+def test_main_empty_history_root_publishes_placeholder(tmp_path, monkeypatch):
+    # Mirrors the Pages empty-state invocation (pages.yml publish_placeholder).
+    baselines = _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+    out = tmp_path / "out"
+    (tmp_path / "empty").mkdir()
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(tmp_path / "empty"),
+        "--baselines", str(baselines),
+        "--out-dir", str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+    assert "No sanitizer runs yet" in (out / "index.html").read_text(encoding="utf-8")
+
+
 def test_main_fails_closed_on_missing_baselines(tmp_path, monkeypatch):
     # A missing/unreadable baselines file must not paint a false-healthy gate: main
     # exits non-zero instead of falling back to an empty baseline set.

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -667,6 +667,8 @@ def test_main_history_root_writes_per_run_landing_pages(tmp_path, monkeypatch):
     # history-root here is a separate directory from <out-dir>/runs.
     assert (out / "runs" / "2026-08-05-33" / "waitcheck" / "sanitizer_report.json").is_file()
     assert (out / "runs" / "2026-08-04-22" / "consan-racy" / "sanitizer_report.json").is_file()
+    # The run manifest is carried too, so the published runs/<id>/ layout is complete.
+    assert (out / "runs" / "2026-08-05-33" / "meta.json").is_file()
     # data.json mirrors the rel / report_rel fields for machine consumers.
     data = json.loads((out / "data.json").read_text(encoding="utf-8"))
     assert data[0]["rel"] == "runs/2026-08-05-33"
@@ -699,6 +701,27 @@ def test_main_history_root_clears_stale_output_runs(tmp_path, monkeypatch):
     assert gen.main() == 0
 
     assert not (out / "runs" / "2026-08-01-01").exists()
+    assert (out / "runs" / "2026-08-05-33" / "waitcheck" / "sanitizer_report.json").is_file()
+
+
+def test_main_history_root_nested_under_output_is_not_wiped(tmp_path, monkeypatch):
+    # If --history-root nests beneath <out-dir>/runs, the stale-clear must NOT
+    # rmtree runs_out (that would delete the source reports before they're copied).
+    baselines = _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+    out = tmp_path / "dashboard"
+    root = out / "runs" / "source"  # nested beneath <out-dir>/runs
+    _write_history_run(root, "2026-08-05-33")
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(root),
+        "--baselines", str(baselines),
+        "--out-dir", str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+
+    # Source reports survive (not wiped) and are still published under the output.
+    assert (root / "2026-08-05-33" / "waitcheck" / "sanitizer_report.json").is_file()
     assert (out / "runs" / "2026-08-05-33" / "waitcheck" / "sanitizer_report.json").is_file()
 
 

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -549,6 +549,20 @@ def test_history_root_keep_caps_to_newest_n(tmp_path):
     assert [r["meta"]["run"] for r in runs] == ["2026-08-05-5", "2026-08-04-4"]
 
 
+def test_history_root_orders_variable_width_run_ids_numerically(tmp_path):
+    root = tmp_path / "runs"
+    # Same day, variable-width run ids: 100 > 10 > 9 numerically, but a plain
+    # string sort would put "-9" ahead of "-10"/"-100" and pick the wrong latest.
+    for run_id in ("2026-08-05-9", "2026-08-05-10", "2026-08-05-100"):
+        _write_history_run(root, run_id)
+
+    runs = gen.runs_from_history_root(root, _baselines())
+
+    assert [r["meta"]["run"] for r in runs] == [
+        "2026-08-05-100", "2026-08-05-10", "2026-08-05-9",
+    ]
+
+
 def test_history_root_missing_report_has_no_report_rel(tmp_path):
     root = tmp_path / "runs"
     run_dir = _write_history_run(root, "2026-08-05-33")
@@ -662,6 +676,30 @@ def test_main_history_root_writes_per_run_landing_pages(tmp_path, monkeypatch):
     )
     # gate stays a JSON boolean (not coerced to the string "True") for consumers.
     assert data[0]["meta"]["gate"] is True
+
+
+def test_main_history_root_clears_stale_output_runs(tmp_path, monkeypatch):
+    # When --history-root is a separate tree from <out-dir>/runs and the output is
+    # reused, a run dropped from the history must not linger as stale published
+    # output. main() clears out/runs before copying the current retained set.
+    baselines = _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+    root = tmp_path / "runs"
+    _write_history_run(root, "2026-08-05-33")
+    out = tmp_path / "dashboard"
+    stale = out / "runs" / "2026-08-01-01" / "waitcheck"
+    stale.mkdir(parents=True)
+    (stale / "sanitizer_report.json").write_text("{}")
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(root),
+        "--baselines", str(baselines),
+        "--out-dir", str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+
+    assert not (out / "runs" / "2026-08-01-01").exists()
+    assert (out / "runs" / "2026-08-05-33" / "waitcheck" / "sanitizer_report.json").is_file()
 
 
 def test_main_empty_history_root_publishes_placeholder(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The sanitizer nightly published only the rendered `dashboard/` to the `sanitizer-results` data branch (served at `/sanitizers/`). Each run's raw per-case `sanitizer_report.json` files lived only in an expiring Actions artifact and were never linked. This PR co-locates each nightly's raw reports on the data branch under `dashboard/runs/<YYYY-MM-DD>-<run_id>/` and links them from the dashboard, keeping a rolling window of the newest 30 runs.

### Target data-branch layout
```
dashboard/
  index.html  summary.md  data.json  status.json      # regenerated each night
  runs/
    <YYYY-MM-DD>-<run_id>/
      meta.json                                        # commit, date, gpu, run_url, gate
      index.html                                       # tiny per-run landing page (3 report links)
      waitcheck/sanitizer_report.json
      consan-clean/sanitizer_report.json
      consan-racy/sanitizer_report.json
```

### Changes
- **`scripts/sanitizers/gen_sanitizer_dashboard.py`**: new `--history-root DIR` / `--keep N` (default 30) input mode (mutually exclusive with `--results-dir` / `--runs-root`) that enumerates the published `DIR/<id>/<case>/sanitizer_report.json` layout newest-first (by the monotonic `<id>` dir name), reading `DIR/<id>/meta.json`. Threads a per-run `rel` (`runs/<id>`) and per-case `report_rel` into the records; emits **relative** links (latest-run table gains a **Report** column + a run-area link, kernel-detail sections get a "view raw report" link, history table's **Run** cell links to `runs/<id>/`); writes a tiny self-contained `runs/<id>/index.html` landing page per retained run; mirrors `rel`/`report_rel` into `data.json`. Pure/rendering functions stay filesystem-free and unit-testable.
- **`.github/workflows/sanitizers-nightly.yml`**: the `publish` job now **preserves** `dashboard/runs/` history (instead of `rm -rf`/re-copy), stages this run into `dashboard/runs/<date>-<run_id>/` (copying `incoming/<case>/sanitizer_report.json` + writing `meta.json`), prunes to the newest 30, then regenerates via `gen_sanitizer_dashboard.py --history-root <merged runs dir> --keep 30`. Keeps the existing fail-closed `git ls-remote` contract and push semantics; still appends `summary.md` to `$GITHUB_STEP_SUMMARY`.
- **`.github/workflows/pages.yml`**: no functional change needed — the recursive `cp -r "$tmp/dashboard/"* _site/sanitizers/` already carries `runs/`, so reports are served at `/sanitizers/runs/...`. Aligned the empty-state placeholder generator call to `--history-root` for consistency.
- **`tests/sanitizers/test_dashboard.py`** and **`docs/ci-nightly-eval.md`** updated.

## Test plan
- [x] `pytest tests/sanitizers/test_dashboard.py -q` → **22 passed** (added tests for `--history-root` enumeration + newest-first ordering, `--keep N` capping, relative link emission in `build_html`, missing-report has no dead link, per-run `index.html` content, and `main()` writing per-run landing pages + mirroring `rel`/`report_rel` into `data.json`).
- [x] `ruff check` clean on changed files.
- [x] Smoke-rendered a 3-run history: verified all report/run-area links are relative (`runs/<id>/<case>/sanitizer_report.json`) and each `runs/<id>/index.html` lists its three reports.
- Note: `tests/sanitizers/test_compare_baselines.py` requires an editable install of the `aorta` package (import-only, pre-existing) and is unaffected by this change.

Closes #352

Made with [Cursor](https://cursor.com)