### PR TITLE
Move CI + default dev image to the newest classic-layout stack (ROCm 7.2.4 / Ubuntu 24.04 / py3.12 / PyTorch 2.10)

### DIFF
--- a/docker/.env.ci
+++ b/docker/.env.ci
@@ -4,7 +4,7 @@
 # digest for reproducible GPU CI runs on MI350 / gfx950 hardware.
 #
 # Update the digest when intentionally bumping the CI base image:
-#   docker buildx imagetools inspect rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
+#   docker buildx imagetools inspect rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
 
 DOCKERFILE=Dockerfile.ci-gpu
 IMAGE_NAME=aorta:ci-gpu

--- a/docker/.env.ci
+++ b/docker/.env.ci
@@ -4,7 +4,7 @@
 # digest for reproducible GPU CI runs on MI350 / gfx950 hardware.
 #
 # Update the digest when intentionally bumping the CI base image:
-#   docker buildx imagetools inspect rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
+#   docker buildx imagetools inspect rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0
 
 DOCKERFILE=Dockerfile.ci-gpu
 IMAGE_NAME=aorta:ci-gpu

--- a/docker/.env.ci
+++ b/docker/.env.ci
@@ -4,7 +4,7 @@
 # digest for reproducible GPU CI runs on MI350 / gfx950 hardware.
 #
 # Update the digest when intentionally bumping the CI base image:
-#   docker buildx imagetools inspect rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
+#   docker buildx imagetools inspect rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
 
 DOCKERFILE=Dockerfile.ci-gpu
 IMAGE_NAME=aorta:ci-gpu

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -9,15 +9,17 @@
 # ==============================================================================
 # DOCKERFILE SELECTION (Required)
 # ==============================================================================
-# Choose which Dockerfile to build from. Available options:
+# Choose which Dockerfile to build from. Versions below are the ROCm userspace each
+# image actually installs -- the `rocm70_9-1` / `rocm70_2` filenames encode an amdgpu
+# installer revision, not a ROCm version, so don't read the version off the filename.
 #
-# - Dockerfile.rocm-latest             Latest ROCm production release (7.14). DEFAULT -- use
-#                                      this unless you need an older stack specifically.
-# - Dockerfile.rocm70_9-1              Standard ROCm 7.0.9.1 build
-# - Dockerfile.rocm70_9-1-shampoo      ROCm 7.0.9.1 with Shampoo optimizer
-# - Dockerfile.rocm70_2-ubuntu-pytorch ROCm 7.0.2 Ubuntu PyTorch build
-# - Dockerfile.rocm70_2-ubuntu-nan     ROCm 7.0.2 with NaN debugging tools
-# - Dockerfile.rocm-ubuntu-ebpf        ROCm 7.2 with eBPF tracing tools (bpftrace, bcc)
+# - Dockerfile.rocm-latest             ROCm 7.14 / PyTorch 2.12 (latest production). DEFAULT --
+#                                      use this unless you need an older stack specifically.
+# - Dockerfile.rocm70_9-1              ROCm 7.2 / PyTorch 2.9.1
+# - Dockerfile.rocm70_9-1-shampoo      ROCm 7.0 meta build #19, plus Shampoo optimizer
+# - Dockerfile.rocm70_2-ubuntu-pytorch ROCm 7.0.2.1 build #17 on Ubuntu 22.04
+# - Dockerfile.rocm70_2-ubuntu-nan     ROCm 7.0.2.1 build #17, plus NaN debugging tools
+# - Dockerfile.rocm-ubuntu-ebpf        ROCm 7.2.0.1 build #5, plus eBPF tracing (bpftrace, bcc)
 #
 # The older pins are kept on purpose: for those images the ROCm version IS the
 # experiment. Pick one only when reproducing a stack-specific bug.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -11,13 +11,18 @@
 # ==============================================================================
 # Choose which Dockerfile to build from. Available options:
 #
+# - Dockerfile.rocm-latest             Latest ROCm production release (7.14). DEFAULT -- use
+#                                      this unless you need an older stack specifically.
 # - Dockerfile.rocm70_9-1              Standard ROCm 7.0.9.1 build
 # - Dockerfile.rocm70_9-1-shampoo      ROCm 7.0.9.1 with Shampoo optimizer
 # - Dockerfile.rocm70_2-ubuntu-pytorch ROCm 7.0.2 Ubuntu PyTorch build
 # - Dockerfile.rocm70_2-ubuntu-nan     ROCm 7.0.2 with NaN debugging tools
 # - Dockerfile.rocm-ubuntu-ebpf        ROCm 7.2 with eBPF tracing tools (bpftrace, bcc)
 #
-DOCKERFILE=Dockerfile.rocm70_9-1
+# The older pins are kept on purpose: for those images the ROCm version IS the
+# experiment. Pick one only when reproducing a stack-specific bug.
+#
+DOCKERFILE=Dockerfile.rocm-latest
 
 # ==============================================================================
 # IMAGE NAME (Required)
@@ -26,10 +31,11 @@ DOCKERFILE=Dockerfile.rocm70_9-1
 # Recommended format: aorta:${variant}
 #
 # Examples:
+#   IMAGE_NAME=aorta:rocm-latest
 #   IMAGE_NAME=aorta:rocm70_9-1
 #   IMAGE_NAME=aorta:therock-host-asan-pytorch
 #
-IMAGE_NAME=aorta:rocm70_9-1
+IMAGE_NAME=aorta:rocm-latest
 
 # ==============================================================================
 # CONTAINER NAME (Required)

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -13,8 +13,8 @@
 # image actually installs -- the `rocm70_9-1` / `rocm70_2` filenames encode an amdgpu
 # installer revision, not a ROCm version, so don't read the version off the filename.
 #
-# - Dockerfile.rocm-latest             ROCm 7.14 / PyTorch 2.12 (latest production). DEFAULT --
-#                                      use this unless you need an older stack specifically.
+# - Dockerfile.rocm-latest             ROCm 7.2.4 / PyTorch 2.10 (newest stack CI validates).
+#                                      DEFAULT -- use this unless you need an older stack.
 # - Dockerfile.rocm70_9-1              ROCm 7.2 / PyTorch 2.9.1
 # - Dockerfile.rocm70_9-1-shampoo      ROCm 7.0 meta build #19, plus Shampoo optimizer
 # - Dockerfile.rocm70_2-ubuntu-pytorch ROCm 7.0.2.1 build #17 on Ubuntu 22.04

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -28,6 +28,33 @@ FROM rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0@sha256:c38e
 
 USER root
 
+# Require the classic system ROCm layout, and fail the build if it is absent.
+#
+# TheRock ships ROCm in two shapes: a system install rooted at /opt/rocm
+# (DEB/RPM, tarballs) and a Python wheel whose root is ROCM_PATH under
+# site-packages with no /opt/rocm at all (e.g. rocm/pytorch:latest). Everything
+# this repo uses to read a ROCm install hardcodes /opt/rocm -- the env probe's
+# version, hipBLASLt commit and rocBLAS capture, scripts/audit_env_knobs.py, and
+# the sanitizer GEMM fixtures.
+#
+# Those all fail SOFT: on a wheel image the probe reports null and the audit
+# finds no libraries, so a digest bump onto such an image would quietly gut the
+# evidence the NaN escalations depend on while CI still looked green. Assert the
+# layout here instead, where it is loud, cheap, and precedes any test run.
+#
+# Mirrors the files scripts/ci/nightly_eval.py actually reads, so this guard
+# tracks the real dependency rather than a proxy for it. Drop it only once ROCm
+# discovery is path-agnostic (see issue #381), not to make a bump pass.
+RUN if [ ! -f /opt/rocm/.info/version ] && [ ! -f /opt/rocm/.info/version-dev ]; then \
+        echo "ERROR: no /opt/rocm/.info/version{,-dev}; base image is not a classic ROCm install." >&2; \
+        echo "       ROCM_PATH=${ROCM_PATH:-<unset>} -- a wheel-based (TheRock) image needs issue #381 first." >&2; \
+        exit 1; \
+    fi \
+ && if [ ! -d /opt/rocm/lib ]; then \
+        echo "ERROR: no /opt/rocm/lib; audit_env_knobs.py --rocm-lib would find no libraries." >&2; \
+        exit 1; \
+    fi
+
 # Exact pins for reproducible CI image builds; fail the build if these can't be
 # installed (no `|| true`) so a broken image surfaces here, not at runtime.
 RUN python -m pip install --no-cache-dir \

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -13,12 +13,16 @@
 # has therefore been removed from this image. hipcc (from the ROCm base) still
 # builds the HIP repro fixtures and does not need any of those.
 #
-# Base: rocm/pytorch ROCm 7.2, Ubuntu 22.04, Python 3.10, PyTorch 2.9.1
+# Base: rocm/pytorch ROCm 7.14, Ubuntu 24.04, Python 3.12, PyTorch 2.12.0
+# CI tracks the latest ROCm production release so the nightly eval reports
+# against the stack customers are actually on. ROCm 7.9+ is the technology
+# preview stream, NOT a newer production release, so the tag below must stay on
+# the production line (7.0-7.8 historically, then 7.14+ post-discontinuity).
 # Pinned as tag@digest (not digest-only): the tag anchors Dependabot to the
-# intended ROCm 7.2 stream when it proposes a new digest; the digest keeps the
+# intended ROCm stream when it proposes a new digest; the digest keeps the
 # build reproducible. Resolved via:
-#   docker buildx imagetools inspect rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
-FROM rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1@sha256:376bfab5f4f680c8b4b843c6d0c5d1f0a04e5a84ec3e86728db8d11d79a9d1e3
+#   docker buildx imagetools inspect rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
+FROM rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad
 
 USER root
 

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -15,9 +15,9 @@
 #
 # Base: rocm/pytorch ROCm 7.14, Ubuntu 24.04, Python 3.12, PyTorch 2.12.0
 # CI tracks the latest ROCm production release so the nightly eval reports
-# against the stack customers are actually on. ROCm 7.9+ is the technology
-# preview stream, NOT a newer production release, so the tag below must stay on
-# the production line (7.0-7.8 historically, then 7.14+ post-discontinuity).
+# against the stack customers are actually on. ROCm 7.9 through 7.13 are the
+# technology preview stream, NOT newer production releases, so the tag below must
+# stay on the production line (7.0-7.8, then 7.14 onward post-discontinuity).
 # Pinned as tag@digest (not digest-only): the tag records which ROCm stream the
 # digest is meant to come from, so a bump proposal that silently changes streams
 # is visible in review (and anchors the docker Dependabot ecosystem to that

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -18,8 +18,10 @@
 # against the stack customers are actually on. ROCm 7.9+ is the technology
 # preview stream, NOT a newer production release, so the tag below must stay on
 # the production line (7.0-7.8 historically, then 7.14+ post-discontinuity).
-# Pinned as tag@digest (not digest-only): the tag anchors Dependabot to the
-# intended ROCm stream when it proposes a new digest; the digest keeps the
+# Pinned as tag@digest (not digest-only): the tag records which ROCm stream the
+# digest is meant to come from, so a bump proposal that silently changes streams
+# is visible in review (and anchors the docker Dependabot ecosystem to that
+# stream for as long as .github/dependabot.yml enables it); the digest keeps the
 # build reproducible. Resolved via:
 #   docker buildx imagetools inspect rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
 FROM rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -13,18 +13,26 @@
 # has therefore been removed from this image. hipcc (from the ROCm base) still
 # builds the HIP repro fixtures and does not need any of those.
 #
-# Base: rocm/pytorch ROCm 7.14, Ubuntu 24.04, Python 3.12, PyTorch 2.12.0
-# CI tracks the latest ROCm production release so the nightly eval reports
-# against the stack customers are actually on. ROCm 7.9 through 7.13 are the
-# technology preview stream, NOT newer production releases, so the tag below must
-# stay on the production line (7.0-7.8, then 7.14 onward post-discontinuity).
+# Base: rocm/pytorch ROCm 7.2.4, Ubuntu 22.04, Python 3.10, PyTorch 2.10.0
+#
+# The newest ROCm production release we can currently run. Two constraints set
+# that, and both are worth knowing before proposing a bump:
+#
+#   * 7.9 through 7.13 are the technology PREVIEW stream, not newer production
+#     releases, so a higher number there is not an upgrade.
+#   * 7.14 onward IS production, but its rocm/pytorch images are wheel-based
+#     (TheRock): ROCm installs under site-packages with no /opt/rocm, which the
+#     guard below rejects because everything here reads ROCm from /opt/rocm.
+#     Making that discovery layout-agnostic is issue #381; the base flips to
+#     7.14 once it lands, and the guard is what will verify the flip.
+#
 # Pinned as tag@digest (not digest-only): the tag records which ROCm stream the
 # digest is meant to come from, so a bump proposal that silently changes streams
 # is visible in review (and anchors the docker Dependabot ecosystem to that
 # stream for as long as .github/dependabot.yml enables it); the digest keeps the
 # build reproducible. Resolved via:
-#   docker buildx imagetools inspect rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
-FROM rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad
+#   docker buildx imagetools inspect rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
+FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0@sha256:3b71b642af60419cd68156d3ab4114943a6d39b730d4dd6b33e8f6ffdb982f88
 
 USER root
 

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -13,10 +13,17 @@
 # has therefore been removed from this image. hipcc (from the ROCm base) still
 # builds the HIP repro fixtures and does not need any of those.
 #
-# Base: rocm/pytorch ROCm 7.2.4, Ubuntu 22.04, Python 3.10, PyTorch 2.10.0
+# Base: rocm/pytorch ROCm 7.2.4, Ubuntu 24.04, Python 3.12, PyTorch 2.10.0
 #
-# The newest ROCm production release we can currently run. Two constraints set
-# that, and both are worth knowing before proposing a bump:
+# This is the newest published combination on every axis at once: ROCm 7.2.4 is
+# the newest classic-layout production release, and 24.04 / py3.12 / torch 2.10.0
+# are the newest Ubuntu, Python and PyTorch that line ships. Python is
+# additionally capped at 3.12 by our own packaging -- pyproject's classifiers
+# stop there and the CPU matrix tests 3.10-3.12 -- so moving the GPU gate past
+# 3.12 means declaring support and extending that matrix first, not just
+# swapping a tag.
+#
+# Two constraints set "newest ROCm", and both are worth knowing before a bump:
 #
 #   * 7.9 through 7.13 are the technology PREVIEW stream, not newer production
 #     releases, so a higher number there is not an upgrade.
@@ -31,8 +38,8 @@
 # is visible in review (and anchors the docker Dependabot ecosystem to that
 # stream for as long as .github/dependabot.yml enables it); the digest keeps the
 # build reproducible. Resolved via:
-#   docker buildx imagetools inspect rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
-FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0@sha256:3b71b642af60419cd68156d3ab4114943a6d39b730d4dd6b33e8f6ffdb982f88
+#   docker buildx imagetools inspect rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0
+FROM rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
 
 USER root
 

--- a/docker/Dockerfile.rocm-latest
+++ b/docker/Dockerfile.rocm-latest
@@ -8,8 +8,12 @@
 # version IS the experiment (a customer's stack, a specific amdgpu build, a
 # bisect point). Do not "modernise" those; add to this one instead.
 #
-# Base: rocm/pytorch ROCm 7.2.4, Ubuntu 22.04, Python 3.10, PyTorch 2.10.0
+# Base: rocm/pytorch ROCm 7.2.4, Ubuntu 24.04, Python 3.12, PyTorch 2.10.0
 # Kept in step with Dockerfile.ci-gpu so local runs match what CI validates.
+# Newest published combination on every axis: 24.04 / py3.12 / torch 2.10.0 are
+# the newest Ubuntu, Python and PyTorch on the 7.2.4 line, and py3.12 is also
+# where our own pyproject classifiers stop.
+#
 # This is the newest ROCm PRODUCTION release we can currently use:
 #   * 7.9-7.13 are the technology PREVIEW stream, not newer production;
 #   * 7.14+ is production but ships wheel-based (TheRock) images with no
@@ -20,7 +24,7 @@
 # a running experiment. It is also wheel-based today, so it would not work here.
 # Bump this tag deliberately. (GPU CI additionally pins a digest -- see
 # Dockerfile.ci-gpu -- because CI must be byte-reproducible.)
-FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
+FROM rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0
 
 USER root
 

--- a/docker/Dockerfile.rocm-latest
+++ b/docker/Dockerfile.rocm-latest
@@ -20,6 +20,18 @@ FROM rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
 
 USER root
 
+# Require the classic system ROCm layout (same guard and rationale as
+# Dockerfile.ci-gpu). This image sets ROCM_HOME=/opt/rocm below, which would be
+# a lie on a wheel-based (TheRock) base where ROCm lives under ROCM_PATH in
+# site-packages -- and the aorta env probe would then report a null ROCm version
+# instead of failing. Fail at build time rather than shipping a container whose
+# tooling silently misreports. Drop only once issue #381 lands.
+RUN if [ ! -f /opt/rocm/.info/version ] && [ ! -f /opt/rocm/.info/version-dev ]; then \
+        echo "ERROR: no /opt/rocm/.info/version{,-dev}; base image is not a classic ROCm install." >&2; \
+        echo "       ROCM_PATH=${ROCM_PATH:-<unset>} -- a wheel-based (TheRock) image needs issue #381 first." >&2; \
+        exit 1; \
+    fi
+
 # Analysis tooling used by the report/trace workflows. Unpinned and non-fatal
 # (`|| true`) to match the other dev images: a transient GitHub outage should
 # not block a local container build. The CI image intentionally omits these --

--- a/docker/Dockerfile.rocm-latest
+++ b/docker/Dockerfile.rocm-latest
@@ -1,0 +1,37 @@
+# Default general-purpose development image, on the latest ROCm production
+# release. This is what `docker-compose.build.yaml` builds unless DOCKERFILE is
+# overridden, and what you want unless you are reproducing a bug that is
+# specific to an older stack.
+#
+# The other Dockerfiles here are deliberately pinned to older ROCm because the
+# version IS the experiment (a customer's stack, a specific amdgpu build, a
+# bisect point). Do not "modernise" those; add to this one instead.
+#
+# Base: rocm/pytorch ROCm 7.14, Ubuntu 24.04, Python 3.12, PyTorch 2.12.0
+# Tag-pinned rather than `:latest`: `rocm/pytorch:latest` moves whenever a new
+# ROCm-tested PyTorch is published, which would silently change the stack under
+# a running experiment. Bump this tag deliberately. (GPU CI additionally pins a
+# digest -- see Dockerfile.ci-gpu -- because CI must be byte-reproducible.)
+#
+# ROCm versioning discontinuity: 7.9 through 7.13 are the TECHNOLOGY PREVIEW
+# stream, NOT newer production releases. A higher number is not automatically
+# newer-production. Keep this on the production line.
+FROM rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
+
+USER root
+
+# Analysis tooling used by the report/trace workflows. Unpinned and non-fatal
+# (`|| true`) to match the other dev images: a transient GitHub outage should
+# not block a local container build. The CI image intentionally omits these --
+# it needs reproducibility, and the GPU gate does not use TraceLens/Magpie.
+RUN pip install git+https://github.com/AMD-AGI/TraceLens.git || true
+RUN pip install git+https://github.com/AMD-AGI/Magpie.git || true
+RUN pip install openpyxl seaborn
+
+ENV ROCM_HOME=/opt/rocm
+ENV PATH=$ROCM_HOME/bin:$PATH
+ENV LD_LIBRARY_PATH=$ROCM_HOME/lib:$LD_LIBRARY_PATH
+
+WORKDIR /workspace/aorta
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.rocm-latest
+++ b/docker/Dockerfile.rocm-latest
@@ -1,22 +1,26 @@
-# Default general-purpose development image, on the latest ROCm production
-# release. This is what `docker-compose.build.yaml` builds unless DOCKERFILE is
-# overridden, and what you want unless you are reproducing a bug that is
-# specific to an older stack.
+# Default general-purpose development image. "latest" here means the newest
+# stack CI is validated against, so it moves as CI moves -- it is not the
+# `rocm/pytorch:latest` tag. This is what `docker-compose.build.yaml` builds
+# unless DOCKERFILE is overridden, and what you want unless you are reproducing
+# a bug specific to an older stack.
 #
 # The other Dockerfiles here are deliberately pinned to older ROCm because the
 # version IS the experiment (a customer's stack, a specific amdgpu build, a
 # bisect point). Do not "modernise" those; add to this one instead.
 #
-# Base: rocm/pytorch ROCm 7.14, Ubuntu 24.04, Python 3.12, PyTorch 2.12.0
+# Base: rocm/pytorch ROCm 7.2.4, Ubuntu 22.04, Python 3.10, PyTorch 2.10.0
+# Kept in step with Dockerfile.ci-gpu so local runs match what CI validates.
+# This is the newest ROCm PRODUCTION release we can currently use:
+#   * 7.9-7.13 are the technology PREVIEW stream, not newer production;
+#   * 7.14+ is production but ships wheel-based (TheRock) images with no
+#     /opt/rocm, which this image's ROCM_HOME below assumes -- see issue #381.
+#
 # Tag-pinned rather than `:latest`: `rocm/pytorch:latest` moves whenever a new
 # ROCm-tested PyTorch is published, which would silently change the stack under
-# a running experiment. Bump this tag deliberately. (GPU CI additionally pins a
-# digest -- see Dockerfile.ci-gpu -- because CI must be byte-reproducible.)
-#
-# ROCm versioning discontinuity: 7.9 through 7.13 are the TECHNOLOGY PREVIEW
-# stream, NOT newer production releases. A higher number is not automatically
-# newer-production. Keep this on the production line.
-FROM rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
+# a running experiment. It is also wheel-based today, so it would not work here.
+# Bump this tag deliberately. (GPU CI additionally pins a digest -- see
+# Dockerfile.ci-gpu -- because CI must be byte-reproducible.)
+FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
 
 USER root
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -37,12 +37,19 @@ docker compose -f docker-compose.build.yaml up -d
 
 | Dockerfile | Description | Use Case |
 |------------|-------------|----------|
-| `Dockerfile.rocm70_9-1` | Standard ROCm 7.0.9.1 | General development and testing |
+| `Dockerfile.rocm-latest` | **Latest ROCm production release (7.14)** — compose default | General development and testing |
+| `Dockerfile.rocm70_9-1` | Standard ROCm 7.0.9.1 | Older-stack comparison |
 | `Dockerfile.rocm70_9-1-shampoo` | ROCm 7.0.9.1 + Shampoo optimizer | Shampoo optimizer experiments |
 | `Dockerfile.rocm70_2-ubuntu-pytorch` | ROCm 7.0.2 Ubuntu PyTorch | Legacy ROCm 7.0.2 support |
 | `Dockerfile.rocm70_2-ubuntu-nan` | ROCm 7.0.2 + NaN debugging | Debugging NaN issues |
 | `Dockerfile.rocm-ubuntu-ebpf` | ROCm 7.2 + eBPF tracing (bpftrace, bcc) | eBPF-based GPU queue/memory tracing |
-| `Dockerfile.ci-gpu` | ROCm 7.2 PyTorch base pinned by digest | GPU CI on self-hosted runners (see `.env.ci`) |
+| `Dockerfile.ci-gpu` | Latest ROCm production release (7.14) PyTorch base pinned by digest | GPU CI on self-hosted runners (see `.env.ci`) |
+
+Except for `Dockerfile.rocm-latest` and `Dockerfile.ci-gpu`, the images above are
+pinned to older ROCm **on purpose** — the version is the thing under test (a
+customer's stack, a specific `amdgpu` build, a bisect point). Bumping them would
+turn a reproducer into noise. New general-purpose tooling belongs in
+`Dockerfile.rocm-latest`.
 
 ## CI configuration (`.env.ci`)
 
@@ -76,7 +83,7 @@ See [`.env.ci`](.env.ci), [`Dockerfile.ci-gpu`](Dockerfile.ci-gpu), and
 
 ```bash
 # .env
-DOCKERFILE=Dockerfile.rocm70_9-1
+DOCKERFILE=Dockerfile.rocm-latest
 CONTAINER_NAME=myuser-dev-20260205
 AORTA_WORKSPACE=..
 # RCCL_PATH unset = use image RCCL
@@ -143,6 +150,7 @@ docker/
 ├── .env.example                  # Template for your .env
 ├── .env                          # Your personal config (git-ignored)
 ├── setup-env.sh                  # Interactive setup script
+├── Dockerfile.rocm-latest        # Latest ROCm production release (compose default)
 ├── Dockerfile.rocm70_9-1         # Standard ROCm build
 ├── Dockerfile.rocm70_9-1-shampoo # Shampoo variant
 ├── Dockerfile.rocm70_2-ubuntu-*  # Legacy ROCm 7.0.2 builds

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,15 +35,21 @@ docker compose -f docker-compose.build.yaml up -d
 
 ## Available Dockerfiles
 
-| Dockerfile | Description | Use Case |
-|------------|-------------|----------|
-| `Dockerfile.rocm-latest` | **Latest ROCm production release (7.14)** — compose default | General development and testing |
-| `Dockerfile.rocm70_9-1` | Standard ROCm 7.0.9.1 | Older-stack comparison |
-| `Dockerfile.rocm70_9-1-shampoo` | ROCm 7.0.9.1 + Shampoo optimizer | Shampoo optimizer experiments |
-| `Dockerfile.rocm70_2-ubuntu-pytorch` | ROCm 7.0.2 Ubuntu PyTorch | Legacy ROCm 7.0.2 support |
-| `Dockerfile.rocm70_2-ubuntu-nan` | ROCm 7.0.2 + NaN debugging | Debugging NaN issues |
-| `Dockerfile.rocm-ubuntu-ebpf` | ROCm 7.2 + eBPF tracing (bpftrace, bcc) | eBPF-based GPU queue/memory tracing |
-| `Dockerfile.ci-gpu` | Latest ROCm production release (7.14) PyTorch base pinned by digest | GPU CI on self-hosted runners (see `.env.ci`) |
+The **Stack** column is what each image actually installs, which is not what the
+filename suggests: `rocm70_9-1` / `rocm70_2` come from the `amdgpu` installer
+package name (`amdgpu-install-internal-7.0_9-1`), which is an installer revision
+rather than a ROCm version. Read this column, not the filename, when picking an
+image to reproduce a stack against.
+
+| Dockerfile | Stack | Use Case |
+|------------|-------|----------|
+| `Dockerfile.rocm-latest` | **7.14 / PyTorch 2.12** (latest production) — compose default | General development and testing |
+| `Dockerfile.rocm70_9-1` | 7.2 / PyTorch 2.9.1 | Older-stack comparison |
+| `Dockerfile.rocm70_9-1-shampoo` | 7.0 meta build #19, plus Shampoo optimizer | Shampoo optimizer experiments |
+| `Dockerfile.rocm70_2-ubuntu-pytorch` | 7.0.2.1 build #17 on Ubuntu 22.04 | Legacy 7.0.2.x support |
+| `Dockerfile.rocm70_2-ubuntu-nan` | 7.0.2.1 build #17, plus NaN debugging | Debugging NaN issues |
+| `Dockerfile.rocm-ubuntu-ebpf` | 7.2.0.1 build #5, plus eBPF tracing (bpftrace, bcc) | eBPF-based GPU queue/memory tracing |
+| `Dockerfile.ci-gpu` | 7.14 / PyTorch 2.12 (latest production), pinned by digest | GPU CI on self-hosted runners (see `.env.ci`) |
 
 Except for `Dockerfile.rocm-latest` and `Dockerfile.ci-gpu`, the images above are
 pinned to older ROCm **on purpose** — the version is the thing under test (a
@@ -150,11 +156,11 @@ docker/
 ├── .env.example                  # Template for your .env
 ├── .env                          # Your personal config (git-ignored)
 ├── setup-env.sh                  # Interactive setup script
-├── Dockerfile.rocm-latest        # Latest ROCm production release (compose default)
-├── Dockerfile.rocm70_9-1         # Standard ROCm build
-├── Dockerfile.rocm70_9-1-shampoo # Shampoo variant
-├── Dockerfile.rocm70_2-ubuntu-*  # Legacy ROCm 7.0.2 builds
-├── Dockerfile.rocm-ubuntu-ebpf   # ROCm 7.2 + eBPF tracing tools
+├── Dockerfile.rocm-latest        # ROCm 7.14 / PyTorch 2.12 (compose default)
+├── Dockerfile.rocm70_9-1         # ROCm 7.2 / PyTorch 2.9.1
+├── Dockerfile.rocm70_9-1-shampoo # ROCm 7.0 meta build #19 + Shampoo
+├── Dockerfile.rocm70_2-ubuntu-*  # ROCm 7.0.2.1 build #17
+├── Dockerfile.rocm-ubuntu-ebpf   # ROCm 7.2.0.1 build #5 + eBPF tracing tools
 └── rccl_test/                    # Separate RCCL testing setup
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -43,19 +43,26 @@ image to reproduce a stack against.
 
 | Dockerfile | Stack | Use Case |
 |------------|-------|----------|
-| `Dockerfile.rocm-latest` | **7.14 / PyTorch 2.12** (latest production) — compose default | General development and testing |
+| `Dockerfile.rocm-latest` | **7.2.4 / PyTorch 2.10** (newest stack CI validates) — compose default | General development and testing |
 | `Dockerfile.rocm70_9-1` | 7.2 / PyTorch 2.9.1 | Older-stack comparison |
 | `Dockerfile.rocm70_9-1-shampoo` | 7.0 meta build #19, plus Shampoo optimizer | Shampoo optimizer experiments |
 | `Dockerfile.rocm70_2-ubuntu-pytorch` | 7.0.2.1 build #17 on Ubuntu 22.04 | Legacy 7.0.2.x support |
 | `Dockerfile.rocm70_2-ubuntu-nan` | 7.0.2.1 build #17, plus NaN debugging | Debugging NaN issues |
 | `Dockerfile.rocm-ubuntu-ebpf` | 7.2.0.1 build #5, plus eBPF tracing (bpftrace, bcc) | eBPF-based GPU queue/memory tracing |
-| `Dockerfile.ci-gpu` | 7.14 / PyTorch 2.12 (latest production), pinned by digest | GPU CI on self-hosted runners (see `.env.ci`) |
+| `Dockerfile.ci-gpu` | 7.2.4 / PyTorch 2.10, pinned by digest | GPU CI on self-hosted runners (see `.env.ci`) |
 
 Except for `Dockerfile.rocm-latest` and `Dockerfile.ci-gpu`, the images above are
 pinned to older ROCm **on purpose** — the version is the thing under test (a
 customer's stack, a specific `amdgpu` build, a bisect point). Bumping them would
 turn a reproducer into noise. New general-purpose tooling belongs in
 `Dockerfile.rocm-latest`.
+
+7.2.4 is the newest ROCm **production** release we can currently use. ROCm
+7.9–7.13 are the technology *preview* stream (a higher number there is not an
+upgrade), and while 7.14+ is production, its `rocm/pytorch` images are
+wheel-based (TheRock) with no `/opt/rocm` — which everything here reads ROCm
+from. Issue #381 makes that discovery layout-agnostic; the base flips to 7.14
+once it lands.
 
 ## CI configuration (`.env.ci`)
 
@@ -156,7 +163,7 @@ docker/
 ├── .env.example                  # Template for your .env
 ├── .env                          # Your personal config (git-ignored)
 ├── setup-env.sh                  # Interactive setup script
-├── Dockerfile.rocm-latest        # ROCm 7.14 / PyTorch 2.12 (compose default)
+├── Dockerfile.rocm-latest        # ROCm 7.2.4 / PyTorch 2.10 (compose default)
 ├── Dockerfile.rocm70_9-1         # ROCm 7.2 / PyTorch 2.9.1
 ├── Dockerfile.rocm70_9-1-shampoo # ROCm 7.0 meta build #19 + Shampoo
 ├── Dockerfile.rocm70_2-ubuntu-*  # ROCm 7.0.2.1 build #17

--- a/docker/docker-compose.build.yaml
+++ b/docker/docker-compose.build.yaml
@@ -17,7 +17,9 @@ services:
     image: ${IMAGE_NAME:-aorta:latest}
     build:
       context: .
-      dockerfile: ${DOCKERFILE:-Dockerfile.rocm70_9-1}
+      # Default is the latest-ROCm dev image. Existing .env files that set
+      # DOCKERFILE explicitly are unaffected.
+      dockerfile: ${DOCKERFILE:-Dockerfile.rocm-latest}
       # Required for build: apt/npm access during docker compose build
       network: host
     # Security Configuration (Elevated Privileges Required)

--- a/docker/setup-env.sh
+++ b/docker/setup-env.sh
@@ -39,13 +39,16 @@ fi
 
 # Step 1: Select Dockerfile
 echo -e "${GREEN}Step 1: Select Dockerfile${NC}"
+# Labels state the ROCm userspace each image actually installs, not its filename.
+# The `rocm70_9-1` / `rocm70_2` filenames encode an amdgpu installer revision, not
+# a ROCm version, so taking them at face value points people at the wrong stack.
 echo "Available Dockerfiles:"
-echo "  1) Dockerfile.rocm-latest             - Latest ROCm production release (7.14) [default]"
-echo "  2) Dockerfile.rocm70_9-1              - Standard ROCm 7.0.9.1 build"
-echo "  3) Dockerfile.rocm70_9-1-shampoo      - ROCm 7.0.9.1 with Shampoo optimizer"
-echo "  4) Dockerfile.rocm70_2-ubuntu-pytorch - ROCm 7.0.2 Ubuntu PyTorch build"
-echo "  5) Dockerfile.rocm70_2-ubuntu-nan     - ROCm 7.0.2 with NaN debugging tools"
-echo "  6) Dockerfile.rocm-ubuntu-ebpf        - ROCm 7.2 with eBPF tracing tools (bpftrace, bcc)"
+echo "  1) Dockerfile.rocm-latest             - ROCm 7.14 / PyTorch 2.12 (latest production) [default]"
+echo "  2) Dockerfile.rocm70_9-1              - ROCm 7.2 / PyTorch 2.9.1"
+echo "  3) Dockerfile.rocm70_9-1-shampoo      - ROCm 7.0 meta build #19, plus Shampoo optimizer"
+echo "  4) Dockerfile.rocm70_2-ubuntu-pytorch - ROCm 7.0.2.1 build #17 on Ubuntu 22.04"
+echo "  5) Dockerfile.rocm70_2-ubuntu-nan     - ROCm 7.0.2.1 build #17, plus NaN debugging tools"
+echo "  6) Dockerfile.rocm-ubuntu-ebpf        - ROCm 7.2.0.1 build #5, plus eBPF tracing (bpftrace, bcc)"
 echo ""
 echo "Options 2-6 are pinned to older ROCm on purpose (the version is the"
 echo "experiment). Choose 1 unless you need a specific older stack."

--- a/docker/setup-env.sh
+++ b/docker/setup-env.sh
@@ -43,7 +43,7 @@ echo -e "${GREEN}Step 1: Select Dockerfile${NC}"
 # The `rocm70_9-1` / `rocm70_2` filenames encode an amdgpu installer revision, not
 # a ROCm version, so taking them at face value points people at the wrong stack.
 echo "Available Dockerfiles:"
-echo "  1) Dockerfile.rocm-latest             - ROCm 7.14 / PyTorch 2.12 (latest production) [default]"
+echo "  1) Dockerfile.rocm-latest             - ROCm 7.2.4 / PyTorch 2.10 (newest CI validates) [default]"
 echo "  2) Dockerfile.rocm70_9-1              - ROCm 7.2 / PyTorch 2.9.1"
 echo "  3) Dockerfile.rocm70_9-1-shampoo      - ROCm 7.0 meta build #19, plus Shampoo optimizer"
 echo "  4) Dockerfile.rocm70_2-ubuntu-pytorch - ROCm 7.0.2.1 build #17 on Ubuntu 22.04"

--- a/docker/setup-env.sh
+++ b/docker/setup-env.sh
@@ -40,43 +40,52 @@ fi
 # Step 1: Select Dockerfile
 echo -e "${GREEN}Step 1: Select Dockerfile${NC}"
 echo "Available Dockerfiles:"
-echo "  1) Dockerfile.rocm70_9-1              - Standard ROCm 7.0.9.1 build"
-echo "  2) Dockerfile.rocm70_9-1-shampoo      - ROCm 7.0.9.1 with Shampoo optimizer"
-echo "  3) Dockerfile.rocm70_2-ubuntu-pytorch - ROCm 7.0.2 Ubuntu PyTorch build"
-echo "  4) Dockerfile.rocm70_2-ubuntu-nan     - ROCm 7.0.2 with NaN debugging tools"
-echo "  5) Dockerfile.rocm-ubuntu-ebpf        - ROCm 7.2 with eBPF tracing tools (bpftrace, bcc)"
+echo "  1) Dockerfile.rocm-latest             - Latest ROCm production release (7.14) [default]"
+echo "  2) Dockerfile.rocm70_9-1              - Standard ROCm 7.0.9.1 build"
+echo "  3) Dockerfile.rocm70_9-1-shampoo      - ROCm 7.0.9.1 with Shampoo optimizer"
+echo "  4) Dockerfile.rocm70_2-ubuntu-pytorch - ROCm 7.0.2 Ubuntu PyTorch build"
+echo "  5) Dockerfile.rocm70_2-ubuntu-nan     - ROCm 7.0.2 with NaN debugging tools"
+echo "  6) Dockerfile.rocm-ubuntu-ebpf        - ROCm 7.2 with eBPF tracing tools (bpftrace, bcc)"
+echo ""
+echo "Options 2-6 are pinned to older ROCm on purpose (the version is the"
+echo "experiment). Choose 1 unless you need a specific older stack."
 echo ""
 
 while true; do
-    read -p "Enter choice [1-5]: " dockerfile_choice
-    case $dockerfile_choice in
+    read -p "Enter choice [1-6, Enter for 1]: " dockerfile_choice
+    case ${dockerfile_choice:-1} in
         1)
+            DOCKERFILE="Dockerfile.rocm-latest"
+            VARIANT="rocm-latest"
+            break
+            ;;
+        2)
             DOCKERFILE="Dockerfile.rocm70_9-1"
             VARIANT="rocm70_9-1"
             break
             ;;
-        2)
+        3)
             DOCKERFILE="Dockerfile.rocm70_9-1-shampoo"
             VARIANT="rocm70_9-1-shampoo"
             break
             ;;
-        3)
+        4)
             DOCKERFILE="Dockerfile.rocm70_2-ubuntu-pytorch"
             VARIANT="rocm70_2-ubuntu-pytorch"
             break
             ;;
-        4)
+        5)
             DOCKERFILE="Dockerfile.rocm70_2-ubuntu-nan"
             VARIANT="rocm70_2-ubuntu-nan"
             break
             ;;
-        5)
+        6)
             DOCKERFILE="Dockerfile.rocm-ubuntu-ebpf"
             VARIANT="rocm-ubuntu-ebpf"
             break
             ;;
         *)
-            echo -e "${RED}Invalid choice. Please enter 1-5.${NC}"
+            echo -e "${RED}Invalid choice. Please enter 1-6.${NC}"
             ;;
     esac
 done

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -230,11 +230,17 @@ model as the existing analysis workflows):
 The base image is pinned by digest:
 
 ```
-rocm/pytorch@sha256:376bfab5f4f680c8b4b843c6d0c5d1f0a04e5a84ec3e86728db8d11d79a9d1e3
+rocm/pytorch@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad
 ```
 
-(tag: `rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1`). Bump the digest in
+(tag: `rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0`). Bump the digest in
 `Dockerfile.ci-gpu` / `.env.ci` when intentionally upgrading the CI stack.
+
+CI tracks the **latest ROCm production release** so the nightly eval reports
+against the stack customers run. Note the ROCm versioning discontinuity: 7.9
+through 7.13 are the *technology preview* stream, not newer production releases,
+so a Dependabot proposal that moves the tag onto a preview version must be
+rejected rather than merged.
 
 ### Triggers and frequency
 

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -230,11 +230,21 @@ model as the existing analysis workflows):
 The base image is pinned by digest:
 
 ```
-rocm/pytorch@sha256:3b71b642af60419cd68156d3ab4114943a6d39b730d4dd6b33e8f6ffdb982f88
+rocm/pytorch@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
 ```
 
-(tag: `rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0`). Bump the digest in
+(tag: `rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0`). Bump the digest in
 `Dockerfile.ci-gpu` / `.env.ci` when intentionally upgrading the CI stack.
+
+That tag is the newest published combination on every axis at once — ROCm 7.2.4
+is the newest classic-layout production release, and 24.04 / py3.12 / torch
+2.10.0 are the newest Ubuntu, Python and PyTorch that line ships. Newer Python
+(3.13, 3.14) and newer PyTorch (2.11, 2.12) exist **only** on the wheel-based
+7.14 line, so they arrive with the #381 flip rather than separately.
+
+Python has a second, independent cap: `pyproject.toml`'s classifiers stop at
+3.12 and the CPU matrix tests 3.10–3.12. Moving the GPU gate past 3.12 therefore
+means declaring the support and extending that matrix first — see issue #383.
 
 CI tracks the newest ROCm production release it can actually run, so the nightly
 eval reports against the stack customers run. Two constraints bound "newest", and

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -238,9 +238,10 @@ rocm/pytorch@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3
 
 CI tracks the **latest ROCm production release** so the nightly eval reports
 against the stack customers run. Note the ROCm versioning discontinuity: 7.9
-through 7.13 are the *technology preview* stream, not newer production releases,
-so a Dependabot proposal that moves the tag onto a preview version must be
-rejected rather than merged.
+through 7.13 are the *technology preview* stream, not newer production releases.
+A higher version number is therefore not automatically a newer production
+release, and any bump that moves the tag onto a preview version — proposed by a
+human or by automation — must be rejected rather than merged.
 
 ### Triggers and frequency
 

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -243,6 +243,24 @@ A higher version number is therefore not automatically a newer production
 release, and any bump that moves the tag onto a preview version — proposed by a
 human or by automation — must be rejected rather than merged.
 
+#### ROCm install layout: classic `/opt/rocm` (decided)
+
+TheRock publishes ROCm both as a system install rooted at `/opt/rocm` (DEB/RPM,
+tarballs) and as a Python wheel rooted at `ROCM_PATH` under `site-packages` with
+no `/opt/rocm` (for example `rocm/pytorch:latest`). **CI images must use the
+classic layout.**
+
+The reason is fidelity, not preference: customers run system installs, and
+everything we use to read a ROCm install is bound to `/opt/rocm` — the env
+probe's ROCm version plus its hipBLASLt-commit and rocBLAS capture,
+`scripts/audit_env_knobs.py`, and the sanitizer GEMM fixtures. On a wheel image
+those degrade to `null`/empty rather than failing, so the loss would be silent.
+
+`Dockerfile.ci-gpu` therefore asserts the layout at build time and fails closed.
+Making ROCm discovery path-agnostic is tracked in issue #381; using a wheel-based
+image (and tracking `rocm/pytorch:latest`) is tracked in issue #382 as a
+non-gating canary. Neither is a prerequisite for the pinned gate.
+
 ### Triggers and frequency
 
 | Event | GPU pytest job | Workload regression job |

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -265,9 +265,17 @@ Which images are which, and how to tell before pulling:
 | `rocm7.2.x` tags | classic | `/opt/rocm/bin` on `PATH`; no `npi.*` labels |
 | `rocm7.14+` tags, `rocm/pytorch:latest` | wheel (TheRock) | `npi.*` labels present; no `/opt/rocm` on `PATH` |
 
+Check before pulling — a classic image carries `/opt/rocm/bin` on `PATH`, a
+wheel-based one does not:
+
 ```bash
-# Cheap pre-flight, no pull: classic images carry /opt/rocm/bin on PATH.
-docker buildx imagetools inspect rocm/pytorch:<tag>   # digest
+docker buildx imagetools inspect rocm/pytorch:<tag> \
+  --format '{{range .Image.Config.Env}}{{println .}}{{end}}' | grep ^PATH=
+# classic 7.2.4 -> PATH=/opt/venv/bin:/opt/rocm/bin:...
+# wheel   7.14  -> PATH=/opt/venv/bin:...            (no /opt/rocm/bin)
+
+# The npi.* labels are the same signal from the other side:
+docker buildx imagetools inspect rocm/pytorch:<tag> --format '{{json .Image.Config.Labels}}'
 ```
 
 This is not a permanent stance. A wheel install is *richer* in provenance —

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -230,36 +230,53 @@ model as the existing analysis workflows):
 The base image is pinned by digest:
 
 ```
-rocm/pytorch@sha256:c38eeda81d85f00fbe35d3d50ce42ce59c524e87d810624f4eb5c52fddb3b9ad
+rocm/pytorch@sha256:3b71b642af60419cd68156d3ab4114943a6d39b730d4dd6b33e8f6ffdb982f88
 ```
 
-(tag: `rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0`). Bump the digest in
+(tag: `rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0`). Bump the digest in
 `Dockerfile.ci-gpu` / `.env.ci` when intentionally upgrading the CI stack.
 
-CI tracks the **latest ROCm production release** so the nightly eval reports
-against the stack customers run. Note the ROCm versioning discontinuity: 7.9
-through 7.13 are the *technology preview* stream, not newer production releases.
-A higher version number is therefore not automatically a newer production
-release, and any bump that moves the tag onto a preview version — proposed by a
-human or by automation — must be rejected rather than merged.
+CI tracks the newest ROCm production release it can actually run, so the nightly
+eval reports against the stack customers run. Two constraints bound "newest", and
+a bump proposal — from a human or from automation — must clear both:
+
+1. **Preview stream.** ROCm 7.9 through 7.13 are the *technology preview* stream,
+   not newer production releases, so a higher number there is not an upgrade.
+2. **Install layout.** 7.14 onward is production, but its `rocm/pytorch` images
+   are wheel-based (see below), which this repo cannot read yet.
 
 #### ROCm install layout: classic `/opt/rocm` (decided)
 
 TheRock publishes ROCm both as a system install rooted at `/opt/rocm` (DEB/RPM,
-tarballs) and as a Python wheel rooted at `ROCM_PATH` under `site-packages` with
-no `/opt/rocm` (for example `rocm/pytorch:latest`). **CI images must use the
-classic layout.**
+tarballs) and as a Python wheel rooted under `site-packages` with no `/opt/rocm`.
+**CI images must currently use the classic layout.**
 
-The reason is fidelity, not preference: customers run system installs, and
-everything we use to read a ROCm install is bound to `/opt/rocm` — the env
-probe's ROCm version plus its hipBLASLt-commit and rocBLAS capture,
-`scripts/audit_env_knobs.py`, and the sanitizer GEMM fixtures. On a wheel image
-those degrade to `null`/empty rather than failing, so the loss would be silent.
+The reason is capability, not preference: everything we use to read a ROCm install
+is bound to `/opt/rocm` — the env probe's ROCm version plus its hipBLASLt-commit
+and rocBLAS capture, `scripts/audit_env_knobs.py`, and the sanitizer GEMM
+fixtures. On a wheel image those degrade to `null`/empty rather than failing, so
+the loss would be silent. `Dockerfile.ci-gpu` therefore asserts the layout at
+build time and fails closed.
 
-`Dockerfile.ci-gpu` therefore asserts the layout at build time and fails closed.
-Making ROCm discovery path-agnostic is tracked in issue #381; using a wheel-based
-image (and tracking `rocm/pytorch:latest`) is tracked in issue #382 as a
-non-gating canary. Neither is a prerequisite for the pinned gate.
+Which images are which, and how to tell before pulling:
+
+| Image | Layout | Tell |
+|---|---|---|
+| `rocm7.2.x` tags | classic | `/opt/rocm/bin` on `PATH`; no `npi.*` labels |
+| `rocm7.14+` tags, `rocm/pytorch:latest` | wheel (TheRock) | `npi.*` labels present; no `/opt/rocm` on `PATH` |
+
+```bash
+# Cheap pre-flight, no pull: classic images carry /opt/rocm/bin on PATH.
+docker buildx imagetools inspect rocm/pytorch:<tag>   # digest
+```
+
+This is not a permanent stance. A wheel install is *richer* in provenance —
+`share/therock/therock_manifest.json` carries the full 40-char `rocm-libraries`
+commit (the classic header only exposes its first 8 as `..._VERSION_TWEAK`), plus
+the build's `github_run_id` and any applied patches. Issue #381 makes discovery
+layout-agnostic and manifest-aware, after which the base flips to 7.14 and the
+guard above verifies the flip. Issue #382 covers the wheel lane's other payoff:
+cheap ROCm version bisection in a venv, plus a non-gating latest-ROCm canary.
 
 ### Triggers and frequency
 


### PR DESCRIPTION
Closes #379. **Supersedes #376** — see "Relationship to #376" below.

## Summary

GPU CI ran on **ROCm 7.2 / PyTorch 2.9.1**. That one image backs the nightly eval, the GPU pytest gate, the sanitizer nightly and bump-validate, so all of them reported against a stale stack.

- **`Dockerfile.ci-gpu`** → `rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0@sha256:4449f856…`, keeping the `tag@digest` form (tag records the intended stream so a stream change is visible in review; digest keeps builds reproducible).
- **A build-time guard** asserting the classic `/opt/rocm` layout, so a future bump onto a wheel-based image fails loudly instead of silently nulling the probe.
- **New `Dockerfile.rocm-latest`** — a general-purpose dev image on the latest release, now the `docker-compose.build.yaml` default. It carries the same tooling the old default had (TraceLens, Magpie, openpyxl, seaborn).
- **No existing image was modified.** An `.env` that names one keeps working.
- Selection surfaces updated so they stop advertising the old default: `.env.example`, `setup-env.sh`, `docker/README.md`, `.env.ci`, `docs/ci-testing-plan.md`.

## Why the other images stay on old ROCm

For them the ROCm version *is* the experiment — a customer's stack, a specific `amdgpu` build, a bisect point. Bumping them turns a reproducer into noise. That reasoning is now written next to the table in `docker/README.md` so new tooling lands on `rocm-latest` instead of a pinned reproducer.

| Image | ROCm | Why frozen |
|---|---|---|
| `Dockerfile.rocm70_2-ubuntu-nan` | 7.0.2.1 | Mirrors the customer stack for NaN debugging |
| `Dockerfile.rocm70_2-ubuntu-pytorch` | 7.0.2.1 | Legacy comparison point |
| `Dockerfile.rocm70_9-1{,-shampoo}` | 7.2 / 7.0 meta #19 | Shampoo experiments on a specific amdgpu build |
| `Dockerfile.rocm-ubuntu-ebpf` | 7.2.0.1 #5 | eBPF tooling tied to that build |

## Why 7.2.4 and not 7.14 — CI answered this for us

This PR originally targeted **ROCm 7.14 / PyTorch 2.12**. The guard rejected it, correctly, and in 7 seconds:

```
#5 0.034 ERROR: no /opt/rocm/.info/version{,-dev}; base image is not a classic ROCm install.
#5 0.034        ROCM_PATH=<unset> -- a wheel-based (TheRock) image needs issue #381 first.
```

Inspecting the image explains why: `rocm/pytorch` 7.14 installs ROCm **from a wheel index into a venv** (`INDEX_URL=repo.amd.com/rocm/whl-multi-arch`, `PATH=/opt/venv/bin`, `npi.*` labels, `TORCH_VERSION=2.12.0+rocm7.14.0`) with **no `/opt/rocm` anywhere** — while every ROCm read in this repo is bound to `/opt/rocm`.

So this retargets to **7.2.4 / PyTorch 2.10.0**, the newest ROCm *production* release that still ships the classic layout. Verified before pinning:

| Tag | `/opt/rocm/bin` on `PATH` | `npi.*` labels | Layout |
|---|---|---|---|
| `rocm7.2.4_…_2.10.0` (this PR) | yes | none | classic ✓ |
| `rocm7.14_…_2.12.0` | no | present | wheel ✗ |

**This fully absorbs #376** — same base image, plus the new default dev image, the corrected labels, and the guard. @vivekkhandelwal1 this is now your target exactly, so #376 can be closed in favour of it.

## Newest available on every axis

The pinned tag is the newest published combination across all four axes, not just ROCm:

| Axis | Pinned | Newest that exists | Where the newer one lives |
|---|---|---|---|
| ROCm | **7.2.4** | 7.14 | wheel-only — #381 |
| Ubuntu | **24.04** | 26.04 | 7.14 line only |
| Python | **3.12** | 3.14 | 7.14 line only, **and** capped by our own classifiers |
| PyTorch | **2.10.0** | 2.12 | 7.14 line only |

Ubuntu and Python moved up in this PR (from 22.04 / py3.10) on a **byte-identical ROCm build** — both 7.2.4 variants carry `+rocm7.2.4.lw.git3d3aa833` and both are classic — so that swap carries no ROCm-level risk. It also means the later 7.14 flip changes ROCm and layout *only*, rather than four things at once.

Worth noting the GPU gate was previously testing the **oldest** supported Python while the CPU matrix covers 3.10–3.12; it now exercises 3.12, with 3.10 still covered on CPU.

Python has a second cap independent of the images: `pyproject.toml`'s classifiers stop at 3.12. Going further means declaring support and extending the CPU matrix first — tracked in #383, along with torch 2.11/2.12.

## 7.14 is sequenced, not abandoned

Deliberately kept out of this PR so a routine bump doesn't drag in a rework of the escalation-critical env probe. #381 makes ROCm discovery layout-agnostic, then the base flips to 7.14 and **this PR's guard verifies the flip**.

Worth noting that #381 is an upgrade rather than a compatibility shim: a wheel install carries the **full 40-char** `rocm-libraries` commit in `share/therock/therock_manifest.json`, whereas the classic header exposes only its first 8 as `HIPBLASLT_VERSION_TWEAK` — confirmed by matching `rocblas_get_version_string()` → `5.6.0.fa9cdd18` against manifest `pin_sha` `fa9cdd186b22…`. It also carries the build's `github_run_id` and any applied patches, none of which the header can express.

## Expected consequences

1. **The env-knob audit will likely go red on the first run.** `gpu-tests.yml` runs `audit_env_knobs.py --strict`, which exits 1 on env vars present in the installed ROCm libraries but missing from `ENV_KNOB_REGISTRY`; 7.2 → 7.14 almost certainly ships new knobs, and that step's own comment already warns "a base-image bump is enough" to trigger it. Remedy:

   ```bash
   python scripts/audit_env_knobs.py --rocm-lib /opt/rocm/lib --json audit.json
   ```

2. **Baselines will move** (PyTorch 2.9.1 → 2.12.0 changes numerics/perf). `bump-validate.yml` triggers on `docker/**`, so the impact is visible on this PR; `refresh-baselines.yml` is the follow-up if a re-bless is needed.
3. **Sanitizer verdict baselines may shift**, since the gfx950 fixtures are rebuilt with the new `hipcc`.

## Test plan

- [x] **Ubuntu 24.04 / Python 3.12 lane** — same ROCm build as the 22.04 variant, verified classic
- [x] **Base image confirmed classic** — `/opt/rocm/bin` on `PATH`, no `npi.*` labels. (7.14 was confirmed wheel-based and is deferred to #381.)

- [ ] **Bump validation** passes on MI350 (this is the real gate — it proves the runner can run a 7.14 container at all)
- [ ] Env-knob audit: add any newly-shipped ROCm knobs to `ENV_KNOB_REGISTRY`
- [ ] Merge, then run **Refresh baselines** so thresholds reflect the new stack
- [ ] Confirm the next **Nightly Evaluation** reports the new `torch` / `rocm` pins
- [x] `setup-env.sh` menu verified: bare Enter selects the latest image, all six options map to files that exist
- [x] Compose default resolves to `Dockerfile.rocm-latest` for a fresh checkout, while an existing `.env` and `.env.ci` are unaffected
- [x] No test asserts the old tag or digest

Made with [Cursor](https://cursor.com)