### PR TITLE
feat(instrumentation): implement the rocprof and proton profiling collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ The standalone `aorta mitigations list` and `aorta environments list` groups are
 | [`aorta sweep`](docs/probe/usage.md) | Unified matrix runner — built-in workloads **or** opaque launch commands |
 | [LLM Determinism](docs/llm-determinism.md) | Bit-exact double-run nondeterminism probe |
 | [Layer Numerics](docs/layer-numerics.md) | Per-layer / per-stage NaN, magnitude, and out-of-range logger |
+| [Profiling Collectors](docs/profiling-collectors.md) | `--collect rocprof` / `--collect proton` — attach a GPU profiler to any command a sweep runs |
 | [`aorta agent`](docs/agent/agentic-testing-guide.md) | Closed-loop mitigation search (optional LLM proposer) |
 | [`aorta bundle`](docs/probe/bundle.md) | Package sweep artifacts with recipe-driven redaction |
 | [Recipes](recipes/README.md) | Recipe schema and running recipes |

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The standalone `aorta mitigations list` and `aorta environments list` groups are
 | [`aorta sweep`](docs/probe/usage.md) | Unified matrix runner — built-in workloads **or** opaque launch commands |
 | [LLM Determinism](docs/llm-determinism.md) | Bit-exact double-run nondeterminism probe |
 | [Layer Numerics](docs/layer-numerics.md) | Per-layer / per-stage NaN, magnitude, and out-of-range logger |
-| [Profiling Collectors](docs/profiling-collectors.md) | `--collect rocprof` / `--collect proton` — attach a GPU profiler to any command a sweep runs |
+| [Profiling Collectors](docs/profiling-collectors.md) | `--collect rocprof` (wraps any subprocess command) / `--collect proton` (Python launches, or `mode: env`) — attach a GPU profiler without editing the payload |
 | [`aorta agent`](docs/agent/agentic-testing-guide.md) | Closed-loop mitigation search (optional LLM proposer) |
 | [`aorta bundle`](docs/probe/bundle.md) | Package sweep artifacts with recipe-driven redaction |
 | [Recipes](recipes/README.md) | Recipe schema and running recipes |

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -1,0 +1,571 @@
+# Profiling Collectors (`rocprof` / `proton`)
+
+Attach a GPU profiler to **any command aorta runs**, without editing the
+command. Both collectors work by rewriting the launch argv — the same seam
+the mirage emulator uses — so an opaque `aorta sweep run ... -- <command>`
+gets profiled for free and the payload never learns it is being measured.
+
+Two collectors ship today:
+
+- **`rocprof`** — runs the whole command under `rocprofv3` (ROCm's
+  kernel/API tracer). Wraps *any* command: a HIP binary, `torchrun`, a
+  shell script. Writes CSV / JSON / pftrace / OTF2 / rocpd artifacts.
+- **`proton`** — runs a Python launch under Triton's Proton profiler, which
+  attributes GPU time back to the **launch site** (Python frame or shadow
+  frame) rather than to a mangled kernel symbol. Writes a `.hatchet` tree.
+
+Both parse their own artifacts after the run and merge a small set of flat
+numeric metrics into the trial's `metrics`, so `rocprof_gpu_time_ms` and
+friends land in `perf.md` and `matrix.json` with no report-side changes.
+
+## When to use them
+
+This is a **measurement** step, not a detection step. It answers *where the
+GPU time went* and *which kernels ran*, for a command you can already run.
+It does not classify a failure, and it does not decide whether a mitigation
+worked — the sweep verdict does that.
+
+- A mitigation changes wall time and you want to know **which kernel** moved.
+- You need a kernel/dispatch trace of a repro you only have as an opaque
+  launch command, and you do not want to fork the launch script to add a
+  profiler.
+- You want a Triton kernel's time attributed to the **Python line that
+  launched it** (`proton`), not to `triton_poi_fused_add_0`.
+- You want the same capture taken identically across every cell of a sweep,
+  next to the trial JSON, so two cells are comparable.
+
+What it is **not**: a passthrough. `--collect rocprof` changes the child's
+stderr (see [Troubleshooting](#troubleshooting)) and both collectors add
+launch overhead. Do not enable a collector on a timing-sensitive race repro
+and then conclude the race is gone.
+
+## Prerequisites
+
+For `rocprof`:
+
+- `rocprofv3` on `$PATH`, or `$ROCPROF_BIN` pointing at it. It ships with
+  ROCm. A missing binary is a hard setup failure, not a silent unprofiled
+  run.
+- Nothing else. The collector is flags-only; no Python dependency.
+
+For `proton`:
+
+- Triton importable **from the interpreter the workload runs under**, since
+  the collector attaches as `<python> -m triton.profiler.proton`. Proton
+  ships inside Triton; there is no separate install.
+- The command must be a Python script launch (or `pytest`) for the default
+  `mode: cli`. Anything else needs `mode: env` — see
+  [Attach modes](#proton-attach-modes).
+- The `proton` / `proton-viewer` console scripts are **not** used by the
+  collector, on purpose: on a typical host those shims are shebanged to
+  whichever interpreter installed Triton, which is usually not the one the
+  workload runs under. `$AORTA_PROTON_PYTHON` overrides the interpreter
+  choice when Triton lives somewhere else again.
+
+Verified against ROCm 7.0.2.2 / `rocprofv3` 1.0.1 on gfx950.
+
+## Standalone usage (supported path)
+
+Both collectors are thin wrappers over tools you can run by hand, and doing
+so is the fastest way to separate "my payload is broken" from "my profiler
+is broken". Run the payload bare first, then under the profiler, then under
+aorta.
+
+`rocprofv3` directly:
+
+```bash
+rocprofv3 --kernel-trace --stats --output-format csv \
+  -d /tmp/rocprof_out -o run -- ./my_gpu_binary --size 512
+ls /tmp/rocprof_out
+# run_kernel_stats.csv  run_kernel_trace.csv  run_domain_stats.csv
+# run_agent_info.csv
+```
+
+Proton directly, from an interpreter that has Triton:
+
+```bash
+python -m triton.profiler.proton -n /tmp/proton_out/run \
+  --context shadow --data tree my_script.py --iters 20
+proton-viewer -m time/s /tmp/proton_out/run.hatchet
+```
+
+Note the argument shapes differ and the collectors preserve that: `rocprofv3`
+takes a `--` separator before the command, Proton's front-end collects the
+script and its arguments with `argparse.REMAINDER` and takes none.
+
+### Startup sanity check
+
+Before trusting a capture, confirm artifacts exist. `rocprofv3` writes
+**nothing at all** when the profiled command dispatched no GPU work, and
+Proton writes no tree when the process never launched a kernel — in both
+cases the trial still passes and simply carries no numeric collector
+metrics. So an empty collector directory means "no GPU work was seen", not
+"the run failed". Collector metrics live under `.result.metrics` in the
+per-trial JSON (see [Output](#output) for where that file sits):
+
+```bash
+jq -r '.result.metrics | to_entries[]
+       | select(.key | startswith("rocprof_"))
+       | "\(.key)=\(.value)"' <run_dir>/<cell>/<workload>/trial_d0_m0_t0.json
+```
+
+If only `rocprof_artifact_dir` comes back, the profiler attached but found
+no kernel data.
+
+## Configuration
+
+Collectors are selected either on the command line or in the recipe.
+
+```bash
+# Names only. Works on both the workload (triage) flow and the
+# subprocess (probe) flow, and overrides any recipe-pinned collect:.
+aorta sweep run --recipe r.yaml --collect rocprof -- ./my_gpu_binary
+aorta sweep run --recipe r.yaml --collect proton -- python train.py
+```
+
+Note that `--collect rocprof,proton` is rejected: with no options to carry,
+the CLI flag gets Proton's default `backend: auto`, which resolves to a
+queue-intercepting backend on AMD and so conflicts with `rocprofv3` (see
+[Combining collectors](#combining-collectors)).
+
+```yaml
+# Recipe, list form -- names only, default options.
+collect: [rocprof]
+```
+
+```yaml
+# Recipe, mapping form -- the only way to set per-collector options.
+collect:
+  rocprof:
+    trace: "kernel,hip"
+    output_format: "csv"
+    summary_units: "usec"
+```
+
+An empty / null value in the mapping form means "enabled, no options":
+
+```yaml
+collect:
+  rocprof:            # enabled, defaults
+```
+
+Precedence and scope:
+
+- `collect:` is **cross-cutting**, not a matrix axis: the same collectors
+  run in every cell.
+- A cell may set its own `collect:`. Absent inherits the recipe level, a
+  present value replaces it for that cell, and `collect: []` disables
+  collection for that cell.
+- A `mode: probe` recipe accepts the same top-level `collect:` block, but has
+  no cell scope to override at — it synthesises its cells from
+  `mitigation_axis x diagnostic_axis`, so the recipe-level collectors apply
+  to every one of them.
+- CLI `--collect` is an operator override applied to every cell; it clears
+  per-cell overrides. **It carries names only** — there is no CLI syntax
+  for per-collector options, so a run that needs options needs a recipe.
+- Every option is validated at recipe-load time. A typo fails the whole
+  recipe up front rather than producing a run with no measurements in it.
+
+### `rocprof` options
+
+| Option | Values | Default | Notes |
+|---|---|---|---|
+| `trace` | comma- or space-separated: `kernel`, `hip`, `hip_runtime`, `memory_copy`, `rccl`, `marker`, `scratch` | `kernel` | Maps one-to-one onto `--kernel-trace`, `--hip-trace`, `--hip-runtime-trace`, `--memory-copy-trace`, `--rccl-trace`, `--marker-trace`, `--scratch-memory-trace`. Must name at least one domain. `kernel` is the only domain the summary parser aggregates. |
+| `output_format` | `csv`, `json`, `pftrace`, `otf2`, `rocpd` | `csv` | Only `csv` yields the numeric metrics below — the parser reads CSV. The others are for out-of-band analysis. |
+| `stats` | `1/true/yes/on` or `0/false/no/off` | `true` | Adds `--stats`, i.e. the pre-aggregated `*_kernel_stats.csv`. With `stats` off the parser falls back to summing dispatch spans from the kernel trace. |
+| `pmc` | comma- or space-separated counter names | (unset) | Hardware counters. Rendered last before the `--` separator because `--pmc` is variadic. Must name at least one counter. |
+| `kernel_include_regex` | regex | (unset) | `--kernel-include-regex`; must be non-empty. |
+| `summary_units` | `sec`, `msec`, `usec`, `nsec` | (unset → rocprofv3's own default) | Unit for the human-readable summary file only. Does not change the parsed metrics, which are always ms. |
+
+### `proton` options
+
+| Option | Values | Default | Notes |
+|---|---|---|---|
+| `mode` | `cli`, `env` | `cli` | See [Attach modes](#proton-attach-modes). |
+| `backend` | `auto`, `rocprofiler`, `roctracer`, `instrumentation`, `cupti` | `auto` | `auto` omits Proton's `-b` and lets Proton pick the backend matching the active runtime — `rocprofiler` where rocprofiler-sdk is available, `roctracer` otherwise. It is the only portable spelling and is why it is the default: **naming a backend is a version commitment.** `rocprofiler` is the preferred AMD backend upstream but Triton 3.7.x and earlier accept only `cupti`/`roctracer`/`instrumentation` and exit with an argparse `invalid choice: 'rocprofiler'` before the payload runs. `roctracer` is the deprecated AMD predecessor; `instrumentation` the intra-kernel path; `cupti` the NVIDIA one, accepted so a recipe stays portable even though aorta's examples are AMD. Pin a backend when you need to know exactly which one measured. |
+| `context` | `shadow`, `python` | `shadow` | How a kernel's time is attributed to a calling frame. |
+| `data` | `tree`, `trace` | `tree` | `tree` writes the `.hatchet` file the parser reads; `trace` writes a chrome trace instead, so it produces no numeric metrics. |
+| `instrumentation_mode` | `default`, `mma`, `pcsampling` | (unset) | **Requires `backend: instrumentation`.** |
+| `granularity` | `cta`, `warp`, `warp_2`, `warp_4`, `warp_8`, `warp_group`, `warp_group_2`, `warp_group_4`, `warp_group_8` | (unset) | **Requires `backend: instrumentation`.** |
+
+`instrumentation_mode` and `granularity` are rejected with an actionable
+error on any other backend rather than accepted-and-ignored: Proton would
+silently produce a profile you did not ask for. Together they render into
+Proton's single `--mode` argument as
+`<instrumentation_mode>:granularity=<granularity>`, with
+`instrumentation_mode` defaulting to `default` when only `granularity` is
+set. When neither is set the collector omits `--mode` entirely and Proton
+keeps its own default.
+
+### Proton attach modes
+
+**`mode: cli` (default)** rewrites the launch:
+
+```
+python train.py --steps 10
+→ python -m triton.profiler.proton -n <out>/proton \
+      --context shadow --data tree train.py --steps 10
+```
+
+Proton's front-end **`exec`s a script**; it is not a generic command runner.
+So the CLI wrap only applies to a Python launch (`python`, `python3`,
+`python3.12`, or `pytest`), plus a small set of no-argument interpreter
+flags that are kept in front of `-m` where they belong: `-u`, `-B`, `-E`,
+`-s`, `-S`, `-O`, `-OO`, `-I`, `-b`, `-q`. Anything else — a HIP binary, a
+shell script, `torchrun`, `python -c`, an interpreter option outside that
+set — raises a `ProtonWrapError` naming `mode: env` as the escape hatch.
+This is deliberate: requesting a measurement that cannot be taken is a
+clean setup failure, not a silently unprofiled run. `rocprof`, by contrast,
+wraps anything.
+
+**`mode: env`** leaves the command's own argv alone and hands it
+`AORTA_PROTON_*` variables, for a workload that calls `proton.start()` /
+`proton.finalize()` itself (scoped or intra-kernel measurement):
+
+```yaml
+collect:
+  proton:
+    mode: "env"
+```
+
+Because the generic collector seam only gets to rewrite argv — it has no
+channel into the child's environment — the variables are delivered via an
+`env(1)` prefix:
+
+```
+./my_launcher.sh
+→ env AORTA_PROTON_CONTEXT=shadow AORTA_PROTON_DATA=tree ... \
+      ./my_launcher.sh
+```
+
+A wrapper-style consumer that owns the child environment directly should
+skip the argv seam and call `aorta.instrumentation.proton.build_env(out_dir,
+options)`, which returns the same bundle as a plain `dict[str, str]` to
+merge into the subprocess env. It never mutates `os.environ`.
+
+| Variable | Meaning |
+|---|---|
+| `AORTA_PROTON_DIR` | Directory the profile should be written into |
+| `AORTA_PROTON_NAME` | Session name (path stem) to pass to `proton.start(name)` |
+| `AORTA_PROTON_BACKEND` | `backend` option value; **absent on the default `backend: auto`**, so the workload passes `backend=None` and gets Proton's own selection |
+| `AORTA_PROTON_CONTEXT` | `context` option value |
+| `AORTA_PROTON_DATA` | `data` option value |
+| `AORTA_PROTON_MODE` | Rendered `--mode` value; absent when no intra-kernel knob is set |
+
+### Device selection on AMD
+
+Proton on AMD reads `ROCR_VISIBLE_DEVICES`; for the queue-intercepting
+backends it does not honour `HIP_VISIBLE_DEVICES` and rejects it outright.
+The collector translates automatically: when the environment the trial runs
+with carries `HIP_VISIBLE_DEVICES` and the backend is `auto`, `rocprofiler`
+or `roctracer`, the wrap becomes
+
+```
+env -u HIP_VISIBLE_DEVICES ROCR_VISIBLE_DEVICES=<value> <proton wrap...>
+```
+
+and a warning is logged. An explicit `ROCR_VISIBLE_DEVICES` already in the
+environment wins. No translation happens on the `instrumentation` or
+`cupti` backends, and none happens if `env` is not on `$PATH` (a warning
+says so, and the profile may target the wrong device).
+
+### Combining collectors
+
+`rocprof` together with `proton` on backend `auto`, `rocprofiler` or
+`roctracer` is **rejected at recipe load**: both install an HSA queue interceptor, and the
+second one to attach will fail or report nothing. The error names the two
+ways out — `backend: instrumentation` (intra-kernel measurement, no queue
+interception), or run the two collectors as separate cells.
+
+Wrap order, when more than one wrap applies:
+
+1. Collectors wrap first, in the order `rocprof`, `proton`, with **rocprof
+   outermost**. `rocprof` runs a whole command under the profiler while
+   Proton takes over a Python script's execution, so rocprof has to be the
+   outer process for the pair to compose at all.
+2. The mirage emulation wrap is applied **after** the collectors, so it ends
+   up outside them and the profiler runs *inside* the emulated environment:
+   `mirage run -- rocprofv3 ... -- <command>`, not the reverse (which would
+   profile the emulator's own launcher).
+
+## Output
+
+Collector artifacts land in a per-trial directory the platform creates and
+threads into the trial config, one subdirectory per collector:
+
+```
+<run_dir>/<cell>/
+  trial_0/                          # probe-flow trial artifacts
+    stdout.log  stderr.log  result.json
+  <workload>/
+    trial_d0_m0_t0.json             # the trial JSON; metrics live here
+    trial_d0_m0_t0/                 # the collector directory
+      rocprof/
+        aorta_kernel_stats.csv
+        aorta_kernel_trace.csv
+        aorta_domain_stats.csv
+        aorta_agent_info.csv
+        aorta_rocprof_summary.txt
+      proton/
+        proton.hatchet
+```
+
+Two things to internalise about that layout. First, the collector directory
+is a **sibling** of the probe flow's `trial_<n>/` artifacts, not inside it —
+it hangs off the per-workload subdirectory, keyed by the trial's matrix
+coordinates. Second, you never have to reconstruct the path: the absolute
+directory is reported as the `rocprof_artifact_dir` / `proton_artifact_dir`
+metric, so `jq` it out of the trial JSON and use that.
+
+The directory is created whether or not the payload produced GPU activity,
+so the trial tree has the same shape either way. `aorta bundle` copies every
+file under the run directory, so collector artifacts travel with a bundle
+automatically.
+
+On the file names: the collector passes `rocprofv3 -o aorta` for
+determinism, which produces the flat `aorta_*.csv` files above. Run
+`rocprofv3` **without** `-o` and it nests its output one level deeper under
+a hostname directory, prefixed by PID
+(`<hostname>/<pid>_kernel_stats.csv`) — worth knowing when comparing an
+aorta capture against a hand-rolled one. The parser globs recursively, so
+either shape reads fine.
+
+`aorta_rocprof_summary.txt` is `rocprofv3`'s human-readable summary, routed
+to a file via `-S --summary-output-file`. Without that redirect it prints to
+stderr, where the probe classifier's stderr detectors would ingest it as
+workload output. Note that `--summary-output-file` takes a filename *stem*
+relative to `-d`, not a path: `rocprofv3` prefixes it with the `-o` basename
+and appends `.txt`, which is where the `aorta_` prefix comes from. Handing it
+an absolute path makes it splice that path into the middle of a filename and
+create stray directories under `-d`.
+
+### Metrics
+
+Each collector contributes the same five keys under its own prefix.
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `<c>_kernel_count` | numeric | Total dispatches summed across kernels |
+| `<c>_gpu_time_ms` | numeric | Total GPU time in ms across all kernels |
+| `<c>_top_kernel_ms` | numeric | GPU time in ms of the single hottest kernel |
+| `<c>_top_kernels` | list | The 5 hottest kernel names, hottest first |
+| `<c>_artifact_dir` | string | Absolute path to the collector's output directory |
+
+`<c>` is `rocprof` or `proton`. The three numeric ones are picked up by the
+`perf.md` metrics table and aggregated per cell into
+`matrix.json::cells[*].metrics_summary` (mean / min / max / n across
+trials). The list and string values are skipped in `perf.md` — it only
+aggregates numeric scalars — but are retained in the per-trial JSON.
+
+Only `<c>_artifact_dir` is guaranteed. A capture with no kernel data
+contributes just that key.
+
+## Analysis recipes
+
+Read the per-cell numbers straight out of the matrix:
+
+```bash
+jq -r '.cells[] | [.name,
+                   (.metrics_summary.rocprof_gpu_time_ms.mean // "-"),
+                   (.metrics_summary.rocprof_kernel_count.mean // "-")]
+       | @tsv' <run_dir>/matrix.json
+```
+
+Find the hottest kernels of one trial, and its artifact directory:
+
+```bash
+TRIAL=<run_dir>/<cell>/<workload>/trial_d0_m0_t0.json
+jq -r '.result.metrics.rocprof_top_kernels[]' "$TRIAL"
+ART=$(jq -r '.result.metrics.rocprof_artifact_dir' "$TRIAL")
+```
+
+The rocprof CSVs are readable directly — `<stem>_kernel_stats.csv` carries
+`Name`, `Calls`, `TotalDurationNs`, `AverageNs`, `Percentage`, `MinNs`,
+`MaxNs`, `StdDev`:
+
+```bash
+column -s, -t < "$ART"/aorta_kernel_stats.csv | head
+```
+
+For the non-CSV formats:
+
+- `output_format: rocpd` gives a queryable SQLite database — join dispatches
+  against agent info with plain SQL instead of post-processing CSV.
+- `output_format: pftrace` opens in <https://ui.perfetto.dev> for a timeline
+  view.
+
+For Proton, list what a profile actually contains before charting it, then
+print the metrics you want:
+
+```bash
+PROFILE=$(jq -r '.result.metrics.proton_artifact_dir' "$TRIAL")/proton.hatchet
+proton-viewer --list "$PROFILE"
+proton-viewer -m time/s,normalized_cycles "$PROFILE"
+```
+
+Run `proton-viewer` in the **same environment as the capture** — it is part
+of Triton, and a host shim bound to a Triton-less interpreter will fail the
+same way the `proton` console script does.
+
+## Troubleshooting
+
+**`rocprofv3 not found`.** Put `rocprofv3` on `$PATH` (it ships with ROCm)
+or set `$ROCPROF_BIN` to the binary. `$ROCPROF_BIN` accepts either a bare
+name resolved through `$PATH` or a path, which must point at an executable
+file. A missing profiler fails the trial's setup deliberately, rather than
+running unprofiled and reporting nothing.
+
+**`proton mode 'cli' needs a Python script launch, got '...'`.** Proton's
+front-end executes a script. Either invoke the workload as
+`<python> <script.py> ...`, or switch the recipe to `proton: {mode: env}`
+and have the workload drive `proton.start()` / `proton.finalize()` itself.
+A `torchrun` or `docker run` command will always hit this.
+
+**`No module named triton`, from the Proton wrap.** The interpreter running
+the workload has no Triton. Run inside a container / venv that has it, or
+point `$AORTA_PROTON_PYTHON` at an interpreter that does. The collector
+uses `-m triton.profiler.proton` rather than the `proton` console script
+precisely because the console script's shebang is frequently the wrong
+interpreter.
+
+**`RuntimeError: Could not load \`libroctracer64.so\`` from Proton.** The
+environment's ROCm ships only the versioned soname
+(`libroctracer64.so.4`) while Proton `dlopen`s the unversioned name. Seen on
+container images whose ROCm comes from Python wheels rather than a system
+install. Add a directory of unversioned symlinks to `$LD_LIBRARY_PATH`, or
+run on a host with a system ROCm install (where both spellings exist).
+
+**`invalid choice: 'rocprofiler'` from Proton, before the payload runs.**
+The installed Triton predates the `rocprofiler` backend. Drop the pin and
+let the default `backend: auto` choose — that is what it is for. See the
+`backend` row of the [Proton options](#proton-options) table.
+
+**A Proton profile with a ROOT node and no children.** Proton's queue
+interceptor has to be installed before the first HSA queue is created; a
+run that initialises the GPU earlier captures nothing and still exits 0.
+The default `backend: auto` avoids this by construction, because Proton's
+own backend selection initialises the runtime before the session starts.
+An explicit backend pin skips that step, so pin one only when you need to.
+
+**No `.hatchet` written at all, and the payload exited 0.** The payload
+ended by raising `SystemExit` (`raise SystemExit(main())`, or a bare
+`sys.exit(0)`) on its success path. Proton runs the script through
+`execute_as_main`, which on Triton 3.6.0 catches `Exception`, not
+`BaseException`, so a success-path `SystemExit` escapes Proton's own CLI
+before `finalize()` writes the profile. Triton 3.7.1 handles it, so this
+looks version-specific from the outside. Return normally on success and
+exit non-zero only on failure:
+
+```python
+if __name__ == "__main__":
+    code = main()
+    if code:
+        raise SystemExit(code)
+```
+
+The shipped examples use exactly this shape; `tests/test_examples.py`
+pins it for every example payload.
+
+**Trial stderr differs from an unprofiled run.** Expected with
+`--collect rocprof`. `rocprofv3` unconditionally writes lines like
+`W... simple_timer.cpp:55] [rocprofv3] ...` and `Opened result file: ...`
+to stderr. The human-readable summary is redirected to
+`rocprof/aorta_rocprof_summary.txt` so the probe classifier's stderr detectors do
+not ingest it, but the remaining noise is the profiler's own and cannot be
+suppressed from here. Profiling is a measurement mode, not a byte-exact
+passthrough — do not use it on a run whose stderr you are diffing.
+
+**No artifacts, but the trial passed.** `rocprofv3` writes no files at all
+when the profiled command performed no GPU work (a probe of `/bin/echo`,
+for instance). That is a legitimate outcome, so parsing is fail-soft and
+you get only `<c>_artifact_dir`. Check the payload actually dispatched a
+kernel before suspecting the collector.
+
+**`<c>_artifact_dir` present but no numeric metrics.** Three common causes:
+`output_format` is not `csv` (the parser reads CSV only), `data: trace`
+rather than `tree` on the Proton side (no `.hatchet` to walk), or the
+payload dispatched nothing. Malformed or partial artifacts degrade the same
+way — an opt-in measurement never turns an otherwise-healthy trial into a
+failure.
+
+**`collect: <name> requested but no _aorta_collect_dir was threaded into the
+trial config (non-writing rank?); skipping.`** The platform only threads the
+collector output directory on the artifact-writing rank, so a non-writing
+rank has nowhere to put artifacts and is skipped rather than scattering
+files into the cwd. Expected on multi-rank launches; profile rank 0.
+
+**Wrong GPU in the Proton profile.** See
+[Device selection on AMD](#device-selection-on-amd). Pin with
+`ROCR_VISIBLE_DEVICES`, not `HIP_VISIBLE_DEVICES`.
+
+**A recipe that used to load now fails with a queue-interception error.**
+You have `rocprof` and `proton` in the same `collect:` block with a
+queue-intercepting Proton backend. Split them into two cells, or use
+`backend: instrumentation`.
+
+**Triton wall time dominated by compilation.** Triton JIT-compiles on first
+launch. That compile dispatches no kernel, so it does not appear in the
+profile but does inflate the trial's wall clock. Give the payload a warmup,
+or compare `<c>_gpu_time_ms` rather than wall time.
+
+## Sweep / collector integration
+
+Unlike `layer_numerics`, these two collectors need **no workload opt-in**.
+The platform launches them itself in the generic subprocess seam, which is
+why an opaque command works:
+
+```bash
+aorta sweep run \
+  --recipe examples/profiling/rocprof/hip-gemm/recipe.yaml \
+  --collect rocprof \
+  --output ./profiling_results \
+  -- /tmp/hip_gemm 512 20
+```
+
+The same names work in a recipe on either flow, and that is the only way to
+pass options:
+
+```yaml
+collect:
+  rocprof:
+    trace: "kernel,hip"
+```
+
+Two consequences worth internalising:
+
+- **Every trial of every cell gets a capture.** With N cells × M trials you
+  get N×M artifact directories. Keep payload sizes and trial counts small
+  when a collector is on.
+- **A collector never changes the verdict.** Summary parsing is fail-soft by
+  construction; the worst case is fewer metrics.
+
+Runnable end-to-end examples for both collectors, with payloads and
+recipes, live in [`examples/profiling/`](../examples/profiling/README.md).
+
+## Reference: environment variables
+
+Recipe options are the primary interface. These environment variables cover
+the cases a recipe cannot express, mostly "the tool is not where the
+collector expects it".
+
+| Var | Read by | Purpose | Default |
+|---|---|---|---|
+| `ROCPROF_BIN` | `rocprof` | Profiler binary: a bare name resolved on `$PATH`, or a path to an executable | `rocprofv3` from `$PATH` |
+| `AORTA_PROTON_PYTHON` | `proton` | Interpreter to run Proton's front-end under; needed when Triton lives in a different interpreter than the workload | the workload's own `argv[0]` when it is a Python interpreter, else the running `sys.executable` |
+| `AORTA_PROTON_*` | the workload | Exported *by* `mode: env` for a workload that drives Proton itself; see [Proton attach modes](#proton-attach-modes) | — |
+
+`ROCR_VISIBLE_DEVICES` / `HIP_VISIBLE_DEVICES` are not collector knobs, but
+the Proton wrap reads and rewrites them — see
+[Device selection on AMD](#device-selection-on-amd).
+
+## See also
+
+- [`examples/profiling/README.md`](../examples/profiling/README.md) — four
+  runnable examples (HIP GEMM, torch matmul, Triton vecadd, Triton softmax).
+- [`recipes/README.md`](../recipes/README.md#schema-rules-full-detail) — the
+  `collect:` schema, cell-level overrides, CLI precedence.
+- [`docs/layer-numerics.md`](layer-numerics.md) — the other documented
+  collector, a per-layer NaN / magnitude logger. Workload opt-in, unlike
+  these two.
+- [`docs/profiling.md`](profiling.md) — the older manual capture routes and
+  the in-workload telemetry these collectors sit alongside.

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -418,7 +418,7 @@ Each collector contributes the same five keys under its own prefix.
 
 | Metric | Type | Meaning |
 |---|---|---|
-| `<c>_kernel_count` | numeric | Total dispatches summed across kernels |
+| `<c>_kernel_count` | numeric | Total dispatches summed across kernels. Omitted (while the timings are still reported) when the capture gave no trustworthy launch count: an unreadable `Calls` column in a rocprof stats row, or a Proton leaf with no readable `count`. Both are per-kernel aggregates, so there is no safe number to substitute, and a fabricated count would read as measured. |
 | `<c>_gpu_time_ms` | numeric | Total GPU time in ms across all kernels |
 | `<c>_top_kernel_ms` | numeric | GPU time in ms of the single hottest kernel |
 | `<c>_top_kernels` | list | The 5 hottest kernel names, hottest first |

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -288,9 +288,15 @@ env -u HIP_VISIBLE_DEVICES ROCR_VISIBLE_DEVICES=<value> <proton wrap...>
 ```
 
 and a warning is logged. An explicit `ROCR_VISIBLE_DEVICES` already in the
-environment wins. No translation happens on the `instrumentation` or
-`cupti` backends, and none happens if `env` is not on `$PATH` (a warning
-says so, and the profile may target the wrong device).
+environment wins — including an explicitly empty one, since an empty device
+list means "hide every device" rather than "unset". The same applies to
+`HIP_VISIBLE_DEVICES`: Proton rejects it on presence, so an empty value is
+translated like any other.
+
+No translation happens on the `instrumentation` or `cupti` backends. If a
+translation *is* needed and `env` is not on `$PATH`, the trial fails setup:
+argv rewriting is the only channel the collector has for these variables, so
+continuing would profile the wrong device or not at all.
 
 ### Combining collectors
 
@@ -341,9 +347,20 @@ directory is reported as the `rocprof_artifact_dir` / `proton_artifact_dir`
 metric, so `jq` it out of the trial JSON and use that.
 
 The directory is created whether or not the payload produced GPU activity,
-so the trial tree has the same shape either way. `aorta bundle` copies every
-file under the run directory, so collector artifacts travel with a bundle
-automatically.
+so the trial tree has the same shape either way. It is created **empty**: a
+resumed trial replays onto the same paths, and inheriting the interrupted
+attempt's files would make the summary report the previous run's numbers.
+`aorta bundle` copies every file under the run directory, so collector
+artifacts travel with a bundle automatically.
+
+Being a sibling of `trial_<n>/` does not exempt the collector directory from
+retention. Profiler traces are the artifact class a recipe's `retain` block
+exists for, so its level prunes this tree too — a sweep with
+`retain: {on_pass: none}` keeps captures only for the trials that failed. The
+metrics are parsed *before* pruning, so `rocprof_gpu_time_ms` and friends
+survive in the trial JSON even at a level that deletes the trace they came
+from, and `result.json` lists each pruned file (with a leading `../`, marking
+it as coming from the collector tree) under `capture.retention.deleted`.
 
 The probe flow's `trial_<n>/result.json` records the argv that actually ran,
 which is the *wrapped* one. So the exact profiler invocation — including any
@@ -446,6 +463,17 @@ or set `$ROCPROF_BIN` to the binary. `$ROCPROF_BIN` accepts either a bare
 name resolved through `$PATH` or a path, which must point at an executable
 file. A missing profiler fails the trial's setup deliberately, rather than
 running unprofiled and reporting nothing.
+
+**`collect: cannot prepare the <name> artifact directory ...`.** The
+collector has nowhere to write — usually a file sitting where the directory
+should be, a read-only output path, or a full disk. Like a missing
+`rocprofv3` this fails setup rather than running the trial unprofiled. Fix
+the `--output` path or drop the collector from the request.
+
+**`proton needs 'env' on $PATH ...`.** The wrap had variables to deliver —
+the `AORTA_PROTON_*` bundle in `mode: env`, or a `HIP_VISIBLE_DEVICES`
+translation — and argv rewriting is its only channel for them. Install
+coreutils in the image, or drop `proton`.
 
 **`proton mode 'cli' needs a Python script launch, got '...'`.** Proton's
 front-end executes a script. Either invoke the workload as

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -1,9 +1,17 @@
 # Profiling Collectors (`rocprof` / `proton`)
 
-Attach a GPU profiler to **any command aorta runs**, without editing the
-command. Both collectors work by rewriting the launch argv — the same seam
-the mirage emulator uses — so an opaque `aorta sweep run ... -- <command>`
-gets profiled for free and the payload never learns it is being measured.
+Attach a GPU profiler to a command aorta runs, without editing the command.
+Both collectors work by rewriting the launch argv — the same seam the mirage
+emulator uses — so an opaque `aorta sweep run ... -- <command>` gets profiled
+and the payload never learns it is being measured.
+
+How wide "a command" is differs by collector, and it is the first thing to
+check: `rocprof` wraps **anything**, while Proton's default `mode: cli` takes
+over a Python *script*, so it attaches only to `python ... <script>.py`, a
+bare `pytest`, or `python -m pytest`. Proton's `mode: env` accepts any argv
+but is not edit-free — it hands the payload `AORTA_PROTON_*` variables that
+the payload itself must act on by calling `proton.start()` / `proton.finalize()`.
+See [Proton attach modes](#proton-attach-modes).
 
 Two collectors ship today:
 
@@ -109,8 +117,12 @@ jq -r '.result.metrics | to_entries[]
        | "\(.key)=\(.value)"' <run_dir>/<cell>/<workload>/trial_d0_m0_t0.json
 ```
 
-If only `rocprof_artifact_dir` comes back, the profiler attached but found
-no kernel data.
+If only `rocprof_artifact_dir` comes back, the profiler attached but nothing
+*parseable* came out of it. That is the expected result for a command that
+dispatched no kernels, but parsing is fail-soft, so it also covers a
+non-CSV `output_format` (the parser reads the CSVs), a partial capture from
+a killed run, and a malformed one. Look in the artifact directory the metric
+points at before concluding the payload did no GPU work.
 
 ## Configuration
 

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -212,16 +212,34 @@ python train.py --steps 10
       --context shadow --data tree train.py --steps 10
 ```
 
-Proton's front-end **`exec`s a script**; it is not a generic command runner.
-So the CLI wrap only applies to a Python launch (`python`, `python3`,
-`python3.12`, or `pytest`), plus a small set of no-argument interpreter
-flags that are kept in front of `-m` where they belong: `-u`, `-B`, `-E`,
-`-s`, `-S`, `-O`, `-OO`, `-I`, `-b`, `-q`. Anything else — a HIP binary, a
-shell script, `torchrun`, `python -c`, an interpreter option outside that
-set — raises a `ProtonWrapError` naming `mode: env` as the escape hatch.
-This is deliberate: requesting a measurement that cannot be taken is a
-clean setup failure, not a silently unprofiled run. `rocprof`, by contrast,
-wraps anything.
+Proton's front-end **runs a script** (through `runpy.run_path`); it is not a
+generic command runner. So the CLI wrap only applies to a Python launch
+(`python`, `python3`, `python3.12`, or `pytest`), plus a small set of
+no-argument interpreter flags that are kept in front of `-m` where they
+belong: `-u`, `-B`, `-E`, `-s`, `-S`, `-O`, `-OO`, `-I`, `-b`, `-q`.
+
+`python -m pytest ...` is accepted and normalised onto the bare
+`pytest ...` spelling, because Proton dispatches on the target's basename
+and runs it as `pytest.main(args)` — the same call `python -m pytest`
+makes. The two spellings therefore produce an identical wrap:
+
+```
+pytest -k gemm
+python -m pytest -k gemm
+→ python -m triton.profiler.proton -n <out>/proton \
+      --context shadow --data tree pytest -k gemm
+```
+
+**No other `-m <module>` works**, and the difference is Proton's, not
+aorta's: `runpy.run_path` resolves a filesystem path, so a module name has
+no spelling Proton can execute. `python -m torch.distributed.run ...` is
+refused at setup with a message naming the working spellings, rather than
+failing later inside Proton. Anything else — a HIP binary, a shell script,
+`torchrun`, `python -c`, an interpreter option outside the set above —
+raises a `ProtonWrapError` naming `mode: env` as the escape hatch. This is
+deliberate: requesting a measurement that cannot be taken is a clean setup
+failure, not a silently unprofiled run. `rocprof`, by contrast, wraps
+anything.
 
 **`mode: env`** leaves the command's own argv alone and hands it
 `AORTA_PROTON_*` variables, for a workload that calls `proton.start()` /
@@ -434,6 +452,12 @@ front-end executes a script. Either invoke the workload as
 `<python> <script.py> ...`, or switch the recipe to `proton: {mode: env}`
 and have the workload drive `proton.start()` / `proton.finalize()` itself.
 A `torchrun` or `docker run` command will always hit this.
+
+**`proton mode 'cli' cannot wrap 'python -m <module>'`.** Proton runs its
+target through `runpy.run_path`, which needs a path; `pytest` is the one
+module it also accepts. Pass the module's script by path, or use
+`mode: env`. `python -m pytest` does *not* hit this — it is normalised onto
+the bare `pytest` spelling.
 
 **`No module named triton`, from the Proton wrap.** The interpreter running
 the workload has no Triton. Run inside a container / venv that has it, or

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -161,8 +161,13 @@ Precedence and scope:
   `mitigation_axis x diagnostic_axis`, so the recipe-level collectors apply
   to every one of them.
 - CLI `--collect` is an operator override applied to every cell; it clears
-  per-cell overrides. **It carries names only** — there is no CLI syntax
-  for per-collector options, so a run that needs options needs a recipe.
+  per-cell overrides. It selects **names only** — there is no CLI syntax for
+  per-collector options, so a run that needs new options needs a recipe. The
+  recipe's options for the collectors that survive the override are kept, so
+  `--collect rocprof,proton` against a recipe that pins
+  `proton: {backend: instrumentation}` runs with that backend (and is
+  accepted, because those options are what resolve the conflict below).
+  Options for collectors the override dropped are discarded with them.
 - Every option is validated at recipe-load time. A typo fails the whole
   recipe up front rather than producing a run with no measurements in it.
 
@@ -321,6 +326,15 @@ The directory is created whether or not the payload produced GPU activity,
 so the trial tree has the same shape either way. `aorta bundle` copies every
 file under the run directory, so collector artifacts travel with a bundle
 automatically.
+
+The probe flow's `trial_<n>/result.json` records the argv that actually ran,
+which is the *wrapped* one. So the exact profiler invocation — including any
+environment rewriting the wrap did, such as the `HIP_VISIBLE_DEVICES`
+translation below — is auditable from the artifact, not just from a log line:
+
+```bash
+jq -r '.argv | join(" ")' <run_dir>/<cell>/trial_0/result.json
+```
 
 On the file names: the collector passes `rocprofv3 -o aorta` for
 determinism, which produces the flat `aorta_*.csv` files above. Run

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -129,11 +129,23 @@ points at before concluding the payload did no GPU work.
 Collectors are selected either on the command line or in the recipe.
 
 ```bash
-# Names only. Works on both the workload (triage) flow and the
-# subprocess (probe) flow, and overrides any recipe-pinned collect:.
+# Names only; overrides any recipe-pinned collect:.
 aorta sweep run --recipe r.yaml --collect rocprof -- ./my_gpu_binary
 aorta sweep run --recipe r.yaml --collect proton -- python train.py
 ```
+
+`--collect` is *accepted* on both the workload (triage) flow and the
+subprocess (probe) flow, but the two argv-wrapping profilers only *measure*
+on the subprocess flow — both commands above are subprocess-flow invocations,
+which is what the trailing `-- <command>` marks. `wrap_argv_for_collectors`
+and `summarize_collectors` are each called from one place,
+`SubprocessWorkload`, so on an in-process workload `collect: [rocprof]`
+validates and lands in the trial config and then does nothing: no argv wrap,
+no artifact directory, no `rocprof_*` metrics. This is the one
+requested-but-not-measured path here that does not announce itself, unlike a
+missing `rocprofv3`, an unpreparable artifact directory, or a missing `env(1)`,
+which all fail the trial's setup. An in-process workload can still opt in by
+reading `_aorta_collect` itself, the way `layer_numerics` does.
 
 Note that `--collect rocprof,proton` is rejected: with no options to carry,
 the CLI flag gets Proton's default `backend: auto`, which resolves to a
@@ -189,7 +201,7 @@ Precedence and scope:
 |---|---|---|---|
 | `trace` | comma- or space-separated: `kernel`, `hip`, `hip_runtime`, `memory_copy`, `rccl`, `marker`, `scratch` | `kernel` | Maps one-to-one onto `--kernel-trace`, `--hip-trace`, `--hip-runtime-trace`, `--memory-copy-trace`, `--rccl-trace`, `--marker-trace`, `--scratch-memory-trace`. Must name at least one domain. `kernel` is the only domain the summary parser aggregates. |
 | `output_format` | `csv`, `json`, `pftrace`, `otf2`, `rocpd` | `csv` | Only `csv` yields the numeric metrics below — the parser reads CSV. The others are for out-of-band analysis. |
-| `stats` | `1/true/yes/on` or `0/false/no/off` | `true` | Adds `--stats`, i.e. the pre-aggregated `*_kernel_stats.csv`. With `stats` off the parser falls back to summing dispatch spans from the kernel trace. |
+| `stats` | `1/true/yes/on` or `0/false/no/off` | `true` | Adds `--stats`, i.e. the pre-aggregated `*_kernel_stats.csv`. The parser falls back to summing dispatch spans from the kernel trace whenever the stats CSVs are absent (`stats` off) or yield no usable rows (a capture truncated mid-write, or a column this parser pins renamed by a future rocprofv3). |
 | `pmc` | comma- or space-separated counter names | (unset) | Hardware counters. Rendered last before the `--` separator because `--pmc` is variadic. Must name at least one counter. |
 | `kernel_include_regex` | regex | (unset) | `--kernel-include-regex`; must be non-empty. |
 | `summary_units` | `sec`, `msec`, `usec`, `nsec` | (unset → rocprofv3's own default) | Unit for the human-readable summary file only. Does not change the parsed metrics, which are always ms. |

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -427,8 +427,9 @@ Each collector contributes the same five keys under its own prefix.
 `<c>` is `rocprof` or `proton`. The three numeric ones are picked up by the
 `perf.md` metrics table and aggregated per cell into
 `matrix.json::cells[*].metrics_summary` (mean / min / max / n across
-trials). The list and string values are skipped in `perf.md` — it only
-aggregates numeric scalars — but are retained in the per-trial JSON.
+trials). The list and string values reach **neither** report — both aggregate
+numeric scalars only — and are readable from the per-trial dispatcher JSON at
+`.result.metrics`, which is where the `jq` recipes below look for them.
 
 Only `<c>_artifact_dir` is guaranteed. A capture with no kernel data
 contributes just that key.

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -602,8 +602,17 @@ Two consequences worth internalising:
 - **Every trial of every cell gets a capture.** With N cells × M trials you
   get N×M artifact directories. Keep payload sizes and trial counts small
   when a collector is on.
-- **A collector never changes the verdict.** Summary parsing is fail-soft by
-  construction; the worst case is fewer metrics.
+- **Summary *parsing* never changes the verdict — attaching a collector
+  can.** Parsing is fail-soft by construction: a missing, partial or malformed
+  capture costs you metrics, never the trial. The attach path is deliberately
+  the opposite. A collector that cannot run (no `rocprofv3`, a Proton wrap of
+  a command its front end cannot execute, no `env(1)` for a device
+  translation, an artifact directory that cannot be prepared) fails the
+  trial's setup rather than running it unprofiled. And a profiler is a real
+  process in the trial: its own non-zero exit is the trial's exit code, and
+  `rocprof`'s `simple_timer` stderr lines are visible to the classifier's
+  stderr detectors (see [Troubleshooting](#troubleshooting)). Profiling is a
+  measurement mode, not a transparent one.
 
 Runnable end-to-end examples for both collectors, with payloads and
 recipes, live in [`examples/profiling/`](../examples/profiling/README.md).
@@ -617,7 +626,7 @@ collector expects it".
 | Var | Read by | Purpose | Default |
 |---|---|---|---|
 | `ROCPROF_BIN` | `rocprof` | Profiler binary: a bare name resolved on `$PATH`, or a path to an executable | `rocprofv3` from `$PATH` |
-| `AORTA_PROTON_PYTHON` | `proton` | Interpreter to run Proton's front-end under; needed when Triton lives in a different interpreter than the workload | the workload's own `argv[0]` when it is a Python interpreter, else the running `sys.executable` |
+| `AORTA_PROTON_PYTHON` | `proton` | Interpreter to run Proton's front-end under; needed when Triton lives in a different interpreter than the workload | the workload's own `argv[0]` when it is a Python interpreter; for a bare `pytest`, the interpreter its console script is shebanged to; else the running `sys.executable` |
 | `AORTA_PROTON_*` | the workload | Exported *by* `mode: env` for a workload that drives Proton itself; see [Proton attach modes](#proton-attach-modes) | — |
 
 `ROCR_VISIBLE_DEVICES` / `HIP_VISIBLE_DEVICES` are not collector knobs, but

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -2,6 +2,29 @@
 
 This guide covers how to capture, analyze, and interpret profiling data from AORTA benchmark runs.
 
+## Start here: the profiling collectors
+
+For **new work, use the `rocprof` and `proton` collectors** — the supported,
+first-class way to attach a GPU profiler to anything aorta runs:
+
+```bash
+aorta sweep run --recipe <recipe>.yaml --collect rocprof -- <your command>
+```
+
+They attach by wrapping the launch argv, so no payload edit is needed; they
+write artifacts next to the trial JSON; and they parse themselves into
+`rocprof_gpu_time_ms` / `proton_gpu_time_ms` and friends, which show up in
+`perf.md` and `matrix.json` for every cell of a sweep.
+
+Full reference — options, artifact layout, analysis recipes, troubleshooting:
+[Profiling Collectors](profiling-collectors.md). Runnable examples:
+[`examples/profiling/`](../examples/profiling/README.md).
+
+The rest of this guide covers two other things: the benchmark harness's own
+built-in telemetry (below), which is independent of the collectors, and the
+older hand-rolled `rocprofv3` capture scripts, which are kept working but are
+no longer the recommended route.
+
 ## Profiling Outputs
 
 Each rank writes `artifacts/rank_<rank>_metrics.jsonl` containing iteration-level telemetry:
@@ -38,7 +61,16 @@ torchrun --nproc_per_node 4 train.py \
 - Adjust `wait`, `warmup`, `active`, and `repeat` to control capture cadence
 - Shapes and memory statistics are recorded by default
 
-## ROCm `rocprofv3` Capture
+## ROCm `rocprofv3` Capture (manual / legacy)
+
+> **Legacy route.** These scripts predate the `rocprof` collector and are kept
+> for reproducing existing captures. They hard-code this repo's `train.py`
+> launch, write outside the sweep results tree, and parse nothing — so their
+> numbers do not reach `perf.md` or `matrix.json`. For new work prefer
+> `--collect rocprof` ([Profiling Collectors](profiling-collectors.md)), which
+> profiles any command and lands its artifacts and metrics in the trial tree.
+
+### Single-node: `scripts/rocprof_capture.sh`
 
 Use the wrapper script to profile an entire ROCm run:
 
@@ -46,11 +78,11 @@ Use the wrapper script to profile an entire ROCm run:
 bash scripts/rocprof_capture.sh config/default.yaml --override training.max_steps=50
 ```
 
-### Output Location
+#### Output Location
 
 Outputs land under `rocprof_traces/run_<timestamp>/`.
 
-### Environment Variables
+#### Environment Variables
 
 Override location or extra flags with environment variables:
 
@@ -58,6 +90,18 @@ Override location or extra flags with environment variables:
 - `ROCPROF_ARGS="--att --kernel-trace --kernel-symbols"`
 
 The script mirrors `launch_rocm.sh` but executes through `rocprofv3`, so you can merge traces with the JSONL metrics using the shared iteration timestamps.
+
+### Multi-node: `scripts/multi_node/local_launch.sh`
+
+The multi-node launcher has its own opt-in `rocprofv3` path, driven by
+positional arguments rather than environment variables: pass `ENABLE_ROCPROF`
+as `true`, optionally followed by `ROCPROF_STATS` (`true` adds `--stats`) and
+`ROCPROF_INPUT` (a `rocprofv3 -i` input file, e.g.
+`scripts/gemm_analysis/rocprof_input.yaml`). When enabled it runs the
+in-container training command under `rocprofv3` and writes to
+`<experiment_dir>/<threads>thread_<channels>channels/rocprof_traces/node_<rank>/`.
+Same caveat as above: a manual capture route tied to this launcher, with no
+parsing and no metrics.
 
 ## Generating Reports
 
@@ -104,6 +148,7 @@ For deeper inspection, combine these scripts with `nsys`, `rocprof`, or PyTorch 
 
 ## Next Steps
 
+- [Profiling Collectors](profiling-collectors.md) - `--collect rocprof` / `--collect proton`: the supported way to profile any command aorta runs
 - [eBPF Usage Guide](ebpf-usage-guide.md) - Kernel-level GPU queue and memory tracing with eBPF
 - [Troubleshooting](troubleshooting.md) - Common issues and solutions
 - [Configuration Guide](configuration.md) - Tune parameters for better overlap

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -68,7 +68,8 @@ torchrun --nproc_per_node 4 train.py \
 > launch, write outside the sweep results tree, and parse nothing — so their
 > numbers do not reach `perf.md` or `matrix.json`. For new work prefer
 > `--collect rocprof` ([Profiling Collectors](profiling-collectors.md)), which
-> profiles any command and lands its artifacts and metrics in the trial tree.
+> profiles any command a sweep runs as a subprocess and lands its artifacts and
+> metrics in the trial tree.
 
 ### Single-node: `scripts/rocprof_capture.sh`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,110 @@
+# Examples
+
+Runnable examples and copy-paste config templates for aorta. Everything here
+is open source, cheap to run, and free of customer or host specifics — point
+it at your own machine, confirm the machinery works, then swap in your own
+workload.
+
+Two kinds of thing live in this directory:
+
+- **Runnable examples** — a payload plus the recipe that runs it, in a
+  category subdirectory. Each one has its own README with requirements, a
+  standalone command, and the aorta command.
+- **Config templates** — single files you pass to a flag. Not runnable on
+  their own.
+
+## Index
+
+| | What it is | Start at |
+|---|---|---|
+| [`profiling/`](profiling/README.md) | Four GPU payloads captured with the `rocprof` and `proton` collectors: a HIP SGEMM, a torch matmul, and two Triton kernels | [`profiling/README.md`](profiling/README.md) |
+| [`mitigations-sidecar.json`](mitigations-sidecar.json) | Template for a sidecar file that adds named mitigations *and* environments without installing a plugin. Pass with `--mitigations-file` | [`src/aorta/registry/README.md`](../src/aorta/registry/README.md) |
+| [`probe-flag-sidecar.json`](probe-flag-sidecar.json) | Ready-made sidecar of workload-internal flags (`FBGEMM_*`, `TORCHINDUCTOR_*`, `EVAL_DISABLE_PIPELINING`) to sweep as mitigations. Pairs with [`recipes/probe/probe-flag-sweep.yaml`](../recipes/probe/probe-flag-sweep.yaml) | [`src/aorta/registry/README.md`](../src/aorta/registry/README.md) |
+
+## Quickstart
+
+The fastest end-to-end check that aorta can run and measure a GPU payload on
+your host. No Python dependencies beyond aorta itself — `hipcc` compiles one
+file:
+
+```bash
+hipcc -O3 -o /tmp/hip_gemm examples/profiling/rocprof/hip-gemm/gemm.hip
+aorta sweep run \
+  --recipe examples/profiling/rocprof/hip-gemm/recipe.yaml \
+  --collect rocprof \
+  --output ./profiling_results \
+  -- /tmp/hip_gemm 512 20
+```
+
+You should get a run directory with `matrix.md` / `perf.md`, and a `rocprof/`
+directory of CSVs under the trial. See
+[`profiling/rocprof/hip-gemm/README.md`](profiling/rocprof/hip-gemm/README.md)
+for what the numbers mean.
+
+A sidecar template needs no GPU at all, so it is a good smoke test of the
+CLI on any host:
+
+```bash
+aorta sweep list-mitigations --mitigations-file examples/mitigations-sidecar.json
+aorta sweep list-environments --mitigations-file examples/mitigations-sidecar.json
+```
+
+Sidecar entries list with `SOURCE = sidecar:<filename>` so it is obvious which
+file shipped which entry.
+
+## Prerequisites
+
+| Example | Needs |
+|---|---|
+| `profiling/rocprof/hip-gemm` | `hipcc`, one AMD GPU, `rocprofv3` |
+| `profiling/rocprof/torch-matmul` | PyTorch for ROCm, `rocprofv3` |
+| `profiling/proton/*` | PyTorch **and** Triton for ROCm |
+| the sidecar templates | nothing — no GPU, no container |
+
+The PyTorch and Triton examples are meant to run **inside** a ROCm container
+with aorta installed there, not from a host interpreter that shells out to
+`docker run`. Each example's README shows the container invocation and
+explains why: a profiler attached to the `docker` client sees no kernels.
+
+## Conventions
+
+Every runnable example in this tree follows the same five rules, and a new
+one should too:
+
+1. **Standalone-runnable.** Reproducible without aorta; the README shows the
+   bare command first.
+2. **Self-checking.** The payload verifies its own output and exits non-zero
+   when wrong, so a bad result is a failed trial rather than a fast one.
+3. **Cheap by default.** Defaults finish in seconds; size and iteration
+   counts come from arguments, never a hard constant.
+4. **Open source, no host specifics.** Original or permissively licensed,
+   with the upstream and its license named in the README's Provenance
+   section. No customer content, no internal repository content, no absolute
+   host paths, no environment dumps.
+5. **One README per example**, covering requirements, standalone run, aorta
+   run, and the artifacts produced.
+
+## Adding an example
+
+Add it under an existing category directory, or create a new category
+alongside them and give it a `README.md` that indexes its examples and a row
+in the [Index](#index) table above. A category README owns its own
+per-example table and conventions — see
+[`profiling/README.md`](profiling/README.md) for the shape to copy.
+
+Keep this file an index: one row per category or template, no duplicated
+run instructions.
+
+## See also
+
+- [`docs/getting-started.md`](../docs/getting-started.md) — installing aorta
+  and a first run.
+- [`docs/profiling-collectors.md`](../docs/profiling-collectors.md) —
+  `rocprof` / `proton` reference: options, artifacts, analysis,
+  troubleshooting.
+- [`recipes/README.md`](../recipes/README.md) — the recipe schema, including
+  the `collect:` block.
+- [`recipes/`](../recipes/) — ready-made recipes, including probe-mode
+  smoke tests.
+- [`src/aorta/registry/README.md`](../src/aorta/registry/README.md) — the
+  sidecar file schema and how mitigations / environments resolve.

--- a/examples/profiling/README.md
+++ b/examples/profiling/README.md
@@ -1,0 +1,125 @@
+# Profiling examples
+
+Runnable, open-source payloads for aorta's profiling collectors. Each one is
+a small GPU workload plus the recipe that captures it, so you can verify a
+collector works on your machine before pointing it at something expensive.
+
+Collectors attach by wrapping the command's argv, so none of these payloads
+knows it is being profiled. Any command you can run, you can profile —
+these examples are just cheap, license-clean things to point the collectors
+at.
+
+## The examples
+
+| Example | What it profiles | Requires | Run it |
+|---|---|---|---|
+| [`rocprof/hip-gemm`](rocprof/hip-gemm/) | One hand-written tiled SGEMM kernel (`sgemm_tiled`) | `hipcc`, a GPU. **No Python deps.** | `aorta sweep run --recipe examples/profiling/rocprof/hip-gemm/recipe.yaml --output ./profiling_results -- /tmp/hip_gemm 512 20` |
+| [`rocprof/torch-matmul`](rocprof/torch-matmul/) | hipBLASLt / rocBLAS GEMM kernels PyTorch picks for `a @ b` | `torch` for ROCm. Container. | `aorta sweep run --recipe examples/profiling/rocprof/torch-matmul/recipe.yaml --output ./profiling_results -- python examples/profiling/rocprof/torch-matmul/matmul.py` |
+| [`proton/triton-vecadd`](proton/triton-vecadd/) | One Triton elementwise kernel, launch-site attribution | `torch` + `triton` for ROCm. Container. | `aorta sweep run --recipe examples/profiling/proton/triton-vecadd/recipe.yaml --output ./profiling_results -- python examples/profiling/proton/triton-vecadd/vecadd.py` |
+| [`proton/triton-softmax`](proton/triton-softmax/) | A Triton fused reduction, Python-frame attribution | `torch` + `triton` for ROCm. Container. | `aorta sweep run --recipe examples/profiling/proton/triton-softmax/recipe.yaml --output ./profiling_results -- python examples/profiling/proton/triton-softmax/softmax.py` |
+
+## Start here
+
+`rocprof/hip-gemm` is the quickstart. It is the only example with zero
+Python dependencies — `hipcc` compiles one file and you have a GPU payload —
+so it is the fastest way to find out whether profiling works at all on a
+given host:
+
+```bash
+hipcc -O3 -o /tmp/hip_gemm examples/profiling/rocprof/hip-gemm/gemm.hip
+aorta sweep run \
+  --recipe examples/profiling/rocprof/hip-gemm/recipe.yaml \
+  --output ./profiling_results \
+  -- /tmp/hip_gemm 512 20
+```
+
+The other three need a PyTorch-for-ROCm interpreter (and Triton, for the
+Proton pair). The reference way to get one is a ROCm PyTorch container with
+aorta installed **inside** it — see each example's README. Running
+`aorta sweep run -- docker run ...` from the host instead would attach the
+profiler to the docker client, which dispatches no kernels and produces an
+empty capture.
+
+## Categories
+
+| Directory | Collector | Notes |
+|---|---|---|
+| `rocprof/` | `rocprof` (`rocprofv3`) | Whole-process kernel and API tracing. Writes CSV / JSON / pftrace. |
+| `proton/` | `proton` (Triton's profiler) | Runs inside the workload's interpreter; writes a hatchet tree. |
+
+`rocprof` and `proton` both intercept HSA queues and will fight if enabled
+together, so the pairing is rejected at recipe load. Only Proton's
+`instrumentation` backend coexists with `rocprof`.
+
+The Proton examples leave `backend: "auto"`, which omits Proton's `-b` and
+lets Proton pick the backend matching the active runtime. That is what makes
+them run out of the box across Triton versions: `rocprofiler` is the
+preferred AMD backend upstream, but Triton 3.7.x and earlier accept only
+`cupti`/`roctracer`/`instrumentation` and exit with an argparse
+`invalid choice: 'rocprofiler'` before the payload runs.
+
+## Where the collector options live
+
+Each example's `recipe.yaml` carries its collector configuration as a
+`collect:` block, so the commands above need no `--collect` flag — the
+recipe is the whole story, and the option values are reviewable,
+copy-pasteable text sitting next to the payload they profile.
+
+`--collect <name>` still works and takes precedence: passing it REPLACES the
+recipe's collector list, keeping only the option blocks of the collectors
+that survive. That is the way to run one example under a different
+collector, or to compare a profiled and an unprofiled run of the same
+payload:
+
+```bash
+# recipe's own collector, with its options
+aorta sweep run --recipe .../hip-gemm/recipe.yaml -- /tmp/hip_gemm 512 20
+
+# override to a different collector (drops rocprof's option block)
+aorta sweep run --recipe .../hip-gemm/recipe.yaml --collect proton -- /tmp/hip_gemm 512 20
+```
+
+To run a payload with no capture at all, comment out the recipe's `collect:`
+block — a useful way to separate "my payload is broken" from "my profiler is
+broken".
+
+## Adding an example
+
+One directory per example, nested under its collector's category. Three
+files, no more:
+
+```
+examples/profiling/<collector>/<example-name>/
+  <payload>.{hip,py,sh}   the workload: standalone-runnable, self-checking,
+                          open-source, cheap by default
+  recipe.yaml             mode: probe, plus the collector's option block
+  README.md               requirements, standalone run, aorta run, artifacts
+```
+
+The conventions the existing four follow, and that a new one should too:
+
+1. **Standalone-runnable.** A user must be able to reproduce the payload
+   without aorta. Every README shows the bare command first.
+2. **Self-checking.** The payload verifies its own output and exits
+   non-zero when wrong, so a bad result is a failed trial rather than a
+   suspiciously fast one.
+3. **Cheap by default.** Defaults finish in seconds. Size and iteration
+   count come from CLI arguments (or environment variables), never a hard
+   constant.
+4. **Open source, no host specifics.** Payloads are original or adapted
+   from permissively licensed upstreams, with the upstream and its license
+   named in the README's Provenance section. No customer content, no
+   internal repository content, no absolute host paths, no environment
+   dumps.
+5. **One collector per example.** Two collectors in one recipe makes a
+   failure ambiguous, and some combinations conflict outright.
+
+Adding a category is the same move one level up: a new directory beside
+`rocprof/` and `proton/`, plus a row in the Categories table above.
+
+## See also
+
+- `docs/profiling-collectors.md` — collector reference: options, artifact
+  layout, analysis recipes, troubleshooting.
+- `recipes/README.md` — recipe schema.
+- `recipes/README-running-recipes.md` — running recipes on a cluster.

--- a/examples/profiling/README.md
+++ b/examples/profiling/README.md
@@ -73,11 +73,21 @@ payload:
 
 ```bash
 # recipe's own collector, with its options
-aorta sweep run --recipe .../hip-gemm/recipe.yaml -- /tmp/hip_gemm 512 20
+aorta sweep run --recipe .../torch-matmul/recipe.yaml \
+  -- python .../torch-matmul/matmul.py
 
 # override to a different collector (drops rocprof's option block)
-aorta sweep run --recipe .../hip-gemm/recipe.yaml --collect proton -- /tmp/hip_gemm 512 20
+aorta sweep run --recipe .../torch-matmul/recipe.yaml --collect proton \
+  -- python .../torch-matmul/matmul.py
 ```
+
+The override is `torch-matmul` rather than `hip-gemm` because the two
+collectors do not accept the same commands. `rocprof` wraps any command, but
+Proton's `mode: cli` takes over a *script*, so it attaches only to `python
+... <script>.py`, a bare `pytest`, or `python -m pytest`. Pointing
+`--collect proton` at a native binary such as `/tmp/hip_gemm` fails at setup
+with a `ProtonWrapError` naming `mode: env` as the escape hatch — deliberately,
+rather than running the payload unprofiled.
 
 To run a payload with no capture at all, comment out the recipe's `collect:`
 block — a useful way to separate "my payload is broken" from "my profiler is

--- a/examples/profiling/proton/triton-softmax/README.md
+++ b/examples/profiling/proton/triton-softmax/README.md
@@ -1,0 +1,106 @@
+# triton-softmax — Proton capture attributed to Python frames
+
+A fused row-softmax: a reduction kernel with a real numerical-stability
+concern, checked against `torch.softmax`. Same attach mechanism as
+[`triton-vecadd`](../triton-vecadd/README.md), but this example's options
+(documented in [`recipe.yaml`](recipe.yaml)) set `context: "python"` so the
+hatchet tree is keyed by Python call stack instead of launch site — the
+configuration you want once a script launches more than one kernel.
+
+## Requirements
+
+| | |
+|---|---|
+| Runtime | Triton + PyTorch built for ROCm, one AMD GPU |
+| Profiler | Proton, which ships inside Triton — no separate install |
+| Python deps | `torch`, `triton` |
+
+**Not runnable against a bare host interpreter** — see the vecadd README for
+why Proton must attach via the workload's own interpreter.
+
+## Run it in a container
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --ipc=host \
+  --security-opt seccomp=unconfined \
+  -v "$PWD:/work" -w /work \
+  rocm/pytorch:latest \
+  bash -lc '
+    pip install -e . &&
+    aorta sweep run \
+      --recipe examples/profiling/proton/triton-softmax/recipe.yaml \
+      --output ./profiling_results \
+      -- python examples/profiling/proton/triton-softmax/softmax.py \
+           --rows 4096 --cols 1024 --iters 20
+  '
+```
+
+## Run standalone
+
+```bash
+python examples/profiling/proton/triton-softmax/softmax.py --rows 4096 --cols 1024 --iters 20
+```
+
+Options: `--rows`, `--cols`, `--iters`. Output:
+
+```
+softmax: device=...
+softmax: rows=4096 cols=1024 iters=20
+softmax: max_abs_err=...
+softmax: PASS
+```
+
+Tolerance is `1e-6` against `torch.softmax`, not exact equality: the fused
+kernel reduces in a different order than PyTorch, so the last bits differ
+legitimately.
+
+The kernel uses one program per row, with `block_size` rounded up to the
+next power of two so a whole row fits in one program. That is what makes the
+softmax "fused", and it is also the limit: a very large `--cols` asks Triton
+for a block it may not be able to allocate registers for. Keep `--cols` at
+or below a few thousand.
+
+## Run standalone under Proton
+
+```bash
+python -m triton.profiler.proton -n softmax -c python \
+  examples/profiling/proton/triton-softmax/softmax.py --rows 4096 --cols 1024
+proton-viewer -m time/s softmax.hatchet
+```
+
+## What you get
+
+The same artifact and metric set as `triton-vecadd`
+(`proton_kernel_count`, `proton_gpu_time_ms`, `proton_top_kernel_ms`,
+`proton_top_kernels`, `proton_artifact_dir`), but with the tree keyed by
+Python frame, so `softmax()` and the correctness-check `torch.softmax` call
+appear as separate nodes.
+
+### Scoped measurement instead
+
+`context: "python"` still measures the whole process. When you want time for
+one region only — a single training step, one layer — switch the recipe to
+`mode: "env"`. Proton then leaves argv untouched, aorta exports the
+`AORTA_PROTON_*` variables, and the payload is expected to call
+`proton.start()` / `proton.finalize()` itself around the region of interest.
+The payload in this directory deliberately does *not* do that: it stays a
+plain Triton script so it can be run and understood without Proton
+installed.
+
+## Notes
+
+- **Device selection.** Use `ROCR_VISIBLE_DEVICES`, not
+  `HIP_VISIBLE_DEVICES` — Proton on AMD does not honor the latter.
+- **Backend.** Left on `backend: "auto"`; see
+  [`../triton-vecadd/README.md`](../triton-vecadd/README.md) for why, and
+  for the `libroctracer64.so` note.
+- **Do not stack this with `rocprof`**; both intercept HSA queues and the
+  pairing is rejected at recipe load. Only the `instrumentation` backend
+  coexists.
+
+## Provenance
+
+The kernel is adapted from the Triton tutorial `02-fused-softmax.py` in
+[triton-lang/triton](https://github.com/triton-lang/triton), MIT License.

--- a/examples/profiling/proton/triton-softmax/recipe.yaml
+++ b/examples/profiling/proton/triton-softmax/recipe.yaml
@@ -1,0 +1,32 @@
+# Proton capture of a Triton fused softmax, attributed to Python frames.
+#
+# Same attach mechanism as triton-vecadd, but with `context: python` so the
+# hatchet tree is keyed by Python call stack rather than by launch site --
+# the configuration you want once a script has more than one kernel.
+#
+#   aorta sweep run \
+#       --recipe examples/profiling/proton/triton-softmax/recipe.yaml \
+#       --output ./profiling_results \
+#       -- python examples/profiling/proton/triton-softmax/softmax.py \
+#            --rows 4096 --cols 1024 --iters 20
+schema_version: 1
+mode: probe
+
+ticket: PROFILING-TRITON-SOFTMAX
+
+trials: 1
+timeout_per_trial: 1800
+
+mitigation_axis: [none]
+diagnostic_axis: [none]
+
+env_passthrough_mode: inherit
+
+# `context: python` is the only difference from triton-vecadd's block. See
+# that recipe for why the backend is left on `auto`.
+collect:
+  proton:
+    mode: "cli"
+    backend: "auto"
+    context: "python"
+    data: "tree"

--- a/examples/profiling/proton/triton-softmax/softmax.py
+++ b/examples/profiling/proton/triton-softmax/softmax.py
@@ -1,0 +1,114 @@
+"""Triton fused row-softmax, sized for Proton profiling.
+
+Adapted from the Triton tutorial ``02-fused-softmax.py`` in
+https://github.com/triton-lang/triton (MIT License). Reduced to the
+one-program-per-row kernel plus a correctness check against
+``torch.softmax``, with CLI/env knobs so the profiled region stays small.
+
+Constexpr kernel parameters are spelled lowercase (``block_size`` rather
+than the tutorial's ``BLOCK_SIZE``) to satisfy this repository's lint
+configuration; Triton treats the name as opaque.
+
+Standalone:
+    python softmax.py --rows 4096 --cols 1024 --iters 20
+
+Requires Triton and PyTorch built for ROCm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def softmax_kernel(
+    out_ptr,
+    in_ptr,
+    in_row_stride,
+    out_row_stride,
+    n_cols,
+    block_size: tl.constexpr,
+):
+    row = tl.program_id(axis=0)
+    col_offsets = tl.arange(0, block_size)
+    mask = col_offsets < n_cols
+
+    row_values = tl.load(in_ptr + row * in_row_stride + col_offsets, mask=mask, other=-float("inf"))
+    # Subtract the row max before exponentiating: the numerically stable
+    # formulation, and the whole reason a fused kernel beats three passes.
+    shifted = row_values - tl.max(row_values, axis=0)
+    numerator = tl.exp(shifted)
+    softmax_out = numerator / tl.sum(numerator, axis=0)
+
+    tl.store(out_ptr + row * out_row_stride + col_offsets, softmax_out, mask=mask)
+
+
+def softmax(x: torch.Tensor) -> torch.Tensor:
+    n_rows, n_cols = x.shape
+    block_size = triton.next_power_of_2(n_cols)
+    out = torch.empty_like(x)
+    softmax_kernel[(n_rows,)](
+        out,
+        x,
+        x.stride(0),
+        out.stride(0),
+        n_cols,
+        block_size=block_size,
+    )
+    return out
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Triton fused softmax for Proton examples")
+    parser.add_argument("--rows", type=int, default=4096, help="rows in the input matrix")
+    parser.add_argument("--cols", type=int, default=1024, help="columns (reduced dimension)")
+    parser.add_argument("--iters", type=int, default=20, help="timed kernel launches")
+    args = parser.parse_args(argv)
+    for name in ("rows", "cols", "iters"):
+        if getattr(args, name) < 1:
+            parser.error(f"--{name} must be >= 1")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not torch.cuda.is_available():
+        print("softmax: no GPU visible to torch; refusing to run on CPU", file=sys.stderr)
+        return 2
+
+    device = torch.device("cuda")
+    print(f"softmax: device={torch.cuda.get_device_name(device)}")
+    print(f"softmax: rows={args.rows} cols={args.cols} iters={args.iters}")
+
+    generator = torch.Generator(device=device).manual_seed(0)
+    x = torch.randn(args.rows, args.cols, device=device, dtype=torch.float32, generator=generator)
+
+    out = softmax(x)
+    torch.cuda.synchronize(device)
+    max_err = torch.max(torch.abs(out - torch.softmax(x, axis=-1))).item()
+
+    for _ in range(args.iters):
+        softmax(x)
+    torch.cuda.synchronize(device)
+
+    print(f"softmax: max_abs_err={max_err:.3e}")
+    if max_err > 1e-6:
+        print("softmax: FAIL result differs from torch.softmax", file=sys.stderr)
+        return 1
+    print("softmax: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    # Only exit non-zero, never SystemExit(0): Proton's execute_as_main on
+    # Triton 3.6.0 catches Exception, not BaseException, so a SystemExit on the
+    # success path escapes its CLI before finalize() writes the .hatchet.
+    code = main()
+    if code:
+        raise SystemExit(code)

--- a/examples/profiling/proton/triton-softmax/softmax.py
+++ b/examples/profiling/proton/triton-softmax/softmax.py
@@ -24,6 +24,10 @@ import torch
 import triton
 import triton.language as tl
 
+#: Absolute-error ceiling against ``torch.softmax``. Not exact equality (unlike
+#: the vector-add example) because the reduction reassociates.
+_MAX_ABS_ERR = 1e-6
+
 
 @triton.jit
 def softmax_kernel(
@@ -102,7 +106,11 @@ def main(argv: list[str] | None = None) -> int:
     torch.cuda.synchronize(device)
 
     print(f"softmax: max_abs_err={max_err:.3e}")
-    if max_err > 1e-6:
+    # Negated bounded comparison, not ``max_err > tol``: every comparison with
+    # NaN is false, so the direct form lets a non-finite result print PASS --
+    # the exact condition this check exists to catch. ``not (x <= tol)`` is
+    # true for NaN.
+    if not (max_err <= _MAX_ABS_ERR):
         print("softmax: FAIL result differs from torch.softmax", file=sys.stderr)
         return 1
     print("softmax: PASS")

--- a/examples/profiling/proton/triton-softmax/softmax.py
+++ b/examples/profiling/proton/triton-softmax/softmax.py
@@ -91,7 +91,11 @@ def main(argv: list[str] | None = None) -> int:
 
     out = softmax(x)
     torch.cuda.synchronize(device)
-    max_err = torch.max(torch.abs(out - torch.softmax(x, axis=-1))).item()
+    # ``dim``, not ``axis``: torch accepts both (``axis`` is its numpy-compat
+    # alias) but only ``dim`` is documented, and this file uses ``axis`` for
+    # Triton's own reduction API a few lines up. Keeping the two spellings on
+    # their own sides of the fence stops the mix reading as a bug.
+    max_err = torch.max(torch.abs(out - torch.softmax(x, dim=-1))).item()
 
     for _ in range(args.iters):
         softmax(x)

--- a/examples/profiling/proton/triton-vecadd/README.md
+++ b/examples/profiling/proton/triton-vecadd/README.md
@@ -1,0 +1,112 @@
+# triton-vecadd — Proton capture of a Triton elementwise kernel
+
+The smallest Proton example: one Triton kernel, launched in a short loop,
+checked against `torch` elementwise add. Use it to confirm the `proton`
+collector attaches and produces a hatchet tree before pointing it at a real
+model.
+
+## Requirements
+
+| | |
+|---|---|
+| Runtime | Triton + PyTorch built for ROCm, one AMD GPU |
+| Profiler | Proton, which ships inside Triton — no separate install |
+| Python deps | `torch`, `triton` |
+
+**Not runnable against a bare host interpreter.** Proton attaches as
+`python -m triton.profiler.proton` using the *workload's own* interpreter,
+so Triton must be importable there. A host that has the `proton` console
+script on `PATH` but no `triton` in its Python will fail — which is exactly
+why the collector uses `-m` rather than the console script.
+
+## Run it in a container
+
+Install aorta inside the container and run the sweep there:
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --ipc=host \
+  --security-opt seccomp=unconfined \
+  -v "$PWD:/work" -w /work \
+  rocm/pytorch:latest \
+  bash -lc '
+    pip install -e . &&
+    aorta sweep run \
+      --recipe examples/profiling/proton/triton-vecadd/recipe.yaml \
+      --output ./profiling_results \
+      -- python examples/profiling/proton/triton-vecadd/vecadd.py \
+           --size 1048576 --iters 20
+  '
+```
+
+Pin the image by digest for anything you intend to compare over time. A
+ROCm venv with `torch` + `triton` on the host works the same way.
+
+## Run standalone
+
+```bash
+python examples/profiling/proton/triton-vecadd/vecadd.py --size 1048576 --iters 20
+```
+
+Options: `--size`, `--iters`, `--block-size`. Output:
+
+```
+vecadd: device=...
+vecadd: size=1048576 iters=20 block_size=1024
+vecadd: max_abs_err=0.000e+00
+vecadd: PASS
+```
+
+The check is exact equality against `x + y` — elementwise float32 addition
+has no reassociation freedom, so anything non-zero means a real indexing or
+masking bug.
+
+## Run standalone under Proton
+
+```bash
+python -m triton.profiler.proton -n vecadd \
+  examples/profiling/proton/triton-vecadd/vecadd.py --size 1048576 --iters 20
+proton-viewer -m time/s vecadd.hatchet
+```
+
+## What you get
+
+A `.hatchet` JSON tree in the trial's `proton/` directory; the absolute path
+is reported as `proton_artifact_dir`. The collector walks the tree and emits
+`proton_kernel_count`, `proton_gpu_time_ms`, `proton_top_kernel_ms`, and the
+non-numeric `proton_top_kernels` list, which reach `perf.md` and
+`matrix.json`.
+
+Read the raw tree yourself with `proton-viewer -m time/s <file>.hatchet`
+(run it in the same environment as the capture).
+
+## Notes
+
+- **Device selection.** Proton on AMD does not honor
+  `HIP_VISIBLE_DEVICES`; use `ROCR_VISIBLE_DEVICES` to pin a GPU or the
+  device ids in the tree will not match the ones you expect.
+- **Backend.** The recipe leaves `backend: "auto"`, which omits Proton's
+  `-b` so Proton picks the backend matching the active runtime
+  (`rocprofiler` where rocprofiler-sdk is available, `roctracer`
+  otherwise). Naming one is a version commitment: `rocprofiler` is the
+  preferred AMD backend upstream, but Triton 3.7.x and earlier accept only
+  `cupti`/`roctracer`/`instrumentation` and exit with an argparse
+  `invalid choice: 'rocprofiler'` before the payload runs. Pin a backend
+  only when you need to know exactly which one measured.
+- **Do not stack this with `rocprof`.** Proton's AMD backends intercept HSA
+  queues, and so does `rocprofv3`; running both fights over the same
+  interception point, and the pairing is rejected at recipe load. Only the
+  `instrumentation` backend coexists with `rocprof`.
+- **`Could not load libroctracer64.so`.** Some container images get ROCm
+  from Python wheels, which ship only `libroctracer64.so.4` while Proton
+  `dlopen`s the unversioned name. Add a directory of unversioned symlinks
+  to `$LD_LIBRARY_PATH`, or use an image with a system ROCm install.
+- Triton compiles on first launch, so a cold kernel cache dominates wall
+  time. That compile does not dispatch a kernel and so does not appear in
+  the tree.
+
+## Provenance
+
+The kernel is adapted from the Triton tutorial `01-vector-add.py` in
+[triton-lang/triton](https://github.com/triton-lang/triton), MIT License.

--- a/examples/profiling/proton/triton-vecadd/README.md
+++ b/examples/profiling/proton/triton-vecadd/README.md
@@ -49,7 +49,9 @@ ROCm venv with `torch` + `triton` on the host works the same way.
 python examples/profiling/proton/triton-vecadd/vecadd.py --size 1048576 --iters 20
 ```
 
-Options: `--size`, `--iters`, `--block-size`. Output:
+Options: `--size`, `--iters`, `--block-size` (must be a power of two, since
+`tl.arange` requires one — a non-power-of-two is rejected by argparse rather
+than failing later inside Triton's compiler). Output:
 
 ```
 vecadd: device=...

--- a/examples/profiling/proton/triton-vecadd/README.md
+++ b/examples/profiling/proton/triton-vecadd/README.md
@@ -76,9 +76,12 @@ proton-viewer -m time/s vecadd.hatchet
 
 A `.hatchet` JSON tree in the trial's `proton/` directory; the absolute path
 is reported as `proton_artifact_dir`. The collector walks the tree and emits
-`proton_kernel_count`, `proton_gpu_time_ms`, `proton_top_kernel_ms`, and the
-non-numeric `proton_top_kernels` list, which reach `perf.md` and
-`matrix.json`.
+`proton_kernel_count`, `proton_gpu_time_ms` and `proton_top_kernel_ms`, which
+reach `perf.md` and `matrix.json::cells[*].metrics_summary` because those
+reports aggregate numeric scalars only. The non-numeric `proton_top_kernels`
+list and `proton_artifact_dir` ride the same metrics channel but appear only
+in the per-trial dispatcher JSON (`.result.metrics`) — look there, not in
+`perf.md`, for the kernel names.
 
 Read the raw tree yourself with `proton-viewer -m time/s <file>.hatchet`
 (run it in the same environment as the capture).

--- a/examples/profiling/proton/triton-vecadd/recipe.yaml
+++ b/examples/profiling/proton/triton-vecadd/recipe.yaml
@@ -1,0 +1,45 @@
+# Proton capture of a Triton elementwise kernel.
+#
+# Proton runs inside the workload's own interpreter (`python -m
+# triton.profiler.proton`), so this recipe must be driven from an
+# interpreter that has Triton installed -- normally a ROCm PyTorch
+# container. See README.md.
+#
+#   aorta sweep run \
+#       --recipe examples/profiling/proton/triton-vecadd/recipe.yaml \
+#       --output ./profiling_results \
+#       -- python examples/profiling/proton/triton-vecadd/vecadd.py \
+#            --size 1048576 --iters 20
+schema_version: 1
+mode: probe
+
+ticket: PROFILING-TRITON-VECADD
+
+trials: 1
+# Triton JIT-compiles on first launch; a cold kernel cache dominates the
+# wall time of a one-kernel payload.
+timeout_per_trial: 1800
+
+mitigation_axis: [none]
+diagnostic_axis: [none]
+
+env_passthrough_mode: inherit
+
+# Baseline Proton configuration on AMD: CLI attach, shadow context so time
+# is attributed to the launching frame, hatchet tree output. These are also
+# the collector's defaults -- spelled out here because this is the example
+# people copy.
+#
+# `backend: "auto"` omits Proton's `-b` and lets Proton pick the backend
+# matching the active runtime: `rocprofiler` where rocprofiler-sdk is
+# available, `roctracer` otherwise. That is the only portable spelling --
+# naming `rocprofiler` explicitly is correct on current upstream Triton but
+# exits with an argparse "invalid choice: 'rocprofiler'" on Triton 3.7.x and
+# earlier, before your payload runs. Pin a backend explicitly only when you
+# need to know exactly which one measured.
+collect:
+  proton:
+    mode: "cli"
+    backend: "auto"
+    context: "shadow"
+    data: "tree"

--- a/examples/profiling/proton/triton-vecadd/vecadd.py
+++ b/examples/profiling/proton/triton-vecadd/vecadd.py
@@ -1,0 +1,96 @@
+"""Triton elementwise vector add, sized for Proton profiling.
+
+Adapted from the Triton tutorial ``01-vector-add.py`` in
+https://github.com/triton-lang/triton (MIT License). Trimmed to a single
+kernel launch loop with a correctness check, and given CLI/env knobs so the
+profiled region stays small.
+
+Constexpr kernel parameters are spelled lowercase (``block_size`` rather
+than the tutorial's ``BLOCK_SIZE``) to satisfy this repository's lint
+configuration; Triton treats the name as opaque.
+
+Standalone:
+    python vecadd.py --size 1048576 --iters 20
+
+Requires Triton and PyTorch built for ROCm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def add_kernel(x_ptr, y_ptr, out_ptr, n_elements, block_size: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * block_size
+    offsets = block_start + tl.arange(0, block_size)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x + y, mask=mask)
+
+
+def add(x: torch.Tensor, y: torch.Tensor, block_size: int) -> torch.Tensor:
+    out = torch.empty_like(x)
+    n_elements = out.numel()
+    grid = (triton.cdiv(n_elements, block_size),)
+    add_kernel[grid](x, y, out, n_elements, block_size=block_size)
+    return out
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Triton vector add for Proton examples")
+    parser.add_argument("--size", type=int, default=1 << 20, help="number of elements")
+    parser.add_argument("--iters", type=int, default=20, help="timed kernel launches")
+    parser.add_argument("--block-size", type=int, default=1024, help="elements per program")
+    args = parser.parse_args(argv)
+    for name in ("size", "iters", "block_size"):
+        if getattr(args, name) < 1:
+            parser.error(f"--{name.replace('_', '-')} must be >= 1")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not torch.cuda.is_available():
+        print("vecadd: no GPU visible to torch; refusing to run on CPU", file=sys.stderr)
+        return 2
+
+    device = torch.device("cuda")
+    print(f"vecadd: device={torch.cuda.get_device_name(device)}")
+    print(f"vecadd: size={args.size} iters={args.iters} block_size={args.block_size}")
+
+    generator = torch.Generator(device=device).manual_seed(0)
+    x = torch.rand(args.size, device=device, dtype=torch.float32, generator=generator)
+    y = torch.rand(args.size, device=device, dtype=torch.float32, generator=generator)
+
+    out = add(x, y, args.block_size)
+    torch.cuda.synchronize(device)
+    max_err = torch.max(torch.abs(out - (x + y))).item()
+
+    for _ in range(args.iters):
+        add(x, y, args.block_size)
+    torch.cuda.synchronize(device)
+
+    print(f"vecadd: max_abs_err={max_err:.3e}")
+    if max_err != 0.0:
+        print("vecadd: FAIL result differs from torch elementwise add", file=sys.stderr)
+        return 1
+    print("vecadd: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    # Only exit non-zero, never SystemExit(0): Proton's execute_as_main on
+    # Triton 3.6.0 catches Exception, not BaseException, so a SystemExit on the
+    # success path escapes its CLI before finalize() writes the .hatchet.
+    code = main()
+    if code:
+        raise SystemExit(code)

--- a/examples/profiling/proton/triton-vecadd/vecadd.py
+++ b/examples/profiling/proton/triton-vecadd/vecadd.py
@@ -53,6 +53,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     for name in ("size", "iters", "block_size"):
         if getattr(args, name) < 1:
             parser.error(f"--{name.replace('_', '-')} must be >= 1")
+    # ``tl.arange(0, block_size)`` requires a power-of-two extent. Rejecting it
+    # here keeps the failure an argparse message instead of a Triton
+    # compilation error raised from inside the kernel launch, which is what a
+    # value like 1000 produced before.
+    if args.block_size & (args.block_size - 1):
+        parser.error(
+            f"--block-size must be a power of two (tl.arange requires one); got "
+            f"{args.block_size}, nearest is {triton.next_power_of_2(args.block_size)}"
+        )
     return args
 
 

--- a/examples/profiling/rocprof/hip-gemm/README.md
+++ b/examples/profiling/rocprof/hip-gemm/README.md
@@ -1,0 +1,114 @@
+# hip-gemm — rocprof kernel trace of a tiled HIP SGEMM
+
+The quickstart profiling example. A single self-contained HIP source file
+compiled by `hipcc`, launching one named kernel (`sgemm_tiled`) per
+iteration, with a built-in correctness check. No Python, no PyTorch, no
+Triton — if you have a ROCm toolchain you can run this.
+
+Use it to answer "does the `rocprof` collector work on this machine at all?"
+before pointing it at a real workload.
+
+## Requirements
+
+| | |
+|---|---|
+| Toolchain | `hipcc` (ships with ROCm) |
+| Runtime | One AMD GPU, `/dev/kfd` + `/dev/dri` visible |
+| Profiler | `rocprofv3` on `PATH` (ROCm 6.2+), or `$ROCPROF_BIN` |
+| Python deps | none |
+
+Verified against ROCm 7.0.2.2 / `rocprofv3` 1.0.1 on gfx950.
+
+## Build
+
+```bash
+hipcc -O3 -o /tmp/hip_gemm examples/profiling/rocprof/hip-gemm/gemm.hip
+```
+
+Build artifacts are intentionally not checked in; `/tmp` keeps the repo
+clean. Add `--offload-arch=<gfx>` if you are cross-building for a GPU that
+is not in the build host.
+
+## Run standalone
+
+```bash
+/tmp/hip_gemm 512 20
+```
+
+Arguments are `[matrix_size] [iterations]`, defaulting to `512 20`; the
+`AORTA_GEMM_N` / `AORTA_GEMM_ITERS` environment variables are the fallback
+when arguments are omitted. Expected output:
+
+```
+gemm: device=0 arch=gfx950:sramecc+:xnack-
+gemm: n=512 iters=20 tile=16
+gemm: mean_kernel_ms=0.0230
+gemm: gflops=11680.22
+gemm: max_rel_err=3.304e-06
+gemm: PASS
+```
+
+The process exits non-zero if the sampled dot products disagree with the
+kernel's output, so a wrong answer is a failed trial rather than a fast one.
+
+## Run standalone under rocprofv3
+
+Useful for comparing what aorta captured against a hand-rolled capture:
+
+```bash
+rocprofv3 --kernel-trace --stats --output-format csv \
+  -d /tmp/rocprof_out -o gemm -- /tmp/hip_gemm 512 20
+```
+
+## Run under aorta
+
+```bash
+aorta sweep run \
+  --recipe examples/profiling/rocprof/hip-gemm/recipe.yaml \
+  --output ./profiling_results \
+  -- /tmp/hip_gemm 512 20
+```
+
+Everything after `--` is the opaque command; [`recipe.yaml`](recipe.yaml)'s
+`collect:` block is what turns on profiling and carries this example's
+rocprof options. Swap the command for any other GPU binary and the same
+recipe still applies — that is the point of the argv-wrapping design.
+
+Passing `--collect <name>` on the command line replaces the recipe's
+collector list, so use it to run this payload under a different collector.
+
+## What you get
+
+Per-trial rocprof artifacts land in the trial's collector directory under
+`rocprof/`; the absolute path is reported as the `rocprof_artifact_dir`
+metric so you never have to guess it.
+
+`rocprofv3` names its CSVs by output stem: with `-o <stem>` they are flat
+files named `<stem>_kernel_stats.csv`, `<stem>_kernel_trace.csv`,
+`<stem>_domain_stats.csv`, and `<stem>_agent_info.csv`. With no `-o` it
+nests them one level deeper as `<hostname>/<pid>_kernel_stats.csv` and so
+on.
+
+`<stem>_kernel_stats.csv` is the summary the collector parses:
+
+```
+"Name","Calls","TotalDurationNs","AverageNs","Percentage","MinNs","MaxNs","StdDev"
+"sgemm_tiled(float const*, float const*, float*, int)",23,538601,23417.434783,100.00,22160,37280,3033.067227
+```
+
+23 calls, not 20 — the payload does three warmup launches before the timed
+loop, and rocprof counts every dispatch.
+
+The parsed numbers reach `perf.md` and `matrix.json` as
+`rocprof_kernel_count`, `rocprof_gpu_time_ms`, and `rocprof_top_kernel_ms`.
+
+## Notes
+
+- `rocprofv3` writes progress and HSA-init lines to **stderr**, so a
+  rocprof-collected trial's stderr is not byte-identical to an unprofiled
+  one. Profiling is a measurement mode, not a transparent passthrough.
+- With no GPU activity `rocprofv3` writes no files at all. A trial whose
+  payload never dispatched a kernel yields no rocprof metrics rather than
+  zeros.
+- Keep `iterations` small. The example exists to produce a clean profile,
+  not a benchmark number; a long run just makes a bigger trace.

--- a/examples/profiling/rocprof/hip-gemm/gemm.hip
+++ b/examples/profiling/rocprof/hip-gemm/gemm.hip
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <vector>
 
 #define HIP_CHECK(expr)                                                                 \
@@ -166,7 +167,15 @@ int main(int argc, char** argv) {
         }
         const double actual = host_c[static_cast<size_t>(row) * n + col];
         const double scale = std::fmax(std::fabs(reference), 1.0);
-        max_rel_err = std::fmax(max_rel_err, static_cast<float>(std::fabs(actual - reference) / scale));
+        const double rel = std::fabs(actual - reference) / scale;
+        // std::fmax returns its non-NaN operand, so folding a NaN sample
+        // through it would discard the NaN and still print PASS. Propagate it
+        // instead: the negated tolerance comparison below rejects a NaN.
+        if (!std::isfinite(rel)) {
+            max_rel_err = std::numeric_limits<float>::quiet_NaN();
+            break;
+        }
+        max_rel_err = std::fmax(max_rel_err, static_cast<float>(rel));
     }
 
     const double mean_kernel_ms = elapsed_ms / static_cast<double>(iters);

--- a/examples/profiling/rocprof/hip-gemm/gemm.hip
+++ b/examples/profiling/rocprof/hip-gemm/gemm.hip
@@ -1,0 +1,192 @@
+// Tiled single-precision GEMM (C = A * B) for AMD GPUs.
+//
+// A deliberately small, dependency-free HIP payload for profiling examples:
+// it needs nothing but `hipcc`, launches exactly one named kernel per
+// iteration, verifies its own output, and prints one `key=value` line per
+// result so a wrapper can regex the numbers out of stdout.
+//
+// Build and run standalone:
+//   hipcc -O3 -o /tmp/hip_gemm gemm.hip
+//   /tmp/hip_gemm 512 20
+//
+// Size and iteration count come from argv, falling back to the
+// AORTA_GEMM_N / AORTA_GEMM_ITERS environment variables, falling back to
+// small defaults that finish in well under a second. Keep it cheap: the
+// point is to produce a clean profile, not a benchmark record.
+
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define HIP_CHECK(expr)                                                                 \
+    do {                                                                                \
+        hipError_t err_ = (expr);                                                        \
+        if (err_ != hipSuccess) {                                                        \
+            std::fprintf(stderr, "gemm: HIP error at %s:%d: %s\n", __FILE__, __LINE__,   \
+                         hipGetErrorString(err_));                                       \
+            return 1;                                                                    \
+        }                                                                                \
+    } while (0)
+
+namespace {
+
+constexpr int kTile = 16;
+constexpr int kDefaultN = 512;
+constexpr int kDefaultIters = 20;
+constexpr int kWarmupIters = 3;
+// Output elements re-computed on the host to validate the kernel. Full
+// verification would be O(n^3) on one CPU thread; a fixed sample of exact
+// dot products catches indexing and tiling bugs at O(samples * n).
+constexpr int kCheckSamples = 64;
+constexpr float kRelTolerance = 1e-3f;
+
+// xorshift32: a deterministic, self-contained generator so every run of the
+// example profiles the identical arithmetic (no <random> engine differences
+// across toolchains).
+unsigned int NextRandom(unsigned int& state) {
+    state ^= state << 13;
+    state ^= state >> 17;
+    state ^= state << 5;
+    return state;
+}
+
+// Fills with values in [-1, 1) so accumulated sums stay well inside float
+// range for the sizes this example uses.
+void FillDeterministic(std::vector<float>& out, unsigned int seed) {
+    unsigned int state = seed;
+    for (float& v : out) {
+        v = static_cast<float>(NextRandom(state) >> 8) / 8388608.0f - 1.0f;
+    }
+}
+
+int ReadPositive(const char* text, int fallback) {
+    if (text == nullptr) {
+        return fallback;
+    }
+    const long parsed = std::strtol(text, nullptr, 10);
+    if (parsed <= 0 || parsed > 16384) {
+        return fallback;
+    }
+    return static_cast<int>(parsed);
+}
+
+}  // namespace
+
+__global__ void sgemm_tiled(const float* __restrict__ a, const float* __restrict__ b,
+                            float* __restrict__ c, int n) {
+    __shared__ float a_tile[kTile][kTile];
+    __shared__ float b_tile[kTile][kTile];
+
+    const int row = blockIdx.y * kTile + threadIdx.y;
+    const int col = blockIdx.x * kTile + threadIdx.x;
+
+    float acc = 0.0f;
+    for (int t = 0; t < (n + kTile - 1) / kTile; ++t) {
+        const int a_col = t * kTile + threadIdx.x;
+        const int b_row = t * kTile + threadIdx.y;
+        a_tile[threadIdx.y][threadIdx.x] = (row < n && a_col < n) ? a[row * n + a_col] : 0.0f;
+        b_tile[threadIdx.y][threadIdx.x] = (b_row < n && col < n) ? b[b_row * n + col] : 0.0f;
+        __syncthreads();
+        for (int k = 0; k < kTile; ++k) {
+            acc += a_tile[threadIdx.y][k] * b_tile[k][threadIdx.x];
+        }
+        __syncthreads();
+    }
+
+    if (row < n && col < n) {
+        c[row * n + col] = acc;
+    }
+}
+
+int main(int argc, char** argv) {
+    const int n = ReadPositive(argc > 1 ? argv[1] : std::getenv("AORTA_GEMM_N"), kDefaultN);
+    const int iters =
+        ReadPositive(argc > 2 ? argv[2] : std::getenv("AORTA_GEMM_ITERS"), kDefaultIters);
+
+    int device = 0;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props{};
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    std::printf("gemm: device=%d arch=%s\n", device, props.gcnArchName);
+    std::printf("gemm: n=%d iters=%d tile=%d\n", n, iters, kTile);
+
+    const size_t elements = static_cast<size_t>(n) * static_cast<size_t>(n);
+    const size_t bytes = elements * sizeof(float);
+
+    std::vector<float> host_a(elements);
+    std::vector<float> host_b(elements);
+    std::vector<float> host_c(elements);
+    FillDeterministic(host_a, 0x9e3779b9u);
+    FillDeterministic(host_b, 0x85ebca6bu);
+
+    float* dev_a = nullptr;
+    float* dev_b = nullptr;
+    float* dev_c = nullptr;
+    HIP_CHECK(hipMalloc(&dev_a, bytes));
+    HIP_CHECK(hipMalloc(&dev_b, bytes));
+    HIP_CHECK(hipMalloc(&dev_c, bytes));
+    HIP_CHECK(hipMemcpy(dev_a, host_a.data(), bytes, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dev_b, host_b.data(), bytes, hipMemcpyHostToDevice));
+
+    const dim3 block(kTile, kTile);
+    const dim3 grid((n + kTile - 1) / kTile, (n + kTile - 1) / kTile);
+
+    for (int i = 0; i < kWarmupIters; ++i) {
+        hipLaunchKernelGGL(sgemm_tiled, grid, block, 0, nullptr, dev_a, dev_b, dev_c, n);
+    }
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hipEvent_t start;
+    hipEvent_t stop;
+    HIP_CHECK(hipEventCreate(&start));
+    HIP_CHECK(hipEventCreate(&stop));
+    HIP_CHECK(hipEventRecord(start, nullptr));
+    for (int i = 0; i < iters; ++i) {
+        hipLaunchKernelGGL(sgemm_tiled, grid, block, 0, nullptr, dev_a, dev_b, dev_c, n);
+    }
+    HIP_CHECK(hipEventRecord(stop, nullptr));
+    HIP_CHECK(hipEventSynchronize(stop));
+    float elapsed_ms = 0.0f;
+    HIP_CHECK(hipEventElapsedTime(&elapsed_ms, start, stop));
+
+    HIP_CHECK(hipMemcpy(host_c.data(), dev_c, bytes, hipMemcpyDeviceToHost));
+
+    float max_rel_err = 0.0f;
+    unsigned int probe_state = 0xc2b2ae35u;
+    for (int s = 0; s < kCheckSamples; ++s) {
+        const int row = static_cast<int>(NextRandom(probe_state) % static_cast<unsigned int>(n));
+        const int col = static_cast<int>(NextRandom(probe_state) % static_cast<unsigned int>(n));
+        double reference = 0.0;
+        for (int k = 0; k < n; ++k) {
+            reference += static_cast<double>(host_a[static_cast<size_t>(row) * n + k]) *
+                         static_cast<double>(host_b[static_cast<size_t>(k) * n + col]);
+        }
+        const double actual = host_c[static_cast<size_t>(row) * n + col];
+        const double scale = std::fmax(std::fabs(reference), 1.0);
+        max_rel_err = std::fmax(max_rel_err, static_cast<float>(std::fabs(actual - reference) / scale));
+    }
+
+    const double mean_kernel_ms = elapsed_ms / static_cast<double>(iters);
+    const double gflops =
+        (2.0 * static_cast<double>(n) * n * n) / (mean_kernel_ms * 1.0e-3) / 1.0e9;
+    std::printf("gemm: mean_kernel_ms=%.4f\n", mean_kernel_ms);
+    std::printf("gemm: gflops=%.2f\n", gflops);
+    std::printf("gemm: max_rel_err=%.3e\n", static_cast<double>(max_rel_err));
+
+    HIP_CHECK(hipEventDestroy(start));
+    HIP_CHECK(hipEventDestroy(stop));
+    HIP_CHECK(hipFree(dev_a));
+    HIP_CHECK(hipFree(dev_b));
+    HIP_CHECK(hipFree(dev_c));
+
+    if (!(max_rel_err < kRelTolerance)) {
+        std::printf("gemm: FAIL correctness (max_rel_err=%.3e >= %.3e)\n",
+                    static_cast<double>(max_rel_err), static_cast<double>(kRelTolerance));
+        return 1;
+    }
+    std::printf("gemm: PASS\n");
+    return 0;
+}

--- a/examples/profiling/rocprof/hip-gemm/recipe.yaml
+++ b/examples/profiling/rocprof/hip-gemm/recipe.yaml
@@ -1,0 +1,38 @@
+# rocprof kernel-trace capture of the tiled HIP SGEMM in this directory.
+#
+# The payload is an opaque command as far as aorta is concerned -- the
+# collector attaches by wrapping argv, so nothing here knows or cares that
+# the command happens to be a HIP binary.
+#
+#   hipcc -O3 -o /tmp/hip_gemm examples/profiling/rocprof/hip-gemm/gemm.hip
+#   aorta sweep run \
+#       --recipe examples/profiling/rocprof/hip-gemm/recipe.yaml \
+#       --output ./profiling_results \
+#       -- /tmp/hip_gemm 512 20
+#
+# See README.md in this directory for the artifact layout and the metrics
+# that reach perf.md / matrix.json.
+schema_version: 1
+mode: probe
+
+ticket: PROFILING-HIP-GEMM
+
+# One trial is enough to demonstrate a capture; raise it to compare
+# kernel time across repeats.
+trials: 1
+timeout_per_trial: 600
+
+mitigation_axis: [none]
+diagnostic_axis: [none]
+
+env_passthrough_mode: inherit
+
+# Smallest useful rocprof configuration: kernel dispatches only, CSV out,
+# per-kernel summary statistics on. `summary_units: msec` keeps the summary
+# readable for a kernel in the tens-of-microseconds range.
+collect:
+  rocprof:
+    trace: "kernel"
+    output_format: "csv"
+    stats: "1"
+    summary_units: "msec"

--- a/examples/profiling/rocprof/torch-matmul/README.md
+++ b/examples/profiling/rocprof/torch-matmul/README.md
@@ -68,8 +68,17 @@ matmul: device=... dtype=float16
 matmul: size=2048 iters=20 warmup=3
 matmul: mean_kernel_ms=...
 matmul: gflops=...
+matmul: max_rel_err=...
 matmul: PASS
 ```
+
+`PASS` means the product was verified, not merely finite. The payload samples
+a handful of off-diagonal `c[i, j]` entries against `dot(a[i, :], b[:, j])`
+recomputed in float32 and fails when the relative error exceeds a
+dtype-appropriate ceiling (`1e-3` float32, matching `hip-gemm`; `2e-2`
+float16; `5e-2` bfloat16). A full reference GEMM would cost as much as the
+payload, and the samples avoid the diagonal on purpose — a transposed result
+leaves `c[i, i]` unchanged, so diagonal probes could never catch one.
 
 The payload exits `2` if torch sees no GPU rather than falling back to CPU:
 a silent CPU run would yield an empty profile and read as a collector bug.

--- a/examples/profiling/rocprof/torch-matmul/README.md
+++ b/examples/profiling/rocprof/torch-matmul/README.md
@@ -1,0 +1,98 @@
+# torch-matmul — rocprof trace of PyTorch library GEMM kernels
+
+Where [`hip-gemm`](../hip-gemm/README.md) profiles a kernel you can read,
+this one profiles the kernels a framework picks for you. The payload issues
+repeated `a @ b` on the GPU and lets PyTorch route it to hipBLASLt /
+rocBLAS, so the kernel trace contains real Tensile kernel names
+(`Cijk_Alik_Bljk_...`) rather than a hand-written symbol.
+
+Use it to check that the collector's summary parsing survives a framework
+stack: many distinct kernels per step, autotuning on the first call, and
+kernel names long enough to stress a CSV reader.
+
+## Requirements
+
+| | |
+|---|---|
+| Runtime | PyTorch built for ROCm, one AMD GPU |
+| Profiler | `rocprofv3` on `PATH`, **inside the same interpreter's container** |
+| Python deps | `torch` |
+
+**This example does not run against a bare host interpreter unless you have
+installed PyTorch-for-ROCm there.** The reference path is a ROCm PyTorch
+container.
+
+## Run it in a container
+
+Install aorta *inside* the container and run the sweep there. Wrapping
+`docker run` from the host would attach `rocprofv3` to the docker client
+process, which dispatches no kernels and therefore produces no profile.
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --ipc=host \
+  --security-opt seccomp=unconfined \
+  -v "$PWD:/work" -w /work \
+  rocm/pytorch:latest \
+  bash -lc '
+    pip install -e . &&
+    aorta sweep run \
+      --recipe examples/profiling/rocprof/torch-matmul/recipe.yaml \
+      --output ./profiling_results \
+      -- python examples/profiling/rocprof/torch-matmul/matmul.py \
+           --size 2048 --iters 20 --dtype float16
+  '
+```
+
+Pin the image by digest rather than `:latest` for anything you intend to
+compare over time.
+
+A ROCm PyTorch virtualenv on the host works identically — the container is
+just the reproducible way to get one.
+
+## Run standalone
+
+Inside the same container or venv:
+
+```bash
+python examples/profiling/rocprof/torch-matmul/matmul.py \
+  --size 2048 --iters 20 --dtype float16
+```
+
+Options: `--size`, `--iters`, `--warmup`, `--dtype`
+(`float32` / `float16` / `bfloat16`), `--device`. Output:
+
+```
+matmul: device=... dtype=float16
+matmul: size=2048 iters=20 warmup=3
+matmul: mean_kernel_ms=...
+matmul: gflops=...
+matmul: PASS
+```
+
+The payload exits `2` if torch sees no GPU rather than falling back to CPU:
+a silent CPU run would yield an empty profile and read as a collector bug.
+
+## What you get
+
+The same artifact set as `hip-gemm` — `<stem>_kernel_stats.csv`,
+`<stem>_kernel_trace.csv`, `<stem>_domain_stats.csv`,
+`<stem>_agent_info.csv` under the trial's `rocprof/` directory — plus HIP
+API rows, because this example's options (documented in
+[`recipe.yaml`](recipe.yaml)) set `trace: "kernel,hip"`.
+
+`kernel_include_regex: "Cijk|gemm|matmul"` restricts the summary to GEMM
+kernels so `rocprof_top_kernel_ms` reports the matmul rather than a
+`fill`/`copy` kernel. Widen or drop it if a kernel you expected is missing
+from the summary — the raw `_kernel_trace.csv` is unfiltered either way.
+
+## Notes
+
+- The first matmul on a cold hipBLASLt cache can take seconds while the
+  library picks a kernel. That autotuning dispatch lands in the trace; the
+  `--warmup` iterations exist to keep it out of the timed loop, not out of
+  the profile.
+- `float16` is the default because it is what the Tensile fast paths are
+  tuned for. Switch to `--dtype float32` to see a different kernel family
+  selected for the same shapes.

--- a/examples/profiling/rocprof/torch-matmul/README.md
+++ b/examples/profiling/rocprof/torch-matmul/README.md
@@ -82,10 +82,13 @@ The same artifact set as `hip-gemm` — `<stem>_kernel_stats.csv`,
 API rows, because this example's options (documented in
 [`recipe.yaml`](recipe.yaml)) set `trace: "kernel,hip"`.
 
-`kernel_include_regex: "Cijk|gemm|matmul"` restricts the summary to GEMM
+`kernel_include_regex: "Cijk|gemm|matmul"` narrows the capture to GEMM
 kernels so `rocprof_top_kernel_ms` reports the matmul rather than a
-`fill`/`copy` kernel. Widen or drop it if a kernel you expected is missing
-from the summary — the raw `_kernel_trace.csv` is unfiltered either way.
+`fill`/`copy` kernel. It is a **collection** filter, not a post-filter: the
+collector passes it to `rocprofv3` as `--kernel-include-regex`, so an excluded
+kernel never reaches `_kernel_trace.csv` either. If a kernel you expected is
+missing, widen or drop the regex and re-run — it is not waiting in the raw
+trace.
 
 ## Notes
 

--- a/examples/profiling/rocprof/torch-matmul/matmul.py
+++ b/examples/profiling/rocprof/torch-matmul/matmul.py
@@ -27,6 +27,53 @@ _DTYPES = {
     "bfloat16": torch.bfloat16,
 }
 
+#: Relative-error ceiling per operand dtype. The reference is computed from the
+#: same already-rounded operands promoted to float32, so the only error being
+#: bounded is the library's accumulation order -- not the input rounding. The
+#: float32 ceiling matches ``hip-gemm``'s ``kRelTolerance``; a backend that
+#: splits the K loop differently must not make a correct example look broken.
+#: Measured against a CPU reference at size 2048: 3.9e-06 / 4.1e-04 / 2.9e-03.
+_REL_TOLERANCE = {
+    "float32": 1e-3,
+    "float16": 2e-2,
+    "bfloat16": 5e-2,
+}
+
+#: How many entries of the product to check against an independent reference.
+_SAMPLES = 8
+
+
+def max_sampled_rel_err(
+    a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, samples: int = _SAMPLES
+) -> float:
+    """Largest relative error over a few sampled entries of ``c``.
+
+    A full reference GEMM would cost as much as the payload, so this checks
+    ``c[i, j] == dot(a[i, :], b[:, j])`` at evenly spaced ``i``. Finiteness
+    alone does not verify a product -- an all-zero or transposed result is
+    perfectly finite -- and rule 2 of the examples contract asks each payload
+    to verify its own output. Mirrors the CPU reference the ``hip-gemm``
+    example computes for the same reason.
+
+    The samples are deliberately **off-diagonal**: a transpose leaves the
+    diagonal untouched (``c.T[i, i] == c[i, i]``), so probing ``c[i, i]``
+    could never catch one.
+    """
+    edge = c.shape[0]
+    step = max(1, edge // samples)
+    # Any fixed non-zero offset breaks the row == column symmetry; a third of
+    # the edge keeps the pairs spread out for a small ``samples``.
+    offset = max(1, edge // 3)
+    worst = 0.0
+    for row in range(0, edge, step):
+        col = (row + offset) % edge
+        reference = torch.dot(a[row].to(torch.float32), b[:, col].to(torch.float32)).item()
+        actual = float(c[row, col].item())
+        # Guard against dividing by a near-zero reference, as hip-gemm does.
+        scale = max(abs(reference), 1.0)
+        worst = max(worst, abs(actual - reference) / scale)
+    return worst
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
@@ -75,10 +122,20 @@ def main(argv: list[str] | None = None) -> int:
     print(f"matmul: mean_kernel_ms={mean_ms:.4f}")
     print(f"matmul: gflops={gflops:.2f}")
 
-    # Cheap sanity check: a finite result rules out the "profiled a NaN
-    # storm" reading of an otherwise plausible looking trace.
+    # Finiteness rules out the "profiled a NaN storm" reading of an otherwise
+    # plausible trace, but it does not verify the product: an all-zero or
+    # transposed result is finite too. The sampled reference does verify it.
     if not torch.isfinite(c).all():
         print("matmul: FAIL non-finite values in result", file=sys.stderr)
+        return 1
+    max_rel_err = max_sampled_rel_err(a, b, c)
+    tolerance = _REL_TOLERANCE[args.dtype]
+    print(f"matmul: max_rel_err={max_rel_err:.3e}")
+    if not (max_rel_err < tolerance):
+        print(
+            f"matmul: FAIL correctness (max_rel_err={max_rel_err:.3e} >= {tolerance:.3e})",
+            file=sys.stderr,
+        )
         return 1
     print("matmul: PASS")
     return 0

--- a/examples/profiling/rocprof/torch-matmul/matmul.py
+++ b/examples/profiling/rocprof/torch-matmul/matmul.py
@@ -1,0 +1,94 @@
+"""Repeated PyTorch matmul on the default accelerator, sized for profiling.
+
+A minimal PyTorch payload for the rocprof collector examples: it dispatches
+a handful of large GEMMs through whatever BLAS backend the installed
+PyTorch uses (hipBLASLt / rocBLAS on ROCm), so a kernel trace shows real
+library kernel names rather than a hand-written one.
+
+Standalone:
+    python matmul.py --size 2048 --iters 20 --dtype float16
+
+Requires PyTorch built for ROCm. There is no CPU fallback on purpose --
+a silent CPU run would produce an empty GPU profile and look like a
+collector bug.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+import torch
+
+_DTYPES = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--size", type=int, default=2048, help="square matrix edge length")
+    parser.add_argument("--iters", type=int, default=20, help="timed matmul iterations")
+    parser.add_argument("--warmup", type=int, default=3, help="untimed warmup iterations")
+    parser.add_argument("--dtype", choices=sorted(_DTYPES), default="float16", help="operand dtype")
+    parser.add_argument("--device", default="cuda", help="torch device (ROCm reports as 'cuda')")
+    args = parser.parse_args(argv)
+    for name in ("size", "iters"):
+        if getattr(args, name) < 1:
+            parser.error(f"--{name} must be >= 1")
+    if args.warmup < 0:
+        parser.error("--warmup must be >= 0")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not torch.cuda.is_available():
+        print("matmul: no GPU visible to torch; refusing to run on CPU", file=sys.stderr)
+        return 2
+
+    device = torch.device(args.device)
+    dtype = _DTYPES[args.dtype]
+    print(f"matmul: device={torch.cuda.get_device_name(device)} dtype={args.dtype}")
+    print(f"matmul: size={args.size} iters={args.iters} warmup={args.warmup}")
+
+    generator = torch.Generator(device=device).manual_seed(1234)
+    a = torch.randn(args.size, args.size, device=device, dtype=dtype, generator=generator)
+    b = torch.randn(args.size, args.size, device=device, dtype=dtype, generator=generator)
+
+    for _ in range(args.warmup):
+        a @ b
+    torch.cuda.synchronize(device)
+
+    start = time.perf_counter()
+    for _ in range(args.iters):
+        c = a @ b
+    torch.cuda.synchronize(device)
+    elapsed_s = time.perf_counter() - start
+
+    mean_ms = elapsed_s * 1e3 / args.iters
+    gflops = 2.0 * args.size**3 / (mean_ms * 1e-3) / 1e9
+    print(f"matmul: mean_kernel_ms={mean_ms:.4f}")
+    print(f"matmul: gflops={gflops:.2f}")
+
+    # Cheap sanity check: a finite result rules out the "profiled a NaN
+    # storm" reading of an otherwise plausible looking trace.
+    if not torch.isfinite(c).all():
+        print("matmul: FAIL non-finite values in result", file=sys.stderr)
+        return 1
+    print("matmul: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    # Only exit non-zero, never SystemExit(0). rocprofv3 does not care, but
+    # --collect proton can be pointed at this payload, and Proton's
+    # execute_as_main on Triton 3.6.0 catches Exception, not BaseException, so a
+    # SystemExit on the success path escapes before finalize() writes the data.
+    code = main()
+    if code:
+        raise SystemExit(code)

--- a/examples/profiling/rocprof/torch-matmul/recipe.yaml
+++ b/examples/profiling/rocprof/torch-matmul/recipe.yaml
@@ -1,0 +1,39 @@
+# rocprof capture of library GEMM kernels dispatched by PyTorch.
+#
+# Unlike hip-gemm, this payload needs a PyTorch-for-ROCm interpreter, so the
+# usual way to run it is to install aorta inside a ROCm PyTorch container and
+# run the whole sweep there -- see README.md. Wrapping `docker run` from the
+# host would profile the docker client, not the GPU work.
+#
+#   aorta sweep run \
+#       --recipe examples/profiling/rocprof/torch-matmul/recipe.yaml \
+#       --output ./profiling_results \
+#       -- python examples/profiling/rocprof/torch-matmul/matmul.py \
+#            --size 2048 --iters 20 --dtype float16
+schema_version: 1
+mode: probe
+
+ticket: PROFILING-TORCH-MATMUL
+
+trials: 1
+# PyTorch import plus hipBLASLt autotuning on a cold cache is slow; the
+# default 1800s probe timeout is kept rather than tightened.
+timeout_per_trial: 1800
+
+mitigation_axis: [none]
+diagnostic_axis: [none]
+
+env_passthrough_mode: inherit
+
+# `hip` is added to the trace so HIP API calls appear alongside dispatches --
+# useful for telling launch overhead apart from kernel time in a framework
+# stack. `kernel_include_regex` narrows the summary to the GEMM kernels
+# (hipBLASLt Tensile kernels are named `Cijk_*`) so memory-fill and
+# elementwise noise stays out of the top-kernel metric.
+collect:
+  rocprof:
+    trace: "kernel,hip"
+    output_format: "csv"
+    stats: "1"
+    kernel_include_regex: "Cijk|gemm|matmul"
+    summary_units: "msec"

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -174,7 +174,12 @@ not how it is merged. For distributed details, see
   write to them directly.
 - **`collect`** -- optional `list[str]` or mapping, default absent (no
   collectors). Names one or more cross-cutting collectors to attach to every
-  cell (e.g. `[layer_numerics]` for the per-layer NaN/magnitude logger).
+  cell: `[rocprof]` or `[proton]` to attach a GPU profiler
+  ([`docs/profiling-collectors.md`](../docs/profiling-collectors.md)),
+  `[layer_numerics]` for the per-layer NaN/magnitude logger. Valid in
+  `mode: probe` recipes as well as triage recipes -- the profiling collectors
+  attach by wrapping the launch argv, so they are meaningful for an opaque
+  `-- <command>` run.
   List form enables collectors with default options; mapping form passes
   per-collector options:
 
@@ -200,7 +205,14 @@ not how it is merged. For distributed details, see
   applies to every cell, clearing any per-cell collector overrides.
 
   Unknown collector names are rejected at load time (validated against
-  `aorta.run.collectors.KNOWN_RECIPES`).
+  `aorta.run.collectors.KNOWN_RECIPES`), as are per-collector options outside
+  their declared schema and collector combinations that cannot run together
+  (`rocprof` alongside a queue-intercepting `proton` backend).
+
+  `rocprof` and `proton` need **no workload opt-in** -- the platform launches
+  them itself in the subprocess seam and parses their artifacts into
+  `rocprof_*` / `proton_*` trial metrics. The caveat below is specific to
+  `layer_numerics`.
 
   For `layer_numerics` (the per-layer NaN/magnitude logger), see
   [`docs/layer-numerics.md`](../docs/layer-numerics.md) for worked Stage 1 /

--- a/src/aorta/cli/probe.py
+++ b/src/aorta/cli/probe.py
@@ -414,6 +414,7 @@ def execute_probe(
     mitigation_files: tuple[Path, ...],
     argv: tuple[str, ...],
     command_label: str = "aorta probe",
+    collect: tuple[str, ...] = (),
 ) -> None:
     """Subprocess-flow body shared by ``aorta sweep run`` and ``aorta probe``.
 
@@ -427,6 +428,10 @@ def execute_probe(
     validating the trailing argv; ``aorta sweep run`` passes its own label
     so a leaked-flag error points at the invoked command, not the
     deprecated ``aorta probe`` alias.
+
+    ``collect`` carries already-split ``--collect`` names. Only
+    ``aorta sweep run`` exposes that flag today; ``aorta probe`` passes the
+    empty default, which leaves any recipe-level ``collect:`` block intact.
     """
     try:
         # ``--env-passthrough-mode`` defaults to None so the handler can
@@ -443,7 +448,7 @@ def execute_probe(
         r = apply_recipe_overrides(
             r, ticket=ticket, cli_passthrough_mode=cli_passthrough_mode,
             cli_stop_after_events=stop_after_events, cli_max_trials=max_trials,
-            cli_disable_detectors=disable_detectors,
+            cli_disable_detectors=disable_detectors, cli_collect=collect,
         )
     except (ProbeUsageError, RecipeSchemaError, RecipeCellError, RegistryError, LookupError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/aorta/cli/run.py
+++ b/src/aorta/cli/run.py
@@ -89,7 +89,14 @@ from aorta.run.dispatcher import RunRequest, run_trials
     help="Directory to write per-trial JSON.",
 )
 @click.option(
-    "--collect", default="", help="Comma-separated collector recipes (MVP: validated, no-op)."
+    "--collect",
+    default="",
+    help=(
+        "Comma-separated collector recipes. Validated and threaded into the "
+        "workload config; the argv-wrapping profilers (rocprof, proton) attach "
+        "on the subprocess flow ('aorta sweep run'), so on an in-process "
+        "workload a collector only produces output if the workload consumes it."
+    ),
 )
 @click.option(
     "--extra-env", default="", help="Comma-separated KEY=VAL pairs (applied after mitigations)."

--- a/src/aorta/cli/sweep.py
+++ b/src/aorta/cli/sweep.py
@@ -355,9 +355,10 @@ def sweep() -> None:
     default="",
     help=(
         "Comma-separated collector recipe names to attach to every cell "
-        "(e.g. 'layer_numerics' for the per-layer NaN logger). Cross-cutting "
-        "capture, not a matrix axis -- allowed together with --recipe, where "
-        "it overrides any recipe-pinned 'collect:'. Workload flow only."
+        "(e.g. 'rocprof' or 'proton' to profile, 'layer_numerics' for the "
+        "per-layer NaN logger). Cross-cutting capture, not a matrix axis -- "
+        "allowed together with --recipe, where it overrides any recipe-pinned "
+        "'collect:'. Valid on both the workload and the probe/subprocess flow."
     ),
 )
 @click.option(
@@ -499,12 +500,6 @@ def sweep_run(
 
     is_probe_flow = has_command or recipe_mode == "probe"
     if is_probe_flow:
-        if parse_csv(collect):
-            raise click.UsageError(
-                "--collect applies to the workload flow only; it has no effect "
-                "on a probe/subprocess run (a user command after '--' or a "
-                "'mode: probe' recipe)."
-            )
         if strict:
             raise click.UsageError(
                 "--strict applies to the workload flow only; a probe/subprocess "
@@ -529,6 +524,7 @@ def sweep_run(
             steps=steps,
             baseline_cell=baseline_cell,
             confound_threshold=confound_threshold,
+            collect=collect,
         )
     else:
         _dispatch_workload_flow(
@@ -573,8 +569,16 @@ def _dispatch_probe_flow(
     steps: int | None,
     baseline_cell: str | None,
     confound_threshold: float | None,
+    collect: str = "",
 ) -> None:
-    """Validate probe-flow-specific preconditions, then run the subprocess flow."""
+    """Validate probe-flow-specific preconditions, then run the subprocess flow.
+
+    ``--collect`` is honoured here as well as on the workload flow: a probe
+    collector attaches by wrapping the user command's argv (see
+    :func:`aorta.run.collectors.wrap_argv_for_collectors`), so profiling an
+    opaque ``-- <command>`` is exactly what it is for. The names REPLACE a
+    recipe-level ``collect:`` block, matching the workload flow's precedence.
+    """
     _reject_triage_only_flags_in_probe_flow(
         workload=workload,
         mitigation_axis=mitigation_axis,
@@ -601,6 +605,7 @@ def _dispatch_probe_flow(
         mitigation_files=mitigation_files,
         argv=argv,
         command_label="aorta sweep run",
+        collect=tuple(parse_csv(collect)),
     )
 
 

--- a/src/aorta/cli/triage.py
+++ b/src/aorta/cli/triage.py
@@ -295,12 +295,18 @@ def execute_triage_run(
             # overrides so the operator-requested collectors apply everywhere.
             cli_collect = parse_csv(collect)
             if cli_collect:
-                collect_names, _ = _parse_collect("--collect", list(cli_collect))
-                collect_options = {
-                    name: opts
-                    for name, opts in r.collect_options.items()
-                    if name in collect_names
-                }
+                # Hand the loader its mapping form, carrying the recipe options
+                # of the collectors that survived: validating the bare name
+                # list would check them against their defaults, which both
+                # misses a conflict the recipe's options create and invents one
+                # they resolve.
+                collect_names, collect_options = _parse_collect(
+                    "--collect",
+                    {
+                        name: dict(r.collect_options.get(name) or {}) or None
+                        for name in dict.fromkeys(cli_collect)
+                    },
+                )
                 r = dataclasses.replace(
                     r,
                     collect=collect_names,

--- a/src/aorta/instrumentation/README.md
+++ b/src/aorta/instrumentation/README.md
@@ -1,7 +1,8 @@
 # aorta.instrumentation
 
-Platform-level introspection for AORTA: the environment probe (issue #147) and the
-per-layer numerics logger. Future submodules (drift watcher, etc.) will live here too.
+Platform-level introspection for AORTA: the environment probe (issue #147), the
+per-layer numerics logger, and the two GPU profiling collectors. Future
+submodules (drift watcher, etc.) will live here too.
 
 ## What's here
 
@@ -9,6 +10,8 @@ per-layer numerics logger. Future submodules (drift watcher, etc.) will live her
 | --- | --- | --- |
 | [`environment`](environment.py) | ROCm + ML stack version snapshot + container/python env detection. See block list below. | `collect_env(...) -> EnvSnapshot`, `capture_to(path, ...) -> EnvSnapshot` |
 | [`layer_numerics`](layer_numerics/README.md) | Per-layer / per-stage NaN, magnitude, and out-of-range logger. Runs standalone as a front-end around a training/repro script (the supported path); also a recognized `layer_numerics` sweep collector — the engine validates the name and threads it into workload config, but a workload must opt in for capture (see [`docs/layer-numerics.md`](../../../docs/layer-numerics.md)). Config via `NANLOG_SPEC` (structured, recommended) or the flat `NANLOG_*` vars. | `build_env(results_dir, overrides=None) -> dict`, `SCRIPT_PATH`, `OUTPUT_SUBDIR` |
+| [`rocprof`](rocprof/__init__.py) | `rocprofv3` kernel/API tracing as the `rocprof` sweep collector. Unlike `layer_numerics` it needs no workload opt-in: it attaches by wrapping the launch argv in the generic subprocess seam, so `aorta sweep run --collect rocprof -- <any command>` profiles an opaque command. Options validated at recipe load; artifacts parsed fail-soft into `rocprof_*` trial metrics. See [`docs/profiling-collectors.md`](../../../docs/profiling-collectors.md). | `wrap_argv(argv, out_dir, options, *, env=None) -> list[str]`, `build_argv_prefix(...)`, `parse_summary(out_dir) -> dict`, `validate_options(...)`, `resolve_binary()`, `OUTPUT_SUBDIR` |
+| [`proton`](proton/__init__.py) | Triton Proton profiler as the `proton` sweep collector, attributing GPU time to the launching Python frame. Same argv seam, but Proton's front-end `exec`s a script, so `mode: cli` attaches to Python launches only and `mode: env` exports `AORTA_PROTON_*` for a workload that drives Proton itself. Translates `HIP_VISIBLE_DEVICES` to `ROCR_VISIBLE_DEVICES` on AMD. See [`docs/profiling-collectors.md`](../../../docs/profiling-collectors.md). | `wrap_argv(argv, out_dir, options, *, env=None) -> list[str]`, `build_argv_prefix(...)`, `build_env(out_dir, options) -> dict`, `parse_summary(out_dir) -> dict`, `validate_options(...)`, `OUTPUT_SUBDIR` |
 | [`rocjitsu_sanitizers`](rocjitsu_sanitizers/README.md) | Experimental typed kernel worklists, deterministic top-N selection, exact-entry static Waitcheck, fail-closed Record/Replay parsing, versioned sanitizer reports, and `mode: sanitizer` recipe execution via `aorta sweep run`. Provisioning and scoped/top-K ConSan remain explicit follow-ups; ConSan never falls back to whole-application instrumentation. | `select_kernels(...)`, `run_waitcheck(...)`, `run_sanitizers(...)`, `execute_sanitizer_run(...)`, `SanitizerReport` |
 | [`build_system`](build_system.py) | Detects Buck2 build environments (issue #163, A1.2a). Wrapped by `collect_env()` and surfaced as the `build_system` field of `EnvSnapshot`. | `detect_build_system() -> dict` |
 | [`buck_invocation`](buck_invocation.py) | Frozen, ordered Buck invocation context: mode/flag files, `-c` overrides, `-m` modifiers, or explicit default confirmation. Builds atomic argv and a redacted comparison fingerprint; no shell/passthrough string. | `BuckInvocationContext` |

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -293,21 +293,33 @@ def _device_env_prefix(
 ) -> list[str]:
     """Build an ``env(1)`` prefix carrying device translation + extra vars.
 
-    Proton on AMD raises outright when ``HIP_VISIBLE_DEVICES`` is set for a
+    Proton on AMD raises outright when ``HIP_VISIBLE_DEVICES`` is *set* for a
     queue-intercepting backend, so the variable is unset and its value moved to
-    ``ROCR_VISIBLE_DEVICES`` (unless the trial already set one). Returns ``[]``
-    when there is nothing to carry, keeping the common argv unchanged.
+    ``ROCR_VISIBLE_DEVICES`` (unless the trial already set one). Presence, not
+    truthiness, drives both halves: Proton rejects the variable on presence
+    alone, and an explicitly empty device list conventionally means "hide every
+    device", which is a selection to preserve rather than an absent one to
+    ignore. Returns ``[]`` when there is nothing to carry, keeping the common
+    argv unchanged.
+
+    Raises:
+        ProtonWrapError: there is something to carry but no ``env(1)`` to carry
+            it with. Argv rewriting is the only environment channel the
+            collector seam has, so an empty prefix here would run the command
+            with none of ``assignments`` -- silently unprofiled in ``mode:
+            env``, and on the wrong device (or crashing inside Proton) when a
+            device translation was requested.
     """
     assignments = dict(extra or {})
     unset: list[str] = []
     hip = env.get("HIP_VISIBLE_DEVICES")
-    if hip and backend in QUEUE_INTERCEPTING_BACKENDS:
+    if hip is not None and backend in QUEUE_INTERCEPTING_BACKENDS:
         unset.append("HIP_VISIBLE_DEVICES")
         rocr = env.get("ROCR_VISIBLE_DEVICES")
-        assignments.setdefault("ROCR_VISIBLE_DEVICES", rocr or hip)
+        assignments.setdefault("ROCR_VISIBLE_DEVICES", hip if rocr is None else rocr)
         log.warning(
-            "proton: HIP_VISIBLE_DEVICES=%s is not honoured by Proton's %s "
-            "backend; running with ROCR_VISIBLE_DEVICES=%s instead.",
+            "proton: HIP_VISIBLE_DEVICES=%r is not honoured by Proton's %s "
+            "backend; running with ROCR_VISIBLE_DEVICES=%r instead.",
             hip,
             backend,
             assignments["ROCR_VISIBLE_DEVICES"],
@@ -316,12 +328,14 @@ def _device_env_prefix(
         return []
     env_bin = shutil.which("env")
     if env_bin is None:
-        log.warning(
-            "proton: 'env' not found on $PATH; cannot apply %s. The profile "
-            "may target the wrong device or be missing.",
-            sorted({*assignments, *unset}),
+        raise ProtonWrapError(
+            "proton needs 'env' on $PATH to apply "
+            f"{sorted({*assignments, *unset})}, and it was not found. Argv "
+            "rewriting is the only channel the collector seam has for these "
+            "variables, so continuing would run the command unprofiled or on "
+            "the wrong device. Install coreutils, or drop 'proton' from the "
+            "collect request."
         )
-        return []
     prefix = [env_bin]
     for name in unset:
         prefix += ["-u", name]
@@ -356,7 +370,8 @@ def wrap_argv(
     Raises:
         ValueError: an option key or value is invalid.
         ProtonWrapError: ``mode: cli`` was requested for a command Proton's
-            front-end cannot execute.
+            front-end cannot execute, or the wrap needs ``env(1)`` to carry
+            variables into the command and it is not on ``$PATH``.
     """
     effective = validate_options(options)
     inner = list(argv)

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -89,6 +89,11 @@ ENV_PREFIX: str = "AORTA_PROTON_"
 #: ``cuda``, so operators pin them with that name.
 _REJECTED_DEVICE_VARS: tuple[str, ...] = ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
 
+#: Backends that establish an AMD host on their own. ``auto`` deliberately is
+#: not one: it resolves to CUPTI on NVIDIA, where ``CUDA_VISIBLE_DEVICES`` is a
+#: real device pin that must be left alone.
+_AMD_BACKENDS: frozenset[str] = frozenset({"rocprofiler", "roctracer"})
+
 _PYTHON_RE = re.compile(r"^python(\d+(\.\d+)?)?$")
 # Interpreter flags that take no argument and can safely stay in front of
 # ``-m triton.profiler.proton``. Anything else means we cannot confidently
@@ -380,7 +385,18 @@ def _device_env_prefix(
         # ROCm's PyTorch reports its devices as ``cuda`` and operators pin them
         # accordingly. Ordered by precedence: HIP wins when both are present,
         # matching the ROCm runtime's own preference.
-        present = [(name, env[name]) for name in _REJECTED_DEVICE_VARS if env.get(name) is not None]
+        # ``HIP_VISIBLE_DEVICES`` is itself an AMD signal, so it is always safe
+        # to translate. ``CUDA_VISIBLE_DEVICES`` is NOT: ``backend: auto``
+        # resolves to CUPTI on an NVIDIA host, where that variable is a normal,
+        # honoured device pin -- rewriting it to ROCR would silently drop the
+        # restriction and profile the wrong GPU. So the CUDA spelling is only
+        # translated once AMD is established, either by an explicitly AMD
+        # backend or by HIP_VISIBLE_DEVICES being set alongside it.
+        candidates = list(_REJECTED_DEVICE_VARS)
+        amd_established = backend in _AMD_BACKENDS or env.get("HIP_VISIBLE_DEVICES") is not None
+        if not amd_established:
+            candidates = [name for name in candidates if name != "CUDA_VISIBLE_DEVICES"]
+        present = [(name, env[name]) for name in candidates if env.get(name) is not None]
         if present:
             unset.extend(name for name, _ in present)
             rocr = env.get("ROCR_VISIBLE_DEVICES")

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -104,18 +104,73 @@ def _is_python(arg: str) -> bool:
     return bool(_PYTHON_RE.match(Path(arg).name))
 
 
+def _shebang_interpreter(command: str) -> str | None:
+    """Return the Python interpreter a console script's ``#!`` line names.
+
+    A ``pytest`` on ``$PATH`` is a generated console script shebanged to the
+    interpreter that installed it, which in probe mode is frequently *not*
+    the one aorta is running under. Reading it back is what keeps the wrap on
+    the environment the operator's command would have used.
+
+    Returns ``None`` when the target cannot be resolved or read, is not a
+    script, or names a non-Python interpreter -- all cases the caller handles
+    by falling back rather than guessing.
+    """
+    resolved = shutil.which(command)
+    if resolved is None:
+        return None
+    try:
+        with open(resolved, "rb") as stream:
+            first_line = stream.readline(256)
+    except OSError:
+        return None
+    if not first_line.startswith(b"#!"):
+        return None
+    try:
+        parts = first_line[2:].decode("utf-8").split()
+    except UnicodeDecodeError:
+        return None
+    if not parts:
+        return None
+    # ``#!/usr/bin/env python3`` names the interpreter in the argument.
+    if Path(parts[0]).name == "env" and len(parts) > 1:
+        parts = parts[1:]
+    return parts[0] if _is_python(parts[0]) else None
+
+
 def resolve_python(argv: list[str] | tuple[str, ...]) -> str:
     """Pick the interpreter that runs Proton's command front-end.
 
     Precedence: ``$AORTA_PROTON_PYTHON`` (an operator override for the case
     where Triton lives elsewhere), then the workload's own ``argv[0]`` when it
-    is a Python interpreter, then :data:`sys.executable`.
+    is a Python interpreter, then -- for the bare ``pytest`` spelling, whose
+    ``argv[0]`` is a console script rather than an interpreter -- the
+    interpreter named by that script's shebang, and finally
+    :data:`sys.executable`.
+
+    The shebang step matters because the wrap replaces the command's own
+    interpreter with this one. Falling straight through to
+    :data:`sys.executable` for ``/some/venv/bin/pytest`` would profile a
+    different environment than the one the operator asked to run, which can
+    import a different dependency set or fail outright on a command that works
+    unprofiled.
     """
     override = os.environ.get(ENV_PROTON_PYTHON)
     if override:
         return os.path.expandvars(os.path.expanduser(override))
     if argv and _is_python(argv[0]):
         return argv[0]
+    if argv and Path(argv[0]).name in _WRAPPABLE_MODULES:
+        interpreter = _shebang_interpreter(argv[0])
+        if interpreter is not None:
+            return interpreter
+        log.warning(
+            "proton: could not read an interpreter from %r; running Proton "
+            "under %s instead. Set $%s if that is the wrong environment.",
+            argv[0],
+            sys.executable,
+            ENV_PROTON_PYTHON,
+        )
     return sys.executable
 
 

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -94,6 +94,12 @@ _REJECTED_DEVICE_VARS: tuple[str, ...] = ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_D
 #: real device pin that must be left alone.
 _AMD_BACKENDS: frozenset[str] = frozenset({"rocprofiler", "roctracer"})
 
+#: ROCm-only environment variables whose presence establishes an AMD host, so
+#: the ambiguous ``CUDA_VISIBLE_DEVICES`` can be translated under
+#: ``backend: auto`` too. ``ROCR_VISIBLE_DEVICES`` is the variable Proton reads
+#: on AMD; ``HIP_VISIBLE_DEVICES`` is the one it refuses.
+_AMD_ENV_SIGNALS: tuple[str, ...] = ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES")
+
 _PYTHON_RE = re.compile(r"^python(\d+(\.\d+)?)?$")
 # Interpreter flags that take no argument and can safely stay in front of
 # ``-m triton.profiler.proton``. Anything else means we cannot confidently
@@ -390,10 +396,16 @@ def _device_env_prefix(
         # resolves to CUPTI on an NVIDIA host, where that variable is a normal,
         # honoured device pin -- rewriting it to ROCR would silently drop the
         # restriction and profile the wrong GPU. So the CUDA spelling is only
-        # translated once AMD is established, either by an explicitly AMD
-        # backend or by HIP_VISIBLE_DEVICES being set alongside it.
+        # translated once AMD is established -- by an explicitly AMD backend,
+        # or by any ROCm-only variable in ``_AMD_ENV_SIGNALS`` being present.
+        # ``ROCR_VISIBLE_DEVICES`` counts among those: it is the variable Proton
+        # *reads* on AMD, so a trial that sets it is already on that path, and
+        # leaving CUDA_VISIBLE_DEVICES beside it just hands Proton a variable it
+        # refuses before profiling starts.
         candidates = list(_REJECTED_DEVICE_VARS)
-        amd_established = backend in _AMD_BACKENDS or env.get("HIP_VISIBLE_DEVICES") is not None
+        amd_established = backend in _AMD_BACKENDS or any(
+            env.get(name) is not None for name in _AMD_ENV_SIGNALS
+        )
         if not amd_established:
             candidates = [name for name in candidates if name != "CUDA_VISIBLE_DEVICES"]
         present = [(name, env[name]) for name in candidates if env.get(name) is not None]

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -14,8 +14,10 @@ Two attach modes, both driven from the same recipe options:
   ``AORTA_PROTON_*`` variables, for a workload that calls ``proton.start()`` /
   ``proton.finalize()`` itself to get scoped or intra-kernel measurement.
 
-Because Proton's CLI front-end ``exec``s a *script* (it is not a generic
-command runner), the CLI wrap only applies to Python launches; anything else
+Because Proton's CLI front-end runs a *script* (it is not a generic command
+runner), the CLI wrap only applies to Python launches: a script path, a bare
+``pytest ...``, or ``<python> -m pytest ...``, which is normalised onto the
+bare spelling since Proton runs both as ``pytest.main(args)``. Anything else
 raises :class:`ProtonWrapError` with the ``mode: env`` escape hatch named,
 rather than silently running unprofiled.
 
@@ -85,6 +87,13 @@ _PYTHON_RE = re.compile(r"^python(\d+(\.\d+)?)?$")
 # ``-m triton.profiler.proton``. Anything else means we cannot confidently
 # locate the script, so the wrap refuses instead of guessing.
 _SAFE_PYTHON_FLAGS = frozenset({"-u", "-B", "-E", "-s", "-S", "-O", "-OO", "-I", "-b", "-q"})
+# ``python -m <module>`` launches the wrap can forward. Proton's front-end
+# runs its target through ``runpy.run_path``, which resolves a *path* and not
+# a module name -- with exactly one exception: a target whose basename is
+# ``pytest`` is run in-process as ``pytest.main(args)``, which is precisely
+# what ``python -m pytest args`` does. So that spelling has an exact
+# equivalent and is translated to it; other modules have none.
+_WRAPPABLE_MODULES = frozenset({"pytest"})
 
 
 class ProtonWrapError(RuntimeError):
@@ -198,16 +207,47 @@ def build_env(
     return env
 
 
+def _module_target(module: str, module_args: list[str], argv: list[str]) -> list[str]:
+    """Translate a ``python -m <module>`` launch into Proton's target argv.
+
+    Only :data:`_WRAPPABLE_MODULES` can be forwarded, and they are forwarded
+    as the bare spelling Proton special-cases -- ``-m pytest`` becomes the
+    ``pytest`` target, which Proton runs as ``pytest.main(args)``, the same
+    call ``python -m pytest`` makes. Refusing here rather than forwarding an
+    unrunnable module name keeps the failure at setup, where it names a fix,
+    instead of surfacing as a ``run_path`` error from inside Proton.
+
+    Raises:
+        ProtonWrapError: ``-m`` carried no module, or one Proton cannot run.
+    """
+    if not module:
+        raise ProtonWrapError(f"proton mode 'cli' saw '-m' with no module name in {argv!r}.")
+    if module not in _WRAPPABLE_MODULES:
+        raise ProtonWrapError(
+            f"proton mode 'cli' cannot wrap 'python -m {module}'. Proton's "
+            "front-end runs its target through runpy.run_path, which resolves "
+            "a script path and not a module name; the only module it also "
+            f"accepts is {sorted(_WRAPPABLE_MODULES)}. Invoke the module's "
+            "script by path, or use 'proton: {mode: env}'."
+        )
+    return [module, *module_args]
+
+
 def _split_python_launch(argv: list[str]) -> tuple[list[str], list[str]]:
     """Split ``python -u script.py a b`` into interpreter flags and the target.
 
+    Accepts the three launch spellings Proton's front-end can take over: a
+    bare ``pytest ...``, a ``<python> <script.py> ...`` script launch, and a
+    ``<python> -m pytest ...`` module launch (see :func:`_module_target`,
+    which normalises the last onto the first).
+
     Raises:
-        ProtonWrapError: the command is not a Python script launch Proton's
-            front-end can take over.
+        ProtonWrapError: the command is not a launch Proton's front-end can
+            take over.
     """
     if not argv:
         raise ProtonWrapError("cannot wrap an empty argv with proton")
-    if Path(argv[0]).name == "pytest":
+    if Path(argv[0]).name in _WRAPPABLE_MODULES:
         return [], list(argv)
     if not _is_python(argv[0]):
         raise ProtonWrapError(
@@ -223,11 +263,22 @@ def _split_python_launch(argv: list[str]) -> tuple[list[str], list[str]]:
         if arg in _SAFE_PYTHON_FLAGS:
             flags.append(arg)
             continue
+        # ``-m`` before the generic option guard: a module launch is a target,
+        # not an interpreter flag, and ``python -m pytest`` must not fail
+        # where the equivalent bare ``pytest`` succeeds. Both the separate
+        # (``-m pytest``) and attached (``-mpytest``) spellings are handled,
+        # for the same reason.
+        if arg == "-m":
+            module = rest[index + 1] if index + 1 < len(rest) else ""
+            return flags, _module_target(module, rest[index + 2 :], argv)
+        if arg.startswith("-m"):
+            return flags, _module_target(arg[2:], rest[index + 1 :], argv)
         if arg.startswith("-"):
             raise ProtonWrapError(
                 f"proton mode 'cli' cannot wrap interpreter option {arg!r} "
-                f"(supported: {sorted(_SAFE_PYTHON_FLAGS)}). Invoke the script "
-                "directly, or use 'proton: {mode: env}'."
+                f"(supported: {sorted(_SAFE_PYTHON_FLAGS)}, plus '-m' with "
+                f"{sorted(_WRAPPABLE_MODULES)}). Invoke the script directly, "
+                "or use 'proton: {mode: env}'."
             )
         return flags, rest[index:]
     raise ProtonWrapError(

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -1,0 +1,351 @@
+"""``proton`` collector: attach Triton's Proton profiler to a command.
+
+Two attach modes, both driven from the same recipe options:
+
+* **CLI wrap** (``mode: cli``, the default) rewrites a Python launch
+  ``<python> <script.py> <args>`` into
+  ``<python> -m triton.profiler.proton <opts> <script.py> <args>``. It is
+  deliberately ``-m triton.profiler.proton`` and never the ``proton`` console
+  script: that shim is shebanged to whichever interpreter installed Triton,
+  which on a typical aorta host is *not* the interpreter the workload runs
+  under. Reusing the workload's own interpreter is the only way the wrap works
+  for an opaque ``aorta probe -- ...`` command.
+* **Env hook** (``mode: env``) leaves the command's own argv alone and hands it
+  ``AORTA_PROTON_*`` variables, for a workload that calls ``proton.start()`` /
+  ``proton.finalize()`` itself to get scoped or intra-kernel measurement.
+
+Because Proton's CLI front-end ``exec``s a *script* (it is not a generic
+command runner), the CLI wrap only applies to Python launches; anything else
+raises :class:`ProtonWrapError` with the ``mode: env`` escape hatch named,
+rather than silently running unprofiled.
+
+On AMD, Proton reads ``ROCR_VISIBLE_DEVICES`` and **rejects**
+``HIP_VISIBLE_DEVICES`` outright for the queue-intercepting backends (verified:
+``ValueError: Proton does not work when the environment variable
+HIP_VISIBLE_DEVICES is set on AMD GPUs``). When a trial's env carries the
+latter it is translated (and the original unset) in the wrap, with a warning,
+so a device-pinned cell still profiles the device it asked for.
+
+The default backend is :data:`AUTO_BACKEND`, which omits Proton's ``-b``
+entirely. Proton then picks the backend matching the active runtime --
+``rocprofiler`` where rocprofiler-sdk is available, ``roctracer`` otherwise.
+Naming a backend explicitly is a version commitment: ``rocprofiler`` is the
+preferred AMD backend upstream but was added after Triton 3.7, whose CLI
+rejects the name at argparse before the payload ever runs.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+from ._options import (
+    AUTO_BACKEND,
+    BACKENDS,
+    CONTEXTS,
+    DATA_FORMATS,
+    GRANULARITIES,
+    INSTRUMENTATION_MODES,
+    MODES,
+    OPTION_KEYS,
+    QUEUE_INTERCEPTING_BACKENDS,
+    mode_argument,
+    validate_options,
+)
+from ._parse import parse_profile, parse_summary
+
+log = logging.getLogger(__name__)
+
+#: Subdirectory (under the trial's collector directory) Proton writes into.
+OUTPUT_SUBDIR: str = "proton"
+
+#: Proton session name (``-n``) stem inside the output directory; Proton
+#: appends the format suffix, so ``data: tree`` yields ``proton.hatchet``.
+PROFILE_BASENAME: str = "proton"
+
+#: Module Proton's command front-end lives in.
+PROTON_MODULE: str = "triton.profiler.proton"
+
+#: Env var overriding the interpreter used for the CLI wrap. Needed when the
+#: probed command is not itself a ``python ...`` invocation, or when Triton
+#: lives in a different interpreter than the one launching the workload.
+ENV_PROTON_PYTHON: str = "AORTA_PROTON_PYTHON"
+
+#: Prefix of the variables ``mode: env`` exports for a workload that drives
+#: Proton itself.
+ENV_PREFIX: str = "AORTA_PROTON_"
+
+_PYTHON_RE = re.compile(r"^python(\d+(\.\d+)?)?$")
+# Interpreter flags that take no argument and can safely stay in front of
+# ``-m triton.profiler.proton``. Anything else means we cannot confidently
+# locate the script, so the wrap refuses instead of guessing.
+_SAFE_PYTHON_FLAGS = frozenset({"-u", "-B", "-E", "-s", "-S", "-O", "-OO", "-I", "-b", "-q"})
+
+
+class ProtonWrapError(RuntimeError):
+    """Raised when the Proton CLI wrap cannot be built for the given argv."""
+
+
+def _is_python(arg: str) -> bool:
+    return bool(_PYTHON_RE.match(Path(arg).name))
+
+
+def resolve_python(argv: list[str] | tuple[str, ...]) -> str:
+    """Pick the interpreter that runs Proton's command front-end.
+
+    Precedence: ``$AORTA_PROTON_PYTHON`` (an operator override for the case
+    where Triton lives elsewhere), then the workload's own ``argv[0]`` when it
+    is a Python interpreter, then :data:`sys.executable`.
+    """
+    override = os.environ.get(ENV_PROTON_PYTHON)
+    if override:
+        return os.path.expandvars(os.path.expanduser(override))
+    if argv and _is_python(argv[0]):
+        return argv[0]
+    return sys.executable
+
+
+def build_argv_prefix(
+    out_dir: Path | str,
+    options: Mapping[str, str] | None = None,
+    *,
+    python: str | None = None,
+) -> list[str]:
+    """Return the ``<python> -m triton.profiler.proton <opts>`` prefix.
+
+    The prefix is followed directly by the script and its arguments -- Proton's
+    front-end collects them with ``argparse.REMAINDER``, so there is no ``--``
+    separator (unlike rocprofv3).
+
+    Args:
+        out_dir: Directory the profile is written into.
+        options: Recipe-supplied options; see :func:`validate_options`.
+        python: Interpreter to run Proton under. Defaults to
+            :data:`sys.executable`; callers with the workload's argv in hand
+            should pass :func:`resolve_python` instead.
+
+    Raises:
+        ValueError: an option key or value is invalid.
+    """
+    effective = validate_options(options)
+    out = Path(out_dir)
+    argv = [
+        python or sys.executable,
+        "-m",
+        PROTON_MODULE,
+        "-n",
+        str(out / PROFILE_BASENAME),
+    ]
+    # ``backend: auto`` means "omit ``-b``", which is what makes the default
+    # work on every Triton: Proton's own ``_select_backend()`` picks the
+    # backend matching the active runtime, whereas naming one that this
+    # Triton's argparse does not list kills the run before the payload starts.
+    if effective["backend"] != AUTO_BACKEND:
+        argv += ["-b", effective["backend"]]
+    argv += [
+        "--context",
+        effective["context"],
+        "--data",
+        effective["data"],
+    ]
+    mode = mode_argument(effective)
+    if mode is not None:
+        argv += ["--mode", mode]
+    return argv
+
+
+def build_env(
+    out_dir: Path | str,
+    options: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return the ``AORTA_PROTON_*`` bundle for ``mode: env``.
+
+    The variables mirror the CLI wrap's flags one-for-one so a workload that
+    drives Proton itself can forward them straight into ``proton.start()``.
+    ``AORTA_PROTON_NAME`` is the session name (path stem) to pass to
+    ``proton.start(name)``; ``AORTA_PROTON_DIR`` is the directory it lives in,
+    for a workload that wants to write sibling artifacts.
+
+    Args:
+        out_dir: Directory the profile should be written into.
+        options: Recipe-supplied options; see :func:`validate_options`.
+
+    Returns:
+        A flat ``dict[str, str]`` the caller merges into the subprocess
+        environment. Never mutates :data:`os.environ`.
+    """
+    effective = validate_options(options)
+    out = Path(out_dir)
+    env = {
+        f"{ENV_PREFIX}DIR": str(out),
+        f"{ENV_PREFIX}NAME": str(out / PROFILE_BASENAME),
+        f"{ENV_PREFIX}CONTEXT": effective["context"],
+        f"{ENV_PREFIX}DATA": effective["data"],
+    }
+    # Omitted for ``backend: auto`` so the workload passes ``backend=None`` to
+    # ``proton.start()`` and gets Proton's own runtime-matched selection, the
+    # same thing dropping ``-b`` gets the CLI wrap.
+    if effective["backend"] != AUTO_BACKEND:
+        env[f"{ENV_PREFIX}BACKEND"] = effective["backend"]
+    mode = mode_argument(effective)
+    if mode is not None:
+        env[f"{ENV_PREFIX}MODE"] = mode
+    return env
+
+
+def _split_python_launch(argv: list[str]) -> tuple[list[str], list[str]]:
+    """Split ``python -u script.py a b`` into interpreter flags and the target.
+
+    Raises:
+        ProtonWrapError: the command is not a Python script launch Proton's
+            front-end can take over.
+    """
+    if not argv:
+        raise ProtonWrapError("cannot wrap an empty argv with proton")
+    if Path(argv[0]).name == "pytest":
+        return [], list(argv)
+    if not _is_python(argv[0]):
+        raise ProtonWrapError(
+            f"proton mode 'cli' needs a Python script launch, got {argv[0]!r}. "
+            "Proton's command front-end executes a script, not an arbitrary "
+            "command. Either invoke the workload as '<python> <script.py> "
+            "...', or switch the recipe to 'proton: {mode: env}' and have the "
+            "workload call proton.start()/finalize() itself."
+        )
+    rest = argv[1:]
+    flags: list[str] = []
+    for index, arg in enumerate(rest):
+        if arg in _SAFE_PYTHON_FLAGS:
+            flags.append(arg)
+            continue
+        if arg.startswith("-"):
+            raise ProtonWrapError(
+                f"proton mode 'cli' cannot wrap interpreter option {arg!r} "
+                f"(supported: {sorted(_SAFE_PYTHON_FLAGS)}). Invoke the script "
+                "directly, or use 'proton: {mode: env}'."
+            )
+        return flags, rest[index:]
+    raise ProtonWrapError(
+        "proton mode 'cli' needs a script path after the interpreter; got " f"{argv!r}"
+    )
+
+
+def _device_env_prefix(
+    backend: str,
+    env: Mapping[str, str],
+    extra: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Build an ``env(1)`` prefix carrying device translation + extra vars.
+
+    Proton on AMD raises outright when ``HIP_VISIBLE_DEVICES`` is set for a
+    queue-intercepting backend, so the variable is unset and its value moved to
+    ``ROCR_VISIBLE_DEVICES`` (unless the trial already set one). Returns ``[]``
+    when there is nothing to carry, keeping the common argv unchanged.
+    """
+    assignments = dict(extra or {})
+    unset: list[str] = []
+    hip = env.get("HIP_VISIBLE_DEVICES")
+    if hip and backend in QUEUE_INTERCEPTING_BACKENDS:
+        unset.append("HIP_VISIBLE_DEVICES")
+        rocr = env.get("ROCR_VISIBLE_DEVICES")
+        assignments.setdefault("ROCR_VISIBLE_DEVICES", rocr or hip)
+        log.warning(
+            "proton: HIP_VISIBLE_DEVICES=%s is not honoured by Proton's %s "
+            "backend; running with ROCR_VISIBLE_DEVICES=%s instead.",
+            hip,
+            backend,
+            assignments["ROCR_VISIBLE_DEVICES"],
+        )
+    if not assignments and not unset:
+        return []
+    env_bin = shutil.which("env")
+    if env_bin is None:
+        log.warning(
+            "proton: 'env' not found on $PATH; cannot apply %s. The profile "
+            "may target the wrong device or be missing.",
+            sorted({*assignments, *unset}),
+        )
+        return []
+    prefix = [env_bin]
+    for name in unset:
+        prefix += ["-u", name]
+    prefix += [f"{key}={value}" for key, value in sorted(assignments.items())]
+    return prefix
+
+
+def wrap_argv(
+    argv: list[str] | tuple[str, ...],
+    out_dir: Path | str,
+    options: Mapping[str, str] | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return ``argv`` running under Proton, writing the profile to ``out_dir``.
+
+    Args:
+        argv: The command the trial would otherwise have run.
+        out_dir: Directory the profile is written into.
+        options: Recipe-supplied options; see :func:`validate_options`.
+        env: The environment the command will run with, read (never mutated)
+            for the ``HIP_VISIBLE_DEVICES`` translation. Defaults to
+            :data:`os.environ`.
+
+    Returns:
+        In ``mode: cli``, the Proton-wrapped launch. In ``mode: env``, the
+        original argv fronted by an ``env(1)`` prefix carrying the
+        ``AORTA_PROTON_*`` bundle -- the generic collector seam only gets to
+        rewrite argv, so that is how the variables reach a command aorta does
+        not otherwise own.
+
+    Raises:
+        ValueError: an option key or value is invalid.
+        ProtonWrapError: ``mode: cli`` was requested for a command Proton's
+            front-end cannot execute.
+    """
+    effective = validate_options(options)
+    inner = list(argv)
+    environ = env if env is not None else os.environ
+    if effective["mode"] == "env":
+        prefix = _device_env_prefix(effective["backend"], environ, build_env(out_dir, options))
+        return [*prefix, *inner]
+
+    flags, target = _split_python_launch(inner)
+    python = resolve_python(inner)
+    proton_argv = build_argv_prefix(out_dir, options, python=python)
+    # Interpreter flags belong to the interpreter, so they must stay in front
+    # of ``-m``, not be handed to Proton's own parser.
+    proton_argv[1:1] = flags
+    prefix = _device_env_prefix(effective["backend"], environ)
+    return [*prefix, *proton_argv, *target]
+
+
+__all__ = [
+    "AUTO_BACKEND",
+    "BACKENDS",
+    "CONTEXTS",
+    "DATA_FORMATS",
+    "ENV_PREFIX",
+    "ENV_PROTON_PYTHON",
+    "GRANULARITIES",
+    "INSTRUMENTATION_MODES",
+    "MODES",
+    "OPTION_KEYS",
+    "OUTPUT_SUBDIR",
+    "PROFILE_BASENAME",
+    "PROTON_MODULE",
+    "QUEUE_INTERCEPTING_BACKENDS",
+    "ProtonWrapError",
+    "build_argv_prefix",
+    "build_env",
+    "mode_argument",
+    "parse_profile",
+    "parse_summary",
+    "resolve_python",
+    "validate_options",
+    "wrap_argv",
+]

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -82,6 +82,13 @@ ENV_PROTON_PYTHON: str = "AORTA_PROTON_PYTHON"
 #: Proton itself.
 ENV_PREFIX: str = "AORTA_PROTON_"
 
+#: Device-selection variables Proton does not honour on AMD, in precedence
+#: order. Both spellings are rejected by Proton for the queue-intercepting
+#: backends -- ``ROCR_VISIBLE_DEVICES`` is the one it reads -- and the CUDA
+#: spelling matters in practice because ROCm's PyTorch presents its devices as
+#: ``cuda``, so operators pin them with that name.
+_REJECTED_DEVICE_VARS: tuple[str, ...] = ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
+
 _PYTHON_RE = re.compile(r"^python(\d+(\.\d+)?)?$")
 # Interpreter flags that take no argument and can safely stay in front of
 # ``-m triton.profiler.proton``. Anything else means we cannot confidently
@@ -367,18 +374,24 @@ def _device_env_prefix(
     """
     assignments = dict(extra or {})
     unset: list[str] = []
-    hip = env.get("HIP_VISIBLE_DEVICES")
-    if hip is not None and backend in QUEUE_INTERCEPTING_BACKENDS:
-        unset.append("HIP_VISIBLE_DEVICES")
-        rocr = env.get("ROCR_VISIBLE_DEVICES")
-        assignments.setdefault("ROCR_VISIBLE_DEVICES", hip if rocr is None else rocr)
-        log.warning(
-            "proton: HIP_VISIBLE_DEVICES=%r is not honoured by Proton's %s "
-            "backend; running with ROCR_VISIBLE_DEVICES=%r instead.",
-            hip,
-            backend,
-            assignments["ROCR_VISIBLE_DEVICES"],
-        )
+    if backend in QUEUE_INTERCEPTING_BACKENDS:
+        # Proton rejects BOTH spellings on AMD, not just the HIP one. The CUDA
+        # spelling is the likelier of the two to be set in practice, because
+        # ROCm's PyTorch reports its devices as ``cuda`` and operators pin them
+        # accordingly. Ordered by precedence: HIP wins when both are present,
+        # matching the ROCm runtime's own preference.
+        present = [(name, env[name]) for name in _REJECTED_DEVICE_VARS if env.get(name) is not None]
+        if present:
+            unset.extend(name for name, _ in present)
+            rocr = env.get("ROCR_VISIBLE_DEVICES")
+            assignments.setdefault("ROCR_VISIBLE_DEVICES", present[0][1] if rocr is None else rocr)
+            log.warning(
+                "proton: %s not honoured by Proton's %s backend; running with "
+                "ROCR_VISIBLE_DEVICES=%r instead.",
+                ", ".join(f"{name}={value!r}" for name, value in present),
+                backend,
+                assignments["ROCR_VISIBLE_DEVICES"],
+            )
     if not assignments and not unset:
         return []
     env_bin = shutil.which("env")

--- a/src/aorta/instrumentation/proton/_options.py
+++ b/src/aorta/instrumentation/proton/_options.py
@@ -1,0 +1,166 @@
+"""Option schema for the ``proton`` collector.
+
+Mirrors :mod:`aorta.instrumentation.rocprof._options`: every knob a recipe may
+set under ``collect: {proton: {...}}`` is declared here and validated at
+recipe-load time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+#: Attach modes. ``cli`` wraps argv with Proton's own command front-end;
+#: ``env`` leaves the command alone and hands it ``AORTA_PROTON_*`` variables
+#: for a workload that calls ``proton.start()`` / ``proton.finalize()`` itself
+#: (scoped or intra-kernel measurement).
+MODES: frozenset[str] = frozenset({"cli", "env"})
+
+#: ``backend`` value meaning "let Proton pick". Not a Proton value: it is the
+#: absence of Proton's ``-b`` flag / a ``backend=None`` argument.
+AUTO_BACKEND: str = "auto"
+
+#: Proton profiling backends. ``auto`` is aorta's spelling for "omit Proton's
+#: ``-b`` and let it choose", which is the only value that is correct on every
+#: Triton: ``rocprofiler`` is the preferred AMD path but was added after
+#: Triton 3.7, whose CLI rejects the name at argparse before the payload runs;
+#: ``roctracer`` is the deprecated AMD predecessor Proton still falls back to;
+#: ``instrumentation`` is the intra-kernel path; ``cupti`` is the NVIDIA one,
+#: accepted so a recipe stays portable even though aorta's examples are AMD.
+BACKENDS: frozenset[str] = frozenset(
+    {"auto", "cupti", "rocprofiler", "roctracer", "instrumentation"}
+)
+
+#: Backends that install an HSA queue interceptor and therefore cannot share a
+#: process with ``rocprofv3``. Consumed by the collector registry's conflict
+#: guard, which is why it lives in the schema rather than in the guard.
+#: ``auto`` is included because on AMD it resolves to ``rocprofiler`` or
+#: ``roctracer`` -- both intercepting -- and the guard has to reject a pairing
+#: it cannot prove is safe.
+QUEUE_INTERCEPTING_BACKENDS: frozenset[str] = frozenset({"auto", "rocprofiler", "roctracer"})
+
+#: ``proton --context`` values.
+CONTEXTS: frozenset[str] = frozenset({"shadow", "python"})
+
+#: ``proton --data`` values. ``tree`` produces the ``.hatchet`` file the
+#: summary parser reads; ``trace`` produces a chrome trace instead.
+DATA_FORMATS: frozenset[str] = frozenset({"tree", "trace"})
+
+#: ``instrumentation_mode`` values (Proton's ``--mode`` name component).
+INSTRUMENTATION_MODES: frozenset[str] = frozenset({"default", "mma", "pcsampling"})
+
+#: ``granularity`` values (Proton's ``--mode`` ``granularity=`` knob).
+GRANULARITIES: frozenset[str] = frozenset(
+    {
+        "cta",
+        "warp",
+        "warp_2",
+        "warp_4",
+        "warp_8",
+        "warp_group",
+        "warp_group_2",
+        "warp_group_4",
+        "warp_group_8",
+    }
+)
+
+#: Recipe-visible option keys, in the order they appear in the docs table.
+OPTION_KEYS: tuple[str, ...] = (
+    "mode",
+    "backend",
+    "context",
+    "data",
+    "instrumentation_mode",
+    "granularity",
+)
+
+_DEFAULTS: dict[str, str] = {
+    "mode": "cli",
+    "backend": "auto",
+    "context": "shadow",
+    "data": "tree",
+}
+
+_ENUMS: dict[str, frozenset[str]] = {
+    "mode": MODES,
+    "backend": BACKENDS,
+    "context": CONTEXTS,
+    "data": DATA_FORMATS,
+    "instrumentation_mode": INSTRUMENTATION_MODES,
+    "granularity": GRANULARITIES,
+}
+
+
+def validate_options(options: Mapping[str, str] | None) -> dict[str, str]:
+    """Validate recipe-supplied ``proton`` options and apply defaults.
+
+    Args:
+        options: The raw ``collect: {proton: {...}}`` mapping, or ``None`` when
+            the collector was enabled with no options.
+
+    Returns:
+        The effective options: the caller's values merged over the defaults
+        (``mode=cli``, ``backend=auto``, ``context=shadow``, ``data=tree``),
+        normalised to lowercase.
+
+    Raises:
+        ValueError: an unknown key, a value outside its declared domain, or an
+            intra-kernel knob (``instrumentation_mode`` / ``granularity``) set
+            without ``backend: instrumentation`` -- Proton would ignore it, so
+            accepting it would silently produce a profile the operator did not
+            ask for.
+    """
+    raw = dict(options or {})
+    unknown = sorted(set(raw) - set(OPTION_KEYS))
+    if unknown:
+        raise ValueError(f"proton: unknown option(s) {unknown}; valid: {list(OPTION_KEYS)}")
+    for key, value in raw.items():
+        if not isinstance(value, str):
+            raise ValueError(f"proton option {key!r}: must be a string, got {type(value).__name__}")
+
+    effective = dict(_DEFAULTS)
+    effective.update({k: v.strip().lower() for k, v in raw.items()})
+
+    for key, allowed in _ENUMS.items():
+        value = effective.get(key)
+        if value is not None and value not in allowed:
+            raise ValueError(f"proton option {key!r}: {value!r} is not one of {sorted(allowed)}")
+
+    intra_kernel = [k for k in ("instrumentation_mode", "granularity") if k in effective]
+    if intra_kernel and effective["backend"] != "instrumentation":
+        raise ValueError(
+            f"proton option(s) {sorted(intra_kernel)} require "
+            "backend: instrumentation (they configure Proton's intra-kernel "
+            f"mode); got backend: {effective['backend']}"
+        )
+    return effective
+
+
+def mode_argument(options: Mapping[str, str]) -> str | None:
+    """Render the Proton ``--mode`` value from the intra-kernel knobs.
+
+    Returns ``None`` when no intra-kernel knob is set, so the CLI wrap omits
+    ``--mode`` entirely and Proton keeps its own default.
+    """
+    name = options.get("instrumentation_mode")
+    granularity = options.get("granularity")
+    if name is None and granularity is None:
+        return None
+    rendered = name or "default"
+    if granularity is not None:
+        rendered = f"{rendered}:granularity={granularity}"
+    return rendered
+
+
+__all__ = [
+    "AUTO_BACKEND",
+    "BACKENDS",
+    "CONTEXTS",
+    "DATA_FORMATS",
+    "GRANULARITIES",
+    "INSTRUMENTATION_MODES",
+    "MODES",
+    "OPTION_KEYS",
+    "QUEUE_INTERCEPTING_BACKENDS",
+    "mode_argument",
+    "validate_options",
+]

--- a/src/aorta/instrumentation/proton/_parse.py
+++ b/src/aorta/instrumentation/proton/_parse.py
@@ -151,9 +151,17 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
         return metrics
 
     ranked = sorted(by_name.items(), key=lambda item: item[1], reverse=True)
+    total_ms = sum(by_name.values())
+    top_ms = ranked[0][1]
+    # The per-leaf finiteness check in ``_time_ms`` does not survive addition:
+    # finite leaves still sum to infinity, across the tree or within one
+    # kernel name. Degrade to the artifact directory rather than writing an
+    # ``Infinity`` token into the trial JSON.
+    if not (math.isfinite(total_ms) and math.isfinite(top_ms)):
+        return metrics
     metrics["proton_kernel_count"] = sum(counts.values())
-    metrics["proton_gpu_time_ms"] = sum(by_name.values())
-    metrics["proton_top_kernel_ms"] = ranked[0][1]
+    metrics["proton_gpu_time_ms"] = total_ms
+    metrics["proton_top_kernel_ms"] = top_ms
     metrics["proton_top_kernels"] = [name for name, _ in ranked[:TOP_N]]
     return metrics
 

--- a/src/aorta/instrumentation/proton/_parse.py
+++ b/src/aorta/instrumentation/proton/_parse.py
@@ -1,0 +1,142 @@
+"""Fail-soft summary parsing of a Proton ``.hatchet`` profile.
+
+A ``.hatchet`` file is JSON: a list whose first element is a nested tree of
+frames (``{"frame": {"name": ...}, "metrics": {...}, "children": [...]}``) and
+whose remaining elements are device metadata. Leaf frames carry the exclusive
+per-kernel measurements, so the summary walks to the leaves and aggregates
+those.
+
+Like the rocprof parser this never raises: ``data: trace``, a crashed workload,
+or a Proton build that emitted nothing all degrade to fewer metrics.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+#: How many kernel names to carry in ``proton_top_kernels``.
+TOP_N = 5
+
+#: Multiplier from each supported ``time (<unit>)`` metric key to milliseconds.
+_TIME_UNIT_TO_MS: dict[str, float] = {
+    "ns": 1e-6,
+    "us": 1e-3,
+    "ms": 1.0,
+    "s": 1e3,
+}
+
+
+def _time_ms(metrics: dict[str, Any]) -> float | None:
+    """Return a node's exclusive GPU time in ms, or ``None`` if it has none.
+
+    Proton names the metric ``time (<unit>)``. ``cpu_time (...)`` and the
+    derived ``(inc)`` columns are deliberately not matched: the former is host
+    time and the latter would double-count parents.
+    """
+    for key, value in metrics.items():
+        head, _, tail = key.partition("(")
+        if head.strip().lower() != "time":
+            continue
+        unit = tail.rstrip(")").strip().lower()
+        factor = _TIME_UNIT_TO_MS.get(unit)
+        if factor is None:
+            continue
+        try:
+            return float(value) * factor
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _count(metrics: dict[str, Any]) -> int:
+    try:
+        return int(float(metrics.get("count", 1)))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _walk(node: Any, by_name: dict[str, float], counts: dict[str, int]) -> None:
+    """Accumulate leaf-frame time/count into ``by_name`` / ``counts``."""
+    if not isinstance(node, dict):
+        return
+    children = node.get("children")
+    children = children if isinstance(children, list) else []
+    for child in children:
+        _walk(child, by_name, counts)
+    if children:
+        return
+    frame = node.get("frame")
+    metrics = node.get("metrics")
+    if not isinstance(frame, dict) or not isinstance(metrics, dict):
+        return
+    name = str(frame.get("name") or "").strip()
+    elapsed_ms = _time_ms(metrics)
+    if not name or elapsed_ms is None:
+        return
+    by_name[name] = by_name.get(name, 0.0) + elapsed_ms
+    counts[name] = counts.get(name, 0) + _count(metrics)
+
+
+def parse_profile(path: Path | str) -> tuple[dict[str, float], dict[str, int]]:
+    """Aggregate one ``.hatchet`` file into per-kernel ms totals + call counts.
+
+    Returns ``({}, {})`` when the file is missing, unreadable, or not a Proton
+    tree profile.
+    """
+    by_name: dict[str, float] = {}
+    counts: dict[str, int] = {}
+    try:
+        with Path(path).open(encoding="utf-8") as stream:
+            database = json.load(stream)
+    except (OSError, ValueError, UnicodeDecodeError):
+        return by_name, counts
+    roots = database if isinstance(database, list) else [database]
+    for root in roots:
+        _walk(root, by_name, counts)
+    return by_name, counts
+
+
+def parse_summary(out_dir: Path | str) -> dict[str, Any]:
+    """Summarise a Proton output directory into trial metrics.
+
+    Args:
+        out_dir: The directory Proton's ``-n <out_dir>/<name>`` wrote into.
+
+    Returns:
+        ``{}`` when the directory does not exist. Otherwise
+        ``{"proton_artifact_dir": str}`` plus, when a tree profile with timing
+        was found, the flat numeric ``proton_kernel_count`` /
+        ``proton_gpu_time_ms`` / ``proton_top_kernel_ms`` and the non-numeric
+        ``proton_top_kernels`` name list.
+    """
+    root = Path(out_dir)
+    try:
+        if not root.is_dir():
+            return {}
+        profiles = sorted(root.rglob("*.hatchet"))
+    except OSError:
+        return {}
+
+    metrics: dict[str, Any] = {"proton_artifact_dir": str(root)}
+    by_name: dict[str, float] = {}
+    counts: dict[str, int] = {}
+    for profile in profiles:
+        file_by_name, file_counts = parse_profile(profile)
+        for name, elapsed_ms in file_by_name.items():
+            by_name[name] = by_name.get(name, 0.0) + elapsed_ms
+        for name, calls in file_counts.items():
+            counts[name] = counts.get(name, 0) + calls
+    if not by_name:
+        return metrics
+
+    ranked = sorted(by_name.items(), key=lambda item: item[1], reverse=True)
+    metrics["proton_kernel_count"] = sum(counts.values())
+    metrics["proton_gpu_time_ms"] = sum(by_name.values())
+    metrics["proton_top_kernel_ms"] = ranked[0][1]
+    metrics["proton_top_kernels"] = [name for name, _ in ranked[:TOP_N]]
+    return metrics
+
+
+__all__ = ["TOP_N", "parse_profile", "parse_summary"]

--- a/src/aorta/instrumentation/proton/_parse.py
+++ b/src/aorta/instrumentation/proton/_parse.py
@@ -13,6 +13,7 @@ or a Proton build that emitted nothing all degrade to fewer metrics.
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,11 @@ def _time_ms(metrics: dict[str, Any]) -> float | None:
     Proton names the metric ``time (<unit>)``. ``cpu_time (...)`` and the
     derived ``(inc)`` columns are deliberately not matched: the former is host
     time and the latter would double-count parents.
+
+    A value that is unreadable, non-finite, or negative is skipped and the
+    remaining metric keys are still inspected: ``NaN`` / infinity would
+    propagate into ``proton_gpu_time_ms`` and be written to the trial JSON as
+    a non-standard token, and no kernel runs for a negative time.
     """
     for key, value in metrics.items():
         head, _, tail = key.partition("(")
@@ -44,17 +50,30 @@ def _time_ms(metrics: dict[str, Any]) -> float | None:
         if factor is None:
             continue
         try:
-            return float(value) * factor
-        except (TypeError, ValueError):
+            elapsed_ms = float(value) * factor
+        except (TypeError, ValueError, OverflowError):
             continue
+        if not math.isfinite(elapsed_ms) or elapsed_ms < 0:
+            continue
+        return elapsed_ms
     return None
 
 
 def _count(metrics: dict[str, Any]) -> int:
+    """Return a leaf's dispatch count, defaulting to 1 when unreadable.
+
+    ``OverflowError`` is caught alongside the parse errors because it is what
+    a huge integer count raises on the conversion to float, and ``int()`` of
+    an infinity raises it too -- both would otherwise escape
+    :func:`parse_summary` and break its never-raises contract.
+    """
     try:
-        return int(float(metrics.get("count", 1)))
-    except (TypeError, ValueError):
+        parsed = float(metrics.get("count", 1))
+    except (TypeError, ValueError, OverflowError):
         return 1
+    if not math.isfinite(parsed) or parsed < 0:
+        return 1
+    return int(parsed)
 
 
 def _walk(node: Any, by_name: dict[str, float], counts: dict[str, int]) -> None:

--- a/src/aorta/instrumentation/proton/_parse.py
+++ b/src/aorta/instrumentation/proton/_parse.py
@@ -59,25 +59,38 @@ def _time_ms(metrics: dict[str, Any]) -> float | None:
     return None
 
 
-def _count(metrics: dict[str, Any]) -> int:
-    """Return a leaf's dispatch count, defaulting to 1 when unreadable.
+def _count(metrics: dict[str, Any]) -> int | None:
+    """Return a leaf's dispatch count, or ``None`` when it is not readable.
+
+    A Proton leaf aggregates every launch of that kernel -- the checked-in real
+    fixture carries ``count: 6`` -- so a missing, non-finite, negative or
+    otherwise malformed value gives no basis for assuming one dispatch.
+    Returning ``None`` lets :func:`parse_summary` drop
+    ``proton_kernel_count`` while still publishing the timings, rather than
+    fabricating a count that reads as measured.
 
     ``OverflowError`` is caught alongside the parse errors because it is what
     a huge integer count raises on the conversion to float, and ``int()`` of
     an infinity raises it too -- both would otherwise escape
     :func:`parse_summary` and break its never-raises contract.
     """
+    if "count" not in metrics:
+        return None
     try:
-        parsed = float(metrics.get("count", 1))
+        parsed = float(metrics["count"])
     except (TypeError, ValueError, OverflowError):
-        return 1
+        return None
     if not math.isfinite(parsed) or parsed < 0:
-        return 1
+        return None
     return int(parsed)
 
 
-def _walk(node: Any, by_name: dict[str, float], counts: dict[str, int]) -> None:
-    """Accumulate leaf-frame time/count into ``by_name`` / ``counts``."""
+def _walk(node: Any, by_name: dict[str, float], counts: dict[str, int | None]) -> None:
+    """Accumulate leaf-frame time/count into ``by_name`` / ``counts``.
+
+    A ``None`` in ``counts`` is sticky: once one leaf of a kernel had an
+    unreadable count, the total for that name can no longer be trusted.
+    """
     if not isinstance(node, dict):
         return
     children = node.get("children")
@@ -95,17 +108,20 @@ def _walk(node: Any, by_name: dict[str, float], counts: dict[str, int]) -> None:
     if not name or elapsed_ms is None:
         return
     by_name[name] = by_name.get(name, 0.0) + elapsed_ms
-    counts[name] = counts.get(name, 0) + _count(metrics)
+    leaf_count = _count(metrics)
+    previous = counts.get(name, 0)
+    counts[name] = None if leaf_count is None or previous is None else previous + leaf_count
 
 
-def parse_profile(path: Path | str) -> tuple[dict[str, float], dict[str, int]]:
+def parse_profile(path: Path | str) -> tuple[dict[str, float], dict[str, int | None]]:
     """Aggregate one ``.hatchet`` file into per-kernel ms totals + call counts.
 
     Returns ``({}, {})`` when the file is missing, unreadable, or not a Proton
-    tree profile.
+    tree profile. A ``None`` count means that kernel's launch total was not
+    readable, so it must not be summed into a published metric.
     """
     by_name: dict[str, float] = {}
-    counts: dict[str, int] = {}
+    counts: dict[str, int | None] = {}
     try:
         with Path(path).open(encoding="utf-8") as stream:
             database = json.load(stream)
@@ -128,7 +144,10 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
         ``{"proton_artifact_dir": str}`` plus, when a tree profile with timing
         was found, the flat numeric ``proton_kernel_count`` /
         ``proton_gpu_time_ms`` / ``proton_top_kernel_ms`` and the non-numeric
-        ``proton_top_kernels`` name list.
+        ``proton_top_kernels`` name list. ``proton_kernel_count`` is omitted --
+        while the timings are still reported -- when any leaf's launch count
+        was unreadable, since a leaf aggregates launches and there is no safe
+        substitute for the real number.
     """
     root = Path(out_dir)
     try:
@@ -140,13 +159,14 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
 
     metrics: dict[str, Any] = {"proton_artifact_dir": str(root)}
     by_name: dict[str, float] = {}
-    counts: dict[str, int] = {}
+    counts: dict[str, int | None] = {}
     for profile in profiles:
         file_by_name, file_counts = parse_profile(profile)
         for name, elapsed_ms in file_by_name.items():
             by_name[name] = by_name.get(name, 0.0) + elapsed_ms
         for name, calls in file_counts.items():
-            counts[name] = counts.get(name, 0) + calls
+            previous = counts.get(name, 0)
+            counts[name] = None if calls is None or previous is None else previous + calls
     if not by_name:
         return metrics
 
@@ -159,7 +179,11 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     # ``Infinity`` token into the trial JSON.
     if not (math.isfinite(total_ms) and math.isfinite(top_ms)):
         return metrics
-    metrics["proton_kernel_count"] = sum(counts.values())
+    # Omitted rather than fabricated when any leaf's launch count was
+    # unreadable; a Proton leaf aggregates launches, so there is no safe
+    # substitute. The timings above stand on their own.
+    if all(value is not None for value in counts.values()):
+        metrics["proton_kernel_count"] = sum(counts.values())  # type: ignore[arg-type]
     metrics["proton_gpu_time_ms"] = total_ms
     metrics["proton_top_kernel_ms"] = top_ms
     metrics["proton_top_kernels"] = [name for name, _ in ranked[:TOP_N]]

--- a/src/aorta/instrumentation/rocprof/__init__.py
+++ b/src/aorta/instrumentation/rocprof/__init__.py
@@ -1,0 +1,197 @@
+"""``rocprof`` collector: attach ``rocprofv3`` to an arbitrary command.
+
+The collector is an **argv prefix**, not a library hook: given the command a
+trial would have run anyway, it returns
+``rocprofv3 <flags> -- <command>``. That is what lets ``aorta probe -- <any
+command>`` be profiled without the workload knowing anything about it, and it
+mirrors the emulator seam in :mod:`aorta.emulation.mirage_launch`.
+
+Package shape follows :mod:`aorta.instrumentation.layer_numerics`: a small
+public surface (:data:`OUTPUT_SUBDIR`, :func:`resolve_binary`,
+:func:`build_argv_prefix`, :func:`parse_summary`, :func:`validate_options`),
+strict validation of recipe-supplied options, and fail-soft post-run parsing.
+
+Three operational notes that are properties of ``rocprofv3`` itself, not of
+this wiring:
+
+* It logs ``W<timestamp> ... simple_timer.cpp:55] [rocprofv3] ...`` lines to
+  **stderr** on every run, and the probe classifier's stderr detectors see
+  them. The run summary is therefore routed to
+  ``<out_dir>/`` :data:`SUMMARY_FILENAME` rather than stderr, but ``--collect
+  rocprof`` still perturbs stderr: it is a measurement mode, not a byte-exact
+  passthrough.
+* ``--summary-output-file`` takes a filename *stem* relative to ``-d``, not a
+  path. Handing it an absolute path makes rocprofv3 splice that path into the
+  middle of a filename and create stray directories under ``-d``, so the stem
+  is passed on its own and the resulting name reconstructed here.
+* When the profiled command performs no GPU work it writes no output files at
+  all, which :func:`parse_summary` treats as "nothing to report" rather than
+  an error.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+
+from ._options import OPTION_KEYS, OUTPUT_FORMATS, SUMMARY_UNITS, TRACE_FLAGS, validate_options
+from ._options import as_bool as _as_bool
+from ._options import split_tokens as _split_tokens
+from ._parse import parse_summary
+
+#: Subdirectory (under the trial's collector directory) rocprofv3 writes into.
+OUTPUT_SUBDIR: str = "rocprof"
+
+#: ``rocprofv3 -o`` basename. With ``-o`` set, rocprofv3 writes the artifacts
+#: flat in the ``-d`` directory as ``<basename>_kernel_stats.csv`` etc.; with
+#: ``-o`` omitted it nests them under ``<hostname>/<pid>_kernel_stats.csv``
+#: instead. The parser globs recursively so it reads either layout.
+OUTPUT_BASENAME: str = "aorta"
+
+#: Value passed to ``rocprofv3 --summary-output-file``. It is a *stem*, not a
+#: path: rocprofv3 resolves it under ``-d``, prefixes it with the ``-o``
+#: basename and appends ``.txt``, so an absolute path here would be spliced
+#: into the middle of a filename and create stray directories.
+SUMMARY_FILE_STEM: str = "rocprof_summary"
+
+#: The file ``rocprofv3 -S`` actually writes, so the summary does not land on
+#: the trial's stderr where the probe classifier would read it as workload
+#: output. Derived from :data:`SUMMARY_FILE_STEM` the same way rocprofv3
+#: derives it.
+SUMMARY_FILENAME: str = f"{OUTPUT_BASENAME}_{SUMMARY_FILE_STEM}.txt"
+
+#: Env var naming the rocprofv3 binary, peer of ``$MIRAGE_BIN``.
+ENV_ROCPROF_BIN: str = "ROCPROF_BIN"
+_DEFAULT_BIN = "rocprofv3"
+
+
+class RocprofUnavailableError(RuntimeError):
+    """Raised when rocprofv3 was requested but cannot be located."""
+
+
+def resolve_binary() -> str:
+    """Resolve the ``rocprofv3`` binary, honouring ``$ROCPROF_BIN``.
+
+    Returns:
+        An absolute path to the profiler binary.
+
+    Raises:
+        RocprofUnavailableError: neither ``$ROCPROF_BIN`` nor a ``rocprofv3``
+            on ``$PATH`` resolves. Requesting a collector that cannot run is a
+            clean setup failure, not a silent unprofiled run.
+    """
+    override = os.environ.get(ENV_ROCPROF_BIN)
+    if override:
+        override = os.path.expandvars(os.path.expanduser(override))
+        if os.path.dirname(override):
+            candidate = os.path.abspath(override)
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+            raise RocprofUnavailableError(
+                f"{ENV_ROCPROF_BIN}={override!r} looks like a path but does "
+                "not point to an executable file."
+            )
+        found = shutil.which(override)
+        if found:
+            return found
+        raise RocprofUnavailableError(f"{ENV_ROCPROF_BIN}={override!r} was not found on $PATH.")
+    found = shutil.which(_DEFAULT_BIN)
+    if found:
+        return found
+    raise RocprofUnavailableError(
+        "rocprofv3 not found: set $ROCPROF_BIN to the profiler binary, or put "
+        "'rocprofv3' on $PATH (it ships with ROCm). Required by "
+        "'--collect rocprof'."
+    )
+
+
+def build_argv_prefix(
+    out_dir: Path | str,
+    options: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return the ``rocprofv3 ... --`` prefix for one collected trial.
+
+    Args:
+        out_dir: Directory rocprofv3 writes artifacts into (``-d``). Created by
+            the caller; rocprofv3 also creates it, but pre-creating keeps the
+            trial tree shaped the same whether or not any GPU work happened.
+        options: Recipe-supplied options; see :func:`validate_options`.
+
+    Returns:
+        An argv prefix ending in ``"--"``, ready to be concatenated with the
+        command being profiled.
+
+    Raises:
+        ValueError: an option key or value is invalid.
+        RocprofUnavailableError: rocprofv3 is not installed.
+    """
+    effective = validate_options(options)
+    out = Path(out_dir)
+    argv: list[str] = [
+        resolve_binary(),
+        "-d",
+        str(out),
+        "-o",
+        OUTPUT_BASENAME,
+        "--output-format",
+        effective["output_format"],
+    ]
+    for token in _split_tokens(effective["trace"]):
+        argv.append(TRACE_FLAGS[token])
+    if _as_bool("stats", effective["stats"]):
+        argv.append("--stats")
+    # ``-S`` without ``--summary-output-file`` prints to stderr, where the
+    # probe classifier's stderr detectors would read it as workload output.
+    argv += ["-S", "--summary-output-file", SUMMARY_FILE_STEM]
+    if "summary_units" in effective:
+        argv += ["-u", effective["summary_units"]]
+    if "kernel_include_regex" in effective:
+        argv += ["--kernel-include-regex", effective["kernel_include_regex"]]
+    # ``--pmc`` is variadic, so it must be the last flag before the ``--``
+    # separator or it would swallow whatever followed it.
+    if "pmc" in effective:
+        argv += ["--pmc", *_split_tokens(effective["pmc"])]
+    argv.append("--")
+    return argv
+
+
+def wrap_argv(
+    argv: list[str] | tuple[str, ...],
+    out_dir: Path | str,
+    options: Mapping[str, str] | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return ``argv`` run under rocprofv3, writing artifacts to ``out_dir``.
+
+    Args:
+        argv: The command the trial would otherwise have run.
+        out_dir: Directory rocprofv3 writes artifacts into.
+        options: Recipe-supplied options; see :func:`validate_options`.
+        env: Accepted for the collector registry's uniform wrap signature and
+            unused -- rocprofv3 is configured entirely through flags, unlike
+            Proton, which has to translate the device-visibility variables.
+    """
+    del env
+    return [*build_argv_prefix(out_dir, options), *argv]
+
+
+__all__ = [
+    "ENV_ROCPROF_BIN",
+    "OPTION_KEYS",
+    "OUTPUT_BASENAME",
+    "OUTPUT_FORMATS",
+    "OUTPUT_SUBDIR",
+    "SUMMARY_FILENAME",
+    "SUMMARY_FILE_STEM",
+    "SUMMARY_UNITS",
+    "TRACE_FLAGS",
+    "RocprofUnavailableError",
+    "build_argv_prefix",
+    "parse_summary",
+    "resolve_binary",
+    "validate_options",
+    "wrap_argv",
+]

--- a/src/aorta/instrumentation/rocprof/_options.py
+++ b/src/aorta/instrumentation/rocprof/_options.py
@@ -1,0 +1,158 @@
+"""Option schema for the ``rocprof`` collector.
+
+Every knob a recipe may set under ``collect: {rocprof: {...}}`` is declared
+here and validated at recipe-load time, so a typo fails the whole recipe up
+front instead of silently producing an unprofiled run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+#: ``trace`` tokens -> the ``rocprofv3`` flag each one turns on. ``kernel`` is
+#: the default because it is the only domain the summary parser aggregates.
+TRACE_FLAGS: dict[str, str] = {
+    "kernel": "--kernel-trace",
+    "hip": "--hip-trace",
+    "hip_runtime": "--hip-runtime-trace",
+    "memory_copy": "--memory-copy-trace",
+    "rccl": "--rccl-trace",
+    "marker": "--marker-trace",
+    "scratch": "--scratch-memory-trace",
+}
+
+#: ``rocprofv3 --output-format`` values. ``csv`` is the only one the summary
+#: parser reads; the others are accepted for operators who want a pftrace /
+#: rocpd artifact and will analyse it out of band.
+OUTPUT_FORMATS: frozenset[str] = frozenset({"csv", "json", "pftrace", "otf2", "rocpd"})
+
+#: ``rocprofv3 -u/--summary-units`` values.
+SUMMARY_UNITS: frozenset[str] = frozenset({"sec", "msec", "usec", "nsec"})
+
+#: Recipe-visible option keys, in the order they appear in the docs table.
+OPTION_KEYS: tuple[str, ...] = (
+    "trace",
+    "output_format",
+    "stats",
+    "pmc",
+    "kernel_include_regex",
+    "summary_units",
+)
+
+_DEFAULTS: dict[str, str] = {
+    "trace": "kernel",
+    "output_format": "csv",
+    "stats": "true",
+}
+
+_TRUE = frozenset({"1", "true", "yes", "on"})
+_FALSE = frozenset({"0", "false", "no", "off"})
+
+
+def split_tokens(value: str) -> list[str]:
+    """Split a comma- or whitespace-separated option value into tokens."""
+    return [tok for tok in value.replace(",", " ").split() if tok]
+
+
+def as_bool(key: str, value: str) -> bool:
+    """Parse a boolean-shaped option value.
+
+    Raises:
+        ValueError: the value is not one of the accepted true/false spellings.
+    """
+    lowered = value.strip().lower()
+    if lowered in _TRUE:
+        return True
+    if lowered in _FALSE:
+        return False
+    raise ValueError(
+        f"rocprof option {key!r}: expected a boolean "
+        f"({'/'.join(sorted(_TRUE | _FALSE))}), got {value!r}"
+    )
+
+
+def validate_options(options: Mapping[str, str] | None) -> dict[str, str]:
+    """Validate recipe-supplied ``rocprof`` options and apply defaults.
+
+    Args:
+        options: The raw ``collect: {rocprof: {...}}`` mapping, or ``None``
+            when the collector was enabled with no options. The recipe loader
+            has already guaranteed ``str -> str``; a programmatic caller that
+            bypasses it is rejected here.
+
+    Returns:
+        The effective options: the caller's values merged over
+        :data:`_DEFAULTS`, with every value normalised to lowercase where the
+        schema is an enum. Free-form values (``pmc``,
+        ``kernel_include_regex``) are passed through verbatim.
+
+    Raises:
+        ValueError: an unknown key, or a value outside its declared domain.
+            The message names the valid values so it is actionable in a
+            recipe-load error.
+    """
+    raw = dict(options or {})
+    unknown = sorted(set(raw) - set(OPTION_KEYS))
+    if unknown:
+        raise ValueError(f"rocprof: unknown option(s) {unknown}; valid: {list(OPTION_KEYS)}")
+    for key, value in raw.items():
+        if not isinstance(value, str):
+            raise ValueError(
+                f"rocprof option {key!r}: must be a string, got " f"{type(value).__name__}"
+            )
+
+    effective = dict(_DEFAULTS)
+    effective.update(raw)
+
+    tokens = split_tokens(effective["trace"].lower())
+    if not tokens:
+        raise ValueError(
+            f"rocprof option 'trace': must name at least one domain; "
+            f"valid: {sorted(TRACE_FLAGS)}"
+        )
+    bad_trace = sorted(set(tokens) - set(TRACE_FLAGS))
+    if bad_trace:
+        raise ValueError(
+            f"rocprof option 'trace': unknown domain(s) {bad_trace}; "
+            f"valid: {sorted(TRACE_FLAGS)}"
+        )
+    effective["trace"] = ",".join(dict.fromkeys(tokens))
+
+    output_format = effective["output_format"].strip().lower()
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(
+            f"rocprof option 'output_format': {output_format!r} is not one of "
+            f"{sorted(OUTPUT_FORMATS)}"
+        )
+    effective["output_format"] = output_format
+
+    as_bool("stats", effective["stats"])
+
+    units = effective.get("summary_units")
+    if units is not None:
+        units = units.strip().lower()
+        if units not in SUMMARY_UNITS:
+            raise ValueError(
+                f"rocprof option 'summary_units': {units!r} is not one of "
+                f"{sorted(SUMMARY_UNITS)}"
+            )
+        effective["summary_units"] = units
+
+    if "kernel_include_regex" in effective and not effective["kernel_include_regex"].strip():
+        raise ValueError("rocprof option 'kernel_include_regex': must be non-empty")
+    if "pmc" in effective and not split_tokens(effective["pmc"]):
+        raise ValueError(
+            "rocprof option 'pmc': must name at least one counter " "(comma- or space-separated)"
+        )
+    return effective
+
+
+__all__ = [
+    "OPTION_KEYS",
+    "OUTPUT_FORMATS",
+    "SUMMARY_UNITS",
+    "TRACE_FLAGS",
+    "as_bool",
+    "split_tokens",
+    "validate_options",
+]

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -125,8 +125,9 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     """Summarise a ``rocprofv3`` output directory into trial metrics.
 
     Prefers the ``--stats`` CSVs (rocprofv3 already did the aggregation) and
-    falls back to summing dispatch spans from the kernel trace when ``stats``
-    is off.
+    falls back to summing dispatch spans from the kernel trace whenever the
+    stats CSVs are absent *or* yield no usable rows -- a truncated or
+    column-renamed stats file must not mask a readable trace.
 
     Args:
         out_dir: The directory passed to ``rocprofv3 -d``.
@@ -150,9 +151,16 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
 
     metrics: dict[str, Any] = {"rocprof_artifact_dir": str(root)}
 
+    # The fallback keys off absence of *data*, not absence of files. A stats
+    # CSV that exists but yields nothing -- rocprofv3 killed mid-write by a
+    # trial timeout, or a future release renaming the columns pinned above --
+    # would otherwise suppress a complete kernel trace sitting beside it, and
+    # report no kernels on a host where profiling works.
+    ns_by_kernel: dict[str, float] = {}
+    calls_by_kernel: dict[str, int] = {}
     if stats_paths:
         ns_by_kernel, calls_by_kernel = _totals_from_stats(stats_paths)
-    else:
+    if not ns_by_kernel and trace_paths:
         ns_by_kernel, calls_by_kernel = _totals_from_trace(trace_paths)
     if not ns_by_kernel:
         return metrics

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -77,10 +77,20 @@ def _to_float(value: Any) -> float | None:
     return parsed if math.isfinite(parsed) else None
 
 
-def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, int]]:
-    """Aggregate ``*_kernel_stats.csv`` into per-kernel ns totals + call counts."""
+def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, int] | None]:
+    """Aggregate ``*_kernel_stats.csv`` into per-kernel ns totals + call counts.
+
+    Returns ``None`` for the counts when any otherwise-usable row had an
+    unreadable ``Calls`` column. A stats row is aggregated **per kernel, not
+    per dispatch**, so an unreadable count could stand for one dispatch or ten
+    thousand; substituting 1 would publish a confident-looking
+    ``rocprof_kernel_count`` that is simply wrong. Omitting the metric while
+    keeping the timings is the fail-soft behaviour the module promises -- fewer
+    metrics, never invented ones.
+    """
     ns_by_kernel: dict[str, float] = {}
     calls_by_kernel: dict[str, int] = {}
+    counts_trustworthy = True
     for path in paths:
         for row in _iter_rows(path):
             name = (row.get(_STATS_NAME) or "").strip()
@@ -92,18 +102,21 @@ def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
             if not name or total_ns is None or total_ns < 0:
                 continue
             ns_by_kernel[name] = ns_by_kernel.get(name, 0.0) + total_ns
-            # A row with no readable ``Calls`` column still evidences one
-            # dispatch, so it counts as one. A readable zero is taken at its
-            # word: ``rocprof_kernel_count`` claims dispatches, so inventing
-            # one would over-count.
-            calls_by_kernel[name] = calls_by_kernel.get(name, 0) + (
-                1 if calls is None or calls < 0 else int(calls)
-            )
-    return ns_by_kernel, calls_by_kernel
+            if calls is None or calls < 0:
+                counts_trustworthy = False
+                continue
+            # A readable zero is taken at its word: ``rocprof_kernel_count``
+            # claims dispatches, so rounding it up would over-count.
+            calls_by_kernel[name] = calls_by_kernel.get(name, 0) + int(calls)
+    return ns_by_kernel, (calls_by_kernel if counts_trustworthy else None)
 
 
-def _totals_from_trace(paths: list[Path]) -> tuple[dict[str, float], dict[str, int]]:
-    """Aggregate ``*_kernel_trace.csv`` dispatch rows into the same shape."""
+def _totals_from_trace(paths: list[Path]) -> tuple[dict[str, float], dict[str, int] | None]:
+    """Aggregate ``*_kernel_trace.csv`` dispatch rows into the same shape.
+
+    Counts are always trustworthy here: a trace row *is* one dispatch, so
+    there is no per-kernel aggregate to misread.
+    """
     ns_by_kernel: dict[str, float] = {}
     calls_by_kernel: dict[str, int] = {}
     for path in paths:
@@ -137,8 +150,11 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
         ``{"rocprof_artifact_dir": str}`` plus, when kernel data was found,
         the flat numeric ``rocprof_kernel_count`` / ``rocprof_gpu_time_ms`` /
         ``rocprof_top_kernel_ms`` and the non-numeric ``rocprof_top_kernels``
-        name list. Never raises: an unreadable or malformed artifact tree
-        degrades to the artifact-dir-only result.
+        name list. ``rocprof_kernel_count`` is omitted -- while the timings
+        are still reported -- when a stats row's ``Calls`` column was
+        unreadable, because a per-kernel aggregate row gives no basis for
+        guessing how many dispatches it stood for. Never raises: an unreadable
+        or malformed artifact tree degrades to the artifact-dir-only result.
     """
     root = Path(out_dir)
     try:
@@ -157,7 +173,7 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     # would otherwise suppress a complete kernel trace sitting beside it, and
     # report no kernels on a host where profiling works.
     ns_by_kernel: dict[str, float] = {}
-    calls_by_kernel: dict[str, int] = {}
+    calls_by_kernel: dict[str, int] | None = {}
     if stats_paths:
         ns_by_kernel, calls_by_kernel = _totals_from_stats(stats_paths)
     if not ns_by_kernel and trace_paths:
@@ -175,7 +191,10 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     # capture rather than publishing an ``Infinity`` token.
     if not (math.isfinite(total_ms) and math.isfinite(top_ms)):
         return metrics
-    metrics["rocprof_kernel_count"] = sum(calls_by_kernel.values())
+    # Omitted rather than fabricated when a stats row's ``Calls`` was
+    # unreadable; the timings above are still sound.
+    if calls_by_kernel is not None:
+        metrics["rocprof_kernel_count"] = sum(calls_by_kernel.values())
     metrics["rocprof_gpu_time_ms"] = total_ms
     metrics["rocprof_top_kernel_ms"] = top_ms
     metrics["rocprof_top_kernels"] = [name for name, _ in ranked[:TOP_N]]

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -1,0 +1,143 @@
+"""Fail-soft summary parsing of a ``rocprofv3`` output directory.
+
+Two verified behaviours drive the shape of this module:
+
+* Where ``rocprofv3`` puts its CSVs under the ``-d`` directory depends on
+  whether ``-o`` was passed: with it they are flat
+  (``<out_dir>/<basename>_kernel_stats.csv``), without it they nest under a
+  hostname directory (``<out_dir>/<hostname>/<pid>_kernel_stats.csv``). Every
+  lookup is therefore a recursive glob rather than a fixed path, so an
+  operator's own ``rocprofv3 -d`` tree parses as well as aorta's.
+* When the profiled command performs no GPU work, ``rocprofv3`` writes **no
+  files at all**. That is a legitimate outcome (e.g. a probe of ``/bin/echo``),
+  not a failure, so a missing/empty/malformed artifact tree yields fewer
+  metrics rather than an exception.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+#: How many kernel names to carry in the non-numeric ``rocprof_top_kernels``
+#: channel. Kept small: it is a triage breadcrumb, not a report.
+TOP_N = 5
+
+_NS_PER_MS = 1_000_000.0
+
+# rocprofv3 ``--stats`` column names (rocprofiler-sdk 1.x).
+_STATS_NAME = "Name"
+_STATS_CALLS = "Calls"
+_STATS_TOTAL_NS = "TotalDurationNs"
+
+# rocprofv3 ``--kernel-trace`` column names.
+_TRACE_KIND = "Kind"
+_TRACE_NAME = "Kernel_Name"
+_TRACE_START = "Start_Timestamp"
+_TRACE_END = "End_Timestamp"
+_KERNEL_DISPATCH = "KERNEL_DISPATCH"
+
+
+def _read_rows(path: Path) -> list[dict[str, str]]:
+    """Read a CSV into dict rows, returning ``[]`` on any read/parse error."""
+    try:
+        with path.open(newline="", encoding="utf-8") as stream:
+            return [dict(row) for row in csv.DictReader(stream)]
+    except (OSError, csv.Error, UnicodeDecodeError):
+        return []
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, int]]:
+    """Aggregate ``*_kernel_stats.csv`` into per-kernel ns totals + call counts."""
+    ns_by_kernel: dict[str, float] = {}
+    calls_by_kernel: dict[str, int] = {}
+    for path in paths:
+        for row in _read_rows(path):
+            name = (row.get(_STATS_NAME) or "").strip()
+            total_ns = _to_float(row.get(_STATS_TOTAL_NS))
+            calls = _to_float(row.get(_STATS_CALLS))
+            if not name or total_ns is None:
+                continue
+            ns_by_kernel[name] = ns_by_kernel.get(name, 0.0) + total_ns
+            # A row with no readable ``Calls`` column still evidences one
+            # dispatch, so it counts as one. A readable zero is taken at its
+            # word: ``rocprof_kernel_count`` claims dispatches, so inventing
+            # one would over-count.
+            calls_by_kernel[name] = calls_by_kernel.get(name, 0) + (
+                1 if calls is None else int(calls)
+            )
+    return ns_by_kernel, calls_by_kernel
+
+
+def _totals_from_trace(paths: list[Path]) -> tuple[dict[str, float], dict[str, int]]:
+    """Aggregate ``*_kernel_trace.csv`` dispatch rows into the same shape."""
+    ns_by_kernel: dict[str, float] = {}
+    calls_by_kernel: dict[str, int] = {}
+    for path in paths:
+        for row in _read_rows(path):
+            kind = (row.get(_TRACE_KIND) or "").strip()
+            if kind and kind != _KERNEL_DISPATCH:
+                continue
+            name = (row.get(_TRACE_NAME) or "").strip()
+            start = _to_float(row.get(_TRACE_START))
+            end = _to_float(row.get(_TRACE_END))
+            if not name or start is None or end is None or end < start:
+                continue
+            ns_by_kernel[name] = ns_by_kernel.get(name, 0.0) + (end - start)
+            calls_by_kernel[name] = calls_by_kernel.get(name, 0) + 1
+    return ns_by_kernel, calls_by_kernel
+
+
+def parse_summary(out_dir: Path | str) -> dict[str, Any]:
+    """Summarise a ``rocprofv3`` output directory into trial metrics.
+
+    Prefers the ``--stats`` CSVs (rocprofv3 already did the aggregation) and
+    falls back to summing dispatch spans from the kernel trace when ``stats``
+    is off.
+
+    Args:
+        out_dir: The directory passed to ``rocprofv3 -d``.
+
+    Returns:
+        ``{}`` when the directory does not exist. Otherwise
+        ``{"rocprof_artifact_dir": str}`` plus, when kernel data was found,
+        the flat numeric ``rocprof_kernel_count`` / ``rocprof_gpu_time_ms`` /
+        ``rocprof_top_kernel_ms`` and the non-numeric ``rocprof_top_kernels``
+        name list. Never raises: an unreadable or malformed artifact tree
+        degrades to the artifact-dir-only result.
+    """
+    root = Path(out_dir)
+    try:
+        if not root.is_dir():
+            return {}
+        stats_paths = sorted(root.rglob("*_kernel_stats.csv"))
+        trace_paths = sorted(root.rglob("*_kernel_trace.csv"))
+    except OSError:
+        return {}
+
+    metrics: dict[str, Any] = {"rocprof_artifact_dir": str(root)}
+
+    if stats_paths:
+        ns_by_kernel, calls_by_kernel = _totals_from_stats(stats_paths)
+    else:
+        ns_by_kernel, calls_by_kernel = _totals_from_trace(trace_paths)
+    if not ns_by_kernel:
+        return metrics
+
+    ranked = sorted(ns_by_kernel.items(), key=lambda item: item[1], reverse=True)
+    metrics["rocprof_kernel_count"] = sum(calls_by_kernel.values())
+    metrics["rocprof_gpu_time_ms"] = sum(ns_by_kernel.values()) / _NS_PER_MS
+    metrics["rocprof_top_kernel_ms"] = ranked[0][1] / _NS_PER_MS
+    metrics["rocprof_top_kernels"] = [name for name, _ in ranked[:TOP_N]]
+    return metrics
+
+
+__all__ = ["TOP_N", "parse_summary"]

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -102,7 +102,10 @@ def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
             if not name or total_ns is None or total_ns < 0:
                 continue
             ns_by_kernel[name] = ns_by_kernel.get(name, 0.0) + total_ns
-            if calls is None or calls < 0:
+            # A fractional count is as unreadable as a missing one: dispatches
+            # are whole, and ``int()`` would silently truncate 1.9 to 1 and
+            # publish it as measured.
+            if calls is None or calls < 0 or not calls.is_integer():
                 counts_trustworthy = False
                 continue
             # A readable zero is taken at its word: ``rocprof_kernel_count``

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -17,6 +17,8 @@ Two verified behaviours drive the shape of this module:
 from __future__ import annotations
 
 import csv
+import math
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -39,20 +41,40 @@ _TRACE_END = "End_Timestamp"
 _KERNEL_DISPATCH = "KERNEL_DISPATCH"
 
 
-def _read_rows(path: Path) -> list[dict[str, str]]:
-    """Read a CSV into dict rows, returning ``[]`` on any read/parse error."""
+def _iter_rows(path: Path) -> Iterator[dict[str, str]]:
+    """Stream a CSV as dict rows, yielding nothing more on a read/parse error.
+
+    A generator rather than a list: with ``stats: false`` a
+    ``*_kernel_trace.csv`` carries one row per dispatch and can reach hundreds
+    of MB, and materialising that before aggregating would add the whole file
+    to the trial process's peak RSS. Both aggregators make a single forward
+    pass, so no caller needs the rows twice.
+
+    Fail-soft like the rest of the module: a truncated or undecodable file
+    contributes the rows read so far and then stops, rather than raising.
+    """
     try:
         with path.open(newline="", encoding="utf-8") as stream:
-            return [dict(row) for row in csv.DictReader(stream)]
+            for row in csv.DictReader(stream):
+                yield dict(row)
     except (OSError, csv.Error, UnicodeDecodeError):
-        return []
+        return
 
 
 def _to_float(value: Any) -> float | None:
+    """Parse a CSV cell into a *finite* float, or ``None`` if it is not one.
+
+    ``float()`` accepts ``"NaN"`` / ``"Infinity"``, and a metric built from
+    those is both meaningless and unserialisable as strict JSON --
+    :func:`json.dump` writes the non-standard ``NaN`` / ``Infinity`` tokens,
+    which a downstream reader is entitled to reject. A row carrying one is
+    dropped like any other malformed row.
+    """
     try:
-        return float(str(value).strip())
+        parsed = float(str(value).strip())
     except (TypeError, ValueError):
         return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, int]]:
@@ -60,11 +82,14 @@ def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
     ns_by_kernel: dict[str, float] = {}
     calls_by_kernel: dict[str, int] = {}
     for path in paths:
-        for row in _read_rows(path):
+        for row in _iter_rows(path):
             name = (row.get(_STATS_NAME) or "").strip()
             total_ns = _to_float(row.get(_STATS_TOTAL_NS))
             calls = _to_float(row.get(_STATS_CALLS))
-            if not name or total_ns is None:
+            # A negative duration is as malformed as an unparseable one: no
+            # dispatch takes less than no time, and letting it through would
+            # silently subtract from the run's total.
+            if not name or total_ns is None or total_ns < 0:
                 continue
             ns_by_kernel[name] = ns_by_kernel.get(name, 0.0) + total_ns
             # A row with no readable ``Calls`` column still evidences one
@@ -72,7 +97,7 @@ def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
             # word: ``rocprof_kernel_count`` claims dispatches, so inventing
             # one would over-count.
             calls_by_kernel[name] = calls_by_kernel.get(name, 0) + (
-                1 if calls is None else int(calls)
+                1 if calls is None or calls < 0 else int(calls)
             )
     return ns_by_kernel, calls_by_kernel
 
@@ -82,7 +107,7 @@ def _totals_from_trace(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
     ns_by_kernel: dict[str, float] = {}
     calls_by_kernel: dict[str, int] = {}
     for path in paths:
-        for row in _read_rows(path):
+        for row in _iter_rows(path):
             kind = (row.get(_TRACE_KIND) or "").strip()
             if kind and kind != _KERNEL_DISPATCH:
                 continue

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -158,9 +158,18 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
         return metrics
 
     ranked = sorted(ns_by_kernel.items(), key=lambda item: item[1], reverse=True)
+    total_ms = sum(ns_by_kernel.values()) / _NS_PER_MS
+    top_ms = ranked[0][1] / _NS_PER_MS
+    # Per-row finiteness is not enough: finite rows still sum to infinity
+    # (1e308 + 1e308), in the aggregate or within one kernel's accumulator.
+    # The metrics channel promises strictly serialisable JSON, so a total that
+    # overflowed degrades to the artifact directory like any other unusable
+    # capture rather than publishing an ``Infinity`` token.
+    if not (math.isfinite(total_ms) and math.isfinite(top_ms)):
+        return metrics
     metrics["rocprof_kernel_count"] = sum(calls_by_kernel.values())
-    metrics["rocprof_gpu_time_ms"] = sum(ns_by_kernel.values()) / _NS_PER_MS
-    metrics["rocprof_top_kernel_ms"] = ranked[0][1] / _NS_PER_MS
+    metrics["rocprof_gpu_time_ms"] = total_ms
+    metrics["rocprof_top_kernel_ms"] = top_ms
     metrics["rocprof_top_kernels"] = [name for name, _ in ranked[:TOP_N]]
     return metrics
 

--- a/src/aorta/probe/cli_helpers.py
+++ b/src/aorta/probe/cli_helpers.py
@@ -209,6 +209,7 @@ def apply_recipe_overrides(
     cli_stop_after_events: int | None = None,
     cli_max_trials: int | None = None,
     cli_disable_detectors: tuple[str, ...] = (),
+    cli_collect: tuple[str, ...] = (),
 ) -> Recipe:
     """Layer CLI flags on top of a loaded probe-mode ``Recipe``.
 
@@ -229,6 +230,11 @@ def apply_recipe_overrides(
       additive rather than a replacement (an operator silencing one
       more detector on top of a recipe shouldn't have to restate the
       recipe's list).
+    * ``--collect`` -- when passed, REPLACES the recipe's collector name
+      list, matching the workload flow's precedence (``aorta triage run``,
+      ``aorta.cli.triage``). Per-collector options are recipe-file-only (the
+      ``collect:`` mapping form), so options for collectors the CLI dropped
+      are discarded and options for the ones it kept survive.
 
     The caller must verify ``recipe.probe_extras is not None`` before
     invoking this helper (probe-mode discriminator is the CLI's
@@ -251,7 +257,37 @@ def apply_recipe_overrides(
         recipe = _overlay_stop_after(recipe, cli_stop_after_events, cli_max_trials)
     if cli_disable_detectors:
         recipe = _overlay_disable_detectors(recipe, cli_disable_detectors)
+    if cli_collect:
+        recipe = _overlay_collect(recipe, cli_collect)
     return recipe
+
+
+def _overlay_collect(recipe: Recipe, names: tuple[str, ...]) -> Recipe:
+    """Replace the recipe's collector list with the ``--collect`` names.
+
+    Runs the names through the recipe loader's own validator so an unknown
+    collector, a bad per-collector option, or an unrunnable pairing fails the
+    same way it would from a recipe file. Probe-mode cells are synthesised
+    without a cell-scope ``collect``, so replacing the recipe-level tuple is
+    enough for the operator's choice to apply to every cell.
+
+    The names are handed to the loader in its *mapping* form, carrying the
+    recipe options of the collectors that survived the replacement. Validating
+    the bare name list instead would check the surviving collectors against
+    their defaults, which both misses a conflict the recipe's options create
+    and invents one they resolve.
+    """
+    from aorta.triage.recipe import RecipeSchemaError, _parse_collect
+
+    surviving = {
+        name: dict(recipe.collect_options.get(name) or {}) or None for name in dict.fromkeys(names)
+    }
+    try:
+        # Already carries a ``--collect:`` label in its message.
+        collect_names, options = _parse_collect("--collect", surviving)
+    except RecipeSchemaError as exc:
+        raise ProbeUsageError(str(exc)) from exc
+    return dataclasses.replace(recipe, collect=collect_names, collect_options=options)
 
 
 def _overlay_stop_after(

--- a/src/aorta/probe/recipe_builder.py
+++ b/src/aorta/probe/recipe_builder.py
@@ -42,6 +42,7 @@ from aorta.triage.recipe import (
     RecipeCellError,
     RecipeSchemaError,
     RetainPolicy,
+    _parse_collect,
     _parse_retain,
     _parse_stop_after,
 )
@@ -336,6 +337,12 @@ def build_probe_recipe_from_dict(
         )
     tier3_vram_growth = tier3_vram_growth_raw
     stop_after = _parse_stop_after("recipe", data.get("stop_after"))
+    # Collectors are cross-cutting: probe-mode synthesises its own cells, so
+    # there is no cell scope to override at and the recipe-level names/options
+    # apply to every (mitigation, diagnostic) pair. ``_parse_collect`` is the
+    # same validator the triage loader uses, so option schemas and the
+    # rocprof/proton conflict guard fire identically in both modes.
+    collect, collect_options = _parse_collect("recipe", data.get("collect"))
     try:
         disable_detectors = normalize_detector_ids(data.get("disable_detectors"))
         disable_detector_tiers = normalize_tiers(data.get("disable_detector_tiers"))
@@ -503,6 +510,8 @@ def build_probe_recipe_from_dict(
         workload_config={},
         save_logs=False,
         stop_after=stop_after,
+        collect=collect,
+        collect_options=collect_options,
         probe_extras=probe_extras,
     )
 

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -24,6 +24,7 @@ package docstring).
 from __future__ import annotations
 
 import logging
+import shutil
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -158,6 +159,27 @@ def _collect_root(config: Mapping[str, Any]) -> Path | None:
     return Path(raw) if isinstance(raw, str) and raw else None
 
 
+def _reset_output_dir(out_dir: Path) -> None:
+    """Create ``out_dir`` empty, discarding any earlier attempt's artifacts.
+
+    Probe resume replays an interrupted trial onto the *same* paths, so a
+    retry would otherwise inherit the previous attempt's profile files and
+    :func:`summarize_collectors` would report the old run's numbers -- or a
+    blend of both, when the retry writes fewer per-rank files than the attempt
+    it replaces. Clearing is safe precisely because this directory belongs to
+    one trial of one collector: nothing else writes here, and the trial record
+    (``result.json``) lives in a different tree.
+
+    Raises:
+        OSError: the directory could not be cleared or created.
+    """
+    if out_dir.is_symlink() or out_dir.is_file():
+        out_dir.unlink()
+    elif out_dir.is_dir():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
+
+
 def validate_collectors(
     names: Sequence[str],
     options: Mapping[str, Mapping[str, str]] | None = None,
@@ -221,9 +243,10 @@ def wrap_argv_for_collectors(
     emulation wrap *after* this one so the profiler runs inside the emulator.
 
     Each collector's output directory (``<collect_dir>/<subdir>``) is created
-    here, so the trial tree has the same shape whether or not the workload
-    produced any GPU activity -- ``rocprofv3`` writes nothing at all when the
-    command does no GPU work.
+    empty here, so the trial tree has the same shape whether or not the
+    workload produced any GPU activity -- ``rocprofv3`` writes nothing at all
+    when the command does no GPU work -- and so a resumed trial never
+    summarises the artifacts of the attempt it is replacing.
 
     Args:
         config: The trial config carrying the reserved ``_aorta_collect*`` keys.
@@ -235,9 +258,10 @@ def wrap_argv_for_collectors(
     Raises:
         ValueError: a collector option is invalid.
         RuntimeError: a requested collector cannot attach (rocprofv3 missing,
-            or a Proton CLI wrap of a non-Python command). Requesting a
-            measurement that cannot be taken is a clean setup failure, not a
-            silently unprofiled run.
+            a Proton CLI wrap of a non-Python command, or an artifact
+            directory that cannot be prepared). Requesting a measurement that
+            cannot be taken is a clean setup failure, not a silently
+            unprofiled run.
     """
     wrapped = list(argv)
     names = active_collectors(config)
@@ -260,10 +284,14 @@ def wrap_argv_for_collectors(
             continue
         out_dir = root / spec.output_subdir
         try:
-            out_dir.mkdir(parents=True, exist_ok=True)
+            _reset_output_dir(out_dir)
         except OSError as exc:
-            log.warning("collect: cannot create %s: %s; skipping %s.", out_dir, exc, name)
-            continue
+            raise RuntimeError(
+                f"collect: cannot prepare the {name} artifact directory "
+                f"{out_dir}: {exc}. The collector has nowhere to write, so the "
+                "trial would run unprofiled; fix the path or drop "
+                f"'{name}' from the collect request."
+            ) from exc
         wrapped = spec.wrap(wrapped, out_dir, _options_for(config, name), env=env)
     return wrapped
 

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -1,24 +1,315 @@
-"""Reserved collector recipe names.
+"""Collector recipe registry.
 
-Collectors are profiling/instrumentation tools that can be attached to
-workload runs. MVP implementation validates names but does not attach
-actual collectors (deferred to P1).
+Collectors are profiling / instrumentation tools attached to a workload run via
+``--collect`` or a recipe's ``collect:`` block. This module is the dispatch
+layer between the reserved ``_aorta_collect*`` config keys the dispatcher
+threads into every trial and the per-collector packages under
+:mod:`aorta.instrumentation`.
 
 Supported recipes:
-    rocprof: AMD ROCm profiler integration
+    rocprof: ``rocprofv3`` kernel/API tracing (:mod:`aorta.instrumentation.rocprof`)
+    proton: Triton Proton profiler (:mod:`aorta.instrumentation.proton`)
     numerics: Numeric health monitoring (NaN/Inf detection)
-    layer_numerics: Per-layer NaN/magnitude logger (aorta.instrumentation.layer_numerics)
+    layer_numerics: Per-layer NaN/magnitude logger (:mod:`aorta.instrumentation.layer_numerics`)
     amd_log: AMD internal logging collector
+
+``rocprof`` and ``proton`` attach generically, by wrapping the launch argv --
+the same seam :func:`aorta.emulation.mirage_launch.wrap_argv_for_environment`
+uses -- so any subprocess-shaped workload, including an opaque ``aorta probe --
+<command>``, can be profiled. The remaining names are still validated-only:
+they are consumed by workload wrappers that opt in (see the ``layer_numerics``
+package docstring).
 """
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
 
 KNOWN_RECIPES: frozenset[str] = frozenset(
     {
         "rocprof",
+        "proton",
         "numerics",
         "layer_numerics",
         "amd_log",
     }
 )
 
+#: Reserved config keys the dispatcher threads into every trial. Mirrored as
+#: literals (not imported from the dispatcher) to keep this module a leaf --
+#: :mod:`aorta.triage.recipe` imports it during recipe load.
+CONFIG_KEY_COLLECT = "_aorta_collect"
+CONFIG_KEY_COLLECT_OPTIONS = "_aorta_collect_options"
+CONFIG_KEY_COLLECT_DIR = "_aorta_collect_dir"
 
-__all__ = ["KNOWN_RECIPES"]
+#: Argv-wrapping order, outermost first. ``rocprof`` runs a whole command under
+#: the profiler while ``proton`` takes over a Python script's execution, so
+#: rocprof must be the outer process for the pair to compose at all. Relative
+#: to the emulator: collectors wrap first and the mirage wrap goes outside
+#: them, i.e. the profiler runs *inside* the emulated environment.
+WRAP_ORDER: tuple[str, ...] = ("rocprof", "proton")
+
+
+@dataclass(frozen=True)
+class CollectorSpec:
+    """How one collector validates, attaches, and reports.
+
+    Attributes:
+        name: The recipe name (a member of :data:`KNOWN_RECIPES`).
+        output_subdir: Subdirectory of the trial's collector directory the
+            collector writes artifacts into.
+        validate: Validates a recipe's option mapping, raising ``ValueError``
+            with an actionable message. Every collector has one; a
+            validated-only collector accepts anything a wrapper defines.
+        wrap: Rewrites the launch argv to attach the collector, or ``None``
+            for a collector the platform does not launch itself.
+        summarize: Parses the collector's artifacts into flat trial metrics,
+            or ``None`` for a collector the platform does not parse.
+    """
+
+    name: str
+    output_subdir: str | None
+    validate: Callable[[Mapping[str, str] | None], Any]
+    wrap: Callable[..., list[str]] | None = None
+    summarize: Callable[[Path], dict[str, Any]] | None = None
+
+
+def _accept_any(options: Mapping[str, str] | None) -> dict[str, str]:
+    """Option validator for collectors whose knobs belong to a wrapper.
+
+    ``layer_numerics`` takes ``NANLOG_*`` env knobs interpreted by the workload
+    wrapper, not by the platform, so the platform has no schema to check them
+    against. The recipe loader has already enforced ``str -> str``.
+    """
+    return dict(options or {})
+
+
+def _registry() -> dict[str, CollectorSpec]:
+    """Build the collector registry.
+
+    The instrumentation packages are imported here rather than at module scope
+    because :mod:`aorta.triage.recipe` imports this module during recipe load;
+    a call-time import keeps that path free of import-order coupling. Both
+    packages are stdlib-only, so the import is cheap.
+    """
+    from aorta.instrumentation import proton, rocprof
+
+    return {
+        "rocprof": CollectorSpec(
+            name="rocprof",
+            output_subdir=rocprof.OUTPUT_SUBDIR,
+            validate=rocprof.validate_options,
+            wrap=rocprof.wrap_argv,
+            summarize=rocprof.parse_summary,
+        ),
+        "proton": CollectorSpec(
+            name="proton",
+            output_subdir=proton.OUTPUT_SUBDIR,
+            validate=proton.validate_options,
+            wrap=proton.wrap_argv,
+            summarize=proton.parse_summary,
+        ),
+        "numerics": CollectorSpec("numerics", None, _accept_any),
+        "layer_numerics": CollectorSpec("layer_numerics", "layer_numerics", _accept_any),
+        "amd_log": CollectorSpec("amd_log", None, _accept_any),
+    }
+
+
+def active_collectors(config: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return the requested collector names, in :data:`WRAP_ORDER`.
+
+    Unknown / non-string entries are dropped: ``run_trials`` and the recipe
+    loader both reject them up front, so anything left here came from a
+    hand-built config and must not crash a trial.
+    """
+    raw = config.get(CONFIG_KEY_COLLECT)
+    if not isinstance(raw, (list, tuple)):
+        return ()
+    names = [n for n in raw if isinstance(n, str) and n in KNOWN_RECIPES]
+    ordered = [n for n in WRAP_ORDER if n in names]
+    ordered += [n for n in dict.fromkeys(names) if n not in WRAP_ORDER]
+    return tuple(ordered)
+
+
+def _options_for(config: Mapping[str, Any], name: str) -> dict[str, str]:
+    all_options = config.get(CONFIG_KEY_COLLECT_OPTIONS)
+    if not isinstance(all_options, dict):
+        return {}
+    per_collector = all_options.get(name)
+    if not isinstance(per_collector, dict):
+        return {}
+    return {str(k): str(v) for k, v in per_collector.items()}
+
+
+def _collect_root(config: Mapping[str, Any]) -> Path | None:
+    """Resolve the per-trial collector output root, or ``None``.
+
+    The dispatcher only injects :data:`CONFIG_KEY_COLLECT_DIR` on the
+    artifact-writing rank, so a non-writing rank has nowhere to put artifacts
+    and the collector is skipped rather than scattering files into the cwd.
+    """
+    raw = config.get(CONFIG_KEY_COLLECT_DIR)
+    return Path(raw) if isinstance(raw, str) and raw else None
+
+
+def validate_collectors(
+    names: Sequence[str],
+    options: Mapping[str, Mapping[str, str]] | None = None,
+) -> None:
+    """Validate a collect request: per-collector options plus cross-collector conflicts.
+
+    Called at recipe-load time (and by any programmatic caller building a run
+    request) so a typo or an unrunnable combination fails before a single trial
+    starts.
+
+    Args:
+        names: The requested collector names. Already checked against
+            :data:`KNOWN_RECIPES` by the caller; unknown names are ignored here
+            so the caller's own error message stays the one the operator sees.
+        options: The per-collector option mapping (the recipe's mapping form).
+
+    Raises:
+        ValueError: an option is invalid for its collector, or ``rocprof`` is
+            combined with a Proton backend that also intercepts HSA queues.
+    """
+    from aorta.instrumentation.proton import AUTO_BACKEND, QUEUE_INTERCEPTING_BACKENDS
+
+    registry = _registry()
+    requested = [n for n in names if n in registry]
+    opts = options or {}
+    effective: dict[str, dict[str, str]] = {}
+    for name in requested:
+        effective[name] = dict(registry[name].validate(opts.get(name)))
+
+    if "rocprof" in effective and "proton" in effective:
+        backend = effective["proton"]["backend"]
+        if backend in QUEUE_INTERCEPTING_BACKENDS:
+            resolved = (
+                " (which resolves to rocprofiler or roctracer on AMD)"
+                if backend == AUTO_BACKEND
+                else ""
+            )
+            raise ValueError(
+                "'rocprof' and 'proton' cannot run together with "
+                f"proton backend {backend!r}{resolved} -- both install an HSA "
+                "queue interceptor and the second one to attach will fail or "
+                "report nothing. Use 'proton: {backend: instrumentation}' "
+                "(intra-kernel measurement, no queue interception) to combine "
+                "them, or run rocprof and proton as two separate cells."
+            )
+
+
+def wrap_argv_for_collectors(
+    config: Mapping[str, Any],
+    argv: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return ``argv`` wrapped in every active collector that attaches via argv.
+
+    The counterpart of
+    :func:`aorta.emulation.mirage_launch.wrap_argv_for_environment`: it returns
+    the argv unchanged when no attaching collector is active, so a run without
+    ``--collect`` is byte-for-byte what it was. Collectors are applied in
+    :data:`WRAP_ORDER` (rocprof outermost), and the caller should apply the
+    emulation wrap *after* this one so the profiler runs inside the emulator.
+
+    Each collector's output directory (``<collect_dir>/<subdir>``) is created
+    here, so the trial tree has the same shape whether or not the workload
+    produced any GPU activity -- ``rocprofv3`` writes nothing at all when the
+    command does no GPU work.
+
+    Args:
+        config: The trial config carrying the reserved ``_aorta_collect*`` keys.
+        argv: The command the trial would otherwise have run.
+        env: Environment the command will run with, forwarded to collectors
+            that need to inspect it (Proton's device-variable translation).
+            Defaults to :data:`os.environ` inside the collector.
+
+    Raises:
+        ValueError: a collector option is invalid.
+        RuntimeError: a requested collector cannot attach (rocprofv3 missing,
+            or a Proton CLI wrap of a non-Python command). Requesting a
+            measurement that cannot be taken is a clean setup failure, not a
+            silently unprofiled run.
+    """
+    wrapped = list(argv)
+    names = active_collectors(config)
+    if not names:
+        return wrapped
+    root = _collect_root(config)
+    registry = _registry()
+    # Reversed so the first entry of WRAP_ORDER ends up outermost.
+    for name in reversed(names):
+        spec = registry.get(name)
+        if spec is None or spec.wrap is None or spec.output_subdir is None:
+            continue
+        if root is None:
+            log.warning(
+                "collect: %s requested but no %s was threaded into the trial "
+                "config (non-writing rank?); skipping.",
+                name,
+                CONFIG_KEY_COLLECT_DIR,
+            )
+            continue
+        out_dir = root / spec.output_subdir
+        try:
+            out_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            log.warning("collect: cannot create %s: %s; skipping %s.", out_dir, exc, name)
+            continue
+        wrapped = spec.wrap(wrapped, out_dir, _options_for(config, name), env=env)
+    return wrapped
+
+
+def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Parse every active collector's artifacts into flat trial metrics.
+
+    Fail-soft by construction: returns ``{}`` when nothing was collected, and a
+    collector whose artifacts are missing, partial, or malformed contributes
+    fewer keys rather than raising. An opt-in measurement must never turn an
+    otherwise-healthy trial into a failure.
+
+    Returns:
+        A flat mapping merged into ``WorkloadResult.metrics``. Numeric values
+        (``rocprof_gpu_time_ms``, ``proton_kernel_count``, ...) are picked up by
+        the ``perf.md`` metrics table; the non-numeric ones (top-kernel name
+        lists, artifact directories) are skipped there but retained in
+        ``matrix.json``.
+    """
+    root = _collect_root(config)
+    if root is None:
+        return {}
+    metrics: dict[str, Any] = {}
+    registry = _registry()
+    for name in active_collectors(config):
+        spec = registry.get(name)
+        if spec is None or spec.summarize is None or spec.output_subdir is None:
+            continue
+        try:
+            metrics.update(spec.summarize(root / spec.output_subdir))
+        except Exception:
+            # An opt-in measurement must never turn a healthy trial into a
+            # failure, so the catch is deliberately unbounded.
+            log.warning("collect: %s summary parsing failed; skipping.", name, exc_info=True)
+    return metrics
+
+
+__all__ = [
+    "CONFIG_KEY_COLLECT",
+    "CONFIG_KEY_COLLECT_DIR",
+    "CONFIG_KEY_COLLECT_OPTIONS",
+    "KNOWN_RECIPES",
+    "WRAP_ORDER",
+    "CollectorSpec",
+    "active_collectors",
+    "summarize_collectors",
+    "validate_collectors",
+    "wrap_argv_for_collectors",
+]

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -253,7 +253,13 @@ def wrap_argv_for_collectors(
         argv: The command the trial would otherwise have run.
         env: Environment the command will run with, forwarded to collectors
             that need to inspect it (Proton's device-variable translation).
-            Defaults to :data:`os.environ` inside the collector.
+            The default is load-bearing rather than a fallback: no production
+            caller passes this. ``SubprocessWorkload`` wraps in ``setup()`` but
+            assembles the child environment later in ``run()``, and that
+            environment is ``os.environ`` plus ``AORTA_ENV_FILE``, so the
+            collector's own :data:`os.environ` default already describes what
+            the child gets. The parameter exists so a caller that does know its
+            child env sooner can supply it, and so tests can.
 
     Raises:
         ValueError: a collector option is invalid.

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -349,9 +349,13 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
     Returns:
         A flat mapping merged into ``WorkloadResult.metrics``. Numeric values
         (``rocprof_gpu_time_ms``, ``proton_kernel_count``, ...) are picked up by
-        the ``perf.md`` metrics table; the non-numeric ones (top-kernel name
-        lists, artifact directories) are skipped there but retained in
-        ``matrix.json``.
+        the ``perf.md`` metrics table and aggregated into
+        ``matrix.json::cells[*].metrics_summary``. The non-numeric ones
+        (top-kernel name lists, artifact directories) reach **neither**:
+        ``_aggregate_metrics`` takes only real int/float scalars, and
+        ``_aggregate_audit_metadata`` works from a fixed key allowlist that
+        does not include collector keys. They live solely in the per-trial
+        dispatcher JSON under ``.result.metrics``.
     """
     root = _collect_root(config)
     if root is None:

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -159,6 +159,31 @@ def _collect_root(config: Mapping[str, Any]) -> Path | None:
     return Path(raw) if isinstance(raw, str) and raw else None
 
 
+def unsafe_collector_paths(config: Mapping[str, Any]) -> list[Path]:
+    """Every collector path for this trial that cannot be safely traversed.
+
+    Returns the collector root plus each active collector's own output
+    subdirectory -- ``<root>/rocprof``, ``<root>/proton`` -- because those are
+    the paths the post-run passes actually walk. Guarding only the root is not
+    enough: the profiled process can swap a *subdirectory* just as easily, and
+    ``parse_summary`` globs the subdirectory while ``apply_retention`` recurses
+    into it.
+
+    Empty when there is nothing to guard (no collector active, no threaded
+    collector directory) or when every path is a real directory.
+    """
+    root = _collect_root(config)
+    if root is None:
+        return []
+    registry = _registry()
+    candidates = [root]
+    for name in active_collectors(config):
+        spec = registry.get(name)
+        if spec is not None and spec.output_subdir is not None:
+            candidates.append(root / spec.output_subdir)
+    return [path for path in candidates if not collector_root_is_traversable(path)]
+
+
 def collector_root_is_traversable(root: Path) -> bool:
     """True when ``root`` can be walked without following a symlink out of the tree.
 
@@ -360,15 +385,18 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
     root = _collect_root(config)
     if root is None:
         return {}
-    if not collector_root_is_traversable(root):
-        # Read-only here, but the parsers glob the tree, so a root swapped for a
-        # symlink while the command ran would pull file contents from outside
-        # the results tree into the trial metrics. Same guard as the retention
-        # pass, which has the destructive version of this exposure.
+    unsafe = unsafe_collector_paths(config)
+    if unsafe:
+        # Read-only here, but the parsers ``rglob`` these directories, so one
+        # swapped for a symlink while the command ran would pull file contents
+        # from outside the results tree into the trial metrics. Checked per
+        # collector directory, not just the shared root -- the payload can swap
+        # either. Same guard as the retention pass, which has the destructive
+        # version of this exposure.
         log.warning(
             "collect: %s is (or is under) a symlink after the run; refusing to "
             "parse artifacts through it. No collector metrics for this trial.",
-            root,
+            ", ".join(str(path) for path in unsafe),
         )
         return {}
     metrics: dict[str, Any] = {}
@@ -396,6 +424,7 @@ __all__ = [
     "active_collectors",
     "collector_root_is_traversable",
     "summarize_collectors",
+    "unsafe_collector_paths",
     "validate_collectors",
     "wrap_argv_for_collectors",
 ]

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -159,6 +159,27 @@ def _collect_root(config: Mapping[str, Any]) -> Path | None:
     return Path(raw) if isinstance(raw, str) and raw else None
 
 
+def collector_root_is_traversable(root: Path) -> bool:
+    """True when ``root`` can be walked without following a symlink out of the tree.
+
+    Checked **again after the command has run**, not only before it launches.
+    The profiled command is handed this path (``rocprofv3 -d``, ``proton -n``),
+    so between the pre-launch reset and any post-run pass it can delete the
+    directory and leave a symlink in its place. Every later step --
+    ``Path.is_dir()``, ``rglob``, and :func:`aorta.run.retention.apply_retention`
+    -- follows links, so traversing one would read, and for retention *delete*,
+    files outside the results tree entirely.
+
+    The parent is checked too, for the same reason
+    :func:`_reset_output_dir` checks it: ``is_dir()`` resolves every component,
+    not just the last.
+    """
+    try:
+        return not (root.is_symlink() or root.parent.is_symlink())
+    except OSError:
+        return False
+
+
 def _reset_output_dir(out_dir: Path) -> None:
     """Create ``out_dir`` empty, discarding any earlier attempt's artifacts.
 
@@ -335,6 +356,17 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
     root = _collect_root(config)
     if root is None:
         return {}
+    if not collector_root_is_traversable(root):
+        # Read-only here, but the parsers glob the tree, so a root swapped for a
+        # symlink while the command ran would pull file contents from outside
+        # the results tree into the trial metrics. Same guard as the retention
+        # pass, which has the destructive version of this exposure.
+        log.warning(
+            "collect: %s is (or is under) a symlink after the run; refusing to "
+            "parse artifacts through it. No collector metrics for this trial.",
+            root,
+        )
+        return {}
     metrics: dict[str, Any] = {}
     registry = _registry()
     for name in active_collectors(config):
@@ -358,6 +390,7 @@ __all__ = [
     "WRAP_ORDER",
     "CollectorSpec",
     "active_collectors",
+    "collector_root_is_traversable",
     "summarize_collectors",
     "validate_collectors",
     "wrap_argv_for_collectors",

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -171,8 +171,23 @@ def _reset_output_dir(out_dir: Path) -> None:
     (``result.json``) lives in a different tree.
 
     Raises:
-        OSError: the directory could not be cleared or created.
+        OSError: the directory could not be cleared or created, or its parent is
+            a symlink (see below).
     """
+    # ``Path.is_dir()`` follows symlinks in *every* component, not just the
+    # last, so checking ``out_dir`` alone is not enough: if the per-trial
+    # collector root is a pre-existing symlink, ``out_dir`` resolves through it
+    # and ``rmtree`` would recursively delete the link target -- a tree outside
+    # the results directory entirely. The results tree is created by the
+    # dispatcher, so a symlink here is anomalous; refuse rather than guess.
+    parent = out_dir.parent
+    if parent.is_symlink():
+        raise OSError(
+            f"refusing to prepare {out_dir}: its parent {parent} is a symlink, "
+            "and clearing through it would delete the link target outside the "
+            "results tree. Remove the symlink or point --results-dir at a real "
+            "directory."
+        )
     if out_dir.is_symlink() or out_dir.is_file():
         out_dir.unlink()
     elif out_dir.is_dir():

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -26,7 +26,7 @@ from aorta._env_rules import is_valid_env_name, value_has_nul
 from aorta.instrumentation.environment import collect_env
 from aorta.registry import Environment, get_environment, get_mitigation
 from aorta.run._process import TrialWorkerError, launch_trial_worker
-from aorta.run.collectors import KNOWN_RECIPES
+from aorta.run.collectors import KNOWN_RECIPES, validate_collectors
 from aorta.run.discovery import (
     get_workload_class,
     get_workload_policy,
@@ -497,6 +497,11 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
             "collect_options entries must be dict[str, str]; invalid collectors: "
             f"{bad_collect_options}"
         )
+    # Per-collector option schemas + cross-collector conflicts. The recipe
+    # loader already applied these, but ``run_trials`` is a public library API:
+    # a programmatic caller deserves to learn its rocprof/proton pairing cannot
+    # run before the first trial launches, not from an empty artifact dir.
+    validate_collectors(request.collect, request.collect_options)
 
     # 3. Validate ``extra_env``. The CLI and recipe loader validate their
     #    inputs, but library callers can construct ``RunRequest`` directly.

--- a/src/aorta/triage/recipe.py
+++ b/src/aorta/triage/recipe.py
@@ -95,6 +95,13 @@ _PROBE_TOP_LEVEL = frozenset(
         "tier3_vram_growth",
         # Issue #232: collect-until-N stopping rule (valid in both modes).
         "stop_after",
+        # Cross-cutting collector names/options (valid in both modes, like
+        # stop_after). A probe-mode collector attaches by wrapping the user
+        # command's argv in SubprocessWorkload.setup(), so it is meaningful
+        # here even though probe-mode synthesises its own cells -- and unlike
+        # the other triage-mode keys it does not describe a matrix axis or a
+        # workload the probe flow fixes internally.
+        "collect",
         # Issue #229: operator detector-disable knobs. Accepted only in
         # mode: probe (triage-mode check below rejects them otherwise).
         "disable_detectors",
@@ -850,11 +857,17 @@ def _parse_collect(
     first-seen order. Option values MUST be strings (they become environment
     variables / CLI-shaped knobs downstream); non-string values are rejected
     at load time rather than silently ``str()``-coerced.
+
+    Options are then handed to
+    :func:`aorta.run.collectors.validate_collectors`, which checks them against
+    each collector's own schema and rejects collector combinations that cannot
+    run together, so a bad knob or an unrunnable pairing fails the recipe
+    instead of producing a run with no measurements in it.
     """
     # Local import keeps the triage->run layering explicit; collectors is a
     # leaf module so there is no cycle, but importing at call time avoids any
     # top-of-module import-order coupling.
-    from aorta.run.collectors import KNOWN_RECIPES
+    from aorta.run.collectors import KNOWN_RECIPES, validate_collectors
 
     if raw is None:
         return (), {}
@@ -895,7 +908,15 @@ def _parse_collect(
             f"valid: {sorted(KNOWN_RECIPES)}"
         )
     # De-duplicate names, preserving first-seen order (dict keys are ordered).
-    return tuple(dict.fromkeys(names)), options
+    deduped = tuple(dict.fromkeys(names))
+    # Per-collector option schemas and cross-collector conflicts (e.g. rocprof
+    # + a queue-intercepting proton backend) are the registry's business; it
+    # raises ValueError, which is a schema error at this layer.
+    try:
+        validate_collectors(deduped, options)
+    except ValueError as exc:
+        raise RecipeSchemaError(f"{label}: {exc}") from exc
+    return deduped, options
 
 
 def _parse_cell(idx: int, raw: Any, inline_envs: dict[str, InlineEnv]) -> Cell:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -40,6 +40,7 @@ Phase-1 minimum shape keeps working.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import os
@@ -318,8 +319,9 @@ class SubprocessWorkload(Workload):
         # the emulated environment: ``mirage run -- rocprofv3 -- <argv>``, not
         # the reverse, which would profile the emulator's own launcher.
         # A requested-but-unattachable collector (rocprofv3 missing, Proton CLI
-        # wrap of a non-Python command) raises here and is reported as a clean
-        # setup failure rather than a silently unprofiled run.
+        # wrap of a non-Python command, an artifact directory that cannot be
+        # prepared) raises here and is reported as a clean setup failure rather
+        # than a silently unprofiled run.
         from aorta.run.collectors import wrap_argv_for_collectors
 
         argv = wrap_argv_for_collectors(self.config, argv)
@@ -848,6 +850,21 @@ class SubprocessWorkload(Workload):
             encoding="utf-8",
         )
 
+        # Collector summaries ride the same ``metrics`` channel as the verdict
+        # bookkeeping, so the numeric ones (``rocprof_gpu_time_ms`` etc.) land
+        # in perf.md's metrics table and all of them in matrix.json. Merged
+        # under the platform keys below so a collector can never shadow
+        # ``verdict`` or ``exit_code``; fail-soft, returning ``{}`` when
+        # nothing was collected.
+        #
+        # Parsed BEFORE retention: retention prunes the profiler artifacts
+        # this reads, so summarising afterwards would silently lose every
+        # metric at any level below ``full``. The numbers survive in the trial
+        # record even when the trace they came from is pruned.
+        from aorta.run.collectors import summarize_collectors
+
+        metrics: dict[str, Any] = dict(summarize_collectors(self.config))
+
         # Issue #231: prune heavy per-trial artifacts now that the verdict
         # is known, keeping the level mapped from this trial's verdict.
         # Runs AFTER result.json is written so the trial record (which
@@ -875,15 +892,6 @@ class SubprocessWorkload(Workload):
         # contract from PR #194 round 4 is independent of the
         # matrix-side semantic.
         passed = verdict_obj.verdict == "pass"
-        # Collector summaries ride the same ``metrics`` channel as the verdict
-        # bookkeeping, so the numeric ones (``rocprof_gpu_time_ms`` etc.) land
-        # in perf.md's metrics table and all of them in matrix.json. Merged
-        # under the platform keys so a collector can never shadow ``verdict``
-        # or ``exit_code``; fail-soft, returning ``{}`` when nothing was
-        # collected.
-        from aorta.run.collectors import summarize_collectors
-
-        metrics: dict[str, Any] = dict(summarize_collectors(self.config))
         metrics.update(
             {
                 "verdict": verdict_obj.verdict,
@@ -1050,6 +1058,10 @@ class SubprocessWorkload(Workload):
     ) -> RetentionOutcome | None:
         """Prune this trial's heavy artifacts per ``retain`` (issue #231).
 
+        Covers both trees a trial writes to: the hand-written ``trial_dir``
+        and, via :meth:`_prune_collector_tree`, the sibling collector artifact
+        directory that rocprof / Proton write into.
+
         Returns the :class:`~aorta.run.retention.RetentionOutcome` so the
         caller can record the applied level + deleted-artifact list into
         ``result.json`` for post-hoc auditability (a reader of a bundled or
@@ -1089,6 +1101,7 @@ class SubprocessWorkload(Workload):
                 exc,
             )
             return None
+        outcome = self._prune_collector_tree(trial_dir, level, outcome)
         if outcome.deleted:
             log.info(
                 "retention[%s]: pruned %d artifact(s) (~%d bytes) from %s",
@@ -1098,6 +1111,66 @@ class SubprocessWorkload(Workload):
                 trial_dir,
             )
         return outcome
+
+    def _prune_collector_tree(
+        self, trial_dir: Path, level: str, outcome: RetentionOutcome
+    ) -> RetentionOutcome:
+        """Fold the collector artifact tree into this trial's retention outcome.
+
+        Profiler traces are the artifact class retention was built for (see
+        :mod:`aorta.run.retention`), but they do not live under ``trial_dir``:
+        the dispatcher threads ``_aorta_collect_dir`` as
+        ``<cell>/<workload>/trial_d<d>_m<m>_t<t>`` while the hand-written trial
+        record sits in ``<cell>/trial_<n>``, so the two trees are siblings.
+        Pruning only ``trial_dir`` would leave every rocprof/Proton capture on
+        disk regardless of ``retain``, which is hundreds of MB per trial across
+        a sweep.
+
+        Deleted paths are recorded relative to ``trial_dir`` (so they carry a
+        leading ``../``), keeping the ``result.json`` audit trail unambiguous
+        about which tree each pruned file came from. Best-effort like the rest
+        of retention: a failure here leaves the collector artifacts in place
+        and returns the trial-dir outcome unchanged.
+        """
+        from aorta.run.collectors import CONFIG_KEY_COLLECT_DIR, active_collectors
+
+        if not active_collectors(self.config):
+            return outcome
+        raw = self.config.get(CONFIG_KEY_COLLECT_DIR)
+        if not isinstance(raw, str) or not raw:
+            return outcome
+        collect_root = Path(raw)
+        if not collect_root.is_dir():
+            return outcome
+        try:
+            collected = apply_retention(collect_root, level)
+        except Exception as exc:  # noqa: BLE001 -- retention is best-effort
+            log.warning(
+                "retention: pruning collector artifacts in %s at level %r "
+                "failed (%s); artifacts kept",
+                collect_root,
+                level,
+                exc,
+            )
+            return outcome
+        try:
+            prefix = Path(os.path.relpath(collect_root, trial_dir)).as_posix()
+        except ValueError:
+            # Only reachable if the two trees are not relatable (a different
+            # drive on Windows; probe is Linux-only by design). The directory
+            # name still says which tree the entry came from.
+            prefix = collect_root.name
+
+        def _rebase(paths: tuple[str, ...]) -> tuple[str, ...]:
+            return tuple(f"{prefix}/{path}" for path in paths)
+
+        return dataclasses.replace(
+            outcome,
+            deleted=outcome.deleted + _rebase(collected.deleted),
+            kept=outcome.kept + _rebase(collected.kept),
+            freed_bytes=outcome.freed_bytes + collected.freed_bytes,
+            no_op=outcome.no_op and collected.no_op,
+        )
 
     @staticmethod
     def _record_retention(result_doc: dict[str, Any], outcome: RetentionOutcome) -> None:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -307,6 +307,23 @@ class SubprocessWorkload(Workload):
                 f"{[type(a).__name__ for a in argv]}"
             )
 
+        # Collector opt-in: when the dispatcher threaded ``_aorta_collect``
+        # into this trial, rewrite the opaque user argv so the requested
+        # profilers attach (``rocprofv3 ... -- <argv>``, ``python -m
+        # triton.profiler.proton ... <script>``). Returns the argv unchanged
+        # when no attaching collector was requested, so a run without
+        # ``--collect`` is byte-for-byte what it was.
+        #
+        # Applied BEFORE the emulation wrap so the profiler ends up *inside*
+        # the emulated environment: ``mirage run -- rocprofv3 -- <argv>``, not
+        # the reverse, which would profile the emulator's own launcher.
+        # A requested-but-unattachable collector (rocprofv3 missing, Proton CLI
+        # wrap of a non-Python command) raises here and is reported as a clean
+        # setup failure rather than a silently unprofiled run.
+        from aorta.run.collectors import wrap_argv_for_collectors
+
+        argv = wrap_argv_for_collectors(self.config, argv)
+
         # GPU-emulation opt-in: when the dispatcher-threaded environment
         # (``_aorta_environment``) targets the mirage emulator, transparently
         # rewrite the opaque user argv to ``mirage run --profile <p> -- <argv>``
@@ -858,6 +875,25 @@ class SubprocessWorkload(Workload):
         # contract from PR #194 round 4 is independent of the
         # matrix-side semantic.
         passed = verdict_obj.verdict == "pass"
+        # Collector summaries ride the same ``metrics`` channel as the verdict
+        # bookkeeping, so the numeric ones (``rocprof_gpu_time_ms`` etc.) land
+        # in perf.md's metrics table and all of them in matrix.json. Merged
+        # under the platform keys so a collector can never shadow ``verdict``
+        # or ``exit_code``; fail-soft, returning ``{}`` when nothing was
+        # collected.
+        from aorta.run.collectors import summarize_collectors
+
+        metrics: dict[str, Any] = dict(summarize_collectors(self.config))
+        metrics.update(
+            {
+                "verdict": verdict_obj.verdict,
+                "exit_code": exit_code,
+                "result_json_path": str(result_path),
+                "failure_detectors_fired": list(verdict_obj.failure_detectors_fired),
+                "error_detectors_fired": list(verdict_obj.error_detectors_fired),
+                "warn_detectors_fired": list(verdict_obj.warn_detectors_fired),
+            }
+        )
         return WorkloadResult(
             passed=passed,
             failure_count=0 if passed else 1,
@@ -881,14 +917,7 @@ class SubprocessWorkload(Workload):
             executed_iterations=1 if launched else 0,
             configured_iterations=1,
             elapsed_sec=walltime_sec,
-            metrics={
-                "verdict": verdict_obj.verdict,
-                "exit_code": exit_code,
-                "result_json_path": str(result_path),
-                "failure_detectors_fired": list(verdict_obj.failure_detectors_fired),
-                "error_detectors_fired": list(verdict_obj.error_detectors_fired),
-                "warn_detectors_fired": list(verdict_obj.warn_detectors_fired),
-            },
+            metrics=metrics,
         )
 
     def _write_env_file_failure_result(

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -1140,7 +1140,7 @@ class SubprocessWorkload(Workload):
         from aorta.run.collectors import (
             CONFIG_KEY_COLLECT_DIR,
             active_collectors,
-            collector_root_is_traversable,
+            unsafe_collector_paths,
         )
 
         if not active_collectors(self.config):
@@ -1155,11 +1155,17 @@ class SubprocessWorkload(Workload):
         # ``apply_retention()`` both follow links, so pruning through one would
         # delete files in the link's target -- outside the results tree, at any
         # level below ``full``. Keep the artifacts rather than risk that.
-        if not collector_root_is_traversable(collect_root):
+        #
+        # Every collector subdirectory is checked, not just the shared root:
+        # ``apply_retention`` recurses into ``<root>/rocprof`` and
+        # ``<root>/proton``, so swapping one of those is the same exposure one
+        # level down.
+        unsafe = unsafe_collector_paths(self.config)
+        if unsafe:
             log.warning(
                 "retention: %s is (or is under) a symlink after the run; "
                 "refusing to prune through it. Collector artifacts kept.",
-                collect_root,
+                ", ".join(str(path) for path in unsafe),
             )
             return outcome
         if not collect_root.is_dir():

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -1103,8 +1103,10 @@ class SubprocessWorkload(Workload):
             return None
         outcome = self._prune_collector_tree(trial_dir, level, outcome)
         if outcome.deleted:
+            # "for" rather than "from": the count can span both the trial dir
+            # and the sibling collector tree.
             log.info(
-                "retention[%s]: pruned %d artifact(s) (~%d bytes) from %s",
+                "retention[%s]: pruned %d artifact(s) (~%d bytes) for trial %s",
                 level,
                 len(outcome.deleted),
                 outcome.freed_bytes,

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -1134,7 +1134,11 @@ class SubprocessWorkload(Workload):
         of retention: a failure here leaves the collector artifacts in place
         and returns the trial-dir outcome unchanged.
         """
-        from aorta.run.collectors import CONFIG_KEY_COLLECT_DIR, active_collectors
+        from aorta.run.collectors import (
+            CONFIG_KEY_COLLECT_DIR,
+            active_collectors,
+            collector_root_is_traversable,
+        )
 
         if not active_collectors(self.config):
             return outcome
@@ -1142,6 +1146,19 @@ class SubprocessWorkload(Workload):
         if not isinstance(raw, str) or not raw:
             return outcome
         collect_root = Path(raw)
+        # Re-checked here, after the command ran, and not only by the pre-launch
+        # reset: the payload is handed this path and can replace the directory
+        # with a symlink while it executes. ``is_dir()`` and
+        # ``apply_retention()`` both follow links, so pruning through one would
+        # delete files in the link's target -- outside the results tree, at any
+        # level below ``full``. Keep the artifacts rather than risk that.
+        if not collector_root_is_traversable(collect_root):
+            log.warning(
+                "retention: %s is (or is under) a symlink after the run; "
+                "refusing to prune through it. Collector artifacts kept.",
+                collect_root,
+            )
+            return outcome
         if not collect_root.is_dir():
             return outcome
         try:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -852,10 +852,13 @@ class SubprocessWorkload(Workload):
 
         # Collector summaries ride the same ``metrics`` channel as the verdict
         # bookkeeping, so the numeric ones (``rocprof_gpu_time_ms`` etc.) land
-        # in perf.md's metrics table and all of them in matrix.json. Merged
-        # under the platform keys below so a collector can never shadow
-        # ``verdict`` or ``exit_code``; fail-soft, returning ``{}`` when
-        # nothing was collected.
+        # in perf.md's metrics table and in matrix.json's metrics_summary. The
+        # non-numeric ones (top-kernel lists, artifact dirs) reach neither --
+        # matrix aggregation takes numeric scalars only -- and are readable
+        # just from this trial's dispatcher JSON. Merged under the platform
+        # keys below so a collector can never shadow ``verdict`` or
+        # ``exit_code``; fail-soft, returning ``{}`` when nothing was
+        # collected.
         #
         # Parsed BEFORE retention: retention prunes the profiler artifacts
         # this reads, so summarising afterwards would silently lose every

--- a/tests/instrumentation/fixtures/proton/tree_capture/proton.hatchet
+++ b/tests/instrumentation/fixtures/proton/tree_capture/proton.hatchet
@@ -1,0 +1,91 @@
+
+[
+    {
+        "children": [
+            {
+                "children": [],
+                "frame": {
+                    "name": "_ZN2at6native12_GLOBAL__N_143distribution_elementwise_grid_stride_kernelIfLi4EZNS0_9templates4cuda21uniform_and_transformIffPNS_17CUDAGeneratorImplEZZZNS4_14uniform_kernelIS7_EEvRNS_18TensorIteratorBaseEddT_ENKUlvE_clEvENKUlvE0_clEvEUlfE_EEvSA_T1_T2_EUlP25hiprandStatePhilox4_32_10E0_ZNS1_27distribution_nullary_kernelIff15HIP_vector_typeIfLj4EES7_SJ_SE_EEvSA_SG_RKT3_T4_EUlifE_EEvlNS_15PhiloxCudaStateESF_SG_",
+                    "type": "function"
+                },
+                "metrics": {
+                    "count": 2,
+                    "device_id": "0",
+                    "device_type": "HIP",
+                    "time (ns)": 9601
+                }
+            },
+            {
+                "children": [],
+                "frame": {
+                    "name": "add_kernel",
+                    "type": "function"
+                },
+                "metrics": {
+                    "count": 6,
+                    "device_id": "0",
+                    "device_type": "HIP",
+                    "time (ns)": 17520
+                }
+            },
+            {
+                "children": [],
+                "frame": {
+                    "name": "_ZN2at6native29vectorized_elementwise_kernelILi4ENS0_15CUDAFunctor_addIfEESt5arrayIPcLm3EEEEviT0_T1_",
+                    "type": "function"
+                },
+                "metrics": {
+                    "count": 2,
+                    "device_id": "0",
+                    "device_type": "HIP",
+                    "time (ns)": 7561
+                }
+            },
+            {
+                "children": [],
+                "frame": {
+                    "name": "_ZN2at6native29vectorized_elementwise_kernelILi4ENS0_10AbsFunctorIfEESt5arrayIPcLm2EEEEviT0_T1_",
+                    "type": "function"
+                },
+                "metrics": {
+                    "count": 1,
+                    "device_id": "0",
+                    "device_type": "HIP",
+                    "time (ns)": 4320
+                }
+            },
+            {
+                "children": [],
+                "frame": {
+                    "name": "_ZN2at6native13reduce_kernelILi512ELi1ENS0_8ReduceOpIfNS0_14func_wrapper_tIfNS0_13MaxNanFunctorIfEEEEjfLi4ELi4EEEEEvT1_",
+                    "type": "function"
+                },
+                "metrics": {
+                    "count": 1,
+                    "device_id": "0",
+                    "device_type": "HIP",
+                    "time (ns)": 15400
+                }
+            }
+        ],
+        "frame": {
+            "name": "ROOT",
+            "type": "function"
+        },
+        "metrics": {
+            "count": 0,
+            "time (ns)": 0
+        }
+    },
+    {
+        "HIP": {
+            "0": {
+                "arch": "gfx950",
+                "bus_width": 8192,
+                "clock_rate": 2200000,
+                "memory_clock_rate": 1900000,
+                "num_sms": 256
+            }
+        }
+    }
+]

--- a/tests/instrumentation/fixtures/rocprof/flat_with_o/aorta_domain_stats.csv
+++ b/tests/instrumentation/fixtures/rocprof/flat_with_o/aorta_domain_stats.csv
@@ -1,0 +1,2 @@
+"Name","Calls","TotalDurationNs","AverageNs","Percentage","MinNs","MaxNs","StdDev"
+"KERNEL_DISPATCH",23,539404,23452.347826,100.00,22560,36320,2813.800546

--- a/tests/instrumentation/fixtures/rocprof/flat_with_o/aorta_kernel_stats.csv
+++ b/tests/instrumentation/fixtures/rocprof/flat_with_o/aorta_kernel_stats.csv
@@ -1,0 +1,2 @@
+"Name","Calls","TotalDurationNs","AverageNs","Percentage","MinNs","MaxNs","StdDev"
+"sgemm_tiled(float const*, float const*, float*, int)",23,539404,23452.347826,100.00,22560,36320,2813.800546

--- a/tests/instrumentation/fixtures/rocprof/flat_with_o/aorta_kernel_trace.csv
+++ b/tests/instrumentation/fixtures/rocprof/flat_with_o/aorta_kernel_trace.csv
@@ -1,0 +1,6 @@
+"Kind","Agent_Id","Queue_Id","Stream_Id","Thread_Id","Dispatch_Id","Kernel_Id","Kernel_Name","Correlation_Id","Start_Timestamp","End_Timestamp","LDS_Block_Size","Scratch_Size","VGPR_Count","Accum_VGPR_Count","SGPR_Count","Workgroup_Size_X","Workgroup_Size_Y","Workgroup_Size_Z","Grid_Size_X","Grid_Size_Y","Grid_Size_Z"
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,1,11,"sgemm_tiled(float const*, float const*, float*, int)",1,1434937317843317,1434937317879637,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,2,11,"sgemm_tiled(float const*, float const*, float*, int)",2,1434937317879637,1434937317902677,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,3,11,"sgemm_tiled(float const*, float const*, float*, int)",3,1434937317902677,1434937317925477,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,4,11,"sgemm_tiled(float const*, float const*, float*, int)",4,1434937317960637,1434937317983997,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,5,11,"sgemm_tiled(float const*, float const*, float*, int)",5,1434937317983997,1434937318006638,2048,0,20,0,32,16,16,1,512,512,1

--- a/tests/instrumentation/fixtures/rocprof/flat_with_o/aorta_rocprof_summary.txt
+++ b/tests/instrumentation/fixtures/rocprof/flat_with_o/aorta_rocprof_summary.txt
@@ -1,0 +1,6 @@
+
+ROCPROFV3 SUMMARY:
+
+|                         NAME                         |     DOMAIN      |      CALLS      | DURATION (msec) | AVERAGE (msec)  | PERCENT (INC) |   MIN (msec)    |   MAX (msec)    |     STDDEV      |
+|------------------------------------------------------|-----------------|-----------------|-----------------|-----------------|---------------|-----------------|-----------------|-----------------|
+| sgemm_tiled(float const*, float const*, float*, int) | KERNEL_DISPATCH |              23 |        0.539404 |       2.345e-02 |    100.000000 |         0.02256 |         0.03632 |       2.814e-03 |

--- a/tests/instrumentation/fixtures/rocprof/malformed/aorta_kernel_stats.csv
+++ b/tests/instrumentation/fixtures/rocprof/malformed/aorta_kernel_stats.csv
@@ -1,0 +1,3 @@
+not,a,rocprof,csv
+this file is garbage
+"unterminated quote,1,2

--- a/tests/instrumentation/fixtures/rocprof/malformed/aorta_kernel_trace.csv
+++ b/tests/instrumentation/fixtures/rocprof/malformed/aorta_kernel_trace.csv
@@ -1,0 +1,2 @@
+"Name","Calls","TotalDurationNs"
+"only_a_header_no_rows"

--- a/tests/instrumentation/fixtures/rocprof/nested_no_o/profiling-host-01/4170984_domain_stats.csv
+++ b/tests/instrumentation/fixtures/rocprof/nested_no_o/profiling-host-01/4170984_domain_stats.csv
@@ -1,0 +1,2 @@
+"Name","Calls","TotalDurationNs","AverageNs","Percentage","MinNs","MaxNs","StdDev"
+"KERNEL_DISPATCH",8,81720,10215.000000,100.00,8680,19160,3629.021907

--- a/tests/instrumentation/fixtures/rocprof/nested_no_o/profiling-host-01/4170984_kernel_stats.csv
+++ b/tests/instrumentation/fixtures/rocprof/nested_no_o/profiling-host-01/4170984_kernel_stats.csv
@@ -1,0 +1,2 @@
+"Name","Calls","TotalDurationNs","AverageNs","Percentage","MinNs","MaxNs","StdDev"
+"sgemm_tiled(float const*, float const*, float*, int)",8,81720,10215.000000,100.00,8680,19160,3629.021907

--- a/tests/instrumentation/fixtures/rocprof/nested_no_o/profiling-host-01/4170984_kernel_trace.csv
+++ b/tests/instrumentation/fixtures/rocprof/nested_no_o/profiling-host-01/4170984_kernel_trace.csv
@@ -1,0 +1,4 @@
+"Kind","Agent_Id","Queue_Id","Stream_Id","Thread_Id","Dispatch_Id","Kernel_Id","Kernel_Name","Correlation_Id","Start_Timestamp","End_Timestamp","LDS_Block_Size","Scratch_Size","VGPR_Count","Accum_VGPR_Count","SGPR_Count","Workgroup_Size_X","Workgroup_Size_Y","Workgroup_Size_Z","Grid_Size_X","Grid_Size_Y","Grid_Size_Z"
+"KERNEL_DISPATCH","Agent 2",1,0,4170984,1,11,"sgemm_tiled(float const*, float const*, float*, int)",1,1434952184689914,1434952184709074,2048,0,20,0,32,16,16,1,256,256,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170984,3,11,"sgemm_tiled(float const*, float const*, float*, int)",3,1434952184717874,1434952184726554,2048,0,20,0,32,16,16,1,256,256,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170984,2,11,"sgemm_tiled(float const*, float const*, float*, int)",2,1434952184709074,1434952184717874,2048,0,20,0,32,16,16,1,256,256,1

--- a/tests/instrumentation/fixtures/rocprof/stats_renamed_columns_trace_ok/aorta_kernel_stats.csv
+++ b/tests/instrumentation/fixtures/rocprof/stats_renamed_columns_trace_ok/aorta_kernel_stats.csv
@@ -1,0 +1,2 @@
+"Name","Invocations","TotalDurationNsec","AverageNsec","Percentage","MinNsec","MaxNsec","StdDev"
+"sgemm_tiled(float const*, float const*, float*, int)",5,128161,25632.200000,100.00,22641,36320,5764.301234

--- a/tests/instrumentation/fixtures/rocprof/stats_renamed_columns_trace_ok/aorta_kernel_trace.csv
+++ b/tests/instrumentation/fixtures/rocprof/stats_renamed_columns_trace_ok/aorta_kernel_trace.csv
@@ -1,0 +1,6 @@
+"Kind","Agent_Id","Queue_Id","Stream_Id","Thread_Id","Dispatch_Id","Kernel_Id","Kernel_Name","Correlation_Id","Start_Timestamp","End_Timestamp","LDS_Block_Size","Scratch_Size","VGPR_Count","Accum_VGPR_Count","SGPR_Count","Workgroup_Size_X","Workgroup_Size_Y","Workgroup_Size_Z","Grid_Size_X","Grid_Size_Y","Grid_Size_Z"
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,1,11,"sgemm_tiled(float const*, float const*, float*, int)",1,1434937317843317,1434937317879637,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,2,11,"sgemm_tiled(float const*, float const*, float*, int)",2,1434937317879637,1434937317902677,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,3,11,"sgemm_tiled(float const*, float const*, float*, int)",3,1434937317902677,1434937317925477,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,4,11,"sgemm_tiled(float const*, float const*, float*, int)",4,1434937317960637,1434937317983997,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,5,11,"sgemm_tiled(float const*, float const*, float*, int)",5,1434937317983997,1434937318006638,2048,0,20,0,32,16,16,1,512,512,1

--- a/tests/instrumentation/fixtures/rocprof/stats_truncated_trace_ok/aorta_kernel_stats.csv
+++ b/tests/instrumentation/fixtures/rocprof/stats_truncated_trace_ok/aorta_kernel_stats.csv
@@ -1,0 +1,2 @@
+"Name","Calls","TotalDurationNs","AverageNs","Percentage","MinNs","MaxNs","StdDev"
+"sgemm_tiled(float const*, float const*, float*, in

--- a/tests/instrumentation/fixtures/rocprof/stats_truncated_trace_ok/aorta_kernel_trace.csv
+++ b/tests/instrumentation/fixtures/rocprof/stats_truncated_trace_ok/aorta_kernel_trace.csv
@@ -1,0 +1,6 @@
+"Kind","Agent_Id","Queue_Id","Stream_Id","Thread_Id","Dispatch_Id","Kernel_Id","Kernel_Name","Correlation_Id","Start_Timestamp","End_Timestamp","LDS_Block_Size","Scratch_Size","VGPR_Count","Accum_VGPR_Count","SGPR_Count","Workgroup_Size_X","Workgroup_Size_Y","Workgroup_Size_Z","Grid_Size_X","Grid_Size_Y","Grid_Size_Z"
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,1,11,"sgemm_tiled(float const*, float const*, float*, int)",1,1434937317843317,1434937317879637,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,2,11,"sgemm_tiled(float const*, float const*, float*, int)",2,1434937317879637,1434937317902677,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,3,11,"sgemm_tiled(float const*, float const*, float*, int)",3,1434937317902677,1434937317925477,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,4,11,"sgemm_tiled(float const*, float const*, float*, int)",4,1434937317960637,1434937317983997,2048,0,20,0,32,16,16,1,512,512,1
+"KERNEL_DISPATCH","Agent 2",1,0,4170503,5,11,"sgemm_tiled(float const*, float const*, float*, int)",5,1434937317983997,1434937318006638,2048,0,20,0,32,16,16,1,512,512,1

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -328,6 +328,67 @@ def test_wrap_argv_cli_accepts_pytest_target(tmp_path):
     assert argv[-3:] == ["pytest", "-k", "gemm"]
 
 
+def test_wrap_argv_cli_accepts_the_dash_m_pytest_spelling(tmp_path):
+    """``python -m pytest`` is the usual venv/CI spelling of ``pytest``."""
+    argv = wrap_argv(["python", "-m", "pytest", "-k", "gemm"], tmp_path, env={})
+    assert argv[:3] == ["python", "-m", PROTON_MODULE]
+    # Normalised onto the bare target: Proton dispatches on basename ==
+    # 'pytest' and runs ``pytest.main(args)``, so ``-m`` must not survive
+    # into the target -- Proton's own ``-m`` is ``--mode``.
+    assert argv[-3:] == ["pytest", "-k", "gemm"]
+
+
+def test_dash_m_pytest_and_bare_pytest_wrap_to_the_same_target(tmp_path):
+    """The finding behind this test: same target, different spelling."""
+    from_module = wrap_argv(["python", "-m", "pytest", "tests/", "-q"], tmp_path, env={})
+    from_bare = wrap_argv(["pytest", "tests/", "-q"], tmp_path, env={})
+    target = ["pytest", "tests/", "-q"]
+    assert from_module[-3:] == target
+    assert from_bare[-3:] == target
+    # Only argv[0] may differ: the bare spelling has no interpreter to reuse,
+    # so ``resolve_python`` falls back to ``sys.executable``.
+    assert from_module[1:] == from_bare[1:]
+
+
+def test_wrap_argv_cli_accepts_the_attached_dash_m_spelling(tmp_path):
+    argv = wrap_argv(["python", "-mpytest", "-k", "gemm"], tmp_path, env={})
+    assert argv[:3] == ["python", "-m", PROTON_MODULE]
+    assert argv[-3:] == ["pytest", "-k", "gemm"]
+
+
+def test_wrap_argv_cli_keeps_interpreter_flags_before_a_dash_m_target(tmp_path):
+    argv = wrap_argv(["python", "-u", "-m", "pytest", "-x"], tmp_path, env={})
+    assert argv[:4] == ["python", "-u", "-m", PROTON_MODULE]
+    assert argv[-2:] == ["pytest", "-x"]
+
+
+def test_wrap_argv_cli_rejects_a_module_proton_cannot_run(tmp_path):
+    """``runpy.run_path`` takes a path, so a module name has no equivalent."""
+    with pytest.raises(ProtonWrapError, match="cannot wrap 'python -m torch.distributed.run'"):
+        wrap_argv(["python", "-m", "torch.distributed.run", "train.py"], tmp_path, env={})
+
+
+def test_module_rejection_names_the_spellings_that_do_work(tmp_path):
+    with pytest.raises(ProtonWrapError) as excinfo:
+        wrap_argv(["python", "-m", "http.server"], tmp_path, env={})
+    message = str(excinfo.value)
+    assert "runpy.run_path" in message
+    assert "pytest" in message
+    assert "mode: env" in message
+
+
+def test_wrap_argv_cli_rejects_dash_m_with_no_module(tmp_path):
+    with pytest.raises(ProtonWrapError, match="no module name"):
+        wrap_argv(["python", "-m"], tmp_path, env={})
+
+
+def test_unknown_interpreter_flag_error_names_the_dash_m_escape(tmp_path):
+    """The supported-spellings list must stay in step with the code."""
+    with pytest.raises(ProtonWrapError) as excinfo:
+        wrap_argv(["python", "-c", "print(1)"], tmp_path, env={})
+    assert "'-m' with ['pytest']" in str(excinfo.value)
+
+
 def test_wrap_argv_cli_rejects_a_non_python_command(tmp_path):
     with pytest.raises(ProtonWrapError, match="mode: env"):
         wrap_argv(["/tmp/aorta_hip_gemm", "512"], tmp_path, env={})

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -254,6 +254,54 @@ def test_resolve_python_env_override_wins(monkeypatch):
     assert resolve_python(["python", "script.py"]) == "/rocm/bin/python"
 
 
+def _console_script(tmp_path, first_line: str, name: str = "pytest"):
+    """Write an executable ``pytest`` console script on ``$PATH``."""
+    script = tmp_path / "scriptbin" / name
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text(f"{first_line}\nraise SystemExit(0)\n")
+    script.chmod(0o755)
+    return script
+
+
+def test_resolve_python_reads_the_pytest_shebang(tmp_path, monkeypatch):
+    """The wrap replaces the command's interpreter, so a bare ``pytest`` must
+    keep the one its console script names -- otherwise a venv's test run gets
+    profiled under aorta's interpreter and a different dependency set."""
+    script = _console_script(tmp_path, "#!/opt/venv/bin/python3.12")
+    monkeypatch.delenv(ENV_PROTON_PYTHON, raising=False)
+    monkeypatch.setenv("PATH", str(script.parent))
+    assert resolve_python(["pytest", "-q"]) == "/opt/venv/bin/python3.12"
+
+
+def test_resolve_python_reads_an_env_style_shebang(tmp_path, monkeypatch):
+    script = _console_script(tmp_path, "#!/usr/bin/env python3")
+    monkeypatch.delenv(ENV_PROTON_PYTHON, raising=False)
+    monkeypatch.setenv("PATH", str(script.parent))
+    assert resolve_python([str(script), "-q"]) == "python3"
+
+
+def test_resolve_python_ignores_a_non_python_shebang(tmp_path, monkeypatch):
+    """A shell wrapper names no interpreter we can run Proton under, so the
+    fallback is honest rather than a guess at ``/bin/sh``."""
+    script = _console_script(tmp_path, "#!/bin/sh")
+    monkeypatch.delenv(ENV_PROTON_PYTHON, raising=False)
+    monkeypatch.setenv("PATH", str(script.parent))
+    assert resolve_python(["pytest"]) == sys.executable
+
+
+def test_resolve_python_falls_back_when_pytest_is_not_on_path(tmp_path, monkeypatch):
+    monkeypatch.delenv(ENV_PROTON_PYTHON, raising=False)
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    assert resolve_python(["pytest"]) == sys.executable
+
+
+def test_resolve_python_override_beats_the_shebang(tmp_path, monkeypatch):
+    script = _console_script(tmp_path, "#!/opt/venv/bin/python3.12")
+    monkeypatch.setenv("PATH", str(script.parent))
+    monkeypatch.setenv(ENV_PROTON_PYTHON, "/rocm/bin/python")
+    assert resolve_python(["pytest"]) == "/rocm/bin/python"
+
+
 # ---- CLI-mode argv construction -----------------------------------------
 
 

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -1,0 +1,715 @@
+"""Tests for the ``proton`` collector package (no GPU, no Triton needed).
+
+Covers the option schema, both attach modes (``cli`` argv rewrite and ``env``
+variable bundle), the ``HIP_VISIBLE_DEVICES`` -> ``ROCR_VISIBLE_DEVICES``
+translation Proton needs on AMD, and fail-soft ``.hatchet`` parsing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from aorta.instrumentation.proton import (
+    AUTO_BACKEND,
+    BACKENDS,
+    ENV_PREFIX,
+    ENV_PROTON_PYTHON,
+    OPTION_KEYS,
+    OUTPUT_SUBDIR,
+    PROFILE_BASENAME,
+    PROTON_MODULE,
+    QUEUE_INTERCEPTING_BACKENDS,
+    ProtonWrapError,
+    build_argv_prefix,
+    build_env,
+    mode_argument,
+    parse_profile,
+    parse_summary,
+    resolve_python,
+    validate_options,
+    wrap_argv,
+)
+from aorta.run.collectors import KNOWN_RECIPES
+
+FIXTURES = Path(__file__).parent / "fixtures" / "proton"
+
+
+@pytest.fixture
+def env_on_path(tmp_path, monkeypatch):
+    """Put a fake ``env(1)`` on ``$PATH`` so the device-translation prefix builds."""
+    fake = tmp_path / "env"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    return fake
+
+
+# ---- Registration + package surface --------------------------------------
+
+
+def test_registered_as_known_recipe():
+    assert "proton" in KNOWN_RECIPES
+
+
+def test_output_subdir_is_proton():
+    assert OUTPUT_SUBDIR == "proton"
+
+
+def test_queue_intercepting_backends_are_a_subset_of_backends():
+    assert QUEUE_INTERCEPTING_BACKENDS <= BACKENDS
+
+
+def test_auto_counts_as_queue_intercepting():
+    """``auto`` resolves to ``rocprofiler`` or ``roctracer`` on AMD, so the
+    rocprof-conflict guard cannot treat it as safe."""
+    assert AUTO_BACKEND in QUEUE_INTERCEPTING_BACKENDS
+
+
+def test_auto_is_not_a_proton_backend_name():
+    """It is aorta's spelling for "omit ``-b``", so it must never be passed
+    through to Proton, whose argparse would reject it."""
+    assert AUTO_BACKEND == "auto"
+    assert "-b" not in build_argv_prefix("/tmp/x", {"backend": AUTO_BACKEND})
+
+
+def test_rocprofiler_stays_a_valid_backend():
+    """``rocprofiler`` is the documented forward path on AMD and is accepted by
+    current upstream Triton. Older Triton (3.7.x) offers only
+    cupti/roctracer/instrumentation, but the validator must not narrow to
+    whichever Triton happens to be installed on the host doing the validating --
+    a recipe is authored once and run on many hosts."""
+    assert "rocprofiler" in BACKENDS
+    assert validate_options({"backend": "rocprofiler"})["backend"] == "rocprofiler"
+
+
+# ---- Option validation ---------------------------------------------------
+
+
+def test_validate_options_defaults():
+    effective = validate_options(None)
+    assert effective == {
+        "mode": "cli",
+        "backend": AUTO_BACKEND,
+        "context": "shadow",
+        "data": "tree",
+    }
+
+
+def test_validate_options_empty_mapping_matches_none():
+    assert validate_options({}) == validate_options(None)
+
+
+def test_validate_options_rejects_unknown_key():
+    with pytest.raises(ValueError, match="unknown option"):
+        validate_options({"backends": "roctracer"})
+
+
+def test_validate_options_rejects_non_string_value():
+    with pytest.raises(ValueError, match="must be a string"):
+        validate_options({"backend": 1})  # type: ignore[dict-item]
+
+
+@pytest.mark.parametrize("mode", ["cli", "env"])
+def test_validate_options_accepts_every_mode(mode):
+    assert validate_options({"mode": mode})["mode"] == mode
+
+
+def test_validate_options_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="'mode'"):
+        validate_options({"mode": "library"})
+
+
+@pytest.mark.parametrize("backend", sorted(BACKENDS))
+def test_validate_options_accepts_every_backend(backend):
+    assert validate_options({"backend": backend})["backend"] == backend
+
+
+def test_validate_options_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="'backend'"):
+        validate_options({"backend": "rocprof"})
+
+
+@pytest.mark.parametrize("context", ["shadow", "python"])
+def test_validate_options_accepts_every_context(context):
+    assert validate_options({"context": context})["context"] == context
+
+
+def test_validate_options_rejects_unknown_context():
+    with pytest.raises(ValueError, match="'context'"):
+        validate_options({"context": "cpp"})
+
+
+@pytest.mark.parametrize("data", ["tree", "trace"])
+def test_validate_options_accepts_every_data_format(data):
+    assert validate_options({"data": data})["data"] == data
+
+
+def test_validate_options_rejects_unknown_data_format():
+    with pytest.raises(ValueError, match="'data'"):
+        validate_options({"data": "hatchet"})
+
+
+def test_validate_options_normalises_case_and_whitespace():
+    assert validate_options({"backend": " ROCTRACER "})["backend"] == "roctracer"
+
+
+@pytest.mark.parametrize("name", ["default", "mma", "pcsampling"])
+def test_validate_options_accepts_every_instrumentation_mode(name):
+    effective = validate_options({"backend": "instrumentation", "instrumentation_mode": name})
+    assert effective["instrumentation_mode"] == name
+
+
+def test_validate_options_rejects_unknown_instrumentation_mode():
+    with pytest.raises(ValueError, match="instrumentation_mode"):
+        validate_options({"backend": "instrumentation", "instrumentation_mode": "nope"})
+
+
+@pytest.mark.parametrize("granularity", ["cta", "warp", "warp_4", "warp_group_8"])
+def test_validate_options_accepts_granularities(granularity):
+    effective = validate_options({"backend": "instrumentation", "granularity": granularity})
+    assert effective["granularity"] == granularity
+
+
+def test_validate_options_rejects_unknown_granularity():
+    with pytest.raises(ValueError, match="'granularity'"):
+        validate_options({"backend": "instrumentation", "granularity": "thread"})
+
+
+@pytest.mark.parametrize("key", ["instrumentation_mode", "granularity"])
+def test_validate_options_rejects_intra_kernel_knob_on_wrong_backend(key):
+    """Proton silently ignores these outside the instrumentation backend, so
+    accepting them would hand back a profile the operator did not ask for."""
+    with pytest.raises(ValueError, match="backend: instrumentation"):
+        validate_options({"backend": "roctracer", key: "cta" if key == "granularity" else "mma"})
+
+
+def test_validate_options_does_not_mutate_input():
+    supplied = {"backend": "ROCTRACER"}
+    validate_options(supplied)
+    assert supplied == {"backend": "ROCTRACER"}
+
+
+def test_option_keys_match_the_validator():
+    samples = {
+        "mode": "cli",
+        "backend": "instrumentation",
+        "context": "shadow",
+        "data": "tree",
+        "instrumentation_mode": "mma",
+        "granularity": "warp",
+    }
+    assert set(samples) == set(OPTION_KEYS)
+    assert validate_options(samples)
+
+
+# ---- --mode rendering ----------------------------------------------------
+
+
+def test_mode_argument_absent_without_intra_kernel_knobs():
+    assert mode_argument(validate_options(None)) is None
+
+
+def test_mode_argument_name_only():
+    effective = validate_options({"backend": "instrumentation", "instrumentation_mode": "mma"})
+    assert mode_argument(effective) == "mma"
+
+
+def test_mode_argument_granularity_only_defaults_the_name():
+    effective = validate_options({"backend": "instrumentation", "granularity": "warp"})
+    assert mode_argument(effective) == "default:granularity=warp"
+
+
+def test_mode_argument_name_and_granularity():
+    effective = validate_options(
+        {"backend": "instrumentation", "instrumentation_mode": "mma", "granularity": "cta"}
+    )
+    assert mode_argument(effective) == "mma:granularity=cta"
+
+
+# ---- Interpreter resolution ---------------------------------------------
+
+
+def test_resolve_python_prefers_the_workloads_own_interpreter():
+    assert resolve_python(["python3.11", "script.py"]) == "python3.11"
+
+
+def test_resolve_python_accepts_an_absolute_interpreter():
+    assert resolve_python(["/opt/venv/bin/python", "script.py"]) == "/opt/venv/bin/python"
+
+
+def test_resolve_python_falls_back_to_sys_executable():
+    assert resolve_python(["/tmp/gemm", "512"]) == sys.executable
+
+
+def test_resolve_python_empty_argv_falls_back():
+    assert resolve_python([]) == sys.executable
+
+
+def test_resolve_python_env_override_wins(monkeypatch):
+    monkeypatch.setenv(ENV_PROTON_PYTHON, "/rocm/bin/python")
+    assert resolve_python(["python", "script.py"]) == "/rocm/bin/python"
+
+
+# ---- CLI-mode argv construction -----------------------------------------
+
+
+def test_build_argv_prefix_shape(tmp_path):
+    argv = build_argv_prefix(tmp_path, python="/rocm/bin/python")
+    assert argv[:3] == ["/rocm/bin/python", "-m", PROTON_MODULE]
+    assert argv[argv.index("-n") + 1] == str(tmp_path / PROFILE_BASENAME)
+    assert argv[argv.index("--context") + 1] == "shadow"
+    assert argv[argv.index("--data") + 1] == "tree"
+    assert "--mode" not in argv
+
+
+def test_build_argv_prefix_omits_backend_flag_by_default(tmp_path):
+    """``backend: auto`` is the absence of ``-b``, which is the only spelling
+    that survives Proton's own version skew: 3.7.x's CLI lists only
+    cupti/roctracer/instrumentation and exits at argparse on anything else,
+    while newer Triton prefers ``rocprofiler``. Dropping the flag hands the
+    choice to Proton's ``_select_backend()`` on whichever version is installed.
+    """
+    assert "-b" not in build_argv_prefix(tmp_path)
+    assert AUTO_BACKEND not in build_argv_prefix(tmp_path)
+
+
+@pytest.mark.parametrize("backend", ["rocprofiler", "roctracer", "instrumentation", "cupti"])
+def test_build_argv_prefix_passes_an_explicit_backend(tmp_path, backend):
+    argv = build_argv_prefix(tmp_path, {"backend": backend})
+    assert argv[argv.index("-b") + 1] == backend
+
+
+def test_build_argv_prefix_uses_module_not_console_script(tmp_path):
+    """The ``proton`` console script is shebanged to whichever interpreter
+    installed Triton, which is typically not the workload's interpreter."""
+    argv = build_argv_prefix(tmp_path)
+    assert "proton" not in {Path(argv[0]).name}
+    assert argv[1] == "-m"
+
+
+def test_build_argv_prefix_defaults_to_sys_executable(tmp_path):
+    assert build_argv_prefix(tmp_path)[0] == sys.executable
+
+
+def test_build_argv_prefix_includes_mode_for_intra_kernel(tmp_path):
+    argv = build_argv_prefix(
+        tmp_path, {"backend": "instrumentation", "instrumentation_mode": "mma"}
+    )
+    assert argv[argv.index("--mode") + 1] == "mma"
+
+
+def test_build_argv_prefix_propagates_option_error(tmp_path):
+    with pytest.raises(ValueError, match="unknown option"):
+        build_argv_prefix(tmp_path, {"nope": "1"})
+
+
+def test_wrap_argv_cli_rewrites_a_python_launch(tmp_path):
+    argv = wrap_argv(["python", "vecadd.py", "--size", "1024"], tmp_path, env={})
+    assert argv[:3] == ["python", "-m", PROTON_MODULE]
+    # No ``--`` separator: Proton's front-end takes the target with REMAINDER.
+    assert "--" not in argv
+    assert argv[-3:] == ["vecadd.py", "--size", "1024"]
+
+
+def test_wrap_argv_cli_keeps_interpreter_flags_in_front_of_dash_m(tmp_path):
+    argv = wrap_argv(["python", "-u", "vecadd.py"], tmp_path, env={})
+    assert argv[:4] == ["python", "-u", "-m", PROTON_MODULE]
+    assert argv[-1] == "vecadd.py"
+
+
+def test_wrap_argv_cli_accepts_pytest_target(tmp_path):
+    """Proton's front-end documents ``proton [options] pytest ...``."""
+    argv = wrap_argv(["pytest", "-k", "gemm"], tmp_path, env={})
+    assert argv[1:3] == ["-m", PROTON_MODULE]
+    assert argv[-3:] == ["pytest", "-k", "gemm"]
+
+
+def test_wrap_argv_cli_rejects_a_non_python_command(tmp_path):
+    with pytest.raises(ProtonWrapError, match="mode: env"):
+        wrap_argv(["/tmp/aorta_hip_gemm", "512"], tmp_path, env={})
+
+
+def test_wrap_argv_cli_rejects_unknown_interpreter_flag(tmp_path):
+    with pytest.raises(ProtonWrapError, match="interpreter option"):
+        wrap_argv(["python", "-c", "print(1)"], tmp_path, env={})
+
+
+def test_wrap_argv_cli_rejects_interpreter_with_no_script(tmp_path):
+    with pytest.raises(ProtonWrapError, match="needs a script path"):
+        wrap_argv(["python", "-u"], tmp_path, env={})
+
+
+def test_wrap_argv_cli_rejects_empty_argv(tmp_path):
+    with pytest.raises(ProtonWrapError, match="empty argv"):
+        wrap_argv([], tmp_path, env={})
+
+
+def test_wrap_argv_does_not_mutate_the_input(tmp_path):
+    inner = ["python", "vecadd.py"]
+    wrap_argv(inner, tmp_path, env={})
+    assert inner == ["python", "vecadd.py"]
+
+
+# ---- Device-variable translation ----------------------------------------
+
+
+def test_wrap_argv_translates_hip_visible_devices(tmp_path, env_on_path):
+    """Proton on AMD does not honour ``HIP_VISIBLE_DEVICES`` for the
+    queue-intercepting backends, so a device-pinned cell would otherwise
+    profile the wrong GPU."""
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "roctracer"},
+        env={"HIP_VISIBLE_DEVICES": "1"},
+    )
+    assert argv[0] == str(env_on_path)
+    assert "-u" in argv[:3]
+    assert "HIP_VISIBLE_DEVICES" in argv
+    assert "ROCR_VISIBLE_DEVICES=1" in argv
+    assert argv[argv.index("-m") - 1].endswith("python")
+
+
+def test_wrap_argv_keeps_an_explicit_rocr_visible_devices(tmp_path, env_on_path):
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "rocprofiler"},
+        env={"HIP_VISIBLE_DEVICES": "1", "ROCR_VISIBLE_DEVICES": "0"},
+    )
+    assert "ROCR_VISIBLE_DEVICES=0" in argv
+
+
+def test_wrap_argv_no_env_prefix_for_instrumentation_backend(tmp_path, env_on_path):
+    """The instrumentation backend installs no queue interceptor, so the
+    device variables mean what they normally mean and are left alone."""
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "instrumentation"},
+        env={"HIP_VISIBLE_DEVICES": "1"},
+    )
+    assert argv[0] == "python"
+
+
+def test_wrap_argv_no_env_prefix_when_no_device_pin(tmp_path, env_on_path):
+    argv = wrap_argv(["python", "vecadd.py"], tmp_path, env={})
+    assert argv[0] == "python"
+
+
+def test_wrap_argv_survives_env_binary_missing(tmp_path, monkeypatch):
+    """No ``env(1)`` means the translation cannot be applied; the wrap still
+    profiles rather than failing the trial outright."""
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "roctracer"},
+        env={"HIP_VISIBLE_DEVICES": "1"},
+    )
+    assert argv[0] == "python"
+
+
+def test_wrap_argv_reads_os_environ_by_default(tmp_path, env_on_path, monkeypatch):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "3")
+    argv = wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": "roctracer"})
+    assert "ROCR_VISIBLE_DEVICES=3" in argv
+
+
+def test_wrap_argv_never_mutates_the_supplied_env(tmp_path, env_on_path):
+    env = {"HIP_VISIBLE_DEVICES": "1"}
+    wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": "roctracer"}, env=env)
+    assert env == {"HIP_VISIBLE_DEVICES": "1"}
+
+
+# ---- env-mode ------------------------------------------------------------
+
+
+def test_build_env_bundle(tmp_path):
+    env = build_env(tmp_path)
+    assert env[f"{ENV_PREFIX}DIR"] == str(tmp_path)
+    assert env[f"{ENV_PREFIX}NAME"] == str(tmp_path / PROFILE_BASENAME)
+    assert env[f"{ENV_PREFIX}CONTEXT"] == "shadow"
+    assert env[f"{ENV_PREFIX}DATA"] == "tree"
+    assert f"{ENV_PREFIX}MODE" not in env
+    assert all(key.startswith(ENV_PREFIX) for key in env)
+
+
+def test_build_env_omits_backend_by_default(tmp_path):
+    """Absent means ``proton.start(backend=None)``: Proton's own selection, the
+    env-mode counterpart of dropping ``-b`` from the CLI wrap."""
+    assert f"{ENV_PREFIX}BACKEND" not in build_env(tmp_path)
+
+
+def test_build_env_carries_an_explicit_backend(tmp_path):
+    env = build_env(tmp_path, {"backend": "rocprofiler"})
+    assert env[f"{ENV_PREFIX}BACKEND"] == "rocprofiler"
+
+
+def test_build_env_includes_mode_for_intra_kernel(tmp_path):
+    env = build_env(tmp_path, {"backend": "instrumentation", "granularity": "warp"})
+    assert env[f"{ENV_PREFIX}MODE"] == "default:granularity=warp"
+
+
+def test_build_env_accepts_str_out_dir():
+    assert build_env("relative/out")[f"{ENV_PREFIX}DIR"] == str(Path("relative/out"))
+
+
+def test_wrap_argv_env_mode_leaves_the_command_alone(tmp_path, env_on_path):
+    argv = wrap_argv(["/tmp/aorta_hip_gemm", "512"], tmp_path, {"mode": "env"}, env={})
+    assert argv[0] == str(env_on_path)
+    assert argv[-2:] == ["/tmp/aorta_hip_gemm", "512"]
+    assert PROTON_MODULE not in argv
+    assert f"{ENV_PREFIX}DATA=tree" in argv
+
+
+def test_wrap_argv_env_mode_wraps_a_non_python_command(tmp_path, env_on_path):
+    """The escape hatch the CLI-mode error message points at."""
+    argv = wrap_argv(["/bin/true"], tmp_path, {"mode": "env"}, env={})
+    assert argv[-1] == "/bin/true"
+
+
+def test_wrap_argv_env_mode_still_translates_devices(tmp_path, env_on_path):
+    argv = wrap_argv(
+        ["/bin/true"],
+        tmp_path,
+        {"mode": "env", "backend": "roctracer"},
+        env={"HIP_VISIBLE_DEVICES": "1"},
+    )
+    assert "ROCR_VISIBLE_DEVICES=1" in argv
+    assert "HIP_VISIBLE_DEVICES" in argv
+
+
+# ---- .hatchet parsing ----------------------------------------------------
+
+
+def _hatchet(tmp_path: Path, payload, name: str = "proton.hatchet") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _tree(children):
+    return [{"frame": {"name": "ROOT"}, "metrics": {}, "children": children}]
+
+
+def _leaf(name, time_ns, count=1):
+    return {
+        "frame": {"name": name, "type": "function"},
+        "metrics": {"count": count, "time (ns)": time_ns},
+        "children": [],
+    }
+
+
+def test_parse_summary_real_capture_fixture():
+    """The checked-in fixture is a real Proton ``data: tree`` capture.
+
+    Produced on a gfx950 host by running the shipped ``triton-vecadd`` example
+    under ``python -m triton.profiler.proton -b roctracer --context shadow
+    --data tree``. Every leaf carries ``count`` and ``time (ns)`` alongside
+    ``device_id`` / ``device_type``, and the Triton kernel (``add_kernel``) is
+    the hot one -- the rest are the torch elementwise/reduction kernels the
+    payload's own correctness check dispatches.
+    """
+    metrics = parse_summary(FIXTURES / "tree_capture")
+    assert metrics["proton_kernel_count"] == 12
+    assert metrics["proton_gpu_time_ms"] == pytest.approx(0.054402)
+    assert metrics["proton_top_kernel_ms"] == pytest.approx(0.01752)
+    assert metrics["proton_top_kernels"][0] == "add_kernel"
+    assert metrics["proton_top_kernel_ms"] < metrics["proton_gpu_time_ms"]
+    assert metrics["proton_artifact_dir"] == str(FIXTURES / "tree_capture")
+
+
+def test_parse_summary_emits_only_expected_keys(tmp_path):
+    _hatchet(tmp_path, _tree([_leaf("k", 1_000_000)]))
+    assert set(parse_summary(tmp_path)) == {
+        "proton_artifact_dir",
+        "proton_kernel_count",
+        "proton_gpu_time_ms",
+        "proton_top_kernel_ms",
+        "proton_top_kernels",
+    }
+
+
+def test_parse_summary_numeric_metrics_are_plain_numbers(tmp_path):
+    _hatchet(tmp_path, _tree([_leaf("k", 1_000_000)]))
+    metrics = parse_summary(tmp_path)
+    for key in ("proton_kernel_count", "proton_gpu_time_ms", "proton_top_kernel_ms"):
+        assert isinstance(metrics[key], (int, float))
+        assert not isinstance(metrics[key], bool)
+
+
+def test_parse_summary_converts_time_units(tmp_path):
+    _hatchet(tmp_path, _tree([_leaf("k", 2_500_000)]))
+    assert parse_summary(tmp_path)["proton_gpu_time_ms"] == pytest.approx(2.5)
+
+
+@pytest.mark.parametrize(
+    ("unit", "value", "expected_ms"),
+    [("ns", 1_000_000, 1.0), ("us", 1500, 1.5), ("ms", 2.5, 2.5), ("s", 0.25, 250.0)],
+)
+def test_parse_summary_accepts_every_time_unit(tmp_path, unit, value, expected_ms):
+    node = {
+        "frame": {"name": "k"},
+        "metrics": {"count": 1, f"time ({unit})": value},
+        "children": [],
+    }
+    _hatchet(tmp_path, _tree([node]))
+    assert parse_summary(tmp_path)["proton_gpu_time_ms"] == pytest.approx(expected_ms)
+
+
+def test_parse_summary_ignores_cpu_time_and_inclusive_columns(tmp_path):
+    node = {
+        "frame": {"name": "k"},
+        "metrics": {"count": 1, "cpu_time (ns)": 9_000_000, "time (ns) (inc)": 9_000_000},
+        "children": [],
+    }
+    _hatchet(tmp_path, _tree([node]))
+    assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_only_counts_leaves(tmp_path):
+    """Interior frames carry inclusive time; counting them double-counts."""
+    parent = {
+        "frame": {"name": "parent"},
+        "metrics": {"count": 1, "time (ns)": 10_000_000},
+        "children": [_leaf("child", 4_000_000)],
+    }
+    _hatchet(tmp_path, _tree([parent]))
+    metrics = parse_summary(tmp_path)
+    assert metrics["proton_top_kernels"] == ["child"]
+    assert metrics["proton_gpu_time_ms"] == pytest.approx(4.0)
+
+
+def test_parse_summary_sums_repeated_kernel_names(tmp_path):
+    _hatchet(
+        tmp_path,
+        _tree([_leaf("k", 1_000_000, count=3), _leaf("k", 2_000_000, count=2)]),
+    )
+    metrics = parse_summary(tmp_path)
+    assert metrics["proton_gpu_time_ms"] == pytest.approx(3.0)
+    assert metrics["proton_kernel_count"] == 5
+
+
+def test_parse_summary_defaults_missing_count_to_one(tmp_path):
+    node = {"frame": {"name": "k"}, "metrics": {"time (ns)": 1_000_000}, "children": []}
+    _hatchet(tmp_path, _tree([node]))
+    assert parse_summary(tmp_path)["proton_kernel_count"] == 1
+
+
+def test_parse_summary_ranks_and_caps_top_kernels(tmp_path):
+    leaves = [_leaf(f"k{i}", (12 - i) * 1_000_000) for i in range(12)]
+    _hatchet(tmp_path, _tree(leaves))
+    metrics = parse_summary(tmp_path)
+    assert metrics["proton_top_kernels"] == ["k0", "k1", "k2", "k3", "k4"]
+    assert metrics["proton_top_kernel_ms"] == pytest.approx(12.0)
+
+
+def test_parse_summary_aggregates_multiple_profiles(tmp_path):
+    _hatchet(tmp_path, _tree([_leaf("k", 1_000_000)]), name="a.hatchet")
+    _hatchet(tmp_path, _tree([_leaf("k", 3_000_000)]), name="b.hatchet")
+    assert parse_summary(tmp_path)["proton_gpu_time_ms"] == pytest.approx(4.0)
+
+
+def test_parse_summary_finds_nested_profiles(tmp_path):
+    nested = tmp_path / "rank0"
+    nested.mkdir()
+    _hatchet(nested, _tree([_leaf("k", 1_000_000)]))
+    assert parse_summary(tmp_path)["proton_gpu_time_ms"] == pytest.approx(1.0)
+
+
+# ---- .hatchet parsing: fail-soft ----------------------------------------
+
+
+def test_parse_summary_missing_dir_is_empty(tmp_path):
+    assert parse_summary(tmp_path / "never-created") == {}
+
+
+def test_parse_summary_file_instead_of_dir_is_empty(tmp_path):
+    path = tmp_path / "not-a-dir"
+    path.write_text("")
+    assert parse_summary(path) == {}
+
+
+def test_parse_summary_empty_dir_reports_only_the_artifact_dir(tmp_path):
+    assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_malformed_json_degrades_without_raising(tmp_path):
+    (tmp_path / "proton.hatchet").write_text("{not json at all", encoding="utf-8")
+    assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_unexpected_json_shape_degrades(tmp_path):
+    _hatchet(tmp_path, {"totally": "different"})
+    assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_trace_format_has_no_tree_to_walk(tmp_path):
+    """``data: trace`` produces a chrome trace, not a hatchet tree."""
+    _hatchet(tmp_path, {"traceEvents": [{"name": "k", "dur": 5}]})
+    assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_skips_unnamed_and_untimed_leaves(tmp_path):
+    _hatchet(
+        tmp_path,
+        _tree(
+            [
+                {"frame": {"name": ""}, "metrics": {"time (ns)": 5_000_000}, "children": []},
+                {"frame": {"name": "no-time"}, "metrics": {"count": 1}, "children": []},
+                _leaf("good", 1_000_000),
+            ]
+        ),
+    )
+    metrics = parse_summary(tmp_path)
+    assert metrics["proton_top_kernels"] == ["good"]
+
+
+def test_parse_summary_tolerates_non_numeric_time(tmp_path):
+    node = {
+        "frame": {"name": "k"},
+        "metrics": {"count": 1, "time (ns)": "n/a"},
+        "children": [],
+    }
+    _hatchet(tmp_path, _tree([node]))
+    assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_tolerates_non_numeric_count(tmp_path):
+    node = {
+        "frame": {"name": "k"},
+        "metrics": {"count": "many", "time (ns)": 1_000_000},
+        "children": [],
+    }
+    _hatchet(tmp_path, _tree([node]))
+    assert parse_summary(tmp_path)["proton_kernel_count"] == 1
+
+
+def test_parse_summary_tolerates_non_dict_children(tmp_path):
+    node = {"frame": {"name": "k"}, "metrics": {"time (ns)": 1_000_000}, "children": ["junk"]}
+    _hatchet(tmp_path, _tree([node]))
+    assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_ignores_device_metadata_elements(tmp_path):
+    """A real hatchet file is a list: the tree plus device metadata dicts."""
+    payload = [
+        {"frame": {"name": "ROOT"}, "metrics": {}, "children": [_leaf("k", 1_000_000)]},
+        {"device": {"0": {"arch": "gfx950", "num_sms": 256}}},
+    ]
+    _hatchet(tmp_path, payload)
+    assert parse_summary(tmp_path)["proton_top_kernels"] == ["k"]
+
+
+def test_parse_profile_missing_file_is_empty(tmp_path):
+    assert parse_profile(tmp_path / "nope.hatchet") == ({}, {})
+
+
+def test_parse_summary_accepts_str_path(tmp_path):
+    _hatchet(tmp_path, _tree([_leaf("k", 1_000_000)]))
+    assert parse_summary(str(tmp_path))["proton_top_kernels"] == ["k"]

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -856,6 +856,24 @@ def test_parse_summary_still_reads_a_good_time_key_after_a_bad_one(tmp_path):
     assert parse_summary(tmp_path)["proton_gpu_time_ms"] == pytest.approx(2.0)
 
 
+def test_parse_summary_drops_metrics_when_the_total_overflows(tmp_path):
+    """``_time_ms`` checks each leaf, but finite leaves still sum to infinity.
+
+    Spelled in ``ms`` so the values reach the accumulator unscaled -- the same
+    magnitude in ``ns`` is divided down to a comfortably finite number.
+    """
+
+    def leaf(name):
+        return {
+            "frame": {"name": name},
+            "metrics": {"count": 1, "time (ms)": 1e308},
+            "children": [],
+        }
+
+    _hatchet(tmp_path, _tree([leaf("a"), leaf("b"), leaf("c")]))
+    assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
 @pytest.mark.parametrize("bad_count", [float("inf"), 10**400, -5])
 def test_parse_summary_survives_an_unusable_count(tmp_path, bad_count):
     """``int(float(...))`` raises ``OverflowError`` for an infinite or huge

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -513,6 +513,49 @@ def test_wrap_argv_unsets_both_device_spellings_and_prefers_hip(tmp_path, env_on
     assert "ROCR_VISIBLE_DEVICES=1" in argv
 
 
+def test_wrap_argv_does_not_touch_cuda_visible_devices_under_auto(tmp_path):
+    """``auto`` resolves to CUPTI on NVIDIA, where a CUDA pin is real.
+
+    Translating it there would silently drop the device restriction and profile
+    the wrong GPU, so the CUDA spelling is only rewritten once AMD is
+    established -- by an explicitly AMD backend, or by HIP_VISIBLE_DEVICES
+    being set alongside it.
+    """
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "auto"},
+        env={"CUDA_VISIBLE_DEVICES": "2"},
+    )
+    assert "CUDA_VISIBLE_DEVICES" not in argv
+    assert not any(part.startswith("ROCR_VISIBLE_DEVICES=") for part in argv)
+
+
+def test_wrap_argv_translates_cuda_under_auto_when_hip_establishes_amd(tmp_path, env_on_path):
+    """HIP_VISIBLE_DEVICES present means AMD, so the CUDA pin is rewritten too."""
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "auto"},
+        env={"HIP_VISIBLE_DEVICES": "1", "CUDA_VISIBLE_DEVICES": "2"},
+    )
+    assert "HIP_VISIBLE_DEVICES" in argv
+    assert "CUDA_VISIBLE_DEVICES" in argv
+    assert "ROCR_VISIBLE_DEVICES=1" in argv
+
+
+def test_wrap_argv_still_translates_hip_under_auto(tmp_path, env_on_path):
+    """HIP_VISIBLE_DEVICES is an AMD signal by itself, so ``auto`` still acts."""
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "auto"},
+        env={"HIP_VISIBLE_DEVICES": "1"},
+    )
+    assert "HIP_VISIBLE_DEVICES" in argv
+    assert "ROCR_VISIBLE_DEVICES=1" in argv
+
+
 def test_wrap_argv_leaves_device_vars_alone_on_a_non_intercepting_backend(tmp_path):
     """``instrumentation`` installs no queue interceptor, so nothing to rewrite."""
     argv = wrap_argv(

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -531,6 +531,24 @@ def test_wrap_argv_does_not_touch_cuda_visible_devices_under_auto(tmp_path):
     assert not any(part.startswith("ROCR_VISIBLE_DEVICES=") for part in argv)
 
 
+def test_wrap_argv_translates_cuda_under_auto_when_rocr_establishes_amd(tmp_path, env_on_path):
+    """``ROCR_VISIBLE_DEVICES`` is ROCm-only, so its presence establishes AMD.
+
+    It is the variable Proton *reads* on AMD, so a trial that sets it is already
+    on that path -- leaving ``CUDA_VISIBLE_DEVICES`` beside it just hands Proton
+    a variable it refuses before profiling starts.
+    """
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "auto"},
+        env={"ROCR_VISIBLE_DEVICES": "0", "CUDA_VISIBLE_DEVICES": "2"},
+    )
+    assert "CUDA_VISIBLE_DEVICES" in argv
+    # The explicit ROCR value wins; it is not overwritten by the CUDA list.
+    assert "ROCR_VISIBLE_DEVICES=0" in argv
+
+
 def test_wrap_argv_translates_cuda_under_auto_when_hip_establishes_amd(tmp_path, env_on_path):
     """HIP_VISIBLE_DEVICES present means AMD, so the CUDA pin is rewritten too."""
     argv = wrap_argv(

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -483,6 +483,48 @@ def test_wrap_argv_translates_hip_visible_devices(tmp_path, env_on_path):
     assert argv[argv.index("-m") - 1].endswith("python")
 
 
+def test_wrap_argv_translates_cuda_visible_devices(tmp_path, env_on_path):
+    """Proton rejects the CUDA spelling on AMD too, and it is the likelier one.
+
+    ROCm's PyTorch presents its devices as ``cuda``, so an operator pinning a
+    GPU commonly reaches for ``CUDA_VISIBLE_DEVICES``. Handling only the HIP
+    spelling left that trial reaching Proton with a variable it refuses.
+    """
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "roctracer"},
+        env={"CUDA_VISIBLE_DEVICES": "2"},
+    )
+    assert "CUDA_VISIBLE_DEVICES" in argv
+    assert "ROCR_VISIBLE_DEVICES=2" in argv
+
+
+def test_wrap_argv_unsets_both_device_spellings_and_prefers_hip(tmp_path, env_on_path):
+    """Both are unset; HIP supplies the ROCR value, matching ROCm's preference."""
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "rocprofiler"},
+        env={"HIP_VISIBLE_DEVICES": "1", "CUDA_VISIBLE_DEVICES": "2"},
+    )
+    assert "HIP_VISIBLE_DEVICES" in argv
+    assert "CUDA_VISIBLE_DEVICES" in argv
+    assert "ROCR_VISIBLE_DEVICES=1" in argv
+
+
+def test_wrap_argv_leaves_device_vars_alone_on_a_non_intercepting_backend(tmp_path):
+    """``instrumentation`` installs no queue interceptor, so nothing to rewrite."""
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "instrumentation"},
+        env={"CUDA_VISIBLE_DEVICES": "2", "HIP_VISIBLE_DEVICES": "1"},
+    )
+    assert "CUDA_VISIBLE_DEVICES" not in argv
+    assert "ROCR_VISIBLE_DEVICES=2" not in argv
+
+
 def test_wrap_argv_keeps_an_explicit_rocr_visible_devices(tmp_path, env_on_path):
     argv = wrap_argv(
         ["python", "vecadd.py"],
@@ -748,10 +790,24 @@ def test_parse_summary_sums_repeated_kernel_names(tmp_path):
     assert metrics["proton_kernel_count"] == 5
 
 
-def test_parse_summary_defaults_missing_count_to_one(tmp_path):
+def test_parse_summary_omits_the_count_when_a_leaf_has_none(tmp_path):
+    """A leaf with no ``count`` yields no ``proton_kernel_count``, not a 1.
+
+    The checked-in real capture has ``count: 6`` on its ``add_kernel`` leaf,
+    which is the proof that a leaf is an aggregate over launches rather than a
+    single dispatch -- so there is nothing 1 could legitimately mean here.
+    """
     node = {"frame": {"name": "k"}, "metrics": {"time (ns)": 1_000_000}, "children": []}
     _hatchet(tmp_path, _tree([node]))
-    assert parse_summary(tmp_path)["proton_kernel_count"] == 1
+    metrics = parse_summary(tmp_path)
+    assert "proton_kernel_count" not in metrics
+    assert metrics.get("proton_gpu_time_ms") == pytest.approx(1.0)
+
+
+def test_parse_summary_real_fixture_counts_aggregate_launches(tmp_path):
+    """Guards the premise above: the real fixture's count exceeds its leaf count."""
+    metrics = parse_summary(FIXTURES / "tree_capture")
+    assert metrics.get("proton_kernel_count", 0) > len(metrics.get("proton_top_kernels", []))
 
 
 def test_parse_summary_ranks_and_caps_top_kernels(tmp_path):
@@ -877,11 +933,16 @@ def test_parse_summary_drops_metrics_when_the_total_overflows(tmp_path):
 @pytest.mark.parametrize("bad_count", [float("inf"), 10**400, -5])
 def test_parse_summary_survives_an_unusable_count(tmp_path, bad_count):
     """``int(float(...))`` raises ``OverflowError`` for an infinite or huge
-    count, which would escape ``parse_summary()``'s never-raises contract."""
+    count, which would escape ``parse_summary()``'s never-raises contract.
+
+    The count is omitted rather than defaulted: a Proton leaf aggregates every
+    launch of its kernel (the real fixture carries ``count: 6``), so 1 is not
+    a safe stand-in. The timing is unaffected and still published.
+    """
     _hatchet(tmp_path, _tree([_leaf("k", 1_000_000, count=bad_count)]))
     metrics = parse_summary(tmp_path)
-    assert metrics["proton_kernel_count"] == 1
-    assert metrics["proton_gpu_time_ms"] == pytest.approx(1.0)
+    assert "proton_kernel_count" not in metrics
+    assert metrics.get("proton_gpu_time_ms") == pytest.approx(1.0)
 
 
 def test_parse_summary_tolerates_non_numeric_count(tmp_path):
@@ -891,7 +952,24 @@ def test_parse_summary_tolerates_non_numeric_count(tmp_path):
         "children": [],
     }
     _hatchet(tmp_path, _tree([node]))
-    assert parse_summary(tmp_path)["proton_kernel_count"] == 1
+    metrics = parse_summary(tmp_path)
+    assert "proton_kernel_count" not in metrics
+    assert metrics.get("proton_gpu_time_ms") == pytest.approx(1.0)
+
+
+def test_parse_summary_one_unreadable_leaf_drops_only_the_count(tmp_path):
+    """A single bad leaf must not poison the timings of its siblings."""
+    good = _leaf("good", 2_000_000, count=4)
+    bad = {
+        "frame": {"name": "bad"},
+        "metrics": {"time (ns)": 1_000_000},  # no ``count`` at all
+        "children": [],
+    }
+    _hatchet(tmp_path, _tree([good, bad]))
+    metrics = parse_summary(tmp_path)
+    assert "proton_kernel_count" not in metrics
+    assert metrics.get("proton_gpu_time_ms") == pytest.approx(3.0)
+    assert metrics.get("proton_top_kernels") == ["good", "bad"]
 
 
 def test_parse_summary_tolerates_non_dict_children(tmp_path):

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -445,6 +445,44 @@ def test_wrap_argv_keeps_an_explicit_rocr_visible_devices(tmp_path, env_on_path)
     assert "ROCR_VISIBLE_DEVICES=0" in argv
 
 
+def test_wrap_argv_translates_an_empty_hip_visible_devices(tmp_path, env_on_path):
+    """Proton rejects ``HIP_VISIBLE_DEVICES`` on presence, not on value.
+
+    An empty device list is also a meaningful selection -- it conventionally
+    hides every device -- so it must be carried across to ROCR rather than
+    dropped, which would silently expose the GPUs the trial hid.
+    """
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "roctracer"},
+        env={"HIP_VISIBLE_DEVICES": ""},
+    )
+    assert "HIP_VISIBLE_DEVICES" in argv
+    assert "ROCR_VISIBLE_DEVICES=" in argv
+
+
+def test_wrap_argv_keeps_an_explicitly_empty_rocr_visible_devices(tmp_path, env_on_path):
+    """An empty ROCR value is an explicit "hide everything", so the documented
+    "explicit ROCR wins" precedence must not overwrite it with the HIP list."""
+    argv = wrap_argv(
+        ["python", "vecadd.py"],
+        tmp_path,
+        {"backend": "roctracer"},
+        env={"HIP_VISIBLE_DEVICES": "1", "ROCR_VISIBLE_DEVICES": ""},
+    )
+    assert "ROCR_VISIBLE_DEVICES=" in argv
+    assert "ROCR_VISIBLE_DEVICES=1" not in argv
+
+
+def test_env_mode_fails_when_env_binary_is_missing(tmp_path, monkeypatch):
+    """``mode: env`` always has an ``AORTA_PROTON_*`` bundle to deliver, so a
+    missing ``env(1)`` would hand back the bare command and profile nothing."""
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    with pytest.raises(ProtonWrapError, match="env"):
+        wrap_argv(["/tmp/gemm", "512"], tmp_path, {"mode": "env"}, env={})
+
+
 def test_wrap_argv_no_env_prefix_for_instrumentation_backend(tmp_path, env_on_path):
     """The instrumentation backend installs no queue interceptor, so the
     device variables mean what they normally mean and are left alone."""
@@ -462,17 +500,23 @@ def test_wrap_argv_no_env_prefix_when_no_device_pin(tmp_path, env_on_path):
     assert argv[0] == "python"
 
 
-def test_wrap_argv_survives_env_binary_missing(tmp_path, monkeypatch):
-    """No ``env(1)`` means the translation cannot be applied; the wrap still
-    profiles rather than failing the trial outright."""
+def test_wrap_argv_fails_when_env_binary_is_missing(tmp_path, monkeypatch):
+    """No ``env(1)`` means the device translation cannot be applied at all.
+
+    Argv rewriting is the collector seam's only environment channel, so
+    continuing would hand the command back unchanged -- with
+    ``HIP_VISIBLE_DEVICES`` still set, which Proton rejects outright. A
+    measurement that cannot be taken is a setup failure, not a silent
+    downgrade.
+    """
     monkeypatch.setenv("PATH", str(tmp_path / "empty"))
-    argv = wrap_argv(
-        ["python", "vecadd.py"],
-        tmp_path,
-        {"backend": "roctracer"},
-        env={"HIP_VISIBLE_DEVICES": "1"},
-    )
-    assert argv[0] == "python"
+    with pytest.raises(ProtonWrapError, match="env"):
+        wrap_argv(
+            ["python", "vecadd.py"],
+            tmp_path,
+            {"backend": "roctracer"},
+            env={"HIP_VISIBLE_DEVICES": "1"},
+        )
 
 
 def test_wrap_argv_reads_os_environ_by_default(tmp_path, env_on_path, monkeypatch):
@@ -739,6 +783,39 @@ def test_parse_summary_tolerates_non_numeric_time(tmp_path):
     }
     _hatchet(tmp_path, _tree([node]))
     assert parse_summary(tmp_path) == {"proton_artifact_dir": str(tmp_path)}
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), -1_000_000])
+def test_parse_summary_skips_non_finite_and_negative_time(tmp_path, bad):
+    """A ``NaN`` / infinite / negative duration must not reach
+    ``proton_gpu_time_ms``: the first two serialise as non-standard JSON
+    tokens, and none of them is a time a kernel can take."""
+    _hatchet(tmp_path, _tree([_leaf("bad", bad), _leaf("good", 1_000_000)]))
+    metrics = parse_summary(tmp_path)
+    assert metrics["proton_top_kernels"] == ["good"]
+    assert metrics["proton_gpu_time_ms"] == pytest.approx(1.0)
+
+
+def test_parse_summary_still_reads_a_good_time_key_after_a_bad_one(tmp_path):
+    """The scan continues past an unusable ``time (...)`` entry rather than
+    giving up on the leaf, so a profile carrying both still reports."""
+    node = {
+        "frame": {"name": "k"},
+        "metrics": {"count": 1, "time (s)": float("nan"), "time (ns)": 2_000_000},
+        "children": [],
+    }
+    _hatchet(tmp_path, _tree([node]))
+    assert parse_summary(tmp_path)["proton_gpu_time_ms"] == pytest.approx(2.0)
+
+
+@pytest.mark.parametrize("bad_count", [float("inf"), 10**400, -5])
+def test_parse_summary_survives_an_unusable_count(tmp_path, bad_count):
+    """``int(float(...))`` raises ``OverflowError`` for an infinite or huge
+    count, which would escape ``parse_summary()``'s never-raises contract."""
+    _hatchet(tmp_path, _tree([_leaf("k", 1_000_000, count=bad_count)]))
+    metrics = parse_summary(tmp_path)
+    assert metrics["proton_kernel_count"] == 1
+    assert metrics["proton_gpu_time_ms"] == pytest.approx(1.0)
 
 
 def test_parse_summary_tolerates_non_numeric_count(tmp_path):

--- a/tests/instrumentation/test_proton_smoke_gpu.py
+++ b/tests/instrumentation/test_proton_smoke_gpu.py
@@ -1,0 +1,179 @@
+"""Real Proton capture of the shipped Triton examples.
+
+The counterpart of ``test_rocprof_smoke_gpu.py``: it runs an example payload
+through the collector seam and asserts the parsed metrics describe the kernel
+the payload actually launched.
+
+Proton is harder to self-host than rocprofv3, so the skip conditions carry more
+weight here. It runs inside the *workload's own* interpreter, which therefore
+needs Triton plus a ROCm PyTorch build -- an aorta host venv with a CPU-only
+torch cannot do it, and the reference environment is a ROCm PyTorch container
+with aorta installed inside it. Every unmet precondition self-skips with the
+reason spelled out, so this never fails for being on the wrong host and never
+passes green for having silently measured nothing.
+
+    pytest tests/instrumentation/test_proton_smoke_gpu.py -m "gpu and rocm"
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from aorta.instrumentation.proton import OUTPUT_SUBDIR, PROFILE_BASENAME
+from aorta.run.collectors import (
+    CONFIG_KEY_COLLECT,
+    CONFIG_KEY_COLLECT_DIR,
+    CONFIG_KEY_COLLECT_OPTIONS,
+    summarize_collectors,
+    wrap_argv_for_collectors,
+)
+
+pytestmark = [pytest.mark.gpu, pytest.mark.rocm]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTON_EXAMPLES = REPO_ROOT / "examples" / "profiling" / "proton"
+
+#: ``(example dir name, payload file, payload args, the Triton kernel's name in
+#: the hatchet tree)``. The kernel name is what makes the assertion mean
+#: something: a tree containing only torch's own kernels would otherwise pass.
+_EXAMPLES = [
+    ("triton-vecadd", "vecadd.py", ["--size", "262144", "--iters", "10"], "add_kernel"),
+    (
+        "triton-softmax",
+        "softmax.py",
+        ["--rows", "512", "--cols", "1024", "--iters", "10"],
+        "softmax_kernel",
+    ),
+]
+
+#: Proton's dlopen failure on an image whose ROCm comes from Python wheels:
+#: those ship only ``libroctracer64.so.4`` while Proton dlopens the unversioned
+#: name. An environment defect with a known fix, not a collector bug, so it
+#: skips with that fix named rather than failing.
+_DLOPEN_MARKER = "Could not load `libroctracer64.so`"
+
+
+def _skip_reason() -> str | None:
+    if not Path("/dev/kfd").exists():
+        return "no /dev/kfd; not a ROCm GPU host"
+    if not PROTON_EXAMPLES.is_dir():
+        return f"proton examples missing: {PROTON_EXAMPLES}"
+    try:
+        import triton  # noqa: F401
+    except Exception as exc:  # a broken native install raises more than ImportError
+        return f"triton not importable ({exc.__class__.__name__}); Proton ships inside Triton"
+    try:
+        import torch
+    except Exception as exc:
+        return f"torch not importable ({exc.__class__.__name__}); the payloads need it"
+    if getattr(torch.version, "hip", None) is None:
+        return (
+            "torch is a CPU-only build (torch.version.hip is None); the Triton "
+            "payloads cannot dispatch GPU work. Run this inside a ROCm PyTorch "
+            "container with aorta installed there."
+        )
+    if not torch.cuda.is_available():
+        return "torch reports no available GPU device"
+    return None
+
+
+_SKIP_REASON = _skip_reason()
+skip_no_proton = pytest.mark.skipif(_SKIP_REASON is not None, reason=_SKIP_REASON or "")
+
+
+def _capture(example: str, payload: str, args: list[str], out_root: Path, options: dict):
+    """Run one example under the collector seam; return (proc, metrics)."""
+    config = {
+        CONFIG_KEY_COLLECT: ["proton"],
+        CONFIG_KEY_COLLECT_DIR: str(out_root),
+        CONFIG_KEY_COLLECT_OPTIONS: {"proton": options},
+    }
+    script = PROTON_EXAMPLES / example / payload
+    argv = wrap_argv_for_collectors(config, [sys.executable, str(script), *args])
+    proc = subprocess.run(
+        argv,
+        cwd=out_root,
+        capture_output=True,
+        text=True,
+        timeout=3600,
+        env={**os.environ, "TRITON_CACHE_DIR": str(out_root / "triton-cache")},
+    )
+    if _DLOPEN_MARKER in proc.stderr:
+        pytest.skip(
+            f"{_DLOPEN_MARKER}: this environment's ROCm ships only versioned "
+            "sonames (a wheel-provided ROCm), while Proton dlopens the "
+            "unversioned name. Add the unversioned symlinks to "
+            "$LD_LIBRARY_PATH, or run on a host with a system ROCm install."
+        )
+    return proc, summarize_collectors(config)
+
+
+@skip_no_proton
+@pytest.mark.parametrize(
+    ("example", "payload", "args", "kernel"),
+    _EXAMPLES,
+    ids=[entry[0] for entry in _EXAMPLES],
+)
+def test_example_capture_has_real_kernel_data(example, payload, args, kernel, tmp_path):
+    proc, metrics = _capture(
+        example, payload, args, tmp_path, {"backend": "auto", "context": "shadow", "data": "tree"}
+    )
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "PASS" in proc.stdout, "the profiler must not perturb the payload's own result"
+
+    profile = tmp_path / OUTPUT_SUBDIR / f"{PROFILE_BASENAME}.hatchet"
+    assert profile.is_file(), sorted(str(p) for p in (tmp_path / OUTPUT_SUBDIR).rglob("*"))
+    assert metrics["proton_kernel_count"] > 0
+    assert 0.0 < metrics["proton_gpu_time_ms"] < 60_000.0
+    assert 0.0 < metrics["proton_top_kernel_ms"] <= metrics["proton_gpu_time_ms"]
+    assert kernel in metrics["proton_top_kernels"], metrics["proton_top_kernels"]
+    assert metrics["proton_artifact_dir"] == str(tmp_path / OUTPUT_SUBDIR)
+
+
+@skip_no_proton
+def test_default_backend_is_accepted_by_the_installed_proton(tmp_path):
+    """``backend: auto`` omits Proton's ``-b`` so Proton picks for itself.
+
+    This is the whole reason the default is ``auto``: Triton 3.7.x's CLI lists
+    only cupti/roctracer/instrumentation and exits at argparse on
+    ``-b rocprofiler``, before the payload runs, while newer Triton prefers
+    ``rocprofiler``. Passing no backend is the only spelling that survives both,
+    and this asserts it against whatever Triton is actually installed.
+    """
+    example, payload, args, kernel = _EXAMPLES[0]
+    proc, metrics = _capture(example, payload, args, tmp_path, {})
+    assert "invalid choice" not in proc.stderr, proc.stderr
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert kernel in metrics["proton_top_kernels"]
+
+
+@skip_no_proton
+def test_python_context_attributes_to_call_paths(tmp_path):
+    """``context: python`` keys the tree by Python call path instead of launch
+    site -- the configuration the softmax example ships."""
+    example, payload, args, kernel = _EXAMPLES[1]
+    proc, metrics = _capture(example, payload, args, tmp_path, {"context": "python"})
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert metrics["proton_kernel_count"] > 0
+    assert metrics["proton_gpu_time_ms"] > 0.0
+    assert kernel in metrics["proton_top_kernels"], metrics["proton_top_kernels"]
+
+
+@skip_no_proton
+def test_hip_visible_devices_is_translated_not_refused(tmp_path, monkeypatch):
+    """Proton raises outright when ``HIP_VISIBLE_DEVICES`` is set on AMD
+    (``Proton does not work when the environment variable HIP_VISIBLE_DEVICES
+    is set on AMD GPUs``). The wrap moves it to ``ROCR_VISIBLE_DEVICES`` so a
+    device-pinned cell profiles rather than crashing, and the profile it gets
+    back is a real one rather than an empty tree."""
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0")
+    example, payload, args, kernel = _EXAMPLES[0]
+    proc, metrics = _capture(example, payload, args, tmp_path, {})
+    assert "HIP_VISIBLE_DEVICES is set" not in proc.stderr, proc.stderr
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert kernel in metrics["proton_top_kernels"]

--- a/tests/instrumentation/test_rocprof.py
+++ b/tests/instrumentation/test_rocprof.py
@@ -17,6 +17,7 @@ Both must parse, because an operator pointing the parser at their own
 
 from __future__ import annotations
 
+import math
 import os
 from pathlib import Path
 
@@ -465,6 +466,26 @@ def test_parse_summary_skips_rows_with_unparseable_duration(tmp_path):
     assert metrics["rocprof_top_kernels"] == ["good"]
     assert metrics["rocprof_gpu_time_ms"] == pytest.approx(1.0)
     assert metrics["rocprof_kernel_count"] == 2
+
+
+def test_parse_summary_skips_non_finite_and_negative_durations(tmp_path):
+    """``float()`` accepts ``NaN`` / ``Infinity``, and letting either through
+    would write a non-standard token into the trial JSON that a strict reader
+    is entitled to reject. A negative duration is malformed for the same
+    reason an inverted trace span is."""
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n'
+        '"good",2,1000000\n'
+        '"nan",1,NaN\n'
+        '"inf",1,Infinity\n'
+        '"negative",1,-5000\n',
+        encoding="utf-8",
+    )
+    metrics = parse_summary(tmp_path)
+    assert metrics["rocprof_top_kernels"] == ["good"]
+    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(1.0)
+    assert metrics["rocprof_kernel_count"] == 2
+    assert math.isfinite(metrics["rocprof_top_kernel_ms"])
 
 
 def test_parse_summary_counts_one_dispatch_when_calls_is_unreadable(tmp_path):

--- a/tests/instrumentation/test_rocprof.py
+++ b/tests/instrumentation/test_rocprof.py
@@ -13,6 +13,12 @@ output captured on a gfx950 host, because the layout depends on a flag:
 
 Both must parse, because an operator pointing the parser at their own
 ``rocprofv3 -d`` tree will have whichever one they ran.
+
+Three further trees are hand-made to pin degradation paths: ``malformed/``
+(garbage stats beside a header-only trace), and ``stats_truncated_trace_ok/`` /
+``stats_renamed_columns_trace_ok/``, which pair an unusable stats CSV with a
+*populated* trace so the fallback is exercised on absence of data rather than
+absence of files.
 """
 
 from __future__ import annotations
@@ -420,6 +426,44 @@ def test_parse_summary_prefers_stats_over_trace():
     metrics = parse_summary(FIXTURES / "flat_with_o")
     assert metrics["rocprof_kernel_count"] == _FLAT_CALLS
     assert metrics["rocprof_kernel_count"] != _TRACE_ROWS
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ["stats_truncated_trace_ok", "stats_renamed_columns_trace_ok"],
+)
+def test_parse_summary_falls_back_when_stats_yields_no_data(fixture):
+    """A stats CSV that *exists* but parses to nothing must not mask the trace.
+
+    The fallback keys off absence of data, not absence of files. Both fixtures
+    pair an unusable ``_kernel_stats.csv`` with the same populated
+    ``_kernel_trace.csv``, covering the two ways this happens in the field:
+
+    * ``stats_truncated_trace_ok`` -- rocprofv3 killed mid-write (a trial
+      timeout or an OOM kill) leaves a header and a half-written row.
+    * ``stats_renamed_columns_trace_ok`` -- version skew. This module pins
+      ``TotalDurationNs`` / ``Calls`` / ``Name`` by name, so a future rocprofv3
+      renaming a ``--stats`` column zeroes the stats path. Gating the fallback
+      on file presence would disable it in exactly that case and report no
+      kernels on a host where profiling works, which is the failure mode
+      hardest to spot from a green run.
+
+    ``fixtures/rocprof/malformed/`` cannot pin this: its trace is header-only,
+    so it yields the artifact-dir-only result under either behaviour.
+    """
+    # ``.get()`` rather than ``[...]``: a regression here drops the keys
+    # entirely, and a KeyError would mask which metric went missing.
+    metrics = parse_summary(FIXTURES / fixture)
+    assert metrics.get("rocprof_kernel_count") == _TRACE_ROWS
+    assert metrics.get("rocprof_gpu_time_ms") == pytest.approx(_TRACE_TOTAL_NS / 1e6)
+    assert metrics.get("rocprof_top_kernels") == [_FLAT_KERNEL]
+
+
+def test_parse_summary_still_degrades_when_neither_source_has_data(tmp_path):
+    """The data-driven fallback must not turn an unusable capture into metrics."""
+    (tmp_path / "aorta_kernel_stats.csv").write_text("garbage\n", encoding="utf-8")
+    (tmp_path / "aorta_kernel_trace.csv").write_text("garbage\n", encoding="utf-8")
+    assert parse_summary(tmp_path) == {"rocprof_artifact_dir": str(tmp_path)}
 
 
 # ---- Summary parsing: fail-soft ------------------------------------------

--- a/tests/instrumentation/test_rocprof.py
+++ b/tests/instrumentation/test_rocprof.py
@@ -1,0 +1,569 @@
+"""Tests for the ``rocprof`` collector package (no GPU, no rocprofv3 needed).
+
+Covers the platform-side contract: the option schema, the ``rocprofv3 ... --``
+argv prefix, binary resolution, and fail-soft summary parsing.
+
+The parser fixtures under ``fixtures/rocprof/`` are real ``rocprofv3`` 1.0.1
+output captured on a gfx950 host, because the layout depends on a flag:
+
+* ``flat_with_o/`` -- what ``-d <dir> -o <stem>`` produces, flat in ``<dir>``
+  as ``<stem>_kernel_stats.csv`` / ``_kernel_trace.csv`` / ``_domain_stats.csv``.
+* ``nested_no_o/`` -- what the same run WITHOUT ``-o`` produces: a
+  ``<hostname>/`` directory holding ``<pid>_kernel_stats.csv`` and friends.
+
+Both must parse, because an operator pointing the parser at their own
+``rocprofv3 -d`` tree will have whichever one they ran.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from aorta.instrumentation.rocprof import (
+    ENV_ROCPROF_BIN,
+    OPTION_KEYS,
+    OUTPUT_BASENAME,
+    OUTPUT_SUBDIR,
+    SUMMARY_FILE_STEM,
+    SUMMARY_FILENAME,
+    RocprofUnavailableError,
+    build_argv_prefix,
+    parse_summary,
+    resolve_binary,
+    validate_options,
+    wrap_argv,
+)
+from aorta.run.collectors import KNOWN_RECIPES
+
+FIXTURES = Path(__file__).parent / "fixtures" / "rocprof"
+
+# Totals of the real capture checked in under fixtures/rocprof/flat_with_o.
+_FLAT_KERNEL = "sgemm_tiled(float const*, float const*, float*, int)"
+_FLAT_CALLS = 23
+_FLAT_TOTAL_NS = 539404.0
+# The trace fixture is the first 5 dispatch rows of the same capture; summing
+# their (End - Start) spans is what the stats-less fallback must produce.
+_TRACE_ROWS = 5
+_TRACE_TOTAL_NS = float(
+    (1434937317879637 - 1434937317843317)
+    + (1434937317902677 - 1434937317879637)
+    + (1434937317925477 - 1434937317902677)
+    + (1434937317983997 - 1434937317960637)
+    + (1434937318006638 - 1434937317983997)
+)
+
+
+@pytest.fixture
+def rocprofv3_on_path(tmp_path, monkeypatch):
+    """Put a fake executable ``rocprofv3`` on ``$PATH`` so resolution succeeds."""
+    fake = tmp_path / "rocprofv3"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.delenv(ENV_ROCPROF_BIN, raising=False)
+    return fake
+
+
+# ---- Registration + package surface --------------------------------------
+
+
+def test_registered_as_known_recipe():
+    assert "rocprof" in KNOWN_RECIPES
+
+
+def test_output_subdir_is_rocprof():
+    assert OUTPUT_SUBDIR == "rocprof"
+
+
+def test_summary_filename_is_what_rocprofv3_actually_writes():
+    """rocprofv3 derives the summary name from ``-o`` + the stem + ``.txt``.
+
+    ``--summary-output-file`` takes a stem relative to ``-d``, not a path, so
+    the file that appears is ``<basename>_<stem>.txt``. Verified on hardware:
+    ``-o aorta --summary-output-file rocprof_summary`` produces
+    ``aorta_rocprof_summary.txt``.
+    """
+    assert SUMMARY_FILENAME == f"{OUTPUT_BASENAME}_{SUMMARY_FILE_STEM}.txt"
+    assert not Path(SUMMARY_FILE_STEM).is_absolute()
+    assert "/" not in SUMMARY_FILE_STEM
+
+
+# ---- Option validation ---------------------------------------------------
+
+
+def test_validate_options_defaults():
+    effective = validate_options(None)
+    assert effective["trace"] == "kernel"
+    assert effective["output_format"] == "csv"
+    assert effective["stats"] == "true"
+    # Optional knobs stay absent so the argv omits their flags entirely.
+    assert "pmc" not in effective
+    assert "summary_units" not in effective
+    assert "kernel_include_regex" not in effective
+
+
+def test_validate_options_empty_mapping_matches_none():
+    assert validate_options({}) == validate_options(None)
+
+
+def test_validate_options_rejects_unknown_key():
+    with pytest.raises(ValueError, match="unknown option"):
+        validate_options({"traces": "kernel"})
+
+
+def test_validate_options_unknown_key_message_names_valid_keys():
+    with pytest.raises(ValueError, match="kernel_include_regex"):
+        validate_options({"nope": "1"})
+
+
+def test_validate_options_rejects_non_string_value():
+    with pytest.raises(ValueError, match="must be a string"):
+        validate_options({"stats": True})  # type: ignore[dict-item]
+
+
+@pytest.mark.parametrize(
+    "domain", sorted(["kernel", "hip", "hip_runtime", "memory_copy", "rccl", "marker", "scratch"])
+)
+def test_validate_options_accepts_every_trace_domain(domain):
+    assert validate_options({"trace": domain})["trace"] == domain
+
+
+def test_validate_options_trace_accepts_comma_and_space_lists():
+    assert validate_options({"trace": "kernel,hip"})["trace"] == "kernel,hip"
+    assert validate_options({"trace": "kernel hip"})["trace"] == "kernel,hip"
+
+
+def test_validate_options_trace_dedups_preserving_order():
+    assert validate_options({"trace": "hip,kernel,hip"})["trace"] == "hip,kernel"
+
+
+def test_validate_options_trace_normalises_case():
+    assert validate_options({"trace": "KERNEL"})["trace"] == "kernel"
+
+
+def test_validate_options_rejects_unknown_trace_domain():
+    with pytest.raises(ValueError, match="unknown domain"):
+        validate_options({"trace": "kernel,gpu"})
+
+
+def test_validate_options_rejects_empty_trace():
+    with pytest.raises(ValueError, match="at least one domain"):
+        validate_options({"trace": " , "})
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "pftrace", "otf2", "rocpd"])
+def test_validate_options_accepts_every_output_format(fmt):
+    assert validate_options({"output_format": fmt})["output_format"] == fmt
+
+
+def test_validate_options_rejects_unknown_output_format():
+    with pytest.raises(ValueError, match="output_format"):
+        validate_options({"output_format": "parquet"})
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", "0", "false", "no", "off"])
+def test_validate_options_accepts_boolean_spellings(value):
+    assert validate_options({"stats": value})["stats"] == value
+
+
+def test_validate_options_rejects_non_boolean_stats():
+    with pytest.raises(ValueError, match="expected a boolean"):
+        validate_options({"stats": "maybe"})
+
+
+@pytest.mark.parametrize("unit", ["sec", "msec", "usec", "nsec"])
+def test_validate_options_accepts_every_summary_unit(unit):
+    assert validate_options({"summary_units": unit})["summary_units"] == unit
+
+
+def test_validate_options_rejects_unknown_summary_unit():
+    with pytest.raises(ValueError, match="summary_units"):
+        validate_options({"summary_units": "minutes"})
+
+
+def test_validate_options_rejects_empty_kernel_include_regex():
+    with pytest.raises(ValueError, match="kernel_include_regex"):
+        validate_options({"kernel_include_regex": "   "})
+
+
+def test_validate_options_keeps_regex_verbatim():
+    """A free-form value must not be case-folded -- a regex is case-sensitive."""
+    assert validate_options({"kernel_include_regex": "Cijk|GEMM"})["kernel_include_regex"] == (
+        "Cijk|GEMM"
+    )
+
+
+def test_validate_options_rejects_empty_pmc():
+    with pytest.raises(ValueError, match="at least one counter"):
+        validate_options({"pmc": ","})
+
+
+def test_validate_options_does_not_mutate_input():
+    supplied = {"trace": "KERNEL"}
+    validate_options(supplied)
+    assert supplied == {"trace": "KERNEL"}
+
+
+# ---- Argv construction ---------------------------------------------------
+
+
+def test_build_argv_prefix_shape(rocprofv3_on_path, tmp_path):
+    argv = build_argv_prefix(tmp_path / "out")
+    assert argv[0] == str(rocprofv3_on_path)
+    assert argv[-1] == "--"
+    assert argv[1:3] == ["-d", str(tmp_path / "out")]
+    assert argv[3:5] == ["-o", OUTPUT_BASENAME]
+    assert "--kernel-trace" in argv
+    assert "--stats" in argv
+    assert ["--output-format", "csv"] == argv[5:7]
+
+
+def test_build_argv_prefix_summary_goes_to_a_file_not_stderr(rocprofv3_on_path, tmp_path):
+    """``-S`` alone prints to stderr, which the probe classifier would read."""
+    argv = build_argv_prefix(tmp_path / "out")
+    assert "-S" in argv
+    assert argv[argv.index("--summary-output-file") + 1] == SUMMARY_FILE_STEM
+
+
+def test_build_argv_prefix_multi_domain_trace(rocprofv3_on_path, tmp_path):
+    argv = build_argv_prefix(tmp_path, {"trace": "kernel,hip,memory_copy"})
+    assert "--kernel-trace" in argv
+    assert "--hip-trace" in argv
+    assert "--memory-copy-trace" in argv
+
+
+def test_build_argv_prefix_stats_off_omits_flag(rocprofv3_on_path, tmp_path):
+    assert "--stats" not in build_argv_prefix(tmp_path, {"stats": "false"})
+
+
+def test_build_argv_prefix_optional_flags_omitted_by_default(rocprofv3_on_path, tmp_path):
+    argv = build_argv_prefix(tmp_path)
+    assert "--pmc" not in argv
+    assert "-u" not in argv
+    assert "--kernel-include-regex" not in argv
+
+
+def test_build_argv_prefix_carries_optional_flags(rocprofv3_on_path, tmp_path):
+    argv = build_argv_prefix(
+        tmp_path,
+        {"summary_units": "msec", "kernel_include_regex": "Cijk|gemm"},
+    )
+    assert argv[argv.index("-u") + 1] == "msec"
+    assert argv[argv.index("--kernel-include-regex") + 1] == "Cijk|gemm"
+
+
+def test_build_argv_prefix_pmc_is_last_flag_before_separator(rocprofv3_on_path, tmp_path):
+    """``--pmc`` is variadic, so anything after it would be eaten as a counter."""
+    argv = build_argv_prefix(tmp_path, {"pmc": "SQ_WAVES,GRBM_COUNT"})
+    pmc = argv.index("--pmc")
+    assert argv[pmc + 1 : -1] == ["SQ_WAVES", "GRBM_COUNT"]
+    assert argv[-1] == "--"
+
+
+def test_build_argv_prefix_accepts_str_out_dir(rocprofv3_on_path):
+    argv = build_argv_prefix("relative/out")
+    assert argv[argv.index("-d") + 1] == str(Path("relative/out"))
+
+
+def test_build_argv_prefix_propagates_option_error(rocprofv3_on_path, tmp_path):
+    with pytest.raises(ValueError, match="unknown option"):
+        build_argv_prefix(tmp_path, {"nope": "1"})
+
+
+def test_wrap_argv_puts_command_after_the_separator(rocprofv3_on_path, tmp_path):
+    argv = wrap_argv(["/tmp/gemm", "512", "20"], tmp_path)
+    sep = argv.index("--")
+    assert argv[sep + 1 :] == ["/tmp/gemm", "512", "20"]
+
+
+def test_wrap_argv_does_not_mutate_the_input(rocprofv3_on_path, tmp_path):
+    inner = ["/tmp/gemm", "512"]
+    wrap_argv(inner, tmp_path)
+    assert inner == ["/tmp/gemm", "512"]
+
+
+def test_wrap_argv_ignores_env(rocprofv3_on_path, tmp_path):
+    """rocprofv3 is flag-configured; the ``env`` kwarg exists for the registry's
+    uniform signature (Proton needs it) and must not change the argv."""
+    with_env = wrap_argv(["/tmp/gemm"], tmp_path, env={"HIP_VISIBLE_DEVICES": "1"})
+    assert with_env == wrap_argv(["/tmp/gemm"], tmp_path)
+
+
+# ---- Binary resolution ---------------------------------------------------
+
+
+def test_resolve_binary_finds_path_entry(rocprofv3_on_path):
+    assert resolve_binary() == str(rocprofv3_on_path)
+
+
+def test_resolve_binary_honours_env_override_path(tmp_path, monkeypatch):
+    custom = tmp_path / "my-rocprof"
+    custom.write_text("#!/bin/sh\nexit 0\n")
+    custom.chmod(0o755)
+    monkeypatch.setenv(ENV_ROCPROF_BIN, str(custom))
+    assert resolve_binary() == str(custom)
+
+
+def test_resolve_binary_expands_user_in_override(tmp_path, monkeypatch):
+    custom = tmp_path / "my-rocprof"
+    custom.write_text("#!/bin/sh\nexit 0\n")
+    custom.chmod(0o755)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(ENV_ROCPROF_BIN, "~/my-rocprof")
+    assert resolve_binary() == str(custom)
+
+
+def test_resolve_binary_override_bare_name_searched_on_path(tmp_path, monkeypatch):
+    fake = tmp_path / "rocprof-custom"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv(ENV_ROCPROF_BIN, "rocprof-custom")
+    assert resolve_binary() == str(fake)
+
+
+def test_resolve_binary_rejects_non_executable_override(tmp_path, monkeypatch):
+    dud = tmp_path / "not-executable"
+    dud.write_text("")
+    monkeypatch.setenv(ENV_ROCPROF_BIN, str(dud))
+    with pytest.raises(RocprofUnavailableError, match="does not"):
+        resolve_binary()
+
+
+def test_resolve_binary_rejects_missing_override_on_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv(ENV_ROCPROF_BIN, "definitely-not-a-profiler-9f8d7")
+    with pytest.raises(RocprofUnavailableError, match="was not found"):
+        resolve_binary()
+
+
+def test_resolve_binary_missing_names_the_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.delenv(ENV_ROCPROF_BIN, raising=False)
+    with pytest.raises(RocprofUnavailableError, match=ENV_ROCPROF_BIN):
+        resolve_binary()
+
+
+def test_wrap_argv_raises_when_profiler_missing(tmp_path, monkeypatch):
+    """A requested-but-unattachable collector is a clean setup failure."""
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.delenv(ENV_ROCPROF_BIN, raising=False)
+    with pytest.raises(RocprofUnavailableError):
+        wrap_argv(["/tmp/gemm"], tmp_path)
+
+
+# ---- Summary parsing: the two real layouts -------------------------------
+
+
+def test_parse_summary_flat_layout_from_dash_o():
+    metrics = parse_summary(FIXTURES / "flat_with_o")
+    assert metrics["rocprof_kernel_count"] == _FLAT_CALLS
+    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(_FLAT_TOTAL_NS / 1e6)
+    assert metrics["rocprof_top_kernel_ms"] == pytest.approx(_FLAT_TOTAL_NS / 1e6)
+    assert metrics["rocprof_top_kernels"] == [_FLAT_KERNEL]
+    assert metrics["rocprof_artifact_dir"] == str(FIXTURES / "flat_with_o")
+
+
+def test_flat_fixture_contains_the_summary_file_the_package_names():
+    """The fixture is a hardware capture (normalised only by the repo's
+    end-of-file hook, which drops rocprofv3's trailing blank line), so it also
+    pins the summary filename: ``-o aorta --summary-output-file rocprof_summary``
+    really does produce ``aorta_rocprof_summary.txt``, flat beside the CSVs."""
+    summary = FIXTURES / "flat_with_o" / SUMMARY_FILENAME
+    assert summary.is_file()
+    assert "ROCPROFV3 SUMMARY" in summary.read_text(encoding="utf-8")
+    # No stray directories: a spliced absolute path would have created some.
+    assert not [path for path in (FIXTURES / "flat_with_o").iterdir() if path.is_dir()]
+
+
+def test_parse_summary_nested_layout_without_dash_o():
+    """Without ``-o``, rocprofv3 nests under ``<hostname>/<pid>_*.csv``."""
+    metrics = parse_summary(FIXTURES / "nested_no_o")
+    assert metrics["rocprof_kernel_count"] == 8
+    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(81720 / 1e6)
+    assert metrics["rocprof_top_kernels"] == [_FLAT_KERNEL]
+
+
+def test_parse_summary_emits_only_expected_keys():
+    assert set(parse_summary(FIXTURES / "flat_with_o")) == {
+        "rocprof_artifact_dir",
+        "rocprof_kernel_count",
+        "rocprof_gpu_time_ms",
+        "rocprof_top_kernel_ms",
+        "rocprof_top_kernels",
+    }
+
+
+def test_parse_summary_numeric_metrics_are_plain_numbers():
+    """perf.md's metrics table only picks up ``int`` / ``float`` values."""
+    metrics = parse_summary(FIXTURES / "flat_with_o")
+    for key in ("rocprof_kernel_count", "rocprof_gpu_time_ms", "rocprof_top_kernel_ms"):
+        assert isinstance(metrics[key], (int, float))
+        assert not isinstance(metrics[key], bool)
+
+
+def test_parse_summary_falls_back_to_kernel_trace(tmp_path):
+    """With ``stats`` off there is no ``_kernel_stats.csv``; sum trace spans."""
+    trace = FIXTURES / "flat_with_o" / "aorta_kernel_trace.csv"
+    (tmp_path / "aorta_kernel_trace.csv").write_bytes(trace.read_bytes())
+    metrics = parse_summary(tmp_path)
+    assert metrics["rocprof_kernel_count"] == _TRACE_ROWS
+    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(_TRACE_TOTAL_NS / 1e6)
+
+
+def test_parse_summary_prefers_stats_over_trace():
+    """Both files are present in the real capture; the stats aggregate wins."""
+    metrics = parse_summary(FIXTURES / "flat_with_o")
+    assert metrics["rocprof_kernel_count"] == _FLAT_CALLS
+    assert metrics["rocprof_kernel_count"] != _TRACE_ROWS
+
+
+# ---- Summary parsing: fail-soft ------------------------------------------
+
+
+def test_parse_summary_missing_dir_is_empty(tmp_path):
+    assert parse_summary(tmp_path / "never-created") == {}
+
+
+def test_parse_summary_file_instead_of_dir_is_empty(tmp_path):
+    path = tmp_path / "not-a-dir"
+    path.write_text("")
+    assert parse_summary(path) == {}
+
+
+def test_parse_summary_empty_dir_reports_only_the_artifact_dir(tmp_path):
+    """Verified on hardware: a command with no GPU work makes rocprofv3 write
+    NOTHING at all. That is a legitimate outcome, not a failure."""
+    assert parse_summary(tmp_path) == {"rocprof_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_malformed_csv_degrades_without_raising():
+    metrics = parse_summary(FIXTURES / "malformed")
+    assert metrics == {"rocprof_artifact_dir": str(FIXTURES / "malformed")}
+
+
+def test_parse_summary_header_only_csv_degrades(tmp_path):
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs","AverageNs","Percentage","MinNs","MaxNs","StdDev"\n',
+        encoding="utf-8",
+    )
+    assert parse_summary(tmp_path) == {"rocprof_artifact_dir": str(tmp_path)}
+
+
+def test_parse_summary_skips_rows_with_unparseable_duration(tmp_path):
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n'
+        '"good",2,1000000\n'
+        '"bad",1,"not-a-number"\n'
+        ",3,5000\n",
+        encoding="utf-8",
+    )
+    metrics = parse_summary(tmp_path)
+    assert metrics["rocprof_top_kernels"] == ["good"]
+    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(1.0)
+    assert metrics["rocprof_kernel_count"] == 2
+
+
+def test_parse_summary_counts_one_dispatch_when_calls_is_unreadable(tmp_path):
+    """A stats row without a readable ``Calls`` column still evidences one
+    dispatch, so it counts as one rather than being dropped."""
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","TotalDurationNs"\n"k",1000000\n', encoding="utf-8"
+    )
+    assert parse_summary(tmp_path)["rocprof_kernel_count"] == 1
+
+
+def test_parse_summary_takes_a_zero_call_count_at_its_word(tmp_path):
+    """``rocprof_kernel_count`` claims dispatches, so a readable zero must not
+    be rounded up to one -- that would over-count the metric its name
+    promises."""
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"idle",0,1000\n"real",2,2000\n',
+        encoding="utf-8",
+    )
+    assert parse_summary(tmp_path)["rocprof_kernel_count"] == 2
+
+
+def test_parse_summary_trace_skips_non_dispatch_and_inverted_rows(tmp_path):
+    (tmp_path / "aorta_kernel_trace.csv").write_text(
+        '"Kind","Kernel_Name","Start_Timestamp","End_Timestamp"\n'
+        '"KERNEL_DISPATCH","k",100,1100\n'
+        '"MEMORY_COPY","memcpy",0,9999999\n'
+        '"KERNEL_DISPATCH","backwards",500,100\n',
+        encoding="utf-8",
+    )
+    metrics = parse_summary(tmp_path)
+    assert metrics["rocprof_top_kernels"] == ["k"]
+    assert metrics["rocprof_kernel_count"] == 1
+
+
+def test_parse_summary_aggregates_multiple_stats_files(tmp_path):
+    """A multi-process capture writes one stats CSV per rank directory."""
+    for idx, total in ((0, 1000000), (1, 3000000)):
+        rank_dir = tmp_path / f"host{idx}"
+        rank_dir.mkdir()
+        (rank_dir / f"{idx}_kernel_stats.csv").write_text(
+            '"Name","Calls","TotalDurationNs"\n' f'"shared",1,{total}\n',
+            encoding="utf-8",
+        )
+    metrics = parse_summary(tmp_path)
+    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(4.0)
+    assert metrics["rocprof_kernel_count"] == 2
+
+
+def test_parse_summary_ranks_top_kernel_by_total_time(tmp_path):
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n'
+        '"small",100,1000\n'
+        '"big",1,9000000\n'
+        '"medium",2,4000000\n',
+        encoding="utf-8",
+    )
+    metrics = parse_summary(tmp_path)
+    assert metrics["rocprof_top_kernels"][:2] == ["big", "medium"]
+    assert metrics["rocprof_top_kernel_ms"] == pytest.approx(9.0)
+
+
+def test_parse_summary_caps_top_kernels(tmp_path):
+    rows = "".join(f'"k{i}",1,{(20 - i) * 1000}\n' for i in range(12))
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n' + rows, encoding="utf-8"
+    )
+    assert len(parse_summary(tmp_path)["rocprof_top_kernels"]) == 5
+
+
+def test_parse_summary_survives_unreadable_file(tmp_path):
+    csv_path = tmp_path / "aorta_kernel_stats.csv"
+    csv_path.write_text('"Name","Calls","TotalDurationNs"\n"k",1,1000\n', encoding="utf-8")
+    csv_path.chmod(0o000)
+    try:
+        if os.access(csv_path, os.R_OK):
+            pytest.skip("running as a user that can read mode-000 files")
+        assert parse_summary(tmp_path) == {"rocprof_artifact_dir": str(tmp_path)}
+    finally:
+        csv_path.chmod(0o644)
+
+
+def test_parse_summary_accepts_str_path():
+    assert parse_summary(str(FIXTURES / "flat_with_o"))["rocprof_kernel_count"] == _FLAT_CALLS
+
+
+# ---- Docs / schema agreement --------------------------------------------
+
+
+def test_option_keys_match_the_validator():
+    """Every declared key must be accepted; the docs table is generated from
+    this tuple, so a key here that the validator rejects is a doc lie."""
+    samples = {
+        "trace": "kernel",
+        "output_format": "csv",
+        "stats": "1",
+        "pmc": "SQ_WAVES",
+        "kernel_include_regex": "gemm",
+        "summary_units": "msec",
+    }
+    assert set(samples) == set(OPTION_KEYS)
+    assert validate_options(samples)

--- a/tests/instrumentation/test_rocprof.py
+++ b/tests/instrumentation/test_rocprof.py
@@ -488,6 +488,16 @@ def test_parse_summary_skips_non_finite_and_negative_durations(tmp_path):
     assert math.isfinite(metrics["rocprof_top_kernel_ms"])
 
 
+def test_parse_summary_drops_metrics_when_the_total_overflows(tmp_path):
+    """Individually-finite rows can still sum to infinity, which would put an
+    ``Infinity`` token in the trial JSON despite the per-row guard."""
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"a",1,1e308\n"b",1,1e308\n"c",1,1e308\n',
+        encoding="utf-8",
+    )
+    assert parse_summary(tmp_path) == {"rocprof_artifact_dir": str(tmp_path)}
+
+
 def test_parse_summary_counts_one_dispatch_when_calls_is_unreadable(tmp_path):
     """A stats row without a readable ``Calls`` column still evidences one
     dispatch, so it counts as one rather than being dropped."""

--- a/tests/instrumentation/test_rocprof.py
+++ b/tests/instrumentation/test_rocprof.py
@@ -560,6 +560,24 @@ def test_parse_summary_omits_the_count_when_calls_is_unreadable(tmp_path):
     assert metrics.get("rocprof_top_kernels") == ["k"]
 
 
+def test_parse_summary_omits_the_count_for_a_fractional_calls_value(tmp_path):
+    """Dispatches are whole; ``int()`` would truncate 1.9 to 1 and publish it."""
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"k",1.9,1000000\n', encoding="utf-8"
+    )
+    metrics = parse_summary(tmp_path)
+    assert "rocprof_kernel_count" not in metrics
+    assert metrics.get("rocprof_gpu_time_ms") == pytest.approx(1.0)
+
+
+def test_parse_summary_accepts_an_integral_float_calls_value(tmp_path):
+    """A whole number written as ``3.0`` is still a usable count."""
+    (tmp_path / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"k",3.0,1000000\n', encoding="utf-8"
+    )
+    assert parse_summary(tmp_path).get("rocprof_kernel_count") == 3
+
+
 def test_parse_summary_keeps_the_count_from_a_trace_without_calls(tmp_path):
     """The trace path is immune: one row *is* one dispatch, so it can count."""
     trace = FIXTURES / "flat_with_o" / "aorta_kernel_trace.csv"

--- a/tests/instrumentation/test_rocprof.py
+++ b/tests/instrumentation/test_rocprof.py
@@ -542,13 +542,29 @@ def test_parse_summary_drops_metrics_when_the_total_overflows(tmp_path):
     assert parse_summary(tmp_path) == {"rocprof_artifact_dir": str(tmp_path)}
 
 
-def test_parse_summary_counts_one_dispatch_when_calls_is_unreadable(tmp_path):
-    """A stats row without a readable ``Calls`` column still evidences one
-    dispatch, so it counts as one rather than being dropped."""
+def test_parse_summary_omits_the_count_when_calls_is_unreadable(tmp_path):
+    """An unreadable ``Calls`` column drops the count but keeps the timings.
+
+    A stats row is a **per-kernel aggregate**, not one dispatch, so an
+    unreadable count could stand for a single launch or ten thousand.
+    Substituting 1 would publish a confident-looking ``rocprof_kernel_count``
+    that is simply wrong; the fail-soft contract is fewer metrics, never
+    invented ones.
+    """
     (tmp_path / "aorta_kernel_stats.csv").write_text(
         '"Name","TotalDurationNs"\n"k",1000000\n', encoding="utf-8"
     )
-    assert parse_summary(tmp_path)["rocprof_kernel_count"] == 1
+    metrics = parse_summary(tmp_path)
+    assert "rocprof_kernel_count" not in metrics
+    assert metrics.get("rocprof_gpu_time_ms") == pytest.approx(1.0)
+    assert metrics.get("rocprof_top_kernels") == ["k"]
+
+
+def test_parse_summary_keeps_the_count_from_a_trace_without_calls(tmp_path):
+    """The trace path is immune: one row *is* one dispatch, so it can count."""
+    trace = FIXTURES / "flat_with_o" / "aorta_kernel_trace.csv"
+    (tmp_path / "aorta_kernel_trace.csv").write_bytes(trace.read_bytes())
+    assert parse_summary(tmp_path).get("rocprof_kernel_count") == _TRACE_ROWS
 
 
 def test_parse_summary_takes_a_zero_call_count_at_its_word(tmp_path):

--- a/tests/instrumentation/test_rocprof_smoke_gpu.py
+++ b/tests/instrumentation/test_rocprof_smoke_gpu.py
@@ -1,0 +1,270 @@
+"""Real ``rocprofv3`` capture of the shipped HIP GEMM example.
+
+Everything in ``test_rocprof.py`` is fixture-driven; this file is the part
+those tests cannot be: it compiles the example payload with ``hipcc``, runs it
+under the collector seam on real hardware, and asserts the parsed metrics are
+sane. It also pins the on-disk layout of an end-to-end ``aorta sweep run``,
+including the fact that collector metrics reach ``perf.md`` and
+``matrix.json::cells[*].metrics_summary``.
+
+Self-skips on a host without a GPU / ROCm toolchain, so the CPU gate
+(``pytest -m "not gpu and not rocm"``) never sees it and a laptop run does not
+fail.
+
+    pytest tests/instrumentation/test_rocprof_smoke_gpu.py -m "gpu and rocm"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from aorta.instrumentation.rocprof import OUTPUT_SUBDIR, SUMMARY_FILENAME
+from aorta.run.collectors import (
+    CONFIG_KEY_COLLECT,
+    CONFIG_KEY_COLLECT_DIR,
+    CONFIG_KEY_COLLECT_OPTIONS,
+    summarize_collectors,
+    wrap_argv_for_collectors,
+)
+
+pytestmark = [pytest.mark.gpu, pytest.mark.rocm]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_DIR = REPO_ROOT / "examples" / "profiling" / "rocprof" / "hip-gemm"
+PAYLOAD = EXAMPLE_DIR / "gemm.hip"
+RECIPE = EXAMPLE_DIR / "recipe.yaml"
+
+# Small enough to finish in well under a second, big enough that the kernel
+# time is comfortably above timer noise.
+_GEMM_N = "512"
+_GEMM_ITERS = "20"
+
+
+def _skip_reason() -> str | None:
+    if shutil.which("rocprofv3") is None:
+        return "rocprofv3 not on PATH (ships with ROCm)"
+    if shutil.which("hipcc") is None:
+        return "hipcc not on PATH (needed to build the example payload)"
+    if not Path("/dev/kfd").exists():
+        return "no /dev/kfd; not a ROCm GPU host"
+    if not PAYLOAD.is_file():
+        return f"example payload missing: {PAYLOAD}"
+    return None
+
+
+_SKIP_REASON = _skip_reason()
+skip_no_gpu = pytest.mark.skipif(_SKIP_REASON is not None, reason=_SKIP_REASON or "")
+
+
+@pytest.fixture(scope="module")
+def gemm_binary(tmp_path_factory) -> Path:
+    """Compile the example payload once for the whole module."""
+    out = tmp_path_factory.mktemp("hip-gemm") / "gemm"
+    proc = subprocess.run(
+        ["hipcc", "-O3", str(PAYLOAD), "-o", str(out)],
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"hipcc failed ({proc.returncode}):\n{proc.stdout}\n{proc.stderr}")
+    return out
+
+
+def _run(argv, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, cwd=cwd, capture_output=True, text=True, timeout=900)
+
+
+# ---- The payload itself -------------------------------------------------
+
+
+@skip_no_gpu
+def test_payload_runs_and_self_checks(gemm_binary, tmp_path):
+    """The example is self-checking, so a bad result is a failed trial rather
+    than a suspiciously fast one."""
+    proc = _run([str(gemm_binary), _GEMM_N, _GEMM_ITERS], tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert "PASS" in proc.stdout
+
+
+# ---- The collector seam on real hardware -------------------------------
+
+
+@skip_no_gpu
+def test_collector_seam_captures_real_kernel_data(gemm_binary, tmp_path):
+    """The generic argv-wrap seam, end to end: wrap, run, parse."""
+    config = {
+        CONFIG_KEY_COLLECT: ["rocprof"],
+        CONFIG_KEY_COLLECT_DIR: str(tmp_path),
+        CONFIG_KEY_COLLECT_OPTIONS: {
+            "rocprof": {"trace": "kernel", "stats": "1", "summary_units": "msec"}
+        },
+    }
+    argv = wrap_argv_for_collectors(config, [str(gemm_binary), _GEMM_N, _GEMM_ITERS])
+    proc = _run(argv, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert "PASS" in proc.stdout, "the profiler must not perturb the payload's own result"
+
+    out_dir = tmp_path / OUTPUT_SUBDIR
+    csvs = sorted(path.name for path in out_dir.rglob("*.csv"))
+    assert csvs, f"rocprofv3 wrote no CSVs into {out_dir}"
+    assert any(name.endswith("_kernel_stats.csv") for name in csvs), csvs
+    assert any(name.endswith("_kernel_trace.csv") for name in csvs), csvs
+
+    metrics = summarize_collectors(config)
+    # The payload launches exactly `iters` kernels plus warmups, so the count
+    # is bounded rather than exact -- but it is certainly not zero.
+    assert metrics["rocprof_kernel_count"] >= int(_GEMM_ITERS)
+    assert 0.0 < metrics["rocprof_gpu_time_ms"] < 60_000.0
+    assert 0.0 < metrics["rocprof_top_kernel_ms"] <= metrics["rocprof_gpu_time_ms"]
+    assert any("sgemm" in name for name in metrics["rocprof_top_kernels"]), metrics[
+        "rocprof_top_kernels"
+    ]
+    assert metrics["rocprof_artifact_dir"] == str(out_dir)
+
+
+@skip_no_gpu
+def test_summary_lands_in_a_file_not_on_stderr(gemm_binary, tmp_path):
+    """``rocprofv3 -S`` prints to stderr by default, where the probe
+    classifier's stderr detectors would read it as workload output.
+
+    ``--summary-output-file`` takes a filename STEM relative to ``-d``, not a
+    path -- handing it an absolute path splices that path into the middle of a
+    filename and scatters directories under ``-d``. This asserts the real file
+    appears where the package says it does, and nowhere else.
+    """
+    config = {
+        CONFIG_KEY_COLLECT: ["rocprof"],
+        CONFIG_KEY_COLLECT_DIR: str(tmp_path),
+    }
+    argv = wrap_argv_for_collectors(config, [str(gemm_binary), _GEMM_N, "5"])
+    proc = _run(argv, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+
+    out_dir = tmp_path / OUTPUT_SUBDIR
+    summary = out_dir / SUMMARY_FILENAME
+    assert summary.is_file(), sorted(str(p.relative_to(out_dir)) for p in out_dir.rglob("*"))
+    assert "ROCPROFV3 SUMMARY" in summary.read_text(encoding="utf-8")
+    assert "ROCPROFV3 SUMMARY" not in proc.stderr
+    # Everything rocprofv3 wrote is a plain file directly under the artifact
+    # dir; a spliced path would have created nested directories instead.
+    assert not [path for path in out_dir.iterdir() if path.is_dir()]
+
+
+@skip_no_gpu
+def test_no_gpu_work_produces_no_artifacts_and_no_metrics(tmp_path):
+    """Verified behaviour of rocprofv3: a command that dispatches no kernels
+    makes it write nothing at all. That is a legitimate outcome (a probe of
+    ``/bin/echo``), so it must not raise or invent numbers."""
+    config = {CONFIG_KEY_COLLECT: ["rocprof"], CONFIG_KEY_COLLECT_DIR: str(tmp_path)}
+    argv = wrap_argv_for_collectors(config, ["/bin/echo", "hi"])
+    proc = _run(argv, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert "hi" in proc.stdout
+
+    out_dir = tmp_path / OUTPUT_SUBDIR
+    assert out_dir.is_dir(), "the seam pre-creates the dir so the trial tree keeps its shape"
+    assert not sorted(out_dir.rglob("*.csv"))
+    assert summarize_collectors(config) == {"rocprof_artifact_dir": str(out_dir)}
+
+
+# ---- End-to-end sweep: artifact layout + report plumbing ---------------
+
+
+@skip_no_gpu
+def test_sweep_run_layout_and_reports(gemm_binary, tmp_path):
+    """A real multi-trial ``aorta sweep run`` of the shipped example recipe.
+
+    Pins three things at once, all of which have to be true together for the
+    feature to be worth anything:
+
+    1. The collector artifact directory is
+       ``<cell>/<workload>/trial_d<d>_m<m>_t<t>/rocprof/`` -- a SIBLING of the
+       hand-written ``<cell>/trial_<n>/`` tree, not inside it.
+    2. Collector metrics ride ``WorkloadResult.metrics`` into the dispatcher's
+       trial JSON at ``.result.metrics``, and NOT into
+       ``<cell>/trial_<n>/result.json``, which ``SubprocessWorkload`` writes
+       before the summary is parsed.
+    3. The numeric metrics reach ``perf.md``'s metrics table and
+       ``matrix.json::cells[*].metrics_summary`` with one entry per trial.
+    """
+    trials = 3
+    recipe_text = RECIPE.read_text(encoding="utf-8").replace("trials: 1", f"trials: {trials}")
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(recipe_text, encoding="utf-8")
+    output = tmp_path / "out"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from aorta.cli import main; main()",
+            "sweep",
+            "run",
+            "--recipe",
+            str(recipe),
+            "--output",
+            str(output),
+            "--",
+            str(gemm_binary),
+            _GEMM_N,
+            _GEMM_ITERS,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=3600,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")},
+    )
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    run_dirs = [path for path in output.iterdir() if path.is_dir()]
+    assert len(run_dirs) == 1, run_dirs
+    run_dir = run_dirs[0]
+
+    # (1) + (2): per-trial layout.
+    trial_jsons = sorted(run_dir.glob("*/*/trial_d*_m*_t*.json"))
+    assert len(trial_jsons) == trials, [str(p) for p in trial_jsons]
+    for trial_json in trial_jsons:
+        doc = json.loads(trial_json.read_text(encoding="utf-8"))
+        metrics = doc["result"]["metrics"]
+        assert metrics["rocprof_kernel_count"] >= int(_GEMM_ITERS)
+        assert metrics["rocprof_gpu_time_ms"] > 0.0
+
+        artifact_dir = trial_json.with_suffix("") / OUTPUT_SUBDIR
+        assert artifact_dir.is_dir(), f"no collector artifacts beside {trial_json.name}"
+        assert sorted(artifact_dir.glob("*_kernel_stats.csv"))
+        assert metrics["rocprof_artifact_dir"] == str(artifact_dir)
+
+        # The hand-written result.json is a sibling of the workload subdir and
+        # predates the summary parse, so it carries no collector metrics.
+        hand_written = Path(metrics["result_json_path"])
+        assert hand_written.is_file()
+        assert artifact_dir not in hand_written.parents
+        assert hand_written.parent not in artifact_dir.parents
+        plain = json.loads(hand_written.read_text(encoding="utf-8"))
+        assert not [key for key in plain if key.startswith("rocprof_")]
+
+    # (3): the reports.
+    perf = (run_dir / "perf.md").read_text(encoding="utf-8")
+    for key in ("rocprof_gpu_time_ms", "rocprof_kernel_count", "rocprof_top_kernel_ms"):
+        assert key in perf, f"{key} missing from perf.md"
+    # The non-numeric channels are deliberately absent from the metrics table.
+    assert "rocprof_top_kernels" not in perf
+    assert "rocprof_artifact_dir" not in perf
+
+    matrix = json.loads((run_dir / "matrix.json").read_text(encoding="utf-8"))
+    summaries = [cell["metrics_summary"] for cell in matrix["cells"]]
+    assert summaries, matrix["cells"]
+    for summary in summaries:
+        entry = summary["rocprof_gpu_time_ms"]
+        assert entry["n"] == trials
+        assert entry["min"] > 0.0
+        assert entry["min"] <= entry["mean"] <= entry["max"]

--- a/tests/probe/test_collect_channel.py
+++ b/tests/probe/test_collect_channel.py
@@ -1,0 +1,302 @@
+"""The probe-mode ``collect:`` channel and the ``--collect`` CLI overlay.
+
+Collectors are cross-cutting rather than a matrix axis, so ``collect`` is valid
+in both recipe modes (like ``stop_after``). Probe mode synthesises its own
+cells, so the recipe-level names/options apply to every ``(mitigation,
+diagnostic)`` pair and there is no cell scope to override at.
+
+``--collect`` REPLACES the recipe's list, matching the workload flow's
+precedence -- these tests pin that it is a replacement and not a merge, and
+that the surviving option set is re-validated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from aorta.cli.sweep import sweep_run
+from aorta.probe.cli_helpers import ProbeUsageError, apply_recipe_overrides
+from aorta.triage.recipe import RecipeSchemaError, load_recipe
+
+_PROBE_HEAD = (
+    "schema_version: 1\n"
+    "mode: probe\n"
+    "trials: 1\n"
+    "mitigation_axis: [none]\n"
+    "diagnostic_axis: [none]\n"
+)
+
+
+def _write(tmp_path: Path, body: str = "") -> Path:
+    path = tmp_path / "r.yaml"
+    path.write_text(_PROBE_HEAD + body, encoding="utf-8")
+    return path
+
+
+def _probe_recipe(tmp_path: Path, body: str = ""):
+    return load_recipe(_write(tmp_path, body))
+
+
+# ---- Recipe-scope acceptance in probe mode ------------------------------
+
+
+def test_probe_recipe_defaults_to_no_collector(tmp_path):
+    recipe = _probe_recipe(tmp_path)
+    assert recipe.collect == ()
+    assert recipe.collect_options == {}
+
+
+def test_probe_recipe_accepts_list_form(tmp_path):
+    recipe = _probe_recipe(tmp_path, "collect: [rocprof]\n")
+    assert recipe.collect == ("rocprof",)
+    assert recipe.collect_options == {}
+
+
+def test_probe_recipe_accepts_mapping_form_with_options(tmp_path):
+    recipe = _probe_recipe(
+        tmp_path,
+        'collect:\n  rocprof:\n    trace: "kernel,hip"\n    summary_units: "msec"\n',
+    )
+    assert recipe.collect == ("rocprof",)
+    assert recipe.collect_options == {"rocprof": {"trace": "kernel,hip", "summary_units": "msec"}}
+
+
+def test_probe_recipe_accepts_proton(tmp_path):
+    recipe = _probe_recipe(tmp_path, 'collect:\n  proton:\n    backend: "roctracer"\n')
+    assert recipe.collect == ("proton",)
+    assert recipe.collect_options == {"proton": {"backend": "roctracer"}}
+
+
+def test_probe_recipe_rejects_unknown_collector(tmp_path):
+    with pytest.raises(RecipeSchemaError, match="unknown collector recipe"):
+        _probe_recipe(tmp_path, "collect: [not_a_collector]\n")
+
+
+def test_probe_recipe_rejects_a_bad_option(tmp_path):
+    with pytest.raises(RecipeSchemaError, match="rocprof: unknown option"):
+        _probe_recipe(tmp_path, 'collect:\n  rocprof:\n    traces: "kernel"\n')
+
+
+def test_probe_recipe_rejects_the_queue_interception_conflict(tmp_path):
+    with pytest.raises(RecipeSchemaError, match="queue interceptor"):
+        _probe_recipe(tmp_path, "collect: [rocprof, proton]\n")
+
+
+def test_probe_recipe_allows_the_instrumentation_backend_alongside_rocprof(tmp_path):
+    recipe = _probe_recipe(
+        tmp_path,
+        'collect:\n  rocprof:\n  proton:\n    backend: "instrumentation"\n',
+    )
+    assert recipe.collect == ("rocprof", "proton")
+
+
+def test_probe_recipe_error_is_labelled_recipe_collect(tmp_path):
+    with pytest.raises(RecipeSchemaError, match=r"^recipe\.collect:"):
+        _probe_recipe(tmp_path, "collect: [rocprof, proton]\n")
+
+
+def test_probe_cells_inherit_the_recipe_collect(tmp_path):
+    """Probe mode synthesises its cells without a cell-scope ``collect``, so
+    replacing the recipe-level tuple is enough to reach every cell."""
+    recipe = _probe_recipe(tmp_path, "collect: [rocprof]\n")
+    for cell in recipe.cells:
+        assert cell.collect is None
+        assert cell.effective_collect(recipe.collect) == ("rocprof",)
+
+
+# ---- --collect overlay: replace, not merge -----------------------------
+
+
+def test_cli_collect_replaces_the_recipe_list(tmp_path):
+    recipe = _probe_recipe(tmp_path, "collect: [rocprof]\n")
+    out = apply_recipe_overrides(
+        recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("layer_numerics",)
+    )
+    assert out.collect == ("layer_numerics",)
+    assert "rocprof" not in out.collect
+
+
+def test_cli_collect_absent_leaves_the_recipe_list_intact(tmp_path):
+    recipe = _probe_recipe(tmp_path, "collect: [rocprof]\n")
+    out = apply_recipe_overrides(recipe, ticket=None, cli_passthrough_mode=None)
+    assert out.collect == ("rocprof",)
+
+
+def test_cli_collect_adds_a_collector_to_a_recipe_with_none(tmp_path):
+    recipe = _probe_recipe(tmp_path)
+    out = apply_recipe_overrides(
+        recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("rocprof",)
+    )
+    assert out.collect == ("rocprof",)
+
+
+def test_cli_collect_drops_options_for_collectors_it_replaced(tmp_path):
+    """Per-collector options are recipe-file-only, so options belonging to a
+    collector the CLI dropped must not survive as orphans."""
+    recipe = _probe_recipe(tmp_path, 'collect:\n  rocprof:\n    trace: "kernel,hip"\n')
+    out = apply_recipe_overrides(
+        recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("layer_numerics",)
+    )
+    assert out.collect_options == {}
+
+
+def test_cli_collect_keeps_options_for_collectors_it_kept(tmp_path):
+    recipe = _probe_recipe(
+        tmp_path,
+        'collect:\n  rocprof:\n    trace: "kernel,hip"\n  layer_numerics:\n    NANLOG_SPEC: "{}"\n',
+    )
+    out = apply_recipe_overrides(
+        recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("rocprof",)
+    )
+    assert out.collect == ("rocprof",)
+    assert out.collect_options == {"rocprof": {"trace": "kernel,hip"}}
+
+
+def test_cli_collect_dedups_preserving_order(tmp_path):
+    recipe = _probe_recipe(tmp_path)
+    out = apply_recipe_overrides(
+        recipe,
+        ticket=None,
+        cli_passthrough_mode=None,
+        cli_collect=("layer_numerics", "rocprof", "layer_numerics"),
+    )
+    assert out.collect == ("layer_numerics", "rocprof")
+
+
+def test_cli_collect_rejects_an_unknown_collector(tmp_path):
+    recipe = _probe_recipe(tmp_path)
+    with pytest.raises(ProbeUsageError, match="unknown collector recipe"):
+        apply_recipe_overrides(
+            recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("not_a_collector",)
+        )
+
+
+def test_cli_collect_error_is_labelled_with_the_flag(tmp_path):
+    recipe = _probe_recipe(tmp_path)
+    with pytest.raises(ProbeUsageError, match=r"^--collect:"):
+        apply_recipe_overrides(
+            recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("not_a_collector",)
+        )
+
+
+def test_cli_collect_rejects_a_conflicting_pair(tmp_path):
+    recipe = _probe_recipe(tmp_path)
+    with pytest.raises(ProbeUsageError, match="queue interceptor"):
+        apply_recipe_overrides(
+            recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("rocprof", "proton")
+        )
+
+
+def test_cli_collect_revalidates_the_surviving_recipe_options(tmp_path):
+    """Narrowing the list can resolve a conflict -- but it can also leave a kept
+    collector paired with a partner the recipe author never validated against.
+
+    Here the recipe pins a Proton backend that is fine on its own; adding
+    ``rocprof`` from the CLI makes the surviving pair unrunnable, and that has
+    to be caught even though the recipe itself loaded clean.
+    """
+    recipe = _probe_recipe(tmp_path, 'collect:\n  proton:\n    backend: "roctracer"\n')
+    with pytest.raises(ProbeUsageError, match="queue interceptor"):
+        apply_recipe_overrides(
+            recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("rocprof", "proton")
+        )
+
+
+def test_cli_collect_restating_a_legal_recipe_pair_is_accepted(tmp_path):
+    """Validating the bare name list would invent a conflict the recipe resolves.
+
+    ``rocprof`` + ``proton`` is only unrunnable on a queue-intercepting Proton
+    backend. This recipe pins the instrumentation backend, so restating both
+    names on the CLI is a no-op and must not be rejected against Proton's
+    *default* backend.
+    """
+    recipe = _probe_recipe(
+        tmp_path,
+        'collect:\n  rocprof:\n  proton:\n    backend: "instrumentation"\n',
+    )
+    out = apply_recipe_overrides(
+        recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("rocprof", "proton")
+    )
+    assert out.collect == ("rocprof", "proton")
+    assert out.collect_options == {"proton": {"backend": "instrumentation"}}
+
+
+def test_cli_collect_narrowing_can_resolve_a_conflict(tmp_path):
+    recipe = _probe_recipe(
+        tmp_path,
+        'collect:\n  rocprof:\n  proton:\n    backend: "instrumentation"\n',
+    )
+    out = apply_recipe_overrides(
+        recipe, ticket=None, cli_passthrough_mode=None, cli_collect=("proton",)
+    )
+    assert out.collect == ("proton",)
+    assert out.collect_options == {"proton": {"backend": "instrumentation"}}
+
+
+# ---- CLI surface -------------------------------------------------------
+
+
+def test_sweep_run_accepts_collect_on_the_probe_flow(tmp_path):
+    """``--collect`` used to be rejected outright on the probe flow. It is now
+    the whole point: a collector attaches by wrapping the user command's argv,
+    so profiling an opaque ``-- <command>`` is exactly what it is for."""
+    result = CliRunner().invoke(
+        sweep_run,
+        [
+            "--recipe",
+            str(_write(tmp_path)),
+            "--output",
+            str(tmp_path / "out"),
+            "--collect",
+            "rocprof",
+            "--dry-run",
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "applies to the workload flow only" not in result.output
+
+
+def test_sweep_run_rejects_an_unknown_collector_on_the_probe_flow(tmp_path):
+    result = CliRunner().invoke(
+        sweep_run,
+        [
+            "--recipe",
+            str(_write(tmp_path)),
+            "--output",
+            str(tmp_path / "out"),
+            "--collect",
+            "not_a_collector",
+            "--dry-run",
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown collector recipe" in result.output
+
+
+def test_sweep_run_rejects_the_conflicting_pair_on_the_probe_flow(tmp_path):
+    result = CliRunner().invoke(
+        sweep_run,
+        [
+            "--recipe",
+            str(_write(tmp_path)),
+            "--output",
+            str(tmp_path / "out"),
+            "--collect",
+            "rocprof,proton",
+            "--dry-run",
+            "--",
+            "echo",
+            "hi",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "queue interceptor" in result.output

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -11,6 +11,7 @@ from reading the code alone.
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -318,6 +319,52 @@ def test_retention_prunes_the_collector_tree(tmp_path, rocprofv3_on_path):
     assert any(entry.endswith("aorta_kernel_stats.csv") for entry in deleted)
     assert any(entry.startswith("..") for entry in deleted)
     assert recorded.get("freed_bytes", 0) > 0
+
+
+def test_retention_refuses_a_collector_root_swapped_for_a_symlink(tmp_path, rocprofv3_on_path):
+    """The payload can replace the collector root with a symlink while it runs.
+
+    This is the time-of-check/time-of-use gap the pre-launch reset cannot close:
+    the profiled command is handed this path (``rocprofv3 -d``), so a guard that
+    only ran before launch proves nothing afterwards. ``apply_retention()``
+    follows links, so pruning through one would delete files in its target,
+    outside the results tree, at any level below ``full``.
+    """
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    outside = tmp_path / "precious"
+    (outside / rocprof.OUTPUT_SUBDIR).mkdir(parents=True)
+    victim = outside / rocprof.OUTPUT_SUBDIR / "aorta_kernel_stats.csv"
+    victim.write_text("not yours to delete", encoding="utf-8")
+
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"], retain={"on_pass": "none"})
+    wl.setup()  # creates the real directory, as a launch would
+    shutil.rmtree(collect_dir)
+    collect_dir.symlink_to(outside, target_is_directory=True)
+
+    wl.run()
+
+    # The whole point: the tree behind the symlink is untouched.
+    assert victim.read_text(encoding="utf-8") == "not yours to delete"
+
+
+def test_summary_refuses_a_collector_root_swapped_for_a_symlink(tmp_path, rocprofv3_on_path):
+    """The read path has the same exposure: the parsers glob the tree.
+
+    Not destructive, but it would pull file contents from outside the results
+    tree into the trial metrics, so it is refused with the same guard.
+    """
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    outside = tmp_path / "elsewhere"
+    _rocprof_artifacts(outside)
+
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"], retain={"on_pass": "full"})
+    wl.setup()
+    shutil.rmtree(collect_dir)
+    collect_dir.symlink_to(outside, target_is_directory=True)
+
+    result = wl.run()
+    assert "rocprof_kernel_count" not in result.metrics
+    assert "rocprof_artifact_dir" not in result.metrics
 
 
 def test_retention_full_keeps_the_collector_tree(tmp_path, rocprofv3_on_path):

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -28,19 +28,50 @@ from aorta.workloads._subprocess import (
     SubprocessWorkload,
 )
 
+#: Stand-in for ``rocprofv3``: drop the profiler's own flags up to the ``--``
+#: separator, then exec the profiled command so the trial observes the
+#: payload's exit code. Every test in this module needs it -- a host that
+#: happens to have ROCm installed must not change what these tests assert.
+_FAKE_ROCPROFV3 = """#!/bin/sh
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--" ]; then
+        shift
+        break
+    fi
+    shift
+done
+[ "$#" -eq 0 ] && exit 0
+exec "$@"
+"""
+
 
 @pytest.fixture
 def rocprofv3_on_path(tmp_path, monkeypatch):
+    """Make ``rocprofv3`` resolution hermetic.
+
+    ``resolve_binary()`` raises when rocprofv3 is absent, so without this the
+    tests below pass only on a ROCm host and fail everywhere else (CI). The
+    stub is a real executable rather than a patched ``resolve_binary`` because
+    these tests run the wrapped argv end-to-end through ``run()``.
+    """
     fake = tmp_path / "fakebin" / "rocprofv3"
     fake.parent.mkdir(parents=True, exist_ok=True)
-    fake.write_text('#!/bin/sh\nexec "$@"\n')
+    fake.write_text(_FAKE_ROCPROFV3)
     fake.chmod(0o755)
     monkeypatch.setenv("PATH", f"{fake.parent}:/usr/bin:/bin")
     monkeypatch.delenv(rocprof.ENV_ROCPROF_BIN, raising=False)
     return fake
 
 
-def _make_workload(tmp_path: Path, argv: list[str], *, collect=(), options=None, collect_dir=None):
+def _make_workload(
+    tmp_path: Path,
+    argv: list[str],
+    *,
+    collect=(),
+    options=None,
+    collect_dir=None,
+    retain=None,
+):
     """Build a workload with the log-prefix / collect-dir shape the runner sets.
 
     The dispatcher sets ``_aorta_log_prefix`` to
@@ -61,6 +92,8 @@ def _make_workload(tmp_path: Path, argv: list[str], *, collect=(), options=None,
             "cell_env_vars": {},
         },
     }
+    if retain is not None:
+        config[CONFIG_KEY_PROBE_EXTRAS]["retain"] = retain
     if collect:
         config[CONFIG_KEY_COLLECT] = list(collect)
         config[CONFIG_KEY_COLLECT_DIR] = str(collect_dir if collect_dir is not None else prefix)
@@ -148,6 +181,12 @@ def test_setup_argv_validation_runs_before_the_collector_wrap(tmp_path, rocprofv
 
 
 def _rocprof_artifacts(collect_dir: Path, total_ns: int = 539404, calls: int = 23) -> Path:
+    """Write the capture a profiled run would have produced.
+
+    Call this *after* ``setup()``: the real rocprofv3 writes while the wrapped
+    command runs, and ``setup()`` deliberately empties the collector directory
+    so a resumed trial cannot summarise the attempt it is replacing.
+    """
     out_dir = collect_dir / rocprof.OUTPUT_SUBDIR
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "aorta_kernel_stats.csv").write_text(
@@ -157,11 +196,11 @@ def _rocprof_artifacts(collect_dir: Path, total_ns: int = 539404, calls: int = 2
     return out_dir
 
 
-def test_run_merges_collector_metrics(tmp_path):
+def test_run_merges_collector_metrics(tmp_path, rocprofv3_on_path):
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
     wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
-    _rocprof_artifacts(collect_dir)
     wl.setup()
+    _rocprof_artifacts(collect_dir)
     result = wl.run()
     assert result.metrics["rocprof_kernel_count"] == 23
     assert result.metrics["rocprof_gpu_time_ms"] == pytest.approx(0.539404)
@@ -182,7 +221,7 @@ def test_run_metrics_unchanged_without_a_collector(tmp_path):
     }
 
 
-def test_run_collector_cannot_shadow_the_platform_keys(tmp_path, monkeypatch):
+def test_run_collector_cannot_shadow_the_platform_keys(tmp_path, monkeypatch, rocprofv3_on_path):
     """The collector summary is merged UNDER the platform bookkeeping, so a
     collector emitting ``verdict`` / ``exit_code`` cannot rewrite the trial's
     outcome."""
@@ -201,7 +240,7 @@ def test_run_collector_cannot_shadow_the_platform_keys(tmp_path, monkeypatch):
     assert result.metrics["rocprof_gpu_time_ms"] == 1.0
 
 
-def test_run_survives_a_collector_that_produced_nothing(tmp_path):
+def test_run_survives_a_collector_that_produced_nothing(tmp_path, rocprofv3_on_path):
     """rocprofv3 writes no files at all for a command with no GPU work."""
     wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
     wl.setup()
@@ -211,33 +250,99 @@ def test_run_survives_a_collector_that_produced_nothing(tmp_path):
     assert result.metrics["verdict"] == "pass"
 
 
-def test_run_survives_a_malformed_capture(tmp_path):
+def test_run_survives_a_malformed_capture(tmp_path, rocprofv3_on_path):
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
-    out_dir = collect_dir / rocprof.OUTPUT_SUBDIR
-    out_dir.mkdir(parents=True)
-    (out_dir / "aorta_kernel_stats.csv").write_text("garbage\n", encoding="utf-8")
     wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
     wl.setup()
+    out_dir = collect_dir / rocprof.OUTPUT_SUBDIR
+    (out_dir / "aorta_kernel_stats.csv").write_text("garbage\n", encoding="utf-8")
     result = wl.run()
     assert result.passed is True
     assert "rocprof_kernel_count" not in result.metrics
 
 
-def test_run_still_reports_metrics_for_a_failing_trial(tmp_path):
+def test_run_still_reports_metrics_for_a_failing_trial(tmp_path, rocprofv3_on_path):
     """A profiled crash is exactly the case an operator wants numbers for."""
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
-    _rocprof_artifacts(collect_dir)
     wl = _make_workload(tmp_path, ["false"], collect=["rocprof"])
     wl.setup()
+    _rocprof_artifacts(collect_dir)
     result = wl.run()
     assert result.passed is False
     assert result.metrics["rocprof_kernel_count"] == 23
 
 
+def test_setup_discards_an_interrupted_attempts_artifacts(tmp_path, rocprofv3_on_path):
+    """Probe resume replays a trial onto the same paths.
+
+    Without a reset the retry would summarise the interrupted attempt's
+    capture -- reporting kernel counts for work the resumed trial never did.
+    """
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    stale = _rocprof_artifacts(collect_dir, total_ns=999_999_999, calls=4242)
+    (stale / "leftover_rank_1.csv").write_text("stale\n", encoding="utf-8")
+
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
+    wl.setup()
+    assert list(stale.iterdir()) == []
+
+    _rocprof_artifacts(collect_dir)
+    result = wl.run()
+    assert result.metrics["rocprof_kernel_count"] == 23
+
+
+# ---- Retention ---------------------------------------------------------
+
+
+def test_retention_prunes_the_collector_tree(tmp_path, rocprofv3_on_path):
+    """Profiler traces are the artifact class retention exists for, but they
+    land in a tree that is a *sibling* of the trial dir. Pruning only the
+    trial dir would keep every capture in a sweep regardless of ``retain``.
+    """
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"], retain={"on_pass": "none"})
+    wl.setup()
+    _rocprof_artifacts(collect_dir)
+    result = wl.run()
+
+    # Summaries are parsed before pruning, so the numbers outlive the trace.
+    assert result.metrics["rocprof_kernel_count"] == 23
+    assert not (collect_dir / rocprof.OUTPUT_SUBDIR / "aorta_kernel_stats.csv").exists()
+
+    # The audit trail names the pruned file and where it came from.
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    recorded = doc.get("capture", {}).get("retention", {})
+    deleted = recorded.get("deleted", [])
+    assert any(entry.endswith("aorta_kernel_stats.csv") for entry in deleted)
+    assert any(entry.startswith("..") for entry in deleted)
+    assert recorded.get("freed_bytes", 0) > 0
+
+
+def test_retention_full_keeps_the_collector_tree(tmp_path, rocprofv3_on_path):
+    """``full`` is the keep-everything default; the collector tree follows it."""
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"], retain={"on_pass": "full"})
+    wl.setup()
+    _rocprof_artifacts(collect_dir)
+    wl.run()
+    assert (collect_dir / rocprof.OUTPUT_SUBDIR / "aorta_kernel_stats.csv").exists()
+
+
+def test_retention_without_a_collector_is_unchanged(tmp_path):
+    """A run with no ``--collect`` must not gain a collector-tree scan."""
+    wl = _make_workload(tmp_path, ["true"], retain={"on_pass": "none"})
+    wl.setup()
+    wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert doc.get("capture", {}).get("retention", {}).get("level") == "none"
+
+
 # ---- Artifact / metrics location --------------------------------------
 
 
-def test_collector_artifacts_are_a_sibling_of_the_hand_written_trial_dir(tmp_path):
+def test_collector_artifacts_are_a_sibling_of_the_hand_written_trial_dir(
+    tmp_path, rocprofv3_on_path
+):
     """Pin the real layout, which is not the obvious one.
 
     ``SubprocessWorkload`` hand-writes ``<cell>/trial_<n>/result.json`` from
@@ -248,9 +353,9 @@ def test_collector_artifacts_are_a_sibling_of_the_hand_written_trial_dir(tmp_pat
     ``WorkloadResult.metrics`` into the dispatcher's trial JSON instead.
     """
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
-    _rocprof_artifacts(collect_dir)
     wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
     wl.setup()
+    _rocprof_artifacts(collect_dir)
     wl.run()
 
     artifact_dir = collect_dir / rocprof.OUTPUT_SUBDIR
@@ -266,11 +371,11 @@ def test_collector_artifacts_are_a_sibling_of_the_hand_written_trial_dir(tmp_pat
     assert hand_written.is_relative_to(tmp_path)
 
 
-def test_hand_written_result_json_carries_no_collector_metrics(tmp_path):
+def test_hand_written_result_json_carries_no_collector_metrics(tmp_path, rocprofv3_on_path):
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
-    _rocprof_artifacts(collect_dir)
     wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
     wl.setup()
+    _rocprof_artifacts(collect_dir)
     result = wl.run()
     doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
     assert not [key for key in doc if key.startswith(("rocprof_", "proton_"))]
@@ -284,9 +389,9 @@ def test_result_json_records_the_wrapped_argv(tmp_path, rocprofv3_on_path):
     HIP_VISIBLE_DEVICES translation -- is auditable from the artifact rather
     than only from a log line."""
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
-    _rocprof_artifacts(collect_dir)
     wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
     wl.setup()
+    _rocprof_artifacts(collect_dir)
     wl.run()
     doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
     recorded = doc.get("argv")

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -1,0 +1,278 @@
+"""Collector wiring inside :class:`SubprocessWorkload` (no GPU, no rocprofv3).
+
+The generic seam is what makes ``aorta probe -- <any command>`` profilable:
+``setup()`` rewrites the opaque user argv, and ``run()`` merges the collectors'
+parsed summaries into ``WorkloadResult.metrics``. These tests pin both,
+plus the on-disk layout the artifacts and metrics actually land in -- which is
+NOT inside the hand-written ``trial_<n>/`` directory, and is easy to get wrong
+from reading the code alone.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aorta.instrumentation import proton, rocprof
+from aorta.run.collectors import (
+    CONFIG_KEY_COLLECT,
+    CONFIG_KEY_COLLECT_DIR,
+    CONFIG_KEY_COLLECT_OPTIONS,
+)
+from aorta.workloads._subprocess import (
+    CONFIG_KEY_LOG_PREFIX,
+    CONFIG_KEY_PROBE_EXTRAS,
+    CONFIG_KEY_SUBPROCESS_ARGV,
+    SubprocessWorkload,
+)
+
+
+@pytest.fixture
+def rocprofv3_on_path(tmp_path, monkeypatch):
+    fake = tmp_path / "fakebin" / "rocprofv3"
+    fake.parent.mkdir(parents=True, exist_ok=True)
+    fake.write_text('#!/bin/sh\nexec "$@"\n')
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake.parent}:/usr/bin:/bin")
+    monkeypatch.delenv(rocprof.ENV_ROCPROF_BIN, raising=False)
+    return fake
+
+
+def _make_workload(tmp_path: Path, argv: list[str], *, collect=(), options=None, collect_dir=None):
+    """Build a workload with the log-prefix / collect-dir shape the runner sets.
+
+    The dispatcher sets ``_aorta_log_prefix`` to
+    ``<cell_dir>/<workload>/trial_d0_m0_t<N>`` and ``_aorta_collect_dir`` to the
+    same stem, so the synthetic config mirrors that and the test exercises the
+    real path decoding.
+    """
+    workload_subdir = tmp_path / "_subprocess"
+    workload_subdir.mkdir(parents=True, exist_ok=True)
+    prefix = workload_subdir / "trial_d0_m0_t0"
+    config: dict = {
+        CONFIG_KEY_SUBPROCESS_ARGV: argv,
+        CONFIG_KEY_LOG_PREFIX: str(prefix),
+        CONFIG_KEY_PROBE_EXTRAS: {
+            "cell_name": "none-none",
+            "env_passthrough_mode": "inherit",
+            "timeout_per_trial": None,
+            "cell_env_vars": {},
+        },
+    }
+    if collect:
+        config[CONFIG_KEY_COLLECT] = list(collect)
+        config[CONFIG_KEY_COLLECT_DIR] = str(collect_dir if collect_dir is not None else prefix)
+    if options:
+        config[CONFIG_KEY_COLLECT_OPTIONS] = options
+    return SubprocessWorkload(config)
+
+
+# ---- setup(): argv rewrite ----------------------------------------------
+
+
+def test_setup_leaves_argv_alone_without_a_collector(tmp_path):
+    """A run without ``--collect`` must launch byte-for-byte what it did."""
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    assert list(wl._argv) == ["true"]
+
+
+def test_setup_leaves_argv_alone_for_a_validated_only_collector(tmp_path):
+    wl = _make_workload(tmp_path, ["true"], collect=["layer_numerics"])
+    wl.setup()
+    assert list(wl._argv) == ["true"]
+
+
+def test_setup_wraps_argv_with_rocprof(tmp_path, rocprofv3_on_path):
+    wl = _make_workload(tmp_path, ["/tmp/gemm", "512"], collect=["rocprof"])
+    wl.setup()
+    assert wl._argv is not None
+    argv = list(wl._argv)
+    assert Path(argv[0]).name == "rocprofv3"
+    assert argv[argv.index("--") + 1 :] == ["/tmp/gemm", "512"]
+
+
+def test_setup_points_rocprof_at_the_threaded_collect_dir(tmp_path, rocprofv3_on_path):
+    wl = _make_workload(tmp_path, ["/tmp/gemm"], collect=["rocprof"])
+    wl.setup()
+    expected = tmp_path / "_subprocess" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    assert list(wl._argv)[list(wl._argv).index("-d") + 1] == str(expected)
+    assert expected.is_dir()
+
+
+def test_setup_forwards_recipe_options(tmp_path, rocprofv3_on_path):
+    wl = _make_workload(
+        tmp_path,
+        ["/tmp/gemm"],
+        collect=["rocprof"],
+        options={"rocprof": {"trace": "kernel,hip"}},
+    )
+    wl.setup()
+    assert "--hip-trace" in list(wl._argv)
+
+
+def test_setup_wraps_argv_with_proton(tmp_path):
+    wl = _make_workload(tmp_path, ["python", "vecadd.py"], collect=["proton"])
+    wl.setup()
+    argv = list(wl._argv)
+    assert argv[1:3] == ["-m", proton.PROTON_MODULE]
+    assert argv[-1] == "vecadd.py"
+
+
+def test_setup_surfaces_an_unattachable_collector_as_a_setup_failure(tmp_path, monkeypatch):
+    """A requested measurement that cannot be taken is a clean setup failure,
+    not a silently unprofiled run."""
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    monkeypatch.delenv(rocprof.ENV_ROCPROF_BIN, raising=False)
+    wl = _make_workload(tmp_path, ["/tmp/gemm"], collect=["rocprof"])
+    with pytest.raises(rocprof.RocprofUnavailableError):
+        wl.setup()
+
+
+def test_setup_rejects_a_proton_cli_wrap_of_a_non_python_command(tmp_path):
+    wl = _make_workload(tmp_path, ["/tmp/gemm", "512"], collect=["proton"])
+    with pytest.raises(proton.ProtonWrapError, match="mode: env"):
+        wl.setup()
+
+
+def test_setup_argv_validation_runs_before_the_collector_wrap(tmp_path, rocprofv3_on_path):
+    """The wrap must not mask the plain 'you gave me no argv' error."""
+    wl = _make_workload(tmp_path, [], collect=["rocprof"])
+    with pytest.raises(RuntimeError, match="non-empty list"):
+        wl.setup()
+
+
+# ---- run(): metrics merge ----------------------------------------------
+
+
+def _rocprof_artifacts(collect_dir: Path, total_ns: int = 539404, calls: int = 23) -> Path:
+    out_dir = collect_dir / rocprof.OUTPUT_SUBDIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n' f'"sgemm_tiled(float const*)",{calls},{total_ns}\n',
+        encoding="utf-8",
+    )
+    return out_dir
+
+
+def test_run_merges_collector_metrics(tmp_path):
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
+    _rocprof_artifacts(collect_dir)
+    wl.setup()
+    result = wl.run()
+    assert result.metrics["rocprof_kernel_count"] == 23
+    assert result.metrics["rocprof_gpu_time_ms"] == pytest.approx(0.539404)
+    assert result.metrics["rocprof_artifact_dir"] == str(collect_dir / rocprof.OUTPUT_SUBDIR)
+
+
+def test_run_metrics_unchanged_without_a_collector(tmp_path):
+    wl = _make_workload(tmp_path, ["true"])
+    wl.setup()
+    result = wl.run()
+    assert set(result.metrics) == {
+        "verdict",
+        "exit_code",
+        "result_json_path",
+        "failure_detectors_fired",
+        "error_detectors_fired",
+        "warn_detectors_fired",
+    }
+
+
+def test_run_collector_cannot_shadow_the_platform_keys(tmp_path, monkeypatch):
+    """The collector summary is merged UNDER the platform bookkeeping, so a
+    collector emitting ``verdict`` / ``exit_code`` cannot rewrite the trial's
+    outcome."""
+    monkeypatch.setattr(
+        rocprof,
+        "parse_summary",
+        lambda _out: {"verdict": "pass", "exit_code": 0, "rocprof_gpu_time_ms": 1.0},
+    )
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    (collect_dir / rocprof.OUTPUT_SUBDIR).mkdir(parents=True)
+    wl = _make_workload(tmp_path, ["false"], collect=["rocprof"])
+    wl.setup()
+    result = wl.run()
+    assert result.metrics["verdict"] == "fail"
+    assert result.metrics["exit_code"] != 0
+    assert result.metrics["rocprof_gpu_time_ms"] == 1.0
+
+
+def test_run_survives_a_collector_that_produced_nothing(tmp_path):
+    """rocprofv3 writes no files at all for a command with no GPU work."""
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
+    wl.setup()
+    result = wl.run()
+    assert result.passed is True
+    assert "rocprof_kernel_count" not in result.metrics
+    assert result.metrics["verdict"] == "pass"
+
+
+def test_run_survives_a_malformed_capture(tmp_path):
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    out_dir = collect_dir / rocprof.OUTPUT_SUBDIR
+    out_dir.mkdir(parents=True)
+    (out_dir / "aorta_kernel_stats.csv").write_text("garbage\n", encoding="utf-8")
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
+    wl.setup()
+    result = wl.run()
+    assert result.passed is True
+    assert "rocprof_kernel_count" not in result.metrics
+
+
+def test_run_still_reports_metrics_for_a_failing_trial(tmp_path):
+    """A profiled crash is exactly the case an operator wants numbers for."""
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    _rocprof_artifacts(collect_dir)
+    wl = _make_workload(tmp_path, ["false"], collect=["rocprof"])
+    wl.setup()
+    result = wl.run()
+    assert result.passed is False
+    assert result.metrics["rocprof_kernel_count"] == 23
+
+
+# ---- Artifact / metrics location --------------------------------------
+
+
+def test_collector_artifacts_are_a_sibling_of_the_hand_written_trial_dir(tmp_path):
+    """Pin the real layout, which is not the obvious one.
+
+    ``SubprocessWorkload`` hand-writes ``<cell>/trial_<n>/result.json`` from
+    ``_aorta_log_prefix``, while the dispatcher threads ``_aorta_collect_dir``
+    as ``<cell>/<workload>/trial_d<d>_m<m>_t<t>``. So the collector artifact
+    directory is a SIBLING of the per-trial ``result.json`` tree, not inside
+    it, and ``result.json`` carries no collector metrics -- those ride
+    ``WorkloadResult.metrics`` into the dispatcher's trial JSON instead.
+    """
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    _rocprof_artifacts(collect_dir)
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
+    wl.setup()
+    wl.run()
+
+    artifact_dir = collect_dir / rocprof.OUTPUT_SUBDIR
+    hand_written = tmp_path / "trial_0"
+    assert artifact_dir.is_dir()
+    assert hand_written.is_dir()
+    # Neither contains the other.
+    assert hand_written not in artifact_dir.parents
+    assert artifact_dir not in hand_written.parents
+    # Both live under the same cell directory, so `aorta bundle` (which copies
+    # everything under the run dir) picks up both.
+    assert artifact_dir.is_relative_to(tmp_path)
+    assert hand_written.is_relative_to(tmp_path)
+
+
+def test_hand_written_result_json_carries_no_collector_metrics(tmp_path):
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    _rocprof_artifacts(collect_dir)
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
+    wl.setup()
+    result = wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    assert not [key for key in doc if key.startswith(("rocprof_", "proton_"))]
+    # The metrics channel is where they live, and it points back at result.json.
+    assert result.metrics["result_json_path"] == str(tmp_path / "trial_0" / "result.json")

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -185,7 +185,9 @@ def _rocprof_artifacts(collect_dir: Path, total_ns: int = 539404, calls: int = 2
 
     Call this *after* ``setup()``: the real rocprofv3 writes while the wrapped
     command runs, and ``setup()`` deliberately empties the collector directory
-    so a resumed trial cannot summarise the attempt it is replacing.
+    so a resumed trial cannot summarise the attempt it is replacing. Calling it
+    before ``setup()`` therefore seeds a stale previous attempt, which is what
+    ``test_setup_discards_an_interrupted_attempts_artifacts`` wants.
     """
     out_dir = collect_dir / rocprof.OUTPUT_SUBDIR
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -367,6 +367,48 @@ def test_summary_refuses_a_collector_root_swapped_for_a_symlink(tmp_path, rocpro
     assert "rocprof_artifact_dir" not in result.metrics
 
 
+@pytest.mark.parametrize("retain_level", ["none", "full"])
+def test_collector_subdir_swapped_for_a_symlink_is_refused(
+    tmp_path, rocprofv3_on_path, retain_level
+):
+    """The guard must cover each collector *subdirectory*, not just the root.
+
+    The parsers glob ``<root>/rocprof``, so swapping that one directory is the
+    read exposure one level below the root. Mutation-verified: with the guard
+    narrowed back to the root alone, this fails with ``rocprof_kernel_count:
+    7`` -- a metric read straight out of a directory outside the run tree.
+
+    Both retention levels are covered, but only the read half is known to be
+    reachable: with the guard removed, ``apply_retention`` did *not* delete the
+    planted file through the symlinked subdirectory. The deletion assertion is
+    kept as a regression guard on that, not as a demonstrated exploit.
+    """
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    # A *parseable* capture outside the run tree, so an unguarded read is
+    # observable as a leaked metric rather than a silently empty one.
+    outside = tmp_path / "outside_capture"
+    outside.mkdir()
+    victim = outside / "aorta_kernel_stats.csv"
+    victim.write_text(
+        '"Name","Calls","TotalDurationNs"\n"leaked_kernel",7,7000000\n',
+        encoding="utf-8",
+    )
+
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"], retain={"on_pass": retain_level})
+    wl.setup()
+    subdir = collect_dir / rocprof.OUTPUT_SUBDIR
+    shutil.rmtree(subdir)
+    subdir.symlink_to(outside, target_is_directory=True)
+
+    result = wl.run()
+
+    # Nothing from outside the run tree may reach the metrics...
+    assert "rocprof_kernel_count" not in result.metrics
+    assert "leaked_kernel" not in str(result.metrics)
+    # ...and nothing out there may be deleted.
+    assert victim.read_text(encoding="utf-8").endswith("7,7000000\n")
+
+
 def test_retention_full_keeps_the_collector_tree(tmp_path, rocprofv3_on_path):
     """``full`` is the keep-everything default; the collector tree follows it."""
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -276,3 +276,20 @@ def test_hand_written_result_json_carries_no_collector_metrics(tmp_path):
     assert not [key for key in doc if key.startswith(("rocprof_", "proton_"))]
     # The metrics channel is where they live, and it points back at result.json.
     assert result.metrics["result_json_path"] == str(tmp_path / "trial_0" / "result.json")
+
+
+def test_result_json_records_the_wrapped_argv(tmp_path, rocprofv3_on_path):
+    """``result.json`` records the argv that actually ran, so an attached
+    collector -- and any environment rewriting it did, such as Proton's
+    HIP_VISIBLE_DEVICES translation -- is auditable from the artifact rather
+    than only from a log line."""
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    _rocprof_artifacts(collect_dir)
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"])
+    wl.setup()
+    wl.run()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    recorded = doc.get("argv")
+    assert recorded is not None
+    assert Path(recorded[0]).name == "rocprofv3"
+    assert recorded[-1] == "true"

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -1,0 +1,420 @@
+"""Tests for the collector registry (:mod:`aorta.run.collectors`).
+
+The registry is the dispatch layer between the reserved ``_aorta_collect*``
+config keys the dispatcher threads into every trial and the per-collector
+packages under :mod:`aorta.instrumentation`. These tests pin the contracts a
+caller depends on: ordering, no-op passthrough, cross-collector conflict
+rejection, nesting relative to the mirage emulator wrap, and the fail-soft
+summary merge.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from aorta.emulation.mirage_launch import (
+    CONFIG_KEY_ENVIRONMENT,
+    ENV_MIRAGE_BIN,
+    wrap_argv_for_environment,
+)
+from aorta.instrumentation import proton, rocprof
+from aorta.registry.types import Environment
+from aorta.run.collectors import (
+    CONFIG_KEY_COLLECT,
+    CONFIG_KEY_COLLECT_DIR,
+    CONFIG_KEY_COLLECT_OPTIONS,
+    KNOWN_RECIPES,
+    WRAP_ORDER,
+    CollectorSpec,
+    active_collectors,
+    summarize_collectors,
+    validate_collectors,
+    wrap_argv_for_collectors,
+)
+
+_INNER = ["python", "train.py", "--steps", "10"]
+
+
+@pytest.fixture
+def profilers_on_path(tmp_path, monkeypatch):
+    """Fake ``rocprofv3`` + ``env`` on ``$PATH`` so both wraps can be built."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name in ("rocprofv3", "env", "mirage"):
+        fake = bin_dir / name
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.delenv(rocprof.ENV_ROCPROF_BIN, raising=False)
+    monkeypatch.delenv(proton.ENV_PROTON_PYTHON, raising=False)
+    monkeypatch.delenv(ENV_MIRAGE_BIN, raising=False)
+    return bin_dir
+
+
+def _config(names, *, collect_dir=None, options=None):
+    config = {CONFIG_KEY_COLLECT: list(names)}
+    if collect_dir is not None:
+        config[CONFIG_KEY_COLLECT_DIR] = str(collect_dir)
+    if options is not None:
+        config[CONFIG_KEY_COLLECT_OPTIONS] = options
+    return config
+
+
+# ---- Registry shape ------------------------------------------------------
+
+
+def test_known_recipes_contains_both_profilers():
+    assert {"rocprof", "proton"} <= KNOWN_RECIPES
+
+
+def test_known_recipes_keeps_the_validated_only_names():
+    """Existing recipes name these; dropping one would break them."""
+    assert {"numerics", "layer_numerics", "amd_log"} <= KNOWN_RECIPES
+
+
+def test_wrap_order_puts_rocprof_outermost():
+    """rocprof runs a whole command under the profiler while Proton takes over
+    a Python script's execution, so rocprof has to be the outer process for the
+    pair to compose at all."""
+    assert WRAP_ORDER == ("rocprof", "proton")
+
+
+def test_wrap_order_names_are_known_recipes():
+    assert set(WRAP_ORDER) <= KNOWN_RECIPES
+
+
+def test_collector_spec_is_frozen():
+    spec = CollectorSpec("x", None, lambda opts: {})
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        spec.name = "y"  # type: ignore[misc]
+
+
+# ---- active_collectors ---------------------------------------------------
+
+
+def test_active_collectors_empty_without_the_key():
+    assert active_collectors({}) == ()
+
+
+def test_active_collectors_empty_for_non_sequence():
+    assert active_collectors({CONFIG_KEY_COLLECT: "rocprof"}) == ()
+
+
+def test_active_collectors_orders_by_wrap_order():
+    assert active_collectors(_config(["proton", "rocprof"])) == ("rocprof", "proton")
+
+
+def test_active_collectors_appends_non_wrapping_names_after():
+    assert active_collectors(_config(["layer_numerics", "proton"])) == (
+        "proton",
+        "layer_numerics",
+    )
+
+
+def test_active_collectors_dedups_non_wrapping_names():
+    assert active_collectors(_config(["layer_numerics", "layer_numerics"])) == ("layer_numerics",)
+
+
+def test_active_collectors_drops_unknown_and_non_string_entries():
+    """``run_trials`` and the recipe loader reject these up front, so anything
+    left here came from a hand-built config and must not crash a trial."""
+    assert active_collectors(_config(["rocprof", "nope", 7, None])) == ("rocprof",)
+
+
+def test_active_collectors_accepts_a_tuple():
+    assert active_collectors({CONFIG_KEY_COLLECT: ("rocprof",)}) == ("rocprof",)
+
+
+# ---- validate_collectors -------------------------------------------------
+
+
+def test_validate_collectors_accepts_empty():
+    validate_collectors([])
+
+
+def test_validate_collectors_accepts_valid_options():
+    validate_collectors(["rocprof"], {"rocprof": {"trace": "kernel,hip"}})
+
+
+def test_validate_collectors_rejects_bad_rocprof_option():
+    with pytest.raises(ValueError, match="rocprof: unknown option"):
+        validate_collectors(["rocprof"], {"rocprof": {"nope": "1"}})
+
+
+def test_validate_collectors_rejects_bad_proton_option():
+    with pytest.raises(ValueError, match="proton option 'backend'"):
+        validate_collectors(["proton"], {"proton": {"backend": "nope"}})
+
+
+def test_validate_collectors_ignores_unknown_names():
+    """The caller already checked against KNOWN_RECIPES; its message stays the
+    one the operator sees."""
+    validate_collectors(["not_a_collector"])
+
+
+def test_validate_collectors_accepts_anything_for_wrapper_owned_collectors():
+    validate_collectors(["layer_numerics"], {"layer_numerics": {"NANLOG_SPEC": "{}"}})
+
+
+@pytest.mark.parametrize("backend", ["auto", "rocprofiler", "roctracer"])
+def test_validate_collectors_rejects_queue_interception_conflict(backend):
+    """rocprof and a queue-intercepting Proton backend both install an HSA
+    queue interceptor; the second to attach reports nothing."""
+    with pytest.raises(ValueError, match="queue interceptor"):
+        validate_collectors(["rocprof", "proton"], {"proton": {"backend": backend}})
+
+
+def test_validate_collectors_conflict_fires_on_the_proton_default():
+    """``collect: [rocprof, proton]`` with no options is the conflicting pair.
+
+    The default backend is ``auto``, which on AMD resolves to ``rocprofiler``
+    or ``roctracer`` -- both intercepting. The guard cannot prove the pairing is
+    safe, so it rejects it and says what ``auto`` resolves to.
+    """
+    with pytest.raises(ValueError, match="'auto'.*resolves to rocprofiler or roctracer"):
+        validate_collectors(["rocprof", "proton"])
+
+
+def test_validate_collectors_conflict_names_the_explicit_backend():
+    with pytest.raises(ValueError, match="'roctracer'"):
+        validate_collectors(["rocprof", "proton"], {"proton": {"backend": "roctracer"}})
+
+
+def test_validate_collectors_conflict_message_names_the_escape_hatch():
+    with pytest.raises(ValueError, match="instrumentation"):
+        validate_collectors(["rocprof", "proton"])
+
+
+def test_validate_collectors_allows_instrumentation_backend_alongside_rocprof():
+    """Intra-kernel measurement needs no queue interception, so the pair runs."""
+    validate_collectors(["rocprof", "proton"], {"proton": {"backend": "instrumentation"}})
+
+
+def test_validate_collectors_order_independent():
+    with pytest.raises(ValueError, match="queue interceptor"):
+        validate_collectors(["proton", "rocprof"])
+
+
+# ---- wrap_argv_for_collectors: no-op path -------------------------------
+
+
+def test_wrap_is_a_noop_without_any_collector():
+    """A run without ``--collect`` must be byte-for-byte what it was."""
+    assert wrap_argv_for_collectors({}, _INNER) == _INNER
+
+
+def test_wrap_is_a_noop_for_validated_only_collectors(tmp_path):
+    config = _config(["layer_numerics"], collect_dir=tmp_path)
+    assert wrap_argv_for_collectors(config, _INNER) == _INNER
+
+
+def test_wrap_returns_a_new_list(tmp_path):
+    inner = list(_INNER)
+    assert wrap_argv_for_collectors({}, inner) is not inner
+
+
+def test_wrap_skips_when_no_collect_dir_was_threaded(profilers_on_path, caplog):
+    """The dispatcher only injects the collect dir on the artifact-writing rank;
+    a non-writing rank has nowhere to put artifacts, so it runs unprofiled
+    rather than scattering files into the cwd."""
+    with caplog.at_level("WARNING"):
+        assert wrap_argv_for_collectors(_config(["rocprof"]), _INNER) == _INNER
+    assert CONFIG_KEY_COLLECT_DIR in caplog.text
+
+
+def test_wrap_skips_when_the_output_dir_cannot_be_created(profilers_on_path, tmp_path, caplog):
+    blocker = tmp_path / "blocked"
+    blocker.write_text("")  # a file where the collector wants a directory
+    config = _config(["rocprof"], collect_dir=blocker)
+    with caplog.at_level("WARNING"):
+        assert wrap_argv_for_collectors(config, _INNER) == _INNER
+    assert "cannot create" in caplog.text
+
+
+# ---- wrap_argv_for_collectors: attaching -------------------------------
+
+
+def test_wrap_creates_the_output_subdir(profilers_on_path, tmp_path):
+    """Pre-created so the trial tree has the same shape whether or not the
+    workload produced GPU activity -- rocprofv3 writes nothing when it did not."""
+    wrap_argv_for_collectors(_config(["rocprof"], collect_dir=tmp_path), _INNER)
+    assert (tmp_path / rocprof.OUTPUT_SUBDIR).is_dir()
+
+
+def test_wrap_rocprof_points_at_its_own_subdir(profilers_on_path, tmp_path):
+    argv = wrap_argv_for_collectors(_config(["rocprof"], collect_dir=tmp_path), _INNER)
+    assert argv[argv.index("-d") + 1] == str(tmp_path / rocprof.OUTPUT_SUBDIR)
+    assert argv[-len(_INNER) :] == _INNER
+
+
+def test_wrap_proton_points_at_its_own_subdir(profilers_on_path, tmp_path):
+    argv = wrap_argv_for_collectors(_config(["proton"], collect_dir=tmp_path), _INNER)
+    expected = tmp_path / proton.OUTPUT_SUBDIR / proton.PROFILE_BASENAME
+    assert argv[argv.index("-n") + 1] == str(expected)
+
+
+def test_wrap_forwards_per_collector_options(profilers_on_path, tmp_path):
+    config = _config(
+        ["rocprof"],
+        collect_dir=tmp_path,
+        options={"rocprof": {"trace": "kernel,hip", "summary_units": "msec"}},
+    )
+    argv = wrap_argv_for_collectors(config, _INNER)
+    assert "--hip-trace" in argv
+    assert argv[argv.index("-u") + 1] == "msec"
+
+
+def test_wrap_ignores_options_for_other_collectors(profilers_on_path, tmp_path):
+    config = _config(
+        ["rocprof"],
+        collect_dir=tmp_path,
+        options={"proton": {"backend": "roctracer"}},
+    )
+    assert "--hip-trace" not in wrap_argv_for_collectors(config, _INNER)
+
+
+def test_wrap_tolerates_a_malformed_options_payload(profilers_on_path, tmp_path):
+    config = _config(["rocprof"], collect_dir=tmp_path, options=["rocprof"])
+    assert wrap_argv_for_collectors(config, _INNER)[-len(_INNER) :] == _INNER
+
+
+def test_wrap_coerces_non_string_option_values(profilers_on_path, tmp_path):
+    config = _config(["rocprof"], collect_dir=tmp_path, options={"rocprof": {"stats": 1}})
+    assert "--stats" in wrap_argv_for_collectors(config, _INNER)
+
+
+def test_wrap_propagates_an_invalid_option(profilers_on_path, tmp_path):
+    config = _config(["rocprof"], collect_dir=tmp_path, options={"rocprof": {"trace": "nope"}})
+    with pytest.raises(ValueError, match="unknown domain"):
+        wrap_argv_for_collectors(config, _INNER)
+
+
+def test_wrap_propagates_an_unattachable_collector(tmp_path, monkeypatch):
+    """Requesting a measurement that cannot be taken is a clean setup failure,
+    not a silently unprofiled run."""
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    monkeypatch.delenv(rocprof.ENV_ROCPROF_BIN, raising=False)
+    with pytest.raises(rocprof.RocprofUnavailableError):
+        wrap_argv_for_collectors(_config(["rocprof"], collect_dir=tmp_path), _INNER)
+
+
+def test_wrap_forwards_env_to_proton(profilers_on_path, tmp_path):
+    config = _config(["proton"], collect_dir=tmp_path, options={"proton": {"backend": "roctracer"}})
+    argv = wrap_argv_for_collectors(config, _INNER, env={"HIP_VISIBLE_DEVICES": "1"})
+    assert "ROCR_VISIBLE_DEVICES=1" in argv
+
+
+# ---- Nesting order ------------------------------------------------------
+
+
+def test_wrap_nests_rocprof_outside_proton(profilers_on_path, tmp_path):
+    config = _config(
+        ["rocprof", "proton"],
+        collect_dir=tmp_path,
+        options={"proton": {"backend": "instrumentation"}},
+    )
+    argv = wrap_argv_for_collectors(config, _INNER)
+    assert Path(argv[0]).name == "rocprofv3"
+    sep = argv.index("--")
+    inner = argv[sep + 1 :]
+    assert inner[1:3] == ["-m", proton.PROTON_MODULE]
+    assert inner[-len(_INNER) + 1 :] == _INNER[1:]
+
+
+def test_wrap_nesting_is_independent_of_the_request_order(profilers_on_path, tmp_path):
+    options = {"proton": {"backend": "instrumentation"}}
+    forward = wrap_argv_for_collectors(
+        _config(["rocprof", "proton"], collect_dir=tmp_path, options=options), _INNER
+    )
+    reverse = wrap_argv_for_collectors(
+        _config(["proton", "rocprof"], collect_dir=tmp_path, options=options), _INNER
+    )
+    assert forward == reverse
+
+
+def test_emulator_wraps_outside_the_collectors(profilers_on_path, tmp_path):
+    """The caller applies the collector wrap first and the mirage wrap after,
+    so the profiler runs *inside* the emulated environment. The other order
+    would profile the emulator's own launcher instead of the workload."""
+    collected = wrap_argv_for_collectors(_config(["rocprof"], collect_dir=tmp_path), _INNER)
+    emulated = wrap_argv_for_environment(
+        {
+            CONFIG_KEY_ENVIRONMENT: asdict(
+                Environment(name="emu", emulator="rocjitsu", mirage_profile="mi350x")
+            )
+        },
+        collected,
+    )
+    assert Path(emulated[0]).name == "mirage"
+    assert emulated[1:4] == ["run", "--profile", "mi350x"]
+    assert Path(emulated[emulated.index("--") + 1]).name == "rocprofv3"
+
+
+# ---- summarize_collectors -----------------------------------------------
+
+
+def test_summarize_is_empty_without_a_collect_dir():
+    assert summarize_collectors(_config(["rocprof"])) == {}
+
+
+def test_summarize_is_empty_without_any_collector(tmp_path):
+    assert summarize_collectors({CONFIG_KEY_COLLECT_DIR: str(tmp_path)}) == {}
+
+
+def test_summarize_skips_validated_only_collectors(tmp_path):
+    config = _config(["layer_numerics"], collect_dir=tmp_path)
+    assert summarize_collectors(config) == {}
+
+
+def test_summarize_reports_the_artifact_dir_for_an_empty_capture(tmp_path):
+    (tmp_path / rocprof.OUTPUT_SUBDIR).mkdir()
+    config = _config(["rocprof"], collect_dir=tmp_path)
+    assert summarize_collectors(config) == {
+        "rocprof_artifact_dir": str(tmp_path / rocprof.OUTPUT_SUBDIR)
+    }
+
+
+def test_summarize_parses_real_rocprof_artifacts(tmp_path):
+    out_dir = tmp_path / rocprof.OUTPUT_SUBDIR
+    out_dir.mkdir()
+    (out_dir / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"sgemm",23,539404\n', encoding="utf-8"
+    )
+    metrics = summarize_collectors(_config(["rocprof"], collect_dir=tmp_path))
+    assert metrics["rocprof_kernel_count"] == 23
+    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(0.539404)
+
+
+def test_summarize_merges_both_collectors(tmp_path):
+    (tmp_path / rocprof.OUTPUT_SUBDIR).mkdir()
+    (tmp_path / proton.OUTPUT_SUBDIR).mkdir()
+    config = _config(["rocprof", "proton"], collect_dir=tmp_path)
+    metrics = summarize_collectors(config)
+    assert "rocprof_artifact_dir" in metrics
+    assert "proton_artifact_dir" in metrics
+
+
+def test_summarize_metric_keys_are_namespaced_by_collector(tmp_path):
+    """Both collectors write into the same flat ``metrics`` mapping, so their
+    keys must not collide."""
+    (tmp_path / rocprof.OUTPUT_SUBDIR).mkdir()
+    (tmp_path / proton.OUTPUT_SUBDIR).mkdir()
+    metrics = summarize_collectors(_config(["rocprof", "proton"], collect_dir=tmp_path))
+    assert all(key.startswith(("rocprof_", "proton_")) for key in metrics)
+
+
+def test_summarize_survives_a_parser_that_raises(tmp_path, monkeypatch, caplog):
+    """An opt-in measurement must never turn a healthy trial into a failure."""
+
+    def boom(_out_dir):
+        raise RuntimeError("parser exploded")
+
+    monkeypatch.setattr(rocprof, "parse_summary", boom)
+    (tmp_path / rocprof.OUTPUT_SUBDIR).mkdir()
+    with caplog.at_level("WARNING"):
+        assert summarize_collectors(_config(["rocprof"], collect_dir=tmp_path)) == {}
+    assert "summary parsing failed" in caplog.text

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -226,13 +226,18 @@ def test_wrap_skips_when_no_collect_dir_was_threaded(profilers_on_path, caplog):
     assert CONFIG_KEY_COLLECT_DIR in caplog.text
 
 
-def test_wrap_skips_when_the_output_dir_cannot_be_created(profilers_on_path, tmp_path, caplog):
+def test_wrap_fails_when_the_output_dir_cannot_be_created(profilers_on_path, tmp_path):
+    """An artifact directory that cannot be prepared is a setup failure.
+
+    The collector would have nowhere to write, so letting the trial proceed
+    would run it unprofiled while the operator believes it was measured --
+    the same contract as a missing rocprofv3.
+    """
     blocker = tmp_path / "blocked"
     blocker.write_text("")  # a file where the collector wants a directory
     config = _config(["rocprof"], collect_dir=blocker)
-    with caplog.at_level("WARNING"):
-        assert wrap_argv_for_collectors(config, _INNER) == _INNER
-    assert "cannot create" in caplog.text
+    with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
+        wrap_argv_for_collectors(config, _INNER)
 
 
 # ---- wrap_argv_for_collectors: attaching -------------------------------

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -240,6 +240,30 @@ def test_wrap_fails_when_the_output_dir_cannot_be_created(profilers_on_path, tmp
         wrap_argv_for_collectors(config, _INNER)
 
 
+def test_wrap_refuses_to_clear_through_a_symlinked_collect_root(profilers_on_path, tmp_path):
+    """A symlinked collector root must not let ``rmtree`` escape the run tree.
+
+    ``Path.is_dir()`` follows symlinks in *every* component, so a per-trial
+    collector root that is a symlink would resolve the output directory through
+    it and delete the link target -- a tree outside the results directory
+    entirely. This is the destructive case, so it fails closed.
+    """
+    outside = tmp_path / "precious"
+    outside.mkdir()
+    (outside / "rocprof").mkdir()
+    (outside / "rocprof" / "keep_me.txt").write_text("not yours to delete", encoding="utf-8")
+
+    link = tmp_path / "trial_d0_m0_t0"
+    link.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
+        wrap_argv_for_collectors(_config(["rocprof"], collect_dir=link), _INNER)
+    # The whole point: the tree behind the symlink is untouched.
+    assert (outside / "rocprof" / "keep_me.txt").read_text(encoding="utf-8") == (
+        "not yours to delete"
+    )
+
+
 # ---- wrap_argv_for_collectors: attaching -------------------------------
 
 

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -280,6 +280,30 @@ class TestRunTrials:
         with pytest.raises(ValueError, match=r"dict\[str, str\]"):
             run_trials(req)
 
+    def test_rejects_invalid_collector_option(self, tmp_path):
+        """``run_trials`` is a public library API: a programmatic caller that
+        never went through the recipe loader still gets its option typo caught
+        before the first trial launches, not from an empty artifact dir."""
+        req = RunRequest(
+            workload="anything",
+            trials=1,
+            collect=("rocprof",),
+            collect_options={"rocprof": {"trace": "gpu"}},
+            results_dir=tmp_path,
+        )
+        with pytest.raises(ValueError, match="unknown domain"):
+            run_trials(req)
+
+    def test_rejects_queue_intercepting_collector_pair(self, tmp_path):
+        req = RunRequest(
+            workload="anything",
+            trials=1,
+            collect=("rocprof", "proton"),
+            results_dir=tmp_path,
+        )
+        with pytest.raises(ValueError, match="queue interceptor"):
+            run_trials(req)
+
     def test_rejects_reserved_aorta_prefix_in_config_overrides(self, tmp_path):
         """``_aorta_*`` keys are reserved for platform-supplied values
         (currently ``_aorta_environment``).  A caller passing one in

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,237 @@
+"""Integrity of the shipped ``examples/`` tree.
+
+The examples double as end-to-end tests of the collectors, so they have to
+stay loadable and self-consistent: every example directory carries a README, a
+payload, and a recipe that loads under the real loader with a real collector
+attached. Broken example recipes are worse than no examples -- they are the
+first thing a new user runs.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from aorta.triage.recipe import load_recipe
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = REPO_ROOT / "examples"
+PROFILING = EXAMPLES / "profiling"
+
+#: Sidecar templates that predate the categorised tree; both are referenced
+#: from ``src/aorta/registry/README.md`` and ``docs/buck2-build-reference.md``.
+_SIDECAR_TEMPLATES = ("mitigations-sidecar.json", "probe-flag-sidecar.json")
+
+
+def _example_dirs() -> list[Path]:
+    """Every leaf example directory: ``profiling/<collector>/<example>/``."""
+    if not PROFILING.is_dir():
+        return []
+    return sorted(
+        child
+        for category in PROFILING.iterdir()
+        if category.is_dir()
+        for child in category.iterdir()
+        if child.is_dir()
+    )
+
+
+def _category_dirs() -> list[Path]:
+    return sorted(child for child in PROFILING.iterdir() if child.is_dir())
+
+
+_EXAMPLE_DIRS = _example_dirs()
+_EXAMPLE_IDS = [str(path.relative_to(EXAMPLES)) for path in _EXAMPLE_DIRS]
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+# ---- Tree shape ---------------------------------------------------------
+
+
+def test_examples_tree_exists():
+    assert EXAMPLES.is_dir()
+    assert PROFILING.is_dir()
+
+
+def test_at_least_one_example_per_collector_category():
+    categories = {path.name for path in _category_dirs()}
+    assert {"rocprof", "proton"} <= categories
+    for category in _category_dirs():
+        assert [c for c in category.iterdir() if c.is_dir()], f"{_rel(category)} has no examples"
+
+
+def test_sidecar_templates_are_still_in_place():
+    """Both are linked from docs that would break if they moved."""
+    for name in _SIDECAR_TEMPLATES:
+        assert (EXAMPLES / name).is_file()
+
+
+def test_index_readmes_exist():
+    assert (EXAMPLES / "README.md").is_file()
+    assert (PROFILING / "README.md").is_file()
+
+
+@pytest.mark.parametrize("category", _category_dirs(), ids=lambda p: p.name)
+def test_every_category_is_listed_in_the_profiling_index(category):
+    index = (PROFILING / "README.md").read_text(encoding="utf-8")
+    assert f"{category.name}/" in index, f"{category.name} missing from profiling/README.md"
+
+
+# ---- Per-example contents ----------------------------------------------
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_has_a_readme(example):
+    readme = example / "README.md"
+    assert readme.is_file(), f"{_rel(example)} has no README.md"
+    assert readme.read_text(encoding="utf-8").strip(), f"{_rel(readme)} is empty"
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_has_a_payload(example):
+    payloads = [
+        path
+        for path in example.iterdir()
+        if path.is_file() and path.suffix in {".py", ".hip", ".sh", ".cpp"}
+    ]
+    assert payloads, f"{_rel(example)} has no payload file"
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_is_listed_in_its_category_index(example):
+    index = (example.parent.parent / "README.md").read_text(encoding="utf-8")
+    assert example.name in index, f"{_rel(example)} missing from profiling/README.md"
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_readme_names_the_collector_and_the_payload(example):
+    readme = (example / "README.md").read_text(encoding="utf-8")
+    assert example.parent.name in readme, f"{_rel(example)}/README.md does not name its collector"
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_carries_no_absolute_host_paths(example):
+    """No host specifics: an example must be runnable on someone else's machine."""
+    forbidden = ("/apps/", "/home/")
+    for path in example.rglob("*"):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for needle in forbidden:
+            assert needle not in text, f"{_rel(path)} contains a host path ({needle})"
+
+
+# ---- Recipes load -----------------------------------------------------
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_recipe_loads(example):
+    recipe_path = example / "recipe.yaml"
+    assert recipe_path.is_file(), f"{_rel(example)} has no recipe.yaml"
+    recipe = load_recipe(recipe_path)
+    assert recipe.cells, f"{_rel(recipe_path)} produced no cells"
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_recipe_activates_its_categorys_collector(example):
+    """The recipe's ``collect:`` block must be ACTIVE (not commented out) and
+    must name the collector whose directory it lives in -- otherwise the
+    example silently demonstrates nothing."""
+    recipe = load_recipe(example / "recipe.yaml")
+    assert recipe.collect == (example.parent.name,), (
+        f"{_rel(example)}/recipe.yaml collects {recipe.collect}, "
+        f"expected exactly ('{example.parent.name}',)"
+    )
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_recipe_is_probe_mode(example):
+    """Every profiling example drives an opaque command after ``--``, which is
+    the probe flow."""
+    recipe = load_recipe(example / "recipe.yaml")
+    assert recipe.probe_extras is not None, f"{_rel(example)}/recipe.yaml is not mode: probe"
+
+
+@pytest.mark.parametrize("example", _EXAMPLE_DIRS, ids=_EXAMPLE_IDS)
+def test_example_recipe_collector_options_validate(example):
+    """``load_recipe`` already validates them; assert the block is non-trivial
+    so an example is a usable template rather than an empty gesture."""
+    recipe = load_recipe(example / "recipe.yaml")
+    name = example.parent.name
+    assert recipe.collect_options.get(name), (
+        f"{_rel(example)}/recipe.yaml sets no {name} options; the examples are "
+        "the copy-paste templates for the option schema"
+    )
+
+
+# ---- Payload exit convention --------------------------------------------
+#
+# Proton runs the payload through ``execute_as_main``, which on Triton 3.6.0
+# catches ``Exception`` -- not ``BaseException``. A ``SystemExit`` on the
+# success path therefore escapes Proton's own CLI before ``finalize()`` writes
+# the ``.hatchet``, and the run reports a clean exit 0 with no profile at all.
+# Payloads must return normally on success and exit non-zero only on failure.
+
+
+def _python_payloads() -> list[Path]:
+    return sorted(path for example in _EXAMPLE_DIRS for path in example.glob("*.py"))
+
+
+_PAYLOADS = _python_payloads()
+_PAYLOAD_IDS = [str(path.relative_to(EXAMPLES)) for path in _PAYLOADS]
+
+
+def _main_guard_body(payload: Path) -> list[ast.stmt]:
+    """Statements under ``if __name__ == "__main__":``, or ``[]`` if absent."""
+    for node in ast.parse(payload.read_text(encoding="utf-8")).body:
+        if isinstance(node, ast.If) and "__name__" in ast.dump(node.test):
+            return node.body
+    return []
+
+
+def _exit_code_of_main_guard(payload: Path, returned: int) -> int | None:
+    """Run *only* the ``__main__`` block with ``main()`` stubbed to return
+    ``returned``, and report how it terminated.
+
+    Executing the guard block alone keeps this a CPU test: the payload's
+    module-level ``import torch`` never runs. Returns the ``SystemExit`` code,
+    or ``None`` when the block fell off the end without raising.
+    """
+    module = ast.Module(body=_main_guard_body(payload), type_ignores=[])
+    ast.fix_missing_locations(module)
+    try:
+        exec(compile(module, str(payload), "exec"), {"main": lambda: returned})  # noqa: S102
+    except SystemExit as exc:
+        return 1 if exc.code is None else int(exc.code)
+    return None
+
+
+@pytest.mark.parametrize("payload", _PAYLOADS, ids=_PAYLOAD_IDS)
+def test_payload_has_a_main_guard(payload):
+    assert _main_guard_body(payload), f'{_rel(payload)} has no if __name__ == "__main__" block'
+
+
+@pytest.mark.parametrize("payload", _PAYLOADS, ids=_PAYLOAD_IDS)
+def test_payload_success_path_does_not_raise_systemexit(payload):
+    """A ``SystemExit(0)`` here costs the whole Proton capture on Triton 3.6.0."""
+    assert _exit_code_of_main_guard(payload, 0) is None, (
+        f"{_rel(payload)} raises SystemExit when main() returns 0; Proton's "
+        "execute_as_main on Triton 3.6.0 lets that escape and skips finalize(), "
+        "so the payload exits 0 having written no profile"
+    )
+
+
+@pytest.mark.parametrize("payload", _PAYLOADS, ids=_PAYLOAD_IDS)
+@pytest.mark.parametrize("code", [1, 2])
+def test_payload_failure_path_still_exits_nonzero(payload, code):
+    """The success-path fix must not swallow the self-check's failure exit:
+    payloads signal a bad result with 1 and a missing GPU with 2, and the
+    platform needs those to mark the trial failed."""
+    assert (
+        _exit_code_of_main_guard(payload, code) == code
+    ), f"{_rel(payload)} does not propagate main() == {code} as an exit status"

--- a/tests/triage/test_recipe.py
+++ b/tests/triage/test_recipe.py
@@ -292,6 +292,127 @@ cells:
     assert cell.effective_collect_options(r.collect_options) == {}
 
 
+# ---- collect option schemas + cross-collector conflicts -------------------
+
+
+def test_collect_rocprof_options_parsed(tmp_path):
+    text = _MINIMAL_YAML + (
+        "collect:\n"
+        "  rocprof:\n"
+        '    trace: "kernel,hip"\n'
+        '    output_format: "csv"\n'
+        '    summary_units: "msec"\n'
+    )
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.collect == ("rocprof",)
+    assert r.collect_options == {
+        "rocprof": {"trace": "kernel,hip", "output_format": "csv", "summary_units": "msec"}
+    }
+
+
+def test_collect_proton_options_parsed(tmp_path):
+    text = _MINIMAL_YAML + (
+        "collect:\n  proton:\n" '    mode: "cli"\n' '    backend: "roctracer"\n'
+    )
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.collect_options == {"proton": {"mode": "cli", "backend": "roctracer"}}
+
+
+def test_collect_rocprof_unknown_option_rejected(tmp_path):
+    """A typo must fail the recipe up front, not silently produce an
+    unprofiled run."""
+    text = _MINIMAL_YAML + 'collect:\n  rocprof:\n    traces: "kernel"\n'
+    with pytest.raises(RecipeSchemaError, match="rocprof: unknown option"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_rocprof_out_of_domain_value_rejected(tmp_path):
+    text = _MINIMAL_YAML + 'collect:\n  rocprof:\n    trace: "gpu"\n'
+    with pytest.raises(RecipeSchemaError, match="unknown domain"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_proton_unknown_option_rejected(tmp_path):
+    text = _MINIMAL_YAML + 'collect:\n  proton:\n    backends: "roctracer"\n'
+    with pytest.raises(RecipeSchemaError, match="proton: unknown option"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_proton_out_of_domain_value_rejected(tmp_path):
+    text = _MINIMAL_YAML + 'collect:\n  proton:\n    backend: "rocprof"\n'
+    with pytest.raises(RecipeSchemaError, match="proton option 'backend'"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_option_error_is_labelled_recipe_collect(tmp_path):
+    with pytest.raises(RecipeSchemaError, match=r"^recipe\.collect:"):
+        _parse_collect("recipe", {"rocprof": {"traces": "kernel"}})
+
+
+def test_collect_rocprof_plus_proton_rejected_at_recipe_scope(tmp_path):
+    """Both install an HSA queue interceptor; the second to attach reports
+    nothing, so the pairing fails at load rather than producing an empty
+    artifact dir."""
+    text = _MINIMAL_YAML + "collect: [rocprof, proton]\n"
+    with pytest.raises(RecipeSchemaError, match="queue interceptor"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_rocprof_plus_proton_instrumentation_allowed(tmp_path):
+    text = _MINIMAL_YAML + 'collect:\n  rocprof:\n  proton:\n    backend: "instrumentation"\n'
+    r = load_recipe(_write_yaml(tmp_path, text))
+    assert r.collect == ("rocprof", "proton")
+
+
+def test_collect_conflict_rejected_at_cell_scope(tmp_path):
+    """A cell-scope ``collect`` replaces the recipe list, so it needs the same
+    conflict guard -- otherwise the pairing sneaks in one cell at a time."""
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+collect: [rocprof]
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+    collect: [rocprof, proton]
+"""
+    with pytest.raises(RecipeSchemaError, match=r"^cells\[0\]\.collect:.*queue interceptor"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_cell_scope_option_error_labelled_with_the_cell(tmp_path):
+    text = """\
+schema_version: 1
+workload: fsdp
+trials: 2
+steps: 100
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+    collect:
+      rocprof:
+        summary_units: "minutes"
+"""
+    with pytest.raises(RecipeSchemaError, match=r"^cells\[0\]\.collect: rocprof option"):
+        load_recipe(_write_yaml(tmp_path, text))
+
+
+def test_collect_flag_mode_rejects_the_conflicting_pair():
+    with pytest.raises(RecipeSchemaError, match="queue interceptor"):
+        build_recipe_from_flags(
+            workload="fsdp",
+            mitigation_axis="none",
+            environment_axis="local",
+            trials=1,
+            steps=1,
+            collect=("rocprof", "proton"),
+        )
+
+
 def test_cell_collect_null_rejected(tmp_path):
     text = """\
 schema_version: 1

--- a/tests/triage/test_runner_b1_api.py
+++ b/tests/triage/test_runner_b1_api.py
@@ -474,6 +474,90 @@ cells:
     assert [req.collect_options for req in reqs] == [{}, {}]
 
 
+def test_cli_collect_override_keeps_surviving_options_and_revalidates(
+    tmp_path, patched_env, patched_run_trials
+):
+    """The CLI override validates against the options that SURVIVE it.
+
+    ``rocprof`` + ``proton`` is only unrunnable on a queue-intercepting Proton
+    backend, so restating both names against a recipe that pins the
+    instrumentation backend has to be accepted -- checking the bare name list
+    would test them against Proton's default backend and invent a conflict.
+    """
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        """\
+schema_version: 1
+ticket: CLI-COLLECT-3
+workload: fsdp
+trials: 1
+steps: 10
+collect:
+  rocprof:
+    trace: "kernel,hip"
+  proton:
+    backend: "instrumentation"
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+""",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        triage,
+        [
+            "run",
+            "--recipe",
+            str(recipe),
+            "--collect",
+            "rocprof,proton",
+            "--output-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    req: RunRequest = patched_run_trials.call_args.args[0]
+    assert req.collect == ("rocprof", "proton")
+    assert req.collect_options == {
+        "rocprof": {"trace": "kernel,hip"},
+        "proton": {"backend": "instrumentation"},
+    }
+
+
+def test_cli_collect_override_rejects_a_conflicting_pair(tmp_path, patched_env, patched_run_trials):
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        """\
+schema_version: 1
+ticket: CLI-COLLECT-4
+workload: fsdp
+trials: 1
+steps: 10
+cells:
+  - name: baseline-local
+    mitigations: [none]
+    environment: local
+""",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        triage,
+        [
+            "run",
+            "--recipe",
+            str(recipe),
+            "--collect",
+            "rocprof,proton",
+            "--output-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "queue interceptor" in result.output
+    assert patched_run_trials.call_count == 0
+
+
 def test_cli_exits_nonzero_when_baseline_did_not_run_but_writes_matrix(
     tmp_path, patched_env, monkeypatch
 ):


### PR DESCRIPTION
Closes #389.

## Problem

`rocprof` was a **reserved collector name only**. `KNOWN_RECIPES` listed it and
the dispatcher threaded `_aorta_collect` / `_aorta_collect_options` /
`_aorta_collect_dir` into every trial config, but nothing consumed it — the
module docstring said so ("deferred to P1", from #148). Triton's Proton
profiler had no presence at all. So the one thing aorta is for here — take the
same measurement identically in every cell, next to the trial JSON — did not
exist for profiling. The existing route (`scripts/rocprof_capture.sh`) hardcodes
this repo's `train.py`, writes outside the results tree, and parses nothing.

## What this does

Implements both as real collectors that attach by **wrapping argv**, mirroring
the pre-existing mirage-emulator seam
(`aorta.emulation.mirage_launch.wrap_argv_for_environment`). A single call site
in `SubprocessWorkload.setup()` means `aorta probe -- <any command>` can be
profiled with no workload opt-in. Collectors wrap first and emulation wraps
last, so profiling happens *inside* the emulated environment; among collectors
`WRAP_ORDER` puts rocprof outermost.

| Area | Change |
|---|---|
| `aorta.run.collectors` | Name list → registry: `wrap_argv_for_collectors`, `summarize_collectors`, `validate_collectors`, `active_collectors`, `CollectorSpec`, `WRAP_ORDER`. `KNOWN_RECIPES` export preserved, `proton` added. |
| `aorta.instrumentation.rocprof` / `.proton` | New packages shaped like the existing `layer_numerics` package: a validated option schema, argv construction, fail-soft summary parsing. |
| Metrics | Flat numerics (`rocprof_kernel_count`, `rocprof_gpu_time_ms`, `rocprof_top_kernel_ms`, `proton_` equivalents) flow automatically into `perf.md` and `matrix.json::cells[*].metrics_summary`, plus non-numeric `*_top_kernels` / `*_artifact_dir`. No report-side change. |
| Guards | `rocprof` + `proton` on a queue-intercepting backend is rejected at recipe load with an actionable message (both install an HSA queue interceptor). `HIP_VISIBLE_DEVICES` is translated to `ROCR_VISIBLE_DEVICES` for Proton on AMD, which does not honour the former. |
| Docs | New `docs/profiling-collectors.md` (following `docs/layer-numerics.md`'s section order); `docs/profiling.md` demotes the ad-hoc `rocprofv3` scripts to manual/legacy; `examples/README.md`. |
| Examples | Categorised, extensible `examples/profiling/{rocprof,proton}/` with four open-source payloads: a self-contained HIP GEMM (needs only `hipcc`), a torch matmul, and Triton vecadd/softmax adapted from Triton's MIT-licensed tutorials with upstream attribution. The two pre-existing sidecar JSONs in `examples/` are untouched. |

### Unplanned but required: the probe-mode collect channel

`collect:` was rejected in `mode: probe` recipes (absent from
`_PROBE_TOP_LEVEL`) and `aorta sweep run` actively refused `--collect` on the
probe flow with *"it has no effect on a probe/subprocess run"*. **That guard was
correct before this change and false after it**, so it is inverted rather than
worked around: `collect` is now valid in probe recipes and `--collect` works on
both flows, replacing the recipe list to match the workload flow's precedence.
Without this the whole feature is unreachable for arbitrary commands.

## Points a reviewer will want flagged

- **`--collect rocprof` perturbs stderr.** `rocprofv3` unconditionally writes
  `simple_timer` lines there. This is a measurement mode, not a byte-exact
  passthrough. The human-readable summary *is* redirected to a file in the
  artifact dir so the probe classifier's stderr detectors do not ingest it, but
  the rest is the profiler's own and cannot be suppressed from here.
- **Proton cannot wrap arbitrary commands.** It `exec`s a Python script rather
  than spawning a subprocess, so it attaches to `python ... script.py` (and
  `pytest`) and raises a clear error naming `mode: env` otherwise. `rocprof`
  wraps anything.
- **Proton's default backend is `auto`** (omit Proton's `-b`), chosen on
  evidence, not preference: no Triton available here accepts `rocprofiler`, and
  in the ROCm wheel image an explicit `-b roctracer` pin captures an empty tree
  while `auto` captures real data — the queue interceptor must be installed
  before the first HSA queue is created. `rocprofiler` remains a valid option
  value as the documented forward path.
- **Artifact layout.** Collector metrics land in the dispatcher's trial JSON at
  `.result.metrics`, not in the `result.json` that `SubprocessWorkload`
  hand-writes, so the collector artifact dir is a **sibling** of `trial_<n>/`.
  `aorta bundle` picks it up regardless (it copies everything under the run
  dir). Pinned by a test, because it is easy to get wrong from the code alone.
- **`--collect` keeps the recipe's options for surviving collectors.** Two
  bugs found in verification: both override paths validated the bare CLI name
  list against Proton's *default* backend, falsely rejecting
  `--collect rocprof,proton` against a recipe that had already resolved the
  conflict with `backend: instrumentation`. Fixed on both paths and pinned.
  (The third verification bug: `--summary-output-file` takes a filename stem
  relative to `-d`, not an absolute path — passing one created stray nested
  directories.)
- **`python -m pytest` and bare `pytest` wrap identically.** Proton dispatches
  on the target's *basename* and runs it as `pytest.main(args)` — exactly what
  `python -m pytest` does — so the `-m pytest` spelling is normalised onto the
  bare one instead of being refused as an unknown interpreter option. No other
  `-m <module>` works, and that limit is Proton's: its front-end resolves the
  target with `runpy.run_path`, which takes a path, not a module name. Those
  are refused at setup with a message naming the spellings that do work,
  rather than failing later inside Proton.
- **`torch.softmax(..., dim=-1)` in the softmax example** reads as `axis=-1` in
  Triton's reductions two lines up. Both spellings work on torch (`axis` is its
  undocumented numpy-compat alias, bit-identical here), but the mix invites a
  false bug report — an automated reviewer filed one — so torch uses `dim` and
  only Triton's own API uses `axis`.
- **Linux-only by design**, like the rest of the probe path: this is ROCm
  tooling behind a `$PATH` lookup, so no portability guards were added.

## Verified on hardware

Two gfx950 GPUs, ROCm 7.0.2.2, `rocprofv3` 1.0.1:

| Collector | Payload | Result |
|---|---|---|
| `rocprof` | HIP GEMM example | 23 kernel dispatches, 0.539 ms GPU time |
| `proton` | Triton vecadd example | 17 dispatches, 0.070 ms, `add_kernel` top-ranked |

Both reached `perf.md` and `matrix.json`. Parser fixtures are captured from
real output and cover **both** real rocprofv3 layouts (`-o` stem flat, and the
nested `<hostname>/<pid>_*` form).

## Test plan

- [x] Bugbot reviewed the branch. It raised two findings, both addressed: the
      `python -m pytest` rejection above (fixed, with the emitted argv verified
      against Proton's own `parse_arguments` / `is_pytest`), and a reported
      `TypeError` from `torch.softmax(axis=...)` that does **not** reproduce —
      `axis` is torch's numpy-compat alias for `dim` — where the spelling was
      still normalised for the reason given above.
- [x] 363 tests across eight new test files (incl. GPU-marked smoke tests),
      plus 16 added to three existing suites — 379 in total, all green
      (`tests/instrumentation/test_{rocprof,proton}.py`,
      `tests/run/test_collectors.py`, `tests/probe/test_collect_channel.py`,
      `tests/probe/test_subprocess_collectors.py`, `tests/test_examples.py`,
      `tests/run/test_dispatcher.py`, `tests/triage/test_{recipe,runner_b1_api}.py`)
- [x] `ruff check` clean on every changed Python file (repo config:
      `select = ["E","F","W","I","N","UP","B","C4"]`, `ignore = ["E501"]`)
- [x] `black --check` clean on all new files. The touched pre-existing files
      already fail `black` on `origin/main` with the current release, so this
      change adds no new failures — `src/aorta/cli/triage.py` in fact stops
      failing. Nothing pre-existing was reformatted.
- [x] Full CPU suite on this branch: **3646 passed, 100 skipped, 17 failed** —
      all 17 in `tests/ebpf/test_runner.py`, and all with
      `BpftraceUnavailableError`: pre-existing and environmental (`bpftrace` is
      not installed on this host). No eBPF file is in this changeset.
- [ ] **The `rocprofiler` Proton backend is accepted by the validator but was
      never exercised on this host**, so that row of the options table is a
      documentation claim, not a measurement.
- [ ] `torch-matmul` and Proton's `mode: env` were not run on GPU, though both
      share the seam the other examples exercised.


## Review round 1 (`47791e6`, `e40b4c9`)

**Red CPU CI, root cause.** Seven tests in
`tests/probe/test_subprocess_collectors.py` omitted the file's own
`rocprofv3_on_path` fixture, so they resolved the *host's* `/usr/bin/rocprofv3`
and passed only on a ROCm box. All three Python legs failed identically with
`RocprofUnavailableError`. The stub is now a real executable that drops
rocprofv3's flags up to `--` and `exec`s the payload, so the pass/fail
assertions still run end-to-end. Verified by running the suite against a `PATH`
mirroring this host minus `rocprofv3`: 7 failures before, 0 after.

**Three paths that degraded silently now fail setup.** An artifact directory
that cannot be prepared, and a missing `env(1)` when the Proton wrap has
variables to deliver, join the already-documented missing-`rocprofv3` case.
Two tests that pinned the old warn-and-continue behaviour were rewritten to
pin the failure. This is a deliberate behaviour change: a requested
measurement that cannot be taken should not resemble one that was.

**Collector artifacts now participate in retention.** The collector tree is a
sibling of `trial_<n>/`, so `apply_retention()` never reached it — `retain`
was ineffective for profiler traces, the artifact class it exists for.
`summarize_collectors()` was also moved ahead of pruning, so the metrics
outlive the trace they came from even at `retain: {on_pass: none}`.

**Parser hardening.** Both parsers drop non-finite and negative values instead
of writing `NaN` / `Infinity` into the trial JSON, the Proton count path
catches the `OverflowError` a huge or infinite count raises, and rocprof's CSV
reader streams rows rather than materialising a trace that can reach hundreds
of MB with `stats: false`.

**Device translation keys off presence, not truthiness**, on both
`HIP_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES`: an empty device list means
"hide every device", which is a selection to preserve.

Known gap left open deliberately: collector artifacts are classified by
retention's filename convention, so `aorta_rocprof_summary.txt` prunes at
`retain: summary`. Wiring the `artifacts.json` manifest seam needs
per-collector filename knowledge that depends on the options in play, and the
numeric summary is already in the trial JSON by that point.

Made with [Cursor](https://cursor.com)

