### PR TITLE
Choose the ROCm 7.14 Tensile bundle by the predicates it is named for

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -212,7 +212,7 @@ jobs:
             echo "[$(date +%T)] fixture build: hipcc consan_lds_race_2wave (racy two-wave LDS repro) …"
             hipcc --offload-arch=gfx950 -O1 -g "${FIXTURES}/repro/consan_lds_race_2wave.hip" \
               -o "${FIXTURES}/bin/consan_lds_race_2wave"
-            echo "[$(date +%T)] fixture build: extracting real per-transpose f32 GEMM code objects for the top-3 shapes (~16MB each; distinct SHA per transpose layout) …"
+            echo "[$(date +%T)] fixture build: extracting real per-transpose f32 GEMM code objects for the top-3 shapes (hundreds of MB each; distinct SHA per transpose layout) …"
             python scripts/sanitizers/prepare_gemm_isa.py \
               --csv "${FIXTURES}/gemm_shapes_unique.csv" --out "${FIXTURES}/isa" --top-n 3
 

--- a/docs/ci-nightly-eval.md
+++ b/docs/ci-nightly-eval.md
@@ -99,8 +99,8 @@ Triggered by `workflow_run` on **"Nightly wheels"** success (+ `workflow_dispatc
    | `REPRODUCE.md` | Commit, command, required env, fixture rebuild steps, and the digests of the artifacts that are not published. |
    | `env.json` | The same provenance, machine-readable (`aorta.sanitizer_run_area/0.1`), including `required_env` (each variable, who sets it, and why -- ConSan's four are listed only for a case that ran ConSan) and `rebuild` (the per-artifact commands, runnable from the repo root). `REPRODUCE.md` and the landing page are rendered *from* those two stored fields, so the prose cannot disagree with them and a retained area keeps describing what it actually recorded. |
 
-   CI-built artifacts are deliberately **not** published: a GEMM `.hsaco` is
-   ~16MB, and shipping one per retained run would bloat the data branch and
+   CI-built artifacts are deliberately **not** published: a GEMM `.hsaco` runs to
+   hundreds of MB, and shipping one per retained run would bloat the data branch and
    Pages. `index.html` / `REPRODUCE.md` / `env.json` instead record each one's
    path, the SHA-256 the report carries for it (the waitcheck binary digest, the
    ConSan repro command and hook digests, every kernel's `code_object_sha256`)

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1267,8 +1267,8 @@ def survey_cases_from_informational_dir(
 # ---------------------------------------------------------------------------
 
 # Fixture paths under these prefixes are CI-built (see
-# recipes/sanitizers/fixtures/.gitignore): a ~16MB Tensile code object or a
-# compiled repro binary. They are never copied into a run area -- publishing
+# recipes/sanitizers/fixtures/.gitignore): a Tensile code object of hundreds of
+# MB, or a compiled repro binary. They are never copied into a run area -- publishing
 # them for every retained run would bloat the data branch and Pages -- so their
 # SHA-256 is recorded instead and a local rebuild can be verified against it.
 _BUILT_FIXTURE_DIRS = ("fixtures/bin/", "fixtures/isa/")

--- a/scripts/sanitizers/prepare_gemm_isa.py
+++ b/scripts/sanitizers/prepare_gemm_isa.py
@@ -94,8 +94,9 @@ GATE_CU_COUNT = 256
 # so resolving by filename tracks the loader rather than guessing.
 #
 # Grammar note: both tokens are optional (ROCm <= 7.2.4 shipped neither), the
-# order is fixed, and the ids are lowercase hex. Anything else is not parsed --
-# see _variants_for on why that is a skip rather than a permissive read.
+# order is fixed, and the ids are lowercase hex. Anything else does not parse,
+# which is fatal rather than skipped -- see _library_for. Extending this regex is
+# the intended response to a release that adds a token.
 _VARIANT_RE = re.compile(r"^(?:_CU(?P<cu>[0-9]+))?(?:_ID(?P<ids>[0-9a-f]+(?:-[0-9a-f]+)*))?$")
 
 # tensilelite's ChipIdRegistry, mirrored as data. A gfx950 device may use a
@@ -247,9 +248,9 @@ def _variants_for(layout: str) -> _Bundles:
 
     Names whose token block does not parse are returned separately rather than
     dropped. Reading one as unconstrained would make it eligible for every device
-    -- the silent wrong answer this selector exists to avoid -- but discarding it
-    without trace is how a new release's added token would quietly widen the
-    choice to a broader bundle, so callers report them.
+    -- the silent wrong answer this selector exists to avoid -- while discarding
+    it without trace is how a new release's added token would quietly widen the
+    choice to a broader bundle. ``_library_for`` treats any of them as fatal.
     """
     prefix = _SS_HEAVY_STEM.format(layout=layout)
     suffix = f"_{GFX}.co"
@@ -302,29 +303,30 @@ def _select_variant(variants: list[_Variant], chip_id: int, cu_count: int) -> _V
 
 def _library_for(layout: str, chip_id: int = GATE_CHIP_ID, cu_count: int = GATE_CU_COUNT) -> Path:
     variants, unparsed = _variants_for(layout)
+    if unparsed:
+        # Fatal even when other bundles parsed. Selecting among candidates only
+        # means anything if every candidate's predicates are known: an
+        # unrecognised token block could be the loader's exact choice for this
+        # device, in which case resolution silently settles on a broader bundle.
+        # Warning and continuing was not enough -- this artifact's digest gets
+        # recorded and blessed into sanitizer baselines, so a plausible-but-wrong
+        # object outlives the log line that mentioned it. Failing here costs a
+        # loud nightly failure at the moment someone is already bumping ROCm,
+        # which is the cheapest time to extend the grammar.
+        names = ", ".join(sorted(path.name for path in unparsed))
+        shipped = len(variants) + len(unparsed)
+        detail = (
+            f"none of {shipped} with a recognised device-token block"
+            if not variants
+            else f"{len(unparsed)} of {shipped} with an unrecognised device-token block"
+        )
+        raise SystemExit(
+            f"no usable {GFX} f32 SS Tensile bundle for layout {layout}: {detail}, "
+            f"so the loader's choice cannot be established: {names}"
+        )
     if not variants:
-        # Distinguish "hipBLASLt shipped nothing" from "it shipped bundles whose
-        # names I did not understand" -- the latter is the expected failure mode of
-        # a release that adds a token, and sends the reader somewhere very different.
-        if unparsed:
-            names = ", ".join(sorted(path.name for path in unparsed))
-            raise SystemExit(
-                f"no usable {GFX} f32 SS Tensile bundle for layout {layout}: "
-                f"{len(unparsed)} shipped, none with a recognised device-token "
-                f"block: {names}"
-            )
         tried = " or ".join(str(d / _SS_HEAVY.format(layout=layout)) for d in _library_dirs())
         raise SystemExit(f"no {GFX} f32 SS Tensile bundle for layout {layout}: {tried}")
-    if unparsed:
-        # Usable bundles exist, so this is not fatal -- but the skipped name may
-        # have been the more specific one, in which case the choice below is
-        # broader than the loader's. Say so rather than widening silently.
-        for path in unparsed:
-            print(
-                f"warning: ignoring {path.name}: unrecognised device-token block; "
-                f"selection for layout {layout} may be broader than hipBLASLt's",
-                file=sys.stderr,
-            )
     selected = _select_variant(variants, chip_id, cu_count)
     if selected is None:
         offered = ", ".join(sorted(variant.path.name for variant in variants))

--- a/scripts/sanitizers/prepare_gemm_isa.py
+++ b/scripts/sanitizers/prepare_gemm_isa.py
@@ -103,7 +103,16 @@ _VARIANT_RE = re.compile(r"^(?:_CU(?P<cu>[0-9]+))?(?:_ID(?P<ids>[0-9a-f]+(?:-[0-
 # ChipIdRegistry::canUseSolution -- so a bundle naming only 0x75a0 still serves an
 # MI355X. Ignoring this made the selector fail closed on five real chip ids that
 # hipBLASLt serves from the 0x75a0 bundles.
-#     include/Tensile/AMDGPUPredicates.hpp, namespace ChipIdRegistry
+#
+# Transcribed from ChipIdRegistry::chipIdFallbacks in
+# rocm-libraries/projects/hipblaslt/tensilelite/include/Tensile/AMDGPUPredicates.hpp
+# (develop, read 2026-08-25, matching the hipBLASLt 1.4.1 docs). Unlike the row
+# table in tests/sanitizers/fixtures, this mirror cannot be pinned to an image:
+# no ROCm image ships the header, so there is nothing on disk to diff against.
+# Its drift story is therefore the error path rather than a test -- a chip id
+# added upstream is one this table lacks, which fails closed naming the device and
+# pointing here (see _library_for). Safe direction, and diagnosable, but it will
+# not announce itself until someone runs on the new part.
 _CHIP_ID_FALLBACKS: dict[int, tuple[int, ...]] = {
     0x75B0: (0x75A0,),
     0x75A2: (0x75A0,),
@@ -113,6 +122,9 @@ _CHIP_ID_FALLBACKS: dict[int, tuple[int, ...]] = {
     0x75A8: (0x75A0,),
     0x75B8: (0x75A0,),
 }
+# Every entry above targets this id, and it has no entry of its own -- so it is a
+# registered chip despite being absent from the table's keys.
+_CHIP_ID_FALLBACK_ROOT = 0x75A0
 
 # How a bundle's predicates admit a device, in the loader's own terms.
 _EXACT = "exact"
@@ -130,7 +142,6 @@ class _Variant(NamedTuple):
     path: Path
     cu_count: int | None
     chip_ids: frozenset[int]
-    dir_rank: int
 
     def admits(self, chip_id: int, cu_count: int) -> str | None:
         """How this bundle admits the device: ``_EXACT``, ``_FALLBACK`` or None.
@@ -149,14 +160,15 @@ class _Variant(NamedTuple):
         return None
 
     @property
-    def row_order(self) -> tuple[int, int, int, int, str]:
+    def row_order(self) -> tuple[int, int, int, str]:
         """Sort key reproducing tensilelite's build-time hardware-row comparator.
 
         Documented order: rows with chip ids before rows without; then smaller
         chip-id sets ("exactness first"); then, when chip precedence does not
         decide, the higher CU count first. Rows with no CU constraint sort behind
-        the constrained ones. ``dir_rank`` and the trailing name make the order
-        total, so it never depends on the order a directory enumerates in.
+        the constrained ones. The trailing name makes the order total -- names are
+        unique within the one directory these all come from -- so it never depends
+        on the order that directory enumerates in.
 
         The documented rule between the set-size and CU steps -- ranking equal-size
         sets by fallback topology -- is deliberately not modelled: it can only
@@ -168,7 +180,6 @@ class _Variant(NamedTuple):
             0 if self.chip_ids else 1,
             len(self.chip_ids),
             -self.cu_count if self.cu_count is not None else 1,
-            self.dir_rank,
             self.path.name,
         )
 
@@ -204,7 +215,9 @@ def _library_dirs() -> list[Path]:
     """Directories that may hold the Tensile bundles, in precedence order.
 
     The classic layout is flat; ROCm 7.14 and the TheRock wheel layout nest the
-    bundles one level deeper under the gfx target (library/gfx950/...).
+    bundles one level deeper under the gfx target (library/gfx950/...). An install
+    is one shape or the other, never a blend -- see ``_variants_for``, which takes
+    the first of these that holds anything and never resolves across both.
     """
     return [HIPBLASLT_LIBRARY, HIPBLASLT_LIBRARY / GFX]
 
@@ -217,7 +230,20 @@ class _Bundles(NamedTuple):
 
 
 def _variants_for(layout: str) -> _Bundles:
-    """Every shipped bundle for this layout, with its parsed device predicates.
+    """The bundles for this layout, from a single tree, with their predicates.
+
+    Resolution stops at the first directory holding anything for this layout,
+    because the two directories are alternative *layouts* rather than one
+    catalogue split in half. Merging them would let an incidental or stale
+    ``gfx950/`` tree outrank the flat install it sits beside, and silently: a
+    tokenised nested bundle is more specific than an untokenised flat one, and
+    specificity is settled before directory order is ever consulted. Neither
+    real-image check could have caught it -- the classic base has no nested tree
+    and the wheel image has nothing at the flat level.
+
+    "Anything" deliberately includes names that do not parse. A stale tree of
+    unrecognised names is precisely the case where falling through to the other
+    layout would look like success, so it fails loudly instead.
 
     Names whose token block does not parse are returned separately rather than
     dropped. Reading one as unconstrained would make it eligible for every device
@@ -227,11 +253,11 @@ def _variants_for(layout: str) -> _Bundles:
     """
     prefix = _SS_HEAVY_STEM.format(layout=layout)
     suffix = f"_{GFX}.co"
-    found: list[_Variant] = []
-    unparsed: list[Path] = []
-    for rank, directory in enumerate(_library_dirs()):
+    for directory in _library_dirs():
         if not directory.is_dir():
             continue
+        found: list[_Variant] = []
+        unparsed: list[Path] = []
         for path in sorted(directory.glob(f"{prefix}*{suffix}")):
             match = _VARIANT_RE.match(path.name[len(prefix) : -len(suffix)])
             if match is None:
@@ -245,10 +271,11 @@ def _variants_for(layout: str) -> _Bundles:
                     chip_ids=(
                         frozenset(int(part, 16) for part in ids.split("-")) if ids else frozenset()
                     ),
-                    dir_rank=rank,
                 )
             )
-    return _Bundles(variants=found, unparsed=unparsed)
+        if found or unparsed:
+            return _Bundles(variants=found, unparsed=unparsed)
+    return _Bundles(variants=[], unparsed=[])
 
 
 def _select_variant(variants: list[_Variant], chip_id: int, cu_count: int) -> _Variant | None:
@@ -301,9 +328,18 @@ def _library_for(layout: str, chip_id: int = GATE_CHIP_ID, cu_count: int = GATE_
     selected = _select_variant(variants, chip_id, cu_count)
     if selected is None:
         offered = ", ".join(sorted(variant.path.name for variant in variants))
+        # A chip id upstream has added to ChipIdRegistry but this mirror lacks
+        # reaches here, and it is the one drift this table cannot detect any other
+        # way, so name the cause rather than leaving it to be inferred.
+        hint = (
+            ""
+            if chip_id in _CHIP_ID_FALLBACKS or chip_id == _CHIP_ID_FALLBACK_ROOT
+            else f"; 0x{chip_id:x} is absent from this script's ChipIdRegistry mirror, "
+            "so if it is a newer part the mirror needs updating from tensilelite"
+        )
         raise SystemExit(
             f"no {GFX} f32 SS Tensile bundle for layout {layout} serves "
-            f"chip 0x{chip_id:x} with {cu_count} CUs; shipped variants: {offered}"
+            f"chip 0x{chip_id:x} with {cu_count} CUs; shipped variants: {offered}{hint}"
         )
     return selected.path
 

--- a/scripts/sanitizers/prepare_gemm_isa.py
+++ b/scripts/sanitizers/prepare_gemm_isa.py
@@ -14,21 +14,28 @@ With ``--consan-object PATH`` it also writes one representative heavy f32 SS obj
 (the NT / ``Ailk_Bjlk`` layout) for driving ConSan over a real code object via
 ``source.consan_command``.
 
+A (family, layout, arch) triple named exactly one bundle through ROCm 7.2.4. From
+ROCm 7.14 the gfx950 libraries are split per device, so the layout alone no longer
+identifies a file and the bundle is chosen for a specific ``--chip-id`` /
+``--cu-count`` -- defaulting to the gate's MI350X. See ``_VARIANT_RE`` for how the
+filename encodes exactly the predicates hipBLASLt gates each variant on.
+
 Size is deliberately not quoted here: the extracted gfx950 object measures ~183 MiB
 on the current CI base (ROCm 7.2.4), so the "~16 MB" this docstring used to claim
 had already drifted by more than a factor of ten. It is a per-release property of
-the shipped Tensile libraries -- ROCm 7.14 splits the same layout into CU-count and
-solution-ID variants of ~156-168 MiB -- so treat any figure as version-specific and
-measure rather than trust a comment.
+the shipped Tensile libraries -- the ROCm 7.14 variants measure ~156-168 MiB -- so
+treat any figure as version-specific and measure rather than trust a comment.
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
+import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 _SRC = Path(__file__).resolve().parents[2] / "src"
 if _SRC.is_dir() and str(_SRC) not in sys.path:
@@ -51,9 +58,67 @@ _LAYOUT = {
     ("T", "N"): "Alik_Bljk",
     ("T", "T"): "Alik_Bjlk",
 }
-# The heavy f32 GEMM library variant. Unbundles to a large gfx950 object -- ~183 MiB
+# The heavy f32 GEMM library family. Unbundles to a large gfx950 object -- ~183 MiB
 # measured on ROCm 7.2.4; see the module docstring on why no fixed size is asserted.
-_SS_HEAVY = "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_{layout}_Cijk_Dijk_" + GFX + ".co"
+_SS_HEAVY_STEM = "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_{layout}_Cijk_Dijk"
+# Through ROCm 7.2.4 that stem plus ``_gfx950.co`` named exactly one file.
+_SS_HEAVY = _SS_HEAVY_STEM + "_" + GFX + ".co"
+
+# Device the fixtures are built to represent: the gate's MI350X reports PCI chip id
+# 0x75a0 with 256 CUs (measured via rocprofv3 agent info -- Device_Id 30112,
+# Cu_Count 256). Fixed rather than probed so the digests recorded beside the
+# artifacts reproduce off-GPU; override with --chip-id / --cu-count.
+GATE_CHIP_ID = 0x75A0
+GATE_CU_COUNT = 256
+
+# ROCm 7.14 splits the gfx950 libraries per device, and the filename carries the
+# very predicates hipBLASLt's own lazy master index (TensileLibrary_lazy_gfx950)
+# gates each variant on:
+#
+#     _CU<n>                 CUCount == n
+#     _ID<hex>[-<hex>...]    PciChipId in {...}
+#
+# so resolving by filename tracks the loader rather than guessing. For the gate's
+# 0x75a0/256-CU part the index selects the CU256_ID75a0 variant; the same file
+# ordering is reproduced by _select_variant's specificity rule below.
+_VARIANT_RE = re.compile(r"^(?:_CU(?P<cu>[0-9]+))?(?:_ID(?P<ids>[0-9a-f]+(?:-[0-9a-f]+)*))?$")
+
+
+class _Variant(NamedTuple):
+    """One shipped bundle for a (family, layout, arch), with its device predicates.
+
+    A NamedTuple rather than a dataclass because the tests load this file as a
+    detached module (``module_from_spec`` without a ``sys.modules`` entry), which
+    is enough to break ``@dataclass``'s annotation resolution.
+    """
+
+    path: Path
+    cu_count: int | None
+    chip_ids: frozenset[int]
+    dir_rank: int
+
+    def serves(self, chip_id: int, cu_count: int) -> bool:
+        """Whether this bundle's predicates admit the requested device."""
+        return (self.cu_count is None or self.cu_count == cu_count) and (
+            not self.chip_ids or chip_id in self.chip_ids
+        )
+
+    @property
+    def specificity(self) -> tuple[int, int, int, int, str]:
+        """Sort key placing the narrowest admitting bundle first.
+
+        Chip and CU precedence mirror the lazy index's row order, which lists a
+        chip's CU-specialised libraries ahead of its unspecialised one and is
+        resolved first-match. ``dir_rank`` and the trailing name make the choice
+        total, so it never depends on the order a directory enumerates in.
+        """
+        return (
+            0 if self.chip_ids else 1,
+            0 if self.cu_count is not None else 1,
+            len(self.chip_ids),
+            self.dir_rank,
+            self.path.name,
+        )
 
 
 def _read_rows(csv_path: Path, top_n: int) -> list[dict[str, str]]:
@@ -83,16 +148,62 @@ def _bundler() -> str:
     )
 
 
-def _library_for(layout: str) -> Path:
-    bundle = _SS_HEAVY.format(layout=layout)
-    # The classic layout is flat; the TheRock wheel layout nests the bundles
-    # one level deeper under the gfx target (library/gfx950/...). Try both.
-    candidates = [HIPBLASLT_LIBRARY / bundle, HIPBLASLT_LIBRARY / GFX / bundle]
-    for candidate in candidates:
-        if candidate.is_file():
-            return candidate
-    tried = " or ".join(str(c) for c in candidates)
-    raise SystemExit(f"no {GFX} f32 SS Tensile bundle for layout {layout}: {tried}")
+def _library_dirs() -> list[Path]:
+    """Directories that may hold the Tensile bundles, in precedence order.
+
+    The classic layout is flat; ROCm 7.14 and the TheRock wheel layout nest the
+    bundles one level deeper under the gfx target (library/gfx950/...).
+    """
+    return [HIPBLASLT_LIBRARY, HIPBLASLT_LIBRARY / GFX]
+
+
+def _variants_for(layout: str) -> list[_Variant]:
+    """Every shipped bundle for this layout, with its parsed device predicates."""
+    prefix = _SS_HEAVY_STEM.format(layout=layout)
+    suffix = f"_{GFX}.co"
+    found: list[_Variant] = []
+    for rank, directory in enumerate(_library_dirs()):
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.glob(f"{prefix}*{suffix}")):
+            match = _VARIANT_RE.match(path.name[len(prefix) : -len(suffix)])
+            if match is None:
+                # An unrecognised token block would silently widen what we treat
+                # as eligible, so skip it rather than assume it is unconstrained.
+                continue
+            ids = match.group("ids")
+            found.append(
+                _Variant(
+                    path=path,
+                    cu_count=int(match.group("cu")) if match.group("cu") else None,
+                    chip_ids=(
+                        frozenset(int(part, 16) for part in ids.split("-")) if ids else frozenset()
+                    ),
+                    dir_rank=rank,
+                )
+            )
+    return found
+
+
+def _select_variant(variants: list[_Variant], chip_id: int, cu_count: int) -> _Variant | None:
+    """The narrowest bundle whose predicates admit this device, or None."""
+    admitting = [variant for variant in variants if variant.serves(chip_id, cu_count)]
+    return min(admitting, key=lambda variant: variant.specificity, default=None)
+
+
+def _library_for(layout: str, chip_id: int = GATE_CHIP_ID, cu_count: int = GATE_CU_COUNT) -> Path:
+    variants = _variants_for(layout)
+    if not variants:
+        tried = " or ".join(str(d / _SS_HEAVY.format(layout=layout)) for d in _library_dirs())
+        raise SystemExit(f"no {GFX} f32 SS Tensile bundle for layout {layout}: {tried}")
+    selected = _select_variant(variants, chip_id, cu_count)
+    if selected is None:
+        offered = ", ".join(sorted(variant.path.name for variant in variants))
+        raise SystemExit(
+            f"no {GFX} f32 SS Tensile bundle for layout {layout} serves "
+            f"chip 0x{chip_id:x} with {cu_count} CUs; shipped variants: {offered}"
+        )
+    return selected.path
 
 
 def _unbundle(bundler: str, src: Path, dst: Path) -> None:
@@ -114,20 +225,36 @@ def main() -> None:
         default=None,
         help="also write one heavy f32 SS object (NT/Ailk_Bjlk) here for ConSan",
     )
+    parser.add_argument(
+        "--chip-id",
+        type=lambda value: int(value, 0),
+        default=GATE_CHIP_ID,
+        help="PCI chip id to pick the ROCm 7.14+ per-device Tensile variant for "
+        f"(default 0x{GATE_CHIP_ID:x}, the gate's MI350X)",
+    )
+    parser.add_argument(
+        "--cu-count",
+        type=int,
+        default=GATE_CU_COUNT,
+        help=f"CU count for the same choice (default {GATE_CU_COUNT})",
+    )
     args = parser.parse_args()
 
     args.out.mkdir(parents=True, exist_ok=True)
     bundler = _bundler()
 
+    def library(layout: str) -> Path:
+        return _library_for(layout, args.chip_id, args.cu_count)
+
     for row in _read_rows(args.csv, args.top_n):
         layout = _LAYOUT.get((row["transA"].strip().upper(), row["transB"].strip().upper()))
         if layout is None:
             raise SystemExit(f"unsupported transpose {row['transA']}/{row['transB']}")
-        _unbundle(bundler, _library_for(layout), args.out / f"sol_{row['top_solution_idx']}.hsaco")
+        _unbundle(bundler, library(layout), args.out / f"sol_{row['top_solution_idx']}.hsaco")
 
     if args.consan_object is not None:
         args.consan_object.parent.mkdir(parents=True, exist_ok=True)
-        _unbundle(bundler, _library_for("Ailk_Bjlk"), args.consan_object)
+        _unbundle(bundler, library("Ailk_Bjlk"), args.consan_object)
 
 
 if __name__ == "__main__":

--- a/scripts/sanitizers/prepare_gemm_isa.py
+++ b/scripts/sanitizers/prepare_gemm_isa.py
@@ -18,7 +18,20 @@ A (family, layout, arch) triple named exactly one bundle through ROCm 7.2.4. Fro
 ROCm 7.14 the gfx950 libraries are split per device, so the layout alone no longer
 identifies a file and the bundle is chosen for a specific ``--chip-id`` /
 ``--cu-count`` -- defaulting to the gate's MI350X. See ``_VARIANT_RE`` for how the
-filename encodes exactly the predicates hipBLASLt gates each variant on.
+filename encodes exactly the predicates hipBLASLt gates each variant on, and
+``_select_variant`` for the resolution order it is matched in.
+
+The selection rules here are transcribed from tensilelite rather than inferred
+from the shipped file names, since a fixture built from a bundle the loader would
+not use for the device would misrepresent what runs:
+
+* ``include/Tensile/ExactLogicLibrary.hpp`` -- ``ExactLogicLibrary::findBestSolution``
+  (exact match returns immediately, first fallback match is kept, and a matching
+  row that yields nothing does not end the walk) and ``HardwarePredicate::isFallbackMatch``;
+* ``include/Tensile/AMDGPUPredicates.hpp`` -- ``ChipIdRegistry`` (the chip-id
+  fallback graph) and ``PciChipIdEqual``;
+* the build-time hardware-row comparator, as documented in hipBLASLt's
+  "PCI chip ID predicates walkthrough".
 
 Size is deliberately not quoted here: the extracted gfx950 object measures ~183 MiB
 on the current CI base (ROCm 7.2.4), so the "~16 MB" this docstring used to claim
@@ -78,10 +91,32 @@ GATE_CU_COUNT = 256
 #     _CU<n>                 CUCount == n
 #     _ID<hex>[-<hex>...]    PciChipId in {...}
 #
-# so resolving by filename tracks the loader rather than guessing. For the gate's
-# 0x75a0/256-CU part the index selects the CU256_ID75a0 variant; the same file
-# ordering is reproduced by _select_variant's specificity rule below.
+# so resolving by filename tracks the loader rather than guessing.
+#
+# Grammar note: both tokens are optional (ROCm <= 7.2.4 shipped neither), the
+# order is fixed, and the ids are lowercase hex. Anything else is not parsed --
+# see _variants_for on why that is a skip rather than a permissive read.
 _VARIANT_RE = re.compile(r"^(?:_CU(?P<cu>[0-9]+))?(?:_ID(?P<ids>[0-9a-f]+(?:-[0-9a-f]+)*))?$")
+
+# tensilelite's ChipIdRegistry, mirrored as data. A gfx950 device may use a
+# solution built for one of its fallback ids, and PciChipIdEqual accepts that via
+# ChipIdRegistry::canUseSolution -- so a bundle naming only 0x75a0 still serves an
+# MI355X. Ignoring this made the selector fail closed on five real chip ids that
+# hipBLASLt serves from the 0x75a0 bundles.
+#     include/Tensile/AMDGPUPredicates.hpp, namespace ChipIdRegistry
+_CHIP_ID_FALLBACKS: dict[int, tuple[int, ...]] = {
+    0x75B0: (0x75A0,),
+    0x75A2: (0x75A0,),
+    0x75B2: (0x75A0,),
+    0x75A3: (0x75A0,),
+    0x75B3: (0x75A0,),
+    0x75A8: (0x75A0,),
+    0x75B8: (0x75A0,),
+}
+
+# How a bundle's predicates admit a device, in the loader's own terms.
+_EXACT = "exact"
+_FALLBACK = "fallback"
 
 
 class _Variant(NamedTuple):
@@ -97,25 +132,42 @@ class _Variant(NamedTuple):
     chip_ids: frozenset[int]
     dir_rank: int
 
-    def serves(self, chip_id: int, cu_count: int) -> bool:
-        """Whether this bundle's predicates admit the requested device."""
-        return (self.cu_count is None or self.cu_count == cu_count) and (
-            not self.chip_ids or chip_id in self.chip_ids
-        )
+    def admits(self, chip_id: int, cu_count: int) -> str | None:
+        """How this bundle admits the device: ``_EXACT``, ``_FALLBACK`` or None.
+
+        Mirrors ``PciChipIdEqual::operator()`` plus
+        ``HardwarePredicate::isFallbackMatch``: a bundle with no chip-id token has
+        no chip constraint, so every match is exact; naming the device's own id is
+        exact; naming one of its registry fallbacks is a fallback match.
+        """
+        if self.cu_count is not None and self.cu_count != cu_count:
+            return None
+        if not self.chip_ids or chip_id in self.chip_ids:
+            return _EXACT
+        if self.chip_ids.intersection(_CHIP_ID_FALLBACKS.get(chip_id, ())):
+            return _FALLBACK
+        return None
 
     @property
-    def specificity(self) -> tuple[int, int, int, int, str]:
-        """Sort key placing the narrowest admitting bundle first.
+    def row_order(self) -> tuple[int, int, int, int, str]:
+        """Sort key reproducing tensilelite's build-time hardware-row comparator.
 
-        Chip and CU precedence mirror the lazy index's row order, which lists a
-        chip's CU-specialised libraries ahead of its unspecialised one and is
-        resolved first-match. ``dir_rank`` and the trailing name make the choice
+        Documented order: rows with chip ids before rows without; then smaller
+        chip-id sets ("exactness first"); then, when chip precedence does not
+        decide, the higher CU count first. Rows with no CU constraint sort behind
+        the constrained ones. ``dir_rank`` and the trailing name make the order
         total, so it never depends on the order a directory enumerates in.
+
+        The documented rule between the set-size and CU steps -- ranking equal-size
+        sets by fallback topology -- is deliberately not modelled: it can only
+        reorder two bundles whose chip-id sets are the same size and different, and
+        no gfx950 release ships such a pair for one layout. _select_variant's
+        exact-before-fallback pass is what actually decides those cases.
         """
         return (
             0 if self.chip_ids else 1,
-            0 if self.cu_count is not None else 1,
             len(self.chip_ids),
+            -self.cu_count if self.cu_count is not None else 1,
             self.dir_rank,
             self.path.name,
         )
@@ -157,19 +209,33 @@ def _library_dirs() -> list[Path]:
     return [HIPBLASLT_LIBRARY, HIPBLASLT_LIBRARY / GFX]
 
 
-def _variants_for(layout: str) -> list[_Variant]:
-    """Every shipped bundle for this layout, with its parsed device predicates."""
+class _Bundles(NamedTuple):
+    """What a layout ships: the bundles we understood, and the names we did not."""
+
+    variants: list[_Variant]
+    unparsed: list[Path]
+
+
+def _variants_for(layout: str) -> _Bundles:
+    """Every shipped bundle for this layout, with its parsed device predicates.
+
+    Names whose token block does not parse are returned separately rather than
+    dropped. Reading one as unconstrained would make it eligible for every device
+    -- the silent wrong answer this selector exists to avoid -- but discarding it
+    without trace is how a new release's added token would quietly widen the
+    choice to a broader bundle, so callers report them.
+    """
     prefix = _SS_HEAVY_STEM.format(layout=layout)
     suffix = f"_{GFX}.co"
     found: list[_Variant] = []
+    unparsed: list[Path] = []
     for rank, directory in enumerate(_library_dirs()):
         if not directory.is_dir():
             continue
         for path in sorted(directory.glob(f"{prefix}*{suffix}")):
             match = _VARIANT_RE.match(path.name[len(prefix) : -len(suffix)])
             if match is None:
-                # An unrecognised token block would silently widen what we treat
-                # as eligible, so skip it rather than assume it is unconstrained.
+                unparsed.append(path)
                 continue
             ids = match.group("ids")
             found.append(
@@ -182,20 +248,56 @@ def _variants_for(layout: str) -> list[_Variant]:
                     dir_rank=rank,
                 )
             )
-    return found
+    return _Bundles(variants=found, unparsed=unparsed)
 
 
 def _select_variant(variants: list[_Variant], chip_id: int, cu_count: int) -> _Variant | None:
-    """The narrowest bundle whose predicates admit this device, or None."""
-    admitting = [variant for variant in variants if variant.serves(chip_id, cu_count)]
-    return min(admitting, key=lambda variant: variant.specificity, default=None)
+    """The bundle the loader would resolve to for this device, or None.
+
+    Mirrors ``ExactLogicLibrary::findBestSolution``: walk the rows in build order,
+    return the first *exact* match, and otherwise keep only the first fallback
+    match -- so an exact match anywhere beats a fallback that appeared earlier.
+
+    The loader's ``if(rv) return rv;`` guard means a row whose predicate matches
+    but which yields no solution does not end the walk. Here that case cannot
+    arise: a variant *is* a shipped file, so a row offering nothing for this
+    family simply contributes none and the walk continues past it.
+    """
+    fallback: _Variant | None = None
+    for variant in sorted(variants, key=lambda candidate: candidate.row_order):
+        admits = variant.admits(chip_id, cu_count)
+        if admits == _EXACT:
+            return variant
+        if admits == _FALLBACK and fallback is None:
+            fallback = variant
+    return fallback
 
 
 def _library_for(layout: str, chip_id: int = GATE_CHIP_ID, cu_count: int = GATE_CU_COUNT) -> Path:
-    variants = _variants_for(layout)
+    variants, unparsed = _variants_for(layout)
     if not variants:
+        # Distinguish "hipBLASLt shipped nothing" from "it shipped bundles whose
+        # names I did not understand" -- the latter is the expected failure mode of
+        # a release that adds a token, and sends the reader somewhere very different.
+        if unparsed:
+            names = ", ".join(sorted(path.name for path in unparsed))
+            raise SystemExit(
+                f"no usable {GFX} f32 SS Tensile bundle for layout {layout}: "
+                f"{len(unparsed)} shipped, none with a recognised device-token "
+                f"block: {names}"
+            )
         tried = " or ".join(str(d / _SS_HEAVY.format(layout=layout)) for d in _library_dirs())
         raise SystemExit(f"no {GFX} f32 SS Tensile bundle for layout {layout}: {tried}")
+    if unparsed:
+        # Usable bundles exist, so this is not fatal -- but the skipped name may
+        # have been the more specific one, in which case the choice below is
+        # broader than the loader's. Say so rather than widening silently.
+        for path in unparsed:
+            print(
+                f"warning: ignoring {path.name}: unrecognised device-token block; "
+                f"selection for layout {layout} may be broader than hipBLASLt's",
+                file=sys.stderr,
+            )
     selected = _select_variant(variants, chip_id, cu_count)
     if selected is None:
         offered = ", ".join(sorted(variant.path.name for variant in variants))

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
@@ -60,8 +60,9 @@ def _optional_str(value: object) -> str | None:
 def sha256_code_object(path: Path) -> str | None:
     """Lowercase SHA-256 of a non-empty code object, or ``None`` if unreadable.
 
-    Streams the file so a large (~16 MB) code object is not read into memory at
-    once. Returns ``None`` for a missing / empty / unreadable path so callers can
+    Streams the file so a large code object (hundreds of MB for a Tensile
+    bundle) is not read into memory at once. Returns ``None`` for a missing /
+    empty / unreadable path so callers can
     degrade gracefully rather than crash: the identity stays digest-less and
     Waitcheck fails closed (``code_object_identity_required``) exactly as it does
     today for a kernel source with no committed digest.

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
@@ -60,12 +60,12 @@ def _optional_str(value: object) -> str | None:
 def sha256_code_object(path: Path) -> str | None:
     """Lowercase SHA-256 of a non-empty code object, or ``None`` if unreadable.
 
-    Streams the file so a large code object (hundreds of MB for a Tensile
-    bundle) is not read into memory at once. Returns ``None`` for a missing /
-    empty / unreadable path so callers can
-    degrade gracefully rather than crash: the identity stays digest-less and
-    Waitcheck fails closed (``code_object_identity_required``) exactly as it does
-    today for a kernel source with no committed digest.
+    Streams the file so a large code object (hundreds of MB for a Tensile bundle)
+    is not read into memory at once. Returns ``None`` for a missing / empty /
+    unreadable path so callers can degrade gracefully rather than crash: the
+    identity stays digest-less and Waitcheck fails closed
+    (``code_object_identity_required``) exactly as it does today for a kernel
+    source with no committed digest.
     """
 
     try:

--- a/tests/sanitizers/fixtures/tensile_lazy_gfx950_rows.json
+++ b/tests/sanitizers/fixtures/tensile_lazy_gfx950_rows.json
@@ -1,0 +1,73 @@
+{
+  "_comment": "Real hipBLASLt hardware-predicate -> Tensile library mapping, extracted from the shipped lazy master index. Ground truth for the variant selection in scripts/sanitizers/prepare_gemm_isa.py: the filename tokens (_CU<n>, _ID<hex>[-<hex>]) restate these predicates, so the selector must reproduce this table. Regenerate by msgpack-decoding the source file below from the image and re-running the extraction.",
+  "source": {
+    "image": "rocm/pytorch:rocm7.14_ubuntu26.04_py3.14_pytorch_release_2.12.0@sha256:8785d67393d9f452cbae2362003f2e211289f9c12163a8c168496724664a0fda",
+    "rocm_version": "7.14.0",
+    "file": "lib/hipblaslt/library/gfx950/TensileLibrary_lazy_gfx950.dat.zlib",
+    "library_type": "Hardware",
+    "family": "SS_SS_HA_Bias_SAV_UA"
+  },
+  "rows": [
+    {
+      "row": 0,
+      "processor": "gfx950",
+      "cu_count": null,
+      "chip_ids": [
+        30120
+      ],
+      "libraries": {}
+    },
+    {
+      "row": 1,
+      "processor": "gfx950",
+      "cu_count": null,
+      "chip_ids": [
+        30114,
+        30115
+      ],
+      "libraries": {
+        "Ailk_Bjlk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bjlk_Cijk_Dijk_ID75a3-75a2_gfx950",
+        "Ailk_Bljk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bljk_Cijk_Dijk_ID75a3-75a2_gfx950",
+        "Alik_Bjlk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Alik_Bjlk_Cijk_Dijk_ID75a3-75a2_gfx950",
+        "Alik_Bljk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Alik_Bljk_Cijk_Dijk_ID75a3-75a2_gfx950"
+      }
+    },
+    {
+      "row": 2,
+      "processor": "gfx950",
+      "cu_count": 256,
+      "chip_ids": [
+        30112
+      ],
+      "libraries": {
+        "Ailk_Bjlk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bjlk_Cijk_Dijk_CU256_ID75a0_gfx950",
+        "Ailk_Bljk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bljk_Cijk_Dijk_CU256_ID75a0_gfx950",
+        "Alik_Bjlk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Alik_Bjlk_Cijk_Dijk_CU256_ID75a0_gfx950",
+        "Alik_Bljk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Alik_Bljk_Cijk_Dijk_CU256_ID75a0_gfx950"
+      }
+    },
+    {
+      "row": 3,
+      "processor": "gfx950",
+      "cu_count": 128,
+      "chip_ids": [
+        30112
+      ],
+      "libraries": {}
+    },
+    {
+      "row": 4,
+      "processor": "gfx950",
+      "cu_count": null,
+      "chip_ids": [
+        30112
+      ],
+      "libraries": {
+        "Ailk_Bjlk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bjlk_Cijk_Dijk_ID75a0_gfx950",
+        "Ailk_Bljk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bljk_Cijk_Dijk_ID75a0_gfx950",
+        "Alik_Bjlk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Alik_Bjlk_Cijk_Dijk_ID75a0_gfx950",
+        "Alik_Bljk": "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Alik_Bljk_Cijk_Dijk_ID75a0_gfx950"
+      }
+    }
+  ]
+}

--- a/tests/sanitizers/fixtures/tensile_lazy_gfx950_rows.json
+++ b/tests/sanitizers/fixtures/tensile_lazy_gfx950_rows.json
@@ -7,6 +7,12 @@
     "library_type": "Hardware",
     "family": "SS_SS_HA_Bias_SAV_UA"
   },
+  "_resolution_comment": "This table is the row DATA only. How the rows are walked is not in it and cannot be inferred from it -- notably that a row whose predicate matches but which offers nothing for a family does not end the walk (findBestSolution guards its return with `if(rv)`), and that a chip id may match a row via the fallback graph. Both come from tensilelite, cited below and mirrored in prepare_gemm_isa.py.",
+  "resolution": {
+    "walk": "tensilelite include/Tensile/ExactLogicLibrary.hpp -- ExactLogicLibrary::findBestSolution, HardwarePredicate::isFallbackMatch",
+    "chip_id_registry": "tensilelite include/Tensile/AMDGPUPredicates.hpp -- ChipIdRegistry::chipIdFallbacks, PciChipIdEqual::operator()",
+    "row_ordering": "hipBLASLt docs, 'PCI chip ID predicates walkthrough' -- Build-time row ordering (fallback-aware)"
+  },
   "rows": [
     {
       "row": 0,

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -2408,7 +2408,7 @@ def test_raw_link_html_renders_run_area_or_nothing():
 
 def test_recipe_fixture_refs_splits_source_inputs_from_built_artifacts():
     # Source inputs are copied into the run area; CI-built artifacts (gitignored,
-    # ~16MB for a GEMM object) are recorded by digest instead.
+    # hundreds of MB for a GEMM object) are recorded by digest instead.
     recipe = (
         "sanitizer_plan:\n"
         "  source:\n"

--- a/tests/sanitizers/test_prepare_gemm_isa.py
+++ b/tests/sanitizers/test_prepare_gemm_isa.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import importlib.util
+import itertools
+import json
 import shutil
 from pathlib import Path
 
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_LAZY_ROWS = Path(__file__).parent / "fixtures" / "tensile_lazy_gfx950_rows.json"
 
 
 def _load():
@@ -130,3 +133,219 @@ def test_library_for_error_names_both_candidate_paths(monkeypatch, tmp_path):
     message = str(excinfo.value)
     assert str(tmp_path / gen._SS_HEAVY.format(layout="Ailk_Bjlk")) in message
     assert str(tmp_path / gen.GFX) in message
+
+
+# --------------------------------------------------------------------------
+# Per-device variant selection (ROCm 7.14+).
+#
+# Through 7.2.4 a (family, layout, arch) triple named exactly one bundle. 7.14
+# splits the gfx950 libraries per device and encodes the split in the filename
+# using the same predicates hipBLASLt's lazy master index gates them on, so the
+# tests below are named after real, measured file sets rather than invented ones.
+# --------------------------------------------------------------------------
+
+# The three variants ROCm 7.14 ships for every one of the four SS layouts.
+_V_CU256_75A0 = "_CU256_ID75a0"
+_V_75A0 = "_ID75a0"
+_V_75A3_75A2 = "_ID75a3-75a2"
+_SHIPPED_714 = (_V_CU256_75A0, _V_75A0, _V_75A3_75A2)
+
+
+def _plant(directory: Path, layout: str, *variants: str) -> dict[str, Path]:
+    """Create empty bundles for ``variants`` and return them by variant token."""
+    directory.mkdir(parents=True, exist_ok=True)
+    stem = gen._SS_HEAVY_STEM.format(layout=layout)
+    made = {}
+    for variant in variants:
+        path = directory / f"{stem}{variant}_{gen.GFX}.co"
+        path.write_bytes(b"stub")
+        made[variant] = path
+    return made
+
+
+def test_variant_tokens_parse_into_the_predicates_they_encode(monkeypatch, tmp_path):
+    """``_CU<n>`` is a CU count and ``_ID<hex>[-<hex>]`` a set of PCI chip ids."""
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714, "")
+    parsed = {
+        variant.path.name: (variant.cu_count, sorted(variant.chip_ids))
+        for variant in gen._variants_for("Ailk_Bjlk")
+    }
+    stem = gen._SS_HEAVY_STEM.format(layout="Ailk_Bjlk")
+    assert parsed[f"{stem}_CU256_ID75a0_{gen.GFX}.co"] == (256, [0x75A0])
+    assert parsed[f"{stem}_ID75a0_{gen.GFX}.co"] == (None, [0x75A0])
+    assert parsed[f"{stem}_ID75a3-75a2_{gen.GFX}.co"] == (None, [0x75A2, 0x75A3])
+    # The 7.2.4 name carries no tokens at all: unconstrained on both axes.
+    assert parsed[f"{stem}_{gen.GFX}.co"] == (None, [])
+
+
+def test_gate_defaults_name_the_measured_mi350x(monkeypatch, tmp_path):
+    """rocprofv3 agent info on the gate reports Device_Id 30112 / Cu_Count 256."""
+    assert (gen.GATE_CHIP_ID, gen.GATE_CU_COUNT) == (0x75A0, 256)
+
+
+def test_classic_single_bundle_is_chosen_for_every_device(monkeypatch, tmp_path):
+    """The 7.2.4 tree must stay byte-identical, and device-independent.
+
+    Its one bundle per layout carries no predicates, so no device may change the
+    answer -- verified end-to-end against the pinned 7.2.4 CI base, where the
+    extracted objects' digests are unchanged by this selector.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", "")[""]
+    for chip, cus in itertools.product((0x75A0, 0x75A2, 0x75A8, 0x1234), (256, 128, 32)):
+        assert gen._library_for("Ailk_Bjlk", chip, cus) == planted
+
+
+def test_gate_device_selects_the_cu_specialised_variant(monkeypatch, tmp_path):
+    """0x75a0 + 256 CUs -> CU256_ID75a0, the lazy index's most specific row."""
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
+    assert gen._library_for("Ailk_Bjlk") == planted[_V_CU256_75A0]
+
+
+def test_same_chip_with_a_different_cu_count_falls_to_the_generic_variant(
+    monkeypatch, tmp_path
+):
+    """A CU predicate that does not hold excludes the bundle outright.
+
+    Measured: 7.14 ships no CU128 bundle for this family, so a 128-CU 0x75a0
+    part resolves to the chip's unspecialised library -- which is what the lazy
+    index does too, its CU128 row offering nothing here.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
+    assert gen._library_for("Ailk_Bjlk", 0x75A0, 128) == planted[_V_75A0]
+
+
+def test_a_multi_chip_variant_serves_every_chip_it_names(monkeypatch, tmp_path):
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
+    for chip in (0x75A2, 0x75A3):
+        assert gen._library_for("Ailk_Bjlk", chip, 256) == planted[_V_75A3_75A2]
+
+
+def test_a_device_no_variant_serves_fails_closed_and_lists_them(monkeypatch, tmp_path):
+    """Silently handing back another device's kernels would be worse than failing.
+
+    0x75a8 is a real gfx950 chip id the 7.14 index knows, yet no bundle in this
+    family names it -- so there is no honest answer to give.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
+    with pytest.raises(SystemExit) as excinfo:
+        gen._library_for("Ailk_Bjlk", 0x75A8, 256)
+    message = str(excinfo.value)
+    assert "0x75a8" in message and "256 CUs" in message
+    # Naming what *was* shipped is what makes the failure actionable.
+    for variant in _SHIPPED_714:
+        assert f"{variant}_{gen.GFX}.co" in message
+
+
+def test_selection_does_not_depend_on_directory_enumeration_order(
+    monkeypatch, tmp_path
+):
+    """Two trees differing only in creation order must resolve identically."""
+    stem = gen._SS_HEAVY_STEM.format(layout="Ailk_Bjlk")
+    chosen = []
+    for order in (_SHIPPED_714, tuple(reversed(_SHIPPED_714))):
+        root = tmp_path / f"order{len(chosen)}"
+        _plant(root, "Ailk_Bjlk", *order)
+        monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", root)
+        chosen.append(gen._library_for("Ailk_Bjlk").name)
+    assert chosen[0] == chosen[1] == f"{stem}{_V_CU256_75A0}_{gen.GFX}.co"
+
+
+def test_chip_specificity_outranks_cu_specificity(monkeypatch, tmp_path):
+    """A chip match beats a CU match when only one of them can be had.
+
+    Synthetic on purpose: no shipped 7.14 bundle carries ``_CU<n>`` without also
+    carrying ``_ID<hex>``, so nothing on disk distinguishes the two orderings and
+    a real-file test cannot pin this. The order still has to be *some* documented
+    thing, and chip-first mirrors the lazy index, whose rows are chip-disjoint and
+    only subdivide by CU count *within* a chip -- making the chip the outer
+    discriminator there too.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", "_CU256", _V_75A0)
+    assert gen._library_for("Ailk_Bjlk", 0x75A0, 256) == planted[_V_75A0]
+
+
+def test_an_unrecognised_token_block_is_ignored_not_treated_as_generic(
+    monkeypatch, tmp_path
+):
+    """A future token must not be mistaken for "no constraints".
+
+    Reading an unparseable block as unconstrained would make it eligible for
+    every device, which is exactly the silent-wrong-answer this selector exists
+    to avoid; the only bundle here is therefore unusable and the call fails.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Ailk_Bjlk", "_XPACK7")
+    assert gen._variants_for("Ailk_Bjlk") == []
+    with pytest.raises(SystemExit, match="Ailk_Bjlk"):
+        gen._library_for("Ailk_Bjlk")
+
+
+def test_selection_reproduces_the_shipped_lazy_master_mapping(monkeypatch, tmp_path):
+    """Drift check against hipBLASLt's own hardware->library table.
+
+    ``fixtures/tensile_lazy_gfx950_rows.json`` records the predicate rows decoded
+    from the ``TensileLibrary_lazy_gfx950`` index in the real 7.14 image, together
+    with the library each row serves per layout. The filename tokens only restate
+    those predicates, so a selector that picks by name has to land on the same
+    file the loader would -- otherwise the fixtures stop representing what runs.
+
+    Rows offering nothing for this family are the fall-through cases: the device
+    must resolve to a *later* row's library, or to nothing at all.
+    """
+    truth = json.loads(_LAZY_ROWS.read_text(encoding="utf-8"))
+    rows = truth["rows"]
+    assert truth["source"]["library_type"] == "Hardware", "first-match row semantics"
+    assert all(row["processor"] == gen.GFX for row in rows)
+
+    def first_match(chip_id: int, cu_count: int, layout: str) -> str | None:
+        """What the index resolves to: first row that matches *and* has a library."""
+        for row in rows:
+            if chip_id not in row["chip_ids"]:
+                continue
+            if row["cu_count"] is not None and row["cu_count"] != cu_count:
+                continue
+            if layout in row["libraries"]:
+                return row["libraries"][layout]
+        return None
+
+    chips = sorted({chip for row in rows for chip in row["chip_ids"]})
+    cu_counts = sorted({row["cu_count"] for row in rows if row["cu_count"]} | {256, 128, 32})
+    layouts = sorted({layout for row in rows for layout in row["libraries"]})
+    assert chips and cu_counts and layouts, "fixture must exercise something"
+
+    checked = 0
+    for chip_id, cu_count, layout in itertools.product(chips, cu_counts, layouts):
+        root = tmp_path / f"{chip_id}-{cu_count}-{layout}"
+        # Plant exactly what 7.14 ships for this layout.
+        _plant(root, layout, *_SHIPPED_714)
+        monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", root)
+        expected = first_match(chip_id, cu_count, layout)
+        if expected is None:
+            # 0x75a8 is a real chip id the index knows but this family never
+            # names, so there is no honest file to hand back.
+            with pytest.raises(SystemExit):
+                gen._library_for(layout, chip_id, cu_count)
+        else:
+            chosen = gen._library_for(layout, chip_id, cu_count)
+            assert chosen.name == f"{expected}.co", f"chip 0x{chip_id:x} cu {cu_count} {layout}"
+        checked += 1
+    assert checked == len(chips) * len(cu_counts) * len(layouts)
+
+    # The recorded table is the real one, not a hand-written stand-in: it must
+    # still describe the device the fixtures are actually built for.
+    gate = [
+        row
+        for row in rows
+        if row["cu_count"] == gen.GATE_CU_COUNT and gen.GATE_CHIP_ID in row["chip_ids"]
+    ]
+    assert len(gate) == 1, "exactly one row pins the gate's chip id and CU count"
+    assert all(
+        name.endswith(f"{_V_CU256_75A0}_{gen.GFX}") for name in gate[0]["libraries"].values()
+    )

--- a/tests/sanitizers/test_prepare_gemm_isa.py
+++ b/tests/sanitizers/test_prepare_gemm_isa.py
@@ -236,7 +236,7 @@ def test_a_stale_tree_of_unparsed_names_does_not_fall_through_to_the_other_layou
     _plant(tmp_path / gen.GFX, "Ailk_Bjlk", *_SHIPPED_714)
     bundles = gen._variants_for("Ailk_Bjlk")
     assert bundles.variants == [] and bundles.unparsed == [stale]
-    with pytest.raises(SystemExit, match="none with a recognised device-token block"):
+    with pytest.raises(SystemExit, match="none of 1 with a recognised device-token block"):
         gen._library_for("Ailk_Bjlk")
 
 
@@ -365,9 +365,7 @@ def test_an_unregistered_chip_id_still_fails_closed(monkeypatch, tmp_path):
     assert "ChipIdRegistry mirror" in message
 
 
-def test_a_registered_chip_that_finds_nothing_does_not_blame_the_registry(
-    monkeypatch, tmp_path
-):
+def test_a_registered_chip_that_finds_nothing_does_not_blame_the_registry(monkeypatch, tmp_path):
     """The mirror hint must not fire for an id the mirror already knows.
 
     0x75a3 is registered, so a miss here means the layout ships nothing usable --
@@ -491,34 +489,45 @@ def test_bundles_that_ship_but_do_not_parse_are_named_not_reported_as_absent(
     with pytest.raises(SystemExit) as excinfo:
         gen._library_for("Ailk_Bjlk")
     message = str(excinfo.value)
-    assert "2 shipped" in message and "none with a recognised device-token block" in message
+    assert "none of 2 with a recognised device-token block" in message
     for name in ("_XPACK7_gfx950.co", "_CU256_ID75a0_XPACK7_gfx950.co"):
         assert name in message
     # And it must NOT claim the canonical 7.2.4 path was what was missing.
     assert str(tmp_path / gen._SS_HEAVY.format(layout="Ailk_Bjlk")) not in message
 
 
-def test_a_skipped_bundle_is_reported_when_others_still_resolve(monkeypatch, tmp_path, capsys):
-    """Skipping is safe but it widens, so it cannot also be silent.
+def test_an_unparsed_bundle_is_fatal_even_when_others_resolve(monkeypatch, tmp_path):
+    """The widening case fails closed rather than warning and continuing.
 
-    If a release tokenises the *specific* bundle and leaves a broader one
-    parseable, selection quietly moves to the broader file. The choice still
-    succeeds -- so a warning, not a failure -- but it has to be visible.
+    This is the shape that matters: a release tokenises the *specific* bundle and
+    leaves a broader one parseable. Selection would settle on `_ID75a0` and exit
+    0, even though the skipped `_CU256_ID75a0_*` may be the loader's exact choice
+    for this device. Ordering only means something when every candidate's
+    predicates are known, so with any of them unknown there is no answer to give.
+
+    Warning and continuing was the earlier behaviour and was not enough: this
+    artifact's digest is recorded and blessed into sanitizer baselines, so a
+    plausible-but-wrong object outlives the log line that mentioned it.
     """
     monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
     planted = _plant(tmp_path, "Ailk_Bjlk", "_CU256_ID75a0_XPACK7", _V_75A0)
-    assert gen._library_for("Ailk_Bjlk") == planted[_V_75A0]
-    stderr = capsys.readouterr().err
-    assert "_CU256_ID75a0_XPACK7_gfx950.co" in stderr
-    assert "may be broader than hipBLASLt's" in stderr
+    with pytest.raises(SystemExit) as excinfo:
+        gen._library_for("Ailk_Bjlk")
+    message = str(excinfo.value)
+    assert "_CU256_ID75a0_XPACK7_gfx950.co" in message
+    assert "1 of 2 with an unrecognised device-token block" in message
+    assert "the loader's choice cannot be established" in message
+    # The broader bundle is right there and parses -- that is the point.
+    assert planted[_V_75A0].is_file()
 
 
-def test_nothing_is_reported_when_every_bundle_parses(monkeypatch, tmp_path, capsys):
-    """The normal case stays quiet, so the warning above means something."""
+def test_every_bundle_parsing_is_what_makes_a_selection_possible(monkeypatch, tmp_path, capsys):
+    """The normal case resolves and says nothing, so a failure means something."""
     monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
-    _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
-    gen._library_for("Ailk_Bjlk")
-    assert capsys.readouterr().err == ""
+    planted = _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
+    assert gen._library_for("Ailk_Bjlk") == planted[_V_CU256_75A0]
+    captured = capsys.readouterr()
+    assert captured.err == "" and captured.out == ""
 
 
 def test_selection_reproduces_the_shipped_lazy_master_mapping(monkeypatch, tmp_path):

--- a/tests/sanitizers/test_prepare_gemm_isa.py
+++ b/tests/sanitizers/test_prepare_gemm_isa.py
@@ -300,9 +300,18 @@ def test_selection_reproduces_the_shipped_lazy_master_mapping(monkeypatch, tmp_p
     must resolve to a *later* row's library, or to nothing at all.
     """
     truth = json.loads(_LAZY_ROWS.read_text(encoding="utf-8"))
-    rows = truth["rows"]
-    assert truth["source"]["library_type"] == "Hardware", "first-match row semantics"
-    assert all(row["processor"] == gen.GFX for row in rows)
+    # Validate the recorded table's shape up front: a bare KeyError from deep in
+    # the loop below would say far less about a mangled fixture than this does.
+    assert truth.get("source", {}).get("library_type") == "Hardware", (
+        "fixture must record a Hardware library, whose rows are resolved first-match"
+    )
+    rows = truth.get("rows")
+    assert isinstance(rows, list) and rows, "fixture must record the predicate rows"
+    for row in rows:
+        assert row.get("processor") == gen.GFX, f"unexpected processor in row {row}"
+        assert isinstance(row.get("chip_ids"), list), f"row {row} has no chip_ids"
+        assert isinstance(row.get("libraries"), dict), f"row {row} has no libraries"
+        assert row.get("cu_count") is None or isinstance(row["cu_count"], int), row
 
     def first_match(chip_id: int, cu_count: int, layout: str) -> str | None:
         """What the index resolves to: first row that matches *and* has a library."""

--- a/tests/sanitizers/test_prepare_gemm_isa.py
+++ b/tests/sanitizers/test_prepare_gemm_isa.py
@@ -87,7 +87,13 @@ def test_library_for_resolves_nested_gfx_subdir(monkeypatch, tmp_path):
 
 
 def test_library_for_prefers_the_flat_bundle_when_both_exist(monkeypatch, tmp_path):
-    """Classic behaviour is unchanged when a per-gfx dir happens to sit beside it."""
+    """Classic behaviour is unchanged when a per-gfx dir happens to sit beside it.
+
+    Same name in both trees, so the two bundles have identical predicates. That
+    makes this necessary but not sufficient on its own: it cannot distinguish
+    "the flat tree wins" from "the tie-break happened to pick flat" -- which is
+    what the next test is for.
+    """
     monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
     bundle = gen._SS_HEAVY.format(layout="Ailk_Bjlk")
     flat = tmp_path / bundle
@@ -183,6 +189,69 @@ def test_variant_tokens_parse_into_the_predicates_they_encode(monkeypatch, tmp_p
 def test_gate_defaults_name_the_measured_mi350x(monkeypatch, tmp_path):
     """rocprofv3 agent info on the gate reports Device_Id 30112 / Cu_Count 256."""
     assert (gen.GATE_CHIP_ID, gen.GATE_CU_COUNT) == (0x75A0, 256)
+
+
+# One tree per layout. The two library directories are alternative *layouts*, so
+# resolution stops at the first that holds anything -- otherwise predicate
+# specificity, which is settled first, lets a nested bundle outrank the flat
+# install it sits beside. No real image can exercise the interaction: the classic
+# base has no nested tree and the wheel image nothing at the flat level.
+
+
+def test_a_more_specific_nested_bundle_does_not_outrank_the_flat_tree(monkeypatch, tmp_path):
+    """The flat tree wins outright, not merely on a tie-break.
+
+    This is the case that separates "one tree per layout" from "merge both and
+    rank": a tokenised nested bundle is *more specific* than an untokenised flat
+    one, so any merge -- however it orders directories -- resolves to the nested
+    file and silently changes the extracted object and the digest recorded beside
+    it. The same-name test above cannot see this, since equal predicates are
+    exactly the case where a directory tie-break is reached.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    flat = _plant(tmp_path, "Ailk_Bjlk", _V_75A0)[_V_75A0]
+    nested = _plant(tmp_path / gen.GFX, "Ailk_Bjlk", _V_CU256_75A0)[_V_CU256_75A0]
+    bundles = gen._variants_for("Ailk_Bjlk")
+    assert [v.path for v in bundles.variants] == [flat], "the nested tree must not contribute"
+    assert gen._library_for("Ailk_Bjlk") == flat
+    # The nested bundle really is what a merged ranking would have picked.
+    assert nested.is_file()
+    assert (
+        gen._Variant(nested, 256, frozenset({0x75A0})).row_order
+        < gen._Variant(flat, None, frozenset({0x75A0})).row_order
+    )
+
+
+def test_a_stale_tree_of_unparsed_names_does_not_fall_through_to_the_other_layout(
+    monkeypatch, tmp_path
+):
+    """Stopping at the first *populated* tree counts names that do not parse.
+
+    Otherwise a leftover tree whose tokens this script does not recognise would
+    silently hand resolution to the other layout -- the one shape where falling
+    through looks like success instead of failing.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    stale = _plant(tmp_path, "Ailk_Bjlk", "_XPACK7")["_XPACK7"]
+    _plant(tmp_path / gen.GFX, "Ailk_Bjlk", *_SHIPPED_714)
+    bundles = gen._variants_for("Ailk_Bjlk")
+    assert bundles.variants == [] and bundles.unparsed == [stale]
+    with pytest.raises(SystemExit, match="none with a recognised device-token block"):
+        gen._library_for("Ailk_Bjlk")
+
+
+def test_the_nested_tree_is_used_when_the_flat_one_holds_nothing_for_this_layout(
+    monkeypatch, tmp_path
+):
+    """The real wheel shape: ``library/`` holds only the per-arch directories.
+
+    A flat tree that exists but holds nothing *for this layout* must not count as
+    populated, or the 7.14 layout would never be reached at all.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Alik_Bljk", _V_CU256_75A0)  # a different layout, flat
+    nested = _plant(tmp_path / gen.GFX, "Ailk_Bjlk", *_SHIPPED_714)
+    assert gen._library_for("Ailk_Bjlk") == nested[_V_CU256_75A0]
 
 
 def test_classic_single_bundle_is_chosen_for_every_device(monkeypatch, tmp_path):
@@ -291,6 +360,31 @@ def test_an_unregistered_chip_id_still_fails_closed(monkeypatch, tmp_path):
     # Naming what *was* shipped is what makes the failure actionable.
     for variant in _SHIPPED_714:
         assert f"{variant}_{gen.GFX}.co" in message
+    # And since the registry mirror cannot be diffed against any image, this
+    # error is its only drift signal -- so it has to name that as the cause.
+    assert "ChipIdRegistry mirror" in message
+
+
+def test_a_registered_chip_that_finds_nothing_does_not_blame_the_registry(
+    monkeypatch, tmp_path
+):
+    """The mirror hint must not fire for an id the mirror already knows.
+
+    0x75a3 is registered, so a miss here means the layout ships nothing usable --
+    pointing at the registry would send the reader to the wrong place.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Ailk_Bjlk", "_CU999_ID75a3")
+    with pytest.raises(SystemExit) as excinfo:
+        gen._library_for("Ailk_Bjlk", 0x75A3, 256)
+    message = str(excinfo.value)
+    assert "0x75a3" in message
+    assert "ChipIdRegistry mirror" not in message
+    # The fallback root has no entry of its own, so it must not be blamed either.
+    _plant(tmp_path, "Ailk_Bjlk", "_CU999_ID75a0")
+    with pytest.raises(SystemExit) as excinfo:
+        gen._library_for("Ailk_Bjlk", gen._CHIP_ID_FALLBACK_ROOT, 256)
+    assert "ChipIdRegistry mirror" not in str(excinfo.value)
 
 
 def test_selection_does_not_depend_on_directory_enumeration_order(monkeypatch, tmp_path):

--- a/tests/sanitizers/test_prepare_gemm_isa.py
+++ b/tests/sanitizers/test_prepare_gemm_isa.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections
 import importlib.util
 import itertools
 import json
@@ -169,7 +170,7 @@ def test_variant_tokens_parse_into_the_predicates_they_encode(monkeypatch, tmp_p
     _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714, "")
     parsed = {
         variant.path.name: (variant.cu_count, sorted(variant.chip_ids))
-        for variant in gen._variants_for("Ailk_Bjlk")
+        for variant in gen._variants_for("Ailk_Bjlk").variants
     }
     stem = gen._SS_HEAVY_STEM.format(layout="Ailk_Bjlk")
     assert parsed[f"{stem}_CU256_ID75a0_{gen.GFX}.co"] == (256, [0x75A0])
@@ -204,14 +205,14 @@ def test_gate_device_selects_the_cu_specialised_variant(monkeypatch, tmp_path):
     assert gen._library_for("Ailk_Bjlk") == planted[_V_CU256_75A0]
 
 
-def test_same_chip_with_a_different_cu_count_falls_to_the_generic_variant(
-    monkeypatch, tmp_path
-):
+def test_same_chip_with_a_different_cu_count_falls_to_the_generic_variant(monkeypatch, tmp_path):
     """A CU predicate that does not hold excludes the bundle outright.
 
     Measured: 7.14 ships no CU128 bundle for this family, so a 128-CU 0x75a0
-    part resolves to the chip's unspecialised library -- which is what the lazy
-    index does too, its CU128 row offering nothing here.
+    part reaches the chip's unspecialised library. ``findBestSolution`` guards
+    its return with ``if(rv)``, so a row whose predicate matches but which
+    offers nothing does not end the walk -- which is why the CU128 row (fp16
+    only for this layout) does not strand the device.
     """
     monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
     planted = _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
@@ -225,26 +226,74 @@ def test_a_multi_chip_variant_serves_every_chip_it_names(monkeypatch, tmp_path):
         assert gen._library_for("Ailk_Bjlk", chip, 256) == planted[_V_75A3_75A2]
 
 
-def test_a_device_no_variant_serves_fails_closed_and_lists_them(monkeypatch, tmp_path):
-    """Silently handing back another device's kernels would be worse than failing.
+def test_registry_mirrors_tensilelites_chip_id_fallback_graph():
+    """Every gfx950 id tensilelite registers a fallback for, with its target.
 
-    0x75a8 is a real gfx950 chip id the 7.14 index knows, yet no bundle in this
-    family names it -- so there is no honest answer to give.
+    Transcribed from ``ChipIdRegistry::chipIdFallbacks``. Getting this wrong is
+    not visible on the gate (0x75a0 needs no fallback), so it is pinned here.
+    """
+    assert gen._CHIP_ID_FALLBACKS == {
+        0x75B0: (0x75A0,),
+        0x75A2: (0x75A0,),
+        0x75B2: (0x75A0,),
+        0x75A3: (0x75A0,),
+        0x75B3: (0x75A0,),
+        0x75A8: (0x75A0,),
+        0x75B8: (0x75A0,),
+    }
+    # 0x75a0 is the fallback root: it targets nothing and everything targets it.
+    assert 0x75A0 not in gen._CHIP_ID_FALLBACKS
+    assert {target for targets in gen._CHIP_ID_FALLBACKS.values() for target in targets} == {0x75A0}
+
+
+@pytest.mark.parametrize("chip", [0x75A8, 0x75B8, 0x75B0, 0x75B2, 0x75B3])
+def test_a_chip_with_no_bundle_of_its_own_uses_its_registry_fallback(monkeypatch, tmp_path, chip):
+    """These ids resolve through the fallback graph, not to a failure.
+
+    ``PciChipIdEqual::operator()`` accepts a solution via
+    ``ChipIdRegistry::canUseSolution``, so a bundle naming only 0x75a0 does serve
+    these parts. An earlier revision failed closed on all five, which would have
+    been a fixture the loader could never have chosen -- and 0x75a8 is a real id
+    the shipped index knows.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
+    assert gen._library_for("Ailk_Bjlk", chip, 256) == planted[_V_CU256_75A0]
+
+
+def test_an_exact_match_beats_a_fallback_that_sorts_earlier(monkeypatch, tmp_path):
+    """An exact match anywhere beats a fallback match that appeared earlier.
+
+    For 0x75a2 the CU256_ID75a0 bundle sorts first (smaller chip set) and admits
+    the device by fallback, while ID75a3-75a2 sorts last and admits it exactly.
+    Taking the first admitting bundle would pick the fallback; the loader does not.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
+    order = sorted(gen._variants_for("Ailk_Bjlk").variants, key=lambda v: v.row_order)
+    assert order[0].path == planted[_V_CU256_75A0], "the fallback candidate sorts first"
+    assert order[0].admits(0x75A2, 256) == gen._FALLBACK
+    assert gen._library_for("Ailk_Bjlk", 0x75A2, 256) == planted[_V_75A3_75A2]
+
+
+def test_an_unregistered_chip_id_still_fails_closed(monkeypatch, tmp_path):
+    """Fallback is a closed registry, not "anything gfx950 will do".
+
+    A chip id tensilelite does not know has no fallback edge, so no bundle admits
+    it and there is no honest answer to give.
     """
     monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
     _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
     with pytest.raises(SystemExit) as excinfo:
-        gen._library_for("Ailk_Bjlk", 0x75A8, 256)
+        gen._library_for("Ailk_Bjlk", 0x1234, 256)
     message = str(excinfo.value)
-    assert "0x75a8" in message and "256 CUs" in message
+    assert "0x1234" in message and "256 CUs" in message
     # Naming what *was* shipped is what makes the failure actionable.
     for variant in _SHIPPED_714:
         assert f"{variant}_{gen.GFX}.co" in message
 
 
-def test_selection_does_not_depend_on_directory_enumeration_order(
-    monkeypatch, tmp_path
-):
+def test_selection_does_not_depend_on_directory_enumeration_order(monkeypatch, tmp_path):
     """Two trees differing only in creation order must resolve identically."""
     stem = gen._SS_HEAVY_STEM.format(layout="Ailk_Bjlk")
     chosen = []
@@ -256,24 +305,46 @@ def test_selection_does_not_depend_on_directory_enumeration_order(
     assert chosen[0] == chosen[1] == f"{stem}{_V_CU256_75A0}_{gen.GFX}.co"
 
 
-def test_chip_specificity_outranks_cu_specificity(monkeypatch, tmp_path):
-    """A chip match beats a CU match when only one of them can be had.
+def test_row_order_follows_the_documented_build_time_comparator(monkeypatch, tmp_path):
+    """Chip ids present first, then smaller chip sets, then higher CU count.
 
-    Synthetic on purpose: no shipped 7.14 bundle carries ``_CU<n>`` without also
-    carrying ``_ID<hex>``, so nothing on disk distinguishes the two orderings and
-    a real-file test cannot pin this. The order still has to be *some* documented
-    thing, and chip-first mirrors the lazy index, whose rows are chip-disjoint and
-    only subdivide by CU count *within* a chip -- making the chip the outer
-    discriminator there too.
+    Transcribed from hipBLASLt's "Build-time row ordering (fallback-aware)".
+    Synthetic file set on purpose: the shipped 7.14 bundles never make the
+    set-size and CU steps disagree (every bundle carries `_ID`, and the two
+    single-chip ones differ only by CU), so no real tree can pin this order.
     """
     monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
-    planted = _plant(tmp_path, "Ailk_Bjlk", "_CU256", _V_75A0)
-    assert gen._library_for("Ailk_Bjlk", 0x75A0, 256) == planted[_V_75A0]
+    planted = _plant(tmp_path, "Ailk_Bjlk", "_CU256", _V_75A0, _V_CU256_75A0, _V_75A3_75A2, "")
+    variants = gen._variants_for("Ailk_Bjlk").variants
+    order = [v.path for v in sorted(variants, key=lambda v: v.row_order)]
+    assert order == [
+        planted[_V_CU256_75A0],  # {75a0}, CU 256
+        planted[_V_75A0],  # {75a0}, no CU
+        planted[_V_75A3_75A2],  # {75a2,75a3} -- larger set sorts after
+        planted["_CU256"],  # no chip id, CU 256
+        planted[""],  # no chip id, no CU
+    ]
+    assert [v.path for v in variants] != order, "name order must differ, or this proves nothing"
+    assert gen._library_for("Ailk_Bjlk", 0x75A0, 256) == planted[_V_CU256_75A0]
 
 
-def test_an_unrecognised_token_block_is_ignored_not_treated_as_generic(
-    monkeypatch, tmp_path
-):
+def test_a_narrower_chip_set_wins_even_when_it_sorts_later_by_name(monkeypatch, tmp_path):
+    """Exactness first: a smaller chip-ID set sorts first.
+
+    This is the one case where walking bundles in directory order gives a
+    different answer from walking them in the documented row order, so it is what
+    proves the selector sorts at all. `-` (0x2d) sorts before `_` (0x5f), so
+    `_ID75a0-75b0` precedes `_ID75a0` by name while being the broader set; both
+    admit 0x75a0 exactly, so only the ordering rule separates them.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", "_ID75a0", "_ID75a0-75b0")
+    by_name = [v.path for v in gen._variants_for("Ailk_Bjlk").variants]
+    assert by_name[0] == planted["_ID75a0-75b0"], "the broader set must sort first by name"
+    assert gen._library_for("Ailk_Bjlk", 0x75A0, 256) == planted["_ID75a0"]
+
+
+def test_an_unrecognised_token_block_is_ignored_not_treated_as_generic(monkeypatch, tmp_path):
     """A future token must not be mistaken for "no constraints".
 
     Reading an unparseable block as unconstrained would make it eligible for
@@ -281,10 +352,79 @@ def test_an_unrecognised_token_block_is_ignored_not_treated_as_generic(
     to avoid; the only bundle here is therefore unusable and the call fails.
     """
     monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
-    _plant(tmp_path, "Ailk_Bjlk", "_XPACK7")
-    assert gen._variants_for("Ailk_Bjlk") == []
+    planted = _plant(tmp_path, "Ailk_Bjlk", "_XPACK7")
+    bundles = gen._variants_for("Ailk_Bjlk")
+    assert bundles.variants == []
+    assert bundles.unparsed == [planted["_XPACK7"]]
     with pytest.raises(SystemExit, match="Ailk_Bjlk"):
         gen._library_for("Ailk_Bjlk")
+
+
+@pytest.mark.parametrize("token", ["_ID75A0", "_ID75a0_CU256", "_CU256_ID75a0_EXTRA"])
+def test_the_token_grammar_is_exactly_as_strict_as_documented(monkeypatch, tmp_path, token):
+    """Uppercase hex, reversed tokens and trailing tokens are all unparsed.
+
+    Each is defensible on its own -- they fail closed -- but they are the shapes a
+    future release could introduce, so pin which ones the grammar rejects rather
+    than discovering it during a bump.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Ailk_Bjlk", token)
+    bundles = gen._variants_for("Ailk_Bjlk")
+    assert bundles.variants == [] and len(bundles.unparsed) == 1
+
+
+def test_a_zero_padded_cu_token_parses(monkeypatch, tmp_path):
+    """`_CU0256` is accepted and means 256 -- not silently a different device."""
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Ailk_Bjlk", "_CU0256_ID75a0")
+    (variant,) = gen._variants_for("Ailk_Bjlk").variants
+    assert variant.cu_count == 256
+
+
+def test_bundles_that_ship_but_do_not_parse_are_named_not_reported_as_absent(
+    monkeypatch, tmp_path, capsys
+):
+    """The message must not send the reader looking for files that are right there.
+
+    Naming the untokenised 7.2.4 path reads as "hipBLASLt shipped nothing for this
+    layout", when the truth is "it shipped bundles whose names I did not
+    understand" -- and since skipping unknown tokens is deliberate, that is the
+    *expected* failure mode of a release that adds one.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Ailk_Bjlk", "_XPACK7", "_CU256_ID75a0_XPACK7")
+    with pytest.raises(SystemExit) as excinfo:
+        gen._library_for("Ailk_Bjlk")
+    message = str(excinfo.value)
+    assert "2 shipped" in message and "none with a recognised device-token block" in message
+    for name in ("_XPACK7_gfx950.co", "_CU256_ID75a0_XPACK7_gfx950.co"):
+        assert name in message
+    # And it must NOT claim the canonical 7.2.4 path was what was missing.
+    assert str(tmp_path / gen._SS_HEAVY.format(layout="Ailk_Bjlk")) not in message
+
+
+def test_a_skipped_bundle_is_reported_when_others_still_resolve(monkeypatch, tmp_path, capsys):
+    """Skipping is safe but it widens, so it cannot also be silent.
+
+    If a release tokenises the *specific* bundle and leaves a broader one
+    parseable, selection quietly moves to the broader file. The choice still
+    succeeds -- so a warning, not a failure -- but it has to be visible.
+    """
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    planted = _plant(tmp_path, "Ailk_Bjlk", "_CU256_ID75a0_XPACK7", _V_75A0)
+    assert gen._library_for("Ailk_Bjlk") == planted[_V_75A0]
+    stderr = capsys.readouterr().err
+    assert "_CU256_ID75a0_XPACK7_gfx950.co" in stderr
+    assert "may be broader than hipBLASLt's" in stderr
+
+
+def test_nothing_is_reported_when_every_bundle_parses(monkeypatch, tmp_path, capsys):
+    """The normal case stays quiet, so the warning above means something."""
+    monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", tmp_path)
+    _plant(tmp_path, "Ailk_Bjlk", *_SHIPPED_714)
+    gen._library_for("Ailk_Bjlk")
+    assert capsys.readouterr().err == ""
 
 
 def test_selection_reproduces_the_shipped_lazy_master_mapping(monkeypatch, tmp_path):
@@ -296,15 +436,19 @@ def test_selection_reproduces_the_shipped_lazy_master_mapping(monkeypatch, tmp_p
     those predicates, so a selector that picks by name has to land on the same
     file the loader would -- otherwise the fixtures stop representing what runs.
 
-    Rows offering nothing for this family are the fall-through cases: the device
-    must resolve to a *later* row's library, or to nothing at all.
+    The model below is ``ExactLogicLibrary::findBestSolution`` transcribed, not a
+    guess at it: rows are walked in order, the first *exact* match returns, only
+    the first *fallback* match is kept, and a row whose predicate matches but
+    which offers nothing for this family does not end the walk -- the loader's
+    ``return`` sits inside an ``if(rv)``. That last point is what makes the CU128
+    row skippable, and it is the one thing here that cannot be read off the table.
     """
     truth = json.loads(_LAZY_ROWS.read_text(encoding="utf-8"))
     # Validate the recorded table's shape up front: a bare KeyError from deep in
     # the loop below would say far less about a mangled fixture than this does.
-    assert truth.get("source", {}).get("library_type") == "Hardware", (
-        "fixture must record a Hardware library, whose rows are resolved first-match"
-    )
+    assert (
+        truth.get("source", {}).get("library_type") == "Hardware"
+    ), "fixture must record a Hardware library, whose rows are walked in order"
     rows = truth.get("rows")
     assert isinstance(rows, list) and rows, "fixture must record the predicate rows"
     for row in rows:
@@ -313,39 +457,57 @@ def test_selection_reproduces_the_shipped_lazy_master_mapping(monkeypatch, tmp_p
         assert isinstance(row.get("libraries"), dict), f"row {row} has no libraries"
         assert row.get("cu_count") is None or isinstance(row["cu_count"], int), row
 
-    def first_match(chip_id: int, cu_count: int, layout: str) -> str | None:
-        """What the index resolves to: first row that matches *and* has a library."""
+    def find_best(chip_id: int, cu_count: int, layout: str) -> str | None:
+        """``ExactLogicLibrary::findBestSolution`` over the recorded rows."""
+        fallback = None
         for row in rows:
-            if chip_id not in row["chip_ids"]:
-                continue
             if row["cu_count"] is not None and row["cu_count"] != cu_count:
+                continue  # CUCount predicate rejects the row outright
+            exact = chip_id in row["chip_ids"]
+            usable = exact or bool(
+                set(row["chip_ids"]).intersection(gen._CHIP_ID_FALLBACKS.get(chip_id, ()))
+            )
+            if not usable:
                 continue
-            if layout in row["libraries"]:
-                return row["libraries"][layout]
-        return None
+            offered = row["libraries"].get(layout)
+            if exact:
+                # `if(rv) return rv;` -- an empty row does not end the walk.
+                if offered is not None:
+                    return offered
+            elif fallback is None and offered is not None:
+                fallback = offered
+        return fallback
 
-    chips = sorted({chip for row in rows for chip in row["chip_ids"]})
+    # Exercise every id tensilelite registers, not only the ones this build's
+    # rows happen to name -- the fallback ids are exactly the ones with no row.
+    chips = sorted({chip for row in rows for chip in row["chip_ids"]} | set(gen._CHIP_ID_FALLBACKS))
     cu_counts = sorted({row["cu_count"] for row in rows if row["cu_count"]} | {256, 128, 32})
     layouts = sorted({layout for row in rows for layout in row["libraries"]})
     assert chips and cu_counts and layouts, "fixture must exercise something"
 
-    checked = 0
+    resolved = collections.Counter()
     for chip_id, cu_count, layout in itertools.product(chips, cu_counts, layouts):
         root = tmp_path / f"{chip_id}-{cu_count}-{layout}"
         # Plant exactly what 7.14 ships for this layout.
         _plant(root, layout, *_SHIPPED_714)
         monkeypatch.setattr(gen, "HIPBLASLT_LIBRARY", root)
-        expected = first_match(chip_id, cu_count, layout)
-        if expected is None:
-            # 0x75a8 is a real chip id the index knows but this family never
-            # names, so there is no honest file to hand back.
-            with pytest.raises(SystemExit):
-                gen._library_for(layout, chip_id, cu_count)
-        else:
-            chosen = gen._library_for(layout, chip_id, cu_count)
-            assert chosen.name == f"{expected}.co", f"chip 0x{chip_id:x} cu {cu_count} {layout}"
-        checked += 1
-    assert checked == len(chips) * len(cu_counts) * len(layouts)
+        expected = find_best(chip_id, cu_count, layout)
+        where = f"chip 0x{chip_id:x} cu {cu_count} {layout}"
+        assert expected is not None, f"no library for {where}"
+        chosen = gen._library_for(layout, chip_id, cu_count)
+        assert chosen.name == f"{expected}.co", where
+        resolved[expected.rsplit("Cijk_Dijk", 1)[-1]] += 1
+    assert sum(resolved.values()) == len(chips) * len(cu_counts) * len(layouts)
+
+    # Every registered gfx950 id resolves, because they all reach 0x75a0 -- which
+    # is exactly why failing closed on 0x75a8 (an earlier revision did) was wrong.
+    # All three shipped variants must be reachable, or the sweep is asserting one
+    # answer over and over.
+    assert set(resolved) == {
+        f"{_V_CU256_75A0}_{gen.GFX}",
+        f"{_V_75A0}_{gen.GFX}",
+        f"{_V_75A3_75A2}_{gen.GFX}",
+    }, resolved
 
     # The recorded table is the real one, not a hand-written stand-in: it must
     # still describe the device the fixtures are actually built for.


### PR DESCRIPTION
Clears the one open blocker on the #383 stack flip: on ROCm 7.14 the sanitizer
GEMM fixtures could not be built at all, because `prepare_gemm_isa.py` needs one
exactly-named Tensile bundle per transpose layout and 7.14 no longer ships one.

**Part of #383.** Stacked on **#387** (base is `feat/rocm-layout-agnostic-stack`,
not `main`) — it needs that PR's resolver to find the wheel layout's library
directory at all. Retarget to `main` once #387 merges.

## The question, and why it had a definite answer

#383 recorded this as needing a judgement call between three variants, since
"choosing a variant changes what ConSan/waitcheck analyse". It turns out not to
be a judgement call: the split is self-describing.

The filename tokens restate exactly the predicates hipBLASLt's own lazy master
index gates each variant on. Decoding
`lib/hipblaslt/library/gfx950/TensileLibrary_lazy_gfx950.dat.zlib` out of the
real 7.14 image gives a `Hardware` library of five first-match rows:

| row | predicate | this family's library |
|---|---|---|
| 0 | `PciChipId 0x75a8` | — |
| 1 | `PciChipId ∈ {0x75a2, 0x75a3}` | `ID75a3-75a2` |
| 2 | `CUCount 256` ∧ `PciChipId 0x75a0` | `CU256_ID75a0` |
| 3 | `CUCount 128` ∧ `PciChipId 0x75a0` | — |
| 4 | `PciChipId 0x75a0` | `ID75a0` |

So `_CU<n>` is `CUCount == n` and `_ID<hex>[-<hex>]` is a set of `PciChipId`s —
PCI chip ids, not the opaque "solution-ID range" #383 guessed at (`0x75a0` =
30112, the MI350 series). The gate's own hardware settles the rest: rocprofv3
agent info from a real run reports `Name gfx950`, `Device_Id 30112`,
`Cu_Count 256`, which is row 2 exactly. **`CU256_ID75a0`**, derived rather than
picked.

That also means "which variant does hipBLASLt load" was the wrong question —
`TensileLibrary_*_gfx950` is a glob, all variants are registered, and
`ChipIdRegistry` resolves per dispatch. There is no single loaded file, only a
per-device answer.

## Where the rules come from

Review asked, fairly, that the *resolution* claims be cited the way the table is
— the table says which library each row holds, but nothing about how rows are
walked. Both now come from tensilelite rather than from reading the file names:

- **Fall-through is real.** `ExactLogicLibrary::findBestSolution` guards its
  return with `if(rv)`, so a row whose predicate matches but which yields no
  solution does **not** end the walk. That is what makes the CU128 row skippable
  rather than terminal. Here the case cannot even arise: a variant *is* a shipped
  file, so a row offering nothing contributes none and the walk passes over it.
- **Chip ids fall back.** `PciChipIdEqual::operator()` admits a solution via
  `ChipIdRegistry::canUseSolution`, and `HardwarePredicate::isFallbackMatch`
  classifies the match. A bundle naming only `0x75a0` therefore *does* serve an
  MI355X.
- **Row order** follows the comparator documented in hipBLASLt's "PCI chip ID
  predicates walkthrough".

Deriving the first of those turned up a second divergence review had not asked
about: modelling exact set membership only made the selector fail closed on five
real chip ids — `0x75a8`, `0x75b0`, `0x75b2`, `0x75b3`, `0x75b8` — that hipBLASLt
serves from the `0x75a0` bundles. All five now resolve. The gate's own device is
unaffected either way, which is precisely why it needed the source rather than a
test on the one part we have.

The one documented rule deliberately not modelled is ranking equal-size chip sets
by fallback topology: it can only reorder two bundles whose chip-id sets are the
same size and different, which no gfx950 release ships for one layout, and the
exact-before-fallback pass decides those cases anyway.

## What changes

`_library_for()` now enumerates the bundles a layout ships, parses each one's
tokens, and resolves them the way the loader does. The rules are **transcribed
from tensilelite, not inferred from the file names** (see "Where the rules come
from"): bundles are ordered by hipBLASLt's documented build-time comparator
(chip ids present, then smaller chip-id sets, then higher CU count), then walked
taking the first *exact* match and keeping only the first *fallback* match, so an
exact match anywhere beats a fallback that sorted earlier. `dir_rank` and the
name make the ordering total so it never depends on directory enumeration order.
A device no bundle serves **fails closed** and lists what shipped, rather than
handing back another device's kernels.

The target defaults to the gate's part (`GATE_CHIP_ID` / `GATE_CU_COUNT`) rather
than being probed, so the digests recorded beside each artifact stay reproducible
off-GPU; `--chip-id` / `--cu-count` override it. Because the defaults *are* the
gate, the nightly's commands and the dashboard's rebuild hints are unchanged.

## Verified in both real images, not reasoned about

- **7.2.4 (the pinned CI base, `sha256:4449f856…`): byte-identical.** Ran the
  parent commit's script and this one over the same fixture CSV; all four
  extracted objects match by SHA-256. Its one bundle per layout carries no
  tokens, so no device can change the answer — asserted directly too.
- **7.14 (`sha256:8785d673…`): end-to-end for the first time.** `--top-n 3` plus
  `--consan-object` both complete and produce real `AMD HSA` / `AMD GPU` ELFs.
  Selection matches the loader for every registered gfx950 chip id, and an
  *unregistered* id fails closed.

## Testing

37 tests. The load-bearing one is a drift check against
`tests/sanitizers/fixtures/tensile_lazy_gfx950_rows.json` — the real decoded
predicate table, with provenance — which walks every chip × CU × layout
combination, models first-match resolution, and requires the selector to agree.
Tampering with one row's library makes it fail; the fixture is force-added past
the blanket `*.json` ignore, as the three existing JSON test fixtures already are.

Per KB#37 I mutation-tested rather than trusting the tests: **19 mutations, all
19 caught** — each ordering step reversed, each predicate dropped, fallback
classified as exact, the registry opened up, first-admitting instead of
exact-first, last fallback instead of first, an unsorted walk, unknown tokens
read as unconstrained or dropped silently, a parse miss reported as absence, the
grammar widened, wrong gate defaults, decimal instead of hex ids.

Two harness findings worth recording, since both are cases where a clean result
was wrong. First, `min`→`max` and a line swap are byte-identical in *size*, so
the cached `.pyc` stayed valid and two mutations falsely passed; the harness now
clears bytecode per case. Second, "walk the bundles unsorted" survived every test
I had, because the shipped 7.14 names happen to sort into row order by
coincidence — killing it needed a two-chip-set fixture, where `-` (0x2d) sorts
before `_` (0x5f) and the broader set therefore comes first by name. That test
now pins the documented "smaller chip-ID sets first" rule, which no real file set
exercises.

CPU suite: 3505 passed, 17 failed — all 17 are `bpftrace` not installed locally
(CI apt-installs it), unchanged from #387.

## Also here

- The nightly's own log line advertised the objects as `~16MB each`; measured,
  they are ~183 MiB on 7.2.4 and 156–168 MiB on 7.14. #387 corrected this figure
  in the script docstring, and a repo-wide sweep found it restated in four more
  places. They only need the magnitude — they justify recording a digest instead
  of publishing, and streaming instead of loading — so they now say "hundreds of
  MB" rather than carrying a number that rots each release.
- **Deliberately not swept:** `waitcheck.py`'s `~a minute on a real ~16MB /
  ~490-kernel Tensile object`. That couples the size to a timing measurement, and
  substituting a new size under an old timing would just be a different wrong
  claim; it needs re-measuring on the new stack.

## Reviewer notes

- `_Variant` is a `NamedTuple`, not a dataclass, on purpose: the tests load this
  file as a detached module (`module_from_spec` with no `sys.modules` entry),
  which is enough to break `@dataclass`'s annotation resolution. That failed
  loudly the first time I ran it in-image.
- `monkeypatch.setattr` without `raising=False` throughout — every target exists,
  so a rename *should* raise; this matches the file's existing tests and #387's
  reasoning.
- Ruff clean on the changed files. Black would also reformat three pre-existing
  spots (#387's `SystemExit`, `_unbundle`'s list, one test string concat); left
  alone to avoid unrelated churn, and my own additions are black-clean.
- **An unrecognised bundle name is fatal**, not a warning. Selecting among
  candidates only means something when every candidate's predicates are known, so
  once one name does not parse there is no justified answer — it could be the
  loader's exact choice for the device, in which case resolution settles on a
  broader bundle. This artifact's digest is recorded and blessed into sanitizer
  baselines, so a plausible-but-wrong object would outlive any log line about it.
  The message names the bundles that did not parse; extending `_VARIANT_RE` is the
  intended response.
- **Diagnostics** separate "hipBLASLt shipped nothing for this layout" from "it
  shipped bundles whose names I could not parse" — the second being the expected
  failure mode of a release that adds a token, and the one the old message steered
  away from by naming the untokenised 7.2.4 path.
- **One tree per layout.** The two library directories are alternative layouts,
  not one catalogue split in half, so resolution stops at the first that holds
  anything. Merging them let a tokenised nested bundle outrank an untokenised flat
  one, since specificity is settled before directory order is consulted — and
  neither real image can exercise that (the classic base has no nested tree, the
  wheel image nothing at the flat level).
- **Still open on #383 after this:** the digest flip itself
  (`Dockerfile.ci-gpu`, `Dockerfile.rocm-latest`, `.env.ci`), re-blessing
  baselines, and watching the first nightly.

