### PR TITLE
Bump CI stack to ROCm 7.2.4 and PyTorch 2.10.0

### DIFF
--- a/docker/.env.ci
+++ b/docker/.env.ci
@@ -4,7 +4,7 @@
 # digest for reproducible GPU CI runs on MI350 / gfx950 hardware.
 #
 # Update the digest when intentionally bumping the CI base image:
-#   docker buildx imagetools inspect rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
+#   docker buildx imagetools inspect rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
 
 DOCKERFILE=Dockerfile.ci-gpu
 IMAGE_NAME=aorta:ci-gpu

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -13,12 +13,12 @@
 # has therefore been removed from this image. hipcc (from the ROCm base) still
 # builds the HIP repro fixtures and does not need any of those.
 #
-# Base: rocm/pytorch ROCm 7.2, Ubuntu 22.04, Python 3.10, PyTorch 2.9.1
+# Base: rocm/pytorch ROCm 7.2.4, Ubuntu 22.04, Python 3.10, PyTorch 2.10.0
 # Pinned as tag@digest (not digest-only): the tag anchors Dependabot to the
 # intended ROCm 7.2 stream when it proposes a new digest; the digest keeps the
 # build reproducible. Resolved via:
-#   docker buildx imagetools inspect rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
-FROM rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1@sha256:376bfab5f4f680c8b4b843c6d0c5d1f0a04e5a84ec3e86728db8d11d79a9d1e3
+#   docker buildx imagetools inspect rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
+FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0@sha256:3b71b642af60419cd68156d3ab4114943a6d39b730d4dd6b33e8f6ffdb982f88
 
 USER root
 

--- a/docker/Dockerfile.rocm70_9-1
+++ b/docker/Dockerfile.rocm70_9-1
@@ -1,6 +1,6 @@
 # Start from the latest public ROCm PyTorch image
-# ROCm 7.2, Ubuntu 22.04, Python 3.10, PyTorch 2.9.1
-FROM rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
+# ROCm 7.2.4, Ubuntu 22.04, Python 3.10, PyTorch 2.10.0
+FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
 
 # Switch to root to install packages
 USER root

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -230,10 +230,10 @@ model as the existing analysis workflows):
 The base image is pinned by digest:
 
 ```
-rocm/pytorch@sha256:376bfab5f4f680c8b4b843c6d0c5d1f0a04e5a84ec3e86728db8d11d79a9d1e3
+rocm/pytorch@sha256:3b71b642af60419cd68156d3ab4114943a6d39b730d4dd6b33e8f6ffdb982f88
 ```
 
-(tag: `rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1`). Bump the digest in
+(tag: `rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0`). Bump the digest in
 `Dockerfile.ci-gpu` / `.env.ci` when intentionally upgrading the CI stack.
 
 ### Triggers and frequency


### PR DESCRIPTION
## Summary
- Upgrade the pinned GPU CI base image from `rocm7.2` / PyTorch 2.9.1 to **ROCm 7.2.4** / **PyTorch 2.10.0** on the existing Ubuntu 22.04 + Python 3.10 lane (MI350 runner compatible)
- Update `Dockerfile.ci-gpu` digest, general-purpose `Dockerfile.rocm70_9-1`, and `docs/ci-testing-plan.md`

## Stack change
| | Before | After |
|---|---|---|
| ROCm | 7.2.0 | 7.2.4 |
| PyTorch | 2.9.1 | 2.10.0 |
| Base tag | `rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1` | `rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0` |

## Test plan
- [ ] **Bump validation** workflow passes on MI350 (full nightly matrix on this PR)
- [ ] Merge to `main`
- [ ] Run **Refresh baselines** workflow (`refresh-baselines.yml`) so perf thresholds reflect the new stack
- [ ] Confirm tonight's **Nightly Evaluation** reports the new `torch` / `rocm` pins on https://rocm.github.io/aorta/

## Notes
- Dashboard generator/layout unchanged; the live site picks up new version strings from the next nightly result JSON after this stack lands on the runner.
- If a larger jump (e.g. ROCm 7.14 / PyTorch 2.12) is required instead, say so and we can retarget the bump.

Made with [Cursor](https://cursor.com)