### PR TITLE
fix(sanitizers): make the published run area page legible

### DIFF
--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -82,8 +82,9 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    reachable from the page.
 
    **Run areas (#384).** A case directory is not just its report -- it carries
-   everything needed to reproduce that case locally, so the copy-paste command
-   the dashboard shows is actionable:
+   the recipe as it ran, the logs the verdict came from, the source-level inputs
+   and a rebuild command for the ones it deliberately does not publish, so the
+   copy-paste command the dashboard shows is actionable:
 
    | File | What it is |
    | --- | --- |
@@ -101,7 +102,11 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    path and SHA-256 (taken from the report, which already carries the waitcheck
    binary digest, the ConSan repro command and hook digests, and every kernel's
    `code_object_sha256`) plus the command to rebuild it, so a local rebuild can
-   be verified.
+   be verified. Since that means the file list is *not* the whole recipe -- for a
+   `source.kind: kernel` recipe the one input the recipe names is exactly the
+   excluded one -- the landing page's Files caption says how many inputs are held
+   back and links to the section carrying their digests and rebuild commands,
+   rather than leaving a reader to tell a deliberate omission from a lost file.
 
    Those rebuild commands are per-artifact, because they are not
    interchangeable: a `--genco` code object is a raw ELF on some ROCm builds and

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -82,9 +82,10 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    reachable from the page.
 
    **Run areas (#384).** A case directory is not just its report -- it carries
-   the recipe as it ran, the logs the verdict came from, the source-level inputs
-   and a rebuild command for the ones it deliberately does not publish, so the
-   copy-paste command the dashboard shows is actionable:
+   the recipe as it ran, the logs the verdict came from, the source-level inputs,
+   and for the artifacts it deliberately does not publish a rebuild command
+   wherever the module's tables know one (see below), so the copy-paste command
+   the dashboard shows is actionable:
 
    | File | What it is |
    | --- | --- |

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -99,14 +99,22 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    CI-built artifacts are deliberately **not** published: a GEMM `.hsaco` is
    ~16MB, and shipping one per retained run would bloat the data branch and
    Pages. `index.html` / `REPRODUCE.md` / `env.json` instead record each one's
-   path and SHA-256 (taken from the report, which already carries the waitcheck
-   binary digest, the ConSan repro command and hook digests, and every kernel's
-   `code_object_sha256`) plus the command to rebuild it, so a local rebuild can
-   be verified. Since that means the file list is *not* the whole recipe -- for a
+   path, the SHA-256 the report carries for it (the waitcheck binary digest, the
+   ConSan repro command and hook digests, every kernel's `code_object_sha256`)
+   and the command that rebuilds it, so a local rebuild can be verified. Neither
+   is universal: a digest is only recorded when the report has one under that
+   artifact's basename, so a bare `isa_dir: fixtures/isa` reference has none, and
+   a reference the module's rebuild tables do not recognise is named without a
+   command rather than given a plausible-looking guess.
+
+   Since that means the file list is *not* the whole recipe -- for a
    `source.kind: kernel` recipe the one input the recipe names is exactly the
    excluded one -- the landing page's Files caption says how many inputs are held
-   back and links to the section carrying their digests and rebuild commands,
-   rather than leaving a reader to tell a deliberate omission from a lost file.
+   back and links to the *Artifacts not published* table that lists them, naming
+   their SHA-256s only when every entry has one. The rebuild commands are their
+   own section higher up the page, so the caption does not promise them under
+   that anchor. Either way a reader can tell a deliberate omission from a lost
+   file.
 
    Those rebuild commands are per-artifact, because they are not
    interchangeable: a `--genco` code object is a raw ELF on some ROCm builds and

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -273,13 +273,24 @@ _CSS = """
   details[open] > summary .chevron { transform:rotate(180deg); }
   .kcard-body { padding:14px; }
 
-  /* Borderless label/value facts. Bordered boxes in a row read as tabs. */
-  .kv { display:grid; grid-template-columns:repeat(auto-fit, minmax(170px, 1fr)); gap:12px 24px;
+  /* Borderless label/value facts. Bordered boxes in a row read as tabs.
+     Sized to content rather than uniformly: equal-width tracks gave a 1-char
+     Findings the same width as a 51-char Recipe, so short facts sat on ~555px
+     of dead space while Commit and Recipe wrapped for want of ~330px. Flex
+     trades the column alignment between rows for giving each fact the width it
+     needs. Derived from content on purpose -- a per-field width table would be
+     wrong as soon as Run and Date grow. */
+  .kv { display:flex; flex-wrap:wrap; gap:12px 28px;
     padding-bottom:14px; margin-bottom:14px; border-bottom:1px solid var(--border); }
+  /* min-width:0 lets a long value wrap inside its own item instead of forcing
+     the row wider; max-width keeps the widest of them within the panel. */
+  .kv > span { flex:0 1 auto; min-width:0; max-width:100%; }
   .kv .k { display:block; font-size:var(--fs-kvk); color:var(--text-3); text-transform:uppercase;
     letter-spacing:.05em; font-weight:600; margin-bottom:3px; }
   .kv .val { display:block; font-size:var(--fs-kvv); color:var(--text-1); }
-  .kv .val.mono { font-family:var(--mono); }
+  /* break-all, not break-word: break-word only breaks a word that cannot fit a
+     line by itself, which still leaves a digest-pinned image ref overflowing. */
+  .kv .val.mono { font-family:var(--mono); word-break:break-all; }
 
   .observation { font-size:var(--fs-obs); color:var(--text-2); line-height:1.5;
     background:rgba(148,163,184,.05); border-left:2px solid rgba(148,163,184,.26);
@@ -290,18 +301,25 @@ _CSS = """
     letter-spacing:.06em; font-weight:600; margin-bottom:3px; }
   .observation .msg { font-family:var(--mono); font-size:14px; word-break:break-word; color:var(--text-1); }
 
-  .repro { display:flex; align-items:center; gap:10px; flex-wrap:wrap; background:var(--sunken);
+  /* Holds the command and nothing else. With the label inside, this box read as
+     a code block whose first token was "REPRODUCE", and selecting it to copy
+     picked the label up along with the command. The label sits above it now. */
+  .repro { display:block; background:var(--sunken);
     border:1px solid var(--border); border-radius:8px; padding:10px 13px; margin-bottom:14px; }
-  .repro .lbl { color:var(--text-3); font-size:12px; text-transform:uppercase;
-    letter-spacing:.05em; font-weight:600; }
   .repro code { font-family:var(--mono); font-size:14px; color:#A5D6FF; word-break:break-all; }
 
-  /* A caption must not share colour, case and weight with the th beneath it. */
+  /* A section heading. Must not share colour, case and weight with the th
+     beneath it -- and has to own its own separation. With margin-top:0 the space
+     above a heading was whatever the previous element happened to leave (14px,
+     against the 8px binding the heading to its own content), so sections ran
+     together; and it was delegated to a `.cap + .table-wrap` adjacency rule, so
+     inserting anything between a heading and its table silently deleted the gap.
+     24px here makes separation ~3x the binding and independent of what precedes. */
   .cap { display:flex; align-items:center; gap:9px; font-size:var(--fs-cap); font-weight:700;
-    text-transform:uppercase; letter-spacing:.06em; color:var(--text-1); margin:0 0 8px; }
+    text-transform:uppercase; letter-spacing:.06em; color:var(--text-1); margin:24px 0 8px; }
+  .cap:first-child { margin-top:0; }
   .cap::before { content:""; width:3px; height:15px; border-radius:2px;
     background:var(--accent, var(--text-3)); flex:0 0 auto; }
-  .cap + .table-wrap { margin-bottom:14px; }
   .card-foot { display:flex; justify-content:flex-end; font-size:13px; }
 
   details.panel { padding:0; }
@@ -1494,6 +1512,11 @@ _REBUILD_NOTE = (
     ".github/workflows/sanitizers-nightly.yml."
 )
 
+# Anchor on the landing page's "Artifacts not published" heading, so the Files
+# caption can point a reader at the digest and rebuild command for an input it
+# deliberately does not list.
+_NOT_PUBLISHED_ID = "artifacts-not-published"
+
 # The env a reproduction needs, as data, so a consumer of
 # ``aorta.sanitizer_run_area/0.1`` can read the variables instead of parsing them
 # out of a sentence. ``set_by`` says whether the operator must export it or
@@ -1603,10 +1626,29 @@ RUN_AREA_CSS_REL = "assets/run-area.css"
 # file serves both; an unused selector costs nothing.
 _DRILLDOWN_CSS = """
   .wrap { max-width:900px; }
+  /* `.cap`'s heading bar is `var(--accent, var(--text-3))`, and --accent is only
+     defined on the root dashboard's kernel cards. These pages have no such
+     ancestor, so every bar fell back to exactly the grey of the th text beneath
+     it -- leaving nothing to tell a section heading from a table header. Scoped
+     here rather than on `.cap` so the root dashboard keeps its per-kind hues. */
+  .panel { --accent:var(--blue); }
   .note { margin:0 0 14px; color:var(--text-3); font-size:13px; }
-  .steps { margin:0 0 6px; padding-left:18px; color:var(--text-2);
-    font-size:var(--fs-obs); }
-  .steps li { margin:3px 0; }
+  .note a { color:#7CB0F8; }
+  /* One rebuild recipe per artifact: path, what it is, the commands as a real
+     block, then the caveat. These pages had no multi-line code affordance at
+     all, which is how the commands ended up as inline <code> runs inside a
+     prose sentence. pre-wrap so a long command is never hidden off-screen, and
+     so a soft wrap does not become a newline when the block is copied. */
+  .rb { margin:0 0 18px; }
+  .rb:last-of-type { margin-bottom:8px; }
+  .rb .path { margin:0 0 4px; font-family:var(--mono); font-size:13.5px;
+    color:var(--text-1); word-break:break-all; }
+  .rb .what { margin:0 0 8px; color:var(--text-3); font-size:13px; }
+  .rb .caveat { margin:0; color:var(--text-3); font-size:13px; }
+  .rb pre { margin:0 0 8px; background:var(--sunken); border:1px solid var(--border);
+    border-radius:8px; padding:11px 13px; }
+  .rb pre code { display:block; font-family:var(--mono); font-size:13px;
+    color:#A5D6FF; white-space:pre-wrap; overflow-wrap:anywhere; }
 """
 
 
@@ -1877,9 +1919,15 @@ def plan_from_env(env: dict[str, Any], built_refs: list[str]) -> list[dict[str, 
 def _rebuild_hints(plan: list[dict[str, Any]]) -> list[str]:
     """One prose rebuild hint per artifact, rendered from a ``rebuild_plan`` (pure).
 
-    Markdown, so REPRODUCE.md uses it verbatim and the landing page runs it
-    through ``_md_code_to_html``. A reference with no known recipe degrades to
-    its bare path rather than a plausible-looking wrong command.
+    Markdown for REPRODUCE.md, which uses it verbatim. A reference with no known
+    recipe degrades to its bare path rather than a plausible-looking wrong
+    command.
+
+    The landing page does NOT go through here: flattening the four fields into
+    one sentence is right for Markdown and wrong for HTML, where it produced a
+    prose paragraph with the commands as inline ``<code>`` runs joined by
+    prose ``;`` -- nothing on the page a reader could select and run. That page
+    renders the same plan structurally instead (``_rebuild_section_html``).
     """
     hints: list[str] = []
     for entry in plan:
@@ -1892,6 +1940,81 @@ def _rebuild_hints(plan: list[dict[str, Any]]) -> list[str]:
             hint += f" {entry['caveat']}"
         hints.append(hint)
     return hints
+
+
+def _rebuild_section_html(plan: list[dict[str, Any]]) -> str:
+    """The landing page's rebuild section, rendered from ``rebuild_plan`` (pure).
+
+    ``rebuild_plan`` already separates ``path`` / ``what`` / ``commands`` /
+    ``caveat`` -- its docstring's whole point is that a consumer can read the
+    commands "rather than parse them out of a sentence", and that anything to
+    branch on is encoded *in* a command "so the list can be executed as-is".
+    Rendering that structure keeps the same promise for a human: the commands
+    land in one block, one per line, with no prose inside it and no sentence
+    period stuck to the final path.
+
+    Each artifact is a titled block rather than a list item, so a case with one
+    unpublished artifact no longer renders a one-item bullet list.
+    """
+    if not plan:
+        return ""
+    blocks: list[str] = []
+    for entry in plan:
+        commands = [str(command) for command in entry.get("commands") or []]
+        parts = [f'<p class="path">{_esc(str(entry["path"]))}</p>']
+        what = entry.get("what")
+        if what:
+            parts.append(f'<p class="what">{_esc(str(what))}</p>')
+        if commands:
+            body = "\n".join(_esc(command) for command in commands)
+            parts.append(f"<pre><code>{body}</code></pre>")
+        else:
+            # Same contract as ``_rebuild_hints``: an unrecognised reference is
+            # named and left at that, never given a plausible-looking guess.
+            parts.append(
+                '<p class="what">No rebuild command is recorded for this reference.</p>'
+            )
+        caveat = entry.get("caveat")
+        if caveat:
+            parts.append(f'<p class="caveat">{_esc(str(caveat))}</p>')
+        blocks.append(f'<div class="rb">{"".join(parts)}</div>')
+    return (
+        '<p class="cap">Rebuild the fixtures</p>'
+        + "".join(blocks)
+        + f'<p class="note">{_esc(_REBUILD_NOTE)}</p>'
+    )
+
+
+def files_caption(env: dict[str, Any], files: list[tuple[str, int]]) -> str:
+    """The Files table's caption, as HTML (pure).
+
+    "Every file published for this case" is true and, on its own, misleading:
+    for a ``source.kind: kernel`` recipe the one input the recipe names is
+    CI-built, so it is recorded under *Artifacts not published* by digest
+    instead of being copied here. Nothing linked the two sections, so a reader
+    could not tell a deliberate omission from a missing file. Say it, and point
+    at where the digest and rebuild command actually are.
+    """
+    if not env.get("logs_published", True):
+        base = (
+            "Every file published for this case. Its logs, recipe copy and inputs "
+            "were pruned for falling outside the nightly's log-retention window."
+        )
+    elif any(rel.endswith(".log.gz") for rel, _size in files):
+        base = "Every file published for this case. Logs are gzipped."
+    else:
+        base = "Every file published for this case."
+    missing = env.get("artifacts_not_published") or []
+    if not missing:
+        return _esc(base)
+    count = len(missing)
+    noun = "input" if count == 1 else "inputs"
+    verb = "is" if count == 1 else "are"
+    return (
+        f"{_esc(base)} It is not the whole recipe: {count} required {noun} {verb} "
+        f'CI-built and excluded by design, listed under <a href="#{_NOT_PUBLISHED_ID}">'
+        f"artifacts not published</a> with a SHA-256 and a command to rebuild it."
+    )
 
 
 def build_case_env(
@@ -2144,18 +2267,7 @@ def build_case_index_html(
         if reason
         else ""
     )
-    hints = _rebuild_hints(plan_from_env(env, built_refs))
-    steps_html = (
-        (
-            '<p class="cap">Rebuild the fixtures</p><ul class="steps">'
-            # The hints are one shared Markdown constant per artifact, so their
-            # `backticks` become <code> here rather than rendering literally.
-            + "".join(f"<li>{_md_code_to_html(hint)}</li>" for hint in hints)
-            + f'</ul><p class="note">{_esc(_REBUILD_NOTE)}</p>'
-        )
-        if hints
-        else ""
-    )
+    steps_html = _rebuild_section_html(plan_from_env(env, built_refs))
     not_published = env.get("artifacts_not_published") or []
     np_html = ""
     if not_published:
@@ -2165,7 +2277,8 @@ def build_case_index_html(
             for item in not_published
         )
         np_html = (
-            '<p class="cap">Artifacts not published</p><div class="table-wrap"><table>'
+            f'<p class="cap" id="{_NOT_PUBLISHED_ID}">Artifacts not published</p>'
+            '<div class="table-wrap"><table>'
             "<thead><tr><th>Path</th><th>SHA-256</th></tr></thead>"
             f"<tbody>{np_rows}</tbody></table></div>"
         )
@@ -2191,17 +2304,6 @@ def build_case_index_html(
         if env.get("run_url")
         else "<span></span>"
     )
-    # Only claim gzipped logs when the listing actually has one: an in-window case
-    # that produced no log at all still rendered "Logs are gzipped."
-    if not env.get("logs_published", True):
-        files_caption = (
-            "Every file published for this case. Its logs, recipe copy and inputs "
-            "were pruned for falling outside the nightly's log-retention window."
-        )
-    elif any(rel.endswith(".log.gz") for rel, _size in files):
-        files_caption = "Every file published for this case. Logs are gzipped."
-    else:
-        files_caption = "Every file published for this case."
     return (
         "<!doctype html>\n"
         "<html lang=en><head><meta charset=utf-8>\n"
@@ -2216,20 +2318,25 @@ def build_case_index_html(
         '<header class="page-header"><div class="brand-tile">'
         f"{_svg(_ICON_FILE, size=24, width=2)}</div><div>\n"
         f"<h1>{_esc(str(env.get('case', '')))}</h1>\n"
-        '<p class="subtitle">Run area &mdash; everything needed to reproduce this '
-        "case locally</p></div></header>\n"
+        # Not "everything needed to reproduce this case locally": for a
+        # kernel-source recipe the one input the recipe names is CI-built and
+        # recorded by digest rather than published (see ``files_caption``).
+        '<p class="subtitle">Run area &mdash; the reproduce command, what this '
+        "case observed, and every file published for it</p></div></header>\n"
         "</div>\n"
         '<section class="panel">\n'
         f"<h2>Case {_verdict_html(observed.get('verdict') or _DASH)}</h2>\n"
         f'<div class="kv">{kv}</div>\n'
         f"{reason_html}\n"
-        '<div class="repro"><span class="lbl">Reproduce</span>'
-        f'<code>{_esc(str(env.get("command", "")))}</code></div>\n'
+        # The label sits outside the box, so selecting the box yields a command
+        # that runs rather than one prefixed with the word "Reproduce".
+        '<p class="cap">Reproduce</p>'
+        f'<div class="repro"><code>{_esc(str(env.get("command", "")))}</code></div>\n'
         f'<p class="note">{_md_code_to_html(required_env_note(env.get("required_env") or []))}</p>\n'
         f"{steps_html}{np_html}{digests_html}"
         "</section>\n"
         '<section class="panel"><h2>Files</h2>\n'
-        f'<p class="cap">{_esc(files_caption)}</p>\n'
+        f'<p class="note">{files_caption(env, files)}</p>\n'
         '<div class="table-wrap"><table>\n'
         "<thead><tr><th>File</th><th class=num>Size</th></tr></thead>\n"
         f"<tbody>{rows}</tbody>\n"
@@ -2927,9 +3034,12 @@ def _survey_howto_html(entry: dict[str, Any]) -> str:
     command = entry.get("command")
     if not command:
         return ""
+    # Label outside the box, matching the run area: with it inside, the box read
+    # as a code block whose first token was "REPRODUCE", and selecting the box to
+    # copy the command picked the label up too.
     return (
-        '<div class="repro"><span class="lbl">Reproduce</span>'
-        f"<code>{_esc(str(command))}</code></div>"
+        '<p class="cap">Reproduce</p>'
+        f'<div class="repro"><code>{_esc(str(command))}</code></div>'
     )
 
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -288,8 +288,13 @@ _CSS = """
   .kv .k { display:block; font-size:var(--fs-kvk); color:var(--text-3); text-transform:uppercase;
     letter-spacing:.05em; font-weight:600; margin-bottom:3px; }
   .kv .val { display:block; font-size:var(--fs-kvv); color:var(--text-1); }
-  /* break-all, not break-word: break-word only breaks a word that cannot fit a
-     line by itself, which still leaves a digest-pinned image ref overflowing. */
+  /* break-all, not break-word. Both break a 40-char SHA or a 136-char
+     digest-pinned image ref once the item is narrower than the token, but the
+     soft wrap opportunities break-word introduces are not counted toward
+     min-content, so each mono fact would keep the whole token as its intrinsic
+     minimum and the row would hold only for as long as the min-width:0 above
+     survives. break-all's breaks do count, and breaking between characters is
+     what a token with no word boundaries wants anyway. */
   .kv .val.mono { font-family:var(--mono); word-break:break-all; }
 
   .observation { font-size:var(--fs-obs); color:var(--text-2); line-height:1.5;
@@ -1640,7 +1645,13 @@ _DRILLDOWN_CSS = """
      prose sentence. pre-wrap so a long command is never hidden off-screen, and
      so a soft wrap does not become a newline when the block is copied. */
   .rb { margin:0 0 18px; }
-  .rb:last-of-type { margin-bottom:8px; }
+  /* The closing note belongs to the section, not to a gap, so the final block
+     sits 8px above it. Marked by class rather than `:last-of-type`, which keys
+     off the tag and not the class: whether it matched depended on what other
+     divs the panel happened to emit afterwards, and on a real page it never did
+     -- a case with rebuild blocks has built refs, so it also has the
+     "Artifacts not published" `.table-wrap` sitting after them. */
+  .rb-last { margin-bottom:8px; }
   .rb .path { margin:0 0 4px; font-family:var(--mono); font-size:13.5px;
     color:var(--text-1); word-break:break-all; }
   .rb .what { margin:0 0 8px; color:var(--text-3); font-size:13px; }
@@ -1741,6 +1752,22 @@ _FIXTURES_FROM_ROOT = "recipes/sanitizers/fixtures"
 _REBUILD_KEYS = frozenset({"path", "what", "commands", "caveat"})
 
 
+def _is_rebuild_entry(item: Any) -> bool:
+    """Whether a stored ``rebuild`` entry is safe for both renderings (pure).
+
+    Key presence alone is not enough. ``commands`` is the one field the
+    renderings do more than stringify -- they iterate it -- so its *type* is
+    part of the contract: an int raises ``TypeError`` mid-render, and a string
+    silently degrades into one command per character. Every other field only
+    ever reaches ``_esc(str(...))`` or an f-string, which accept anything.
+    """
+    return (
+        isinstance(item, dict)
+        and _REBUILD_KEYS <= item.keys()
+        and isinstance(item["commands"], list)
+    )
+
+
 def _runnable(ref: str) -> str:
     """A recipe-relative fixture path rewritten to run from the repo root."""
     return f"{_FIXTURES_FROM_ROOT}{ref[len('fixtures'):]}" if ref.startswith("fixtures") else ref
@@ -1801,9 +1828,11 @@ def rebuild_plan(built_refs: list[str], *, target: str) -> list[dict[str, Any]]:
 
     ``env.json`` carries this so a consumer of ``aorta.sanitizer_run_area/0.1``
     can read the exact commands rather than parse them out of a sentence, and
-    both prose renderings are generated from it by ``_rebuild_hints`` -- so the
-    landing page, REPRODUCE.md and the manifest cannot disagree about how an
-    artifact was built.
+    both prose renderings are generated from it -- REPRODUCE.md's Markdown by
+    ``_rebuild_hints``, the landing page's HTML by ``_rebuild_section_html`` --
+    so the landing page, REPRODUCE.md and the manifest cannot disagree about how
+    an artifact was built. The two renderers share this structure, not a code
+    path: changing one does not change the other.
 
     Each entry is ``{"path", "what", "commands", "caveat"}``. ``path`` stays
     recipe-relative, matching how a recipe names the artifact and how
@@ -1913,17 +1942,16 @@ def plan_from_env(env: dict[str, Any], built_refs: list[str]) -> list[dict[str, 
     preserved, so recomputing the commands from the module's current tables would
     rewrite historical instructions and leave the prose contradicting the
     manifest sitting beside it. Fall back to recomputation only for an area
-    published before the field existed -- or one whose stored entries do not
-    carry the keys both renderers read. Both renderers index those keys directly,
-    and this runs over a manifest read off the data branch, so accepting a
-    partial entry here would turn one hand-edited or half-written ``env.json``
-    into a ``KeyError`` that fails the whole dashboard render rather than one
-    area's rebuild section.
+    published before the field existed -- or one whose stored entries are not
+    shaped the way both renderers read them (see ``_is_rebuild_entry``). Those
+    renderers index and iterate the entry directly, and this runs over a
+    manifest read off the data branch, so trusting a partial or wrongly-typed
+    entry here would turn one hand-edited or half-written ``env.json`` into a
+    ``KeyError``/``TypeError`` that fails the whole dashboard render rather
+    than one area's rebuild section.
     """
     stored = env.get("rebuild")
-    if isinstance(stored, list) and all(
-        isinstance(item, dict) and _REBUILD_KEYS <= item.keys() for item in stored
-    ):
+    if isinstance(stored, list) and all(_is_rebuild_entry(item) for item in stored):
         return stored
     return rebuild_plan(built_refs, target=str(env.get("target") or "gfx950"))
 
@@ -1971,7 +1999,7 @@ def _rebuild_section_html(plan: list[dict[str, Any]]) -> str:
     if not plan:
         return ""
     blocks: list[str] = []
-    for entry in plan:
+    for index, entry in enumerate(plan):
         commands = [str(command) for command in entry.get("commands") or []]
         parts = [f'<p class="path">{_esc(str(entry["path"]))}</p>']
         what = entry.get("what")
@@ -1989,7 +2017,8 @@ def _rebuild_section_html(plan: list[dict[str, Any]]) -> str:
         caveat = entry.get("caveat")
         if caveat:
             parts.append(f'<p class="caveat">{_esc(str(caveat))}</p>')
-        blocks.append(f'<div class="rb">{"".join(parts)}</div>')
+        last = " rb-last" if index == len(plan) - 1 else ""
+        blocks.append(f'<div class="rb{last}">{"".join(parts)}</div>')
     return (
         '<p class="cap">Rebuild the fixtures</p>'
         + "".join(blocks)
@@ -2005,7 +2034,15 @@ def _files_caption(env: dict[str, Any], files: list[tuple[str, int]]) -> str:
     CI-built, so it is recorded under *Artifacts not published* by digest
     instead of being copied here. Nothing linked the two sections, so a reader
     could not tell a deliberate omission from a missing file. Say it, and point
-    at where the digest and rebuild command actually are.
+    at the listing.
+
+    Claims only what that listing actually carries. The digest is mentioned
+    only when every excluded entry has one -- ``artifacts_not_published``
+    records ``sha256`` from the report by basename, so a bare ``isa_dir:
+    fixtures/isa`` reference has none and its row renders an em dash. The
+    rebuild commands are deliberately not promised under this anchor: they are
+    their own section further up the page, and an unrecognised reference has no
+    command at all.
     """
     if not env.get("logs_published", True):
         base = (
@@ -2022,10 +2059,16 @@ def _files_caption(env: dict[str, Any], files: list[tuple[str, int]]) -> str:
     count = len(missing)
     noun = "input" if count == 1 else "inputs"
     verb = "is" if count == 1 else "are"
+    listing = f'<a href="#{_NOT_PUBLISHED_ID}">artifacts not published</a>'
+    has_digests = all(isinstance(item, dict) and item.get("sha256") for item in missing)
+    where = (
+        f"listed under {listing} with {'its SHA-256' if count == 1 else 'their SHA-256s'}"
+        if has_digests
+        else f"listed under {listing}"
+    )
     return (
         f"{_esc(base)} It is not the whole recipe: {count} required {noun} {verb} "
-        f'CI-built and excluded by design, listed under <a href="#{_NOT_PUBLISHED_ID}">'
-        f"artifacts not published</a> with a SHA-256 and a command to rebuild it."
+        f"CI-built and excluded by design, {where}."
     )
 
 
@@ -2104,8 +2147,9 @@ def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
 
     The downloadable companion to the landing page rather than a strict twin of
     it: the two share the run identity, the reproduce command and the rebuild
-    section (via ``_rebuild_hints``), and this file additionally carries the
-    required env and the recorded digests that the page links it for.
+    plan -- rendered here as Markdown by ``_rebuild_hints`` and on the page
+    structurally by ``_rebuild_section_html`` -- and this file additionally
+    carries the required env and the recorded digests that the page links it for.
     """
     observed = env.get("observed") or {}
     # Point at the file table rather than restating an inventory here: what a run

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1735,6 +1735,11 @@ _BIN_OBJECT = {
 # only the recorded ``path`` stays recipe-relative.
 _FIXTURES_FROM_ROOT = "recipes/sanitizers/fixtures"
 
+# The keys every ``rebuild_plan`` entry carries, and that both renderings index
+# directly. ``plan_from_env`` checks a *stored* plan against these before
+# trusting it, since that one comes off the data branch rather than from here.
+_REBUILD_KEYS = frozenset({"path", "what", "commands", "caveat"})
+
 
 def _runnable(ref: str) -> str:
     """A recipe-relative fixture path rewritten to run from the repo root."""
@@ -1908,10 +1913,17 @@ def plan_from_env(env: dict[str, Any], built_refs: list[str]) -> list[dict[str, 
     preserved, so recomputing the commands from the module's current tables would
     rewrite historical instructions and leave the prose contradicting the
     manifest sitting beside it. Fall back to recomputation only for an area
-    published before the field existed.
+    published before the field existed -- or one whose stored entries do not
+    carry the keys both renderers read. Both renderers index those keys directly,
+    and this runs over a manifest read off the data branch, so accepting a
+    partial entry here would turn one hand-edited or half-written ``env.json``
+    into a ``KeyError`` that fails the whole dashboard render rather than one
+    area's rebuild section.
     """
     stored = env.get("rebuild")
-    if isinstance(stored, list) and all(isinstance(item, dict) for item in stored):
+    if isinstance(stored, list) and all(
+        isinstance(item, dict) and _REBUILD_KEYS <= item.keys() for item in stored
+    ):
         return stored
     return rebuild_plan(built_refs, target=str(env.get("target") or "gfx950"))
 
@@ -1985,7 +1997,7 @@ def _rebuild_section_html(plan: list[dict[str, Any]]) -> str:
     )
 
 
-def files_caption(env: dict[str, Any], files: list[tuple[str, int]]) -> str:
+def _files_caption(env: dict[str, Any], files: list[tuple[str, int]]) -> str:
     """The Files table's caption, as HTML (pure).
 
     "Every file published for this case" is true and, on its own, misleading:
@@ -2320,7 +2332,7 @@ def build_case_index_html(
         f"<h1>{_esc(str(env.get('case', '')))}</h1>\n"
         # Not "everything needed to reproduce this case locally": for a
         # kernel-source recipe the one input the recipe names is CI-built and
-        # recorded by digest rather than published (see ``files_caption``).
+        # recorded by digest rather than published (see ``_files_caption``).
         '<p class="subtitle">Run area &mdash; the reproduce command, what this '
         "case observed, and every file published for it</p></div></header>\n"
         "</div>\n"
@@ -2336,7 +2348,7 @@ def build_case_index_html(
         f"{steps_html}{np_html}{digests_html}"
         "</section>\n"
         '<section class="panel"><h2>Files</h2>\n'
-        f'<p class="note">{files_caption(env, files)}</p>\n'
+        f'<p class="note">{_files_caption(env, files)}</p>\n'
         '<div class="table-wrap"><table>\n'
         "<thead><tr><th>File</th><th class=num>Size</th></tr></thead>\n"
         f"<tbody>{rows}</tbody>\n"

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1518,8 +1518,9 @@ _REBUILD_NOTE = (
 )
 
 # Anchor on the landing page's "Artifacts not published" heading, so the Files
-# caption can point a reader at the digest and rebuild command for an input it
-# deliberately does not list.
+# caption can point a reader at the listing of the inputs it deliberately does
+# not carry. That table is Path + SHA-256; the rebuild commands are their own
+# section above it, which is why the caption does not promise them here.
 _NOT_PUBLISHED_ID = "artifacts-not-published"
 
 # The env a reproduction needs, as data, so a consumer of

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2386,10 +2386,201 @@ def test_run_area_stylesheet_carries_the_rules_those_pages_use():
     sheet = gen.run_area_stylesheet()
     assert gen._CSS in sheet
     # The rules the two drill-down pages add on top of the dashboard sheet.
-    for selector in (".wrap {", ".note {", ".steps {", ".steps li {"):
+    for selector in (
+        ".wrap {",
+        ".note {",
+        # The rebuild section renders structurally now, so `.steps` (its old
+        # bullet list) is gone and these carry the command block instead.
+        ".rb {",
+        ".rb .path {",
+        ".rb pre {",
+        ".rb pre code {",
+        # `.cap`'s heading bar reads `var(--accent, ...)`, which only the root
+        # dashboard's kernel cards define -- without this these pages render it
+        # in the same grey as the `th` text beneath it.
+        ".panel { --accent:",
+    ):
         assert selector in sheet, selector
+    assert ".steps {" not in sheet
     # Byte-stable, so re-publishing does not churn the data branch.
     assert gen.run_area_stylesheet() == sheet
+
+
+# --- Run area rendering (#391) -------------------------------------------------
+
+
+def _css_rule(sheet: str, selector: str) -> str:
+    """One selector's declaration block, so a test can assert on it alone."""
+    start = sheet.index(selector) + len(selector)
+    return sheet[start : sheet.index("}", start)]
+
+
+def test_fact_row_sizes_each_fact_to_its_content():
+    # Equal-width tracks gave a 1-char Findings the same width as a 51-char
+    # Recipe: ~555px of dead space on one row while Commit and Recipe wrapped
+    # for want of ~330px.
+    sheet = gen.run_area_stylesheet()
+    row = _css_rule(sheet, ".kv {")
+    assert "display:flex" in row and "flex-wrap:wrap" in row
+    # The uniform grid is gone, not merely overridden by a later rule.
+    assert "minmax(170px, 1fr)" not in sheet
+    # A long value wraps inside its own item instead of widening the row.
+    item = _css_rule(sheet, ".kv > span {")
+    assert "min-width:0" in item and "max-width:100%" in item
+
+
+def test_long_mono_facts_break_rather_than_overflow_their_neighbour():
+    # A 40-char SHA painted over Date; a 136-char digest-pinned image ref ran off
+    # the page. break-word fixes only the first -- it breaks a word just when the
+    # word cannot fit a line by itself.
+    rule = _css_rule(gen.run_area_stylesheet(), ".kv .val.mono {")
+    assert "word-break:break-all" in rule
+    assert "break-word" not in rule
+
+    image = (
+        "rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0"
+        "@sha256:" + "4" * 64
+    )
+    commit = "78d1ae686dc3a786e8cfdb1216efc4b7516c8896"
+    page = gen.build_case_index_html(
+        {
+            "case": "c",
+            "observed": {},
+            "commit": commit,
+            "date": "2026-08-23",
+            "container_image": image,
+        },
+        [],
+        built_refs=[],
+        up="../../",
+    )
+    # Both survive in full: the fix is wrapping, not truncation. The image digest
+    # is what makes the run reproducible at all.
+    assert commit in page
+    assert image in page
+
+
+def test_reproduce_label_sits_outside_the_command_box():
+    # The box is a copy target. With the label inside it, the box read as a code
+    # block whose first token was REPRODUCE, and selecting it to copy the command
+    # picked the label up too.
+    command = "aorta sweep run --recipe recipes/sanitizers/daily-waitcheck-gemm-object.yaml"
+    page = gen.build_case_index_html(
+        {"case": "c", "observed": {}, "command": command},
+        [], built_refs=[], up="../../",
+    )
+    assert '<p class="cap">Reproduce</p><div class="repro"><code>' in page
+    assert 'class="lbl">Reproduce' not in page
+
+    # The dashboard's Tab 2 strip is the same markup, so the two cannot diverge.
+    strip = gen._survey_howto_html({"command": command})
+    assert '<p class="cap">Reproduce</p><div class="repro"><code>' in strip
+    assert 'class="lbl">Reproduce' not in strip
+    assert gen._survey_howto_html({"command": ""}) == ""
+
+    # Holding only the command, the box no longer needs a flex row.
+    assert "display:block" in _css_rule(gen.run_area_stylesheet(), ".repro {")
+
+
+def test_section_headings_own_their_separation_from_the_previous_section():
+    # `.cap` shipped with margin-top:0, so the space above a heading was whatever
+    # the previous element left -- 14px, against the 8px binding a heading to its
+    # own content -- and it was delegated to a `.cap + .table-wrap` adjacency
+    # rule that any element inserted between the two silently broke.
+    sheet = gen.run_area_stylesheet()
+    above, below = 24, 8
+    assert f"margin:{above}px 0 {below}px" in _css_rule(sheet, ".cap {")
+    # Separation has to be clearly greater than the binding or neither reads as
+    # grouping the section with its heading.
+    assert above >= 3 * below
+    # A panel's first heading must not double the panel's own padding.
+    assert ".cap:first-child { margin-top:0; }" in sheet
+    # The fragile adjacency rule is removed, not worked around. Matching the
+    # declaration rather than the bare selector, which the comment above it names.
+    assert ".cap + .table-wrap {" not in sheet
+
+
+def test_rebuild_section_renders_its_commands_as_one_runnable_block():
+    # `_rebuild_hints` flattens path/what/commands/caveat into one sentence. That
+    # is right for REPRODUCE.md and wrong here: the commands became inline <code>
+    # runs joined by a prose ";", with the sentence period stuck to the final
+    # path, so nothing on the page could be selected and run.
+    plan = gen.rebuild_plan(["fixtures/isa/consan_gemm_f32.hsaco"], target="gfx950")
+    html = gen._rebuild_section_html(plan)
+    entry = plan[0]
+
+    block = re.search(r"<pre><code>(.*?)</code></pre>", html, re.S)
+    assert block
+    body = block.group(1)
+    # Every command, one per line, in a single block.
+    assert body.split("\n") == [gen._esc(command) for command in entry["commands"]]
+    # No prose inside the copy target...
+    assert entry["what"] not in body
+    assert entry["caveat"] not in body
+    # ...no "; " joining the commands as prose, and no sentence period abutting
+    # the final path (which made it a path that does not exist).
+    assert "; " not in body
+    assert not body.endswith(".")
+    # One artifact is a titled block, not a one-item bullet list.
+    assert "<ul" not in html and "<li>" not in html
+    # what and caveat are still shown, outside the block.
+    assert entry["what"] in html and entry["caveat"] in html
+
+
+def test_rebuild_section_names_an_unknown_reference_without_inventing_a_command():
+    # Same contract as the Markdown hints: never a plausible-looking guess.
+    plan = gen.rebuild_plan(["fixtures/other/x"], target="gfx950")
+    assert plan[0]["commands"] == []
+    html = gen._rebuild_section_html(plan)
+    assert "fixtures/other/x" in html
+    assert "<pre>" not in html
+    assert gen._rebuild_section_html([]) == ""
+
+
+def test_reproduce_md_keeps_the_flattened_markdown_hints():
+    # The page renders structurally now. REPRODUCE.md consumes the Markdown
+    # verbatim, so it must be untouched by that change.
+    refs = ["fixtures/isa/lds.hsaco"]
+    env = gen.build_case_env(
+        case="waitcheck", cls="guardrail", recipe="r.yaml", command="c",
+        meta={"gpu": "gfx950"}, summary={}, report=None,
+        built_refs=refs, inputs=[],
+    )
+    md = gen.build_reproduce_md(env, built_refs=refs)
+    for hint in gen._rebuild_hints(gen.rebuild_plan(refs, target="gfx950")):
+        assert hint in md
+
+
+def test_files_caption_discloses_an_input_that_is_excluded_by_design():
+    # "Every file published for this case" is true and, on its own, misleading:
+    # for a kernel-source recipe the one input the recipe names is CI-built and
+    # recorded by digest instead of copied. Nothing linked the two sections, so a
+    # reader could not tell a deliberate omission from a missing file.
+    env = {
+        "case": "c",
+        "observed": {},
+        "logs_published": True,
+        "artifacts_not_published": [
+            {"path": "fixtures/isa/consan_gemm_f32.hsaco", "sha256": "ab"}
+        ],
+    }
+    files = [("sanitizer_report.json", 12)]
+    caption = gen.files_caption(env, files)
+    assert "1 required input is" in caption
+    assert f'href="#{gen._NOT_PUBLISHED_ID}"' in caption
+
+    page = gen.build_case_index_html(env, files, built_refs=[], up="../../")
+    # The anchor the caption points at exists on the page.
+    assert f'id="{gen._NOT_PUBLISHED_ID}"' in page
+    # And the header no longer makes the absolute claim the caption walks back.
+    assert "everything needed to reproduce" not in page
+
+    # Plural agreement, and no claim at all when there is nothing to disclose.
+    two = {**env, "artifacts_not_published": [{"path": "a"}, {"path": "b"}]}
+    assert "2 required inputs are" in gen.files_caption(two, files)
+    assert gen.files_caption({**env, "artifacts_not_published": []}, files) == (
+        "Every file published for this case."
+    )
 
 
 def test_genco_rebuild_cleans_up_its_temporary_object():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2392,6 +2392,7 @@ def test_run_area_stylesheet_carries_the_rules_those_pages_use():
         # The rebuild section renders structurally now, so `.steps` (its old
         # bullet list) is gone and these carry the command block instead.
         ".rb {",
+        ".rb-last {",
         ".rb .path {",
         ".rb pre {",
         ".rb pre code {",
@@ -2431,8 +2432,11 @@ def test_fact_row_sizes_each_fact_to_its_content():
 
 def test_long_mono_facts_break_rather_than_overflow_their_neighbour():
     # A 40-char SHA painted over Date; a 136-char digest-pinned image ref ran off
-    # the page. break-word fixes only the first -- it breaks a word just when the
-    # word cannot fit a line by itself.
+    # the page. break-all rather than break-word: break-word would break these
+    # too once the item is narrower than the token, but the opportunities it
+    # introduces are not counted toward min-content, so each mono fact would keep
+    # the whole token as its intrinsic minimum and the row would hold only for as
+    # long as `.kv > span` keeps min-width:0. break-all's breaks do count.
     rule = _css_rule(gen.run_area_stylesheet(), ".kv .val.mono {")
     assert "word-break:break-all" in rule
     assert "break-word" not in rule
@@ -2537,7 +2541,38 @@ def test_rebuild_section_names_an_unknown_reference_without_inventing_a_command(
     assert gen._rebuild_section_html([]) == ""
 
 
-def test_stored_rebuild_plan_is_only_trusted_when_it_carries_every_key():
+def test_final_rebuild_block_is_marked_by_class_not_last_of_type():
+    # `.rb:last-of-type` keys off the tag, not the class: it matches the last
+    # `div` sibling only if that div happens to be a `.rb`. On a real page it
+    # never is -- a case with rebuild blocks has built refs, so `build_case_env`
+    # also gives it an "Artifacts not published" `.table-wrap` after them.
+    sheet = gen.run_area_stylesheet()
+    assert ".rb-last {" in sheet
+    assert ".rb:last-of-type" not in sheet
+
+    plan = gen.rebuild_plan(
+        ["fixtures/isa/lds.hsaco", "fixtures/bin/consan_load"], target="gfx950"
+    )
+    html = gen._rebuild_section_html(plan)
+    assert html.count('<div class="rb">') == len(plan) - 1
+    assert html.count('<div class="rb rb-last">') == 1
+    # It is the last one, not merely one of them.
+    assert html.rindex('<div class="rb rb-last">') > html.rindex('<div class="rb">')
+
+    # A single-artifact case still gets the marker, and it reaches the page.
+    single = gen._rebuild_section_html(plan[:1])
+    assert single.count('<div class="rb rb-last">') == 1
+    assert '<div class="rb">' not in single
+    page = gen.build_case_index_html(
+        {"case": "c", "observed": {}},
+        [],
+        built_refs=["fixtures/isa/lds.hsaco"],
+        up="../../",
+    )
+    assert 'class="rb rb-last"' in page
+
+
+def test_stored_rebuild_plan_is_only_trusted_when_both_renderers_can_read_it():
     # A retained area's own env.json is preferred over recomputation so history
     # keeps its instructions. But it is read off the data branch, and both
     # renderers index the four keys directly -- so a half-written or hand-edited
@@ -2557,6 +2592,22 @@ def test_stored_rebuild_plan_is_only_trusted_when_it_carries_every_key():
     # A non-list or a list of non-dicts falls back the same way.
     for junk in ("nope", [1, 2], {"path": "x"}):
         assert gen.plan_from_env({"rebuild": junk, "target": "gfx950"}, refs) == full
+
+    # Key presence is not enough: `commands` is the one field the renderers
+    # iterate rather than stringify, so its type is part of the contract. An int
+    # is a TypeError mid-render and a string degrades into one command per
+    # character -- either way the whole dashboard render, not one area, breaks.
+    for bad in (1, "hipcc x.hip", None, {"0": "hipcc x.hip"}):
+        entry = [{**full[0], "commands": bad}]
+        recovered = gen.plan_from_env({"rebuild": entry, "target": "gfx950"}, refs)
+        assert recovered == full, bad
+        assert gen._rebuild_hints(recovered)
+        assert gen._rebuild_section_html(recovered)
+
+    # An empty command list is legitimate (an unrecognised reference), so it is
+    # trusted rather than recomputed.
+    empty = [{**full[0], "commands": []}]
+    assert gen.plan_from_env({"rebuild": empty, "target": "gfx950"}, refs) is empty
 
 
 def test_reproduce_md_keeps_the_flattened_markdown_hints():
@@ -2590,6 +2641,7 @@ def test_files_caption_discloses_an_input_that_is_excluded_by_design():
     caption = gen._files_caption(env, files)
     assert "1 required input is" in caption
     assert f'href="#{gen._NOT_PUBLISHED_ID}"' in caption
+    assert "its SHA-256" in caption
 
     page = gen.build_case_index_html(env, files, built_refs=[], up="../../")
     # The anchor the caption points at exists on the page.
@@ -2598,11 +2650,49 @@ def test_files_caption_discloses_an_input_that_is_excluded_by_design():
     assert "everything needed to reproduce" not in page
 
     # Plural agreement, and no claim at all when there is nothing to disclose.
-    two = {**env, "artifacts_not_published": [{"path": "a"}, {"path": "b"}]}
+    two = {
+        **env,
+        "artifacts_not_published": [
+            {"path": "a", "sha256": "ab"}, {"path": "b", "sha256": "cd"}
+        ],
+    }
     assert "2 required inputs are" in gen._files_caption(two, files)
+    assert "their SHA-256s" in gen._files_caption(two, files)
     assert gen._files_caption({**env, "artifacts_not_published": []}, files) == (
         "Every file published for this case."
     )
+
+
+def test_files_caption_claims_only_what_the_listing_actually_carries():
+    # `artifacts_not_published` records sha256 from the report by basename, so a
+    # bare `isa_dir: fixtures/isa` reference has none and its row is an em dash.
+    # The caption must not promise a digest for it. Rebuild commands are never
+    # promised under this anchor either: that table is Path + SHA-256, the
+    # commands are their own section above it, and an unrecognised reference has
+    # no command at all.
+    env = {"case": "c", "observed": {}, "logs_published": True}
+    files = [("sanitizer_report.json", 12)]
+
+    undigested = {**env, "artifacts_not_published": [{"path": "fixtures/isa"}]}
+    caption = gen._files_caption(undigested, files)
+    assert "1 required input is" in caption
+    assert f'href="#{gen._NOT_PUBLISHED_ID}"' in caption
+    assert "SHA-256" not in caption
+
+    # One entry without a digest is enough to drop the claim for the whole list.
+    mixed = {
+        **env,
+        "artifacts_not_published": [
+            {"path": "fixtures/isa/x.hsaco", "sha256": "ab"},
+            {"path": "fixtures/isa", "sha256": None},
+        ],
+    }
+    assert "SHA-256" not in gen._files_caption(mixed, files)
+
+    # No caption on any of these paths claims a rebuild command under the
+    # anchor, because the anchored table does not carry one.
+    for case in (undigested, mixed):
+        assert "rebuild" not in gen._files_caption(case, files).lower()
 
 
 def test_genco_rebuild_cleans_up_its_temporary_object():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2537,6 +2537,28 @@ def test_rebuild_section_names_an_unknown_reference_without_inventing_a_command(
     assert gen._rebuild_section_html([]) == ""
 
 
+def test_stored_rebuild_plan_is_only_trusted_when_it_carries_every_key():
+    # A retained area's own env.json is preferred over recomputation so history
+    # keeps its instructions. But it is read off the data branch, and both
+    # renderers index the four keys directly -- so a half-written or hand-edited
+    # entry has to fall back, not KeyError the whole dashboard render.
+    refs = ["fixtures/isa/lds.hsaco"]
+    full = gen.rebuild_plan(refs, target="gfx950")
+    assert gen.plan_from_env({"rebuild": full, "target": "gfx950"}, refs) is full
+
+    for missing in sorted(gen._REBUILD_KEYS):
+        partial = [{k: v for k, v in full[0].items() if k != missing}]
+        recovered = gen.plan_from_env({"rebuild": partial, "target": "gfx950"}, refs)
+        assert recovered == full, missing
+        # Both renderers survive the fallback.
+        assert gen._rebuild_hints(recovered)
+        assert gen._rebuild_section_html(recovered)
+
+    # A non-list or a list of non-dicts falls back the same way.
+    for junk in ("nope", [1, 2], {"path": "x"}):
+        assert gen.plan_from_env({"rebuild": junk, "target": "gfx950"}, refs) == full
+
+
 def test_reproduce_md_keeps_the_flattened_markdown_hints():
     # The page renders structurally now. REPRODUCE.md consumes the Markdown
     # verbatim, so it must be untouched by that change.
@@ -2565,7 +2587,7 @@ def test_files_caption_discloses_an_input_that_is_excluded_by_design():
         ],
     }
     files = [("sanitizer_report.json", 12)]
-    caption = gen.files_caption(env, files)
+    caption = gen._files_caption(env, files)
     assert "1 required input is" in caption
     assert f'href="#{gen._NOT_PUBLISHED_ID}"' in caption
 
@@ -2577,8 +2599,8 @@ def test_files_caption_discloses_an_input_that_is_excluded_by_design():
 
     # Plural agreement, and no claim at all when there is nothing to disclose.
     two = {**env, "artifacts_not_published": [{"path": "a"}, {"path": "b"}]}
-    assert "2 required inputs are" in gen.files_caption(two, files)
-    assert gen.files_caption({**env, "artifacts_not_published": []}, files) == (
+    assert "2 required inputs are" in gen._files_caption(two, files)
+    assert gen._files_caption({**env, "artifacts_not_published": []}, files) == (
         "Every file published for this case."
     )
 


### PR DESCRIPTION
Closes #391.

## Problem

Eight presentation defects shipped with the run area in #386. Individually small; together they undermined the page's stated purpose, because the two values that make a case reproducible — the image digest and the rebuild command — were the two that rendered worst.

## What this does

All eight fixes live in one stylesheet and one render function.

| # | Defect | Fix |
|---|---|---|
| 1 | 40-char `COMMIT` painted over `DATE` | `word-break:break-all` on `.kv .val.mono` |
| 2 | 136-char digest-pinned `CONTAINER` ran off the page | same rule; `break-all` rather than `break-word` for min-content sizing (below) |
| 3 | Every fact got the same ~187px regardless of content | `.kv` becomes a wrapping flex row, each fact sized to content |
| 4 | `REPRODUCE` label sat inside the box it labels | label moved out, at both call sites; `.repro` becomes `display:block` |
| 5 | Section headings indistinguishable from the `th` beneath them | `--accent` scoped to drill-down `.panel`; prose caption moved off `.cap` |
| 6 | Sections ran into the next heading | `.cap` owns a 24px top margin; the fragile adjacency rule removed |
| 7 | Rebuild hint flattened path, prose and 3 commands into one sentence | renders from the structured `rebuild_plan` |
| 8 | Files caption claimed "every file" while one input is excluded by design | says how many, and links to their digests |

## Points a reviewer will want flagged

**Why `break-all` and not `break-word`.** *Corrected after review — this section originally claimed `break-word` would leave the 136-char ref overflowing, which is wrong.* With `.kv > span` carrying `min-width:0; max-width:100%`, that ref *is* a word which cannot fit a line by itself, so `break-word` would break it and it would not overflow. The real distinction is intrinsic sizing: the soft-wrap opportunities `break-word` introduces **do not count toward min-content**, so every mono fact would keep the whole unbroken token as its intrinsic minimum, and the row would hold only for as long as that `min-width:0` survives. `break-all`'s breaks do count, and breaking between characters is what a token with no word boundaries wants anyway. It is also what the rest of this sheet already uses for mono values — `.runrow .rv`, `.repro code` — it had just never been applied to `.kv`. Thanks to Copilot for catching the false premise; the CSS comment and the test comment carry the corrected reasoning.

**Defect 3 could not ship separately from 1 and 2.** Those let long values wrap; 3 is the allocation. Fixing wrapping alone converts an overflow bug into a visible three-line wrap beside ~555px of dead space. Measured before, at 818px of panel width with every track at exactly `186.587px`:

| Fact | chars | cell | content | lines | dead |
|---|--:|--:|--:|--:|--:|
| `RUN` | 22 | 187 | 169 | 1 | 18 |
| `COMMIT` | 40 | 187 | 185 | **2** | — |
| `DATE` | 10 | 187 | 77 | 1 | **110** |
| `TARGET` | 6 | 187 | 46 | 1 | **141** |
| `RECIPE` | 51 | 187 | 185 | **3** | — |
| `EXECUTION` | 8 | 187 | 62 | 1 | **125** |
| `FINDINGS` | 1 | 187 | 8 | 1 | **179** |

After, every fact is one line: `COMMIT` 308px, `RECIPE` 393px, `FINDINGS` 62px, `TARGET` 48px, and page overflow is 0.

**Flex loses the column alignment between rows.** That is the accepted trade-off, chosen over a fixed count of content-sized `auto` tracks (keeps alignment, but column 1 becomes as wide as `RECIPE` even where `RUN` sits) and a per-fact span lattice (keeps alignment, needs a hint maintained per fact). Widths are derived from content deliberately: #392 lengthens `RUN` from 22 to 29 characters and `DATE` from 10 to ~23, so any per-field width table written today would be wrong the moment it lands.

**`--accent` was silently disabled on exactly these pages.** `.cap`'s heading bar is `background:var(--accent, var(--text-3))`, and `--accent` is only defined on the root dashboard's `.kcard.wc/.cs/.nu`. Run-area pages have no such ancestor, so every bar fell back to `#94A3B8` — the exact grey of the `th` text beneath it. Scoped in `_DRILLDOWN_CSS` rather than on `.cap`, so the dashboard keeps its per-kind hues.

**Defect 6 was structural, not a spacing tweak.** `.cap` shipped with `margin-top:0`, so separation was whatever the previous element left (14px, against the 8px binding a heading to its own content) and it was delegated to `.cap + .table-wrap`. Any element inserted between a heading and its table silently deleted the gap — which happened while prototyping defect 7, dropping `Recorded digests` to **0px**. Since 7 restructures that exact region, the adjacency rule is removed rather than worked around.

**Defect 7 is an intent inversion, not just ugly markup.** `rebuild_plan`'s docstring states the structured form exists so a consumer "can read the exact commands **rather than parse them out of a sentence**", and that anything to branch on is encoded *in* a command "so the list can be executed as-is". `_rebuild_hints` then flattened it into precisely that sentence — commands as individually-backticked inline `<code>` runs joined by a prose `;`, with the sentence period abutting the final path so the visible command ended `…consan_gemm_f32.hsaco.`. The page now renders the structure; **REPRODUCE.md still consumes the Markdown verbatim and is unchanged.**

**`.steps` is deleted, not orphaned** — it existed only for the bullet list defect 7 removes.

**No published-data change, verified rather than asserted.** Publishing a two-run history from this branch and from `main` and byte-comparing every `env.json`, `REPRODUCE.md`, `meta.json`, `data.json` and `summary.md` — 18 files — shows them identical. Only the stylesheet, the root dashboard and the case pages differ.

**The dashboard is affected and was checked.** `.cap`, `.kv` and `.repro` are shared. Measured on a dashboard built from this branch: kernel-card facts are now content-sized too (`Backend` 192px, `Kernels` 55px, previously all uniform), section gaps are a uniform 24px, the Tab 2 strip has a single `code` child preceded by the label, and horizontal overflow is 0. The `.cap` top margin is a deliberate, visible dashboard change: 14px → 24px above `Kernels` / `Findings`.

**The header subtitle changed.** "everything needed to reproduce this case locally" was inaccurate for a `source.kind: kernel` recipe, whose one named input is the excluded one. `docs/ci-nightly-eval.md` opened its run-area section with the same overstatement and reconciled it two paragraphs later; both now say what the area actually carries.

## Test plan

- [x] `pytest tests/sanitizers/test_dashboard.py` — 144 pass (9 new, 1 updated)
- [x] `ruff check` clean on both changed Python files
- [x] Rendered and measured in a browser at 1080px: fact widths, section gaps, `documentElement.scrollWidth - clientWidth == 0`
- [x] Full dashboard published from this branch and from `main`; published data byte-identical across 18 files
- [x] Dashboard kernel cards and Tab 2 survey strip measured for regressions
- [x] Self-review loop + Bugbot pass: 3 findings, 3 fixed, Bugbot clean
- [ ] **Not yet seen in real CI.** The first nightly after merge re-renders all 30 retained areas, including ones whose `env.json` predates this change; `plan_from_env`'s new key check is what makes that safe and is unit-tested, but the real tree is the real test.

## Note on #392

#392 (a time of day in the run id and the `DATE` fact) is deliberately separate: it changes what the nightly publishes. Its longer `RUN` and `DATE` values are why defect 3's fix derives width from content rather than per-field hints, so the two should not conflict textually or semantically.

Made with [Cursor](https://cursor.com)
