### PR TITLE
feat(sanitizers): consume prebuilt RocJITsu artifacts instead of source build

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -101,9 +101,13 @@ jobs:
             # ROCm/rocm-systems (#350): fetch the upstream downloader, then pull
             # bin/rj_waitcheck + lib/librocjitsu_dbi_hooks.so for the latest
             # successful run on ${ROCJITSU_REF}. This replaces the old
-            # clone + cmake source build (its docker toolchain deps -- cmake,
-            # ninja, libzstd-dev, g++-13, Findzstd shim in
-            # docker/Dockerfile.ci-gpu -- are now unused by this gate).
+            # clone + cmake source build, whose docker toolchain deps (cmake,
+            # ninja, libzstd-dev, g++-13, Findzstd shim) have been removed from
+            # docker/Dockerfile.ci-gpu.
+            # Downloading Actions artifacts requires a token with actions:read
+            # even though rocm-systems is public: the unauthenticated artifact
+            # /zip endpoint returns 401 and no equivalent GitHub Release exists.
+            # See the step env (GH_TOKEN) and the token note there.
             rm -rf "${ROCJITSU_PREBUILT}"
             mkdir -p "${SANITIZER_ROOT}"
             DL_SCRIPT="${SANITIZER_ROOT}/download_sanitizer_artifacts.py"

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -21,7 +21,7 @@ env:
   # clones + builds rocm-systems from source (#350); it downloads the bundle
   # published by ROCm/rocm-systems' `rocjitsu-sanitizer-artifacts` workflow and
   # points the resolvers at it via ROCJITSU_PREBUILT. `--run latest` on this
-  # branch is resolved by the upstream downloader.
+  # branch is resolved by the vendored downloader (scripts/sanitizers/).
   # TODO(#330): these are ephemeral (30-day) Actions artifacts, not an immutable
   # Release. For a truly immutable gate, pin an explicit reviewed run ID (record
   # the commit from the bundle's MANIFEST.json for provenance) or promote the
@@ -98,7 +98,7 @@ jobs:
             pip install -e ".[tests]"
 
             # Consume the prebuilt sanitizer bundle published by
-            # ROCm/rocm-systems (#350): fetch the upstream downloader, then pull
+            # ROCm/rocm-systems (#350): run the vendored downloader to pull
             # bin/rj_waitcheck + lib/librocjitsu_dbi_hooks.so for the latest
             # successful run on ${ROCJITSU_REF}. This replaces the old
             # clone + cmake source build, whose docker toolchain deps (cmake,
@@ -110,30 +110,26 @@ jobs:
             # See the step env (GH_TOKEN) and the token note there.
             rm -rf "${ROCJITSU_PREBUILT}"
             mkdir -p "${SANITIZER_ROOT}"
-            DL_SCRIPT="${SANITIZER_ROOT}/download_sanitizer_artifacts.py"
-            python - "${DL_SCRIPT}" "${ROCJITSU_REF}" <<"PY"
-          import os, sys, urllib.request
-          dest, ref = sys.argv[1], sys.argv[2]
-          url = (
-              "https://api.github.com/repos/ROCm/rocm-systems/contents/"
-              "emulation/rocjitsu/scripts/download_sanitizer_artifacts.py?ref=" + ref
-          )
-          token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
-          headers = {"Accept": "application/vnd.github.raw",
-                     "User-Agent": "aorta-sanitizers-nightly"}
-          if token:
-              headers["Authorization"] = "Bearer " + token
-          with urllib.request.urlopen(
-              urllib.request.Request(url, headers=headers), timeout=60
-          ) as resp:
-              body = resp.read()
-          with open(dest, "wb") as fh:
-              fh.write(body)
-          PY
-            python "${DL_SCRIPT}" --branch "${ROCJITSU_REF}" \
-              --dest "${ROCJITSU_PREBUILT}" --force
+            # Run the VENDORED downloader (scripts/sanitizers/, copied from a
+            # reviewed rocm-systems commit) rather than fetching executable code
+            # from the mutable ${ROCJITSU_REF} branch and running it with the
+            # artifacts token -- a moving/compromised branch could otherwise run
+            # arbitrary code in this job and exfiltrate the PAT.
+            python scripts/sanitizers/download_sanitizer_artifacts.py \
+              --branch "${ROCJITSU_REF}" --dest "${ROCJITSU_PREBUILT}" --force
             export ROCJITSU_PREBUILT="$(cd "${ROCJITSU_PREBUILT}" && pwd)"
             echo "ROCJITSU_PREBUILT=${ROCJITSU_PREBUILT}"
+            # Fail closed: the downloader only *warns* when sha256sums.txt is
+            # absent, which would admit an unverified bundle. Require it.
+            if [ ! -f "${ROCJITSU_PREBUILT}/sha256sums.txt" ]; then
+              echo "::error::prebuilt bundle has no sha256sums.txt; refusing unverified artifacts" >&2
+              exit 1
+            fi
+            # The token is only needed for the download above. Drop it before
+            # building fixtures or running any artifact-provided code
+            # (rj_waitcheck and the ConSan hook, which copies os.environ) so
+            # those never inherit the cross-repo PAT.
+            unset GH_TOKEN GITHUB_TOKEN
             # Record the source commit for provenance (bundle is ephemeral).
             python -c "import json,sys; m=json.load(open(sys.argv[1])); \
               print(\"ROCJITSU bundle commit:\", m.get(\"commit\"), \

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -17,9 +17,15 @@ concurrency:
 
 env:
   CONTAINER_NAME: aorta-ci-gpu
-  # Immutable RocJITsu input. rocm-systems is public, so the checkout needs no
-  # token. TODO(#330): replace this branch ref with the reviewed commit SHA so
-  # the gate pins an immutable input rather than a mutable branch.
+  # Branch whose prebuilt sanitizer artifacts we consume. The nightly no longer
+  # clones + builds rocm-systems from source (#350); it downloads the bundle
+  # published by ROCm/rocm-systems' `rocjitsu-sanitizer-artifacts` workflow and
+  # points the resolvers at it via ROCJITSU_PREBUILT. `--run latest` on this
+  # branch is resolved by the upstream downloader.
+  # TODO(#330): these are ephemeral (30-day) Actions artifacts, not an immutable
+  # Release. For a truly immutable gate, pin an explicit reviewed run ID (record
+  # the commit from the bundle's MANIFEST.json for provenance) or promote the
+  # build to a durable store.
   ROCJITSU_REF: "shared/rocjitsu/sanitizers"
 
 jobs:
@@ -67,42 +73,72 @@ jobs:
       # the same pinned ROCm container as gpu-tests.yml / eval-reusable.yml.
       # Workspace-relative paths keep artifacts visible on the host for upload.
       - name: Run sanitizer regression
+        env:
+          # Downloading GitHub Actions artifacts requires a token with
+          # `actions:read` -- even for a public repo. The default GITHUB_TOKEN is
+          # scoped to THIS repo (ROCm/aorta) only and CANNOT read another repo's
+          # (ROCm/rocm-systems) artifacts, so a PAT with `actions:read` on
+          # rocm-systems must be provided as the ROCJITSU_ARTIFACTS_TOKEN secret.
+          # The GITHUB_TOKEN fallback keeps the step wired, but will 403 on the
+          # cross-repo download until the secret is configured.
+          ROCJITSU_ARTIFACTS_TOKEN: ${{ secrets.ROCJITSU_ARTIFACTS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           bash scripts/ci/docker_cmd.sh exec \
             -e ROCJITSU_REF="${ROCJITSU_REF}" \
+            -e GH_TOKEN="${ROCJITSU_ARTIFACTS_TOKEN}" \
             "${{ env.CONTAINER_NAME }}" bash -lc '
             set -euo pipefail
             cd /workspace/aorta
             SANITIZER_ROOT=".sanitizer-nightly"
-            ROCJITSU_SRC="${SANITIZER_ROOT}/rocjitsu-src"
-            ROCJITSU_BUILD="${SANITIZER_ROOT}/rocjitsu-build"
+            ROCJITSU_PREBUILT="${SANITIZER_ROOT}/rocjitsu-prebuilt"
             SANITIZER_OUT="${SANITIZER_ROOT}/out"
             FIXTURES=recipes/sanitizers/fixtures
 
             python -m pip install --upgrade pip
             pip install -e ".[tests]"
-            # rocjitsu build deps (cmake, ninja, libzstd-dev, g++-13, Findzstd
-            # shim) are baked into docker/Dockerfile.ci-gpu; see that file.
-            RJ_CMAKE_MODULE_PATH=/opt/aorta/cmake
 
-            rm -rf "${ROCJITSU_SRC}" "${ROCJITSU_BUILD}"
-            git clone --filter=blob:none https://github.com/ROCm/rocm-systems.git "${ROCJITSU_SRC}"
-            git -C "${ROCJITSU_SRC}" checkout "${ROCJITSU_REF}"
-            echo "ROCJITSU checkout: $(git -C "${ROCJITSU_SRC}" rev-parse HEAD)"
-            if command -v ninja >/dev/null 2>&1; then
-              cmake -S "${ROCJITSU_SRC}/emulation/rocjitsu" -B "${ROCJITSU_BUILD}" -GNinja \
-                -DCMAKE_MODULE_PATH="${RJ_CMAKE_MODULE_PATH}"
-            else
-              cmake -S "${ROCJITSU_SRC}/emulation/rocjitsu" -B "${ROCJITSU_BUILD}" \
-                -DCMAKE_MODULE_PATH="${RJ_CMAKE_MODULE_PATH}"
-            fi
-            cmake --build "${ROCJITSU_BUILD}" --parallel \
-              --target rj_waitcheck rocjitsu_dbi_hooks
-            export ROCJITSU_BUILD="${ROCJITSU_BUILD}"
+            # Consume the prebuilt sanitizer bundle published by
+            # ROCm/rocm-systems (#350): fetch the upstream downloader, then pull
+            # bin/rj_waitcheck + lib/librocjitsu_dbi_hooks.so for the latest
+            # successful run on ${ROCJITSU_REF}. This replaces the old
+            # clone + cmake source build (its docker toolchain deps -- cmake,
+            # ninja, libzstd-dev, g++-13, Findzstd shim in
+            # docker/Dockerfile.ci-gpu -- are now unused by this gate).
+            rm -rf "${ROCJITSU_PREBUILT}"
+            mkdir -p "${SANITIZER_ROOT}"
+            DL_SCRIPT="${SANITIZER_ROOT}/download_sanitizer_artifacts.py"
+            python - "${DL_SCRIPT}" "${ROCJITSU_REF}" <<"PY"
+          import os, sys, urllib.request
+          dest, ref = sys.argv[1], sys.argv[2]
+          url = (
+              "https://api.github.com/repos/ROCm/rocm-systems/contents/"
+              "emulation/rocjitsu/scripts/download_sanitizer_artifacts.py?ref=" + ref
+          )
+          token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+          headers = {"Accept": "application/vnd.github.raw",
+                     "User-Agent": "aorta-sanitizers-nightly"}
+          if token:
+              headers["Authorization"] = "Bearer " + token
+          with urllib.request.urlopen(
+              urllib.request.Request(url, headers=headers), timeout=60
+          ) as resp:
+              body = resp.read()
+          with open(dest, "wb") as fh:
+              fh.write(body)
+          PY
+            python "${DL_SCRIPT}" --branch "${ROCJITSU_REF}" \
+              --dest "${ROCJITSU_PREBUILT}" --force
+            export ROCJITSU_PREBUILT="$(cd "${ROCJITSU_PREBUILT}" && pwd)"
+            echo "ROCJITSU_PREBUILT=${ROCJITSU_PREBUILT}"
+            # Record the source commit for provenance (bundle is ephemeral).
+            python -c "import json,sys; m=json.load(open(sys.argv[1])); \
+              print(\"ROCJITSU bundle commit:\", m.get(\"commit\"), \
+              \"run:\", m.get(\"run_url\"))" \
+              "${ROCJITSU_PREBUILT}/MANIFEST.json"
 
             # hipcc shells out to clang-offload-bundler, which lives in the ROCm
-            # LLVM bindir (same dir as the amdclang++ used above) but is not on
-            # PATH -- the image only exports /opt/rocm/bin -- so the fixture
+            # LLVM bindir but is not on PATH -- the image only exports
+            # /opt/rocm/bin -- so the fixture
             # build failed with "clang-offload-bundler not found on PATH" (run
             # 31161251100). Add the LLVM bindir so hipcc can find its tools.
             export PATH="${ROCM_PATH:-${ROCM_HOME:-/opt/rocm}}/lib/llvm/bin:${PATH}"

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -1,13 +1,17 @@
 # CI GPU image for the aorta GPU test gate + workload regression smokes.
 #
 # Reproducibility: the ROCm PyTorch base is pinned by manifest digest. Extra
-# dependencies are exact-pinned PyPI packages where possible, plus a small set
-# of apt packages (libzstd-dev, g++-13 from the toolchain PPA) and a baked
-# Findzstd.cmake shim for the nightly rocjitsu sanitizer build. The GPU pytest
-# gate and the current workload smokes (gpu_smoke / inference / race) do not
-# need TraceLens / Magpie, so those unpinned git installs from the general-
-# purpose image are intentionally omitted here to keep the CI image reproducible
-# and fast to build.
+# dependencies are exact-pinned PyPI packages. The GPU pytest gate and the
+# current workload smokes (gpu_smoke / inference / race) do not need TraceLens /
+# Magpie, so those unpinned git installs from the general-purpose image are
+# intentionally omitted here to keep the CI image reproducible and fast to build.
+#
+# The nightly sanitizer gate no longer builds RocJITsu from source (#350): it
+# consumes prebuilt rj_waitcheck / rocjitsu_dbi_hooks artifacts published by
+# ROCm/rocm-systems. The former source-build toolchain (cmake, ninja,
+# libzstd-dev, g++-13 from the toolchain PPA, and a baked Findzstd.cmake shim)
+# has therefore been removed from this image. hipcc (from the ROCm base) still
+# builds the HIP repro fixtures and does not need any of those.
 #
 # Base: rocm/pytorch ROCm 7.2, Ubuntu 22.04, Python 3.10, PyTorch 2.9.1
 # Pinned as tag@digest (not digest-only): the tag anchors Dependabot to the
@@ -22,48 +26,7 @@ USER root
 # installed (no `|| true`) so a broken image surfaces here, not at runtime.
 RUN python -m pip install --no-cache-dir \
     "openpyxl==3.1.5" \
-    "seaborn==0.13.2" \
-    "cmake==4.4.2" \
-    "ninja==1.13.0"
-
-# rocjitsu build deps for the nightly sanitizer gate (see sanitizers-nightly.yml):
-#   - libzstd-dev: headers/lib for find_package(zstd)
-#   - g++-13: libstdc++ with C++20 <format> (GCC 12 in the base image lacks it)
-# g++-13 comes from the toolchain PPA and is not version-pinned (PPA versions
-# rotate); this matches the prior runtime install behavior.
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends software-properties-common \
-    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends libzstd-dev g++-13 \
-    && rm -rf /var/lib/apt/lists/*
-
-# Findzstd.cmake -- minimal module-mode shim for the rocjitsu build.
-# rocjitsu does find_package(zstd REQUIRED) expecting zstd's config package
-# (zstdConfig.cmake + zstd::libzstd_shared). Ubuntu's libzstd-dev ships the
-# headers and library but no CMake package config, so this shim wraps the distro
-# lib into the imported target rocjitsu aliases from.
-RUN mkdir -p /opt/aorta/cmake && cat > /opt/aorta/cmake/Findzstd.cmake <<'CMAKE'
-include(FindPackageHandleStandardArgs)
-
-find_path(zstd_INCLUDE_DIR NAMES zstd.h)
-find_library(zstd_LIBRARY NAMES zstd)
-
-find_package_handle_standard_args(zstd
-  REQUIRED_VARS zstd_LIBRARY zstd_INCLUDE_DIR
-)
-
-if(zstd_FOUND AND NOT TARGET zstd::libzstd_shared)
-  add_library(zstd::libzstd_shared UNKNOWN IMPORTED)
-  set_target_properties(zstd::libzstd_shared PROPERTIES
-    IMPORTED_LOCATION "${zstd_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${zstd_INCLUDE_DIR}"
-  )
-endif()
-
-mark_as_advanced(zstd_INCLUDE_DIR zstd_LIBRARY)
-CMAKE
+    "seaborn==0.13.2"
 
 ENV ROCM_HOME=/opt/rocm
 ENV PATH=$ROCM_HOME/bin:$PATH

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -264,8 +264,8 @@ The RocJITsu sanitizer engine (`rocjitsu_sanitizers`) is gfx-hardware code, so
 its sources, recipes, dashboard scripts, and tests are GPU-relevant. The GPU
 gate's `test_sanitizers_gpu.py` always runs a fail-closed guardrail on the
 runner; its real clean/racy ConSan repro cases run when the DBI hook
-(`ROCJITSU_BUILD`) and `hipcc` are present (as in `sanitizers-nightly.yml`) and
-self-skip otherwise.
+(provisioned via `ROCJITSU_PREBUILT` or `ROCJITSU_BUILD`) and `hipcc` are
+present (as in `sanitizers-nightly.yml`) and self-skip otherwise.
 
 **Concurrency:** one GPU workflow run per ref; newer pushes cancel superseded PR
 runs so the single runner is not starved by stale jobs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,10 +211,14 @@ markers = [
 line-length = 100
 target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
+# Vendored verbatim from ROCm/rocm-systems (see the file header); kept in sync
+# with upstream rather than reformatted to our style.
+force-exclude = 'scripts/sanitizers/download_sanitizer_artifacts\.py'
 
 [tool.isort]
 profile = "black"
 line_length = 100
+extend_skip = ["scripts/sanitizers/download_sanitizer_artifacts.py"]
 
 [tool.mypy]
 python_version = "3.10"
@@ -226,3 +230,6 @@ ignore_missing_imports = true
 line-length = 100
 select = ["E", "F", "W", "I", "N", "UP", "B", "C4"]
 ignore = ["E501"]
+# Vendored verbatim from ROCm/rocm-systems (see the file header); kept in sync
+# with upstream rather than reformatted to our lints.
+extend-exclude = ["scripts/sanitizers/download_sanitizer_artifacts.py"]

--- a/scripts/sanitizers/download_sanitizer_artifacts.py
+++ b/scripts/sanitizers/download_sanitizer_artifacts.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# VENDORED from ROCm/rocm-systems, path
+# emulation/rocjitsu/scripts/download_sanitizer_artifacts.py, at the reviewed
+# immutable commit 7d2c61e7e467d13daa967480eb76ecb07d0ea762 (the rocm-systems#9681
+# merge; sha256 cb6ad77a5287c61c5db44434a2de37245db8cebc2924cf2c61edcfb753c18288).
+# It is copied in-tree rather than fetched at runtime because sanitizers-nightly
+# executes it with a cross-repo actions:read token, and running code fetched
+# from a mutable upstream branch would be a supply-chain / token-exfiltration
+# risk. To update: re-copy the file from a newer reviewed commit and refresh this
+# header (do not edit the body in place).
+
+"""Download prebuilt waitcheck and ConSan artifacts from GitHub Actions.
+
+The ``rocjitsu-sanitizer-artifacts`` workflow publishes a bundle containing
+``bin/rj_waitcheck`` and ``lib/librocjitsu_dbi_hooks.so`` for every build of
+the sanitizer integration branch.  This script resolves a workflow run
+(``--run latest`` by default), downloads its artifact, verifies the recorded
+SHA-256 digests, and unpacks a ready-to-use tree.
+
+GitHub does not serve Actions artifacts anonymously, so a token with
+``actions:read`` scope is required even though the repository is public.  The
+token is taken from ``--token``, then ``$GITHUB_TOKEN``, then ``$GH_TOKEN``,
+and finally from ``gh auth token``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+
+DEFAULT_REPOSITORY = 'ROCm/rocm-systems'
+DEFAULT_WORKFLOW = 'rocjitsu-sanitizer-artifacts.yml'
+DEFAULT_BRANCH = 'shared/rocjitsu/sanitizers'
+ARTIFACT_PREFIX = 'rocjitsu-sanitizers'
+API_ROOT = 'https://api.github.com'
+API_VERSION = '2022-11-28'
+# Artifacts are large enough that a short read timeout produces spurious
+# failures on slow links; the API calls themselves are small.
+API_TIMEOUT_SECONDS = 30
+DOWNLOAD_TIMEOUT_SECONDS = 600
+EXECUTABLE_BITS = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+
+
+class DownloadError(RuntimeError):
+    """A user-facing failure that should not print a traceback."""
+
+
+def resolve_token(explicit: str | None) -> str:
+    """Return an API token, preferring explicit input over the environment."""
+    if explicit:
+        return explicit
+    for variable in ('GITHUB_TOKEN', 'GH_TOKEN'):
+        value = os.environ.get(variable)
+        if value:
+            return value
+    gh = shutil.which('gh')
+    if gh:
+        try:
+            completed = subprocess.run(
+                [gh, 'auth', 'token'],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=API_TIMEOUT_SECONDS,
+            )
+        except (subprocess.SubprocessError, OSError):
+            pass
+        else:
+            token = completed.stdout.strip()
+            if token:
+                return token
+    raise DownloadError(
+        'no GitHub token available. GitHub requires authentication to '
+        'download Actions artifacts, even from public repositories.\n'
+        'Provide one with --token, set GITHUB_TOKEN, or run `gh auth login`.'
+    )
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Surface redirects as errors so the caller controls the second request."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def http_error(error: urllib.error.HTTPError, url: str) -> DownloadError:
+    """Translate an HTTP failure into an actionable message."""
+    detail = error.read().decode('utf-8', 'replace').strip()
+    if error.code in (401, 403):
+        return DownloadError(
+            f'GitHub rejected the request ({error.code}). The token needs '
+            f'`actions:read` scope for this repository.\n{detail}'
+        )
+    if error.code == 404:
+        return DownloadError(
+            f'not found ({url}). Check --repo, --workflow, and --run.\n{detail}'
+        )
+    if error.code == 410:
+        return DownloadError(
+            f'the artifact has expired and is no longer downloadable.\n{detail}'
+        )
+    return DownloadError(f'GitHub request failed ({error.code}): {detail}')
+
+
+def api_headers(token: str | None, accept: str) -> dict[str, str]:
+    headers = {'Accept': accept, 'User-Agent': 'rocjitsu-download-sanitizer-artifacts'}
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+        headers['X-GitHub-Api-Version'] = API_VERSION
+    return headers
+
+
+def request(url: str, token: str | None, *, timeout: int, accept: str) -> bytes:
+    """Perform a GET and return the response body, authenticating when given a token."""
+    try:
+        with urllib.request.urlopen(
+            urllib.request.Request(url, headers=api_headers(token, accept)),
+            timeout=timeout,
+        ) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        raise http_error(error, url) from error
+    except urllib.error.URLError as error:
+        raise DownloadError(f'could not reach GitHub: {error.reason}') from error
+
+
+def get_json(url: str, token: str) -> dict:
+    body = request(
+        url, token, timeout=API_TIMEOUT_SECONDS, accept='application/vnd.github+json'
+    )
+    return json.loads(body)
+
+
+def find_latest_run(repository: str, workflow: str, branch: str, token: str) -> dict:
+    """Return the most recent successful workflow run for a branch."""
+    query = urllib.parse.urlencode(
+        {
+            'branch': branch,
+            'status': 'success',
+            'per_page': '1',
+            'exclude_pull_requests': 'true',
+        }
+    )
+    url = f'{API_ROOT}/repos/{repository}/actions/workflows/{workflow}/runs?{query}'
+    payload = get_json(url, token)
+    runs = payload.get('workflow_runs') or []
+    if not runs:
+        raise DownloadError(
+            f'no successful `{workflow}` run found on branch `{branch}`.\n'
+            'Trigger the workflow, or pass an explicit --run ID.'
+        )
+    return runs[0]
+
+
+def get_run(repository: str, run_id: str, token: str) -> dict:
+    return get_json(f'{API_ROOT}/repos/{repository}/actions/runs/{run_id}', token)
+
+
+def list_artifacts(repository: str, run_id: int, token: str) -> list[dict]:
+    url = f'{API_ROOT}/repos/{repository}/actions/runs/{run_id}/artifacts?per_page=100'
+    return get_json(url, token).get('artifacts') or []
+
+
+def select_artifact(artifacts: list[dict], name: str | None) -> dict:
+    """Pick the requested artifact, or the sole sanitizer bundle."""
+    live = [artifact for artifact in artifacts if not artifact.get('expired')]
+    if not live:
+        raise DownloadError(
+            'the run has no unexpired artifacts. Artifacts are retained for a '
+            'limited window; pick a newer run.'
+        )
+    if name:
+        for artifact in live:
+            if artifact['name'] == name:
+                return artifact
+        available = ', '.join(sorted(artifact['name'] for artifact in live))
+        raise DownloadError(f'artifact `{name}` not found. Available: {available}')
+
+    matching = [
+        artifact for artifact in live if artifact['name'].startswith(ARTIFACT_PREFIX)
+    ]
+    if len(matching) == 1:
+        return matching[0]
+    if not matching:
+        available = ', '.join(sorted(artifact['name'] for artifact in live))
+        raise DownloadError(
+            f'no `{ARTIFACT_PREFIX}*` artifact in this run. Available: {available}'
+        )
+    available = ', '.join(sorted(artifact['name'] for artifact in matching))
+    raise DownloadError(f'several bundles matched; pass --artifact. Found: {available}')
+
+
+def download_artifact(repository: str, artifact: dict, token: str) -> bytes:
+    """Fetch an artifact zip, handling the redirect to blob storage by hand.
+
+    The API answers with a 302 to a pre-signed storage URL. That URL carries
+    its own credentials, and the storage backend rejects the request outright
+    if a stray ``Authorization`` header rides along -- which is exactly what
+    urllib would do if it followed the redirect for us.
+    """
+    url = f'{API_ROOT}/repos/{repository}/actions/artifacts/{artifact["id"]}/zip'
+    opener = urllib.request.build_opener(_NoRedirect)
+    headers = api_headers(token, 'application/vnd.github+json')
+    try:
+        with opener.open(
+            urllib.request.Request(url, headers=headers),
+            timeout=DOWNLOAD_TIMEOUT_SECONDS,
+        ) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        if error.code not in (301, 302, 303, 307, 308):
+            raise http_error(error, url) from error
+        location = error.headers.get('Location')
+        error.close()
+        if not location:
+            raise DownloadError(
+                'GitHub redirected the download without a Location header'
+            )
+        if urllib.parse.urlparse(location).scheme != 'https':
+            raise DownloadError(
+                f'refusing to follow a non-HTTPS redirect to {location}'
+            )
+    except urllib.error.URLError as error:
+        raise DownloadError(f'could not reach GitHub: {error.reason}') from error
+
+    return request(location, None, timeout=DOWNLOAD_TIMEOUT_SECONDS, accept='*/*')
+
+
+def safe_extract(archive: zipfile.ZipFile, destination: Path) -> list[Path]:
+    """Extract an archive, rejecting entries that escape the destination."""
+    root = destination.resolve()
+    extracted: list[Path] = []
+    for info in archive.infolist():
+        if info.is_dir():
+            continue
+        target = (root / info.filename).resolve()
+        if not target.is_relative_to(root):
+            raise DownloadError(
+                f'refusing to extract outside destination: {info.filename}'
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with archive.open(info) as source, open(target, 'wb') as sink:
+            shutil.copyfileobj(source, sink)
+        extracted.append(target)
+    return extracted
+
+
+def verify_digests(destination: Path) -> int:
+    """Check extracted payload files against the bundle's sha256sums.txt."""
+    checksums = destination / 'sha256sums.txt'
+    if not checksums.is_file():
+        print(
+            'warning: bundle has no sha256sums.txt; skipping verification',
+            file=sys.stderr,
+        )
+        return 0
+
+    verified = 0
+    for line in checksums.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        expected, _, relative = line.partition('  ')
+        relative = relative.strip()
+        if not expected or not relative:
+            raise DownloadError(f'malformed sha256sums.txt entry: {line}')
+        target = destination / relative
+        if not target.is_file():
+            raise DownloadError(f'bundle is missing a checksummed file: {relative}')
+        digest = hashlib.sha256(target.read_bytes()).hexdigest()
+        if digest != expected:
+            raise DownloadError(
+                f'checksum mismatch for {relative}\n  expected {expected}\n  actual   {digest}'
+            )
+        verified += 1
+    if not verified:
+        raise DownloadError('sha256sums.txt contained no entries')
+    return verified
+
+
+def mark_executable(destination: Path) -> None:
+    """Restore the executable bit that the artifact zip does not preserve."""
+    for target in list((destination / 'bin').glob('*')) + list(
+        (destination / 'lib').glob('*.so')
+    ):
+        if target.is_file():
+            target.chmod(target.stat().st_mode | EXECUTABLE_BITS)
+
+
+def describe_run(run: dict) -> str:
+    return (
+        f'run {run["id"]} (#{run.get("run_number", "?")}) '
+        f'{run.get("head_branch", "?")}@{(run.get("head_sha") or "")[:12]} '
+        f'{run.get("status", "?")}/{run.get("conclusion", "?")} '
+        f'{run.get("created_at", "?")}'
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        '--run',
+        default='latest',
+        help='workflow run ID, or "latest" for the newest successful build (default: latest)',
+    )
+    parser.add_argument(
+        '--branch',
+        default=DEFAULT_BRANCH,
+        help=f'branch to resolve "latest" against (default: {DEFAULT_BRANCH})',
+    )
+    parser.add_argument(
+        '--repo',
+        default=DEFAULT_REPOSITORY,
+        help=f'owner/name (default: {DEFAULT_REPOSITORY})',
+    )
+    parser.add_argument(
+        '--workflow',
+        default=DEFAULT_WORKFLOW,
+        help=f'workflow file name or ID (default: {DEFAULT_WORKFLOW})',
+    )
+    parser.add_argument(
+        '--artifact',
+        help='artifact name; inferred when the run publishes a single bundle',
+    )
+    parser.add_argument(
+        '--dest',
+        type=Path,
+        default=Path('rocjitsu-sanitizers'),
+        help='directory to unpack into (default: ./rocjitsu-sanitizers)',
+    )
+    parser.add_argument(
+        '--keep-zip', action='store_true', help='also save the downloaded artifact zip'
+    )
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help='overwrite a non-empty destination directory',
+    )
+    parser.add_argument(
+        '--list',
+        action='store_true',
+        help='list the resolved run and its artifacts, then exit',
+    )
+    parser.add_argument(
+        '--token', help='GitHub token (default: $GITHUB_TOKEN, $GH_TOKEN, gh)'
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = resolve_token(args.token)
+
+    if args.run == 'latest':
+        run = find_latest_run(args.repo, args.workflow, args.branch, token)
+    else:
+        if not args.run.isdigit():
+            raise DownloadError(
+                f'--run must be a numeric run ID or "latest", got `{args.run}`'
+            )
+        run = get_run(args.repo, args.run, token)
+
+    print(f'resolved {describe_run(run)}')
+    print(f'  {run.get("html_url", "")}')
+
+    artifacts = list_artifacts(args.repo, run['id'], token)
+    if args.list:
+        if not artifacts:
+            print('  (no artifacts)')
+        for artifact in artifacts:
+            state = 'expired' if artifact.get('expired') else 'available'
+            size_mib = artifact.get('size_in_bytes', 0) / (1024 * 1024)
+            print(f'  {artifact["name"]}  {size_mib:.1f} MiB  {state}')
+        return 0
+
+    if run.get('conclusion') != 'success':
+        print(
+            f'warning: run conclusion is `{run.get("conclusion")}`; '
+            'artifacts may be incomplete',
+            file=sys.stderr,
+        )
+
+    artifact = select_artifact(artifacts, args.artifact)
+
+    # Reject an occupied destination before spending the download.
+    destination = args.dest
+    if destination.exists() and any(destination.iterdir()) and not args.force:
+        raise DownloadError(f'{destination} is not empty; pass --force to overwrite')
+
+    size_mib = artifact.get('size_in_bytes', 0) / (1024 * 1024)
+    print(f'downloading {artifact["name"]} ({size_mib:.1f} MiB)')
+    payload = download_artifact(args.repo, artifact, token)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    if args.keep_zip:
+        zip_path = destination.with_suffix('.zip')
+        zip_path.write_bytes(payload)
+        print(f'saved {zip_path}')
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            extracted = safe_extract(archive, destination)
+    except zipfile.BadZipFile as error:
+        raise DownloadError(
+            f'downloaded artifact is not a valid zip: {error}'
+        ) from error
+
+    verified = verify_digests(destination)
+    mark_executable(destination)
+
+    print(f'extracted {len(extracted)} files to {destination}')
+    if verified:
+        print(f'verified {verified} SHA-256 digests')
+
+    hook = destination / 'lib' / 'librocjitsu_dbi_hooks.so'
+    waitcheck = destination / 'bin' / 'rj_waitcheck'
+    if hook.is_file() and waitcheck.is_file():
+        print('\nRun the combined waitcheck + ConSan hook with:')
+        print(f'  env HSA_TOOLS_DISABLE_REGISTER=1 \\')
+        print(f'      HSA_TOOLS_LIB="{hook.resolve()}" \\')
+        print(f'      ./application')
+        print('\nInspect a saved code object with:')
+        print(f'  "{waitcheck.resolve()}" path/to/kernel.hsaco')
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except DownloadError as error:
+        print(f'error: {error}', file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
@@ -88,6 +88,43 @@ Waitcheck requires an exact final-code identity: code-object path plus kernel
 entry offset, with code-object index when the container has multiple device
 images. Fuzzy filename matching is deliberately not supported.
 
+## Provisioning the RocJITsu binaries
+
+`mode: sanitizer` runs need two RocJITsu binaries: the standalone Waitcheck CLI
+(`rj_waitcheck`) and the combined Waitcheck + ConSan DBI hook
+(`librocjitsu_dbi_hooks.so`). The resolvers discover them from either of two
+environment variables (an explicit `waitcheck_binary` / `hook_lib` argument
+still wins, and `rj_waitcheck` on `PATH` is a final fallback):
+
+- **`ROCJITSU_PREBUILT`** (recommended) -- points at an unpacked *prebuilt
+  bundle* published by ROCm/rocm-systems. The tree is flattened:
+  `bin/rj_waitcheck` and `lib/librocjitsu_dbi_hooks.so`. Fetch it with the
+  upstream `emulation/rocjitsu/scripts/download_sanitizer_artifacts.py`, which
+  resolves the latest successful `rocjitsu-sanitizer-artifacts` run on
+  `shared/rocjitsu/sanitizers`, verifies the recorded SHA-256 digests, and
+  unpacks the bundle:
+
+  ```bash
+  python download_sanitizer_artifacts.py --dest ./rocjitsu-sanitizers
+  export ROCJITSU_PREBUILT="$PWD/rocjitsu-sanitizers"
+  ```
+
+  GitHub does not serve Actions artifacts anonymously, so the downloader needs a
+  token with `actions:read` (from `--token`, `$GITHUB_TOKEN`, `$GH_TOKEN`, or
+  `gh auth token`) even though the repository is public. The binaries are built
+  in the ROCm manylinux image (glibc 2.28) with zlib/zstd/libgcc/libstdc++
+  statically linked, so glibc is their only runtime dependency -- no ROCm SDK is
+  required to *run* `rj_waitcheck`. These are ephemeral (default 30-day) run
+  artifacts, not durable Releases; record the commit from the bundle's
+  `MANIFEST.json` for provenance.
+
+- **`ROCJITSU_BUILD`** -- points at a raw CMake *build tree* from a local
+  rocm-systems source build. Here the resolvers expect the build-tree layout
+  (`tools/rj_waitcheck` and
+  `lib/rocjitsu/src/rocjitsu/hooks/librocjitsu_dbi_hooks.so`).
+
+When both are set, the prebuilt bundle wins.
+
 ## Verdict and health rules
 
 - Waitcheck structured hazard → `warn`.

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
@@ -111,7 +111,11 @@ still wins, and `rj_waitcheck` on `PATH` is a final fallback):
 
   GitHub does not serve Actions artifacts anonymously, so the downloader needs a
   token with `actions:read` (from `--token`, `$GITHUB_TOKEN`, `$GH_TOKEN`, or
-  `gh auth token`) even though the repository is public. The binaries are built
+  `gh auth token`) even though the repository is public: the unauthenticated
+  artifact download endpoint returns HTTP 401, and these binaries are not
+  published as a GitHub Release, so there is no anonymous download path. (In CI,
+  note that the default `GITHUB_TOKEN` is scoped to its own repository and cannot
+  read another repo's artifacts cross-repo.) The binaries are built
   in the ROCm manylinux image (glibc 2.28) with zlib/zstd/libgcc/libstdc++
   statically linked, so glibc is their only runtime dependency -- no ROCm SDK is
   required to *run* `rj_waitcheck`. These are ephemeral (default 30-day) run

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/consan.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/consan.py
@@ -416,21 +416,37 @@ def scoped_consan_not_checked(worklist: KernelWorklist) -> CheckResult:
 
 
 def resolve_consan_hook(explicit: Path | None = None) -> Path | None:
-    build_root = os.environ.get("ROCJITSU_BUILD", "").strip()
+    """Locate the RocJITsu DBI hook, preferring an explicit override.
+
+    Two provisioning layouts are supported. ``ROCJITSU_PREBUILT`` points at an
+    unpacked prebuilt sanitizer bundle (published by ROCm/rocm-systems), whose
+    flattened tree keeps the hook at ``lib/librocjitsu_dbi_hooks.so``.
+    ``ROCJITSU_BUILD`` points at a raw CMake build tree, where the hook lives
+    under ``lib/rocjitsu/src/rocjitsu/hooks/``. The prebuilt bundle wins when
+    both are set.
+    """
+
     if explicit is not None:
         return explicit
-    if not build_root:
-        return None
-    candidate = (
-        Path(build_root)
-        / "lib"
-        / "rocjitsu"
-        / "src"
-        / "rocjitsu"
-        / "hooks"
-        / "librocjitsu_dbi_hooks.so"
-    )
-    return candidate if candidate.is_file() else None
+    prebuilt = os.environ.get("ROCJITSU_PREBUILT", "").strip()
+    if prebuilt:
+        candidate = Path(prebuilt) / "lib" / "librocjitsu_dbi_hooks.so"
+        if candidate.is_file():
+            return candidate
+    build_root = os.environ.get("ROCJITSU_BUILD", "").strip()
+    if build_root:
+        candidate = (
+            Path(build_root)
+            / "lib"
+            / "rocjitsu"
+            / "src"
+            / "rocjitsu"
+            / "hooks"
+            / "librocjitsu_dbi_hooks.so"
+        )
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 WAITCHECK_PREFLIGHT = "waitcheck_preflight"

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from aorta.triage.recipe import RecipeSchemaError, load_recipe_mapping
 
+from .consan import resolve_consan_hook
 from .models import CheckResult, ExecutionState, SelectionRequirement, Verdict
 from .pipeline import run_sanitizers
 from .report import build_report, write_report
@@ -315,28 +316,33 @@ def _resolve_observations(recipe: SanitizerRecipe) -> tuple:
     raise ValueError(f"unsupported source kind {recipe.source_kind!r}")
 
 
-def _resolve_rocjitsu_build() -> Path | None:
-    raw = os.environ.get("ROCJITSU_BUILD", "").strip()
+def _env_dir(name: str) -> Path | None:
+    raw = os.environ.get(name, "").strip()
     if not raw:
         return None
-    build = Path(raw)
-    return build if build.is_dir() else None
+    root = Path(raw)
+    return root if root.is_dir() else None
 
 
-def _resolve_waitcheck_binary(build: Path | None) -> Path | None:
-    if build is None:
-        return None
-    candidate = build / "tools" / "rj_waitcheck"
-    return candidate if candidate.is_file() else None
+def _resolve_waitcheck_binary() -> Path | None:
+    """Locate ``rj_waitcheck`` in a prebuilt bundle or a CMake build tree.
 
+    Prefers the flattened prebuilt sanitizer bundle published by
+    ROCm/rocm-systems (``$ROCJITSU_PREBUILT/bin/rj_waitcheck``), then falls back
+    to the raw CMake build-tree layout (``$ROCJITSU_BUILD/tools/rj_waitcheck``).
+    """
 
-def _resolve_consan_hook(build: Path | None) -> Path | None:
-    if build is None:
-        return None
-    candidate = (
-        build / "lib" / "rocjitsu" / "src" / "rocjitsu" / "hooks" / "librocjitsu_dbi_hooks.so"
-    )
-    return candidate if candidate.is_file() else None
+    prebuilt = _env_dir("ROCJITSU_PREBUILT")
+    if prebuilt is not None:
+        candidate = prebuilt / "bin" / "rj_waitcheck"
+        if candidate.is_file():
+            return candidate
+    build = _env_dir("ROCJITSU_BUILD")
+    if build is not None:
+        candidate = build / "tools" / "rj_waitcheck"
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def execute_sanitizer_run(
@@ -373,9 +379,8 @@ def execute_sanitizer_run(
         )
         return report_path
 
-    build = _resolve_rocjitsu_build()
-    waitcheck_binary = _resolve_waitcheck_binary(build)
-    consan_hook = _resolve_consan_hook(build)
+    waitcheck_binary = _resolve_waitcheck_binary()
+    consan_hook = resolve_consan_hook()
     consan_command = recipe.consan_command
     # Cross-check the executed repro against the single selected identity so a
     # recipe cannot name one repro while ConSan runs against another selection.

--- a/tests/instrumentation/rocjitsu_sanitizers/test_artifact_resolvers.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_artifact_resolvers.py
@@ -1,0 +1,125 @@
+"""Resolver tests for the prebuilt bundle vs. CMake build-tree layouts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aorta.instrumentation.rocjitsu_sanitizers.consan import resolve_consan_hook
+from aorta.instrumentation.rocjitsu_sanitizers.recipe import _resolve_waitcheck_binary
+
+_BUILD_HOOK = Path("lib") / "rocjitsu" / "src" / "rocjitsu" / "hooks" / "librocjitsu_dbi_hooks.so"
+_PREBUILT_HOOK = Path("lib") / "librocjitsu_dbi_hooks.so"
+
+
+def _make_prebuilt_bundle(root: Path) -> Path:
+    """Materialize a flattened prebuilt bundle (bin/ + lib/) under ``root``."""
+
+    (root / "bin").mkdir(parents=True)
+    (root / "lib").mkdir(parents=True)
+    (root / "bin" / "rj_waitcheck").write_bytes(b"waitcheck")
+    (root / _PREBUILT_HOOK).write_bytes(b"hook")
+    return root
+
+
+def _make_build_tree(root: Path) -> Path:
+    """Materialize a raw CMake build tree (tools/ + nested lib/) under ``root``."""
+
+    (root / "tools").mkdir(parents=True)
+    (root / "tools" / "rj_waitcheck").write_bytes(b"waitcheck")
+    (root / _BUILD_HOOK).parent.mkdir(parents=True)
+    (root / _BUILD_HOOK).write_bytes(b"hook")
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ROCJITSU_PREBUILT", raising=False)
+    monkeypatch.delenv("ROCJITSU_BUILD", raising=False)
+
+
+def test_waitcheck_resolver_prefers_prebuilt_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bundle = _make_prebuilt_bundle(tmp_path / "bundle")
+    monkeypatch.setenv("ROCJITSU_PREBUILT", str(bundle))
+
+    assert _resolve_waitcheck_binary() == bundle / "bin" / "rj_waitcheck"
+
+
+def test_waitcheck_resolver_accepts_build_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    build = _make_build_tree(tmp_path / "build")
+    monkeypatch.setenv("ROCJITSU_BUILD", str(build))
+
+    assert _resolve_waitcheck_binary() == build / "tools" / "rj_waitcheck"
+
+
+def test_waitcheck_resolver_prebuilt_wins_over_build_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bundle = _make_prebuilt_bundle(tmp_path / "bundle")
+    build = _make_build_tree(tmp_path / "build")
+    monkeypatch.setenv("ROCJITSU_PREBUILT", str(bundle))
+    monkeypatch.setenv("ROCJITSU_BUILD", str(build))
+
+    assert _resolve_waitcheck_binary() == bundle / "bin" / "rj_waitcheck"
+
+
+def test_waitcheck_resolver_none_when_unset() -> None:
+    assert _resolve_waitcheck_binary() is None
+
+
+def test_waitcheck_resolver_ignores_missing_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A bundle root that exists but lacks bin/rj_waitcheck must not resolve.
+    (tmp_path / "empty").mkdir()
+    monkeypatch.setenv("ROCJITSU_PREBUILT", str(tmp_path / "empty"))
+
+    assert _resolve_waitcheck_binary() is None
+
+
+def test_consan_hook_resolver_prefers_prebuilt_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bundle = _make_prebuilt_bundle(tmp_path / "bundle")
+    monkeypatch.setenv("ROCJITSU_PREBUILT", str(bundle))
+
+    assert resolve_consan_hook() == bundle / _PREBUILT_HOOK
+
+
+def test_consan_hook_resolver_accepts_build_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    build = _make_build_tree(tmp_path / "build")
+    monkeypatch.setenv("ROCJITSU_BUILD", str(build))
+
+    assert resolve_consan_hook() == build / _BUILD_HOOK
+
+
+def test_consan_hook_resolver_prebuilt_wins_over_build_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bundle = _make_prebuilt_bundle(tmp_path / "bundle")
+    build = _make_build_tree(tmp_path / "build")
+    monkeypatch.setenv("ROCJITSU_PREBUILT", str(bundle))
+    monkeypatch.setenv("ROCJITSU_BUILD", str(build))
+
+    assert resolve_consan_hook() == bundle / _PREBUILT_HOOK
+
+
+def test_consan_hook_resolver_explicit_overrides_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bundle = _make_prebuilt_bundle(tmp_path / "bundle")
+    monkeypatch.setenv("ROCJITSU_PREBUILT", str(bundle))
+    explicit = tmp_path / "explicit.so"
+
+    assert resolve_consan_hook(explicit) == explicit
+
+
+def test_consan_hook_resolver_none_when_unset() -> None:
+    assert resolve_consan_hook() is None

--- a/tests/instrumentation/rocjitsu_sanitizers/test_sanitizers_gpu.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_sanitizers_gpu.py
@@ -17,8 +17,9 @@ exercising the full backend when it is available:
 2. **Real ConSan repro cases** (opt-in): build and run the committed clean/racy
    LDS repros -- the same "our cases" the ``sanitizers-nightly.yml`` workflow
    exercises -- and assert ``clean => pass`` / ``racy => fail`` on real
-   hardware. Self-skips unless ``ROCJITSU_BUILD`` (the DBI hook) and ``hipcc``
-   are both present, so the standard PR container stays green.
+   hardware. Self-skips unless the DBI hook (provisioned via
+   ``ROCJITSU_PREBUILT`` or ``ROCJITSU_BUILD``) and ``hipcc`` are both present,
+   so the standard PR container stays green.
 """
 
 from __future__ import annotations
@@ -79,14 +80,17 @@ skip_no_rocm = pytest.mark.skipif(
     reason="no AMD ROCm GPU detected (rocminfo reported no gfx target)",
 )
 
-# The real-repro layer needs the private DBI hook (via ROCJITSU_BUILD) *and* a
-# compiler to build the fixture. Missing either => skip, never fail: the PR gate
-# container has neither, so it must stay green.
+# The real-repro layer needs the private DBI hook (via ROCJITSU_PREBUILT or
+# ROCJITSU_BUILD) *and* a compiler to build the fixture. Missing either => skip,
+# never fail: the PR gate container has neither, so it must stay green.
 _HAVE_HIPCC = shutil.which("hipcc") is not None
 _HAVE_HOOK = resolve_consan_hook() is not None
 skip_no_backend = pytest.mark.skipif(
     not (_HAVE_HIPCC and _HAVE_HOOK),
-    reason="set ROCJITSU_BUILD (ConSan DBI hook) and install hipcc to run real repros",
+    reason=(
+        "set ROCJITSU_PREBUILT (or ROCJITSU_BUILD) for the ConSan DBI hook and "
+        "install hipcc to run real repros"
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

The `sanitizers-nightly.yml` gate cloned `ROCm/rocm-systems` and built
`rj_waitcheck` / `rocjitsu_dbi_hooks` from source (cmake/ninja, ~multi-minute,
with a baked-in toolchain in `docker/Dockerfile.ci-gpu`). `ROCm/rocm-systems`
now **publishes those binaries** as GitHub Actions artifacts
([rocm-systems#9681](https://github.com/ROCm/rocm-systems/pull/9681), merged into
`shared/rocjitsu/sanitizers`). This PR makes aorta **consume the prebuilt
bundle** instead of building from source, and removes the now-dead source-build
toolchain from the CI image.

Closes #350.

### What changed

- **Resolvers** (`recipe.py`, `consan.py`): understand the flattened prebuilt
  bundle layout via a new `ROCJITSU_PREBUILT` env var pointing at the unpacked
  bundle root (`bin/rj_waitcheck`, `lib/librocjitsu_dbi_hooks.so`). The existing
  CMake build-tree layout under `ROCJITSU_BUILD` (`tools/rj_waitcheck`,
  `lib/rocjitsu/src/rocjitsu/hooks/librocjitsu_dbi_hooks.so`) still works; the
  prebuilt bundle wins when both are set. The `shutil.which("rj_waitcheck")`
  fallback is retained.
- **Workflow** (`sanitizers-nightly.yml`): runs the **vendored**
  `download_sanitizer_artifacts.py` (see below) to download + unpack the bundle
  for the latest successful run (SHA-256 verified by the script), records the
  source commit from `MANIFEST.json` for provenance, and exports
  `ROCJITSU_PREBUILT`. The clone+cmake steps are gone. After the download it
  `unset`s the artifacts token before running any artifact-provided code, and
  fails closed if the bundle has no `sha256sums.txt`.

_Update (review): the downloader is now vendored into
`scripts/sanitizers/download_sanitizer_artifacts.py` (a verbatim copy of the
reviewed rocm-systems commit `7d2c61e`) rather than fetched from the mutable
branch at runtime — see the "Addressed review feedback" comment below._
- **Docker** (`docker/Dockerfile.ci-gpu`): removed the source-build toolchain
  that existed only for the rocjitsu cmake build (see "Docker cleanup" below).
- **README**: documents provisioning from the prebuilt bundle or a source build,
  and the definitive token requirement.
- **Tests**: `test_artifact_resolvers.py` covers both layouts, prebuilt
  precedence, explicit override, and the missing/unset cases.

## Docker cleanup

Removed from `docker/Dockerfile.ci-gpu` (all solely for the deleted rocjitsu
source build; confirmed via repo-wide grep that no remaining Dockerfile step,
workflow, script, or test invokes them):

- `cmake==4.4.2` and `ninja==1.13.0` (pip)
- `libzstd-dev` and `g++-13` (apt, plus the `software-properties-common` +
  `ppa:ubuntu-toolchain-r/test` scaffolding that existed only to install g++-13)
- the baked `Findzstd.cmake` shim and its `/opt/aorta/cmake` dir

**Kept:** `openpyxl` / `seaborn` (general analysis deps, unrelated to rocjitsu).
`hipcc` (from the ROCm base image) still builds the HIP repro fixtures and needs
none of the removed deps — it does not use cmake/ninja/g++-13. The `cmake`/`ninja`
mentions elsewhere in the tree are the env-probe *parsing* PyTorch's own
`CMakeCache.txt` / `build.ninja` at runtime, which needs no cmake/ninja binaries.
A full CI image rebuild wasn't run here; the removal is proven inert by grep and
the released-binary flow is verified on-host below.

## Token: is auth really required? (definitive — yes)

Empirically verified against run `31207611362` on `ROCm/rocm-systems` with **no**
auth header:

- Artifact **metadata list** (`/actions/runs/<id>/artifacts`) → **HTTP 200**
  (visible anonymously), but this returns only metadata, not the bytes.
- Artifact **download** (`/actions/artifacts/<id>/zip`) → **HTTP 401
  "Requires authentication"**.
- **No GitHub Release** carries these binaries (12 releases on rocm-systems; none
  are rocjitsu/sanitizer), and the upstream workflow uses `actions/upload-artifact`
  only — so there is **no anonymous download path**.

Therefore a token with `actions:read` is genuinely required. CI wiring is kept:
`ROCJITSU_ARTIFACTS_TOKEN` (a PAT with `actions:read` on rocm-systems), falling
back to `GITHUB_TOKEN`. Note the default `GITHUB_TOKEN` is scoped to **this** repo
(`ROCm/aorta`) and **cannot** read another repo's artifacts, so it will 403 on the
cross-repo download until the secret is configured. This is now documented in the
workflow comment and the README. (Locally, a `gh` token with `repo` scope works.)

## Pinning (#330)

Per maintainer decision, the nightly stays on `--run latest` for
`shared/rocjitsu/sanitizers` (records the built commit from `MANIFEST.json` for
provenance). The immutable-pin tradeoff remains tracked as `TODO(#330)` in the
workflow env comment.

## Verification (exercised the released binaries on a gfx950 host)

Downloaded and ran the real published bundle end-to-end — **re-run after the
Docker cleanup**, same verdicts.

**Download + SHA-256 verify** (run `31207611362`, commit `7d2c61e7e467`):
```
$ python download_sanitizer_artifacts.py --dest bundle
resolved run 31207611362 (#3) shared/rocjitsu/sanitizers@7d2c61e7e467 completed/success
downloading rocjitsu-sanitizers-Release-7d2c61e7e467 (10.7 MiB)
extracted 4 files to bundle
verified 2 SHA-256 digests
```

**Smoke test** — binary runs on this host (glibc-only): `rj_waitcheck --help`
lists supported targets (gfx942, gfx950, ...).

**End-to-end through aorta with `ROCJITSU_PREBUILT` set** (both sanitizers, real
gfx950 GPU):

| recipe | verdict | backend used |
|---|---|---|
| `daily-waitcheck-gemm.yaml` | `warn` (complete) | `bundle/bin/rj_waitcheck` |
| `daily-consan-clean.yaml` | `pass` | `bundle/lib/librocjitsu_dbi_hooks.so` |
| `daily-consan-racy.yaml` | `fail` (race detected) | `bundle/lib/librocjitsu_dbi_hooks.so` |

The report `backend` records confirm the resolvers picked the prebuilt paths, so
**waitcheck AND ConSan were both actually exercised** against the released
binaries — nothing was skipped on this host.

## Test / lint

- `pytest tests/instrumentation/rocjitsu_sanitizers -q` → **97 passed, 3 skipped**
  (10 new resolver tests).
- `ruff check` clean on changed files; new code `black`/`isort` clean. (Two
  pre-existing `black` reformats and one pre-existing `mypy` note on untouched
  lines were left alone to avoid unrelated churn.)
- pre-commit hooks (trailing-whitespace / end-of-file / check-yaml) pass.
