### PR TITLE
ci(sanitizers): stream nightly progress logs and parallelize waitcheck scans

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -94,6 +94,12 @@ jobs:
             SANITIZER_OUT="${SANITIZER_ROOT}/out"
             FIXTURES=recipes/sanitizers/fixtures
 
+            # Timestamped phase markers keep the job log alive: the sanitizer
+            # scans below are minutes of silent, CPU-bound static work, so an
+            # unannotated run looks frozen for ~15 min (#366). Each phase prints
+            # "[HH:MM:SS] <phase> …" so an operator can see what is executing and
+            # how long it takes.
+            echo "[$(date +%T)] setup: installing aorta (editable, [tests]) …"
             python -m pip install --upgrade pip
             pip install -e ".[tests]"
 
@@ -108,6 +114,7 @@ jobs:
             # even though rocm-systems is public: the unauthenticated artifact
             # /zip endpoint returns 401 and no equivalent GitHub Release exists.
             # See the step env (GH_TOKEN) and the token note there.
+            echo "[$(date +%T)] setup: downloading prebuilt rocjitsu sanitizer bundle (${ROCJITSU_REF}) …"
             rm -rf "${ROCJITSU_PREBUILT}"
             mkdir -p "${SANITIZER_ROOT}"
             # Run the VENDORED downloader (scripts/sanitizers/, copied from a
@@ -131,6 +138,7 @@ jobs:
             # those never inherit the cross-repo PAT.
             unset GH_TOKEN GITHUB_TOKEN
             # Record the source commit for provenance (bundle is ephemeral).
+            echo "[$(date +%T)] setup: verified bundle digests; recording rocjitsu provenance …"
             python -c "import json,sys; m=json.load(open(sys.argv[1])); \
               print(\"ROCJITSU bundle commit:\", m.get(\"commit\"), \
               \"run:\", m.get(\"run_url\"))" \
@@ -144,10 +152,13 @@ jobs:
             export PATH="${ROCM_PATH:-${ROCM_HOME:-/opt/rocm}}/lib/llvm/bin:${PATH}"
 
             mkdir -p "${FIXTURES}/bin" "${FIXTURES}/isa"
+            echo "[$(date +%T)] fixture build: hipcc consan_lds_race (clean single-wave LDS repro) …"
             hipcc --offload-arch=gfx950 -O1 -g "${FIXTURES}/repro/consan_lds_race.hip" \
               -o "${FIXTURES}/bin/consan_lds_race"
+            echo "[$(date +%T)] fixture build: hipcc consan_lds_race_2wave (racy two-wave LDS repro) …"
             hipcc --offload-arch=gfx950 -O1 -g "${FIXTURES}/repro/consan_lds_race_2wave.hip" \
               -o "${FIXTURES}/bin/consan_lds_race_2wave"
+            echo "[$(date +%T)] fixture build: extracting real per-transpose f32 GEMM code objects for the top-3 shapes (~16MB each; distinct SHA per transpose layout) …"
             python scripts/sanitizers/prepare_gemm_isa.py \
               --csv "${FIXTURES}/gemm_shapes_unique.csv" --out "${FIXTURES}/isa" --top-n 3
 
@@ -155,10 +166,13 @@ jobs:
             # guardrail-safe CLI. The authoritative gate is the baseline
             # comparator below, so these only need to produce reports.
             mkdir -p "${SANITIZER_OUT}/waitcheck" "${SANITIZER_OUT}/consan-clean" "${SANITIZER_OUT}/consan-racy"
+            echo "[$(date +%T)] daily-waitcheck-gemm: concurrent rj_waitcheck scan of the top-3 shapes' distinct f32 GEMM transpose objects (CPU-bound, ~1 min each) …"
             aorta sweep run --recipe recipes/sanitizers/daily-waitcheck-gemm.yaml \
               --output-dir "${SANITIZER_OUT}/waitcheck" || true
+            echo "[$(date +%T)] daily-consan-clean: ConSan on single-wave LDS repro (expect pass) …"
             aorta sweep run --recipe recipes/sanitizers/daily-consan-clean.yaml \
               --output-dir "${SANITIZER_OUT}/consan-clean" || true
+            echo "[$(date +%T)] daily-consan-racy: ConSan on two-wave LDS race repro (expect fail) …"
             aorta sweep run --recipe recipes/sanitizers/daily-consan-racy.yaml \
               --output-dir "${SANITIZER_OUT}/consan-racy" || true
 
@@ -168,6 +182,7 @@ jobs:
             # sweeps -- runs in a guarded subshell so no failure here (a bad genco,
             # bundler, or compile) can abort the job before the gate below. It is
             # best-effort: a missing report simply omits that dashboard row.
+            echo "[$(date +%T)] informational: ConSan over caller-supplied code objects (#347; non-gating) …"
             (
               set +e
               KROOT="${FIXTURES}/kernels"
@@ -211,6 +226,7 @@ jobs:
 
             # Gate is the three daily controls only; the guarded informational block
             # above cannot reach this line with a non-zero status.
+            echo "[$(date +%T)] gate: comparing reports against verdict_baselines.json …"
             python scripts/sanitizers/compare_verdict_baselines.py "${SANITIZER_OUT}"
           '
 

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -35,6 +35,11 @@ jobs:
     # `self-hosted, gpu, mi350x` (same set the other GPU workflows target, e.g.
     # gpu-tests.yml / eval-reusable.yml use `self-hosted, gpu`).
     runs-on: [self-hosted, gpu]
+    # 120 min is GitHub's ceiling for this job, not necessarily the binding
+    # limit: an effective ~20-min cap has been observed on the [self-hosted,
+    # gpu] runner (a runner/org Actions policy that a workflow's timeout-minutes
+    # can only lower, never raise). Confirming and raising that effective cap is
+    # tracked in #370 (split out of #366).
     timeout-minutes: 120
     steps:
       # Sibling GPU jobs (gpu-tests.yml et al.) run aorta in a root ROCm CI

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
 from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Protocol
 
@@ -434,8 +436,8 @@ def run_waitcheck(
         ("sha256", _sha256_file(resolved)),
     )
     output_dir.mkdir(parents=True, exist_ok=True)
-    kernel_results: list[KernelCheckResult] = []
     scanned_objects: set[tuple[str | None, int | None]] = set()
+    scan_tasks: list[tuple[int, KernelIdentity]] = []
     for index, observation in enumerate(worklist.kernels):
         identity = observation.identity
         # A whole-code-object scan (no entry offset) covers the entire object, so
@@ -447,16 +449,35 @@ def run_waitcheck(
             if object_key in scanned_objects:
                 continue
             scanned_objects.add(object_key)
-        kernel_results.append(
-            _run_one(
-                identity,
-                binary=resolved,
-                log_path=output_dir / f"waitcheck-{index}.log",
-                timeout_seconds=timeout_seconds,
-                execute=execute,
-            )
+        scan_tasks.append((index, identity))
+
+    def _scan(task: tuple[int, KernelIdentity]) -> KernelCheckResult:
+        task_index, task_identity = task
+        return _run_one(
+            task_identity,
+            binary=resolved,
+            log_path=output_dir / f"waitcheck-{task_index}.log",
+            timeout_seconds=timeout_seconds,
+            execute=execute,
         )
-    kernel_results = tuple(kernel_results)
+
+    # Each selected code object is an independent rj_waitcheck subprocess doing
+    # CPU-bound static disassembly (~a minute on a real ~16MB / ~490-kernel
+    # Tensile object, #366), so scan distinct objects concurrently to cut
+    # wall-clock time. This is coverage-preserving -- every selected object is
+    # still scanned with its full per-scan timeout -- so the gate is unchanged;
+    # it only removes the serialization penalty when the worklist spans more
+    # than one object (the daily GEMM fixture spans the distinct NT/TT transpose
+    # objects, so two scans run in parallel). Shapes that share a transpose
+    # already dedup to one object above, and a single-object worklist keeps the
+    # exact serial path. ``ThreadPoolExecutor.map`` preserves task order, so
+    # results stay deterministic regardless of completion order.
+    if len(scan_tasks) <= 1:
+        kernel_results = tuple(_scan(task) for task in scan_tasks)
+    else:
+        max_workers = min(len(scan_tasks), os.cpu_count() or 1)
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            kernel_results = tuple(pool.map(_scan, scan_tasks))
     findings = tuple(finding for result in kernel_results for finding in result.findings)
     if not kernel_results:
         return CheckResult(

--- a/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
@@ -420,6 +420,117 @@ def test_waitcheck_scans_shared_object_once_without_kernel_attribution(tmp_path:
     assert all(finding.kernel_name is None for finding in result.findings)
 
 
+def test_waitcheck_scans_distinct_objects_in_order(tmp_path: Path) -> None:
+    # Distinct code objects are scanned concurrently (#366), but results must
+    # stay in worklist order and every object must be scanned exactly once,
+    # independent of completion order -- coverage is preserved.
+    binary = tmp_path / "rj_waitcheck"
+    binary.write_text("binary")
+    artifacts = []
+    for name in ("a", "b", "c"):
+        artifact = tmp_path / f"{name}.hsaco"
+        artifact.write_bytes(b"\x7fELF" + name.encode())
+        artifacts.append(artifact)
+    worklist = KernelWorklist(
+        requirement=SelectionRequirement.TOP_DISPATCH_COUNT,
+        top_n=3,
+        kernels=tuple(
+            KernelObservation(
+                identity=KernelIdentity(
+                    name=f"gemm_{artifact.stem}",
+                    target="gfx950",
+                    code_object=str(artifact),
+                    code_object_sha256=hashlib.sha256(artifact.read_bytes()).hexdigest(),
+                    code_object_index=0,
+                ),
+                total_time_ms=0.0,
+                dispatch_count=count,
+                sources=("gemm_csv",),
+            )
+            for artifact, count in zip(artifacts, (3, 2, 1))
+        ),
+    )
+    scanned: list[str] = []
+
+    def execute(argv, *, timeout_seconds, env=None):
+        target_object = argv[1]
+        scanned.append(target_object)
+        output = f"{target_object}:gfx950[0]: instructions=10 memory-events=2 diagnostics=0"
+        return ProcessResult(tuple(argv), 0, output, "")
+
+    result = run_waitcheck(
+        worklist, output_dir=tmp_path / "out", binary=binary, execute=execute
+    )
+
+    assert result.state is ExecutionState.RAN
+    assert result.verdict is Verdict.PASS
+    assert len(result.kernel_results) == 3
+    assert sorted(scanned) == sorted(str(artifact) for artifact in artifacts)
+    scanned_in_result = [str(item.identity.code_object) for item in result.kernel_results]
+    assert scanned_in_result == [str(artifact) for artifact in artifacts]
+
+
+def test_waitcheck_daily_fixture_topology_scans_two_of_three(tmp_path: Path) -> None:
+    # Mirrors the real daily GEMM fixture: the top-3 shapes are two NT shapes
+    # (which resolve to the SAME real transpose object -> one scan) plus one TT
+    # shape (a distinct object -> its own scan). Waitcheck must dedup the shared
+    # NT object to a single scan and still scan the distinct TT object, i.e. two
+    # concurrent scans, not one and not three.
+    binary = tmp_path / "rj_waitcheck"
+    binary.write_text("binary")
+    nt = tmp_path / "nt.hsaco"
+    nt.write_bytes(b"\x7fELFnt")
+    tt = tmp_path / "tt.hsaco"
+    tt.write_bytes(b"\x7fELFtt")
+    nt_sha = hashlib.sha256(nt.read_bytes()).hexdigest()
+    tt_sha = hashlib.sha256(tt.read_bytes()).hexdigest()
+
+    def _obj(name: str, artifact: Path, sha: str, count: int) -> KernelObservation:
+        return KernelObservation(
+            identity=KernelIdentity(
+                name=name,
+                target="gfx950",
+                code_object=str(artifact),
+                code_object_sha256=sha,
+                code_object_index=0,
+            ),
+            total_time_ms=0.0,
+            dispatch_count=count,
+            sources=("gemm_csv",),
+        )
+
+    worklist = KernelWorklist(
+        requirement=SelectionRequirement.TOP_DISPATCH_COUNT,
+        top_n=3,
+        kernels=(
+            _obj("gemm_NT_a", nt, nt_sha, 3),
+            _obj("gemm_NT_b", nt, nt_sha, 2),
+            _obj("gemm_TT_c", tt, tt_sha, 1),
+        ),
+    )
+    scanned: list[str] = []
+
+    def execute(argv, *, timeout_seconds, env=None):
+        target_object = argv[1]
+        scanned.append(target_object)
+        output = "\n".join(
+            (
+                f"{target_object}:gfx950[0]: instructions=10 memory-events=2 diagnostics=1",
+                f"{target_object}:gfx950[0]:.text+0x20: missing s_waitcnt lgkmcnt(0)",
+            )
+        )
+        return ProcessResult(tuple(argv), 4, output, "")
+
+    result = run_waitcheck(
+        worklist, output_dir=tmp_path / "out", binary=binary, execute=execute
+    )
+
+    assert result.state is ExecutionState.RAN
+    assert result.verdict is Verdict.WARN
+    assert sorted(scanned) == sorted((str(nt), str(tt)))  # two scans, NT deduped
+    assert len(result.kernel_results) == 2
+
+
 def test_waitcheck_rejects_changed_code_object(tmp_path: Path) -> None:
     binary = tmp_path / "rj_waitcheck"
     binary.write_text("binary")

--- a/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import threading
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
@@ -447,7 +449,7 @@ def test_waitcheck_scans_distinct_objects_in_order(tmp_path: Path) -> None:
                 dispatch_count=count,
                 sources=("gemm_csv",),
             )
-            for artifact, count in zip(artifacts, (3, 2, 1))
+            for artifact, count in zip(artifacts, (3, 2, 1), strict=True)
         ),
     )
     scanned: list[str] = []
@@ -468,6 +470,77 @@ def test_waitcheck_scans_distinct_objects_in_order(tmp_path: Path) -> None:
     assert sorted(scanned) == sorted(str(artifact) for artifact in artifacts)
     scanned_in_result = [str(item.identity.code_object) for item in result.kernel_results]
     assert scanned_in_result == [str(artifact) for artifact in artifacts]
+
+
+def test_waitcheck_runs_distinct_object_scans_concurrently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression guard for #366: distinct code objects must actually be scanned
+    # *concurrently*, not merely produce ordered results. rj_waitcheck is
+    # CPU-bound static work, so the bug this fixes is three ~minute scans running
+    # back to back. The ordering/dedup test above still passes on a serial loop
+    # (its fake execute returns immediately); this test does not. A barrier that
+    # only releases once every scan is in flight proves real overlap -- on a
+    # serial loop the first scan would block until the barrier's timeout and
+    # raise BrokenBarrierError, failing loudly instead of silently passing.
+    #
+    # Force a multi-core cpu_count: max_workers = min(len(tasks), os.cpu_count()),
+    # so on a single-core CI box the pool would otherwise cap to one worker and
+    # deadlock this barrier.
+    monkeypatch.setattr(os, "cpu_count", lambda: 4)
+    binary = tmp_path / "rj_waitcheck"
+    binary.write_text("binary")
+    artifacts = []
+    for name in ("a", "b", "c"):
+        artifact = tmp_path / f"{name}.hsaco"
+        artifact.write_bytes(b"\x7fELF" + name.encode())
+        artifacts.append(artifact)
+    worklist = KernelWorklist(
+        requirement=SelectionRequirement.TOP_DISPATCH_COUNT,
+        top_n=3,
+        kernels=tuple(
+            KernelObservation(
+                identity=KernelIdentity(
+                    name=f"gemm_{artifact.stem}",
+                    target="gfx950",
+                    code_object=str(artifact),
+                    code_object_sha256=hashlib.sha256(artifact.read_bytes()).hexdigest(),
+                    code_object_index=0,
+                ),
+                total_time_ms=0.0,
+                dispatch_count=count,
+                sources=("gemm_csv",),
+            )
+            for artifact, count in zip(artifacts, (3, 2, 1), strict=True)
+        ),
+    )
+
+    barrier = threading.Barrier(len(artifacts), timeout=10)
+    lock = threading.Lock()
+    active = 0
+    max_active = 0
+
+    def execute(argv, *, timeout_seconds, env=None):
+        nonlocal active, max_active
+        target_object = argv[1]
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        # Completes only once every scan is simultaneously in flight, proving
+        # real overlap. Raises BrokenBarrierError (timeout) on a serial loop.
+        barrier.wait()
+        with lock:
+            active -= 1
+        output = f"{target_object}:gfx950[0]: instructions=10 memory-events=2 diagnostics=0"
+        return ProcessResult(tuple(argv), 0, output, "")
+
+    result = run_waitcheck(
+        worklist, output_dir=tmp_path / "out", binary=binary, execute=execute
+    )
+
+    assert result.state is ExecutionState.RAN
+    assert max_active == len(artifacts)  # all distinct scans overlapped
+    assert len(result.kernel_results) == len(artifacts)
 
 
 def test_waitcheck_daily_fixture_topology_scans_two_of_three(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #366.

The `sanitizers-nightly` "Run sanitizer regression" step went silent for ~15 min between the rocjitsu setup and the first report, so the job log looked frozen. This PR adds two coverage-preserving changes on top of current `main` (the distinct-object extractor this relies on already landed via the prebuilt-artifacts work — see note below).

### Task 1 — timestamped per-phase progress logging (`sanitizers-nightly.yml`)
Adds `echo "[$(date +%T)] <phase> …"` markers before each phase of the regression step: pip install, prebuilt bundle download, provenance record, both `hipcc` LDS repros, the per-transpose GEMM ISA extraction, each daily recipe run (`waitcheck` / `consan-clean` / `consan-racy`), the #347 informational ConSan block, and the final gate. An operator can now see what is executing and how long it takes, eliminating the ~15-min silent window.

### Task 2 — parallelized `run_waitcheck` scan loop (`waitcheck.py`)
The per-object `rj_waitcheck` scans (CPU-bound static disassembly, ~1 min on a real ~16MB / ~490-kernel Tensile object) are now dispatched concurrently via a `ThreadPoolExecutor` over the already-deduplicated worklist:
- **No `top_n` change, no timeout cap** — every selected object is still scanned with its full per-scan timeout, so coverage is identical.
- Same-transpose objects still dedup to a single scan; a single-object worklist keeps the exact serial path.
- `ThreadPoolExecutor.map` preserves task order, so results stay deterministic regardless of completion order.

### Extractor root cause + fix (already on `main`)
The original `prepare_gemm_isa.py` unbundled one fp8 (`*SB*`) library and `shutil.copy2`'d it to every `sol_<idx>.hsaco`, so all top-N objects had identical SHA-256 and `run_waitcheck` deduped them to a **single** scan — parallelization would have been a no-op. The fix maps each shape's `(transA, transB)` to its real f32 (`Type_SS`) hipBLASLt code object for that transpose layout, yielding genuinely distinct objects. **This fix already merged into `main` via the prebuilt-artifacts work (#356)**, so this PR does not re-introduce it; it only adds the still-missing progress logging + parallelization that sit on top of it.

### Honest concurrency note (2-way, not 3-way)
The current top-3 shapes are **NT / NT / TT**, which resolve to **2** genuinely-distinct code objects — the two NT shapes truly share the NT transpose object, so `run_waitcheck` correctly dedups them to one scan. Concurrency is therefore **2-way, not 3-way**, and no third distinct object is fabricated. Measured **~72s vs ~130s serial (~1.8x)**.

### Gate semantics unchanged
The 3/3 gate is preserved: **waitcheck `warn` / consan-clean `pass` / consan-racy `fail`**. `verdict_baselines.json` needs **no change** — it pins `overall_verdict` + `execution_status` + per-check verdict + `finding_shape` (a string like `"missing s_waitcnt"`), **not** a numeric finding count, and none of those shift under parallelization or logging.

### Job timeout — #366 Task 3, split out to #370
#366's Task 3 (raise the job timeout) is **not** addressed here and cannot be: the workflow already declares `timeout-minutes: 120`, but that is GitHub's ceiling and can only *lower* the limit — the observed **effective ~20-min cap** is a self-hosted-runner / org Actions policy the workflow file cannot raise. Task 3 was therefore removed from #366's acceptance criteria and split into its own tracking issue **#370**; a comment at the `timeout-minutes` line documents the caveat. With #366 now scoped to Tasks 1 & 2 (both shipped here), `Closes #366` is accurate.

## Test plan
- [x] YAML validated: `python -c "import yaml; yaml.safe_load(open('.github/workflows/sanitizers-nightly.yml'))"` → OK.
- [x] `pytest tests/instrumentation/rocjitsu_sanitizers/ tests/sanitizers/` → **168 passed, 3 skipped** (GPU-only) on top of current `main`.
- [x] Unit tests in `test_waitcheck.py`: `test_waitcheck_scans_distinct_objects_in_order` (order + dedup), `test_waitcheck_daily_fixture_topology_scans_two_of_three` (NT/NT/TT → exactly 2 scans), and `test_waitcheck_runs_distinct_object_scans_concurrently` (barrier-based, proves distinct scans actually overlap — added in response to review).
- Empirical GPU waitcheck timing (~72s 2-way vs ~130s serial) was measured separately against ROCm 7.0.2.2 + `rj_waitcheck`; not re-run in this CPU-only environment.

Made with [Cursor](https://cursor.com)
