### PR TITLE
fix(sanitizers): remove apostrophe that broke the nightly bash -lc payload

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -171,7 +171,7 @@ jobs:
             # guardrail-safe CLI. The authoritative gate is the baseline
             # comparator below, so these only need to produce reports.
             mkdir -p "${SANITIZER_OUT}/waitcheck" "${SANITIZER_OUT}/consan-clean" "${SANITIZER_OUT}/consan-racy"
-            echo "[$(date +%T)] daily-waitcheck-gemm: concurrent rj_waitcheck scan of the top-3 shapes' distinct f32 GEMM transpose objects (CPU-bound, ~1 min each) …"
+            echo "[$(date +%T)] daily-waitcheck-gemm: concurrent rj_waitcheck scan of the distinct f32 GEMM transpose objects for the top-3 shapes (CPU-bound, ~1 min each) …"
             aorta sweep run --recipe recipes/sanitizers/daily-waitcheck-gemm.yaml \
               --output-dir "${SANITIZER_OUT}/waitcheck" || true
             echo "[$(date +%T)] daily-consan-clean: ConSan on single-wave LDS repro (expect pass) …"


### PR DESCRIPTION
## Summary

Post-merge follow-up to #369 (caught by Copilot). The `daily-waitcheck-gemm` progress marker added in #369 contained an apostrophe:

```
echo "[$(date +%T)] ... concurrent rj_waitcheck scan of the top-3 shapes' distinct f32 GEMM transpose objects ..."
```

That `'` closes the single-quoted `bash -lc '...'` payload that the "Run sanitizer regression" step opens, so the **host** shell misparses the remainder of the command and the sanitizer step fails before reaching any scan. YAML validation doesn't catch this (it's valid YAML; the break is at host-shell tokenization), and the PR's CPU/lint checks don't exercise the GPU nightly, so it slipped through.

## Fix

Reword the marker to drop the apostrophe — no behavior change, marker text only:

```
... concurrent rj_waitcheck scan of the distinct f32 GEMM transpose objects for the top-3 shapes ...
```

## Sweep

Checked the **entire** single-quoted payload (the whole `bash -lc '...'` block): this was its **only** apostrophe — 0 remain strictly inside it, so the opening `'` and closing `'` are balanced. Other apostrophes in the file are in YAML comments or the second job's direct `run:` blocks (not nested single-quoting), so they're harmless.

## Test plan

- [x] `yaml.safe_load(...)` → OK.
- [x] Verified the payload contains exactly the opening/closing `'` and no interior apostrophe.
- Full validation is the next scheduled `sanitizers-nightly` run reaching the scans (the failure was pre-scan).

Made with [Cursor](https://cursor.com)