### PR TITLE
feat(sanitizers): populate Tab 2 workload survey with generic hipBLASLt GEMM + synthetic controls (#367)

### DIFF
--- a/recipes/sanitizers/survey/.gitignore
+++ b/recipes/sanitizers/survey/.gitignore
@@ -1,0 +1,6 @@
+# The repo-root .gitignore ignores *.json (experiment outputs). The survey spec
+# and its recorded, scrubbed report fixtures are committed *source data*, not
+# experiment output -- re-include them so `gen_survey_spec.py` regeneration plus a
+# plain `git add` tracks them (no `git add -f` needed).
+!*.json
+!**/*.json

--- a/recipes/sanitizers/survey/README.md
+++ b/recipes/sanitizers/survey/README.md
@@ -1,0 +1,95 @@
+# Workload survey (Tab 2) — public-safe generic-GEMM survey
+
+This directory populates the **Workload survey (observed-only)** tab (Tab 2) of
+the sanitizer dashboard rendered by
+`scripts/sanitizers/gen_sanitizer_dashboard.py --survey`. It realizes the #367
+scope update ("populate aorta-internal kernels on Tab 2") in a strictly
+de-branded, public-safe form.
+
+Tab 2 is **observed-only**: it shows kernels drawn from multiple workloads with
+no expected/baseline comparison. A `warn`, `error`, or `not_checked` here is an
+observation, **never** a regression — it does not affect the guardrail gate
+(Tab 1).
+
+## What Tab 2 shows
+
+Each kernel is run under **both** sanitizers — `waitcheck` (static ISA scan) and
+`ConSan` (dynamic) — giving six survey cases:
+
+| Kernel | Workload label | Sanitizer | Observed verdict |
+|---|---|---|---|
+| `hipblaslt_gemm_f32_nt_128x128` | `hipblaslt:gemm_f32` | waitcheck (static) | `warn` (many `wait_hazard` findings) |
+| `hipblaslt_gemm_f32_nt_128x128` | `hipblaslt:gemm_f32` | ConSan (dynamic) | `error` (`consan_strict_load_rejection`) |
+| `tiny_vecadd` | `synthetic:vecadd` | waitcheck (static) | `pass` |
+| `tiny_vecadd` | `synthetic:vecadd` | ConSan (dynamic) | `error` (fails closed, exit 86) |
+| `lds_reduce` | `synthetic:lds_reduce` | waitcheck (static) | `pass` |
+| `lds_reduce` | `synthetic:lds_reduce` | ConSan (dynamic) | `error` (fails closed, exit 86) |
+
+Showing an `error`/`warn` here is intended — Tab 2 records what the sanitizers
+observed, including fail-closed behavior on heavy production code objects.
+
+## Layout
+
+```
+recipes/sanitizers/survey/
+├── README.md                      # this file
+├── generic_gemm_survey.json       # the --survey spec (committed, generated)
+├── generic-gemm-survey.yaml       # reproduction recipe: hipBLASLt GEMM, both sanitizers
+├── tiny-vecadd-survey.yaml        # reproduction recipe: tiny_vecadd control, both sanitizers
+├── lds-reduce-survey.yaml         # reproduction recipe: lds_reduce control, both sanitizers
+└── reports/<case>/sanitizer_report.json   # committed, scrubbed recorded outputs
+```
+
+The spec's `report_path` points at the committed fixtures so the dashboard loads
+real recorded data at render time. The spec's `report_rel` is the *published*
+drill-down link (`survey/<case>/sanitizer_report.json`), which the publish step
+co-locates next to `index.html` — mirroring the guardrail `runs/<id>/`
+co-location.
+
+## Rendering
+
+```bash
+python scripts/sanitizers/gen_sanitizer_dashboard.py \
+    --results-dir <guardrail-run-dir> \
+    --baselines recipes/sanitizers/fixtures/expected/verdict_baselines.json \
+    --survey recipes/sanitizers/survey/generic_gemm_survey.json \
+    --out-dir dashboard
+```
+
+## Regenerating
+
+* **The spec** (`generic_gemm_survey.json`) is generated deterministically from
+  the committed report fixtures — re-running reproduces it byte-for-byte:
+
+  ```bash
+  python scripts/sanitizers/gen_survey_spec.py \
+      --reports-dir recipes/sanitizers/survey/reports \
+      --out recipes/sanitizers/survey/generic_gemm_survey.json
+  ```
+
+* **The reports** are recorded GPU outputs, not fabricated. To regenerate them on
+  a gfx950 host, run the reproduction recipes (`*-survey.yaml`) with the aorta
+  sanitizer runner; each runs both sanitizers over its kernel and emits a
+  `sanitizer_report.json`. Then scrub any absolute paths / labels before
+  committing (see the policy below).
+
+## De-branded / public-safe policy (CLAUDE.md rule #4)
+
+This lives in the **public** `ROCm/aorta` repo, so it carries **no** customer,
+project-codename, org-label, ticket, or NDA identifiers.
+
+* The GEMM lane scans the **generic public hipBLASLt gfx950 f32 Tensile object**
+  (`TensileLibrary_*SB*gfx950.co` content, the same kind
+  `scripts/sanitizers/prepare_gemm_isa.py` prepares). Only the *label* was ever
+  customer-branded; the scanned ISA itself is generic public content.
+* `tiny_vecadd` and `lds_reduce` are ordinary, independently-authored synthetic
+  repros with no customer association.
+* All committed data is **scrubbed**: private absolute run-area paths are
+  replaced with generic relative paths (e.g.
+  `survey_isa/hipblaslt_gemm_f32.hsaco`); customer/codename/ticket names are
+  removed; kernels are named generically. The `aorta.sanitizer_report/0.1`
+  schema is preserved so the generator and `summarize_case` parse the fixtures.
+* `tests/sanitizers/test_survey_generic_gemm.py` enforces a scrub guard: a
+  forbidden-substring denylist (customer/codename/org tokens, private absolute
+  paths, internal run/user identifiers) must not appear in the committed spec,
+  the fixtures, or the rendered dashboard output.

--- a/recipes/sanitizers/survey/generic-gemm-survey.yaml
+++ b/recipes/sanitizers/survey/generic-gemm-survey.yaml
@@ -1,0 +1,44 @@
+schema_version: 1
+mode: sanitizer
+ticket: SURVEY-GENERIC-GEMM
+description: >
+  Workload-survey (observed-only, Tab 2 of the sanitizer dashboard, #367)
+  reproduction over the GENERIC PUBLIC hipBLASLt gfx950 f32 Tensile GEMM object
+  (the same TensileLibrary_*SB*gfx950.co content prepared by
+  scripts/sanitizers/prepare_gemm_isa.py -- no customer/NDA association; only a
+  generic public code object is scanned, per CLAUDE.md rule #4). Runs BOTH
+  sanitizers over the kernel: waitcheck (static ISA scan) and ConSan (dynamic).
+  This is the reproduction path for the committed survey fixtures
+  reports/gemm_f32_waitcheck and reports/gemm_f32_consan; the committed reports
+  are the recorded outputs, this recipe documents how to regenerate them on a
+  gfx950 host. Survey rows are OBSERVED-ONLY: a warn/error here is an
+  observation, never a gate regression.
+sanitizer_plan:
+  target: gfx950
+  source:
+    kind: kernel
+    kernel:
+      name: hipblaslt_gemm_f32_nt_128x128
+      code_object: ../fixtures/isa/consan_gemm_f32.hsaco
+      code_object_index: 0
+    # Dynamic ConSan lane loads exactly the selected identity on-device (see the
+    # consan_app.py loader pattern); resolved relative to this recipe file.
+    consan_command: ../fixtures/bin/consan_gemm_load
+    consan_log: true
+  scope:
+    kind: kernel
+  selection:
+    requirement: top_dispatch_count
+    top_n: 1
+  sanitizers:
+    - waitcheck
+    - consan
+  policy:
+    consan_policy: strict
+    on_missing_backend: fail
+    # Large production code object: the ConSan MOI transform can exceed the
+    # default ceiling and fail closed (consan_strict_load_rejection); keep the
+    # observed error as survey data rather than a false pass.
+    timeout_seconds: 300
+  output:
+    report: sanitizer_report.json

--- a/recipes/sanitizers/survey/generic_gemm_survey.json
+++ b/recipes/sanitizers/survey/generic_gemm_survey.json
@@ -1,0 +1,52 @@
+{
+  "cases": [
+    {
+      "name": "hipblaslt-gemm-f32-nt-128x128-waitcheck",
+      "label": "hipBLASLt GEMM f32 nt 128x128 \u00b7 waitcheck (static)",
+      "backend": "waitcheck (static)",
+      "workload": "hipblaslt:gemm_f32",
+      "report_path": "reports/gemm_f32_waitcheck/sanitizer_report.json",
+      "report_rel": "survey/gemm_f32_waitcheck/sanitizer_report.json"
+    },
+    {
+      "name": "hipblaslt-gemm-f32-nt-128x128-consan",
+      "label": "hipBLASLt GEMM f32 nt 128x128 \u00b7 ConSan (dynamic)",
+      "backend": "consan (dynamic)",
+      "workload": "hipblaslt:gemm_f32",
+      "report_path": "reports/gemm_f32_consan/sanitizer_report.json",
+      "report_rel": "survey/gemm_f32_consan/sanitizer_report.json"
+    },
+    {
+      "name": "tiny-vecadd-waitcheck",
+      "label": "tiny_vecadd \u00b7 waitcheck (static)",
+      "backend": "waitcheck (static)",
+      "workload": "synthetic:vecadd",
+      "report_path": "reports/tiny_vecadd_waitcheck/sanitizer_report.json",
+      "report_rel": "survey/tiny_vecadd_waitcheck/sanitizer_report.json"
+    },
+    {
+      "name": "tiny-vecadd-consan",
+      "label": "tiny_vecadd \u00b7 ConSan (dynamic)",
+      "backend": "consan (dynamic)",
+      "workload": "synthetic:vecadd",
+      "report_path": "reports/tiny_vecadd_consan/sanitizer_report.json",
+      "report_rel": "survey/tiny_vecadd_consan/sanitizer_report.json"
+    },
+    {
+      "name": "lds-reduce-waitcheck",
+      "label": "lds_reduce \u00b7 waitcheck (static)",
+      "backend": "waitcheck (static)",
+      "workload": "synthetic:lds_reduce",
+      "report_path": "reports/lds_reduce_waitcheck/sanitizer_report.json",
+      "report_rel": "survey/lds_reduce_waitcheck/sanitizer_report.json"
+    },
+    {
+      "name": "lds-reduce-consan",
+      "label": "lds_reduce \u00b7 ConSan (dynamic)",
+      "backend": "consan (dynamic)",
+      "workload": "synthetic:lds_reduce",
+      "report_path": "reports/lds_reduce_consan/sanitizer_report.json",
+      "report_rel": "survey/lds_reduce_consan/sanitizer_report.json"
+    }
+  ]
+}

--- a/recipes/sanitizers/survey/lds-reduce-survey.yaml
+++ b/recipes/sanitizers/survey/lds-reduce-survey.yaml
@@ -1,0 +1,35 @@
+schema_version: 1
+mode: sanitizer
+ticket: SURVEY-LDS-REDUCE
+description: >
+  Workload-survey (observed-only, Tab 2, #367) reproduction over the synthetic
+  lds_reduce control kernel -- an ordinary, independently-authored shared-memory
+  (LDS) reduction repro with no customer association. Runs BOTH sanitizers:
+  waitcheck (static, observes a clean pass) and ConSan (dynamic, fails closed
+  with exit 86 on the current rocjitsu build; see ROCm/rocm-systems#9972).
+  Reproduction path for the committed survey fixtures
+  reports/lds_reduce_waitcheck and reports/lds_reduce_consan.
+sanitizer_plan:
+  target: gfx950
+  source:
+    kind: kernel
+    kernel:
+      name: lds_reduce
+      code_object: ../fixtures/isa/lds.hsaco
+      code_object_index: 0
+    consan_command: ../fixtures/bin/lds_dispatch
+    consan_log: true
+  scope:
+    kind: kernel
+  selection:
+    requirement: top_dispatch_count
+    top_n: 1
+  sanitizers:
+    - waitcheck
+    - consan
+  policy:
+    consan_policy: strict
+    on_missing_backend: fail
+    timeout_seconds: 600
+  output:
+    report: sanitizer_report.json

--- a/recipes/sanitizers/survey/reports/gemm_f32_consan/sanitizer_report.json
+++ b/recipes/sanitizers/survey/reports/gemm_f32_consan/sanitizer_report.json
@@ -1,0 +1,76 @@
+{
+  "checks": [
+    {
+      "backend": {
+        "command": "load_gemm_f32.sh",
+        "command_sha256": "fbf8c5f415c858583ad028a1008d7e07bb875c344cdeaa4743ffc1a10b1a2264",
+        "hook": "lib/rocjitsu/src/rocjitsu/hooks/librocjitsu_dbi_hooks.so",
+        "hook_sha256": "de9d9f09ce51e29e89de4e3a32e1a25cfa7da0eb602853ef725ce9aebfc6d925",
+        "selected_identity_sha256": "40f2bad2c2a23a56bbf489765793470250ae4aa3b8d73f54ca4d89dbea8836eb",
+        "selected_kernel": "hipblaslt_gemm_f32_nt_128x128"
+      },
+      "coverage": [],
+      "findings": [],
+      "kernel_results": [
+        {
+          "findings": [],
+          "identity": {
+            "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+            "code_object_index": 0,
+            "code_object_sha256": null,
+            "entry_offset": null,
+            "name": "hipblaslt_gemm_f32_nt_128x128",
+            "target": "gfx950"
+          },
+          "reason": "consan_strict_load_rejection",
+          "returncode": 92,
+          "state": "error",
+          "verdict": "error"
+        }
+      ],
+      "reason": "consan_strict_load_rejection",
+      "returncode": 92,
+      "sanitizer": "consan",
+      "state": "error",
+      "verdict": "error"
+    },
+    {
+      "backend": {},
+      "coverage": [],
+      "findings": [],
+      "kernel_results": [],
+      "reason": "consan_strict_load_rejection",
+      "returncode": 92,
+      "sanitizer": "waitcheck_preflight",
+      "state": "error",
+      "verdict": "error"
+    }
+  ],
+  "execution_status": "error",
+  "overall_verdict": "error",
+  "schema": "aorta.sanitizer_report/0.1",
+  "target": "gfx950",
+  "worklist": {
+    "kernel_count": 1,
+    "kernels": [
+      {
+        "dispatch_count": 1,
+        "identity": {
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "code_object_index": 0,
+          "code_object_sha256": null,
+          "entry_offset": null,
+          "name": "hipblaslt_gemm_f32_nt_128x128",
+          "target": "gfx950"
+        },
+        "sources": [
+          "kernel_list"
+        ],
+        "total_time_ms": 0.0
+      }
+    ],
+    "requirement": "top_dispatch_count",
+    "schema": "aorta.kernel_worklist/0.1",
+    "top_n": 1
+  }
+}

--- a/recipes/sanitizers/survey/reports/gemm_f32_waitcheck/sanitizer_report.json
+++ b/recipes/sanitizers/survey/reports/gemm_f32_waitcheck/sanitizer_report.json
@@ -1,0 +1,895 @@
+{
+  "checks": [
+    {
+      "backend": {
+        "path": "tools/rj_waitcheck",
+        "sha256": "472fcf288714d6d5851c258d2f36f39fe29be407929f69d910c4a2f93ed10455"
+      },
+      "coverage": [],
+      "findings": [
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x105690: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x105680: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x105690: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x11d958: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x11d948: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x11d958: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x134b04: missing s_waitcnt lgkmcnt(0) before def of s49",
+          "metadata": {
+            "context_1": "producer .text+0x134af4: s_load_dwordx8 s[44:51], s[0:1], 0x50",
+            "context_2": "consumer .text+0x134b04: s_load_dword s49, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x139704: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x1396f4: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x139704: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x14f858: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x14f848: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x14f858: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x181958: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x181948: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x181958: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x19c490: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x19c480: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x19c490: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x1ab348: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x1ab338: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x1ab348: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x1be190: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x1be180: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x1be190: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x1d8d04: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x1d8cf4: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x1d8d04: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x1e0348: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x1e0338: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x1e0348: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x20363c: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x20362c: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x20363c: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x218658: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x218648: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x218658: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x227e10: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x227e00: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x227e10: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x23a904: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x23a8f4: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x23a904: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x24f93c: missing s_waitcnt lgkmcnt(0) before def of s49",
+          "metadata": {
+            "context_1": "producer .text+0x24f92c: s_load_dwordx8 s[44:51], s[0:1], 0x50",
+            "context_2": "consumer .text+0x24f93c: s_load_dword s49, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x256990: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x256980: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x256990: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x271558: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x271548: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x271558: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x2a3a90: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x2a3a80: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x2a3a90: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x2bac90: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x2bac80: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x2bac90: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x2d1e90: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x2d1e80: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x2d1e90: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x2f1b90: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x2f1b80: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x2f1b90: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x30a864: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x30a854: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x30a864: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x33623c: missing s_waitcnt lgkmcnt(0) before def of s49",
+          "metadata": {
+            "context_1": "producer .text+0x33622c: s_load_dwordx8 s[44:51], s[0:1], 0x50",
+            "context_2": "consumer .text+0x33623c: s_load_dword s49, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x341a3c: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x341a2c: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x341a3c: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x3fa58: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x3fa48: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x3fa58: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x448: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x438: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x448: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x4e890: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x4e880: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x4e890: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x6753c: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x6752c: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x6753c: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x71d1c: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0x71d0c: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0x71d1c: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0xb2848: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0xb2838: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0xb2848: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        },
+        {
+          "code": "wait_hazard",
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "entry_offset": null,
+          "kernel_name": null,
+          "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0xfae04: missing s_waitcnt lgkmcnt(0) before def of s45",
+          "metadata": {
+            "context_1": "producer .text+0xfadf4: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+            "context_2": "consumer .text+0xfae04: s_load_dword s45, s[0:1], 0x8c"
+          },
+          "sanitizer": "waitcheck",
+          "severity": "warning"
+        }
+      ],
+      "kernel_results": [
+        {
+          "findings": [
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x105690: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x105680: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x105690: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x11d958: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x11d948: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x11d958: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x134b04: missing s_waitcnt lgkmcnt(0) before def of s49",
+              "metadata": {
+                "context_1": "producer .text+0x134af4: s_load_dwordx8 s[44:51], s[0:1], 0x50",
+                "context_2": "consumer .text+0x134b04: s_load_dword s49, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x139704: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x1396f4: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x139704: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x14f858: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x14f848: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x14f858: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x181958: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x181948: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x181958: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x19c490: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x19c480: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x19c490: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x1ab348: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x1ab338: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x1ab348: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x1be190: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x1be180: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x1be190: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x1d8d04: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x1d8cf4: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x1d8d04: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x1e0348: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x1e0338: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x1e0348: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x20363c: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x20362c: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x20363c: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x218658: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x218648: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x218658: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x227e10: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x227e00: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x227e10: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x23a904: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x23a8f4: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x23a904: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x24f93c: missing s_waitcnt lgkmcnt(0) before def of s49",
+              "metadata": {
+                "context_1": "producer .text+0x24f92c: s_load_dwordx8 s[44:51], s[0:1], 0x50",
+                "context_2": "consumer .text+0x24f93c: s_load_dword s49, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x256990: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x256980: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x256990: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x271558: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x271548: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x271558: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x2a3a90: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x2a3a80: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x2a3a90: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x2bac90: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x2bac80: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x2bac90: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x2d1e90: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x2d1e80: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x2d1e90: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x2f1b90: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x2f1b80: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x2f1b90: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x30a864: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x30a854: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x30a864: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x33623c: missing s_waitcnt lgkmcnt(0) before def of s49",
+              "metadata": {
+                "context_1": "producer .text+0x33622c: s_load_dwordx8 s[44:51], s[0:1], 0x50",
+                "context_2": "consumer .text+0x33623c: s_load_dword s49, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x341a3c: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x341a2c: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x341a3c: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x3fa58: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x3fa48: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x3fa58: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x448: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x438: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x448: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x4e890: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x4e880: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x4e890: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x6753c: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x6752c: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x6753c: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0x71d1c: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0x71d0c: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0x71d1c: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0xb2848: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0xb2838: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0xb2848: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            },
+            {
+              "code": "wait_hazard",
+              "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+              "entry_offset": null,
+              "kernel_name": null,
+              "message": "survey_isa/hipblaslt_gemm_f32.hsaco:gfx950[0]:.text+0xfae04: missing s_waitcnt lgkmcnt(0) before def of s45",
+              "metadata": {
+                "context_1": "producer .text+0xfadf4: s_load_dwordx8 s[40:47], s[0:1], 0x50",
+                "context_2": "consumer .text+0xfae04: s_load_dword s45, s[0:1], 0x8c"
+              },
+              "sanitizer": "waitcheck",
+              "severity": "warning"
+            }
+          ],
+          "identity": {
+            "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+            "code_object_index": 0,
+            "code_object_sha256": "74f07deaefd3f12cd1b5d0d8ca04fb1f678c3c3cf4f87a434e4126278b661825",
+            "entry_offset": null,
+            "name": "hipblaslt_gemm_f32_nt_128x128",
+            "target": "gfx950"
+          },
+          "reason": null,
+          "returncode": 4,
+          "state": "ran",
+          "verdict": "warn"
+        }
+      ],
+      "reason": null,
+      "returncode": null,
+      "sanitizer": "waitcheck",
+      "state": "ran",
+      "verdict": "warn"
+    }
+  ],
+  "execution_status": "complete",
+  "overall_verdict": "warn",
+  "schema": "aorta.sanitizer_report/0.1",
+  "target": "gfx950",
+  "worklist": {
+    "kernel_count": 1,
+    "kernels": [
+      {
+        "dispatch_count": 1,
+        "identity": {
+          "code_object": "survey_isa/hipblaslt_gemm_f32.hsaco",
+          "code_object_index": 0,
+          "code_object_sha256": "74f07deaefd3f12cd1b5d0d8ca04fb1f678c3c3cf4f87a434e4126278b661825",
+          "entry_offset": null,
+          "name": "hipblaslt_gemm_f32_nt_128x128",
+          "target": "gfx950"
+        },
+        "sources": [
+          "kernel_list"
+        ],
+        "total_time_ms": 0.0
+      }
+    ],
+    "requirement": "top_dispatch_count",
+    "schema": "aorta.kernel_worklist/0.1",
+    "top_n": 1
+  }
+}

--- a/recipes/sanitizers/survey/reports/lds_reduce_consan/sanitizer_report.json
+++ b/recipes/sanitizers/survey/reports/lds_reduce_consan/sanitizer_report.json
@@ -1,0 +1,76 @@
+{
+  "checks": [
+    {
+      "backend": {
+        "command": "load_lds_reduce.sh",
+        "command_sha256": "ac4d9bbb333f8b66e39622a55a99b36947e85bf0e98515b69d60df2540546985",
+        "hook": "lib/rocjitsu/src/rocjitsu/hooks/librocjitsu_dbi_hooks.so",
+        "hook_sha256": "de9d9f09ce51e29e89de4e3a32e1a25cfa7da0eb602853ef725ce9aebfc6d925",
+        "selected_identity_sha256": "22c99afd50f23d20bdb52c9ae1f9844f4d27e94a2e8f0360b57f2fcd72bb917a",
+        "selected_kernel": "lds_reduce"
+      },
+      "coverage": [],
+      "findings": [],
+      "kernel_results": [
+        {
+          "findings": [],
+          "identity": {
+            "code_object": "survey_isa/lds_reduce.hsaco",
+            "code_object_index": 0,
+            "code_object_sha256": null,
+            "entry_offset": null,
+            "name": "lds_reduce",
+            "target": "gfx950"
+          },
+          "reason": "combined_hook_exit_86",
+          "returncode": 86,
+          "state": "error",
+          "verdict": "error"
+        }
+      ],
+      "reason": "combined_hook_exit_86",
+      "returncode": 86,
+      "sanitizer": "consan",
+      "state": "error",
+      "verdict": "error"
+    },
+    {
+      "backend": {},
+      "coverage": [],
+      "findings": [],
+      "kernel_results": [],
+      "reason": "combined_hook_exit_86",
+      "returncode": 86,
+      "sanitizer": "waitcheck_preflight",
+      "state": "error",
+      "verdict": "error"
+    }
+  ],
+  "execution_status": "error",
+  "overall_verdict": "error",
+  "schema": "aorta.sanitizer_report/0.1",
+  "target": "gfx950",
+  "worklist": {
+    "kernel_count": 1,
+    "kernels": [
+      {
+        "dispatch_count": 1,
+        "identity": {
+          "code_object": "survey_isa/lds_reduce.hsaco",
+          "code_object_index": 0,
+          "code_object_sha256": null,
+          "entry_offset": null,
+          "name": "lds_reduce",
+          "target": "gfx950"
+        },
+        "sources": [
+          "kernel_list"
+        ],
+        "total_time_ms": 0.0
+      }
+    ],
+    "requirement": "top_dispatch_count",
+    "schema": "aorta.kernel_worklist/0.1",
+    "top_n": 1
+  }
+}

--- a/recipes/sanitizers/survey/reports/lds_reduce_waitcheck/sanitizer_report.json
+++ b/recipes/sanitizers/survey/reports/lds_reduce_waitcheck/sanitizer_report.json
@@ -1,0 +1,61 @@
+{
+  "checks": [
+    {
+      "backend": {
+        "path": "tools/rj_waitcheck",
+        "sha256": "472fcf288714d6d5851c258d2f36f39fe29be407929f69d910c4a2f93ed10455"
+      },
+      "coverage": [],
+      "findings": [],
+      "kernel_results": [
+        {
+          "findings": [],
+          "identity": {
+            "code_object": "survey_isa/lds_reduce.hsaco",
+            "code_object_index": 0,
+            "code_object_sha256": "17b7af9c4703974c26e5b69d9cea286eb43ede642668ee133548b61b64c2d392",
+            "entry_offset": null,
+            "name": "lds_reduce",
+            "target": "gfx950"
+          },
+          "reason": null,
+          "returncode": 0,
+          "state": "ran",
+          "verdict": "pass"
+        }
+      ],
+      "reason": null,
+      "returncode": null,
+      "sanitizer": "waitcheck",
+      "state": "ran",
+      "verdict": "pass"
+    }
+  ],
+  "execution_status": "complete",
+  "overall_verdict": "pass",
+  "schema": "aorta.sanitizer_report/0.1",
+  "target": "gfx950",
+  "worklist": {
+    "kernel_count": 1,
+    "kernels": [
+      {
+        "dispatch_count": 1,
+        "identity": {
+          "code_object": "survey_isa/lds_reduce.hsaco",
+          "code_object_index": 0,
+          "code_object_sha256": "17b7af9c4703974c26e5b69d9cea286eb43ede642668ee133548b61b64c2d392",
+          "entry_offset": null,
+          "name": "lds_reduce",
+          "target": "gfx950"
+        },
+        "sources": [
+          "kernel_list"
+        ],
+        "total_time_ms": 0.0
+      }
+    ],
+    "requirement": "top_dispatch_count",
+    "schema": "aorta.kernel_worklist/0.1",
+    "top_n": 1
+  }
+}

--- a/recipes/sanitizers/survey/reports/tiny_vecadd_consan/sanitizer_report.json
+++ b/recipes/sanitizers/survey/reports/tiny_vecadd_consan/sanitizer_report.json
@@ -1,0 +1,76 @@
+{
+  "checks": [
+    {
+      "backend": {
+        "command": "load_tiny_vecadd.sh",
+        "command_sha256": "3e265d0b26c0cf0d8fe5b6c06c95751ea5566266f3a5be0d7c07239fc3b5aa4d",
+        "hook": "lib/rocjitsu/src/rocjitsu/hooks/librocjitsu_dbi_hooks.so",
+        "hook_sha256": "de9d9f09ce51e29e89de4e3a32e1a25cfa7da0eb602853ef725ce9aebfc6d925",
+        "selected_identity_sha256": "74b76953e8ffe76116e4545986f70da1a9bba2a0a86d006a78f0034d799e1684",
+        "selected_kernel": "tiny_vecadd"
+      },
+      "coverage": [],
+      "findings": [],
+      "kernel_results": [
+        {
+          "findings": [],
+          "identity": {
+            "code_object": "survey_isa/tiny_vecadd.hsaco",
+            "code_object_index": 0,
+            "code_object_sha256": null,
+            "entry_offset": null,
+            "name": "tiny_vecadd",
+            "target": "gfx950"
+          },
+          "reason": "combined_hook_exit_86",
+          "returncode": 86,
+          "state": "error",
+          "verdict": "error"
+        }
+      ],
+      "reason": "combined_hook_exit_86",
+      "returncode": 86,
+      "sanitizer": "consan",
+      "state": "error",
+      "verdict": "error"
+    },
+    {
+      "backend": {},
+      "coverage": [],
+      "findings": [],
+      "kernel_results": [],
+      "reason": "combined_hook_exit_86",
+      "returncode": 86,
+      "sanitizer": "waitcheck_preflight",
+      "state": "error",
+      "verdict": "error"
+    }
+  ],
+  "execution_status": "error",
+  "overall_verdict": "error",
+  "schema": "aorta.sanitizer_report/0.1",
+  "target": "gfx950",
+  "worklist": {
+    "kernel_count": 1,
+    "kernels": [
+      {
+        "dispatch_count": 1,
+        "identity": {
+          "code_object": "survey_isa/tiny_vecadd.hsaco",
+          "code_object_index": 0,
+          "code_object_sha256": null,
+          "entry_offset": null,
+          "name": "tiny_vecadd",
+          "target": "gfx950"
+        },
+        "sources": [
+          "kernel_list"
+        ],
+        "total_time_ms": 0.0
+      }
+    ],
+    "requirement": "top_dispatch_count",
+    "schema": "aorta.kernel_worklist/0.1",
+    "top_n": 1
+  }
+}

--- a/recipes/sanitizers/survey/reports/tiny_vecadd_waitcheck/sanitizer_report.json
+++ b/recipes/sanitizers/survey/reports/tiny_vecadd_waitcheck/sanitizer_report.json
@@ -1,0 +1,61 @@
+{
+  "checks": [
+    {
+      "backend": {
+        "path": "tools/rj_waitcheck",
+        "sha256": "472fcf288714d6d5851c258d2f36f39fe29be407929f69d910c4a2f93ed10455"
+      },
+      "coverage": [],
+      "findings": [],
+      "kernel_results": [
+        {
+          "findings": [],
+          "identity": {
+            "code_object": "survey_isa/tiny_vecadd.hsaco",
+            "code_object_index": 0,
+            "code_object_sha256": "454078f63825e0e5b6df20effd358ae55566193702c6137600ed6d9d36084d9b",
+            "entry_offset": null,
+            "name": "tiny_vecadd",
+            "target": "gfx950"
+          },
+          "reason": null,
+          "returncode": 0,
+          "state": "ran",
+          "verdict": "pass"
+        }
+      ],
+      "reason": null,
+      "returncode": null,
+      "sanitizer": "waitcheck",
+      "state": "ran",
+      "verdict": "pass"
+    }
+  ],
+  "execution_status": "complete",
+  "overall_verdict": "pass",
+  "schema": "aorta.sanitizer_report/0.1",
+  "target": "gfx950",
+  "worklist": {
+    "kernel_count": 1,
+    "kernels": [
+      {
+        "dispatch_count": 1,
+        "identity": {
+          "code_object": "survey_isa/tiny_vecadd.hsaco",
+          "code_object_index": 0,
+          "code_object_sha256": "454078f63825e0e5b6df20effd358ae55566193702c6137600ed6d9d36084d9b",
+          "entry_offset": null,
+          "name": "tiny_vecadd",
+          "target": "gfx950"
+        },
+        "sources": [
+          "kernel_list"
+        ],
+        "total_time_ms": 0.0
+      }
+    ],
+    "requirement": "top_dispatch_count",
+    "schema": "aorta.kernel_worklist/0.1",
+    "top_n": 1
+  }
+}

--- a/recipes/sanitizers/survey/tiny-vecadd-survey.yaml
+++ b/recipes/sanitizers/survey/tiny-vecadd-survey.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+mode: sanitizer
+ticket: SURVEY-TINY-VECADD
+description: >
+  Workload-survey (observed-only, Tab 2, #367) reproduction over the synthetic
+  tiny_vecadd control kernel -- an ordinary, independently-authored single-kernel
+  vector-add repro with no customer association. Runs BOTH sanitizers: waitcheck
+  (static, observes a clean pass) and ConSan (dynamic, fails closed with exit 86
+  since there is nothing analyzable). Reproduction path for the committed survey
+  fixtures reports/tiny_vecadd_waitcheck and reports/tiny_vecadd_consan.
+sanitizer_plan:
+  target: gfx950
+  source:
+    kind: kernel
+    kernel:
+      name: tiny_vecadd
+      code_object: ../fixtures/isa/tiny.hsaco
+      code_object_index: 0
+    consan_command: ../fixtures/bin/consan_tiny_load
+    consan_log: true
+  scope:
+    kind: kernel
+  selection:
+    requirement: top_dispatch_count
+    top_n: 1
+  sanitizers:
+    - waitcheck
+    - consan
+  policy:
+    consan_policy: strict
+    on_missing_backend: fail
+  output:
+    report: sanitizer_report.json

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -4,11 +4,17 @@
 Consumes the three daily recipe reports and the committed verdict baselines and
 emits, into ``--out-dir``:
 
-* ``index.html`` -- a self-contained (no CDN) status page: baseline-health banner,
-  latest per-recipe table, **per-kernel detail** (selected worklist kernels with
-  their code object / SHA-256 / dispatch count / observed sanitizer verdict and
-  finding count), a findings-by-(code, severity) summary, and a cross-run
-  history/trend table.
+* ``index.html`` -- a self-contained (no CDN / no external JS) status page with two
+  tabs (a pure CSS ``:checked`` radio toggle -- switching needs no network):
+  **Expected behavior (guardrails)** -- the baseline-checked regression gate:
+  baseline-health banner, latest per-recipe table, **per-kernel detail** (code
+  object / SHA-256 / dispatch count / observed sanitizer verdict / finding count),
+  and a cross-run history/trend table; and **Workload survey (observed-only)** --
+  kernels drawn from multiple workloads (including aorta-internal-sourced kernels
+  supplied via ``--survey``) shown with the same kernel-detail shape but **no
+  expected/match column** (a fail / not_checked here is an observation, never a
+  regression). Both tabs link each case to its ``sanitizer_report.json`` and carry
+  a one-line observation summary.
 * ``summary.md`` -- a GitHub Actions job-summary fragment (append to
   ``$GITHUB_STEP_SUMMARY``) carrying the same gate, table, and kernel detail.
 * ``data.json`` -- the aggregated structure for any richer consumer.
@@ -98,14 +104,72 @@ def _clean_msg(message: str, limit: int = 160) -> str:
     return text if len(text) <= limit else text[: limit - 1] + "\u2026"
 
 
+def _primary_checks(checks: list[dict[str, Any]]) -> dict[str, Any]:
+    """Reduce a report's checks to a primary (sanitizer, verdict, reason) plus the
+    ConSan ``waitcheck_preflight`` verdict.
+
+    Folds the ``gen_new_kernels_dashboard.py`` prototype's ``_primary`` helper into
+    the generator (rather than a post-hoc HTML splice): the last non-preflight
+    check wins as the "primary" sanitizer/verdict/reason, and the preflight verdict
+    is surfaced separately. Values are kept as-is (``None`` preserved) so callers
+    decide how to render an absent field.
+    """
+    primary: dict[str, Any] = {
+        "sanitizer": None, "verdict": None, "reason": None, "preflight": None
+    }
+    for check in checks:
+        if check.get("sanitizer") == "waitcheck_preflight":
+            primary["preflight"] = check.get("verdict")
+        else:
+            primary["sanitizer"] = check.get("sanitizer")
+            primary["verdict"] = check.get("verdict")
+            primary["reason"] = check.get("reason")
+    return primary
+
+
+def _observation_text(
+    primary: dict[str, Any],
+    findings: int,
+    finding_groups: list[dict[str, Any]],
+    *,
+    present: bool = True,
+) -> str:
+    """A one-line human summary of what a case observed.
+
+    Combines the primary sanitizer + verdict + fail-closed reason + a finding
+    highlight into a compact string surfaced on both tabs (guardrail and survey).
+    Observational only -- it never encodes a pass/fail health signal.
+    """
+    if not present:
+        return "report missing"
+    san, verdict = primary.get("sanitizer"), primary.get("verdict")
+    head = f"{san or _DASH} {verdict or _DASH}" if (san or verdict) else "no sanitizer check ran"
+    parts = [head]
+    if primary.get("reason"):
+        parts.append(f"reason {primary['reason']}")
+    if findings:
+        top = finding_groups[0]["code"] if finding_groups else None
+        parts.append(f"{findings} finding(s)" + (f" ({top})" if top else ""))
+    if primary.get("preflight"):
+        parts.append(f"preflight {primary['preflight']}")
+    return "; ".join(parts)
+
+
 def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[str, Any]:
-    """Reduce one report to the fields the dashboard renders (pure)."""
+    """Reduce one report to the fields the dashboard renders (pure).
+
+    ``expected=None`` marks an observed-only *survey* case (``match`` is ``True``):
+    the reduced row carries no baseline signal and the renderer must treat it as
+    observational, never as a passing/failing gate row.
+    """
     if report is None:
         return {
             "present": False, "verdict": "—", "execution": "missing", "findings": 0,
             "coverage": "", "backend": None, "expected": expected, "match": False,
             "worklist": {"requirement": None, "top_n": None, "kernel_count": 0},
             "kernels": [], "finding_groups": [],
+            "primary": {"sanitizer": None, "verdict": None, "reason": None, "preflight": None},
+            "observation": "report missing",
         }
     checks = report.get("checks", [])
     findings_total = sum(len(c.get("findings", [])) for c in checks)
@@ -173,6 +237,8 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     ]
 
     verdict = report.get("overall_verdict")
+    primary = _primary_checks(checks)
+    observation = _observation_text(primary, findings_total, finding_groups)
     return {
         "present": True, "verdict": verdict, "execution": report.get("execution_status"),
         "findings": findings_total, "coverage": coverage, "backend": backend,
@@ -183,6 +249,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             "kernel_count": worklist.get("kernel_count"),
         },
         "kernels": kernels, "finding_groups": finding_groups,
+        "primary": primary, "observation": observation,
     }
 
 
@@ -192,6 +259,11 @@ def _run_record(
     *,
     rel: str | None = None,
 ) -> dict[str, Any]:
+    # Guardrail rows are the baseline-checked class (Tab 1). Tag them so data.json
+    # carries the guardrail/survey case-class split; survey cases live in the
+    # separate ``survey`` list attached to the latest run.
+    for r in rows.values():
+        r.setdefault("cls", "guardrail")
     # Fail closed: a missing report (present=False -> match=False) turns the gate
     # unhealthy, mirroring compare_verdict_baselines.py which errors on absent reports.
     gate = all(r["match"] for r in rows.values())
@@ -335,6 +407,65 @@ def runs_from_history_root(
             rows[case] = row
         runs.append(_run_record(_run_meta_from_history(run_dir), rows, rel=rel))
     return runs
+
+
+def survey_cases_from_spec(
+    spec: dict[str, Any] | list[Any], *, base_dir: Path | None = None
+) -> list[dict[str, Any]]:
+    """Build ordered observed-only *survey* case entries from a spec (pure-ish).
+
+    The survey tab shows kernels drawn from multiple workloads -- including kernels
+    extracted from aorta-internal workloads -- with no expected/baseline signal. To
+    keep this public repo free of customer/NDA identifiers (CLAUDE.md rule #4), the
+    survey *data* is supplied at run time via ``--survey`` (JSON), never hardcoded
+    here: an internal-hosted build feeds internal-sourced rows through the same
+    renderer, while the public build feeds only scrubbed/public rows.
+
+    Spec shape (a bare list of cases, or ``{"cases": [...]}``); each case::
+
+        {
+          "name": "top5-gemm-consan",          # stable id
+          "label": "top-5 f32 GEMM \u00b7 ConSan",   # display label (defaults to name)
+          "backend": "consan (dynamic)",       # backend/tool label
+          "workload": "internal:gemm_top5",    # originating workload (optional)
+          "report_rel": "runs/<id>/survey/top5-gemm-consan/sanitizer_report.json",  # optional link
+          "report": { ...inline sanitizer_report... }   # inline report, OR
+          "report_path": "relative/or/abs/report.json"   # a file to load
+        }
+
+    Each entry carries ``cls="survey"`` and a ``summarize_case(report, None)``
+    summary (``expected=None`` -> observational, ``match=True``), so failures /
+    ``not_checked`` are shown as data and never rendered as a regression.
+    """
+    cases = spec.get("cases", []) if isinstance(spec, dict) else spec
+    entries: list[dict[str, Any]] = []
+    for case in cases or []:
+        if not isinstance(case, dict):
+            continue
+        report = case.get("report")
+        if report is None and case.get("report_path"):
+            path = Path(case["report_path"])
+            if base_dir is not None and not path.is_absolute():
+                path = base_dir / path
+            report = _load(path)
+        summary = summarize_case(report if isinstance(report, dict) else None, None)
+        name = str(case.get("name", case.get("label", "survey")))
+        backend = case.get("backend")
+        if not backend:
+            b = summary.get("backend")
+            backend = b["name"] if b else _DASH
+        entries.append(
+            {
+                "name": name,
+                "label": str(case.get("label", name)),
+                "backend": str(backend),
+                "workload": case.get("workload"),
+                "report_rel": case.get("report_rel"),
+                "cls": "survey",
+                "summary": summary,
+            }
+        )
+    return entries
 
 
 def _status_banner_html(status: dict[str, Any] | None) -> str:
@@ -510,62 +641,122 @@ def _run_cell_html(run: dict[str, Any]) -> str:
     return _esc(label)
 
 
+def _backend_txt_html(backend: dict[str, Any] | None) -> str:
+    if not backend:
+        return "&mdash;"
+    return f'{_esc(backend["name"])} <span class=mono>{_esc(backend["sha"])}</span>'
+
+
+def _meta_line_html(row: dict[str, Any]) -> str:
+    wl = row["worklist"]
+    return (
+        f"<div class=meta>backend {_backend_txt_html(row['backend'])} &middot; selection "
+        f"{_esc(str(wl['requirement']))} top&#8209;{_esc(str(wl['top_n']))} &middot; "
+        f"{_esc(str(wl['kernel_count']))} kernel(s) &middot; execution "
+        f"{_execution_html(row['execution'])}</div>"
+    )
+
+
+def _kernel_tables_html(row: dict[str, Any]) -> str:
+    """The shared kernel-detail + findings tables (identical shape on both tabs)."""
+    krows = (
+        "".join(
+            f"<tr><td class=mono>{_esc(str(k['name']))}</td>"
+            f"<td class=num>{_esc(str(k['dispatch']))}</td>"
+            f"<td>{_observed_html(k['verdict'])}</td>"
+            f"<td class=num>{_esc(str(k['findings']))}</td>"
+            f"<td class=mono>{_esc(k['code_object']) or '&mdash;'}</td>"
+            f"<td class=mono>{_esc(k['sha']) or '&mdash;'}</td></tr>"
+            for k in row["kernels"]
+        )
+        or "<tr><td colspan=6>no kernels selected</td></tr>"
+    )
+    frows = (
+        "".join(
+            f"<tr><td>{_esc(str(g['sanitizer']))}</td><td class=mono>{_esc(str(g['code']))}</td>"
+            f"<td>{_esc(str(g['severity']))}</td><td class=num>{g['count']}</td>"
+            f"<td class=mono>{_esc(g['example'])}</td></tr>"
+            for g in row["finding_groups"]
+        )
+        or "<tr><td colspan=5>no findings</td></tr>"
+    )
+    return (
+        "<table><tr><th>Kernel</th><th>Dispatch</th>"
+        "<th>Observed sanitizer verdict</th><th>Findings</th>"
+        f"<th>Code object</th><th>SHA-256</th></tr>{krows}</table>"
+        "<table><tr><th>Sanitizer</th><th>Code</th><th>Severity</th><th>Count</th>"
+        f"<th>Example</th></tr>{frows}</table>"
+    )
+
+
+def _raw_link_html(report_rel: str | None) -> str:
+    return f' <a class=raw href="{_esc(report_rel)}">view raw report</a>' if report_rel else ""
+
+
 def _kernel_detail_html(rows: dict[str, dict[str, Any]]) -> str:
+    """Tab 1 (guardrails): expected-vs-observed kernel detail with baseline status."""
     blocks: list[str] = []
     for case, _key, label, _backend_label in CASES:
         row = rows[case]
-        report_rel = row.get("report_rel")
-        raw_link = (
-            f' <a class=raw href="{_esc(report_rel)}">view raw report</a>' if report_rel else ""
-        )
+        raw_link = _raw_link_html(row.get("report_rel"))
         if not row["present"]:
             blocks.append(
                 f"<h3>{_esc(label)} &middot; {_baseline_status_html(row)}</h3>"
                 f"<p>Observed sanitizer verdict: {_observed_html(row['verdict'])}</p>"
             )
             continue
-        wl = row["worklist"]
-        backend = row["backend"]
-        backend_txt = (
-            f'{_esc(backend["name"])} <span class=mono>{_esc(backend["sha"])}</span>'
-            if backend
-            else "&mdash;"
-        )
-        krows = (
-            "".join(
-                f"<tr><td class=mono>{_esc(str(k['name']))}</td>"
-                f"<td class=num>{_esc(str(k['dispatch']))}</td>"
-                f"<td>{_observed_html(k['verdict'])}</td>"
-                f"<td class=num>{_esc(str(k['findings']))}</td>"
-                f"<td class=mono>{_esc(k['code_object']) or '&mdash;'}</td>"
-                f"<td class=mono>{_esc(k['sha']) or '&mdash;'}</td></tr>"
-                for k in row["kernels"]
-            )
-            or "<tr><td colspan=6>no kernels selected</td></tr>"
-        )
-        frows = (
-            "".join(
-                f"<tr><td>{_esc(str(g['sanitizer']))}</td><td class=mono>{_esc(str(g['code']))}</td>"
-                f"<td>{_esc(str(g['severity']))}</td><td class=num>{g['count']}</td>"
-                f"<td class=mono>{_esc(g['example'])}</td></tr>"
-                for g in row["finding_groups"]
-            )
-            or "<tr><td colspan=5>no findings</td></tr>"
-        )
         blocks.append(
             f"<h3>{_esc(label)} &middot; {_baseline_status_html(row)}{raw_link}</h3>"
             f'<div class="secondary">Observed sanitizer verdict '
             f"{_observed_html(row['verdict'])} &middot; expected "
             f"{_observed_html(row['expected'] or _DASH)}</div>"
-            f"<div class=meta>backend {backend_txt} &middot; selection "
-            f"{_esc(str(wl['requirement']))} top&#8209;{_esc(str(wl['top_n']))} &middot; "
-            f"{_esc(str(wl['kernel_count']))} kernel(s) &middot; execution "
-            f"{_execution_html(row['execution'])}</div>"
-            "<table><tr><th>Kernel</th><th>Dispatch</th>"
-            "<th>Observed sanitizer verdict</th><th>Findings</th>"
-            f"<th>Code object</th><th>SHA-256</th></tr>{krows}</table>"
-            "<table><tr><th>Sanitizer</th><th>Code</th><th>Severity</th><th>Count</th>"
-            f"<th>Example</th></tr>{frows}</table>"
+            f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}</div>'
+            f"{_meta_line_html(row)}"
+            f"{_kernel_tables_html(row)}"
+        )
+    return "".join(blocks)
+
+
+def _survey_note_html() -> str:
+    return (
+        '<p class="secondary survey-note">Workload survey &mdash; observed sanitizer '
+        "behavior only. <b>No expected-behavior comparison on this tab</b>: a "
+        "<span class=mono>fail</span> or <span class=mono>not_checked</span> here is an "
+        "observation, not a regression. Kernels may be drawn from multiple workloads, "
+        "including aorta-internal-sourced kernels supplied via the survey input.</p>"
+    )
+
+
+def _survey_detail_html(survey: list[dict[str, Any]]) -> str:
+    """Tab 2 (workload survey): observed-only kernel detail, no expected/match column."""
+    if not survey:
+        return (
+            f"{_survey_note_html()}"
+            "<p class=secondary>No workload-survey kernels in this run.</p>"
+        )
+    blocks: list[str] = [_survey_note_html()]
+    for entry in survey:
+        row = entry["summary"]
+        raw_link = _raw_link_html(entry.get("report_rel"))
+        workload = entry.get("workload")
+        workload_txt = f" &middot; source {_esc(str(workload))}" if workload else ""
+        head = (
+            f"<h3>{_esc(str(entry['label']))} &middot; {_observed_html(row['verdict'])}"
+            f"{raw_link}</h3>"
+        )
+        if not row["present"]:
+            blocks.append(
+                f"{head}"
+                f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}'
+                f"{workload_txt}</div>"
+            )
+            continue
+        blocks.append(
+            f"{head}"
+            f'<div class="secondary">backend {_esc(str(entry["backend"]))}{workload_txt}</div>'
+            f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}</div>'
+            f"{_meta_line_html(row)}"
+            f"{_kernel_tables_html(row)}"
         )
     return "".join(blocks)
 
@@ -662,6 +853,7 @@ def build_html(
     title: str = "Sanitizers Nightly",
     status: dict[str, Any] | None = None,
     informational: list[dict[str, Any]] | None = None,
+    survey: list[dict[str, Any]] | None = None,
 ) -> str:
     banner = _status_banner_html(status)
     if not runs:
@@ -730,6 +922,17 @@ def build_html(
   .meta {{ color:#57606a; font-size:12px; margin-bottom:12px; }}
   .secondary {{ color:#57606a; font-size:12px; margin:4px 0 8px; }}
   a.raw {{ font-size:12px; font-weight:400; margin-left:8px; }}
+  /* Self-contained tabs (no external JS/CSS): radios toggle sibling panels via :checked. */
+  .tabradio {{ position:absolute; opacity:0; pointer-events:none; }}
+  .tabbar {{ display:flex; gap:4px; border-bottom:1px solid #d0d7de; margin:16px 0 0; }}
+  .tabbar label {{ cursor:pointer; padding:8px 14px; font-weight:600; color:#57606a;
+          border:1px solid transparent; border-bottom:none; border-radius:8px 8px 0 0; }}
+  #tab-guardrails:checked ~ .tabbar label[for="tab-guardrails"],
+  #tab-survey:checked ~ .tabbar label[for="tab-survey"] {{
+          color:#1f2328; background:#fff; border-color:#d0d7de; }}
+  .tabpanel {{ display:none; padding-top:8px; }}
+  #tab-guardrails:checked ~ #panel-guardrails {{ display:block; }}
+  #tab-survey:checked ~ #panel-survey {{ display:block; }}
   .mono {{ font-family: ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; }}
   .gate {{ color:#fff; background:{gate_color}; padding:12px 16px; border-radius:8px;
           font-weight:600; margin:12px 0 20px; }}
@@ -750,6 +953,9 @@ def build_html(
     th,td {{ border-color:#30363d; }}
     .meta,.secondary {{ color:#8b949e; }}
     .observed {{ color:#c9d1d9; background:#6e768133; border-color:#6e7681; }}
+    #tab-guardrails:checked ~ .tabbar label[for="tab-guardrails"],
+    #tab-survey:checked ~ .tabbar label[for="tab-survey"] {{
+            color:#e6edf3; background:#161b22; border-color:#30363d; }}
   }}
 </style></head>
 <body><div class=wrap>
@@ -764,6 +970,17 @@ def build_html(
      verdicts may be expected positive-control outcomes. Baseline status is the
      regression-health signal.</p>
 
+  <div class=tabs>
+  <input type=radio name=santab id=tab-guardrails class=tabradio checked>
+  <input type=radio name=santab id=tab-survey class=tabradio>
+  <div class=tabbar>
+    <label for="tab-guardrails">Expected behavior (guardrails)</label>
+    <label for="tab-survey">Workload survey (observed-only)</label>
+  </div>
+
+  <section class=tabpanel id=panel-guardrails>
+  <p class=secondary>Baseline-checked kernels: expected vs observed sanitizer behavior.
+     This tab is the regression gate.</p>
   <h2>Latest run</h2>
   <table>
     <tr><th>Recipe</th><th>Backend</th><th>Baseline status</th><th>Observed</th>
@@ -774,12 +991,19 @@ def build_html(
   <h2>Kernel details</h2>
   {_kernel_detail_html(latest['rows'])}
 
-  {build_informational_html(informational or [])}
   <h2>History / trend</h2>
   <table>
     <tr><th>Run</th><th>Commit</th><th>Date</th>{hist_head}<th>Gate</th></tr>
     {hist_rows}
   </table>
+  </section>
+
+  <section class=tabpanel id=panel-survey>
+  <h2>Workload survey</h2>
+  {_survey_detail_html(survey or [])}
+  {build_informational_html(informational or [])}
+  </section>
+  </div>
 </div></body></html>
 """
 
@@ -852,11 +1076,51 @@ def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightl
     )
 
 
+def _survey_section_md(survey: list[dict[str, Any]]) -> list[str]:
+    """Tab 2 mirror for the GitHub job summary: observed-only, non-gating."""
+    lines = [
+        "## Workload survey (observed-only)",
+        "",
+        "Observed sanitizer behavior only \u2014 **no expected-behavior comparison on this "
+        "tab**; a `fail` / `not_checked` here is an observation, not a regression. Kernels "
+        "may be drawn from multiple workloads, including aorta-internal-sourced kernels "
+        "supplied via the survey input.",
+        "",
+    ]
+    if not survey:
+        lines += ["No workload-survey kernels in this run.", ""]
+        return lines
+    for entry in survey:
+        r = entry["summary"]
+        workload = f" \u00b7 source `{entry['workload']}`" if entry.get("workload") else ""
+        lines.append(
+            f"<details><summary><b>{entry['label']}</b> \u2014 observed "
+            f"`{r['verdict']}`</summary>"
+        )
+        lines += ["", f"Observation: {r.get('observation', '')}{workload}"]
+        if not r["present"]:
+            lines += ["", "</details>", ""]
+            continue
+        lines += [
+            "",
+            "| Kernel | Dispatch | Observed sanitizer verdict | Findings | Code object | SHA-256 |",
+            "|---|--:|---|--:|---|---|",
+        ]
+        for k in r["kernels"]:
+            lines.append(
+                f"| `{k['name']}` | {k['dispatch']} | `{k['verdict']}` | {k['findings']} | "
+                f"`{k['code_object'] or _DASH}` | `{k['sha'] or _DASH}` |"
+            )
+        lines += ["", "</details>", ""]
+    return lines
+
+
 def build_summary_md(
     runs: list[dict[str, Any]],
     *,
     status: dict[str, Any] | None = None,
     informational: list[dict[str, Any]] | None = None,
+    survey: list[dict[str, Any]] | None = None,
 ) -> str:
     banner = _status_banner_md(status)
     if not runs:
@@ -892,7 +1156,14 @@ def build_summary_md(
             f"{_execution_md(r['execution'])} | {r['findings']} | {r['coverage'] or _DASH} |"
         )
 
-    lines += ["", "## Kernel details", ""]
+    lines += [
+        "",
+        "Two views below: **Expected behavior (guardrails)** (baseline-checked, the gate) "
+        "and **Workload survey (observed-only)** (non-gating).",
+        "",
+        "## Expected behavior (guardrails) \u00b7 Kernel details",
+        "",
+    ]
     for case, _key, label, _backend in CASES:
         r = latest["rows"][case]
         lines.append(
@@ -938,6 +1209,8 @@ def build_summary_md(
                     f"| {g['sanitizer']} | `{g['code']}` | {g['severity']} | {g['count']} | {example} |"
                 )
         lines += ["", "</details>", ""]
+
+    lines += _survey_section_md(survey or [])
 
     informational_md = build_informational_md(informational or [])
     if informational_md:
@@ -990,6 +1263,13 @@ def main() -> int:
         help="dir of <case>/sanitizer_report.json rendered as a non-gating informational "
         "section (experimental caller-supplied ConSan objects; does not affect the gate)",
     )
+    ap.add_argument(
+        "--survey",
+        type=Path,
+        help="JSON spec of observed-only workload-survey cases for the survey tab "
+        "(see survey_cases_from_spec). Data is supplied here at run time so this public "
+        "repo hardcodes no customer/NDA identifiers; a fail/not_checked never gates.",
+    )
     args = ap.parse_args()
 
     # Optional run-status manifest (see sanitizers-nightly.yml). A malformed or
@@ -1026,9 +1306,22 @@ def main() -> int:
         else []
     )
 
+    # Observed-only survey cases for Tab 2. A malformed/absent spec degrades to an
+    # empty survey (Tab 2 renders its empty-state note) rather than crashing render.
+    survey: list[dict[str, Any]] = []
+    if args.survey is not None:
+        spec = _load(args.survey)
+        if isinstance(spec, (dict, list)):
+            survey = survey_cases_from_spec(spec, base_dir=args.survey.parent)
+    # Mirror the two-class split into data.json: attach the survey list to the
+    # latest run record (additive; existing per-run keys are untouched).
+    if runs:
+        runs[0]["survey"] = survey
+
     args.out_dir.mkdir(parents=True, exist_ok=True)
     (args.out_dir / "index.html").write_text(
-        build_html(runs, status=status, informational=informational), encoding="utf-8"
+        build_html(runs, status=status, informational=informational, survey=survey),
+        encoding="utf-8",
     )
     # In published-history mode, write each retained run's tiny landing page next
     # to its co-located raw reports (out_dir/runs/<id>/index.html). Bounded by
@@ -1075,7 +1368,8 @@ def main() -> int:
                 build_run_index_html(run), encoding="utf-8"
             )
     (args.out_dir / "summary.md").write_text(
-        build_summary_md(runs, status=status, informational=informational), encoding="utf-8"
+        build_summary_md(runs, status=status, informational=informational, survey=survey),
+        encoding="utf-8",
     )
     (args.out_dir / "data.json").write_text(
         json.dumps(runs, indent=2, sort_keys=True) + "\n", encoding="utf-8"

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -13,8 +13,9 @@ emits, into ``--out-dir``:
   kernels drawn from multiple workloads (including aorta-internal-sourced kernels
   supplied via ``--survey``) shown with the same kernel-detail shape but **no
   expected/match column** (a fail / not_checked here is an observation, never a
-  regression). Both tabs link each case to its ``sanitizer_report.json`` and carry
-  a one-line observation summary.
+  regression). Both tabs link each case -- in its heading and in a per-kernel-row
+  ``Report`` column -- to its ``sanitizer_report.json`` (satisfying #367's per-row
+  drill-down), and carry a one-line observation summary.
 * ``summary.md`` -- a GitHub Actions job-summary fragment (append to
   ``$GITHUB_STEP_SUMMARY``) carrying the same gate, table, and kernel detail.
 * ``data.json`` -- the aggregated structure for any richer consumer.
@@ -706,8 +707,19 @@ def _meta_line_html(row: dict[str, Any]) -> str:
     )
 
 
-def _kernel_tables_html(row: dict[str, Any]) -> str:
-    """The shared kernel-detail + findings tables (identical shape on both tabs)."""
+def _kernel_tables_html(row: dict[str, Any], *, report_rel: str | None = None) -> str:
+    """The shared kernel-detail + findings tables (identical shape on both tabs).
+
+    ``report_rel`` is the case's raw ``sanitizer_report.json`` link; when it is a
+    safe relative path it is rendered in a per-row **Report** column so every
+    kernel row drills down to the report (#367's per-row acceptance criterion),
+    for both the guardrail and survey callers. It degrades to an em dash when the
+    case carries no link -- an absent report, an unsafe caller value, or an input
+    mode (results-dir / runs-root) that publishes no co-located reports -- so no
+    dead or unsafe link is ever emitted. All kernel rows of one case share the
+    single case-level report, so they all point at the same file.
+    """
+    link = _report_link_html(_safe_report_rel(report_rel))
     krows = (
         "".join(
             f"<tr><td class=mono>{_esc(str(k['name']))}</td>"
@@ -715,10 +727,11 @@ def _kernel_tables_html(row: dict[str, Any]) -> str:
             f"<td>{_observed_html(k['verdict'])}</td>"
             f"<td class=num>{_esc(str(k['findings']))}</td>"
             f"<td class=mono>{_esc(k['code_object']) or '&mdash;'}</td>"
-            f"<td class=mono>{_esc(k['sha']) or '&mdash;'}</td></tr>"
+            f"<td class=mono>{_esc(k['sha']) or '&mdash;'}</td>"
+            f"<td>{link}</td></tr>"
             for k in row["kernels"]
         )
-        or "<tr><td colspan=6>no kernels selected</td></tr>"
+        or "<tr><td colspan=7>no kernels selected</td></tr>"
     )
     frows = (
         "".join(
@@ -732,7 +745,7 @@ def _kernel_tables_html(row: dict[str, Any]) -> str:
     return (
         "<table><tr><th>Kernel</th><th>Dispatch</th>"
         "<th>Observed sanitizer verdict</th><th>Findings</th>"
-        f"<th>Code object</th><th>SHA-256</th></tr>{krows}</table>"
+        f"<th>Code object</th><th>SHA-256</th><th>Report</th></tr>{krows}</table>"
         "<table><tr><th>Sanitizer</th><th>Code</th><th>Severity</th><th>Count</th>"
         f"<th>Example</th></tr>{frows}</table>"
     )
@@ -761,7 +774,7 @@ def _kernel_detail_html(rows: dict[str, dict[str, Any]]) -> str:
             f"{_observed_html(row['expected'] or _DASH)}</div>"
             f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}</div>'
             f"{_meta_line_html(row)}"
-            f"{_kernel_tables_html(row)}"
+            f"{_kernel_tables_html(row, report_rel=row.get('report_rel'))}"
         )
     return "".join(blocks)
 
@@ -805,7 +818,7 @@ def _survey_detail_html(survey: list[dict[str, Any]]) -> str:
             f'<div class="secondary">backend {_esc(str(entry["backend"]))}{workload_txt}</div>'
             f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}</div>'
             f"{_meta_line_html(row)}"
-            f"{_kernel_tables_html(row)}"
+            f"{_kernel_tables_html(row, report_rel=entry.get('report_rel'))}"
         )
     return "".join(blocks)
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -163,9 +163,13 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     observational, never as a passing/failing gate row.
     """
     if report is None:
+        # Match follows the same rule as the present path: a survey case
+        # (expected is None) is never a mismatch, while a guardrail case keeps a
+        # non-null expectation and so a missing report stays a mismatch (the gate
+        # fails closed). Hardcoding False here contradicted the survey contract.
         return {
             "present": False, "verdict": "—", "execution": "missing", "findings": 0,
-            "coverage": "", "backend": None, "expected": expected, "match": False,
+            "coverage": "", "backend": None, "expected": expected, "match": expected is None,
             "worklist": {"requirement": None, "top_n": None, "kernel_count": 0},
             "kernels": [], "finding_groups": [],
             "primary": {"sanitizer": None, "verdict": None, "reason": None, "preflight": None},
@@ -409,6 +413,31 @@ def runs_from_history_root(
     return runs
 
 
+def _safe_report_rel(value: Any) -> str | None:
+    """Accept only a same-origin *relative* path for a survey report link.
+
+    ``report_rel`` on a survey case is caller-supplied JSON, so a value like
+    ``javascript:alert(1)`` or ``//evil.example/x`` would otherwise render as an
+    executable or off-origin ``<a href>`` -- HTML-escaping the attribute does not
+    neutralize a URL scheme. Reject anything that is not a plain relative path:
+    a URL scheme (``scheme:``), absolute or protocol-relative paths (leading
+    ``/``), backslashes, and embedded control/whitespace characters. The
+    internally-computed guardrail/history links already have this shape, so this
+    only tightens the untrusted survey field.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    if value != value.strip() or any(ord(ch) < 0x20 for ch in value):
+        return None
+    if value.startswith("/") or "\\" in value:
+        return None
+    # A relative path never carries a URL scheme; a colon in the first segment
+    # (before the first "/", e.g. ``javascript:``) means it is a scheme, not a path.
+    if ":" in value.split("/", 1)[0]:
+        return None
+    return value
+
+
 def survey_cases_from_spec(
     spec: dict[str, Any] | list[Any], *, base_dir: Path | None = None
 ) -> list[dict[str, Any]]:
@@ -436,15 +465,30 @@ def survey_cases_from_spec(
     Each entry carries ``cls="survey"`` and a ``summarize_case(report, None)``
     summary (``expected=None`` -> observational, ``match=True``), so failures /
     ``not_checked`` are shown as data and never rendered as a regression.
+
+    ``report_rel`` is retained only for a *present* report (no dead link, matching
+    the guardrail path in ``runs_from_history_root``) and only when it is a safe
+    relative path (it is untrusted caller JSON; see ``_safe_report_rel``). A
+    malformed spec (a non-list ``cases`` wrapper, a non-string ``report_path``)
+    degrades to an empty / absent survey rather than raising.
     """
     cases = spec.get("cases", []) if isinstance(spec, dict) else spec
+    # A malformed wrapper (e.g. ``{"cases": 1}``) must degrade to an empty survey,
+    # not raise a TypeError when iterated -- matching the CLI's promise that a bad
+    # --survey spec renders the empty-state note rather than aborting the render.
+    if not isinstance(cases, list):
+        cases = []
     entries: list[dict[str, Any]] = []
-    for case in cases or []:
+    for case in cases:
         if not isinstance(case, dict):
             continue
         report = case.get("report")
-        if report is None and case.get("report_path"):
-            path = Path(case["report_path"])
+        # Only construct a path from a non-empty string; a non-string report_path
+        # (e.g. a numeric JSON value) would otherwise raise in Path() and abort the
+        # whole dashboard instead of rendering this case as absent.
+        report_path = case.get("report_path")
+        if report is None and isinstance(report_path, str) and report_path:
+            path = Path(report_path)
             if base_dir is not None and not path.is_absolute():
                 path = base_dir / path
             report = _load(path)
@@ -460,7 +504,12 @@ def survey_cases_from_spec(
                 "label": str(case.get("label", name)),
                 "backend": str(backend),
                 "workload": case.get("workload"),
-                "report_rel": case.get("report_rel"),
+                # Keep a report link only for a present report (no dead link,
+                # matching runs_from_history_root) and only when it is a safe
+                # relative path (report_rel is untrusted caller JSON).
+                "report_rel": (
+                    _safe_report_rel(case.get("report_rel")) if summary["present"] else None
+                ),
                 "cls": "survey",
                 "summary": summary,
             }
@@ -930,6 +979,12 @@ def build_html(
   #tab-guardrails:checked ~ .tabbar label[for="tab-guardrails"],
   #tab-survey:checked ~ .tabbar label[for="tab-survey"] {{
           color:#1f2328; background:#fff; border-color:#d0d7de; }}
+  /* The radios are visually hidden (opacity:0) so they show no native focus
+     ring; mirror :focus-visible onto the associated label so keyboard users can
+     see which tab control is focused. */
+  #tab-guardrails:focus-visible ~ .tabbar label[for="tab-guardrails"],
+  #tab-survey:focus-visible ~ .tabbar label[for="tab-survey"] {{
+          outline:2px solid #0969da; outline-offset:-2px; }}
   .tabpanel {{ display:none; padding-top:8px; }}
   #tab-guardrails:checked ~ #panel-guardrails {{ display:block; }}
   #tab-survey:checked ~ #panel-survey {{ display:block; }}

--- a/scripts/sanitizers/gen_survey_spec.py
+++ b/scripts/sanitizers/gen_survey_spec.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Emit the workload-survey ``--survey`` spec for the sanitizer dashboard (Tab 2).
+
+The survey tab (``gen_sanitizer_dashboard.py --survey``) renders observed-only
+kernels drawn from multiple workloads with *no* baseline/expected comparison: a
+``warn``/``error``/``not_checked`` here is an observation, never a regression.
+
+This generator is a thin, deterministic adapter: it enumerates the committed,
+already-scrubbed ``sanitizer_report.json`` fixtures under ``reports/<case>/`` and
+writes a ``{"cases": [...]}`` spec that ``survey_cases_from_spec`` consumes. It
+does **not** run GPUs or fabricate results -- the committed reports are the
+recorded outputs; this only maps them into spec cases. Re-running reproduces the
+committed spec byte-for-byte (see ``tests/sanitizers/test_survey_generic_gemm.py``).
+
+Public-safe policy (CLAUDE.md rule #4): every case is generically named. The
+GEMM lane scans the *generic public* hipBLASLt gfx950 Tensile object; the
+synthetic ``tiny_vecadd`` / ``lds_reduce`` controls are ordinary repros. No
+customer, NDA, or ticket identifiers appear here or in the fixtures. The scrub
+guard that enforces this (a forbidden-token denylist over the committed spec,
+fixtures, and rendered output) lives in
+``tests/sanitizers/test_survey_generic_gemm.py``.
+
+Regenerate the committed spec with:
+
+    python scripts/sanitizers/gen_survey_spec.py \
+        --reports-dir recipes/sanitizers/survey/reports \
+        --out recipes/sanitizers/survey/generic_gemm_survey.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+# Ordered survey cases: (report case dir, stable name, display label, workload, backend).
+# Both sanitizers (waitcheck static + ConSan dynamic) are represented for every
+# kernel, so the survey shows each kernel under each tool it was observed with.
+CASES: tuple[tuple[str, str, str, str, str], ...] = (
+    (
+        "gemm_f32_waitcheck",
+        "hipblaslt-gemm-f32-nt-128x128-waitcheck",
+        "hipBLASLt GEMM f32 nt 128x128 \u00b7 waitcheck (static)",
+        "hipblaslt:gemm_f32",
+        "waitcheck (static)",
+    ),
+    (
+        "gemm_f32_consan",
+        "hipblaslt-gemm-f32-nt-128x128-consan",
+        "hipBLASLt GEMM f32 nt 128x128 \u00b7 ConSan (dynamic)",
+        "hipblaslt:gemm_f32",
+        "consan (dynamic)",
+    ),
+    (
+        "tiny_vecadd_waitcheck",
+        "tiny-vecadd-waitcheck",
+        "tiny_vecadd \u00b7 waitcheck (static)",
+        "synthetic:vecadd",
+        "waitcheck (static)",
+    ),
+    (
+        "tiny_vecadd_consan",
+        "tiny-vecadd-consan",
+        "tiny_vecadd \u00b7 ConSan (dynamic)",
+        "synthetic:vecadd",
+        "consan (dynamic)",
+    ),
+    (
+        "lds_reduce_waitcheck",
+        "lds-reduce-waitcheck",
+        "lds_reduce \u00b7 waitcheck (static)",
+        "synthetic:lds_reduce",
+        "waitcheck (static)",
+    ),
+    (
+        "lds_reduce_consan",
+        "lds-reduce-consan",
+        "lds_reduce \u00b7 ConSan (dynamic)",
+        "synthetic:lds_reduce",
+        "consan (dynamic)",
+    ),
+)
+
+def build_spec(reports_dir: Path, *, report_root: Path | None = None) -> dict:
+    """Build the ``{"cases": [...]}`` survey spec from the committed report tree.
+
+    ``report_path`` is emitted relative to ``report_root`` (the spec's own
+    directory, so the dashboard resolves fixtures next to the spec at render
+    time). ``report_rel`` is the *published* drill-down link (``survey/<case>/``,
+    co-located next to ``index.html`` by the publish step), a safe same-origin
+    relative path.
+    """
+    root = report_root if report_root is not None else reports_dir
+    cases: list[dict] = []
+    for case_dir, name, label, workload, backend in CASES:
+        report_file = reports_dir / case_dir / "sanitizer_report.json"
+        report = json.loads(report_file.read_text(encoding="utf-8"))
+        _assert_public_safe(report, case_dir)
+        rel_path = (reports_dir / case_dir / "sanitizer_report.json").relative_to(root)
+        cases.append(
+            {
+                "name": name,
+                "label": label,
+                "backend": backend,
+                "workload": workload,
+                "report_path": rel_path.as_posix(),
+                "report_rel": f"survey/{case_dir}/sanitizer_report.json",
+            }
+        )
+    return {"cases": cases}
+
+
+def _assert_public_safe(report: dict, case_dir: str) -> None:
+    # Schema check only; the forbidden-token scrub guard lives in the test module
+    # so this generator carries no denylist literals of its own.
+    if report.get("schema") != "aorta.sanitizer_report/0.1":
+        raise SystemExit(f"{case_dir}: unexpected schema {report.get('schema')!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--reports-dir",
+        type=Path,
+        default=Path("recipes/sanitizers/survey/reports"),
+        help="directory of <case>/sanitizer_report.json survey fixtures",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("recipes/sanitizers/survey/generic_gemm_survey.json"),
+        help="survey spec JSON to write",
+    )
+    args = parser.parse_args()
+    # report_path is resolved by the dashboard relative to the spec's own dir, so
+    # compute it relative to the spec's parent directory.
+    spec = build_spec(args.reports_dir, report_root=args.out.parent)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {args.out} ({len(spec['cases'])} survey cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -878,9 +878,13 @@ def test_summarize_case_survey_is_observational_with_primary_and_observation():
     # a guardrail case (expected set) keeps its baseline match semantics
     guard = gen.summarize_case(_consan_racy_report(), "pass")
     assert guard["match"] is False and guard["expected"] == "pass"
-    # a missing report degrades to an explicit, observational placeholder
+    # a missing report degrades to an explicit, observational placeholder; with no
+    # expectation it is NOT a mismatch (survey contract), while a missing guardrail
+    # report (non-null expected) stays a mismatch so the gate fails closed.
     missing = gen.summarize_case(None, None)
     assert missing["present"] is False and missing["observation"] == "report missing"
+    assert missing["match"] is True
+    assert gen.summarize_case(None, "pass")["match"] is False
 
 
 def test_primary_prefers_last_nonpreflight_and_captures_preflight():
@@ -932,6 +936,59 @@ def test_survey_cases_from_spec_classifies_and_threads_links(tmp_path):
     assert gen.survey_cases_from_spec([{"name": "x", "report": _waitcheck_report()}])[0][
         "cls"
     ] == "survey"
+
+
+def test_survey_cases_from_spec_degrades_on_malformed_specs():
+    # A malformed wrapper value must not raise (the CLI promises the survey tab
+    # degrades to its empty-state note rather than aborting the whole render).
+    assert gen.survey_cases_from_spec({"cases": 1}) == []
+    assert gen.survey_cases_from_spec({"cases": "nope"}) == []
+    assert gen.survey_cases_from_spec({}) == []
+    # A non-string report_path (e.g. a numeric JSON value) is ignored instead of
+    # raising in Path(); the case still renders, just as an absent report.
+    entries = gen.survey_cases_from_spec(
+        {"cases": [{"name": "bad", "label": "bad path", "report_path": 5}]}
+    )
+    assert len(entries) == 1
+    assert entries[0]["summary"]["present"] is False
+    assert entries[0]["report_rel"] is None
+
+
+def test_survey_report_rel_rejects_unsafe_links():
+    # report_rel is untrusted caller JSON: a URL scheme, an absolute path, or a
+    # protocol-relative link must be dropped (HTML-escaping does not make a URL
+    # safe), while a plain relative path is preserved.
+    for unsafe in (
+        "javascript:alert(1)",
+        "/etc/passwd",
+        "//evil.example/x",
+        "\\\\unc\\share",
+        "data:text/html,<script>1</script>",
+        " runs/x/report.json",  # leading whitespace browsers would strip
+    ):
+        spec = {"cases": [{"name": "s", "report_rel": unsafe, "report": _consan_racy_report()}]}
+        entry = gen.survey_cases_from_spec(spec)[0]
+        assert entry["report_rel"] is None, unsafe
+
+    safe = "runs/2026-08-05-33/survey/top5/sanitizer_report.json"
+    spec = {"cases": [{"name": "s", "report_rel": safe, "report": _consan_racy_report()}]}
+    assert gen.survey_cases_from_spec(spec)[0]["report_rel"] == safe
+
+    # An unsafe report_rel must never reach the rendered HTML as an href.
+    bad = gen.survey_cases_from_spec(
+        {"cases": [{"name": "s", "label": "xss", "report_rel": "javascript:alert(1)",
+                    "report": _consan_racy_report()}]}
+    )
+    html = gen.build_html([_healthy_guardrail_run()], survey=bad)
+    assert "javascript:alert(1)" not in html
+
+
+def test_build_html_tabs_have_keyboard_focus_style():
+    # The visually-hidden radios (opacity:0) must project a focus indicator onto
+    # their labels so keyboard users can see which tab is focused.
+    html = gen.build_html([_healthy_guardrail_run()])
+    assert ':focus-visible ~ .tabbar label[for="tab-guardrails"]' in html
+    assert ':focus-visible ~ .tabbar label[for="tab-survey"]' in html
 
 
 def _healthy_guardrail_run() -> dict:

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -860,3 +860,248 @@ def test_informational_section_renders_reason_and_is_non_gating():
     page = gen.build_html([healthy], informational=cases)
     assert "HEALTHY" in page
     assert "combined_hook_timeout" in page and "non-gating" in page
+
+
+# --- #367: two-tab (guardrail + workload survey) kernel-level dashboard ---
+
+
+def test_summarize_case_survey_is_observational_with_primary_and_observation():
+    # expected=None marks a survey (observed-only) case: match is True (no baseline
+    # comparison) and the folded primary/observation fields are surfaced for both tabs.
+    case = gen.summarize_case(_consan_racy_report(), None)
+    assert case["expected"] is None
+    assert case["match"] is True
+    assert case["primary"] == {
+        "sanitizer": "consan", "verdict": "fail", "reason": None, "preflight": None
+    }
+    assert case["observation"].startswith("consan fail")
+    # a guardrail case (expected set) keeps its baseline match semantics
+    guard = gen.summarize_case(_consan_racy_report(), "pass")
+    assert guard["match"] is False and guard["expected"] == "pass"
+    # a missing report degrades to an explicit, observational placeholder
+    missing = gen.summarize_case(None, None)
+    assert missing["present"] is False and missing["observation"] == "report missing"
+
+
+def test_primary_prefers_last_nonpreflight_and_captures_preflight():
+    report = _informational_report("consan_strict_load_rejection")
+    primary = gen._primary_checks(report["checks"])
+    assert primary["sanitizer"] == "consan"
+    assert primary["verdict"] == "error"
+    assert primary["reason"] == "consan_strict_load_rejection"
+    # the waitcheck_preflight check is captured separately, not as the primary
+    assert primary["preflight"] == "error"
+
+
+def test_run_record_tags_rows_as_guardrail():
+    rows = {c: gen.summarize_case(_waitcheck_report(), "warn") for c, *_ in gen.CASES}
+    rec = gen._run_record({"run": "r"}, rows)
+    assert all(r["cls"] == "guardrail" for r in rec["rows"].values())
+
+
+def test_survey_cases_from_spec_classifies_and_threads_links(tmp_path):
+    (tmp_path / "wc.json").write_text(json.dumps(_waitcheck_report()))
+    spec = {
+        "cases": [
+            {
+                "name": "top5", "label": "top-5 f32 GEMM \u00b7 ConSan",
+                "backend": "consan (dynamic)", "workload": "internal:gemm_top5",
+                "report_rel": "runs/x/survey/top5/sanitizer_report.json",
+                "report": _consan_racy_report(),
+            },
+            {"name": "wc", "label": "waitcheck survey", "report_path": "wc.json"},
+            {"name": "missing", "label": "absent case", "report_path": "does-not-exist.json"},
+        ]
+    }
+    entries = gen.survey_cases_from_spec(spec, base_dir=tmp_path)
+
+    assert [e["cls"] for e in entries] == ["survey", "survey", "survey"]
+    top = entries[0]
+    # observed-only: expected None, match True -> never a regression
+    assert top["summary"]["expected"] is None and top["summary"]["match"] is True
+    assert top["summary"]["verdict"] == "fail"
+    assert top["report_rel"] == "runs/x/survey/top5/sanitizer_report.json"
+    assert top["workload"] == "internal:gemm_top5"
+    assert top["summary"]["observation"].startswith("consan fail")
+    # report_path is loaded relative to base_dir
+    assert entries[1]["summary"]["verdict"] == "warn"
+    # a missing report degrades gracefully: still an entry, no dead link
+    assert entries[2]["summary"]["present"] is False
+    assert entries[2]["report_rel"] is None
+    # a bare list (no "cases" wrapper) is accepted too
+    assert gen.survey_cases_from_spec([{"name": "x", "report": _waitcheck_report()}])[0][
+        "cls"
+    ] == "survey"
+
+
+def _healthy_guardrail_run() -> dict:
+    rows = {c: gen.summarize_case(_waitcheck_report(), "warn") for c, *_ in gen.CASES}
+    return gen._run_record(
+        {"run": "r1", "commit": "abc", "date": "d", "gpu": "gfx950"}, rows
+    )
+
+
+def test_build_html_renders_two_self_contained_tabs():
+    survey = gen.survey_cases_from_spec(
+        {"cases": [{"name": "top5", "label": "top-5 GEMM survey",
+                    "backend": "consan (dynamic)", "report": _consan_racy_report()}]}
+    )
+    html = gen.build_html([_healthy_guardrail_run()], survey=survey)
+
+    # both tabs, radio-toggled, guardrails default-selected
+    assert "id=tab-guardrails class=tabradio checked" in html
+    assert "id=tab-survey class=tabradio" in html
+    assert "Expected behavior (guardrails)" in html
+    assert "Workload survey (observed-only)" in html
+    # self-contained: no external JS/CSS, no CDN, no protocol-absolute links
+    assert "<script" not in html.lower()
+    assert "cdn" not in html.lower()
+    assert "http://" not in html and "https://" not in html
+    # explicit observed-only note on the survey tab
+    assert "No expected-behavior comparison on this tab" in html
+
+
+def test_build_html_survey_fail_is_observed_neutral_never_a_regression():
+    # Guardrails are all healthy warn; the survey case observed a fail. The survey
+    # fail must render as a neutral observed verdict and must NOT turn the gate red
+    # or be labelled a regression / mismatch / unexpected outcome.
+    survey = gen.survey_cases_from_spec(
+        {"cases": [{"name": "s", "label": "survey fail case",
+                    "report": _consan_racy_report()}]}
+    )
+    html = gen.build_html([_healthy_guardrail_run()], survey=survey)
+
+    assert "HEALTHY — 3/3 sanitizer outcomes match their baselines" in html
+    # the fail is surfaced as an observed (neutral) verdict, not a health colour
+    assert '<span class="observed">fail</span>' in html
+    # none of the guardrail regression vocabulary leaks in from the survey
+    assert "REGRESSION" not in html and "Regression" not in html
+    assert "Unexpected outcome" not in html and "Mismatch" not in html
+    # no baseline/expected column on the survey tab (no "expected <verdict>" phrasing
+    # is emitted for the survey case; that phrasing is guardrail-only)
+    assert "survey fail case" in html
+    # observation summary is present on the tab
+    assert "Observation:" in html
+
+
+def test_build_html_survey_report_link_and_graceful_absence():
+    survey = gen.survey_cases_from_spec(
+        {"cases": [
+            {"name": "linked", "label": "linked survey",
+             "report_rel": "runs/x/survey/linked/sanitizer_report.json",
+             "report": _consan_racy_report()},
+            {"name": "nolink", "label": "nolink survey", "report": _waitcheck_report()},
+        ]}
+    )
+    html = gen.build_html([_healthy_guardrail_run()], survey=survey)
+
+    # the linked survey case drills down to its raw report; the unlinked one still
+    # renders (degrades to no link). Guardrail rows carry no report_rel here, so the
+    # only "view raw report" link comes from the linked survey case.
+    assert 'href="runs/x/survey/linked/sanitizer_report.json"' in html
+    assert html.count("view raw report") == 1
+    assert "linked survey" in html and "nolink survey" in html
+
+
+def test_build_html_empty_survey_shows_placeholder_note():
+    html = gen.build_html([_healthy_guardrail_run()], survey=[])
+    assert "Workload survey (observed-only)" in html
+    assert "No workload-survey kernels in this run." in html
+
+
+def test_build_summary_md_mirrors_two_tab_split():
+    survey = gen.survey_cases_from_spec(
+        {"cases": [{"name": "top5", "label": "top-5 survey",
+                    "workload": "internal:gemm_top5", "report": _consan_racy_report()}]}
+    )
+    rows = {c: gen.summarize_case(_waitcheck_report(), "warn") for c, *_ in gen.CASES}
+    run = gen._run_record({"run": "r1", "commit": "abc", "date": "d"}, rows)
+    md = gen.build_summary_md([run], survey=survey)
+
+    # guardrail section stays labelled and keeps the substring existing tests rely on
+    assert "Expected behavior (guardrails) \u00b7 Kernel details" in md
+    assert "Kernel details" in md
+    # survey section present, observed-only, non-gating
+    assert "## Workload survey (observed-only)" in md
+    assert "no expected-behavior comparison on this tab" in md.lower()
+    assert "observed `fail`" in md
+    assert "source `internal:gemm_top5`" in md
+    # the survey fail never flips the gate
+    assert "**HEALTHY**" in md
+    assert "**REGRESSION**" not in md
+
+
+def test_main_survey_flows_into_html_and_data_json(tmp_path, monkeypatch):
+    baselines = (
+        _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+    )
+    incoming = tmp_path / "incoming"
+    for case, report in (
+        ("waitcheck", _waitcheck_report()),
+        ("consan-clean", _consan_clean_report()),
+        ("consan-racy", _consan_racy_report()),
+    ):
+        (incoming / case).mkdir(parents=True)
+        (incoming / case / "sanitizer_report.json").write_text(json.dumps(report))
+
+    survey_spec = tmp_path / "survey.json"
+    survey_spec.write_text(json.dumps({"cases": [
+        {"name": "top5", "label": "top-5 GEMM survey", "backend": "consan (dynamic)",
+         "workload": "internal:gemm_top5",
+         "report_rel": "survey/top5/sanitizer_report.json",
+         "report": _consan_racy_report()},
+    ]}))
+    out = tmp_path / "out"
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--results-dir", str(incoming),
+        "--baselines", str(baselines),
+        "--survey", str(survey_spec),
+        "--out-dir", str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+
+    html = (out / "index.html").read_text(encoding="utf-8")
+    assert "Workload survey (observed-only)" in html and "top-5 GEMM survey" in html
+    assert 'href="survey/top5/sanitizer_report.json"' in html
+
+    data = json.loads((out / "data.json").read_text(encoding="utf-8"))
+    # guardrail/survey case-class split is mirrored into data.json (additive fields)
+    assert data[0]["rows"]["waitcheck"]["cls"] == "guardrail"
+    survey = data[0]["survey"]
+    assert len(survey) == 1 and survey[0]["cls"] == "survey"
+    assert survey[0]["summary"]["expected"] is None
+    assert survey[0]["report_rel"] == "survey/top5/sanitizer_report.json"
+
+    md = (out / "summary.md").read_text(encoding="utf-8")
+    assert "## Workload survey (observed-only)" in md
+
+
+def test_main_without_survey_omits_survey_rows_but_renders_tab(tmp_path, monkeypatch):
+    # The survey flag is additive: existing invocations (no --survey) still work and
+    # render Tab 2 with its empty-state note; data.json carries an empty survey list.
+    baselines = (
+        _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+    )
+    incoming = tmp_path / "incoming"
+    for case, report in (
+        ("waitcheck", _waitcheck_report()),
+        ("consan-clean", _consan_clean_report()),
+        ("consan-racy", _consan_racy_report()),
+    ):
+        (incoming / case).mkdir(parents=True)
+        (incoming / case / "sanitizer_report.json").write_text(json.dumps(report))
+    out = tmp_path / "out"
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--results-dir", str(incoming),
+        "--baselines", str(baselines),
+        "--out-dir", str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+    html = (out / "index.html").read_text(encoding="utf-8")
+    assert "No workload-survey kernels in this run." in html
+    data = json.loads((out / "data.json").read_text(encoding="utf-8"))
+    assert data[0]["survey"] == []

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1060,6 +1060,57 @@ def test_build_html_survey_report_link_and_graceful_absence():
     assert "linked survey" in html and "nolink survey" in html
 
 
+def test_kernel_tables_html_links_each_row_to_report():
+    # #367 per-row acceptance: each kernel row links to the case's raw report via a
+    # Report column, and degrades to an em dash (never a dead/unsafe link) when the
+    # case carries no safe link.
+    row = gen.summarize_case(_waitcheck_report(), "warn")
+    assert len(row["kernels"]) == 1
+    rel = "runs/2026-08-05-33/waitcheck/sanitizer_report.json"
+
+    linked = gen._kernel_tables_html(row, report_rel=rel)
+    assert "<th>Report</th>" in linked
+    assert linked.count(f'<a href="{rel}">report</a>') == len(row["kernels"])
+
+    # absent link -> Report column present but each row shows an em dash, no link
+    absent = gen._kernel_tables_html(row, report_rel=None)
+    assert "<th>Report</th>" in absent
+    assert "sanitizer_report.json" not in absent
+    assert ">report</a>" not in absent
+
+    # unsafe caller value is rejected in the shared helper too (defense in depth)
+    unsafe = gen._kernel_tables_html(row, report_rel="javascript:alert(1)")
+    assert "javascript:alert(1)" not in unsafe
+    assert ">report</a>" not in unsafe
+
+    # empty-kernel case spans the full (now 7-column) row
+    empty = gen._kernel_tables_html({**row, "kernels": []}, report_rel=rel)
+    assert "colspan=7>no kernels selected" in empty
+
+
+def test_build_html_kernel_rows_link_reports_on_both_tabs(tmp_path):
+    root = tmp_path / "runs"
+    _write_history_run(root, "2026-08-05-33")
+    runs = gen.runs_from_history_root(root, _baselines())
+    survey = gen.survey_cases_from_spec(
+        {"cases": [{"name": "s", "label": "survey linked",
+                    "report_rel": "runs/x/survey/s/sanitizer_report.json",
+                    "report": _consan_racy_report()}]}
+    )
+    html = gen.build_html(runs, survey=survey)
+
+    # Guardrail kernel-detail row links to its case report (in addition to the
+    # latest-run table's Report cell) -> the waitcheck report link now appears
+    # twice: the latest-run table cell and the per-kernel-row Report column.
+    wc = 'href="runs/2026-08-05-33/waitcheck/sanitizer_report.json">report</a>'
+    assert html.count(wc) == 2
+    # Survey kernel row links to the survey case's report_rel (the heading uses the
+    # distinct "view raw report" text, so a "report" link here is the per-row one).
+    assert 'href="runs/x/survey/s/sanitizer_report.json">report</a>' in html
+    # no dead/unsafe links leaked in
+    assert 'href="/runs/' not in html and "javascript:" not in html
+
+
 def test_build_html_empty_survey_shows_placeholder_note():
     html = gen.build_html([_healthy_guardrail_run()], survey=[])
     assert "Workload survey (observed-only)" in html

--- a/tests/sanitizers/test_survey_generic_gemm.py
+++ b/tests/sanitizers/test_survey_generic_gemm.py
@@ -1,0 +1,252 @@
+"""Tests for the public-safe generic-GEMM workload survey (Tab 2, #367).
+
+Covers: the committed spec + fixtures parse and render as survey cases; both
+sanitizers (waitcheck static + ConSan dynamic) are represented; a survey
+``warn``/``error`` renders as a neutral observation and never a gate regression;
+the committed spec is reproducible from ``gen_survey_spec.py``; and a scrub guard
+asserts no customer/NDA tokens leak into the committed spec, fixtures, or the
+rendered dashboard output (CLAUDE.md rule #4).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SURVEY_DIR = _REPO_ROOT / "recipes" / "sanitizers" / "survey"
+_SPEC = _SURVEY_DIR / "generic_gemm_survey.json"
+_REPORTS_DIR = _SURVEY_DIR / "reports"
+_BASELINES = (
+    _REPO_ROOT / "recipes" / "sanitizers" / "fixtures" / "expected" / "verdict_baselines.json"
+)
+
+# Data artifacts (the committed spec, the report fixtures, and the rendered
+# dashboard output) must be fully scrubbed: no customer/NDA project name, org
+# label, private absolute paths, internal run/user/ticket tokens, and not even
+# the generic word "customer".
+_FORBIDDEN = (
+    "recom",
+    "Meta",
+    "/apps/",
+    "vivekag",
+    "pr347",
+    "feature_consan_waitcheck",
+    "customer",
+)
+
+# Reproduction recipes/scripts carry de-branding *prose* that legitimately uses
+# the generic word "customer" (as existing public recipes in this repo already
+# do, e.g. consan-code-objects.yaml). Guard those against customer NAMES,
+# private paths, and internal tokens -- but not the generic word itself.
+_FORBIDDEN_NAMES = (
+    "recom",
+    "Meta",
+    "/apps/",
+    "vivekag",
+    "pr347",
+    "feature_consan_waitcheck",
+)
+
+
+def _load_module(name: str):
+    path = _REPO_ROOT / "scripts" / "sanitizers" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gen = _load_module("gen_sanitizer_dashboard")
+gen_spec = _load_module("gen_survey_spec")
+
+
+def _assert_no_forbidden(blob: str, where: str, tokens: tuple[str, ...] = _FORBIDDEN) -> None:
+    for token in tokens:
+        assert token not in blob, f"forbidden token {token!r} found in {where}"
+
+
+def _survey_entries() -> list[dict]:
+    spec = json.loads(_SPEC.read_text(encoding="utf-8"))
+    return gen.survey_cases_from_spec(spec, base_dir=_SPEC.parent)
+
+
+def _healthy_guardrail_run() -> dict:
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "warn", "execution_status": "complete",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 1, "kernel_count": 1,
+            "kernels": [{
+                "identity": {"name": "g", "target": "gfx950", "code_object": "isa/g.hsaco",
+                             "code_object_sha256": "abc", "code_object_index": 0,
+                             "entry_offset": None},
+                "total_time_ms": 0.0, "dispatch_count": 1, "sources": ["gemm_csv"],
+            }],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "ran", "verdict": "warn",
+            "reason": None, "returncode": 0, "findings": [], "kernel_results": [],
+            "coverage": [], "backend": {"path": "tools/rj_waitcheck", "sha256": "472fcf288714"},
+        }],
+    }
+    rows = {c: gen.summarize_case(report, "warn") for c, *_ in gen.CASES}
+    return gen._run_record({"run": "r1", "commit": "abc", "date": "d", "gpu": "gfx950"}, rows)
+
+
+# --- spec + fixtures parse and render as survey cases ---
+
+
+def test_committed_spec_parses_into_six_present_survey_cases():
+    entries = _survey_entries()
+    assert len(entries) == 6
+    assert all(e["cls"] == "survey" for e in entries)
+    assert all(e["summary"]["present"] for e in entries)
+    # observed-only: every survey case carries no baseline expectation
+    assert all(e["summary"]["expected"] is None for e in entries)
+    assert all(e["summary"]["match"] is True for e in entries)
+
+
+def test_both_sanitizers_are_represented():
+    backends = {e["backend"] for e in _survey_entries()}
+    assert "waitcheck (static)" in backends
+    assert "consan (dynamic)" in backends
+
+
+def test_gemm_and_control_verdicts_match_recorded_reports():
+    by_name = {e["name"]: e["summary"] for e in _survey_entries()}
+    # generic hipBLASLt GEMM: waitcheck observes warn w/ many hazards; consan errors
+    assert by_name["hipblaslt-gemm-f32-nt-128x128-waitcheck"]["verdict"] == "warn"
+    assert by_name["hipblaslt-gemm-f32-nt-128x128-waitcheck"]["findings"] >= 1
+    assert by_name["hipblaslt-gemm-f32-nt-128x128-consan"]["verdict"] == "error"
+    # synthetic controls: waitcheck passes; consan fails closed (observed error)
+    assert by_name["tiny-vecadd-waitcheck"]["verdict"] == "pass"
+    assert by_name["tiny-vecadd-consan"]["verdict"] == "error"
+    assert by_name["lds-reduce-waitcheck"]["verdict"] == "pass"
+    assert by_name["lds-reduce-consan"]["verdict"] == "error"
+
+
+def test_kernel_identities_are_generic():
+    names = {k["name"] for e in _survey_entries() for k in e["summary"]["kernels"]}
+    assert names == {"hipblaslt_gemm_f32_nt_128x128", "tiny_vecadd", "lds_reduce"}
+
+
+# --- survey warn/error is neutral, never a gate regression ---
+
+
+def test_survey_error_and_warn_never_flip_the_gate():
+    run = _healthy_guardrail_run()
+    survey = _survey_entries()
+    html = gen.build_html([run], survey=survey)
+    md = gen.build_summary_md([run], survey=survey)
+    # guardrail gate stays healthy despite survey warn/error rows
+    assert "HEALTHY" in html
+    assert "REGRESSION" not in html
+    assert "**HEALTHY**" in md and "**REGRESSION**" not in md
+    # survey rows are observed-only (explicit note on the tab)
+    assert "No expected-behavior comparison on this tab" in html
+    # each case drills down to its published report link
+    for entry in survey:
+        assert entry["report_rel"] in html
+
+
+def test_build_html_renders_all_survey_kernels_with_drilldown():
+    html = gen.build_html([_healthy_guardrail_run()], survey=_survey_entries())
+    for label in (
+        "hipBLASLt GEMM f32 nt 128x128 \u00b7 waitcheck (static)",
+        "hipBLASLt GEMM f32 nt 128x128 \u00b7 ConSan (dynamic)",
+        "tiny_vecadd \u00b7 waitcheck (static)",
+        "lds_reduce \u00b7 ConSan (dynamic)",
+    ):
+        assert label in html
+
+
+# --- reproducibility: the committed spec is regenerated byte-for-byte ---
+
+
+def test_gen_survey_spec_reproduces_committed_spec():
+    rebuilt = gen_spec.build_spec(_REPORTS_DIR, report_root=_SPEC.parent)
+    rebuilt_text = json.dumps(rebuilt, indent=2) + "\n"
+    assert rebuilt_text == _SPEC.read_text(encoding="utf-8")
+
+
+# --- scrub guard: no customer/NDA tokens in committed or rendered artifacts ---
+
+
+def test_committed_spec_and_fixtures_are_public_safe():
+    _assert_no_forbidden(_SPEC.read_text(encoding="utf-8"), "generic_gemm_survey.json")
+    fixtures = sorted(_REPORTS_DIR.glob("*/sanitizer_report.json"))
+    assert len(fixtures) == 6
+    for fixture in fixtures:
+        text = fixture.read_text(encoding="utf-8")
+        _assert_no_forbidden(text, str(fixture.relative_to(_REPO_ROOT)))
+        # schema is preserved so the generator can parse it
+        assert json.loads(text)["schema"] == "aorta.sanitizer_report/0.1"
+
+
+def test_committed_recipes_are_public_safe():
+    recipes = sorted(_SURVEY_DIR.glob("*.yaml"))
+    assert recipes, "expected reproduction recipes under recipes/sanitizers/survey/"
+    for recipe in recipes:
+        _assert_no_forbidden(
+            recipe.read_text(encoding="utf-8"), str(recipe.name), tokens=_FORBIDDEN_NAMES
+        )
+
+
+def test_rendered_dashboard_output_is_public_safe(tmp_path, monkeypatch):
+    incoming = tmp_path / "incoming"
+    for case, verdict, san in (
+        ("waitcheck", "warn", "waitcheck"),
+        ("consan-clean", "pass", "consan"),
+        ("consan-racy", "fail", "consan"),
+    ):
+        (incoming / case).mkdir(parents=True)
+        report = {
+            "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+            "overall_verdict": verdict, "execution_status": "complete",
+            "worklist": {
+                "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+                "top_n": 1, "kernel_count": 1,
+                "kernels": [{
+                    "identity": {"name": f"g_{case}", "target": "gfx950",
+                                 "code_object": "isa/g.hsaco", "code_object_sha256": "abc",
+                                 "code_object_index": 0, "entry_offset": None},
+                    "total_time_ms": 0.0, "dispatch_count": 1, "sources": ["gemm_csv"],
+                }],
+            },
+            "checks": [{
+                "sanitizer": san, "state": "ran", "verdict": verdict,
+                "reason": None, "returncode": 0, "findings": [], "kernel_results": [],
+                "coverage": [], "backend": {},
+            }],
+        }
+        (incoming / case / "sanitizer_report.json").write_text(json.dumps(report))
+
+    out = tmp_path / "out"
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--results-dir", str(incoming),
+        "--baselines", str(_BASELINES),
+        "--survey", str(_SPEC),
+        "--out-dir", str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+
+    html = (out / "index.html").read_text(encoding="utf-8")
+    md = (out / "summary.md").read_text(encoding="utf-8")
+    data = (out / "data.json").read_text(encoding="utf-8")
+    _assert_no_forbidden(html, "index.html")
+    _assert_no_forbidden(md, "summary.md")
+    _assert_no_forbidden(data, "data.json")
+
+    # Tab 2 populated with the survey kernels and both sanitizers; gate healthy
+    assert "hipblaslt_gemm_f32_nt_128x128" in html
+    assert "Workload survey (observed-only)" in html
+    parsed = json.loads(data)
+    assert len(parsed[0]["survey"]) == 6
+    assert parsed[0]["gate"] is True


### PR DESCRIPTION
## Summary

Populates the sanitizer dashboard's **Workload survey (observed-only)** tab (Tab 2)
with a public-safe, de-branded survey, realizing the scope update on #367
("populate aorta-internal kernels on Tab 2"). Tab 2 is observed-only: a
`warn`/`error`/`not_checked` here is an observation, **never** a gate regression.

Six survey cases (each kernel run under **both** sanitizers — `waitcheck` static
+ `ConSan` dynamic):

| Kernel | Workload | Sanitizer | Observed verdict |
|---|---|---|---|
| `hipblaslt_gemm_f32_nt_128x128` | `hipblaslt:gemm_f32` | waitcheck (static) | `warn` (32 `wait_hazard` findings) |
| `hipblaslt_gemm_f32_nt_128x128` | `hipblaslt:gemm_f32` | ConSan (dynamic) | `error` (`consan_strict_load_rejection`) |
| `tiny_vecadd` | `synthetic:vecadd` | waitcheck (static) | `pass` |
| `tiny_vecadd` | `synthetic:vecadd` | ConSan (dynamic) | `error` (fails closed, exit 86) |
| `lds_reduce` | `synthetic:lds_reduce` | waitcheck (static) | `pass` |
| `lds_reduce` | `synthetic:lds_reduce` | ConSan (dynamic) | `error` (fails closed, exit 86) |

Showing an `error`/`warn` here is intended — Tab 2 records observed behavior,
including fail-closed behavior on heavy production code objects.

## Dependency on #368 (stacked)

This consumes the `--survey` feature (`survey_cases_from_spec`) added by #368.
**#368 is not yet merged**, and its branch `feat/sanitizer-dashboard-two-tabs`
does not exist in `ROCm/aorta`, so this PR is based on `main`; its diff will
therefore include #368's commits until #368 merges (after which GitHub narrows
this diff to just the 14 new files below). **Please review/merge after #368.**
`scripts/sanitizers/gen_sanitizer_dashboard.py` is **not modified** here — this
PR only consumes `--survey`.

## NDA / de-branding decision (CLAUDE.md rule #4)

This is the **public** `ROCm/aorta` repo, so it carries **no** customer,
project-codename, org-label, ticket, or NDA identifiers.

- The GEMM lane scans the **generic public hipBLASLt gfx950 f32 Tensile object**
  (`TensileLibrary_*SB*gfx950.co` content — the same kind
  `prepare_gemm_isa.py` prepares). Only the *label* was ever customer-branded;
  the scanned ISA itself is generic public content.
- `tiny_vecadd` and `lds_reduce` are ordinary independently-authored synthetic
  repros with no customer association.
- All committed data is **scrubbed**: private absolute run-area paths are
  replaced with generic relative paths (e.g. `survey_isa/hipblaslt_gemm_f32.hsaco`),
  customer/codename/ticket labels removed, kernels named generically. The
  `aorta.sanitizer_report/0.1` schema is preserved so the generator parses them.
- A scrub-guard test enforces a forbidden-substring denylist over the committed
  spec, fixtures, and rendered dashboard output.

Refs #367 (does not close it).

## Files added (all additive, public-safe)

- `recipes/sanitizers/survey/generic_gemm_survey.json` — the `--survey` spec
- `recipes/sanitizers/survey/reports/<case>/sanitizer_report.json` — 6 scrubbed report fixtures
- `recipes/sanitizers/survey/{generic-gemm,tiny-vecadd,lds-reduce}-survey.yaml` — both-sanitizer reproduction recipes
- `scripts/sanitizers/gen_survey_spec.py` — deterministic spec generator (does not fabricate GPU results)
- `tests/sanitizers/test_survey_generic_gemm.py` — parse/render + reproducibility + scrub-guard tests
- `recipes/sanitizers/survey/README.md` — spec format, regeneration steps, de-branding policy
- `recipes/sanitizers/survey/.gitignore` — re-includes the committed spec/fixtures past the repo-root `*.json` ignore

## Test plan

- [x] `python -m pytest tests/sanitizers/test_survey_generic_gemm.py tests/sanitizers/test_dashboard.py -q` — 62 passed
- [x] `ruff check` on new Python files — clean
- [x] pre-commit hooks (trailing-whitespace, end-of-file-fixer, check-yaml) — pass
- [x] Rendered `--survey` into a temp dir: Tab 2 shows all six kernels with per-case report drill-down links + observation summaries; guardrail gate/Tab 1 unaffected (HEALTHY); rendered HTML/summary.md/data.json contain no customer/codename strings and no `/apps/` absolute paths
- [ ] Re-verify after #368 merges (diff narrows to the 14 new files)

Note: two pre-existing sanitizer tests fail in this local env only (`test_gemm_fixture.py` uses `zip(strict=)` needing Python 3.10+, and `test_compare_baselines.py` needs the `aorta` package installed); both are unrelated to this change and pass under the CI Python/interpreter.

Made with [Cursor](https://cursor.com)