### PR TITLE
ci: bless nightly-eval correctness baselines (2026-08-10)

### DIFF
--- a/config/ci/regression_baselines.yaml
+++ b/config/ci/regression_baselines.yaml
@@ -1,25 +1,42 @@
 # Expected-outcome baselines for the nightly evaluation.
-#
-# Keyed by "<entry>::<cell>" (entry from config/ci/nightly_eval_matrix.yaml, cell
-# from the recipe). Empty => RECORD-ONLY: the harness records observed metrics and
-# passes; it only compares/fails a cell once a blessed baseline entry exists here.
-#
-# Baselines are ROCm/stack-specific (numerics + step times move with ROCm /
-# hipBLASLt), so they are (re)generated on the runner and blessed via a PR from
-# the refresh-baselines workflow (scripts/ci/refresh_baselines.py) -- never
-# hand-edited blindly, never auto-committed.
-#
-# Entry shape (once blessed):
-#   "<entry>::<cell>":
-#     passed: true                     # require the cell to pass (clean run)
-#     step_time_ms: { max: <float> }   # fail if mean_step_time_ms exceeds max
-#                                      #   (a configured max with a MISSING
-#                                      #   observation is also a fail)
-#     metrics:                         # generic metric bounds with explicit policy
-#       gflops:            { policy: min,   value: <float> }   # fail if below
-#       decode_latency_ms: { policy: max,   value: <float> }   # fail if above
-#       logits_checksum:   { policy: equal, value: <number> }  # fail if != value
-#       # `required: false` allows a metric to be absent without failing;
-#       # policy defaults to eval_lib._METRIC_POLICIES when omitted.
+# Blessed from nightly run 2026-08-10 (16/16 record, 0 skip) on MI350.
+# Correctness-only (checksum equal policies); perf gating not enabled.
+# Regenerate via scripts/ci/refresh_baselines.py after stack bumps.
+baselines:
+  gpu_smoke::baseline-local:
+    passed: true
+  inference_offline::baseline-local:
+    metrics:
+      logits_checksum:
+        policy: equal
+        value: 33904201.0
+    passed: true
+  llm_determinism::baseline-bf16-24L:
+    passed: true
+  llm_determinism::bf16-12L:
+    passed: true
+  llm_determinism::moe4-bf16-12L:
+    passed: true
+  llm_determinism::tf32_off-bf16-24L:
+    passed: true
+  llm_determinism_8gpu::baseline-bf16-24L:
+    passed: true
+  llm_determinism_8gpu::bf16-12L:
+    passed: true
+  llm_determinism_8gpu::moe4-bf16-12L:
+    passed: true
+  llm_determinism_8gpu::tf32_off-bf16-24L:
+    passed: true
+  race::smoke:
+    passed: true
+  race_8gpu::smoke:
+    passed: true
+  training_ddp::baseline-local:
+    passed: true
+  training_ddp_8gpu::baseline-local:
+    passed: true
+  training_fsdp::baseline-local:
+    passed: true
+  training_fsdp_8gpu::baseline-local:
+    passed: true
 version: 1
-baselines: {}


### PR DESCRIPTION
## Summary

Blesses `config/ci/regression_baselines.yaml` from the stable **2026-08-10** nightly on MI350 (16/16 record, 0 skip).

- **16 cells** across all public-matrix workloads
- **Correctness-only**: `logits_checksum` equal policies where present; `passed: true` for all cells
- **No perf gating** yet (`--perf-gate` deferred)

After merge, the next nightly should grade pass/fail and the dashboard can show **Healthy** / **Regression detected**.

## Test plan

- [ ] CI passes
- [ ] Next nightly shows non-zero pass/fail counts
- [ ] Dashboard moves off **Baseline setup** when all cells pass

Made with [Cursor](https://cursor.com)