### PR TITLE
ROCm stack health dashboard UX

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -231,6 +231,7 @@ jobs:
             _site/ci/index.html
             _site/data.json
             _site/ci/data.json
+            _site/status.json
             _site/sanitizers/index.html
           )
           for f in "${routes[@]}"; do
@@ -247,7 +248,7 @@ jobs:
             echo "::error::/docs/ still claims the dashboard's URL as its own"
             exit 1
           fi
-          echo "routes ok: / /docs/ /ci/ /data.json /ci/data.json /sanitizers/"
+          echo "routes ok: / /docs/ /ci/ /data.json /ci/data.json /status.json /sanitizers/"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/scripts/ci/dashboard_metadata.py
+++ b/scripts/ci/dashboard_metadata.py
@@ -45,6 +45,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
             "title": "GPU platform smoke",
             "summary": "Verifies the ROCm/PyTorch stack loads and runs on GPU.",
             "headline_metrics": ["mean_step_time_ms"],
+            "recipe": "recipes/ci/gpu-smoke.yaml",
+            "min_gpus": 1,
             "run_command": "aorta sweep run --recipe recipes/ci/gpu-smoke.yaml",
         },
         "inference_offline": {
@@ -56,6 +58,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
                 "decode_latency_ms",
                 "logits_checksum",
             ],
+            "recipe": "recipes/inference/example-inference-smoke.yaml",
+            "min_gpus": 1,
             "run_command": (
                 "aorta sweep run --recipe recipes/inference/example-inference-smoke.yaml"
             ),
@@ -64,6 +68,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
             "title": "PyTorch DDP training (2 GPU)",
             "summary": "Distributed data parallel training step time on two GPUs.",
             "headline_metrics": ["step_time_p50", "step_time_p99"],
+            "recipe": "recipes/training/example-training-ddp-smoke.yaml",
+            "min_gpus": 2,
             "run_command": (
                 "torchrun --standalone --nproc_per_node=2 $(which aorta) "
                 "sweep run --recipe recipes/training/example-training-ddp-smoke.yaml"
@@ -73,6 +79,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
             "title": "PyTorch DDP training (8 GPU)",
             "summary": "Distributed data parallel training step time on eight GPUs.",
             "headline_metrics": ["step_time_p50", "step_time_p99"],
+            "recipe": "recipes/training/example-training-ddp-smoke.yaml",
+            "min_gpus": 8,
             "run_command": (
                 "torchrun --standalone --nproc_per_node=8 $(which aorta) "
                 "sweep run --recipe recipes/training/example-training-ddp-smoke.yaml"
@@ -82,6 +90,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
             "title": "PyTorch FSDP training (2 GPU)",
             "summary": "Fully sharded data parallel training on two GPUs.",
             "headline_metrics": ["step_time_p50", "step_time_p99"],
+            "recipe": "recipes/training/example-training-fsdp-smoke.yaml",
+            "min_gpus": 2,
             "run_command": (
                 "torchrun --standalone --nproc_per_node=2 $(which aorta) "
                 "sweep run --recipe recipes/training/example-training-fsdp-smoke.yaml"
@@ -91,6 +101,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
             "title": "PyTorch FSDP training (8 GPU)",
             "summary": "Fully sharded data parallel training on eight GPUs.",
             "headline_metrics": ["step_time_p50", "step_time_p99"],
+            "recipe": "recipes/training/example-training-fsdp-smoke.yaml",
+            "min_gpus": 8,
             "run_command": (
                 "torchrun --standalone --nproc_per_node=8 $(which aorta) "
                 "sweep run --recipe recipes/training/example-training-fsdp-smoke.yaml"
@@ -103,6 +115,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
                 "silent corruption."
             ),
             "headline_metrics": ["ranks_with_divergence"],
+            "recipe": "recipes/llm-determinism/example-llm-determinism.yaml",
+            "min_gpus": 2,
             "run_command": (
                 "torchrun --standalone --nproc_per_node=2 $(which aorta) "
                 "sweep run --recipe recipes/llm-determinism/example-llm-determinism.yaml"
@@ -112,6 +126,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
             "title": "LLM determinism (8 GPU)",
             "summary": "Bit-exact repeatability at full-node scale.",
             "headline_metrics": ["ranks_with_divergence"],
+            "recipe": "recipes/llm-determinism/example-llm-determinism.yaml",
+            "min_gpus": 8,
             "run_command": (
                 "torchrun --standalone --nproc_per_node=8 $(which aorta) "
                 "sweep run --recipe recipes/llm-determinism/example-llm-determinism.yaml"
@@ -123,6 +139,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
                 "Detects timing races and silent data corruption in distributed layers."
             ),
             "headline_metrics": ["layer_checksum_mismatches"],
+            "recipe": "recipes/race/race_smoke.yaml",
+            "min_gpus": 2,
             "run_command": (
                 "torchrun --standalone --nproc_per_node=2 $(which aorta) "
                 "sweep run --recipe recipes/race/race_smoke.yaml"
@@ -132,6 +150,8 @@ DASHBOARD_METADATA: dict[str, Any] = {
             "title": "RCCL race detection (8 GPU)",
             "summary": "Race detection at full-node scale.",
             "headline_metrics": ["layer_checksum_mismatches"],
+            "recipe": "recipes/race/race_smoke.yaml",
+            "min_gpus": 8,
             "run_command": (
                 "torchrun --standalone --nproc_per_node=8 $(which aorta) "
                 "sweep run --recipe recipes/race/race_smoke.yaml"

--- a/scripts/ci/dashboard_metadata.py
+++ b/scripts/ci/dashboard_metadata.py
@@ -1,4 +1,4 @@
-"""Customer-facing labels for the nightly CI dashboard.
+"""Workload and category labels for the nightly CI dashboard.
 
 Kept as a Python module (not JSON) because the repo gitignores ``*.json``.
 """
@@ -138,29 +138,4 @@ DASHBOARD_METADATA: dict[str, Any] = {
             ),
         },
     },
-    "engineer_only_metrics": [
-        "rank",
-        "world_size",
-        "local_world_size",
-        "node_count",
-        "corruption_details_omitted",
-        "parameter_count",
-        "num_experts",
-        "num_layers",
-        "generate_tokens",
-        "decoded_tokens",
-        "prompt_len",
-        "batch_size",
-        "eff_batch_size",
-        "eff_ffn_size",
-        "eff_num_heads",
-        "eff_seq_len",
-        "declared_h2d_tensor_size",
-        "effective_h2d_tensor_size",
-        "layers_verified",
-        "expected",
-        "n",
-        "sum",
-        "final_loss",
-    ],
 }

--- a/scripts/ci/dashboard_metadata.py
+++ b/scripts/ci/dashboard_metadata.py
@@ -1,0 +1,166 @@
+"""Customer-facing labels for the nightly CI dashboard.
+
+Kept as a Python module (not JSON) because the repo gitignores ``*.json``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+DASHBOARD_METADATA: dict[str, Any] = {
+    "categories": {
+        "platform": {
+            "label": "Platform",
+            "summary": "ROCm and PyTorch load and execute on GPU.",
+            "workloads": ["gpu_smoke"],
+        },
+        "inference": {
+            "label": "Inference",
+            "summary": "Offline LLM prefill/decode latency and throughput.",
+            "workloads": ["inference_offline"],
+        },
+        "training": {
+            "label": "Training",
+            "summary": "PyTorch DDP and FSDP training step times.",
+            "workloads": [
+                "training_ddp",
+                "training_ddp_8gpu",
+                "training_fsdp",
+                "training_fsdp_8gpu",
+            ],
+        },
+        "correctness": {
+            "label": "Correctness",
+            "summary": "Numerical determinism and distributed race detection.",
+            "workloads": [
+                "llm_determinism",
+                "llm_determinism_8gpu",
+                "race",
+                "race_8gpu",
+            ],
+        },
+    },
+    "workloads": {
+        "gpu_smoke": {
+            "title": "GPU platform smoke",
+            "summary": "Verifies the ROCm/PyTorch stack loads and runs on GPU.",
+            "headline_metrics": ["mean_step_time_ms"],
+            "run_command": "aorta sweep run --recipe recipes/ci/gpu-smoke.yaml",
+        },
+        "inference_offline": {
+            "title": "Offline LLM inference",
+            "summary": "Validates prefill/decode latency, throughput, and logits checksum.",
+            "headline_metrics": [
+                "tokens_per_sec",
+                "prefill_latency_ms",
+                "decode_latency_ms",
+                "logits_checksum",
+            ],
+            "run_command": (
+                "aorta sweep run --recipe recipes/inference/example-inference-smoke.yaml"
+            ),
+        },
+        "training_ddp": {
+            "title": "PyTorch DDP training (2 GPU)",
+            "summary": "Distributed data parallel training step time on two GPUs.",
+            "headline_metrics": ["step_time_p50", "step_time_p99"],
+            "run_command": (
+                "torchrun --standalone --nproc_per_node=2 $(which aorta) "
+                "sweep run --recipe recipes/training/example-training-ddp-smoke.yaml"
+            ),
+        },
+        "training_ddp_8gpu": {
+            "title": "PyTorch DDP training (8 GPU)",
+            "summary": "Distributed data parallel training step time on eight GPUs.",
+            "headline_metrics": ["step_time_p50", "step_time_p99"],
+            "run_command": (
+                "torchrun --standalone --nproc_per_node=8 $(which aorta) "
+                "sweep run --recipe recipes/training/example-training-ddp-smoke.yaml"
+            ),
+        },
+        "training_fsdp": {
+            "title": "PyTorch FSDP training (2 GPU)",
+            "summary": "Fully sharded data parallel training on two GPUs.",
+            "headline_metrics": ["step_time_p50", "step_time_p99"],
+            "run_command": (
+                "torchrun --standalone --nproc_per_node=2 $(which aorta) "
+                "sweep run --recipe recipes/training/example-training-fsdp-smoke.yaml"
+            ),
+        },
+        "training_fsdp_8gpu": {
+            "title": "PyTorch FSDP training (8 GPU)",
+            "summary": "Fully sharded data parallel training on eight GPUs.",
+            "headline_metrics": ["step_time_p50", "step_time_p99"],
+            "run_command": (
+                "torchrun --standalone --nproc_per_node=8 $(which aorta) "
+                "sweep run --recipe recipes/training/example-training-fsdp-smoke.yaml"
+            ),
+        },
+        "llm_determinism": {
+            "title": "LLM determinism (2 GPU)",
+            "summary": (
+                "Bit-exact repeatability across ranks; divergence indicates "
+                "silent corruption."
+            ),
+            "headline_metrics": ["ranks_with_divergence"],
+            "run_command": (
+                "torchrun --standalone --nproc_per_node=2 $(which aorta) "
+                "sweep run --recipe recipes/llm-determinism/example-llm-determinism.yaml"
+            ),
+        },
+        "llm_determinism_8gpu": {
+            "title": "LLM determinism (8 GPU)",
+            "summary": "Bit-exact repeatability at full-node scale.",
+            "headline_metrics": ["ranks_with_divergence"],
+            "run_command": (
+                "torchrun --standalone --nproc_per_node=8 $(which aorta) "
+                "sweep run --recipe recipes/llm-determinism/example-llm-determinism.yaml"
+            ),
+        },
+        "race": {
+            "title": "RCCL race detection (2 GPU)",
+            "summary": (
+                "Detects timing races and silent data corruption in distributed layers."
+            ),
+            "headline_metrics": ["layer_checksum_mismatches"],
+            "run_command": (
+                "torchrun --standalone --nproc_per_node=2 $(which aorta) "
+                "sweep run --recipe recipes/race/race_smoke.yaml"
+            ),
+        },
+        "race_8gpu": {
+            "title": "RCCL race detection (8 GPU)",
+            "summary": "Race detection at full-node scale.",
+            "headline_metrics": ["layer_checksum_mismatches"],
+            "run_command": (
+                "torchrun --standalone --nproc_per_node=8 $(which aorta) "
+                "sweep run --recipe recipes/race/race_smoke.yaml"
+            ),
+        },
+    },
+    "engineer_only_metrics": [
+        "rank",
+        "world_size",
+        "local_world_size",
+        "node_count",
+        "corruption_details_omitted",
+        "parameter_count",
+        "num_experts",
+        "num_layers",
+        "generate_tokens",
+        "decoded_tokens",
+        "prompt_len",
+        "batch_size",
+        "eff_batch_size",
+        "eff_ffn_size",
+        "eff_num_heads",
+        "eff_seq_len",
+        "declared_h2d_tensor_size",
+        "effective_h2d_tensor_size",
+        "layers_verified",
+        "expected",
+        "n",
+        "sum",
+        "final_loss",
+    ],
+}

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -34,7 +34,7 @@ except Exception:  # pragma: no cover - dashboard must render even if import fai
         return None
 
     def _is_correctness_metric(_name: str) -> bool:  # type: ignore
-        return _name.endswith("_checksum") or _name.endswith("checksum")
+        return _name.endswith("checksum")
 
     def _is_performance_metric(name: str) -> bool:  # type: ignore
         return name in _METRIC_UNITS and name not in (
@@ -167,25 +167,56 @@ def _engineer_only_metrics() -> frozenset[str]:
     return _DEFAULT_ENGINEER_METRICS | frozenset(str(m) for m in extra)
 
 
-def _category_for_workload(entry_name: str) -> str:
-    for cat_id, cat in (load_dashboard_metadata().get("categories") or {}).items():
-        if entry_name in (cat.get("workloads") or []):
-            return str(cat_id)
-    return "other"
+# Correctness counters: any night-over-night change is significant.
+_CORRECTNESS_COUNTERS = frozenset({
+    "ranks_with_divergence",
+    "layer_checksum_mismatches",
+})
 
 
-def _format_headline_metric(name: str, raw: Any) -> str:
+def _is_correctness_change_metric(name: str) -> bool:
+    """True when any value change in this metric should surface in Correctness."""
+    return _is_correctness_metric(name) or name in _CORRECTNESS_COUNTERS
+
+
+def _checksum_headline(name: str, raw: Any, entry: dict[str, Any]) -> str:
+    """Headline for checksum metrics — neutral unless comparison confirms match."""
+    label = name.replace("_", " ")
+    if not _isnum(raw):
+        return f"{label}: —"
+    deltas = entry.get("deltas") or {}
+    metric_delta = (deltas.get("metrics") or {}).get(name)
+    if metric_delta:
+        policy = metric_delta.get("policy")
+        expected = metric_delta.get("value")
+        observed = metric_delta.get("observed", raw)
+        if policy == "equal" and expected is not None:
+            if observed == expected:
+                return f"{label}: match ✓"
+            return f"{label}: mismatch ✗"
+    verdict = str(entry.get("verdict", ""))
+    if verdict == "fail":
+        needle = name.replace("_", " ")
+        for reason in entry.get("reasons") or []:
+            text = str(reason).lower()
+            if name in text or needle in text or "checksum" in text:
+                return f"{label}: mismatch ✗"
+    return f"{label}: captured ({_fmt_num(raw)})"
+
+
+def _format_headline_metric(
+    name: str, raw: Any, entry: dict[str, Any] | None = None,
+) -> str:
     """One headline metric for customer view."""
-    if name in ("ranks_with_divergence", "layer_checksum_mismatches"):
+    entry = entry or {}
+    if name in _CORRECTNESS_COUNTERS:
         if _isnum(raw) and float(raw) == 0:
             return f"{name.replace('_', ' ')}: 0 ✓"
         if _isnum(raw):
             return f"{name.replace('_', ' ')}: {_fmt_num(raw)} ✗"
         return f"{name.replace('_', ' ')}: —"
     if name in ("logits_checksum", "output_checksum", "checksum"):
-        if _isnum(raw):
-            return f"{name.replace('_', ' ')}: match ✓"
-        return f"{name.replace('_', ' ')}: —"
+        return _checksum_headline(name, raw, entry)
     unit = _METRIC_UNITS.get(name, "")
     if name == "mean_step_time_ms":
         return f"step time: {_fmt_ms(raw)}"
@@ -209,7 +240,7 @@ def _headline_block(entry: dict[str, Any], entry_name: str) -> str:
             raw = metrics.get(name)
         else:
             raw = summary.get(name)
-        parts.append(_format_headline_metric(str(name), raw))
+        parts.append(_format_headline_metric(str(name), raw, entry))
     if not parts:
         return ""
     return (
@@ -258,7 +289,8 @@ def build_category_summary(
         color = _VERDICT_COLOR.get(worst, _UNKNOWN_COLOR)
         glyph = _VERDICT_GLYPH.get(worst, _UNKNOWN_GLYPH)
         tally_txt = _tally_text(counts)
-        anchor = f"wl-{_esc(str(workloads[0]))}" if workloads else ""
+        present = [str(wl) for wl in workloads if by_entry.get(str(wl))]
+        anchor = f"wl-{_esc(present[0])}" if present else ""
         tiles.append(
             f"<a class='cat-tile' href='#{anchor}' style='border-left-color:{color}'>"
             f"<div class='cat-k'>{_esc(label)}</div>"
@@ -712,21 +744,34 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
         after_m = _measurements(latest_by[k])
         for metric in sorted(set(before_m) & set(after_m)):
             b, a = before_m[metric], after_m[metric]
+            if b == a:
+                continue
+            if _is_correctness_change_metric(metric):
+                movers_corr.append((0, 0, k, metric, b, a, latest_by[k]))
+                continue
             if not b:  # a move from zero has no meaningful percentage
                 continue
             pct = (a - b) / abs(b) * 100.0
             if abs(pct) > _MOVE_PCT:
                 row = (abs(pct), pct, k, metric, b, a, latest_by[k])
-                if _is_correctness_metric(metric):
-                    movers_corr.append(row)
-                elif _is_performance_metric(metric):
+                if _is_performance_metric(metric):
                     movers_perf.append(row)
                 else:
                     movers_other.append(row)
-    movers_corr.sort(reverse=True)
+    movers_corr.sort(key=lambda r: (r[5], r[4]), reverse=True)
     movers_perf.sort(reverse=True)
     movers_other.sort(reverse=True)
     movers = movers_corr + movers_perf + movers_other
+
+    def _corr_mover_li(row: tuple) -> str:
+        _, _, _k, metric, b, a, entry = row
+        unit = _METRIC_UNITS.get(metric, "")
+        return (
+            f"<li class='corr'><span class='mono'>{_esc(_cell_label(entry))}</span> "
+            f"<span class='mono'>{_esc(metric)}</span> "
+            f"<span class='muted'>{_esc(_fmt_num(b))} → {_esc(_fmt_num(a))}"
+            f"{(' ' + _esc(unit)) if unit else ''}</span></li>"
+        )
 
     def _mover_li(row: tuple, css: str) -> str:
         _, pct, _k, metric, b, a, entry = row
@@ -742,7 +787,7 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
     if movers_corr:
         items.append("<li class='change-hdr corr'>Correctness</li>")
         for row in movers_corr[:4]:
-            items.append(_mover_li(row, "corr"))
+            items.append(_corr_mover_li(row))
     if movers_perf:
         items.append("<li class='change-hdr perf'>Performance</li>")
         for row in movers_perf[:4]:

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -128,6 +128,7 @@ _CUSTOMER_STATUS = {
     "unrecognised": "Unrecognised verdict",
     "failing": "Regression detected",
     "passing": "Healthy",
+    "partial": "Partial run",
     "recording": "Baseline setup",
     "skipping": "Incomplete run",
 }
@@ -408,6 +409,10 @@ def _latest_status(results: list[dict[str, Any]]) -> tuple[str, str]:
     if total > sum(_count(s.get(v)) for v in _VERDICT_ORDER):
         return "unrecognised", _UNKNOWN_COLOR
     if _count(s.get("pass")):
+        # A mix of pass and skip is not a fully healthy run — some workloads
+        # never executed (e.g. not enough GPUs for the 8-GPU matrix entries).
+        if _count(s.get("skip")):
+            return "partial", _VERDICT_COLOR["record"]
         return "passing", _VERDICT_COLOR["pass"]
     if _count(s.get("record")):
         return "recording", _VERDICT_COLOR["record"]
@@ -1072,6 +1077,14 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
             f"<div class='notice'>Nothing ran: all {total} results were "
             f"<strong>skipped</strong>, so this build establishes nothing. Check that "
             f"the runner exposes as many GPUs as the matrix asks for.</div>"
+        )
+    elif status == "partial":
+        pass_now = _count(s.get("pass"))
+        notices.append(
+            f"<div class='notice'>This run is <strong>partial</strong>: "
+            f"{pass_now} of {total} results passed but {skip_now} workload(s) were "
+            f"<strong>skipped</strong> — not every configured matrix entry ran. "
+            f"Check that the runner exposes as many GPUs as the matrix asks for.</div>"
         )
     elif shared_reason:
         notices.append(

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -27,9 +27,19 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 try:
     import eval_lib  # for metric_policy display
     _metric_policy = eval_lib.metric_policy
+    _is_correctness_metric = eval_lib.is_correctness_metric
+    _is_performance_metric = eval_lib.is_performance_metric
 except Exception:  # pragma: no cover - dashboard must render even if import fails
     def _metric_policy(_name: str):  # type: ignore
         return None
+
+    def _is_correctness_metric(_name: str) -> bool:  # type: ignore
+        return _name.endswith("_checksum") or _name.endswith("checksum")
+
+    def _is_performance_metric(name: str) -> bool:  # type: ignore
+        return name in _METRIC_UNITS and name not in (
+            "logits_checksum", "output_checksum", "checksum"
+        )
 
 # Links back to the source of truth. This dashboard only ever describes this
 # repo's nightly run, so the slug is fixed rather than plumbed through.
@@ -103,6 +113,167 @@ _TOOLCHAIN_FIELDS = (
     ("rocm", "ROCm"),
     ("hip", "HIP"),
 )
+
+try:
+    from dashboard_metadata import DASHBOARD_METADATA as _DEFAULT_METADATA
+except ImportError:  # pragma: no cover
+    _DEFAULT_METADATA: dict[str, Any] = {
+        "categories": {}, "workloads": {}, "engineer_only_metrics": [],
+    }
+
+# Customer-facing headline for each internal _latest_status() label.
+_CUSTOMER_STATUS = {
+    "unknown": "Unknown",
+    "empty": "No data",
+    "unrecognised": "Unrecognised verdict",
+    "failing": "Regression detected",
+    "passing": "Healthy",
+    "recording": "Baseline setup",
+    "skipping": "Incomplete run",
+}
+
+# Metrics shown only in the engineer metrics table, not the headline row.
+_DEFAULT_ENGINEER_METRICS = frozenset({
+    "rank", "world_size", "local_world_size", "node_count",
+    "corruption_details_omitted", "parameter_count", "num_experts", "num_layers",
+    "generate_tokens", "decoded_tokens", "prompt_len", "batch_size",
+    "eff_batch_size", "eff_ffn_size", "eff_num_heads", "eff_seq_len",
+    "declared_h2d_tensor_size", "effective_h2d_tensor_size", "layers_verified",
+    "expected", "n", "sum", "final_loss",
+})
+
+
+def load_dashboard_metadata() -> dict[str, Any]:
+    """Load customer-facing workload/category metadata (pure, cached per process)."""
+    if not hasattr(load_dashboard_metadata, "_cache"):
+        load_dashboard_metadata._cache = None  # type: ignore[attr-defined]
+    if load_dashboard_metadata._cache is not None:  # type: ignore[attr-defined]
+        return load_dashboard_metadata._cache  # type: ignore[attr-defined]
+    load_dashboard_metadata._cache = dict(_DEFAULT_METADATA)  # type: ignore[attr-defined]
+    return load_dashboard_metadata._cache  # type: ignore[attr-defined]
+
+
+def _customer_status_label(status: str) -> str:
+    return _CUSTOMER_STATUS.get(status, status.replace("_", " ").title())
+
+
+def _workload_meta(entry_name: str) -> dict[str, Any]:
+    return (load_dashboard_metadata().get("workloads") or {}).get(entry_name) or {}
+
+
+def _engineer_only_metrics() -> frozenset[str]:
+    meta = load_dashboard_metadata()
+    extra = meta.get("engineer_only_metrics") or []
+    return _DEFAULT_ENGINEER_METRICS | frozenset(str(m) for m in extra)
+
+
+def _category_for_workload(entry_name: str) -> str:
+    for cat_id, cat in (load_dashboard_metadata().get("categories") or {}).items():
+        if entry_name in (cat.get("workloads") or []):
+            return str(cat_id)
+    return "other"
+
+
+def _format_headline_metric(name: str, raw: Any) -> str:
+    """One headline metric for customer view."""
+    if name in ("ranks_with_divergence", "layer_checksum_mismatches"):
+        if _isnum(raw) and float(raw) == 0:
+            return f"{name.replace('_', ' ')}: 0 ✓"
+        if _isnum(raw):
+            return f"{name.replace('_', ' ')}: {_fmt_num(raw)} ✗"
+        return f"{name.replace('_', ' ')}: —"
+    if name in ("logits_checksum", "output_checksum", "checksum"):
+        if _isnum(raw):
+            return f"{name.replace('_', ' ')}: match ✓"
+        return f"{name.replace('_', ' ')}: —"
+    unit = _METRIC_UNITS.get(name, "")
+    if name == "mean_step_time_ms":
+        return f"step time: {_fmt_ms(raw)}"
+    label = name.replace("_", " ")
+    if _isnum(raw):
+        val = f"{_fmt_num(raw)} {unit}".strip()
+        return f"{label}: {val}"
+    return f"{label}: —"
+
+
+def _headline_block(entry: dict[str, Any], entry_name: str) -> str:
+    meta = _workload_meta(entry_name)
+    names = meta.get("headline_metrics") or []
+    if not names:
+        return ""
+    summary = ((entry.get("metrics") or {}).get("summary") or {})
+    metrics = entry.get("metrics") or {}
+    parts = []
+    for name in names:
+        if name in _HARNESS_METRICS:
+            raw = metrics.get(name)
+        else:
+            raw = summary.get(name)
+        parts.append(_format_headline_metric(str(name), raw))
+    if not parts:
+        return ""
+    return (
+        "<ul class='headlines'>"
+        + "".join(f"<li>{_esc(p)}</li>" for p in parts)
+        + "</ul>"
+    )
+
+
+def _run_command_block(entry_name: str) -> str:
+    cmd = _workload_meta(entry_name).get("run_command") or ""
+    if not cmd:
+        return ""
+    return (
+        "<details class='run-cmd'>"
+        "<summary>Run this workload locally</summary>"
+        f"<pre class='mono'>{_esc(cmd)}</pre>"
+        "</details>"
+    )
+
+
+def build_category_summary(
+    latest_entries: list[dict[str, Any]],
+) -> str:
+    """Four category tiles summarising worst verdict per use-case area."""
+    meta = load_dashboard_metadata()
+    categories = meta.get("categories") or {}
+    if not categories:
+        return ""
+
+    by_entry: dict[str, list[dict[str, Any]]] = {}
+    for e in latest_entries:
+        by_entry.setdefault(str(e.get("entry")), []).append(e)
+
+    tiles = []
+    for cat_id, cat in categories.items():
+        label = str(cat.get("label") or cat_id)
+        workloads = cat.get("workloads") or []
+        group: list[dict[str, Any]] = []
+        for wl in workloads:
+            group.extend(by_entry.get(str(wl), []))
+        if not group:
+            continue
+        counts = _tally(group)
+        worst = _worst_verdict(counts)
+        color = _VERDICT_COLOR.get(worst, _UNKNOWN_COLOR)
+        glyph = _VERDICT_GLYPH.get(worst, _UNKNOWN_GLYPH)
+        tally_txt = _tally_text(counts)
+        anchor = f"wl-{_esc(str(workloads[0]))}" if workloads else ""
+        tiles.append(
+            f"<a class='cat-tile' href='#{anchor}' style='border-left-color:{color}'>"
+            f"<div class='cat-k'>{_esc(label)}</div>"
+            f"<div class='cat-v'>{glyph} {_esc(worst or '—')}</div>"
+            f"<div class='cat-sub muted'>{_esc(tally_txt)}</div>"
+            f"</a>"
+        )
+    if not tiles:
+        return ""
+    return (
+        "<h2>Category health</h2>"
+        "<p class='muted'>Worst verdict in each area from tonight's run. "
+        "Click a tile to jump to workloads.</p>"
+        f"<div class='cat-grid'>{''.join(tiles)}</div>"
+    )
 
 
 def _isnum(v: Any) -> bool:
@@ -533,7 +704,9 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
             f"<li>no longer reported <span class='mono'>{_esc(_cell_label(prev_by[k]))}</span></li>"
         )
 
-    movers = []
+    movers_corr: list[tuple] = []
+    movers_perf: list[tuple] = []
+    movers_other: list[tuple] = []
     for k in sorted(set(prev_by) & set(latest_by)):
         before_m = _measurements(prev_by[k])
         after_m = _measurements(latest_by[k])
@@ -543,17 +716,42 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
                 continue
             pct = (a - b) / abs(b) * 100.0
             if abs(pct) > _MOVE_PCT:
-                movers.append((abs(pct), pct, k, metric, b, a, latest_by[k]))
-    movers.sort(reverse=True)
-    for _, pct, _k, metric, b, a, entry in movers[:6]:
+                row = (abs(pct), pct, k, metric, b, a, latest_by[k])
+                if _is_correctness_metric(metric):
+                    movers_corr.append(row)
+                elif _is_performance_metric(metric):
+                    movers_perf.append(row)
+                else:
+                    movers_other.append(row)
+    movers_corr.sort(reverse=True)
+    movers_perf.sort(reverse=True)
+    movers_other.sort(reverse=True)
+    movers = movers_corr + movers_perf + movers_other
+
+    def _mover_li(row: tuple, css: str) -> str:
+        _, pct, _k, metric, b, a, entry = row
         unit = _METRIC_UNITS.get(metric, "")
         arrow = "▲" if pct > 0 else "▼"
-        items.append(
-            f"<li><span class='mono'>{_esc(_cell_label(entry))}</span> "
+        return (
+            f"<li class='{css}'><span class='mono'>{_esc(_cell_label(entry))}</span> "
             f"<span class='mono'>{_esc(metric)}</span> {arrow} {pct:+.1f}% "
             f"<span class='muted'>{_esc(_fmt_num(b))} → {_esc(_fmt_num(a))}"
             f"{(' ' + _esc(unit)) if unit else ''}</span></li>"
         )
+
+    if movers_corr:
+        items.append("<li class='change-hdr corr'>Correctness</li>")
+        for row in movers_corr[:4]:
+            items.append(_mover_li(row, "corr"))
+    if movers_perf:
+        items.append("<li class='change-hdr perf'>Performance</li>")
+        for row in movers_perf[:4]:
+            items.append(_mover_li(row, "perf"))
+    for row in movers_other[:2]:
+        items.append(_mover_li(row, ""))
+
+    shown = min(len(movers_corr), 4) + min(len(movers_perf), 4) + min(len(movers_other), 2)
+    extra = len(movers) - shown
 
     since = _fmt_timestamp(str(prev.get("generated_at") or "")).split(" ")[0]
     if not items:
@@ -562,7 +760,6 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
             f"metric changed by more than {_MOVE_PCT:.0f}%.</p>"
         )
     else:
-        extra = len(movers) - 6
         more = (
             f"<p class='muted'>and {extra} more metric"
             f"{'' if extra == 1 else 's'} past {_MOVE_PCT:.0f}%</p>"
@@ -578,6 +775,7 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
 def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     """Render the full dashboard HTML from the results history (pure)."""
     status, status_color = _latest_status(results)
+    customer_status = _customer_status_label(status)
     latest = results[-1] if results else {"build": {}, "summary": {}, "entries": []}
     build = latest.get("build", {}) or {}
     s = latest.get("summary", {}) or {}
@@ -688,10 +886,19 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         if len(durs) == 1 and max(durs) > 0:
             head += f" · workload run {max(durs):,.0f}s"
 
+        wl_meta = _workload_meta(entry_name)
+        wl_title = str(wl_meta.get("title") or entry_name)
+        wl_summary = str(wl_meta.get("summary") or "")
+        summary_html = (
+            f"<p class='wl-sum muted'>{_esc(wl_summary)}</p>" if wl_summary else ""
+        )
         rows = [
-            f"<tr class='grp'><th colspan='{ncols}' scope='rowgroup'>"
-            f"<span class='wl'>{_esc(entry_name)}</span>"
+            f"<tr class='grp' id='wl-{_esc(entry_name)}'><th colspan='{ncols}' scope='rowgroup'>"
+            f"<div class='wl-head'><strong>{_esc(wl_title)}</strong>"
+            f"<span class='mono muted wl-id'>{_esc(entry_name)}</span></div>"
+            f"{summary_html}"
             f"<span class='muted'> {_esc(head)}</span>"
+            f"{_run_command_block(entry_name)}"
             f"</th></tr>"
         ]
         for k in cell_keys:
@@ -721,6 +928,13 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
                 )
             rows.append(f"<tr>{''.join(cells)}</tr>")
 
+            headlines = _headline_block(e, entry_name)
+            if headlines:
+                rows.append(
+                    f"<tr class='headline-row'><td class='cell' colspan='{ncols}'>"
+                    f"{headlines}</td></tr>"
+                )
+
             mrows = _metric_rows(k, e, mhist, show_metric_trend)
             if mrows:
                 n_metrics = len((e.get("metrics") or {}).get("summary") or {})
@@ -734,7 +948,8 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
                     prov.append(f"{n_trials} trial{'s' if n_trials != 1 else ''}")
                 rows.append(
                     f"<tr class='mrow'><td colspan='{ncols}'><details>"
-                    f"<summary>{n_metrics} metric{'s' if n_metrics != 1 else ''}</summary>"
+                    f"<summary>All metrics (engineer) — {n_metrics} metric"
+                    f"{'s' if n_metrics != 1 else ''}</summary>"
                     f"<p class='prov'>{' · '.join(prov)}</p>"
                     f"<table class='inner'><thead><tr><th>metric</th>"
                     f"<th class='center'>policy</th><th class='num'>latest</th>"
@@ -796,7 +1011,8 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         notices.append(
             f"<div class='notice'>No baselines are blessed yet, so nothing was graded "
             f"pass or fail — this run <strong>recorded</strong> metrics for {scope} "
-            f"to become the reference.{extra}</div>"
+            f"to become the reference. Pass/fail grading starts after the first "
+            f"blessed baseline PR.{extra}</div>"
         )
     elif nothing_graded:
         notices.append(
@@ -813,6 +1029,28 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
             "<div class='notice muted-notice'>Trend charts need at least two nightly "
             "runs; they appear automatically once more history accumulates.</div>"
         )
+
+    fail_now = _count(s.get("fail"))
+    action_panel = ""
+    if fail_now:
+        action_panel = (
+            "<div class='notice fail-actions'>"
+            "<strong>Next steps</strong> "
+            "Capture your environment with "
+            "<code class='mono'>aorta env probe -o env.json</code>, "
+            "review the failing workload below, and "
+            f"<a href='https://github.com/{_REPO}/issues/new/choose'>"
+            "open a ROCm issue</a> with the stack versions above."
+            "</div>"
+        )
+
+    scope_notice = (
+        "<div class='notice scope-notice muted-notice'>"
+        "<strong>Reference hardware:</strong> single-node MI350 runner with pinned "
+        "ROCm + PyTorch wheels. Numbers are nightly CI references — not a guarantee "
+        "on other AMD GPUs or cluster configurations."
+        "</div>"
+    )
 
     # Counts go through _fmt_num so a malformed summary shows "—" rather than
     # printing whatever str() makes of it ("nan", "True").
@@ -835,11 +1073,12 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
 
     changes_html = build_change_summary(results)
     history_html = build_history_grid(results)
+    category_html = build_category_summary(latest_entries)
 
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>aorta nightly CI</title>
+<title>ROCm stack health · AORTA nightly</title>
 <style>
   :root {{ --bg:#0d1117; --panel:#161b22; --border:#21262d; --fg:#c9d1d9;
            --muted:#8b949e; --accent:#539bf5; }}
@@ -950,30 +1189,68 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
                      border:1px solid var(--border); border-radius:6px;
                      padding:.25rem .6rem; font-size:.75rem; cursor:pointer; }}
   .toolbar button:hover {{ border-color:var(--accent); color:var(--accent); }}
+  .cat-grid {{ display:grid; gap:.65rem; margin:.5rem 0 0;
+               grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); }}
+  .cat-tile {{ display:block; background:var(--panel); border:1px solid var(--border);
+               border-left:3px solid var(--border); border-radius:8px;
+               padding:.65rem .85rem; text-decoration:none; color:inherit; }}
+  .cat-tile:hover {{ border-color:var(--accent); }}
+  .cat-k {{ font-size:.72rem; color:var(--muted); text-transform:uppercase;
+            letter-spacing:.06em; }}
+  .cat-v {{ font-size:1rem; font-weight:600; margin:.2rem 0; }}
+  .cat-sub {{ font-size:.75rem; }}
+  .scope-notice {{ margin-top:.65rem; }}
+  .fail-actions {{ border-left-color:#f85149; }}
+  .wl-head {{ display:flex; align-items:baseline; gap:.6rem; flex-wrap:wrap; }}
+  .wl-head strong {{ color:#e6edf3; font-size:.95rem; }}
+  .wl-id {{ font-size:.72rem; }}
+  .wl-sum {{ margin:.25rem 0 .35rem; font-size:.82rem; }}
+  ul.headlines {{ list-style:none; margin:.35rem 0 0; padding:0;
+                  display:flex; flex-wrap:wrap; gap:.35rem .75rem; }}
+  ul.headlines li {{ background:#12161b; border:1px solid var(--border);
+                     border-radius:6px; padding:.2rem .55rem; font-size:.78rem; }}
+  tr.headline-row > td {{ padding-top:0; padding-bottom:.5rem; }}
+  details.run-cmd {{ margin:.45rem 0 0; font-size:.78rem; }}
+  details.run-cmd pre {{ background:#0d1117; border:1px solid var(--border);
+                         border-radius:6px; padding:.5rem .65rem; margin:.35rem 0 0;
+                         overflow-x:auto; white-space:pre-wrap; word-break:break-word; }}
+  ul.changes li.change-hdr {{ background:transparent; border:none; padding:.15rem 0;
+                              font-size:.72rem; text-transform:uppercase;
+                              letter-spacing:.06em; color:var(--muted); }}
+  ul.changes li.corr {{ border-left-color:#f85149; }}
+  ul.changes li.perf {{ border-left-color:#d29922; }}
+  .status-sub {{ font-size:.68rem; color:var(--muted); margin-left:.25rem; }}
 </style></head>
 <body>
   <div class="wrap">
     <header>
       <div class="titlebar">
-        <h1>aorta nightly CI</h1>
-        <span class="status-pill">{status}</span>
+        <h1>ROCm stack health</h1>
+        <span class="status-pill" title="{_esc(status)}">{_esc(customer_status)}</span>
+        <span class="status-sub mono">({_esc(status)})</span>
       </div>
-      <p class="lede">Every night AORTA installs the freshly built wheel on an
-        MI350 runner and replays its workload sweep, comparing each result
-        against a blessed baseline. This page is that run.</p>
+      <p class="lede">Every night AORTA installs the freshly built wheel on a
+        reference MI350 runner and replays representative PyTorch workloads —
+        training, inference, and distributed correctness checks — comparing each
+        result against a blessed baseline when one exists.</p>
       <p class="nav"><a href="docs/">AORTA documentation</a> ·
-        <a href="sanitizers/">sanitizer nightly</a> ·
-        <a href="https://github.com/{_REPO}">repository</a></p>
+        <a href="sanitizers/">Sanitizer nightly</a> ·
+        <a href="https://github.com/{_REPO}">Repository</a> ·
+        <a href="data.json">data.json</a></p>
       <div class="chips">{toolchain}</div>
       <p class="prov-line">{' · '.join(provenance)}</p>
     </header>
 
+    {scope_notice}
     {''.join(notices)}
+    {action_panel}
 
     <div class="cards">
       {cards_html}
       <div class="card trend"><div class="k">pass-rate trend</div><div class="v">{_svg_sparkline(passrate, width=240)}</div></div>
     </div>
+
+    {category_html}
 
     {changes_html}
 

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -176,28 +176,35 @@ def _is_dashboard_performance_metric(name: str) -> bool:
     return name in _METRIC_UNITS or name in _HARNESS_METRICS
 
 
+def _checksum_metric_failed(entry: dict[str, Any], name: str) -> bool:
+    """True when the harness reported this checksum metric failed comparison."""
+    needle = name.replace("_", " ")
+    for reason in entry.get("reasons") or []:
+        text = str(reason)
+        lower = text.lower()
+        if name in text or needle in text or "checksum" in lower:
+            if "!=" in text or "expected" in lower or "mismatch" in lower:
+                return True
+    return False
+
+
 def _checksum_headline(name: str, raw: Any, entry: dict[str, Any]) -> str:
-    """Headline for checksum metrics — neutral unless comparison confirms match."""
+    """Headline for checksum metrics — neutral unless the harness confirms match.
+
+    Checksums are serialized as floats in nightly JSON; ``observed == expected``
+    is unsafe for large int64 checksums that can collide after rounding. Trust
+    the entry verdict and failure reasons from ``compare_to_baseline`` instead.
+    """
     label = name.replace("_", " ")
     if not _isnum(raw):
         return f"{label}: —"
+    verdict = str(entry.get("verdict", ""))
     deltas = entry.get("deltas") or {}
     metric_delta = (deltas.get("metrics") or {}).get(name)
-    if metric_delta:
-        policy = metric_delta.get("policy")
-        expected = metric_delta.get("value")
-        observed = metric_delta.get("observed", raw)
-        if policy == "equal" and expected is not None:
-            if observed == expected:
-                return f"{label}: match ✓"
-            return f"{label}: mismatch ✗"
-    verdict = str(entry.get("verdict", ""))
-    if verdict == "fail":
-        needle = name.replace("_", " ")
-        for reason in entry.get("reasons") or []:
-            text = str(reason).lower()
-            if name in text or needle in text or "checksum" in text:
-                return f"{label}: mismatch ✗"
+    if verdict == "fail" and _checksum_metric_failed(entry, name):
+        return f"{label}: mismatch ✗"
+    if verdict == "pass" and metric_delta and metric_delta.get("policy") == "equal":
+        return f"{label}: match ✓"
     return f"{label}: captured ({_fmt_num(raw)})"
 
 

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -255,14 +255,163 @@ def _headline_block(entry: dict[str, Any], entry_name: str) -> str:
 
 
 def _run_command_block(entry_name: str) -> str:
-    cmd = _workload_meta(entry_name).get("run_command") or ""
+    """Step-by-step instructions to reproduce a workload outside CI."""
+    meta = _workload_meta(entry_name)
+    cmd = str(meta.get("run_command") or "")
     if not cmd:
         return ""
+    recipe = str(meta.get("recipe") or "")
+    min_gpus = meta.get("min_gpus")
+    if not _isnum(min_gpus):
+        min_gpus = 8 if entry_name.endswith("_8gpu") else 1
+    min_gpus = int(min_gpus)
+    gpu_note = (
+        f"At least {min_gpus} AMD GPU(s) visible to PyTorch"
+        if min_gpus > 1 else "One AMD GPU visible to PyTorch"
+    )
+    recipe_line = ""
+    if recipe:
+        recipe_line = (
+            f"<p class='repro-note muted'>Recipe: "
+            f"<a class='mono' href='https://github.com/{_REPO}/blob/main/{_esc(recipe)}'>"
+            f"{_esc(recipe)}</a></p>"
+        )
     return (
-        "<details class='run-cmd'>"
-        "<summary>Run this workload locally</summary>"
-        f"<pre class='mono'>{_esc(cmd)}</pre>"
-        "</details>"
+        f"<div class='repro-panel' id='repro-{_esc(entry_name)}'>"
+        f"<p class='repro-kicker muted'>Run this workload locally</p>"
+        f"<ol class='repro-steps'>"
+        f"<li><strong>Requirements:</strong> {gpu_note}; ROCm + PyTorch installed "
+        f"(match the stack versions in the header when comparing numbers).</li>"
+        f"<li><strong>Install AORTA</strong> — follow the "
+        f"<a href='docs/'>getting started guide</a> and clone this repository.</li>"
+        f"<li><strong>Run from the repo root:</strong>"
+        f"<pre class='mono repro-cmd'>{_esc(cmd)}</pre></li>"
+        f"<li><strong>Distributed workloads:</strong> see "
+        f"<a href='https://github.com/{_REPO}/blob/main/recipes/README-running-recipes.md'>"
+        f"recipes/README-running-recipes.md</a> for torchrun and multi-node notes.</li>"
+        f"</ol>{recipe_line}</div>"
+    )
+
+
+def _category_statuses(
+    latest_entries: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Structured category health for ``data.json`` consumers."""
+    meta = load_dashboard_metadata()
+    categories = meta.get("categories") or {}
+    by_entry: dict[str, list[dict[str, Any]]] = {}
+    for e in latest_entries:
+        by_entry.setdefault(str(e.get("entry")), []).append(e)
+    out: dict[str, dict[str, Any]] = {}
+    for cat_id, cat in categories.items():
+        workloads = cat.get("workloads") or []
+        group: list[dict[str, Any]] = []
+        for wl in workloads:
+            group.extend(by_entry.get(str(wl), []))
+        if not group:
+            continue
+        counts = _tally(group)
+        worst = _worst_verdict(counts)
+        out[str(cat_id)] = {
+            "label": str(cat.get("label") or cat_id),
+            "worst_verdict": worst,
+            "counts": dict(counts),
+            "workloads": [str(w) for w in workloads if by_entry.get(str(w))],
+        }
+    return out
+
+
+def _headline_metrics_for_entries(
+    latest_entries: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Latest headline metric values keyed by ``entry::cell``."""
+    out: dict[str, dict[str, Any]] = {}
+    for e in latest_entries:
+        entry_name = str(e.get("entry") or "")
+        cell = e.get("cell")
+        key = f"{entry_name}::{cell}" if cell else entry_name
+        metrics: dict[str, Any] = {}
+        meta = _workload_meta(entry_name)
+        for name in meta.get("headline_metrics") or []:
+            raw = ((e.get("metrics") or {}).get("summary") or {}).get(name)
+            if name in _HARNESS_METRICS:
+                raw = (e.get("metrics") or {}).get(name, raw)
+            if _isnum(raw):
+                metrics[str(name)] = raw
+        if metrics:
+            out[key] = metrics
+    return out
+
+
+def build_data_json(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate history plus structured latest-night summary for embeds."""
+    latest = results[-1] if results else None
+    status, _ = _latest_status(results)
+    latest_entries = list((latest or {}).get("entries") or [])
+    latest_block: dict[str, Any] = {
+        "status": status,
+        "customer_status": _customer_status_label(status),
+        "generated_at": (latest or {}).get("generated_at"),
+        "build": (latest or {}).get("build") or {},
+        "summary": (latest or {}).get("summary") or {},
+        "categories": _category_statuses(latest_entries),
+        "headline_metrics": _headline_metrics_for_entries(latest_entries),
+    }
+    return {
+        "schema_version": 2,
+        "latest": latest_block,
+        "results": results,
+    }
+
+
+def build_scaling_summary(latest_entries: list[dict[str, Any]]) -> str:
+    """2-GPU vs 8-GPU step-time scaling for training workloads."""
+    by_entry: dict[str, list[dict[str, Any]]] = {}
+    for e in latest_entries:
+        by_entry.setdefault(str(e.get("entry")), []).append(e)
+
+    def _step_p50(entry_name: str) -> float | None:
+        for e in by_entry.get(entry_name) or []:
+            raw = ((e.get("metrics") or {}).get("summary") or {}).get("step_time_p50")
+            if _isnum(raw):
+                return float(raw)
+        return None
+
+    pairs = (
+        ("training_ddp", "training_ddp_8gpu", "DDP"),
+        ("training_fsdp", "training_fsdp_8gpu", "FSDP"),
+    )
+    rows = []
+    for two_gpu, eight_gpu, label in pairs:
+        p50_2 = _step_p50(two_gpu)
+        p50_8 = _step_p50(eight_gpu)
+        if p50_2 is None or p50_8 is None:
+            continue
+        ratio = p50_8 / p50_2 if p50_2 else None
+        # Ideal 8-GPU step time with perfect 4× scaling from 2 GPUs.
+        ideal_8 = p50_2 / 4.0
+        efficiency = (ideal_8 / p50_8 * 100.0) if p50_8 else None
+        eff_txt = f"{efficiency:.0f}%" if efficiency is not None else "—"
+        ratio_txt = f"{ratio:.2f}×" if ratio is not None else "—"
+        rows.append(
+            f"<tr><td>{_esc(label)}</td>"
+            f"<td class='num'>{_esc(_fmt_ms(p50_2))}</td>"
+            f"<td class='num'>{_esc(_fmt_ms(p50_8))}</td>"
+            f"<td class='num'>{_esc(ratio_txt)}</td>"
+            f"<td class='num'>{_esc(eff_txt)}</td></tr>"
+        )
+    if not rows:
+        return ""
+    return (
+        "<h2>Training scaling (2 → 8 GPU)</h2>"
+        "<p class='muted'>Reference step_time_p50 from the latest nightly. "
+        "Scaling efficiency assumes ideal 4× speedup from 2 to 8 GPUs on the "
+        "same recipe.</p>"
+        "<div class='tablewrap'><table class='scaling'>"
+        "<thead><tr><th>strategy</th><th class='num'>2 GPU p50</th>"
+        "<th class='num'>8 GPU p50</th><th class='num'>slowdown</th>"
+        "<th class='num'>efficiency</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 
 
@@ -604,7 +753,10 @@ def build_history_grid(results: list[dict[str, Any]], max_runs: int = _GRID_RUNS
         return ""
 
     head = "".join(
-        f"<th scope='col' class='wlcol' title='{_esc(n)}'>{_esc(n)}</th>" for n in ordered
+        f"<th scope='col' class='wlcol'>"
+        f"<a href='#wl-{_esc(n)}' title='{_esc(n)} — jump to workload'>"
+        f"{_esc(str(_workload_meta(n).get('title') or n))}</a></th>"
+        for n in ordered
     )
 
     newest_first = list(reversed(runs))
@@ -616,6 +768,7 @@ def build_history_grid(results: list[dict[str, Any]], max_runs: int = _GRID_RUNS
             by_entry.setdefault(str(e.get("entry")), []).append(e)
 
         status, color = _latest_status([doc])
+        customer_status = _customer_status_label(status)
         date = _fmt_timestamp(str(doc.get("generated_at") or "")).split(" ")[0] or "—"
         run_id = str(build.get("upstream_run_id") or "")
         when = (
@@ -661,27 +814,30 @@ def build_history_grid(results: list[dict[str, Any]], max_runs: int = _GRID_RUNS
             # screen reader is free to ignore the label and announce only the
             # glyph and count -- the least useful part for a mixed group.
             cells.append(
-                f"<td class='gcell'><span class='dot' role='img' style='background:{bg}' "
-                f"title='{_esc(breakdown)}' aria-label='{_esc(breakdown)}'>"
-                f"{_esc(_VERDICT_GLYPH.get(worst, _UNKNOWN_GLYPH))} {_esc(count)}</span></td>"
+                f"<td class='gcell'><a class='gcell-link' href='#wl-{_esc(name)}' "
+                f"title='{_esc(breakdown)} — jump to workload'>"
+                f"<span class='dot' role='img' style='background:{bg}' "
+                f"aria-label='{_esc(breakdown)}'>"
+                f"{_esc(_VERDICT_GLYPH.get(worst, _UNKNOWN_GLYPH))} {_esc(count)}</span></a></td>"
             )
 
         rows.append(
             f"<tr><th scope='row' class='runcell'>{when}{flag}"
             f"<span class='runmeta'>{_esc(str(build.get('amd_aorta_version') or ''))}</span></th>"
-            f"<td class='center'><span class='badge sm' style='background:{color}'>"
-            f"{_esc(status)}</span></td>{''.join(cells)}</tr>"
+            f"<td class='center'><span class='badge sm' style='background:{color}' "
+            f"title='{_esc(status)}'>{_esc(customer_status)}</span></td>"
+            f"{''.join(cells)}</tr>"
         )
 
     return (
-        "<h2>Run history</h2>"
-        "<p class='muted'>Each row is one nightly run, newest first; each column is a "
-        "workload. A cell shows the worst verdict among that workload's results "
-        "(✓ pass · ✗ fail · ◆ record · ○ skip · ? unrecognised) and how many there were — "
-        "<span class='mono'>✗ 1/4</span> means one of four failed. Hover for the "
-        "full breakdown.</p>"
+        "<h2>Nightly release health</h2>"
+        "<p class='muted'>Each row is one nightly release (newest first). The "
+        "<strong>overall health</strong> column summarises that night's graded "
+        "verdicts; workload columns link to reproduction steps below. "
+        "Cell glyphs: ✓ pass · ✗ fail · ◆ record · ○ skip.</p>"
         "<div class='tablewrap'><table class='grid'>"
-        f"<thead><tr><th scope='col'>run</th><th scope='col' class='center'>status</th>"
+        f"<thead><tr><th scope='col'>release</th>"
+        f"<th scope='col' class='center'>overall health</th>"
         f"{head}</tr></thead><tbody>{''.join(rows)}</tbody></table></div>"
     )
 
@@ -959,7 +1115,9 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         )
         rows = [
             f"<tr class='grp' id='wl-{_esc(entry_name)}'><th colspan='{ncols}' scope='rowgroup'>"
-            f"<div class='wl-head'><strong>{_esc(wl_title)}</strong>"
+            f"<div class='wl-head'>"
+            f"<a class='wl-title' href='#repro-{_esc(entry_name)}'>"
+            f"<strong>{_esc(wl_title)}</strong></a>"
             f"<span class='mono muted wl-id'>{_esc(entry_name)}</span></div>"
             f"{summary_html}"
             f"<span class='muted'> {_esc(head)}</span>"
@@ -1147,6 +1305,7 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     changes_html = build_change_summary(results)
     history_html = build_history_grid(results)
     category_html = build_category_summary(latest_entries)
+    scaling_html = build_scaling_summary(latest_entries)
 
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
@@ -1283,10 +1442,23 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
   ul.headlines li {{ background:#12161b; border:1px solid var(--border);
                      border-radius:6px; padding:.2rem .55rem; font-size:.78rem; }}
   tr.headline-row > td {{ padding-top:0; padding-bottom:.5rem; }}
-  details.run-cmd {{ margin:.45rem 0 0; font-size:.78rem; }}
-  details.run-cmd pre {{ background:#0d1117; border:1px solid var(--border);
-                         border-radius:6px; padding:.5rem .65rem; margin:.35rem 0 0;
-                         overflow-x:auto; white-space:pre-wrap; word-break:break-word; }}
+  .repro-panel {{ margin:.55rem 0 0; padding:.65rem .75rem; background:#12161b;
+                  border:1px solid var(--border); border-radius:8px; }}
+  .repro-kicker {{ margin:0 0 .35rem; font-size:.72rem; text-transform:uppercase;
+                   letter-spacing:.05em; }}
+  ol.repro-steps {{ margin:.35rem 0 0; padding-left:1.25rem; font-size:.82rem; }}
+  ol.repro-steps li {{ margin:.35rem 0; }}
+  .repro-cmd {{ background:#0d1117; border:1px solid var(--border); border-radius:6px;
+                padding:.5rem .65rem; margin:.35rem 0 0; overflow-x:auto;
+                white-space:pre-wrap; word-break:break-word; }}
+  .repro-note {{ margin:.45rem 0 0; font-size:.75rem; }}
+  a.wl-title {{ color:#e6edf3; text-decoration:none; }}
+  a.wl-title:hover {{ color:var(--accent); text-decoration:underline; }}
+  a.gcell-link {{ color:inherit; text-decoration:none; display:inline-block; }}
+  a.gcell-link:hover .dot {{ outline:2px solid var(--accent); outline-offset:1px; }}
+  table.scaling {{ margin-top:.5rem; }}
+  table.grid th.wlcol a {{ color:var(--muted); text-decoration:none; font-size:.62rem; }}
+  table.grid th.wlcol a:hover {{ color:var(--accent); text-decoration:underline; }}
   ul.changes li.change-hdr {{ background:transparent; border:none; padding:.15rem 0;
                               font-size:.72rem; text-transform:uppercase;
                               letter-spacing:.06em; color:var(--muted); }}
@@ -1306,7 +1478,8 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         reference MI350 runner and replays representative PyTorch workloads —
         training, inference, and distributed correctness checks — comparing each
         result against a blessed baseline when one exists.</p>
-      <p class="nav"><a href="docs/">AORTA documentation</a> ·
+      <p class="nav"><strong>Stack health</strong> ·
+        <a href="docs/">AORTA documentation</a> ·
         <a href="sanitizers/">Sanitizer nightly</a> ·
         <a href="https://github.com/{_REPO}">Repository</a> ·
         <a href="data.json">data.json</a></p>
@@ -1328,6 +1501,8 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
     {changes_html}
 
     {history_html}
+
+    {scaling_html}
 
     <div class="secthead">
       <h2>Workloads</h2>
@@ -1385,7 +1560,8 @@ def main() -> int:
         results = results[-args.max_builds:]
     args.out_dir.mkdir(parents=True, exist_ok=True)
     (args.out_dir / "index.html").write_text(build_dashboard_html(results), encoding="utf-8")
-    (args.out_dir / "data.json").write_text(json.dumps(results, indent=2), encoding="utf-8")
+    (args.out_dir / "data.json").write_text(
+        json.dumps(build_data_json(results), indent=2), encoding="utf-8")
     print(f"dashboard: {len(results)} build(s) -> {args.out_dir / 'index.html'}", flush=True)
     return 0
 

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -189,22 +189,18 @@ def _checksum_metric_failed(entry: dict[str, Any], name: str) -> bool:
 
 
 def _checksum_headline(name: str, raw: Any, entry: dict[str, Any]) -> str:
-    """Headline for checksum metrics — neutral unless the harness confirms match.
+    """Headline for checksum metrics — neutral unless the harness reports failure.
 
-    Checksums are serialized as floats in nightly JSON; ``observed == expected``
-    is unsafe for large int64 checksums that can collide after rounding. Trust
-    the entry verdict and failure reasons from ``compare_to_baseline`` instead.
+    Checksums are serialized as floats in nightly JSON; both ``observed == expected``
+    and a ``pass`` verdict can be wrong for large int64 values that collide after
+    rounding. Only surface a definite mismatch from failure reasons; otherwise
+    show the captured value.
     """
     label = name.replace("_", " ")
     if not _isnum(raw):
         return f"{label}: —"
-    verdict = str(entry.get("verdict", ""))
-    deltas = entry.get("deltas") or {}
-    metric_delta = (deltas.get("metrics") or {}).get(name)
-    if verdict == "fail" and _checksum_metric_failed(entry, name):
+    if str(entry.get("verdict", "")) == "fail" and _checksum_metric_failed(entry, name):
         return f"{label}: mismatch ✗"
-    if verdict == "pass" and metric_delta and metric_delta.get("policy") == "equal":
-        return f"{label}: match ✓"
     return f"{label}: captured ({_fmt_num(raw)})"
 
 
@@ -296,7 +292,7 @@ def _run_command_block(entry_name: str) -> str:
 def _category_statuses(
     latest_entries: list[dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
-    """Structured category health for ``data.json`` consumers."""
+    """Structured category health for ``status.json`` consumers."""
     meta = load_dashboard_metadata()
     categories = meta.get("categories") or {}
     by_entry: dict[str, list[dict[str, Any]]] = {}
@@ -343,8 +339,8 @@ def _headline_metrics_for_entries(
     return out
 
 
-def build_data_json(results: list[dict[str, Any]]) -> dict[str, Any]:
-    """Aggregate history plus structured latest-night summary for embeds."""
+def build_status_json(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Structured latest-night summary for embeds (separate from the history feed)."""
     latest = results[-1] if results else None
     status, _ = _latest_status(results)
     latest_entries = list((latest or {}).get("entries") or [])
@@ -360,7 +356,6 @@ def build_data_json(results: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "schema_version": 2,
         "latest": latest_block,
-        "results": results,
     }
 
 
@@ -388,9 +383,9 @@ def build_scaling_summary(latest_entries: list[dict[str, Any]]) -> str:
         if p50_2 is None or p50_8 is None:
             continue
         ratio = p50_8 / p50_2 if p50_2 else None
-        # Ideal 8-GPU step time with perfect 4× scaling from 2 GPUs.
-        ideal_8 = p50_2 / 4.0
-        efficiency = (ideal_8 / p50_8 * 100.0) if p50_8 else None
+        # Weak scaling: recipes keep the same per-rank batch, so global batch
+        # grows 4× from 2 to 8 GPUs and ideal step time stays flat.
+        efficiency = (p50_2 / p50_8 * 100.0) if p50_8 else None
         eff_txt = f"{efficiency:.0f}%" if efficiency is not None else "—"
         ratio_txt = f"{ratio:.2f}×" if ratio is not None else "—"
         rows.append(
@@ -405,8 +400,9 @@ def build_scaling_summary(latest_entries: list[dict[str, Any]]) -> str:
     return (
         "<h2>Training scaling (2 → 8 GPU)</h2>"
         "<p class='muted'>Reference step_time_p50 from the latest nightly. "
-        "Scaling efficiency assumes ideal 4× speedup from 2 to 8 GPUs on the "
-        "same recipe.</p>"
+        "Recipes use the same per-rank batch at 2 and 8 GPUs (weak scaling), so "
+        "ideal step time is flat. Efficiency is "
+        "<span class='mono'>p50_2 / p50_8</span> as a percentage.</p>"
         "<div class='tablewrap'><table class='scaling'>"
         "<thead><tr><th>strategy</th><th class='num'>2 GPU p50</th>"
         "<th class='num'>8 GPU p50</th><th class='num'>slowdown</th>"
@@ -752,12 +748,23 @@ def build_history_grid(results: list[dict[str, Any]], max_runs: int = _GRID_RUNS
     if not ordered:
         return ""
 
-    head = "".join(
-        f"<th scope='col' class='wlcol'>"
-        f"<a href='#wl-{_esc(n)}' title='{_esc(n)} — jump to workload'>"
-        f"{_esc(str(_workload_meta(n).get('title') or n))}</a></th>"
-        for n in ordered
-    )
+    active = set(newest)
+
+    def _wl_col_header(name: str) -> str:
+        title = str(_workload_meta(name).get("title") or name)
+        if name in active:
+            return (
+                f"<th scope='col' class='wlcol'>"
+                f"<a href='#wl-{_esc(name)}' title='{_esc(name)} — jump to workload'>"
+                f"{_esc(title)}</a></th>"
+            )
+        return (
+            f"<th scope='col' class='wlcol retired' "
+            f"title='{_esc(name)} — retired (no section below)'>"
+            f"{_esc(title)}</th>"
+        )
+
+    head = "".join(_wl_col_header(n) for n in ordered)
 
     newest_first = list(reversed(runs))
     rows = []
@@ -809,17 +816,21 @@ def build_history_grid(results: list[dict[str, Any]], max_runs: int = _GRID_RUNS
             # leaves anyone who cannot separate red from green — or who is on a
             # touch screen with no hover — unable to read the row at all.
             breakdown = f"{name} — {_tally_text(counts)}"
-            # role='img' so the aria-label is actually exposed: a plain span has
-            # the implicit generic role, which has no accessible name, so a
-            # screen reader is free to ignore the label and announce only the
-            # glyph and count -- the least useful part for a mixed group.
-            cells.append(
-                f"<td class='gcell'><a class='gcell-link' href='#wl-{_esc(name)}' "
-                f"title='{_esc(breakdown)} — jump to workload'>"
+            dot = (
                 f"<span class='dot' role='img' style='background:{bg}' "
                 f"aria-label='{_esc(breakdown)}'>"
-                f"{_esc(_VERDICT_GLYPH.get(worst, _UNKNOWN_GLYPH))} {_esc(count)}</span></a></td>"
+                f"{_esc(_VERDICT_GLYPH.get(worst, _UNKNOWN_GLYPH))} {_esc(count)}</span>"
             )
+            if name in active:
+                cells.append(
+                    f"<td class='gcell'><a class='gcell-link' href='#wl-{_esc(name)}' "
+                    f"title='{_esc(breakdown)} — jump to workload'>{dot}</a></td>"
+                )
+            else:
+                cells.append(
+                    f"<td class='gcell'><span class='gcell-retired' "
+                    f"title='{_esc(breakdown)} (retired workload)'>{dot}</span></td>"
+                )
 
         rows.append(
             f"<tr><th scope='row' class='runcell'>{when}{flag}"
@@ -833,7 +844,8 @@ def build_history_grid(results: list[dict[str, Any]], max_runs: int = _GRID_RUNS
         "<h2>Nightly release health</h2>"
         "<p class='muted'>Each row is one nightly release (newest first). The "
         "<strong>overall health</strong> column summarises that night's graded "
-        "verdicts; workload columns link to reproduction steps below. "
+        "verdicts; active workload columns link to reproduction steps below. "
+        "Retired columns (no longer in the latest matrix) are plain text. "
         "Cell glyphs: ✓ pass · ✗ fail · ◆ record · ○ skip.</p>"
         "<div class='tablewrap'><table class='grid'>"
         f"<thead><tr><th scope='col'>release</th>"
@@ -1482,7 +1494,8 @@ def build_dashboard_html(results: list[dict[str, Any]]) -> str:
         <a href="docs/">AORTA documentation</a> ·
         <a href="sanitizers/">Sanitizer nightly</a> ·
         <a href="https://github.com/{_REPO}">Repository</a> ·
-        <a href="data.json">data.json</a></p>
+        <a href="data.json">data.json</a> ·
+        <a href="status.json">status.json</a></p>
       <div class="chips">{toolchain}</div>
       <p class="prov-line">{' · '.join(provenance)}</p>
     </header>
@@ -1560,8 +1573,9 @@ def main() -> int:
         results = results[-args.max_builds:]
     args.out_dir.mkdir(parents=True, exist_ok=True)
     (args.out_dir / "index.html").write_text(build_dashboard_html(results), encoding="utf-8")
-    (args.out_dir / "data.json").write_text(
-        json.dumps(build_data_json(results), indent=2), encoding="utf-8")
+    (args.out_dir / "data.json").write_text(json.dumps(results, indent=2), encoding="utf-8")
+    (args.out_dir / "status.json").write_text(
+        json.dumps(build_status_json(results), indent=2), encoding="utf-8")
     print(f"dashboard: {len(results)} build(s) -> {args.out_dir / 'index.html'}", flush=True)
     return 0
 

--- a/scripts/ci/gen_dashboard.py
+++ b/scripts/ci/gen_dashboard.py
@@ -118,10 +118,10 @@ try:
     from dashboard_metadata import DASHBOARD_METADATA as _DEFAULT_METADATA
 except ImportError:  # pragma: no cover
     _DEFAULT_METADATA: dict[str, Any] = {
-        "categories": {}, "workloads": {}, "engineer_only_metrics": [],
+        "categories": {}, "workloads": {},
     }
 
-# Customer-facing headline for each internal _latest_status() label.
+# Plain-language headline for each internal _latest_status() label.
 _CUSTOMER_STATUS = {
     "unknown": "Unknown",
     "empty": "No data",
@@ -132,19 +132,9 @@ _CUSTOMER_STATUS = {
     "skipping": "Incomplete run",
 }
 
-# Metrics shown only in the engineer metrics table, not the headline row.
-_DEFAULT_ENGINEER_METRICS = frozenset({
-    "rank", "world_size", "local_world_size", "node_count",
-    "corruption_details_omitted", "parameter_count", "num_experts", "num_layers",
-    "generate_tokens", "decoded_tokens", "prompt_len", "batch_size",
-    "eff_batch_size", "eff_ffn_size", "eff_num_heads", "eff_seq_len",
-    "declared_h2d_tensor_size", "effective_h2d_tensor_size", "layers_verified",
-    "expected", "n", "sum", "final_loss",
-})
-
 
 def load_dashboard_metadata() -> dict[str, Any]:
-    """Load customer-facing workload/category metadata (pure, cached per process)."""
+    """Load workload/category metadata for the dashboard (pure, cached per process)."""
     if not hasattr(load_dashboard_metadata, "_cache"):
         load_dashboard_metadata._cache = None  # type: ignore[attr-defined]
     if load_dashboard_metadata._cache is not None:  # type: ignore[attr-defined]
@@ -161,12 +151,6 @@ def _workload_meta(entry_name: str) -> dict[str, Any]:
     return (load_dashboard_metadata().get("workloads") or {}).get(entry_name) or {}
 
 
-def _engineer_only_metrics() -> frozenset[str]:
-    meta = load_dashboard_metadata()
-    extra = meta.get("engineer_only_metrics") or []
-    return _DEFAULT_ENGINEER_METRICS | frozenset(str(m) for m in extra)
-
-
 # Correctness counters: any night-over-night change is significant.
 _CORRECTNESS_COUNTERS = frozenset({
     "ranks_with_divergence",
@@ -177,6 +161,18 @@ _CORRECTNESS_COUNTERS = frozenset({
 def _is_correctness_change_metric(name: str) -> bool:
     """True when any value change in this metric should surface in Correctness."""
     return _is_correctness_metric(name) or name in _CORRECTNESS_COUNTERS
+
+
+def _is_dashboard_performance_metric(name: str) -> bool:
+    """True for timing/throughput metrics the dashboard treats as performance.
+
+    Uses the dashboard's own unit map (and harness timings), not the eval-lib
+    gating allowlist — step_time_p50/p99 and mean_step_time_ms are headline
+    metrics here but are not eval_lib performance gates.
+    """
+    if _is_correctness_change_metric(name):
+        return False
+    return name in _METRIC_UNITS or name in _HARNESS_METRICS
 
 
 def _checksum_headline(name: str, raw: Any, entry: dict[str, Any]) -> str:
@@ -754,14 +750,13 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
             pct = (a - b) / abs(b) * 100.0
             if abs(pct) > _MOVE_PCT:
                 row = (abs(pct), pct, k, metric, b, a, latest_by[k])
-                if _is_performance_metric(metric):
+                if _is_dashboard_performance_metric(metric):
                     movers_perf.append(row)
                 else:
                     movers_other.append(row)
     movers_corr.sort(key=lambda r: (r[5], r[4]), reverse=True)
     movers_perf.sort(reverse=True)
     movers_other.sort(reverse=True)
-    movers = movers_corr + movers_perf + movers_other
 
     def _corr_mover_li(row: tuple) -> str:
         _, _, _k, metric, b, a, entry = row
@@ -795,8 +790,11 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
     for row in movers_other[:2]:
         items.append(_mover_li(row, ""))
 
-    shown = min(len(movers_corr), 4) + min(len(movers_perf), 4) + min(len(movers_other), 2)
-    extra = len(movers) - shown
+    shown_corr = min(len(movers_corr), 4)
+    shown_perf = min(len(movers_perf), 4)
+    shown_other = min(len(movers_other), 2)
+    extra_corr = len(movers_corr) - shown_corr
+    extra_thresholded = (len(movers_perf) - shown_perf) + (len(movers_other) - shown_other)
 
     since = _fmt_timestamp(str(prev.get("generated_at") or "")).split(" ")[0]
     if not items:
@@ -805,10 +803,20 @@ def build_change_summary(results: list[dict[str, Any]]) -> str:
             f"metric changed by more than {_MOVE_PCT:.0f}%.</p>"
         )
     else:
+        more_parts: list[str] = []
+        if extra_corr:
+            more_parts.append(
+                f"and {extra_corr} more correctness change"
+                f"{'' if extra_corr == 1 else 's'}"
+            )
+        if extra_thresholded:
+            more_parts.append(
+                f"and {extra_thresholded} more metric"
+                f"{'' if extra_thresholded == 1 else 's'} past {_MOVE_PCT:.0f}%"
+            )
         more = (
-            f"<p class='muted'>and {extra} more metric"
-            f"{'' if extra == 1 else 's'} past {_MOVE_PCT:.0f}%</p>"
-            if extra > 0 else ""
+            "".join(f"<p class='muted'>{p}</p>" for p in more_parts)
+            if more_parts else ""
         )
         body = f"<ul class='changes'>{''.join(items)}</ul>{more}"
 

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -443,7 +443,7 @@ def test_history_grid_needs_two_runs_before_it_says_anything():
     one = [_run(3, [_cell("w", "c")], total=1, record=1)]
     assert gen_dashboard.build_history_grid(one) == ""
     assert gen_dashboard.build_history_grid([]) == ""
-    assert "<h2>Run history</h2>" not in gen_dashboard.build_dashboard_html(one)
+    assert "<h2>Nightly release health</h2>" not in gen_dashboard.build_dashboard_html(one)
 
 
 def test_history_grid_puts_runs_on_rows_and_workloads_on_columns():
@@ -486,10 +486,9 @@ def test_history_grid_never_renders_an_unrecognised_verdict_as_healthy():
              total=2, **{"pass": 1}),
     ]
     grid = gen_dashboard.build_history_grid(runs)
-    cell = f"background:{gen_dashboard._UNKNOWN_COLOR}' title='w — 1 pass · 1 error'"
-    assert cell in grid          # the mixed group takes the unknown colour, not green
-    assert "? 1/2" in grid       # and reads as one unrecognised of two
-    assert "1 pass · 1 error" in grid  # the unknown is still counted in the hover
+    assert f"background:{gen_dashboard._UNKNOWN_COLOR}" in grid
+    assert "? 1/2" in grid
+    assert "1 pass · 1 error" in grid
 
 
 def test_history_grid_ranks_a_known_failure_above_an_unrecognised_verdict():
@@ -848,6 +847,72 @@ def test_dashboard_run_command_block():
     html = gen_dashboard.build_dashboard_html([r])
     assert "Run this workload locally" in html
     assert "example-inference-smoke.yaml" in html
+    assert "getting started guide" in html
+    assert "README-running-recipes.md" in html
+    assert "id='repro-inference_offline'" in html
+    assert "href='#repro-inference_offline'" in html
+
+
+def test_history_grid_workloads_and_cells_link_to_repro_sections():
+    runs = [
+        _run(3, [_cell("gpu_smoke", "c"), _cell("race", "smoke")], total=2, record=2),
+        _run(4, [_cell("gpu_smoke", "c"), _cell("race", "smoke")], total=2, record=2),
+    ]
+    grid = gen_dashboard.build_history_grid(runs)
+    assert "href='#wl-gpu_smoke'" in grid
+    assert "gcell-link" in grid
+    assert "overall health" in grid
+
+
+def test_history_grid_overall_health_uses_customer_label():
+    runs = [
+        _run(3, [_cell("w", "c")], total=1, record=1),
+        _run(4, [_cell("w", "c")], total=1, record=1),
+    ]
+    grid = gen_dashboard.build_history_grid(runs)
+    assert "Baseline setup" in grid
+
+
+def test_build_data_json_v2_wraps_results_with_latest_summary():
+    entries = [
+        {"entry": "gpu_smoke", "cell": "baseline-local", "verdict": "record",
+         "reasons": [], "metrics": {"mean_step_time_ms": 1.0}},
+    ]
+    runs = [_results("2026-08-03T12:00:00Z", entries, total=1, record=1)]
+    doc = gen_dashboard.build_data_json(runs)
+    assert doc["schema_version"] == 2
+    assert doc["latest"]["customer_status"] == "Baseline setup"
+    assert doc["latest"]["categories"]["platform"]["worst_verdict"] == "record"
+    assert doc["results"] == runs
+
+
+def test_scaling_summary_renders_when_two_and_eight_gpu_training_present():
+    entries = [
+        _cell("training_ddp", "c", summary={"step_time_p50": 8.0}),
+        _cell("training_ddp_8gpu", "c", summary={"step_time_p50": 2.5}),
+        _cell("training_fsdp", "c", summary={"step_time_p50": 10.0}),
+        _cell("training_fsdp_8gpu", "c", summary={"step_time_p50": 3.0}),
+    ]
+    html = gen_dashboard.build_scaling_summary(entries)
+    assert "Training scaling" in html
+    assert "DDP" in html and "FSDP" in html
+
+
+def test_dashboard_metadata_covers_nightly_matrix():
+    matrix_path = _REPO_ROOT / "config" / "ci" / "nightly_eval_matrix.yaml"
+    text = matrix_path.read_text(encoding="utf-8")
+    names = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("- name:"):
+            names.append(line.split(":", 1)[1].strip())
+    meta = gen_dashboard.load_dashboard_metadata()
+    workloads = meta.get("workloads") or {}
+    missing = [n for n in names if n not in workloads]
+    assert not missing, f"missing dashboard metadata for {missing}"
+    for name in names:
+        assert workloads[name].get("run_command"), name
+        assert workloads[name].get("recipe"), name
 
 
 def test_dashboard_failure_action_panel():

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -811,6 +811,22 @@ def test_dashboard_renders_category_health_tiles():
     assert "Healthy" in html  # one pass + one record => passing headline
 
 
+def test_dashboard_pass_and_skip_is_not_labelled_healthy():
+    entries = [
+        {"entry": "gpu_smoke", "cell": "baseline-local", "verdict": "pass",
+         "reasons": [], "metrics": {"mean_step_time_ms": 1.0}},
+        {"entry": "training_ddp_8gpu", "cell": None, "verdict": "skip",
+         "reasons": ["needs 8 GPU(s), have 2"], "metrics": {}},
+    ]
+    doc = _results("2026-07-30T00:00:00Z", entries, total=2, **{"pass": 1, "skip": 1})
+    assert gen_dashboard._latest_status([doc])[0] == "partial"
+    html = gen_dashboard.build_dashboard_html([doc])
+    assert "Partial run" in html
+    assert ">Healthy<" not in html
+    assert "partial" in html
+    assert "partial</strong>" in html or "<strong>partial</strong>" in html
+
+
 def test_dashboard_record_only_shows_baseline_setup_label():
     r = _results("2026-07-30T00:00:00Z",
                  [{"entry": "w", "cell": "c", "verdict": "record",

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -623,6 +623,7 @@ def test_change_summary_lists_metrics_that_moved_past_the_threshold():
              total=1, record=1),
     ]
     html = gen_dashboard.build_change_summary(runs)
+    assert "Performance" in html
     assert "mean_step_time_ms" in html and "+50.0%" in html
     assert "latency_ms" not in html  # 2% is inside the noise floor
 
@@ -901,3 +902,28 @@ def test_category_tile_anchors_to_workload_that_actually_ran():
         [_results("2026-08-03T00:00:00Z", entries, total=1, record=1)])
     assert "href='#wl-training_ddp_8gpu'" in html
     assert "href='#wl-training_ddp'" not in html
+
+
+def test_change_summary_groups_step_time_p99_under_performance():
+    runs = [
+        _run(3, [_cell("w", "c", summary={"step_time_p99": 40.0})], total=1, record=1),
+        _run(4, [_cell("w", "c", summary={"step_time_p99": 50.0})], total=1, record=1),
+    ]
+    html = gen_dashboard.build_change_summary(runs)
+    assert "Performance" in html
+    assert "step_time_p99" in html
+
+
+def test_change_summary_footer_splits_correctness_from_thresholded():
+    cells = [
+        _cell("w", f"c{i}", summary={"layer_checksum_mismatches": i})
+        for i in range(6)
+    ]
+    runs = [
+        _run(3, cells[:6], total=6, record=6),
+        _run(4, [_cell("w", f"c{i}", summary={"layer_checksum_mismatches": i + 1})
+                 for i in range(6)], total=6, record=6),
+    ]
+    html = gen_dashboard.build_change_summary(runs)
+    assert "and 2 more correctness changes" in html
+    assert "past 10%" not in html

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -853,6 +853,17 @@ def test_dashboard_run_command_block():
     assert "href='#repro-inference_offline'" in html
 
 
+def test_history_grid_retired_workloads_do_not_link_to_missing_sections():
+    runs = [
+        _run(3, [_cell("old_workload", "c")], total=1, record=1),
+        _run(4, [_cell("gpu_smoke", "c")], total=1, record=1),
+    ]
+    grid = gen_dashboard.build_history_grid(runs)
+    assert "href='#wl-old_workload'" not in grid
+    assert "gcell-retired" in grid
+    assert "href='#wl-gpu_smoke'" in grid
+
+
 def test_history_grid_workloads_and_cells_link_to_repro_sections():
     runs = [
         _run(3, [_cell("gpu_smoke", "c"), _cell("race", "smoke")], total=2, record=2),
@@ -873,17 +884,39 @@ def test_history_grid_overall_health_uses_customer_label():
     assert "Baseline setup" in grid
 
 
-def test_build_data_json_v2_wraps_results_with_latest_summary():
+def test_build_status_json_structured_latest_summary():
     entries = [
         {"entry": "gpu_smoke", "cell": "baseline-local", "verdict": "record",
          "reasons": [], "metrics": {"mean_step_time_ms": 1.0}},
     ]
     runs = [_results("2026-08-03T12:00:00Z", entries, total=1, record=1)]
-    doc = gen_dashboard.build_data_json(runs)
+    doc = gen_dashboard.build_status_json(runs)
     assert doc["schema_version"] == 2
     assert doc["latest"]["customer_status"] == "Baseline setup"
     assert doc["latest"]["categories"]["platform"]["worst_verdict"] == "record"
-    assert doc["results"] == runs
+    assert "results" not in doc
+
+
+def test_data_json_feed_stays_a_top_level_array():
+    entries = [
+        {"entry": "gpu_smoke", "cell": "baseline-local", "verdict": "record",
+         "reasons": [], "metrics": {"mean_step_time_ms": 1.0}},
+    ]
+    runs = [_results("2026-08-03T12:00:00Z", entries, total=1, record=1)]
+    import json
+    feed = json.loads(json.dumps(runs, indent=2))
+    assert isinstance(feed, list)
+    assert feed == runs
+
+
+def test_scaling_summary_uses_weak_scaling_efficiency():
+    entries = [
+        _cell("training_ddp", "c", summary={"step_time_p50": 8.0}),
+        _cell("training_ddp_8gpu", "c", summary={"step_time_p50": 2.0}),
+    ]
+    html = gen_dashboard.build_scaling_summary(entries)
+    assert "weak scaling" in html
+    assert "400%" in html  # 8.0 / 2.0 * 100
 
 
 def test_scaling_summary_renders_when_two_and_eight_gpu_training_present():
@@ -938,7 +971,8 @@ def test_headline_checksum_record_only_shows_captured_not_match():
     assert "match ✓" not in html
 
 
-def test_headline_checksum_shows_match_when_comparison_confirms():
+def test_headline_checksum_pass_verdict_still_shows_captured_not_match():
+    """A pass verdict cannot confirm exact checksum equality after float rounding."""
     entry = {"entry": "inference_offline", "cell": "baseline-local",
              "verdict": "pass", "reasons": [],
              "metrics": {"mean_step_time_ms": 4.0,
@@ -947,7 +981,8 @@ def test_headline_checksum_shows_match_when_comparison_confirms():
                  "observed": 33904201, "policy": "equal", "value": 33904201}}}}
     html = gen_dashboard.build_dashboard_html(
         [_results("2026-07-30T00:00:00Z", [entry], total=1, **{"pass": 1})])
-    assert "logits checksum: match ✓" in html
+    assert "logits checksum: captured (33,904,201)" in html
+    assert "logits checksum: match ✓" not in html
 
 
 def test_headline_checksum_no_match_on_float_equality_when_harness_failed():

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -842,3 +842,62 @@ def test_dashboard_failure_action_panel():
     html = gen_dashboard.build_dashboard_html([r])
     assert "Next steps" in html
     assert "aorta env probe" in html
+
+
+def test_headline_checksum_record_only_shows_captured_not_match():
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "inference_offline", "cell": "baseline-local",
+                   "verdict": "record", "reasons": ["no baseline (record-only)"],
+                   "metrics": {"mean_step_time_ms": 4.0,
+                               "summary": {"logits_checksum": 33904201}}}],
+                 total=1, record=1)
+    html = gen_dashboard.build_dashboard_html([r])
+    assert "captured (33,904,201)" in html
+    assert "match ✓" not in html
+
+
+def test_headline_checksum_shows_match_when_comparison_confirms():
+    entry = {"entry": "inference_offline", "cell": "baseline-local",
+             "verdict": "pass", "reasons": [],
+             "metrics": {"mean_step_time_ms": 4.0,
+                         "summary": {"logits_checksum": 33904201}},
+             "deltas": {"metrics": {"logits_checksum": {
+                 "observed": 33904201, "policy": "equal", "value": 33904201}}}}
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-07-30T00:00:00Z", [entry], total=1, **{"pass": 1})])
+    assert "logits checksum: match ✓" in html
+
+
+def test_change_summary_reports_correctness_counter_without_pct_gate():
+    runs = [
+        _run(3, [_cell("race", "smoke", summary={"layer_checksum_mismatches": 0})],
+             total=1, record=1),
+        _run(4, [_cell("race", "smoke", summary={"layer_checksum_mismatches": 1})],
+             total=1, record=1),
+    ]
+    html = gen_dashboard.build_change_summary(runs)
+    assert "Correctness" in html
+    assert "layer_checksum_mismatches" in html
+    assert "0 → 1" in html
+
+
+def test_change_summary_reports_checksum_inequality_below_pct_gate():
+    runs = [
+        _run(3, [_cell("w", "c", summary={"logits_checksum": 100})], total=1, record=1),
+        _run(4, [_cell("w", "c", summary={"logits_checksum": 102})], total=1, record=1),
+    ]
+    html = gen_dashboard.build_change_summary(runs)
+    assert "Correctness" in html
+    assert "logits_checksum" in html
+    assert "100 → 102" in html
+
+
+def test_category_tile_anchors_to_workload_that_actually_ran():
+    entries = [
+        {"entry": "training_ddp_8gpu", "cell": "baseline-local", "verdict": "record",
+         "reasons": [], "metrics": {"mean_step_time_ms": 10.0}},
+    ]
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-08-03T00:00:00Z", entries, total=1, record=1)])
+    assert "href='#wl-training_ddp_8gpu'" in html
+    assert "href='#wl-training_ddp'" not in html

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -45,8 +45,9 @@ def test_dashboard_renders_status_and_rows():
                     "reasons": ["mean_step_time_ms 9 > max 5"], "metrics": {"mean_step_time_ms": 9.0}}],
                   total=1, fail=1)
     html = gen_dashboard.build_dashboard_html([r1, r2])
-    assert "aorta nightly CI" in html
-    assert "failing" in html  # latest run failed
+    assert "ROCm stack health" in html
+    assert "Regression detected" in html
+    assert "failing" in html  # internal label still visible
     # Cells are grouped under their workload, so the two names render separately.
     assert "inference_offline" in html
     assert "baseline-local" in html
@@ -61,7 +62,7 @@ def test_dashboard_empty_history():
 def test_dashboard_links_to_sanitizer_nightly():
     html = gen_dashboard.build_dashboard_html([])
     assert 'href="sanitizers/"' in html
-    assert "sanitizer nightly" in html
+    assert "Sanitizer nightly" in html
 
 
 def test_dashboard_renders_summary_metric_series():
@@ -274,8 +275,9 @@ def test_dashboard_groups_cells_under_their_workload():
     ]
     html = gen_dashboard.build_dashboard_html(
         [_results("2026-07-30T00:00:00Z", entries, total=2, record=2)])
-    # One group header for the workload, and each cell listed beneath it.
-    assert html.count("llm_determinism") == 1
+    # Customer title once in the group header; internal id in wl-id + category anchor.
+    assert "LLM determinism" in html
+    assert html.count("llm_determinism") >= 1
     assert "bf16-12L" in html and "tf32-24L" in html
 
 
@@ -791,3 +793,52 @@ def test_dashboard_hides_the_js_only_controls_until_the_script_runs():
     assert '<div class="toolbar" id="toolbar" hidden>' in html
     assert "bar.hidden = false" in html
     assert "Expand all" in html
+
+
+def test_dashboard_renders_category_health_tiles():
+    entries = [
+        {"entry": "gpu_smoke", "cell": "baseline-local", "verdict": "record",
+         "reasons": [], "metrics": {"mean_step_time_ms": 254.0}},
+        {"entry": "inference_offline", "cell": "baseline-local", "verdict": "pass",
+         "reasons": [], "metrics": {"mean_step_time_ms": 4.0,
+                                    "summary": {"tokens_per_sec": 4160}}},
+    ]
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-08-03T00:00:00Z", entries, total=2, record=1, **{"pass": 1})])
+    assert "Category health" in html
+    assert "Platform" in html and "Inference" in html
+    assert "Healthy" in html  # one pass + one record => passing headline
+
+
+def test_dashboard_record_only_shows_baseline_setup_label():
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "w", "cell": "c", "verdict": "record",
+                   "reasons": ["no baseline (record-only)"],
+                   "metrics": {"mean_step_time_ms": 1.0}}],
+                 total=1, record=1)
+    html = gen_dashboard.build_dashboard_html([r])
+    assert "Baseline setup" in html
+    assert "recording" in html
+    assert ">passing<" not in html
+
+
+def test_dashboard_run_command_block():
+    r = _results("2026-07-30T00:00:00Z",
+                 [{"entry": "inference_offline", "cell": "baseline-local",
+                   "verdict": "record", "reasons": [],
+                   "metrics": {"mean_step_time_ms": 4.0}}],
+                 total=1, record=1)
+    html = gen_dashboard.build_dashboard_html([r])
+    assert "Run this workload locally" in html
+    assert "example-inference-smoke.yaml" in html
+
+
+def test_dashboard_failure_action_panel():
+    r = _results("2026-07-29T00:00:00Z",
+                 [{"entry": "race", "cell": "smoke", "verdict": "fail",
+                   "reasons": ["expected passing cell but it did not pass"],
+                   "metrics": {"mean_step_time_ms": 1.0}}],
+                 total=1, fail=1)
+    html = gen_dashboard.build_dashboard_html([r])
+    assert "Next steps" in html
+    assert "aorta env probe" in html

--- a/tests/ci/test_dashboard_and_alert.py
+++ b/tests/ci/test_dashboard_and_alert.py
@@ -885,6 +885,22 @@ def test_headline_checksum_shows_match_when_comparison_confirms():
     assert "logits checksum: match ✓" in html
 
 
+def test_headline_checksum_no_match_on_float_equality_when_harness_failed():
+    """Distinct int64 checksums can round to the same float; trust verdict, not ==."""
+    collided = 9007199254740992.0  # 2**53 — float equality hides int64 differences
+    entry = {"entry": "inference_offline", "cell": "baseline-local",
+             "verdict": "fail",
+             "reasons": ["metric 'logits_checksum' != expected 9007199254740993"],
+             "metrics": {"mean_step_time_ms": 4.0,
+                         "summary": {"logits_checksum": collided}},
+             "deltas": {"metrics": {"logits_checksum": {
+                 "observed": collided, "policy": "equal", "value": collided}}}}
+    html = gen_dashboard.build_dashboard_html(
+        [_results("2026-07-30T00:00:00Z", [entry], total=1, fail=1)])
+    assert "logits checksum: mismatch ✗" in html
+    assert "logits checksum: match ✓" not in html
+
+
 def test_change_summary_reports_correctness_counter_without_pct_gate():
     runs = [
         _run(3, [_cell("race", "smoke", summary={"layer_checksum_mismatches": 0})],


### PR DESCRIPTION
## Summary

- **Clickable workloads** — category tiles, nightly health grid columns/cells, and workload titles link to reproduction steps (active workloads only)
- **Reproduce locally** — step-by-step panels per workload (GPU requirements, install guide, exact command, recipe link)
- **Nightly release health** — customer-facing overall health per release row
- **Category health tiles** — Platform · Inference · Training · Correctness
- **Training scaling table** — weak-scaling efficiency (`p50_2 / p50_8`) for 2→8 GPU recipes
- **Change summary** — correctness vs performance grouping
- **status.json** — structured latest-night summary (`schema_version: 2`); **`data.json` unchanged** (top-level history array for existing pollers)
- **Failure next steps** — env probe + ROCm issue guidance

Presentation-only in `gen_dashboard.py` / `dashboard_metadata.py`.

## Test plan

- [x] `pytest tests/ci/test_dashboard_and_alert.py` (77 tests)
- [ ] Verify `/data.json` and `/ci/data.json` remain identical arrays after deploy
- [ ] Verify `/status.json` for embed consumers