### PR TITLE
Fix sanitizers nightly docker exec shell quoting

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -163,7 +163,7 @@ jobs:
               --output-dir "${SANITIZER_OUT}/consan-racy" || true
 
             # Informational (non-gating) ConSan over caller-supplied code objects
-            # (#347), rendered in the dashboard's informational section. The ENTIRE
+            # (#347), rendered in the dashboard informational section. The ENTIRE
             # informational path -- fixture build (hipcc/genco/unbundle) AND the
             # sweeps -- runs in a guarded subshell so no failure here (a bad genco,
             # bundler, or compile) can abort the job before the gate below. It is
@@ -177,7 +177,7 @@ jobs:
               genco_object() {  # <hip-source> <final .hsaco>
                 local tmp; tmp="$(mktemp --suffix=.o)" || return 1
                 hipcc --genco --offload-arch=gfx950 "$1" -o "$tmp" || return 1
-                if head -c 24 "$tmp" | grep -q '__CLANG_OFFLOAD_BUNDLE__'; then
+                if head -c 24 "$tmp" | grep -qF __CLANG_OFFLOAD_BUNDLE__; then
                   clang-offload-bundler --type=o --unbundle --input="$tmp" \
                     --targets=hipv4-amdgcn-amd-amdhsa--gfx950 --output="$2" || return 1
                 else


### PR DESCRIPTION
## Summary
Fixes the Sanitizers Nightly failure introduced in #362 where part of the job ran on the self-hosted runner host instead of inside the `aorta-ci-gpu` container.

The `Run sanitizer regression` step passes its script via `bash -lc '...'`. Two unescaped single quotes inside that string terminated the argument early:
- `dashboard's` in a comment (first break)
- `'__CLANG_OFFLOAD_BUNDLE__'` in `grep` (second break)

After the break, the host tried to run `mkdir "${SANITIZER_OUT}/informational/..."` with an unset `SANITIZER_OUT`, creating `/informational/...`, and failed with `python`/`aorta`/`hipcc` not found (exit 127).

## Changes
- Reword comment: `dashboard's` → `dashboard` (no apostrophe)
- Use `grep -qF __CLANG_OFFLOAD_BUNDLE__` (no single quotes)

Verified: zero `'` characters remain inside the `bash -lc` payload.

## Test plan
- [x] YAML parses
- [x] Confirmed no single quotes remain inside the `bash -lc '...'` block
- [x] `pytest tests/sanitizers/test_dashboard.py` (36 passed)
- [ ] Re-run Sanitizers Nightly workflow on merge


Made with [Cursor](https://cursor.com)