### PR TITLE
fix(sanitizers): use solid pass/fail colors for the dashboard gate

### DIFF
--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -348,7 +348,7 @@ def _history_case_html(row: dict[str, Any]) -> str:
 
 def _history_gate_html(run: dict[str, Any]) -> str:
     summary = _gate_summary(run["rows"])
-    emphasis = "ok" if run["gate"] else "bad"
+    emphasis = "pass" if run["gate"] else "fail"
     return f'<td><span class="pill {emphasis}">{_esc(summary["short"])}</span></td>'
 
 
@@ -450,7 +450,7 @@ def build_html(
     latest = runs[0]
     meta = latest["meta"]
     summary = _gate_summary(latest["rows"])
-    gate_color = "#1a7f37" if summary["ok"] else "#cf222e"
+    gate_color = "#2c7d3b" if summary["ok"] else "#c92c35"
     gate_text = f"{summary['label']} \u2014 {summary['detail']}"
 
     latest_rows = "".join(
@@ -502,6 +502,7 @@ def build_html(
   .execution.bad {{ color:#cf222e; font-weight:600; }}
   .pill {{ padding:2px 8px; border-radius:999px; font-size:12px; font-weight:600; }}
   .pill.ok {{ background:#1a7f3722; color:#1a7f37; }} .pill.bad {{ background:#cf222e22; color:#cf222e; }}
+  .pill.pass {{ background:#2c7d3b; color:#fff; }} .pill.fail {{ background:#c92c35; color:#fff; }}
   @media (prefers-color-scheme: dark) {{
     body {{ background:#0d1117; color:#e6edf3; }}
     table {{ background:#161b22; }} th {{ background:#161b22; color:#8b949e; }}

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -199,7 +199,7 @@ def test_build_html_expected_warn_and_fail_are_healthy_and_neutral():
     assert "gemm_x" in html and "Kernel details" in html
     assert "Observed sanitizer verdict" in html
     assert '<span class="pill ok">Match</span>' in html
-    assert '<span class="pill ok">Healthy</span>' in html
+    assert '<span class="pill pass">Healthy</span>' in html
     assert ">green<" not in html and ">red<" not in html
 
 
@@ -224,7 +224,7 @@ def test_build_html_mismatch_is_primary_regression_signal():
     assert '<span class="pill bad">Mismatch</span>' in html
     assert 'Observed <span class="observed">fail</span>' in html
     assert 'expected <span class="observed">pass</span>' in html
-    assert '<span class="pill bad">Regression</span>' in html
+    assert '<span class="pill fail">Regression</span>' in html
 
 
 def test_renderers_make_missing_report_explicit():
@@ -308,7 +308,7 @@ def test_missing_only_run_is_incomplete_not_regression():
     md = gen.build_summary_md(runs)
 
     assert "INCOMPLETE — 1/3 sanitizer report(s) are missing" in html
-    assert '<span class="pill bad">Incomplete</span>' in html
+    assert '<span class="pill fail">Incomplete</span>' in html
     assert "**INCOMPLETE** — 1/3 sanitizer report(s) are missing" in md
     assert "Incomplete |" in md
     # a missing report must not be surfaced as a verdict regression anywhere
@@ -338,7 +338,7 @@ def test_combined_mismatch_and_missing_is_unhealthy():
 
     detail = "investigate 1/3 mismatched outcome(s) and 1/3 missing report(s)"
     assert f"UNHEALTHY — {detail}" in html
-    assert '<span class="pill bad">Unhealthy</span>' in html
+    assert '<span class="pill fail">Unhealthy</span>' in html
     assert f"**UNHEALTHY** — {detail}" in md
     assert "Unhealthy |" in md
 


### PR DESCRIPTION
## Summary

Follow-up to #353. Make the sanitizer dashboard's aggregate gate read at a glance by rendering it as solid pass/fail badges:

- Gate banner: solid green `#2c7d3b` when healthy, solid red `#c92c35` otherwise.
- History "Gate" column: solid `pass`/`fail` pills (white text) using the same two colors.
- Per-case baseline-status pills (`Expected outcome`, `Report missing`, `Match`/`Mismatch`) keep their existing subtle styling — only the aggregate gate uses the solid colors, so the "baseline status is the health signal" model from #353 is unchanged.

Rendering-only change: no change to aggregation, verdict/baseline logic, `data.json`, or workflow behavior.

## Test plan

- `python -m pytest tests/sanitizers/test_dashboard.py` (20 passed) — updated the four gate-pill assertions to the new `pass`/`fail` classes.
- `ruff check scripts/sanitizers/gen_sanitizer_dashboard.py tests/sanitizers/test_dashboard.py` (clean)
- `git diff --check` (clean)
- Rendered a local dashboard and confirmed the banner uses `#2c7d3b`/`#c92c35` and the history Gate pills are solid `pass`/`fail`.

Made with Cursor

Made with [Cursor](https://cursor.com)