### PR TITLE
feat(sanitizers): put a time of day in the run id and the rendered date

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -661,7 +661,19 @@ jobs:
           # this loop found nothing.
           run_dir_id=""
           for existing in "$runs_dir"/*-"${GITHUB_RUN_ID}"; do
-            if [ -d "$existing" ]; then run_dir_id="$(basename "$existing")"; fi
+            name="$(basename "$existing")"
+            # The glob matches any name ending in this run id, but only a name
+            # the generator recognises may be reused: publishing into, say, a
+            # stray source-${GITHUB_RUN_ID} would write a run that neither the
+            # prune nor the page ever enumerates, so tonight's results would be
+            # invisible on the dashboard and would never rotate out either. It
+            # is also what makes the ordering argument above hold, since such a
+            # name could otherwise sort last and win. The shapes are _RUN_ID_RE's.
+            # [[:digit:]] rather than [0-9]: a bracket *range* is collation-based,
+            # and under a UTF-8 locale bash matches Unicode decimal digits with
+            # [0-9] -- the POSIX class is the ASCII digits on both sides.
+            [[ "$name" =~ ^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}(T[[:digit:]]{6})?-[[:digit:]]+$ ]] || continue
+            if [ -d "$existing" ]; then run_dir_id="$name"; fi
           done
           : "${run_dir_id:=${started_id}-${GITHUB_RUN_ID}}"
           dest="$runs_dir/${run_dir_id}"
@@ -747,11 +759,12 @@ jobs:
           # run the page still lists past the tail, i.e. delete it. `ls -p` marks
           # directories with a trailing slash and the pattern requires it, which
           # is the is_dir() half; the rest of the pattern is deliberately exactly
-          # as permissive as that regex. This mirrors the enumeration, it does not
-          # tighten it.
+          # as permissive as that regex, and spells its digits the same way the
+          # reuse guard above does and for the same reason. This mirrors the
+          # enumeration, it does not tighten it.
           if [ -d "$runs_dir" ]; then
             ls -1p "$runs_dir" \
-              | sed -n 's|^\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\(T[0-9]\{6\}\)\{0,1\}\)-\([0-9][0-9]*\)/$|\1 \3|p' \
+              | sed -n 's|^\([[:digit:]]\{4\}-[[:digit:]]\{2\}-[[:digit:]]\{2\}\(T[[:digit:]]\{6\}\)\{0,1\}\)-\([[:digit:]][[:digit:]]*\)/$|\1 \3|p' \
               | LC_ALL=C sort -k1,1r -k2,2nr \
               | tr ' ' '-' \
               | tail -n +"$((keep + 1))" | while IFS= read -r old; do

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -638,9 +638,12 @@ jobs:
           # dashboard/runs/). A failed/absent report is simply not copied; the
           # generator then renders that case as missing -> a red per-run gate.
           runs_dir="$tmp/dashboard/runs"
-          # <YYYY-MM-DD>T<HHMMSS>-<run_id>: sortable to the second, unique, and the
-          # T keeps the run id in the 4th "-" field, so the prune sort below is
-          # unchanged and still orders a mixed old/new history correctly.
+          # <YYYY-MM-DD>T<HHMMSS>-<run_id>: sortable to the second, and unique.
+          # The T puts the time *inside* the date field rather than adding another
+          # "-" field, so a field-wise numeric sort of the date parts reads only
+          # the day and would order same-day runs by run id alone. The prune below
+          # therefore splits the trailing run id off and sorts the rest lexically,
+          # mirroring the generator's _history_sort_key -- see that sort's comment.
           #
           # A re-run reuses GITHUB_RUN_ID (only GITHUB_RUN_ATTEMPT changes) and has
           # to land on the directory its first attempt minted. Stamping a fresh

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -605,8 +605,14 @@ jobs:
         run: |
           set -euo pipefail
           keep=30
-          date="$(date -u +%Y-%m-%d)"
-          run_dir_id="${date}-${GITHUB_RUN_ID}"   # <YYYY-MM-DD>-<run_id>: date-sortable + unique
+          # One clock read for the directory name and the recorded instant alike,
+          # so a published area cannot report a time its own directory disagrees
+          # with. run_dir_id is resolved after the clone -- it may reuse a name
+          # already on the branch (see below).
+          now="$(date -u +%s)"
+          date="$(date -u -d "@${now}" +%Y-%m-%d)"
+          started_id="$(date -u -d "@${now}" +%Y-%m-%dT%H%M%S)"
+          started_iso="$(date -u -d "@${now}" +%Y-%m-%dT%H:%M:%S+00:00)"
           repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           tmp="$(mktemp -d)"
           # Fail closed: distinguish a genuinely-absent sanitizer-results branch
@@ -632,11 +638,26 @@ jobs:
           # dashboard/runs/). A failed/absent report is simply not copied; the
           # generator then renders that case as missing -> a red per-run gate.
           runs_dir="$tmp/dashboard/runs"
+          # <YYYY-MM-DD>T<HHMMSS>-<run_id>: sortable to the second, unique, and the
+          # T keeps the run id in the 4th "-" field, so the prune sort below is
+          # unchanged and still orders a mixed old/new history correctly.
+          #
+          # A re-run reuses GITHUB_RUN_ID (only GITHUB_RUN_ATTEMPT changes) and has
+          # to land on the directory its first attempt minted. Stamping a fresh
+          # time would create a second directory for one workflow run: two of the
+          # keep slots, two rows in history, and the earlier attempt reports left
+          # in place -- which is exactly what the rm -rf below exists to prevent.
+          # Reuse whatever name already carries this run id, old shape included.
+          run_dir_id=""
+          for existing in "$runs_dir"/*-"${GITHUB_RUN_ID}"; do
+            if [ -d "$existing" ]; then run_dir_id="$(basename "$existing")"; break; fi
+          done
+          : "${run_dir_id:=${started_id}-${GITHUB_RUN_ID}}"
           dest="$runs_dir/${run_dir_id}"
-          # A same-day Actions re-run reuses GITHUB_RUN_ID (only GITHUB_RUN_ATTEMPT
-          # changes), so it targets this same directory. Clear it first so a report
-          # absent from the current attempt cannot survive from a prior one and mask
-          # a now-missing case (the generator fails such a case closed).
+          echo "[$(date +%T)] publishing run ${run_dir_id}"
+          # Clear it first so a report absent from the current attempt cannot
+          # survive from a prior one and mask a now-missing case (the generator
+          # fails such a case closed).
           rm -rf "$dest"
           mkdir -p "$dest"
           # Copy the whole case directory, not just the report: the sanitizer
@@ -661,12 +682,19 @@ jobs:
           # gate mirrors the GPU job result (its comparator step is the gate); the
           # rendered history recomputes it from the reports + baselines regardless.
           if [ "${GPU_RESULT}" = "success" ]; then gate=true; else gate=false; fi
-          python - "$run_dir_id" "$date" "$gate" > "$dest/meta.json" <<'PY'
-          import json, os, sys
-          run_id, date, gate = sys.argv[1], sys.argv[2], sys.argv[3] == "true"
+          python - "$run_dir_id" "$started_iso" "$gate" > "$dest/meta.json" <<'PY'
+          import json, os, re, sys
+          run_id, started_iso, gate = sys.argv[1], sys.argv[2], sys.argv[3] == "true"
           server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
           repo = os.environ.get("GITHUB_REPOSITORY", "")
           gh_run = os.environ.get("GITHUB_RUN_ID", "")
+          # Take the instant from the directory name so the two cannot disagree: a
+          # re-run reuses the name its first attempt minted, and recording this
+          # attempt clock beside that name would contradict it. A name from before
+          # the timestamped scheme carries no instant, so this publish supplies one
+          # rather than inventing a midnight.
+          stamped = re.match(r"^(\d{4}-\d{2}-\d{2})T(\d{2})(\d{2})(\d{2})-", run_id)
+          date = "{}T{}:{}:{}+00:00".format(*stamped.groups()) if stamped else started_iso
           print(json.dumps({
               "run": run_id,
               "commit": os.environ.get("GITHUB_SHA", ""),
@@ -677,13 +705,24 @@ jobs:
           }, indent=2, sort_keys=True))
           PY
 
-          # Rolling window: drop all but the newest N run directories. Sort by the
-          # date fields then the run-id numerically (-t- splits <YYYY-MM-DD>-<run_id>
-          # into fields 1-4), so a variable-width run id (...-9 vs ...-10) still
-          # orders newest-first -- a plain lexical sort would prune the wrong dir.
+          # Rolling window: drop all but the newest N run directories, in exactly
+          # the order the generator renders them (_history_sort_key) -- if the two
+          # disagree this deletes a directory the page still lists. That key is
+          # "everything before the trailing run id, lexically; then that id as an
+          # integer", the integer part because it is variable-width and a plain
+          # lexical sort puts ...-9 after ...-10. sed splits the id onto its own
+          # field so sort can treat the two halves differently, and tr rejoins it
+          # (a run id has no spaces -- the schema is digits and dashes).
+          #
+          # One pass covers both id shapes: the timestamp lives in the lexical
+          # half, so a date-only name from before the timestamped scheme compares
+          # as that day's earliest, which is what it is. LC_ALL=C so the lexical
+          # half is byte-ordered like Python's, not collated by the runner locale.
           if [ -d "$runs_dir" ]; then
             ls -1 "$runs_dir" \
-              | sort -t- -k1,1nr -k2,2nr -k3,3nr -k4,4nr \
+              | sed 's/-\([0-9][0-9]*\)$/ \1/' \
+              | LC_ALL=C sort -k1,1r -k2,2nr \
+              | tr ' ' '-' \
               | tail -n +"$((keep + 1))" | while IFS= read -r old; do
               [ -n "$old" ] && rm -rf "${runs_dir:?}/${old}"
             done

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -610,7 +610,6 @@ jobs:
           # with. run_dir_id is resolved after the clone -- it may reuse a name
           # already on the branch (see below).
           now="$(date -u +%s)"
-          date="$(date -u -d "@${now}" +%Y-%m-%d)"
           started_id="$(date -u -d "@${now}" +%Y-%m-%dT%H%M%S)"
           started_iso="$(date -u -d "@${now}" +%Y-%m-%dT%H:%M:%S+00:00)"
           repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -778,10 +777,18 @@ jobs:
           cp -a "$tmp/dashboard" dashboard
           cat dashboard/summary.md >> "$GITHUB_STEP_SUMMARY"
 
+          # Two identifiers because they answer different questions and a re-run
+          # moves only one: run_dir_id is the area this commit published (reused
+          # from the first attempt), started_iso is when this publish ran. A
+          # date-only title gave two same-day runs the same subject; run_dir_id
+          # alone would give a re-run the same subject as the attempt it
+          # replaces. Reading git log, equal instants mean a first attempt and
+          # different ones a re-run. run_dir_id already ends in GITHUB_RUN_ID, so
+          # naming the run id again would just print it twice.
           ( cd "$tmp"
             git add -A
             if git -c user.name=aorta-ci -c user.email=aorta-ci@users.noreply.github.com \
-                 commit -m "sanitizer dashboard ${date} (run ${GITHUB_RUN_ID})"; then
+                 commit -m "sanitizer dashboard ${run_dir_id} (published ${started_iso})"; then
               git push origin sanitizer-results   # not swallowed -- a push failure fails the job
             else
               echo "no changes to commit"

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -650,10 +650,15 @@ jobs:
           # keep slots, two rows in history, and the earlier attempt reports left
           # in place -- which is exactly what the rm -rf below exists to prevent.
           # Reuse whatever name already carries this run id, old shape included.
-          # No break: the glob expands in ascending order, so the last match wins
-          # and the newest directory is reused. The old scheme could leave two for
-          # one run id -- a re-run that crossed midnight got a second date -- and
-          # re-publishing into the older of those would strand the newer one.
+          # No break, so the last match wins. Only the old scheme could leave two
+          # names for one run id -- a re-run that crossed midnight got a second
+          # date -- and re-publishing into the older of those would strand the
+          # newer one, so the last match has to be the later day. Those two names
+          # differ in a date digit, which every collation orders the same way, so
+          # glob order settles it without pinning LC_COLLATE here; the prune below
+          # compares "-" against "T" across run ids and does need LC_ALL=C. A
+          # timestamped name cannot collide with either: one is minted only when
+          # this loop found nothing.
           run_dir_id=""
           for existing in "$runs_dir"/*-"${GITHUB_RUN_ID}"; do
             if [ -d "$existing" ]; then run_dir_id="$(basename "$existing")"; fi
@@ -694,13 +699,22 @@ jobs:
           server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
           repo = os.environ.get("GITHUB_REPOSITORY", "")
           gh_run = os.environ.get("GITHUB_RUN_ID", "")
-          # Take the instant from the directory name so the two cannot disagree: a
+          # Take the date from the directory name so the two cannot disagree: a
           # re-run reuses the name its first attempt minted, and recording this
           # attempt clock beside that name would contradict it. A name from before
-          # the timestamped scheme carries no instant, so this publish supplies one
-          # rather than inventing a midnight.
-          stamped = re.match(r"^(\d{4}-\d{2}-\d{2})T(\d{2})(\d{2})(\d{2})-", run_id)
-          date = "{}T{}:{}:{}+00:00".format(*stamped.groups()) if stamped else started_iso
+          # the timestamped scheme still carries its day, and re-publishing into
+          # one must keep that day rather than stamp it with today: rm -rf cleared
+          # a meta.json that already held the right date-only value, and
+          # format_instant passes such a value through unchanged, so nothing has
+          # to be invented (docs/ci-nightly-eval.md -- those runs keep their
+          # date-only manifests). Only a name of neither shape has no date to take.
+          stamped = re.match(r"^(\d{4}-\d{2}-\d{2})(?:T(\d{2})(\d{2})(\d{2}))?-", run_id)
+          if stamped and stamped.group(2):
+              date = "{}T{}:{}:{}+00:00".format(*stamped.groups())
+          elif stamped:
+              date = stamped.group(1)
+          else:
+              date = started_iso
           print(json.dumps({
               "run": run_id,
               "commit": os.environ.get("GITHUB_SHA", ""),
@@ -724,9 +738,20 @@ jobs:
           # half, so a date-only name from before the timestamped scheme compares
           # as that day's earliest, which is what it is. LC_ALL=C so the lexical
           # half is byte-ordered like Python's, not collated by the runner locale.
+          #
+          # The sed only prints entries the generator would also count, so the two
+          # spend the same keep slots: it enumerates directories whose name is a
+          # well-formed id (p.is_dir() and _is_run_id / _RUN_ID_RE), so anything
+          # else here -- a leftover source/ from a nested --history-root layout,
+          # say -- would take a slot the page does not spend and push the oldest
+          # run the page still lists past the tail, i.e. delete it. `ls -p` marks
+          # directories with a trailing slash and the pattern requires it, which
+          # is the is_dir() half; the rest of the pattern is deliberately exactly
+          # as permissive as that regex. This mirrors the enumeration, it does not
+          # tighten it.
           if [ -d "$runs_dir" ]; then
-            ls -1 "$runs_dir" \
-              | sed 's/-\([0-9][0-9]*\)$/ \1/' \
+            ls -1p "$runs_dir" \
+              | sed -n 's|^\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\(T[0-9]\{6\}\)\{0,1\}\)-\([0-9][0-9]*\)/$|\1 \3|p' \
               | LC_ALL=C sort -k1,1r -k2,2nr \
               | tr ' ' '-' \
               | tail -n +"$((keep + 1))" | while IFS= read -r old; do

--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -648,9 +648,13 @@ jobs:
           # keep slots, two rows in history, and the earlier attempt reports left
           # in place -- which is exactly what the rm -rf below exists to prevent.
           # Reuse whatever name already carries this run id, old shape included.
+          # No break: the glob expands in ascending order, so the last match wins
+          # and the newest directory is reused. The old scheme could leave two for
+          # one run id -- a re-run that crossed midnight got a second date -- and
+          # re-publishing into the older of those would strand the newer one.
           run_dir_id=""
           for existing in "$runs_dir"/*-"${GITHUB_RUN_ID}"; do
-            if [ -d "$existing" ]; then run_dir_id="$(basename "$existing")"; break; fi
+            if [ -d "$existing" ]; then run_dir_id="$(basename "$existing")"; fi
           done
           : "${run_dir_id:=${started_id}-${GITHUB_RUN_ID}}"
           dest="$runs_dir/${run_dir_id}"

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -67,7 +67,9 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    Each nightly's per-case results are co-located on the `sanitizer-results` data
    branch under `dashboard/runs/<YYYY-MM-DD>T<HHMMSS>-<run_id>/` (one directory per
    guardrail recipe, one under `survey/` per observed-only case, plus a
-   `meta.json` with commit / date / gpu / run_url / gate), and the rendered page
+   `meta.json` with commit / date / gpu / run_url / gate, where `date` is an
+   ISO-8601 instant -- runs published before the directory carried a time keep
+   their date-only names and manifests, and are never renamed), and the rendered page
    links to them: the latest run table has a per-recipe **Report** link, each
    kernel-detail card carries a **run area** link to the case's directory, and
    each **Run** row in the history table links to its `runs/<id>/` area. A

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -65,7 +65,7 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    published.
 
    Each nightly's per-case results are co-located on the `sanitizer-results` data
-   branch under `dashboard/runs/<YYYY-MM-DD>-<run_id>/` (one directory per
+   branch under `dashboard/runs/<YYYY-MM-DD>T<HHMMSS>-<run_id>/` (one directory per
    guardrail recipe, one under `survey/` per observed-only case, plus a
    `meta.json` with commit / date / gpu / run_url / gate), and the rendered page
    links to them: the latest run table has a per-recipe **Report** link, each

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -539,9 +539,12 @@ def _basename(path: str | None) -> str:
 # `+0000` began parsing; 1-digit fractions too). Gating on this shape is what
 # keeps the rendering identical on every interpreter the repo supports -- what it
 # admits, 3.10 and 3.13 parse the same way; what it rejects is passed through
-# untouched on both. This is what the publishers emit.
+# untouched on both. This is what the publishers emit. ASCII digits, since that
+# is what `fromisoformat` itself accepts -- `\d` would admit Unicode decimal
+# digits that no interpreter parses, which is a claim this gate should not make.
 _INSTANT_RE = re.compile(
-    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d{3}|\.\d{6})?)?([+-]\d{2}:\d{2}|Z)?$"
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}"
+    r"(:[0-9]{2}(\.[0-9]{3}|\.[0-9]{6})?)?([+-][0-9]{2}:[0-9]{2}|Z)?$"
 )
 
 
@@ -847,7 +850,12 @@ def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
 # integer). The time is optional because runs published before it was added keep
 # their ``<YYYY-MM-DD>-<run_id>`` names -- they are never renamed, so both shapes
 # are live in the retained window and in the data branch's history.
-_RUN_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{6})?-\d+$")
+#
+# ASCII digits, not ``\d``: the nightly's prune filter and directory-reuse guard
+# spell the same shapes with ``[0-9]``, and this enumeration has to admit exactly
+# what they admit -- a name of Unicode decimal digits that only this side accepted
+# would be rendered on the page while the prune ignored it.
+_RUN_ID_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{6})?-[0-9]+$")
 # Nothing here parses the instant back out of an id: the publisher records it in
 # ``meta.json`` and this renders that value (``format_instant``). Reading it off
 # the directory name too would be a second source for one fact.

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -39,8 +39,10 @@ Three input shapes are supported:
   ``out/<case>/sanitizer_report.json``; used locally to render a history/trend.
 * ``--history-root DIR`` -- the PUBLISHED data-branch layout
   ``DIR/<id>/<case>/sanitizer_report.json`` plus a per-run ``DIR/<id>/meta.json``
-  (keys: commit, date, gpu, run_url, gate). ``<id>`` is ``<YYYY-MM-DD>-<run_id>``
-  (date-sortable, unique), enumerated newest-first and capped by ``--keep N``
+  (keys: commit, date, gpu, run_url, gate). ``<id>`` is
+  ``<YYYY-MM-DD>T<HHMMSS>-<run_id>`` (sortable to the second, unique; runs
+  published before the time was added keep their date-only names and are never
+  renamed), enumerated newest-first and capped by ``--keep N``
   (default 30). This is the shape the nightly publishes and Pages serves under
   ``/sanitizers/``: each run's case dirs are co-located under ``runs/<id>/`` and
   linked from the rendered page, and a ``runs/<id>/index.html`` landing page is
@@ -484,7 +486,7 @@ def _run_card_html(meta: dict[str, Any]) -> str:
     rows = (
         ("Run", meta.get("run", "")),
         ("Commit", meta.get("commit", "")),
-        ("Date", meta.get("date", "")),
+        ("Date", format_instant(meta.get("date", ""))),
         ("Target", meta.get("gpu", "gfx950")),
     )
     body = "".join(
@@ -528,6 +530,35 @@ def _short(value: str | None, width: int = 10) -> str:
 
 def _basename(path: str | None) -> str:
     return path.rsplit("/", 1)[-1] if path else ""
+
+
+def format_instant(value: Any) -> str:
+    """A recorded timestamp as something a reader can act on (pure).
+
+    ``meta.json`` and ``status.json`` record an ISO-8601 instant; this renders it
+    as ``YYYY-MM-DD HH:MM:SS UTC`` -- the zone spelled out, because a reader
+    comparing a run against their own logs has to know which one it is in.
+
+    Anything that is not an instant is returned **unchanged**: a date-only value
+    from a run published before the id carried a time, or a malformed manifest.
+    Requiring a time separator before parsing is what makes that safe --
+    ``datetime.fromisoformat("2026-08-23")`` succeeds and would render a
+    confident ``00:00:00`` for a run that happened at nine in the morning.
+    """
+    text = str(value or "").strip()
+    if "T" not in text and " " not in text:
+        return text
+    try:
+        # `Z` is only accepted by fromisoformat from 3.11; the writers here emit
+        # an explicit offset, but a hand-edited manifest may not.
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return text
+    if parsed.tzinfo is None:
+        # Naive means UTC by construction: every writer uses `date -u` or
+        # datetime.now(tz=timezone.utc).
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def _clean_msg(message: str, limit: int = 160) -> str:
@@ -769,7 +800,7 @@ def runs_from_runs_root(runs_root: Path, baselines: dict) -> list[dict[str, Any]
 def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
     """Read a published run's ``meta.json`` (commit, date, gpu, run_url, gate).
 
-    The run id (``<YYYY-MM-DD>-<run_id>``) is authoritative from the directory
+    The run id (see ``_RUN_ID_RE``) is authoritative from the directory
     name; ``meta.json`` supplies the rest. A missing/corrupt manifest degrades to
     an id-only record rather than crashing the whole dashboard render.
     """
@@ -795,23 +826,33 @@ def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
     return meta
 
 
-# A published run directory is ``<YYYY-MM-DD>-<run_id>`` (run_id an integer).
-_RUN_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d+$")
+# A published run directory is ``<YYYY-MM-DD>T<HHMMSS>-<run_id>`` (run_id an
+# integer). The time is optional because runs published before it was added keep
+# their ``<YYYY-MM-DD>-<run_id>`` names -- they are never renamed, so both shapes
+# are live in the retained window and in the data branch's history.
+_RUN_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{6})?-\d+$")
+# The instant embedded in a run id, if it carries one.
+_RUN_ID_STAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})T(\d{2})(\d{2})(\d{2})-")
 
 
 def _is_run_id(name: str) -> bool:
-    """Whether a directory name is a well-formed ``<YYYY-MM-DD>-<run_id>`` id."""
+    """Whether a directory name is a well-formed run id, with or without a time."""
     return _RUN_ID_RE.match(name) is not None
 
 
 def _history_sort_key(name: str) -> tuple[str, int]:
-    """Order key for a published run id (``<YYYY-MM-DD>-<run_id>``).
+    """Order key for a published run id (see ``_RUN_ID_RE``).
 
     Enumeration is already filtered to well-formed ids (``_is_run_id``); this key
     exists because the trailing run id is a *variable-width* integer, so a plain
     name sort mis-orders ``...-9`` after ``...-10`` and would pick the wrong
     latest run (and prune the wrong dir). Split the numeric suffix off and compare
     it as an int. The malformed fallback ``(name, -1)`` is defensive only.
+
+    Both id shapes sort correctly against each other without special-casing: the
+    head is a zero-padded date optionally followed by ``T<HHMMSS>``, and a bare
+    date is a prefix of any timestamped id for the same day, so it compares as
+    the earlier one. That is also what the workflow's field-wise ``sort`` does.
     """
     head, sep, tail = name.rpartition("-")
     if sep and tail.isdigit():
@@ -824,14 +865,14 @@ def runs_from_history_root(
 ) -> list[dict[str, Any]]:
     """Enumerate the PUBLISHED ``DIR/<id>/<case>/sanitizer_report.json`` layout.
 
-    Runs are ordered newest-first by ``<id>`` (``<YYYY-MM-DD>-<run_id>``) using a
+    Runs are ordered newest-first by ``<id>`` (see ``_RUN_ID_RE``) using a
     date-then-numeric key (see ``_history_sort_key``; a plain string sort would
     put ``...-9`` after ``...-10``) and capped to the newest ``keep``. Each
     summarized row is tagged with a ``report_rel`` pointing at its raw JSON
     relative to the dashboard root, and each record with the run's ``rel`` area,
     so ``build_html`` can emit relative links that work under ``/sanitizers/``.
     """
-    # Only enumerate well-formed <YYYY-MM-DD>-<run_id> dirs: a stray child (e.g. a
+    # Only enumerate well-formed run-id dirs: a stray child (e.g. a
     # leftover `source/` from a nested --history-root layout) must not become a
     # phantom "latest" pseudo-run or consume a --keep slot.
     run_dirs = sorted(
@@ -2222,7 +2263,7 @@ def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
         "## Run",
         "",
         f"- Commit: `{env.get('commit', '')}`",
-        f"- Date: {env.get('date', '')}",
+        f"- Date: {format_instant(env.get('date', ''))}",
         f"- Target: `{env.get('target', '')}`",
         f"- Class: {env.get('class', '')} "
         + ("(gated guardrail)" if env.get("class") == "guardrail" else "(observed-only, non-gating)"),
@@ -2356,7 +2397,7 @@ def build_case_index_html(
     facts = [
         ("Run", _esc(str(env.get("run", "")))),
         ("Commit", _esc(str(env.get("commit", "")))),
-        ("Date", _esc(str(env.get("date", "")))),
+        ("Date", _esc(format_instant(env.get("date", "")))),
         ("Target", _esc(str(env.get("target", "")))),
         ("Recipe", _esc(str(env.get("recipe", "")))),
         ("Execution", _esc(str(observed.get("execution") or _DASH))),
@@ -2599,7 +2640,7 @@ def _status_banner_html(status: dict[str, Any] | None) -> str:
     run_id = str(status.get("run_id", "") or "")
     url = str(status.get("run_url", "") or "")
     conclusion = str(status.get("conclusion", "") or "unknown")
-    when = str(status.get("date", "") or "")
+    when = format_instant(status.get("date", ""))
     run_txt = f" run {_esc(run_id)}" if run_id else ""
     link = f' <a href="{_esc(url)}">view failed run</a>' if url else ""
     when_txt = f" ({_esc(when)})" if when else ""
@@ -3537,7 +3578,7 @@ def build_html(
     hist_rows = "".join(
         f"<tr><td class=mono>{_run_cell_html(run)}</td>"
         f"<td class=mono>{_esc(run['meta'].get('commit', ''))}</td>"
-        f"<td>{_esc(run['meta'].get('date', ''))}</td>"
+        f"<td>{_esc(format_instant(run['meta'].get('date', '')))}</td>"
         + "".join(f"<td>{_history_case_html(run['rows'][c])}</td>" for c, _k, _l, _b in CASES)
         + _history_gate_html(run)
         + "</tr>"
@@ -3883,7 +3924,7 @@ def build_summary_md(
         lines += [banner, ""]
     lines += [
         f"Run `{meta.get('run', '')}` \u00b7 commit `{meta.get('commit', '')}` \u00b7 "
-        f"{meta.get('date', '')}",
+        f"{format_instant(meta.get('date', ''))}",
         "",
         gate,
         "",
@@ -4011,7 +4052,7 @@ def main() -> int:
     ap.add_argument(
         "--current-run",
         default="",
-        help="the <YYYY-MM-DD>-<run_id> this job just staged. Only that run's area "
+        help="the run id this job just staged. Only that run's area "
         "is written from the live checkout and environment; without it the newest "
         "retained run is assumed, which is wrong when an older workflow is re-run "
         "after a newer same-day one (its lower run id sorts behind).",

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -831,8 +831,9 @@ def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
 # their ``<YYYY-MM-DD>-<run_id>`` names -- they are never renamed, so both shapes
 # are live in the retained window and in the data branch's history.
 _RUN_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{6})?-\d+$")
-# The instant embedded in a run id, if it carries one.
-_RUN_ID_STAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})T(\d{2})(\d{2})(\d{2})-")
+# Nothing here parses the instant back out of an id: the publisher records it in
+# ``meta.json`` and this renders that value (``format_instant``). Reading it off
+# the directory name too would be a second source for one fact.
 
 
 def _is_run_id(name: str) -> bool:
@@ -4118,8 +4119,9 @@ def main() -> int:
         runs = runs_from_history_root(args.history_root, baselines, keep=args.keep)
 
     # Which retained run this job actually produced. NOT simply the newest one:
-    # re-running an older workflow reuses its lower GITHUB_RUN_ID, so its
-    # <date>-<run_id> sorts *behind* a newer same-day run. Taking position 0 then
+    # re-running an older workflow reuses its lower GITHUB_RUN_ID and the run
+    # directory it already minted, so it sorts *behind* a newer same-day run
+    # (under either id shape -- see _RUN_ID_RE). Taking position 0 then
     # stamps the newer area with this job's container/bundle/recipe and publishes
     # this job's survey under the wrong run. Fall back to the newest run only when
     # the caller did not say (the results-dir / runs-root modes, and older callers).

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -2677,11 +2677,16 @@ def _status_banner_md(status: dict[str, Any] | None) -> str:
     run_id = str(status.get("run_id", "") or "")
     url = str(status.get("run_url", "") or "")
     conclusion = str(status.get("conclusion", "") or "unknown")
+    # Same instant as the HTML banner: both name when the failed nightly ran, so
+    # a reader of the job summary can tell a fresh failure from a stale one.
+    when = format_instant(status.get("date", ""))
     run_txt = f" run `{run_id}`" if run_id else ""
     link = f" [view failed run]({url})" if url else ""
+    when_txt = f" ({when})" if when else ""
     return (
         f"> \u26a0\ufe0f **Stale** \u2014 latest sanitizer nightly{run_txt} did not "
-        f"complete successfully ({conclusion}); the data below may be stale.{link}"
+        f"complete successfully ({conclusion}); the data below may be stale."
+        f"{link}{when_txt}"
     )
 
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -544,7 +544,7 @@ def _basename(path: str | None) -> str:
 # digits that no interpreter parses, which is a claim this gate should not make.
 _INSTANT_RE = re.compile(
     r"^[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}"
-    r"(:[0-9]{2}(\.[0-9]{3}|\.[0-9]{6})?)?([+-][0-9]{2}:[0-9]{2}|Z)?$"
+    r"(:[0-9]{2}(\.[0-9]{3}|\.[0-9]{6})?)?([+-][0-9]{2}:[0-9]{2}|Z)?\Z"
 )
 
 
@@ -854,8 +854,11 @@ def _run_meta_from_history(run_dir: Path) -> dict[str, Any]:
 # ASCII digits, not ``\d``: the nightly's prune filter and directory-reuse guard
 # spell the same shapes with ``[0-9]``, and this enumeration has to admit exactly
 # what they admit -- a name of Unicode decimal digits that only this side accepted
-# would be rendered on the page while the prune ignored it.
-_RUN_ID_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{6})?-[0-9]+$")
+# would be rendered on the page while the prune ignored it. `\Z` not `$` for the
+# same reason: `$` also matches before a trailing newline, and a directory name
+# may contain one, so `$` would accept a name the shell -- which reads `ls` output
+# a line at a time -- can only ever see as two records, and reject.
+_RUN_ID_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{6})?-[0-9]+\Z")
 # Nothing here parses the instant back out of an id: the publisher records it in
 # ``meta.json`` and this renders that value (``format_instant``). Reading it off
 # the directory name too would be a second source for one fact.
@@ -2669,12 +2672,14 @@ def _status_banner_html(status: dict[str, Any] | None) -> str:
     when = format_instant(status.get("date", ""))
     run_txt = f" run {_esc(run_id)}" if run_id else ""
     link = f' <a href="{_esc(url)}">view failed run</a>' if url else ""
+    # The instant belongs to the run, not to the link that follows the sentence.
     when_txt = f" ({_esc(when)})" if when else ""
     return (
         '<div class="stale">'
         "<span>&#9888;</span><span><strong>Stale.</strong> "
-        f"Latest sanitizer nightly{run_txt} did not complete successfully "
-        f"({_esc(conclusion)}) &mdash; the data below may be stale.{link}{when_txt}"
+        f"Latest sanitizer nightly{run_txt}{when_txt} did not complete "
+        f"successfully ({_esc(conclusion)}) &mdash; the data below may be "
+        f"stale.{link}"
         "</span></div>"
     )
 
@@ -2692,9 +2697,9 @@ def _status_banner_md(status: dict[str, Any] | None) -> str:
     link = f" [view failed run]({url})" if url else ""
     when_txt = f" ({when})" if when else ""
     return (
-        f"> \u26a0\ufe0f **Stale** \u2014 latest sanitizer nightly{run_txt} did not "
-        f"complete successfully ({conclusion}); the data below may be stale."
-        f"{link}{when_txt}"
+        f"> \u26a0\ufe0f **Stale** \u2014 latest sanitizer nightly{run_txt}{when_txt} "
+        f"did not complete successfully ({conclusion}); the data below may be "
+        f"stale.{link}"
     )
 
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -564,7 +564,10 @@ def format_instant(value: Any) -> str:
     from 3.11 ``fromisoformat("2026-08-23T0941")`` succeeds too. The output is
     committed to the data branch, so it must not depend on the interpreter.
     """
-    text = str(value or "").strip()
+    # Only an absent value is empty. `value or ""` would also swallow 0 and
+    # False, i.e. render a malformed manifest as a blank cell instead of showing
+    # what it holds -- which is the opposite of returning it unchanged.
+    text = "" if value is None else str(value).strip()
     if not _INSTANT_RE.match(text):
         return text
     try:

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -532,6 +532,19 @@ def _basename(path: str | None) -> str:
     return path.rsplit("/", 1)[-1] if path else ""
 
 
+# The one timestamp spelling this renders: an ISO date, a `T`/space separator and
+# a **colon-separated** clock, optionally seconds, 3/6-digit fractional seconds
+# and a `Z`/`+HH:MM` offset. Deliberately narrower than `datetime.fromisoformat`,
+# whose accepted set *widened in 3.11* (ISO 8601 basic format, so `T094112` and
+# `+0000` began parsing; 1-digit fractions too). Gating on this shape is what
+# keeps the rendering identical on every interpreter the repo supports -- what it
+# admits, 3.10 and 3.13 parse the same way; what it rejects is passed through
+# untouched on both. This is what the publishers emit.
+_INSTANT_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d{3}|\.\d{6})?)?([+-]\d{2}:\d{2}|Z)?$"
+)
+
+
 def format_instant(value: Any) -> str:
     """A recorded timestamp as something a reader can act on (pure).
 
@@ -539,20 +552,24 @@ def format_instant(value: Any) -> str:
     as ``YYYY-MM-DD HH:MM:SS UTC`` -- the zone spelled out, because a reader
     comparing a run against their own logs has to know which one it is in.
 
-    Anything that is not an instant is returned **unchanged**: a date-only value
-    from a run published before the id carried a time, or a malformed manifest.
-    Requiring a time separator before parsing is what makes that safe --
+    Anything that is not that shape (see ``_INSTANT_RE``) is returned
+    **unchanged**: a date-only value from a run published before the id carried a
+    time, the compact ``T094112`` a run id embeds, or a malformed manifest.
+    Requiring a real clock before parsing is what makes that safe --
     ``datetime.fromisoformat("2026-08-23")`` succeeds and would render a
-    confident ``00:00:00`` for a run that happened at nine in the morning.
+    confident ``00:00:00`` for a run that happened at nine in the morning, and
+    from 3.11 ``fromisoformat("2026-08-23T0941")`` succeeds too. The output is
+    committed to the data branch, so it must not depend on the interpreter.
     """
     text = str(value or "").strip()
-    if "T" not in text and " " not in text:
+    if not _INSTANT_RE.match(text):
         return text
     try:
         # `Z` is only accepted by fromisoformat from 3.11; the writers here emit
         # an explicit offset, but a hand-edited manifest may not.
         parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
     except ValueError:
+        # Shape-valid but not a real date (month 13, day 32).
         return text
     if parsed.tzinfo is None:
         # Naive means UTC by construction: every writer uses `date -u` or

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -757,6 +757,13 @@ def test_workflow_reuses_the_directory_a_rerun_already_minted(tmp_path):
     (runs / "2026-08-23T094112-4704").mkdir()
     assert _run_shell(script, tmp_path, env) == "2026-08-24T031500-32638584704"
 
+    # The old scheme could leave two directories for one run id -- a re-run that
+    # crossed midnight got a second date -- so reuse the newest of them rather
+    # than re-publishing into the older one and stranding the newer.
+    (runs / "2026-08-23-32638584704").mkdir()
+    (runs / "2026-08-24-32638584704").mkdir()
+    assert _run_shell(script, tmp_path, env) == "2026-08-24-32638584704"
+
 
 def test_workflow_and_generator_agree_on_the_embedded_instant():
     # The workflow derives meta.json's date from the resolved directory name so a
@@ -809,7 +816,7 @@ def test_published_pages_show_the_instant_but_env_json_keeps_it_machine_readable
     env = json.loads(
         (out / "runs" / run_id / "waitcheck" / "env.json").read_text(encoding="utf-8")
     )
-    assert env["date"] == "2026-08-23T09:41:12+00:00"
+    assert env.get("date") == "2026-08-23T09:41:12+00:00"
 
 
 def test_history_root_missing_report_has_no_report_rel(tmp_path):

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -652,7 +652,11 @@ def _run_shell(script: str, cwd: Path, env: dict[str, str]) -> str:
 def _dedent_block(workflow: str, start: str, end: str) -> str:
     """Lift a run-step fragment out of the workflow, YAML indentation removed."""
     lines = workflow.splitlines()
-    first = next(i for i, line in enumerate(lines) if line.strip().startswith(start))
+    starts = [i for i, line in enumerate(lines) if line.strip().startswith(start)]
+    # A marker matching twice would lift some other step's block, and that shell
+    # can still exit 0 -- the test would then pass without running the subject.
+    assert len(starts) == 1, f"{start!r} matches {len(starts)} lines, want 1"
+    first = starts[0]
     last = next(
         i for i, line in enumerate(lines[first:], first)
         if line.strip().startswith(end)
@@ -765,11 +769,57 @@ def test_workflow_reuses_the_directory_a_rerun_already_minted(tmp_path):
     assert _run_shell(script, tmp_path, env) == "2026-08-24-32638584704"
 
 
-def test_workflow_and_generator_agree_on_the_embedded_instant():
+def test_workflow_and_generator_agree_on_the_embedded_instant(tmp_path):
     # The workflow derives meta.json's date from the resolved directory name so a
-    # re-run cannot report a clock its own directory contradicts. It parses that
-    # name with the same pattern the generator uses; pin them together.
-    assert gen._RUN_ID_STAMP_RE.pattern in _publish_step()
+    # re-run cannot report a clock its own directory contradicts. Run the step's
+    # own metadata writer over both id shapes: asserting that its copy of
+    # _RUN_ID_STAMP_RE appears in the file would still pass if the block stopped
+    # consulting the directory name at all.
+    block = _dedent_block(
+        _publish_step(), 'if [ "${GPU_RESULT}" = "success" ]; then gate=true', "PY"
+    )
+    # That block runs `python`; the interpreter running these tests may only be
+    # on PATH under another name, so shim the name the workflow uses.
+    shim = tmp_path / "bin"
+    shim.mkdir()
+    (shim / "python").write_text(
+        f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding="utf-8"
+    )
+    (shim / "python").chmod(0o755)
+    started_iso = "2026-08-24T03:15:00+00:00"
+    env = {
+        "PATH": f"{shim}{os.pathsep}{os.environ['PATH']}",
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_REPOSITORY": "ROCm/aorta",
+        "GITHUB_RUN_ID": "32638584704",
+        "GITHUB_SHA": "f" * 40,
+        "GPU_RESULT": "success",
+        "started_iso": started_iso,
+    }
+
+    for run_id, expected in (
+        # A timestamped name reports the instant it carries, not this attempt's
+        # clock -- that is what makes a re-run's manifest match its directory.
+        ("2026-08-23T094112-32638584704", "2026-08-23T09:41:12+00:00"),
+        # A name from before the scheme carries no instant, so this publish
+        # supplies its own rather than inventing that date's midnight.
+        ("2026-08-23-32638584704", started_iso),
+    ):
+        dest = tmp_path / run_id
+        dest.mkdir()
+        _run_shell(block, tmp_path, {**env, "dest": str(dest), "run_dir_id": run_id})
+
+        meta = json.loads((dest / "meta.json").read_text(encoding="utf-8"))
+        assert meta["date"] == expected, run_id
+        assert meta["run"] == run_id
+        assert meta["gate"] is True  # mirrors GPU_RESULT=success
+        # The generator parses the same name with its own copy of the pattern, so
+        # the two have to read the same instant out of it.
+        stamp = gen._RUN_ID_STAMP_RE.match(run_id)
+        if stamp:
+            assert meta["date"] == "{}T{}:{}:{}+00:00".format(*stamp.groups())
+        # Either way the recorded value is one the renderer can render.
+        assert gen.format_instant(meta["date"]).endswith(" UTC")
 
 
 def test_format_instant_renders_a_time_and_never_invents_one():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -969,6 +969,11 @@ def test_format_instant_renders_a_time_and_never_invents_one():
     for junk in ("", None, "d", "not a date", "2026-08-23 morning",
                  "2026-13-23T09:41:12+00:00"):
         assert gen.format_instant(junk) == (junk or "")
+    # Only *absent* renders as empty. A falsy value from a malformed manifest is
+    # shown, not swallowed -- a blank cell reads as "no date recorded", which is
+    # a different fact and hides the one that needs fixing.
+    for falsy, shown in ((0, "0"), (False, "False")):
+        assert gen.format_instant(falsy) == shown
 
 
 def test_format_instant_renders_the_same_on_every_supported_interpreter():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -809,6 +809,10 @@ def test_every_implementation_of_the_run_id_shape_admits_the_same_names(tmp_path
         "2026-08-23T0941-32638584704": False,
         "2026-8-3T094112-32638584704": False,
         "\u0662\u0660\u0662\u0666-08-23-32638584704": False,  # Unicode digits
+        # A name may contain a newline, and Python's `$` matches before a
+        # trailing one -- the shell reads `ls` a line at a time and can only see
+        # this as two records, so `$` here would be a name only Python accepts.
+        "2026-08-23T094112-32638584704\n": False,
     }
     runs = tmp_path / "runs"
     reuse = _dedent_block(_publish_step(), 'run_dir_id=""', ': "${run_dir_id:=')

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -795,6 +795,48 @@ def test_workflow_reuses_the_directory_a_rerun_already_minted(tmp_path):
     assert _run_shell(script, tmp_path, env) == "2026-08-24-32638584704"
 
 
+def test_every_implementation_of_the_run_id_shape_admits_the_same_names(tmp_path):
+    # The shape is spelled three times -- _RUN_ID_RE, the prune filter and the
+    # reuse guard -- because a workflow cannot import a Python constant. Assert
+    # they agree on one table rather than eyeballing three regexes: a name only
+    # the generator accepts is rendered but never pruned, and a name only the
+    # reuse glob accepts is published where nothing ever looks.
+    names = {
+        "2026-08-23T094112-32638584704": True,
+        "2026-08-23-32638584704": True,       # published before the time existed
+        "2026-13-99-32638584704": True,       # the regex does not range-check
+        "source-32638584704": False,          # the glob's suffix match is not enough
+        "2026-08-23T0941-32638584704": False,
+        "2026-8-3T094112-32638584704": False,
+        "\u0662\u0660\u0662\u0666-08-23-32638584704": False,  # Unicode digits
+    }
+    runs = tmp_path / "runs"
+    reuse = _dedent_block(_publish_step(), 'run_dir_id=""', ': "${run_dir_id:=')
+    env = {"runs_dir": str(runs), "GITHUB_RUN_ID": "32638584704",
+           "started_id": "2026-08-24T031500"}
+
+    for name, want in names.items():
+        assert gen._is_run_id(name) is want, name
+        # The reuse guard: only a name the generator would enumerate may be
+        # published into; anything else has to be passed over for a fresh one.
+        shutil.rmtree(runs, ignore_errors=True)
+        runs.mkdir()
+        (runs / name).mkdir()
+        resolved = _run_shell(f'{reuse}\nprintf "%s" "$run_dir_id"', tmp_path, env)
+        assert resolved == (name if want else "2026-08-24T031500-32638584704"), name
+
+    # The prune filter, over the whole table at once -- what it keeps is exactly
+    # what the generator enumerates, so neither spends a keep slot the other does
+    # not. (Ordering is asserted separately, over ids that differ.)
+    shutil.rmtree(runs, ignore_errors=True)
+    runs.mkdir()
+    for name in names:
+        (runs / name).mkdir()
+    pipeline = _dedent_block(_publish_step(), "ls -1", "| tr ").rstrip().rstrip("\\")
+    kept = _run_shell(pipeline, tmp_path, {"runs_dir": str(runs)}).splitlines()
+    assert sorted(kept) == sorted(n for n, want in names.items() if want)
+
+
 def test_workflow_and_generator_agree_on_the_embedded_instant(tmp_path):
     # The workflow derives meta.json's date from the resolved directory name so a
     # re-run cannot report a clock its own directory contradicts. Run the step's

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import gzip
 import importlib.util
 import json
+import os
 import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -625,6 +628,188 @@ def test_history_root_ignores_malformed_run_dirs(tmp_path):
     runs = gen.runs_from_history_root(root, _baselines())
 
     assert [r["meta"]["run"] for r in runs] == ["2026-08-05-33"]
+
+
+# --- Timestamped run ids (#392) ------------------------------------------------
+
+
+def _publish_step() -> str:
+    """The nightly's publish step, so tests can exercise its shell directly."""
+    return (_REPO_ROOT / ".github/workflows/sanitizers-nightly.yml").read_text(
+        encoding="utf-8"
+    )
+
+
+def _run_shell(script: str, cwd: Path, env: dict[str, str]) -> str:
+    proc = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", script],
+        cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def _dedent_block(workflow: str, start: str, end: str) -> str:
+    """Lift a run-step fragment out of the workflow, YAML indentation removed."""
+    lines = workflow.splitlines()
+    first = next(i for i, line in enumerate(lines) if line.strip().startswith(start))
+    last = next(
+        i for i, line in enumerate(lines[first:], first)
+        if line.strip().startswith(end)
+    )
+    block = lines[first : last + 1]
+    pad = min(len(line) - len(line.lstrip()) for line in block if line.strip())
+    return "\n".join(line[pad:] for line in block)
+
+
+def test_run_id_accepts_both_shapes_and_still_rejects_junk():
+    # Runs published before the time was added keep their date-only names -- they
+    # are never renamed, so both shapes are live in the retained window.
+    for name in ("2026-08-23T094112-32638584704", "2026-08-23-32638584704",
+                 "2026-08-23-9", "2026-08-23T000000-1"):
+        assert gen._is_run_id(name), name
+    for name in ("source", "not-a-run", "2026-08-23", "2026-08-23T0941-7",
+                 "2026-08-23T094112", "2026-08-23T094112-", "2026-8-3T094112-7"):
+        assert not gen._is_run_id(name), name
+
+
+def test_history_order_is_correct_across_a_mixed_shape_history(tmp_path):
+    # The two shapes have to sort against each other without special-casing: a
+    # bare date is a prefix of any timestamped id for the same day, so it reads
+    # as the earlier one, and the variable-width run id still breaks ties.
+    root = tmp_path / "runs"
+    ids = [
+        "2026-08-23-32638584704",          # pre-change, same day
+        "2026-08-23T094112-32638584705",
+        "2026-08-24T031500-32700000001",
+        "2026-08-23T094112-9",
+        "2026-08-23T094112-10",
+    ]
+    for run_id in ids:
+        _write_history_run(root, run_id)
+
+    ordered = [r["meta"]["run"] for r in gen.runs_from_history_root(root, _baselines())]
+    assert ordered == [
+        "2026-08-24T031500-32700000001",
+        "2026-08-23T094112-32638584705",
+        "2026-08-23T094112-10",
+        "2026-08-23T094112-9",
+        "2026-08-23-32638584704",
+    ]
+    # --keep counts from the newest end of that same order.
+    kept = gen.runs_from_history_root(root, _baselines(), keep=2)
+    assert [r["meta"]["run"] for r in kept] == ordered[:2]
+
+
+def test_workflow_prune_order_matches_the_generator_exactly(tmp_path):
+    # The shell prunes and the generator renders from the same directory list, so
+    # a disagreement deletes a directory the page still lists. Run the workflow's
+    # own pipeline rather than a paraphrase of it.
+    lines = _publish_step().splitlines()
+    start = next(i for i, line in enumerate(lines) if 'ls -1 "$runs_dir"' in line)
+    end = next(i for i, line in enumerate(lines[start:], start) if "| tr " in line)
+    pipeline = " ".join(line.strip().rstrip("\\").strip() for line in lines[start : end + 1])
+
+    ids = [
+        "2026-08-23-32638584704",        # pre-change shape, same day
+        "2026-08-23T094112-32638584705",
+        "2026-08-24T031500-32700000001",
+        "2026-08-23T094112-9",           # variable-width run ids on one instant
+        "2026-08-23T094112-10",
+        "2026-08-22T235959-1",
+    ]
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    for run_id in ids:
+        (runs / run_id).mkdir()
+
+    shell = _run_shell(pipeline, tmp_path, {"runs_dir": str(runs)}).splitlines()
+    assert shell == sorted(ids, key=gen._history_sort_key, reverse=True)
+
+
+def test_workflow_reuses_the_directory_a_rerun_already_minted(tmp_path):
+    # A re-run reuses GITHUB_RUN_ID, so it must land on the directory its first
+    # attempt minted. A fresh timestamp would give one workflow run two
+    # directories: two --keep slots, two history rows, and the earlier attempt's
+    # reports left in place -- which is what the step's `rm -rf` exists to stop.
+    block = _dedent_block(_publish_step(), 'run_dir_id=""', ': "${run_dir_id:=')
+    script = f'{block}\nprintf "%s" "$run_dir_id"'
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    env = {"runs_dir": str(runs), "GITHUB_RUN_ID": "32638584704",
+           "started_id": "2026-08-24T031500"}
+
+    # Nothing published yet: mint a name from this attempt's clock.
+    assert _run_shell(script, tmp_path, env) == "2026-08-24T031500-32638584704"
+
+    # A re-run of a timestamped run reuses that name, not the current time.
+    (runs / "2026-08-23T094112-32638584704").mkdir()
+    assert _run_shell(script, tmp_path, env) == "2026-08-23T094112-32638584704"
+
+    # ...and a re-run of a run published before the scheme keeps its old name,
+    # so no directory is ever renamed underneath a published URL.
+    shutil.rmtree(runs / "2026-08-23T094112-32638584704")
+    (runs / "2026-08-23-32638584704").mkdir()
+    assert _run_shell(script, tmp_path, env) == "2026-08-23-32638584704"
+
+    # A different run id is not mistaken for this one, including a suffix match.
+    shutil.rmtree(runs / "2026-08-23-32638584704")
+    (runs / "2026-08-23T094112-4704").mkdir()
+    assert _run_shell(script, tmp_path, env) == "2026-08-24T031500-32638584704"
+
+
+def test_workflow_and_generator_agree_on_the_embedded_instant():
+    # The workflow derives meta.json's date from the resolved directory name so a
+    # re-run cannot report a clock its own directory contradicts. It parses that
+    # name with the same pattern the generator uses; pin them together.
+    assert gen._RUN_ID_STAMP_RE.pattern in _publish_step()
+
+
+def test_format_instant_renders_a_time_and_never_invents_one():
+    assert gen.format_instant("2026-08-23T09:41:12+00:00") == "2026-08-23 09:41:12 UTC"
+    # An explicit Z, which fromisoformat only accepts from 3.11.
+    assert gen.format_instant("2026-08-23T09:41:12Z") == "2026-08-23 09:41:12 UTC"
+    # Naive means UTC by construction: every writer uses `date -u` or utcnow.
+    assert gen.format_instant("2026-08-23T09:41:12") == "2026-08-23 09:41:12 UTC"
+    # A non-UTC offset is normalised rather than shown in the writer's zone.
+    assert gen.format_instant("2026-08-23T11:41:12+02:00") == "2026-08-23 09:41:12 UTC"
+
+    # A date-only value comes from a run published before the id carried a time.
+    # fromisoformat() would accept it and render a confident 00:00:00, so the
+    # value is returned untouched instead of inventing a midnight.
+    assert gen.format_instant("2026-08-23") == "2026-08-23"
+    # Malformed or absent values pass through: the run identity around them is
+    # still worth rendering.
+    for junk in ("", None, "d", "not a date", "2026-08-23T0941"):
+        assert gen.format_instant(junk) == (junk or "")
+
+
+def test_published_pages_show_the_instant_but_env_json_keeps_it_machine_readable(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "runs"
+    run_id = "2026-08-23T094112-32638584705"
+    _write_history_run(root, run_id, meta={"date": "2026-08-23T09:41:12+00:00"})
+    monkeypatch.setattr(sys, "argv", [
+        "gen_sanitizer_dashboard", "--history-root", str(root),
+        "--baselines",
+        str(_REPO_ROOT / "recipes/sanitizers/fixtures/expected/verdict_baselines.json"),
+        "--out-dir", str(tmp_path / "dashboard"),
+    ])
+    assert gen.main() == 0
+    out = tmp_path / "dashboard"
+
+    human = "2026-08-23 09:41:12 UTC"
+    for page in (out / "index.html", out / "runs" / run_id / "waitcheck" / "index.html"):
+        assert human in page.read_text(encoding="utf-8"), page
+    assert human in (out / "summary.md").read_text(encoding="utf-8")
+
+    # The manifest a consumer of aorta.sanitizer_run_area/0.1 reads keeps the
+    # ISO instant: the human rendering is a display concern, not a stored one.
+    env = json.loads(
+        (out / "runs" / run_id / "waitcheck" / "env.json").read_text(encoding="utf-8")
+    )
+    assert env["date"] == "2026-08-23T09:41:12+00:00"
 
 
 def test_history_root_missing_report_has_no_report_rel(tmp_path):

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -772,9 +772,9 @@ def test_workflow_reuses_the_directory_a_rerun_already_minted(tmp_path):
 def test_workflow_and_generator_agree_on_the_embedded_instant(tmp_path):
     # The workflow derives meta.json's date from the resolved directory name so a
     # re-run cannot report a clock its own directory contradicts. Run the step's
-    # own metadata writer over both id shapes: asserting that its copy of
-    # _RUN_ID_STAMP_RE appears in the file would still pass if the block stopped
-    # consulting the directory name at all.
+    # own metadata writer over both id shapes and render what it wrote: asserting
+    # that its parsing pattern appears in the file would still pass if the block
+    # stopped consulting the directory name at all.
     block = _dedent_block(
         _publish_step(), 'if [ "${GPU_RESULT}" = "success" ]; then gate=true', "PY"
     )
@@ -797,29 +797,30 @@ def test_workflow_and_generator_agree_on_the_embedded_instant(tmp_path):
         "started_iso": started_iso,
     }
 
-    for run_id, expected in (
+    for run_id, expected, rendered in (
         # A timestamped name reports the instant it carries, not this attempt's
         # clock -- that is what makes a re-run's manifest match its directory.
-        ("2026-08-23T094112-32638584704", "2026-08-23T09:41:12+00:00"),
+        (
+            "2026-08-23T094112-32638584704",
+            "2026-08-23T09:41:12+00:00",
+            "2026-08-23 09:41:12 UTC",
+        ),
         # A name from before the scheme carries no instant, so this publish
         # supplies its own rather than inventing that date's midnight.
-        ("2026-08-23-32638584704", started_iso),
+        ("2026-08-23-32638584704", started_iso, "2026-08-24 03:15:00 UTC"),
     ):
         dest = tmp_path / run_id
         dest.mkdir()
         _run_shell(block, tmp_path, {**env, "dest": str(dest), "run_dir_id": run_id})
 
         meta = json.loads((dest / "meta.json").read_text(encoding="utf-8"))
-        assert meta["date"] == expected, run_id
-        assert meta["run"] == run_id
-        assert meta["gate"] is True  # mirrors GPU_RESULT=success
-        # The generator parses the same name with its own copy of the pattern, so
-        # the two have to read the same instant out of it.
-        stamp = gen._RUN_ID_STAMP_RE.match(run_id)
-        if stamp:
-            assert meta["date"] == "{}T{}:{}:{}+00:00".format(*stamp.groups())
-        # Either way the recorded value is one the renderer can render.
-        assert gen.format_instant(meta["date"]).endswith(" UTC")
+        assert meta.get("date") == expected, run_id
+        assert meta.get("run") == run_id
+        assert meta.get("gate") is True  # mirrors GPU_RESULT=success
+        # What the generator will put on the page for that manifest -- for the
+        # timestamped name, the 094112 its own directory carries. Agreement is
+        # asserted through the renderer rather than by pinning a shared pattern.
+        assert gen.format_instant(meta.get("date")) == rendered, run_id
 
 
 def test_format_instant_renders_a_time_and_never_invents_one():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -832,14 +832,42 @@ def test_format_instant_renders_a_time_and_never_invents_one():
     # A non-UTC offset is normalised rather than shown in the writer's zone.
     assert gen.format_instant("2026-08-23T11:41:12+02:00") == "2026-08-23 09:41:12 UTC"
 
+    # Sub-second precision from a hand-written manifest still renders, truncated.
+    assert (
+        gen.format_instant("2026-08-23T09:41:12.500000+00:00")
+        == "2026-08-23 09:41:12 UTC"
+    )
+
     # A date-only value comes from a run published before the id carried a time.
     # fromisoformat() would accept it and render a confident 00:00:00, so the
     # value is returned untouched instead of inventing a midnight.
     assert gen.format_instant("2026-08-23") == "2026-08-23"
     # Malformed or absent values pass through: the run identity around them is
-    # still worth rendering.
-    for junk in ("", None, "d", "not a date", "2026-08-23T0941"):
+    # still worth rendering. A shape-valid impossible date lands here too.
+    for junk in ("", None, "d", "not a date", "2026-08-23 morning",
+                 "2026-13-23T09:41:12+00:00"):
         assert gen.format_instant(junk) == (junk or "")
+
+
+def test_format_instant_renders_the_same_on_every_supported_interpreter():
+    # datetime.fromisoformat's accepted set widened in 3.11 (ISO 8601 basic
+    # format, and 1-2 digit fractional seconds), and the repo's CI matrix spans
+    # 3.10-3.12. Left to fromisoformat these shapes render a time on 3.11+ and
+    # pass through on 3.10 -- for output that is committed to the data branch,
+    # which is a byte-diff that depends on which runner published. format_instant
+    # gates on an explicit shape so every interpreter passes them through.
+    for widened in (
+        "2026-08-23T0941",  # basic format, minutes
+        "2026-08-23T094112",  # basic format -- the form a run id embeds
+        "2026-08-23T09:41:12+0000",  # offset without its colon
+        "2026-08-23T09:41:12.1",  # a fraction 3.10 rejects
+    ):
+        assert gen.format_instant(widened) == widened
+
+    # The run id carries that compact stamp, and its own directory name must not
+    # be mistaken for a rendered instant anywhere it is displayed.
+    run_id = "2026-08-23T094112-32638584704"
+    assert gen.format_instant(run_id) == run_id
 
 
 def test_published_pages_show_the_instant_but_env_json_keeps_it_machine_readable(

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -823,6 +823,49 @@ def test_workflow_and_generator_agree_on_the_embedded_instant(tmp_path):
         assert gen.format_instant(meta.get("date")) == rendered, run_id
 
 
+def test_workflow_commit_message_names_the_area_and_the_publish(tmp_path):
+    # A date-only subject gave two same-day runs the same commit title on the data
+    # branch, and a subject named only by run_dir_id would give a re-run the same
+    # title as the attempt it replaces (the name is reused). Naming both makes
+    # every publish distinct and self-consistent with the directory it wrote.
+    # Run the step's own tail -- that also proves both variables are in scope
+    # inside the subshell and the message survives as one -m argument.
+    block = _dedent_block(_publish_step(), "# Mirror the rendered dashboard", "fi )")
+
+    remote = tmp_path / "remote.git"
+    work = tmp_path / "checkout"
+    (work / "dashboard").mkdir(parents=True)
+    (work / "dashboard" / "summary.md").write_text("# summary\n", encoding="utf-8")
+    # symbolic-ref / checkout -b rather than `git init -b`, which needs git 2.28.
+    _run_shell(
+        f'git init -q --bare "{remote}"'
+        f' && git -C "{remote}" symbolic-ref HEAD refs/heads/sanitizer-results'
+        f' && git init -q "{work}" && git -C "{work}" checkout -q -b sanitizer-results'
+        f' && git -C "{work}" remote add origin "{remote}"',
+        tmp_path,
+        {},
+    )
+    env = {
+        "tmp": str(work),
+        "run_dir_id": "2026-08-23T094112-32638584704",
+        "started_iso": "2026-08-24T03:15:00+00:00",
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "step_summary.md"),
+    }
+    _run_shell(block, tmp_path, env)
+
+    # The subject the reader of `git log` on sanitizer-results sees, and it is on
+    # the branch the step pushes to -- read back from the remote, not the clone.
+    subject = _run_shell(f'git -C "{remote}" log -1 --format=%s sanitizer-results',
+                         tmp_path, {})
+    assert subject == (
+        "sanitizer dashboard 2026-08-23T094112-32638584704 "
+        "(published 2026-08-24T03:15:00+00:00)"
+    )
+    # A re-run reuses run_dir_id, so only the publish instant moves it -- that is
+    # what keeps the two commits distinguishable.
+    assert env["run_dir_id"] in subject and env["started_iso"] in subject
+
+
 def test_format_instant_renders_a_time_and_never_invents_one():
     assert gen.format_instant("2026-08-23T09:41:12+00:00") == "2026-08-23 09:41:12 UTC"
     # An explicit Z, which fromisoformat only accepts from 3.11.

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -431,9 +431,14 @@ def test_build_html_no_banner_when_healthy():
 
 def test_build_summary_md_stale_banner():
     status = {"healthy": False, "conclusion": "failure", "run_id": "9",
-              "run_url": "https://x/9", "date": "d"}
+              "run_url": "https://x/9", "date": "2026-08-23T09:41:12+00:00"}
     md = gen.build_summary_md([], status=status)
     assert "Stale" in md and "https://x/9" in md
+    # Both banners name when the failed nightly ran, and render it identically:
+    # a job-summary reader has to be able to tell a fresh failure from a stale
+    # one without opening the page.
+    assert "2026-08-23 09:41:12 UTC" in md
+    assert "2026-08-23 09:41:12 UTC" in gen._status_banner_html(status)
 
 
 def test_main_empty_runs_root_publishes_placeholder(tmp_path, monkeypatch):
@@ -709,10 +714,12 @@ def test_workflow_prune_order_matches_the_generator_exactly(tmp_path):
     # The shell prunes and the generator renders from the same directory list, so
     # a disagreement deletes a directory the page still lists. Run the workflow's
     # own pipeline rather than a paraphrase of it.
-    lines = _publish_step().splitlines()
-    start = next(i for i, line in enumerate(lines) if 'ls -1 "$runs_dir"' in line)
-    end = next(i for i, line in enumerate(lines[start:], start) if "| tr " in line)
-    pipeline = " ".join(line.strip().rstrip("\\").strip() for line in lines[start : end + 1])
+    # Anchored on `ls`, not on its flags, so a change to those fails on the
+    # behaviour below rather than on finding nothing; _dedent_block still asserts
+    # the marker is unique, so it cannot silently lift some other step's shell.
+    # Cut before `tail`, so this asserts what the prune sees and not what it
+    # deletes; that leaves the continuation joining the two, which has to go.
+    pipeline = _dedent_block(_publish_step(), "ls -1", "| tr ").rstrip().rstrip("\\")
 
     ids = [
         "2026-08-23-32638584704",        # pre-change shape, same day
@@ -721,13 +728,32 @@ def test_workflow_prune_order_matches_the_generator_exactly(tmp_path):
         "2026-08-23T094112-9",           # variable-width run ids on one instant
         "2026-08-23T094112-10",
         "2026-08-22T235959-1",
+        "2026-13-99-1",                  # the generator's regex admits this; mirror it
     ]
+    # The generator enumerates well-formed ids only, so anything else here must
+    # not reach the prune either: it would spend a keep slot the page does not,
+    # pushing the oldest run the page still lists past the tail -- deleting it.
+    strays = ["source", "assets", "2026-08-23T0941-7", "2026-08-23"]
     runs = tmp_path / "runs"
     runs.mkdir()
-    for run_id in ids:
+    for run_id in ids + strays:
         (runs / run_id).mkdir()
+    # The enumeration takes directories only, so a *file* is skipped however it
+    # is named -- both halves of `p.is_dir() and _is_run_id(p.name)` have to
+    # mirror or the shell spends a slot on something the page never shows.
+    (runs / "index.html").write_text("", encoding="utf-8")
+    (runs / "2026-08-25T031500-2").write_text("", encoding="utf-8")
 
     shell = _run_shell(pipeline, tmp_path, {"runs_dir": str(runs)}).splitlines()
+    # Same filter and same order as the enumeration, asserted through the
+    # generator's own predicate and key rather than a copy of either.
+    assert shell == [
+        p.name for p in sorted(
+            (p for p in runs.iterdir() if p.is_dir() and gen._is_run_id(p.name)),
+            key=lambda p: gen._history_sort_key(p.name),
+            reverse=True,
+        )
+    ]
     assert shell == sorted(ids, key=gen._history_sort_key, reverse=True)
 
 
@@ -805,9 +831,16 @@ def test_workflow_and_generator_agree_on_the_embedded_instant(tmp_path):
             "2026-08-23T09:41:12+00:00",
             "2026-08-23 09:41:12 UTC",
         ),
-        # A name from before the scheme carries no instant, so this publish
-        # supplies its own rather than inventing that date's midnight.
-        ("2026-08-23-32638584704", started_iso, "2026-08-24 03:15:00 UTC"),
+        # A name from before the scheme carries no time, but it does carry its
+        # day, and re-publishing into one must keep that day: `rm -rf` cleared a
+        # manifest that already held it, so taking this attempt's clock instead
+        # would render an August instant for a July directory. Pinned as the
+        # rendering too, because what must not move is what the page shows.
+        ("2026-08-23-32638584704", "2026-08-23", "2026-08-23"),
+        # Only a name of neither shape has no day to keep; then the publish clock
+        # is all there is. Not reachable from the naming scheme -- the fallback
+        # exists so an unexpected name still gets a manifest.
+        ("nightly-32638584704", started_iso, "2026-08-24 03:15:00 UTC"),
     ):
         dest = tmp_path / run_id
         dest.mkdir()


### PR DESCRIPTION
Closes #392.

## Problem

Nothing in the published tree said what *time* a nightly ran. The run directory was date-only (`2026-08-23-32638584704`) and the Case card's `DATE` fact was date-only too, so same-day runs — a manual dispatch, or a re-run — could not be ordered from either.

## What this does

- Run directories become **`<YYYY-MM-DD>T<HHMMSS>-<run_id>`** in UTC.
- `meta.json` records a full **ISO-8601 instant**, taken from the directory name so the two cannot disagree, and every display site renders it as `2026-08-23 09:41:12 UTC` — the run card, the history table, the Case card, `REPRODUCE.md`, the job summary and the stale banner. A run published before the name carried a time keeps its **date-only** manifest, even when re-published.
- `env.json` keeps the ISO value. The human form is a display concern, not a stored one.
- The data-branch commit subject becomes `sanitizer dashboard <run_dir_id> (published <ISO instant>)`, so two same-day runs no longer share a title.

Both, deliberately: the run id is an identifier (compact, sortable, filesystem- and URL-safe), the `DATE` fact is prose for a reader.

## Points a reviewer will want flagged

**A re-run must not mint a second directory.** `run_dir_id` was previously stable across attempts because it came from the date alone. A re-run reuses `GITHUB_RUN_ID` (only `GITHUB_RUN_ATTEMPT` changes), so with a fresh timestamp one workflow run would get *two* directories: two of the `keep` slots, two history rows, and the earlier attempt's reports left in place — exactly what the step's `rm -rf "$dest"` exists to prevent. The name is now resolved by globbing for an existing `*-$GITHUB_RUN_ID` first, so a re-run lands on the directory its first attempt minted, old date-only names included. **No directory is ever renamed under a published URL.**

**The pruner and the renderer must agree — and the obvious separator choice broke that.** I originally chose `T` on the grounds that `sort -t- -k1,1nr … -k4,4nr` keeps the run id in field 4 and needs no change, and verified it on a sample. That was wrong on a wider sample. The timestamp lives *inside* field 3 (`23T094112`), where `-n` reads only the day, so the shell ordered same-day runs by run id alone and diverged from `_history_sort_key` whenever a run id was not monotonic with the clock:

```
shell:  … 2026-08-23T094112-32638584705, 2026-08-23-32638584704, 2026-08-23T094112-10
python: … 2026-08-23T094112-32638584705, 2026-08-23T094112-10,   2026-08-23-32638584704
```

A disagreement here deletes a directory the page still lists. The pipeline now mirrors `_history_sort_key` exactly — split the trailing run id onto its own field, sort the head lexically under `LC_ALL=C` and the id numerically, rejoin — and a test runs **the workflow's own pipeline** and asserts the result equals the Python ordering over a mixed-shape history with variable-width ids.

Real `GITHUB_RUN_ID`s are monotonic, so this divergence was unlikely to bite in production. It is fixed rather than documented because the repo already carries a rule about keeping these two in step (#354), and "unlikely" is not a property the prune step should depend on.

**A date-only value must not become a fabricated midnight.** `datetime.fromisoformat("2026-08-23")` *succeeds*, so a naive formatter would render a confident `00:00:00` for a run that happened at nine in the morning. `format_instant` gates the parse on an explicit shape -- an ISO date, a `T`/space, and a **colon-separated** clock (`_INSTANT_RE`) -- and returns anything else untouched — which is the common case, since ~30 already-published runs keep date-only manifests and are re-rendered nightly.

**The old scheme could already leave two directories for one run id** — a re-run that crossed midnight got a second date. The reuse glob therefore takes the *newest* match rather than the first, so re-publishing cannot land in the older directory and strand the newer one. Covered by a test.

**`_RUN_ID_RE` accepts both shapes** and still rejects junk (`source`, `2026-08-23`, `2026-08-23T0941-7`). `_history_sort_key` needed **no change**: the head is a zero-padded date optionally followed by `T<HHMMSS>`, and a bare date is a prefix of any timestamped id for the same day, so it compares as that day's earliest — which is what it is.

**Doc sweep.** The id shape appears in the module docstring, the `--current-run` help and `docs/ci-nightly-eval.md`; all updated, plus a note that `meta.json`'s `date` is now an instant and that pre-existing runs keep date-only manifests.

**Addressed in review (Copilot, `d08a971`).** Two valid findings, both about a claim outrunning the code. The workflow/generator agreement test only asserted that the id-parsing pattern's *text* appeared in the workflow, so it would still have passed if the step stopped deriving `meta.json`'s `date` from the reused directory at all; it now lifts the step's **own** metadata writer and asserts the JSON it produces for both id shapes (checked by deleting the derivation locally -- the old assertion passed, the new one fails). And the run-id comment still carried the original, wrong claim that the `T` left the prune sort unchanged, directly above the corrected explanation; it now describes the split/sort/rejoin scheme. Two knock-ons: `_dedent_block` now requires a unique start marker -- the first marker I used lifted the earlier `status.json` writer, which still exits 0, so the test passed without touching its subject -- and `_RUN_ID_STAMP_RE` is deleted, since with the text pin gone it had no consumer in the generator, which renders `meta.json`'s `date` through `format_instant` and never parses an id.

**One interpreter, one rendering (`be83851`, after a red CI).** `pytest (CPU, py3.11/py3.12)` failed while py3.10 passed: `datetime.fromisoformat` gained ISO 8601 **basic-format** support in 3.11, so `2026-08-23T0941` — chosen as a junk fixture *because* 3.10 rejects it — parses there and rendered as `09:41:00`. Three more shapes cross the same line, including the compact `T094112` a run id embeds, an offset without its colon, and a 1-digit fraction. The wrong expectation was the symptom; the defect is that one input rendered differently per interpreter, and that text is **committed to the `sanitizer-results` branch** — and the publish job has no `setup-python`, so it runs whatever `ubuntu-latest` ships, not necessarily the minor CI tests on. The parse is now gated on `_INSTANT_RE` before `fromisoformat` sees the value: what it admits, 3.10 and 3.13 parse identically; what it rejects passes through untouched on both. All prior contracts are unchanged, and a new test pins the four widened shapes as pass-through so the difference is asserted rather than incidental.

**The commit subject needs both identifiers, not one.** `sanitizer dashboard ${date} (run ${GITHUB_RUN_ID})` gave two same-day runs the same title on `sanitizer-results`. Swapping in the run directory alone would fix that but re-create it for a re-run — `run_dir_id` is reused from the first attempt, so the re-run's commit would be titled identically to the attempt it replaces. Swapping in this publish's clock alone would contradict the instant embedded in the directory being published. They answer different questions, and a re-run moves only the second, so the subject names both: reading `git log`, equal instants mean a first attempt and different ones a re-run. `run_dir_id` already ends in `GITHUB_RUN_ID`, so `(run …)` is dropped rather than printing the run id twice, and `${date}` — whose last consumer this was — is deleted with it. A test executes the step's own tail against a real repo with a bare remote and asserts the subject **on the pushed branch**, which also pins that both variables are in scope inside the `( cd "$tmp" … )` subshell.

**Addressed in review (human, `be83851`) — re-publishing a pre-timestamp run overwrote its correct date.** The blocking finding, and it was right. For a directory from before the naming change the `meta.json` writer fell through to *this* attempt's clock, so re-publishing `2026-07-14-<id>` rendered an August instant for a July run — contradicting the invariant this PR opens with, and `docs/ci-nightly-eval.md`, which promises those runs keep their date-only manifests. Destructive rather than imprecise: `rm -rf "$dest"` had already cleared a `meta.json` that held the correct date. The comment's justification ("rather than inventing a midnight") did not apply — `format_instant` returns a date-only value **unchanged** by design, so keeping `2026-07-14` invents nothing. The time group is now optional: a name with a time reports that instant, a name without one keeps its day, and only a name of neither shape falls back to the publish clock. The existing test's second case became `("2026-08-23-32638584704", "2026-08-23", "2026-08-23")`, which also pins that an old run's rendering does not move.

**The prune counted what the page does not (Copilot, `e8ace6a`).** Same class as the ordering bug above, on the other axis: the generator enumerates children that are **directories whose name is a well-formed run id**, while the shell counted every `ls` entry. A stray child — a leftover `source/` from a nested `--history-root` layout — would spend one of the 30 keep slots the page does not spend, pushing the oldest run the page still lists past `tail` and deleting it. `ls -1p` plus a pattern requiring the trailing slash mirrors **both** halves of `p.is_dir() and _is_run_id(p.name)`, deliberately no stricter than that regex, and the test now asserts the shell's output against the generator's own predicate and key over a directory seeded with strays — including a run-id-shaped *file*, which is the half I would otherwise have left un-mirrored. Not reachable today; the invariant this PR is built on is that the two enumerations agree, and "not reachable" is not agreement.

**The run-id shape is spelled three times, and the three did not agree (Copilot, `8113ad9`).** Fixing the prune's enumeration exposed the other two. The reuse glob matched *any* directory ending in this `GITHUB_RUN_ID`, so a stray `source-<run_id>` would be cleared, republished into, and then ignored by both the prune and the page — the night's results invisible on the dashboard and never rotating out. It also completes the ordering argument beside it: such a name sorts after a date in byte order, so it would have won. And `_RUN_ID_RE` used `\d`, which admits Unicode decimal digits that the shell's ASCII filter rejects — a run rendered on the page that nothing ever prunes.

The digit classes are worth a note, because both intuitions were wrong. GNU `sed` treats `[0-9]` as the ASCII range, so the prune filter was already correct; **bash** matches Unicode digits with `[[ =~ [0-9] ]]` under a UTF-8 locale, because a bracket range is collation-based — so the first version of the reuse guard accepted exactly the name the other finding was about. Python now uses `[0-9]`, both shell sides use `[[:digit:]]`, and a test drives one table of names (both valid shapes, `source-<id>`, a short time, an unpadded date, a Unicode-digit name) through **all three** implementations and asserts they classify every name identically, so the copies cannot drift apart again silently.

Two smaller items from the earlier round: the Markdown stale banner now names when the failed nightly ran, like its HTML twin (a job-summary reader could not tell a fresh failure from a stale one); and the reuse loop's comment no longer asserts a byte-ordering guarantee that only the prune sort pins — the review is right that glob expansion sorts under `LC_COLLATE`. The comment now says what is actually true, which is narrower: the only two names that can collide there are two date-only days for one run id, and they differ in a date digit, which every collation orders alike. The prune needs `LC_ALL=C` because it compares `-` against `T` across run ids; this does not.

**Three more from the same class, and one unrelated (Copilot, `4b1fc83`; two flagged as optional in the approving review).** `_RUN_ID_RE` and `_INSTANT_RE` were anchored with `$`, which in Python also matches before a *trailing newline* — and a directory name may contain one, so `_is_run_id` accepted a name the prune can only ever see as two records of `ls` output and reject. Both use `\Z` now, and that name is in the cross-implementation table beside the Unicode-digit one. The stale banner puts the instant with the run it describes rather than after the link that ends the sentence, in **both** renderers: the odd ordering was in the HTML twin too, so moving only the Markdown would have traded a wording nit for a divergence between the twins the parity test exists to prevent. And `format_instant` blanked falsy non-`None` values (`0`, `False`) while documenting that a non-instant value is returned unchanged — a blank cell reads as "no date recorded", which is a different fact from "this manifest holds something that is not a date" and hides the one worth fixing; only an absent value is empty now.

The unpinned publish-job Python is filed as #401 rather than fixed here, at the reviewer's request. It is hardening, not a live bug — `_INSTANT_RE` gates the parse, so 3.9-3.13 render identically — but nothing stops the next version-sensitive call from reintroducing the class.

## Interaction with #393

Checked rather than assumed, since textual mergeability is not the same as no interaction:

- Trial merge of #393 into this branch is clean.
- The **union test suite passes: 157 tests**, on py3.9, py3.11 and py3.13 (re-checked after each review round).
- Rendered the merged result: the 29-character `RUN` and the `2026-08-23 09:41:12 UTC` `DATE` both sit on one line in #393's new content-sized fact row. That is why #393 derives fact widths from content rather than a per-field table — this PR lengthens `RUN` from 22 to 29 characters and `DATE` from 10 to 23, and needs no follow-up there.

Neither branch has a test pinning a file the other changes: #393's touch the stylesheet and the case-page render, this one's touch `_RUN_ID_RE`, `format_instant` and the workflow pipeline. The two workflow-reading tests that already exist (`_ROCM_LLVM_PATH_EXPORT`, the `hipcc` build flags) read lines neither PR modifies.

## Test plan

- [x] `pytest tests/sanitizers/test_dashboard.py` — 145 pass (10 new; one drives the run-id shape through all three of its implementations), on **py3.9, py3.11 and py3.13**
- [x] 166 pass across `tests/sanitizers/` on py3.11 (excluding the one module that needs the installed package)
- [x] `ruff check` clean on both changed Python files
- [x] Workflow parses as YAML; publish step extracted and `bash -n` clean
- [x] The workflow's **own** prune pipeline, directory-reuse block, `meta.json` writer and commit/push tail are executed by tests, not paraphrased
- [x] End-to-end publish over a mixed-shape history: timestamped runs render the instant, the legacy date-only run passes through unchanged, `env.json` keeps ISO
- [x] Trial merge + 157-test union suite with #393, on all three interpreters
- [x] Every fix in the review rounds mutation-checked: break the one line, watch the named test fail, restore
- [x] Self-review loop + Bugbot: 3 findings before review, 4 in the first review round, 1 after the red CI, 4 in the human/Copilot round and 6 across the three rounds after it (one of which I had missed until auditing every thread), all fixed
- [ ] **Not yet run in real CI.** The first nightly after merge is the real test: the reuse glob against the live data branch, and the first re-run is what actually exercises the one-directory-per-run property.

Made with [Cursor](https://cursor.com)





