### PR TITLE
feat(sanitizers): reach JIT-compiled Triton/Gluon kernels with ConSan

### DIFF
--- a/recipes/sanitizers/consan-triton-kernel.yaml
+++ b/recipes/sanitizers/consan-triton-kernel.yaml
@@ -23,6 +23,12 @@ description: >
   Point code_object at the same .hsaco the shim loads: the loader hashes it at
   recipe load time so ConSan attributes its verdict to a real identity.
 
+  The shim also pins the SHA-256 of the object, the metadata, and any launch
+  spec, because a Triton cache entry can be evicted and repopulated under the
+  same path. So a shim goes stale whenever the kernel is recompiled, and refuses
+  to run rather than loading the new bytes under the old identity: re-run
+  emit-command after any recompile.
+
   One logical Triton kernel often compiles to several objects (shape-selected
   variants). ConSan takes exactly one code object per run, so harvest one shim
   and one recipe per object; the loader fails closed and lists the candidates if

--- a/recipes/sanitizers/consan-triton-kernel.yaml
+++ b/recipes/sanitizers/consan-triton-kernel.yaml
@@ -17,16 +17,18 @@ description: >
     python3 scripts/sanitizers/triton_consan_loader.py emit-command \
       --cache-entry "$TRITON_CACHE_DIR" \
       --kernel-name _mfma_lds_mediumm_kernel \
+      --copy-object recipes/sanitizers/fixtures/isa/_mfma_lds_mediumm_kernel.hsaco \
       --output recipes/sanitizers/fixtures/bin/consan_triton_kernel
 
-  Both paths below are per-run artifacts of that harvest, not committed fixtures.
-  Point code_object at the same .hsaco the shim loads: the loader hashes it at
-  recipe load time so ConSan attributes its verdict to a real identity.
+  That one command writes both paths below, which are per-run artifacts of the
+  harvest rather than committed fixtures. --copy-object matters: the Triton cache
+  is scratch space that gets evicted and recompiled, so the object is lifted out
+  to a stable path that the shim loads and code_object names -- the same file, so
+  the digest the recipe loader computes describes what actually runs.
 
   The shim also pins the SHA-256 of the object, the metadata, and any launch
-  spec, because a Triton cache entry can be evicted and repopulated under the
-  same path. So a shim goes stale whenever the kernel is recompiled, and refuses
-  to run rather than loading the new bytes under the old identity: re-run
+  spec. A shim therefore goes stale whenever the kernel is recompiled, and
+  refuses to run rather than loading new bytes under the old identity: re-run
   emit-command after any recompile.
 
   One logical Triton kernel often compiles to several objects (shape-selected

--- a/recipes/sanitizers/consan-triton-kernel.yaml
+++ b/recipes/sanitizers/consan-triton-kernel.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+mode: sanitizer
+ticket: CONSAN-TRITON-KERNEL
+description: >
+  Drive ConSan over a JIT-compiled Triton/Gluon kernel on gfx950 (ROCm/aorta#399).
+  A Triton code object cannot be pinned in a fixture directory the way
+  consan-code-objects.yaml pins a Tensile object: it does not exist until the
+  kernel runs, it is keyed by a content hash under TRITON_CACHE_DIR, and it is
+  specific to the image, the GPU target, and the compiled shapes. So there is no
+  HIP source to build a -DOBJECT loader from.
+
+  scripts/sanitizers/triton_consan_loader.py closes that gap. It resolves the
+  code object at run time through ctypes rather than at compile time, and its
+  emit-command mode writes the zero-argument shim named below (consan_command is
+  executed as a bare argv, so the loader's arguments are baked into the shim):
+
+    python3 scripts/sanitizers/triton_consan_loader.py emit-command \
+      --cache-entry "$TRITON_CACHE_DIR" \
+      --kernel-name _mfma_lds_mediumm_kernel \
+      --output recipes/sanitizers/fixtures/bin/consan_triton_kernel
+
+  Both paths below are per-run artifacts of that harvest, not committed fixtures.
+  Point code_object at the same .hsaco the shim loads: the loader hashes it at
+  recipe load time so ConSan attributes its verdict to a real identity.
+
+  One logical Triton kernel often compiles to several objects (shape-selected
+  variants). ConSan takes exactly one code object per run, so harvest one shim
+  and one recipe per object; the loader fails closed and lists the candidates if
+  a selection is ambiguous.
+sanitizer_plan:
+  target: gfx950
+  source:
+    kind: kernel
+    kernel:
+      name: _mfma_lds_mediumm_kernel
+      code_object: fixtures/isa/_mfma_lds_mediumm_kernel.hsaco
+      code_object_index: 0
+    consan_command: fixtures/bin/consan_triton_kernel
+    consan_log: true
+  scope:
+    kind: kernel
+  selection:
+    requirement: top_dispatch_count
+    top_n: 1
+  sanitizers:
+    - consan
+  policy:
+    consan_policy: strict
+    on_missing_backend: fail
+    timeout_seconds: 600
+  output:
+    report: sanitizer_report.json

--- a/scripts/sanitizers/triton_consan_loader.py
+++ b/scripts/sanitizers/triton_consan_loader.py
@@ -45,12 +45,20 @@ same recorded command and selected identity.
 Usage:
 
     # One shim per code object, named as source.consan_command in a recipe.
+    # --copy-object lifts the object out of the scratch cache so the recipe's
+    # code_object has a stable path.
     ./triton_consan_loader.py emit-command \\
         --cache-entry "$TRITON_CACHE_DIR/M3AQ...SCA" \\
-        --output fixtures/bin/consan_add_kernel
+        --copy-object recipes/sanitizers/fixtures/isa/add_kernel.hsaco \\
+        --output recipes/sanitizers/fixtures/bin/consan_add_kernel
 
     # Or run it directly to check an object loads before wiring up a recipe.
     ./triton_consan_loader.py run --cache-entry "$TRITON_CACHE_DIR/M3AQ...SCA"
+
+Note for anyone importing this module by path rather than running it: register it
+in ``sys.modules`` before ``exec_module``, because ``@dataclass`` resolves
+annotations through there. Its sibling ``prepare_gemm_isa.py`` has no such
+requirement, so the two scripts load differently (see the companion test).
 """
 
 from __future__ import annotations
@@ -61,14 +69,17 @@ import hashlib
 import json
 import re
 import shlex
+import shutil
 import stat
 import struct
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-# Scalar Triton signature types -> (struct size, alignment) in the launch buffer.
-# Pointers are handled separately: every ``*T`` is one device address.
+# Scalar Triton signature type -> its size in bytes in the launch buffer, which
+# is also its natural alignment there. Pointers are handled separately: every
+# ``*T`` is one device address.
 _POINTER_SIZE = 8
 _SCALAR_TYPES: dict[str, int] = {
     "i1": 1,
@@ -299,37 +310,78 @@ class ArgSpec:
 
 
 def parse_signature(signature: object) -> tuple[ArgSpec, ...]:
-    """Turn a Triton ``signature`` mapping into ordered, packable arg specs.
+    """Turn a Triton ``signature`` into ordered, packable arg specs.
+
+    Two forms are accepted, and the difference matters. A JSON *object*
+    (``{"x_ptr": "*fp32", "n": "i32"}``) is what Triton itself emits, and its key
+    order is the argument order. A JSON *array* of ``[name, type]`` pairs states
+    that order explicitly.
+
+    Prefer the array form for a hand-authored ``--launch-spec``. Key order is not
+    semantically meaningful in JSON, so nothing stops an editor or
+    ``json.dumps(sort_keys=True)`` from reordering an object -- and a permutation
+    keeps the packed buffer exactly the same size, so ``check_kernarg_fit`` cannot
+    catch it. The kernel would then read a scalar where a pointer belongs.
 
     ``constexpr`` parameters are compiled into the kernel rather than passed, so
     they are dropped from the launch buffer.
     """
 
-    if not isinstance(signature, dict):
-        raise LoaderError("signature must be a JSON object of {arg_name: triton_type}")
+    if isinstance(signature, dict):
+        items: list[tuple[object, object]] = list(signature.items())
+    elif isinstance(signature, list):
+        items = []
+        for index, pair in enumerate(signature):
+            if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+                raise LoaderError(
+                    f"signature[{index}] must be a [name, triton_type] pair, got {pair!r}"
+                )
+            items.append((pair[0], pair[1]))
+    else:
+        raise LoaderError(
+            "signature must be a JSON object of {arg_name: triton_type} or a JSON "
+            "array of [name, triton_type] pairs"
+        )
+
     specs = []
-    for name, ttype in signature.items():
+    seen: set[str] = set()
+    for name, ttype in items:
         if not isinstance(ttype, str):
             raise LoaderError(f"signature entry {name!r} must map to a type string")
+        key = str(name)
+        if key in seen:
+            raise LoaderError(f"signature names a duplicate argument {key!r}")
+        seen.add(key)
         if ttype == "constexpr":
             continue
-        specs.append(ArgSpec(name=str(name), ttype=ttype))
+        specs.append(ArgSpec(name=key, ttype=ttype))
     return tuple(specs)
+
+
+def _positive_int(value: object) -> int | None:
+    """Return a positive integer, or ``None``.
+
+    ``bool`` is excluded deliberately: ``isinstance(True, int)`` is true, so a
+    metadata file with ``"num_warps": true`` would otherwise yield block size 1
+    instead of failing.
+    """
+
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
 
 
 def block_dim(metadata: dict[str, object]) -> int:
     """Derive the Triton launch block size (``num_warps`` lanes of ``warp_size``)."""
 
     target = metadata.get("target")
-    warp_size = None
-    if isinstance(target, dict):
-        warp_size = target.get("warp_size")
-    if not isinstance(warp_size, int):
-        warp_size = metadata.get("warp_size")
-    if not isinstance(warp_size, int) or warp_size <= 0:
+    warp_size = _positive_int(target.get("warp_size")) if isinstance(target, dict) else None
+    if warp_size is None:
+        warp_size = _positive_int(metadata.get("warp_size"))
+    if warp_size is None:
         raise LoaderError("metadata has no positive 'warp_size'")
-    num_warps = metadata.get("num_warps")
-    if not isinstance(num_warps, int) or num_warps <= 0:
+    num_warps = _positive_int(metadata.get("num_warps"))
+    if num_warps is None:
         raise LoaderError("metadata has no positive 'num_warps'")
     return require_in_range(
         num_warps * warp_size, name="block size (num_warps * warp_size)", minimum=1, maximum=_UINT_MAX
@@ -357,6 +409,21 @@ def pack_arguments(
     memory supply both the extents (``--buffer-bytes``) and the scalars
     (``--arg``).
     """
+
+    known = {spec.name for spec in specs}
+    unknown = sorted(set(scalars) - known)
+    if unknown:
+        raise LoaderError(f"--arg names not in the kernel signature: {', '.join(unknown)}")
+    # Pointers always get a fresh zeroed allocation, so an --arg on one would be
+    # accepted and then quietly discarded -- a launch that differs from the one
+    # the caller asked for.
+    pointers_overridden = sorted(set(scalars) & {s.name for s in specs if s.is_pointer})
+    if pointers_overridden:
+        raise LoaderError(
+            f"--arg cannot set pointer arguments: {', '.join(pointers_overridden)}. "
+            "Pointer arguments are allocated by the loader; use --buffer-bytes to "
+            "size them."
+        )
 
     buffer = bytearray()
     for spec in specs:
@@ -589,16 +656,31 @@ class Hip:
 # --------------------------------------------------------------------------
 
 
+def _release(action: Callable[[], None], *, what: str) -> None:
+    """Run one cleanup step without letting it replace the failure being unwound.
+
+    ``Hip.check`` raises, so a failing ``hipFree`` in a ``finally`` would abort the
+    remaining cleanup and overwrite the in-flight exception -- the operator would
+    read "hipFree failed" instead of the launch error they need. Cleanup reports
+    itself and steps aside.
+    """
+
+    try:
+        action()
+    except LoaderError as exc:
+        print(f"[triton-consan-loader] warning: {what}: {exc}", file=sys.stderr)
+
+
 def run_load(hip: Hip, entry: CacheEntry) -> None:
     module = hip.module_load(entry.hsaco)
     try:
         hip.module_get_function(module, entry.kernel_name)
         print(
-            f"[triton-consan-loader] loaded+instrumented {entry.kernel_name} "
-            f"arch={entry.arch} from {entry.hsaco} (no dispatch)"
+            f"[triton-consan-loader] loaded+instrumented {one_line(entry.kernel_name)} "
+            f"arch={one_line(entry.arch)} from {one_line(entry.hsaco)} (no dispatch)"
         )
     finally:
-        hip.module_unload(module)
+        _release(lambda: hip.module_unload(module), what="hipModuleUnload")
 
 
 def run_dispatch(
@@ -610,10 +692,6 @@ def run_dispatch(
     buffer_bytes: int,
     scalars: dict[str, str],
 ) -> None:
-    unknown = sorted(set(scalars) - {spec.name for spec in specs})
-    if unknown:
-        raise LoaderError(f"--arg names not in the kernel signature: {', '.join(unknown)}")
-
     module = hip.module_load(entry.hsaco)
     allocations: list[ctypes.c_void_p] = []
     try:
@@ -637,14 +715,33 @@ def run_dispatch(
             arguments=arguments,
         )
         print(
-            f"[triton-consan-loader] dispatched {entry.kernel_name} "
+            f"[triton-consan-loader] dispatched {one_line(entry.kernel_name)} "
             f"grid={grid} block={block} shared={shared} "
             f"args={len(arguments)}B buffers={len(allocations)}x{buffer_bytes}B"
         )
     finally:
         for allocation in allocations:
-            hip.free(allocation)
-        hip.module_unload(module)
+            _release(lambda a=allocation: hip.free(a), what="hipFree")  # type: ignore[misc]
+        _release(lambda: hip.module_unload(module), what="hipModuleUnload")
+
+
+def one_line(value: object) -> str:
+    """Escape CR/LF so a value cannot forge a new line of shell or of log output.
+
+    Newlines are legal in Linux paths, and this loader puts paths into two places
+    where a line break changes meaning: shell comments in the generated shim
+    (where the remainder would become a command that runs before the quoted
+    ``exec``), and stdout, which ``run_consan`` folds into ``consan.log`` and
+    parses for ``[rocjitsu-dbi-hooks]`` verdict lines.
+    """
+
+    return str(value).replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n")
+
+
+def shell_comment(label: str, value: object) -> str:
+    """Render one ``#`` comment line that cannot break out of its own comment."""
+
+    return f"# {label}: {one_line(value)}\n"
 
 
 def render_shim(loader: Path, argv: list[str], *, entry: CacheEntry) -> str:
@@ -654,17 +751,17 @@ def render_shim(loader: Path, argv: list[str], *, entry: CacheEntry) -> str:
     return (
         "#!/bin/sh\n"
         "# Generated by scripts/sanitizers/triton_consan_loader.py -- do not edit.\n"
-        f"# ConSan target for Triton kernel '{entry.kernel_name}' (arch {entry.arch}).\n"
-        f"# Code object: {entry.hsaco}\n"
-        f"# Metadata:    {entry.metadata_path}\n"
-        "#\n"
+        + shell_comment("Kernel", entry.kernel_name)
+        + shell_comment("Arch", entry.arch)
+        + shell_comment("Code object", entry.hsaco)
+        + shell_comment("Metadata", entry.metadata_path)
+        + "#\n"
         "# sanitizer_plan.source.consan_command must be a bare executable taking no\n"
         "# arguments, so the loader's arguments are baked in here instead. The\n"
         "# --expect-*-sha256 digests pin the bytes this was generated against: a\n"
         "# Triton cache entry can be evicted and repopulated, so the paths alone\n"
         "# would not stop a rebuilt cache from feeding different code to the same\n"
         "# recorded command. Re-run emit-command after any recompile.\n"
-        "set -e\n"
         f"exec {shlex.quote(sys.executable)} {shlex.quote(str(loader))} \\\n    {quoted}\n"
     )
 
@@ -731,7 +828,11 @@ def _add_selection_arguments(parser: argparse.ArgumentParser) -> None:
         "--launch-spec",
         type=Path,
         default=None,
-        help="JSON supplying 'signature' when the Triton metadata omits it",
+        help=(
+            "JSON supplying 'signature' when the Triton metadata omits it, as either "
+            "an object (key order is the argument order) or, preferably for a "
+            "hand-authored file, an array of [name, type] pairs"
+        ),
     )
     parser.add_argument(
         "--grid",
@@ -827,8 +928,38 @@ def _command_run(args: argparse.Namespace) -> int:
     return 0
 
 
+_COPIED_SIDECARS = (
+    # The metadata is required (kernel name, block size, LDS); the assembly
+    # listing is optional but carries .kernarg_segment_size, and losing it would
+    # silently disable the dispatch-time kernarg cross-check.
+    ".json",
+    ".amdgcn",
+)
+
+
+def copy_entry(entry: CacheEntry, destination: Path) -> CacheEntry:
+    """Copy a cache entry out to a stable location and return the copy.
+
+    A Triton cache is scratch space: entries are evicted and recompiled, and the
+    recipe's ``code_object`` has to point at something that still exists at run
+    time. Copying the object *and* its sidecars out, then pointing the shim at the
+    copy, makes the harvested artifact the thing that gets pinned.
+    """
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(entry.hsaco, destination)
+    for suffix in _COPIED_SIDECARS:
+        source = entry.hsaco.with_suffix(suffix)
+        if source.is_file():
+            shutil.copy2(source, destination.with_suffix(suffix))
+    return entry_from_hsaco(destination)
+
+
 def _command_emit(args: argparse.Namespace) -> int:
     entry = _resolve_entry(args)
+    if args.copy_object is not None:
+        entry = copy_entry(entry, args.copy_object)
+        print(f"[triton-consan-loader] copied {one_line(entry.kernel_name)} -> {args.copy_object}")
     loader = Path(__file__).resolve()
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(
@@ -841,7 +972,8 @@ def _command_emit(args: argparse.Namespace) -> int:
 
 def _command_list(args: argparse.Namespace) -> int:
     for entry in discover_entries(args.cache_entry):
-        print(f"{entry.kernel_name}\t{entry.metadata.get('hash', '?')}\t{entry.arch}\t{entry.hsaco}")
+        fields = (entry.kernel_name, entry.metadata.get("hash", "?"), entry.arch, entry.hsaco)
+        print("\t".join(one_line(field) for field in fields))
     return 0
 
 
@@ -866,6 +998,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_selection_arguments(emit)
     emit.add_argument("--output", type=Path, required=True, help="shim path to write")
+    emit.add_argument(
+        "--copy-object",
+        type=Path,
+        default=None,
+        metavar="DEST.hsaco",
+        help=(
+            "copy the code object and its sidecars here and point the shim at the "
+            "copy, so a recipe's code_object has a stable path the Triton cache "
+            "cannot evict"
+        ),
+    )
     emit.set_defaults(handler=_command_emit)
 
     listing = subparsers.add_parser("list", help="list the Triton cache entries under a directory")

--- a/scripts/sanitizers/triton_consan_loader.py
+++ b/scripts/sanitizers/triton_consan_loader.py
@@ -35,9 +35,12 @@ Two modes, mirroring the two committed HIP loaders:
 ``run_consan`` executes ``source.consan_command`` as a bare argv with no
 arguments, so a parameterised loader cannot be named directly. ``emit-command``
 bridges that: it writes a tiny executable shim with the resolved arguments baked
-in, which is the run-time analogue of the ``-DOBJECT`` build step. Hashing the
-shim (``run_consan`` records ``command_sha256``) then pins the exact object the
-run loaded.
+in, which is the run-time analogue of the ``-DOBJECT`` build step. It also bakes
+in a SHA-256 for every input whose bytes decide what runs, and ``run`` re-checks
+each one before touching the device. That is what makes the ``command_sha256``
+``run_consan`` records meaningful: a cache entry can be evicted and repopulated,
+so pinning the paths alone would let a rebuilt cache feed different code to the
+same recorded command and selected identity.
 
 Usage:
 
@@ -54,6 +57,7 @@ from __future__ import annotations
 
 import argparse
 import ctypes
+import hashlib
 import json
 import re
 import shlex
@@ -91,9 +95,24 @@ _HIP_LAUNCH_PARAM_END = ctypes.c_void_p(0x03)
 
 _DEFAULT_BUFFER_BYTES = 8 * 1024 * 1024
 
+# Widths of the C types every launch parameter is narrowed into. ctypes wraps
+# silently on overflow -- c_uint(2**32 + 1) is 1 -- which would turn an oversized
+# grid or buffer into a quietly tiny launch, so each value is range-checked
+# against the real platform width before conversion.
+_UINT_MAX = 2 ** (8 * ctypes.sizeof(ctypes.c_uint)) - 1
+_SIZE_MAX = 2 ** (8 * ctypes.sizeof(ctypes.c_size_t)) - 1
+
 
 class LoaderError(Exception):
     """A fail-closed loader error: never degrade into a vacuous clean run."""
+
+
+def require_in_range(value: int, *, name: str, minimum: int, maximum: int) -> int:
+    """Reject a value that would wrap when narrowed into its C type."""
+
+    if value < minimum or value > maximum:
+        raise LoaderError(f"{name} must be in {minimum}..{maximum}, got {value}")
+    return value
 
 
 # --------------------------------------------------------------------------
@@ -125,6 +144,36 @@ class CacheEntry:
                 return arch
         arch = self.metadata.get("arch")
         return arch if isinstance(arch, str) else None
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_digest(path: Path, expected: str | None, *, what: str) -> None:
+    """Fail closed when a pinned input's bytes have changed since emission.
+
+    A Triton cache entry is keyed by a content hash, but the entry can be evicted
+    and repopulated, so a path alone does not pin the bytes. Baking the digest
+    into the emitted shim and re-checking it here means the ``command_sha256``
+    ``run_consan`` records covers *what* is loaded, not just where it lives --
+    otherwise a rebuilt cache could feed different code to the same recorded
+    command and selected identity.
+    """
+
+    if expected is None:
+        return
+    actual = sha256_file(path)
+    if actual != expected:
+        raise LoaderError(
+            f"{what} digest mismatch for {path}: expected {expected}, found {actual}. "
+            "The Triton cache entry changed since this command was emitted; "
+            "re-run emit-command against the current cache."
+        )
 
 
 def read_json_object(path: Path, *, what: str = "Triton metadata") -> dict[str, object]:
@@ -282,14 +331,16 @@ def block_dim(metadata: dict[str, object]) -> int:
     num_warps = metadata.get("num_warps")
     if not isinstance(num_warps, int) or num_warps <= 0:
         raise LoaderError("metadata has no positive 'num_warps'")
-    return num_warps * warp_size
+    return require_in_range(
+        num_warps * warp_size, name="block size (num_warps * warp_size)", minimum=1, maximum=_UINT_MAX
+    )
 
 
 def shared_bytes(metadata: dict[str, object]) -> int:
     value = metadata.get("shared", 0)
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise LoaderError("metadata 'shared' must be a non-negative integer")
-    return value
+    return require_in_range(value, name="metadata 'shared'", minimum=0, maximum=_UINT_MAX)
 
 
 def pack_arguments(
@@ -332,14 +383,22 @@ def _pack_float(spec: ArgSpec, raw: str) -> bytes:
         value = float(raw)
     except ValueError as exc:
         raise LoaderError(f"argument {spec.name!r} expects a float, got {raw!r}") from exc
-    if spec.ttype == "fp32":
-        return struct.pack("<f", value)
-    if spec.ttype == "fp64":
-        return struct.pack("<d", value)
-    if spec.ttype == "fp16":
-        return struct.pack("<e", value)
-    # bf16 is the upper half of the fp32 bit pattern (round-to-nearest-even).
-    bits = int.from_bytes(struct.pack("<f", value), "little")
+    # struct.pack raises OverflowError for a finite value too wide for the target
+    # format (fp16 above 65504, fp32 above ~3.4e38). Surface it as a loader error
+    # so an out-of-range --arg fails closed instead of raising a traceback.
+    try:
+        if spec.ttype == "fp32":
+            return struct.pack("<f", value)
+        if spec.ttype == "fp64":
+            return struct.pack("<d", value)
+        if spec.ttype == "fp16":
+            return struct.pack("<e", value)
+        # bf16 is the upper half of the fp32 bit pattern (round-to-nearest-even).
+        bits = int.from_bytes(struct.pack("<f", value), "little")
+    except OverflowError as exc:
+        raise LoaderError(
+            f"argument {spec.name!r} value {value} does not fit in {spec.ttype}"
+        ) from exc
     rounded = (bits + 0x7FFF + ((bits >> 16) & 1)) >> 16
     return (rounded & 0xFFFF).to_bytes(2, "little")
 
@@ -402,8 +461,8 @@ def parse_grid(raw: str) -> tuple[int, int, int]:
         dims = tuple(int(part) for part in parts)
     except ValueError as exc:
         raise LoaderError(f"--grid must be three integers, got {raw!r}") from exc
-    if any(dim < 1 for dim in dims):
-        raise LoaderError(f"--grid dimensions must be >= 1, got {raw!r}")
+    for axis, dim in zip("xyz", dims, strict=True):
+        require_in_range(dim, name=f"--grid {axis}", minimum=1, maximum=_UINT_MAX)
     return dims  # type: ignore[return-value]
 
 
@@ -473,6 +532,7 @@ class Hip:
         return function
 
     def malloc(self, size: int) -> ctypes.c_void_p:
+        require_in_range(size, name="buffer bytes", minimum=1, maximum=_SIZE_MAX)
         pointer = ctypes.c_void_p()
         self.check(self._lib.hipMalloc(ctypes.byref(pointer), ctypes.c_size_t(size)), "hipMalloc")
         try:
@@ -599,7 +659,11 @@ def render_shim(loader: Path, argv: list[str], *, entry: CacheEntry) -> str:
         f"# Metadata:    {entry.metadata_path}\n"
         "#\n"
         "# sanitizer_plan.source.consan_command must be a bare executable taking no\n"
-        "# arguments, so the loader's arguments are baked in here instead.\n"
+        "# arguments, so the loader's arguments are baked in here instead. The\n"
+        "# --expect-*-sha256 digests pin the bytes this was generated against: a\n"
+        "# Triton cache entry can be evicted and repopulated, so the paths alone\n"
+        "# would not stop a rebuilt cache from feeding different code to the same\n"
+        "# recorded command. Re-run emit-command after any recompile.\n"
         "set -e\n"
         f"exec {shlex.quote(sys.executable)} {shlex.quote(str(loader))} \\\n    {quoted}\n"
     )
@@ -608,6 +672,37 @@ def render_shim(loader: Path, argv: list[str], *, entry: CacheEntry) -> str:
 # --------------------------------------------------------------------------
 # CLI
 # --------------------------------------------------------------------------
+
+
+# Inputs whose bytes decide what actually runs, so the emitted shim pins each by
+# digest: the code object is loaded, the metadata sets the kernel name / block /
+# LDS, and the launch spec sets the argument signature.
+_PINNED_INPUTS = {
+    "object": "code object",
+    "metadata": "Triton metadata",
+    "launch-spec": "launch spec",
+}
+
+
+def _buffer_bytes(raw: str) -> int:
+    """Validate ``--buffer-bytes`` at parse time, before it reaches a shim or HIP."""
+
+    try:
+        value = int(raw, 0)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"must be an integer, got {raw!r}") from exc
+    if value < 1 or value > _SIZE_MAX:
+        raise argparse.ArgumentTypeError(f"must be in 1..{_SIZE_MAX}, got {value}")
+    return value
+
+
+def _grid(raw: str) -> tuple[int, int, int]:
+    """Validate ``--grid`` at parse time, so emit-command cannot bake a bad one in."""
+
+    try:
+        return parse_grid(raw)
+    except LoaderError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
 def _add_selection_arguments(parser: argparse.ArgumentParser) -> None:
@@ -638,10 +733,15 @@ def _add_selection_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="JSON supplying 'signature' when the Triton metadata omits it",
     )
-    parser.add_argument("--grid", default="1,1,1", help="dispatch grid 'X,Y,Z' (default 1,1,1)")
+    parser.add_argument(
+        "--grid",
+        type=_grid,
+        default=(1, 1, 1),
+        help="dispatch grid 'X,Y,Z' (default 1,1,1)",
+    )
     parser.add_argument(
         "--buffer-bytes",
-        type=int,
+        type=_buffer_bytes,
         default=_DEFAULT_BUFFER_BYTES,
         help="bytes to allocate per pointer argument in dispatch mode",
     )
@@ -677,11 +777,22 @@ def _loader_argv(args: argparse.Namespace, entry: CacheEntry) -> list[str]:
         str(entry.metadata_path),
         "--mode",
         args.mode,
+        "--expect-object-sha256",
+        sha256_file(entry.hsaco),
+        "--expect-metadata-sha256",
+        sha256_file(entry.metadata_path),
     ]
     if args.mode == "dispatch":
-        argv += ["--grid", args.grid, "--buffer-bytes", str(args.buffer_bytes)]
+        grid = ",".join(str(dim) for dim in args.grid)
+        argv += ["--grid", grid, "--buffer-bytes", str(args.buffer_bytes)]
         if args.launch_spec is not None:
-            argv += ["--launch-spec", str(args.launch_spec.resolve())]
+            launch_spec = args.launch_spec.resolve()
+            argv += [
+                "--launch-spec",
+                str(launch_spec),
+                "--expect-launch-spec-sha256",
+                sha256_file(launch_spec),
+            ]
         for override in args.arg:
             argv += ["--arg", override]
     return argv
@@ -689,19 +800,24 @@ def _loader_argv(args: argparse.Namespace, entry: CacheEntry) -> list[str]:
 
 def _command_run(args: argparse.Namespace) -> int:
     entry = _resolve_entry(args)
+    # Check every pinned input before touching the device, so a cache that was
+    # repopulated since emission fails closed instead of loading other bytes.
+    verify_digest(entry.hsaco, args.expect_object_sha256, what="code object")
+    verify_digest(entry.metadata_path, args.expect_metadata_sha256, what="Triton metadata")
     hip = Hip()
     if args.mode == "load":
         run_load(hip, entry)
         return 0
-    launch_spec = (
-        read_json_object(args.launch_spec, what="launch spec") if args.launch_spec else None
-    )
+    launch_spec = None
+    if args.launch_spec:
+        verify_digest(args.launch_spec, args.expect_launch_spec_sha256, what="launch spec")
+        launch_spec = read_json_object(args.launch_spec, what="launch spec")
     specs = parse_signature(resolve_signature(entry, launch_spec))
     run_dispatch(
         hip,
         entry,
         specs=specs,
-        grid=parse_grid(args.grid),
+        grid=args.grid,
         buffer_bytes=args.buffer_bytes,
         scalars=parse_arg_overrides(args.arg),
     )
@@ -732,6 +848,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     run = subparsers.add_parser("run", help="load (and optionally dispatch) the code object")
     _add_selection_arguments(run)
+    # Set by emit-command so the shim pins the bytes it was generated against, not
+    # just their paths. Optional when running by hand against a live cache.
+    for name, what in _PINNED_INPUTS.items():
+        run.add_argument(
+            f"--expect-{name}-sha256",
+            default=None,
+            help=f"fail unless the {what} matches this SHA-256 (set by emit-command)",
+        )
     run.set_defaults(handler=_command_run)
 
     emit = subparsers.add_parser(

--- a/scripts/sanitizers/triton_consan_loader.py
+++ b/scripts/sanitizers/triton_consan_loader.py
@@ -63,10 +63,6 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-# Triton writes one metadata JSON per cache entry next to the code object, plus a
-# ``__grp__``-prefixed index of sibling files that is not kernel metadata.
-_GROUP_PREFIX = "__grp__"
-
 # Scalar Triton signature types -> (struct size, alignment) in the launch buffer.
 # Pointers are handled separately: every ``*T`` is one device address.
 _POINTER_SIZE = 8
@@ -131,13 +127,13 @@ class CacheEntry:
         return arch if isinstance(arch, str) else None
 
 
-def read_metadata(path: Path) -> dict[str, object]:
+def read_json_object(path: Path, *, what: str = "Triton metadata") -> dict[str, object]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
-        raise LoaderError(f"{path}: cannot read Triton metadata: {exc}") from exc
+        raise LoaderError(f"{path}: cannot read {what}: {exc}") from exc
     if not isinstance(data, dict):
-        raise LoaderError(f"{path}: Triton metadata must be a JSON object")
+        raise LoaderError(f"{path}: {what} must be a JSON object")
     return data
 
 
@@ -155,7 +151,7 @@ def entry_from_hsaco(hsaco: Path, metadata_path: Path | None = None) -> CacheEnt
     return CacheEntry(
         hsaco=hsaco.resolve(),
         metadata_path=resolved_metadata.resolve(),
-        metadata=read_metadata(resolved_metadata),
+        metadata=read_json_object(resolved_metadata),
     )
 
 
@@ -171,9 +167,11 @@ def discover_entries(root: Path) -> list[CacheEntry]:
     if not root.is_dir():
         raise LoaderError(f"Triton cache directory not found: {root}")
     entries: list[CacheEntry] = []
+    # Driving off the code objects rather than the JSON files keeps Triton's
+    # ``__grp__`` sibling index out of the results: it has no matching .hsaco.
     for hsaco in sorted(root.rglob("*.hsaco")):
         sidecar = hsaco.with_suffix(".json")
-        if not sidecar.is_file() or sidecar.name.startswith(_GROUP_PREFIX):
+        if not sidecar.is_file():
             continue
         entries.append(entry_from_hsaco(hsaco, sidecar))
     if not entries:
@@ -477,10 +475,13 @@ class Hip:
     def malloc(self, size: int) -> ctypes.c_void_p:
         pointer = ctypes.c_void_p()
         self.check(self._lib.hipMalloc(ctypes.byref(pointer), ctypes.c_size_t(size)), "hipMalloc")
-        self.check(
-            self._lib.hipMemset(pointer, 0, ctypes.c_size_t(size)),
-            "hipMemset",
-        )
+        try:
+            self.check(self._lib.hipMemset(pointer, 0, ctypes.c_size_t(size)), "hipMemset")
+        except LoaderError:
+            # The allocation succeeded, so release it before propagating rather
+            # than leaking device memory the caller never learns about.
+            self._lib.hipFree(pointer)
+            raise
         return pointer
 
     def free(self, pointer: ctypes.c_void_p) -> None:
@@ -501,7 +502,7 @@ class Hip:
             _HIP_LAUNCH_PARAM_BUFFER_POINTER,
             ctypes.cast(buffer, ctypes.c_void_p),
             _HIP_LAUNCH_PARAM_BUFFER_SIZE,
-            ctypes.cast(ctypes.byref(size), ctypes.c_void_p),
+            ctypes.c_void_p(ctypes.addressof(size)),
             _HIP_LAUNCH_PARAM_END,
         )
         self.check(
@@ -692,7 +693,9 @@ def _command_run(args: argparse.Namespace) -> int:
     if args.mode == "load":
         run_load(hip, entry)
         return 0
-    launch_spec = read_metadata(args.launch_spec) if args.launch_spec else None
+    launch_spec = (
+        read_json_object(args.launch_spec, what="launch spec") if args.launch_spec else None
+    )
     specs = parse_signature(resolve_signature(entry, launch_spec))
     run_dispatch(
         hip,
@@ -709,7 +712,9 @@ def _command_emit(args: argparse.Namespace) -> int:
     entry = _resolve_entry(args)
     loader = Path(__file__).resolve()
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(render_shim(loader, _loader_argv(args, entry), entry=entry), "utf-8")
+    args.output.write_text(
+        render_shim(loader, _loader_argv(args, entry), entry=entry), encoding="utf-8"
+    )
     args.output.chmod(args.output.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     print(f"[triton-consan-loader] wrote {args.output} -> {entry.kernel_name} ({args.mode})")
     return 0

--- a/scripts/sanitizers/triton_consan_loader.py
+++ b/scripts/sanitizers/triton_consan_loader.py
@@ -27,7 +27,9 @@ Two modes, mirroring the two committed HIP loaders:
     Additionally launch the kernel once, for record/replay's dynamic coverage.
     This needs the argument signature, which Triton does **not** always write to
     the metadata JSON (it is absent in 3.7.1), so pass ``--launch-spec`` when the
-    metadata has no ``signature``. Note that dispatching a caller-supplied object
+    metadata has no ``signature`` -- preferably as an array of ``[name, type]``
+    pairs, since argument order is load-bearing and JSON object key order is not
+    (see ``parse_signature``). Note that dispatching a caller-supplied object
     currently fails closed on the shipping RocJITsu build for the same reason
     ``daily-consan-lds-dispatch.yaml`` does (zero captured records -> exit 86,
     ROCm/rocm-systems#9972).
@@ -408,6 +410,10 @@ def pack_arguments(
     sanitizer run into a memory fault. Callers who want the kernel to touch
     memory supply both the extents (``--buffer-bytes``) and the scalars
     (``--arg``).
+
+    Every pointer gets a fresh zeroed allocation, so a ``--arg`` naming one is
+    rejected rather than silently discarded -- as is a name the signature does
+    not contain.
     """
 
     known = {spec.name for spec in specs}

--- a/scripts/sanitizers/triton_consan_loader.py
+++ b/scripts/sanitizers/triton_consan_loader.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""Generic ConSan target for JIT-compiled Triton/Gluon kernels (ROCm/aorta#399).
+
+``source.consan_command`` needs an executable that puts exactly the selected code
+object on the device, so the RocJITsu hook instruments that object and nothing
+else. The committed loaders (``consan_load.hip``, ``lds_dispatch.hip``) bake the
+object path in at *compile* time via ``-DOBJECT``, which cannot work for a Triton
+kernel: the ``.hsaco`` does not exist until the kernel runs, it is keyed by a
+content hash under ``TRITON_CACHE_DIR``, and it is specific to the image, the GPU
+target, and the compiled shapes. There is nothing to pin in a fixture directory
+and no source to compile.
+
+This loader binds ``libamdhip64`` through ctypes instead, so the object path is
+resolved at *run* time and no compiler is in the loop. Point it at a Triton cache
+entry (a ``.hsaco`` plus the adjacent ``.json`` Triton writes next to it) and it
+loads that object under whatever hook the parent set in ``HSA_TOOLS_LIB``.
+
+Two modes, mirroring the two committed HIP loaders:
+
+``load`` (default)
+    ``hipModuleLoad`` the object and resolve the kernel symbol. Needs no
+    knowledge of the launch ABI, so it works for *any* Triton kernel. This is the
+    Triton analogue of ``consan_load.hip``, and is what makes ConSan reachable at
+    all -- ConSan instruments a code object when it is loaded.
+
+``dispatch``
+    Additionally launch the kernel once, for record/replay's dynamic coverage.
+    This needs the argument signature, which Triton does **not** always write to
+    the metadata JSON (it is absent in 3.7.1), so pass ``--launch-spec`` when the
+    metadata has no ``signature``. Note that dispatching a caller-supplied object
+    currently fails closed on the shipping RocJITsu build for the same reason
+    ``daily-consan-lds-dispatch.yaml`` does (zero captured records -> exit 86,
+    ROCm/rocm-systems#9972).
+
+``run_consan`` executes ``source.consan_command`` as a bare argv with no
+arguments, so a parameterised loader cannot be named directly. ``emit-command``
+bridges that: it writes a tiny executable shim with the resolved arguments baked
+in, which is the run-time analogue of the ``-DOBJECT`` build step. Hashing the
+shim (``run_consan`` records ``command_sha256``) then pins the exact object the
+run loaded.
+
+Usage:
+
+    # One shim per code object, named as source.consan_command in a recipe.
+    ./triton_consan_loader.py emit-command \\
+        --cache-entry "$TRITON_CACHE_DIR/M3AQ...SCA" \\
+        --output fixtures/bin/consan_add_kernel
+
+    # Or run it directly to check an object loads before wiring up a recipe.
+    ./triton_consan_loader.py run --cache-entry "$TRITON_CACHE_DIR/M3AQ...SCA"
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import re
+import shlex
+import stat
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Triton writes one metadata JSON per cache entry next to the code object, plus a
+# ``__grp__``-prefixed index of sibling files that is not kernel metadata.
+_GROUP_PREFIX = "__grp__"
+
+# Scalar Triton signature types -> (struct size, alignment) in the launch buffer.
+# Pointers are handled separately: every ``*T`` is one device address.
+_POINTER_SIZE = 8
+_SCALAR_TYPES: dict[str, int] = {
+    "i1": 1,
+    "i8": 1,
+    "i16": 2,
+    "i32": 4,
+    "i64": 8,
+    "u1": 1,
+    "u8": 1,
+    "u16": 2,
+    "u32": 4,
+    "u64": 8,
+    "fp16": 2,
+    "bf16": 2,
+    "fp32": 4,
+    "fp64": 8,
+}
+_FLOAT_TYPES = frozenset({"fp16", "bf16", "fp32", "fp64"})
+
+# hip/hip_runtime.h launch-config sentinels.
+_HIP_LAUNCH_PARAM_BUFFER_POINTER = ctypes.c_void_p(0x01)
+_HIP_LAUNCH_PARAM_BUFFER_SIZE = ctypes.c_void_p(0x02)
+_HIP_LAUNCH_PARAM_END = ctypes.c_void_p(0x03)
+
+_DEFAULT_BUFFER_BYTES = 8 * 1024 * 1024
+
+
+class LoaderError(Exception):
+    """A fail-closed loader error: never degrade into a vacuous clean run."""
+
+
+# --------------------------------------------------------------------------
+# Triton cache entry resolution
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    """One Triton cache entry: a code object plus its sidecar metadata."""
+
+    hsaco: Path
+    metadata_path: Path
+    metadata: dict[str, object]
+
+    @property
+    def kernel_name(self) -> str:
+        name = self.metadata.get("name")
+        if not isinstance(name, str) or not name:
+            raise LoaderError(f"{self.metadata_path}: metadata has no 'name'")
+        return name
+
+    @property
+    def arch(self) -> str | None:
+        target = self.metadata.get("target")
+        if isinstance(target, dict):
+            arch = target.get("arch")
+            if isinstance(arch, str):
+                return arch
+        arch = self.metadata.get("arch")
+        return arch if isinstance(arch, str) else None
+
+
+def read_metadata(path: Path) -> dict[str, object]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise LoaderError(f"{path}: cannot read Triton metadata: {exc}") from exc
+    if not isinstance(data, dict):
+        raise LoaderError(f"{path}: Triton metadata must be a JSON object")
+    return data
+
+
+def entry_from_hsaco(hsaco: Path, metadata_path: Path | None = None) -> CacheEntry:
+    """Pair a ``.hsaco`` with its sidecar JSON, defaulting to the adjacent one."""
+
+    if not hsaco.is_file():
+        raise LoaderError(f"code object not found: {hsaco}")
+    resolved_metadata = metadata_path or hsaco.with_suffix(".json")
+    if not resolved_metadata.is_file():
+        raise LoaderError(
+            f"no Triton metadata beside {hsaco}: expected {resolved_metadata}. "
+            "Pass --metadata to name it explicitly."
+        )
+    return CacheEntry(
+        hsaco=hsaco.resolve(),
+        metadata_path=resolved_metadata.resolve(),
+        metadata=read_metadata(resolved_metadata),
+    )
+
+
+def discover_entries(root: Path) -> list[CacheEntry]:
+    """Find every ``.hsaco``/``.json`` pair at or under a Triton cache directory.
+
+    Accepts either a single cache entry directory or a whole cache root, so the
+    several distinct objects one logical kernel compiles to (shape-selected
+    variants such as ``_mfma_lds_mediumm_kernel`` / ``_mfma_lds_largem_kernel``)
+    are all discoverable from one path.
+    """
+
+    if not root.is_dir():
+        raise LoaderError(f"Triton cache directory not found: {root}")
+    entries: list[CacheEntry] = []
+    for hsaco in sorted(root.rglob("*.hsaco")):
+        sidecar = hsaco.with_suffix(".json")
+        if not sidecar.is_file() or sidecar.name.startswith(_GROUP_PREFIX):
+            continue
+        entries.append(entry_from_hsaco(hsaco, sidecar))
+    if not entries:
+        raise LoaderError(
+            f"no Triton code objects under {root}: expected a '<kernel>.hsaco' "
+            "with an adjacent '<kernel>.json'. Has the kernel been run yet?"
+        )
+    return entries
+
+
+def select_entry(
+    entries: list[CacheEntry],
+    *,
+    kernel_name: str | None = None,
+    cache_hash: str | None = None,
+) -> CacheEntry:
+    """Narrow a candidate list to exactly one entry, or fail closed.
+
+    ConSan is only meaningful for a single selected identity (``run_consan``
+    rejects a multi-kernel worklist), so an ambiguous selection must not silently
+    pick one. The error lists the candidates and how to disambiguate them.
+    """
+
+    candidates = entries
+    if kernel_name is not None:
+        candidates = [entry for entry in candidates if entry.kernel_name == kernel_name]
+    if cache_hash is not None:
+        candidates = [
+            entry for entry in candidates if str(entry.metadata.get("hash", "")).startswith(cache_hash)
+        ]
+    if not candidates:
+        raise LoaderError(
+            "no Triton cache entry matches "
+            f"kernel_name={kernel_name!r} hash={cache_hash!r}; "
+            f"available: {', '.join(sorted(entry.kernel_name for entry in entries))}"
+        )
+    if len(candidates) > 1:
+        listing = "\n".join(
+            f"  {entry.kernel_name}  hash={entry.metadata.get('hash', '?')}  {entry.hsaco}"
+            for entry in candidates
+        )
+        raise LoaderError(
+            f"{len(candidates)} Triton cache entries match; ConSan needs exactly one "
+            f"code object per run. Narrow it with --kernel-name / --cache-hash:\n{listing}"
+        )
+    return candidates[0]
+
+
+# --------------------------------------------------------------------------
+# Launch plan
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArgSpec:
+    """One kernel argument as it appears in the packed Triton launch buffer."""
+
+    name: str
+    ttype: str
+
+    @property
+    def is_pointer(self) -> bool:
+        return self.ttype.startswith("*")
+
+    @property
+    def size(self) -> int:
+        if self.is_pointer:
+            return _POINTER_SIZE
+        size = _SCALAR_TYPES.get(self.ttype)
+        if size is None:
+            raise LoaderError(
+                f"argument {self.name!r} has unsupported Triton type {self.ttype!r}; "
+                f"supported: *T pointers and {', '.join(sorted(_SCALAR_TYPES))}"
+            )
+        return size
+
+
+def parse_signature(signature: object) -> tuple[ArgSpec, ...]:
+    """Turn a Triton ``signature`` mapping into ordered, packable arg specs.
+
+    ``constexpr`` parameters are compiled into the kernel rather than passed, so
+    they are dropped from the launch buffer.
+    """
+
+    if not isinstance(signature, dict):
+        raise LoaderError("signature must be a JSON object of {arg_name: triton_type}")
+    specs = []
+    for name, ttype in signature.items():
+        if not isinstance(ttype, str):
+            raise LoaderError(f"signature entry {name!r} must map to a type string")
+        if ttype == "constexpr":
+            continue
+        specs.append(ArgSpec(name=str(name), ttype=ttype))
+    return tuple(specs)
+
+
+def block_dim(metadata: dict[str, object]) -> int:
+    """Derive the Triton launch block size (``num_warps`` lanes of ``warp_size``)."""
+
+    target = metadata.get("target")
+    warp_size = None
+    if isinstance(target, dict):
+        warp_size = target.get("warp_size")
+    if not isinstance(warp_size, int):
+        warp_size = metadata.get("warp_size")
+    if not isinstance(warp_size, int) or warp_size <= 0:
+        raise LoaderError("metadata has no positive 'warp_size'")
+    num_warps = metadata.get("num_warps")
+    if not isinstance(num_warps, int) or num_warps <= 0:
+        raise LoaderError("metadata has no positive 'num_warps'")
+    return num_warps * warp_size
+
+
+def shared_bytes(metadata: dict[str, object]) -> int:
+    value = metadata.get("shared", 0)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise LoaderError("metadata 'shared' must be a non-negative integer")
+    return value
+
+
+def pack_arguments(
+    specs: tuple[ArgSpec, ...],
+    *,
+    pointers: dict[str, int],
+    scalars: dict[str, str],
+) -> bytes:
+    """Pack one Triton launch buffer, honouring each argument's natural alignment.
+
+    Scalars default to zero. That is deliberate: a synthesized non-zero size or
+    stride would index buffers whose real extents we cannot know, turning a
+    sanitizer run into a memory fault. Callers who want the kernel to touch
+    memory supply both the extents (``--buffer-bytes``) and the scalars
+    (``--arg``).
+    """
+
+    buffer = bytearray()
+    for spec in specs:
+        size = spec.size
+        padding = (-len(buffer)) % size
+        buffer.extend(b"\x00" * padding)
+        if spec.is_pointer:
+            buffer.extend(pointers[spec.name].to_bytes(_POINTER_SIZE, "little"))
+            continue
+        raw = scalars.get(spec.name, "0")
+        if spec.ttype in _FLOAT_TYPES:
+            buffer.extend(_pack_float(spec, raw))
+        else:
+            buffer.extend(_pack_int(spec, raw, size))
+    # Trailing pad to the widest member, matching C struct sizing.
+    if specs:
+        widest = max(spec.size for spec in specs)
+        buffer.extend(b"\x00" * ((-len(buffer)) % widest))
+    return bytes(buffer)
+
+
+def _pack_float(spec: ArgSpec, raw: str) -> bytes:
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise LoaderError(f"argument {spec.name!r} expects a float, got {raw!r}") from exc
+    if spec.ttype == "fp32":
+        return struct.pack("<f", value)
+    if spec.ttype == "fp64":
+        return struct.pack("<d", value)
+    if spec.ttype == "fp16":
+        return struct.pack("<e", value)
+    # bf16 is the upper half of the fp32 bit pattern (round-to-nearest-even).
+    bits = int.from_bytes(struct.pack("<f", value), "little")
+    rounded = (bits + 0x7FFF + ((bits >> 16) & 1)) >> 16
+    return (rounded & 0xFFFF).to_bytes(2, "little")
+
+
+def _pack_int(spec: ArgSpec, raw: str, size: int) -> bytes:
+    try:
+        value = int(raw, 0)
+    except ValueError as exc:
+        raise LoaderError(f"argument {spec.name!r} expects an integer, got {raw!r}") from exc
+    signed = not spec.ttype.startswith("u")
+    try:
+        return value.to_bytes(size, "little", signed=signed)
+    except OverflowError as exc:
+        raise LoaderError(
+            f"argument {spec.name!r} value {value} does not fit in {spec.ttype}"
+        ) from exc
+
+
+_KERNARG_SIZE = re.compile(r"^\s*\.kernarg_segment_size:\s*(\d+)\s*$", re.MULTILINE)
+
+
+def kernarg_segment_size(entry: CacheEntry) -> int | None:
+    """Read the kernel's kernarg segment size from the adjacent ``.amdgcn`` listing.
+
+    Triton writes the generated assembly beside the code object, and its metadata
+    block records the segment size the kernel was compiled for. Returns ``None``
+    when the listing is absent, since it is not required to exist.
+    """
+
+    listing = entry.hsaco.with_suffix(".amdgcn")
+    if not listing.is_file():
+        return None
+    match = _KERNARG_SIZE.search(listing.read_text(encoding="utf-8", errors="replace"))
+    return int(match.group(1)) if match else None
+
+
+def check_kernarg_fit(packed: int, segment: int | None, *, kernel: str) -> None:
+    """Reject a launch buffer larger than the kernel's kernarg segment.
+
+    HIP does not validate ``HIP_LAUNCH_PARAM_BUFFER_SIZE`` against the kernel
+    descriptor, so a wrong ``--launch-spec`` signature otherwise dispatches
+    silently and can scribble past the segment. The segment also covers the
+    hidden arguments the compiler appends, so a *smaller* buffer is normal and
+    only the over-run direction is provably wrong.
+    """
+
+    if segment is not None and packed > segment:
+        raise LoaderError(
+            f"packed launch buffer for {kernel!r} is {packed} bytes but the kernel's "
+            f"kernarg segment is {segment} bytes: the signature does not match this "
+            "code object"
+        )
+
+
+def parse_grid(raw: str) -> tuple[int, int, int]:
+    parts = raw.split(",")
+    if len(parts) != 3:
+        raise LoaderError(f"--grid must be 'X,Y,Z', got {raw!r}")
+    try:
+        dims = tuple(int(part) for part in parts)
+    except ValueError as exc:
+        raise LoaderError(f"--grid must be three integers, got {raw!r}") from exc
+    if any(dim < 1 for dim in dims):
+        raise LoaderError(f"--grid dimensions must be >= 1, got {raw!r}")
+    return dims  # type: ignore[return-value]
+
+
+def parse_arg_overrides(pairs: list[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for pair in pairs:
+        name, separator, value = pair.partition("=")
+        if not separator or not name.strip():
+            raise LoaderError(f"--arg must be 'name=value', got {pair!r}")
+        overrides[name.strip()] = value.strip()
+    return overrides
+
+
+def resolve_signature(entry: CacheEntry, launch_spec: dict[str, object] | None) -> object:
+    """Prefer an explicit launch spec's signature, else the metadata's."""
+
+    if launch_spec is not None and "signature" in launch_spec:
+        return launch_spec["signature"]
+    if "signature" in entry.metadata:
+        return entry.metadata["signature"]
+    raise LoaderError(
+        f"{entry.metadata_path} has no 'signature' and no --launch-spec was given. "
+        "Triton does not emit the argument signature in every version (it is absent "
+        "in 3.7.1), so dispatch mode needs it supplied explicitly. Use --mode load "
+        "to instrument the object without launching it."
+    )
+
+
+# --------------------------------------------------------------------------
+# HIP runtime binding
+# --------------------------------------------------------------------------
+
+
+class Hip:
+    """The thin slice of the HIP runtime this loader needs, via ctypes."""
+
+    def __init__(self, library: str = "libamdhip64.so") -> None:
+        try:
+            self._lib = ctypes.CDLL(library)
+        except OSError as exc:
+            raise LoaderError(f"cannot load {library}: {exc}") from exc
+        self._lib.hipGetErrorString.restype = ctypes.c_char_p
+        self._lib.hipGetErrorString.argtypes = [ctypes.c_int]
+
+    def check(self, code: int, what: str) -> None:
+        if code != 0:
+            message = self._lib.hipGetErrorString(code) or b"unknown error"
+            raise LoaderError(f"{what} failed: {message.decode(errors='replace')} ({code})")
+
+    def module_load(self, path: Path) -> ctypes.c_void_p:
+        module = ctypes.c_void_p()
+        self.check(
+            self._lib.hipModuleLoad(ctypes.byref(module), str(path).encode()),
+            f"hipModuleLoad({path})",
+        )
+        return module
+
+    def module_unload(self, module: ctypes.c_void_p) -> None:
+        self.check(self._lib.hipModuleUnload(module), "hipModuleUnload")
+
+    def module_get_function(self, module: ctypes.c_void_p, name: str) -> ctypes.c_void_p:
+        function = ctypes.c_void_p()
+        self.check(
+            self._lib.hipModuleGetFunction(ctypes.byref(function), module, name.encode()),
+            f"hipModuleGetFunction({name})",
+        )
+        return function
+
+    def malloc(self, size: int) -> ctypes.c_void_p:
+        pointer = ctypes.c_void_p()
+        self.check(self._lib.hipMalloc(ctypes.byref(pointer), ctypes.c_size_t(size)), "hipMalloc")
+        self.check(
+            self._lib.hipMemset(pointer, 0, ctypes.c_size_t(size)),
+            "hipMemset",
+        )
+        return pointer
+
+    def free(self, pointer: ctypes.c_void_p) -> None:
+        self.check(self._lib.hipFree(pointer), "hipFree")
+
+    def launch(
+        self,
+        function: ctypes.c_void_p,
+        *,
+        grid: tuple[int, int, int],
+        block: int,
+        shared: int,
+        arguments: bytes,
+    ) -> None:
+        buffer = ctypes.create_string_buffer(arguments, len(arguments))
+        size = ctypes.c_size_t(len(arguments))
+        config = (ctypes.c_void_p * 5)(
+            _HIP_LAUNCH_PARAM_BUFFER_POINTER,
+            ctypes.cast(buffer, ctypes.c_void_p),
+            _HIP_LAUNCH_PARAM_BUFFER_SIZE,
+            ctypes.cast(ctypes.byref(size), ctypes.c_void_p),
+            _HIP_LAUNCH_PARAM_END,
+        )
+        self.check(
+            self._lib.hipModuleLaunchKernel(
+                function,
+                ctypes.c_uint(grid[0]),
+                ctypes.c_uint(grid[1]),
+                ctypes.c_uint(grid[2]),
+                ctypes.c_uint(block),
+                ctypes.c_uint(1),
+                ctypes.c_uint(1),
+                ctypes.c_uint(shared),
+                ctypes.c_void_p(None),
+                ctypes.c_void_p(None),
+                config,
+            ),
+            "hipModuleLaunchKernel",
+        )
+        self.check(self._lib.hipDeviceSynchronize(), "hipDeviceSynchronize")
+
+
+# --------------------------------------------------------------------------
+# Modes
+# --------------------------------------------------------------------------
+
+
+def run_load(hip: Hip, entry: CacheEntry) -> None:
+    module = hip.module_load(entry.hsaco)
+    try:
+        hip.module_get_function(module, entry.kernel_name)
+        print(
+            f"[triton-consan-loader] loaded+instrumented {entry.kernel_name} "
+            f"arch={entry.arch} from {entry.hsaco} (no dispatch)"
+        )
+    finally:
+        hip.module_unload(module)
+
+
+def run_dispatch(
+    hip: Hip,
+    entry: CacheEntry,
+    *,
+    specs: tuple[ArgSpec, ...],
+    grid: tuple[int, int, int],
+    buffer_bytes: int,
+    scalars: dict[str, str],
+) -> None:
+    unknown = sorted(set(scalars) - {spec.name for spec in specs})
+    if unknown:
+        raise LoaderError(f"--arg names not in the kernel signature: {', '.join(unknown)}")
+
+    module = hip.module_load(entry.hsaco)
+    allocations: list[ctypes.c_void_p] = []
+    try:
+        function = hip.module_get_function(module, entry.kernel_name)
+        pointers: dict[str, int] = {}
+        for spec in specs:
+            if not spec.is_pointer:
+                continue
+            allocation = hip.malloc(buffer_bytes)
+            allocations.append(allocation)
+            pointers[spec.name] = allocation.value or 0
+        arguments = pack_arguments(specs, pointers=pointers, scalars=scalars)
+        check_kernarg_fit(len(arguments), kernarg_segment_size(entry), kernel=entry.kernel_name)
+        block = block_dim(entry.metadata)
+        shared = shared_bytes(entry.metadata)
+        hip.launch(
+            function,
+            grid=grid,
+            block=block,
+            shared=shared,
+            arguments=arguments,
+        )
+        print(
+            f"[triton-consan-loader] dispatched {entry.kernel_name} "
+            f"grid={grid} block={block} shared={shared} "
+            f"args={len(arguments)}B buffers={len(allocations)}x{buffer_bytes}B"
+        )
+    finally:
+        for allocation in allocations:
+            hip.free(allocation)
+        hip.module_unload(module)
+
+
+def render_shim(loader: Path, argv: list[str], *, entry: CacheEntry) -> str:
+    """Render the zero-argument shim that a recipe names as ``consan_command``."""
+
+    quoted = " \\\n    ".join(shlex.quote(item) for item in argv)
+    return (
+        "#!/bin/sh\n"
+        "# Generated by scripts/sanitizers/triton_consan_loader.py -- do not edit.\n"
+        f"# ConSan target for Triton kernel '{entry.kernel_name}' (arch {entry.arch}).\n"
+        f"# Code object: {entry.hsaco}\n"
+        f"# Metadata:    {entry.metadata_path}\n"
+        "#\n"
+        "# sanitizer_plan.source.consan_command must be a bare executable taking no\n"
+        "# arguments, so the loader's arguments are baked in here instead.\n"
+        "set -e\n"
+        f"exec {shlex.quote(sys.executable)} {shlex.quote(str(loader))} \\\n    {quoted}\n"
+    )
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _add_selection_arguments(parser: argparse.ArgumentParser) -> None:
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--cache-entry",
+        type=Path,
+        help="Triton cache directory (one entry, or a cache root to search)",
+    )
+    source.add_argument("--hsaco", type=Path, help="Triton code object path")
+    parser.add_argument(
+        "--metadata",
+        type=Path,
+        default=None,
+        help="sidecar metadata JSON (default: the .json beside --hsaco)",
+    )
+    parser.add_argument("--kernel-name", default=None, help="disambiguate by kernel name")
+    parser.add_argument("--cache-hash", default=None, help="disambiguate by Triton hash prefix")
+    parser.add_argument(
+        "--mode",
+        choices=("load", "dispatch"),
+        default="load",
+        help="load the object only (default), or also launch it once",
+    )
+    parser.add_argument(
+        "--launch-spec",
+        type=Path,
+        default=None,
+        help="JSON supplying 'signature' when the Triton metadata omits it",
+    )
+    parser.add_argument("--grid", default="1,1,1", help="dispatch grid 'X,Y,Z' (default 1,1,1)")
+    parser.add_argument(
+        "--buffer-bytes",
+        type=int,
+        default=_DEFAULT_BUFFER_BYTES,
+        help="bytes to allocate per pointer argument in dispatch mode",
+    )
+    parser.add_argument(
+        "--arg",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="scalar argument override; repeatable (default: every scalar is 0)",
+    )
+
+
+def _resolve_entry(args: argparse.Namespace) -> CacheEntry:
+    if args.hsaco is not None:
+        return entry_from_hsaco(args.hsaco, args.metadata)
+    entries = discover_entries(args.cache_entry)
+    return select_entry(entries, kernel_name=args.kernel_name, cache_hash=args.cache_hash)
+
+
+def _loader_argv(args: argparse.Namespace, entry: CacheEntry) -> list[str]:
+    """Build the fully-resolved ``run`` argv a shim should exec.
+
+    Everything is resolved to an absolute path and a concrete object here, so the
+    shim never depends on the cache still being searchable or on a relative
+    working directory at ConSan time.
+    """
+
+    argv = [
+        "run",
+        "--hsaco",
+        str(entry.hsaco),
+        "--metadata",
+        str(entry.metadata_path),
+        "--mode",
+        args.mode,
+    ]
+    if args.mode == "dispatch":
+        argv += ["--grid", args.grid, "--buffer-bytes", str(args.buffer_bytes)]
+        if args.launch_spec is not None:
+            argv += ["--launch-spec", str(args.launch_spec.resolve())]
+        for override in args.arg:
+            argv += ["--arg", override]
+    return argv
+
+
+def _command_run(args: argparse.Namespace) -> int:
+    entry = _resolve_entry(args)
+    hip = Hip()
+    if args.mode == "load":
+        run_load(hip, entry)
+        return 0
+    launch_spec = read_metadata(args.launch_spec) if args.launch_spec else None
+    specs = parse_signature(resolve_signature(entry, launch_spec))
+    run_dispatch(
+        hip,
+        entry,
+        specs=specs,
+        grid=parse_grid(args.grid),
+        buffer_bytes=args.buffer_bytes,
+        scalars=parse_arg_overrides(args.arg),
+    )
+    return 0
+
+
+def _command_emit(args: argparse.Namespace) -> int:
+    entry = _resolve_entry(args)
+    loader = Path(__file__).resolve()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_shim(loader, _loader_argv(args, entry), entry=entry), "utf-8")
+    args.output.chmod(args.output.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    print(f"[triton-consan-loader] wrote {args.output} -> {entry.kernel_name} ({args.mode})")
+    return 0
+
+
+def _command_list(args: argparse.Namespace) -> int:
+    for entry in discover_entries(args.cache_entry):
+        print(f"{entry.kernel_name}\t{entry.metadata.get('hash', '?')}\t{entry.arch}\t{entry.hsaco}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run = subparsers.add_parser("run", help="load (and optionally dispatch) the code object")
+    _add_selection_arguments(run)
+    run.set_defaults(handler=_command_run)
+
+    emit = subparsers.add_parser(
+        "emit-command", help="write a zero-argument shim for source.consan_command"
+    )
+    _add_selection_arguments(emit)
+    emit.add_argument("--output", type=Path, required=True, help="shim path to write")
+    emit.set_defaults(handler=_command_emit)
+
+    listing = subparsers.add_parser("list", help="list the Triton cache entries under a directory")
+    listing.add_argument("--cache-entry", type=Path, required=True)
+    listing.set_defaults(handler=_command_list)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except LoaderError as exc:
+        print(f"triton_consan_loader: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sanitizers/triton_consan_loader.py
+++ b/scripts/sanitizers/triton_consan_loader.py
@@ -804,6 +804,9 @@ def _command_run(args: argparse.Namespace) -> int:
     # repopulated since emission fails closed instead of loading other bytes.
     verify_digest(entry.hsaco, args.expect_object_sha256, what="code object")
     verify_digest(entry.metadata_path, args.expect_metadata_sha256, what="Triton metadata")
+    if args.expect_launch_spec_sha256 is not None and not args.launch_spec:
+        # A requested check that silently does not run is worse than no check.
+        raise LoaderError("--expect-launch-spec-sha256 given without --launch-spec")
     hip = Hip()
     if args.mode == "load":
         run_load(hip, entry)

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
@@ -157,9 +157,14 @@ python3 scripts/sanitizers/triton_consan_loader.py emit-command \
 
 `run_consan` executes `consan_command` as a bare argv with no arguments, so
 `emit-command` writes a small executable shim with the resolved arguments baked
-in -- the run-time analogue of the `-DOBJECT` build step. Because `run_consan`
-records `command_sha256`, hashing that shim pins the exact object the run
-loaded. `recipes/sanitizers/consan-triton-kernel.yaml` is a worked example.
+in -- the run-time analogue of the `-DOBJECT` build step. The shim also carries a
+SHA-256 for every input whose bytes decide what runs (the code object, the
+metadata, and the launch spec), and `run` re-checks each before touching the
+device. That is what makes the `command_sha256` `run_consan` records meaningful:
+a Triton cache entry can be evicted and repopulated, so pinning the paths alone
+would let a rebuilt cache feed different code to the same recorded command and
+selected identity. Re-run `emit-command` after any recompile.
+`recipes/sanitizers/consan-triton-kernel.yaml` is a worked example.
 
 Two modes mirror the two committed HIP loaders:
 

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
@@ -152,8 +152,18 @@ python3 scripts/sanitizers/triton_consan_loader.py list --cache-entry "$TRITON_C
 python3 scripts/sanitizers/triton_consan_loader.py emit-command \
   --cache-entry "$TRITON_CACHE_DIR" \
   --kernel-name _mfma_lds_mediumm_kernel \
-  --output fixtures/bin/consan_triton_kernel
+  --copy-object recipes/sanitizers/fixtures/isa/_mfma_lds_mediumm_kernel.hsaco \
+  --output recipes/sanitizers/fixtures/bin/consan_triton_kernel
 ```
+
+Both paths are recipe-relative: a recipe resolves `consan_command` and
+`code_object` against its own directory, so writing them under
+`recipes/sanitizers/fixtures/` is what makes
+`recipes/sanitizers/consan-triton-kernel.yaml` runnable as written.
+`--copy-object` lifts the object and its sidecars out of the Triton cache, which
+is scratch space that gets evicted and recompiled, and points the shim at the
+copy -- so the recipe's `code_object` and the object the shim loads are the same
+file, and it still exists on the next run.
 
 `run_consan` executes `consan_command` as a bare argv with no arguments, so
 `emit-command` writes a small executable shim with the resolved arguments baked
@@ -177,6 +187,18 @@ Two modes mirror the two committed HIP loaders:
   version (it is absent in 3.7.1), so pass `--launch-spec` with an explicit
   `signature` when the metadata has none. Block size comes from
   `num_warps * warp_size` and dynamic LDS from `shared`.
+
+A `--launch-spec` signature accepts either a JSON object (what Triton emits,
+where key order is the argument order) or a JSON array of `[name, type]` pairs.
+Prefer the array form when hand-authoring one: key order carries no meaning in
+JSON, so an editor or `json.dumps(sort_keys=True)` can silently reorder an
+object, and a permutation keeps the packed buffer the same size — so the kernarg
+cross-check below cannot catch it and the kernel reads a scalar where a pointer
+belongs.
+
+```json
+{"signature": [["x_ptr", "*fp32"], ["y_ptr", "*fp32"], ["n_elements", "i32"]]}
+```
 
 Scalar arguments default to zero and pointer arguments get a fresh zeroed
 buffer, because a synthesized size or stride would index buffers whose real

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
@@ -129,6 +129,71 @@ still wins, and `rj_waitcheck` on `PATH` is a final fallback):
 
 When both are set, the prebuilt bundle wins.
 
+## Driving ConSan over a JIT-compiled Triton/Gluon kernel
+
+ConSan only runs against a caller-supplied `source.consan_command`; it never
+wraps a whole application to reach a few selected kernels. For a code object
+built from HIP source that command is a small loader compiled per object with
+`-DOBJECT` (`consan_load.hip`). A Triton/Gluon kernel cannot use that pattern:
+the `.hsaco` does not exist until the kernel runs, it is keyed by a content hash
+under `TRITON_CACHE_DIR`, and it is specific to the image, the GPU target, and
+the compiled shapes -- there is nothing to pin in a fixture directory and no
+source to compile ([#399](https://github.com/ROCm/aorta/issues/399)).
+
+`scripts/sanitizers/triton_consan_loader.py` is the generic equivalent. It binds
+`libamdhip64` through ctypes, so the object path is resolved at *run* time and no
+compiler is involved. Point it at a Triton cache entry -- a `.hsaco` plus the
+adjacent `.json` Triton writes beside it -- and it loads that object under
+whatever hook the parent set in `HSA_TOOLS_LIB`:
+
+```bash
+# List what the JIT actually compiled, then emit one shim per code object.
+python3 scripts/sanitizers/triton_consan_loader.py list --cache-entry "$TRITON_CACHE_DIR"
+python3 scripts/sanitizers/triton_consan_loader.py emit-command \
+  --cache-entry "$TRITON_CACHE_DIR" \
+  --kernel-name _mfma_lds_mediumm_kernel \
+  --output fixtures/bin/consan_triton_kernel
+```
+
+`run_consan` executes `consan_command` as a bare argv with no arguments, so
+`emit-command` writes a small executable shim with the resolved arguments baked
+in -- the run-time analogue of the `-DOBJECT` build step. Because `run_consan`
+records `command_sha256`, hashing that shim pins the exact object the run
+loaded. `recipes/sanitizers/consan-triton-kernel.yaml` is a worked example.
+
+Two modes mirror the two committed HIP loaders:
+
+- **`load` (default)** -- `hipModuleLoad` the object and resolve the kernel
+  symbol. ConSan instruments a code object when it is loaded, so this is enough
+  to reach the kernel, and it needs no knowledge of the launch ABI. Works for
+  any Triton kernel.
+- **`dispatch`** -- additionally launch the kernel once. This needs the argument
+  signature, which Triton does **not** write to the metadata JSON in every
+  version (it is absent in 3.7.1), so pass `--launch-spec` with an explicit
+  `signature` when the metadata has none. Block size comes from
+  `num_warps * warp_size` and dynamic LDS from `shared`.
+
+Scalar arguments default to zero and pointer arguments get a fresh zeroed
+buffer, because a synthesized size or stride would index buffers whose real
+extents are unknowable and turn a sanitizer run into a memory fault. Use
+`--arg NAME=VALUE` / `--buffer-bytes` to make the kernel touch memory. HIP does
+not validate the launch buffer against the kernel descriptor, so the loader
+cross-checks the packed buffer against `.kernarg_segment_size` from the
+`.amdgcn` listing Triton writes beside the object and refuses to dispatch a
+buffer that would over-run the segment.
+
+Two limits are worth stating plainly. One logical Triton kernel usually compiles
+to several objects (shape-selected variants), and ConSan takes exactly one code
+object per run, so harvest one shim and one recipe per object; an ambiguous
+selection fails closed and lists the candidates. And on the currently shipping
+RocJITsu build, record/replay reports itself as `an inventory-only stub`, so a
+dispatch captures no dynamic records and strict policy fails closed with exit 86
+— the same outcome the committed `daily-consan-tiny.yaml` and
+`daily-consan-lds-dispatch.yaml` lanes document
+([ROCm/rocm-systems#9972](https://github.com/ROCm/rocm-systems/issues/9972)).
+The loader removes the aorta-side gap; the dynamic-coverage half stays blocked
+upstream.
+
 ## Verdict and health rules
 
 - Waitcheck structured hazard → `warn`.

--- a/tests/sanitizers/test_triton_consan_loader.py
+++ b/tests/sanitizers/test_triton_consan_loader.py
@@ -1,0 +1,450 @@
+"""Unit tests for the generic Triton ConSan loader (pure logic; no GPU/ROCm needed).
+
+Everything that touches HIP lives behind ``Hip``; these tests cover the cache
+resolution, launch-ABI packing, and shim generation around it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Shape of a real Triton 3.7.1 metadata sidecar (gfx950). Note the absence of
+# ``signature``: that field is why dispatch mode needs --launch-spec.
+_METADATA = {
+    "hash": "66c1005ec4e1c371fab4395b6074084db48e3da68423542e611f0a14baf82c84",
+    "target": {"backend": "hip", "arch": "gfx950", "warp_size": 64},
+    "num_warps": 4,
+    "num_stages": 2,
+    "shared": 0,
+    "name": "add_kernel",
+}
+
+
+def _load():
+    path = _REPO_ROOT / "scripts" / "sanitizers" / "triton_consan_loader.py"
+    spec = importlib.util.spec_from_file_location("triton_consan_loader", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # @dataclass resolves annotations through sys.modules, so register before exec.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+loader = _load()
+
+
+def _entry_dir(root: Path, *, name: str = "add_kernel", **overrides) -> Path:
+    """Write one Triton-cache-shaped entry directory and return it."""
+
+    metadata = {**_METADATA, "name": name, **overrides}
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{name}.hsaco").write_bytes(b"\x7fELF fake code object")
+    (root / f"{name}.json").write_text(json.dumps(metadata), encoding="utf-8")
+    # Triton also writes a sibling group index that is not kernel metadata.
+    (root / f"__grp__{name}.json").write_text(json.dumps({"child_paths": {}}), encoding="utf-8")
+    return root
+
+
+# --------------------------------------------------------------------------
+# Cache entry resolution
+# --------------------------------------------------------------------------
+
+
+def test_entry_from_hsaco_pairs_the_adjacent_sidecar(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    entry = loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco")
+    assert entry.kernel_name == "add_kernel"
+    assert entry.arch == "gfx950"
+    assert entry.metadata_path == (entry_dir / "add_kernel.json").resolve()
+
+
+def test_entry_from_hsaco_without_metadata_fails_closed(tmp_path):
+    tmp_path.joinpath("orphan.hsaco").write_bytes(b"\x7fELF")
+    with pytest.raises(loader.LoaderError, match="no Triton metadata beside"):
+        loader.entry_from_hsaco(tmp_path / "orphan.hsaco")
+
+
+def test_entry_from_hsaco_missing_object_fails_closed(tmp_path):
+    with pytest.raises(loader.LoaderError, match="code object not found"):
+        loader.entry_from_hsaco(tmp_path / "absent.hsaco")
+
+
+def test_arch_falls_back_to_flat_key(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY", target={"backend": "hip"}, arch="gfx942")
+    assert loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco").arch == "gfx942"
+
+
+def test_kernel_name_missing_fails_closed(tmp_path):
+    entry_dir = tmp_path / "ENTRY"
+    entry_dir.mkdir()
+    (entry_dir / "k.hsaco").write_bytes(b"\x7fELF")
+    (entry_dir / "k.json").write_text(json.dumps({"target": {}}), encoding="utf-8")
+    entry = loader.entry_from_hsaco(entry_dir / "k.hsaco")
+    with pytest.raises(loader.LoaderError, match="metadata has no 'name'"):
+        _ = entry.kernel_name
+
+
+def test_read_metadata_rejects_non_object(tmp_path):
+    path = tmp_path / "meta.json"
+    path.write_text("[1, 2]", encoding="utf-8")
+    with pytest.raises(loader.LoaderError, match="must be a JSON object"):
+        loader.read_metadata(path)
+
+
+def test_discover_entries_recurses_and_skips_group_index(tmp_path):
+    _entry_dir(tmp_path / "AAAA", name="mediumm_kernel")
+    _entry_dir(tmp_path / "BBBB", name="largem_kernel")
+    entries = loader.discover_entries(tmp_path)
+    assert sorted(entry.kernel_name for entry in entries) == [
+        "largem_kernel",
+        "mediumm_kernel",
+    ]
+
+
+def test_discover_entries_on_empty_cache_fails_closed(tmp_path):
+    with pytest.raises(loader.LoaderError, match="no Triton code objects under"):
+        loader.discover_entries(tmp_path)
+
+
+def test_discover_entries_missing_directory_fails_closed(tmp_path):
+    with pytest.raises(loader.LoaderError, match="cache directory not found"):
+        loader.discover_entries(tmp_path / "nope")
+
+
+def test_select_entry_is_ambiguous_when_several_objects_match(tmp_path):
+    """One logical Triton kernel compiles to several shape-selected objects.
+
+    ConSan takes exactly one code object per run, so an ambiguous selection must
+    fail closed and list the candidates rather than silently picking one.
+    """
+
+    _entry_dir(tmp_path / "AAAA", name="mm_kernel", hash="aaaa1111")
+    _entry_dir(tmp_path / "BBBB", name="mm_kernel", hash="bbbb2222")
+    entries = loader.discover_entries(tmp_path)
+    with pytest.raises(loader.LoaderError, match="2 Triton cache entries match") as excinfo:
+        loader.select_entry(entries)
+    assert "aaaa1111" in str(excinfo.value)
+    assert "bbbb2222" in str(excinfo.value)
+
+
+def test_select_entry_narrows_by_name_and_hash_prefix(tmp_path):
+    _entry_dir(tmp_path / "AAAA", name="mediumm_kernel", hash="aaaa1111")
+    _entry_dir(tmp_path / "BBBB", name="largem_kernel", hash="bbbb2222")
+    entries = loader.discover_entries(tmp_path)
+    assert loader.select_entry(entries, kernel_name="largem_kernel").kernel_name == "largem_kernel"
+    assert loader.select_entry(entries, cache_hash="aaaa").kernel_name == "mediumm_kernel"
+
+
+def test_select_entry_without_a_match_lists_what_is_available(tmp_path):
+    _entry_dir(tmp_path / "AAAA", name="mediumm_kernel")
+    entries = loader.discover_entries(tmp_path)
+    with pytest.raises(loader.LoaderError, match="mediumm_kernel"):
+        loader.select_entry(entries, kernel_name="absent_kernel")
+
+
+# --------------------------------------------------------------------------
+# Launch ABI
+# --------------------------------------------------------------------------
+
+
+def test_parse_signature_drops_constexpr_and_keeps_order():
+    specs = loader.parse_signature(
+        {"x_ptr": "*fp32", "n_elements": "i32", "BLOCK_SIZE": "constexpr"}
+    )
+    assert [spec.name for spec in specs] == ["x_ptr", "n_elements"]
+    assert specs[0].is_pointer and not specs[1].is_pointer
+
+
+@pytest.mark.parametrize("bad", [["*fp32"], "*fp32", 3])
+def test_parse_signature_rejects_non_mapping(bad):
+    with pytest.raises(loader.LoaderError, match="signature must be a JSON object"):
+        loader.parse_signature(bad)
+
+
+def test_parse_signature_rejects_non_string_type():
+    with pytest.raises(loader.LoaderError, match="must map to a type string"):
+        loader.parse_signature({"x": 32})
+
+
+def test_unsupported_argument_type_fails_closed():
+    with pytest.raises(loader.LoaderError, match="unsupported Triton type"):
+        _ = loader.ArgSpec(name="x", ttype="tensor").size
+
+
+def test_pack_arguments_matches_the_real_add_kernel_layout():
+    """3 pointers + i32, padded to the widest member -- 32 bytes on the device.
+
+    Verified against a real gfx950 ``add_kernel`` dispatch.
+    """
+
+    specs = loader.parse_signature(
+        {
+            "x_ptr": "*fp32",
+            "y_ptr": "*fp32",
+            "out_ptr": "*fp32",
+            "n_elements": "i32",
+            "BLOCK_SIZE": "constexpr",
+        }
+    )
+    packed = loader.pack_arguments(
+        specs,
+        pointers={"x_ptr": 0x1000, "y_ptr": 0x2000, "out_ptr": 0x3000},
+        scalars={"n_elements": "1024"},
+    )
+    assert len(packed) == 32
+    assert struct.unpack_from("<QQQi", packed) == (0x1000, 0x2000, 0x3000, 1024)
+
+
+def test_pack_arguments_aligns_a_wide_scalar_after_a_narrow_one():
+    specs = loader.parse_signature({"small": "i8", "wide": "i64"})
+    packed = loader.pack_arguments(specs, pointers={}, scalars={"small": "7", "wide": "1"})
+    # i64 must start at offset 8, not 1.
+    assert len(packed) == 16
+    assert struct.unpack_from("<q", packed, 8) == (1,)
+
+
+def test_pack_arguments_defaults_every_scalar_to_zero():
+    specs = loader.parse_signature({"n": "i32", "m": "i32"})
+    assert loader.pack_arguments(specs, pointers={}, scalars={}) == b"\x00" * 8
+
+
+def test_pack_arguments_supports_hex_and_negative_integers():
+    specs = loader.parse_signature({"n": "i32"})
+    assert loader.pack_arguments(specs, pointers={}, scalars={"n": "0x10"}) == b"\x10\x00\x00\x00"
+    assert loader.pack_arguments(specs, pointers={}, scalars={"n": "-1"}) == b"\xff" * 4
+
+
+def test_pack_arguments_rejects_out_of_range_and_malformed_scalars():
+    specs = loader.parse_signature({"n": "i32"})
+    with pytest.raises(loader.LoaderError, match="does not fit in i32"):
+        loader.pack_arguments(specs, pointers={}, scalars={"n": str(2**40)})
+    with pytest.raises(loader.LoaderError, match="expects an integer"):
+        loader.pack_arguments(specs, pointers={}, scalars={"n": "abc"})
+
+
+@pytest.mark.parametrize(
+    ("ttype", "value", "expected"),
+    [
+        ("fp32", "1.5", struct.pack("<f", 1.5)),
+        ("fp64", "1.5", struct.pack("<d", 1.5)),
+        ("fp16", "1.5", struct.pack("<e", 1.5)),
+        ("bf16", "1.5", b"\xc0\x3f"),
+        ("bf16", "0", b"\x00\x00"),
+    ],
+)
+def test_float_scalars_pack_to_their_device_widths(ttype, value, expected):
+    specs = loader.parse_signature({"v": ttype})
+    assert loader.pack_arguments(specs, pointers={}, scalars={"v": value}) == expected
+
+
+def test_float_scalar_rejects_non_numeric():
+    specs = loader.parse_signature({"v": "fp32"})
+    with pytest.raises(loader.LoaderError, match="expects a float"):
+        loader.pack_arguments(specs, pointers={}, scalars={"v": "not-a-number"})
+
+
+def test_block_dim_multiplies_warps_by_warp_size():
+    assert loader.block_dim(_METADATA) == 256
+    assert loader.block_dim({"num_warps": 2, "warp_size": 64}) == 128
+
+
+@pytest.mark.parametrize(
+    ("metadata", "match"),
+    [
+        ({"num_warps": 4}, "warp_size"),
+        ({"warp_size": 64}, "num_warps"),
+        ({"num_warps": 0, "warp_size": 64}, "num_warps"),
+    ],
+)
+def test_block_dim_fails_closed_on_incomplete_metadata(metadata, match):
+    with pytest.raises(loader.LoaderError, match=match):
+        loader.block_dim(metadata)
+
+
+def test_shared_bytes_reads_lds_requirement():
+    assert loader.shared_bytes({"shared": 16384}) == 16384
+    assert loader.shared_bytes({}) == 0
+    with pytest.raises(loader.LoaderError, match="non-negative integer"):
+        loader.shared_bytes({"shared": -1})
+
+
+@pytest.mark.parametrize("bad", ["1,1", "1,1,1,1", "a,b,c", "0,1,1"])
+def test_parse_grid_rejects_malformed_input(bad):
+    with pytest.raises(loader.LoaderError):
+        loader.parse_grid(bad)
+
+
+def test_parse_grid_accepts_three_dimensions():
+    assert loader.parse_grid("4, 2,1") == (4, 2, 1)
+
+
+def test_parse_arg_overrides_splits_on_first_equals():
+    assert loader.parse_arg_overrides(["n=1", "s=a=b"]) == {"n": "1", "s": "a=b"}
+    with pytest.raises(loader.LoaderError, match="must be 'name=value'"):
+        loader.parse_arg_overrides(["bare"])
+
+
+def test_resolve_signature_prefers_the_launch_spec(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY", signature={"a": "i32"})
+    entry = loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco")
+    assert loader.resolve_signature(entry, {"signature": {"b": "i64"}}) == {"b": "i64"}
+    assert loader.resolve_signature(entry, None) == {"a": "i32"}
+
+
+def test_resolve_signature_without_one_points_at_the_workaround(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    entry = loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco")
+    with pytest.raises(loader.LoaderError, match="--launch-spec") as excinfo:
+        loader.resolve_signature(entry, None)
+    assert "--mode load" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# kernarg cross-check
+# --------------------------------------------------------------------------
+
+
+def test_kernarg_segment_size_read_from_the_amdgcn_listing(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    (entry_dir / "add_kernel.amdgcn").write_text(
+        ".amdhsa_kernarg_size 48\n"
+        "  .kernarg_segment_align: 8\n"
+        "  .kernarg_segment_size: 48\n",
+        encoding="utf-8",
+    )
+    entry = loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco")
+    assert loader.kernarg_segment_size(entry) == 48
+
+
+def test_kernarg_segment_size_absent_listing_is_not_an_error(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    entry = loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco")
+    assert loader.kernarg_segment_size(entry) is None
+
+
+def test_check_kernarg_fit_rejects_only_the_overrun_direction():
+    # HIP does not validate the launch buffer size, so an over-long buffer is the
+    # one provably-wrong case we can catch before it scribbles past the segment.
+    with pytest.raises(loader.LoaderError, match="does not match this code object"):
+        loader.check_kernarg_fit(56, 48, kernel="add_kernel")
+    # Hidden arguments make the compiled segment larger than the explicit args.
+    loader.check_kernarg_fit(32, 48, kernel="add_kernel")
+    loader.check_kernarg_fit(999, None, kernel="add_kernel")
+
+
+# --------------------------------------------------------------------------
+# consan_command shim
+# --------------------------------------------------------------------------
+
+
+def test_emitted_shim_is_executable_and_self_contained(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    output = tmp_path / "bin" / "consan_add_kernel"
+    assert (
+        loader.main(
+            [
+                "emit-command",
+                "--cache-entry",
+                str(entry_dir),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    assert os.access(output, os.X_OK)
+    assert output.stat().st_mode & stat.S_IXUSR
+    body = output.read_text(encoding="utf-8")
+    assert body.startswith("#!/bin/sh\n")
+    # The shim must name absolute paths: ConSan runs it with no arguments and
+    # from an unspecified working directory.
+    assert str((entry_dir / "add_kernel.hsaco").resolve()) in body
+    assert str((entry_dir / "add_kernel.json").resolve()) in body
+    assert "--mode load" in body.replace(" \\\n    ", " ")
+
+
+def test_shim_bakes_in_dispatch_options(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    output = tmp_path / "consan_dispatch"
+    spec = tmp_path / "launch.json"
+    spec.write_text(json.dumps({"signature": {"x": "*fp32"}}), encoding="utf-8")
+    assert (
+        loader.main(
+            [
+                "emit-command",
+                "--cache-entry",
+                str(entry_dir),
+                "--output",
+                str(output),
+                "--mode",
+                "dispatch",
+                "--grid",
+                "8,1,1",
+                "--arg",
+                "n_elements=1024",
+                "--launch-spec",
+                str(spec),
+            ]
+        )
+        == 0
+    )
+    flattened = output.read_text(encoding="utf-8").replace(" \\\n    ", " ")
+    assert "--mode dispatch" in flattened
+    assert "--grid 8,1,1" in flattened
+    assert "--arg n_elements=1024" in flattened
+    assert f"--launch-spec {spec.resolve()}" in flattened
+
+
+def test_shim_quotes_paths_containing_spaces(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "cache dir")
+    output = tmp_path / "shim"
+    assert loader.main(["emit-command", "--cache-entry", str(entry_dir), "--output", str(output)]) == 0
+    assert "'" in output.read_text(encoding="utf-8")
+
+
+def test_loader_argv_omits_dispatch_flags_in_load_mode(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    entry = loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco")
+    args = loader.build_parser().parse_args(
+        ["run", "--cache-entry", str(entry_dir), "--grid", "4,1,1"]
+    )
+    argv = loader._loader_argv(args, entry)
+    assert "--grid" not in argv
+    assert argv[:2] == ["run", "--hsaco"]
+
+
+# --------------------------------------------------------------------------
+# CLI wiring
+# --------------------------------------------------------------------------
+
+
+def test_main_reports_loader_errors_without_a_traceback(tmp_path, capsys):
+    assert loader.main(["list", "--cache-entry", str(tmp_path)]) == 1
+    assert "triton_consan_loader:" in capsys.readouterr().err
+
+
+def test_list_prints_one_row_per_code_object(tmp_path, capsys):
+    _entry_dir(tmp_path / "AAAA", name="mediumm_kernel", hash="aaaa1111")
+    _entry_dir(tmp_path / "BBBB", name="largem_kernel", hash="bbbb2222")
+    assert loader.main(["list", "--cache-entry", str(tmp_path)]) == 0
+    rows = capsys.readouterr().out.strip().splitlines()
+    assert len(rows) == 2
+    assert all(row.count("\t") == 3 for row in rows)
+
+
+def test_hsaco_and_cache_entry_are_mutually_exclusive(tmp_path):
+    with pytest.raises(SystemExit):
+        loader.build_parser().parse_args(
+            ["run", "--cache-entry", str(tmp_path), "--hsaco", str(tmp_path / "k.hsaco")]
+        )

--- a/tests/sanitizers/test_triton_consan_loader.py
+++ b/tests/sanitizers/test_triton_consan_loader.py
@@ -6,6 +6,7 @@ resolution, launch-ABI packing, and shim generation around it.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import os
@@ -263,6 +264,15 @@ def test_float_scalar_rejects_non_numeric():
         loader.pack_arguments(specs, pointers={}, scalars={"v": "not-a-number"})
 
 
+@pytest.mark.parametrize(("ttype", "value"), [("fp16", "70000"), ("fp32", "1e300")])
+def test_float_scalar_too_wide_for_its_type_fails_closed(ttype, value):
+    # struct.pack raises OverflowError, not ValueError; without translating it the
+    # loader would traceback instead of exiting non-zero like every other error.
+    specs = loader.parse_signature({"v": ttype})
+    with pytest.raises(loader.LoaderError, match=f"does not fit in {ttype}"):
+        loader.pack_arguments(specs, pointers={}, scalars={"v": value})
+
+
 def test_block_dim_multiplies_warps_by_warp_size():
     assert loader.block_dim(_METADATA) == 256
     assert loader.block_dim({"num_warps": 2, "warp_size": 64}) == 128
@@ -296,6 +306,72 @@ def test_parse_grid_rejects_malformed_input(bad):
 
 def test_parse_grid_accepts_three_dimensions():
     assert loader.parse_grid("4, 2,1") == (4, 2, 1)
+
+
+# --------------------------------------------------------------------------
+# Narrowing into fixed-width C types
+#
+# ctypes wraps silently -- c_uint(2**32 + 1) is 1 -- so an oversized launch
+# dimension would quietly become a tiny one and invalidate the run.
+# --------------------------------------------------------------------------
+
+
+def test_require_in_range_bounds_both_ends():
+    assert loader.require_in_range(5, name="v", minimum=1, maximum=10) == 5
+    with pytest.raises(loader.LoaderError, match=r"v must be in 1\.\.10, got 0"):
+        loader.require_in_range(0, name="v", minimum=1, maximum=10)
+    with pytest.raises(loader.LoaderError, match=r"v must be in 1\.\.10, got 11"):
+        loader.require_in_range(11, name="v", minimum=1, maximum=10)
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_grid_dimension_above_c_uint_fails_closed(axis):
+    dims = ["1", "1", "1"]
+    dims[axis] = str(loader._UINT_MAX + 1)
+    with pytest.raises(loader.LoaderError, match="--grid"):
+        loader.parse_grid(",".join(dims))
+
+
+def test_grid_dimension_at_the_c_uint_ceiling_is_allowed():
+    assert loader.parse_grid(f"{loader._UINT_MAX},1,1") == (loader._UINT_MAX, 1, 1)
+
+
+def test_block_size_above_c_uint_fails_closed():
+    with pytest.raises(loader.LoaderError, match="block size"):
+        loader.block_dim({"num_warps": loader._UINT_MAX, "warp_size": 64})
+
+
+def test_shared_bytes_above_c_uint_fails_closed():
+    with pytest.raises(loader.LoaderError, match="metadata 'shared'"):
+        loader.shared_bytes({"shared": loader._UINT_MAX + 1})
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", str(2**64 + 1), "abc"])
+def test_buffer_bytes_rejects_values_that_would_wrap(bad):
+    # argparse surfaces ArgumentTypeError as SystemExit(2), so a wrapping size
+    # never reaches HIP nor gets baked into a shim.
+    with pytest.raises(SystemExit):
+        loader.build_parser().parse_args(
+            ["run", "--hsaco", "/tmp/k.hsaco", "--buffer-bytes", bad]
+        )
+
+
+def test_buffer_bytes_accepts_hex_and_plain_sizes():
+    args = loader.build_parser().parse_args(
+        ["run", "--hsaco", "/tmp/k.hsaco", "--buffer-bytes", "0x1000"]
+    )
+    assert args.buffer_bytes == 4096
+
+
+@pytest.mark.parametrize("bad", ["4294967296,1,1", "0,1,1", "1,1", "a,b,c"])
+def test_grid_is_validated_at_parse_time_so_no_shim_can_bake_a_bad_one(bad):
+    with pytest.raises(SystemExit):
+        loader.build_parser().parse_args(["emit-command", "--hsaco", "/tmp/k.hsaco", "--output", "/tmp/s", "--grid", bad])
+
+
+def test_grid_defaults_to_a_single_block():
+    args = loader.build_parser().parse_args(["run", "--hsaco", "/tmp/k.hsaco"])
+    assert args.grid == (1, 1, 1)
 
 
 def test_parse_arg_overrides_splits_on_first_equals():
@@ -350,6 +426,134 @@ def test_check_kernarg_fit_rejects_only_the_overrun_direction():
     # Hidden arguments make the compiled segment larger than the explicit args.
     loader.check_kernarg_fit(32, 48, kernel="add_kernel")
     loader.check_kernarg_fit(999, None, kernel="add_kernel")
+
+
+# --------------------------------------------------------------------------
+# Content pinning
+#
+# A Triton cache entry is keyed by a content hash, but it can be evicted and
+# repopulated, so a path alone does not pin the bytes that get loaded.
+# --------------------------------------------------------------------------
+
+
+def test_sha256_file_matches_hashlib(tmp_path):
+    path = tmp_path / "blob"
+    path.write_bytes(b"triton code object")
+    assert loader.sha256_file(path) == hashlib.sha256(b"triton code object").hexdigest()
+
+
+def test_verify_digest_accepts_unchanged_bytes(tmp_path):
+    path = tmp_path / "blob"
+    path.write_bytes(b"same")
+    loader.verify_digest(path, loader.sha256_file(path), what="code object")
+
+
+def test_verify_digest_without_a_pin_is_a_no_op(tmp_path):
+    path = tmp_path / "blob"
+    path.write_bytes(b"whatever")
+    loader.verify_digest(path, None, what="code object")
+
+
+def test_verify_digest_rejects_repopulated_bytes(tmp_path):
+    path = tmp_path / "blob"
+    path.write_bytes(b"original")
+    pinned = loader.sha256_file(path)
+    path.write_bytes(b"recompiled")
+    with pytest.raises(loader.LoaderError, match="code object digest mismatch") as excinfo:
+        loader.verify_digest(path, pinned, what="code object")
+    assert "re-run emit-command" in str(excinfo.value)
+
+
+def test_emitted_shim_pins_object_and_metadata_digests(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    output = tmp_path / "shim"
+    assert loader.main(["emit-command", "--cache-entry", str(entry_dir), "--output", str(output)]) == 0
+    flattened = output.read_text(encoding="utf-8").replace(" \\\n    ", " ")
+    assert f"--expect-object-sha256 {loader.sha256_file(entry_dir / 'add_kernel.hsaco')}" in flattened
+    assert (
+        f"--expect-metadata-sha256 {loader.sha256_file(entry_dir / 'add_kernel.json')}" in flattened
+    )
+
+
+def test_emitted_shim_pins_the_launch_spec_in_dispatch_mode(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    spec = tmp_path / "launch.json"
+    spec.write_text(json.dumps({"signature": {"x": "*fp32"}}), encoding="utf-8")
+    output = tmp_path / "shim"
+    assert (
+        loader.main(
+            [
+                "emit-command",
+                "--cache-entry",
+                str(entry_dir),
+                "--output",
+                str(output),
+                "--mode",
+                "dispatch",
+                "--launch-spec",
+                str(spec),
+            ]
+        )
+        == 0
+    )
+    flattened = output.read_text(encoding="utf-8").replace(" \\\n    ", " ")
+    assert f"--expect-launch-spec-sha256 {loader.sha256_file(spec)}" in flattened
+
+
+def test_run_fails_closed_when_the_pinned_object_changed(tmp_path, capsys, monkeypatch):
+    """The whole point of the pin: a recompiled cache entry must not silently run.
+
+    ``Hip`` is patched to a sentinel that raises, proving the digest check runs
+    before anything touches the device.
+    """
+
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    hsaco = entry_dir / "add_kernel.hsaco"
+    pinned = loader.sha256_file(hsaco)
+    hsaco.write_bytes(b"\x7fELF a different, recompiled object")
+
+    def _explode():
+        raise AssertionError("device must not be touched before the digest is verified")
+
+    monkeypatch.setattr(loader, "Hip", _explode)
+    assert (
+        loader.main(
+            [
+                "run",
+                "--hsaco",
+                str(hsaco),
+                "--expect-object-sha256",
+                pinned,
+            ]
+        )
+        == 1
+    )
+    assert "code object digest mismatch" in capsys.readouterr().err
+
+
+def test_run_fails_closed_when_the_pinned_metadata_changed(tmp_path, capsys, monkeypatch):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    metadata = entry_dir / "add_kernel.json"
+    pinned = loader.sha256_file(metadata)
+    metadata.write_text(json.dumps({**_METADATA, "num_warps": 8}), encoding="utf-8")
+
+    def _explode():
+        raise AssertionError("device must not be touched before the digest is verified")
+
+    monkeypatch.setattr(loader, "Hip", _explode)
+    assert (
+        loader.main(
+            [
+                "run",
+                "--hsaco",
+                str(entry_dir / "add_kernel.hsaco"),
+                "--expect-metadata-sha256",
+                pinned,
+            ]
+        )
+        == 1
+    )
+    assert "Triton metadata digest mismatch" in capsys.readouterr().err
 
 
 # --------------------------------------------------------------------------
@@ -431,6 +635,10 @@ def test_loader_argv_omits_dispatch_flags_in_load_mode(tmp_path):
     argv = loader._loader_argv(args, entry)
     assert "--grid" not in argv
     assert argv[:2] == ["run", "--hsaco"]
+    # The object/metadata pins are not dispatch-only: load mode runs the kernel's
+    # code object too, so both are always baked in.
+    assert "--expect-object-sha256" in argv
+    assert "--expect-metadata-sha256" in argv
 
 
 # --------------------------------------------------------------------------

--- a/tests/sanitizers/test_triton_consan_loader.py
+++ b/tests/sanitizers/test_triton_consan_loader.py
@@ -531,6 +531,28 @@ def test_run_fails_closed_when_the_pinned_object_changed(tmp_path, capsys, monke
     assert "code object digest mismatch" in capsys.readouterr().err
 
 
+def test_pinned_launch_spec_without_a_launch_spec_fails_closed(tmp_path, capsys, monkeypatch):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+
+    def _explode():
+        raise AssertionError("device must not be touched")
+
+    monkeypatch.setattr(loader, "Hip", _explode)
+    assert (
+        loader.main(
+            [
+                "run",
+                "--hsaco",
+                str(entry_dir / "add_kernel.hsaco"),
+                "--expect-launch-spec-sha256",
+                "deadbeef",
+            ]
+        )
+        == 1
+    )
+    assert "--expect-launch-spec-sha256 given without --launch-spec" in capsys.readouterr().err
+
+
 def test_run_fails_closed_when_the_pinned_metadata_changed(tmp_path, capsys, monkeypatch):
     entry_dir = _entry_dir(tmp_path / "ENTRY")
     metadata = entry_dir / "add_kernel.json"

--- a/tests/sanitizers/test_triton_consan_loader.py
+++ b/tests/sanitizers/test_triton_consan_loader.py
@@ -12,6 +12,7 @@ import json
 import os
 import stat
 import struct
+import subprocess
 import sys
 from pathlib import Path
 
@@ -176,10 +177,57 @@ def test_parse_signature_drops_constexpr_and_keeps_order():
     assert specs[0].is_pointer and not specs[1].is_pointer
 
 
-@pytest.mark.parametrize("bad", [["*fp32"], "*fp32", 3])
-def test_parse_signature_rejects_non_mapping(bad):
-    with pytest.raises(loader.LoaderError, match="signature must be a JSON object"):
+def test_parse_signature_accepts_an_explicitly_ordered_pair_list():
+    """The ordered form exists because JSON key order is not load-bearing.
+
+    An editor or ``json.dumps(sort_keys=True)`` can permute a hand-authored
+    object, and a permutation preserves the packed size, so the kernarg check
+    cannot see it. The pair list states the order instead of implying it.
+    """
+
+    specs = loader.parse_signature(
+        [["x_ptr", "*fp32"], ["n_elements", "i32"], ["BLOCK_SIZE", "constexpr"]]
+    )
+    assert [spec.name for spec in specs] == ["x_ptr", "n_elements"]
+
+
+def test_ordered_and_mapping_forms_pack_identically():
+    mapping = loader.parse_signature({"x_ptr": "*fp32", "n": "i32"})
+    ordered = loader.parse_signature([["x_ptr", "*fp32"], ["n", "i32"]])
+    pack = {"pointers": {"x_ptr": 0xDEAD0000}, "scalars": {"n": "7"}}
+    assert loader.pack_arguments(mapping, **pack) == loader.pack_arguments(ordered, **pack)
+
+
+def test_a_permuted_signature_packs_different_bytes_at_the_same_size():
+    """Pins the hazard the ordered form exists to avoid."""
+
+    declared = loader.parse_signature([["x_ptr", "*fp32"], ["n", "i32"], ["stride", "i64"]])
+    permuted = loader.parse_signature([["n", "i32"], ["stride", "i64"], ["x_ptr", "*fp32"]])
+    pack = {"pointers": {"x_ptr": 0xDEAD0000}, "scalars": {"n": "7", "stride": "3"}}
+    a = loader.pack_arguments(declared, **pack)
+    b = loader.pack_arguments(permuted, **pack)
+    assert len(a) == len(b)
+    assert a != b
+    # Same size, so the kernarg cross-check accepts both -- ordering has to be
+    # stated by the caller, it cannot be recovered here.
+    loader.check_kernarg_fit(len(b), 48, kernel="k")
+
+
+@pytest.mark.parametrize("bad", ["*fp32", 3, None])
+def test_parse_signature_rejects_a_form_that_is_neither_object_nor_pair_list(bad):
+    with pytest.raises(loader.LoaderError, match="must be a JSON object .* or a JSON array"):
         loader.parse_signature(bad)
+
+
+@pytest.mark.parametrize("bad", [["*fp32"], [["x", "i32", "extra"]], [{"x": "i32"}]])
+def test_parse_signature_rejects_malformed_pairs(bad):
+    with pytest.raises(loader.LoaderError, match=r"must be a \[name, triton_type\] pair"):
+        loader.parse_signature(bad)
+
+
+def test_parse_signature_rejects_a_duplicate_argument():
+    with pytest.raises(loader.LoaderError, match="duplicate argument 'x'"):
+        loader.parse_signature([["x", "i32"], ["x", "i64"]])
 
 
 def test_parse_signature_rejects_non_string_type():
@@ -222,6 +270,20 @@ def test_pack_arguments_aligns_a_wide_scalar_after_a_narrow_one():
     # i64 must start at offset 8, not 1.
     assert len(packed) == 16
     assert struct.unpack_from("<q", packed, 8) == (1,)
+
+
+def test_pack_arguments_rejects_an_override_for_a_pointer():
+    # Pointers always get a fresh zeroed allocation, so accepting --arg on one
+    # would silently launch something other than what was asked for.
+    specs = loader.parse_signature({"x_ptr": "*fp32", "n": "i32"})
+    with pytest.raises(loader.LoaderError, match="cannot set pointer arguments: x_ptr"):
+        loader.pack_arguments(specs, pointers={"x_ptr": 0x1000}, scalars={"x_ptr": "0x2000"})
+
+
+def test_pack_arguments_rejects_an_unknown_override():
+    specs = loader.parse_signature({"n": "i32"})
+    with pytest.raises(loader.LoaderError, match="not in the kernel signature: nope"):
+        loader.pack_arguments(specs, pointers={}, scalars={"nope": "1"})
 
 
 def test_pack_arguments_defaults_every_scalar_to_zero():
@@ -284,11 +346,20 @@ def test_block_dim_multiplies_warps_by_warp_size():
         ({"num_warps": 4}, "warp_size"),
         ({"warp_size": 64}, "num_warps"),
         ({"num_warps": 0, "warp_size": 64}, "num_warps"),
+        # isinstance(True, int) is true, so bool needs an explicit guard or a
+        # malformed metadata file yields block size 1 instead of failing.
+        ({"num_warps": True, "warp_size": True}, "warp_size"),
+        ({"num_warps": True, "warp_size": 64}, "num_warps"),
     ],
 )
 def test_block_dim_fails_closed_on_incomplete_metadata(metadata, match):
     with pytest.raises(loader.LoaderError, match=match):
         loader.block_dim(metadata)
+
+
+def test_block_dim_prefers_the_target_warp_size_then_the_flat_key():
+    assert loader.block_dim({"target": {"warp_size": 32}, "num_warps": 2, "warp_size": 64}) == 64
+    assert loader.block_dim({"target": {}, "num_warps": 2, "warp_size": 64}) == 128
 
 
 def test_shared_bytes_reads_lds_requirement():
@@ -641,6 +712,60 @@ def test_shim_bakes_in_dispatch_options(tmp_path):
     assert f"--launch-spec {spec.resolve()}" in flattened
 
 
+def test_shell_comment_cannot_be_escaped_by_a_newline():
+    # A newline is the only way to end a shell comment, and it is legal in a
+    # Linux path -- so this is the whole guard.
+    rendered = loader.shell_comment("Code object", "/cache/ent\ntouch /tmp/OWNED   #/k.hsaco")
+    assert rendered.count("\n") == 1
+    assert rendered.endswith("\n")
+    assert "\\n" in rendered
+
+
+def test_emitted_shim_seals_its_comment_block_against_a_newline_in_a_path(tmp_path):
+    """Every line before the exec must still be a comment.
+
+    The exec line itself may legitimately span lines, because shlex.quote wraps a
+    newline-containing path in single quotes where the newline is inert data.
+    """
+
+    entry_dir = _entry_dir(tmp_path / "ent\ntouch OWNED   #")
+    output = tmp_path / "shim"
+    assert loader.main(["emit-command", "--cache-entry", str(entry_dir), "--output", str(output)]) == 0
+    body = output.read_text(encoding="utf-8")
+    preamble, _, _ = body.partition("exec ")
+    for line in preamble.splitlines()[1:]:  # skip the #! line
+        assert line.startswith("#"), line
+
+
+def test_a_newline_in_a_cache_path_does_not_execute(tmp_path):
+    """The reviewer's reproduction, as a regression test.
+
+    The injected text ran *before* the quoted exec, so it fired even with a bogus
+    loader path. Running the shim must not produce the sentinel; the loader
+    itself is expected to fail here (fake code object / no HIP), which is fine --
+    the point is what does *not* happen first.
+    """
+
+    entry_dir = _entry_dir(tmp_path / "ent\ntouch OWNED   #")
+    shim = tmp_path / "shim"
+    assert loader.main(["emit-command", "--cache-entry", str(entry_dir), "--output", str(shim)]) == 0
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    subprocess.run(["sh", str(shim)], cwd=sandbox, capture_output=True, timeout=120, check=False)
+    assert not (sandbox / "OWNED").exists(), "shim comment block executed injected text"
+
+
+def test_emitted_shim_neutralises_a_newline_in_the_kernel_name(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY", name="add_kernel")
+    metadata = entry_dir / "add_kernel.json"
+    metadata.write_text(
+        json.dumps({**_METADATA, "name": "k\ntouch OWNED   #"}), encoding="utf-8"
+    )
+    output = tmp_path / "shim"
+    assert loader.main(["emit-command", "--cache-entry", str(entry_dir), "--output", str(output)]) == 0
+    assert "\ntouch OWNED" not in output.read_text(encoding="utf-8")
+
+
 def test_shim_quotes_paths_containing_spaces(tmp_path):
     entry_dir = _entry_dir(tmp_path / "cache dir")
     output = tmp_path / "shim"
@@ -664,8 +789,88 @@ def test_loader_argv_omits_dispatch_flags_in_load_mode(tmp_path):
 
 
 # --------------------------------------------------------------------------
+# Lifting the object out of the scratch cache
+# --------------------------------------------------------------------------
+
+
+def test_copy_object_writes_the_object_and_its_sidecars(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    (entry_dir / "add_kernel.amdgcn").write_text(
+        "  .kernarg_segment_size: 48\n", encoding="utf-8"
+    )
+    destination = tmp_path / "fixtures" / "isa" / "harvested.hsaco"
+    copied = loader.copy_entry(
+        loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco"), destination
+    )
+    assert copied.hsaco == destination.resolve()
+    assert copied.kernel_name == "add_kernel"
+    assert destination.with_suffix(".json").is_file()
+    # The .amdgcn carries .kernarg_segment_size; dropping it would silently
+    # disable the dispatch-time kernarg cross-check.
+    assert loader.kernarg_segment_size(copied) == 48
+
+
+def test_copy_object_tolerates_a_missing_optional_sidecar(tmp_path):
+    entry_dir = _entry_dir(tmp_path / "ENTRY")
+    destination = tmp_path / "isa" / "harvested.hsaco"
+    copied = loader.copy_entry(
+        loader.entry_from_hsaco(entry_dir / "add_kernel.hsaco"), destination
+    )
+    assert loader.kernarg_segment_size(copied) is None
+
+
+def test_emit_command_points_the_shim_at_the_copy_not_the_cache(tmp_path):
+    """The recipe's code_object and the shim's object must be the same file."""
+
+    entry_dir = _entry_dir(tmp_path / "CACHE")
+    destination = tmp_path / "fixtures" / "isa" / "harvested.hsaco"
+    output = tmp_path / "fixtures" / "bin" / "shim"
+    assert (
+        loader.main(
+            [
+                "emit-command",
+                "--cache-entry",
+                str(entry_dir),
+                "--copy-object",
+                str(destination),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    flattened = output.read_text(encoding="utf-8").replace(" \\\n    ", " ")
+    assert str(destination.resolve()) in flattened
+    assert str(entry_dir.resolve()) not in flattened
+    # The pinned digest describes the copy, so evicting the cache changes nothing.
+    assert f"--expect-object-sha256 {loader.sha256_file(destination)}" in flattened
+
+
+# --------------------------------------------------------------------------
 # CLI wiring
 # --------------------------------------------------------------------------
+
+
+def test_release_reports_a_cleanup_failure_without_replacing_the_real_one(capsys):
+    """Cleanup must not out-prioritise the failure being unwound.
+
+    ``Hip.check`` raises, so a failing hipFree in a ``finally`` would otherwise
+    overwrite the launch error the operator actually needs to read.
+    """
+
+    def _boom():
+        raise loader.LoaderError("hipFree failed: invalid argument")
+
+    try:
+        try:
+            raise loader.LoaderError("hipModuleLaunchKernel failed: the real problem")
+        finally:
+            loader._release(_boom, what="hipFree")
+    except loader.LoaderError as exc:
+        assert "the real problem" in str(exc)
+    else:
+        raise AssertionError("the original error must still propagate")
+    assert "hipFree failed" in capsys.readouterr().err
 
 
 def test_main_reports_loader_errors_without_a_traceback(tmp_path, capsys):

--- a/tests/sanitizers/test_triton_consan_loader.py
+++ b/tests/sanitizers/test_triton_consan_loader.py
@@ -95,11 +95,20 @@ def test_kernel_name_missing_fails_closed(tmp_path):
         _ = entry.kernel_name
 
 
-def test_read_metadata_rejects_non_object(tmp_path):
+def test_read_json_object_rejects_non_object(tmp_path):
     path = tmp_path / "meta.json"
     path.write_text("[1, 2]", encoding="utf-8")
-    with pytest.raises(loader.LoaderError, match="must be a JSON object"):
-        loader.read_metadata(path)
+    with pytest.raises(loader.LoaderError, match="Triton metadata must be a JSON object"):
+        loader.read_json_object(path)
+    with pytest.raises(loader.LoaderError, match="launch spec must be a JSON object"):
+        loader.read_json_object(path, what="launch spec")
+
+
+def test_read_json_object_reports_malformed_json(tmp_path):
+    path = tmp_path / "meta.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(loader.LoaderError, match="cannot read Triton metadata"):
+        loader.read_json_object(path)
 
 
 def test_discover_entries_recurses_and_skips_group_index(tmp_path):


### PR DESCRIPTION
Fixes #399.

## The gap

ConSan only runs against a caller-supplied `source.consan_command` — it never wraps a whole application to reach a few selected kernels, and that fail-closed behaviour is right. But the only supported way to *satisfy* it was a loader compiled per object with `-DOBJECT` (`consan_load.hip`), and that cannot work for a Triton/Gluon kernel:

- the `.hsaco` does not exist until the kernel runs, so there is nothing to pin in a fixture directory;
- it is keyed by a content hash under `TRITON_CACHE_DIR` and is specific to the image, the GPU target, and the compiled shapes;
- there is no HIP source to compile a loader from.

So `consan` on a Triton kernel could only ever return `consan_command_not_provisioned`.

## What this adds

`scripts/sanitizers/triton_consan_loader.py` — a generic loader that binds `libamdhip64` through **ctypes**, so the object path is resolved at *run* time and no compiler is in the loop. Point it at a Triton cache entry (a `.hsaco` plus the adjacent `.json`) and it loads that object under whatever hook the parent set in `HSA_TOOLS_LIB`.

`run_consan` executes `consan_command` as a bare argv with no arguments, so a parameterised loader cannot be named directly. `emit-command` bridges that by writing a small executable shim with the resolved arguments baked in — the run-time analogue of the `-DOBJECT` build step. The shim also carries a SHA-256 for every input whose bytes decide what runs (object, metadata, launch spec), and `run` re-checks each before touching the device: a Triton cache entry can be evicted and repopulated, so pinning the paths alone would let a rebuilt cache feed different code to the same recorded `command_sha256` and selected identity. `--copy-object` lifts the object out of the scratch cache so the recipe's `code_object` and the shim name the same stable file.

```bash
python3 scripts/sanitizers/triton_consan_loader.py list --cache-entry "$TRITON_CACHE_DIR"
python3 scripts/sanitizers/triton_consan_loader.py emit-command \
  --cache-entry "$TRITON_CACHE_DIR" --kernel-name _mfma_lds_mediumm_kernel \
  --copy-object recipes/sanitizers/fixtures/isa/_mfma_lds_mediumm_kernel.hsaco \
  --output recipes/sanitizers/fixtures/bin/consan_triton_kernel
```

Two modes mirror the two committed HIP loaders. **`load`** (default) does `hipModuleLoad` plus a symbol resolve; ConSan instruments a code object when it is loaded, so this reaches the kernel with no knowledge of the launch ABI and works for any Triton kernel. **`dispatch`** additionally launches it once, taking the block size from `num_warps * warp_size` and dynamic LDS from `shared`.

Also included: `recipes/sanitizers/consan-triton-kernel.yaml` as a worked example, a new README section, and 53 unit tests. **No schema or engine change** — `source.consan_command` already accepted any executable, so the blast radius is one new script.

## Verified on hardware

gfx950 (MI350), ROCm 7.0, against a real Triton 3.7.1 JIT code object and the real RocJITsu hook. ConSan now genuinely executes instead of returning `not_checked`, and the hook inventories the Triton object:

```
[rocjitsu-dbi-hooks] ConSan code-object reader=... target=gfx950 arch=cdna4 text_sections=1 kernels=1 functions=0
[rocjitsu-dbi-hooks] ConSan MOI inventory begin reader=... bytes=5912
```

Dispatch mode was validated too (`grid=(1,1,1) block=256 shared=0 args=32B`), including the packed-argument layout.

## Two things this does not deliver

Worth stating plainly rather than leaving to discovery:

1. **Triton does not always emit the argument signature.** It is absent from the metadata JSON in 3.7.1, which is what the gfx950 setup in #399 uses — I confirmed this against real cache entries rather than assuming. `dispatch` therefore needs `--launch-spec` to supply a `signature` explicitly. `load` needs nothing.
2. **The dynamic-coverage half stays blocked upstream.** The shipping RocJITsu build reports `ConSan MOI record_replay engine is an inventory-only stub`, so a dispatch captures no records and strict policy fails closed with exit 86 — the same outcome the committed `daily-consan-tiny.yaml` and `daily-consan-lds-dispatch.yaml` lanes already document (ROCm/rocm-systems#9972). This PR closes the aorta-side gap (there was no way to reach the kernel at all); it cannot close the upstream one.

The issue's alternative direction — driving ConSan through Record/Replay against a real application run with an entry-point allowlist — is not attempted here, since it depends on the same RocJITsu allowlist the README already tracks as unavailable.

## Design notes for review

- **Scalars default to zero and pointers get a fresh zeroed buffer.** A synthesized size or stride would index buffers whose real extents are unknowable, turning a sanitizer run into a memory fault. `--arg` / `--buffer-bytes` opt into touching memory.
- **HIP does not validate `HIP_LAUNCH_PARAM_BUFFER_SIZE` against the kernel descriptor** — I tested this: a deliberately wrong 16-byte buffer for a 32-byte kernel dispatched silently. So the loader cross-checks the packed buffer against `.kernarg_segment_size` from the `.amdgcn` listing Triton writes beside the object and refuses to over-run the segment. Only the over-run direction is provably wrong, since the segment also covers compiler-added hidden arguments.
- **Ambiguity fails closed.** One logical Triton kernel usually compiles to several shape-selected objects, and ConSan takes exactly one per run, so an ambiguous selection errors and lists the candidates rather than picking one.
- **Every error path raises and exits non-zero**, so a failure surfaces as `combined_hook_exit_N` rather than a quiet clean run.
- **Linux/ROCm-only by design** (it dlopens `libamdhip64.so`), consistent with the rest of `scripts/sanitizers/`.

## Test plan

- [x] 101 unit tests, no GPU required (HIP is isolated behind one `Hip` class)
- [x] Full suite: 3360 passed, 93 skipped (the one `tests/ebpf` failure is pre-existing on this host — no bpftrace — and reproduces on the base commit)
- [x] `ruff` and `mypy` clean on changed files
- [x] End-to-end on gfx950 through `execute_sanitizer_run` with the real hook, including the worked example as documented


---

## Review round 2

Addressed a human review (CHANGES_REQUESTED) and two Copilot passes; nothing declined. Details in the [reply thread](https://github.com/ROCm/aorta/pull/403#issuecomment-5412388461).

The one worth calling out here: **`render_shim` had a command injection.** It interpolated the kernel name, arch, and both paths into shell comments unquoted while carefully `shlex.quote`-ing the `exec` line below. A newline — legal in a Linux path, so no crafted input needed — ended the comment and the remainder ran as a command, *before* the `exec`. Reproduced, fixed by escaping CR/LF in every interpolated value, and mutation-tested. The same escape now covers the loader's stdout, which `run_consan` folds into `consan.log` and parses for `[rocjitsu-dbi-hooks]` verdict lines — a forged coverage record there would be a false-*clean*, not just a false-fail.

Also: `--launch-spec` accepts an explicitly ordered `[name, type]` array, because JSON object key order silently decided the packed layout and a permutation is invisible to the kernarg size check; `--copy-object` makes the worked example runnable (previously it failed on `code_object_identity_required` because nothing produced the object); `--arg` on a pointer is rejected instead of discarded; cleanup in `finally` no longer replaces the failure being unwound; and every value narrowed into a fixed-width C type is range-checked.
