### PR TITLE
fix(sanitizers): one guarded reader for artifacts_not_published (#393 follow-up)

### DIFF
--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -83,7 +83,7 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
 
    **Run areas (#384).** A case directory is not just its report -- it carries
    the recipe as it ran, the logs the verdict came from, the source-level inputs,
-   and for the artifacts it deliberately does not publish a rebuild command
+   and -- for the artifacts it deliberately does not publish -- a rebuild command
    wherever the module's tables know one (see below), so the copy-paste command
    the dashboard shows is actionable:
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1757,15 +1757,20 @@ def _is_rebuild_entry(item: Any) -> bool:
     """Whether a stored ``rebuild`` entry is safe for both renderings (pure).
 
     Key presence alone is not enough. ``commands`` is the one field the
-    renderings do more than stringify -- they iterate it -- so its *type* is
-    part of the contract: an int raises ``TypeError`` mid-render, and a string
-    silently degrades into one command per character. Every other field only
-    ever reaches ``_esc(str(...))`` or an f-string, which accept anything.
+    renderings do more than stringify -- they iterate it and publish each
+    element as a line a reader is invited to paste -- so both its type and its
+    elements are part of the contract. An int raises ``TypeError`` mid-render, a
+    string silently degrades into one command per character, and a non-string
+    element renders its ``repr`` as a command line (``[{"a": 1}]`` publishes
+    ``{'a': 1}``): no crash, but a fabricated command in the one block on the
+    page that promises to be runnable. Every other field only ever reaches
+    ``_esc(str(...))`` or an f-string, which accept anything.
     """
     return (
         isinstance(item, dict)
         and _REBUILD_KEYS <= item.keys()
         and isinstance(item["commands"], list)
+        and all(isinstance(command, str) for command in item["commands"])
     )
 
 
@@ -2027,6 +2032,43 @@ def _rebuild_section_html(plan: list[dict[str, Any]]) -> str:
     )
 
 
+def _not_published_rows(env: dict[str, Any]) -> list[tuple[str, str]]:
+    """The excluded inputs as ``(path, sha256)`` pairs (pure).
+
+    One reader for the three places that describe this field -- the Files
+    caption, the table it links to, and REPRODUCE.md -- so the count in the
+    prose cannot disagree with the rows beneath it. Missing values come back as
+    ``""`` and each renderer supplies its own dash.
+
+    Tolerant of a malformed entry for the same reason ``plan_from_env`` is: this
+    is read off the data branch, and indexing it directly turned one hand-edited
+    or half-written ``env.json`` into a ``KeyError``/``TypeError`` that failed
+    the whole dashboard render rather than one area's table.
+    ``refresh_published_case_area`` already filters the same field this way to
+    derive ``built_refs``, then passed the unfiltered list to both renderers.
+
+    Nothing is dropped, though, which is the one place this differs from
+    ``plan_from_env``: there a rejected plan is recomputed, so nothing is lost,
+    whereas an entry skipped here would stop the caption disclosing an input
+    that genuinely is being held back -- the overstatement this section exists
+    to correct. An unreadable entry is counted and shown as a dash instead.
+
+    A bare string is read as the path, which is how the field gets hand-edited.
+    Anything else becomes a dash rather than its ``repr``: a cell reading
+    ``['a', 'b']`` would be inventing a path the manifest never recorded, and
+    the dash already says "this entry could not be read".
+    """
+    stored = env.get("artifacts_not_published")
+    if not isinstance(stored, list):
+        return []
+    return [
+        (str(item.get("path") or ""), str(item.get("sha256") or ""))
+        if isinstance(item, dict)
+        else (item if isinstance(item, str) else "", "")
+        for item in stored
+    ]
+
+
 def _files_caption(env: dict[str, Any], files: list[tuple[str, int]]) -> str:
     """The Files table's caption, as HTML (pure).
 
@@ -2054,14 +2096,14 @@ def _files_caption(env: dict[str, Any], files: list[tuple[str, int]]) -> str:
         base = "Every file published for this case. Logs are gzipped."
     else:
         base = "Every file published for this case."
-    missing = env.get("artifacts_not_published") or []
+    missing = _not_published_rows(env)
     if not missing:
         return _esc(base)
     count = len(missing)
     noun = "input" if count == 1 else "inputs"
     verb = "is" if count == 1 else "are"
     listing = f'<a href="#{_NOT_PUBLISHED_ID}">artifacts not published</a>'
-    has_digests = all(isinstance(item, dict) and item.get("sha256") for item in missing)
+    has_digests = all(sha for _path, sha in missing)
     where = (
         f"listed under {listing} with {'its SHA-256' if count == 1 else 'their SHA-256s'}"
         if has_digests
@@ -2236,7 +2278,8 @@ def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
         "```",
         "",
     ]
-    if env.get("artifacts_not_published"):
+    not_published = _not_published_rows(env)
+    if not_published:
         lines += [
             "## Artifacts not published",
             "",
@@ -2246,8 +2289,8 @@ def build_reproduce_md(env: dict[str, Any], *, built_refs: list[str]) -> str:
             "| Path | SHA-256 |",
             "|---|---|",
         ]
-        for item in env["artifacts_not_published"]:
-            lines.append(f"| `{item['path']}` | `{item.get('sha256') or _DASH}` |")
+        for path, sha in not_published:
+            lines.append(f"| `{path or _DASH}` | `{sha or _DASH}` |")
         lines.append("")
     if env.get("digests"):
         lines += ["## Recorded digests", "", "| Key | Value |", "|---|---|"]
@@ -2325,13 +2368,13 @@ def build_case_index_html(
         else ""
     )
     steps_html = _rebuild_section_html(plan_from_env(env, built_refs))
-    not_published = env.get("artifacts_not_published") or []
+    not_published = _not_published_rows(env)
     np_html = ""
     if not_published:
         np_rows = "".join(
-            f'<tr><td class=mono>{_esc(str(item["path"]))}</td>'
-            f'<td class="mono wrap-any">{_esc(str(item.get("sha256") or "")) or "&mdash;"}</td></tr>'
-            for item in not_published
+            f"<tr><td class=mono>{_esc(path) or '&mdash;'}</td>"
+            f'<td class="mono wrap-any">{_esc(sha) or "&mdash;"}</td></tr>'
+            for path, sha in not_published
         )
         np_html = (
             f'<p class="cap" id="{_NOT_PUBLISHED_ID}">Artifacts not published</p>'

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -2035,17 +2035,19 @@ def _rebuild_section_html(plan: list[dict[str, Any]]) -> str:
 def _not_published_rows(env: dict[str, Any]) -> list[tuple[str, str]]:
     """The excluded inputs as ``(path, sha256)`` pairs (pure).
 
-    One reader for the three places that describe this field -- the Files
-    caption, the table it links to, and REPRODUCE.md -- so the count in the
-    prose cannot disagree with the rows beneath it. Missing values come back as
-    ``""`` and each renderer supplies its own dash.
+    The *only* reader of this field: the Files caption that counts it, the table
+    it links to, REPRODUCE.md, and the ``built_refs`` that
+    ``refresh_published_case_area`` derives from it. So the count in the prose
+    cannot disagree with the rows beneath it. Missing values come back as ``""``
+    and each renderer supplies its own dash.
 
     Tolerant of a malformed entry for the same reason ``plan_from_env`` is: this
     is read off the data branch, and indexing it directly turned one hand-edited
     or half-written ``env.json`` into a ``KeyError``/``TypeError`` that failed
-    the whole dashboard render rather than one area's table.
-    ``refresh_published_case_area`` already filters the same field this way to
-    derive ``built_refs``, then passed the unfiltered list to both renderers.
+    the whole dashboard render rather than one area's table. Being the only
+    reader is what makes that true -- while ``refresh_published_case_area``
+    iterated the field itself, a non-list value still aborted the render before
+    either renderer was reached, however careful the renderers were.
 
     Nothing is dropped, though, which is the one place this differs from
     ``plan_from_env``: there a rejected plan is recomputed, so nothing is lost,
@@ -2054,17 +2056,22 @@ def _not_published_rows(env: dict[str, Any]) -> list[tuple[str, str]]:
     to correct. An unreadable entry is counted and shown as a dash instead.
 
     A bare string is read as the path, which is how the field gets hand-edited.
-    Anything else becomes a dash rather than its ``repr``: a cell reading
+    Anything else -- including a *value* of the wrong type inside an otherwise
+    well-formed entry -- becomes a dash rather than its ``repr``: a cell reading
     ``['a', 'b']`` would be inventing a path the manifest never recorded, and
     the dash already says "this entry could not be read".
     """
+
+    def cell(value: Any) -> str:
+        return value if isinstance(value, str) else ""
+
     stored = env.get("artifacts_not_published")
     if not isinstance(stored, list):
         return []
     return [
-        (str(item.get("path") or ""), str(item.get("sha256") or ""))
+        (cell(item.get("path")), cell(item.get("sha256")))
         if isinstance(item, dict)
-        else (item if isinstance(item, str) else "", "")
+        else (cell(item), "")
         for item in stored
     ]
 
@@ -2556,11 +2563,10 @@ def refresh_published_case_area(case_dir: Path, out_dir: Path, *, logs: bool) ->
     # Only re-staging from the source sweep can restore them, which goes through
     # write_case_run_area rather than here.
     env["logs_published"] = bool(env.get("logs_published", True)) and logs
-    built_refs = [
-        str(item["path"])
-        for item in env.get("artifacts_not_published") or []
-        if isinstance(item, dict) and item.get("path")
-    ]
+    # Through the same reader as the two renderings, so this path cannot be the
+    # one that still trips over the field: iterating it directly here meant a
+    # non-list value raised ``TypeError`` before either renderer was reached.
+    built_refs = [path for path, _sha in _not_published_rows(env) if path]
     up, run_up = case_dir_up(case_dir, out_dir)
     (case_dir / "env.json").write_text(
         json.dumps(env, indent=2, sort_keys=True) + "\n", encoding="utf-8"

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2604,6 +2604,19 @@ def test_stored_rebuild_plan_is_only_trusted_when_both_renderers_can_read_it():
         assert gen._rebuild_hints(recovered)
         assert gen._rebuild_section_html(recovered)
 
+    # A list of the right type but the wrong elements does not crash -- it
+    # publishes the element's repr as a command line, in the one block on the
+    # page that promises to be runnable. Fabricating a command is worse than
+    # falling back to the module's own tables, so the elements are checked too.
+    for bad_elements in ([{"a": 1}], [123], [None], ["ok", 7]):
+        entry = [{**full[0], "commands": bad_elements}]
+        recovered = gen.plan_from_env({"rebuild": entry, "target": "gfx950"}, refs)
+        assert recovered == full, bad_elements
+        rendered = gen._rebuild_section_html(recovered) + " ".join(
+            gen._rebuild_hints(recovered)
+        )
+        assert "{'a': 1}" not in rendered and "None" not in rendered
+
     # An empty command list is legitimate (an unrecognised reference), so it is
     # trusted rather than recomputed.
     empty = [{**full[0], "commands": []}]
@@ -2693,6 +2706,83 @@ def test_files_caption_claims_only_what_the_listing_actually_carries():
     # anchor, because the anchored table does not carry one.
     for case in (undigested, mixed):
         assert "rebuild" not in gen._files_caption(case, files).lower()
+
+
+def _np_body_rows(page: str) -> int:
+    """Body rows of the "Artifacts not published" table, header excluded."""
+    anchor = f'id="{gen._NOT_PUBLISHED_ID}"'
+    assert anchor in page, "the page has no artifacts-not-published section"
+    start = page.index(anchor)
+    return page[start : page.index("</table>", start)].count("<tr><td")
+
+
+def _np_md_rows(md: str) -> int:
+    """Rows of REPRODUCE.md's "Artifacts not published" table."""
+    assert "## Artifacts not published" in md, "REPRODUCE.md has no such section"
+    section = md[md.index("## Artifacts not published") :].split("\n\n")[2]
+    return len([line for line in section.splitlines() if line.startswith("| `")])
+
+
+def test_every_reading_of_artifacts_not_published_agrees_and_survives_a_bad_entry():
+    # The caption counts this field, agrees its noun and verb with the count and
+    # links to it; the page renders it as a table; REPRODUCE.md renders it again.
+    # All three read it off the data branch, and two of them used to index
+    # `item["path"]` directly -- so one hand-edited env.json raised KeyError (a
+    # dict with no path) or TypeError (a bare string) and failed the whole
+    # dashboard render, while `refresh_published_case_area` was already filtering
+    # the same field to derive built_refs. One reader now serves all three, so
+    # the count in the prose cannot disagree with the rows beneath it.
+    env = {"case": "c", "observed": {}, "logs_published": True}
+    files = [("sanitizer_report.json", 12)]
+
+    good = [{"path": "fixtures/isa/x.hsaco", "sha256": "ab"}]
+    for stored in (
+        good,
+        [{"sha256": "ab"}],              # dict with no path
+        ["fixtures/isa/x.hsaco"],        # bare string, as hand-edited
+        [None],
+        good + [{"sha256": "cd"}],       # one good, one unreadable
+    ):
+        case = {**env, "artifacts_not_published": stored}
+        page = gen.build_case_index_html(case, files, built_refs=[], up="../../")
+        md = gen.build_reproduce_md(case, built_refs=[])
+
+        # The count in the caption is the number of rows in the table it links
+        # to, and the same number of rows reaches REPRODUCE.md.
+        assert _np_body_rows(page) == len(stored), stored
+        assert _np_md_rows(md) == len(stored), stored
+
+        # Nothing is dropped: an unreadable entry is still disclosed, because
+        # silently omitting it restores the overstatement this section fixes.
+        caption = gen._files_caption(case, files)
+        assert f"{len(stored)} required input" in caption, stored
+        assert "It is not the whole recipe" in caption, stored
+
+    # The digest claim still tracks the digest column and nothing else. An entry
+    # that lost its path but kept its sha256 does render a SHA-256, so the claim
+    # holds; one with no digest withdraws it, whether or not it is readable.
+    assert "SHA-256" in gen._files_caption(
+        {**env, "artifacts_not_published": good}, files
+    )
+    assert "SHA-256" in gen._files_caption(
+        {**env, "artifacts_not_published": good + [{"sha256": "cd"}]}, files
+    )
+    for undigested in ([{"path": "y"}], ["fixtures/isa/y.hsaco"], [None]):
+        assert "SHA-256" not in gen._files_caption(
+            {**env, "artifacts_not_published": good + undigested}, files
+        ), undigested
+
+    # A field that is not a list at all yields no section, not a row per char.
+    for junk in ("fixtures/isa/x.hsaco", {"path": "x"}, 7):
+        case = {**env, "artifacts_not_published": junk}
+        assert gen._not_published_rows(case) == []
+        assert f'id="{gen._NOT_PUBLISHED_ID}"' not in gen.build_case_index_html(
+            case, files, built_refs=[], up="../../"
+        )
+        assert "Artifacts not published" not in gen.build_reproduce_md(
+            case, built_refs=[]
+        )
+        assert gen._files_caption(case, files) == "Every file published for this case."
 
 
 def test_genco_rebuild_cleans_up_its_temporary_object():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2784,6 +2784,41 @@ def test_every_reading_of_artifacts_not_published_agrees_and_survives_a_bad_entr
         )
         assert gen._files_caption(case, files) == "Every file published for this case."
 
+    # A wrongly-typed value inside a well-formed entry is a dash too, not its
+    # repr: `{"path": ["a", "b"]}` publishing `['a', 'b']` would invent a path
+    # the manifest never recorded, which is the fault this reader exists to stop.
+    assert gen._not_published_rows(
+        {"artifacts_not_published": [{"path": ["a", "b"], "sha256": 7}]}
+    ) == [("", "")]
+    page = gen.build_case_index_html(
+        {**env, "artifacts_not_published": [{"path": ["a", "b"]}]},
+        files,
+        built_refs=[],
+        up="../../",
+    )
+    assert "['a', 'b']" not in page and _np_body_rows(page) == 1
+
+
+def test_a_malformed_artifact_list_does_not_abort_a_retained_area_refresh(tmp_path):
+    # The renderers being careful is not enough on its own: the nightly re-renders
+    # every retained area through refresh_published_case_area, which derived
+    # built_refs from this same field. While it iterated the field itself, a
+    # non-list value raised TypeError there -- before either renderer was
+    # reached -- so one hand-edited env.json still aborted the whole render.
+    area = tmp_path / "dashboard" / "runs" / "r" / "survey" / "c"
+    area.mkdir(parents=True)
+    (area / "sanitizer_report.json").write_text("{}")
+
+    for junk in (7, "fixtures/isa/x.hsaco", {"path": "x"}, [None], [{"sha256": "ab"}]):
+        (area / "env.json").write_text(
+            json.dumps({"case": "c", "observed": {}, "artifacts_not_published": junk})
+        )
+        assert (
+            gen.refresh_published_case_area(area, tmp_path / "dashboard", logs=True)
+            is True
+        ), junk
+        assert "['a', 'b']" not in (area / "index.html").read_text()
+
 
 def test_genco_rebuild_cleans_up_its_temporary_object():
     # The command runs in the reader's repo root, so without the trailing rm it


### PR DESCRIPTION
Follow-up to #393, which merged (905b1f9) before @vivekkhandelwal1's two
non-blocking approval-review items were addressed. Both reproduce on `main`.

## 1. `artifacts_not_published` was the load-bearing field still unguarded

Every retained run area is re-rendered nightly from the `env.json` it persisted
on the data branch. `rebuild` is defended on that read path (`_is_rebuild_entry`
+ recomputation), but its sibling field was read directly by every consumer, so
one hand-edited or half-written manifest failed the **whole** dashboard render
rather than one area's table:

```
artifacts_not_published = [{'sha256': 'ab'}]       -> KeyError: 'path'
artifacts_not_published = ['fixtures/isa/x.hsaco'] -> TypeError: string indices must be integers
artifacts_not_published = 7                        -> TypeError: 'int' object is not iterable
```

The reviewer's point was that #393 made this field carry noticeably more weight:
`_files_caption` now counts it, agrees its noun and verb with the count, and
links to it — and guards the entries where the table it points at did not.

`_not_published_rows` is now the **only** reader of the field, shared by all four
consumers: the Files caption, the page's table, REPRODUCE.md, and the
`built_refs` that `refresh_published_case_area` derives from it. The count in the
prose therefore cannot disagree with the rows beneath it by construction.

That last consumer matters more than it looks, and I had it wrong in the first
revision of this PR — thanks to Copilot for catching it. While
`refresh_published_case_area` iterated the field itself, careful renderers bought
nothing: the non-list case raised before either renderer was reached, so the
abort-the-nightly failure was still reachable on the path the nightly actually
takes. The regression test drives the malformed shapes through
`refresh_published_case_area`, not through the renderers alone.

**Nothing is dropped**, which is the one place this deliberately differs from
`plan_from_env`. There a rejected plan is recomputed, so nothing is lost. Here an
`isinstance(item, dict)` filter would silently omit an entry, and if it were the
only one the caption would revert to a bare "Every file published for this
case." — restoring the exact overstatement #393 existed to correct. So an
unreadable entry is counted and rendered as a dash. Only a real `str` is
published, for entries *and* for the values inside them, since a cell reading
`['a', 'b']` would invent a path the manifest never recorded.

## 2. `_is_rebuild_entry` pinned `commands` to a list but not its elements

`commands: [{"a": 1}]` passed the guard and published `{'a': 1}` as a command
line. No crash — but a fabricated command in the one block on the page that
promises to be runnable, so falling back to the module's own tables is the better
answer. All elements must now be `str`. `rebuild_plan` only ever emits strings,
so no valid historical plan starts falling back.

## 3. Docs

Fixed the garden-path sentence at `ci-nightly-eval.md:86` — "...does not publish
a rebuild command wherever the module's tables know one" reads as "does not
publish a rebuild command" until "wherever". Introduced by my own round-2 edit
on #393.

## Deliberately not in scope

The same class affects `required_env`, `digests` and `observed` on the same read
path, and `digests` has the same page-vs-REPRODUCE.md asymmetry. Filed as #398
rather than folded in here, since none of them are touched by #393.

## Verification

- 148 tests pass on **py3.9 and py3.11** (146 -> 148), ruff clean, Bugbot clean.
- **No output change on well-formed data**: rendering the fixture nightly from
  this branch and from merged `main` gives byte-identical trees — all 18
  published-data files (`env.json`, `REPRODUCE.md`, `meta.json`, `data.json`,
  `summary.md`) and all 10 HTML pages. This is pure hardening.
- Tests assert, for a well-formed manifest and for five malformed shapes, that
  the caption's count equals the HTML row count equals the REPRODUCE.md row
  count, that an unreadable entry is still disclosed, that no cell publishes a
  `repr`, and that `refresh_published_case_area` completes rather than raising.
  The last was verified to fail with `TypeError: 'int' object is not iterable`
  before the fix, rather than assumed to be covered.