### PR TITLE
fix(sanitizers): cap informational consan-gemm nightly timeout at 300s

### DIFF
--- a/recipes/sanitizers/daily-consan-gemm.yaml
+++ b/recipes/sanitizers/daily-consan-gemm.yaml
@@ -30,6 +30,12 @@ sanitizer_plan:
   policy:
     consan_policy: strict
     on_missing_backend: fail
-    timeout_seconds: 3600
+    # This object's MOI inventory does not terminate on the current rocjitsu build
+    # (ROCm/rocm-systems#9964), so it always hits combined_hook_timeout and the run
+    # consumes the full ceiling. Keep it small (past the ~70s load-time waitcheck,
+    # into the inventory) so the informational row documents that state without
+    # adding ~an hour to every nightly. Raise it once #9964 lands and the object can
+    # actually complete.
+    timeout_seconds: 300
   output:
     report: sanitizer_report.json


### PR DESCRIPTION
## Summary

Follow-up to #362. The informational `daily-consan-gemm` case drives ConSan over a heavy f32 GEMM object whose MOI inventory **does not terminate** on the current rocjitsu build (ROCm/rocm-systems#9964), so it always hits `combined_hook_timeout` and the run consumes the **entire** `timeout_seconds`. At `3600` that adds **~an hour to every sanitizer-nightly** for the exact same informational verdict a short ceiling produces.

Cap it at **300s** (past the ~70s load-time waitcheck, into the inventory) so the informational row still documents the timeout state without dominating the nightly. Raise it once #9964 lands and the object can actually complete.

## Impact on nightly runtime

- Before: informational `consan-gemm` ran the full **~60 min** (never completes → killed at 3600s).
- After: **~5 min** for that case; same `combined_hook_timeout` verdict.
- The other informational cases (`lds-dispatch`, `tiny`) fail closed in ~seconds; the guarded informational block cannot affect the daily gate.

Recipe-only change; no code.

Made with Cursor

Made with [Cursor](https://cursor.com)