### PR TITLE
feat(sanitizers): redesign the nightly dashboard for scannability

### DIFF
--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -79,6 +79,398 @@ CASES: tuple[tuple[str, str, str, str], ...] = (
 _DASH = "\u2014"  # em dash; kept as a name so it can sit inside f-string braces (py3.11)
 
 
+# Dashboard stylesheet. Kept as a module-level plain string (not part of the
+# f-string body) so CSS braces need no doubling and the design diffs cleanly.
+#
+# Two colour axes that must not be conflated:
+#   identity  -- which sanitizer/stage this is; lives on square icon tiles only
+#                (blue = infrastructure, purple = waitcheck, green = consan)
+#   verdict   -- what was observed; lives on pills only (.v)
+# Green therefore means "consan" on a tile and "pass" on a pill; they never
+# share a surface. Baseline status (.pill) is the only *solid* fill, so the
+# regression-health signal outranks the observed verdict visually.
+_CSS = """
+  :root {
+    color-scheme: dark;
+    --bg:#0B1220; --panel:#111827; --inset:#0E1626; --raised:#131C2E; --sunken:#0A101C;
+    --text-1:#F9FAFB; --text-2:#D1D5DB; --text-3:#94A3B8;
+    --blue:#3B82F6; --purple:#8B5CF6; --green:#22C55E;
+    --v-warn:#F59E0B; --v-fail:#EF4444;
+    --solid-ok:#15803D; --solid-bad:#B91C1C;
+    --border:rgba(148,163,184,.13); --border-hover:rgba(148,163,184,.26);
+    --fs-td:15px; --fs-th:12.5px; --fs-kvk:12.5px; --fs-kvv:14px;
+    --fs-obs:14.5px; --fs-cap:14px; --fs-name:16px; --fs-kind:13.5px; --fs-badge:12.5px;
+    --radius:12px; --radius-sm:10px;
+    --shadow:0 1px 2px rgba(0,0,0,.30), 0 6px 20px rgba(0,0,0,.28);
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  * { box-sizing:border-box; }
+  html,body { margin:0; background:var(--bg); color:var(--text-1);
+    font:14px/1.5 -apple-system,BlinkMacSystemFont,Segoe UI,Inter,Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1180px; margin:0 auto; padding:24px; }
+  .mono { font-family:var(--mono); }
+  a { color:#7CB0F8; text-decoration:none; } a:hover { text-decoration:underline; }
+
+  .navrow { display:flex; align-items:center; justify-content:space-between; gap:12px;
+    font-size:13px; margin-bottom:16px; }
+  .navrow a { color:var(--text-3); } .navrow a:hover { color:var(--text-2); }
+
+  .topbar { display:flex; align-items:flex-start; justify-content:space-between; gap:20px; margin-bottom:14px; }
+  .page-header { display:flex; align-items:center; gap:14px; }
+  .brand-tile { width:46px; height:46px; flex:0 0 auto; border-radius:var(--radius);
+    display:grid; place-items:center; color:var(--blue);
+    background:rgba(59,130,246,.12); border:1px solid rgba(59,130,246,.28); }
+  .page-header h1 { font-size:30px; font-weight:600; margin:0; letter-spacing:-.02em; line-height:1.1; }
+  .page-header .subtitle { font-size:14px; color:var(--text-2); margin:4px 0 0; }
+
+  .runcard { flex:0 0 auto; width:288px; background:var(--panel);
+    border:1px solid var(--border); border-radius:var(--radius-sm); padding:2px 12px; box-shadow:var(--shadow); }
+  .runrow { display:flex; align-items:baseline; justify-content:space-between; gap:12px;
+    padding:5px 0; border-bottom:1px solid var(--border); }
+  .runrow:last-child { border-bottom:none; }
+  .runrow .k { font-size:10px; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--text-3); font-weight:600; white-space:nowrap; }
+  /* .rv, not .v -- .v is the verdict badge and would draw a pill outline here. */
+  .runrow .rv { font-family:var(--mono); font-size:11.5px; color:var(--text-2);
+    text-align:right; word-break:break-all; }
+
+  .toolgrid { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+  .feature-card { background:var(--panel); border:1px solid var(--border); border-radius:var(--radius);
+    padding:16px; box-shadow:var(--shadow); display:flex; gap:14px; align-items:flex-start;
+    transition:border-color .16s ease, transform .16s ease; }
+  .feature-card:hover { border-color:var(--border-hover); transform:translateY(-1px); }
+  .feature-card .tile { width:44px; height:44px; border-radius:var(--radius-sm); }
+  .feature-card .title-row { display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-bottom:6px; }
+  .feature-card h3 { font-size:var(--fs-name); font-weight:700; margin:0; letter-spacing:-.01em; }
+  .feature-card p { font-size:14px; color:var(--text-2); margin:0; line-height:1.5; }
+  .feature-card code { font-family:var(--mono); font-size:13.5px; color:var(--text-1); }
+  .badge { font-size:12px; font-weight:600; padding:2px 9px; border-radius:999px; border:1px solid transparent; }
+  .badge.purple { color:#C4B5FD; background:rgba(139,92,246,.14); border-color:rgba(139,92,246,.30); }
+  .badge.green  { color:#86EFAC; background:rgba(34,197,94,.14);  border-color:rgba(34,197,94,.30); }
+
+  .tile { width:34px; height:34px; flex:0 0 auto; border-radius:9px; display:grid; place-items:center;
+    background:rgba(148,163,184,.07); border:1px solid var(--border); }
+  .tile.blue   { color:var(--blue);   border-color:rgba(59,130,246,.32); background:rgba(59,130,246,.09); }
+  .tile.purple { color:var(--purple); border-color:rgba(139,92,246,.32); background:rgba(139,92,246,.09); }
+  .tile.green  { color:var(--green);  border-color:rgba(34,197,94,.32);  background:rgba(34,197,94,.09); }
+
+  /* Self-contained tabs (no external JS/CSS): radios toggle sibling panels via :checked. */
+  .tabradio { position:absolute; opacity:0; pointer-events:none; }
+  .tabbar { display:flex; gap:4px; border-bottom:1px solid var(--border); margin:18px 0 16px; }
+  .tabbar label { cursor:pointer; padding:10px 18px; font-size:14px; font-weight:600; color:var(--text-3);
+    border:1px solid transparent; border-bottom:none; border-radius:10px 10px 0 0; margin-bottom:-1px;
+    transition:color .15s ease, background .15s ease; }
+  .tabbar label:hover { color:var(--text-2); }
+  #tab-guardrails:checked ~ .tabbar label[for="tab-guardrails"],
+  #tab-survey:checked ~ .tabbar label[for="tab-survey"] {
+    color:var(--text-1); background:var(--panel);
+    border-color:var(--border); border-bottom:1px solid var(--panel); }
+  /* The radios are visually hidden (opacity:0) so they show no native focus ring;
+     mirror :focus-visible onto the label so keyboard users can see the focused tab. */
+  #tab-guardrails:focus-visible ~ .tabbar label[for="tab-guardrails"],
+  #tab-survey:focus-visible ~ .tabbar label[for="tab-survey"] {
+    outline:2px solid var(--blue); outline-offset:-2px; }
+  .tabpanel { display:none; }
+  #tab-guardrails:checked ~ #panel-guardrails { display:block; }
+  #tab-survey:checked ~ #panel-survey { display:block; }
+
+  .gate { display:flex; align-items:center; gap:13px; border-radius:var(--radius);
+    padding:14px 16px; margin-bottom:12px; border:1px solid; border-left-width:3px; }
+  .gate .gate-icon { width:30px; height:30px; border-radius:50%; display:grid; place-items:center; flex:0 0 auto; }
+  .gate .gate-text { font-size:14.5px; color:var(--text-2); }
+  .gate .gate-text strong { display:block; font-size:15.5px; font-weight:700; letter-spacing:.02em; margin-bottom:1px; }
+  .gate.ok  { background:rgba(34,197,94,.08); border-color:rgba(34,197,94,.26); border-left-color:var(--green); }
+  .gate.ok .gate-icon { background:rgba(34,197,94,.16); color:var(--green); }
+  .gate.ok .gate-text strong { color:#86EFAC; }
+  .gate.bad { background:rgba(239,68,68,.08); border-color:rgba(239,68,68,.26); border-left-color:var(--v-fail); }
+  .gate.bad .gate-icon { background:rgba(239,68,68,.16); color:var(--v-fail); }
+  .gate.bad .gate-text strong { color:#FCA5A5; }
+
+  .info-banner { display:flex; gap:12px; align-items:flex-start; background:rgba(59,130,246,.07);
+    border:1px solid rgba(59,130,246,.26); border-left:3px solid var(--blue);
+    border-radius:var(--radius); padding:13px 16px; margin-bottom:12px; }
+  .info-banner > svg { flex:0 0 auto; color:var(--blue); margin-top:2px; }
+  .info-banner p { margin:0; font-size:14px; color:var(--text-2); line-height:1.5; }
+  .info-banner strong { color:var(--text-1); font-weight:600; }
+
+  .stale { display:flex; gap:12px; align-items:flex-start; background:rgba(239,68,68,.10);
+    border:1px solid rgba(239,68,68,.30); border-left:3px solid var(--v-fail);
+    border-radius:var(--radius); padding:13px 16px; margin-bottom:12px;
+    font-size:14px; color:var(--text-2); }
+  .stale strong { color:#FCA5A5; }
+  .stale a { color:#FCA5A5; text-decoration:underline; }
+
+  .panel { background:var(--panel); border:1px solid var(--border); border-radius:var(--radius);
+    padding:16px; box-shadow:var(--shadow); margin-bottom:12px; }
+  .panel > h2 { font-size:17px; font-weight:600; margin:0 0 12px; letter-spacing:-.01em;
+    display:flex; align-items:center; gap:9px; }
+  .count { font-size:12px; font-weight:600; color:var(--text-3); background:var(--inset);
+    border:1px solid var(--border); border-radius:999px; padding:1px 10px; }
+
+  .table-wrap { border:1px solid var(--border); border-radius:var(--radius-sm); overflow:hidden; }
+  table { width:100%; border-collapse:separate; border-spacing:0; }
+  th { text-align:left; padding:10px 12px; font-size:var(--fs-th); font-weight:600;
+    text-transform:uppercase; letter-spacing:.06em; color:var(--text-3);
+    background:var(--inset); border-bottom:1px solid var(--border); white-space:nowrap; }
+  td { padding:11px 12px; font-size:var(--fs-td); border-bottom:1px solid var(--border);
+    color:var(--text-2); vertical-align:top; }
+  tbody tr:last-child td { border-bottom:none; }
+  tbody tr:hover td { background:rgba(148,163,184,.035); }
+  /* Numeric headers right-align with their cells so a value sits under its label. */
+  th.num, td.num { text-align:right; font-variant-numeric:tabular-nums; }
+  td.mono { font-family:var(--mono); font-size:14px; color:var(--text-1); }
+  td.wrap-any { word-break:break-word; }
+  td.empty { color:var(--text-3); font-style:italic; }
+  .dash { color:var(--text-3); }
+
+  /* Verdict badge: tinted, never solid. fail and error share one red. */
+  .v { display:inline-block; padding:2px 10px; border-radius:999px;
+    font:600 var(--fs-badge) var(--mono); border:1px solid transparent; white-space:nowrap; }
+  .v.pass  { color:#86EFAC; background:rgba(34,197,94,.13);  border-color:rgba(34,197,94,.32); }
+  .v.warn  { color:#FCD34D; background:rgba(245,158,11,.13); border-color:rgba(245,158,11,.34); }
+  .v.fail, .v.error { color:#FCA5A5; background:rgba(239,68,68,.13); border-color:rgba(239,68,68,.34); }
+  .v.neutral { color:var(--text-3); background:rgba(148,163,184,.10); border-color:rgba(148,163,184,.24); }
+
+  /* Baseline status: the only solid fill on the page. */
+  .pill { display:inline-block; padding:3px 11px; border-radius:999px;
+    font-size:var(--fs-badge); font-weight:600; color:#fff; white-space:nowrap; }
+  .pill.ok, .pill.pass { background:var(--solid-ok); }
+  .pill.bad, .pill.fail { background:var(--solid-bad); }
+
+  .kcard { background:var(--inset); border:1px solid var(--border); border-radius:var(--radius-sm);
+    margin-bottom:10px; overflow:hidden; }
+  .kcard:last-child { margin-bottom:0; }
+  .kcard.wc { --accent:var(--purple); }
+  .kcard.cs { --accent:var(--green); }
+  .kcard.nu { --accent:var(--blue); }
+  .kcard > summary { list-style:none; cursor:pointer; user-select:none; display:flex;
+    align-items:center; gap:11px; flex-wrap:wrap; padding:12px 14px; transition:background .14s ease; }
+  .kcard > summary::-webkit-details-marker { display:none; }
+  .kcard > summary:hover { background:rgba(148,163,184,.04); }
+  .kcard > summary:focus-visible { outline:2px solid var(--blue); outline-offset:-2px; }
+  .kcard[open] > summary { border-bottom:1px solid var(--border); }
+  .kcard summary .name { font-family:var(--mono); font-weight:700; font-size:var(--fs-name); color:var(--text-1); }
+  .kcard summary .kind { font-size:var(--fs-kind); color:var(--text-3); }
+  .kcard summary .findings { font-size:13px; color:var(--text-3); background:rgba(148,163,184,.07);
+    border:1px solid var(--border); border-radius:999px; padding:2px 10px; }
+  .kcard summary .findings.has { color:#FCD34D; border-color:rgba(245,158,11,.30); background:rgba(245,158,11,.08); }
+  .kcard summary .spacer { flex:1 1 auto; }
+  .chevron { color:var(--text-3); transition:transform .2s ease; flex:0 0 auto; }
+  details[open] > summary .chevron { transform:rotate(180deg); }
+  .kcard-body { padding:14px; }
+
+  /* Borderless label/value facts. Bordered boxes in a row read as tabs. */
+  .kv { display:grid; grid-template-columns:repeat(auto-fit, minmax(170px, 1fr)); gap:12px 24px;
+    padding-bottom:14px; margin-bottom:14px; border-bottom:1px solid var(--border); }
+  .kv .k { display:block; font-size:var(--fs-kvk); color:var(--text-3); text-transform:uppercase;
+    letter-spacing:.05em; font-weight:600; margin-bottom:3px; }
+  .kv .val { display:block; font-size:var(--fs-kvv); color:var(--text-1); }
+  .kv .val.mono { font-family:var(--mono); }
+
+  .observation { font-size:var(--fs-obs); color:var(--text-2); line-height:1.5;
+    background:rgba(148,163,184,.05); border-left:2px solid rgba(148,163,184,.26);
+    border-radius:0 8px 8px 0; padding:10px 13px; margin-bottom:14px; }
+  .observation.warn { border-left-color:var(--v-warn); background:rgba(245,158,11,.06); }
+  .observation.fail, .observation.error { border-left-color:var(--v-fail); background:rgba(239,68,68,.06); }
+  .observation .lbl { display:block; font-size:12px; color:var(--text-3); text-transform:uppercase;
+    letter-spacing:.06em; font-weight:600; margin-bottom:3px; }
+  .observation .msg { font-family:var(--mono); font-size:14px; word-break:break-word; color:var(--text-1); }
+
+  .repro { display:flex; align-items:center; gap:10px; flex-wrap:wrap; background:var(--sunken);
+    border:1px solid var(--border); border-radius:8px; padding:10px 13px; margin-bottom:14px; }
+  .repro .lbl { color:var(--text-3); font-size:12px; text-transform:uppercase;
+    letter-spacing:.05em; font-weight:600; }
+  .repro code { font-family:var(--mono); font-size:14px; color:#A5D6FF; word-break:break-all; }
+
+  /* A caption must not share colour, case and weight with the th beneath it. */
+  .cap { display:flex; align-items:center; gap:9px; font-size:var(--fs-cap); font-weight:700;
+    text-transform:uppercase; letter-spacing:.06em; color:var(--text-1); margin:0 0 8px; }
+  .cap::before { content:""; width:3px; height:15px; border-radius:2px;
+    background:var(--accent, var(--text-3)); flex:0 0 auto; }
+  .cap + .table-wrap { margin-bottom:14px; }
+  .card-foot { display:flex; justify-content:flex-end; font-size:13px; }
+
+  details.panel { padding:0; }
+  details.panel > summary { list-style:none; cursor:pointer; user-select:none; display:flex;
+    align-items:center; gap:10px; padding:15px 16px; font-size:17px; font-weight:600; }
+  details.panel > summary::-webkit-details-marker { display:none; }
+  details.panel > summary:hover { background:rgba(148,163,184,.03); }
+  details.panel > summary:focus-visible { outline:2px solid var(--blue); outline-offset:-2px; }
+  details.panel[open] > summary { border-bottom:1px solid var(--border); }
+  details.panel > summary .spacer { flex:1 1 auto; }
+  .panel-body { padding:16px; }
+
+  .chips { display:grid; grid-template-columns:repeat(3, 1fr); gap:12px; }
+  .chip { background:var(--inset); border:1px solid var(--border); border-radius:var(--radius-sm);
+    padding:13px 15px; display:flex; gap:12px; align-items:center;
+    transition:border-color .16s ease, background .16s ease; }
+  .chip:hover { border-color:var(--border-hover); background:var(--raised); }
+  .chip .circle { width:34px; height:34px; flex:0 0 auto; border-radius:50%; display:grid; place-items:center; }
+  .chip .circle.blue   { background:rgba(59,130,246,.14); color:var(--blue);   box-shadow:0 0 0 1px rgba(59,130,246,.24) inset; }
+  .chip .circle.purple { background:rgba(139,92,246,.14); color:var(--purple); box-shadow:0 0 0 1px rgba(139,92,246,.24) inset; }
+  .chip .circle.green  { background:rgba(34,197,94,.14);  color:var(--green);  box-shadow:0 0 0 1px rgba(34,197,94,.24) inset; }
+  .chip .h { font-size:14px; font-weight:600; color:var(--text-1); display:block; }
+  .chip .d { font-size:13px; color:var(--text-3); display:block; margin-top:2px; line-height:1.4; }
+
+  .two-col { display:grid; grid-template-columns:1.85fr 1fr; gap:12px; align-items:start; margin-bottom:12px; }
+  .two-col > .panel { margin-bottom:0; }
+
+  .flow { display:flex; align-items:flex-start; justify-content:space-between; gap:4px; padding:2px 0; }
+  .step { display:flex; flex-direction:column; align-items:center; text-align:center; width:104px; }
+  .step-num { width:21px; height:21px; border-radius:50%; display:grid; place-items:center;
+    font-size:11.5px; font-weight:700; margin-bottom:7px; color:#fff; }
+  .step-num.blue { background:rgba(59,130,246,.85); }
+  .step-num.purple { background:rgba(139,92,246,.85); }
+  .step-num.green { background:rgba(34,197,94,.85); }
+  .step .tile { width:46px; height:46px; border-radius:var(--radius-sm); }
+  .step .label { font-size:13px; font-weight:600; color:var(--text-1); margin-top:9px; line-height:1.25; }
+  .step .desc { font-size:12px; color:var(--text-3); margin-top:4px; line-height:1.35; }
+  .flow-arrow { color:rgba(148,163,184,.42); font-size:15px; margin-top:46px; flex:0 0 auto; }
+
+  .panel-note { margin-top:14px; display:flex; align-items:center; gap:10px; background:var(--inset);
+    border:1px solid var(--border); border-radius:var(--radius-sm); padding:11px 14px;
+    font-size:13px; color:var(--text-2); }
+  .panel-note svg { flex:0 0 auto; color:var(--text-3); }
+
+  details.notes > summary { justify-content:space-between; }
+  details.notes ul { list-style:none; margin:0; padding:0 16px 15px; display:flex; flex-direction:column; gap:11px; }
+  details.notes li { display:flex; gap:9px; align-items:flex-start; font-size:13px; color:var(--text-2); line-height:1.45; }
+  .check { flex:0 0 auto; width:17px; height:17px; border-radius:50%; display:grid; place-items:center;
+    margin-top:1px; background:rgba(34,197,94,.14); color:var(--green);
+    box-shadow:0 0 0 1px rgba(34,197,94,.26) inset; }
+
+  .statline { display:flex; flex-wrap:wrap; align-items:center; gap:8px; margin-bottom:12px; }
+  .statline .lead { font-size:14px; color:var(--text-2); margin-right:4px; }
+  .kgroup-title .kname { font-family:var(--mono); font-size:16px; }
+  .survey-empty { font-size:14px; color:var(--text-2); margin:8px 0; }
+
+  @media (max-width:1000px) {
+    .topbar { flex-direction:column; } .runcard { width:100%; }
+    .two-col { grid-template-columns:1fr; }
+    .flow { flex-wrap:wrap; justify-content:center; gap:10px; }
+  }
+  @media (max-width:720px) { .toolgrid, .chips { grid-template-columns:1fr; } }
+"""
+
+
+# Inline SVG icons (Feather/Lucide outline, 1.8-2.0 stroke, never filled). Inline
+# so the page stays self-contained -- no CDN, no sprite sheet, no web font.
+_ICON_ACTIVITY = '<path d="M22 12h-4l-3 9L9 3l-3 9H2"/>'
+_ICON_SHIELD = (
+    '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>'
+    '<polyline points="9 12 11 14 15 10"/>'
+)
+_ICON_INFO = (
+    '<circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/>'
+    '<line x1="12" y1="8" x2="12.01" y2="8"/>'
+)
+_ICON_CHECK = '<polyline points="20 6 9 17 4 12"/>'
+_ICON_CHEVRON = '<polyline points="6 9 12 15 18 9"/>'
+_ICON_FILE = (
+    '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>'
+    '<polyline points="14 2 14 8 20 8"/>'
+)
+_ICON_FOLDER = '<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>'
+_ICON_CODE = '<polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>'
+_ICON_LAYOUT = (
+    '<rect x="3" y="3" width="18" height="18" rx="2"/>'
+    '<line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/>'
+)
+_ICON_SEARCH = '<circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>'
+_ICON_BUG = (
+    '<path d="m8 2 1.9 1.9M14.1 3.9 16 2"/><path d="M9 7.1v-1a3 3 0 1 1 6 0v1"/>'
+    '<path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6"/>'
+    '<path d="M12 20v-9M6 13H2M22 13h-4"/>'
+    '<path d="M6.5 9C4.6 8.8 3 7.1 3 5M21 5c0 2.1-1.6 3.8-3.5 4"/>'
+    '<path d="M3 21c0-2.1 1.7-3.9 3.8-4M17.2 17c2.1.1 3.8 1.9 3.8 4"/>'
+)
+_ICON_REPEAT = (
+    '<polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/>'
+    '<path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>'
+)
+
+
+def _svg(body: str, *, size: int = 18, width: float = 2, cls: str = "") -> str:
+    """Wrap an inline icon path set in a stroked, unfilled ``<svg>``."""
+    class_attr = f' class="{cls}"' if cls else ""
+    return (
+        f'<svg{class_attr} width="{size}" height="{size}" viewBox="0 0 24 24" fill="none" '
+        f'stroke="currentColor" stroke-width="{width}" stroke-linecap="round" '
+        f'stroke-linejoin="round">{body}</svg>'
+    )
+
+
+def _chevron_html() -> str:
+    return _svg(_ICON_CHEVRON, size=18, width=2, cls="chevron")
+
+
+def _tool_cards_html() -> str:
+    """WaitCheck / ConSan explainer cards.
+
+    Page level, above the tab bar: both tabs surface results from both
+    sanitizers, so the definitions are common context. Tab-specific framing
+    (the gate banner, the observed-only banner) lives inside each tab.
+    """
+    return (
+        '<section class="toolgrid">'
+        '<article class="feature-card">'
+        f'<div class="tile purple">{_svg(_ICON_SHIELD, size=22, width=1.8)}</div>'
+        "<div>"
+        '<div class="title-row"><h3>WaitCheck</h3>'
+        '<span class="badge purple">Static Analysis</span></div>'
+        "<p>Detects potential <code>s_waitcnt</code> synchronization hazards "
+        "using static code analysis.</p>"
+        "</div></article>"
+        '<article class="feature-card">'
+        f'<div class="tile green">{_svg(_ICON_ACTIVITY, size=22, width=1.8)}</div>'
+        "<div>"
+        '<div class="title-row"><h3>ConSan</h3>'
+        '<span class="badge green">Runtime Analysis</span></div>'
+        "<p>Detects runtime data races and concurrency issues during execution.</p>"
+        "</div></article>"
+        "</section>"
+    )
+
+
+def _run_card_html(meta: dict[str, Any]) -> str:
+    """Run provenance as a compact top-right card.
+
+    Deliberately *not* a row of bordered chips: bordered boxes in a horizontal
+    row directly above the tab bar read as a second set of tabs.
+    """
+    rows = (
+        ("Run", meta.get("run", "")),
+        ("Commit", meta.get("commit", "")),
+        ("Date", meta.get("date", "")),
+        ("Target", meta.get("gpu", "gfx950")),
+    )
+    body = "".join(
+        f'<div class="runrow"><span class="k">{_esc(label)}</span>'
+        f'<span class="rv">{_esc(str(value))}</span></div>'
+        for label, value in rows
+    )
+    return f'<aside class="runcard">{body}</aside>'
+
+
+def _gate_hero_html(summary: dict[str, Any]) -> str:
+    """The Tab 1 gate banner: state on one line, detail on the next.
+
+    Lives inside Tab 1, not the page header -- baselines do not exist on the
+    survey tab, so a gate verdict is meaningless there.
+    """
+    cls = "ok" if summary["ok"] else "bad"
+    icon = _ICON_CHECK if summary["ok"] else _ICON_INFO
+    return (
+        f'<div class="gate {cls}">'
+        f'<span class="gate-icon">{_svg(icon, size=17, width=3)}</span>'
+        f'<span class="gate-text"><strong>{_esc(summary["label"])}</strong>'
+        f'{_esc(summary["detail"])}</span></div>'
+    )
+
+
+
+
 def _load(path: Path) -> dict[str, Any] | None:
     if not path.is_file():
         return None
@@ -688,17 +1080,14 @@ def _status_banner_html(status: dict[str, Any] | None) -> str:
     conclusion = str(status.get("conclusion", "") or "unknown")
     when = str(status.get("date", "") or "")
     run_txt = f" run {_esc(run_id)}" if run_id else ""
-    link = (
-        f' <a href="{_esc(url)}" style="color:#fff;text-decoration:underline">view failed run</a>'
-        if url else ""
-    )
-    when_txt = f' <span style="font-weight:400">({_esc(when)})</span>' if when else ""
+    link = f' <a href="{_esc(url)}">view failed run</a>' if url else ""
+    when_txt = f" ({_esc(when)})" if when else ""
     return (
-        '<div style="color:#fff;background:#cf222e;padding:12px 16px;border-radius:8px;'
-        'font-weight:600;margin:12px 0 20px">'
-        f"&#9888; Latest sanitizer nightly{run_txt} did not complete successfully "
+        '<div class="stale">'
+        "<span>&#9888;</span><span><strong>Stale.</strong> "
+        f"Latest sanitizer nightly{run_txt} did not complete successfully "
         f"({_esc(conclusion)}) &mdash; the data below may be stale.{link}{when_txt}"
-        "</div>"
+        "</span></div>"
     )
 
 
@@ -732,47 +1121,40 @@ def _baseline_status_html(row: dict[str, Any], *, history: bool = False) -> str:
     return f'<span class="pill {emphasis}">{_esc(text)}</span>'
 
 
-def _observed_html(verdict: Any) -> str:
-    """Render an exact sanitizer verdict without regression-health coloring."""
-    return f'<span class="observed">{_esc(str(verdict))}</span>'
-
-
-# Solid-color verdict chip classes for the observed-only survey tab (Tab 2). The
-# color keys on the *observed* verdict string so a reader can scan outcomes at a
-# glance; it is purely descriptive (this tab never gates), so a red ``fail``/``error``
-# chip here is an observation and never flips the guardrail gate. not_checked /
-# unknown / anything unmapped stays neutral grey.
-_VERDICT_CHIP_CLASS: dict[str, str] = {
-    "error": "err", "fail": "err", "warn": "warn", "pass": "pass",
+# Verdict badge classes, keyed on the observed verdict string. ``fail`` and
+# ``error`` get distinct class names but share one red in CSS, matching the
+# existing summary.md wording -- splitting the hues later is a CSS-only change.
+# not_checked / unknown / anything unmapped stays neutral grey.
+_VERDICT_CLASS: dict[str, str] = {
+    "error": "error", "fail": "fail", "warn": "warn", "pass": "pass",
 }
 
 
-def _verdict_chip_html(verdict: Any) -> str:
-    """Render an observed verdict as a solid color-coded chip (survey tab only)."""
+def _verdict_html(verdict: Any) -> str:
+    """Render an observed sanitizer verdict as a tinted badge.
+
+    Used by *both* tabs. Verdict colour is descriptive, never a health signal:
+    on the guardrail tab a red ``fail`` sitting beside a solid green "Expected
+    outcome" pill is a positive control behaving as designed. The solid baseline
+    pill is what carries regression health, and it outranks this badge visually.
+    """
     text = str(verdict)
-    cls = _VERDICT_CHIP_CLASS.get(text.strip().lower(), "neutral")
-    return f'<span class="vchip {cls}">{_esc(text)}</span>'
+    cls = _VERDICT_CLASS.get(text.strip().lower(), "neutral")
+    return f'<span class="v {cls}">{_esc(text)}</span>'
 
 
-def _execution_html(execution: Any) -> str:
-    text = str(execution)
-    if text == "complete":
-        return _esc(text)
-    return f'<span class="execution bad">{_esc(text)}</span>'
+def _execution_html(execution: Any, *, observed: bool = False) -> str:
+    """Execution status: plain when complete, otherwise flagged.
 
-
-def _execution_observed_html(execution: Any) -> str:
-    """Neutral (never health-colored) execution status for the survey tab.
-
-    Tab 2 promises observed-only rendering, so a non-``complete`` execution (the
-    committed ConSan survey reports carry ``execution_status: "error"``) is an
-    observation, not a regression: it must not get the red ``execution bad`` class
-    that the guardrail tab uses. Mirrors ``_observed_html`` for verdicts.
+    ``observed=True`` (the survey tab) renders a non-complete status as plain
+    text. Tab 2 promises observed-only rendering, and the committed ConSan
+    survey reports carry ``execution_status: "error"``; that is an observation,
+    not a regression, so it must not get the guardrail tab's red badge.
     """
     text = str(execution)
-    if text == "complete":
+    if text == "complete" or observed:
         return _esc(text)
-    return f'<span class="observed">{_esc(text)}</span>'
+    return f'<span class="v fail">{_esc(text)}</span>'
 
 
 def _execution_md(execution: Any) -> str:
@@ -834,10 +1216,10 @@ def _gate_summary(
 def _history_case_html(row: dict[str, Any]) -> str:
     expected = ""
     if row["present"] and not row["match"]:
-        expected = f" &middot; expected {_observed_html(row['expected'])}"
+        expected = f' <span class="dash">expected</span> {_verdict_html(row["expected"])}'
     return (
-        f"{_baseline_status_html(row, history=True)}"
-        f'<div class="secondary">Observed {_observed_html(row["verdict"])}{expected}</div>'
+        f"{_baseline_status_html(row, history=True)} "
+        f'{_verdict_html(row["verdict"])}{expected}'
     )
 
 
@@ -880,36 +1262,47 @@ def _run_cell_html(run: dict[str, Any]) -> str:
 
 def _backend_txt_html(backend: dict[str, Any] | None) -> str:
     if not backend:
-        return "&mdash;"
-    return f'{_esc(backend["name"])} <span class=mono>{_esc(backend["sha"])}</span>'
+        return '<span class="dash">&mdash;</span>'
+    return f'{_esc(backend["name"])} {_esc(backend["sha"])}'
 
 
-def _meta_line_html(row: dict[str, Any], *, observed: bool = False) -> str:
-    """Backend / selection / execution meta line.
+def _fact_html(label: str, value: str, *, mono: bool = False) -> str:
+    cls = "val mono" if mono else "val"
+    return f'<span><span class="k">{_esc(label)}</span><span class="{cls}">{value}</span></span>'
 
-    ``observed=True`` (the survey tab) renders execution neutrally so an observed
-    ``error``/incomplete status is not health-colored; the guardrail tab keeps the
-    health-colored ``_execution_html``.
+
+def _facts_html(
+    row: dict[str, Any],
+    *,
+    observed: bool = False,
+    extra: tuple[tuple[str, str], ...] = (),
+) -> str:
+    """Backend / selection / kernels / execution as a borderless label/value grid.
+
+    Replaces the old middot-separated meta line. A row of bordered chips reads
+    as a tab strip, so these are plain label-over-value pairs on a grid.
+    ``extra`` prepends caller-supplied pairs (the guardrail tab leads with
+    observed/expected). ``observed=True`` keeps execution un-health-coloured.
     """
     wl = row["worklist"]
-    execution = (
-        _execution_observed_html(row["execution"])
-        if observed
-        else _execution_html(row["execution"])
+    items = [_fact_html(label, value) for label, value in extra]
+    items.append(_fact_html("Backend", _backend_txt_html(row["backend"]), mono=True))
+    items.append(
+        _fact_html(
+            "Selection",
+            f"{_esc(str(wl['requirement']))} top&#8209;{_esc(str(wl['top_n']))}",
+            mono=True,
+        )
     )
-    return (
-        f"<div class=meta>backend {_backend_txt_html(row['backend'])} &middot; selection "
-        f"{_esc(str(wl['requirement']))} top&#8209;{_esc(str(wl['top_n']))} &middot; "
-        f"{_esc(str(wl['kernel_count']))} kernel(s) &middot; execution "
-        f"{execution}</div>"
-    )
+    items.append(_fact_html("Kernels", _esc(str(wl["kernel_count"]))))
+    items.append(_fact_html("Execution", _execution_html(row["execution"], observed=observed)))
+    return f'<div class="kv">{"".join(items)}</div>'
 
 
 def _kernel_tables_html(
     row: dict[str, Any],
     *,
     report_rel: str | None = None,
-    verdict_html: Any = _observed_html,
 ) -> str:
     """The shared kernel-detail + findings tables (identical shape on both tabs).
 
@@ -922,108 +1315,266 @@ def _kernel_tables_html(
     dead or unsafe link is ever emitted. All kernel rows of one case share the
     single case-level report, so they all point at the same file.
 
-    ``verdict_html`` renders each kernel's verdict cell. The guardrail tab keeps
-    the neutral ``_observed_html`` chip; the survey tab passes ``_verdict_chip_html``
-    so a per-kernel verdict is a solid-color-coded chip (red/amber/green/grey).
+    Both tabs render the same tinted ``_verdict_html`` badge per kernel; verdict
+    colour is descriptive on either tab (see ``_verdict_html``).
+
+    Numeric columns right-align the ``th`` as well as the ``td`` so each value
+    sits directly under its own header rather than drifting to the far edge.
     """
     link = _report_link_html(_safe_report_rel(report_rel))
     krows = (
         "".join(
             f"<tr><td class=mono>{_esc(str(k['name']))}</td>"
             f"<td class=num>{_esc(str(k['dispatch']))}</td>"
-            f"<td>{verdict_html(k['verdict'])}</td>"
+            f"<td>{_verdict_html(k['verdict'])}</td>"
             f"<td class=num>{_esc(str(k['findings']))}</td>"
             f"<td class=mono>{_esc(k['code_object']) or '&mdash;'}</td>"
             f"<td class=mono>{_esc(k['sha']) or '&mdash;'}</td>"
             f"<td>{link}</td></tr>"
             for k in row["kernels"]
         )
-        or "<tr><td colspan=7>no kernels selected</td></tr>"
+        or '<tr><td class=empty colspan=7>no kernels selected</td></tr>'
     )
     frows = (
         "".join(
             f"<tr><td>{_esc(str(g['sanitizer']))}</td><td class=mono>{_esc(str(g['code']))}</td>"
             f"<td>{_esc(str(g['severity']))}</td><td class=num>{g['count']}</td>"
-            f"<td class=mono>{_esc(g['example'])}</td></tr>"
+            f"<td class='mono wrap-any'>{_esc(g['example'])}</td></tr>"
             for g in row["finding_groups"]
         )
-        or "<tr><td colspan=5>no findings</td></tr>"
+        or '<tr><td class=empty colspan=5>no findings</td></tr>'
     )
     return (
-        "<table><tr><th>Kernel</th><th>Dispatch</th>"
-        "<th>Observed sanitizer verdict</th><th>Findings</th>"
-        f"<th>Code object</th><th>SHA-256</th><th>Report</th></tr>{krows}</table>"
-        "<table><tr><th>Sanitizer</th><th>Code</th><th>Severity</th><th>Count</th>"
-        f"<th>Example</th></tr>{frows}</table>"
+        '<p class="cap">Kernels</p><div class="table-wrap"><table>'
+        "<thead><tr><th>Kernel</th><th class=num>Dispatch</th>"
+        "<th>Observed</th><th class=num>Findings</th>"
+        f"<th>Code object</th><th>SHA-256</th><th>Report</th></tr></thead>"
+        f"<tbody>{krows}</tbody></table></div>"
+        '<p class="cap">Findings</p><div class="table-wrap"><table>'
+        "<thead><tr><th>Sanitizer</th><th>Code</th><th>Severity</th><th class=num>Count</th>"
+        f"<th>Example</th></tr></thead><tbody>{frows}</tbody></table></div>"
     )
 
 
 def _raw_link_html(report_rel: str | None) -> str:
-    return f' <a class=raw href="{_esc(report_rel)}">view raw report</a>' if report_rel else ""
+    """The raw-report link, as a card footer.
+
+    Deliberately in the card body rather than the ``<summary>`` row: a link
+    inside a summary competes with the disclosure toggle.
+    """
+    if not report_rel:
+        return ""
+    return f'<div class="card-foot"><a href="{_esc(report_rel)}">view raw report</a></div>'
+
+
+def _findings_chip_html(row: dict[str, Any]) -> str:
+    """Findings count for a collapsed card's summary row."""
+    count = int(row.get("findings") or 0)
+    if not count:
+        return '<span class="findings">no findings</span>'
+    return f'<span class="findings has">{count} finding{"" if count == 1 else "s"}</span>'
+
+
+def _observation_html(row: dict[str, Any], *, tone: str = "") -> str:
+    """The observation callout: uppercase label over the observation text."""
+    text = row.get("observation", "")
+    if not text:
+        return ""
+    cls = f"observation {tone}".strip()
+    return (
+        f'<div class="{cls}"><span class="lbl">Observation</span>{_esc(text)}</div>'
+    )
+
+
+def _tone_for(verdict: Any) -> str:
+    """Map a verdict onto the callout tint class (empty for pass/unknown)."""
+    return _VERDICT_CLASS.get(str(verdict).strip().lower(), "").replace("pass", "")
+
+
+def _sanitizer_accent(backend_label: str) -> str:
+    """Identity accent class for a case: purple = waitcheck, green = consan."""
+    label = backend_label.lower()
+    if "waitcheck" in label:
+        return "wc"
+    if "consan" in label:
+        return "cs"
+    return "nu"
+
+
+def _card_summary_html(
+    *,
+    accent: str,
+    icon: str,
+    name: str,
+    kind: str,
+    trailing: str,
+) -> str:
+    """The collapsed card's triage row.
+
+    Every card ships closed, so this row has to carry enough status that a
+    reader can decide what to open without opening anything: identity icon,
+    name, kind, then the caller's status badges.
+    """
+    tile = {"wc": "purple", "cs": "green"}.get(accent, "blue")
+    return (
+        f'<summary><span class="tile {tile}">{_svg(icon, size=17, width=1.9)}</span>'
+        f'<span class="name">{_esc(name)}</span>'
+        f'<span class="kind">{_esc(kind)}</span>'
+        f'{trailing}<span class="spacer"></span>{_chevron_html()}</summary>'
+    )
 
 
 def _kernel_detail_html(rows: dict[str, dict[str, Any]]) -> str:
-    """Tab 1 (guardrails): expected-vs-observed kernel detail with baseline status."""
+    """Tab 1 (guardrails): expected-vs-observed kernel detail with baseline status.
+
+    One collapsed ``<details>`` card per recipe. Pure HTML disclosure -- no JS,
+    matching the CSS-radio tabs.
+    """
     blocks: list[str] = []
-    for case, _key, label, _backend_label in CASES:
+    for case, _key, label, backend_label in CASES:
         row = rows[case]
-        raw_link = _raw_link_html(row.get("report_rel"))
+        accent = _sanitizer_accent(backend_label)
+        icon = _ICON_SHIELD if accent == "wc" else _ICON_ACTIVITY
+        trailing = (
+            f"{_baseline_status_html(row)}{_verdict_html(row['verdict'])}"
+            f"{_findings_chip_html(row)}"
+        )
+        summary = _card_summary_html(
+            accent=accent, icon=icon, name=label, kind=backend_label, trailing=trailing
+        )
+        tone = _tone_for(row["verdict"])
         if not row["present"]:
-            blocks.append(
-                f"<h3>{_esc(label)} &middot; {_baseline_status_html(row)}</h3>"
-                f"<p>Observed sanitizer verdict: {_observed_html(row['verdict'])}</p>"
-                f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}</div>'
+            body = _observation_html(row, tone="fail")
+        else:
+            body = (
+                _facts_html(
+                    row,
+                    extra=(
+                        ("Observed", _esc(str(row["verdict"]))),
+                        ("Expected", _esc(str(row["expected"] or _DASH))),
+                    ),
+                )
+                + _observation_html(row, tone=tone)
+                + _kernel_tables_html(row, report_rel=row.get("report_rel"))
+                + _raw_link_html(row.get("report_rel"))
             )
-            continue
         blocks.append(
-            f"<h3>{_esc(label)} &middot; {_baseline_status_html(row)}{raw_link}</h3>"
-            f'<div class="secondary">Observed sanitizer verdict '
-            f"{_observed_html(row['verdict'])} &middot; expected "
-            f"{_observed_html(row['expected'] or _DASH)}</div>"
-            f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}</div>'
-            f"{_meta_line_html(row)}"
-            f"{_kernel_tables_html(row, report_rel=row.get('report_rel'))}"
+            f'<details class="kcard {accent}">{summary}'
+            f'<div class="kcard-body">{body}</div></details>'
         )
     return "".join(blocks)
 
 
-def _survey_note_html() -> str:
-    """Readable (body-size, non-muted) intro for the workload-survey tab.
+_SURVEY_CHIPS: tuple[tuple[str, str, str, str], ...] = (
+    ("blue", _ICON_SEARCH, "Understand kernel behavior",
+     "See how real kernels behave under sanitizers."),
+    ("purple", _ICON_BUG, "Investigate sanitizer findings",
+     "Review issues detected by WaitCheck or ConSan."),
+    ("green", _ICON_REPEAT, "Reproduce issues locally",
+     "Use provided commands to reproduce runs."),
+)
 
-    Rewritten for #374: frames Tab 2 as real GPU kernels run under AMD's two
-    sanitizers (waitcheck static wait-count scan + ConSan dynamic data-race check),
-    states plainly that it is observed-only / non-gating, and points at the per-case
-    reproduce line. Rendered at normal body size (class ``survey-intro``), not the
-    12px muted fine print it used to be. Kept free of the "experimental" /
-    "caller-supplied code objects" framing.
+# Workload -> kernel -> waitcheck -> consan -> dashboard, as a horizontal band.
+# Numbered, with a one-line description per node so the diagram needs no legend.
+_SURVEY_FLOW: tuple[tuple[str, str, str, str], ...] = (
+    ("blue", _ICON_FOLDER, "Workload", "Run a workload or test recipe"),
+    ("blue", _ICON_CODE, "Kernel Generated", "GPU kernel is compiled / extracted"),
+    ("purple", _ICON_SHIELD, "WaitCheck Analysis", "Static scan for s_waitcnt hazards"),
+    ("green", _ICON_ACTIVITY, "ConSan Analysis", "Runtime data-race / concurrency check"),
+    ("blue", _ICON_LAYOUT, "Dashboard Results", "Reports shown under each sanitizer"),
+)
+
+_SURVEY_NOTES: tuple[str, ...] = (
+    "This tab is informational only and does not affect nightly pass/fail status.",
+    "Findings represent observed behavior, not regressions.",
+    "Where both sanitizers produced a report the kernel appears under each; "
+    "a skipped or missing scan simply does not appear.",
+    "Every case lists the recipe that produced the kernel and a reproducible command.",
+)
+
+
+def _survey_flow_html() -> str:
+    parts: list[str] = []
+    for index, (accent, icon, label, desc) in enumerate(_SURVEY_FLOW, start=1):
+        if parts:
+            parts.append('<span class="flow-arrow">&#8594;</span>')
+        parts.append(
+            f'<div class="step"><span class="step-num {accent}">{index}</span>'
+            f'<div class="tile {accent}">{_svg(icon, size=22, width=1.85)}</div>'
+            f'<div class="label">{_esc(label)}</div>'
+            f'<div class="desc">{_esc(desc)}</div></div>'
+        )
+    return f'<div class="flow">{"".join(parts)}</div>'
+
+
+def _survey_note_html() -> str:
+    """The workload-survey tab's orientation panel.
+
+    States plainly that Tab 2 is observed-only / non-gating, lists what the tab
+    is for, and shows how a result is produced. The WaitCheck / ConSan
+    definitions are *not* here -- they are page-level cards shown above the tab
+    bar, because Tab 1 reports the same two sanitizers and needs them too.
     """
+    chips = "".join(
+        f'<div class="chip"><span class="circle {accent}">{_svg(icon, size=16, width=1.95)}</span>'
+        f'<span><span class="h">{_esc(head)}</span>'
+        f'<span class="d">{_esc(desc)}</span></span></div>'
+        for accent, icon, head, desc in _SURVEY_CHIPS
+    )
+    notes = "".join(
+        f'<li><span class="check">{_svg(_ICON_CHECK, size=10, width=3.5)}</span>{_esc(note)}</li>'
+        for note in _SURVEY_NOTES
+    )
     return (
-        '<div class="survey-intro">'
-        "<p>This tab shows how <b>real GPU kernels</b> behave when AMD&rsquo;s sanitizers "
-        "run over them: <b>waitcheck</b> (a static <span class=mono>s_waitcnt</span> "
-        "wait-count hazard scan of the code object) and <b>ConSan</b> (a dynamic "
-        "data-race / concurrency check at run time). Where <b>both</b> produced a "
-        "report, the kernel is shown under each; when a scan was skipped or its "
-        "report is missing (e.g. a non-GPU run), only the sanitizer(s) that actually "
-        "ran appear.</p>"
-        "<p><b>No expected-behavior comparison on this tab</b> &mdash; it is "
-        "observed-only and does <b>not</b> gate the nightly. An "
-        "<span class=mono>error</span>, <span class=mono>fail</span>, or "
-        "<span class=mono>warn</span> here records how the kernel behaved under the "
-        "sanitizer; it is never a regression. Each case lists the recipe that produced "
-        "it and a copy-paste command to reproduce the run yourself.</p>"
+        '<div class="info-banner">'
+        f"{_svg(_ICON_INFO, size=18, width=2)}"
+        "<p><strong>This tab is observational only.</strong> Results do not affect "
+        "nightly pass/fail status and should be interpreted independently.</p></div>"
+        f'<section class="panel"><h2>What You Can Do Here</h2>'
+        f'<div class="chips">{chips}</div></section>'
+        '<div class="two-col">'
+        '<div class="panel"><h2>How Results Are Produced</h2>'
+        f"{_survey_flow_html()}"
+        f'<div class="panel-note">{_svg(_ICON_FILE, size=16, width=1.8)}'
+        "Each result includes the workload/recipe and a copy-paste command to "
+        "reproduce the run.</div></div>"
+        '<details class="panel notes" open><summary>Important Notes'
+        f"{_chevron_html()}</summary><ul>{notes}</ul></details>"
         "</div>"
     )
 
 
 def _sanitizer_label(entry: dict[str, Any]) -> str:
-    """Human sanitizer heading for a grouped (both-sanitizer) survey sub-block."""
+    """Human sanitizer heading for a grouped (both-sanitizer) survey sub-block.
+
+    Retained for the markdown mirror, which has no room for a two-part heading.
+    """
     san = str(entry.get("sanitizer") or "").strip().lower()
     if san == "waitcheck":
         return "waitcheck (static wait-count scan)"
     if san == "consan":
         return "ConSan (dynamic data-race check)"
     return str(entry.get("label") or san or "sanitizer")
+
+
+def _sanitizer_name(entry: dict[str, Any]) -> str:
+    """Card title: the sanitizer's product name."""
+    san = str(entry.get("sanitizer") or "").strip().lower()
+    if san == "waitcheck":
+        return "WaitCheck"
+    if san == "consan":
+        return "ConSan"
+    return str(entry.get("label") or san or "sanitizer")
+
+
+def _sanitizer_kind(entry: dict[str, Any]) -> str:
+    """Card subtitle: what the sanitizer does, in four words."""
+    san = str(entry.get("sanitizer") or "").strip().lower()
+    if san == "waitcheck":
+        return "static wait-count scan"
+    if san == "consan":
+        return "dynamic data-race check"
+    return ""
 
 
 def _survey_group_label(group: str, entries: list[dict[str, Any]]) -> str:
@@ -1036,13 +1587,26 @@ def _survey_group_label(group: str, entries: list[dict[str, Any]]) -> str:
     return group.replace("-", " ").replace("_", " ")
 
 
+def _survey_panel_title(group: str, entries: list[dict[str, Any]]) -> str:
+    """Heading for a kernel-group panel.
+
+    A lone ungrouped case leads with its own ``label``: the group key falls back
+    to its terser ``name``, so the label is the only human name it has. Grouped
+    kernels use the shared group label. Roll-up table rows keep using
+    ``_survey_group_label`` so the HTML and markdown mirrors stay in parity.
+    """
+    if len(entries) == 1 and entries[0].get("label"):
+        return str(entries[0]["label"])
+    return _survey_group_label(group, entries)
+
+
 def _survey_howto_html(entry: dict[str, Any]) -> str:
-    """A copy-pasteable "reproduce this run yourself" line (empty when unknown)."""
+    """A copy-pasteable "reproduce this run yourself" strip (empty when unknown)."""
     command = entry.get("command")
     if not command:
         return ""
     return (
-        '<div class="survey-howto">Reproduce: '
+        '<div class="repro"><span class="lbl">Reproduce</span>'
         f"<code>{_esc(str(command))}</code></div>"
     )
 
@@ -1082,7 +1646,12 @@ def _survey_message_html(row: dict[str, Any]) -> str:
     label, text = _survey_message_parts(row)
     if not text:
         return ""
-    return f'<div class="survey-msg">{label}: {_esc(text)}</div>'
+    tone = _tone_for(row.get("verdict"))
+    cls = f"observation {tone}".strip()
+    return (
+        f'<div class="{cls}"><span class="lbl">{_esc(label)}</span>'
+        f'<span class="msg">{_esc(text)}</span></div>'
+    )
 
 
 _SANITIZER_RANK = {"waitcheck": 0, "consan": 1}
@@ -1163,6 +1732,28 @@ def _survey_headline(stats: dict[str, Any]) -> str:
     )
 
 
+def _survey_headline_html(stats: dict[str, Any]) -> str:
+    """The roll-up stat strip: a lead sentence plus one badge per verdict bucket.
+
+    Same arithmetic as ``_survey_headline`` (which stays the MD twin); the
+    badges reuse the shared verdict colours so the strip matches the table.
+    """
+    verdicts = stats.get("verdicts", {})
+    kernels = int(stats.get("kernels", 0))
+    runs = int(stats.get("runs", 0))
+    lead = (
+        f'<span class="lead">Surveyed <b>{kernels} kernel'
+        f"{'' if kernels == 1 else 's'}</b> across <b>{runs} sanitizer run"
+        f"{'' if runs == 1 else 's'}</b></span>"
+    )
+    badges = "".join(
+        f'<span class="v {_VERDICT_CLASS.get(bucket, "neutral")}">{n} {_esc(bucket)}</span>'
+        for bucket in _SURVEY_VERDICT_BUCKETS
+        if (n := verdicts.get(bucket, 0))
+    )
+    return lead + (badges or '<span class="v neutral">no sanitizer runs</span>')
+
+
 def _survey_group_by_sanitizer(
     entries: list[dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
@@ -1210,11 +1801,11 @@ def _survey_group_note(entries: list[dict[str, Any]]) -> str:
 
 
 def _survey_summary_cell_html(entry: dict[str, Any] | None) -> str:
-    """A verdict-chip roll-up cell, or an em dash when the sanitizer did not run."""
+    """A verdict-badge roll-up cell, or an em dash when the sanitizer did not run."""
     row = (entry or {}).get("summary") or {}
     if entry is None or not row.get("present"):
-        return "&mdash;"
-    return _verdict_chip_html(row.get("verdict"))
+        return '<span class="dash">&mdash;</span>'
+    return _verdict_html(row.get("verdict"))
 
 
 def _survey_summary_table_html(
@@ -1223,7 +1814,7 @@ def _survey_summary_table_html(
     """The Tab 2 roll-up: a headline stat + one row per kernel (pure).
 
     Columns: Kernel | waitcheck | ConSan | Findings | Note. Verdict cells reuse the
-    solid-color ``_verdict_chip_html`` chips; a sanitizer not run for a kernel shows
+    tinted ``_verdict_html`` badges; a sanitizer not run for a kernel shows
     an em dash rather than a fabricated verdict. Observed-only: nothing here gates.
     Empty groups render nothing (the caller shows the empty-state note).
     """
@@ -1234,51 +1825,61 @@ def _survey_summary_table_html(
     for key, entries in groups:
         by_san = _survey_group_by_sanitizer(entries)
         note = _survey_group_note(entries)
+        note_html = f"<td class=mono>{_esc(note)}</td>" if note else '<td class="dash">&mdash;</td>'
         rows.append(
-            f"<tr><td>{_esc(_survey_group_label(key, entries))}</td>"
+            f"<tr><td class=mono>{_esc(_survey_group_label(key, entries))}</td>"
             f"<td>{_survey_summary_cell_html(by_san.get('waitcheck'))}</td>"
             f"<td>{_survey_summary_cell_html(by_san.get('consan'))}</td>"
             f"<td class=num>{_survey_group_findings(entries)}</td>"
-            f"<td>{_esc(note) or '&mdash;'}</td></tr>"
+            f"{note_html}</tr>"
         )
     return (
-        f'<p class="survey-headline">{_esc(_survey_headline(stats))}</p>'
-        '<table class="survey-summary">'
-        "<tr><th>Kernel</th><th>waitcheck</th><th>ConSan</th>"
-        "<th>Findings</th><th>Note</th></tr>"
-        f'{"".join(rows)}</table>'
+        '<section class="panel survey-summary"><h2>Survey summary</h2>'
+        f'<div class="statline">{_survey_headline_html(stats)}</div>'
+        '<div class="table-wrap"><table><thead>'
+        "<tr><th>Kernel</th><th>WaitCheck</th><th>ConSan</th>"
+        "<th class=num>Findings</th><th>Note</th></tr></thead>"
+        f'<tbody>{"".join(rows)}</tbody></table></div></section>'
     )
 
 
-def _survey_case_html(entry: dict[str, Any], *, heading: str, level: int = 3) -> str:
-    """One observed-only survey case: colored verdict chip, inline message, reproduce
-    line, meta, and kernel tables. ``level`` is the heading tag (3 for a standalone
-    case, 4 for a sanitizer sub-block inside a kernel group)."""
+def _survey_case_html(entry: dict[str, Any], *, heading: str, kind: str = "") -> str:
+    """One observed-only survey case as a collapsed ``<details>`` card.
+
+    The summary row carries the verdict badge and findings count so a reader can
+    triage every case without expanding any of them. The body holds the facts
+    grid, the inline finding/reason, the reproduce command and the tables.
+    """
     row = entry["summary"]
-    tag = f"h{level}"
-    raw_link = _raw_link_html(entry.get("report_rel"))
+    san = str(entry.get("sanitizer") or "").strip().lower()
+    accent = {"waitcheck": "wc", "consan": "cs"}.get(san, "nu")
+    icon = _ICON_SHIELD if accent == "wc" else _ICON_ACTIVITY
+    trailing = f"{_verdict_html(row['verdict'])}{_findings_chip_html(row)}"
+    summary = _card_summary_html(
+        accent=accent, icon=icon, name=heading, kind=kind, trailing=trailing
+    )
     workload = entry.get("workload")
-    workload_txt = f" &middot; source {_esc(str(workload))}" if workload else ""
-    head = (
-        f"<{tag}>{_esc(heading)} &middot; {_verdict_chip_html(row['verdict'])}"
-        f"{raw_link}</{tag}>"
+    extra: tuple[tuple[str, str], ...] = (
+        (("Source", _esc(str(workload))),) if workload else ()
     )
     if not row["present"]:
-        return (
-            f"{head}"
-            f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}'
-            f"{workload_txt}</div>"
-            f"{_survey_message_html(row)}"
-            f"{_survey_howto_html(entry)}"
+        body = (
+            _observation_html(row, tone=_tone_for(row["verdict"]))
+            + _survey_message_html(row)
+            + _survey_howto_html(entry)
+        )
+    else:
+        body = (
+            _facts_html(row, observed=True, extra=extra)
+            + _observation_html(row, tone=_tone_for(row["verdict"]))
+            + _survey_message_html(row)
+            + _survey_howto_html(entry)
+            + _kernel_tables_html(row, report_rel=entry.get("report_rel"))
+            + _raw_link_html(entry.get("report_rel"))
         )
     return (
-        f"{head}"
-        f'<div class="secondary">backend {_esc(str(entry["backend"]))}{workload_txt}</div>'
-        f'<div class="secondary">Observation: {_esc(row.get("observation", ""))}</div>'
-        f"{_survey_message_html(row)}"
-        f"{_survey_howto_html(entry)}"
-        f"{_meta_line_html(row, observed=True)}"
-        f"{_kernel_tables_html(row, report_rel=entry.get('report_rel'), verdict_html=_verdict_chip_html)}"
+        f'<details class="kcard {accent}">{summary}'
+        f'<div class="kcard-body">{body}</div></details>'
     )
 
 
@@ -1300,19 +1901,24 @@ def _survey_detail_html(survey: list[dict[str, Any]]) -> str:
     # so the reader sees coverage + outcomes at a glance without scrolling.
     blocks: list[str] = [_survey_note_html(), _survey_summary_table_html(grouped)]
     for key, entries in grouped:
-        if len(entries) == 1:
-            entry = entries[0]
-            heading = str(entry.get("label") or key)
-            blocks.append(_survey_case_html(entry, heading=heading, level=3))
-            continue
         ordered = sorted(
             entries, key=lambda e: _SANITIZER_RANK.get(str(e.get("sanitizer")), 99)
         )
-        blocks.append(
-            f'<h3 class="survey-group">{_esc(_survey_group_label(key, entries))}</h3>'
+        runs = len(ordered)
+        cards = "".join(
+            _survey_case_html(
+                entry,
+                heading=_sanitizer_name(entry),
+                kind=_sanitizer_kind(entry),
+            )
+            for entry in ordered
         )
-        for entry in ordered:
-            blocks.append(_survey_case_html(entry, heading=_sanitizer_label(entry), level=4))
+        blocks.append(
+            '<section class="panel"><h2 class="kgroup-title">'
+            f'<span class="kname">{_esc(_survey_panel_title(key, entries))}</span>'
+            f'<span class="count">{runs} sanitizer run{"" if runs == 1 else "s"}</span>'
+            f"</h2>{cards}</section>"
+        )
     return "".join(blocks)
 
 
@@ -1344,24 +1950,24 @@ def build_html(
     latest = runs[0]
     meta = latest["meta"]
     summary = _gate_summary(latest["rows"], recorded_gate=latest["meta"].get("gate"))
-    gate_color = "#2c7d3b" if summary["ok"] else "#c92c35"
-    gate_text = f"{summary['label']} \u2014 {summary['detail']}"
 
     latest_rows = "".join(
-        f"<tr><td>{_esc(label)}</td><td>{_esc(backend)}</td>"
+        f"<tr><td class=mono>{_esc(label)}</td><td>{_esc(backend)}</td>"
         f"<td>{_baseline_status_html(latest['rows'][case])}</td>"
-        f"<td>{_observed_html(latest['rows'][case]['verdict'])}</td>"
-        f"<td>{_observed_html(latest['rows'][case]['expected'] or _DASH)}</td>"
+        f"<td>{_verdict_html(latest['rows'][case]['verdict'])}</td>"
+        f"<td>{_verdict_html(latest['rows'][case]['expected'] or _DASH)}</td>"
         f"<td>{_execution_html(latest['rows'][case]['execution'])}</td>"
         f"<td class=num>{latest['rows'][case]['findings']}</td>"
-        f"<td>{_esc(latest['rows'][case]['coverage']) or '&mdash;'}</td>"
+        f"<td class=mono>{_esc(latest['rows'][case]['coverage']) or '<span class=dash>&mdash;</span>'}</td>"
         f"<td>{_report_link_html(latest['rows'][case].get('report_rel'))}</td></tr>"
         for case, _key, label, backend in CASES
     )
     # Link to the whole run area (co-located raw reports) when published there.
     latest_rel = latest.get("rel")
     run_area_link = (
-        f' &middot; <a href="{_esc(latest_rel)}/">raw reports</a>' if latest_rel else ""
+        f'<a href="{_esc(latest_rel)}/">{_svg(_ICON_FILE, size=14, width=2)} raw reports</a>'
+        if latest_rel
+        else "<span></span>"
     )
 
     hist_head = "".join(f"<th>{_esc(label)}</th>" for _c, _k, label, _b in CASES)
@@ -1374,96 +1980,35 @@ def build_html(
         + "</tr>"
         for run in runs
     )
+    run_count = len(runs)
+    hist_gate = (
+        f'<span class="pill {"ok" if latest["gate"] else "bad"}">'
+        f'latest: {_esc(summary["short"])}</span>'
+    )
 
     return f"""<!doctype html>
 <html lang=en><head><meta charset=utf-8>
 <meta name=viewport content="width=device-width, initial-scale=1">
 <title>{_esc(title)}</title>
-<style>
-  :root {{ color-scheme: light dark; }}
-  body {{ font: 14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
-         margin:0; padding:24px; background:#f6f8fa; color:#1f2328; }}
-  .wrap {{ max-width: 1000px; margin: 0 auto; }}
-  h1 {{ font-size:20px; margin:0 0 4px; }}
-  h2 {{ font-size:15px; margin:20px 0 8px; }}
-  h3 {{ font-size:14px; margin:18px 0 4px; }}
-  .meta {{ color:#57606a; font-size:12px; margin-bottom:12px; }}
-  .secondary {{ color:#57606a; font-size:12px; margin:4px 0 8px; }}
-  a.raw {{ font-size:12px; font-weight:400; margin-left:8px; }}
-  /* Self-contained tabs (no external JS/CSS): radios toggle sibling panels via :checked. */
-  .tabradio {{ position:absolute; opacity:0; pointer-events:none; }}
-  .tabbar {{ display:flex; gap:4px; border-bottom:1px solid #d0d7de; margin:16px 0 0; }}
-  .tabbar label {{ cursor:pointer; padding:8px 14px; font-weight:600; color:#57606a;
-          border:1px solid transparent; border-bottom:none; border-radius:8px 8px 0 0; }}
-  #tab-guardrails:checked ~ .tabbar label[for="tab-guardrails"],
-  #tab-survey:checked ~ .tabbar label[for="tab-survey"] {{
-          color:#1f2328; background:#fff; border-color:#d0d7de; }}
-  /* The radios are visually hidden (opacity:0) so they show no native focus
-     ring; mirror :focus-visible onto the associated label so keyboard users can
-     see which tab control is focused. */
-  #tab-guardrails:focus-visible ~ .tabbar label[for="tab-guardrails"],
-  #tab-survey:focus-visible ~ .tabbar label[for="tab-survey"] {{
-          outline:2px solid #0969da; outline-offset:-2px; }}
-  .tabpanel {{ display:none; padding-top:8px; }}
-  #tab-guardrails:checked ~ #panel-guardrails {{ display:block; }}
-  #tab-survey:checked ~ #panel-survey {{ display:block; }}
-  .mono {{ font-family: ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; }}
-  .gate {{ color:#fff; background:{gate_color}; padding:12px 16px; border-radius:8px;
-          font-weight:600; margin:12px 0 20px; }}
-  table {{ width:100%; border-collapse:collapse; background:#fff; border-radius:8px;
-          overflow:hidden; margin-bottom:16px; }}
-  th,td {{ text-align:left; padding:7px 10px; border-bottom:1px solid #d0d7de; vertical-align:top; }}
-  th {{ background:#f6f8fa; font-size:11px; text-transform:uppercase; letter-spacing:.03em; color:#57606a; }}
-  td.num {{ text-align:right; font-variant-numeric:tabular-nums; }}
-  .observed {{ display:inline-block; color:#57606a; background:#afb8c133; border:1px solid #afb8c1;
-               padding:1px 7px; border-radius:999px; font:600 12px ui-monospace,SFMono-Regular,Menlo,monospace; }}
-  .execution.bad {{ color:#cf222e; font-weight:600; }}
-  .pill {{ padding:2px 8px; border-radius:999px; font-size:12px; font-weight:600; }}
-  .pill.ok {{ background:#1a7f3722; color:#1a7f37; }} .pill.bad {{ background:#cf222e22; color:#cf222e; }}
-  .pill.pass {{ background:#2c7d3b; color:#fff; }} .pill.fail {{ background:#c92c35; color:#fff; }}
-  /* Survey tab (Tab 2): readable body-size intro + solid color-coded verdict chips.
-     The chips are descriptive only (this tab never gates). */
-  .survey-intro {{ font-size:14px; line-height:1.55; color:#1f2328; margin:8px 0 16px; max-width:70ch; }}
-  .survey-intro p {{ margin:0 0 10px; }}
-  .survey-headline {{ font-size:14px; font-weight:600; color:#1f2328; margin:8px 0 10px; }}
-  .survey-summary {{ margin-bottom:20px; }}
-  .survey-group {{ font-size:15px; margin:22px 0 4px; padding-top:6px; border-top:1px solid #d0d7de; }}
-  .survey-howto {{ font-size:13px; margin:4px 0 8px; }}
-  .survey-howto code {{ background:#afb8c133; border:1px solid #afb8c1; border-radius:6px;
-          padding:1px 6px; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; }}
-  .survey-msg {{ font-size:13px; line-height:1.5; margin:4px 0 8px; color:#1f2328;
-          font-family:ui-monospace,SFMono-Regular,Menlo,monospace; word-break:break-word; }}
-  .survey-empty {{ font-size:14px; color:#1f2328; margin:8px 0; }}
-  .vchip {{ display:inline-block; color:#fff; padding:1px 8px; border-radius:999px;
-          font:600 12px ui-monospace,SFMono-Regular,Menlo,monospace; }}
-  .vchip.err {{ background:#cf222e; }} .vchip.warn {{ background:#9a6700; }}
-  .vchip.pass {{ background:#1a7f37; }} .vchip.neutral {{ background:#6e7681; }}
-  @media (prefers-color-scheme: dark) {{
-    body {{ background:#0d1117; color:#e6edf3; }}
-    table {{ background:#161b22; }} th {{ background:#161b22; color:#8b949e; }}
-    th,td {{ border-color:#30363d; }}
-    .meta,.secondary {{ color:#8b949e; }}
-    .observed {{ color:#c9d1d9; background:#6e768133; border-color:#6e7681; }}
-    .survey-intro,.survey-msg,.survey-empty,.survey-headline {{ color:#e6edf3; }}
-    .survey-group {{ border-color:#30363d; }}
-    .survey-howto code {{ background:#6e768133; border-color:#6e7681; }}
-    .vchip.warn {{ background:#9e6a00; }}
-    #tab-guardrails:checked ~ .tabbar label[for="tab-guardrails"],
-    #tab-survey:checked ~ .tabbar label[for="tab-survey"] {{
-            color:#e6edf3; background:#161b22; border-color:#30363d; }}
-  }}
-</style></head>
+<style>{_CSS}</style></head>
 <body><div class=wrap>
-  <p class=nav><a href="../">back to CI dashboard</a></p>
+  <div class=navrow>
+    <a href="../">&larr; back to CI dashboard</a>
+    {run_area_link}
+  </div>
   {banner}
-  <h1>{_esc(title)} &middot; gfx950</h1>
-  <div class=meta>latest run <span class=mono>{_esc(meta.get('run', ''))}</span>
-     &middot; commit <span class=mono>{_esc(meta.get('commit', ''))}</span>
-     &middot; {_esc(meta.get('date', ''))} &middot; target {_esc(meta.get('gpu', 'gfx950'))}{run_area_link}</div>
-  <div class=gate>{_esc(gate_text)}</div>
-  <p class=secondary>Observed <span class=mono>WARN</span> or <span class=mono>FAIL</span>
-     verdicts may be expected positive-control outcomes. Baseline status is the
-     regression-health signal.</p>
+  <div class=topbar>
+    <header class="page-header">
+      <div class="brand-tile">{_svg(_ICON_ACTIVITY, size=24, width=2)}</div>
+      <div>
+        <h1>{_esc(title)}</h1>
+        <p class="subtitle">GPU sanitizer guardrails and workload survey</p>
+      </div>
+    </header>
+    {_run_card_html(meta)}
+  </div>
+
+  {_tool_cards_html()}
 
   <div class=tabs>
   <input type=radio name=santab id=tab-guardrails class=tabradio checked>
@@ -1474,27 +2019,38 @@ def build_html(
   </div>
 
   <section class=tabpanel id=panel-guardrails>
-  <p class=secondary>Baseline-checked kernels: expected vs observed sanitizer behavior.
-     This tab is the regression gate.</p>
-  <h2>Latest run</h2>
-  <table>
-    <tr><th>Recipe</th><th>Backend</th><th>Baseline status</th><th>Observed</th>
-        <th>Expected</th><th>Execution</th><th>Findings</th><th>Coverage</th><th>Report</th></tr>
-    {latest_rows}
-  </table>
+  {_gate_hero_html(summary)}
+  <div class="info-banner">{_svg(_ICON_INFO, size=18, width=2)}
+    <p><strong>This tab is the regression gate.</strong> Baseline status column
+       will determine if regression failed or passed.</p></div>
 
-  <h2>Kernel details</h2>
-  {_kernel_detail_html(latest['rows'])}
+  <section class="panel">
+    <h2>Latest run <span class=count>{len(CASES)} recipes</span></h2>
+    <div class="table-wrap"><table><thead>
+      <tr><th>Recipe</th><th>Backend</th><th>Baseline status</th><th>Observed</th>
+          <th>Expected</th><th>Execution</th><th class=num>Findings</th>
+          <th>Coverage</th><th>Report</th></tr></thead>
+      <tbody>{latest_rows}</tbody>
+    </table></div>
+  </section>
 
-  <h2>History / trend</h2>
-  <table>
-    <tr><th>Run</th><th>Commit</th><th>Date</th>{hist_head}<th>Gate</th></tr>
-    {hist_rows}
-  </table>
+  <section class="panel">
+    <h2>Kernel details <span class=count>{len(CASES)} recipes</span></h2>
+    {_kernel_detail_html(latest['rows'])}
+  </section>
+
+  <details class="panel">
+    <summary>History / trend
+      <span class=count>{run_count} run{'' if run_count == 1 else 's'}</span>
+      {hist_gate}<span class="spacer"></span>{_chevron_html()}</summary>
+    <div class="panel-body"><div class="table-wrap"><table><thead>
+      <tr><th>Run</th><th>Commit</th><th>Date</th>{hist_head}<th>Gate</th></tr></thead>
+      <tbody>{hist_rows}</tbody>
+    </table></div></div>
+  </details>
   </section>
 
   <section class=tabpanel id=panel-survey>
-  <h2>Workload survey</h2>
   {_survey_detail_html(survey or [])}
   </section>
   </div>
@@ -1514,59 +2070,45 @@ def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightl
     # Reuse the shared aggregate classifier so a missing report reads as
     # INCOMPLETE rather than a misleading "verdict mismatch" (mirrors build_html).
     summary = _gate_summary(rows, recorded_gate=run["meta"].get("gate"))
-    gate_color = "#1a7f37" if summary["ok"] else "#cf222e"
-    gate_text = f"{summary['label']} \u2014 {summary['detail']}"
     run_url = meta.get("run_url", "")
     run_link = (
-        f' &middot; <a href="{_esc(run_url)}">workflow run</a>' if run_url else ""
+        f'<a href="{_esc(run_url)}">workflow run</a>' if run_url else "<span></span>"
     )
 
     def _cell(case: str, present: bool) -> str:
         if not present:
-            return "report missing"
+            return '<span class="dash">report missing</span>'
         href = _esc(f"{case}/sanitizer_report.json")
         return f'<a href="{href}">sanitizer_report.json</a>'
 
     report_rows = "".join(
-        f"<tr><td>{_esc(label)}</td>"
-        f"<td>{_baseline_status_html(rows[case])}"
-        f'<div class="secondary">Observed {_observed_html(rows[case]["verdict"])}</div></td>'
+        f"<tr><td class=mono>{_esc(label)}</td>"
+        f"<td>{_baseline_status_html(rows[case])} {_verdict_html(rows[case]['verdict'])}</td>"
         f"<td>{_cell(case, rows[case]['present'])}</td></tr>"
         for case, _key, label, _backend in CASES
     )
+    # Shares the dashboard stylesheet so a drill-down does not look like a
+    # different product; only the narrower wrap differs.
     return (
         "<!doctype html>\n"
         "<html lang=en><head><meta charset=utf-8>\n"
         '<meta name=viewport content="width=device-width, initial-scale=1">\n'
         f"<title>{_esc(title)} &middot; {_esc(meta.get('run', ''))}</title>\n"
-        "<style>\n"
-        "  body { font: 14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;\n"
-        "         max-width:900px; margin:0 auto; padding:24px; color:#1f2328; }\n"
-        "  h1 { font-size:18px; margin:0 0 4px; }\n"
-        "  .meta { color:#57606a; font-size:12px; margin-bottom:12px; }\n"
-        "  .mono { font-family: ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; }\n"
-        f"  .gate {{ color:#fff; background:{gate_color}; padding:10px 14px; border-radius:8px;\n"
-        "          font-weight:600; margin:12px 0 18px; }\n"
-        "  table { width:100%; border-collapse:collapse; }\n"
-        "  th,td { text-align:left; padding:7px 10px; border-bottom:1px solid #d0d7de; }\n"
-        "  .secondary { color:#57606a; font-size:12px; margin:4px 0 0; }\n"
-        "  .pill { padding:2px 8px; border-radius:999px; font-size:12px; font-weight:600; }\n"
-        "  .pill.ok { background:#1a7f3722; color:#1a7f37; } .pill.bad { background:#cf222e22; color:#cf222e; }\n"
-        "  .observed { display:inline-block; color:#57606a; background:#afb8c133; border:1px solid #afb8c1;\n"
-        "              padding:1px 7px; border-radius:999px; font:600 12px ui-monospace,SFMono-Regular,Menlo,monospace; }\n"
-        "</style></head>\n"
-        "<body>\n"
-        '<p><a href="../../">back to sanitizer dashboard</a></p>\n'
-        f"<h1>{_esc(title)} &middot; run <span class=mono>{_esc(meta.get('run', ''))}</span></h1>\n"
-        f"<div class=meta>commit <span class=mono>{_esc(meta.get('commit', ''))}</span>"
-        f" &middot; {_esc(meta.get('date', ''))} &middot; target {_esc(meta.get('gpu', 'gfx950'))}"
+        f"<style>{_CSS}\n  .wrap {{ max-width:900px; }}</style></head>\n"
+        "<body><div class=wrap>\n"
+        '<div class=navrow><a href="../../">&larr; back to sanitizer dashboard</a>\n'
         f"{run_link}</div>\n"
-        f"<div class=gate>{_esc(gate_text)}</div>\n"
-        "<table>\n"
-        "<tr><th>Recipe</th><th>Baseline status</th><th>Raw report</th></tr>\n"
-        f"{report_rows}\n"
-        "</table>\n"
-        "</body></html>\n"
+        '<header class="page-header"><div class="brand-tile">'
+        f"{_svg(_ICON_ACTIVITY, size=24, width=2)}</div><div>\n"
+        f"<h1>{_esc(title)}</h1>\n"
+        f'<p class="subtitle">run {_esc(meta.get("run", ""))}</p></div></header>\n'
+        f"{_run_card_html(meta)}\n"
+        f"{_gate_hero_html(summary)}\n"
+        '<section class="panel"><h2>Raw reports</h2><div class="table-wrap"><table>\n'
+        "<thead><tr><th>Recipe</th><th>Baseline status</th><th>Raw report</th></tr></thead>\n"
+        f"<tbody>{report_rows}</tbody>\n"
+        "</table></div></section>\n"
+        "</div></body></html>\n"
     )
 
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1867,7 +1867,9 @@ def _survey_case_html(entry: dict[str, Any], *, heading: str, kind: str = "") ->
 
     The summary row carries the verdict badge and findings count so a reader can
     triage every case without expanding any of them. The body holds the facts
-    grid, the inline finding/reason, the reproduce command and the tables.
+    grid, the inline finding/reason, the reproduce command and the tables. An
+    absent report keeps its originating workload but drops the facts that would
+    describe a report that was never produced.
     """
     row = entry["summary"]
     san = str(entry.get("sanitizer") or "").strip().lower()
@@ -1882,8 +1884,13 @@ def _survey_case_html(entry: dict[str, Any], *, heading: str, kind: str = "") ->
         (("Source", _esc(str(workload))),) if workload else ()
     )
     if not row["present"]:
+        # Provenance only: the rest of the facts grid (backend, selection,
+        # execution) would describe a report that does not exist. The source
+        # still belongs here -- the MD twin names it on this branch too.
+        facts = "".join(_fact_html(label, value) for label, value in extra)
         body = (
-            _observation_html(row, tone=_tone_for(row["verdict"]))
+            (f'<div class="kv">{facts}</div>' if facts else "")
+            + _observation_html(row, tone=_tone_for(row["verdict"]))
             + _survey_message_html(row)
             + _survey_howto_html(entry)
         )

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -208,7 +208,11 @@ _CSS = """
   .count { font-size:12px; font-weight:600; color:var(--text-3); background:var(--inset);
     border:1px solid var(--border); border-radius:999px; padding:1px 10px; }
 
-  .table-wrap { border:1px solid var(--border); border-radius:var(--radius-sm); overflow:hidden; }
+  /* overflow-x:auto, not hidden: the latest-run table has nine columns with
+     non-wrapping headers, so clipping would put the rightmost columns and the
+     report links out of reach on a narrow viewport. A scroll container still
+     clips to the border-radius. */
+  .table-wrap { border:1px solid var(--border); border-radius:var(--radius-sm); overflow-x:auto; }
   table { width:100%; border-collapse:separate; border-spacing:0; }
   th { text-align:left; padding:10px 12px; font-size:var(--fs-th); font-weight:600;
     text-transform:uppercase; letter-spacing:.06em; color:var(--text-3);
@@ -1503,7 +1507,7 @@ _SURVEY_NOTES: tuple[str, ...] = (
     "This tab is informational only and does not affect nightly pass/fail status.",
     "Findings represent observed behavior, not regressions.",
     "Where both sanitizers produced a report the kernel appears under each; "
-    "a skipped or missing scan simply does not appear.",
+    "a skipped or missing scan still appears, marked report missing with no verdict.",
     "Every case lists the recipe that produced the kernel and a reproducible command.",
 )
 
@@ -1694,6 +1698,16 @@ def _survey_verdict_bucket(row: dict[str, Any]) -> str:
     return verdict if verdict in ("pass", "warn", "fail", "error") else "not_checked"
 
 
+def _survey_present_runs(entries: list[dict[str, Any]]) -> int:
+    """Sanitizer runs in a kernel group that actually produced a report (pure).
+
+    Single source of truth for "how many runs", so the kernel-group heading and the
+    roll-up headline agree: an absent report still renders a card (with no verdict)
+    but it is not a run.
+    """
+    return sum(1 for entry in entries if (entry.get("summary") or {}).get("present"))
+
+
 def _survey_summary_stats(
     groups: list[tuple[str, list[dict[str, Any]]]],
 ) -> dict[str, Any]:
@@ -1708,11 +1722,11 @@ def _survey_summary_stats(
     verdicts = dict.fromkeys(_SURVEY_VERDICT_BUCKETS, 0)
     runs = 0
     for _key, entries in groups:
+        runs += _survey_present_runs(entries)
         for entry in entries:
             row = entry.get("summary") or {}
             if not row.get("present"):
                 continue
-            runs += 1
             verdicts[_survey_verdict_bucket(row)] += 1
     return {"kernels": len(groups), "runs": runs, "verdicts": verdicts}
 
@@ -1906,7 +1920,9 @@ def _survey_detail_html(survey: list[dict[str, Any]]) -> str:
         ordered = sorted(
             entries, key=lambda e: _SANITIZER_RANK.get(str(e.get("sanitizer")), 99)
         )
-        runs = len(ordered)
+        # Counting spec entries instead would show "2 sanitizer runs" on a group
+        # whose second report is missing while the roll-up above it counts one.
+        runs = _survey_present_runs(ordered)
         cards = "".join(
             _survey_case_html(
                 entry,
@@ -1935,19 +1951,25 @@ def build_html(
     if not runs:
         # Rendered before the first successful nightly (empty runs-root) so the
         # /sanitizers/ route never 404s, and whenever a run fails with no data.
+        # Shares _CSS: this branch still renders the stale banner, which is the
+        # most safety-relevant thing on the page, and an unstyled warning on an
+        # otherwise-dark site reads as a broken page rather than an alert.
         return (
             "<!doctype html>\n"
             "<html lang=en><head><meta charset=utf-8>\n"
             '<meta name=viewport content="width=device-width, initial-scale=1">\n'
-            f"<title>{_esc(title)}</title></head>\n"
-            '<body style="font:14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,'
-            'sans-serif;max-width:1000px;margin:0 auto;padding:24px">\n'
-            '<p><a href="../">back to CI dashboard</a></p>\n'
+            f"<title>{_esc(title)}</title>\n"
+            f"<style>{_CSS}</style></head>\n"
+            "<body><div class=wrap>\n"
+            '<div class=navrow><a href="../">&larr; back to CI dashboard</a></div>\n'
             f"{banner}"
+            '<header class="page-header"><div class="brand-tile">'
+            f"{_svg(_ICON_ACTIVITY, size=24, width=2)}</div><div>\n"
             f"<h1>{_esc(title)}</h1>\n"
-            "<p>No sanitizer runs yet. This page will populate after the first "
-            "successful sanitizer nightly.</p>\n"
-            "</body></html>\n"
+            '<p class="subtitle">No runs yet</p></div></header>\n'
+            '<section class="panel"><p>No sanitizer runs yet. This page will '
+            "populate after the first successful sanitizer nightly.</p></section>\n"
+            "</div></body></html>\n"
         )
     latest = runs[0]
     meta = latest["meta"]
@@ -2162,8 +2184,9 @@ def _survey_section_md(survey: list[dict[str, Any]]) -> list[str]:
         "",
         "How real GPU kernels behave under AMD's sanitizers \u2014 **waitcheck** (static "
         "`s_waitcnt` wait-count scan) and **ConSan** (dynamic data-race check); where "
-        "both produced a report the kernel is shown under each, and when a scan was "
-        "skipped or its report is missing only the sanitizer(s) that ran appear. **No "
+        "both produced a report the kernel is shown under each, and a scan that was "
+        "skipped or whose report is missing still appears, marked report missing with "
+        "no verdict. **No "
         "expected-behavior comparison on this tab**; an `error` / `fail` / `warn` here "
         "is an observation of how the kernel behaved, not a regression. Each case lists "
         "a copy-paste command to reproduce the run.",

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -318,11 +318,14 @@ _CSS = """
 
   .flow { display:flex; align-items:flex-start; justify-content:space-between; gap:4px; padding:2px 0; }
   .step { display:flex; flex-direction:column; align-items:center; text-align:center; width:104px; }
+  /* Solid, deepened fills: white on the identity accents at 85% alpha measured
+     2.99:1 for green (WCAG AA needs 4.5:1 for this 11.5px bold text). These
+     opaque shades clear it -- blue 5.2:1, purple 5.7:1, green 5.0:1. */
   .step-num { width:21px; height:21px; border-radius:50%; display:grid; place-items:center;
     font-size:11.5px; font-weight:700; margin-bottom:7px; color:#fff; }
-  .step-num.blue { background:rgba(59,130,246,.85); }
-  .step-num.purple { background:rgba(139,92,246,.85); }
-  .step-num.green { background:rgba(34,197,94,.85); }
+  .step-num.blue { background:#2563EB; }
+  .step-num.purple { background:#7C3AED; }
+  .step-num.green { background:#15803D; }
   .step .tile { width:46px; height:46px; border-radius:var(--radius-sm); }
   .step .label { font-size:13px; font-weight:600; color:var(--text-1); margin-top:9px; line-height:1.25; }
   .step .desc { font-size:12px; color:var(--text-3); margin-top:4px; line-height:1.35; }
@@ -1368,7 +1371,14 @@ def _raw_link_html(report_rel: str | None) -> str:
 
 
 def _findings_chip_html(row: dict[str, Any]) -> str:
-    """Findings count for a collapsed card's summary row."""
+    """Findings count for a collapsed card's summary row.
+
+    An absent report also carries ``findings: 0``, but "no findings" would
+    claim a clean scan where none ran. Emit nothing in that case and let the
+    verdict badge (and, on the guardrail tab, the "Report missing" pill) say so.
+    """
+    if not row.get("present"):
+        return ""
     count = int(row.get("findings") or 0)
     if not count:
         return '<span class="findings">no findings</span>'
@@ -1387,8 +1397,13 @@ def _observation_html(row: dict[str, Any], *, tone: str = "") -> str:
 
 
 def _tone_for(verdict: Any) -> str:
-    """Map a verdict onto the callout tint class (empty for pass/unknown)."""
-    return _VERDICT_CLASS.get(str(verdict).strip().lower(), "").replace("pass", "")
+    """Map a verdict onto the callout tint class.
+
+    Returns "" for pass and for anything unmapped, so a healthy or unknown
+    observation keeps the neutral grey callout rather than being tinted.
+    """
+    cls = _VERDICT_CLASS.get(str(verdict).strip().lower(), "")
+    return "" if cls == "pass" else cls
 
 
 def _sanitizer_accent(backend_label: str) -> str:
@@ -1542,19 +1557,6 @@ def _survey_note_html() -> str:
         f"{_chevron_html()}</summary><ul>{notes}</ul></details>"
         "</div>"
     )
-
-
-def _sanitizer_label(entry: dict[str, Any]) -> str:
-    """Human sanitizer heading for a grouped (both-sanitizer) survey sub-block.
-
-    Retained for the markdown mirror, which has no room for a two-part heading.
-    """
-    san = str(entry.get("sanitizer") or "").strip().lower()
-    if san == "waitcheck":
-        return "waitcheck (static wait-count scan)"
-    if san == "consan":
-        return "ConSan (dynamic data-race check)"
-    return str(entry.get("label") or san or "sanitizer")
 
 
 def _sanitizer_name(entry: dict[str, Any]) -> str:
@@ -2098,11 +2100,13 @@ def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightl
         "<body><div class=wrap>\n"
         '<div class=navrow><a href="../../">&larr; back to sanitizer dashboard</a>\n'
         f"{run_link}</div>\n"
+        '<div class=topbar>\n'
         '<header class="page-header"><div class="brand-tile">'
         f"{_svg(_ICON_ACTIVITY, size=24, width=2)}</div><div>\n"
         f"<h1>{_esc(title)}</h1>\n"
         f'<p class="subtitle">run {_esc(meta.get("run", ""))}</p></div></header>\n'
         f"{_run_card_html(meta)}\n"
+        "</div>\n"
         f"{_gate_hero_html(summary)}\n"
         '<section class="panel"><h2>Raw reports</h2><div class="table-wrap"><table>\n'
         "<thead><tr><th>Recipe</th><th>Baseline status</th><th>Raw report</th></tr></thead>\n"

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -320,7 +320,10 @@ _CSS = """
   .two-col { display:grid; grid-template-columns:1.85fr 1fr; gap:12px; align-items:start; margin-bottom:12px; }
   .two-col > .panel { margin-bottom:0; }
 
-  .flow { display:flex; align-items:flex-start; justify-content:space-between; gap:4px; padding:2px 0; }
+  /* Same reachability rule as .table-wrap: the five steps are fixed-width, so a
+     narrow viewport scrolls the band instead of spilling it out of its panel. */
+  .flow { display:flex; align-items:flex-start; justify-content:space-between; gap:4px;
+    padding:2px 0; overflow-x:auto; }
   .step { display:flex; flex-direction:column; align-items:center; text-align:center; width:104px; }
   /* Solid, deepened fills: white on the identity accents at 85% alpha measured
      2.99:1 for green (WCAG AA needs 4.5:1 for this 11.5px bold text). These

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -191,15 +191,16 @@ def test_build_html_expected_warn_and_fail_are_healthy_and_neutral():
     ]
     html = gen.build_html(runs)
     assert "<!doctype html>" in html
-    assert "HEALTHY — 3/3 sanitizer outcomes match their baselines" in html
+    # the gate hero splits state and detail onto two lines
+    assert "<strong>HEALTHY</strong>3/3 sanitizer outcomes match their baselines" in html
     assert html.count('<span class="pill ok">Expected outcome</span>') >= 3
-    assert '<span class="observed">warn</span>' in html
-    assert '<span class="observed">fail</span>' in html
-    assert "positive-control outcomes" in html
+    # verdicts are tinted badges; the solid baseline pill carries regression health
+    assert '<span class="v warn">warn</span>' in html
+    assert '<span class="v fail">fail</span>' in html
+    assert "This tab is the regression gate." in html
     assert "<th>Baseline status</th><th>Observed</th>" in html
     assert "<th>Expected</th><th>Execution</th>" in html
     assert "gemm_x" in html and "Kernel details" in html
-    assert "Observed sanitizer verdict" in html
     assert '<span class="pill ok">Match</span>' in html
     assert '<span class="pill pass">Healthy</span>' in html
     assert ">green<" not in html and ">red<" not in html
@@ -221,11 +222,11 @@ def test_build_html_mismatch_is_primary_regression_signal():
 
     html = gen.build_html(runs)
 
-    assert "REGRESSION — investigate 1/3 sanitizer outcomes" in html
+    assert "<strong>REGRESSION</strong>investigate 1/3 sanitizer outcomes" in html
     assert '<span class="pill bad">Unexpected outcome</span>' in html
     assert '<span class="pill bad">Mismatch</span>' in html
-    assert 'Observed <span class="observed">fail</span>' in html
-    assert 'expected <span class="observed">pass</span>' in html
+    assert '<span class="v fail">fail</span>' in html
+    assert '<span class="dash">expected</span> <span class="v pass">pass</span>' in html
     assert '<span class="pill fail">Regression</span>' in html
 
 
@@ -247,13 +248,13 @@ def test_renderers_make_missing_report_explicit():
     md = gen.build_summary_md(runs)
 
     assert '<span class="pill bad">Report missing</span>' in html
-    assert 'Observed <span class="observed">—</span>' in html
+    assert '<span class="v neutral">—</span>' in html
     assert "❌ **Report missing**" in md
     assert "Observed sanitizer verdict: `—`" in md
     assert "❌ **Report missing**<br>Observed: `—`" in md
     # the per-case observation summary renders for a missing guardrail report too,
     # on both Tab 1 renderers (parity with the survey missing branch / #367).
-    assert '<div class="secondary">Observation: report missing</div>' in html
+    assert '<span class="lbl">Observation</span>report missing' in html
     assert "Observation: report missing" in md
 
 
@@ -313,7 +314,7 @@ def test_missing_only_run_is_incomplete_not_regression():
     html = gen.build_html(runs)
     md = gen.build_summary_md(runs)
 
-    assert "INCOMPLETE — 1/3 sanitizer report(s) are missing" in html
+    assert "<strong>INCOMPLETE</strong>1/3 sanitizer report(s) are missing" in html
     assert '<span class="pill fail">Incomplete</span>' in html
     assert "**INCOMPLETE** — 1/3 sanitizer report(s) are missing" in md
     assert "Incomplete |" in md
@@ -343,7 +344,7 @@ def test_combined_mismatch_and_missing_is_unhealthy():
     md = gen.build_summary_md(runs)
 
     detail = "investigate 1/3 mismatched outcome(s) and 1/3 missing report(s)"
-    assert f"UNHEALTHY — {detail}" in html
+    assert f"<strong>UNHEALTHY</strong>{detail}" in html
     assert '<span class="pill fail">Unhealthy</span>' in html
     assert f"**UNHEALTHY** — {detail}" in md
     assert "Unhealthy |" in md
@@ -679,7 +680,7 @@ def test_build_run_index_html_missing_report_reads_incomplete(tmp_path):
     page = gen.build_run_index_html(run)
 
     # A missing report must read as INCOMPLETE, not a misleading verdict mismatch.
-    assert "INCOMPLETE \u2014 1/3 sanitizer report(s) are missing" in page
+    assert "<strong>INCOMPLETE</strong>1/3 sanitizer report(s) are missing" in page
     assert "verdict mismatch" not in page
 
 
@@ -922,41 +923,62 @@ def test_survey_recipe_for_uses_real_recipe_not_derived_guess():
     assert gen._survey_recipe_for("waitcheck-gemm") != "daily-waitcheck-gemm"
 
 
-def test_verdict_chip_html_colors_by_verdict():
-    # #374 D: solid color-coded verdict chips keyed on the verdict string.
-    assert gen._verdict_chip_html("error") == '<span class="vchip err">error</span>'
-    assert gen._verdict_chip_html("fail") == '<span class="vchip err">fail</span>'
-    assert gen._verdict_chip_html("warn") == '<span class="vchip warn">warn</span>'
-    assert gen._verdict_chip_html("pass") == '<span class="vchip pass">pass</span>'
-    assert (
-        gen._verdict_chip_html("not_checked") == '<span class="vchip neutral">not_checked</span>'
-    )
-    assert gen._verdict_chip_html("\u2014") == '<span class="vchip neutral">\u2014</span>'
+def test_verdict_html_colors_by_verdict():
+    # #374 D: verdict badges keyed on the verdict string. fail and error keep
+    # distinct class names but share one red in CSS, so the hues can be split
+    # later without touching markup.
+    assert gen._verdict_html("error") == '<span class="v error">error</span>'
+    assert gen._verdict_html("fail") == '<span class="v fail">fail</span>'
+    assert gen._verdict_html("warn") == '<span class="v warn">warn</span>'
+    assert gen._verdict_html("pass") == '<span class="v pass">pass</span>'
+    assert gen._verdict_html("not_checked") == '<span class="v neutral">not_checked</span>'
+    assert gen._verdict_html("\u2014") == '<span class="v neutral">\u2014</span>'
+
+
+def test_verdict_and_baseline_use_separate_visual_axes():
+    # The verdict badge is always tinted; the baseline status pill is always
+    # solid. That is what lets a red observed `fail` sit beside a green
+    # "Expected outcome" pill without reading as a regression.
+    row = gen.summarize_case(_consan_racy_report(), "fail")
+    assert 'class="v fail"' in gen._verdict_html(row["verdict"])
+    assert gen._baseline_status_html(row) == '<span class="pill ok">Expected outcome</span>'
+    css = gen._CSS
+    assert ".pill.ok, .pill.pass { background:var(--solid-ok); }" in css
+    assert "background:rgba(239,68,68,.13)" in css  # verdict red stays tinted
 
 
 def test_survey_intro_is_readable_and_drops_experimental_framing():
-    # #374 A/B: the intro is body-size readable copy (not 12px muted fine print) and
-    # frames the tab as real kernels under both sanitizers, dropping the old
-    # "experimental" / "caller-supplied code objects" framing from user-facing copy.
+    # #374 A/B: the survey tab states plainly that it is observed-only and
+    # non-gating, dropping the old "experimental" / "caller-supplied code
+    # objects" framing from user-facing copy. The WaitCheck / ConSan
+    # definitions are page-level cards (both tabs report both sanitizers).
     html = gen.build_html([_healthy_guardrail_run()], survey=[])
-    assert 'class="survey-intro"' in html
-    assert ".survey-intro { font-size:14px" in html  # readable body size
-    assert "real GPU kernels" in html
-    assert "waitcheck" in html and "ConSan" in html
-    assert "No expected-behavior comparison on this tab" in html
+    assert "This tab is observational only." in html
+    assert "do not affect nightly pass/fail status" in html
+    assert "WaitCheck" in html and "ConSan" in html
+    assert "Findings represent observed behavior, not regressions." in html
     assert "experimental" not in html.lower()
     assert "caller-supplied" not in html.lower()
+
+
+def test_tool_cards_are_page_level_so_both_tabs_get_them():
+    # Both tabs report waitcheck and consan results, so the definitions sit
+    # above the tab bar rather than inside the survey panel.
+    html = gen.build_html([_healthy_guardrail_run()], survey=[])
+    tabbar = html.index('<div class=tabbar>')
+    assert html.index('<section class="toolgrid">') < tabbar
+    assert html.count("Static Analysis") == 1 and html.count("Runtime Analysis") == 1
 
 
 def test_survey_intro_qualifies_the_both_sanitizers_claim():
     # Review (#374): the absolute "shown under both sanitizers" claim is false on the
     # supported degraded path (an absent/unreadable report skips a sanitizer). The
-    # HTML intro + MD mirror must qualify it so the UI never claims both ran when only
+    # HTML notes + MD mirror must qualify it so the UI never claims both ran when only
     # one report exists.
     html = gen.build_html([_healthy_guardrail_run()], survey=[])
     # the old absolute claim is gone; the qualified degraded-path copy is present
     assert "shown under <b>both</b> sanitizers." not in html
-    assert "only the sanitizer(s) that actually ran appear" in html
+    assert "a skipped or missing scan simply does not appear" in html
     md = gen.build_summary_md([_healthy_guardrail_run()], survey=[])
     assert "shown under both." not in md
     assert "only the sanitizer(s) that ran appear" in md
@@ -995,14 +1017,17 @@ def test_survey_message_error_reason_takes_precedence_over_partial_findings():
     assert errored["verdict"] == "error" and errored["findings"] == 1  # partial finding present
     assert gen._survey_message_parts(errored) == ("Reason", "combined_hook_timeout")
     assert gen._survey_message_html(errored) == (
-        '<div class="survey-msg">Reason: combined_hook_timeout</div>'
+        '<div class="observation error"><span class="lbl">Reason</span>'
+        '<span class="msg">combined_hook_timeout</span></div>'
     )
     assert gen._survey_message_md(errored) == "Reason: `combined_hook_timeout`"
 
     # a warn case with a finding still leads with the finding (unchanged behavior)
     warn = gen.summarize_case(_waitcheck_report(), None)
     assert gen._survey_message_parts(warn)[0] == "Finding"
-    assert gen._survey_message_html(warn).startswith('<div class="survey-msg">Finding:')
+    assert gen._survey_message_html(warn).startswith(
+        '<div class="observation warn"><span class="lbl">Finding</span>'
+    )
     assert gen._survey_message_md(warn).startswith("Finding: `")
 
     # the summary-table note also surfaces the errored group's reason ahead of a
@@ -1019,7 +1044,7 @@ def test_survey_message_error_reason_takes_precedence_over_partial_findings():
     assert gen._survey_group_note(groups[0][1]) == "combined_hook_timeout"
     # rendered end-to-end: the errored reason shows on the page, gate stays HEALTHY
     html = gen.build_html([_healthy_guardrail_run()], survey=entries)
-    assert "Reason: combined_hook_timeout" in html
+    assert '<span class="lbl">Reason</span><span class="msg">combined_hook_timeout' in html
     assert "HEALTHY" in html
     assert "REGRESSION" not in html and "Regression" not in html
 
@@ -1078,13 +1103,15 @@ def test_survey_informational_groups_both_sanitizers_with_chips_and_repro(tmp_pa
     )
 
     html = gen.build_html([_healthy_guardrail_run()], survey=entries)
-    # one kernel-group heading, both sanitizer sub-blocks
-    assert 'class="survey-group">gemm</h3>' in html
-    assert "waitcheck (static wait-count scan)" in html
-    assert "ConSan (dynamic data-race check)" in html
-    # solid color-coded chips: consan error -> red, waitcheck warn -> amber
-    assert '<span class="vchip err">error</span>' in html
-    assert '<span class="vchip warn">warn</span>' in html
+    # one kernel-group panel, one collapsed card per sanitizer
+    assert '<span class="kname">gemm</span>' in html
+    assert '<span class="name">WaitCheck</span>' in html
+    assert '<span class="kind">static wait-count scan</span>' in html
+    assert '<span class="name">ConSan</span>' in html
+    assert '<span class="kind">dynamic data-race check</span>' in html
+    # color-coded verdict badges: consan error -> red, waitcheck warn -> amber
+    assert '<span class="v error">error</span>' in html
+    assert '<span class="v warn">warn</span>' in html
     # per-case copy-paste reproduce command reflects the ACTUAL recipe: the gemm
     # waitcheck survey uses its dedicated object recipe, NOT the gated Tab-1
     # daily-waitcheck-gemm guardrail (which is never reused for the survey).
@@ -1096,8 +1123,8 @@ def test_survey_informational_groups_both_sanitizers_with_chips_and_repro(tmp_pa
     assert "recipes/sanitizers/daily-waitcheck-gemm.yaml" not in html
     # the actual message is inline on the page (not only behind the raw-report link):
     # the errored ConSan case shows its reason; the waitcheck case shows a finding.
-    assert "Reason: combined_hook_timeout" in html
-    assert "Finding:" in html
+    assert '<span class="lbl">Reason</span><span class="msg">combined_hook_timeout' in html
+    assert '<span class="lbl">Finding</span>' in html
     # gate stays healthy; no regression vocabulary leaks from the survey
     assert "HEALTHY" in html
     assert "REGRESSION" not in html and "Regression" not in html
@@ -1180,24 +1207,24 @@ def test_survey_summary_table_renders_chips_emdash_and_gate_stays_healthy():
     table = gen._survey_summary_table_html(groups)
 
     # readable headline stat (not tiny muted text) with the accurate breakdown
-    assert 'class="survey-headline"' in table
-    assert "Surveyed 3 kernels across 5 sanitizer runs" in table
+    assert 'class="statline"' in table
+    assert "Surveyed <b>3 kernels</b> across <b>5 sanitizer runs</b>" in table
     for part in ("2 pass", "1 warn", "1 fail", "1 error"):
         assert part in table
     # one row per kernel group with a stable header
-    assert "<th>Kernel</th><th>waitcheck</th><th>ConSan</th>" in table
-    # solid-color chips for every observed verdict (error/fail red, warn amber, pass green)
-    assert '<span class="vchip warn">warn</span>' in table
-    assert '<span class="vchip err">fail</span>' in table
-    assert '<span class="vchip err">error</span>' in table
-    assert '<span class="vchip pass">pass</span>' in table
+    assert "<th>Kernel</th><th>WaitCheck</th><th>ConSan</th>" in table
+    # color-coded verdict badges (error/fail red, warn amber, pass green)
+    assert '<span class="v warn">warn</span>' in table
+    assert '<span class="v fail">fail</span>' in table
+    assert '<span class="v error">error</span>' in table
+    assert '<span class="v pass">pass</span>' in table
     # the obj group's waitcheck did not run -> em dash cell, never a fake verdict
-    assert "<td>&mdash;</td>" in table
+    assert '<td><span class="dash">&mdash;</span></td>' in table
 
     # rendered on the page: gate stays HEALTHY, no regression vocabulary
     html = gen.build_html([_healthy_guardrail_run()], survey=entries)
-    assert 'class="survey-headline"' in html
-    assert "HEALTHY — 3/3 sanitizer outcomes match their baselines" in html
+    assert 'class="statline"' in html
+    assert "<strong>HEALTHY</strong>3/3 sanitizer outcomes match their baselines" in html
     assert "REGRESSION" not in html and "Regression" not in html
     assert "Unexpected outcome" not in html and "Mismatch" not in html
 
@@ -1406,9 +1433,9 @@ def _healthy_guardrail_run() -> dict:
 
 def test_survey_execution_status_renders_neutral_not_health_colored():
     # An observed-only survey error must not be health-colored on Tab 2. The
-    # committed ConSan survey reports carry execution_status="error"; the meta
-    # line must render it with the neutral `observed` style, never the red
-    # `execution bad` class the guardrail tab uses for a broken run.
+    # committed ConSan survey reports carry execution_status="error"; the facts
+    # grid must render it as plain text, never the red badge the guardrail tab
+    # uses for a broken run.
     err = {
         "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
         "overall_verdict": "error", "execution_status": "error",
@@ -1424,21 +1451,20 @@ def test_survey_execution_status_renders_neutral_not_health_colored():
     }
     survey = gen.survey_cases_from_spec({"cases": [{"name": "s", "label": "obs", "report": err}]})
     # Only non-complete execution on the page is the survey one (guardrail runs
-    # are complete), so a neutral survey render means no `execution bad` at all.
+    # are complete), so a neutral survey render means no red execution badge.
     html = gen.build_html([_healthy_guardrail_run()], survey=survey)
-    assert "execution bad" not in html
-    # execution status stays neutral (never health-colored) on the survey tab
-    assert '<span class="observed">error</span>' in html
-    # but the observed *verdict* is now a solid color-coded chip (#374 D): an error
-    # verdict is a solid-red chip. This is descriptive only -- the gate stays healthy.
-    assert '<span class="vchip err">error</span>' in html
-    assert "HEALTHY — 3/3 sanitizer outcomes match their baselines" in html
+    # execution status stays plain (never health-colored) on the survey tab
+    assert '<span class="k">Execution</span><span class="val">error</span>' in html
+    # but the observed *verdict* is a color-coded badge (#374 D): an error verdict
+    # is red. This is descriptive only -- the gate stays healthy.
+    assert '<span class="v error">error</span>' in html
+    assert "<strong>HEALTHY</strong>3/3 sanitizer outcomes match their baselines" in html
     assert "REGRESSION" not in html and "Regression" not in html
 
-    # Unit: the survey meta line neutralizes execution; the guardrail one colors it.
+    # Unit: the survey facts grid neutralizes execution; the guardrail one flags it.
     row = survey[0]["summary"]
-    assert "execution bad" not in gen._meta_line_html(row, observed=True)
-    assert "execution bad" in gen._meta_line_html(row, observed=False)
+    assert '<span class="v fail">error</span>' not in gen._facts_html(row, observed=True)
+    assert '<span class="v fail">error</span>' in gen._facts_html(row, observed=False)
 
 
 def test_build_html_renders_two_self_contained_tabs():
@@ -1458,7 +1484,9 @@ def test_build_html_renders_two_self_contained_tabs():
     assert "cdn" not in html.lower()
     assert "http://" not in html and "https://" not in html
     # explicit observed-only note on the survey tab
-    assert "No expected-behavior comparison on this tab" in html
+    assert "This tab is observational only." in html
+    # folding is pure HTML disclosure, so the no-JS promise still holds
+    assert "<details" in html and "<summary>" in html
 
 
 def test_build_html_survey_fail_is_color_coded_but_never_a_regression():
@@ -1471,10 +1499,10 @@ def test_build_html_survey_fail_is_color_coded_but_never_a_regression():
     )
     html = gen.build_html([_healthy_guardrail_run()], survey=survey)
 
-    assert "HEALTHY — 3/3 sanitizer outcomes match their baselines" in html
-    # the fail is a solid-red verdict chip (color-coded), never the neutral grey chip
-    assert '<span class="vchip err">fail</span>' in html
-    assert '<span class="observed">fail</span>' not in html
+    assert "<strong>HEALTHY</strong>3/3 sanitizer outcomes match their baselines" in html
+    # the fail is a red verdict badge (color-coded), never the neutral grey one
+    assert '<span class="v fail">fail</span>' in html
+    assert '<span class="v neutral">fail</span>' not in html
     # none of the guardrail regression vocabulary leaks in from the survey, and the
     # gate banner stays healthy (a survey fail/error is observational, never a gate).
     assert "REGRESSION" not in html and "Regression" not in html
@@ -1483,8 +1511,8 @@ def test_build_html_survey_fail_is_color_coded_but_never_a_regression():
     # is emitted for the survey case; that phrasing is guardrail-only)
     assert "survey fail case" in html
     # observation summary + inline message are present on the tab
-    assert "Observation:" in html
-    assert "Finding:" in html
+    assert '<span class="lbl">Observation</span>' in html
+    assert '<span class="lbl">Finding</span>' in html
 
 
 def test_build_html_survey_report_link_and_graceful_absence():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -375,6 +376,21 @@ def test_build_html_empty_shows_placeholder_and_back_link():
     assert "No sanitizer runs yet" in html
 
 
+def test_empty_page_styles_its_stale_banner():
+    # The empty-runs branch still renders the stale banner, which is the most
+    # safety-relevant thing on the page. It uses the shared .stale class, so the
+    # branch has to embed _CSS -- otherwise a failed nightly with no data shows
+    # the warning as an unstyled div and it reads as a broken page, not an alert.
+    status = {
+        "healthy": False, "conclusion": "failure", "run_id": "13",
+        "run_url": "https://github.com/ROCm/aorta/actions/runs/13", "date": "2026-08-05",
+    }
+    html = gen.build_html([], status=status)
+    assert 'class="stale"' in html
+    assert ".stale {" in html, "empty-runs page renders .stale without embedding _CSS"
+    assert "No sanitizer runs yet" in html
+
+
 def test_build_html_renders_stale_banner_when_unhealthy():
     rows = {
         "waitcheck": gen.summarize_case(_waitcheck_report(), "warn"),
@@ -402,6 +418,11 @@ def test_build_html_no_banner_when_healthy():
     empty = gen.build_html([], status={"healthy": False, "conclusion": "failure",
                                        "run_id": "7", "run_url": "", "date": ""})
     assert "did not complete successfully" in empty
+    # Review (#378): the banner is drawn by the .stale rules, so the empty-state
+    # document has to embed the shared sheet. Without it the one page a reader
+    # lands on when the nightly is broken shows its warning as an unstyled div.
+    assert '<div class="stale">' in empty
+    assert ".stale {" in empty
 
 
 def test_build_summary_md_stale_banner():
@@ -955,19 +976,67 @@ def test_every_white_on_solid_fill_clears_wcag_aa():
     # *not* WCAG "large text", so they need the full 4.5:1 too -- white on the
     # brand green at 85% alpha measured 2.99:1 before this was pinned.
     css = gen._CSS
-    solid_fills = {
-        "--solid-ok": "#15803D",
-        "--solid-bad": "#B91C1C",
-        ".step-num.blue": "#2563EB",
-        ".step-num.purple": "#7C3AED",
-        ".step-num.green": "#15803D",
+    # Read the colour actually bound to each selector rather than asserting a
+    # hardcoded pair: "#15803D appears somewhere in the sheet" would still pass
+    # if .step-num.green regressed, because --solid-ok uses the same value.
+    hexcolor = r"(#[0-9A-Fa-f]{6})"
+    declarations = {
+        "--solid-ok": rf"--solid-ok:\s*{hexcolor}",
+        "--solid-bad": rf"--solid-bad:\s*{hexcolor}",
+        ".step-num.blue": rf"\.step-num\.blue\s*\{{\s*background:\s*{hexcolor}",
+        ".step-num.purple": rf"\.step-num\.purple\s*\{{\s*background:\s*{hexcolor}",
+        ".step-num.green": rf"\.step-num\.green\s*\{{\s*background:\s*{hexcolor}",
     }
-    for name, fill in solid_fills.items():
-        assert fill in css, f"{name} fill {fill} is no longer in the stylesheet"
+    for selector, pattern in declarations.items():
+        match = re.search(pattern, css)
+        assert match, f"no opaque solid fill declared for {selector}"
+        fill = match.group(1)
         ratio = _contrast_with_white(fill)
-        assert ratio >= 4.5, f"white on {name} ({fill}) is {ratio:.2f}:1, below WCAG AA"
+        assert ratio >= 4.5, f"white on {selector} ({fill}) is {ratio:.2f}:1, below WCAG AA"
+    # the audited custom properties only matter while the pills still consume
+    # them, and the whole sweep only matters while this text is still white
+    assert ".pill.ok, .pill.pass { background:var(--solid-ok); }" in css
+    assert ".pill.bad, .pill.fail { background:var(--solid-bad); }" in css
+    assert re.search(r"\.pill\s*\{[^}]*color:#fff", css), ".pill no longer sets white text"
+    assert re.search(r"\.step-num\s*\{[^}]*color:#fff", css), ".step-num lost white text"
     # a semi-transparent fill under white text would silently reintroduce the bug
     assert "background:rgba(34,197,94,.85)" not in css
+
+
+def test_table_wrapper_scrolls_instead_of_clipping():
+    # Review (#378): the latest-run table carries nine columns and its headers do
+    # not wrap, so a clipping wrapper put the rightmost columns -- including the
+    # report links -- permanently out of reach on a narrow viewport.
+    rule = re.search(r"\.table-wrap\s*\{([^}]*)\}", gen._CSS)
+    assert rule, "the .table-wrap rule is no longer in the stylesheet"
+    assert "overflow-x:auto" in rule.group(1)
+    assert "overflow:hidden" not in rule.group(1)
+
+
+def test_group_run_count_matches_the_rollup_and_excludes_absent_reports():
+    # The per-kernel panel's "N sanitizer runs" chip and the roll-up's run total
+    # must agree. Counting spec entries would show 2 here and 1 above for a group
+    # whose second report is missing.
+    entries = gen.survey_cases_from_spec(
+        {"cases": [
+            {"name": "waitcheck-k", "group": "k", "sanitizer": "waitcheck",
+             "report": _waitcheck_report()},
+            {"name": "consan-k", "group": "k", "sanitizer": "consan"},  # no report
+        ]}
+    )
+    present = [e for e in entries if (e.get("summary") or {}).get("present")]
+    assert len(entries) == 2 and len(present) == 1
+
+    grouped = gen._group_survey_entries(entries)
+    assert gen._survey_summary_stats(grouped).get("runs") == 1
+
+    html = gen._survey_detail_html(entries)
+    assert '<span class="count">1 sanitizer run</span>' in html
+    assert "2 sanitizer runs" not in html
+    # the absent sanitizer still gets a card -- it is listed, not hidden, which
+    # is what the "Important Notes" copy has to describe
+    kcards = [tag for tag in re.findall(r"<details[^>]*>", html) if 'class="kcard' in tag]
+    assert len(kcards) == 2
 
 
 def test_absent_report_never_claims_no_findings():
@@ -1016,6 +1085,18 @@ def test_run_index_page_lays_out_header_and_run_card_together():
     assert "</div>" in page[page.index('<aside class="runcard">'):]
 
 
+def test_wide_tables_stay_reachable_on_narrow_viewports():
+    # The latest-run table has nine columns and th is white-space:nowrap, so a
+    # clipping wrapper would put the rightmost columns and the report links out
+    # of reach on a narrow viewport instead of letting the user scroll to them.
+    css = gen._CSS
+    match = re.search(r"\.table-wrap\s*\{([^}]*)\}", css)
+    assert match, ".table-wrap rule not found"
+    rule = match.group(1)
+    assert "overflow-x:auto" in rule.replace(" ", ""), f".table-wrap must scroll: {rule}"
+    assert "overflow:hidden" not in rule.replace(" ", "")
+
+
 def test_verdict_and_baseline_use_separate_visual_axes():
     # The verdict badge is always tinted; the baseline status pill is always
     # solid. That is what lets a red observed `fail` sit beside a green
@@ -1056,13 +1137,42 @@ def test_survey_intro_qualifies_the_both_sanitizers_claim():
     # supported degraded path (an absent/unreadable report skips a sanitizer). The
     # HTML notes + MD mirror must qualify it so the UI never claims both ran when only
     # one report exists.
+    #
+    # Review (#378): the qualification must also match what the degraded path
+    # actually renders. An absent report still gets a card (marked "report
+    # missing", no verdict), so copy claiming it "does not appear" is wrong.
     html = gen.build_html([_healthy_guardrail_run()], survey=[])
     # the old absolute claim is gone; the qualified degraded-path copy is present
     assert "shown under <b>both</b> sanitizers." not in html
-    assert "a skipped or missing scan simply does not appear" in html
+    assert "simply does not appear" not in html
+    assert "a skipped or missing scan still appears, marked report missing" in html
     md = gen.build_summary_md([_healthy_guardrail_run()], survey=[])
     assert "shown under both." not in md
-    assert "only the sanitizer(s) that ran appear" in md
+    assert "only the sanitizer(s) that ran appear" not in md
+    assert "still appears, marked report missing with no verdict" in md
+
+
+def test_survey_absent_report_still_renders_a_card_and_is_not_counted_as_a_run():
+    # Review (#378), the behavior the intro copy above promises: a survey entry
+    # whose report is missing still renders its own card so the gap is visible,
+    # but it is not a sanitizer run -- the kernel-group heading must agree with
+    # the roll-up headline instead of counting spec entries.
+    entries = gen.survey_cases_from_spec(
+        {"cases": [
+            {"name": "waitcheck-half", "group": "half", "sanitizer": "waitcheck",
+             "report": _waitcheck_report()},
+            {"name": "consan-half", "group": "half", "sanitizer": "consan"},
+        ]}
+    )
+    detail = gen._survey_detail_html(entries)
+    # both entries render a card, so the missing scan is visible rather than dropped
+    assert detail.count('<details class="kcard') == 2
+    assert "report missing" in detail
+    # ... but only the one that produced a report counts as a run
+    assert '<span class="count">1 sanitizer run</span>' in detail
+    assert "2 sanitizer runs" not in detail
+    stats = gen._survey_summary_stats(gen._group_survey_entries(entries))
+    assert stats["runs"] == 1
 
 
 def _errored_report_with_partial_findings(reason: str = "combined_hook_timeout") -> dict:

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1176,7 +1176,7 @@ def test_survey_absent_report_still_renders_a_card_and_is_not_counted_as_a_run()
     assert '<span class="count">1 sanitizer run</span>' in detail
     assert "2 sanitizer runs" not in detail
     stats = gen._survey_summary_stats(gen._group_survey_entries(entries))
-    assert stats["runs"] == 1
+    assert stats.get("runs") == 1
 
 
 def _errored_report_with_partial_findings(reason: str = "combined_hook_timeout") -> dict:

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -935,6 +935,87 @@ def test_verdict_html_colors_by_verdict():
     assert gen._verdict_html("\u2014") == '<span class="v neutral">\u2014</span>'
 
 
+def _relative_luminance(hex_color: str) -> float:
+    channels = []
+    for offset in (0, 2, 4):
+        value = int(hex_color[offset : offset + 2], 16) / 255
+        channels.append(value / 12.92 if value <= 0.03928 else ((value + 0.055) / 1.055) ** 2.4)
+    r, g, b = channels
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast_with_white(hex_color: str) -> float:
+    return 1.05 / (_relative_luminance(hex_color.lstrip("#")) + 0.05)
+
+
+def test_every_white_on_solid_fill_clears_wcag_aa():
+    # Sweep the whole class rather than one chip (precedent: the .vchip.warn
+    # contrast fix). Every solid fill that carries white text must clear 4.5:1
+    # for normal-size text. The step-number badges are 11.5px bold, which is
+    # *not* WCAG "large text", so they need the full 4.5:1 too -- white on the
+    # brand green at 85% alpha measured 2.99:1 before this was pinned.
+    css = gen._CSS
+    solid_fills = {
+        "--solid-ok": "#15803D",
+        "--solid-bad": "#B91C1C",
+        ".step-num.blue": "#2563EB",
+        ".step-num.purple": "#7C3AED",
+        ".step-num.green": "#15803D",
+    }
+    for name, fill in solid_fills.items():
+        assert fill in css, f"{name} fill {fill} is no longer in the stylesheet"
+        ratio = _contrast_with_white(fill)
+        assert ratio >= 4.5, f"white on {name} ({fill}) is {ratio:.2f}:1, below WCAG AA"
+    # a semi-transparent fill under white text would silently reintroduce the bug
+    assert "background:rgba(34,197,94,.85)" not in css
+
+
+def test_absent_report_never_claims_no_findings():
+    # An absent case also carries findings: 0, so a naive count chip would put
+    # "no findings" next to a "Report missing" pill and claim a clean scan that
+    # never ran. Sweep both tabs: the guardrail card and the survey card.
+    missing = gen.summarize_case(None, "pass")
+    assert missing["present"] is False and missing["findings"] == 0
+    assert gen._findings_chip_html(missing) == ""
+
+    rows = {
+        "waitcheck": gen.summarize_case(_waitcheck_report(), "warn"),
+        "consan-clean": missing,
+        "consan-racy": gen.summarize_case(_consan_racy_report(), "fail"),
+    }
+    html = gen.build_html(
+        [{"meta": {"run": "r1", "commit": "abc", "date": "d", "gpu": "gfx950"},
+          "rows": rows, "gate": False}]
+    )
+    assert '<span class="pill bad">Report missing</span>' in html
+    # the surviving "no findings" chip belongs to a present case, never the absent one
+    assert 'Report missing</span><span class="v neutral">' in html
+    assert '<span class="v neutral">\u2014</span><span class="findings">' not in html
+
+    # same on the survey tab, which has no baseline pill to fall back on
+    survey = gen.survey_cases_from_spec({"cases": [{"name": "s", "label": "gone"}]})
+    assert survey[0]["summary"]["present"] is False
+    card = gen._survey_case_html(survey[0], heading="gone")
+    assert "no findings" not in card
+
+
+def test_run_index_page_lays_out_header_and_run_card_together():
+    # The run card only sits top-right when it shares the .topbar flex row with
+    # the header; emitting it as a bare sibling silently drops the layout.
+    run = {
+        "meta": {"run": "2026-08-05-33", "commit": "abc", "date": "d", "gpu": "gfx950"},
+        "rows": {
+            case: gen.summarize_case(_waitcheck_report(), "warn")
+            for case, _k, _l, _b in gen.CASES
+        },
+        "gate": True,
+    }
+    page = gen.build_run_index_html(run)
+    topbar = page.index("<div class=topbar>")
+    assert topbar < page.index('<header class="page-header">') < page.index('<aside class="runcard">')
+    assert "</div>" in page[page.index('<aside class="runcard">'):]
+
+
 def test_verdict_and_baseline_use_separate_visual_axes():
     # The verdict badge is always tinted; the baseline status pill is always
     # solid. That is what lets a red observed `fail` sit beside a green

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1007,10 +1007,14 @@ def test_table_wrapper_scrolls_instead_of_clipping():
     # Review (#378): the latest-run table carries nine columns and its headers do
     # not wrap, so a clipping wrapper put the rightmost columns -- including the
     # report links -- permanently out of reach on a narrow viewport.
-    rule = re.search(r"\.table-wrap\s*\{([^}]*)\}", gen._CSS)
-    assert rule, "the .table-wrap rule is no longer in the stylesheet"
-    assert "overflow-x:auto" in rule.group(1)
-    assert "overflow:hidden" not in rule.group(1)
+    #
+    # Swept to the survey flow band for the same reason: its five steps are
+    # fixed-width, so without a scroll container they spill out of their panel.
+    for selector in (r"\.table-wrap", r"\.flow"):
+        rule = re.search(rf"{selector}\s*\{{([^}}]*)\}}", gen._CSS)
+        assert rule, f"the {selector} rule is no longer in the stylesheet"
+        assert "overflow-x:auto" in rule.group(1)
+        assert "overflow:hidden" not in rule.group(1)
 
 
 def test_group_run_count_matches_the_rollup_and_excludes_absent_reports():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1179,6 +1179,26 @@ def test_survey_absent_report_still_renders_a_card_and_is_not_counted_as_a_run()
     assert stats.get("runs") == 1
 
 
+def test_survey_absent_card_keeps_its_workload_provenance():
+    # Bugbot (#378): moving the survey meta line into the facts grid rendered the
+    # grid only on the present branch, so an absent card silently lost the
+    # "Source" pair that the pre-redesign HTML and the Markdown twin both keep.
+    # The rest of the grid stays off that branch: backend / selection /
+    # execution would describe a report that was never produced.
+    entries = gen.survey_cases_from_spec(
+        {"cases": [
+            {"name": "consan-ghost", "sanitizer": "consan", "workload": "internal:gemm_top5"},
+        ]}
+    )
+    card = gen._survey_case_html(entries[0], heading="ConSan")
+    assert "report missing" in card
+    assert '<span class="k">Source</span>' in card
+    assert "internal:gemm_top5" in card
+    assert "Backend" not in card and "Execution" not in card
+    md = "\n".join(gen._survey_section_md(entries))
+    assert "source `internal:gemm_top5`" in md
+
+
 def _errored_report_with_partial_findings(reason: str = "combined_hook_timeout") -> dict:
     # An errored ConSan run that still emitted a partial finding before aborting
     # (e.g. coverage-incomplete): overall_verdict=error AND a finding is present.

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -975,7 +975,7 @@ def test_absent_report_never_claims_no_findings():
     # "no findings" next to a "Report missing" pill and claim a clean scan that
     # never ran. Sweep both tabs: the guardrail card and the survey card.
     missing = gen.summarize_case(None, "pass")
-    assert missing["present"] is False and missing["findings"] == 0
+    assert missing.get("present") is False and missing.get("findings") == 0
     assert gen._findings_chip_html(missing) == ""
 
     rows = {
@@ -994,7 +994,7 @@ def test_absent_report_never_claims_no_findings():
 
     # same on the survey tab, which has no baseline pill to fall back on
     survey = gen.survey_cases_from_spec({"cases": [{"name": "s", "label": "gone"}]})
-    assert survey[0]["summary"]["present"] is False
+    assert survey[0].get("summary", {}).get("present") is False
     card = gen._survey_case_html(survey[0], heading="gone")
     assert "no findings" not in card
 

--- a/tests/sanitizers/test_survey_generic_gemm.py
+++ b/tests/sanitizers/test_survey_generic_gemm.py
@@ -176,8 +176,8 @@ def test_committed_spec_groups_into_three_kernels_with_both_sanitizers():
         by_san = gen._survey_group_by_sanitizer(members)
         assert set(by_san) == {"waitcheck", "consan"}
     table = gen._survey_summary_table_html(groups)
-    assert "Surveyed 3 kernels across 6 sanitizer runs" in table
-    assert "&mdash;" not in table  # every cell has a real verdict chip
+    assert "Surveyed <b>3 kernels</b> across <b>6 sanitizer runs</b>" in table
+    assert "&mdash;" not in table  # every cell has a real verdict badge
 
 
 # --- survey warn/error is neutral, never a gate regression ---
@@ -193,7 +193,8 @@ def test_survey_error_and_warn_never_flip_the_gate():
     assert "REGRESSION" not in html
     assert "**HEALTHY**" in md and "**REGRESSION**" not in md
     # survey rows are observed-only (explicit note on the tab)
-    assert "No expected-behavior comparison on this tab" in html
+    assert "This tab is observational only." in html
+    assert "Findings represent observed behavior, not regressions." in html
     # each case drills down to its published report link
     for entry in survey:
         assert entry["report_rel"] in html
@@ -202,16 +203,19 @@ def test_survey_error_and_warn_never_flip_the_gate():
 def test_build_html_renders_all_survey_kernels_with_drilldown():
     survey = _survey_entries()
     html = gen.build_html([_healthy_guardrail_run()], survey=survey)
-    # Cases are now grouped by kernel: each kernel shows a group heading with a
-    # waitcheck + ConSan sub-block (rather than six standalone case headings).
+    # Cases are grouped by kernel: each kernel is one panel holding a collapsed
+    # waitcheck card and a collapsed ConSan card (not six standalone headings).
     for group_heading in (
-        '<h3 class="survey-group">hipBLASLt GEMM f32 nt 128x128</h3>',
-        '<h3 class="survey-group">tiny_vecadd</h3>',
-        '<h3 class="survey-group">lds_reduce</h3>',
+        '<span class="kname">hipBLASLt GEMM f32 nt 128x128</span>',
+        '<span class="kname">tiny_vecadd</span>',
+        '<span class="kname">lds_reduce</span>',
     ):
         assert group_heading in html
-    assert "waitcheck (static wait-count scan)" in html
-    assert "ConSan (dynamic data-race check)" in html
+    assert html.count('<span class="name">WaitCheck</span>') == 3
+    assert html.count('<span class="name">ConSan</span>') == 3
+    # every card ships collapsed, so its summary row must carry the verdict
+    assert html.count("<details class=\"kcard") == 6 + len(gen.CASES)
+    assert "<details open" not in html
     # every case still drills down to its published raw report
     for entry in survey:
         assert entry["report_rel"] in html

--- a/tests/sanitizers/test_survey_generic_gemm.py
+++ b/tests/sanitizers/test_survey_generic_gemm.py
@@ -213,9 +213,13 @@ def test_build_html_renders_all_survey_kernels_with_drilldown():
         assert group_heading in html
     assert html.count('<span class="name">WaitCheck</span>') == 3
     assert html.count('<span class="name">ConSan</span>') == 3
-    # every card ships collapsed, so its summary row must carry the verdict
-    assert html.count("<details class=\"kcard") == 6 + len(gen.CASES)
-    assert "<details open" not in html
+    # Every card ships collapsed (its summary row carries the verdict instead).
+    # Inspect each opening tag: a substring check for '<details class="kcard'
+    # would still match '<details class="kcard wc" open>'.
+    kcards = [tag for tag in re.findall(r"<details[^>]*>", html) if 'class="kcard' in tag]
+    assert len(kcards) == 6 + len(gen.CASES)
+    opened = [tag for tag in kcards if re.search(r"\bopen\b", tag)]
+    assert not opened, f"kernel cards must ship collapsed, found: {opened}"
     # every case still drills down to its published raw report
     for entry in survey:
         assert entry["report_rel"] in html


### PR DESCRIPTION
## Summary

Presentation-layer redesign of the sanitizer nightly dashboard. **No data, schema, gate semantics, or markdown job-summary behavior change** — `build_summary_md` is untouched.

The page had grown into a wall of stacked tables. The kernel-detail section alone ran ~1100px, run provenance was a `·`-separated line, and the guardrail/survey framing sat above the tab bar where it applied to only one tab. Tab 1 now fits on roughly one screen.

### Structure

- **Page level holds only what both tabs share**: title, run card, and the WaitCheck / ConSan explainer cards. Both tabs report results from both sanitizers, so the definitions belong above the tab bar. The gate hero and the baseline banner move *into* Tab 1 — baselines do not exist on the survey tab, so a gate verdict there was misleading.
- **Detail cards and History are closed-by-default `<details>`.** The summary row carries icon, name, kind, baseline pill, verdict and findings count, so nothing has to be opened to triage a run.
- **Run provenance is a compact top-right card.** It was a row of bordered pills directly above the tab bar, which read as a second set of tabs.

### Visual

- **Dark-only.** The `prefers-color-scheme` block and the light palette are gone, so the stylesheet shrinks even as the design gains components.
- **Two colour axes that never share a surface:** identity (blue = infrastructure, purple = waitcheck, green = consan) on square icon tiles; verdict on pills. Baseline status is the only *solid* fill.
- Table body 15px (was 13px), captions 14px. Numeric column headers right-align with their cells so a value sits under its own label — previously the header was left-aligned and the number drifted to the far edge.

### Internals

- CSS lifts to a module-level `_CSS` constant, so it is no longer inside an f-string and needs no brace doubling.
- `_observed_html` + `_verdict_chip_html` collapse into one `_verdict_html` used by both tabs; `_meta_line_html` becomes the `_facts_html` grid.
- The per-run landing page shares the same stylesheet instead of carrying its own light-mode copy.

## Called out for review

**Tab 1 observed verdicts are now colour-coded.** Previously they used a neutral grey chip specifically so an expected `warn` positive control did not look like a problem. They are now tinted by verdict on both tabs, and the mitigation is hierarchy: baseline status is the only solid fill, so a red `fail` sits beside a solid green "Expected outcome" and the eye lands on the pill first. This was an explicit design decision, not an oversight — flagging it since it reverses an earlier choice.

**Observed-only semantics on Tab 2 are preserved** (KB precedent from #368 5th pass): execution status renders as plain text there, never the guardrail tab's red badge, and a survey `error` still never gates. There is a test for it.

**`fail` and `error` keep distinct class names but share one red**, matching the existing `summary.md` wording. Splitting the hues later is a CSS-only change.

## Constraints preserved

- **No JavaScript.** Tabs remain CSS `:checked` radios; folding is native `<details>`.
- **Fully self-contained** — no CDN, no external CSS, no web fonts; icons are inline SVG. Asserted in tests.
- The `:focus-visible` → label rule the visually-hidden tab radios depend on (#368) is intact; `<summary>` elements get their own focus outline.
- Untrusted survey `report_rel` values still go through `_safe_report_rel`.

## Accessibility

Every solid fill carrying white text clears WCAG AA. White on the brand green at 85% alpha measured **2.99:1** on the numbered workflow badges (11.5px bold is *not* WCAG "large text"), so all three step-number fills are pinned to opaque AA-safe shades — blue 5.2:1, purple 5.7:1, green 5.0:1. `test_every_white_on_solid_fill_clears_wcag_aa` computes the ratios and sweeps the whole class rather than the one fill that failed.

## Test plan

- [x] `pytest tests/sanitizers/test_dashboard.py tests/sanitizers/test_survey_generic_gemm.py` — 84 pass (79 before; 5 added)
- [x] `ruff check` clean
- [x] Rendered the real generator output from the committed survey spec + fixtures and inspected both tabs in a browser, collapsed and expanded, plus the per-run landing page
- [x] Exercised the failure states: missing report → `INCOMPLETE` (not mislabeled `REGRESSION`, per #353/#354), mismatch → `REGRESSION`, and the solid red "Report missing" / "Unexpected outcome" pills
- [x] Verified the emitted HTML has zero `<script>` tags and zero `http(s)://` references

New tests cover: the two visual axes, the WCAG sweep, page-level tool cards, cards shipping collapsed, an absent report never claiming "no findings", and the run-index header/run-card layout.

Made with [Cursor](https://cursor.com)