### PR TITLE
feat(sanitizers): publish a reproducible run area per dashboard case

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -465,8 +465,14 @@ jobs:
           # The digest-pinned ROCm base image the sanitizers actually ran in.
           AORTA_CI_IMAGE="$(sed -n 's/^FROM  *//p' docker/Dockerfile.ci-gpu | tail -n1)"
           export AORTA_CI_IMAGE
+          # --current-run names the run THIS job staged. Without it the generator
+          # assumes the newest retained run, which is wrong when an older workflow
+          # is re-run after a newer same-day one: the re-run reuses its lower
+          # GITHUB_RUN_ID, so its dir sorts behind and the newer area would be
+          # stamped with this job's container/bundle/recipe (#384).
           python scripts/sanitizers/gen_sanitizer_dashboard.py \
             --history-root "$runs_dir" --keep "$keep" --keep-logs 7 \
+            --current-run "$run_dir_id" \
             --baselines recipes/sanitizers/fixtures/expected/verdict_baselines.json \
             --commit "${GITHUB_SHA}" --run-label "run ${GITHUB_RUN_ID}" \
             --status status.json \

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -410,6 +410,14 @@ jobs:
             fi
           done
 
+          # Report what this run adds. --keep-logs bounds the checkout, but a blob
+          # stays reachable from the commit that added it, so anything published
+          # here is permanent in the branch history -- if real ConSan logs turn out
+          # large, capping them is a code change now and a history rewrite later
+          # (#384). Print the number every night so that is never a surprise.
+          echo "[$(date +%T)] staged case-dir sizes (pre-gzip):"
+          du -sh "$dest"/* 2>/dev/null | sed 's/^/  /' || true
+
           # Per-run manifest read back by gen_sanitizer_dashboard.py --history-root.
           # gate mirrors the GPU job result (its comparator step is the gate); the
           # rendered history recomputes it from the reports + baselines regardless.

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -148,6 +148,14 @@ jobs:
               print(\"ROCJITSU bundle commit:\", m.get(\"commit\"), \
               \"run:\", m.get(\"run_url\"))" \
               "${ROCJITSU_PREBUILT}/MANIFEST.json"
+            # Carry that provenance into the uploaded results so the publish job
+            # (a different runner, which never sees the bundle) can record which
+            # sanitizer build produced each report in its run area (#384).
+            mkdir -p "${SANITIZER_OUT}"
+            python -c "import json,sys; m=json.load(open(sys.argv[1])); \
+              json.dump({\"commit\": m.get(\"commit\"), \"run_url\": m.get(\"run_url\")}, \
+              open(sys.argv[2], \"w\"), indent=2, sort_keys=True)" \
+              "${ROCJITSU_PREBUILT}/MANIFEST.json" "${SANITIZER_OUT}/rocjitsu.json"
 
             # hipcc shells out to clang-offload-bundler, which lives in the ROCm
             # LLVM bindir but is not on PATH -- the image only exports
@@ -392,11 +400,13 @@ jobs:
           # a now-missing case (the generator fails such a case closed).
           rm -rf "$dest"
           mkdir -p "$dest"
+          # Copy the whole case directory, not just the report: the sanitizer
+          # logs the verdict was derived from (waitcheck/*.log, consan/consan.log)
+          # are what make the published run area reproducible (#384). The
+          # generator gzips them and prunes them outside its --keep-logs window.
           for case in waitcheck consan-clean consan-racy; do
-            report="incoming/${case}/sanitizer_report.json"
-            if [ -f "$report" ]; then
-              mkdir -p "$dest/${case}"
-              cp -a "$report" "$dest/${case}/sanitizer_report.json"
+            if [ -f "incoming/${case}/sanitizer_report.json" ]; then
+              cp -a "incoming/${case}" "$dest/${case}"
             fi
           done
 
@@ -444,8 +454,19 @@ jobs:
           if [ -d incoming/informational ]; then
             info_arg=(--informational-results-dir incoming/informational)
           fi
+          # Provenance the reports themselves cannot carry, recorded into each
+          # run area's env.json / REPRODUCE.md (#384). Both are best-effort: an
+          # absent value is omitted rather than published empty.
+          if [ -f incoming/rocjitsu.json ]; then
+            AORTA_ROCJITSU_COMMIT="$(python -c "import json;print(json.load(open('incoming/rocjitsu.json')).get('commit') or '')")"
+            AORTA_ROCJITSU_RUN_URL="$(python -c "import json;print(json.load(open('incoming/rocjitsu.json')).get('run_url') or '')")"
+            export AORTA_ROCJITSU_COMMIT AORTA_ROCJITSU_RUN_URL
+          fi
+          # The digest-pinned ROCm base image the sanitizers actually ran in.
+          AORTA_CI_IMAGE="$(sed -n 's/^FROM  *//p' docker/Dockerfile.ci-gpu | tail -n1)"
+          export AORTA_CI_IMAGE
           python scripts/sanitizers/gen_sanitizer_dashboard.py \
-            --history-root "$runs_dir" --keep "$keep" \
+            --history-root "$runs_dir" --keep "$keep" --keep-logs 7 \
             --baselines recipes/sanitizers/fixtures/expected/verdict_baselines.json \
             --commit "${GITHUB_SHA}" --run-label "run ${GITHUB_RUN_ID}" \
             --status status.json \

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -64,14 +64,15 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    previous green page). Only sanitizer data produced by a `main` run is
    published.
 
-   Each nightly's raw per-case `sanitizer_report.json` files are co-located on the
-   `sanitizer-results` data branch under `dashboard/runs/<YYYY-MM-DD>-<run_id>/`
-   (one `<case>/sanitizer_report.json` per recipe plus a `meta.json` with commit /
-   date / gpu / run_url / gate), and the rendered page links to them: the latest
-   run table has a per-recipe **Report** link, the kernel-detail sections carry a
-   "view raw report" link, and each **Run** row in the history table links to its
-   `runs/<id>/` area. A tiny `runs/<id>/index.html` landing page lists that run's
-   three reports. Because `pages.yml` copies `dashboard/*` recursively into
+   Each nightly's per-case results are co-located on the `sanitizer-results` data
+   branch under `dashboard/runs/<YYYY-MM-DD>-<run_id>/` (one directory per
+   guardrail recipe, one under `survey/` per observed-only case, plus a
+   `meta.json` with commit / date / gpu / run_url / gate), and the rendered page
+   links to them: the latest run table has a per-recipe **Report** link, each
+   kernel-detail card carries a **run area** link to the case's directory, and
+   each **Run** row in the history table links to its `runs/<id>/` area. A
+   `runs/<id>/index.html` landing page lists that run's guardrail reports and its
+   survey cases. Because `pages.yml` copies `dashboard/*` recursively into
    `_site/sanitizers/`, everything under `runs/` is served at
    `/sanitizers/runs/...` with relative links and no change to `pages.yml`. The
    publish job keeps a rolling window of the newest **30** run directories
@@ -79,6 +80,33 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    pruned. Previously these raw reports lived only in an expiring Actions
    artifact and were never linked; the rolling window makes them durable and
    reachable from the page.
+
+   **Run areas (#384).** A case directory is not just its report -- it carries
+   everything needed to reproduce that case locally, so the copy-paste command
+   the dashboard shows is actionable:
+
+   | File | What it is |
+   | --- | --- |
+   | `index.html` | Landing page: the command, run identity, observed verdict, and every file below as a download. GitHub Pages does not auto-index a directory, so this is what makes the run-area link resolve. |
+   | `sanitizer_report.json` | The full `aorta.sanitizer_report/0.1` document the dashboard renders from. |
+   | `consan/consan.log.gz`, `waitcheck/waitcheck-*.log.gz` | The sanitizer output the verdict was derived from, gzipped. |
+   | `recipe.yaml` | The recipe exactly as it ran, pinned to this run. |
+   | `inputs/` | The recipe's source-level fixture inputs (the `.hip` repro sources, the GEMM shape CSV) -- a few KB in total. |
+   | `REPRODUCE.md` | Commit, command, required env, fixture rebuild steps, and the digests of the artifacts that are not published. |
+   | `env.json` | The same provenance, machine-readable (`aorta.sanitizer_run_area/0.1`). |
+
+   CI-built artifacts are deliberately **not** published: a GEMM `.hsaco` is
+   ~16MB, and shipping one per retained run would bloat the data branch and
+   Pages. `REPRODUCE.md` / `env.json` instead record each one's path and SHA-256
+   (taken from the report, which already carries the waitcheck binary digest, the
+   ConSan repro command and hook digests, and every kernel's `code_object_sha256`)
+   plus the command to rebuild it, so a local rebuild can be verified.
+
+   Logs, the recipe copy and its inputs are kept only for the newest **7** runs
+   (`--keep-logs 7`) -- guardrail and survey areas alike -- while reports stay for
+   the full 30. An older run keeps its report, manifests and landing page, and
+   both are re-rendered when it is pruned so the page lists only the files still
+   present and `env.json` stops naming the inputs it no longer carries.
 
    The dashboard previously lived at `/ci/`, so that path is kept: `/ci/`
    redirects to the root and `/ci/data.json` is published alongside

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -93,7 +93,7 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    | `recipe.yaml` | The recipe exactly as it ran, pinned to this run. |
    | `inputs/` | The recipe's source-level fixture inputs (the `.hip` repro sources, the GEMM shape CSV) -- a few KB in total. |
    | `REPRODUCE.md` | Commit, command, required env, fixture rebuild steps, and the digests of the artifacts that are not published. |
-   | `env.json` | The same provenance, machine-readable (`aorta.sanitizer_run_area/0.1`). |
+   | `env.json` | The same provenance, machine-readable (`aorta.sanitizer_run_area/0.1`), including `required_env` (each variable, who sets it, and why) and `rebuild` (the per-artifact commands). `REPRODUCE.md` and the landing page are rendered *from* those two fields, so the prose cannot disagree with them. |
 
    CI-built artifacts are deliberately **not** published: a GEMM `.hsaco` is
    ~16MB, and shipping one per retained run would bloat the data branch and

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -211,13 +211,23 @@ the `ci-results` data branch (older ones are pruned), and the dashboard renders 
 most the last 180 builds (`gen_dashboard.py --max-builds`). Files are tiny; adjust
 the cap in `nightly-eval.yml` / the flag if a longer window is wanted.
 
-The **sanitizer** nightly keeps a separate rolling window on the
-`sanitizer-results` data branch: the newest **30** `dashboard/runs/<id>/`
-directories (each holding that run's three raw `sanitizer_report.json` files and a
-`meta.json`). The publish job prunes older ones and re-renders with
-`gen_sanitizer_dashboard.py --history-root dashboard/runs --keep 30`; adjust
-`keep` in `sanitizers-nightly.yml` (and the matching `--keep`) to change the
-window.
+The **sanitizer** nightly keeps its own rolling window on the `sanitizer-results`
+data branch, and it has **two** bounds rather than one:
+
+- **Reports: newest 30 runs.** `dashboard/runs/<id>/` holds one directory per
+  guardrail recipe, one under `survey/` per observed-only case, and a `meta.json`.
+  Each case directory is a *run area* (report, gzipped logs, `recipe.yaml`,
+  `inputs/`, `REPRODUCE.md`, `env.json`, `index.html`) — see the run-area table
+  earlier in this document. The publish job prunes older runs and re-renders with
+  `gen_sanitizer_dashboard.py --history-root dashboard/runs --keep 30`.
+- **Bulk: newest 7 runs.** `--keep-logs 7` bounds the logs, the recipe copy and
+  the copied inputs, for guardrail and survey areas alike. An older run keeps its
+  report, manifests and landing page; its bulk is pruned and the area is
+  re-rendered so the page lists only what is still there. Pruning is one-way —
+  raising `--keep-logs` later does not bring deleted logs back.
+
+Adjust `keep` in `sanitizers-nightly.yml` (and the matching `--keep`) for the
+report window, and `--keep-logs` for the bulk window.
 
 ## Operating checklist
 

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -229,6 +229,17 @@ data branch, and it has **two** bounds rather than one:
 Adjust `keep` in `sanitizers-nightly.yml` (and the matching `--keep`) for the
 report window, and `--keep-logs` for the bulk window.
 
+Both windows bound the **checkout**, not the branch history. Pruning deletes a
+file from the working tree, but the blob stays reachable from the commit that
+added it, so every log ever published remains in `.git` even after its area is
+pruned — `sanitizer-results` accumulates ordinary commits indefinitely. Day to
+day that costs nothing (the publish job clones `--depth 1` and Pages deploys from
+the workspace copy), so the exposure is remote repository size. It does change the
+deadline for one decision, though: if real ConSan logs turn out large, capping
+their size is a code change *before* the first publish and a history rewrite
+afterwards. Measure them on the first nightly (`du -sh` the staged case dirs in
+the publish job) rather than waiting for the branch to grow.
+
 ## Operating checklist
 
 1. Set GitHub Pages **source = "GitHub Actions"** (Settings -> Pages). This

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -93,7 +93,7 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    | `recipe.yaml` | The recipe exactly as it ran, pinned to this run. |
    | `inputs/` | The recipe's source-level fixture inputs (the `.hip` repro sources, the GEMM shape CSV) -- a few KB in total. |
    | `REPRODUCE.md` | Commit, command, required env, fixture rebuild steps, and the digests of the artifacts that are not published. |
-   | `env.json` | The same provenance, machine-readable (`aorta.sanitizer_run_area/0.1`), including `required_env` (each variable, who sets it, and why) and `rebuild` (the per-artifact commands). `REPRODUCE.md` and the landing page are rendered *from* those two fields, so the prose cannot disagree with them. |
+   | `env.json` | The same provenance, machine-readable (`aorta.sanitizer_run_area/0.1`), including `required_env` (each variable, who sets it, and why -- ConSan's four are listed only for a case that ran ConSan) and `rebuild` (the per-artifact commands, runnable from the repo root). `REPRODUCE.md` and the landing page are rendered *from* those two stored fields, so the prose cannot disagree with them and a retained area keeps describing what it actually recorded. |
 
    CI-built artifacts are deliberately **not** published: a GEMM `.hsaco` is
    ~16MB, and shipping one per retained run would bloat the data branch and
@@ -111,6 +111,13 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    rather than compiled; and each `consan_load` / `lds_dispatch` binary needs the
    `-DOBJECT` / `-DLDS_HSACO` define naming the object it loads. A generic
    "`hipcc` it" hint would build a different file and fail the digest check.
+
+   The commands are also written to be pasted as-is from the repo root, which is
+   where the `git clone` in `REPRODUCE.md` leaves you: fixture paths are rooted at
+   `recipes/sanitizers/fixtures/...` (there is no top-level `fixtures/`), the
+   gitignored output directory is created first, and the conditional unbundle is a
+   single `if ... else cp ... fi` command rather than a prose aside, so an
+   automated consumer of `rebuild` can execute the list without interpreting it.
 
    Logs, the recipe copy and its inputs are kept only for the newest **7** runs
    (`--keep-logs 7`) -- guardrail and survey areas alike -- while reports stay for

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -114,10 +114,13 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
 
    The commands are also written to be pasted as-is from the repo root, which is
    where the `git clone` in `REPRODUCE.md` leaves you: fixture paths are rooted at
-   `recipes/sanitizers/fixtures/...` (there is no top-level `fixtures/`), the
-   gitignored output directory is created first, and the conditional unbundle is a
-   single `if ... else cp ... fi` command rather than a prose aside, so an
-   automated consumer of `rebuild` can execute the list without interpreting it.
+   `recipes/sanitizers/fixtures/...` (there is no top-level `fixtures/`), each one
+   starts by putting the ROCm LLVM bindir on `PATH` (the container exports only
+   `/opt/rocm/bin`, while `clang-offload-bundler` -- which `hipcc` and
+   `prepare_gemm_isa.py` both need -- lives beside the compilers) and creating the
+   gitignored output directory, and the conditional unbundle is a single
+   `if ... else cp ... fi` command rather than a prose aside, so an automated
+   consumer of `rebuild` can execute the list without interpreting it.
 
    Logs, the recipe copy and its inputs are kept only for the newest **7** runs
    (`--keep-logs 7`) -- guardrail and survey areas alike -- while reports stay for

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -87,7 +87,7 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
 
    | File | What it is |
    | --- | --- |
-   | `index.html` | Landing page: the command, run identity, observed verdict, and every file below as a download. GitHub Pages does not auto-index a directory, so this is what makes the run-area link resolve. |
+   | `index.html` | Landing page: the command, the env a reproduction needs, run identity, observed verdict, the recorded digests (including each `code_object_sha256`), the fixture rebuild steps, and every file below as a download. GitHub Pages does not auto-index a directory, so this is what makes the run-area link resolve. |
    | `sanitizer_report.json` | The full `aorta.sanitizer_report/0.1` document the dashboard renders from. |
    | `consan/consan.log.gz`, `waitcheck/waitcheck-*.log.gz` | The sanitizer output the verdict was derived from, gzipped. |
    | `recipe.yaml` | The recipe exactly as it ran, pinned to this run. |
@@ -97,10 +97,20 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
 
    CI-built artifacts are deliberately **not** published: a GEMM `.hsaco` is
    ~16MB, and shipping one per retained run would bloat the data branch and
-   Pages. `REPRODUCE.md` / `env.json` instead record each one's path and SHA-256
-   (taken from the report, which already carries the waitcheck binary digest, the
-   ConSan repro command and hook digests, and every kernel's `code_object_sha256`)
-   plus the command to rebuild it, so a local rebuild can be verified.
+   Pages. `index.html` / `REPRODUCE.md` / `env.json` instead record each one's
+   path and SHA-256 (taken from the report, which already carries the waitcheck
+   binary digest, the ConSan repro command and hook digests, and every kernel's
+   `code_object_sha256`) plus the command to rebuild it, so a local rebuild can
+   be verified.
+
+   Those rebuild commands are per-artifact, because they are not
+   interchangeable: a `--genco` code object is a raw ELF on some ROCm builds and
+   a clang-offload bundle on others, so it must be unbundled conditionally (the
+   recorded digest is of the unbundled object the loader opens); the GEMM objects
+   are *extracted* from the shipped Tensile libraries by `prepare_gemm_isa.py`
+   rather than compiled; and each `consan_load` / `lds_dispatch` binary needs the
+   `-DOBJECT` / `-DLDS_HSACO` define naming the object it loads. A generic
+   "`hipcc` it" hint would build a different file and fail the digest check.
 
    Logs, the recipe copy and its inputs are kept only for the newest **7** runs
    (`--keep-logs 7`) -- guardrail and survey areas alike -- while reports stay for

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -898,7 +898,10 @@ def _load_survey_report(report_path: str, base_dir: Path | None) -> dict[str, An
 
 
 def survey_cases_from_spec(
-    spec: dict[str, Any] | list[Any], *, base_dir: Path | None = None
+    spec: dict[str, Any] | list[Any],
+    *,
+    base_dir: Path | None = None,
+    rel: str | None = None,
 ) -> list[dict[str, Any]]:
     """Build ordered observed-only *survey* case entries from a spec (pure-ish).
 
@@ -991,17 +994,24 @@ def survey_cases_from_spec(
                 # only a name that is one plain path segment can be claimed, since
                 # the area link is built from it and `..` would traverse.
                 #
-                # The name must also *agree* with report_rel. The two renderers use
-                # different sources -- the run page builds survey/<name>/ while the
-                # card footer takes the directory of report_rel -- so a spec naming
-                # "foo" with a report under survey/bar/ advertised two different run
-                # areas, one of which is wrong. Validating them independently was
-                # not enough; they have to describe the same directory.
+                # The two renderers derive this link from different sources -- the
+                # run page builds ``survey/<name>/`` relative to the run it is
+                # rendering, the card footer takes the directory of ``report_rel``
+                # -- so they can only be trusted if the *whole* area is pinned to
+                # one run. Comparing only the case segment was not enough: a report
+                # under ``runs/other/survey/foo/`` matched ``name="foo"`` while the
+                # footer pointed into a different run. Require the complete path
+                # for the run being rendered, which is exactly what the
+                # informational builder constructs, so the two agree by
+                # construction. Without a run context (``rel=None``) nothing can be
+                # verified and no spec entry may claim an area.
                 "staged": (
                     case.get("staged") is True
                     and summary["present"]
                     and _safe_case_segment(name) is not None
-                    and _report_rel_case_segment(case.get("report_rel")) == name
+                    and bool(rel)
+                    and _safe_report_rel(case.get("report_rel"))
+                    == f"{rel}/survey/{name}/sanitizer_report.json"
                 ),
                 "cls": "survey",
                 "summary": summary,
@@ -1040,6 +1050,17 @@ def _split_survey_case(name: str) -> tuple[str, str | None]:
         if name.startswith(prefix):
             return name[len(prefix):], san
     return name, None
+
+
+def _published_command(case_dir: Path) -> str:
+    """The reproduce command a published run area recorded, or "" (no manifest).
+
+    A fresh sweep's results dir has no ``env.json``, so this is empty there and the
+    caller falls back to the recipe map.
+    """
+    env = _load(case_dir / "env.json")
+    command = env.get("command") if isinstance(env, dict) else None
+    return command if isinstance(command, str) and command else ""
 
 
 def survey_cases_from_informational_dir(
@@ -1109,7 +1130,15 @@ def survey_cases_from_informational_dir(
                 "sanitizer": sanitizer,
                 "backend": str(backend_name),
                 "workload": None,
-                "command": (
+                # An already-published area records the command it actually ran, so
+                # prefer it over recomputing from the current recipe map. This
+                # function also reconstructs a published run's survey (see
+                # ``displayed_survey`` in ``main``), and recomputing there let a
+                # recipe rename rewrite a historical run's reproduce command --
+                # the same "prose must not outlive its manifest" rule the run-area
+                # renderers follow.
+                "command": _published_command(case_dir)
+                or (
                     "aorta sweep run --recipe "
                     f"recipes/sanitizers/{_survey_recipe_for(name)}.yaml"
                 ),
@@ -1213,21 +1242,6 @@ def _safe_case_segment(name: Any) -> str | None:
     if not isinstance(name, str) or not _CASE_SEGMENT_RE.fullmatch(name):
         return None
     return name
-
-
-def _report_rel_case_segment(report_rel: Any) -> str | None:
-    """The case-directory name a ``report_rel`` points at, validated (pure).
-
-    Used to cross-check the two sources the renderers use for one area: the run
-    page builds ``survey/<name>/`` from the case name while the card footer takes
-    the directory of ``report_rel``. Validating each on its own still allowed a
-    spec to name ``foo`` while its report sat under ``survey/bar/``, advertising two
-    different directories for one case.
-    """
-    area = _case_dir_rel(_safe_report_rel(report_rel))
-    if not area:
-        return None
-    return _safe_case_segment(area.rstrip("/").rsplit("/", 1)[-1])
 
 
 def _case_dir_rel(report_rel: str | None) -> str | None:
@@ -3826,7 +3840,9 @@ def main() -> int:
     if args.survey is not None:
         spec = _load(args.survey)
         if isinstance(spec, (dict, list)):
-            survey = survey_cases_from_spec(spec, base_dir=args.survey.parent)
+            survey = survey_cases_from_spec(
+                spec, base_dir=args.survey.parent, rel=current_rel
+            )
     # Caller-supplied ConSan cases (#347) now render as observed-only workload-survey
     # (Tab 2) entries rather than a separate informational section. They are appended
     # after any explicit --survey spec cases so an explicit spec (if wired) leads, and

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1406,6 +1406,12 @@ def _publish_recipe_inputs(
         return [], []
     (case_dir / "recipe.yaml").write_text(recipe_text, encoding="utf-8")
     source_refs, built_refs = _recipe_fixture_refs(recipe_text)
+    # Plus the sources the rebuild commands read. A recipe names only the built
+    # artifact it consumes -- every daily-consan-* recipe lists a .hsaco and a
+    # loader binary and nothing else -- so scanning the recipe text alone left
+    # inputs/ empty for exactly the cases whose published commands read the most
+    # (decision 10 asks for every input a reproduction needs).
+    source_refs = list(dict.fromkeys(source_refs + rebuild_input_sources(built_refs)))
     recipe_dir = recipe_src.parent
     copied: list[str] = []
     inputs_root = (case_dir / "inputs").resolve()
@@ -1642,10 +1648,42 @@ def _runnable(ref: str) -> str:
     return f"{_FIXTURES_FROM_ROOT}{ref[len('fixtures'):]}" if ref.startswith("fixtures") else ref
 
 
+_GEMM_ISA_CSV = "fixtures/gemm_shapes_unique.csv"
 _GEMM_ISA_SCRIPT = (
     "python scripts/sanitizers/prepare_gemm_isa.py "
-    f"--csv {_FIXTURES_FROM_ROOT}/gemm_shapes_unique.csv --out {_FIXTURES_FROM_ROOT}/isa"
+    f"--csv {_runnable(_GEMM_ISA_CSV)} --out {_FIXTURES_FROM_ROOT}/isa"
 )
+
+
+def rebuild_input_sources(built_refs: list[str]) -> list[str]:
+    """Recipe-relative source files the rebuild commands for these artifacts read.
+
+    Pure, and derived from the same tables ``rebuild_plan`` renders from, so the
+    inputs a run area copies cannot disagree with the commands it publishes.
+
+    Needed because a recipe names only the built artifact it *consumes*: every
+    ``daily-consan-*`` recipe lists a ``.hsaco`` and a loader binary and nothing
+    else, so scanning the recipe text alone left ``inputs/`` empty for exactly the
+    cases whose published commands read the most. A binary's loaded code object is
+    folded in too, since rebuilding the binary means rebuilding that object first
+    -- ``consan_gemm_load`` needs ``consan_load.hip`` *and* the GEMM shape CSV its
+    object is extracted with.
+    """
+    refs = list(built_refs) + [
+        _BIN_OBJECT[ref] for ref in built_refs if ref in _BIN_OBJECT
+    ]
+    sources: list[str] = []
+    for ref in dict.fromkeys(refs):
+        genco = _GENCO_ISA_SOURCES.get(ref)
+        if genco:
+            sources.append(genco)
+        elif f"{ref}/".startswith("fixtures/isa/") or ref == "fixtures/isa":
+            # Every isa/ artifact not built by --genco is extracted by
+            # prepare_gemm_isa.py, which reads the shape CSV.
+            sources.append(_GEMM_ISA_CSV)
+        if ref in _BIN_SOURCES:
+            sources.append(_BIN_SOURCES[ref][0])
+    return list(dict.fromkeys(sources))
 
 # Every rebuild starts here, because the tool none of them can run without is not
 # on PATH in the image that built the artifact: the ROCm container exports only

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -971,6 +971,13 @@ def survey_cases_from_spec(
                 "report_rel": (
                     _safe_report_rel(case.get("report_rel")) if summary["present"] else None
                 ),
+                # Whether this case's whole run-area *directory* is published, not
+                # just its report. A spec entry renders from an inline report or an
+                # out-of-tree report_path, so by default nothing stages the
+                # directory and no run-area link may be emitted for it (a present
+                # report is not evidence the directory exists). A caller that does
+                # publish complete areas can say so with `"staged": true`.
+                "staged": case.get("staged") is True and summary["present"],
                 "cls": "survey",
                 "summary": summary,
             }
@@ -1082,6 +1089,13 @@ def survey_cases_from_informational_dir(
                     f"recipes/sanitizers/{_survey_recipe_for(name)}.yaml"
                 ),
                 "report_rel": report_rel,
+                # These are the cases ``main`` co-publishes as complete run areas
+                # (report + logs + manifests + index.html) under
+                # ``<rel>/survey/<name>/``, so unlike a ``--survey`` spec entry the
+                # directory link is safe to emit. Gated on ``rel`` for the same
+                # reason ``report_rel`` is: the results-dir / runs-root modes
+                # publish nothing co-located.
+                "staged": rel is not None and summary["present"],
                 "cls": "survey",
                 "summary": summary,
             }
@@ -1374,25 +1388,116 @@ _REBUILD_NOTE = (
     ".github/workflows/sanitizers-nightly.yml."
 )
 
+# The env a reproduction needs, shared by both renderings so the page and the
+# downloadable file cannot drift (#384 decision 9 renders REPRODUCE.md into the
+# landing page, so its reproduction details have to be on both).
+_REQUIRED_ENV_NOTE = (
+    "The sanitizer backends (`rj_waitcheck`, the ConSan hook) come from the "
+    "prebuilt rocjitsu bundle; point `ROCJITSU_PREBUILT` at an unpacked bundle "
+    "before running. ConSan additionally requires `HSA_TOOLS_LIB`, "
+    "`HSA_TOOLS_DISABLE_REGISTER=1`, `RJ_CONSAN_MODE` and `RJ_CONSAN_POLICY`, "
+    "which `aorta` sets for you from the recipe's policy block."
+)
+
+
+def _md_code_to_html(text: str) -> str:
+    """Render a shared Markdown prose constant's ``backticks`` as ``<code>``.
+
+    Lets the page and REPRODUCE.md render the same constant natively rather than
+    keeping two hand-synced copies of the same sentence. Escaping happens first,
+    so the split can never introduce markup from the text itself.
+    """
+    parts = _esc(text).split("`")
+    return "".join(
+        part if index % 2 == 0 else f"<code>{part}</code>"
+        for index, part in enumerate(parts)
+    )
+
+# Which source each unpublished fixture is built from, and how. Paths are
+# recipe-relative, matching how a recipe names them.
+#
+# These are per-artifact rather than one hint per directory because the commands
+# are NOT interchangeable, and a generic "hipcc it" hint produces a file whose
+# digest does not match the one recorded beside it:
+#
+# * an ``--genco`` object is a raw code object on some ROCm builds and a
+#   clang-offload bundle on others, so it must be unbundled conditionally -- the
+#   recorded digest is of the unbundled object the loader opens;
+# * the GEMM objects are *extracted* from the shipped Tensile libraries by
+#   prepare_gemm_isa.py, never compiled from a .hip source;
+# * every consan_load / lds_dispatch binary is one source compiled with a define
+#   naming the code object it loads, so omitting the define builds the wrong
+#   binary rather than failing loudly.
+_GENCO_ISA_SOURCES = {
+    "fixtures/isa/lds.hsaco": "fixtures/kernels/lds_reduce.hip",
+    "fixtures/isa/tiny.hsaco": "fixtures/kernels/tiny_vecadd.hip",
+}
+# ref -> (source, define name or None). A define binds the binary to its object.
+_BIN_SOURCES: dict[str, tuple[str, str | None]] = {
+    "fixtures/bin/consan_lds_race": ("fixtures/repro/consan_lds_race.hip", None),
+    "fixtures/bin/consan_lds_race_2wave": (
+        "fixtures/repro/consan_lds_race_2wave.hip",
+        None,
+    ),
+    "fixtures/bin/consan_tiny_load": ("fixtures/kernels/consan_load.hip", "OBJECT"),
+    "fixtures/bin/consan_gemm_load": ("fixtures/kernels/consan_load.hip", "OBJECT"),
+    "fixtures/bin/lds_dispatch": ("fixtures/kernels/lds_dispatch.hip", "LDS_HSACO"),
+}
+# The code object each defined binary loads, so the define can name it.
+_BIN_OBJECT = {
+    "fixtures/bin/consan_tiny_load": "fixtures/isa/tiny.hsaco",
+    "fixtures/bin/consan_gemm_load": "fixtures/isa/consan_gemm_f32.hsaco",
+    "fixtures/bin/lds_dispatch": "fixtures/isa/lds.hsaco",
+}
+_GEMM_ISA_HINT = (
+    "extracted from the shipped Tensile libraries (not compiled from a .hip "
+    "source) by `python scripts/sanitizers/prepare_gemm_isa.py --csv "
+    "fixtures/gemm_shapes_unique.csv --out fixtures/isa"
+)
+
 
 def _rebuild_hints(built_refs: list[str], *, target: str) -> list[str]:
     """One rebuild hint per artifact the run area deliberately does not ship (pure).
 
     Single source of truth so the REPRODUCE.md and landing-page renderings of
-    the rebuild section stay in parity.
+    the rebuild section stay in parity. Each hint is the command the nightly
+    actually ran (see the tables above), because a rebuild that differs from it
+    will not reproduce the SHA-256 recorded next to the artifact.
     """
     hints: list[str] = []
     for ref in built_refs:
-        if f"{ref}/".startswith("fixtures/isa/"):
+        source = _GENCO_ISA_SOURCES.get(ref)
+        if source:
             hints.append(
-                f"{ref} -- a gfx code object: `hipcc --genco --offload-arch={target}` "
-                "from the matching fixtures/kernels/*.hip source, or "
-                "scripts/sanitizers/prepare_gemm_isa.py for the GEMM objects."
+                f"{ref} -- a gfx code object: `hipcc --genco --offload-arch={target} "
+                f"{source} -o tmp.o`, then unbundle only if the result is a bundle "
+                "(`head -c 24 tmp.o | grep -qF __CLANG_OFFLOAD_BUNDLE__`) with "
+                "`clang-offload-bundler --type=o --unbundle --input=tmp.o "
+                f"--targets=hipv4-amdgcn-amd-amdhsa--{target} --output={ref}`, "
+                "otherwise copy tmp.o to it. The recorded digest is of the "
+                "unbundled object, so skipping that check will not match."
             )
-        elif f"{ref}/".startswith("fixtures/bin/"):
+        elif ref == "fixtures/isa/consan_gemm_f32.hsaco":
+            hints.append(f"{ref} -- {_GEMM_ISA_HINT} --top-n 0 --consan-object {ref}`.")
+        elif f"{ref}/".startswith("fixtures/isa/") or ref == "fixtures/isa":
+            # sol_<n>.hsaco, or a bare isa_dir reference covering them.
             hints.append(
-                f"{ref} -- a host repro binary: "
-                f"`hipcc --offload-arch={target} <source>.hip -o {ref}`."
+                f"{ref} -- per-transpose f32 GEMM code objects (sol_<n>.hsaco), "
+                f"{_GEMM_ISA_HINT} --top-n 3`."
+            )
+        elif ref in _BIN_SOURCES:
+            source, define = _BIN_SOURCES[ref]
+            flags = f"--offload-arch={target}"
+            if define:
+                flags += f' -D{define}="\\"$(pwd)/{_BIN_OBJECT[ref]}\\""'
+            hints.append(
+                f"{ref} -- a host repro binary: `hipcc {flags} {source} -o {ref}`."
+                + (
+                    ""
+                    if not define
+                    else f" The -D{define} define is required: it is how the binary "
+                    "learns which code object to load."
+                )
             )
         else:
             hints.append(ref)
@@ -1527,11 +1632,7 @@ def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
         f"{env.get('command', '')}",
         "```",
         "",
-        "The sanitizer backends (`rj_waitcheck`, the ConSan hook) come from the "
-        "prebuilt rocjitsu bundle; point `ROCJITSU_PREBUILT` at an unpacked bundle "
-        "before running. ConSan additionally requires `HSA_TOOLS_LIB`, "
-        "`HSA_TOOLS_DISABLE_REGISTER=1`, `RJ_CONSAN_MODE` and `RJ_CONSAN_POLICY`, "
-        "which `aorta` sets for you from the recipe's policy block.",
+        _REQUIRED_ENV_NOTE,
         "",
     ]
     hints = _rebuild_hints(built_refs, target=str(env.get("target") or "gfx950"))
@@ -1620,6 +1721,7 @@ def build_case_index_html(
         ("Date", _esc(str(env.get("date", "")))),
         ("Target", _esc(str(env.get("target", "")))),
         ("Recipe", _esc(str(env.get("recipe", "")))),
+        ("Execution", _esc(str(observed.get("execution") or _DASH))),
         ("Findings", _esc(str(observed.get("findings", 0)))),
     ]
     if env.get("container_image"):
@@ -1638,7 +1740,9 @@ def build_case_index_html(
     steps_html = (
         (
             '<p class="cap">Rebuild the fixtures</p><ul class="steps">'
-            + "".join(f"<li>{_esc(hint)}</li>" for hint in hints)
+            # The hints are one shared Markdown constant per artifact, so their
+            # `backticks` become <code> here rather than rendering literally.
+            + "".join(f"<li>{_md_code_to_html(hint)}</li>" for hint in hints)
             + f'</ul><p class="note">{_esc(_REBUILD_NOTE)}</p>'
         )
         if hints
@@ -1656,6 +1760,23 @@ def build_case_index_html(
             '<p class="cap">Artifacts not published</p><div class="table-wrap"><table>'
             "<thead><tr><th>Path</th><th>SHA-256</th></tr></thead>"
             f"<tbody>{np_rows}</tbody></table></div>"
+        )
+    # #384 requires the code-object SHA-256 on this page, and the artifacts table
+    # above cannot carry it on its own: a recipe that names only a bare
+    # ``isa_dir: fixtures/isa`` has one row and no per-object digest, so without
+    # this section those digests would exist only in env.json / REPRODUCE.md.
+    digests_html = ""
+    digests = env.get("digests") or {}
+    if isinstance(digests, dict) and digests:
+        digest_rows = "".join(
+            f"<tr><td class=mono>{_esc(str(key))}</td>"
+            f'<td class="mono wrap-any">{_esc(str(value))}</td></tr>'
+            for key, value in sorted(digests.items())
+        )
+        digests_html = (
+            '<p class="cap">Recorded digests</p><div class="table-wrap"><table>'
+            "<thead><tr><th>Key</th><th>Value</th></tr></thead>"
+            f"<tbody>{digest_rows}</tbody></table></div>"
         )
     run_link = (
         f'<a href="{_esc(str(env["run_url"]))}">workflow run</a>'
@@ -1695,7 +1816,8 @@ def build_case_index_html(
         f"{reason_html}\n"
         '<div class="repro"><span class="lbl">Reproduce</span>'
         f'<code>{_esc(str(env.get("command", "")))}</code></div>\n'
-        f"{steps_html}{np_html}"
+        f'<p class="note">{_md_code_to_html(_REQUIRED_ENV_NOTE)}</p>\n'
+        f"{steps_html}{np_html}{digests_html}"
         "</section>\n"
         '<section class="panel"><h2>Files</h2>\n'
         f'<p class="cap">{_esc(files_caption)}</p>\n'
@@ -2128,7 +2250,7 @@ def _kernel_tables_html(
     )
 
 
-def _raw_link_html(report_rel: str | None) -> str:
+def _raw_link_html(report_rel: str | None, *, staged: bool = True) -> str:
     """The run-area link, as a card footer.
 
     Points at the case's published *directory*, not just its
@@ -2138,10 +2260,17 @@ def _raw_link_html(report_rel: str | None) -> str:
     (#384). The per-kernel-row ``Report`` column still links the JSON directly
     for a schema drill-down.
 
+    ``staged=False`` emits nothing. A directory link needs an ``index.html`` that
+    only the publisher of the area can write, so a case whose *report* was staged
+    by someone else (a ``--survey`` spec supplying an inline report) has a
+    reachable JSON but no reachable directory. Guardrail rows default to ``True``:
+    their ``report_rel`` is generator-computed for present cases, and the same
+    loop publishes the area it names.
+
     Deliberately in the card body rather than the ``<summary>`` row: a link
     inside a summary competes with the disclosure toggle.
     """
-    rel = _case_dir_rel(report_rel)
+    rel = _case_dir_rel(report_rel) if staged else None
     if not rel:
         return ""
     return f'<div class="card-foot"><a href="{_esc(rel)}">run area</a></div>'
@@ -2671,7 +2800,7 @@ def _survey_case_html(entry: dict[str, Any], *, heading: str, kind: str = "") ->
             + _survey_message_html(row)
             + _survey_howto_html(entry)
             + _kernel_tables_html(row, report_rel=entry.get("report_rel"))
-            + _raw_link_html(entry.get("report_rel"))
+            + _raw_link_html(entry.get("report_rel"), staged=bool(entry.get("staged")))
         )
     return (
         f'<details class="kcard {accent}">{summary}'
@@ -2867,10 +2996,17 @@ def _run_index_survey_html(survey: list[dict[str, Any]] | None) -> str:
 
     Without this the page lists only the three gated guardrail recipes, so the
     top-nav "raw reports" link never mentions the survey cases published
-    alongside them under ``survey/<case>/`` (#384). Links are case-local, and
-    only a present report gets one so the page never points at a 404. For a past
-    run the entries come from ``survey_entries_from_published``, whose recorded
-    verdict can be absent -- hence the em-dash fallback rather than a "None".
+    alongside them under ``survey/<case>/`` (#384). For a past run the entries
+    come from ``survey_entries_from_published``, whose recorded verdict can be
+    absent -- hence the em-dash fallback rather than a "None".
+
+    A run-area link is emitted only for an entry marked ``staged`` -- i.e. one
+    whose whole directory was published -- never from the case name plus report
+    presence. A report can be *present* (it parsed) without its directory
+    existing at all: a ``--survey`` spec's entries render from an inline report
+    or an out-of-tree ``report_path``, while only ``--informational-results-dir``
+    entries are staged under ``survey/<case>/``. Keying on presence therefore
+    emitted a 404 on exactly that invocation.
     """
     if not survey:
         return ""
@@ -2880,7 +3016,7 @@ def _run_index_survey_html(survey: list[dict[str, Any]] | None) -> str:
         f"<td class=mono>{_esc(str(entry.get('command') or ''))}</td>"
         + (
             f'<td><a href="survey/{_esc(str(entry.get("name", "")))}/">run area</a></td>'
-            if (entry.get("summary") or {}).get("present")
+            if entry.get("staged")
             else '<td><span class="dash">&mdash;</span></td>'
         )
         + "</tr>"
@@ -2904,6 +3040,9 @@ def survey_entries_from_published(run_dir: Path) -> list[dict[str, Any]]:
     from -- leaving the survey areas still on the data branch under it reachable
     only by typing the URL, on a site that cannot auto-index a directory. Each
     area's own ``env.json`` already records everything that table shows.
+
+    Every entry is ``staged``: these are read off disk, so the directory is known
+    to exist by construction.
     """
     entries: list[dict[str, Any]] = []
     for case_dir in sorted(p for p in (run_dir / "survey").glob("*") if p.is_dir()):
@@ -2915,6 +3054,7 @@ def survey_entries_from_published(run_dir: Path) -> list[dict[str, Any]]:
             "name": case_dir.name,
             "label": str(env.get("case") or case_dir.name),
             "command": str(env.get("command") or ""),
+            "staged": True,
             "summary": {
                 "verdict": observed.get("verdict"),
                 "present": (case_dir / "sanitizer_report.json").is_file(),
@@ -3327,6 +3467,7 @@ def main() -> int:
         # Describes this job's GPU run only, so it is stamped onto the run being
         # published now and never onto the older runs re-rendered beside it.
         provenance = provenance_from_environ()
+        info_dir = args.informational_results_dir
         runs_out = args.out_dir / "runs"
         runs_out_res = runs_out.resolve()
         history_res = args.history_root.resolve()
@@ -3450,7 +3591,6 @@ def main() -> int:
         # that (re)creates out_dir/<rel>, using the same rel + case name as
         # survey_cases_from_informational_dir so the copied path matches the link.
         latest_rel = runs[0].get("rel") if runs else None
-        info_dir = args.informational_results_dir
         if latest_rel and info_dir is not None and info_dir.is_dir():
             survey_by_name = {str(entry.get("name")): entry for entry in survey}
             for case_dir in sorted(p for p in info_dir.iterdir() if p.is_dir()):

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1187,10 +1187,21 @@ def _recipe_fixture_refs(recipe_text: str) -> tuple[list[str], list[str]]:
     Source inputs (the ``.hip`` repro sources, the GEMM shape CSV) are small --
     hundreds of bytes to a few KB -- and are copied into the run area. Built
     artifacts are recorded by digest only. Order is first-seen and de-duplicated.
+
+    References containing a ``..`` segment are dropped here, at the one boundary
+    both consumers share. ``_FIXTURE_REF_RE`` admits ``.`` so it can match a file
+    extension, which also let ``fixtures/../../../README.md`` through -- and while
+    the copy validated that the *source* stayed inside the repo, it then joined the
+    same unchecked value onto the destination and wrote outside the case
+    directory. Nothing under ``fixtures/`` legitimately needs a parent segment,
+    and rejecting it here keeps the copied inputs and the recorded
+    not-published list consistent about which refs exist.
     """
     source: list[str] = []
     built: list[str] = []
     for ref in dict.fromkeys(_FIXTURE_REF_RE.findall(recipe_text)):
+        if ".." in ref.split("/"):
+            continue
         (built if _is_built_fixture(ref) else source).append(ref)
     return source, built
 
@@ -1331,6 +1342,7 @@ def _publish_recipe_inputs(
     source_refs, built_refs = _recipe_fixture_refs(recipe_text)
     recipe_dir = recipe_src.parent
     copied: list[str] = []
+    inputs_root = (case_dir / "inputs").resolve()
     for ref in source_refs:
         src = recipe_dir / ref
         # Recipe text is repo-authored, but resolve defensively anyway: an input
@@ -1344,6 +1356,14 @@ def _publish_recipe_inputs(
         if not resolved.is_file():
             continue
         dest = case_dir / "inputs" / ref
+        # ...and the same check on the *write*, not just the read.
+        # ``_recipe_fixture_refs`` already drops parent segments; this is the
+        # belt-and-braces half, because a validator that covers only one use of a
+        # value is how the traversal got through in the first place.
+        try:
+            dest.resolve().relative_to(inputs_root)
+        except (OSError, ValueError):
+            continue
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(resolved, dest)
         copied.append(ref)
@@ -1388,9 +1408,30 @@ _REBUILD_NOTE = (
     ".github/workflows/sanitizers-nightly.yml."
 )
 
-# The env a reproduction needs, shared by both renderings so the page and the
-# downloadable file cannot drift (#384 decision 9 renders REPRODUCE.md into the
-# landing page, so its reproduction details have to be on both).
+# The env a reproduction needs, as data, so a consumer of
+# ``aorta.sanitizer_run_area/0.1`` can read the variables instead of parsing them
+# out of a sentence. ``set_by`` says whether the operator must export it or
+# ``aorta`` derives it from the recipe's policy block.
+_REQUIRED_ENV: tuple[dict[str, str], ...] = (
+    {
+        "var": "ROCJITSU_PREBUILT",
+        "set_by": "operator",
+        "purpose": "unpacked rocjitsu bundle supplying rj_waitcheck and the ConSan hook",
+    },
+    {"var": "HSA_TOOLS_LIB", "set_by": "aorta", "purpose": "ConSan hook to load"},
+    {
+        "var": "HSA_TOOLS_DISABLE_REGISTER",
+        "set_by": "aorta",
+        "purpose": "must be 1 so the hook is not double-registered",
+    },
+    {"var": "RJ_CONSAN_MODE", "set_by": "aorta", "purpose": "ConSan detection mode"},
+    {"var": "RJ_CONSAN_POLICY", "set_by": "aorta", "purpose": "ConSan reporting policy"},
+)
+
+# The prose rendering of exactly those facts, shared by both renderings so the
+# page and the downloadable file cannot drift (#384 decision 9 renders
+# REPRODUCE.md into the landing page, so the reproduction details are on both).
+# ``test_required_env_note_names_every_machine_readable_variable`` binds the two.
 _REQUIRED_ENV_NOTE = (
     "The sanitizer backends (`rj_waitcheck`, the ConSan hook) come from the "
     "prebuilt rocjitsu bundle; point `ROCJITSU_PREBUILT` at an unpacked bundle "
@@ -1432,16 +1473,25 @@ _GENCO_ISA_SOURCES = {
     "fixtures/isa/lds.hsaco": "fixtures/kernels/lds_reduce.hip",
     "fixtures/isa/tiny.hsaco": "fixtures/kernels/tiny_vecadd.hip",
 }
-# ref -> (source, define name or None). A define binds the binary to its object.
-_BIN_SOURCES: dict[str, tuple[str, str | None]] = {
-    "fixtures/bin/consan_lds_race": ("fixtures/repro/consan_lds_race.hip", None),
+# ref -> (source, define name or None, extra flags). A define binds the binary to
+# its object. ``extra`` is verbatim from the workflow: the two guardrail repro
+# binaries are built ``-O1 -g`` and the loader binaries are not, and optimisation
+# /debug flags change the executable -- so dropping them would not reproduce the
+# recorded ``command_sha256`` any more than dropping the define would.
+_BIN_SOURCES: dict[str, tuple[str, str | None, str]] = {
+    "fixtures/bin/consan_lds_race": (
+        "fixtures/repro/consan_lds_race.hip",
+        None,
+        "-O1 -g",
+    ),
     "fixtures/bin/consan_lds_race_2wave": (
         "fixtures/repro/consan_lds_race_2wave.hip",
         None,
+        "-O1 -g",
     ),
-    "fixtures/bin/consan_tiny_load": ("fixtures/kernels/consan_load.hip", "OBJECT"),
-    "fixtures/bin/consan_gemm_load": ("fixtures/kernels/consan_load.hip", "OBJECT"),
-    "fixtures/bin/lds_dispatch": ("fixtures/kernels/lds_dispatch.hip", "LDS_HSACO"),
+    "fixtures/bin/consan_tiny_load": ("fixtures/kernels/consan_load.hip", "OBJECT", ""),
+    "fixtures/bin/consan_gemm_load": ("fixtures/kernels/consan_load.hip", "OBJECT", ""),
+    "fixtures/bin/lds_dispatch": ("fixtures/kernels/lds_dispatch.hip", "LDS_HSACO", ""),
 }
 # The code object each defined binary loads, so the define can name it.
 _BIN_OBJECT = {
@@ -1449,58 +1499,108 @@ _BIN_OBJECT = {
     "fixtures/bin/consan_gemm_load": "fixtures/isa/consan_gemm_f32.hsaco",
     "fixtures/bin/lds_dispatch": "fixtures/isa/lds.hsaco",
 }
-_GEMM_ISA_HINT = (
-    "extracted from the shipped Tensile libraries (not compiled from a .hip "
-    "source) by `python scripts/sanitizers/prepare_gemm_isa.py --csv "
-    "fixtures/gemm_shapes_unique.csv --out fixtures/isa"
+_GEMM_ISA_SCRIPT = (
+    "python scripts/sanitizers/prepare_gemm_isa.py "
+    "--csv fixtures/gemm_shapes_unique.csv --out fixtures/isa"
 )
 
 
-def _rebuild_hints(built_refs: list[str], *, target: str) -> list[str]:
-    """One rebuild hint per artifact the run area deliberately does not ship (pure).
+def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
+    """How to rebuild each unpublished artifact, as data (pure).
 
-    Single source of truth so the REPRODUCE.md and landing-page renderings of
-    the rebuild section stay in parity. Each hint is the command the nightly
-    actually ran (see the tables above), because a rebuild that differs from it
-    will not reproduce the SHA-256 recorded next to the artifact.
+    ``env.json`` carries this so a consumer of ``aorta.sanitizer_run_area/0.1``
+    can read the exact commands rather than parse them out of a sentence, and
+    both prose renderings are generated from it by ``_rebuild_hints`` -- so the
+    landing page, REPRODUCE.md and the manifest cannot disagree about how an
+    artifact was built.
+
+    Each entry is ``{"path", "what", "commands", "caveat"}``. ``commands`` are the
+    nightly's own invocations (see the tables above): they are per-artifact and
+    not interchangeable, because a rebuild that differs from them will not
+    reproduce the SHA-256 recorded beside the artifact. An unrecognised reference
+    yields commands ``[]`` rather than a guess.
     """
-    hints: list[str] = []
+    plan: list[dict[str, Any]] = []
     for ref in built_refs:
         source = _GENCO_ISA_SOURCES.get(ref)
         if source:
-            hints.append(
-                f"{ref} -- a gfx code object: `hipcc --genco --offload-arch={target} "
-                f"{source} -o tmp.o`, then unbundle only if the result is a bundle "
-                "(`head -c 24 tmp.o | grep -qF __CLANG_OFFLOAD_BUNDLE__`) with "
-                "`clang-offload-bundler --type=o --unbundle --input=tmp.o "
-                f"--targets=hipv4-amdgcn-amd-amdhsa--{target} --output={ref}`, "
-                "otherwise copy tmp.o to it. The recorded digest is of the "
-                "unbundled object, so skipping that check will not match."
-            )
+            plan.append({
+                "path": ref,
+                "what": f"a gfx code object built from {source}",
+                "commands": [
+                    f"hipcc --genco --offload-arch={target} {source} -o tmp.o",
+                    f"clang-offload-bundler --type=o --unbundle --input=tmp.o "
+                    f"--targets=hipv4-amdgcn-amd-amdhsa--{target} --output={ref}",
+                ],
+                "caveat": (
+                    "Run the second command only if the first produced a bundle "
+                    "(`head -c 24 tmp.o | grep -qF __CLANG_OFFLOAD_BUNDLE__`), "
+                    "otherwise copy tmp.o into place: --genco emits a raw object on "
+                    "some ROCm builds and a bundle on others. The recorded digest is "
+                    "of the unbundled object, so skipping the check will not match."
+                ),
+            })
         elif ref == "fixtures/isa/consan_gemm_f32.hsaco":
-            hints.append(f"{ref} -- {_GEMM_ISA_HINT} --top-n 0 --consan-object {ref}`.")
+            plan.append({
+                "path": ref,
+                "what": "one representative heavy f32 SS GEMM code object",
+                "commands": [f"{_GEMM_ISA_SCRIPT} --top-n 0 --consan-object {ref}"],
+                "caveat": (
+                    "Extracted from the shipped Tensile libraries, never compiled "
+                    "from a .hip source."
+                ),
+            })
         elif f"{ref}/".startswith("fixtures/isa/") or ref == "fixtures/isa":
             # sol_<n>.hsaco, or a bare isa_dir reference covering them.
-            hints.append(
-                f"{ref} -- per-transpose f32 GEMM code objects (sol_<n>.hsaco), "
-                f"{_GEMM_ISA_HINT} --top-n 3`."
-            )
+            plan.append({
+                "path": ref,
+                "what": "the per-transpose f32 GEMM code objects (sol_<n>.hsaco)",
+                "commands": [f"{_GEMM_ISA_SCRIPT} --top-n 3"],
+                "caveat": (
+                    "Extracted from the shipped Tensile libraries, never compiled "
+                    "from a .hip source."
+                ),
+            })
         elif ref in _BIN_SOURCES:
-            source, define = _BIN_SOURCES[ref]
+            source, define, extra = _BIN_SOURCES[ref]
             flags = f"--offload-arch={target}"
+            if extra:
+                flags += f" {extra}"
             if define:
                 flags += f' -D{define}="\\"$(pwd)/{_BIN_OBJECT[ref]}\\""'
-            hints.append(
-                f"{ref} -- a host repro binary: `hipcc {flags} {source} -o {ref}`."
-                + (
-                    ""
-                    if not define
-                    else f" The -D{define} define is required: it is how the binary "
-                    "learns which code object to load."
-                )
-            )
+            plan.append({
+                "path": ref,
+                "what": f"a host repro binary built from {source}",
+                "commands": [f"hipcc {flags} {source} -o {ref}"],
+                "caveat": (
+                    f"The -D{define} define is required: it is how the binary learns "
+                    "which code object to load."
+                    if define
+                    else ""
+                ),
+            })
         else:
-            hints.append(ref)
+            plan.append({"path": ref, "what": "", "commands": [], "caveat": ""})
+    return plan
+
+
+def _rebuild_hints(built_refs: list[str], *, target: str) -> list[str]:
+    """One prose rebuild hint per artifact, rendered from ``rebuild_plan`` (pure).
+
+    Markdown, so REPRODUCE.md uses it verbatim and the landing page runs it
+    through ``_md_code_to_html``. A reference with no known recipe degrades to
+    its bare path rather than a plausible-looking wrong command.
+    """
+    hints: list[str] = []
+    for entry in rebuild_plan(built_refs, target=target):
+        if not entry["commands"]:
+            hints.append(str(entry["path"]))
+            continue
+        commands = "; ".join(f"`{command}`" for command in entry["commands"])
+        hint = f"{entry['path']} -- {entry['what']}: {commands}."
+        if entry["caveat"]:
+            hint += f" {entry['caveat']}"
+        hints.append(hint)
     return hints
 
 
@@ -1555,6 +1655,12 @@ def build_case_env(
         },
         "inputs": inputs,
         "logs_published": logs,
+        # Machine-readable counterparts of the two things REPRODUCE.md explains in
+        # prose, so a consumer of this schema does not have to parse English to
+        # learn which variables to export or how to rebuild an artifact. Both
+        # renderings are generated from these, not written alongside them.
+        "required_env": [dict(item) for item in _REQUIRED_ENV],
+        "rebuild": rebuild_plan(built_refs, target=str(meta.get("gpu") or "")),
         "artifacts_not_published": [
             {"path": ref, "sha256": by_basename.get(_basename(ref))} for ref in built_refs
         ],
@@ -3468,6 +3574,13 @@ def main() -> int:
         # published now and never onto the older runs re-rendered beside it.
         provenance = provenance_from_environ()
         info_dir = args.informational_results_dir
+        # Survey areas the co-publish loop further below rewrites from this job's
+        # own results. Every *other* published area -- an older run's, or one this
+        # run inherited from the history being re-rendered -- is refreshed in the
+        # run loop instead, so no published area is left without a landing page.
+        staged_now = (
+            {str(entry.get("name")) for entry in survey} if info_dir is not None else set()
+        )
         runs_out = args.out_dir / "runs"
         runs_out_res = runs_out.resolve()
         history_res = args.history_root.resolve()
@@ -3498,6 +3611,13 @@ def main() -> int:
                     src_case = src_run / case
                     if src_case.is_dir():
                         shutil.copytree(src_case, run_out / case, dirs_exist_ok=True)
+                # The survey subtree belongs to the run too. The stale-clear above
+                # emptied the output tree, so without this a retained run silently
+                # loses the survey areas its history holds -- their downloads 404
+                # and the regenerated run index drops the survey table.
+                src_survey = src_run / "survey"
+                if src_survey.is_dir():
+                    shutil.copytree(src_survey, run_out / "survey", dirs_exist_ok=True)
                 # Carry the run manifest too so the published layout
                 # (runs/<id>/meta.json) is complete, not just the reports.
                 src_meta = src_run / "meta.json"
@@ -3542,42 +3662,51 @@ def main() -> int:
             # time, so it ages out of the log window with the rest of that run --
             # without this its ConSan log, the bulkiest thing published, would
             # outlive the guardrail logs beside it by --keep minus --keep-logs.
-            # The current run's areas are (re)written from this job's own results
-            # further below, so they are not touched here.
-            if not current:
-                for survey_case in sorted(
-                    p for p in (run_out / "survey").glob("*") if p.is_dir()
+            for survey_case in sorted(
+                p for p in (run_out / "survey").glob("*") if p.is_dir()
+            ):
+                if current and survey_case.name in staged_now:
+                    continue  # rewritten from this job's own results further below
+                if not keep_logs:
+                    _prune_run_area_bulk(survey_case)
+                if refresh_published_case_area(
+                    survey_case, args.out_dir, logs=keep_logs
                 ):
-                    if not keep_logs:
-                        _prune_run_area_bulk(survey_case)
-                    if refresh_published_case_area(
-                        survey_case, args.out_dir, logs=keep_logs
-                    ):
-                        continue
-                    # Co-published before run areas existed: retrofit one, the same
-                    # way an older guardrail case is handled above. Without this an
-                    # area with a report but no manifest stays invisible -- it gets
-                    # no landing page, and survey_entries_from_published skips it.
-                    survey_report = _load(survey_case / "sanitizer_report.json")
-                    if not isinstance(survey_report, dict):
-                        continue
-                    stem = _survey_recipe_for(survey_case.name)
-                    up, run_up = case_dir_up(survey_case, args.out_dir)
-                    write_case_run_area(
-                        survey_case,
-                        case=survey_case.name,
-                        cls="survey",
-                        recipe_stem=stem,
-                        command=f"aorta sweep run --recipe recipes/sanitizers/{stem}.yaml",
-                        meta=run["meta"],
-                        summary=summarize_case(survey_report, None),
-                        report=survey_report,
-                        repo_root=args.repo_root,
-                        up=up,
-                        run_up=run_up,
-                        logs=keep_logs,
-                        current=False,
-                    )
+                    continue
+                # Co-published before run areas existed: retrofit one, the same way
+                # an older guardrail case is handled above. Without this an area
+                # with a report but no manifest stays invisible -- it gets no
+                # landing page, and survey_entries_from_published skips it.
+                survey_report = _load(survey_case / "sanitizer_report.json")
+                if not isinstance(survey_report, dict):
+                    continue
+                # A top-level dict can still hold a malformed *nested* shape
+                # (``{"checks": null}``) that makes the reduction raise, which is
+                # why survey_cases_from_informational_dir isolates the same call.
+                # Without this an orphan area left on the data branch by an earlier
+                # publish aborts the entire dashboard, days later and for a
+                # non-gating input. Skip it as unreadable instead.
+                try:
+                    survey_summary = summarize_case(survey_report, None)
+                except (AttributeError, KeyError, TypeError, ValueError):
+                    continue
+                stem = _survey_recipe_for(survey_case.name)
+                up, run_up = case_dir_up(survey_case, args.out_dir)
+                write_case_run_area(
+                    survey_case,
+                    case=survey_case.name,
+                    cls="survey",
+                    recipe_stem=stem,
+                    command=f"aorta sweep run --recipe recipes/sanitizers/{stem}.yaml",
+                    meta=run["meta"],
+                    summary=survey_summary,
+                    report=survey_report,
+                    repo_root=args.repo_root,
+                    up=up,
+                    run_up=run_up,
+                    logs=keep_logs,
+                    current=False,
+                )
             (run_out / "index.html").write_text(
                 build_run_index_html(
                     run,
@@ -3592,19 +3721,32 @@ def main() -> int:
         # survey_cases_from_informational_dir so the copied path matches the link.
         latest_rel = runs[0].get("rel") if runs else None
         if latest_rel and info_dir is not None and info_dir.is_dir():
+            # The latest run's own retention decision, so --keep-logs applies to
+            # guardrail and survey areas alike as documented (with --keep-logs 0
+            # the survey area is pruned too, not left as the one unbounded thing).
+            latest_keeps_logs = 0 < max(args.keep_logs, 0)
             survey_by_name = {str(entry.get("name")): entry for entry in survey}
             for case_dir in sorted(p for p in info_dir.iterdir() if p.is_dir()):
                 src_report = case_dir / "sanitizer_report.json"
                 if not src_report.is_file():
                     continue
+                # Resolve the entry BEFORE copying. A case whose report was
+                # rejected as malformed has no entry, and copying it anyway left an
+                # orphan directory with no manifest: the next nightly then treats
+                # it as an older survey area and retrofits one from that same
+                # unusable report. Nothing should persist into history that the
+                # survey loader already decided it could not read.
+                entry = survey_by_name.get(case_dir.name)
+                if entry is None:
+                    continue
                 dest = args.out_dir / latest_rel / "survey" / case_dir.name
                 # The whole case dir, so the ConSan/waitcheck logs behind the
                 # observed verdict ship with the report (#384).
                 shutil.copytree(case_dir, dest, dirs_exist_ok=True)
-                _gzip_logs(dest)
-                entry = survey_by_name.get(case_dir.name)
-                if entry is None:
-                    continue
+                if latest_keeps_logs:
+                    _gzip_logs(dest)
+                else:
+                    _prune_run_area_bulk(dest)
                 up, run_up = case_dir_up(dest, args.out_dir)
                 write_case_run_area(
                     dest,
@@ -3618,6 +3760,7 @@ def main() -> int:
                     repo_root=args.repo_root,
                     up=up,
                     run_up=run_up,
+                    logs=latest_keeps_logs,
                     provenance=provenance,
                 )
     (args.out_dir / "summary.md").write_text(

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -979,10 +979,18 @@ def survey_cases_from_spec(
                 # publish complete areas can say so with `"staged": true` -- but
                 # only a name that is one plain path segment can be claimed, since
                 # the area link is built from it and `..` would traverse.
+                #
+                # The name must also *agree* with report_rel. The two renderers use
+                # different sources -- the run page builds survey/<name>/ while the
+                # card footer takes the directory of report_rel -- so a spec naming
+                # "foo" with a report under survey/bar/ advertised two different run
+                # areas, one of which is wrong. Validating them independently was
+                # not enough; they have to describe the same directory.
                 "staged": (
                     case.get("staged") is True
                     and summary["present"]
                     and _safe_case_segment(name) is not None
+                    and _report_rel_case_segment(case.get("report_rel")) == name
                 ),
                 "cls": "survey",
                 "summary": summary,
@@ -1188,6 +1196,21 @@ def _safe_case_segment(name: Any) -> str | None:
     if any(char.isspace() or ord(char) < 0x20 for char in name):
         return None
     return name
+
+
+def _report_rel_case_segment(report_rel: Any) -> str | None:
+    """The case-directory name a ``report_rel`` points at, validated (pure).
+
+    Used to cross-check the two sources the renderers use for one area: the run
+    page builds ``survey/<name>/`` from the case name while the card footer takes
+    the directory of ``report_rel``. Validating each on its own still allowed a
+    spec to name ``foo`` while its report sat under ``survey/bar/``, advertising two
+    different directories for one case.
+    """
+    area = _case_dir_rel(_safe_report_rel(report_rel))
+    if not area:
+        return None
+    return _safe_case_segment(area.rstrip("/").rsplit("/", 1)[-1])
 
 
 def _case_dir_rel(report_rel: str | None) -> str | None:
@@ -1866,26 +1889,26 @@ def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
     ]
     if observed.get("reason"):
         lines.append(f"- Reason: `{observed['reason']}`")
+    # Ordered so the document runs top to bottom. The sweep command comes *last*:
+    # the fixtures it needs are gitignored, so on a fresh clone it fails before the
+    # reader would ever reach a rebuild section printed after it.
     lines += [
         "",
         "## Run it yourself",
+        "",
+        "First, the checkout this run used:",
         "",
         "```",
         "git clone https://github.com/ROCm/aorta && cd aorta",
         f"git checkout {env.get('commit', '')}",
         "pip install -e .",
-        f"{env.get('command', '')}",
         "```",
-        "",
-        required_env_note(env.get("required_env") or []),
         "",
     ]
     hints = _rebuild_hints(plan_from_env(env, built_refs))
     if hints:
         lines += [
-            "## Rebuild the fixtures",
-            "",
-            "This case needs CI-built fixtures that are not published here (see "
+            "Then rebuild the CI-built fixtures, which are not published here (see "
             "'Artifacts not published' below). Run these from the repo root, the "
             "directory the clone above leaves you in:",
             "",
@@ -1894,6 +1917,17 @@ def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
             _REBUILD_NOTE,
             "",
         ]
+    env_note = required_env_note(env.get("required_env") or [])
+    if env_note:
+        lines += [env_note, ""]
+    lines += [
+        "Finally, the sweep itself:",
+        "",
+        "```",
+        f"{env.get('command', '')}",
+        "```",
+        "",
+    ]
     if env.get("artifacts_not_published"):
         lines += [
             "## Artifacts not published",
@@ -2180,7 +2214,12 @@ def refresh_published_case_area(case_dir: Path, out_dir: Path, *, logs: bool) ->
         # The manifest described an area that still had its bulk. Restate it for
         # what is left, so it does not name inputs that are no longer there.
         env["inputs"] = []
-    env["logs_published"] = logs
+    # Pruning is one-way: the files were deleted from the published history and
+    # cannot be recovered from it, so raising --keep-logs later must not flip this
+    # back to true and have the page and REPRODUCE.md offer logs that are gone.
+    # Only re-staging from the source sweep can restore them, which goes through
+    # write_case_run_area rather than here.
+    env["logs_published"] = bool(env.get("logs_published", True)) and logs
     built_refs = [
         str(item["path"])
         for item in env.get("artifacts_not_published") or []
@@ -3621,6 +3660,14 @@ def main() -> int:
         "is pruned so the data branch stays bounded (#384).",
     )
     ap.add_argument(
+        "--current-run",
+        default="",
+        help="the <YYYY-MM-DD>-<run_id> this job just staged. Only that run's area "
+        "is written from the live checkout and environment; without it the newest "
+        "retained run is assumed, which is wrong when an older workflow is re-run "
+        "after a newer same-day one (its lower run id sorts behind).",
+    )
+    ap.add_argument(
         "--repo-root",
         type=Path,
         default=Path(__file__).resolve().parents[2],
@@ -3680,6 +3727,27 @@ def main() -> int:
     else:
         runs = runs_from_history_root(args.history_root, baselines, keep=args.keep)
 
+    # Which retained run this job actually produced. NOT simply the newest one:
+    # re-running an older workflow reuses its lower GITHUB_RUN_ID, so its
+    # <date>-<run_id> sorts *behind* a newer same-day run. Taking position 0 then
+    # stamps the newer area with this job's container/bundle/recipe and publishes
+    # this job's survey under the wrong run. Fall back to the newest run only when
+    # the caller did not say (the results-dir / runs-root modes, and older callers).
+    current_index: int | None = None
+    if runs:
+        if args.current_run:
+            current_index = next(
+                (
+                    index
+                    for index, run in enumerate(runs)
+                    if str(run["meta"].get("run", "")) == args.current_run
+                ),
+                None,  # staged run already pruned out of the window: nothing is current
+            )
+        else:
+            current_index = 0
+    current_rel = runs[current_index].get("rel") if current_index is not None else None
+
     # Observed-only survey cases for Tab 2. A malformed/absent spec degrades to an
     # empty survey (Tab 2 renders its empty-state note) rather than crashing render.
     survey: list[dict[str, Any]] = []
@@ -3692,15 +3760,17 @@ def main() -> int:
     # after any explicit --survey spec cases so an explicit spec (if wired) leads, and
     # their report_rel is threaded to the latest run's published area so per-case /
     # per-kernel raw-report links resolve once the reports are co-published below.
+    informational_survey: list[dict[str, Any]] = []
     if args.informational_results_dir is not None:
-        survey += survey_cases_from_informational_dir(
+        informational_survey = survey_cases_from_informational_dir(
             args.informational_results_dir,
-            rel=runs[0].get("rel") if runs else None,
+            rel=current_rel,
         )
-    # Mirror the two-class split into data.json: attach the survey list to the
-    # latest run record (additive; existing per-run keys are untouched).
-    if runs:
-        runs[0]["survey"] = survey
+        survey += informational_survey
+    # Mirror the two-class split into data.json: attach the survey list to the run
+    # this job produced (additive; existing per-run keys are untouched).
+    if current_index is not None:
+        runs[current_index]["survey"] = survey
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     (args.out_dir / "index.html").write_text(
@@ -3726,9 +3796,12 @@ def main() -> int:
         # own results. Every *other* published area -- an older run's, or one this
         # run inherited from the history being re-rendered -- is refreshed in the
         # run loop instead, so no published area is left without a landing page.
-        staged_now = (
-            {str(entry.get("name")) for entry in survey} if info_dir is not None else set()
-        )
+        #
+        # Only the informational entries, never a --survey spec's: the co-publish
+        # loop stages only those. Including a spec name here skipped an area in the
+        # run loop that nothing later rewrote, so it kept its raw logs even under
+        # --keep-logs 0.
+        staged_now = {str(entry.get("name")) for entry in informational_survey}
         runs_out = args.out_dir / "runs"
         runs_out_res = runs_out.resolve()
         history_res = args.history_root.resolve()
@@ -3775,7 +3848,7 @@ def main() -> int:
             # written from the live checkout and environment (see
             # write_case_run_area); older ones are re-rendered from what they
             # captured themselves.
-            current = position == 0
+            current = position == current_index
             for case, _key, label, _backend in CASES:
                 row = run["rows"][case]
                 case_out = run_out / case
@@ -3867,17 +3940,19 @@ def main() -> int:
                 ),
                 encoding="utf-8",
             )
-        # Co-publish each caller-supplied ConSan report (#347) under the latest run's
-        # survey area so the report_rel links threaded above (survey/<name>/...)
-        # resolve. Done after the stale-clear (shutil.rmtree) and the per-run loop
-        # that (re)creates out_dir/<rel>, using the same rel + case name as
-        # survey_cases_from_informational_dir so the copied path matches the link.
-        latest_rel = runs[0].get("rel") if runs else None
-        if latest_rel and info_dir is not None and info_dir.is_dir():
-            # The latest run's own retention decision, so --keep-logs applies to
+        # Co-publish each caller-supplied ConSan report (#347) under the survey area
+        # of the run this job produced, so the report_rel links threaded above
+        # (survey/<name>/...) resolve. Done after the stale-clear (shutil.rmtree)
+        # and the per-run loop that (re)creates out_dir/<rel>, using the same rel +
+        # case name as survey_cases_from_informational_dir so the copied path
+        # matches the link. current_rel, not runs[0]: on a re-run of an older
+        # workflow these differ, and staging under the newer run would attribute
+        # this job's sweep to a run that did not produce it.
+        if current_rel and info_dir is not None and info_dir.is_dir():
+            # That run's own retention decision, so --keep-logs applies to
             # guardrail and survey areas alike as documented (with --keep-logs 0
             # the survey area is pruned too, not left as the one unbounded thing).
-            latest_keeps_logs = 0 < max(args.keep_logs, 0)
+            latest_keeps_logs = (current_index or 0) < max(args.keep_logs, 0)
             survey_by_name = {str(entry.get("name")): entry for entry in survey}
             for case_dir in sorted(p for p in info_dir.iterdir() if p.is_dir()):
                 src_report = case_dir / "sanitizer_report.json"
@@ -3892,7 +3967,7 @@ def main() -> int:
                 entry = survey_by_name.get(case_dir.name)
                 if entry is None:
                     continue
-                dest = args.out_dir / latest_rel / "survey" / case_dir.name
+                dest = args.out_dir / current_rel / "survey" / case_dir.name
                 # Replace the destination rather than merging into it: a file that
                 # disappeared from this sweep (an old log especially) would
                 # otherwise survive and be listed on the landing page as evidence
@@ -3919,7 +3994,7 @@ def main() -> int:
                     cls="survey",
                     recipe_stem=_survey_recipe_for(case_dir.name),
                     command=str(entry.get("command") or ""),
-                    meta=runs[0]["meta"],
+                    meta=runs[current_index or 0]["meta"],
                     summary=entry.get("summary") or {},
                     report=_load(dest / "sanitizer_report.json"),
                     repo_root=args.repo_root,

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1590,6 +1590,43 @@ def required_env_note(required_env: list[dict[str, Any]]) -> str:
     return " ".join(parts)
 
 
+# The drill-down pages -- a run's landing page and each case's run area -- link
+# one stylesheet instead of inlining ``_CSS``. ``_CSS`` is ~18KB and over 80% of
+# such a page, and at ``--keep 30`` with five areas per run that is ~2.7MB of
+# byte-identical CSS in the published tree: more than everything else in it
+# combined, and well past the gzipped logs ``--keep-logs`` exists to bound. The
+# root dashboard page keeps its inline copy -- there is only ever one of it, and
+# it has to render standalone (including its empty-state stale banner).
+RUN_AREA_CSS_REL = "assets/run-area.css"
+
+# What those pages add on top of ``_CSS``. The union of both pages' needs, so one
+# file serves both; an unused selector costs nothing.
+_DRILLDOWN_CSS = """
+  .wrap { max-width:900px; }
+  .note { margin:0 0 14px; color:var(--text-3); font-size:13px; }
+  .steps { margin:0 0 6px; padding-left:18px; color:var(--text-2);
+    font-size:var(--fs-obs); }
+  .steps li { margin:3px 0; }
+"""
+
+
+def run_area_stylesheet() -> str:
+    """The stylesheet the drill-down pages link, as text (pure)."""
+    return f"{_CSS}{_DRILLDOWN_CSS}"
+
+
+def write_shared_assets(out_dir: Path) -> Path:
+    """Write the drill-down stylesheet under ``out_dir`` and return its path.
+
+    Byte-stable for unchanged input, like the gzipped logs, so re-publishing the
+    retained history does not churn the data branch.
+    """
+    path = out_dir / RUN_AREA_CSS_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(run_area_stylesheet(), encoding="utf-8")
+    return path
+
+
 def _md_code_to_html(text: str) -> str:
     """Render a shared Markdown prose constant's ``backticks`` as ``<code>``.
 
@@ -1754,10 +1791,15 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
                     # One command, because which branch is correct depends on the
                     # ROCm build: --genco emits a raw object on some and a bundle
                     # on others, and the recorded digest is of the unbundled one.
+                    # ...and clean up after itself. The workflow's genco_object
+                    # builds into a mktemp file and rm -f's it; this runs in the
+                    # reader's repo root, so without the trailing rm it drops an
+                    # untracked tmp.o next to pyproject.toml. `&&` keeps it for
+                    # inspection if the conversion failed.
                     "if head -c 24 tmp.o | grep -qF __CLANG_OFFLOAD_BUNDLE__; then "
                     "clang-offload-bundler --type=o --unbundle --input=tmp.o "
                     f"--targets=hipv4-amdgcn-amd-amdhsa--{target} --output={out}; "
-                    f"else cp tmp.o {out}; fi",
+                    f"else cp tmp.o {out}; fi && rm -f tmp.o",
                 ],
                 "caveat": (
                     "The conditional matters: --genco emits a raw code object on "
@@ -2149,22 +2191,23 @@ def build_case_index_html(
         if env.get("run_url")
         else "<span></span>"
     )
-    files_caption = (
-        "Every file published for this case. Logs are gzipped."
-        if env.get("logs_published", True)
-        else "Every file published for this case. Its logs, recipe copy and inputs "
-        "were pruned for falling outside the nightly's log-retention window."
-    )
+    # Only claim gzipped logs when the listing actually has one: an in-window case
+    # that produced no log at all still rendered "Logs are gzipped."
+    if not env.get("logs_published", True):
+        files_caption = (
+            "Every file published for this case. Its logs, recipe copy and inputs "
+            "were pruned for falling outside the nightly's log-retention window."
+        )
+    elif any(rel.endswith(".log.gz") for rel, _size in files):
+        files_caption = "Every file published for this case. Logs are gzipped."
+    else:
+        files_caption = "Every file published for this case."
     return (
         "<!doctype html>\n"
         "<html lang=en><head><meta charset=utf-8>\n"
         '<meta name=viewport content="width=device-width, initial-scale=1">\n'
         f"<title>{_esc(title)} &middot; {_esc(str(env.get('case', '')))}</title>\n"
-        f"<style>{_CSS}\n  .wrap {{ max-width:900px; }}\n"
-        "  .note { margin:0 0 14px; color:var(--text-3); font-size:13px; }\n"
-        "  .steps { margin:0 0 6px; padding-left:18px; color:var(--text-2);\n"
-        "    font-size:var(--fs-obs); }\n"
-        "  .steps li { margin:3px 0; }</style></head>\n"
+        f'<link rel=stylesheet href="{_esc(up)}{RUN_AREA_CSS_REL}"></head>\n'
         "<body><div class=wrap>\n"
         f'<div class=navrow><span><a href="{_esc(up)}">&larr; back to sanitizer dashboard</a>'
         f' &middot; <a href="{_esc(run_up)}">run {_esc(str(env.get("run", "")))}</a></span>\n'
@@ -3447,6 +3490,7 @@ def build_run_index_html(
     *,
     title: str = "Sanitizers Nightly",
     survey: list[dict[str, Any]] | None = None,
+    up: str = "../../",
 ) -> str:
     """A tiny, self-contained landing page for one published run (pure).
 
@@ -3484,13 +3528,14 @@ def build_run_index_html(
         for case, _key, label, _backend in CASES
     )
     # Shares the dashboard stylesheet so a drill-down does not look like a
-    # different product; only the narrower wrap differs.
+    # different product; only the narrower wrap differs. Linked rather than
+    # inlined -- there is one of these per retained run (see RUN_AREA_CSS_REL).
     return (
         "<!doctype html>\n"
         "<html lang=en><head><meta charset=utf-8>\n"
         '<meta name=viewport content="width=device-width, initial-scale=1">\n'
         f"<title>{_esc(title)} &middot; {_esc(meta.get('run', ''))}</title>\n"
-        f"<style>{_CSS}\n  .wrap {{ max-width:900px; }}</style></head>\n"
+        f'<link rel=stylesheet href="{_esc(up)}{RUN_AREA_CSS_REL}"></head>\n'
         "<body><div class=wrap>\n"
         '<div class=navrow><a href="../../">&larr; back to sanitizer dashboard</a>\n'
         f"{run_link}</div>\n"
@@ -3743,7 +3788,9 @@ def main() -> int:
         help="keep sanitizer logs + the recipe copy and its inputs for only the "
         "newest N runs (default 7), guardrail and survey areas alike. Older "
         "retained runs keep their report, manifests and landing page; their bulk "
-        "is pruned so the data branch stays bounded (#384).",
+        "is pruned so the published tree stays bounded (#384). Note this bounds the "
+        "checkout, not the branch history: a pruned blob stays reachable from the "
+        "commit that added it, so anything ever published is permanent.",
     )
     ap.add_argument(
         "--current-run",
@@ -3885,6 +3932,9 @@ def main() -> int:
     # to its co-located raw reports (out_dir/runs/<id>/index.html). Bounded by
     # --keep, so pruned runs stop getting a page.
     if args.history_root is not None:
+        # The one stylesheet every run and run-area page links, written once for
+        # the whole tree rather than inlined into each of them.
+        write_shared_assets(args.out_dir)
         # When the raw reports live in a separate tree from the output (the copy
         # branch below), a reused --out-dir would keep run dirs dropped by --keep
         # (or reports since removed from a retained run) as stale published output.

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -14,9 +14,12 @@ emits, into ``--out-dir``:
   supplied via ``--survey`` and the caller-supplied ConSan cases from
   ``--informational-results-dir``, #347) shown with the same kernel-detail shape
   but **no expected/match column** (a fail / not_checked here is an observation,
-  never a regression). Both tabs link each case -- in its heading and in a
-  per-kernel-row ``Report`` column -- to its ``sanitizer_report.json`` (satisfying
-  #367's per-row drill-down), and carry a one-line observation summary.
+  never a regression). On both tabs a per-kernel-row ``Report`` column links the
+  case's ``sanitizer_report.json`` (satisfying #367's per-row drill-down) and the
+  card footer links its **run area** -- the published case *directory*, which also
+  carries the sanitizer logs, the recipe as it ran and a REPRODUCE.md, so the
+  reproduce command on the card is actionable (#384). Each case also carries a
+  one-line observation summary.
 * ``summary.md`` -- a GitHub Actions job-summary fragment (append to
   ``$GITHUB_STEP_SUMMARY``) carrying the same gate, table, and kernel detail.
 * ``data.json`` -- the aggregated structure for any richer consumer.
@@ -39,13 +42,18 @@ Three input shapes are supported:
   (keys: commit, date, gpu, run_url, gate). ``<id>`` is ``<YYYY-MM-DD>-<run_id>``
   (date-sortable, unique), enumerated newest-first and capped by ``--keep N``
   (default 30). This is the shape the nightly publishes and Pages serves under
-  ``/sanitizers/``: each run's raw reports are co-located under ``runs/<id>/`` and
-  linked from the rendered page, and a tiny ``runs/<id>/index.html`` landing page
-  is written for each retained run.
+  ``/sanitizers/``: each run's case dirs are co-located under ``runs/<id>/`` and
+  linked from the rendered page, and a ``runs/<id>/index.html`` landing page is
+  written for each retained run. Every case dir is completed into a *run area*
+  (report + gzipped logs + recipe + inputs + REPRODUCE.md + env.json + its own
+  ``index.html``); ``--keep-logs N`` (default 7) bounds how many runs keep the
+  bulky parts -- guardrail and survey areas alike -- while reports stay for the
+  full ``--keep`` window.
 
 Pure rendering lives in ``build_html`` / ``build_summary_md`` /
-``build_run_index_html`` and pure aggregation in ``summarize_case`` so they are
-unit testable without the FS.
+``build_run_index_html`` / ``build_case_index_html`` / ``build_reproduce_md`` and
+pure aggregation in ``summarize_case`` / ``report_digests`` so they are unit
+testable without the FS.
 
 Usage (CI, published-history mode):
     python scripts/sanitizers/gen_sanitizer_dashboard.py \
@@ -59,6 +67,7 @@ Usage (CI, published-history mode):
 from __future__ import annotations
 
 import argparse
+import gzip
 import json
 import os
 import re
@@ -750,6 +759,10 @@ def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
             value = data.get(key)
             if value not in (None, ""):
                 meta[key] = str(value)
+        # The unabbreviated SHA as well: ``commit`` is shortened for display, but
+        # a run area's reproduce instructions need a checkout-able revision.
+        if data.get("commit"):
+            meta["commit_full"] = str(data["commit"])
         # Preserve the manifest's recorded gate with its JSON type. Coercing it to
         # str would emit "True"/"False" into data.json, where "False" is truthy
         # for machine consumers and the documented boolean type is lost.
@@ -1076,6 +1089,755 @@ def survey_cases_from_informational_dir(
     return entries
 
 
+# ---------------------------------------------------------------------------
+# Run area (#384)
+#
+# A published case directory is the "run area" a card footer links to. It holds
+# everything needed to reproduce that one case locally: the report, the
+# sanitizer logs the verdict was derived from, the recipe exactly as it ran,
+# that recipe's source-level inputs, and REPRODUCE.md / env.json recording the
+# CI-built artifacts that are deliberately NOT published, by digest.
+#
+# Everything here is stdlib-only on purpose: the publish job runs this script
+# from a bare checkout with no ``pip install``, so PyYAML is not importable.
+# ---------------------------------------------------------------------------
+
+# Fixture paths under these prefixes are CI-built (see
+# recipes/sanitizers/fixtures/.gitignore): a ~16MB Tensile code object or a
+# compiled repro binary. They are never copied into a run area -- publishing
+# them for every retained run would bloat the data branch and Pages -- so their
+# SHA-256 is recorded instead and a local rebuild can be verified against it.
+_BUILT_FIXTURE_DIRS = ("fixtures/bin/", "fixtures/isa/")
+
+# Any fixture path a sanitizer recipe references. Recipes name them under
+# several different keys (``path``, ``isa_dir``, ``code_object``,
+# ``consan_command``, ``hip``, ``command``), so match the value shape rather
+# than enumerating keys -- a recipe that adds a new key needs no change here.
+_FIXTURE_REF_RE = re.compile(r"fixtures/[A-Za-z0-9._/-]+")
+
+
+def _is_built_fixture(ref: str) -> bool:
+    """Whether a recipe's fixture reference names CI-built output.
+
+    Compares with a trailing slash appended so a bare directory reference
+    (``isa_dir: fixtures/isa``) is classified alongside the files inside it; a
+    plain ``startswith`` on the prefixes would let that one through as a source
+    input and leave it off the "not published" list.
+    """
+    return f"{ref}/".startswith(_BUILT_FIXTURE_DIRS)
+
+
+RUN_AREA_ENV_SCHEMA = "aorta.sanitizer_run_area/0.1"
+
+# Provenance the workflow knows but the report does not. Absent => omitted from
+# env.json rather than emitted empty, so the file only ever states what the run
+# actually captured.
+_RUN_AREA_ENV_VARS: tuple[tuple[str, str], ...] = (
+    ("container_image", "AORTA_CI_IMAGE"),
+    ("rocjitsu_commit", "AORTA_ROCJITSU_COMMIT"),
+    ("rocjitsu_run_url", "AORTA_ROCJITSU_RUN_URL"),
+)
+
+
+def provenance_from_environ() -> dict[str, str]:
+    """The publish job's environment-derived provenance for the run it just staged.
+
+    These describe *this* job's GPU run -- the container image it ran in and the
+    rocjitsu bundle its sanitizer backends came from -- so they are only valid
+    for the run being published now, never for the older runs re-rendered
+    alongside it (see ``write_case_run_area``).
+    """
+    return {key: os.environ[var] for key, var in _RUN_AREA_ENV_VARS if os.environ.get(var)}
+
+
+def _case_dir_rel(report_rel: str | None) -> str | None:
+    """The run-area directory holding a case's report, as a relative link.
+
+    Derived from ``report_rel`` and re-validated through ``_safe_report_rel``,
+    so the footer link inherits exactly the same relative-only guarantee as the
+    report link it replaces: no URL scheme, no absolute path, no ``..``
+    traversal. Returns ``None`` when there is no safe directory to link -- an
+    absent or unsafe ``report_rel``, or a bare filename with no directory part
+    -- so an unlinkable case still renders, just without a footer.
+    """
+    safe = _safe_report_rel(report_rel)
+    if not safe or "/" not in safe:
+        return None
+    return f"{safe.rsplit('/', 1)[0]}/"
+
+
+def _recipe_fixture_refs(recipe_text: str) -> tuple[list[str], list[str]]:
+    """Split a recipe's fixture references into ``(source, built)`` paths (pure).
+
+    Paths are as written in the recipe, i.e. relative to ``recipes/sanitizers/``.
+    Source inputs (the ``.hip`` repro sources, the GEMM shape CSV) are small --
+    hundreds of bytes to a few KB -- and are copied into the run area. Built
+    artifacts are recorded by digest only. Order is first-seen and de-duplicated.
+    """
+    source: list[str] = []
+    built: list[str] = []
+    for ref in dict.fromkeys(_FIXTURE_REF_RE.findall(recipe_text)):
+        (built if _is_built_fixture(ref) else source).append(ref)
+    return source, built
+
+
+def report_digests(report: dict[str, Any] | None) -> dict[str, str]:
+    """Artifact digests a run area records for the files it does not publish.
+
+    Both sanitizers already write this provenance into every report and nothing
+    renders it today: waitcheck stores its binary's ``path``/``sha256``, ConSan
+    stores the repro ``command`` and hook plus their digests, and each worklist
+    kernel carries its ``code_object_sha256``. Flattened into one mapping so
+    REPRODUCE.md and env.json can name the exact artifacts a local rebuild has
+    to match. A malformed report degrades to ``{}`` rather than raising.
+    """
+    digests: dict[str, str] = {}
+    if not isinstance(report, dict):
+        return digests
+    checks = report.get("checks")
+    for check in checks if isinstance(checks, list) else []:
+        backend = check.get("backend") if isinstance(check, dict) else None
+        if not isinstance(backend, dict):
+            continue
+        for key, value in backend.items():
+            if isinstance(value, str) and value:
+                digests.setdefault(str(key), value)
+    worklist = report.get("worklist")
+    kernels = worklist.get("kernels") if isinstance(worklist, dict) else None
+    for entry in kernels if isinstance(kernels, list) else []:
+        identity = entry.get("identity") if isinstance(entry, dict) else None
+        if not isinstance(identity, dict):
+            continue
+        obj, sha = identity.get("code_object"), identity.get("code_object_sha256")
+        if isinstance(obj, str) and obj and isinstance(sha, str) and sha:
+            digests.setdefault(f"code_object:{_basename(obj)}", sha)
+    return digests
+
+
+def artifact_digest_index(digests: dict[str, str]) -> dict[str, str]:
+    """Index recorded digests by artifact *basename* (pure).
+
+    The two sanitizers name the same kind of thing differently: waitcheck records
+    its binary as ``path``/``sha256``, ConSan records the repro binary as
+    ``command``/``command_sha256`` and its hook as ``hook``/``hook_sha256``, and
+    worklist kernels arrive from ``report_digests`` already keyed as
+    ``code_object:<basename>``. A run area names the artifacts it did not publish
+    by their recipe-relative path, so index by basename and look them up with one
+    rule -- keying only on ``code_object:`` left every ``fixtures/bin/`` repro
+    binary showing an em dash while its digest sat in the report unused.
+    """
+    index: dict[str, str] = {}
+    for name_key, sha_key in (
+        ("path", "sha256"),
+        ("command", "command_sha256"),
+        ("hook", "hook_sha256"),
+    ):
+        name, sha = digests.get(name_key), digests.get(sha_key)
+        if name and sha:
+            index.setdefault(_basename(name), sha)
+    for key, value in digests.items():
+        prefix, sep, base = key.partition("code_object:")
+        if sep and not prefix and base:
+            index.setdefault(base, value)
+    return index
+
+
+def _gzip_logs(case_dir: Path) -> None:
+    """Compress every ``*.log`` in a published case dir to ``*.log.gz`` in place.
+
+    ConSan runs with hook logging at debug level, so an uncompressed log is the
+    bulkiest thing in a run area; gzip keeps a 7-run log window cheap on the
+    data branch. ``mtime=0`` keeps the output byte-stable for identical input,
+    so re-publishing an unchanged run does not churn the branch. Idempotent: a
+    case dir that was already compressed has no ``*.log`` left to convert.
+    """
+    for src in sorted(case_dir.rglob("*.log")):
+        if not src.is_file():
+            continue
+        dest = src.with_name(f"{src.name}.gz")
+        with src.open("rb") as raw, dest.open("wb") as fh:
+            with gzip.GzipFile(filename="", mode="wb", fileobj=fh, mtime=0) as out:
+                shutil.copyfileobj(raw, out)
+        src.unlink()
+
+
+def _prune_run_area_bulk(case_dir: Path) -> None:
+    """Drop the heavy, regenerable parts of a run area outside the log window.
+
+    Keeps ``sanitizer_report.json`` (and the landing page / manifests written
+    next to it) so an older run still renders and still drills down; removes the
+    logs, the copied inputs and the recipe copy. ``recipe.yaml`` is pruned even
+    though it is tiny, so that a run area's contents depend only on its age and
+    not on whether it was ever published inside the window -- ``env.json`` still
+    records the recipe path, and the commit it ran at, to recover it from.
+
+    The caller must re-render ``index.html`` afterwards: it enumerates what is
+    on disk, so a page written before pruning would link files that are gone.
+    """
+    if not case_dir.is_dir():
+        return
+    for log in sorted(case_dir.rglob("*.log.gz")) + sorted(case_dir.rglob("*.log")):
+        log.unlink(missing_ok=True)
+    shutil.rmtree(case_dir / "inputs", ignore_errors=True)
+    (case_dir / "recipe.yaml").unlink(missing_ok=True)
+    # Remove the now-empty per-sanitizer log dirs so the file list is not a row
+    # of empty folders.
+    for sub in sorted(p for p in case_dir.iterdir() if p.is_dir()):
+        if not any(sub.iterdir()):
+            sub.rmdir()
+
+
+def _read_text_or_empty(path: Path) -> str:
+    """Read a repo file, or "" when it is missing/unreadable.
+
+    A run area whose recipe cannot be read is still worth publishing; aborting
+    the whole dashboard over it is not.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _publish_recipe_inputs(
+    case_dir: Path, *, recipe_src: Path, repo_root: Path
+) -> tuple[list[str], list[str]]:
+    """Copy a case's recipe and its source-level inputs into the run area.
+
+    Returns ``(copied, built)``: the recipe-relative paths copied under
+    ``inputs/``, and the referenced CI-built artifacts that were deliberately
+    skipped (recorded by digest by the caller). A recipe that cannot be read
+    yields ``([], [])`` -- a run area missing its inputs is worth publishing,
+    an aborted dashboard is not.
+    """
+    recipe_text = _read_text_or_empty(recipe_src)
+    if not recipe_text:
+        return [], []
+    (case_dir / "recipe.yaml").write_text(recipe_text, encoding="utf-8")
+    source_refs, built_refs = _recipe_fixture_refs(recipe_text)
+    recipe_dir = recipe_src.parent
+    copied: list[str] = []
+    for ref in source_refs:
+        src = recipe_dir / ref
+        # Recipe text is repo-authored, but resolve defensively anyway: an input
+        # must stay inside the recipe tree so a stray path cannot pull an
+        # unrelated file into a published, publicly-served directory.
+        try:
+            resolved = src.resolve()
+            resolved.relative_to(repo_root.resolve())
+        except (OSError, ValueError):
+            continue
+        if not resolved.is_file():
+            continue
+        dest = case_dir / "inputs" / ref
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(resolved, dest)
+        copied.append(ref)
+    return copied, built_refs
+
+
+def _human_size(num_bytes: int) -> str:
+    """A compact file size for the run-area file table."""
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    value = float(num_bytes)
+    for unit in ("KB", "MB", "GB"):
+        value /= 1024.0
+        if value < 1024.0:
+            return f"{value:.1f} {unit}"
+    return f"{value:.1f} TB"
+
+
+def run_area_files(case_dir: Path) -> list[tuple[str, int]]:
+    """Every published file in a run area as ``(relative path, size)`` pairs.
+
+    Enumerates what is actually on disk rather than what was expected, so the
+    landing page never links a file that pruning removed or a run never
+    produced. ``index.html`` itself is excluded (it is the page doing the
+    listing). Sorted for a stable page across re-publishes.
+    """
+    if not case_dir.is_dir():
+        return []
+    files: list[tuple[str, int]] = []
+    for path in sorted(case_dir.rglob("*")):
+        if not path.is_file() or path.name == "index.html":
+            continue
+        files.append((path.relative_to(case_dir).as_posix(), path.stat().st_size))
+    return files
+
+
+# Both renderers of the rebuild section share this trailer: the workflow is what
+# actually built the artifacts, so it -- not a paraphrase here -- is the source
+# of truth for the exact invocation.
+_REBUILD_NOTE = (
+    "The exact invocations the nightly used are in "
+    ".github/workflows/sanitizers-nightly.yml."
+)
+
+
+def _rebuild_hints(built_refs: list[str], *, target: str) -> list[str]:
+    """One rebuild hint per artifact the run area deliberately does not ship (pure).
+
+    Single source of truth so the REPRODUCE.md and landing-page renderings of
+    the rebuild section stay in parity.
+    """
+    hints: list[str] = []
+    for ref in built_refs:
+        if f"{ref}/".startswith("fixtures/isa/"):
+            hints.append(
+                f"{ref} -- a gfx code object: `hipcc --genco --offload-arch={target}` "
+                "from the matching fixtures/kernels/*.hip source, or "
+                "scripts/sanitizers/prepare_gemm_isa.py for the GEMM objects."
+            )
+        elif f"{ref}/".startswith("fixtures/bin/"):
+            hints.append(
+                f"{ref} -- a host repro binary: "
+                f"`hipcc --offload-arch={target} <source>.hip -o {ref}`."
+            )
+        else:
+            hints.append(ref)
+    return hints
+
+
+def build_case_env(
+    *,
+    case: str,
+    cls: str,
+    recipe: str,
+    command: str,
+    meta: dict[str, Any],
+    summary: dict[str, Any],
+    report: dict[str, Any] | None,
+    built_refs: list[str],
+    inputs: list[str],
+    logs: bool = True,
+    provenance: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """The machine-readable provenance manifest for one run area (pure).
+
+    Deliberately narrow: it states only what the publishing job genuinely knows
+    -- the run identity, the recipe and command, what was observed, and the
+    digests already present in the report. It is NOT an env-probe snapshot;
+    the nightly never runs one, so anything shaped like that schema here would
+    be fabricated fields rather than captured ones.
+
+    ``provenance`` is passed in rather than read from the environment here, so a
+    caller re-rendering an *older* run's area cannot accidentally relabel it with
+    the current job's image and bundle; an empty mapping omits those fields.
+
+    ``logs`` records whether this area still carries the bulk it was published
+    with, or has been pruned back to the report for falling outside the
+    ``--keep-logs`` window. Both renderings read it, so neither promises files
+    that a pruned area no longer has.
+    """
+    digests = report_digests(report)
+    by_basename = artifact_digest_index(digests)
+    env: dict[str, Any] = {
+        "schema": RUN_AREA_ENV_SCHEMA,
+        "case": case,
+        "class": cls,
+        "recipe": recipe,
+        "command": command,
+        "run": meta.get("run", ""),
+        "commit": meta.get("commit_full") or meta.get("commit", ""),
+        "date": meta.get("date", ""),
+        "target": meta.get("gpu", ""),
+        "observed": {
+            "verdict": summary.get("verdict"),
+            "execution": summary.get("execution"),
+            "reason": (summary.get("primary") or {}).get("reason"),
+            "findings": summary.get("findings", 0),
+        },
+        "inputs": inputs,
+        "logs_published": logs,
+        "artifacts_not_published": [
+            {"path": ref, "sha256": by_basename.get(_basename(ref))} for ref in built_refs
+        ],
+        "digests": digests,
+    }
+    if meta.get("run_url"):
+        env["run_url"] = meta["run_url"]
+    for key, value in (provenance or {}).items():
+        if value:
+            env[key] = value
+    return env
+
+
+def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
+    """REPRODUCE.md for one run area (pure).
+
+    The downloadable companion to the landing page rather than a strict twin of
+    it: the two share the run identity, the reproduce command and the rebuild
+    section (via ``_rebuild_hints``), and this file additionally carries the
+    required env and the recorded digests that the page links it for.
+    """
+    observed = env.get("observed") or {}
+    # Point at the file table rather than restating an inventory here: what a run
+    # area holds depends on its age (see ``--keep-logs``) and on whether it was
+    # published by the job that ran it, and a fixed sentence would go stale.
+    pruned = (
+        ""
+        if env.get("logs_published", True)
+        else " Its logs, recipe copy and inputs were pruned for falling outside the "
+        "nightly's log-retention window."
+    )
+    lines = [
+        f"# Reproduce `{env['case']}`",
+        "",
+        f"Sanitizer case `{env['case']}` from run `{env.get('run', '')}` of the AORTA "
+        "sanitizer nightly. This directory is the run area for that one case: its "
+        "report, the sanitizer output the verdict came from, and the provenance "
+        f"below.{pruned} See `index.html` for every file actually published here.",
+        "",
+        "## Run",
+        "",
+        f"- Commit: `{env.get('commit', '')}`",
+        f"- Date: {env.get('date', '')}",
+        f"- Target: `{env.get('target', '')}`",
+        f"- Class: {env.get('class', '')} "
+        + ("(gated guardrail)" if env.get("class") == "guardrail" else "(observed-only, non-gating)"),
+    ]
+    if env.get("run_url"):
+        lines.append(f"- Workflow run: {env['run_url']}")
+    if env.get("container_image"):
+        lines.append(f"- Container image: `{env['container_image']}`")
+    if env.get("rocjitsu_commit"):
+        bundle = f"- rocjitsu bundle: `{env['rocjitsu_commit']}`"
+        if env.get("rocjitsu_run_url"):
+            bundle += f" ({env['rocjitsu_run_url']})"
+        lines.append(bundle)
+    lines += [
+        "",
+        "## Observed",
+        "",
+        f"- Verdict: `{observed.get('verdict') or _DASH}`",
+        f"- Execution: `{observed.get('execution') or _DASH}`",
+        f"- Findings: {observed.get('findings', 0)}",
+    ]
+    if observed.get("reason"):
+        lines.append(f"- Reason: `{observed['reason']}`")
+    lines += [
+        "",
+        "## Run it yourself",
+        "",
+        "```",
+        "git clone https://github.com/ROCm/aorta && cd aorta",
+        f"git checkout {env.get('commit', '')}",
+        "pip install -e .",
+        f"{env.get('command', '')}",
+        "```",
+        "",
+        "The sanitizer backends (`rj_waitcheck`, the ConSan hook) come from the "
+        "prebuilt rocjitsu bundle; point `ROCJITSU_PREBUILT` at an unpacked bundle "
+        "before running. ConSan additionally requires `HSA_TOOLS_LIB`, "
+        "`HSA_TOOLS_DISABLE_REGISTER=1`, `RJ_CONSAN_MODE` and `RJ_CONSAN_POLICY`, "
+        "which `aorta` sets for you from the recipe's policy block.",
+        "",
+    ]
+    hints = _rebuild_hints(built_refs, target=str(env.get("target") or "gfx950"))
+    if hints:
+        lines += [
+            "## Rebuild the fixtures",
+            "",
+            "This case needs CI-built fixtures that are not published here (see "
+            "'Artifacts not published' below). Rebuild them with:",
+            "",
+            *(f"- {hint}" for hint in hints),
+            "",
+            _REBUILD_NOTE,
+            "",
+        ]
+    if env.get("artifacts_not_published"):
+        lines += [
+            "## Artifacts not published",
+            "",
+            "These are CI-built and too large to publish for every retained run. "
+            "Rebuild them as above and check the digest matches.",
+            "",
+            "| Path | SHA-256 |",
+            "|---|---|",
+        ]
+        for item in env["artifacts_not_published"]:
+            lines.append(f"| `{item['path']}` | `{item.get('sha256') or _DASH}` |")
+        lines.append("")
+    if env.get("digests"):
+        lines += ["## Recorded digests", "", "| Key | Value |", "|---|---|"]
+        for key, value in sorted(env["digests"].items()):
+            lines.append(f"| `{key}` | `{value}` |")
+        lines.append("")
+    lines += [
+        "## Files here",
+        "",
+        "See `index.html` for the browsable list. "
+        + ("Logs are gzipped; " if env.get("logs_published", True) else "")
+        + "`sanitizer_report.json` is the full `aorta.sanitizer_report/0.1` document "
+        "the dashboard renders from.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def case_dir_up(case_dir: Path, out_dir: Path) -> tuple[str, str]:
+    """Relative paths from a case dir back to ``(dashboard root, its run dir)``.
+
+    Derived from the published depth rather than hardcoded per caller, because
+    the two tabs sit at different depths -- ``runs/<id>/<case>/`` for a guardrail
+    case and ``runs/<id>/survey/<case>/`` for a survey one -- and an off-by-one
+    here is a broken back-link on a page nothing else links to.
+    """
+    try:
+        depth = len(case_dir.resolve().relative_to(out_dir.resolve()).parts)
+    except ValueError:
+        return "../../", "../"
+    return "../" * depth, "../" * max(depth - 2, 1)
+
+
+def build_case_index_html(
+    env: dict[str, Any],
+    files: list[tuple[str, int]],
+    *,
+    built_refs: list[str],
+    up: str,
+    run_up: str = "../",
+    title: str = "Sanitizers Nightly",
+) -> str:
+    """The run area's landing page: what this case was, and every file to download.
+
+    GitHub Pages does not auto-index a directory, so this page is what makes the
+    card footer's directory link resolve at all. ``up`` / ``run_up`` are the
+    relative paths back to the dashboard root and to this case's run area (case
+    dirs sit at different depths on the two tabs; see ``case_dir_up``).
+    """
+    observed = env.get("observed") or {}
+    rows = "".join(
+        f'<tr><td class=mono><a href="{_esc(rel)}">{_esc(rel)}</a></td>'
+        f"<td class=num>{_esc(_human_size(size))}</td></tr>"
+        for rel, size in files
+    ) or '<tr><td class=empty colspan=2>no files published for this case</td></tr>'
+    facts = [
+        ("Run", _esc(str(env.get("run", "")))),
+        ("Commit", _esc(str(env.get("commit", "")))),
+        ("Date", _esc(str(env.get("date", "")))),
+        ("Target", _esc(str(env.get("target", "")))),
+        ("Recipe", _esc(str(env.get("recipe", "")))),
+        ("Findings", _esc(str(observed.get("findings", 0)))),
+    ]
+    if env.get("container_image"):
+        facts.append(("Container", _esc(str(env["container_image"]))))
+    if env.get("rocjitsu_commit"):
+        facts.append(("rocjitsu bundle", _esc(str(env["rocjitsu_commit"]))))
+    kv = "".join(_fact_html(label, value, mono=True) for label, value in facts)
+    reason = observed.get("reason")
+    reason_html = (
+        f'<div class="observation {_tone_for(observed.get("verdict"))}">'
+        f'<span class="lbl">Reason</span><span class="msg">{_esc(str(reason))}</span></div>'
+        if reason
+        else ""
+    )
+    hints = _rebuild_hints(built_refs, target=str(env.get("target") or "gfx950"))
+    steps_html = (
+        (
+            '<p class="cap">Rebuild the fixtures</p><ul class="steps">'
+            + "".join(f"<li>{_esc(hint)}</li>" for hint in hints)
+            + f'</ul><p class="note">{_esc(_REBUILD_NOTE)}</p>'
+        )
+        if hints
+        else ""
+    )
+    not_published = env.get("artifacts_not_published") or []
+    np_html = ""
+    if not_published:
+        np_rows = "".join(
+            f'<tr><td class=mono>{_esc(str(item["path"]))}</td>'
+            f'<td class="mono wrap-any">{_esc(str(item.get("sha256") or "")) or "&mdash;"}</td></tr>'
+            for item in not_published
+        )
+        np_html = (
+            '<p class="cap">Artifacts not published</p><div class="table-wrap"><table>'
+            "<thead><tr><th>Path</th><th>SHA-256</th></tr></thead>"
+            f"<tbody>{np_rows}</tbody></table></div>"
+        )
+    run_link = (
+        f'<a href="{_esc(str(env["run_url"]))}">workflow run</a>'
+        if env.get("run_url")
+        else "<span></span>"
+    )
+    files_caption = (
+        "Every file published for this case. Logs are gzipped."
+        if env.get("logs_published", True)
+        else "Every file published for this case. Its logs, recipe copy and inputs "
+        "were pruned for falling outside the nightly's log-retention window."
+    )
+    return (
+        "<!doctype html>\n"
+        "<html lang=en><head><meta charset=utf-8>\n"
+        '<meta name=viewport content="width=device-width, initial-scale=1">\n'
+        f"<title>{_esc(title)} &middot; {_esc(str(env.get('case', '')))}</title>\n"
+        f"<style>{_CSS}\n  .wrap {{ max-width:900px; }}\n"
+        "  .note { margin:0 0 14px; color:var(--text-3); font-size:13px; }\n"
+        "  .steps { margin:0 0 6px; padding-left:18px; color:var(--text-2);\n"
+        "    font-size:var(--fs-obs); }\n"
+        "  .steps li { margin:3px 0; }</style></head>\n"
+        "<body><div class=wrap>\n"
+        f'<div class=navrow><span><a href="{_esc(up)}">&larr; back to sanitizer dashboard</a>'
+        f' &middot; <a href="{_esc(run_up)}">run {_esc(str(env.get("run", "")))}</a></span>\n'
+        f"{run_link}</div>\n"
+        '<div class=topbar>\n'
+        '<header class="page-header"><div class="brand-tile">'
+        f"{_svg(_ICON_FILE, size=24, width=2)}</div><div>\n"
+        f"<h1>{_esc(str(env.get('case', '')))}</h1>\n"
+        '<p class="subtitle">Run area &mdash; everything needed to reproduce this '
+        "case locally</p></div></header>\n"
+        "</div>\n"
+        '<section class="panel">\n'
+        f"<h2>Case {_verdict_html(observed.get('verdict') or _DASH)}</h2>\n"
+        f'<div class="kv">{kv}</div>\n'
+        f"{reason_html}\n"
+        '<div class="repro"><span class="lbl">Reproduce</span>'
+        f'<code>{_esc(str(env.get("command", "")))}</code></div>\n'
+        f"{steps_html}{np_html}"
+        "</section>\n"
+        '<section class="panel"><h2>Files</h2>\n'
+        f'<p class="cap">{_esc(files_caption)}</p>\n'
+        '<div class="table-wrap"><table>\n'
+        "<thead><tr><th>File</th><th class=num>Size</th></tr></thead>\n"
+        f"<tbody>{rows}</tbody>\n"
+        "</table></div></section>\n"
+        "</div></body></html>\n"
+    )
+
+
+def write_case_run_area(
+    case_dir: Path,
+    *,
+    case: str,
+    cls: str,
+    recipe_stem: str,
+    command: str,
+    meta: dict[str, Any],
+    summary: dict[str, Any],
+    report: dict[str, Any] | None,
+    repo_root: Path,
+    up: str,
+    run_up: str = "../",
+    logs: bool = True,
+    provenance: dict[str, str] | None = None,
+    current: bool = True,
+) -> None:
+    """Materialise one run area: recipe + inputs + REPRODUCE.md + env.json + index.
+
+    Called after the case's report and logs are already in ``case_dir``, so the
+    file listing on the landing page reflects exactly what was published.
+
+    ``current`` means this run is the one the publishing job just staged, and is
+    what gates the two things only that job can source correctly: the ``recipe``
+    and its inputs, which come from *its* checkout, and ``provenance``, which
+    describes *its* container and sanitizer build. Re-rendering an older run's
+    area must leave both alone -- copying today's recipe into a three-week-old
+    area would replace the recipe as it ran with whatever is on ``main`` now,
+    beside an ``env.json`` still telling the reader to check out that run's
+    commit. Older areas keep what they captured while they were current (see
+    ``refresh_published_case_area``); this path is the fallback for a run
+    published before run areas existed, which can only state what its own
+    ``meta.json`` and report still say.
+
+    ``logs=False`` (a run outside the ``--keep-logs`` window) still writes the
+    manifests and the page -- which stay useful and cost bytes, not megabytes --
+    and both renderings then describe the area as pruned rather than promising
+    files it does not have.
+    """
+    recipe_rel = f"recipes/sanitizers/{recipe_stem}.yaml"
+    inputs: list[str] = []
+    built_refs: list[str] = []
+    if current and logs:
+        inputs, built_refs = _publish_recipe_inputs(
+            case_dir, recipe_src=repo_root / recipe_rel, repo_root=repo_root
+        )
+    else:
+        # The referenced built artifacts are still worth naming by digest even
+        # when nothing is copied; the recipe is only read, never published.
+        _, built_refs = _recipe_fixture_refs(
+            _read_text_or_empty(repo_root / recipe_rel)
+        )
+    env = build_case_env(
+        case=case,
+        cls=cls,
+        recipe=recipe_rel,
+        command=command,
+        meta=meta,
+        summary=summary,
+        report=report,
+        built_refs=built_refs,
+        inputs=inputs,
+        logs=logs,
+        provenance=provenance if current else None,
+    )
+    (case_dir / "env.json").write_text(
+        json.dumps(env, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (case_dir / "REPRODUCE.md").write_text(
+        build_reproduce_md(env, built_refs=built_refs), encoding="utf-8"
+    )
+    (case_dir / "index.html").write_text(
+        build_case_index_html(
+            env,
+            run_area_files(case_dir),
+            built_refs=built_refs,
+            up=up,
+            run_up=run_up,
+        ),
+        encoding="utf-8",
+    )
+
+
+def refresh_published_case_area(case_dir: Path, out_dir: Path, *, logs: bool) -> bool:
+    """Re-render an already-published run area from its own persisted manifest.
+
+    Every retained run is re-rendered on every nightly, but only the run being
+    published now can be described from the live job. So an older area keeps the
+    ``env.json`` it captured while it was current -- its commit, its container
+    image, its rocjitsu bundle -- and only its rendering is rebuilt. That rebuild
+    is what keeps the page honest once the area has been pruned: the file table
+    enumerates what is on disk, so a page written before pruning would go on
+    linking logs that are gone.
+
+    Call after gzipping or pruning, with ``logs`` saying which happened. Returns
+    ``False`` when there is no manifest to rebuild from (a run published before
+    run areas existed), leaving the caller to write a fresh one.
+    """
+    env = _load(case_dir / "env.json")
+    if not isinstance(env, dict):
+        return False
+    if not logs:
+        # The manifest described an area that still had its bulk. Restate it for
+        # what is left, so it does not name inputs that are no longer there.
+        env["inputs"] = []
+    env["logs_published"] = logs
+    built_refs = [
+        str(item["path"])
+        for item in env.get("artifacts_not_published") or []
+        if isinstance(item, dict) and item.get("path")
+    ]
+    up, run_up = case_dir_up(case_dir, out_dir)
+    (case_dir / "env.json").write_text(
+        json.dumps(env, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (case_dir / "REPRODUCE.md").write_text(
+        build_reproduce_md(env, built_refs=built_refs), encoding="utf-8"
+    )
+    (case_dir / "index.html").write_text(
+        build_case_index_html(
+            env,
+            run_area_files(case_dir),
+            built_refs=built_refs,
+            up=up,
+            run_up=run_up,
+        ),
+        encoding="utf-8",
+    )
+    return True
+
+
 def _status_banner_html(status: dict[str, Any] | None) -> str:
     """Staleness banner shown when the latest nightly did not publish healthily.
 
@@ -1367,14 +2129,22 @@ def _kernel_tables_html(
 
 
 def _raw_link_html(report_rel: str | None) -> str:
-    """The raw-report link, as a card footer.
+    """The run-area link, as a card footer.
+
+    Points at the case's published *directory*, not just its
+    ``sanitizer_report.json``: the run area also carries the sanitizer logs the
+    verdict came from, the recipe as it ran, its source-level inputs and a
+    REPRODUCE.md, which is what makes the card's reproduce command actionable
+    (#384). The per-kernel-row ``Report`` column still links the JSON directly
+    for a schema drill-down.
 
     Deliberately in the card body rather than the ``<summary>`` row: a link
     inside a summary competes with the disclosure toggle.
     """
-    if not report_rel:
+    rel = _case_dir_rel(report_rel)
+    if not rel:
         return ""
-    return f'<div class="card-foot"><a href="{_esc(report_rel)}">view raw report</a></div>'
+    return f'<div class="card-foot"><a href="{_esc(rel)}">run area</a></div>'
 
 
 def _findings_chip_html(row: dict[str, Any]) -> str:
@@ -2092,12 +2862,79 @@ def build_html(
 """
 
 
-def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightly") -> str:
+def _run_index_survey_html(survey: list[dict[str, Any]] | None) -> str:
+    """The run landing page's workload-survey table (pure).
+
+    Without this the page lists only the three gated guardrail recipes, so the
+    top-nav "raw reports" link never mentions the survey cases published
+    alongside them under ``survey/<case>/`` (#384). Links are case-local, and
+    only a present report gets one so the page never points at a 404. For a past
+    run the entries come from ``survey_entries_from_published``, whose recorded
+    verdict can be absent -- hence the em-dash fallback rather than a "None".
+    """
+    if not survey:
+        return ""
+    rows = "".join(
+        f"<tr><td class=mono>{_esc(str(entry.get('label') or entry.get('name', '')))}</td>"
+        f"<td>{_verdict_html((entry.get('summary') or {}).get('verdict') or _DASH)}</td>"
+        f"<td class=mono>{_esc(str(entry.get('command') or ''))}</td>"
+        + (
+            f'<td><a href="survey/{_esc(str(entry.get("name", "")))}/">run area</a></td>'
+            if (entry.get("summary") or {}).get("present")
+            else '<td><span class="dash">&mdash;</span></td>'
+        )
+        + "</tr>"
+        for entry in survey
+    )
+    return (
+        '<section class="panel"><h2>Workload survey '
+        f'<span class=count>{len(survey)} observed-only</span></h2>'
+        '<div class="table-wrap"><table>\n'
+        "<thead><tr><th>Case</th><th>Observed</th><th>Reproduce</th><th>Files</th></tr></thead>\n"
+        f"<tbody>{rows}</tbody>\n"
+        "</table></div></section>\n"
+    )
+
+
+def survey_entries_from_published(run_dir: Path) -> list[dict[str, Any]]:
+    """Reconstruct a past run's survey list from the areas published under it.
+
+    The live survey list only ever covers the run being published now, so an
+    older run's landing page has nothing to render its Workload survey section
+    from -- leaving the survey areas still on the data branch under it reachable
+    only by typing the URL, on a site that cannot auto-index a directory. Each
+    area's own ``env.json`` already records everything that table shows.
+    """
+    entries: list[dict[str, Any]] = []
+    for case_dir in sorted(p for p in (run_dir / "survey").glob("*") if p.is_dir()):
+        env = _load(case_dir / "env.json")
+        if not isinstance(env, dict):
+            continue
+        observed = env.get("observed") or {}
+        entries.append({
+            "name": case_dir.name,
+            "label": str(env.get("case") or case_dir.name),
+            "command": str(env.get("command") or ""),
+            "summary": {
+                "verdict": observed.get("verdict"),
+                "present": (case_dir / "sanitizer_report.json").is_file(),
+            },
+        })
+    return entries
+
+
+def build_run_index_html(
+    run: dict[str, Any],
+    *,
+    title: str = "Sanitizers Nightly",
+    survey: list[dict[str, Any]] | None = None,
+) -> str:
     """A tiny, self-contained landing page for one published run (pure).
 
     Lives at ``runs/<id>/index.html`` alongside the run's raw reports, so the
     report links are case-local (``<case>/sanitizer_report.json``) rather than
-    dashboard-root-relative.
+    dashboard-root-relative. ``survey`` adds the observed-only cases published
+    under ``survey/<case>/`` for this run, so the page covers both tabs.
     """
     meta = run["meta"]
     rows = run["rows"]
@@ -2115,10 +2952,16 @@ def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightl
         href = _esc(f"{case}/sanitizer_report.json")
         return f'<a href="{href}">sanitizer_report.json</a>'
 
+    def _area_cell(case: str, present: bool) -> str:
+        if not present:
+            return '<span class="dash">&mdash;</span>'
+        return f'<a href="{_esc(case)}/">run area</a>'
+
     report_rows = "".join(
         f"<tr><td class=mono>{_esc(label)}</td>"
         f"<td>{_baseline_status_html(rows[case])} {_verdict_html(rows[case]['verdict'])}</td>"
-        f"<td>{_cell(case, rows[case]['present'])}</td></tr>"
+        f"<td>{_cell(case, rows[case]['present'])}</td>"
+        f"<td>{_area_cell(case, rows[case]['present'])}</td></tr>"
         for case, _key, label, _backend in CASES
     )
     # Shares the dashboard stylesheet so a drill-down does not look like a
@@ -2141,9 +2984,11 @@ def build_run_index_html(run: dict[str, Any], *, title: str = "Sanitizers Nightl
         "</div>\n"
         f"{_gate_hero_html(summary)}\n"
         '<section class="panel"><h2>Raw reports</h2><div class="table-wrap"><table>\n'
-        "<thead><tr><th>Recipe</th><th>Baseline status</th><th>Raw report</th></tr></thead>\n"
+        "<thead><tr><th>Recipe</th><th>Baseline status</th><th>Raw report</th>"
+        "<th>Files</th></tr></thead>\n"
         f"<tbody>{report_rows}</tbody>\n"
         "</table></div></section>\n"
+        f"{_run_index_survey_html(survey)}"
         "</div></body></html>\n"
     )
 
@@ -2372,6 +3217,22 @@ def main() -> int:
         default=30,
         help="in --history-root mode, render only the newest N runs (default 30)",
     )
+    ap.add_argument(
+        "--keep-logs",
+        type=int,
+        default=7,
+        help="keep sanitizer logs + the recipe copy and its inputs for only the "
+        "newest N runs (default 7), guardrail and survey areas alike. Older "
+        "retained runs keep their report, manifests and landing page; their bulk "
+        "is pruned so the data branch stays bounded (#384).",
+    )
+    ap.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repo checkout the recipes and their source-level fixture inputs are "
+        "copied from into each run area (defaults to this script's own checkout)",
+    )
     ap.add_argument("--baselines", type=Path, required=True)
     ap.add_argument("--out-dir", type=Path, required=True)
     ap.add_argument("--commit", default=os.environ.get("GITHUB_SHA", ""))
@@ -2463,6 +3324,9 @@ def main() -> int:
         # exactly. Skip when history_root IS runs_out (CI) or nests beneath it
         # (e.g. --history-root out/runs/source --out-dir out) -- removing runs_out
         # would delete the very reports we are about to copy.
+        # Describes this job's GPU run only, so it is stamped onto the run being
+        # published now and never onto the older runs re-rendered beside it.
+        provenance = provenance_from_environ()
         runs_out = args.out_dir / "runs"
         runs_out_res = runs_out.resolve()
         history_res = args.history_root.resolve()
@@ -2471,30 +3335,114 @@ def main() -> int:
         )
         if runs_out.exists() and not history_within_runs_out:
             shutil.rmtree(runs_out)
-        for run in runs:
+        for position, run in enumerate(runs):
             rel = run.get("rel")
             if not rel:
                 continue
             run_out = args.out_dir / rel
             run_out.mkdir(parents=True, exist_ok=True)
-            # Co-locate each retained run's raw reports under the output tree so the
-            # emitted runs/<id>/<case>/sanitizer_report.json links resolve even when
-            # --history-root is not already <out-dir>/runs. In CI both resolve to the
-            # same path, so the copy is skipped and this is a no-op.
+            # Logs and copied inputs are kept only for the newest --keep-logs runs;
+            # every retained run still keeps its report, manifests and landing page.
+            keep_logs = position < max(args.keep_logs, 0)
+            # Co-locate each retained run's raw case dirs under the output tree so the
+            # emitted runs/<id>/<case>/... links resolve even when --history-root is
+            # not already <out-dir>/runs. In CI both resolve to the same path, so the
+            # copy is skipped and only the in-place steps below apply.
             src_run = args.history_root / run["meta"].get("run", "")
             if src_run.is_dir() and src_run.resolve() != run_out.resolve():
                 for case, _key, _label, _backend in CASES:
-                    src_report = src_run / case / "sanitizer_report.json"
-                    if src_report.is_file():
-                        (run_out / case).mkdir(parents=True, exist_ok=True)
-                        shutil.copy2(src_report, run_out / case / "sanitizer_report.json")
+                    # Copy the whole case dir, not just the report: the sanitizer
+                    # logs the verdict came from are what make the run area
+                    # reproducible (#384).
+                    src_case = src_run / case
+                    if src_case.is_dir():
+                        shutil.copytree(src_case, run_out / case, dirs_exist_ok=True)
                 # Carry the run manifest too so the published layout
                 # (runs/<id>/meta.json) is complete, not just the reports.
                 src_meta = src_run / "meta.json"
                 if src_meta.is_file():
                     shutil.copy2(src_meta, run_out / "meta.json")
+            # Only the newest run was produced by this job, so only its area may be
+            # written from the live checkout and environment (see
+            # write_case_run_area); older ones are re-rendered from what they
+            # captured themselves.
+            current = position == 0
+            for case, _key, label, _backend in CASES:
+                row = run["rows"][case]
+                case_out = run_out / case
+                if not row.get("present") or not case_out.is_dir():
+                    continue
+                if keep_logs:
+                    _gzip_logs(case_out)
+                else:
+                    _prune_run_area_bulk(case_out)
+                if not current and refresh_published_case_area(
+                    case_out, args.out_dir, logs=keep_logs
+                ):
+                    continue
+                up, run_up = case_dir_up(case_out, args.out_dir)
+                write_case_run_area(
+                    case_out,
+                    case=case,
+                    cls="guardrail",
+                    recipe_stem=label,
+                    command=f"aorta sweep run --recipe recipes/sanitizers/{label}.yaml",
+                    meta=run["meta"],
+                    summary=row,
+                    report=_load(case_out / "sanitizer_report.json"),
+                    repo_root=args.repo_root,
+                    up=up,
+                    run_up=run_up,
+                    logs=keep_logs,
+                    provenance=provenance,
+                    current=current,
+                )
+            # A survey area is published under whichever run was latest at the
+            # time, so it ages out of the log window with the rest of that run --
+            # without this its ConSan log, the bulkiest thing published, would
+            # outlive the guardrail logs beside it by --keep minus --keep-logs.
+            # The current run's areas are (re)written from this job's own results
+            # further below, so they are not touched here.
+            if not current:
+                for survey_case in sorted(
+                    p for p in (run_out / "survey").glob("*") if p.is_dir()
+                ):
+                    if not keep_logs:
+                        _prune_run_area_bulk(survey_case)
+                    if refresh_published_case_area(
+                        survey_case, args.out_dir, logs=keep_logs
+                    ):
+                        continue
+                    # Co-published before run areas existed: retrofit one, the same
+                    # way an older guardrail case is handled above. Without this an
+                    # area with a report but no manifest stays invisible -- it gets
+                    # no landing page, and survey_entries_from_published skips it.
+                    survey_report = _load(survey_case / "sanitizer_report.json")
+                    if not isinstance(survey_report, dict):
+                        continue
+                    stem = _survey_recipe_for(survey_case.name)
+                    up, run_up = case_dir_up(survey_case, args.out_dir)
+                    write_case_run_area(
+                        survey_case,
+                        case=survey_case.name,
+                        cls="survey",
+                        recipe_stem=stem,
+                        command=f"aorta sweep run --recipe recipes/sanitizers/{stem}.yaml",
+                        meta=run["meta"],
+                        summary=summarize_case(survey_report, None),
+                        report=survey_report,
+                        repo_root=args.repo_root,
+                        up=up,
+                        run_up=run_up,
+                        logs=keep_logs,
+                        current=False,
+                    )
             (run_out / "index.html").write_text(
-                build_run_index_html(run), encoding="utf-8"
+                build_run_index_html(
+                    run,
+                    survey=survey if current else survey_entries_from_published(run_out),
+                ),
+                encoding="utf-8",
             )
         # Co-publish each caller-supplied ConSan report (#347) under the latest run's
         # survey area so the report_rel links threaded above (survey/<name>/...)
@@ -2504,13 +3452,34 @@ def main() -> int:
         latest_rel = runs[0].get("rel") if runs else None
         info_dir = args.informational_results_dir
         if latest_rel and info_dir is not None and info_dir.is_dir():
+            survey_by_name = {str(entry.get("name")): entry for entry in survey}
             for case_dir in sorted(p for p in info_dir.iterdir() if p.is_dir()):
                 src_report = case_dir / "sanitizer_report.json"
                 if not src_report.is_file():
                     continue
                 dest = args.out_dir / latest_rel / "survey" / case_dir.name
-                dest.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src_report, dest / "sanitizer_report.json")
+                # The whole case dir, so the ConSan/waitcheck logs behind the
+                # observed verdict ship with the report (#384).
+                shutil.copytree(case_dir, dest, dirs_exist_ok=True)
+                _gzip_logs(dest)
+                entry = survey_by_name.get(case_dir.name)
+                if entry is None:
+                    continue
+                up, run_up = case_dir_up(dest, args.out_dir)
+                write_case_run_area(
+                    dest,
+                    case=case_dir.name,
+                    cls="survey",
+                    recipe_stem=_survey_recipe_for(case_dir.name),
+                    command=str(entry.get("command") or ""),
+                    meta=runs[0]["meta"],
+                    summary=entry.get("summary") or {},
+                    report=_load(dest / "sanitizer_report.json"),
+                    repo_root=args.repo_root,
+                    up=up,
+                    run_up=run_up,
+                    provenance=provenance,
+                )
     (args.out_dir / "summary.md").write_text(
         build_summary_md(runs, status=status, survey=survey),
         encoding="utf-8",

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -680,8 +680,8 @@ def _run_record(
     rel: str | None = None,
 ) -> dict[str, Any]:
     # Guardrail rows are the baseline-checked class (Tab 1). Tag them so data.json
-    # carries the guardrail/survey case-class split; survey cases live in the
-    # separate ``survey`` list attached to the latest run.
+    # carries the guardrail/survey case-class split; survey cases live in a separate
+    # ``survey`` list attached by ``main`` to the run each list describes.
     for r in rows.values():
         r.setdefault("cls", "guardrail")
     # Fail closed: a missing report (present=False -> match=False) turns the gate
@@ -841,8 +841,10 @@ def _safe_report_rel(value: Any) -> str | None:
     executable or off-origin ``<a href>`` -- HTML-escaping the attribute does not
     neutralize a URL scheme. Reject anything that is not a plain relative path:
     a URL scheme (``scheme:``), absolute or protocol-relative paths (leading
-    ``/``), backslashes, ``..`` parent-directory traversal, and embedded
-    control/whitespace characters. The internally-computed guardrail/history
+    ``/``), backslashes, ``..`` parent-directory traversal, embedded
+    control/whitespace characters, and the URL delimiters ``?``, ``#`` and ``%``
+    -- which address something other than the path they appear in. The
+    internally-computed guardrail/history
     links already have this shape, so this only tightens the untrusted survey
     field. Rejecting ``..`` also makes the value safe to join onto a base
     directory when it is (re)used as a filesystem ``report_path`` (see
@@ -853,6 +855,15 @@ def _safe_report_rel(value: Any) -> str | None:
     if value != value.strip() or any(ord(ch) < 0x20 for ch in value):
         return None
     if value.startswith("/") or "\\" in value:
+        return None
+    # URL syntax has to go as well, not just filesystem-unsafe characters: the
+    # value is used verbatim in an ``href``, where ``?`` and ``#`` turn the rest of
+    # the path into a query/fragment on the segment before them, and a
+    # percent-escape can be normalised back into ``..`` by URL resolution. So
+    # ``runs/x?old/survey/foo/sanitizer_report.json`` passes every check below
+    # while the browser requests ``runs/x``. None of the paths this generator
+    # builds contain any of them.
+    if any(ch in value for ch in "?#%"):
         return None
     # A relative path never carries a URL scheme; a colon in the first segment
     # (before the first "/", e.g. ``javascript:``) means it is a scheme, not a path.
@@ -1178,8 +1189,18 @@ def provenance_from_environ() -> dict[str, str]:
     return {key: os.environ[var] for key, var in _RUN_AREA_ENV_VARS if os.environ.get(var)}
 
 
+# The characters a survey case directory is actually named with (``consan-gemm``,
+# ``waitcheck-gemm``, ``consan-lds-dispatch``), leading with an alphanumeric so
+# ``.``/``..`` cannot match. An allowlist rather than a list of things to reject,
+# because the value is simultaneously a path segment and a URL segment: excluding
+# only the filesystem-dangerous characters still admitted ``foo#bar`` and ``foo?x``
+# -- which a browser reads as a fragment/query on ``foo`` -- and ``%2e%2e``, which
+# URL resolution can normalise back into traversal.
+_CASE_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
 def _safe_case_segment(name: Any) -> str | None:
-    """A survey case name accepted only as one plain path segment.
+    """A survey case name accepted only as one plain, URL-safe path segment.
 
     The run page's area link is ``survey/<name>/``, and ``name`` on a ``--survey``
     entry is caller-supplied JSON. HTML-escaping that attribute does not neutralise
@@ -1189,11 +1210,7 @@ def _safe_case_segment(name: Any) -> str | None:
     agree by construction, since ``report_rel`` is built as
     ``<rel>/survey/<name>/sanitizer_report.json`` from this same value.
     """
-    if not isinstance(name, str) or not name or name in {".", ".."}:
-        return None
-    if "/" in name or "\\" in name or ":" in name:
-        return None
-    if any(char.isspace() or ord(char) < 0x20 for char in name):
+    if not isinstance(name, str) or not _CASE_SEGMENT_RE.fullmatch(name):
         return None
     return name
 
@@ -1630,6 +1647,18 @@ _GEMM_ISA_SCRIPT = (
     f"--csv {_FIXTURES_FROM_ROOT}/gemm_shapes_unique.csv --out {_FIXTURES_FROM_ROOT}/isa"
 )
 
+# Every rebuild starts here, because the tool none of them can run without is not
+# on PATH in the image that built the artifact: the ROCm container exports only
+# ``/opt/rocm/bin``, while ``clang-offload-bundler`` lives in the LLVM bindir. hipcc
+# shells out to it, ``prepare_gemm_isa.py`` requires it (``shutil.which``), and the
+# genco branch invokes it directly -- so a command that names it by bare name fails
+# exactly as the nightly's own fixture build once did ("clang-offload-bundler not
+# found on PATH"). Byte-identical to the export in sanitizers-nightly.yml, which
+# ``test_rebuild_commands_export_the_rocm_llvm_path`` cross-checks.
+_ROCM_LLVM_PATH_EXPORT = (
+    'export PATH="${ROCM_PATH:-${ROCM_HOME:-/opt/rocm}}/lib/llvm/bin:${PATH}"'
+)
+
 
 def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
     """How to rebuild each unpublished artifact, as data (pure).
@@ -1643,8 +1672,9 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
     Each entry is ``{"path", "what", "commands", "caveat"}``. ``path`` stays
     recipe-relative, matching how a recipe names the artifact and how
     ``artifacts_not_published`` records it; ``commands`` are rewritten to run from
-    the repo root, which is where REPRODUCE.md leaves the reader, and create the
-    gitignored output directory first. They are the nightly's own invocations
+    the repo root, which is where REPRODUCE.md leaves the reader, and open with the
+    two prerequisites a fresh shell lacks -- the ROCm LLVM bindir on ``PATH`` and
+    the gitignored output directory. They are the nightly's own invocations
     (see the tables above): per-artifact and not interchangeable, because a
     rebuild that differs from them will not reproduce the SHA-256 recorded beside
     the artifact. An unrecognised reference yields commands ``[]`` rather than a
@@ -1653,17 +1683,21 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
     Anything a consumer must branch on is encoded *in* a command rather than left
     to ``caveat`` prose, so the list can be executed as-is.
     """
+
+    def prelude(sub: str) -> list[str]:
+        """What every rebuild needs before its first tool call, shell order."""
+        return [_ROCM_LLVM_PATH_EXPORT, f"mkdir -p {_FIXTURES_FROM_ROOT}/{sub}"]
+
     plan: list[dict[str, Any]] = []
     for ref in built_refs:
         out = _runnable(ref)
-        mkdir = f"mkdir -p {_FIXTURES_FROM_ROOT}"
         source = _GENCO_ISA_SOURCES.get(ref)
         if source:
             plan.append({
                 "path": ref,
                 "what": f"a gfx code object built from {source}",
                 "commands": [
-                    f"{mkdir}/isa",
+                    *prelude("isa"),
                     f"hipcc --genco --offload-arch={target} {_runnable(source)} -o tmp.o",
                     # One command, because which branch is correct depends on the
                     # ROCm build: --genco emits a raw object on some and a bundle
@@ -1684,7 +1718,7 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
                 "path": ref,
                 "what": "one representative heavy f32 SS GEMM code object",
                 "commands": [
-                    f"{mkdir}/isa",
+                    *prelude("isa"),
                     f"{_GEMM_ISA_SCRIPT} --top-n 0 --consan-object {out}",
                 ],
                 "caveat": (
@@ -1697,7 +1731,7 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
             plan.append({
                 "path": ref,
                 "what": "the per-transpose f32 GEMM code objects (sol_<n>.hsaco)",
-                "commands": [f"{mkdir}/isa", f"{_GEMM_ISA_SCRIPT} --top-n 3"],
+                "commands": [*prelude("isa"), f"{_GEMM_ISA_SCRIPT} --top-n 3"],
                 "caveat": (
                     "Extracted from the shipped Tensile libraries, never compiled "
                     "from a .hip source."
@@ -1716,7 +1750,7 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
                 "path": ref,
                 "what": f"a host repro binary built from {source}",
                 "commands": [
-                    f"{mkdir}/bin",
+                    *prelude("bin"),
                     f"hipcc {flags} {_runnable(source)} -o {out}",
                 ],
                 "caveat": (
@@ -3771,10 +3805,26 @@ def main() -> int:
     # this job produced (additive; existing per-run keys are untouched).
     if current_index is not None:
         runs[current_index]["survey"] = survey
+    # What the dashboard page and the job summary show on Tab 2. Both take their
+    # guardrail data from runs[0], so the survey rendered beside it has to describe
+    # that same run -- and the run this job staged is not always the newest one (see
+    # --current-run). Passing this job's survey there would label the newer run
+    # "Latest run" while showing an older re-run's observations under it, and would
+    # drop the newer run's own published survey from data.json, which nothing else
+    # reconstructs. A published ``survey/`` has the same <case>/sanitizer_report.json
+    # layout an informational results dir does, so the newest run's list is rebuilt
+    # from the areas already published under it, at full card fidelity.
+    displayed_survey = survey
+    if runs and current_index != 0 and args.history_root is not None:
+        displayed_survey = survey_cases_from_informational_dir(
+            args.history_root / str(runs[0]["meta"].get("run", "")) / "survey",
+            rel=runs[0].get("rel"),
+        )
+        runs[0]["survey"] = displayed_survey
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     (args.out_dir / "index.html").write_text(
-        build_html(runs, status=status, survey=survey),
+        build_html(runs, status=status, survey=displayed_survey),
         encoding="utf-8",
     )
     # In published-history mode, write each retained run's tiny landing page next
@@ -3948,12 +3998,26 @@ def main() -> int:
         # matches the link. current_rel, not runs[0]: on a re-run of an older
         # workflow these differ, and staging under the newer run would attribute
         # this job's sweep to a run that did not produce it.
-        if current_rel and info_dir is not None and info_dir.is_dir():
+        if (
+            current_index is not None
+            and current_rel
+            and info_dir is not None
+            and info_dir.is_dir()
+        ):
             # That run's own retention decision, so --keep-logs applies to
             # guardrail and survey areas alike as documented (with --keep-logs 0
             # the survey area is pruned too, not left as the one unbounded thing).
-            latest_keeps_logs = (current_index or 0) < max(args.keep_logs, 0)
-            survey_by_name = {str(entry.get("name")): entry for entry in survey}
+            # The staged run's position, never a fallback to the newest one: that
+            # substitution is the mistake --current-run exists to prevent.
+            staged_keeps_logs = current_index < max(args.keep_logs, 0)
+            # Informational entries only, never a --survey spec's: this loop copies
+            # only what info_dir holds, and a spec entry that happens to share a
+            # rejected case's name would satisfy the lookup below and publish the
+            # very directory the survey loader refused to read -- with a summary and
+            # command describing a different report.
+            survey_by_name = {
+                str(entry.get("name")): entry for entry in informational_survey
+            }
             for case_dir in sorted(p for p in info_dir.iterdir() if p.is_dir()):
                 src_report = case_dir / "sanitizer_report.json"
                 if not src_report.is_file():
@@ -3983,7 +4047,7 @@ def main() -> int:
                 # The whole case dir, so the ConSan/waitcheck logs behind the
                 # observed verdict ship with the report (#384).
                 shutil.copytree(case_dir, dest, dirs_exist_ok=True)
-                if latest_keeps_logs:
+                if staged_keeps_logs:
                     _gzip_logs(dest)
                 else:
                     _prune_run_area_bulk(dest)
@@ -3994,17 +4058,17 @@ def main() -> int:
                     cls="survey",
                     recipe_stem=_survey_recipe_for(case_dir.name),
                     command=str(entry.get("command") or ""),
-                    meta=runs[current_index or 0]["meta"],
+                    meta=runs[current_index]["meta"],
                     summary=entry.get("summary") or {},
                     report=_load(dest / "sanitizer_report.json"),
                     repo_root=args.repo_root,
                     up=up,
                     run_up=run_up,
-                    logs=latest_keeps_logs,
+                    logs=staged_keeps_logs,
                     provenance=provenance,
                 )
     (args.out_dir / "summary.md").write_text(
-        build_summary_md(runs, status=status, survey=survey),
+        build_summary_md(runs, status=status, survey=displayed_survey),
         encoding="utf-8",
     )
     (args.out_dir / "data.json").write_text(

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -976,8 +976,14 @@ def survey_cases_from_spec(
                 # out-of-tree report_path, so by default nothing stages the
                 # directory and no run-area link may be emitted for it (a present
                 # report is not evidence the directory exists). A caller that does
-                # publish complete areas can say so with `"staged": true`.
-                "staged": case.get("staged") is True and summary["present"],
+                # publish complete areas can say so with `"staged": true` -- but
+                # only a name that is one plain path segment can be claimed, since
+                # the area link is built from it and `..` would traverse.
+                "staged": (
+                    case.get("staged") is True
+                    and summary["present"]
+                    and _safe_case_segment(name) is not None
+                ),
                 "cls": "survey",
                 "summary": summary,
             }
@@ -1162,6 +1168,26 @@ def provenance_from_environ() -> dict[str, str]:
     alongside it (see ``write_case_run_area``).
     """
     return {key: os.environ[var] for key, var in _RUN_AREA_ENV_VARS if os.environ.get(var)}
+
+
+def _safe_case_segment(name: Any) -> str | None:
+    """A survey case name accepted only as one plain path segment.
+
+    The run page's area link is ``survey/<name>/``, and ``name`` on a ``--survey``
+    entry is caller-supplied JSON. HTML-escaping that attribute does not neutralise
+    path semantics, so a name like ``../../other`` would render a traversal link --
+    and would also disagree with the card footer, which derives its link from the
+    separately-validated ``report_rel``. Requiring a single segment makes the two
+    agree by construction, since ``report_rel`` is built as
+    ``<rel>/survey/<name>/sanitizer_report.json`` from this same value.
+    """
+    if not isinstance(name, str) or not name or name in {".", ".."}:
+        return None
+    if "/" in name or "\\" in name or ":" in name:
+        return None
+    if any(char.isspace() or ord(char) < 0x20 for char in name):
+        return None
+    return name
 
 
 def _case_dir_rel(report_rel: str | None) -> str | None:
@@ -1412,33 +1438,96 @@ _REBUILD_NOTE = (
 # ``aorta.sanitizer_run_area/0.1`` can read the variables instead of parsing them
 # out of a sentence. ``set_by`` says whether the operator must export it or
 # ``aorta`` derives it from the recipe's policy block.
-_REQUIRED_ENV: tuple[dict[str, str], ...] = (
+# ``consan_only`` keeps the manifest honest per case: the prose has always said
+# these four are what "ConSan additionally requires", so listing them for a
+# waitcheck reproduction would have the machine-readable field contradict it.
+_REQUIRED_ENV: tuple[dict[str, Any], ...] = (
     {
         "var": "ROCJITSU_PREBUILT",
         "set_by": "operator",
         "purpose": "unpacked rocjitsu bundle supplying rj_waitcheck and the ConSan hook",
+        "consan_only": False,
     },
-    {"var": "HSA_TOOLS_LIB", "set_by": "aorta", "purpose": "ConSan hook to load"},
+    {
+        "var": "HSA_TOOLS_LIB",
+        "set_by": "aorta",
+        "purpose": "ConSan hook to load",
+        "consan_only": True,
+    },
     {
         "var": "HSA_TOOLS_DISABLE_REGISTER",
         "set_by": "aorta",
         "purpose": "must be 1 so the hook is not double-registered",
+        "consan_only": True,
     },
-    {"var": "RJ_CONSAN_MODE", "set_by": "aorta", "purpose": "ConSan detection mode"},
-    {"var": "RJ_CONSAN_POLICY", "set_by": "aorta", "purpose": "ConSan reporting policy"},
+    {
+        "var": "RJ_CONSAN_MODE",
+        "set_by": "aorta",
+        "purpose": "ConSan detection mode",
+        "consan_only": True,
+    },
+    {
+        "var": "RJ_CONSAN_POLICY",
+        "set_by": "aorta",
+        "purpose": "ConSan reporting policy",
+        "consan_only": True,
+    },
 )
 
-# The prose rendering of exactly those facts, shared by both renderings so the
-# page and the downloadable file cannot drift (#384 decision 9 renders
-# REPRODUCE.md into the landing page, so the reproduction details are on both).
-# ``test_required_env_note_names_every_machine_readable_variable`` binds the two.
-_REQUIRED_ENV_NOTE = (
-    "The sanitizer backends (`rj_waitcheck`, the ConSan hook) come from the "
-    "prebuilt rocjitsu bundle; point `ROCJITSU_PREBUILT` at an unpacked bundle "
-    "before running. ConSan additionally requires `HSA_TOOLS_LIB`, "
-    "`HSA_TOOLS_DISABLE_REGISTER=1`, `RJ_CONSAN_MODE` and `RJ_CONSAN_POLICY`, "
-    "which `aorta` sets for you from the recipe's policy block."
-)
+
+def required_env_for(*, case: str, report: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """The env a *this* case's reproduction needs (pure).
+
+    ConSan's four variables are dropped for a waitcheck-only case, so the
+    machine-readable list cannot claim more than the prose does. Whether ConSan
+    ran is taken from the report's own check/finding sanitizers where possible,
+    falling back to the case name -- the naming convention every guardrail and
+    survey case follows (``consan-*`` / ``*-consan``).
+    """
+    names: set[str] = set()
+    checks = (report or {}).get("checks")
+    for check in checks if isinstance(checks, list) else []:
+        if not isinstance(check, dict):
+            continue
+        if isinstance(check.get("sanitizer"), str):
+            names.add(check["sanitizer"].lower())
+        for finding in check.get("findings") or []:
+            if isinstance(finding, dict) and isinstance(finding.get("sanitizer"), str):
+                names.add(finding["sanitizer"].lower())
+    consan = (
+        any("consan" in name for name in names)
+        if names
+        else "consan" in case.lower()
+    )
+    return [
+        {key: value for key, value in item.items() if key != "consan_only"}
+        for item in _REQUIRED_ENV
+        if consan or not item["consan_only"]
+    ]
+
+def required_env_note(required_env: list[dict[str, Any]]) -> str:
+    """Markdown prose for exactly the variables a manifest lists (pure).
+
+    Generated from ``env["required_env"]`` rather than written beside it, so the
+    sentence is per-case (a waitcheck area does not describe ConSan's variables)
+    and a retained area's prose keeps describing what *it* recorded even after
+    the module's own table changes.
+    """
+    operator = [item for item in required_env if item.get("set_by") == "operator"]
+    derived = [item for item in required_env if item.get("set_by") == "aorta"]
+    parts: list[str] = []
+    for item in operator:
+        parts.append(
+            f"Set `{item['var']}` ({item.get('purpose', '')}) before running."
+            if item.get("purpose")
+            else f"Set `{item['var']}` before running."
+        )
+    if derived:
+        names = ", ".join(f"`{item['var']}`" for item in derived)
+        parts.append(
+            f"`aorta` sets {names} for you from the recipe's policy block."
+        )
+    return " ".join(parts)
 
 
 def _md_code_to_html(text: str) -> str:
@@ -1499,9 +1588,23 @@ _BIN_OBJECT = {
     "fixtures/bin/consan_gemm_load": "fixtures/isa/consan_gemm_f32.hsaco",
     "fixtures/bin/lds_dispatch": "fixtures/isa/lds.hsaco",
 }
+# Recipe-relative paths (how a recipe names a fixture, and how this run area
+# records one) are NOT runnable paths. REPRODUCE.md puts the reader at the repo
+# root after ``cd aorta``, where there is no top-level ``fixtures/`` -- the tree
+# lives here, which is also what the nightly's own ``FIXTURES`` variable is set
+# to. Every emitted command is prefixed with this so it can be pasted and run;
+# only the recorded ``path`` stays recipe-relative.
+_FIXTURES_FROM_ROOT = "recipes/sanitizers/fixtures"
+
+
+def _runnable(ref: str) -> str:
+    """A recipe-relative fixture path rewritten to run from the repo root."""
+    return f"{_FIXTURES_FROM_ROOT}{ref[len('fixtures'):]}" if ref.startswith("fixtures") else ref
+
+
 _GEMM_ISA_SCRIPT = (
     "python scripts/sanitizers/prepare_gemm_isa.py "
-    "--csv fixtures/gemm_shapes_unique.csv --out fixtures/isa"
+    f"--csv {_FIXTURES_FROM_ROOT}/gemm_shapes_unique.csv --out {_FIXTURES_FROM_ROOT}/isa"
 )
 
 
@@ -1514,37 +1617,53 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
     landing page, REPRODUCE.md and the manifest cannot disagree about how an
     artifact was built.
 
-    Each entry is ``{"path", "what", "commands", "caveat"}``. ``commands`` are the
-    nightly's own invocations (see the tables above): they are per-artifact and
-    not interchangeable, because a rebuild that differs from them will not
-    reproduce the SHA-256 recorded beside the artifact. An unrecognised reference
-    yields commands ``[]`` rather than a guess.
+    Each entry is ``{"path", "what", "commands", "caveat"}``. ``path`` stays
+    recipe-relative, matching how a recipe names the artifact and how
+    ``artifacts_not_published`` records it; ``commands`` are rewritten to run from
+    the repo root, which is where REPRODUCE.md leaves the reader, and create the
+    gitignored output directory first. They are the nightly's own invocations
+    (see the tables above): per-artifact and not interchangeable, because a
+    rebuild that differs from them will not reproduce the SHA-256 recorded beside
+    the artifact. An unrecognised reference yields commands ``[]`` rather than a
+    guess.
+
+    Anything a consumer must branch on is encoded *in* a command rather than left
+    to ``caveat`` prose, so the list can be executed as-is.
     """
     plan: list[dict[str, Any]] = []
     for ref in built_refs:
+        out = _runnable(ref)
+        mkdir = f"mkdir -p {_FIXTURES_FROM_ROOT}"
         source = _GENCO_ISA_SOURCES.get(ref)
         if source:
             plan.append({
                 "path": ref,
                 "what": f"a gfx code object built from {source}",
                 "commands": [
-                    f"hipcc --genco --offload-arch={target} {source} -o tmp.o",
-                    f"clang-offload-bundler --type=o --unbundle --input=tmp.o "
-                    f"--targets=hipv4-amdgcn-amd-amdhsa--{target} --output={ref}",
+                    f"{mkdir}/isa",
+                    f"hipcc --genco --offload-arch={target} {_runnable(source)} -o tmp.o",
+                    # One command, because which branch is correct depends on the
+                    # ROCm build: --genco emits a raw object on some and a bundle
+                    # on others, and the recorded digest is of the unbundled one.
+                    "if head -c 24 tmp.o | grep -qF __CLANG_OFFLOAD_BUNDLE__; then "
+                    "clang-offload-bundler --type=o --unbundle --input=tmp.o "
+                    f"--targets=hipv4-amdgcn-amd-amdhsa--{target} --output={out}; "
+                    f"else cp tmp.o {out}; fi",
                 ],
                 "caveat": (
-                    "Run the second command only if the first produced a bundle "
-                    "(`head -c 24 tmp.o | grep -qF __CLANG_OFFLOAD_BUNDLE__`), "
-                    "otherwise copy tmp.o into place: --genco emits a raw object on "
-                    "some ROCm builds and a bundle on others. The recorded digest is "
-                    "of the unbundled object, so skipping the check will not match."
+                    "The conditional matters: --genco emits a raw code object on "
+                    "some ROCm builds and a clang-offload bundle on others, and the "
+                    "recorded digest is of the unbundled object."
                 ),
             })
         elif ref == "fixtures/isa/consan_gemm_f32.hsaco":
             plan.append({
                 "path": ref,
                 "what": "one representative heavy f32 SS GEMM code object",
-                "commands": [f"{_GEMM_ISA_SCRIPT} --top-n 0 --consan-object {ref}"],
+                "commands": [
+                    f"{mkdir}/isa",
+                    f"{_GEMM_ISA_SCRIPT} --top-n 0 --consan-object {out}",
+                ],
                 "caveat": (
                     "Extracted from the shipped Tensile libraries, never compiled "
                     "from a .hip source."
@@ -1555,7 +1674,7 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
             plan.append({
                 "path": ref,
                 "what": "the per-transpose f32 GEMM code objects (sol_<n>.hsaco)",
-                "commands": [f"{_GEMM_ISA_SCRIPT} --top-n 3"],
+                "commands": [f"{mkdir}/isa", f"{_GEMM_ISA_SCRIPT} --top-n 3"],
                 "caveat": (
                     "Extracted from the shipped Tensile libraries, never compiled "
                     "from a .hip source."
@@ -1567,11 +1686,16 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
             if extra:
                 flags += f" {extra}"
             if define:
-                flags += f' -D{define}="\\"$(pwd)/{_BIN_OBJECT[ref]}\\""'
+                # $(pwd) is the repo root here, so the define must carry the
+                # root-relative path to the object, not the recipe-relative one.
+                flags += f' -D{define}="\\"$(pwd)/{_runnable(_BIN_OBJECT[ref])}\\""'
             plan.append({
                 "path": ref,
                 "what": f"a host repro binary built from {source}",
-                "commands": [f"hipcc {flags} {source} -o {ref}"],
+                "commands": [
+                    f"{mkdir}/bin",
+                    f"hipcc {flags} {_runnable(source)} -o {out}",
+                ],
                 "caveat": (
                     f"The -D{define} define is required: it is how the binary learns "
                     "which code object to load."
@@ -1584,15 +1708,30 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
     return plan
 
 
-def _rebuild_hints(built_refs: list[str], *, target: str) -> list[str]:
-    """One prose rebuild hint per artifact, rendered from ``rebuild_plan`` (pure).
+def plan_from_env(env: dict[str, Any], built_refs: list[str]) -> list[dict[str, Any]]:
+    """A run area's rebuild plan, preferring the one it persisted (pure).
+
+    Every retained area is re-rendered nightly while its ``env.json`` is
+    preserved, so recomputing the commands from the module's current tables would
+    rewrite historical instructions and leave the prose contradicting the
+    manifest sitting beside it. Fall back to recomputation only for an area
+    published before the field existed.
+    """
+    stored = env.get("rebuild")
+    if isinstance(stored, list) and all(isinstance(item, dict) for item in stored):
+        return stored
+    return rebuild_plan(built_refs, target=str(env.get("target") or "gfx950"))
+
+
+def _rebuild_hints(plan: list[dict[str, Any]]) -> list[str]:
+    """One prose rebuild hint per artifact, rendered from a ``rebuild_plan`` (pure).
 
     Markdown, so REPRODUCE.md uses it verbatim and the landing page runs it
     through ``_md_code_to_html``. A reference with no known recipe degrades to
     its bare path rather than a plausible-looking wrong command.
     """
     hints: list[str] = []
-    for entry in rebuild_plan(built_refs, target=target):
+    for entry in plan:
         if not entry["commands"]:
             hints.append(str(entry["path"]))
             continue
@@ -1659,7 +1798,7 @@ def build_case_env(
         # prose, so a consumer of this schema does not have to parse English to
         # learn which variables to export or how to rebuild an artifact. Both
         # renderings are generated from these, not written alongside them.
-        "required_env": [dict(item) for item in _REQUIRED_ENV],
+        "required_env": required_env_for(case=case, report=report),
         "rebuild": rebuild_plan(built_refs, target=str(meta.get("gpu") or "")),
         "artifacts_not_published": [
             {"path": ref, "sha256": by_basename.get(_basename(ref))} for ref in built_refs
@@ -1738,16 +1877,17 @@ def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
         f"{env.get('command', '')}",
         "```",
         "",
-        _REQUIRED_ENV_NOTE,
+        required_env_note(env.get("required_env") or []),
         "",
     ]
-    hints = _rebuild_hints(built_refs, target=str(env.get("target") or "gfx950"))
+    hints = _rebuild_hints(plan_from_env(env, built_refs))
     if hints:
         lines += [
             "## Rebuild the fixtures",
             "",
             "This case needs CI-built fixtures that are not published here (see "
-            "'Artifacts not published' below). Rebuild them with:",
+            "'Artifacts not published' below). Run these from the repo root, the "
+            "directory the clone above leaves you in:",
             "",
             *(f"- {hint}" for hint in hints),
             "",
@@ -1842,7 +1982,7 @@ def build_case_index_html(
         if reason
         else ""
     )
-    hints = _rebuild_hints(built_refs, target=str(env.get("target") or "gfx950"))
+    hints = _rebuild_hints(plan_from_env(env, built_refs))
     steps_html = (
         (
             '<p class="cap">Rebuild the fixtures</p><ul class="steps">'
@@ -1922,7 +2062,7 @@ def build_case_index_html(
         f"{reason_html}\n"
         '<div class="repro"><span class="lbl">Reproduce</span>'
         f'<code>{_esc(str(env.get("command", "")))}</code></div>\n'
-        f'<p class="note">{_md_code_to_html(_REQUIRED_ENV_NOTE)}</p>\n'
+        f'<p class="note">{_md_code_to_html(required_env_note(env.get("required_env") or []))}</p>\n'
         f"{steps_html}{np_html}{digests_html}"
         "</section>\n"
         '<section class="panel"><h2>Files</h2>\n'
@@ -3113,18 +3253,26 @@ def _run_index_survey_html(survey: list[dict[str, Any]] | None) -> str:
     or an out-of-tree ``report_path``, while only ``--informational-results-dir``
     entries are staged under ``survey/<case>/``. Keying on presence therefore
     emitted a 404 on exactly that invocation.
+
+    The link path itself goes through ``_safe_case_segment``, because ``name`` is
+    caller-supplied on a spec entry: a staged spec naming ``../../other`` would
+    otherwise render a traversal link here while the card footer -- which derives
+    its link from the validated ``report_rel`` -- pointed somewhere else entirely.
     """
     if not survey:
         return ""
+
+    def _area_cell(entry: dict[str, Any]) -> str:
+        segment = _safe_case_segment(entry.get("name")) if entry.get("staged") else None
+        if not segment:
+            return '<td><span class="dash">&mdash;</span></td>'
+        return f'<td><a href="survey/{_esc(segment)}/">run area</a></td>'
+
     rows = "".join(
         f"<tr><td class=mono>{_esc(str(entry.get('label') or entry.get('name', '')))}</td>"
         f"<td>{_verdict_html((entry.get('summary') or {}).get('verdict') or _DASH)}</td>"
         f"<td class=mono>{_esc(str(entry.get('command') or ''))}</td>"
-        + (
-            f'<td><a href="survey/{_esc(str(entry.get("name", "")))}/">run area</a></td>'
-            if entry.get("staged")
-            else '<td><span class="dash">&mdash;</span></td>'
-        )
+        + _area_cell(entry)
         + "</tr>"
         for entry in survey
     )
@@ -3667,7 +3815,12 @@ def main() -> int:
             ):
                 if current and survey_case.name in staged_now:
                     continue  # rewritten from this job's own results further below
-                if not keep_logs:
+                # Same treatment as a guardrail area: an in-window area still has
+                # to be gzipped, or a disjoint history (or an area published before
+                # run areas existed) publishes its raw *.log uncompressed.
+                if keep_logs:
+                    _gzip_logs(survey_case)
+                else:
                     _prune_run_area_bulk(survey_case)
                 if refresh_published_case_area(
                     survey_case, args.out_dir, logs=keep_logs
@@ -3740,6 +3893,18 @@ def main() -> int:
                 if entry is None:
                     continue
                 dest = args.out_dir / latest_rel / "survey" / case_dir.name
+                # Replace the destination rather than merging into it: a file that
+                # disappeared from this sweep (an old log especially) would
+                # otherwise survive and be listed on the landing page as evidence
+                # for the *new* report. The nightly clears its run dir first, but
+                # this co-publish path is documented for reusable output trees too.
+                # Skip the clear if the source somehow sits underneath it, which
+                # would delete the very tree about to be read.
+                if dest.exists() and not (
+                    dest.resolve() == case_dir.resolve()
+                    or dest.resolve() in case_dir.resolve().parents
+                ):
+                    shutil.rmtree(dest)
                 # The whole case dir, so the ConSan/waitcheck logs behind the
                 # observed verdict ship with the report (#384).
                 shutil.copytree(case_dir, dest, dirs_exist_ok=True)

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2120,7 +2120,7 @@ def test_rebuild_hint_binary_flags_match_the_workflow():
         assert built_with_o1g == ("-O1 -g" in extra), (
             f"{ref}: workflow uses -O1 -g = {built_with_o1g}, hint says {extra!r}"
         )
-        hint = gen._rebuild_hints([ref], target="gfx950")[0]
+        hint = gen._rebuild_hints(gen.rebuild_plan([ref], target="gfx950"))[0]
         assert ("-O1 -g" in hint) == built_with_o1g, ref
 
 
@@ -2163,7 +2163,7 @@ def test_publish_recipe_inputs_never_writes_outside_the_case_inputs_dir(tmp_path
 
 def test_rebuild_hints_match_the_nightly_commands_per_artifact():
     def hint(ref: str) -> str:
-        return gen._rebuild_hints([ref], target="gfx950")[0]
+        return gen._rebuild_hints(gen.rebuild_plan([ref], target="gfx950"))[0]
 
     hints = {
         ref: hint(ref)
@@ -2179,7 +2179,10 @@ def test_rebuild_hints_match_the_nightly_commands_per_artifact():
     # and the recorded digest is of the unbundled object -- so the conditional
     # unbundle is part of the instruction, not an optional detail.
     lds = hints["fixtures/isa/lds.hsaco"]
-    assert "hipcc --genco --offload-arch=gfx950 fixtures/kernels/lds_reduce.hip" in lds
+    assert (
+        "hipcc --genco --offload-arch=gfx950 "
+        "recipes/sanitizers/fixtures/kernels/lds_reduce.hip" in lds
+    )
     assert "__CLANG_OFFLOAD_BUNDLE__" in lds
     assert "clang-offload-bundler --type=o --unbundle" in lds
     # The GEMM objects are extracted from Tensile libraries, never compiled.
@@ -2188,16 +2191,68 @@ def test_rebuild_hints_match_the_nightly_commands_per_artifact():
     assert "--top-n 3" in hints["fixtures/isa"]
     # A loader binary needs the define naming its object, or it builds the wrong one.
     assert "-DLDS_HSACO=" in hints["fixtures/bin/lds_dispatch"]
-    assert "fixtures/isa/lds.hsaco" in hints["fixtures/bin/lds_dispatch"]
+    assert "recipes/sanitizers/fixtures/isa/lds.hsaco" in hints["fixtures/bin/lds_dispatch"]
     # A plain repro binary has no define to add.
     assert "-D" not in hints["fixtures/bin/consan_lds_race"]
-    assert "fixtures/repro/consan_lds_race.hip" in hints["fixtures/bin/consan_lds_race"]
+    assert (
+        "recipes/sanitizers/fixtures/repro/consan_lds_race.hip"
+        in hints["fixtures/bin/consan_lds_race"]
+    )
     # An unknown reference degrades to the bare path rather than a wrong command.
-    assert gen._rebuild_hints(["fixtures/other/x"], target="gfx950") == ["fixtures/other/x"]
+    assert gen._rebuild_hints(
+        gen.rebuild_plan(["fixtures/other/x"], target="gfx950")
+    ) == ["fixtures/other/x"]
     # Every hint's backticks are balanced, so the page renders them as <code>
     # spans rather than leaving a stray literal backtick in the markup.
     for ref, text in hints.items():
         assert text.count("`") % 2 == 0, ref
+
+
+def test_rebuild_commands_are_runnable_from_the_repo_root():
+    """Every emitted command must work from where REPRODUCE.md leaves the reader.
+
+    The manifest records artifacts recipe-relative (``fixtures/isa/...``), but
+    ``cd aorta`` puts you at the repo root where no top-level ``fixtures/`` exists
+    -- so a command carrying the recorded path verbatim fails immediately. The
+    output directories are gitignored, so they also have to be created.
+    """
+    refs = [
+        "fixtures/isa/lds.hsaco",
+        "fixtures/isa/consan_gemm_f32.hsaco",
+        "fixtures/isa",
+        "fixtures/bin/consan_gemm_load",
+        "fixtures/bin/consan_lds_race",
+    ]
+    for entry in gen.rebuild_plan(refs, target="gfx950"):
+        # The recorded path stays recipe-relative; only the commands are rewritten.
+        assert entry["path"].startswith("fixtures/"), entry["path"]
+        assert entry["commands"], entry["path"]
+        assert entry["commands"][0].startswith("mkdir -p recipes/sanitizers/fixtures/")
+        for command in entry["commands"]:
+            # No bare recipe-relative path survives into an executable command:
+            # every fixtures/ token must be reached through recipes/sanitizers/.
+            unrooted = re.findall(r"(?<![\w/.])fixtures/[\w./-]+", command)
+            assert not unrooted, f"{entry['path']}: unrooted {unrooted} in {command!r}"
+    # The paths a command does name resolve in this checkout (sources at least;
+    # bin/ and isa/ are gitignored build outputs).
+    for entry in gen.rebuild_plan(refs, target="gfx950"):
+        for command in entry["commands"]:
+            for token in re.findall(r"recipes/sanitizers/fixtures/[\w./-]+", command):
+                if "/isa/" in token or "/bin/" in token or token.endswith("/isa"):
+                    continue
+                assert (_REPO_ROOT / token).exists(), f"{entry['path']}: {token}"
+
+
+def test_genco_rebuild_encodes_the_bundle_check_as_one_command():
+    # A consumer executing `commands` in order cannot branch on prose, so the
+    # raw-ELF-vs-bundle decision has to live inside a command.
+    entry = gen.rebuild_plan(["fixtures/isa/tiny.hsaco"], target="gfx950")[0]
+    conditional = [c for c in entry["commands"] if c.startswith("if ")]
+    assert len(conditional) == 1
+    assert "__CLANG_OFFLOAD_BUNDLE__" in conditional[0]
+    assert "clang-offload-bundler" in conditional[0]
+    # ...and the else-branch copies rather than silently skipping.
+    assert "else cp tmp.o recipes/sanitizers/fixtures/isa/tiny.hsaco; fi" in conditional[0]
 
 
 def test_case_index_page_carries_the_reproduction_details(tmp_path, monkeypatch):
@@ -2214,11 +2269,15 @@ def test_case_index_page_carries_the_reproduction_details(tmp_path, monkeypatch)
     assert env["digests"]["code_object:sol_1.hsaco"] == "93f09ae670abcdef"
     for key, value in env["digests"].items():
         assert key in page and value in page
-    # The env a reproduction needs is on the page too, from the same constant as
-    # REPRODUCE.md, so the two cannot drift.
+    # The env a reproduction needs is on the page too, rendered from this area's
+    # own required_env, so the page and REPRODUCE.md cannot drift.
+    note = gen.required_env_note(env["required_env"])
     assert "ROCJITSU_PREBUILT" in page
     assert "<code>ROCJITSU_PREBUILT</code>" in page
-    assert gen._REQUIRED_ENV_NOTE in (case / "REPRODUCE.md").read_text(encoding="utf-8")
+    assert note in (case / "REPRODUCE.md").read_text(encoding="utf-8")
+    # This is a waitcheck case, so ConSan's variables are not claimed for it.
+    assert [item["var"] for item in env["required_env"]] == ["ROCJITSU_PREBUILT"]
+    assert "HSA_TOOLS_LIB" not in page
     # Execution status was in the MD twin but missing from the page.
     assert "Execution" in page
     # The rebuild commands render as code, not as literal Markdown backticks.
@@ -2226,16 +2285,32 @@ def test_case_index_page_carries_the_reproduction_details(tmp_path, monkeypatch)
     assert "`" not in page
 
 
-def test_required_env_note_names_every_machine_readable_variable():
-    # env.json carries required_env as data; the prose is the human rendering of
-    # the same facts. Bind them so a new variable cannot be added to one only.
-    for item in gen._REQUIRED_ENV:
-        assert item["var"] in gen._REQUIRED_ENV_NOTE, item["var"]
-        assert item["set_by"] in {"operator", "aorta"}
-        assert item["purpose"]
-    # ...and no variable is described in the prose that the data omits.
-    named = set(re.findall(r"`([A-Z][A-Z0-9_]+)(?:=\S+)?`", gen._REQUIRED_ENV_NOTE))
-    assert named == {item["var"] for item in gen._REQUIRED_ENV}
+def test_required_env_is_per_case_and_the_note_names_exactly_it():
+    # The prose has always said the four HSA/RJ variables are what ConSan
+    # *additionally* requires, so listing them for a waitcheck reproduction would
+    # make the machine-readable field contradict it.
+    waitcheck = gen.required_env_for(case="waitcheck", report=_waitcheck_report())
+    assert [item["var"] for item in waitcheck] == ["ROCJITSU_PREBUILT"]
+
+    consan = gen.required_env_for(case="consan-racy", report=_consan_racy_report())
+    assert [item["var"] for item in consan] == [item["var"] for item in gen._REQUIRED_ENV]
+    # The internal flag is not leaked into the published manifest.
+    assert all("consan_only" not in item for item in consan)
+
+    # With no usable report the case name decides, following the naming convention
+    # every guardrail and survey case uses.
+    assert len(gen.required_env_for(case="consan-gemm", report=None)) == len(consan)
+    assert len(gen.required_env_for(case="waitcheck-gemm", report=None)) == 1
+
+    # The note names exactly the variables it was given -- no more, no fewer.
+    for required in (waitcheck, consan):
+        note = gen.required_env_note(required)
+        named = set(re.findall(r"`([A-Z][A-Z0-9_]+)`", note))
+        assert named == {item["var"] for item in required}
+        for item in required:
+            assert item["set_by"] in {"operator", "aorta"}
+            assert item["purpose"]
+    assert gen.required_env_note([]) == ""
 
 
 def test_rebuild_plan_is_machine_readable_and_prose_is_generated_from_it():
@@ -2248,18 +2323,27 @@ def test_rebuild_plan_is_machine_readable_and_prose_is_generated_from_it():
 
     lds = plan[0]
     assert lds["commands"] == [
-        "hipcc --genco --offload-arch=gfx950 fixtures/kernels/lds_reduce.hip -o tmp.o",
+        "mkdir -p recipes/sanitizers/fixtures/isa",
+        "hipcc --genco --offload-arch=gfx950 "
+        "recipes/sanitizers/fixtures/kernels/lds_reduce.hip -o tmp.o",
+        "if head -c 24 tmp.o | grep -qF __CLANG_OFFLOAD_BUNDLE__; then "
         "clang-offload-bundler --type=o --unbundle --input=tmp.o "
-        "--targets=hipv4-amdgcn-amd-amdhsa--gfx950 --output=fixtures/isa/lds.hsaco",
+        "--targets=hipv4-amdgcn-amd-amdhsa--gfx950 "
+        "--output=recipes/sanitizers/fixtures/isa/lds.hsaco; "
+        "else cp tmp.o recipes/sanitizers/fixtures/isa/lds.hsaco; fi",
     ]
-    assert "__CLANG_OFFLOAD_BUNDLE__" in lds["caveat"]
-    assert "-O1 -g" not in plan[1]["commands"][0]  # loader binaries are built without
-    assert "-DLDS_HSACO=" in plan[1]["commands"][0]
+    # The bundle check lives in a command, not only in the prose caveat, so an
+    # automated consumer can execute the branch.
+    assert "__CLANG_OFFLOAD_BUNDLE__" in " ".join(lds["commands"])
+    assert "--genco" in lds["caveat"]
+    hipcc = plan[1]["commands"][1]
+    assert "-O1 -g" not in hipcc  # loader binaries are built without
+    assert "-DLDS_HSACO=" in hipcc
     # An unknown reference yields no command rather than a plausible wrong one.
     assert plan[2]["commands"] == []
 
     # Every command in the plan appears verbatim in the rendered prose.
-    hints = gen._rebuild_hints(refs, target="gfx950")
+    hints = gen._rebuild_hints(plan)
     assert len(hints) == len(plan)
     for index, entry in enumerate(plan):
         for command in entry["commands"]:
@@ -2275,14 +2359,16 @@ def test_env_json_records_required_env_and_rebuild_commands(tmp_path, monkeypatc
         )
     )
 
+    # A ConSan case, so it carries the full set.
     assert [item["var"] for item in env["required_env"]] == [
         item["var"] for item in gen._REQUIRED_ENV
     ]
     rebuild = {entry["path"]: entry for entry in env["rebuild"]}
     # The recipe's built refs each carry their own commands, at this run's target.
     assert "fixtures/isa/consan_gemm_f32.hsaco" in rebuild
-    assert "prepare_gemm_isa.py" in rebuild["fixtures/isa/consan_gemm_f32.hsaco"]["commands"][0]
-    gemm_bin = rebuild["fixtures/bin/consan_gemm_load"]["commands"][0]
+    gemm_isa = rebuild["fixtures/isa/consan_gemm_f32.hsaco"]["commands"]
+    assert any("prepare_gemm_isa.py" in command for command in gemm_isa)
+    gemm_bin = " ".join(rebuild["fixtures/bin/consan_gemm_load"]["commands"])
     assert "--offload-arch=gfx950" in gemm_bin
     assert "-DOBJECT=" in gemm_bin
 
@@ -2408,9 +2494,13 @@ def test_run_area_records_unpublished_artifacts_by_digest(tmp_path, monkeypatch)
     # generic "hipcc it" hint would build a different file than the recorded
     # digest, which is the whole point of recording the digest.
     assert "prepare_gemm_isa.py" in survey_md
-    assert "--consan-object fixtures/isa/consan_gemm_f32.hsaco" in survey_md
+    # Root-relative in the command, because that is where the clone leaves you.
+    assert (
+        "--consan-object recipes/sanitizers/fixtures/isa/consan_gemm_f32.hsaco"
+        in survey_md
+    )
     assert "-DOBJECT=" in survey_md
-    assert "fixtures/kernels/consan_load.hip" in survey_md
+    assert "recipes/sanitizers/fixtures/kernels/consan_load.hip" in survey_md
 
 
 def test_case_index_lists_every_published_file(tmp_path, monkeypatch):
@@ -2686,6 +2776,159 @@ def test_disjoint_history_and_output_trees_keep_the_survey_subtree(
     assert (published / "index.html").is_file()
     # The source history is untouched by the copy.
     assert (area / "sanitizer_report.json").is_file()
+
+
+def test_prose_is_rendered_from_the_persisted_manifest_not_current_constants():
+    """A retained area's instructions must not be rewritten by a later code change.
+
+    Every retained area is re-rendered nightly while its ``env.json`` is
+    preserved, so recomputing the commands from the module's current tables would
+    silently rewrite historical instructions and leave the prose contradicting the
+    manifest beside it.
+    """
+    env = {
+        "case": "consan-gemm",
+        "target": "gfx950",
+        "required_env": [
+            {"var": "OLD_VAR", "set_by": "operator", "purpose": "what this run needed"}
+        ],
+        "rebuild": [{
+            "path": "fixtures/isa/x.hsaco",
+            "what": "an object built the way this run built it",
+            "commands": ["hipcc --historical-flag x.hip -o x.hsaco"],
+            "caveat": "",
+        }],
+        "observed": {},
+        "artifacts_not_published": [{"path": "fixtures/isa/x.hsaco", "sha256": "ab"}],
+    }
+    md = gen.build_reproduce_md(env, built_refs=["fixtures/isa/x.hsaco"])
+    assert "hipcc --historical-flag x.hip -o x.hsaco" in md
+    assert "OLD_VAR" in md
+    # Today's tables are not consulted when the manifest has its own answer.
+    assert "prepare_gemm_isa.py" not in md
+    assert "ROCJITSU_PREBUILT" not in md
+
+    page = gen.build_case_index_html(
+        env, [], built_refs=["fixtures/isa/x.hsaco"], up="../../"
+    )
+    assert "hipcc --historical-flag x.hip -o x.hsaco" in page
+    assert "OLD_VAR" in page
+
+    # An area published before the fields existed still gets instructions.
+    legacy = {k: v for k, v in env.items() if k not in {"rebuild", "required_env"}}
+    fallback = gen.build_reproduce_md(legacy, built_refs=["fixtures/isa/lds.hsaco"])
+    assert "hipcc --genco" in fallback
+
+
+def test_refresh_keeps_the_manifests_own_instructions(tmp_path, monkeypatch):
+    # End-to-end version of the above: refreshing an older area must not restamp
+    # its rebuild commands from the current module tables.
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    _write_history_run(dashboard / "runs", "2026-08-05-33")
+    area = dashboard / "runs" / "2026-08-05-33" / "survey" / "consan-gemm"
+    area.mkdir(parents=True)
+    (area / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    (area / "env.json").write_text(json.dumps({
+        "case": "consan-gemm", "command": "aorta sweep run", "target": "gfx950",
+        "observed": {"verdict": "error"},
+        "required_env": [{"var": "OLD_VAR", "set_by": "operator", "purpose": "historic"}],
+        "rebuild": [{"path": "fixtures/isa/x.hsaco", "what": "historic",
+                     "commands": ["hipcc --historical-flag"], "caveat": ""}],
+        "artifacts_not_published": [{"path": "fixtures/isa/x.hsaco", "sha256": "ab"}],
+    }))
+    _write_history_run(dashboard / "runs", "2026-08-06-44")
+    assert _publish_into(dashboard, monkeypatch) == 0
+
+    md = (area / "REPRODUCE.md").read_text(encoding="utf-8")
+    assert "hipcc --historical-flag" in md
+    assert "OLD_VAR" in md
+    env = json.loads((area / "env.json").read_text(encoding="utf-8"))
+    assert env["rebuild"][0]["commands"] == ["hipcc --historical-flag"]
+
+
+def test_copublish_replaces_the_destination_instead_of_merging(tmp_path, monkeypatch):
+    # A file that vanished from this sweep must not survive and be listed on the
+    # landing page as evidence for the new report.
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    _write_history_run(dashboard / "runs", "2026-08-05-33")
+    stale = dashboard / "runs" / "2026-08-05-33" / "survey" / "consan-gemm"
+    (stale / "consan").mkdir(parents=True)
+    (stale / "consan" / "consan.log.gz").write_bytes(b"stale evidence")
+    (stale / "sanitizer_report.json").write_text("{}")
+
+    info = tmp_path / "informational"
+    (info / "consan-gemm").mkdir(parents=True)
+    (info / "consan-gemm" / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    assert _publish_into(dashboard, monkeypatch, info=info) == 0
+
+    # This sweep produced no log, so none is published or listed.
+    assert not list(stale.rglob("*.log.gz"))
+    assert not (stale / "consan").exists()
+    assert ".log.gz" not in (stale / "index.html").read_text(encoding="utf-8")
+
+
+def test_in_window_survey_areas_are_gzipped_like_guardrail_areas(tmp_path, monkeypatch):
+    # An area carried in from a disjoint history (or published before run areas
+    # existed) holds raw *.log; the log window must compress it, not publish it.
+    history = tmp_path / "history"
+    out = tmp_path / "dashboard"
+    _write_history_run(history, "2026-08-05-33")
+    area = history / "2026-08-05-33" / "survey" / "consan-gemm"
+    (area / "consan").mkdir(parents=True)
+    (area / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    (area / "consan" / "consan.log").write_text("raw uncompressed log\n")
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(history),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(out),
+    ])
+    assert gen.main() == 0
+
+    published = out / "runs/2026-08-05-33/survey/consan-gemm"
+    assert (published / "consan" / "consan.log.gz").is_file()
+    assert not (published / "consan" / "consan.log").exists()
+    assert gzip.decompress(
+        (published / "consan" / "consan.log.gz").read_bytes()
+    ) == b"raw uncompressed log\n"
+
+
+def test_survey_area_link_rejects_an_unsafe_caller_supplied_name():
+    # `name` is caller JSON on a --survey entry and the run page's link is
+    # survey/<name>/. HTML-escaping the attribute does not neutralize path
+    # semantics, so a staged spec naming ../../other would traverse -- and would
+    # disagree with the card footer, which derives its link from report_rel.
+    for unsafe in ("../../other", "a/b", "..", "", "a b", "http://x", "a\\b"):
+        assert gen._safe_case_segment(unsafe) is None, unsafe
+    assert gen._safe_case_segment("consan-gemm") == "consan-gemm"
+
+    survey = gen.survey_cases_from_spec({"cases": [{
+        "name": "../../other", "label": "traversal", "staged": True,
+        "report_rel": "runs/x/survey/other/sanitizer_report.json",
+        "report": _consan_racy_report(),
+    }]})
+    # An unsafe name cannot be claimed as staged at all, so no renderer links it.
+    assert survey[0]["staged"] is False
+    page = gen._run_index_survey_html(survey)
+    assert "href=" not in page
+    assert "run area" not in page
+    # Even if an entry arrives already marked staged, the renderer still refuses to
+    # build a link from it. The name may still appear as escaped label *text* --
+    # that is display, not a path -- but never inside an href.
+    forced = gen._run_index_survey_html([
+        {"name": "../../other", "staged": True, "summary": {"verdict": "fail"}}
+    ])
+    assert "href=" not in forced
+    assert "&mdash;" in forced
 
 
 def test_refresh_published_case_area_reports_an_unusable_manifest(tmp_path):

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2290,6 +2290,60 @@ def test_rebuild_commands_export_the_rocm_llvm_path():
     assert gen.rebuild_plan(["fixtures/other/x"], target="gfx950")[0]["commands"] == []
 
 
+def test_run_area_ships_every_source_its_rebuild_commands_read():
+    """Decision 10 asks for the inputs a reproduction needs, not just the named ones.
+
+    A recipe names only the built artifact it *consumes*: every ``daily-consan-*``
+    lists a ``.hsaco`` and a loader binary and nothing else. Scanning the recipe
+    text alone therefore left ``inputs/`` empty for exactly the cases whose
+    published rebuild commands read the most.
+    """
+    recipes = _REPO_ROOT / "recipes" / "sanitizers"
+    generated = ("fixtures/isa", "fixtures/bin")
+    for recipe in sorted(recipes.glob("daily-*.yaml")):
+        text = recipe.read_text(encoding="utf-8")
+        named, built = gen._recipe_fixture_refs(text)
+        published = set(named) | set(gen.rebuild_input_sources(built))
+        # Every non-generated fixture path the commands name must be published.
+        for entry in gen.rebuild_plan(built, target="gfx950"):
+            for command in entry["commands"]:
+                for token in re.findall(
+                    r"recipes/sanitizers/fixtures/[\w./-]+", command
+                ):
+                    ref = f"fixtures{token[len('recipes/sanitizers/fixtures'):]}"
+                    if any(
+                        ref == root or ref.startswith(f"{root}/") for root in generated
+                    ):
+                        continue
+                    assert ref in published, f"{recipe.name}: {ref} not in inputs/"
+        # ...and each one is a real file, so the copy actually happens.
+        for ref in published:
+            assert (recipes / ref).is_file(), f"{recipe.name}: {ref}"
+
+
+def test_consan_recipes_publish_their_transitive_sources(tmp_path, monkeypatch):
+    # End-to-end: the ConSan survey case used to ship an empty inputs/ even though
+    # its own commands read the shape CSV and the loader source.
+    out = _publish_with_logs(tmp_path, monkeypatch, run_ids=["2026-08-05-33"])
+    area = out / "runs" / "2026-08-05-33" / "survey" / "consan-gemm"
+
+    inputs = sorted(
+        p.relative_to(area / "inputs").as_posix()
+        for p in (area / "inputs").rglob("*")
+        if p.is_file()
+    )
+    assert inputs == [
+        "fixtures/gemm_shapes_unique.csv",
+        "fixtures/kernels/consan_load.hip",
+    ]
+    env = json.loads((area / "env.json").read_text(encoding="utf-8"))
+    assert sorted(env["inputs"]) == inputs
+    # They are listed as downloads on the landing page, like any published file.
+    page = (area / "index.html").read_text(encoding="utf-8")
+    for rel in inputs:
+        assert f'href="inputs/{rel}"' in page
+
+
 def test_genco_rebuild_encodes_the_bundle_check_as_one_command():
     # A consumer executing `commands` in order cannot branch on prose, so the
     # raw-ELF-vs-bundle decision has to live inside a command.

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2089,10 +2089,76 @@ def test_rebuild_hint_sources_all_exist_in_the_repo():
     recipes = _REPO_ROOT / "recipes" / "sanitizers"
     for ref, source in gen._GENCO_ISA_SOURCES.items():
         assert (recipes / source).is_file(), f"{ref} -> {source}"
-    for ref, (source, define) in gen._BIN_SOURCES.items():
+    for ref, (source, define, _extra) in gen._BIN_SOURCES.items():
         assert (recipes / source).is_file(), f"{ref} -> {source}"
         # A define means the binary is bound to a code object it must be told about.
         assert (define is None) == (ref not in gen._BIN_OBJECT), ref
+
+
+def test_rebuild_hint_binary_flags_match_the_workflow():
+    """Cross-check the flags against the workflow that actually builds them.
+
+    Optimisation/debug flags change the executable, so a hint that drops them
+    cannot reproduce the recorded `command_sha256`. The nightly builds the two
+    guardrail repro binaries `-O1 -g` and the loader binaries without, and this
+    asserts the map still agrees rather than trusting it to stay in step.
+    """
+    workflow = (_REPO_ROOT / ".github/workflows/sanitizers-nightly.yml").read_text(
+        encoding="utf-8"
+    )
+    # Join shell line continuations so one hipcc invocation is one line.
+    joined = workflow.replace("\\\n", " ")
+    for ref, (_source, _define, extra) in gen._BIN_SOURCES.items():
+        name = ref.rsplit("/", 1)[-1]
+        lines = [
+            line
+            for line in joined.splitlines()
+            if "hipcc" in line and f'/bin/{name}"' in line
+        ]
+        assert len(lines) == 1, f"{ref}: expected one build line, got {len(lines)}"
+        built_with_o1g = "-O1 -g" in lines[0]
+        assert built_with_o1g == ("-O1 -g" in extra), (
+            f"{ref}: workflow uses -O1 -g = {built_with_o1g}, hint says {extra!r}"
+        )
+        hint = gen._rebuild_hints([ref], target="gfx950")[0]
+        assert ("-O1 -g" in hint) == built_with_o1g, ref
+
+
+def test_recipe_fixture_refs_rejects_parent_traversal():
+    # _FIXTURE_REF_RE admits "." so it can match an extension, which also matched
+    # a parent segment. The copy checked the source against the repo root but then
+    # joined the same value onto the destination, writing outside the case dir.
+    source, built = gen._recipe_fixture_refs(
+        "source:\n  path: fixtures/../../../README.md\n"
+        "  hip: fixtures/repro/consan_lds_race.hip\n"
+        "  code_object: fixtures/isa/../../../etc/passwd\n"
+    )
+    assert source == ["fixtures/repro/consan_lds_race.hip"]
+    assert built == []
+
+
+def test_publish_recipe_inputs_never_writes_outside_the_case_inputs_dir(tmp_path):
+    case_dir = tmp_path / "runs" / "id" / "case"
+    case_dir.mkdir(parents=True)
+    recipe = tmp_path / "repo" / "recipes" / "sanitizers" / "evil.yaml"
+    recipe.parent.mkdir(parents=True)
+    (tmp_path / "repo" / "secret.txt").write_text("do not publish me")
+    # The ref must actually resolve to a real file inside repo_root, or the copy
+    # is skipped for an unrelated reason and this test proves nothing. From
+    # recipes/sanitizers/fixtures that is three parent segments up.
+    recipe.write_text("source:\n  path: fixtures/../../../secret.txt\n")
+    assert (recipe.parent / "fixtures/../../../secret.txt").resolve().is_file()
+
+    copied, built = gen._publish_recipe_inputs(
+        case_dir, recipe_src=recipe, repo_root=tmp_path / "repo"
+    )
+
+    assert copied == [] and built == []
+    # recipe.yaml is the only thing written, and nothing escaped the case dir.
+    written = sorted(p.name for p in case_dir.rglob("*") if p.is_file())
+    assert written == ["recipe.yaml"]
+    assert not (tmp_path / "runs" / "id" / "secret.txt").exists()
+    assert not (tmp_path / "runs" / "secret.txt").exists()
 
 
 def test_rebuild_hints_match_the_nightly_commands_per_artifact():
@@ -2158,6 +2224,67 @@ def test_case_index_page_carries_the_reproduction_details(tmp_path, monkeypatch)
     # The rebuild commands render as code, not as literal Markdown backticks.
     assert "prepare_gemm_isa.py" in page
     assert "`" not in page
+
+
+def test_required_env_note_names_every_machine_readable_variable():
+    # env.json carries required_env as data; the prose is the human rendering of
+    # the same facts. Bind them so a new variable cannot be added to one only.
+    for item in gen._REQUIRED_ENV:
+        assert item["var"] in gen._REQUIRED_ENV_NOTE, item["var"]
+        assert item["set_by"] in {"operator", "aorta"}
+        assert item["purpose"]
+    # ...and no variable is described in the prose that the data omits.
+    named = set(re.findall(r"`([A-Z][A-Z0-9_]+)(?:=\S+)?`", gen._REQUIRED_ENV_NOTE))
+    assert named == {item["var"] for item in gen._REQUIRED_ENV}
+
+
+def test_rebuild_plan_is_machine_readable_and_prose_is_generated_from_it():
+    # A consumer of aorta.sanitizer_run_area/0.1 should read commands as data
+    # rather than parse them out of English, and the prose must not be able to
+    # disagree with them.
+    refs = ["fixtures/isa/lds.hsaco", "fixtures/bin/lds_dispatch", "fixtures/other/x"]
+    plan = gen.rebuild_plan(refs, target="gfx950")
+    assert [entry["path"] for entry in plan] == refs
+
+    lds = plan[0]
+    assert lds["commands"] == [
+        "hipcc --genco --offload-arch=gfx950 fixtures/kernels/lds_reduce.hip -o tmp.o",
+        "clang-offload-bundler --type=o --unbundle --input=tmp.o "
+        "--targets=hipv4-amdgcn-amd-amdhsa--gfx950 --output=fixtures/isa/lds.hsaco",
+    ]
+    assert "__CLANG_OFFLOAD_BUNDLE__" in lds["caveat"]
+    assert "-O1 -g" not in plan[1]["commands"][0]  # loader binaries are built without
+    assert "-DLDS_HSACO=" in plan[1]["commands"][0]
+    # An unknown reference yields no command rather than a plausible wrong one.
+    assert plan[2]["commands"] == []
+
+    # Every command in the plan appears verbatim in the rendered prose.
+    hints = gen._rebuild_hints(refs, target="gfx950")
+    assert len(hints) == len(plan)
+    for index, entry in enumerate(plan):
+        for command in entry["commands"]:
+            assert f"`{command}`" in hints[index], entry["path"]
+    assert hints[2] == "fixtures/other/x"
+
+
+def test_env_json_records_required_env_and_rebuild_commands(tmp_path, monkeypatch):
+    out = _publish_with_logs(tmp_path, monkeypatch, run_ids=["2026-08-05-33"])
+    env = json.loads(
+        (out / "runs/2026-08-05-33/survey/consan-gemm/env.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert [item["var"] for item in env["required_env"]] == [
+        item["var"] for item in gen._REQUIRED_ENV
+    ]
+    rebuild = {entry["path"]: entry for entry in env["rebuild"]}
+    # The recipe's built refs each carry their own commands, at this run's target.
+    assert "fixtures/isa/consan_gemm_f32.hsaco" in rebuild
+    assert "prepare_gemm_isa.py" in rebuild["fixtures/isa/consan_gemm_f32.hsaco"]["commands"][0]
+    gemm_bin = rebuild["fixtures/bin/consan_gemm_load"]["commands"][0]
+    assert "--offload-arch=gfx950" in gemm_bin
+    assert "-DOBJECT=" in gemm_bin
 
 
 def test_md_code_to_html_escapes_before_converting_backticks():
@@ -2443,6 +2570,122 @@ def test_keep_logs_window_also_bounds_survey_logs(tmp_path, monkeypatch):
         for href in re.findall(r'href="([^"#]+)"', page):
             if not href.startswith("http"):
                 assert (area / href).resolve().exists(), f"{run_id}: {href}"
+
+
+def _publish_into(dashboard, monkeypatch, *, info=None, keep_logs=None):
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(dashboard / "runs"),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(dashboard),
+    ]
+    if info is not None:
+        argv += ["--informational-results-dir", str(info)]
+    if keep_logs is not None:
+        argv += ["--keep-logs", str(keep_logs)]
+    monkeypatch.setattr(sys, "argv", argv)
+    return gen.main()
+
+
+def test_a_rejected_survey_report_never_persists_and_cannot_abort_a_later_publish(
+    tmp_path, monkeypatch
+):
+    """A malformed best-effort report must not take the whole dashboard down.
+
+    ``survey_cases_from_informational_dir`` deliberately skips a report whose
+    nested shape makes the reduction raise. The copy loop ran before that
+    decision was consulted, so the directory was published anyway with no
+    manifest -- and on the *next* nightly the retrofit path re-read that same
+    report and raised, aborting publication days later for a non-gating input.
+    """
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    info = tmp_path / "informational"
+    (info / "consan-gemm").mkdir(parents=True)
+    # A dict (so the isinstance guard passes) whose nested shape breaks reduction.
+    (info / "consan-gemm" / "sanitizer_report.json").write_text(
+        json.dumps({"schema": "aorta.sanitizer_report/0.1", "checks": None})
+    )
+    assert gen.survey_cases_from_informational_dir(info, rel="runs/2026-08-05-33") == []
+
+    _write_history_run(dashboard / "runs", "2026-08-05-33")
+    assert _publish_into(dashboard, monkeypatch, info=info) == 0
+    # Nothing the survey loader refused to read is left in the published history.
+    assert not (dashboard / "runs/2026-08-05-33/survey/consan-gemm").exists()
+
+    # And an orphan already on the data branch degrades instead of aborting.
+    orphan = dashboard / "runs/2026-08-05-33/survey/consan-gemm"
+    orphan.mkdir(parents=True)
+    (orphan / "sanitizer_report.json").write_text(
+        json.dumps({"schema": "aorta.sanitizer_report/0.1", "checks": None})
+    )
+    _write_history_run(dashboard / "runs", "2026-08-06-44")
+    assert _publish_into(dashboard, monkeypatch) == 0
+    assert not (orphan / "index.html").exists()
+
+
+def test_keep_logs_zero_prunes_the_current_runs_survey_area_too(tmp_path, monkeypatch):
+    # --keep-logs is documented as applying to "guardrail and survey areas alike".
+    # The survey co-publish always gzipped and defaulted logs=True, so with
+    # --keep-logs 0 the survey area was the one unbounded thing left.
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    info = tmp_path / "informational"
+    (info / "consan-gemm" / "consan").mkdir(parents=True)
+    (info / "consan-gemm" / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    (info / "consan-gemm" / "consan" / "consan.log").write_text("hook timeout\n")
+    run_dir = _write_history_run(dashboard / "runs", "2026-08-05-33")
+    (run_dir / "waitcheck" / "waitcheck").mkdir(parents=True)
+    (run_dir / "waitcheck" / "waitcheck" / "waitcheck-0.log").write_text("scan\n")
+
+    assert _publish_into(dashboard, monkeypatch, info=info, keep_logs=0) == 0
+
+    guardrail = dashboard / "runs/2026-08-05-33/waitcheck"
+    area = dashboard / "runs/2026-08-05-33/survey/consan-gemm"
+    assert not list(guardrail.rglob("*.log*"))
+    assert not list(area.rglob("*.log*")), "survey bulk escaped --keep-logs 0"
+    env = json.loads((area / "env.json").read_text(encoding="utf-8"))
+    assert env["logs_published"] is False
+    # Still browsable, like a pruned guardrail area.
+    assert (area / "index.html").is_file()
+    assert ".log" not in (area / "index.html").read_text(encoding="utf-8")
+
+
+def test_disjoint_history_and_output_trees_keep_the_survey_subtree(
+    tmp_path, monkeypatch
+):
+    # With --history-root separate from <out-dir>/runs the output tree is cleared
+    # and re-copied. Copying only the guardrail case dirs dropped the survey areas
+    # the history holds, so retained runs lost their survey downloads.
+    history = tmp_path / "history"
+    out = tmp_path / "dashboard"
+    _write_history_run(history, "2026-08-05-33")
+    area = history / "2026-08-05-33" / "survey" / "consan-gemm"
+    (area / "consan").mkdir(parents=True)
+    (area / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    (area / "consan" / "consan.log.gz").write_bytes(b"x")
+    (area / "env.json").write_text(json.dumps({
+        "case": "consan-gemm", "command": "aorta sweep run", "observed": {"verdict": "error"},
+    }))
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(history),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(out),
+    ])
+    assert gen.main() == 0
+
+    published = out / "runs/2026-08-05-33/survey/consan-gemm"
+    assert (published / "sanitizer_report.json").is_file()
+    assert (published / "index.html").is_file()
+    # The source history is untouched by the copy.
+    assert (area / "sanitizer_report.json").is_file()
 
 
 def test_refresh_published_case_area_reports_an_unusable_manifest(tmp_path):

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1749,7 +1749,8 @@ def test_build_html_survey_report_link_and_graceful_absence():
              "report_rel": "runs/x/survey/linked/sanitizer_report.json",
              "report": _consan_racy_report()},
             {"name": "nolink", "label": "nolink survey", "report": _waitcheck_report()},
-        ]}
+        ]},
+        rel="runs/x",
     )
     html = gen.build_html([_healthy_guardrail_run()], survey=survey)
 
@@ -1819,7 +1820,8 @@ def test_build_html_kernel_rows_link_reports_on_both_tabs(tmp_path):
     survey = gen.survey_cases_from_spec(
         {"cases": [{"name": "s", "label": "survey linked", "staged": True,
                     "report_rel": "runs/x/survey/s/sanitizer_report.json",
-                    "report": _consan_racy_report()}]}
+                    "report": _consan_racy_report()}]},
+        rel="runs/x",
     )
     html = gen.build_html(runs, survey=survey)
 
@@ -2880,6 +2882,43 @@ def test_disjoint_history_and_output_trees_keep_the_survey_subtree(
     assert (area / "sanitizer_report.json").is_file()
 
 
+def test_published_survey_area_keeps_its_recorded_command(tmp_path):
+    """Reconstructing a published run must not recompute its reproduce command.
+
+    ``displayed_survey`` rebuilds the newest run's Tab 2 list from the areas
+    published under it. Recomputing the command from the current
+    ``_survey_recipe_for`` map meant a recipe rename would rewrite a historical
+    run's advertised command, even though that area's manifest records the one it
+    actually ran -- the same rule the run-area renderers already follow.
+    """
+    published = tmp_path / "survey"
+    (published / "consan-gemm").mkdir(parents=True)
+    (published / "consan-gemm" / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    (published / "consan-gemm" / "env.json").write_text(
+        json.dumps({"case": "consan-gemm", "command": "aorta sweep run --recipe old/name.yaml"})
+    )
+    entries = gen.survey_cases_from_informational_dir(published, rel="runs/x")
+    assert entries[0]["command"] == "aorta sweep run --recipe old/name.yaml"
+
+    # A fresh sweep's results dir has no manifest, so the recipe map still applies.
+    fresh = tmp_path / "informational"
+    (fresh / "consan-gemm").mkdir(parents=True)
+    (fresh / "consan-gemm" / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    fresh_entries = gen.survey_cases_from_informational_dir(fresh, rel="runs/x")
+    assert fresh_entries[0]["command"] == (
+        "aorta sweep run --recipe recipes/sanitizers/daily-consan-gemm.yaml"
+    )
+    # A malformed manifest degrades to the recipe map rather than raising.
+    (published / "consan-gemm" / "env.json").write_text("[]")
+    assert gen.survey_cases_from_informational_dir(published, rel="runs/x")[0][
+        "command"
+    ] == fresh_entries[0]["command"]
+
+
 def test_prose_is_rendered_from_the_persisted_manifest_not_current_constants():
     """A retained area's instructions must not be rewritten by a later code change.
 
@@ -3224,30 +3263,45 @@ def test_the_page_renders_the_survey_of_the_run_it_calls_latest(tmp_path, monkey
     assert [e["name"] for e in by_run[newer].get("survey", [])] == ["waitcheck-gemm"]
 
 
-def test_staged_requires_the_report_to_sit_in_the_named_case_directory():
-    # The run page builds survey/<name>/ while the card footer takes report_rel's
-    # directory, so a spec naming one and pointing at the other advertised two
-    # different run areas -- one of them wrong.
-    mismatched = gen.survey_cases_from_spec({"cases": [{
-        "name": "foo", "label": "mismatched", "staged": True,
-        "report_rel": "runs/x/survey/bar/sanitizer_report.json",
-        "report": _consan_racy_report(),
-    }]})
-    assert mismatched[0]["staged"] is False
-    html = gen.build_html([_healthy_guardrail_run()], survey=mismatched)
-    assert "run area</a>" not in html
-    assert "run area" not in gen._run_index_survey_html(mismatched)
+def test_staged_requires_the_whole_area_to_match_the_run_being_rendered():
+    """The two renderers derive one link from different sources, so pin the area.
 
-    agreeing = gen.survey_cases_from_spec({"cases": [{
-        "name": "foo", "label": "agreeing", "staged": True,
-        "report_rel": "runs/x/survey/foo/sanitizer_report.json",
-        "report": _consan_racy_report(),
-    }]})
+    The run page builds ``survey/<name>/`` relative to the run it renders; the card
+    footer takes ``report_rel``'s directory. Comparing only the case segment left a
+    report under a *different run* passing, so the footer pointed into that other
+    run while the run page pointed at its own.
+    """
+    def spec(name, report_rel, rel="runs/x"):
+        return gen.survey_cases_from_spec(
+            {"cases": [{
+                "name": name, "label": name, "staged": True,
+                "report_rel": report_rel, "report": _consan_racy_report(),
+            }]},
+            rel=rel,
+        )
+
+    # Wrong case directory, and -- the case that survived the segment-only check --
+    # the right case under the wrong run.
+    for name, report_rel in (
+        ("foo", "runs/x/survey/bar/sanitizer_report.json"),
+        ("foo", "runs/other/survey/foo/sanitizer_report.json"),
+        ("foo", "runs/x/foo/sanitizer_report.json"),
+    ):
+        entries = spec(name, report_rel)
+        assert entries[0]["staged"] is False, report_rel
+        assert "run area</a>" not in gen.build_html(
+            [_healthy_guardrail_run()], survey=entries
+        )
+        assert "run area" not in gen._run_index_survey_html(entries)
+
+    agreeing = spec("foo", "runs/x/survey/foo/sanitizer_report.json")
     assert agreeing[0]["staged"] is True
     assert 'href="survey/foo/">run area</a>' in gen._run_index_survey_html(agreeing)
-    assert gen._report_rel_case_segment("runs/x/survey/foo/sanitizer_report.json") == "foo"
-    assert gen._report_rel_case_segment("javascript:alert(1)") is None
-    assert gen._report_rel_case_segment(None) is None
+
+    # With no run context nothing can be verified, so nothing may be claimed.
+    assert spec("foo", "runs/x/survey/foo/sanitizer_report.json", rel=None)[0][
+        "staged"
+    ] is False
 
 
 def test_pruning_is_irreversible_when_keep_logs_is_raised_later(tmp_path):

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2937,6 +2937,167 @@ def test_survey_area_link_rejects_an_unsafe_caller_supplied_name():
     assert "&mdash;" in forced
 
 
+def test_current_run_is_the_staged_one_not_merely_the_newest(tmp_path, monkeypatch):
+    """A re-run of an older workflow must not stamp the newer run's area.
+
+    The dir id is ``<date>-<GITHUB_RUN_ID>`` and a re-run reuses its original,
+    lower run id -- so it sorts *behind* a newer same-day run. Keying "the run this
+    job produced" on list position then wrote this job's container image, rocjitsu
+    bundle and recipe copy into the newer run's area, and published this job's
+    survey under a run that did not produce it.
+    """
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    older, newer = "2026-08-05-10", "2026-08-05-99"
+    for run_id in (older, newer):
+        _write_history_run(dashboard / "runs", run_id)
+    info = tmp_path / "informational"
+    (info / "consan-gemm").mkdir(parents=True)
+    (info / "consan-gemm" / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    monkeypatch.setenv("AORTA_CI_IMAGE", "rocm/pytorch@sha256:rerun")
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(dashboard / "runs"),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(dashboard),
+        "--informational-results-dir", str(info),
+        # This job re-ran the OLDER workflow; the newer run is already published.
+        "--current-run", older,
+    ])
+    assert gen.main() == 0
+
+    def _env(run_id, case):
+        path = dashboard / "runs" / run_id / case / "env.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    # The re-run's provenance lands on its own area...
+    assert _env(older, "waitcheck").get("container_image") == "rocm/pytorch@sha256:rerun"
+    assert (dashboard / "runs" / older / "waitcheck" / "recipe.yaml").is_file()
+    # ...and never on the newer run that a different job produced.
+    assert "container_image" not in _env(newer, "waitcheck")
+    assert not (dashboard / "runs" / newer / "waitcheck" / "recipe.yaml").exists()
+    # The survey is co-published under the run that swept it.
+    assert (dashboard / "runs" / older / "survey" / "consan-gemm").is_dir()
+    assert not (dashboard / "runs" / newer / "survey").exists()
+    # data.json attaches the survey to that run too.
+    data = json.loads((dashboard / "data.json").read_text(encoding="utf-8"))
+    by_run = {run["meta"]["run"]: run for run in data}
+    assert by_run[older].get("survey")
+    assert not by_run[newer].get("survey")
+
+
+def test_a_survey_spec_name_is_not_treated_as_staged_by_the_copublish_loop(
+    tmp_path, monkeypatch
+):
+    # staged_now gated the run loop's refresh, but the co-publish loop only rewrites
+    # --informational-results-dir entries. Including a spec name skipped an area
+    # that nothing later rewrote, so it kept raw logs even under --keep-logs 0.
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    _write_history_run(dashboard / "runs", "2026-08-05-33")
+    spec_area = dashboard / "runs" / "2026-08-05-33" / "survey" / "spec-case"
+    (spec_area / "consan").mkdir(parents=True)
+    (spec_area / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    (spec_area / "consan" / "consan.log").write_text("raw log\n")
+    spec = tmp_path / "survey.json"
+    spec.write_text(json.dumps({"cases": [{
+        "name": "spec-case", "label": "spec case", "staged": True,
+        "report_rel": "runs/2026-08-05-33/survey/spec-case/sanitizer_report.json",
+        "report": _consan_racy_report(),
+    }]}))
+    info = tmp_path / "informational"
+    (info / "consan-gemm").mkdir(parents=True)
+    (info / "consan-gemm" / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(dashboard / "runs"),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(dashboard),
+        "--survey", str(spec),
+        "--informational-results-dir", str(info),
+        "--keep-logs", "0",
+    ])
+    assert gen.main() == 0
+
+    # The spec area is not staged by this job, so the run loop prunes it.
+    assert not list(spec_area.rglob("*.log")), "spec area escaped --keep-logs 0"
+    assert not list(spec_area.rglob("*.log.gz"))
+
+
+def test_staged_requires_the_report_to_sit_in_the_named_case_directory():
+    # The run page builds survey/<name>/ while the card footer takes report_rel's
+    # directory, so a spec naming one and pointing at the other advertised two
+    # different run areas -- one of them wrong.
+    mismatched = gen.survey_cases_from_spec({"cases": [{
+        "name": "foo", "label": "mismatched", "staged": True,
+        "report_rel": "runs/x/survey/bar/sanitizer_report.json",
+        "report": _consan_racy_report(),
+    }]})
+    assert mismatched[0]["staged"] is False
+    html = gen.build_html([_healthy_guardrail_run()], survey=mismatched)
+    assert "run area</a>" not in html
+    assert "run area" not in gen._run_index_survey_html(mismatched)
+
+    agreeing = gen.survey_cases_from_spec({"cases": [{
+        "name": "foo", "label": "agreeing", "staged": True,
+        "report_rel": "runs/x/survey/foo/sanitizer_report.json",
+        "report": _consan_racy_report(),
+    }]})
+    assert agreeing[0]["staged"] is True
+    assert 'href="survey/foo/">run area</a>' in gen._run_index_survey_html(agreeing)
+    assert gen._report_rel_case_segment("runs/x/survey/foo/sanitizer_report.json") == "foo"
+    assert gen._report_rel_case_segment("javascript:alert(1)") is None
+    assert gen._report_rel_case_segment(None) is None
+
+
+def test_pruning_is_irreversible_when_keep_logs_is_raised_later(tmp_path):
+    # The logs were deleted from the published history and cannot be recovered from
+    # it, so a later, larger --keep-logs must not claim they are available again.
+    area = tmp_path / "dashboard" / "runs" / "r" / "survey" / "c"
+    area.mkdir(parents=True)
+    (area / "sanitizer_report.json").write_text("{}")
+    (area / "env.json").write_text(json.dumps({
+        "case": "c", "command": "aorta sweep run", "target": "gfx950",
+        "observed": {}, "logs_published": False, "inputs": [],
+        "artifacts_not_published": [],
+    }))
+
+    assert gen.refresh_published_case_area(
+        area, tmp_path / "dashboard", logs=True
+    ) is True
+
+    env = json.loads((area / "env.json").read_text(encoding="utf-8"))
+    assert env["logs_published"] is False
+    page = (area / "index.html").read_text(encoding="utf-8")
+    assert "pruned" in page
+    assert "Logs are gzipped" not in page
+
+
+def test_reproduce_md_runs_top_to_bottom(tmp_path, monkeypatch):
+    # The fixtures the sweep needs are gitignored, so a document that invokes the
+    # sweep before the rebuild steps fails on a fresh clone before the reader ever
+    # reaches them.
+    out = _publish_with_logs(tmp_path, monkeypatch, run_ids=["2026-08-05-33"])
+    md = (
+        out / "runs/2026-08-05-33/survey/consan-gemm/REPRODUCE.md"
+    ).read_text(encoding="utf-8")
+
+    checkout = md.index("git clone https://github.com/ROCm/aorta")
+    rebuild = md.index("prepare_gemm_isa.py")
+    env_note = md.index("ROCJITSU_PREBUILT")
+    sweep = md.index("aorta sweep run --recipe")
+    assert checkout < rebuild < sweep, "sweep must come after the rebuild steps"
+    assert env_note < sweep, "required env must be set before the sweep"
+
+
 def test_refresh_published_case_area_reports_an_unusable_manifest(tmp_path):
     # env.json is the only input for re-rendering an older area, so a missing or
     # malformed one must be reported (the caller then writes a fresh area) rather

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2346,6 +2346,86 @@ def test_consan_recipes_publish_their_transitive_sources(tmp_path, monkeypatch):
         assert f'href="inputs/{rel}"' in page
 
 
+def test_drilldown_pages_link_one_stylesheet_instead_of_inlining_it(
+    tmp_path, monkeypatch
+):
+    """_CSS was over 80% of every run and run-area page, duplicated per run.
+
+    At ``--keep 30`` with five areas per run that is ~2.7MB of byte-identical CSS
+    in the published tree -- more than everything else in it, and past the gzipped
+    logs ``--keep-logs`` exists to bound.
+    """
+    out = _publish_with_logs(tmp_path, monkeypatch, run_ids=["2026-08-05-33"])
+    asset = out / gen.RUN_AREA_CSS_REL
+    assert asset.is_file()
+    assert asset.read_text(encoding="utf-8") == gen.run_area_stylesheet()
+
+    drilldowns = sorted(out.glob("runs/*/index.html")) + sorted(
+        out.glob("runs/*/*/index.html")
+    ) + sorted(out.glob("runs/*/survey/*/index.html"))
+    assert drilldowns
+    for page in drilldowns:
+        html = page.read_text(encoding="utf-8")
+        # Linked, not inlined...
+        assert "<style>" not in html, page
+        assert gen._CSS not in html, page
+        href = re.search(r'href="([^"]*run-area\.css)"', html)
+        assert href, page
+        # ...and the link resolves from this page's depth.
+        assert (page.parent / href.group(1)).resolve() == asset.resolve(), page
+        # A drill-down page is now a small document.
+        assert page.stat().st_size < len(gen._CSS), page
+
+    # The root dashboard keeps its inline copy: one of it, and it must render
+    # standalone (its empty state carries the stale banner).
+    root = (out / "index.html").read_text(encoding="utf-8")
+    assert "<style>" in root and ".stale {" in root
+
+
+def test_run_area_stylesheet_carries_the_rules_those_pages_use():
+    sheet = gen.run_area_stylesheet()
+    assert gen._CSS in sheet
+    # The rules the two drill-down pages add on top of the dashboard sheet.
+    for selector in (".wrap {", ".note {", ".steps {", ".steps li {"):
+        assert selector in sheet, selector
+    # Byte-stable, so re-publishing does not churn the data branch.
+    assert gen.run_area_stylesheet() == sheet
+
+
+def test_genco_rebuild_cleans_up_its_temporary_object():
+    # The command runs in the reader's repo root, so without the trailing rm it
+    # drops an untracked tmp.o next to pyproject.toml. The workflow's own
+    # genco_object uses mktemp + rm -f.
+    entry = gen.rebuild_plan(["fixtures/isa/lds.hsaco"], target="gfx950")[0]
+    conditional = [c for c in entry["commands"] if c.startswith("if ")][0]
+    assert conditional.endswith("&& rm -f tmp.o")
+    # Every command that creates tmp.o is paired with a command that removes it.
+    creates = [c for c in entry["commands"] if "-o tmp.o" in c]
+    removes = [c for c in entry["commands"] if "rm -f tmp.o" in c]
+    assert len(creates) == len(removes) == 1
+
+
+def test_files_caption_only_claims_gzipped_logs_when_a_log_is_listed():
+    env = {"case": "c", "observed": {}, "logs_published": True}
+    with_log = gen.build_case_index_html(
+        env, [("consan/consan.log.gz", 34)], built_refs=[], up="../../"
+    )
+    assert "Logs are gzipped." in with_log
+
+    # An in-window case that produced no log at all claimed one anyway.
+    without = gen.build_case_index_html(
+        env, [("sanitizer_report.json", 12)], built_refs=[], up="../../"
+    )
+    assert "Every file published for this case." in without
+    assert "gzipped" not in without
+
+    pruned = gen.build_case_index_html(
+        {**env, "logs_published": False}, [("sanitizer_report.json", 12)],
+        built_refs=[], up="../../",
+    )
+    assert "pruned" in pruned and "gzipped" not in pruned
+
+
 def test_genco_rebuild_encodes_the_bundle_check_as_one_command():
     # A consumer executing `commands` in order cannot branch on prose, so the
     # raw-ELF-vs-bundle decision has to live inside a command.
@@ -2434,7 +2514,7 @@ def test_rebuild_plan_is_machine_readable_and_prose_is_generated_from_it():
         "clang-offload-bundler --type=o --unbundle --input=tmp.o "
         "--targets=hipv4-amdgcn-amd-amdhsa--gfx950 "
         "--output=recipes/sanitizers/fixtures/isa/lds.hsaco; "
-        "else cp tmp.o recipes/sanitizers/fixtures/isa/lds.hsaco; fi",
+        "else cp tmp.o recipes/sanitizers/fixtures/isa/lds.hsaco; fi && rm -f tmp.o",
     ]
     # The bundle check lives in a command, not only in the prose caveat, so an
     # automated consumer can execute the branch.

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2233,12 +2233,18 @@ def test_rebuild_commands_are_runnable_from_the_repo_root():
             # every fixtures/ token must be reached through recipes/sanitizers/.
             unrooted = re.findall(r"(?<![\w/.])fixtures/[\w./-]+", command)
             assert not unrooted, f"{entry['path']}: unrooted {unrooted} in {command!r}"
-    # The paths a command does name resolve in this checkout (sources at least;
-    # bin/ and isa/ are gitignored build outputs).
+    # Every *input* path a command names resolves in a clean checkout. The two
+    # build-output roots are gitignored, so they are skipped by prefix rather than
+    # by substring -- an earlier version matched "/bin/" and so happened to pass
+    # only on a machine where a previous run had already created those dirs.
+    generated = (
+        "recipes/sanitizers/fixtures/isa",
+        "recipes/sanitizers/fixtures/bin",
+    )
     for entry in gen.rebuild_plan(refs, target="gfx950"):
         for command in entry["commands"]:
             for token in re.findall(r"recipes/sanitizers/fixtures/[\w./-]+", command):
-                if "/isa/" in token or "/bin/" in token or token.endswith("/isa"):
+                if any(token == root or token.startswith(f"{root}/") for root in generated):
                     continue
                 assert (_REPO_ROOT / token).exists(), f"{entry['path']}: {token}"
 

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gzip
 import importlib.util
 import json
 import re
@@ -649,8 +650,10 @@ def test_build_html_emits_relative_report_links(tmp_path):
 
     # Latest-run table links each case to its raw JSON, relative to /sanitizers/.
     assert 'href="runs/2026-08-05-33/waitcheck/sanitizer_report.json"' in html
-    # A "view raw report" link appears in the kernel-detail section.
-    assert "view raw report" in html
+    # The kernel-detail card footer links the case's run area (its directory),
+    # not just the report, so the logs/recipe/inputs are one click away (#384).
+    assert 'href="runs/2026-08-05-33/waitcheck/">run area</a>' in html
+    assert "view raw report" not in html
     # The run area is linked from the latest-run header and the history table.
     assert 'href="runs/2026-08-05-33/"' in html
     assert 'href="runs/2026-08-04-22/"' in html
@@ -1741,11 +1744,13 @@ def test_build_html_survey_report_link_and_graceful_absence():
     )
     html = gen.build_html([_healthy_guardrail_run()], survey=survey)
 
-    # the linked survey case drills down to its raw report; the unlinked one still
-    # renders (degrades to no link). Guardrail rows carry no report_rel here, so the
-    # only "view raw report" link comes from the linked survey case.
+    # the linked survey case drills down to its raw report (per-kernel row) and to
+    # its run area (card footer); the unlinked one still renders, degrading to
+    # neither link. Guardrail rows carry no report_rel here, so the only run-area
+    # footer comes from the linked survey case.
     assert 'href="runs/x/survey/linked/sanitizer_report.json"' in html
-    assert html.count("view raw report") == 1
+    assert html.count('href="runs/x/survey/linked/">run area</a>') == 1
+    assert html.count("run area</a>") == 1
     assert "linked survey" in html and "nolink survey" in html
 
 
@@ -1793,9 +1798,11 @@ def test_build_html_kernel_rows_link_reports_on_both_tabs(tmp_path):
     # twice: the latest-run table cell and the per-kernel-row Report column.
     wc = 'href="runs/2026-08-05-33/waitcheck/sanitizer_report.json">report</a>'
     assert html.count(wc) == 2
-    # Survey kernel row links to the survey case's report_rel (the heading uses the
-    # distinct "view raw report" text, so a "report" link here is the per-row one).
+    # Survey kernel row links to the survey case's report_rel (the card footer uses
+    # the distinct "run area" text pointing at the directory, so a "report" link
+    # here is the per-row one).
     assert 'href="runs/x/survey/s/sanitizer_report.json">report</a>' in html
+    assert 'href="runs/x/survey/s/">run area</a>' in html
     # no dead/unsafe links leaked in
     assert 'href="/runs/' not in html and "javascript:" not in html
 
@@ -1902,3 +1909,555 @@ def test_main_without_survey_omits_survey_rows_but_renders_tab(tmp_path, monkeyp
     assert "No workload-survey kernels in this run." in html
     data = json.loads((out / "data.json").read_text(encoding="utf-8"))
     assert data[0]["survey"] == []
+
+
+# --------------------------------------------------------------------------
+# Run area (#384): the case directory a card footer links to
+# --------------------------------------------------------------------------
+
+
+def _publish_with_logs(tmp_path, monkeypatch, *, run_ids, keep_logs=None, survey=True):
+    """Publish a history (each case carrying a sweep log) plus one survey case."""
+    root = tmp_path / "runs"
+    for run_id in run_ids:
+        run_dir = _write_history_run(root, run_id)
+        (run_dir / "waitcheck" / "waitcheck").mkdir(parents=True)
+        (run_dir / "waitcheck" / "waitcheck" / "waitcheck-0.log").write_text("scan output\n")
+        (run_dir / "consan-racy" / "consan").mkdir(parents=True)
+        (run_dir / "consan-racy" / "consan" / "consan.log").write_text("race detected\n")
+    argv = [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(root),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(tmp_path / "dashboard"),
+    ]
+    if survey:
+        info = tmp_path / "informational"
+        (info / "consan-gemm" / "consan").mkdir(parents=True)
+        (info / "consan-gemm" / "sanitizer_report.json").write_text(
+            json.dumps(_informational_report("combined_hook_timeout"))
+        )
+        (info / "consan-gemm" / "consan" / "consan.log").write_text("hook timeout\n")
+        argv += ["--informational-results-dir", str(info)]
+    if keep_logs is not None:
+        argv += ["--keep-logs", str(keep_logs)]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert gen.main() == 0
+    return tmp_path / "dashboard"
+
+
+def test_case_dir_rel_points_at_the_directory_and_rejects_unsafe_values():
+    # The footer link is the case's directory, derived from report_rel so it
+    # inherits the same relative-only guarantee as the report link.
+    assert (
+        gen._case_dir_rel("runs/2026-08-05-33/survey/consan-gemm/sanitizer_report.json")
+        == "runs/2026-08-05-33/survey/consan-gemm/"
+    )
+    assert gen._case_dir_rel("runs/x/waitcheck/sanitizer_report.json") == "runs/x/waitcheck/"
+    # No safe directory to link -> no link at all, never a dead or unsafe href.
+    for unsafe in (
+        None, "", "sanitizer_report.json", "javascript:alert(1)",
+        "/runs/x/c/sanitizer_report.json", "../../etc/passwd",
+        "//evil.example/x/sanitizer_report.json",
+    ):
+        assert gen._case_dir_rel(unsafe) is None, unsafe
+
+
+def test_raw_link_html_renders_run_area_or_nothing():
+    linked = gen._raw_link_html("runs/x/survey/s/sanitizer_report.json")
+    assert 'href="runs/x/survey/s/">run area</a>' in linked
+    assert "view raw report" not in linked
+    assert gen._raw_link_html(None) == ""
+    assert gen._raw_link_html("javascript:alert(1)") == ""
+
+
+def test_recipe_fixture_refs_splits_source_inputs_from_built_artifacts():
+    # Source inputs are copied into the run area; CI-built artifacts (gitignored,
+    # ~16MB for a GEMM object) are recorded by digest instead.
+    recipe = (
+        "sanitizer_plan:\n"
+        "  source:\n"
+        "    hip: fixtures/repro/consan_lds_race.hip\n"
+        "    path: fixtures/gemm_shapes_unique.csv\n"
+        "    code_object: fixtures/isa/consan_gemm_f32.hsaco\n"
+        "    consan_command: fixtures/bin/consan_gemm_load\n"
+        "    isa_dir: fixtures/isa\n"
+    )
+    source, built = gen._recipe_fixture_refs(recipe)
+    assert source == ["fixtures/repro/consan_lds_race.hip", "fixtures/gemm_shapes_unique.csv"]
+    assert built == [
+        "fixtures/isa/consan_gemm_f32.hsaco",
+        "fixtures/bin/consan_gemm_load",
+        "fixtures/isa",
+    ]
+
+
+def test_report_digests_flattens_backend_and_code_object_provenance():
+    # waitcheck records its binary path/sha256; every worklist kernel records its
+    # code-object digest. Both are already in the report and rendered nowhere.
+    digests = gen.report_digests(_waitcheck_report())
+    assert digests["path"] == "/tmp/build/tools/rj_waitcheck"
+    assert digests["sha256"] == "472fcf288714beef"
+    assert digests["code_object:sol_1.hsaco"] == "93f09ae670abcdef"
+    # ConSan's repro command / hook digests are picked up from the same field.
+    consan = _consan_clean_report()
+    consan["checks"][0]["backend"] = {
+        "command": "/w/fixtures/bin/consan_gemm_load", "command_sha256": "deadbeef",
+        "hook": "/w/librocjitsu_dbi_hooks.so", "hook_sha256": "feedface",
+    }
+    assert gen.report_digests(consan)["command_sha256"] == "deadbeef"
+    # A malformed report degrades to {} rather than raising.
+    for bad in (None, [], "oops", {"checks": None}, {"worklist": {"kernels": [1]}}):
+        assert gen.report_digests(bad) == {}
+
+
+def test_artifact_digest_index_covers_every_key_shape_a_sanitizer_writes():
+    # The unpublished-artifact table looks digests up by basename, because the two
+    # sanitizers name the same kind of artifact under different report keys.
+    index = gen.artifact_digest_index({
+        "path": "/tmp/build/tools/rj_waitcheck", "sha256": "aa",
+        "command": "/w/fixtures/bin/consan_gemm_load", "command_sha256": "bb",
+        "hook": "/w/librocjitsu_dbi_hooks.so", "hook_sha256": "cc",
+        "code_object:consan_gemm_f32.hsaco": "dd",
+    })
+    assert index == {
+        "rj_waitcheck": "aa", "consan_gemm_load": "bb",
+        "librocjitsu_dbi_hooks.so": "cc", "consan_gemm_f32.hsaco": "dd",
+    }
+    # A half-recorded pair contributes nothing rather than a partial entry.
+    assert gen.artifact_digest_index({"command": "/w/x", "sha256": "aa"}) == {}
+    assert gen.artifact_digest_index({}) == {}
+
+
+def test_run_area_names_the_consan_repro_binary_digest_not_an_em_dash():
+    # ConSan records the repro binary as command/command_sha256. Keying only on
+    # "code_object:" left every fixtures/bin/ artifact with a null digest, so the
+    # "rebuild it and check the digest" instruction had nothing to check against.
+    report = _consan_clean_report()
+    report["checks"][0]["backend"] = {
+        "command": "/w/fixtures/bin/consan_gemm_load", "command_sha256": "deadbeef",
+    }
+    env = gen.build_case_env(
+        case="consan-gemm", cls="survey",
+        recipe="recipes/sanitizers/daily-consan-gemm.yaml", command="aorta sweep run",
+        meta={}, summary={}, report=report,
+        built_refs=["fixtures/bin/consan_gemm_load", "fixtures/isa"], inputs=[],
+    )
+    by_path = {item["path"]: item["sha256"] for item in env["artifacts_not_published"]}
+    assert by_path["fixtures/bin/consan_gemm_load"] == "deadbeef"
+    # A bare directory reference still has no digest to record; that stays honest.
+    assert by_path["fixtures/isa"] is None
+    assert "deadbeef" in gen.build_reproduce_md(env, built_refs=list(by_path))
+
+
+def test_case_dir_up_matches_the_published_depth_of_each_tab(tmp_path):
+    out = tmp_path / "dashboard"
+    guardrail = out / "runs" / "2026-08-05-33" / "waitcheck"
+    survey = out / "runs" / "2026-08-05-33" / "survey" / "consan-gemm"
+    guardrail.mkdir(parents=True)
+    survey.mkdir(parents=True)
+    # A guardrail case sits one level shallower than a survey case, so a single
+    # hardcoded "up" would break the back-link on one of the two tabs.
+    assert gen.case_dir_up(guardrail, out) == ("../../../", "../")
+    assert gen.case_dir_up(survey, out) == ("../../../../", "../../")
+
+
+def test_main_publishes_full_case_dirs_with_gzipped_logs(tmp_path, monkeypatch):
+    out = _publish_with_logs(tmp_path, monkeypatch, run_ids=["2026-08-05-33"])
+    case = out / "runs" / "2026-08-05-33" / "waitcheck"
+    survey_case = out / "runs" / "2026-08-05-33" / "survey" / "consan-gemm"
+
+    # The logs the verdict came from are published, gzipped, and still readable.
+    log = case / "waitcheck" / "waitcheck-0.log.gz"
+    assert log.is_file() and not (case / "waitcheck" / "waitcheck-0.log").exists()
+    assert gzip.decompress(log.read_bytes()) == b"scan output\n"
+    survey_log = survey_case / "consan" / "consan.log.gz"
+    assert gzip.decompress(survey_log.read_bytes()) == b"hook timeout\n"
+
+    # Every run area carries the inputs needed to reproduce it.
+    for area in (case, survey_case):
+        assert (area / "sanitizer_report.json").is_file()
+        assert (area / "recipe.yaml").is_file()
+        assert (area / "REPRODUCE.md").is_file()
+        assert (area / "env.json").is_file()
+        assert (area / "index.html").is_file()
+    # Source-level recipe inputs are copied; the CI-built artifacts are not.
+    assert (case / "inputs" / "fixtures" / "gemm_shapes_unique.csv").is_file()
+    assert not list(case.rglob("*.hsaco"))
+    assert not (survey_case / "inputs" / "fixtures" / "isa").exists()
+
+
+def test_run_area_records_unpublished_artifacts_by_digest(tmp_path, monkeypatch):
+    out = _publish_with_logs(tmp_path, monkeypatch, run_ids=["2026-08-05-33"])
+    case = out / "runs" / "2026-08-05-33" / "waitcheck"
+
+    env = json.loads((case / "env.json").read_text(encoding="utf-8"))
+    assert env["schema"] == gen.RUN_AREA_ENV_SCHEMA
+    assert env["class"] == "guardrail"
+    assert env["recipe"] == "recipes/sanitizers/daily-waitcheck-gemm.yaml"
+    assert env["command"] == (
+        "aorta sweep run --recipe recipes/sanitizers/daily-waitcheck-gemm.yaml"
+    )
+    # The full SHA is recorded, not the display-shortened one, so the reproduce
+    # instructions name a revision you can actually check out.
+    assert env["commit"] == "0123456789abcdef"
+    assert env["observed"]["verdict"] == "warn"
+    assert env["digests"]["sha256"] == "472fcf288714beef"
+
+    md = (case / "REPRODUCE.md").read_text(encoding="utf-8")
+    assert "aorta sweep run --recipe recipes/sanitizers/daily-waitcheck-gemm.yaml" in md
+    assert "git checkout 0123456789abcdef" in md
+    assert "472fcf288714beef" in md
+
+    # The survey case's recipe references built artifacts, so they are named with
+    # their digest under "artifacts not published" rather than shipped.
+    survey_env = json.loads(
+        (out / "runs/2026-08-05-33/survey/consan-gemm/env.json").read_text(encoding="utf-8")
+    )
+    paths = [item["path"] for item in survey_env["artifacts_not_published"]]
+    assert "fixtures/isa/consan_gemm_f32.hsaco" in paths
+    survey_md = (
+        out / "runs/2026-08-05-33/survey/consan-gemm/REPRODUCE.md"
+    ).read_text(encoding="utf-8")
+    assert "Artifacts not published" in survey_md
+    assert "hipcc --genco" in survey_md
+
+
+def test_case_index_lists_every_published_file(tmp_path, monkeypatch):
+    out = _publish_with_logs(tmp_path, monkeypatch, run_ids=["2026-08-05-33"])
+    case = out / "runs" / "2026-08-05-33" / "survey" / "consan-gemm"
+    page = (case / "index.html").read_text(encoding="utf-8")
+
+    # Pages does not auto-index a directory, so this page is what makes the
+    # footer's directory link resolve; it must link everything actually present.
+    for rel, _size in gen.run_area_files(case):
+        assert f'href="{rel}"' in page
+    assert 'href="consan/consan.log.gz"' in page
+    assert 'href="sanitizer_report.json"' in page
+    # It never links itself, and every link resolves on disk.
+    assert 'href="index.html"' not in page
+    for href in re.findall(r'href="([^"#]+)"', page):
+        if href.startswith("http"):
+            continue
+        target = (case / href).resolve()
+        assert target.exists(), href
+        if target.is_dir():
+            assert (target / "index.html").is_file(), href
+
+
+def test_keep_logs_window_prunes_bulk_but_keeps_report_and_page(tmp_path, monkeypatch):
+    # Reports are retained for --keep runs; logs and copied inputs only for the
+    # newest --keep-logs, so the data branch stays bounded (#384).
+    out = _publish_with_logs(
+        tmp_path,
+        monkeypatch,
+        run_ids=["2026-08-05-33", "2026-08-04-22", "2026-08-03-11"],
+        keep_logs=2,
+        survey=False,
+    )
+    latest = out / "runs" / "2026-08-05-33" / "waitcheck"
+    inside = out / "runs" / "2026-08-04-22" / "waitcheck"
+    outside = out / "runs" / "2026-08-03-11" / "waitcheck"
+
+    assert (inside / "waitcheck" / "waitcheck-0.log.gz").is_file()
+    # The recipe and its inputs are pinned to the checkout that ran the case, so
+    # only the run this job staged gets them -- publishing today's recipe into an
+    # older area would contradict the commit its env.json names.
+    assert (latest / "recipe.yaml").is_file()
+    assert (latest / "inputs").is_dir()
+    assert not (inside / "recipe.yaml").exists()
+    assert not (inside / "inputs").exists()
+
+    # The pruned run keeps what makes it still readable and still drillable.
+    assert (outside / "sanitizer_report.json").is_file()
+    assert (outside / "index.html").is_file()
+    assert (outside / "env.json").is_file()
+    assert not list(outside.rglob("*.log.gz"))
+    assert not (outside / "inputs").exists()
+    assert not (outside / "recipe.yaml").exists()
+    # Both renderings say the area was pruned rather than promising its logs.
+    env = json.loads((outside / "env.json").read_text(encoding="utf-8"))
+    assert env["logs_published"] is False
+    assert env["inputs"] == []
+    assert "pruned" in (outside / "REPRODUCE.md").read_text(encoding="utf-8")
+    assert json.loads((inside / "env.json").read_text(encoding="utf-8"))["logs_published"] is True
+    # An empty per-sanitizer log dir is removed rather than left as a stub, and
+    # the page lists only files that survived -- no dead links.
+    assert not (outside / "waitcheck").exists()
+    page = (outside / "index.html").read_text(encoding="utf-8")
+    assert ".log.gz" not in page
+    for href in re.findall(r'href="([^"#]+)"', page):
+        if not href.startswith("http"):
+            assert (outside / href).resolve().exists(), href
+
+
+def test_run_index_lists_survey_cases_and_run_areas(tmp_path):
+    root = tmp_path / "runs"
+    _write_history_run(root, "2026-08-05-33")
+    run = gen.runs_from_history_root(root, _baselines())[0]
+    survey = gen.survey_cases_from_spec(
+        {"cases": [{
+            "name": "consan-gemm", "label": "gemm - ConSan",
+            "command": "aorta sweep run --recipe recipes/sanitizers/daily-consan-gemm.yaml",
+            "report_rel": "runs/2026-08-05-33/survey/consan-gemm/sanitizer_report.json",
+            "report": _consan_racy_report(),
+        }]}
+    )
+
+    page = gen.build_run_index_html(run, survey=survey)
+
+    # Without this the run page lists only the three gated guardrail recipes, so
+    # the top-nav "raw reports" link never mentions the survey cases beside them.
+    assert "Workload survey" in page
+    assert 'href="survey/consan-gemm/">run area</a>' in page
+    assert "daily-consan-gemm.yaml" in page
+    # Guardrail rows link their own run area alongside the raw report.
+    assert 'href="waitcheck/">run area</a>' in page
+    assert 'href="waitcheck/sanitizer_report.json"' in page
+
+    # A run with no survey cases renders exactly as before (no empty section).
+    assert "Workload survey" not in gen.build_run_index_html(run)
+
+
+def test_keep_logs_window_also_bounds_survey_logs(tmp_path, monkeypatch):
+    """The log window must bound the survey areas, not just the guardrail cases.
+
+    A survey area is only ever published under the run that was latest at the
+    time, and then persists on the data branch under that run -- so it is only
+    reachable for pruning on a *later* publish. Publishing once per run into one
+    output tree is what the nightly does to the ``sanitizer-results`` branch, and
+    it is the only way this shows up: a single publish leaves every survey area
+    inside the window and looks correct.
+    """
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    run_ids = ["2026-08-03-11", "2026-08-04-22", "2026-08-05-33"]
+    for run_id in run_ids:
+        run_dir = _write_history_run(dashboard / "runs", run_id)
+        (run_dir / "consan-racy" / "consan").mkdir(parents=True)
+        (run_dir / "consan-racy" / "consan" / "consan.log").write_text("race\n")
+        info = tmp_path / f"informational-{run_id}"
+        (info / "consan-gemm" / "consan").mkdir(parents=True)
+        (info / "consan-gemm" / "sanitizer_report.json").write_text(
+            json.dumps(_informational_report("combined_hook_timeout"))
+        )
+        (info / "consan-gemm" / "consan" / "consan.log").write_text("hook timeout\n")
+        monkeypatch.setattr(sys, "argv", [
+            "gen_sanitizer_dashboard",
+            "--history-root", str(dashboard / "runs"),
+            "--baselines",
+            str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+            "--out-dir", str(dashboard),
+            "--keep-logs", "1",
+            "--informational-results-dir", str(info),
+        ])
+        assert gen.main() == 0
+
+    latest = dashboard / "runs/2026-08-05-33/survey/consan-gemm"
+    assert (latest / "consan" / "consan.log.gz").is_file()
+
+    for run_id in run_ids[:-1]:
+        area = dashboard / "runs" / run_id / "survey" / "consan-gemm"
+        # ConSan survey logs are the bulkiest thing published; unbounded here they
+        # would outlive the guardrail logs beside them by --keep / --keep-logs.
+        assert not list(area.rglob("*.log.gz")), run_id
+        assert not list(area.rglob("*.log")), run_id
+        # Still readable and still drillable, like a pruned guardrail area.
+        assert (area / "sanitizer_report.json").is_file(), run_id
+        env = json.loads((area / "env.json").read_text(encoding="utf-8"))
+        assert env["logs_published"] is False, run_id
+        # The page is re-rendered from that manifest, so it cannot keep linking
+        # the log it no longer has.
+        page = (area / "index.html").read_text(encoding="utf-8")
+        assert ".log.gz" not in page, run_id
+        for href in re.findall(r'href="([^"#]+)"', page):
+            if not href.startswith("http"):
+                assert (area / href).resolve().exists(), f"{run_id}: {href}"
+
+
+def test_refresh_published_case_area_reports_an_unusable_manifest(tmp_path):
+    # env.json is the only input for re-rendering an older area, so a missing or
+    # malformed one must be reported (the caller then writes a fresh area) rather
+    # than raising and aborting the whole dashboard.
+    area = tmp_path / "dashboard" / "runs" / "r" / "survey" / "c"
+    area.mkdir(parents=True)
+    (area / "sanitizer_report.json").write_text("{}")
+
+    assert gen.refresh_published_case_area(area, tmp_path / "dashboard", logs=True) is False
+    (area / "env.json").write_text("[]")  # valid JSON, wrong shape
+    assert gen.refresh_published_case_area(area, tmp_path / "dashboard", logs=True) is False
+
+
+def test_older_run_areas_keep_their_own_provenance_not_the_current_job(tmp_path, monkeypatch):
+    """An older area must not be relabelled with the publishing job's environment.
+
+    ``AORTA_CI_IMAGE`` / ``AORTA_ROCJITSU_*`` describe the GPU run being published
+    now. Every retained run's area is re-rendered on every nightly, so stamping
+    them unconditionally would tell a reader that a three-week-old run used
+    today's container image and sanitizer build.
+    """
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    for run_id, image, bundle in (
+        ("2026-08-04-22", "rocm/pytorch@sha256:old", "oldbundle"),
+        ("2026-08-05-33", "rocm/pytorch@sha256:new", "newbundle"),
+    ):
+        _write_history_run(dashboard / "runs", run_id)
+        monkeypatch.setenv("AORTA_CI_IMAGE", image)
+        monkeypatch.setenv("AORTA_ROCJITSU_COMMIT", bundle)
+        monkeypatch.setattr(sys, "argv", [
+            "gen_sanitizer_dashboard",
+            "--history-root", str(dashboard / "runs"),
+            "--baselines",
+            str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+            "--out-dir", str(dashboard),
+        ])
+        assert gen.main() == 0
+
+    def _env(run_id):
+        path = dashboard / "runs" / run_id / "waitcheck" / "env.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    assert _env("2026-08-04-22")["container_image"] == "rocm/pytorch@sha256:old"
+    assert _env("2026-08-04-22")["rocjitsu_commit"] == "oldbundle"
+    assert _env("2026-08-05-33")["container_image"] == "rocm/pytorch@sha256:new"
+    # It also survives into the rendering, not just the manifest.
+    assert "rocm/pytorch@sha256:old" in (
+        dashboard / "runs/2026-08-04-22/waitcheck/REPRODUCE.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_past_run_pages_still_list_the_survey_areas_published_under_them(
+    tmp_path, monkeypatch
+):
+    # The live survey list only covers the run being published now, so a past
+    # run's page has to be rebuilt from the areas on disk -- otherwise the areas
+    # kept under it are reachable only by typing the URL, on a site with no
+    # directory listing. Uses the nightly's layout (history nested under the
+    # output tree); with disjoint trees runs/ is cleared and re-copied instead.
+    out = tmp_path / "dashboard"
+    out.mkdir()
+    for run_id, with_survey in (("2026-08-05-33", True), ("2026-08-06-44", False)):
+        _write_history_run(out / "runs", run_id)
+        argv = [
+            "gen_sanitizer_dashboard",
+            "--history-root", str(out / "runs"),
+            "--baselines",
+            str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+            "--out-dir", str(out),
+        ]
+        if with_survey:
+            info = tmp_path / "informational"
+            (info / "consan-gemm").mkdir(parents=True)
+            (info / "consan-gemm" / "sanitizer_report.json").write_text(
+                json.dumps(_informational_report("combined_hook_timeout"))
+            )
+            argv += ["--informational-results-dir", str(info)]
+        monkeypatch.setattr(sys, "argv", argv)
+        assert gen.main() == 0
+
+    older = (out / "runs/2026-08-05-33/index.html").read_text(encoding="utf-8")
+    assert "Workload survey" in older
+    assert 'href="survey/consan-gemm/">run area</a>' in older
+    assert "None" not in older
+    # The newest run has no survey cases of its own, so no empty section.
+    assert "Workload survey" not in (
+        out / "runs/2026-08-06-44/index.html"
+    ).read_text(encoding="utf-8")
+
+
+def test_older_survey_areas_published_before_run_areas_are_retrofitted(
+    tmp_path, monkeypatch
+):
+    # History co-published before #384 holds survey dirs with only a report. They
+    # get the same retrofit as an older guardrail case, so retained history is
+    # uniformly browsable instead of holding areas with no landing page.
+    out = tmp_path / "dashboard"
+    out.mkdir()
+    _write_history_run(out / "runs", "2026-08-05-33")
+    bare = out / "runs" / "2026-08-05-33" / "survey" / "consan-gemm"
+    bare.mkdir(parents=True)
+    (bare / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    _write_history_run(out / "runs", "2026-08-06-44")
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(out / "runs"),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(out),
+    ])
+    assert gen.main() == 0
+
+    assert (bare / "index.html").is_file()
+    env = json.loads((bare / "env.json").read_text(encoding="utf-8"))
+    assert env["class"] == "survey"
+    assert env["recipe"] == "recipes/sanitizers/daily-consan-gemm.yaml"
+    # Retrofitted from the report alone, so it claims no live provenance and no
+    # recipe copy -- neither is knowable for a run this job did not execute.
+    assert "container_image" not in env
+    assert not (bare / "recipe.yaml").exists()
+    # And it is now reachable from the run page rather than only by direct URL.
+    page = (out / "runs/2026-08-05-33/index.html").read_text(encoding="utf-8")
+    assert 'href="survey/consan-gemm/">run area</a>' in page
+
+
+def test_survey_entries_from_published_degrades_on_a_missing_manifest(tmp_path):
+    run_dir = tmp_path / "runs" / "r"
+    (run_dir / "survey" / "good").mkdir(parents=True)
+    (run_dir / "survey" / "bare").mkdir(parents=True)
+    (run_dir / "survey" / "good" / "sanitizer_report.json").write_text("{}")
+    (run_dir / "survey" / "good" / "env.json").write_text(
+        json.dumps({"case": "good", "command": "aorta sweep run", "observed": {}})
+    )
+
+    entries = gen.survey_entries_from_published(run_dir)
+
+    # An area with no manifest is skipped rather than rendered from guesses.
+    assert [e["name"] for e in entries] == ["good"]
+    # A recorded verdict may be absent; the table must not print "None" for it.
+    assert entries[0]["summary"]["verdict"] is None
+    page = gen._run_index_survey_html(entries)
+    assert "None" not in page and gen._DASH in page
+    assert gen.survey_entries_from_published(tmp_path / "runs" / "absent") == []
+
+
+def test_build_case_env_takes_provenance_rather_than_reading_the_environment(monkeypatch):
+    # Keeping it a parameter is what makes it impossible to relabel an older run
+    # by accident; the function stays pure and testable.
+    monkeypatch.setenv("AORTA_CI_IMAGE", "rocm/pytorch@sha256:leak")
+    kwargs = {
+        "case": "waitcheck", "cls": "guardrail", "recipe": "r.yaml",
+        "command": "aorta sweep run", "meta": {}, "summary": {},
+        "report": None, "built_refs": [], "inputs": [],
+    }
+    assert "container_image" not in gen.build_case_env(**kwargs)
+    assert gen.provenance_from_environ()["container_image"] == "rocm/pytorch@sha256:leak"
+    stamped = gen.build_case_env(**kwargs, provenance=gen.provenance_from_environ())
+    assert stamped["container_image"] == "rocm/pytorch@sha256:leak"
+
+
+def test_run_area_renders_em_dash_for_a_report_missing_its_verdict():
+    # summarize_case keeps a structurally-degraded report as present, so verdict /
+    # execution can be None. Rendering those as the literal "None" is the bug this
+    # guards; env.json still records null, which is honest for a machine consumer.
+    env = gen.build_case_env(
+        case="consan-gemm", cls="survey",
+        recipe="recipes/sanitizers/daily-consan-gemm.yaml", command="aorta sweep run",
+        meta={"run": "r", "commit_full": "abc", "date": "2026-08-05", "gpu": "gfx950"},
+        summary=gen.summarize_case({"schema": "aorta.sanitizer_report/0.1"}, None),
+        report=None, built_refs=[], inputs=[],
+    )
+    assert env["observed"]["verdict"] is None
+    assert env["observed"]["execution"] is None
+
+    md = gen.build_reproduce_md(env, built_refs=[])
+    assert f"- Verdict: `{gen._DASH}`" in md
+    assert f"- Execution: `{gen._DASH}`" in md
+    assert "None" not in md
+
+    page = gen.build_case_index_html(env, [], built_refs=[], up="../../")
+    assert ">None<" not in page
+    assert gen._DASH in page

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1736,7 +1736,9 @@ def test_build_html_survey_fail_is_color_coded_but_never_a_regression():
 def test_build_html_survey_report_link_and_graceful_absence():
     survey = gen.survey_cases_from_spec(
         {"cases": [
-            {"name": "linked", "label": "linked survey",
+            # "staged" says the whole directory was published, so the card footer
+            # may link it; report_rel alone only makes the JSON reachable.
+            {"name": "linked", "label": "linked survey", "staged": True,
              "report_rel": "runs/x/survey/linked/sanitizer_report.json",
              "report": _consan_racy_report()},
             {"name": "nolink", "label": "nolink survey", "report": _waitcheck_report()},
@@ -1752,6 +1754,27 @@ def test_build_html_survey_report_link_and_graceful_absence():
     assert html.count('href="runs/x/survey/linked/">run area</a>') == 1
     assert html.count("run area</a>") == 1
     assert "linked survey" in html and "nolink survey" in html
+
+
+def test_build_html_survey_report_without_staged_area_emits_no_directory_link():
+    # A spec entry's report can be staged by the caller while its *directory* is
+    # not: a directory link needs an index.html only the area's publisher writes.
+    # Linking it anyway published a 404 on every --survey invocation.
+    survey = gen.survey_cases_from_spec(
+        {"cases": [{
+            "name": "linked", "label": "linked survey",
+            "report_rel": "runs/x/survey/linked/sanitizer_report.json",
+            "report": _consan_racy_report(),
+        }]}
+    )
+    assert survey[0]["staged"] is False
+    html = gen.build_html([_healthy_guardrail_run()], survey=survey)
+
+    # The per-kernel Report column still reaches the JSON the caller did stage.
+    assert 'href="runs/x/survey/linked/sanitizer_report.json"' in html
+    # ...but nothing claims the directory.
+    assert 'href="runs/x/survey/linked/"' not in html
+    assert "run area</a>" not in html
 
 
 def test_kernel_tables_html_links_each_row_to_report():
@@ -1787,7 +1810,7 @@ def test_build_html_kernel_rows_link_reports_on_both_tabs(tmp_path):
     _write_history_run(root, "2026-08-05-33")
     runs = gen.runs_from_history_root(root, _baselines())
     survey = gen.survey_cases_from_spec(
-        {"cases": [{"name": "s", "label": "survey linked",
+        {"cases": [{"name": "s", "label": "survey linked", "staged": True,
                     "report_rel": "runs/x/survey/s/sanitizer_report.json",
                     "report": _consan_racy_report()}]}
     )
@@ -1996,20 +2019,152 @@ def test_recipe_fixture_refs_splits_source_inputs_from_built_artifacts():
 def test_report_digests_flattens_backend_and_code_object_provenance():
     # waitcheck records its binary path/sha256; every worklist kernel records its
     # code-object digest. Both are already in the report and rendered nowhere.
+    # .get() throughout: whether the key was picked up at all is exactly what is
+    # under test, so a miss should read as the assertion it is rather than a
+    # KeyError that hides which digest went missing.
     digests = gen.report_digests(_waitcheck_report())
-    assert digests["path"] == "/tmp/build/tools/rj_waitcheck"
-    assert digests["sha256"] == "472fcf288714beef"
-    assert digests["code_object:sol_1.hsaco"] == "93f09ae670abcdef"
+    assert digests.get("path") == "/tmp/build/tools/rj_waitcheck"
+    assert digests.get("sha256") == "472fcf288714beef"
+    assert digests.get("code_object:sol_1.hsaco") == "93f09ae670abcdef"
     # ConSan's repro command / hook digests are picked up from the same field.
     consan = _consan_clean_report()
     consan["checks"][0]["backend"] = {
         "command": "/w/fixtures/bin/consan_gemm_load", "command_sha256": "deadbeef",
         "hook": "/w/librocjitsu_dbi_hooks.so", "hook_sha256": "feedface",
     }
-    assert gen.report_digests(consan)["command_sha256"] == "deadbeef"
+    assert gen.report_digests(consan).get("command_sha256") == "deadbeef"
     # A malformed report degrades to {} rather than raising.
     for bad in (None, [], "oops", {"checks": None}, {"worklist": {"kernels": [1]}}):
         assert gen.report_digests(bad) == {}
+
+
+def test_main_with_a_survey_spec_emits_no_run_area_link_it_cannot_publish(
+    tmp_path, monkeypatch
+):
+    # --survey entries render from an inline report; only
+    # --informational-results-dir entries get their directory staged. Keying the
+    # run-index link on report presence published a dead survey/<case>/ link on
+    # exactly this invocation.
+    out = tmp_path / "dashboard"
+    out.mkdir()
+    _write_history_run(out / "runs", "2026-08-05-33")
+    spec = tmp_path / "survey.json"
+    spec.write_text(json.dumps({"cases": [{
+        "name": "consan-gemm", "label": "gemm - ConSan",
+        "command": "aorta sweep run --recipe recipes/sanitizers/daily-consan-gemm.yaml",
+        "report_rel": "runs/2026-08-05-33/survey/consan-gemm/sanitizer_report.json",
+        "report": _consan_racy_report(),
+    }]}))
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(out / "runs"),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(out),
+        "--survey", str(spec),
+    ])
+    assert gen.main() == 0
+
+    assert not (out / "runs/2026-08-05-33/survey").exists()
+    # The case is still listed on both pages; it just carries no directory link.
+    run_page = (out / "runs/2026-08-05-33/index.html").read_text(encoding="utf-8")
+    assert "Workload survey" in run_page
+    assert "survey/consan-gemm/" not in run_page
+    # Same on the dashboard's Tab 2 card footer: no directory link is claimed.
+    # (The per-row Report link to the JSON is the caller's to stage, unchanged.)
+    dashboard = (out / "index.html").read_text(encoding="utf-8")
+    assert 'href="runs/2026-08-05-33/survey/consan-gemm/"' not in dashboard
+    # Every relative link on the run page resolves.
+    for href in re.findall(r'href="([^"#]+)"', run_page):
+        if href.startswith("http"):
+            continue
+        target = (out / "runs/2026-08-05-33" / href).resolve()
+        ok = (target / "index.html").is_file() if target.is_dir() else target.exists()
+        assert ok, href
+
+
+def test_rebuild_hint_sources_all_exist_in_the_repo():
+    # The hints name concrete source paths so a rebuild reproduces the recorded
+    # digest. A rename must break here rather than silently ship a stale command.
+    recipes = _REPO_ROOT / "recipes" / "sanitizers"
+    for ref, source in gen._GENCO_ISA_SOURCES.items():
+        assert (recipes / source).is_file(), f"{ref} -> {source}"
+    for ref, (source, define) in gen._BIN_SOURCES.items():
+        assert (recipes / source).is_file(), f"{ref} -> {source}"
+        # A define means the binary is bound to a code object it must be told about.
+        assert (define is None) == (ref not in gen._BIN_OBJECT), ref
+
+
+def test_rebuild_hints_match_the_nightly_commands_per_artifact():
+    def hint(ref: str) -> str:
+        return gen._rebuild_hints([ref], target="gfx950")[0]
+
+    hints = {
+        ref: hint(ref)
+        for ref in (
+            "fixtures/isa/lds.hsaco",
+            "fixtures/isa/consan_gemm_f32.hsaco",
+            "fixtures/isa",
+            "fixtures/bin/lds_dispatch",
+            "fixtures/bin/consan_lds_race",
+        )
+    }
+    # A --genco object may be a bundle or a raw ELF depending on the ROCm build,
+    # and the recorded digest is of the unbundled object -- so the conditional
+    # unbundle is part of the instruction, not an optional detail.
+    lds = hints["fixtures/isa/lds.hsaco"]
+    assert "hipcc --genco --offload-arch=gfx950 fixtures/kernels/lds_reduce.hip" in lds
+    assert "__CLANG_OFFLOAD_BUNDLE__" in lds
+    assert "clang-offload-bundler --type=o --unbundle" in lds
+    # The GEMM objects are extracted from Tensile libraries, never compiled.
+    assert "prepare_gemm_isa.py" in hints["fixtures/isa/consan_gemm_f32.hsaco"]
+    assert "hipcc" not in hints["fixtures/isa/consan_gemm_f32.hsaco"]
+    assert "--top-n 3" in hints["fixtures/isa"]
+    # A loader binary needs the define naming its object, or it builds the wrong one.
+    assert "-DLDS_HSACO=" in hints["fixtures/bin/lds_dispatch"]
+    assert "fixtures/isa/lds.hsaco" in hints["fixtures/bin/lds_dispatch"]
+    # A plain repro binary has no define to add.
+    assert "-D" not in hints["fixtures/bin/consan_lds_race"]
+    assert "fixtures/repro/consan_lds_race.hip" in hints["fixtures/bin/consan_lds_race"]
+    # An unknown reference degrades to the bare path rather than a wrong command.
+    assert gen._rebuild_hints(["fixtures/other/x"], target="gfx950") == ["fixtures/other/x"]
+    # Every hint's backticks are balanced, so the page renders them as <code>
+    # spans rather than leaving a stray literal backtick in the markup.
+    for ref, text in hints.items():
+        assert text.count("`") % 2 == 0, ref
+
+
+def test_case_index_page_carries_the_reproduction_details(tmp_path, monkeypatch):
+    # #384 requires the code-object SHA-256 on the landing page, and decision 9
+    # renders REPRODUCE.md's reproduction details there. The artifacts table alone
+    # cannot carry the digests: the waitcheck GEMM recipe names only a bare
+    # `isa_dir: fixtures/isa`, so it has one row and no per-object digest.
+    out = _publish_with_logs(tmp_path, monkeypatch, run_ids=["2026-08-05-33"])
+    case = out / "runs" / "2026-08-05-33" / "waitcheck"
+    page = (case / "index.html").read_text(encoding="utf-8")
+    env = json.loads((case / "env.json").read_text(encoding="utf-8"))
+
+    assert "Recorded digests" in page
+    assert env["digests"]["code_object:sol_1.hsaco"] == "93f09ae670abcdef"
+    for key, value in env["digests"].items():
+        assert key in page and value in page
+    # The env a reproduction needs is on the page too, from the same constant as
+    # REPRODUCE.md, so the two cannot drift.
+    assert "ROCJITSU_PREBUILT" in page
+    assert "<code>ROCJITSU_PREBUILT</code>" in page
+    assert gen._REQUIRED_ENV_NOTE in (case / "REPRODUCE.md").read_text(encoding="utf-8")
+    # Execution status was in the MD twin but missing from the page.
+    assert "Execution" in page
+    # The rebuild commands render as code, not as literal Markdown backticks.
+    assert "prepare_gemm_isa.py" in page
+    assert "`" not in page
+
+
+def test_md_code_to_html_escapes_before_converting_backticks():
+    assert gen._md_code_to_html("use `X` now") == "use <code>X</code> now"
+    # Escaping happens first, so text cannot inject markup of its own.
+    assert gen._md_code_to_html("<b>&`x`") == "&lt;b&gt;&amp;<code>x</code>"
+    assert gen._md_code_to_html("plain") == "plain"
 
 
 def test_artifact_digest_index_covers_every_key_shape_a_sanitizer_writes():
@@ -2121,7 +2276,14 @@ def test_run_area_records_unpublished_artifacts_by_digest(tmp_path, monkeypatch)
         out / "runs/2026-08-05-33/survey/consan-gemm/REPRODUCE.md"
     ).read_text(encoding="utf-8")
     assert "Artifacts not published" in survey_md
-    assert "hipcc --genco" in survey_md
+    # The GEMM object is *extracted* by prepare_gemm_isa.py, not compiled from a
+    # .hip source, and the binary that loads it needs the -DOBJECT define. A
+    # generic "hipcc it" hint would build a different file than the recorded
+    # digest, which is the whole point of recording the digest.
+    assert "prepare_gemm_isa.py" in survey_md
+    assert "--consan-object fixtures/isa/consan_gemm_f32.hsaco" in survey_md
+    assert "-DOBJECT=" in survey_md
+    assert "fixtures/kernels/consan_load.hip" in survey_md
 
 
 def test_case_index_lists_every_published_file(tmp_path, monkeypatch):
@@ -2210,8 +2372,15 @@ def test_run_index_lists_survey_cases_and_run_areas(tmp_path):
     # Without this the run page lists only the three gated guardrail recipes, so
     # the top-nav "raw reports" link never mentions the survey cases beside them.
     assert "Workload survey" in page
-    assert 'href="survey/consan-gemm/">run area</a>' in page
     assert "daily-consan-gemm.yaml" in page
+    # A spec entry carries no area_rel: its report parsed, but nothing staged the
+    # directory, so the case is listed with no run-area link rather than a 404.
+    assert "survey/consan-gemm/" not in page
+    assert "&mdash;" in page
+    # Once the caller has actually published the area it may claim it.
+    staged = [{**survey[0], "staged": True}]
+    linked = gen.build_run_index_html(run, survey=staged)
+    assert 'href="survey/consan-gemm/">run area</a>' in linked
     # Guardrail rows link their own run area alongside the raw report.
     assert 'href="waitcheck/">run area</a>' in page
     assert 'href="waitcheck/sanitizer_report.json"' in page

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1590,6 +1590,13 @@ def test_survey_report_rel_rejects_unsafe_links():
         " runs/x/report.json",  # leading whitespace browsers would strip
         "../runs/x/report.json",  # parent-directory traversal
         "a/../../b/report.json",  # traversal buried mid-path
+        # URL syntax the browser acts on but a directory does not: the tail of each
+        # of these is a query/fragment on the segment before it, so the request
+        # never reaches the published path -- and a percent-escape can be
+        # normalised back into "..".
+        "runs/x?old/survey/foo/sanitizer_report.json",
+        "runs/x#old/survey/foo/sanitizer_report.json",
+        "runs/%2e%2e/survey/foo/sanitizer_report.json",
     ):
         spec = {"cases": [{"name": "s", "report_rel": unsafe, "report": _consan_racy_report()}]}
         entry = gen.survey_cases_from_spec(spec)[0]
@@ -1983,6 +1990,10 @@ def test_case_dir_rel_points_at_the_directory_and_rejects_unsafe_values():
         None, "", "sanitizer_report.json", "javascript:alert(1)",
         "/runs/x/c/sanitizer_report.json", "../../etc/passwd",
         "//evil.example/x/sanitizer_report.json",
+        # A query/fragment makes the emitted URL address "runs/x", not the case
+        # directory, so there is no safe area link to derive from it.
+        "runs/x?old/survey/foo/sanitizer_report.json",
+        "runs/x#old/survey/foo/sanitizer_report.json",
     ):
         assert gen._case_dir_rel(unsafe) is None, unsafe
 
@@ -2227,7 +2238,8 @@ def test_rebuild_commands_are_runnable_from_the_repo_root():
         # The recorded path stays recipe-relative; only the commands are rewritten.
         assert entry["path"].startswith("fixtures/"), entry["path"]
         assert entry["commands"], entry["path"]
-        assert entry["commands"][0].startswith("mkdir -p recipes/sanitizers/fixtures/")
+        assert entry["commands"][0] == gen._ROCM_LLVM_PATH_EXPORT
+        assert entry["commands"][1].startswith("mkdir -p recipes/sanitizers/fixtures/")
         for command in entry["commands"]:
             # No bare recipe-relative path survives into an executable command:
             # every fixtures/ token must be reached through recipes/sanitizers/.
@@ -2247,6 +2259,35 @@ def test_rebuild_commands_are_runnable_from_the_repo_root():
                 if any(token == root or token.startswith(f"{root}/") for root in generated):
                     continue
                 assert (_REPO_ROOT / token).exists(), f"{entry['path']}: {token}"
+
+
+def test_rebuild_commands_export_the_rocm_llvm_path():
+    """The bundler is not on PATH in the image that produced these artifacts.
+
+    The ROCm container exports only ``/opt/rocm/bin``, so the nightly adds the LLVM
+    bindir before building any fixture -- hipcc shells out to
+    ``clang-offload-bundler``, ``prepare_gemm_isa.py`` looks it up with
+    ``shutil.which``, and the genco branch calls it directly. A pasteable command
+    that names it bare fails the way that job's fixture build once did, so every
+    entry opens with the export and it has to stay the workflow's own.
+    """
+    workflow = (_REPO_ROOT / ".github/workflows/sanitizers-nightly.yml").read_text(
+        encoding="utf-8"
+    )
+    assert gen._ROCM_LLVM_PATH_EXPORT in workflow
+    refs = [
+        "fixtures/isa/lds.hsaco",  # hipcc --genco + an explicit unbundle
+        "fixtures/isa/consan_gemm_f32.hsaco",  # prepare_gemm_isa.py
+        "fixtures/isa",
+        "fixtures/bin/consan_lds_race",  # hipcc host+device compile
+    ]
+    for entry in gen.rebuild_plan(refs, target="gfx950"):
+        assert entry["commands"][0] == gen._ROCM_LLVM_PATH_EXPORT, entry["path"]
+    # Rendered into the prose too, since the hints are generated from the plan.
+    hint = gen._rebuild_hints(gen.rebuild_plan(["fixtures/isa"], target="gfx950"))[0]
+    assert f"`{gen._ROCM_LLVM_PATH_EXPORT}`" in hint
+    # An unrecognised reference still yields no commands rather than a bare export.
+    assert gen.rebuild_plan(["fixtures/other/x"], target="gfx950")[0]["commands"] == []
 
 
 def test_genco_rebuild_encodes_the_bundle_check_as_one_command():
@@ -2329,6 +2370,7 @@ def test_rebuild_plan_is_machine_readable_and_prose_is_generated_from_it():
 
     lds = plan[0]
     assert lds["commands"] == [
+        gen._ROCM_LLVM_PATH_EXPORT,
         "mkdir -p recipes/sanitizers/fixtures/isa",
         "hipcc --genco --offload-arch=gfx950 "
         "recipes/sanitizers/fixtures/kernels/lds_reduce.hip -o tmp.o",
@@ -2342,7 +2384,7 @@ def test_rebuild_plan_is_machine_readable_and_prose_is_generated_from_it():
     # automated consumer can execute the branch.
     assert "__CLANG_OFFLOAD_BUNDLE__" in " ".join(lds["commands"])
     assert "--genco" in lds["caveat"]
-    hipcc = plan[1]["commands"][1]
+    hipcc = plan[1]["commands"][2]
     assert "-O1 -g" not in hipcc  # loader binaries are built without
     assert "-DLDS_HSACO=" in hipcc
     # An unknown reference yields no command rather than a plausible wrong one.
@@ -2913,9 +2955,16 @@ def test_survey_area_link_rejects_an_unsafe_caller_supplied_name():
     # survey/<name>/. HTML-escaping the attribute does not neutralize path
     # semantics, so a staged spec naming ../../other would traverse -- and would
     # disagree with the card footer, which derives its link from report_rel.
-    for unsafe in ("../../other", "a/b", "..", "", "a b", "http://x", "a\\b"):
+    for unsafe in (
+        "../../other", "a/b", "..", "", "a b", "http://x", "a\\b",
+        # A URL delimiter is as wrong as a path one: the browser reads the tail as a
+        # fragment/query on "foo", so the link misses the published directory
+        # entirely, and a percent-escape can be normalised back into traversal.
+        "foo#bar", "foo?x=1", "%2e%2e", "foo%2Fbar",
+    ):
         assert gen._safe_case_segment(unsafe) is None, unsafe
-    assert gen._safe_case_segment("consan-gemm") == "consan-gemm"
+    for ok in ("consan-gemm", "waitcheck-gemm", "consan-lds-dispatch", "sol_1.hsaco"):
+        assert gen._safe_case_segment(ok) == ok
 
     survey = gen.survey_cases_from_spec({"cases": [{
         "name": "../../other", "label": "traversal", "staged": True,
@@ -3030,6 +3079,95 @@ def test_a_survey_spec_name_is_not_treated_as_staged_by_the_copublish_loop(
     # The spec area is not staged by this job, so the run loop prunes it.
     assert not list(spec_area.rglob("*.log")), "spec area escaped --keep-logs 0"
     assert not list(spec_area.rglob("*.log.gz"))
+
+
+def test_a_spec_entry_cannot_publish_a_rejected_informational_case(tmp_path, monkeypatch):
+    # The copy loop resolves each case dir against the survey entries, but keying
+    # that lookup on the combined list let a --survey spec entry stand in for a
+    # report the informational loader had refused to read: the directory was
+    # published anyway, with a summary and command describing a different report.
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    _write_history_run(dashboard / "runs", "2026-08-05-33")
+    info = tmp_path / "informational"
+    (info / "consan-gemm").mkdir(parents=True)
+    # A malformed nested shape: it passes the isinstance guard, then makes the
+    # reduction raise, so survey_cases_from_informational_dir skips the case.
+    (info / "consan-gemm" / "sanitizer_report.json").write_text(json.dumps({"checks": None}))
+    spec = tmp_path / "survey.json"
+    spec.write_text(json.dumps({"cases": [{
+        # Same name, a healthy inline report, and staged -- so before the fix this
+        # entry satisfied the lookup for the rejected directory.
+        "name": "consan-gemm", "label": "spec case", "staged": True,
+        "report_rel": "runs/2026-08-05-33/survey/consan-gemm/sanitizer_report.json",
+        "report": _consan_racy_report(),
+    }]}))
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(dashboard / "runs"),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(dashboard),
+        "--survey", str(spec),
+        "--informational-results-dir", str(info),
+    ])
+    assert gen.main() == 0
+
+    assert not (dashboard / "runs/2026-08-05-33/survey/consan-gemm").exists()
+
+
+def test_the_page_renders_the_survey_of_the_run_it_calls_latest(tmp_path, monkeypatch):
+    """Tab 1 and Tab 2 must describe the same run.
+
+    ``build_html``/``build_summary_md`` take their guardrail data from the newest
+    run, so on a re-run of an older workflow (see ``--current-run``) passing this
+    job's survey to them labelled the newer run "Latest run" while showing the
+    older re-run's observations under it -- and regenerating data.json dropped the
+    newer run's own published survey.
+    """
+    dashboard = tmp_path / "dashboard"
+    dashboard.mkdir()
+    older, newer = "2026-08-05-10", "2026-08-05-99"
+    for run_id in (older, newer):
+        _write_history_run(dashboard / "runs", run_id)
+    # The newer run published a survey area of its own on the day it ran.
+    published = dashboard / "runs" / newer / "survey" / "waitcheck-gemm"
+    published.mkdir(parents=True)
+    (published / "sanitizer_report.json").write_text(json.dumps(_waitcheck_report()))
+    info = tmp_path / "informational"
+    (info / "consan-gemm").mkdir(parents=True)
+    (info / "consan-gemm" / "sanitizer_report.json").write_text(
+        json.dumps(_informational_report("combined_hook_timeout"))
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard",
+        "--history-root", str(dashboard / "runs"),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(dashboard),
+        "--informational-results-dir", str(info),
+        "--current-run", older,  # this job re-ran the older workflow
+    ])
+    assert gen.main() == 0
+
+    page = (dashboard / "index.html").read_text(encoding="utf-8")
+    # The newest run's own survey is what the page shows, rebuilt from the area
+    # published under it -- links, reproduce command and all.
+    assert f"runs/{newer}/survey/waitcheck-gemm/" in page
+    assert "daily-waitcheck-gemm-object.yaml" in page
+    # ...and this job's survey is not rendered as if it belonged to that run.
+    assert "daily-consan-gemm.yaml" not in page
+    assert f"runs/{older}/survey/" not in page
+    summary_md = (dashboard / "summary.md").read_text(encoding="utf-8")
+    assert "daily-waitcheck-gemm-object.yaml" in summary_md
+    assert "daily-consan-gemm.yaml" not in summary_md
+    # Each run's record keeps its own survey, so neither is dropped or reattributed.
+    by_run = {
+        run["meta"]["run"]: run
+        for run in json.loads((dashboard / "data.json").read_text(encoding="utf-8"))
+    }
+    assert [e["name"] for e in by_run[older].get("survey", [])] == ["consan-gemm"]
+    assert [e["name"] for e in by_run[newer].get("survey", [])] == ["waitcheck-gemm"]
 
 
 def test_staged_requires_the_report_to_sit_in_the_named_case_directory():


### PR DESCRIPTION
Closes #384.

## Problem

Tab 2 prints a copy-paste reproduce command, but the card footer ("view raw
report") resolved to a single `sanitizer_report.json`, and the publish job copied
only that file. The sanitizer logs the verdict came from were written by the
sweep, uploaded to the 30-day Actions artifact, and then deleted. So the command
had nothing to reproduce against.

## What this does

Renames that footer to **run area** on both tabs, points it at the case
*directory*, and fills that directory with what a reproduction needs:

| File | What it is |
|---|---|
| `index.html` | Landing page: command, run identity, observed verdict, and every file as a download. GitHub Pages does not auto-index a directory, so without this the new link 404s. |
| `sanitizer_report.json` | Unchanged; still the per-kernel-row `Report` target. |
| `consan/consan.log.gz`, `waitcheck/waitcheck-*.log.gz` | The output the verdict was derived from. Gzipped with `mtime=0`, so an unchanged log is byte-identical on re-publish and does not churn the data branch. |
| `recipe.yaml` | The recipe as it ran. |
| `inputs/` | The recipe's source-level fixture inputs (a few KB). |
| `REPRODUCE.md` / `env.json` | Commit, command, required env, rebuild steps, digests — prose and machine-readable (`aorta.sanitizer_run_area/0.1`). |

No new detail blocks were added to the dashboard page itself, per the issue's
"Agreed direction".

The digests were already in every report and rendered nowhere: waitcheck's binary
`path`/`sha256`, ConSan's `command`/`command_sha256`/`hook`/`hook_sha256`, and each
kernel's `code_object_sha256`. `report_digests()` flattens them and
`artifact_digest_index()` indexes them by basename, because the two sanitizers name
the same kind of artifact under different keys.

## Points a reviewer will want flagged

- **Decisions 3 vs 10 conflict** (publish no built artifacts / copy every
  referenced input). Resolved in the issue body: source-level inputs are copied,
  the two CI-built kinds are recorded by path + SHA-256. The single switch is
  `_is_built_fixture()` plus `_BUILT_FIXTURE_DIRS`.
- **Provenance is scoped to the run that produced it.** All 30 retained areas are
  re-rendered nightly, so the container image, rocjitsu bundle and recipe copy are
  sourced only for the run the job just staged; older areas keep what they captured
  while they were current. Otherwise a three-week-old area would claim today's
  image beside an `env.json` naming its own commit. `build_case_env` therefore
  takes `provenance` as a parameter instead of reading `os.environ`, which also
  makes it pure.
- **`summary.md` stays link-free on purpose.** The job-summary Markdown twin still
  describes only the reproduce command: relative Pages links do not resolve inside
  an Actions summary, the same precedent as #368.
- **`summarize_case()` still ignores ConSan's backend keys**, so Tab 2 ConSan cards
  show Backend as an em dash even though the digests exist. Deliberately out of
  scope here — a small, separate fix.
- **`artifacts_not_published[].sha256` can still be `null`** when the report
  genuinely carries no digest (a bare `isa_dir:` directory reference, or an empty
  backend block). It renders as an em dash.
- **The script stays stdlib-only.** The publish job runs it from a bare checkout
  with no `pip install`, so PyYAML is not importable — which is why recipe scanning
  is a regex over `fixtures/...` paths rather than a YAML parse.

## Workflow changes

1. The GPU job writes `${SANITIZER_OUT}/rocjitsu.json` from the prebuilt bundle's
   `MANIFEST.json`, so the publish job (a different runner that never sees the
   bundle) can record which sanitizer build produced the reports.
2. The publish job copies whole case directories rather than one file per case.
3. It exports `AORTA_ROCJITSU_COMMIT`, `AORTA_ROCJITSU_RUN_URL` and
   `AORTA_CI_IMAGE` (the digest-pinned `FROM` of `docker/Dockerfile.ci-gpu`).
4. The generator is invoked with `--keep-logs 7`.

`pages.yml` needs no change: it already copies `dashboard/*` recursively.

## Retention

`--keep-logs N` (default 7) bounds logs, the recipe copy and inputs for guardrail
and survey areas alike, while reports stay for the full `--keep 30`. A pruned area
is re-rendered from its own manifest so its file table stops linking logs that are
gone, and both renderings then describe it as pruned rather than promising files it
no longer has.

## Test plan

- [x] `pytest tests/sanitizers/test_dashboard.py` — 98 pass (10 new)
- [x] `ruff check` clean on both changed Python files
- [x] `.github/workflows/sanitizers-nightly.yml` parses as YAML
- [x] End-to-end publish of a 4-run history with a survey case: 137 relative links
      all resolve, including from pruned areas
- [x] Log retention verified across *sequential* publishes into one tree (the
      data-branch pattern) — a single publish cannot show it
- [ ] **Not yet run in real CI.** The first nightly after merge is the real test,
      in particular the `cp -a` of case dirs and the `rocjitsu.json` hop between
      jobs. `.log.gz` behaviour over the Pages CDN is also unverified — one `curl`
      after the first deploy is worth it.
- [ ] Real ConSan log sizes are unmeasured (only toy fixtures were gzipped
      locally). `--keep-logs 7` bounds growth; if a real log turns out large,
      decision 6's alternative (a size cap with a truncation note) is the fallback.

Made with [Cursor](https://cursor.com)