### PR TITLE
Anchor collector symlink guards to the operator's --results-dir

### DIFF
--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -59,7 +59,12 @@ from ._options import (
     mode_argument,
     validate_options,
 )
-from ._parse import parse_profile, parse_summary
+from ._parse import (
+    parse_profile,
+    parse_profile_stream,
+    parse_summary,
+    parse_summary_from_streams,
+)
 
 log = logging.getLogger(__name__)
 
@@ -506,7 +511,9 @@ __all__ = [
     "build_env",
     "mode_argument",
     "parse_profile",
+    "parse_profile_stream",
     "parse_summary",
+    "parse_summary_from_streams",
     "resolve_python",
     "validate_options",
     "wrap_argv",

--- a/src/aorta/instrumentation/proton/_parse.py
+++ b/src/aorta/instrumentation/proton/_parse.py
@@ -12,10 +12,9 @@ or a Proton build that emitted nothing all degrade to fewer metrics.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import math
-from collections.abc import Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -152,15 +151,20 @@ def parse_profile(path: Path | str) -> tuple[dict[str, float], dict[str, int | N
 
 
 def parse_summary_from_streams(
-    artifact_dir: str, profile_streams: Sequence[TextIO]
+    artifact_dir: str, profile_streams: Iterable[TextIO]
 ) -> dict[str, Any]:
     """Summarise pre-opened ``.hatchet`` handles into trial metrics.
 
     The stream-taking core of :func:`parse_summary`. The caller supplies the
-    already-open profile handles -- the collector path opens them ``O_NOFOLLOW``
-    under a directory fd so a payload symlink swapped in after the guard cannot
+    profile handles -- the collector path opens them ``O_NOFOLLOW`` under a
+    directory fd so a payload symlink swapped in after the guard cannot
     redirect the read -- and the display string for ``proton_artifact_dir``.
     Same metrics contract as :func:`parse_summary`; never raises.
+
+    ``profile_streams`` may be a **lazy** iterator that opens one profile at a
+    time (both callers pass one): each handle is aggregated and closed before
+    the next opens, so a run with a profile per rank never needs a descriptor
+    per rank.
     """
     metrics: dict[str, Any] = {"proton_artifact_dir": artifact_dir}
     by_name: dict[str, float] = {}
@@ -199,11 +203,14 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     """Summarise a Proton output directory into trial metrics.
 
     Path-based convenience wrapper over :func:`parse_summary_from_streams`: it
-    globs the ``.hatchet`` profiles and opens them itself. The collector
-    post-run path uses the stream entrypoint instead, opening each file
-    ``O_NOFOLLOW`` under a directory fd so a payload symlink cannot redirect the
-    read; this wrapper follows symlinks like any ``open`` and is for callers
-    that already hold a trusted directory (tests, an operator's own tree).
+    globs the ``.hatchet`` profiles and opens them itself, one at a time -- a
+    run can emit a profile per rank and holding them all open at once could
+    exceed ``RLIMIT_NOFILE``, which would have dropped the later ranks from the
+    totals without saying so. The collector post-run path uses the stream
+    entrypoint instead, opening each file ``O_NOFOLLOW`` under a directory fd so
+    a payload symlink cannot redirect the read; this wrapper follows symlinks
+    like any ``open`` and is for callers that already hold a trusted directory
+    (tests, an operator's own tree).
 
     Args:
         out_dir: The directory Proton's ``-n <out_dir>/<name>`` wrote into.
@@ -225,14 +232,25 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
         profiles = sorted(root.rglob("*.hatchet"))
     except OSError:
         return {}
-    with contextlib.ExitStack() as stack:
-        streams: list[TextIO] = []
-        for profile in profiles:
-            try:
-                streams.append(stack.enter_context(profile.open(encoding="utf-8")))
-            except OSError:
-                continue
-        return parse_summary_from_streams(str(root), streams)
+    return parse_summary_from_streams(str(root), _open_each(profiles))
+
+
+def _open_each(paths: Sequence[Path]) -> Iterator[TextIO]:
+    """Yield each profile as an open handle, closing it before opening the next.
+
+    One descriptor at a time: Proton writes a profile per rank, so a large
+    distributed capture holds more artifacts than the soft fd limit allows, and
+    an ``EMFILE`` partway through a batch open would have left the remaining
+    ranks out of the totals with nothing in the output to say so. A file that
+    cannot be opened is skipped -- this wrapper promises never to raise.
+    """
+    for path in paths:
+        try:
+            handle = path.open(encoding="utf-8")
+        except OSError:
+            continue
+        with handle:
+            yield handle
 
 
 __all__ = ["TOP_N", "parse_profile", "parse_profile_stream", "parse_summary", "parse_summary_from_streams"]

--- a/src/aorta/instrumentation/proton/_parse.py
+++ b/src/aorta/instrumentation/proton/_parse.py
@@ -12,10 +12,12 @@ or a Proton build that emitted nothing all degrade to fewer metrics.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import math
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 #: How many kernel names to carry in ``proton_top_kernels``.
 TOP_N = 5
@@ -113,18 +115,20 @@ def _walk(node: Any, by_name: dict[str, float], counts: dict[str, int | None]) -
     counts[name] = None if leaf_count is None or previous is None else previous + leaf_count
 
 
-def parse_profile(path: Path | str) -> tuple[dict[str, float], dict[str, int | None]]:
-    """Aggregate one ``.hatchet`` file into per-kernel ms totals + call counts.
+def parse_profile_stream(stream: TextIO) -> tuple[dict[str, float], dict[str, int | None]]:
+    """Aggregate one open ``.hatchet`` handle into per-kernel ms totals + counts.
 
-    Returns ``({}, {})`` when the file is missing, unreadable, or not a Proton
-    tree profile. A ``None`` count means that kernel's launch total was not
-    readable, so it must not be summed into a published metric.
+    The stream-taking core of :func:`parse_profile`. The caller owns the handle
+    -- the collector path opens it ``O_NOFOLLOW`` under a directory fd so a
+    payload symlink swapped in after the guard cannot redirect the read.
+    Returns ``({}, {})`` when the handle is unreadable or not a Proton tree
+    profile. A ``None`` count means that kernel's launch total was not readable,
+    so it must not be summed into a published metric.
     """
     by_name: dict[str, float] = {}
     counts: dict[str, int | None] = {}
     try:
-        with Path(path).open(encoding="utf-8") as stream:
-            database = json.load(stream)
+        database = json.load(stream)
     except (OSError, ValueError, UnicodeDecodeError):
         return by_name, counts
     roots = database if isinstance(database, list) else [database]
@@ -133,35 +137,36 @@ def parse_profile(path: Path | str) -> tuple[dict[str, float], dict[str, int | N
     return by_name, counts
 
 
-def parse_summary(out_dir: Path | str) -> dict[str, Any]:
-    """Summarise a Proton output directory into trial metrics.
+def parse_profile(path: Path | str) -> tuple[dict[str, float], dict[str, int | None]]:
+    """Aggregate one ``.hatchet`` file into per-kernel ms totals + call counts.
 
-    Args:
-        out_dir: The directory Proton's ``-n <out_dir>/<name>`` wrote into.
-
-    Returns:
-        ``{}`` when the directory does not exist. Otherwise
-        ``{"proton_artifact_dir": str}`` plus, when a tree profile with timing
-        was found, the flat numeric ``proton_kernel_count`` /
-        ``proton_gpu_time_ms`` / ``proton_top_kernel_ms`` and the non-numeric
-        ``proton_top_kernels`` name list. ``proton_kernel_count`` is omitted --
-        while the timings are still reported -- when any leaf's launch count
-        was unreadable, since a leaf aggregates launches and there is no safe
-        substitute for the real number.
+    Path-based convenience wrapper over :func:`parse_profile_stream`. Returns
+    ``({}, {})`` when the file is missing, unreadable, or not a Proton tree
+    profile.
     """
-    root = Path(out_dir)
     try:
-        if not root.is_dir():
-            return {}
-        profiles = sorted(root.rglob("*.hatchet"))
+        with Path(path).open(encoding="utf-8") as stream:
+            return parse_profile_stream(stream)
     except OSError:
-        return {}
+        return {}, {}
 
-    metrics: dict[str, Any] = {"proton_artifact_dir": str(root)}
+
+def parse_summary_from_streams(
+    artifact_dir: str, profile_streams: Sequence[TextIO]
+) -> dict[str, Any]:
+    """Summarise pre-opened ``.hatchet`` handles into trial metrics.
+
+    The stream-taking core of :func:`parse_summary`. The caller supplies the
+    already-open profile handles -- the collector path opens them ``O_NOFOLLOW``
+    under a directory fd so a payload symlink swapped in after the guard cannot
+    redirect the read -- and the display string for ``proton_artifact_dir``.
+    Same metrics contract as :func:`parse_summary`; never raises.
+    """
+    metrics: dict[str, Any] = {"proton_artifact_dir": artifact_dir}
     by_name: dict[str, float] = {}
     counts: dict[str, int | None] = {}
-    for profile in profiles:
-        file_by_name, file_counts = parse_profile(profile)
+    for stream in profile_streams:
+        file_by_name, file_counts = parse_profile_stream(stream)
         for name, elapsed_ms in file_by_name.items():
             by_name[name] = by_name.get(name, 0.0) + elapsed_ms
         for name, calls in file_counts.items():
@@ -190,4 +195,44 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     return metrics
 
 
-__all__ = ["TOP_N", "parse_profile", "parse_summary"]
+def parse_summary(out_dir: Path | str) -> dict[str, Any]:
+    """Summarise a Proton output directory into trial metrics.
+
+    Path-based convenience wrapper over :func:`parse_summary_from_streams`: it
+    globs the ``.hatchet`` profiles and opens them itself. The collector
+    post-run path uses the stream entrypoint instead, opening each file
+    ``O_NOFOLLOW`` under a directory fd so a payload symlink cannot redirect the
+    read; this wrapper follows symlinks like any ``open`` and is for callers
+    that already hold a trusted directory (tests, an operator's own tree).
+
+    Args:
+        out_dir: The directory Proton's ``-n <out_dir>/<name>`` wrote into.
+
+    Returns:
+        ``{}`` when the directory does not exist. Otherwise
+        ``{"proton_artifact_dir": str}`` plus, when a tree profile with timing
+        was found, the flat numeric ``proton_kernel_count`` /
+        ``proton_gpu_time_ms`` / ``proton_top_kernel_ms`` and the non-numeric
+        ``proton_top_kernels`` name list. ``proton_kernel_count`` is omitted --
+        while the timings are still reported -- when any leaf's launch count
+        was unreadable, since a leaf aggregates launches and there is no safe
+        substitute for the real number.
+    """
+    root = Path(out_dir)
+    try:
+        if not root.is_dir():
+            return {}
+        profiles = sorted(root.rglob("*.hatchet"))
+    except OSError:
+        return {}
+    with contextlib.ExitStack() as stack:
+        streams: list[TextIO] = []
+        for profile in profiles:
+            try:
+                streams.append(stack.enter_context(profile.open(encoding="utf-8")))
+            except OSError:
+                continue
+        return parse_summary_from_streams(str(root), streams)
+
+
+__all__ = ["TOP_N", "parse_profile", "parse_profile_stream", "parse_summary", "parse_summary_from_streams"]

--- a/src/aorta/instrumentation/proton/_parse.py
+++ b/src/aorta/instrumentation/proton/_parse.py
@@ -159,12 +159,18 @@ def parse_summary_from_streams(
     profile handles -- the collector path opens them ``O_NOFOLLOW`` under a
     directory fd so a payload symlink swapped in after the guard cannot
     redirect the read -- and the display string for ``proton_artifact_dir``.
-    Same metrics contract as :func:`parse_summary`; never raises.
+    Same metrics contract as :func:`parse_summary`.
 
     ``profile_streams`` may be a **lazy** iterator that opens one profile at a
     time (both callers pass one): each handle is aggregated and closed before
     the next opens, so a run with a profile per rank never needs a descriptor
     per rank.
+
+    Raises nothing of its own -- an unreadable or non-Proton profile
+    contributes nothing -- but an exception from the caller's iterator
+    propagates. That is deliberate: the collector's iterator re-raises
+    descriptor exhaustion so its metrics are dropped rather than published as
+    totals covering only the ranks read before the limit.
     """
     metrics: dict[str, Any] = {"proton_artifact_dir": artifact_dir}
     by_name: dict[str, float] = {}

--- a/src/aorta/instrumentation/rocprof/__init__.py
+++ b/src/aorta/instrumentation/rocprof/__init__.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from ._options import OPTION_KEYS, OUTPUT_FORMATS, SUMMARY_UNITS, TRACE_FLAGS, validate_options
 from ._options import as_bool as _as_bool
 from ._options import split_tokens as _split_tokens
-from ._parse import parse_summary
+from ._parse import parse_summary, parse_summary_from_streams
 
 #: Subdirectory (under the trial's collector directory) rocprofv3 writes into.
 OUTPUT_SUBDIR: str = "rocprof"
@@ -191,6 +191,7 @@ __all__ = [
     "RocprofUnavailableError",
     "build_argv_prefix",
     "parse_summary",
+    "parse_summary_from_streams",
     "resolve_binary",
     "validate_options",
     "wrap_argv",

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -16,11 +16,12 @@ Two verified behaviours drive the shape of this module:
 
 from __future__ import annotations
 
+import contextlib
 import csv
 import math
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 #: How many kernel names to carry in the non-numeric ``rocprof_top_kernels``
 #: channel. Kept small: it is a triage breadcrumb, not a report.
@@ -41,8 +42,8 @@ _TRACE_END = "End_Timestamp"
 _KERNEL_DISPATCH = "KERNEL_DISPATCH"
 
 
-def _iter_rows(path: Path) -> Iterator[dict[str, str]]:
-    """Stream a CSV as dict rows, yielding nothing more on a read/parse error.
+def _iter_rows(stream: TextIO) -> Iterator[dict[str, str]]:
+    """Stream an open CSV handle as dict rows, stopping on a read/parse error.
 
     A generator rather than a list: with ``stats: false`` a
     ``*_kernel_trace.csv`` carries one row per dispatch and can reach hundreds
@@ -51,12 +52,14 @@ def _iter_rows(path: Path) -> Iterator[dict[str, str]]:
     pass, so no caller needs the rows twice.
 
     Fail-soft like the rest of the module: a truncated or undecodable file
-    contributes the rows read so far and then stops, rather than raising.
+    contributes the rows read so far and then stops, rather than raising. The
+    caller owns the handle -- taking an already-open stream (rather than a path)
+    lets the collector supply one opened ``O_NOFOLLOW`` under a directory fd, so
+    a payload symlink swapped in after the guard cannot redirect the read.
     """
     try:
-        with path.open(newline="", encoding="utf-8") as stream:
-            for row in csv.DictReader(stream):
-                yield dict(row)
+        for row in csv.DictReader(stream):
+            yield dict(row)
     except (OSError, csv.Error, UnicodeDecodeError):
         return
 
@@ -77,7 +80,9 @@ def _to_float(value: Any) -> float | None:
     return parsed if math.isfinite(parsed) else None
 
 
-def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, int] | None]:
+def _totals_from_stats(
+    streams: Sequence[TextIO],
+) -> tuple[dict[str, float], dict[str, int] | None]:
     """Aggregate ``*_kernel_stats.csv`` into per-kernel ns totals + call counts.
 
     Returns ``None`` for the counts when any otherwise-usable row had an
@@ -91,8 +96,8 @@ def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
     ns_by_kernel: dict[str, float] = {}
     calls_by_kernel: dict[str, int] = {}
     counts_trustworthy = True
-    for path in paths:
-        for row in _iter_rows(path):
+    for stream in streams:
+        for row in _iter_rows(stream):
             name = (row.get(_STATS_NAME) or "").strip()
             total_ns = _to_float(row.get(_STATS_TOTAL_NS))
             calls = _to_float(row.get(_STATS_CALLS))
@@ -114,7 +119,9 @@ def _totals_from_stats(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
     return ns_by_kernel, (calls_by_kernel if counts_trustworthy else None)
 
 
-def _totals_from_trace(paths: list[Path]) -> tuple[dict[str, float], dict[str, int] | None]:
+def _totals_from_trace(
+    streams: Sequence[TextIO],
+) -> tuple[dict[str, float], dict[str, int] | None]:
     """Aggregate ``*_kernel_trace.csv`` dispatch rows into the same shape.
 
     Counts are always trustworthy here: a trace row *is* one dispatch, so
@@ -122,8 +129,8 @@ def _totals_from_trace(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
     """
     ns_by_kernel: dict[str, float] = {}
     calls_by_kernel: dict[str, int] = {}
-    for path in paths:
-        for row in _iter_rows(path):
+    for stream in streams:
+        for row in _iter_rows(stream):
             kind = (row.get(_TRACE_KIND) or "").strip()
             if kind and kind != _KERNEL_DISPATCH:
                 continue
@@ -137,38 +144,21 @@ def _totals_from_trace(paths: list[Path]) -> tuple[dict[str, float], dict[str, i
     return ns_by_kernel, calls_by_kernel
 
 
-def parse_summary(out_dir: Path | str) -> dict[str, Any]:
-    """Summarise a ``rocprofv3`` output directory into trial metrics.
+def parse_summary_from_streams(
+    artifact_dir: str,
+    stats_streams: Sequence[TextIO],
+    trace_streams: Sequence[TextIO],
+) -> dict[str, Any]:
+    """Summarise pre-opened ``rocprofv3`` CSV handles into trial metrics.
 
-    Prefers the ``--stats`` CSVs (rocprofv3 already did the aggregation) and
-    falls back to summing dispatch spans from the kernel trace whenever the
-    stats CSVs are absent *or* yield no usable rows -- a truncated or
-    column-renamed stats file must not mask a readable trace.
-
-    Args:
-        out_dir: The directory passed to ``rocprofv3 -d``.
-
-    Returns:
-        ``{}`` when the directory does not exist. Otherwise
-        ``{"rocprof_artifact_dir": str}`` plus, when kernel data was found,
-        the flat numeric ``rocprof_kernel_count`` / ``rocprof_gpu_time_ms`` /
-        ``rocprof_top_kernel_ms`` and the non-numeric ``rocprof_top_kernels``
-        name list. ``rocprof_kernel_count`` is omitted -- while the timings
-        are still reported -- when a stats row's ``Calls`` column was
-        unreadable, because a per-kernel aggregate row gives no basis for
-        guessing how many dispatches it stood for. Never raises: an unreadable
-        or malformed artifact tree degrades to the artifact-dir-only result.
+    The stream-taking core of :func:`parse_summary`. The caller supplies the
+    already-open ``*_kernel_stats.csv`` and ``*_kernel_trace.csv`` handles --
+    the collector path opens them ``O_NOFOLLOW`` under a directory fd so a
+    payload symlink swapped in after the guard cannot redirect the read -- and
+    the display string for ``rocprof_artifact_dir``. Same metrics contract as
+    :func:`parse_summary`; never raises.
     """
-    root = Path(out_dir)
-    try:
-        if not root.is_dir():
-            return {}
-        stats_paths = sorted(root.rglob("*_kernel_stats.csv"))
-        trace_paths = sorted(root.rglob("*_kernel_trace.csv"))
-    except OSError:
-        return {}
-
-    metrics: dict[str, Any] = {"rocprof_artifact_dir": str(root)}
+    metrics: dict[str, Any] = {"rocprof_artifact_dir": artifact_dir}
 
     # The fallback keys off absence of *data*, not absence of files. A stats
     # CSV that exists but yields nothing -- rocprofv3 killed mid-write by a
@@ -177,10 +167,10 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     # report no kernels on a host where profiling works.
     ns_by_kernel: dict[str, float] = {}
     calls_by_kernel: dict[str, int] | None = {}
-    if stats_paths:
-        ns_by_kernel, calls_by_kernel = _totals_from_stats(stats_paths)
-    if not ns_by_kernel and trace_paths:
-        ns_by_kernel, calls_by_kernel = _totals_from_trace(trace_paths)
+    if stats_streams:
+        ns_by_kernel, calls_by_kernel = _totals_from_stats(stats_streams)
+    if not ns_by_kernel and trace_streams:
+        ns_by_kernel, calls_by_kernel = _totals_from_trace(trace_streams)
     if not ns_by_kernel:
         return metrics
 
@@ -204,4 +194,55 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     return metrics
 
 
-__all__ = ["TOP_N", "parse_summary"]
+def parse_summary(out_dir: Path | str) -> dict[str, Any]:
+    """Summarise a ``rocprofv3`` output directory into trial metrics.
+
+    Prefers the ``--stats`` CSVs (rocprofv3 already did the aggregation) and
+    falls back to summing dispatch spans from the kernel trace whenever the
+    stats CSVs are absent *or* yield no usable rows -- a truncated or
+    column-renamed stats file must not mask a readable trace.
+
+    Path-based convenience wrapper over :func:`parse_summary_from_streams`: it
+    globs the two CSV families and opens them itself. The collector post-run
+    path uses the stream entrypoint instead, opening each file ``O_NOFOLLOW``
+    under a directory fd so a payload symlink cannot redirect the read; this
+    wrapper follows symlinks like any ``open`` and is for callers that already
+    hold a trusted directory (tests, an operator's own ``rocprofv3 -d`` tree).
+
+    Args:
+        out_dir: The directory passed to ``rocprofv3 -d``.
+
+    Returns:
+        ``{}`` when the directory does not exist. Otherwise
+        ``{"rocprof_artifact_dir": str}`` plus, when kernel data was found,
+        the flat numeric ``rocprof_kernel_count`` / ``rocprof_gpu_time_ms`` /
+        ``rocprof_top_kernel_ms`` and the non-numeric ``rocprof_top_kernels``
+        name list. ``rocprof_kernel_count`` is omitted -- while the timings
+        are still reported -- when a stats row's ``Calls`` column was
+        unreadable, because a per-kernel aggregate row gives no basis for
+        guessing how many dispatches it stood for. Never raises: an unreadable
+        or malformed artifact tree degrades to the artifact-dir-only result.
+    """
+    root = Path(out_dir)
+    try:
+        if not root.is_dir():
+            return {}
+        stats_paths = sorted(root.rglob("*_kernel_stats.csv"))
+        trace_paths = sorted(root.rglob("*_kernel_trace.csv"))
+    except OSError:
+        return {}
+    with contextlib.ExitStack() as stack:
+        stats_streams: list[TextIO] = []
+        trace_streams: list[TextIO] = []
+        for paths, streams in ((stats_paths, stats_streams), (trace_paths, trace_streams)):
+            for path in paths:
+                try:
+                    streams.append(
+                        stack.enter_context(path.open(newline="", encoding="utf-8"))
+                    )
+                except OSError:
+                    continue
+        return parse_summary_from_streams(str(root), stats_streams, trace_streams)
+
+
+__all__ = ["TOP_N", "parse_summary", "parse_summary_from_streams"]

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -16,10 +16,9 @@ Two verified behaviours drive the shape of this module:
 
 from __future__ import annotations
 
-import contextlib
 import csv
 import math
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -81,7 +80,7 @@ def _to_float(value: Any) -> float | None:
 
 
 def _totals_from_stats(
-    streams: Sequence[TextIO],
+    streams: Iterable[TextIO],
 ) -> tuple[dict[str, float], dict[str, int] | None]:
     """Aggregate ``*_kernel_stats.csv`` into per-kernel ns totals + call counts.
 
@@ -120,7 +119,7 @@ def _totals_from_stats(
 
 
 def _totals_from_trace(
-    streams: Sequence[TextIO],
+    streams: Iterable[TextIO],
 ) -> tuple[dict[str, float], dict[str, int] | None]:
     """Aggregate ``*_kernel_trace.csv`` dispatch rows into the same shape.
 
@@ -146,17 +145,22 @@ def _totals_from_trace(
 
 def parse_summary_from_streams(
     artifact_dir: str,
-    stats_streams: Sequence[TextIO],
-    trace_streams: Sequence[TextIO],
+    stats_streams: Iterable[TextIO],
+    trace_streams: Iterable[TextIO],
 ) -> dict[str, Any]:
     """Summarise pre-opened ``rocprofv3`` CSV handles into trial metrics.
 
     The stream-taking core of :func:`parse_summary`. The caller supplies the
-    already-open ``*_kernel_stats.csv`` and ``*_kernel_trace.csv`` handles --
-    the collector path opens them ``O_NOFOLLOW`` under a directory fd so a
-    payload symlink swapped in after the guard cannot redirect the read -- and
-    the display string for ``rocprof_artifact_dir``. Same metrics contract as
+    ``*_kernel_stats.csv`` and ``*_kernel_trace.csv`` handles -- the collector
+    path opens them ``O_NOFOLLOW`` under a directory fd so a payload symlink
+    swapped in after the guard cannot redirect the read -- and the display
+    string for ``rocprof_artifact_dir``. Same metrics contract as
     :func:`parse_summary`; never raises.
+
+    Each group may be a **lazy** iterator that opens one file at a time (both
+    callers pass one), so a multi-rank capture never needs a descriptor per
+    artifact. Each is consumed at most once, and the trace group is not
+    consumed at all when the stats group yielded data.
     """
     metrics: dict[str, Any] = {"rocprof_artifact_dir": artifact_dir}
 
@@ -164,12 +168,10 @@ def parse_summary_from_streams(
     # CSV that exists but yields nothing -- rocprofv3 killed mid-write by a
     # trial timeout, or a future release renaming the columns pinned above --
     # would otherwise suppress a complete kernel trace sitting beside it, and
-    # report no kernels on a host where profiling works.
-    ns_by_kernel: dict[str, float] = {}
-    calls_by_kernel: dict[str, int] | None = {}
-    if stats_streams:
-        ns_by_kernel, calls_by_kernel = _totals_from_stats(stats_streams)
-    if not ns_by_kernel and trace_streams:
+    # report no kernels on a host where profiling works. An empty stats group
+    # aggregates to nothing and falls through the same way.
+    ns_by_kernel, calls_by_kernel = _totals_from_stats(stats_streams)
+    if not ns_by_kernel:
         ns_by_kernel, calls_by_kernel = _totals_from_trace(trace_streams)
     if not ns_by_kernel:
         return metrics
@@ -203,11 +205,14 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
     column-renamed stats file must not mask a readable trace.
 
     Path-based convenience wrapper over :func:`parse_summary_from_streams`: it
-    globs the two CSV families and opens them itself. The collector post-run
-    path uses the stream entrypoint instead, opening each file ``O_NOFOLLOW``
-    under a directory fd so a payload symlink cannot redirect the read; this
-    wrapper follows symlinks like any ``open`` and is for callers that already
-    hold a trusted directory (tests, an operator's own ``rocprofv3 -d`` tree).
+    globs the two CSV families and opens them itself, one at a time -- a
+    distributed run emits a CSV pair per rank and holding them all open at once
+    could exceed ``RLIMIT_NOFILE``, which would have dropped the later ranks
+    from the totals without saying so. The collector post-run path uses the
+    stream entrypoint instead, opening each file ``O_NOFOLLOW`` under a
+    directory fd so a payload symlink cannot redirect the read; this wrapper
+    follows symlinks like any ``open`` and is for callers that already hold a
+    trusted directory (tests, an operator's own ``rocprofv3 -d`` tree).
 
     Args:
         out_dir: The directory passed to ``rocprofv3 -d``.
@@ -231,18 +236,28 @@ def parse_summary(out_dir: Path | str) -> dict[str, Any]:
         trace_paths = sorted(root.rglob("*_kernel_trace.csv"))
     except OSError:
         return {}
-    with contextlib.ExitStack() as stack:
-        stats_streams: list[TextIO] = []
-        trace_streams: list[TextIO] = []
-        for paths, streams in ((stats_paths, stats_streams), (trace_paths, trace_streams)):
-            for path in paths:
-                try:
-                    streams.append(
-                        stack.enter_context(path.open(newline="", encoding="utf-8"))
-                    )
-                except OSError:
-                    continue
-        return parse_summary_from_streams(str(root), stats_streams, trace_streams)
+    return parse_summary_from_streams(
+        str(root), _open_each(stats_paths), _open_each(trace_paths)
+    )
+
+
+def _open_each(paths: Sequence[Path]) -> Iterator[TextIO]:
+    """Yield each CSV as an open handle, closing it before opening the next.
+
+    One descriptor at a time: ``rocprofv3`` writes a stats/trace pair per
+    process, so a large distributed capture holds more artifacts than the soft
+    fd limit allows, and an ``EMFILE`` partway through a batch open would have
+    left the remaining ranks out of the totals with nothing in the output to
+    say so. A file that cannot be opened is skipped -- this wrapper promises
+    never to raise.
+    """
+    for path in paths:
+        try:
+            handle = path.open(newline="", encoding="utf-8")
+        except OSError:
+            continue
+        with handle:
+            yield handle
 
 
 __all__ = ["TOP_N", "parse_summary", "parse_summary_from_streams"]

--- a/src/aorta/instrumentation/rocprof/_parse.py
+++ b/src/aorta/instrumentation/rocprof/_parse.py
@@ -155,12 +155,18 @@ def parse_summary_from_streams(
     path opens them ``O_NOFOLLOW`` under a directory fd so a payload symlink
     swapped in after the guard cannot redirect the read -- and the display
     string for ``rocprof_artifact_dir``. Same metrics contract as
-    :func:`parse_summary`; never raises.
+    :func:`parse_summary`.
 
     Each group may be a **lazy** iterator that opens one file at a time (both
     callers pass one), so a multi-rank capture never needs a descriptor per
     artifact. Each is consumed at most once, and the trace group is not
     consumed at all when the stats group yielded data.
+
+    Raises nothing of its own -- a malformed, truncated or undecodable artifact
+    yields fewer metrics -- but an exception from the caller's iterator
+    propagates. That is deliberate: the collector's iterator re-raises
+    descriptor exhaustion so its metrics are dropped rather than published as
+    totals covering only the ranks read before the limit.
     """
     metrics: dict[str, Any] = {"rocprof_artifact_dir": artifact_dir}
 

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -18,13 +18,26 @@ it. This module is the shared leaf both :mod:`aorta.run.collectors` and
 :mod:`aorta.run.retention` build on; it depends only on the stdlib so retention
 stays dependency-free.
 
-The descent needs one more thing than ``O_NOFOLLOW``, because "no component is a
-symlink" does not mean "this is still the operator's directory": a rename can
-move a *real* directory into the anchor's pathname, and the anchor's parent is
-necessarily opened by pathname (it lives above the operator's boundary and may
-hold the operator's own links). :class:`TrustedAnchor` therefore carries the
-``(st_dev, st_ino)`` the anchor had before the first payload launched, and the
-descent refuses to continue when the directory it opened is a different inode.
+Two things are needed beyond ``O_NOFOLLOW``, because it is a narrower guarantee
+than it looks:
+
+* **It does not say the anchor is still the operator's directory.** A rename can
+  move a *real* directory into the anchor's pathname, and the anchor's parent is
+  necessarily opened by pathname (it lives above the operator's boundary and may
+  hold the operator's own links). :class:`TrustedAnchor` therefore carries the
+  ``(st_dev, st_ino)`` the anchor had before the first payload launched, and the
+  descent refuses to continue when the directory it opened is a different inode.
+* **It only guards the final component, and ``dir_fd`` only applies to a
+  relative path.** So a "component" that is absolute, ``..``, or carries a
+  separator silently converts a guarded descent into an unguarded one. Every
+  name handed to a primitive here is therefore checked to be a single directory
+  entry (:func:`_require_child_name`) before it reaches the kernel.
+
+One property is also *not* obtainable from the descent: the type of a file can
+change between the walk that selected it and the read that consumes it. A
+regular file replaced by a FIFO turns a blocking ``open`` into an indefinite
+hang, so :func:`secure_open_read` opens ``O_NONBLOCK`` and validates the
+*descriptor* rather than trusting the earlier ``lstat``.
 
 Everything here is POSIX-only (``O_NOFOLLOW`` / ``O_DIRECTORY`` / ``dir_fd``).
 :data:`HAVE_FD_TRAVERSAL` is ``False`` on a platform that lacks them; callers
@@ -48,6 +61,7 @@ log = logging.getLogger(__name__)
 
 _O_NOFOLLOW: int = getattr(os, "O_NOFOLLOW", 0)
 _O_DIRECTORY: int = getattr(os, "O_DIRECTORY", 0)
+_O_NONBLOCK: int = getattr(os, "O_NONBLOCK", 0)
 
 #: True when the platform exposes the primitives needed for race-free,
 #: fd-relative traversal. False on Windows and anywhere ``O_NOFOLLOW`` /
@@ -57,11 +71,15 @@ HAVE_FD_TRAVERSAL: bool = bool(_O_NOFOLLOW and _O_DIRECTORY and os.open in os.su
 
 
 class UnsafePathError(OSError):
-    """A component below the trusted root was a symlink, missing, or not a dir.
+    """A path could not be used without leaving the trusted tree.
 
-    Raised while descending with :func:`open_dir_nofollow`. It is an
-    :class:`OSError` subclass so existing ``except OSError`` guards in the
-    collector and retention paths keep failing closed without a new import.
+    Covers a component that is a symlink, missing, or not a directory; a name
+    that is not a single directory entry; an anchor that is no longer the frozen
+    inode; and a file that turned into something other than a regular file
+    between the walk and the open. It is an :class:`OSError` subclass so
+    existing ``except OSError`` guards in the collector and retention paths keep
+    failing closed without a new import. Callers that need to tell *absent* from
+    *hostile* read ``errno`` (``ENOENT`` is the only benign one).
     """
 
 
@@ -135,6 +153,44 @@ def as_anchor(trusted_root: TrustedAnchor | Path | str) -> TrustedAnchor:
     return TrustedAnchor(Path(os.fspath(trusted_root)))
 
 
+def _require_child_name(name: str, where: str) -> str:
+    """Refuse a ``name`` that is anything other than one entry of a directory.
+
+    Every fd-relative primitive here promises to act *inside* the descriptor it
+    is handed, but ``dir_fd`` alone does not deliver that: an absolute path
+    makes :func:`os.open` ignore ``dir_fd`` outright, ``..`` walks above it, and
+    ``O_NOFOLLOW`` only guards the **final** component, so a name carrying a
+    separator has its intermediate components resolved with symlinks followed.
+    Each of those turns a guarded descent into an unguarded one, so the name is
+    checked before it reaches the kernel.
+
+    Today's callers cannot trip this -- :func:`relative_components` decomposes a
+    ``relative_to`` result and everything else forwards ``os.listdir`` entries,
+    neither of which can produce such a name -- so this enforces the contract
+    for the next caller rather than fixing a live escape. That is the point: the
+    guarantee belongs to these helpers, not to the discipline of whoever calls
+    them.
+
+    Raises:
+        UnsafePathError: the name is empty, ``.``, ``..``, absolute, or contains
+            a path separator.
+    """
+    separators = [sep for sep in (os.sep, os.altsep) if sep]
+    if (
+        not name
+        or name in (os.curdir, os.pardir)
+        or os.path.isabs(name)
+        or any(sep in name for sep in separators)
+    ):
+        raise UnsafePathError(
+            errno.EINVAL,
+            f"refusing to use {name!r} under {where!r}: expected a single "
+            "directory entry name, not an empty, absolute, relative-traversal "
+            "or multi-component path",
+        )
+    return name
+
+
 def relative_components(trusted_root: Path, target: Path) -> list[str] | None:
     """The lexical path components of ``target`` below ``trusted_root``.
 
@@ -182,8 +238,8 @@ def open_dir_nofollow(
 
     Raises:
         UnsafePathError: a component is a symlink, is missing (and
-            ``create_missing`` is false), is not a directory, or the anchor is
-            no longer the frozen inode.
+            ``create_missing`` is false), is not a directory, is not a single
+            directory entry name, or the anchor is no longer the frozen inode.
     """
     anchor = as_anchor(trusted_root)
     dir_fd = _open_anchor(anchor, create_missing)
@@ -252,7 +308,13 @@ def _open_anchor(anchor: TrustedAnchor, create_missing: bool) -> int:
 def _open_child_dir(
     parent_fd: int, name: str, trusted_root: Path | str, create_missing: bool
 ) -> int:
-    """Open (or optionally create) directory ``name`` under ``parent_fd``, no-follow."""
+    """Open (or optionally create) directory ``name`` under ``parent_fd``, no-follow.
+
+    The single funnel every descent goes through (:func:`open_dir_nofollow`,
+    :func:`open_dir_at`, :func:`_open_anchor`), so the child-name check lives
+    here rather than being repeated at each entry point.
+    """
+    _require_child_name(name, os.fspath(trusted_root))
     try:
         return os.open(name, os.O_RDONLY | _O_NOFOLLOW | _O_DIRECTORY, dir_fd=parent_fd)
     except FileNotFoundError:
@@ -300,7 +362,8 @@ def open_dir_at(base_fd: int, components: Sequence[str]) -> Iterator[int]:
     couple of descriptors.
 
     Raises:
-        UnsafePathError: a component is a symlink, missing, or not a directory.
+        UnsafePathError: a component is a symlink, missing, not a directory, or
+            not a single directory entry name.
     """
     dir_fd = os.dup(base_fd)
     try:
@@ -318,7 +381,15 @@ def stat_at(dir_fd: int, name: str) -> os.stat_result | None:
 
     Never follows a final-component symlink (``follow_symlinks=False``), so the
     caller sees the link itself rather than its target.
+
+    ``None`` means *absent*, which is not the same as *unusable*: a name that is
+    not a single directory entry raises instead, because ``stat_at(fd, "..")``
+    would report on the parent and read as a legitimate answer.
+
+    Raises:
+        UnsafePathError: ``name`` is not a single directory entry name.
     """
+    _require_child_name(name, f"fd {dir_fd}")
     try:
         return os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
     except FileNotFoundError:
@@ -338,6 +409,10 @@ def remove_entry_at(dir_fd: int, name: str) -> tuple[int, int]:
     ``lstat`` before the unlink; a file that vanishes mid-walk contributes 0.
 
     Raises:
+        UnsafePathError: ``name`` is not a single directory entry name. That
+            matters most here of all the primitives in this module:
+            ``remove_entry_at(fd, "..")`` would recursively empty the *parent*
+            of the held directory.
         OSError: the entry could not be removed. Callers decide tolerance.
     """
     info = stat_at(dir_fd, name)
@@ -413,13 +488,61 @@ def secure_open_read(dir_fd: int, name: str, **text_kwargs: object) -> Iterator[
     Refuses a symlink at the final component (``O_NOFOLLOW``). ``text_kwargs``
     are forwarded to :func:`os.fdopen` (e.g. ``encoding="utf-8"``,
     ``newline=""``). The stream (and its fd) is closed on context exit.
+
+    The open is ``O_NONBLOCK`` and the *opened descriptor* is then checked to be
+    a regular file. A caller that saw a regular file in an earlier ``lstat``
+    cannot rely on that here: a surviving payload process can unlink the file
+    and ``mkfifo`` in its place, and a blocking ``O_RDONLY`` on a FIFO with no
+    writer waits forever -- which would hang post-run summarization or the
+    retention sweep rather than degrade it. Checking the fd rather than the name
+    closes the window, because by then the descriptor is the thing we will read.
+    ``O_NONBLOCK`` is cleared once the type is confirmed, so the stream behaves
+    like any other file read.
+
+    Raises:
+        UnsafePathError: ``name`` is not a single directory entry name, or what
+            was opened is not a regular file.
+        OSError: the file could not be opened.
     """
-    fd = os.open(name, os.O_RDONLY | _O_NOFOLLOW, dir_fd=dir_fd)
-    stream = os.fdopen(fd, "r", **text_kwargs)  # type: ignore[arg-type]
+    _require_child_name(name, f"fd {dir_fd}")
+    fd = os.open(name, os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK, dir_fd=dir_fd)
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise UnsafePathError(
+                errno.EINVAL,
+                f"refusing to read {name!r}: it is not a regular file "
+                f"(mode {stat.filemode(info.st_mode)}); it was replaced after "
+                "the directory walk saw it",
+            )
+        _clear_nonblock(fd)
+        stream = os.fdopen(fd, "r", **text_kwargs)  # type: ignore[arg-type]
+    except BaseException:
+        # Nothing owns the fd yet -- ``fdopen`` only adopts it on success -- so
+        # a refusal here (or an interrupt) would otherwise leak it.
+        os.close(fd)
+        raise
     try:
         yield stream
     finally:
         stream.close()
+
+
+def _clear_nonblock(fd: int) -> None:
+    """Drop ``O_NONBLOCK`` from ``fd``, best effort.
+
+    Only reached once ``fd`` is known to be a regular file, where the flag is a
+    no-op for reads on Linux. Cleared anyway so the handle handed to a parser is
+    an ordinary blocking file, and suppressed rather than raised because failing
+    to tidy a flag is not a reason to drop a readable artifact.
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - POSIX-only, like the rest of this module
+        return
+    with contextlib.suppress(OSError):
+        flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+        fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~_O_NONBLOCK)
 
 
 def prune_empty_dirs(base_fd: int) -> None:

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -546,33 +546,38 @@ def secure_open_read(dir_fd: int, name: str, **text_kwargs: object) -> Iterator[
 
 
 def open_write_nofollow(dir_fd: int, name: str, **text_kwargs: object) -> TextIO:
-    """Create/truncate ``name`` under ``dir_fd`` for writing, refusing a symlink.
+    """Create/truncate ``name`` under ``dir_fd`` for writing, refusing links.
 
     The write-side counterpart of :func:`secure_open_read`, and returns the
     stream rather than a context manager so a caller can keep the existing
     ``fh = open(...)`` shape (the dispatcher's log capture holds both handles for
     the length of a trial and has its own cleanup path for a partial open).
 
-    ``O_NOFOLLOW`` refuses a symlink planted at the final component, so a
-    payload cannot redirect a record write outside the tree by leaving a link
-    where the file goes. ``O_CREAT`` without ``O_EXCL`` on purpose: a re-run
-    legitimately overwrites its own trial record, and ``O_EXCL`` would break
-    probe resume. ``O_NONBLOCK`` plus an ``S_ISREG`` check on the *descriptor*
-    covers the write-side version of the FIFO trap -- opening a FIFO for writing
-    blocks until a reader appears (or fails ``ENXIO`` non-blocking), which would
-    hang the trial rather than fail it.
+    ``O_NOFOLLOW`` refuses a symlink planted at the final component. A hard link
+    is different: opening it with ``O_TRUNC`` would damage its other name before
+    the descriptor could be checked. Open without ``O_TRUNC``, reject an inode
+    whose link count is not exactly one, and only then truncate the pinned
+    descriptor. A link added after that check can only name this already-opened
+    inode; it cannot redirect the descriptor to a pre-existing outside file.
+
+    ``O_CREAT`` without ``O_EXCL`` is intentional: a re-run legitimately
+    overwrites its own trial record, and ``O_EXCL`` would break probe resume.
+    ``O_NONBLOCK`` plus an ``S_ISREG`` check on the *descriptor* covers the
+    write-side version of the FIFO trap -- opening a FIFO for writing blocks
+    until a reader appears (or fails ``ENXIO`` non-blocking), which would hang
+    the trial rather than fail it.
 
     The caller owns the returned stream and must close it.
 
     Raises:
         UnsafePathError: ``name`` is not a single directory entry name, or what
-            was opened is not a regular file.
+            was opened is not a singly-linked regular file.
         OSError: the file could not be created or opened.
     """
     _require_child_name(name, f"fd {dir_fd}")
     fd = os.open(
         name,
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | _O_NOFOLLOW | _O_NONBLOCK,
+        os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW | _O_NONBLOCK,
         0o644,
         dir_fd=dir_fd,
     )
@@ -584,6 +589,13 @@ def open_write_nofollow(dir_fd: int, name: str, **text_kwargs: object) -> TextIO
                 f"refusing to write {name!r}: it is not a regular file "
                 f"(mode {stat.filemode(info.st_mode)})",
             )
+        if info.st_nlink != 1:
+            raise UnsafePathError(
+                errno.EMLINK,
+                f"refusing to write {name!r}: regular file has "
+                f"{info.st_nlink} hard links",
+            )
+        os.ftruncate(fd, 0)
         _clear_nonblock(fd)
         return os.fdopen(fd, "w", **text_kwargs)  # type: ignore[arg-type,return-value]
     except BaseException:

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -645,6 +645,8 @@ def open_write_nofollow(
 
     ``O_CREAT`` without ``O_EXCL`` is intentional: a re-run legitimately
     overwrites its own trial record, and ``O_EXCL`` would break probe resume.
+    When ``permissions`` is supplied, it is applied to the held descriptor
+    before truncation and before the stream is returned.
     ``O_NONBLOCK`` plus an ``S_ISREG`` check on the *descriptor* covers the
     write-side version of the FIFO trap -- opening a FIFO for writing blocks
     until a reader appears (or fails ``ENXIO`` non-blocking), which would hang

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -18,6 +18,14 @@ it. This module is the shared leaf both :mod:`aorta.run.collectors` and
 :mod:`aorta.run.retention` build on; it depends only on the stdlib so retention
 stays dependency-free.
 
+The descent needs one more thing than ``O_NOFOLLOW``, because "no component is a
+symlink" does not mean "this is still the operator's directory": a rename can
+move a *real* directory into the anchor's pathname, and the anchor's parent is
+necessarily opened by pathname (it lives above the operator's boundary and may
+hold the operator's own links). :class:`TrustedAnchor` therefore carries the
+``(st_dev, st_ino)`` the anchor had before the first payload launched, and the
+descent refuses to continue when the directory it opened is a different inode.
+
 Everything here is POSIX-only (``O_NOFOLLOW`` / ``O_DIRECTORY`` / ``dir_fd``).
 :data:`HAVE_FD_TRAVERSAL` is ``False`` on a platform that lacks them; callers
 fall back to their previous lexical guards there. ``aorta probe`` is Linux-only
@@ -27,12 +35,14 @@ by design, so the fd path is the one that runs in practice.
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import errno
 import logging
 import os
 import stat
 from collections.abc import Iterator, Sequence
 from pathlib import Path
+from typing import TextIO
 
 log = logging.getLogger(__name__)
 
@@ -53,6 +63,68 @@ class UnsafePathError(OSError):
     :class:`OSError` subclass so existing ``except OSError`` guards in the
     collector and retention paths keep failing closed without a new import.
     """
+
+
+@dataclasses.dataclass(frozen=True)
+class TrustedAnchor:
+    """A canonical directory path plus the inode it named before the payload ran.
+
+    ``O_NOFOLLOW`` answers "is this component a symlink", which is not the same
+    question as "is this still the operator's directory". Two swaps slip past a
+    no-follow-only descent:
+
+    * The anchor's *parent* is opened by pathname, above the operator's
+      boundary, because it may legitimately hold the operator's own links. A
+      payload that can write the grandparent can rename that parent aside and
+      leave a symlink to a planted tree that contains an ordinary ``results``
+      directory; the anchor then opens with no symlink in sight.
+    * The anchor itself can be renamed aside and a *real* directory renamed
+      into its place. Nothing in that pathname is a link, so every no-follow
+      check passes.
+
+    Both are defeated by naming the inode rather than the path: ``identity`` is
+    the ``(st_dev, st_ino)`` pair captured before the first payload launches,
+    and :func:`open_dir_nofollow` refuses to descend when the directory it
+    opened is not that inode. A file descriptor would be the stronger pin, but
+    the anchor has to cross the isolated-worker process boundary, and fds do
+    not.
+
+    ``identity`` is ``None`` for an anchor nobody froze -- a direct
+    programmatic caller, or a platform where the stat failed. The descent then
+    keeps its no-follow-only behaviour rather than inventing a pin.
+    """
+
+    path: Path
+    identity: tuple[int, int] | None = None
+
+    @classmethod
+    def freeze(cls, path: Path | str) -> TrustedAnchor:
+        """Capture ``path``'s current inode identity as the trust anchor.
+
+        The caller must do this *before* any payload runs and after the
+        directory exists, which for the dispatcher means after it has created
+        the results tree. A stat failure yields an unpinned anchor rather than
+        raising: an anchor that cannot be pinned is still worth threading for
+        its no-follow descent.
+        """
+        anchor = Path(os.fspath(path))
+        try:
+            info = os.stat(anchor)
+        except OSError as exc:
+            log.debug("could not pin the trust anchor %s (%s)", anchor, exc)
+            return cls(anchor)
+        return cls(anchor, (info.st_dev, info.st_ino))
+
+
+def as_anchor(trusted_root: TrustedAnchor | Path | str) -> TrustedAnchor:
+    """Coerce a path or an already-frozen anchor into a :class:`TrustedAnchor`.
+
+    Lets every guard take either form, so a caller that has no frozen identity
+    (a test, a direct programmatic caller) keeps passing a plain path.
+    """
+    if isinstance(trusted_root, TrustedAnchor):
+        return trusted_root
+    return TrustedAnchor(Path(os.fspath(trusted_root)))
 
 
 def relative_components(trusted_root: Path, target: Path) -> list[str] | None:
@@ -76,7 +148,7 @@ def relative_components(trusted_root: Path, target: Path) -> list[str] | None:
 
 @contextlib.contextmanager
 def open_dir_nofollow(
-    trusted_root: Path | str,
+    trusted_root: TrustedAnchor | Path | str,
     components: Sequence[str],
     *,
     create_missing: bool = False,
@@ -84,19 +156,15 @@ def open_dir_nofollow(
     """Yield a dir fd for ``trusted_root``/*components*, opened without following
     any symlink below ``trusted_root``.
 
-    The **parent** of ``trusted_root`` is opened plainly (``O_RDONLY |
-    O_DIRECTORY``): it sits *above* the operator's ``--results-dir``, so it is
-    not payload-writable and may legitimately contain the operator's own
-    symlinks (a ``/tmp`` that is really ``/private/tmp``, a mounted scratch
-    path) that the dispatcher already resolved away. The ``--results-dir``
-    inode itself is the *first* payload-swappable component -- the payload can
-    replace the results directory with a symlink after launch -- so it, and
-    every component below it, is opened ``O_RDONLY | O_NOFOLLOW | O_DIRECTORY``
-    relative to its parent fd. A payload-owned symlink at any of them (including
-    the anchor itself) raises :class:`UnsafePathError` instead of redirecting the
-    descent. All intermediate fds are closed as the walk proceeds; the yielded
-    leaf fd is closed on context exit. The caller must not use the fd after the
-    ``with`` block.
+    The anchor directory is opened first (see :func:`_open_anchor`) and, when
+    the caller froze a :class:`TrustedAnchor`, checked to be the inode the
+    operator's ``--results-dir`` named before the payload launched. Every
+    component below it is then opened ``O_RDONLY | O_NOFOLLOW | O_DIRECTORY``
+    relative to its parent fd, so a payload-owned symlink at any of them raises
+    :class:`UnsafePathError` instead of redirecting the descent. All
+    intermediate fds are closed as the walk proceeds; the yielded leaf fd is
+    closed on context exit. The caller must not use the fd after the ``with``
+    block.
 
     When ``create_missing`` is set, a component that does not exist is created
     with ``os.mkdir(dir_fd=...)`` and then opened -- the fd-relative equivalent
@@ -106,30 +174,71 @@ def open_dir_nofollow(
 
     Raises:
         UnsafePathError: a component is a symlink, is missing (and
-            ``create_missing`` is false), or is not a directory.
+            ``create_missing`` is false), is not a directory, or the anchor is
+            no longer the frozen inode.
     """
-    anchor = Path(os.fspath(trusted_root))
-    anchor_name = anchor.name
-    if anchor_name:
-        # Open the parent (above --results-dir, not payload territory) plainly,
-        # then descend the results-dir inode itself no-follow so a swap of it is
-        # caught like any component below it.
-        base = os.fspath(anchor.parent)
-        walk: list[str] = [anchor_name, *components]
-    else:
-        # Degenerate anchor (a filesystem root has no name): nothing above it to
-        # anchor against, so open it plainly and rely on the below-components.
-        base = os.fspath(trusted_root)
-        walk = list(components)
-    dir_fd = os.open(base, os.O_RDONLY | _O_DIRECTORY)
+    anchor = as_anchor(trusted_root)
+    dir_fd = _open_anchor(anchor, create_missing)
     try:
-        for name in walk:
-            child = _open_child_dir(dir_fd, name, trusted_root, create_missing)
+        for name in components:
+            child = _open_child_dir(dir_fd, name, anchor.path, create_missing)
             os.close(dir_fd)
             dir_fd = child
         yield dir_fd
     finally:
         os.close(dir_fd)
+
+
+def _open_anchor(anchor: TrustedAnchor, create_missing: bool) -> int:
+    """Open the trusted root itself and confirm it is the frozen inode.
+
+    The anchor's **parent** is opened plainly (``O_RDONLY | O_DIRECTORY``): it
+    sits *above* the operator's ``--results-dir``, so it may legitimately
+    contain the operator's own symlinks (a ``/tmp`` that is really
+    ``/private/tmp``, a mounted scratch path) that the dispatcher already
+    resolved away. The anchor inode itself is the *first* payload-swappable
+    component -- the payload can replace the results directory after launch --
+    so it is opened ``O_NOFOLLOW`` relative to that parent fd.
+
+    Opening the parent by pathname is what makes the identity check
+    load-bearing rather than belt-and-braces: a payload that can write the
+    grandparent can rename the parent aside and leave a symlink to a planted
+    tree whose own ``results`` directory is perfectly ordinary, and no
+    no-follow check below would notice. Comparing ``fstat`` against
+    :attr:`TrustedAnchor.identity` also catches the reverse trick of renaming
+    the anchor aside and moving a *real* directory into its pathname.
+
+    Raises:
+        UnsafePathError: the anchor is a symlink, is missing (and
+            ``create_missing`` is false), or is not the frozen inode.
+    """
+    name = anchor.path.name
+    if name:
+        parent_fd = os.open(os.fspath(anchor.path.parent), os.O_RDONLY | _O_DIRECTORY)
+        try:
+            dir_fd = _open_child_dir(parent_fd, name, anchor.path, create_missing)
+        finally:
+            os.close(parent_fd)
+    else:
+        # Degenerate anchor (a filesystem root has no name): nothing above it to
+        # descend from, so open it plainly and rely on the below-components.
+        dir_fd = os.open(os.fspath(anchor.path), os.O_RDONLY | _O_DIRECTORY)
+    if anchor.identity is None:
+        return dir_fd
+    try:
+        info = os.fstat(dir_fd)
+        if (info.st_dev, info.st_ino) != anchor.identity:
+            raise UnsafePathError(
+                errno.ESTALE,
+                f"refusing to descend into {os.fspath(anchor.path)!r}: it is no "
+                f"longer the directory frozen before the run "
+                f"(expected inode {anchor.identity}, found "
+                f"{(info.st_dev, info.st_ino)}), so it was renamed or replaced",
+            )
+    except BaseException:
+        os.close(dir_fd)
+        raise
+    return dir_fd
 
 
 def _open_child_dir(
@@ -169,6 +278,31 @@ def _open_child_dir(
             f"refusing to descend into {name!r} under {os.fspath(trusted_root)!r}: "
             f"{exc.strerror}",
         ) from exc
+
+
+@contextlib.contextmanager
+def open_dir_at(base_fd: int, components: Sequence[str]) -> Iterator[int]:
+    """Yield a dir fd for *components* under ``base_fd``, no-follow at every step.
+
+    The short form of :func:`open_dir_nofollow` for a caller that already holds
+    a verified directory fd and wants to reach a subdirectory of it. No anchor
+    identity check is needed: ``base_fd`` names an inode directly, so the
+    descent cannot be redirected by any pathname swap. Used to reopen one
+    artifact's directory at a time so a large capture never holds more than a
+    couple of descriptors.
+
+    Raises:
+        UnsafePathError: a component is a symlink, missing, or not a directory.
+    """
+    dir_fd = os.dup(base_fd)
+    try:
+        for name in components:
+            child = _open_child_dir(dir_fd, name, ".", False)
+            os.close(dir_fd)
+            dir_fd = child
+        yield dir_fd
+    finally:
+        os.close(dir_fd)
 
 
 def stat_at(dir_fd: int, name: str) -> os.stat_result | None:
@@ -265,7 +399,7 @@ def _walk(dir_fd: int, prefix: str) -> Iterator[tuple[str, int, str, int]]:
 
 
 @contextlib.contextmanager
-def secure_open_read(dir_fd: int, name: str, **text_kwargs: object) -> Iterator[object]:
+def secure_open_read(dir_fd: int, name: str, **text_kwargs: object) -> Iterator[TextIO]:
     """Open ``name`` under ``dir_fd`` read-only and no-follow as a text stream.
 
     Refuses a symlink at the final component (``O_NOFOLLOW``). ``text_kwargs``
@@ -313,8 +447,11 @@ def _prune(dir_fd: int) -> None:
 
 __all__ = [
     "HAVE_FD_TRAVERSAL",
+    "TrustedAnchor",
     "UnsafePathError",
+    "as_anchor",
     "iter_regular_files",
+    "open_dir_at",
     "open_dir_nofollow",
     "prune_empty_dirs",
     "relative_components",

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -1,0 +1,324 @@
+"""No-follow, fd-relative filesystem primitives for collector path guards.
+
+The collector output tree (``<results_root>/<workload>/<trial>/<subdir>``) is
+handed to the profiled command as a ``-d`` / ``-n`` target. Everything below the
+operator's ``--results-dir`` is therefore payload-writable *during the run*, and
+a pathname-based guard is inherently time-of-check/time-of-use: after
+``resolve()`` and an ``is_symlink()`` walk return, ``rmtree`` / ``rglob`` /
+retention reopen the path from ``/`` and a payload descendant that outlived its
+process group (a ``setsid``'d child, a detached container) can have swapped an
+ancestor for a symlink in the gap, redirecting the operation outside the tree.
+
+The only race-free defence is to stop re-resolving pathnames: descend the tree
+once with ``O_NOFOLLOW`` on every component below the trusted anchor, hold the
+resulting directory file descriptors, and perform every subsequent stat / read /
+unlink / rmdir *relative to those fds*. The kernel resolves a name under a dir fd
+only within that inode, so a later swap of an ancestor pathname cannot redirect
+it. This module is the shared leaf both :mod:`aorta.run.collectors` and
+:mod:`aorta.run.retention` build on; it depends only on the stdlib so retention
+stays dependency-free.
+
+Everything here is POSIX-only (``O_NOFOLLOW`` / ``O_DIRECTORY`` / ``dir_fd``).
+:data:`HAVE_FD_TRAVERSAL` is ``False`` on a platform that lacks them; callers
+fall back to their previous lexical guards there. ``aorta probe`` is Linux-only
+by design, so the fd path is the one that runs in practice.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import logging
+import os
+import stat
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_O_NOFOLLOW: int = getattr(os, "O_NOFOLLOW", 0)
+_O_DIRECTORY: int = getattr(os, "O_DIRECTORY", 0)
+
+#: True when the platform exposes the primitives needed for race-free,
+#: fd-relative traversal. False on Windows and anywhere ``O_NOFOLLOW`` /
+#: ``O_DIRECTORY`` / ``dir_fd`` are unavailable, where callers keep their
+#: lexical (``resolve()`` + ``is_symlink()``) guards.
+HAVE_FD_TRAVERSAL: bool = bool(_O_NOFOLLOW and _O_DIRECTORY and os.open in os.supports_dir_fd)
+
+
+class UnsafePathError(OSError):
+    """A component below the trusted root was a symlink, missing, or not a dir.
+
+    Raised while descending with :func:`open_dir_nofollow`. It is an
+    :class:`OSError` subclass so existing ``except OSError`` guards in the
+    collector and retention paths keep failing closed without a new import.
+    """
+
+
+def relative_components(trusted_root: Path, target: Path) -> list[str] | None:
+    """The lexical path components of ``target`` below ``trusted_root``.
+
+    Returns the component names to descend, or ``None`` when ``target`` is not
+    lexically inside ``trusted_root`` or any component is ``..`` / empty. Neither
+    path is touched on disk; this is pure lexical decomposition of two absolute
+    paths the caller already holds (the anchor and the collector dir), so the fd
+    walk can reject an escape before opening anything.
+    """
+    try:
+        rel = target.relative_to(trusted_root)
+    except ValueError:
+        return None
+    parts = [part for part in rel.parts if part not in ("", os.curdir)]
+    if any(part == os.pardir for part in parts):
+        return None
+    return parts
+
+
+@contextlib.contextmanager
+def open_dir_nofollow(
+    trusted_root: Path | str,
+    components: Sequence[str],
+    *,
+    create_missing: bool = False,
+) -> Iterator[int]:
+    """Yield a dir fd for ``trusted_root``/*components*, opened without following
+    any symlink below ``trusted_root``.
+
+    The **parent** of ``trusted_root`` is opened plainly (``O_RDONLY |
+    O_DIRECTORY``): it sits *above* the operator's ``--results-dir``, so it is
+    not payload-writable and may legitimately contain the operator's own
+    symlinks (a ``/tmp`` that is really ``/private/tmp``, a mounted scratch
+    path) that the dispatcher already resolved away. The ``--results-dir``
+    inode itself is the *first* payload-swappable component -- the payload can
+    replace the results directory with a symlink after launch -- so it, and
+    every component below it, is opened ``O_RDONLY | O_NOFOLLOW | O_DIRECTORY``
+    relative to its parent fd. A payload-owned symlink at any of them (including
+    the anchor itself) raises :class:`UnsafePathError` instead of redirecting the
+    descent. All intermediate fds are closed as the walk proceeds; the yielded
+    leaf fd is closed on context exit. The caller must not use the fd after the
+    ``with`` block.
+
+    When ``create_missing`` is set, a component that does not exist is created
+    with ``os.mkdir(dir_fd=...)`` and then opened -- the fd-relative equivalent
+    of ``mkdir(parents=True)``, so a reset can build its trial subdirectory
+    chain without ever following a symlink. A component that exists as a symlink
+    or a non-directory still raises rather than being created over.
+
+    Raises:
+        UnsafePathError: a component is a symlink, is missing (and
+            ``create_missing`` is false), or is not a directory.
+    """
+    anchor = Path(os.fspath(trusted_root))
+    anchor_name = anchor.name
+    if anchor_name:
+        # Open the parent (above --results-dir, not payload territory) plainly,
+        # then descend the results-dir inode itself no-follow so a swap of it is
+        # caught like any component below it.
+        base = os.fspath(anchor.parent)
+        walk: list[str] = [anchor_name, *components]
+    else:
+        # Degenerate anchor (a filesystem root has no name): nothing above it to
+        # anchor against, so open it plainly and rely on the below-components.
+        base = os.fspath(trusted_root)
+        walk = list(components)
+    dir_fd = os.open(base, os.O_RDONLY | _O_DIRECTORY)
+    try:
+        for name in walk:
+            child = _open_child_dir(dir_fd, name, trusted_root, create_missing)
+            os.close(dir_fd)
+            dir_fd = child
+        yield dir_fd
+    finally:
+        os.close(dir_fd)
+
+
+def _open_child_dir(
+    parent_fd: int, name: str, trusted_root: Path | str, create_missing: bool
+) -> int:
+    """Open (or optionally create) directory ``name`` under ``parent_fd``, no-follow."""
+    try:
+        return os.open(name, os.O_RDONLY | _O_NOFOLLOW | _O_DIRECTORY, dir_fd=parent_fd)
+    except FileNotFoundError:
+        if not create_missing:
+            raise UnsafePathError(
+                errno.ENOENT,
+                f"refusing to descend into {name!r} under {os.fspath(trusted_root)!r}: "
+                "no such directory",
+            ) from None
+    except OSError as exc:
+        # ELOOP: the component is a symlink and O_NOFOLLOW refused it. ENOTDIR:
+        # it is a non-directory (a file, or a symlink to one). Both mean "cannot
+        # descend here without leaving the trusted tree" -- fail closed.
+        raise UnsafePathError(
+            exc.errno,
+            f"refusing to descend into {name!r} under {os.fspath(trusted_root)!r}: "
+            f"{exc.strerror}",
+        ) from exc
+    # create_missing and the component was absent: make it, then open it. A
+    # concurrent create losing the mkdir race is fine -- the open below still
+    # gets the (real) directory, or refuses a symlink a payload planted instead.
+    try:
+        os.mkdir(name, dir_fd=parent_fd)
+    except FileExistsError:
+        pass
+    try:
+        return os.open(name, os.O_RDONLY | _O_NOFOLLOW | _O_DIRECTORY, dir_fd=parent_fd)
+    except OSError as exc:
+        raise UnsafePathError(
+            exc.errno,
+            f"refusing to descend into {name!r} under {os.fspath(trusted_root)!r}: "
+            f"{exc.strerror}",
+        ) from exc
+
+
+def stat_at(dir_fd: int, name: str) -> os.stat_result | None:
+    """``lstat`` ``name`` relative to ``dir_fd``, or ``None`` when it is missing.
+
+    Never follows a final-component symlink (``follow_symlinks=False``), so the
+    caller sees the link itself rather than its target.
+    """
+    try:
+        return os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+
+
+def remove_entry_at(dir_fd: int, name: str) -> tuple[int, int]:
+    """Recursively remove ``name`` under ``dir_fd`` without following symlinks.
+
+    A symlink or regular file is unlinked directly (never dereferenced). A real
+    directory is emptied depth-first through fds opened ``O_NOFOLLOW`` relative
+    to their parent, then ``rmdir``-ed. Because every descent holds a dir fd, a
+    payload swap of an interior component after the walk began cannot redirect a
+    later unlink outside the subtree.
+
+    Returns ``(files_removed, bytes_freed)`` -- best effort sizes taken from an
+    ``lstat`` before the unlink; a file that vanishes mid-walk contributes 0.
+
+    Raises:
+        OSError: the entry could not be removed. Callers decide tolerance.
+    """
+    info = stat_at(dir_fd, name)
+    if info is None:
+        return (0, 0)
+    if not stat.S_ISDIR(info.st_mode):
+        size = info.st_size
+        os.unlink(name, dir_fd=dir_fd)
+        return (1, size)
+    child_fd = os.open(name, os.O_RDONLY | _O_NOFOLLOW | _O_DIRECTORY, dir_fd=dir_fd)
+    try:
+        files, freed = _empty_dir(child_fd)
+    finally:
+        os.close(child_fd)
+    os.rmdir(name, dir_fd=dir_fd)
+    return (files, freed)
+
+
+def _empty_dir(dir_fd: int) -> tuple[int, int]:
+    """Remove every entry under ``dir_fd`` (leaving the dir itself)."""
+    files = 0
+    freed = 0
+    for name in os.listdir(dir_fd):
+        removed, bytes_freed = remove_entry_at(dir_fd, name)
+        files += removed
+        freed += bytes_freed
+    return (files, freed)
+
+
+def iter_regular_files(base_fd: int) -> Iterator[tuple[str, int, str, int]]:
+    """Walk the tree under ``base_fd``, yielding one entry per regular file.
+
+    Yields ``(relative_posix_path, parent_dir_fd, name, size)`` for every
+    non-symlink regular file, never following a symlink and never descending
+    into a symlinked directory. ``parent_dir_fd`` is a live directory fd the
+    file sits directly in; the caller MUST act on it (``os.open`` /
+    ``os.unlink`` / ``os.stat`` with ``dir_fd=parent_dir_fd``) before the
+    generator advances, because the fd is closed once its directory is
+    exhausted. Directories are visited top-down; the caller cannot rely on
+    order beyond that.
+    """
+    yield from _walk(base_fd, "")
+
+
+def _walk(dir_fd: int, prefix: str) -> Iterator[tuple[str, int, str, int]]:
+    subdirs: list[str] = []
+    for name in sorted(os.listdir(dir_fd)):
+        info = stat_at(dir_fd, name)
+        if info is None or stat.S_ISLNK(info.st_mode):
+            continue
+        rel = f"{prefix}{name}"
+        if stat.S_ISDIR(info.st_mode):
+            subdirs.append(name)
+        elif stat.S_ISREG(info.st_mode):
+            yield (rel, dir_fd, name, info.st_size)
+    for name in subdirs:
+        try:
+            child_fd = os.open(
+                name, os.O_RDONLY | _O_NOFOLLOW | _O_DIRECTORY, dir_fd=dir_fd
+            )
+        except OSError:
+            continue
+        try:
+            yield from _walk(child_fd, f"{prefix}{name}/")
+        finally:
+            os.close(child_fd)
+
+
+@contextlib.contextmanager
+def secure_open_read(dir_fd: int, name: str, **text_kwargs: object) -> Iterator[object]:
+    """Open ``name`` under ``dir_fd`` read-only and no-follow as a text stream.
+
+    Refuses a symlink at the final component (``O_NOFOLLOW``). ``text_kwargs``
+    are forwarded to :func:`os.fdopen` (e.g. ``encoding="utf-8"``,
+    ``newline=""``). The stream (and its fd) is closed on context exit.
+    """
+    fd = os.open(name, os.O_RDONLY | _O_NOFOLLOW, dir_fd=dir_fd)
+    stream = os.fdopen(fd, "r", **text_kwargs)  # type: ignore[arg-type]
+    try:
+        yield stream
+    finally:
+        stream.close()
+
+
+def prune_empty_dirs(base_fd: int) -> None:
+    """Remove now-empty subdirectories under ``base_fd``, depth-first.
+
+    The base directory itself is never removed. Symlinked directories are never
+    descended or removed. Best-effort: a directory that cannot be removed (still
+    non-empty, or a race) is left in place.
+    """
+    _prune(base_fd)
+
+
+def _prune(dir_fd: int) -> None:
+    for name in os.listdir(dir_fd):
+        info = stat_at(dir_fd, name)
+        if info is None or not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+            continue
+        try:
+            child_fd = os.open(
+                name, os.O_RDONLY | _O_NOFOLLOW | _O_DIRECTORY, dir_fd=dir_fd
+            )
+        except OSError:
+            continue
+        try:
+            _prune(child_fd)
+            is_empty = not os.listdir(child_fd)
+        finally:
+            os.close(child_fd)
+        if is_empty:
+            with contextlib.suppress(OSError):
+                os.rmdir(name, dir_fd=dir_fd)
+
+
+__all__ = [
+    "HAVE_FD_TRAVERSAL",
+    "UnsafePathError",
+    "iter_regular_files",
+    "open_dir_nofollow",
+    "prune_empty_dirs",
+    "relative_components",
+    "remove_entry_at",
+    "secure_open_read",
+    "stat_at",
+]

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -1,4 +1,4 @@
-"""No-follow, fd-relative filesystem primitives for collector path guards.
+"""No-follow, fd-relative filesystem primitives for paths below ``--results-dir``.
 
 The collector output tree (``<results_root>/<workload>/<trial>/<subdir>``) is
 handed to the profiled command as a ``-d`` / ``-n`` target. Everything below the
@@ -12,11 +12,18 @@ ancestor for a symlink in the gap, redirecting the operation outside the tree.
 The only race-free defence is to stop re-resolving pathnames: descend the tree
 once with ``O_NOFOLLOW`` on every component below the trusted anchor, hold the
 resulting directory file descriptors, and perform every subsequent stat / read /
-unlink / rmdir *relative to those fds*. The kernel resolves a name under a dir fd
-only within that inode, so a later swap of an ancestor pathname cannot redirect
-it. This module is the shared leaf both :mod:`aorta.run.collectors` and
-:mod:`aorta.run.retention` build on; it depends only on the stdlib so retention
-stays dependency-free.
+write / unlink / rmdir *relative to those fds*. The kernel resolves a name under
+a dir fd only within that inode, so a later swap of an ancestor pathname cannot
+redirect it. This module is the shared leaf :mod:`aorta.run.collectors`,
+:mod:`aorta.run.retention` and :mod:`aorta.run.dispatcher` build on; it depends
+only on the stdlib so retention stays dependency-free.
+
+The same reasoning covers the dispatcher's *own* output, not just the collector
+artifacts. The per-workload directory sits below the same operator boundary, so
+the trial record and the captured logs are written through a held fd with
+:func:`open_write_nofollow` rather than by pathname -- otherwise a stale or
+payload-planted link at the workload component silently redirects the audit
+trail outside ``--results-dir``.
 
 Two things are needed beyond ``O_NOFOLLOW``, because it is a narrower guarantee
 than it looks:
@@ -36,8 +43,9 @@ than it looks:
 One property is also *not* obtainable from the descent: the type of a file can
 change between the walk that selected it and the read that consumes it. A
 regular file replaced by a FIFO turns a blocking ``open`` into an indefinite
-hang, so :func:`secure_open_read` opens ``O_NONBLOCK`` and validates the
-*descriptor* rather than trusting the earlier ``lstat``.
+hang, so :func:`secure_open_read` and :func:`open_write_nofollow` open
+``O_NONBLOCK`` and validate the *descriptor* rather than trusting the earlier
+``lstat``.
 
 Everything here is POSIX-only (``O_NOFOLLOW`` / ``O_DIRECTORY`` / ``dir_fd``).
 :data:`HAVE_FD_TRAVERSAL` is ``False`` on a platform that lacks them; callers
@@ -537,6 +545,54 @@ def secure_open_read(dir_fd: int, name: str, **text_kwargs: object) -> Iterator[
         stream.close()
 
 
+def open_write_nofollow(dir_fd: int, name: str, **text_kwargs: object) -> TextIO:
+    """Create/truncate ``name`` under ``dir_fd`` for writing, refusing a symlink.
+
+    The write-side counterpart of :func:`secure_open_read`, and returns the
+    stream rather than a context manager so a caller can keep the existing
+    ``fh = open(...)`` shape (the dispatcher's log capture holds both handles for
+    the length of a trial and has its own cleanup path for a partial open).
+
+    ``O_NOFOLLOW`` refuses a symlink planted at the final component, so a
+    payload cannot redirect a record write outside the tree by leaving a link
+    where the file goes. ``O_CREAT`` without ``O_EXCL`` on purpose: a re-run
+    legitimately overwrites its own trial record, and ``O_EXCL`` would break
+    probe resume. ``O_NONBLOCK`` plus an ``S_ISREG`` check on the *descriptor*
+    covers the write-side version of the FIFO trap -- opening a FIFO for writing
+    blocks until a reader appears (or fails ``ENXIO`` non-blocking), which would
+    hang the trial rather than fail it.
+
+    The caller owns the returned stream and must close it.
+
+    Raises:
+        UnsafePathError: ``name`` is not a single directory entry name, or what
+            was opened is not a regular file.
+        OSError: the file could not be created or opened.
+    """
+    _require_child_name(name, f"fd {dir_fd}")
+    fd = os.open(
+        name,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | _O_NOFOLLOW | _O_NONBLOCK,
+        0o644,
+        dir_fd=dir_fd,
+    )
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise UnsafePathError(
+                errno.EINVAL,
+                f"refusing to write {name!r}: it is not a regular file "
+                f"(mode {stat.filemode(info.st_mode)})",
+            )
+        _clear_nonblock(fd)
+        return os.fdopen(fd, "w", **text_kwargs)  # type: ignore[arg-type,return-value]
+    except BaseException:
+        # ``fdopen`` only adopts the fd on success, so a refusal or an interrupt
+        # in between would otherwise leak it.
+        os.close(fd)
+        raise
+
+
 def _clear_nonblock(fd: int) -> None:
     """Drop ``O_NONBLOCK`` from ``fd``, best effort.
 
@@ -591,6 +647,7 @@ __all__ = [
     "iter_regular_files",
     "open_dir_at",
     "open_dir_nofollow",
+    "open_write_nofollow",
     "prune_empty_dirs",
     "relative_components",
     "remove_entry_at",

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -104,14 +104,22 @@ class TrustedAnchor:
         The caller must do this *before* any payload runs and after the
         directory exists, which for the dispatcher means after it has created
         the results tree. A stat failure yields an unpinned anchor rather than
-        raising: an anchor that cannot be pinned is still worth threading for
-        its no-follow descent.
+        raising -- an anchor that cannot be pinned is still worth threading for
+        its no-follow descent -- but it is logged at WARNING rather than
+        swallowed: the guard silently drops to its weaker form, and the
+        dispatcher creates the directory first precisely so this cannot happen.
         """
         anchor = Path(os.fspath(path))
         try:
             info = os.stat(anchor)
         except OSError as exc:
-            log.debug("could not pin the trust anchor %s (%s)", anchor, exc)
+            log.warning(
+                "could not pin the trust anchor %s (%s); path guards fall back "
+                "to no-follow-only, which cannot detect the directory being "
+                "renamed aside and replaced by a real one",
+                anchor,
+                exc,
+            )
             return cls(anchor)
         return cls(anchor, (info.st_dev, info.st_ino))
 

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -63,6 +63,15 @@ _O_NOFOLLOW: int = getattr(os, "O_NOFOLLOW", 0)
 _O_DIRECTORY: int = getattr(os, "O_DIRECTORY", 0)
 _O_NONBLOCK: int = getattr(os, "O_NONBLOCK", 0)
 
+# Feature detection in the same spirit as the flags above, not an optional
+# third-party dependency: ``fcntl`` is a CPython builtin extension present on
+# every POSIX build and absent on Windows, so ``ImportError`` is the only way
+# this can fail -- there is no half-installed state to fail differently.
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows, where the fd path is off anyway
+    _fcntl = None  # type: ignore[assignment]
+
 #: True when the platform exposes the primitives needed for race-free,
 #: fd-relative traversal. False on Windows and anywhere ``O_NOFOLLOW`` /
 #: ``O_DIRECTORY`` / ``dir_fd`` are unavailable, where callers keep their
@@ -536,13 +545,11 @@ def _clear_nonblock(fd: int) -> None:
     an ordinary blocking file, and suppressed rather than raised because failing
     to tidy a flag is not a reason to drop a readable artifact.
     """
-    try:
-        import fcntl
-    except ImportError:  # pragma: no cover - POSIX-only, like the rest of this module
+    if _fcntl is None:
         return
     with contextlib.suppress(OSError):
-        flags = fcntl.fcntl(fd, fcntl.F_GETFL)
-        fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~_O_NONBLOCK)
+        flags = _fcntl.fcntl(fd, _fcntl.F_GETFL)
+        _fcntl.fcntl(fd, _fcntl.F_SETFL, flags & ~_O_NONBLOCK)
 
 
 def prune_empty_dirs(base_fd: int) -> None:

--- a/src/aorta/run/_fsafe.py
+++ b/src/aorta/run/_fsafe.py
@@ -18,12 +18,11 @@ redirect it. This module is the shared leaf :mod:`aorta.run.collectors`,
 :mod:`aorta.run.retention` and :mod:`aorta.run.dispatcher` build on; it depends
 only on the stdlib so retention stays dependency-free.
 
-The same reasoning covers the dispatcher's *own* output, not just the collector
-artifacts. The per-workload directory sits below the same operator boundary, so
-the trial record and the captured logs are written through a held fd with
-:func:`open_write_nofollow` rather than by pathname -- otherwise a stale or
-payload-planted link at the workload component silently redirects the audit
-trail outside ``--results-dir``.
+The same reasoning covers every platform-owned output below that boundary, not
+just collector artifacts. The dispatcher's per-workload records/logs and
+``_subprocess`` probe trial tree are written through held directory fds rather
+than by pathname -- otherwise a stale or payload-planted link at any component
+silently redirects the audit trail outside ``--results-dir``.
 
 Two things are needed beyond ``O_NOFOLLOW``, because it is a narrower guarantee
 than it looks:
@@ -63,7 +62,7 @@ import os
 import stat
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import TextIO
+from typing import BinaryIO, TextIO
 
 log = logging.getLogger(__name__)
 
@@ -459,6 +458,19 @@ def _empty_dir(dir_fd: int) -> tuple[int, int]:
     return (files, freed)
 
 
+def iter_entries(
+    base_fd: int,
+) -> Iterator[tuple[str, int, str, os.stat_result]]:
+    """Walk ``base_fd`` without following links, yielding every leaf entry.
+
+    Yields ``(relative_posix_path, parent_dir_fd, name, lstat_result)`` for
+    regular files, special files, and symlinks. Real directories are descended;
+    symlinked directories are yielded as links and never traversed.
+    ``parent_dir_fd`` remains live only until the generator advances.
+    """
+    yield from _walk_entries(base_fd, "")
+
+
 def iter_regular_files(base_fd: int) -> Iterator[tuple[str, int, str, int]]:
     """Walk the tree under ``base_fd``, yielding one entry per regular file.
 
@@ -471,20 +483,24 @@ def iter_regular_files(base_fd: int) -> Iterator[tuple[str, int, str, int]]:
     exhausted. Directories are visited top-down; the caller cannot rely on
     order beyond that.
     """
-    yield from _walk(base_fd, "")
+    for rel, dir_fd, name, info in iter_entries(base_fd):
+        if stat.S_ISREG(info.st_mode) and not stat.S_ISLNK(info.st_mode):
+            yield (rel, dir_fd, name, info.st_size)
 
 
-def _walk(dir_fd: int, prefix: str) -> Iterator[tuple[str, int, str, int]]:
+def _walk_entries(
+    dir_fd: int, prefix: str
+) -> Iterator[tuple[str, int, str, os.stat_result]]:
     subdirs: list[str] = []
     for name in sorted(os.listdir(dir_fd)):
         info = stat_at(dir_fd, name)
-        if info is None or stat.S_ISLNK(info.st_mode):
+        if info is None:
             continue
         rel = f"{prefix}{name}"
-        if stat.S_ISDIR(info.st_mode):
+        if stat.S_ISDIR(info.st_mode) and not stat.S_ISLNK(info.st_mode):
             subdirs.append(name)
-        elif stat.S_ISREG(info.st_mode):
-            yield (rel, dir_fd, name, info.st_size)
+        else:
+            yield (rel, dir_fd, name, info)
     for name in subdirs:
         try:
             child_fd = os.open(
@@ -493,9 +509,29 @@ def _walk(dir_fd: int, prefix: str) -> Iterator[tuple[str, int, str, int]]:
         except OSError:
             continue
         try:
-            yield from _walk(child_fd, f"{prefix}{name}/")
+            yield from _walk_entries(child_fd, f"{prefix}{name}/")
         finally:
             os.close(child_fd)
+
+
+def _open_read_fd_nofollow(dir_fd: int, name: str) -> int:
+    """Open and validate a regular read-only leaf, returning its owned fd."""
+    _require_child_name(name, f"fd {dir_fd}")
+    fd = os.open(name, os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK, dir_fd=dir_fd)
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise UnsafePathError(
+                errno.EINVAL,
+                f"refusing to read {name!r}: it is not a regular file "
+                f"(mode {stat.filemode(info.st_mode)}); it was replaced after "
+                "the directory walk saw it",
+            )
+        _clear_nonblock(fd)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
 
 
 @contextlib.contextmanager
@@ -521,18 +557,8 @@ def secure_open_read(dir_fd: int, name: str, **text_kwargs: object) -> Iterator[
             was opened is not a regular file.
         OSError: the file could not be opened.
     """
-    _require_child_name(name, f"fd {dir_fd}")
-    fd = os.open(name, os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK, dir_fd=dir_fd)
+    fd = _open_read_fd_nofollow(dir_fd, name)
     try:
-        info = os.fstat(fd)
-        if not stat.S_ISREG(info.st_mode):
-            raise UnsafePathError(
-                errno.EINVAL,
-                f"refusing to read {name!r}: it is not a regular file "
-                f"(mode {stat.filemode(info.st_mode)}); it was replaced after "
-                "the directory walk saw it",
-            )
-        _clear_nonblock(fd)
         stream = os.fdopen(fd, "r", **text_kwargs)  # type: ignore[arg-type]
     except BaseException:
         # Nothing owns the fd yet -- ``fdopen`` only adopts it on success -- so
@@ -545,7 +571,64 @@ def secure_open_read(dir_fd: int, name: str, **text_kwargs: object) -> Iterator[
         stream.close()
 
 
-def open_write_nofollow(dir_fd: int, name: str, **text_kwargs: object) -> TextIO:
+@contextlib.contextmanager
+def secure_open_read_binary(dir_fd: int, name: str) -> Iterator[BinaryIO]:
+    """Binary counterpart of :func:`secure_open_read`."""
+    fd = _open_read_fd_nofollow(dir_fd, name)
+    try:
+        stream = os.fdopen(fd, "rb")
+    except BaseException:
+        os.close(fd)
+        raise
+    try:
+        yield stream
+    finally:
+        stream.close()
+
+
+def _open_write_fd_nofollow(
+    dir_fd: int, name: str, *, permissions: int | None = None
+) -> int:
+    """Open, validate, and truncate a writable leaf, returning its owned fd."""
+    _require_child_name(name, f"fd {dir_fd}")
+    create_mode = 0o644 if permissions is None else permissions
+    fd = os.open(
+        name,
+        os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW | _O_NONBLOCK,
+        create_mode,
+        dir_fd=dir_fd,
+    )
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise UnsafePathError(
+                errno.EINVAL,
+                f"refusing to write {name!r}: it is not a regular file "
+                f"(mode {stat.filemode(info.st_mode)})",
+            )
+        if info.st_nlink != 1:
+            raise UnsafePathError(
+                errno.EMLINK,
+                f"refusing to write {name!r}: regular file has "
+                f"{info.st_nlink} hard links",
+            )
+        if permissions is not None:
+            os.fchmod(fd, permissions)
+        os.ftruncate(fd, 0)
+        _clear_nonblock(fd)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def open_write_nofollow(
+    dir_fd: int,
+    name: str,
+    *,
+    permissions: int | None = None,
+    **text_kwargs: object,
+) -> TextIO:
     """Create/truncate ``name`` under ``dir_fd`` for writing, refusing links.
 
     The write-side counterpart of :func:`secure_open_read`, and returns the
@@ -574,33 +657,24 @@ def open_write_nofollow(dir_fd: int, name: str, **text_kwargs: object) -> TextIO
             was opened is not a singly-linked regular file.
         OSError: the file could not be created or opened.
     """
-    _require_child_name(name, f"fd {dir_fd}")
-    fd = os.open(
-        name,
-        os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW | _O_NONBLOCK,
-        0o644,
-        dir_fd=dir_fd,
-    )
+    fd = _open_write_fd_nofollow(dir_fd, name, permissions=permissions)
     try:
-        info = os.fstat(fd)
-        if not stat.S_ISREG(info.st_mode):
-            raise UnsafePathError(
-                errno.EINVAL,
-                f"refusing to write {name!r}: it is not a regular file "
-                f"(mode {stat.filemode(info.st_mode)})",
-            )
-        if info.st_nlink != 1:
-            raise UnsafePathError(
-                errno.EMLINK,
-                f"refusing to write {name!r}: regular file has "
-                f"{info.st_nlink} hard links",
-            )
-        os.ftruncate(fd, 0)
-        _clear_nonblock(fd)
         return os.fdopen(fd, "w", **text_kwargs)  # type: ignore[arg-type,return-value]
     except BaseException:
         # ``fdopen`` only adopts the fd on success, so a refusal or an interrupt
         # in between would otherwise leak it.
+        os.close(fd)
+        raise
+
+
+def open_write_binary_nofollow(
+    dir_fd: int, name: str, *, permissions: int | None = None
+) -> BinaryIO:
+    """Binary counterpart of :func:`open_write_nofollow`."""
+    fd = _open_write_fd_nofollow(dir_fd, name, permissions=permissions)
+    try:
+        return os.fdopen(fd, "wb")
+    except BaseException:
         os.close(fd)
         raise
 
@@ -656,13 +730,16 @@ __all__ = [
     "TrustedAnchor",
     "UnsafePathError",
     "as_anchor",
+    "iter_entries",
     "iter_regular_files",
     "open_dir_at",
     "open_dir_nofollow",
+    "open_write_binary_nofollow",
     "open_write_nofollow",
     "prune_empty_dirs",
     "relative_components",
     "remove_entry_at",
     "secure_open_read",
+    "secure_open_read_binary",
     "stat_at",
 ]

--- a/src/aorta/run/_trial_runtime.py
+++ b/src/aorta/run/_trial_runtime.py
@@ -24,6 +24,7 @@ def execute_trial(
     results_dir: Path,
     should_write: bool,
     persist_result: bool,
+    results_root: Path | None = None,
     result_transform: (Callable[[WorkloadResult, str], tuple[WorkloadResult, str]] | None) = None,
     skip_cleanup_on_error: bool = False,
 ) -> TrialResult:
@@ -38,6 +39,7 @@ def execute_trial(
         mitigation_env=mitigation_env,
         results_dir=results_dir,
         should_write=should_write,
+        results_root=results_root,
         persist_result=persist_result,
         result_transform=result_transform,
         skip_cleanup_on_error=skip_cleanup_on_error,

--- a/src/aorta/run/_trial_runtime.py
+++ b/src/aorta/run/_trial_runtime.py
@@ -11,6 +11,7 @@ from aorta.run.results import TrialResult
 from aorta.workloads import Workload, WorkloadResult
 
 if TYPE_CHECKING:
+    from aorta.run._fsafe import TrustedAnchor
     from aorta.run.dispatcher import RunRequest
 
 
@@ -24,7 +25,7 @@ def execute_trial(
     results_dir: Path,
     should_write: bool,
     persist_result: bool,
-    results_root: Path | None = None,
+    results_root: TrustedAnchor | None = None,
     result_transform: (Callable[[WorkloadResult, str], tuple[WorkloadResult, str]] | None) = None,
     skip_cleanup_on_error: bool = False,
 ) -> TrialResult:

--- a/src/aorta/run/_trial_worker.py
+++ b/src/aorta/run/_trial_worker.py
@@ -365,6 +365,14 @@ def _main(request_path: Path, response_path: Path) -> int:
             env_descriptor=env_descriptor,
             mitigation_env=dict(envelope["mitigation_env"]),
             results_dir=Path(envelope["results_dir"]),
+            # The parent froze this before its trial loop; inheriting it is
+            # what keeps an isolated trial from resolving a fresh anchor after
+            # an earlier trial's payload has run.
+            results_root=(
+                Path(envelope["results_root"])
+                if envelope.get("results_root") is not None
+                else None
+            ),
             should_write=bool(envelope["should_write"]),
             persist_result=False,
             result_transform=(

--- a/src/aorta/run/_trial_worker.py
+++ b/src/aorta/run/_trial_worker.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Literal
 
+from aorta.run import _fsafe
 from aorta.run._worker_protocol import (
     PROTOCOL_VERSION,
     read_envelope,
@@ -116,6 +117,26 @@ def _run_request_from_dict(data: dict[str, Any]):
         save_logs=bool(data.get("save_logs", False)),
         env_probe=(dict(data["env_probe"]) if data.get("env_probe") is not None else None),
     )
+
+
+def _anchor_from_envelope(envelope: dict[str, Any]) -> _fsafe.TrustedAnchor | None:
+    """Rebuild the parent's frozen collector anchor from the worker envelope.
+
+    The pinned inode is optional: an older parent, or one whose stat failed,
+    sends the path alone and the descent keeps its no-follow-only behaviour.
+    Refreezing here would defeat the point -- this process starts *after* an
+    earlier trial's payload has run.
+    """
+    raw_path = envelope.get("results_root")
+    if raw_path is None:
+        return None
+    raw_id = envelope.get("results_root_id")
+    identity = (
+        (int(raw_id[0]), int(raw_id[1]))
+        if isinstance(raw_id, (list, tuple)) and len(raw_id) == 2
+        else None
+    )
+    return _fsafe.TrustedAnchor(Path(raw_path), identity)
 
 
 def _synchronize_workload_result(
@@ -365,14 +386,10 @@ def _main(request_path: Path, response_path: Path) -> int:
             env_descriptor=env_descriptor,
             mitigation_env=dict(envelope["mitigation_env"]),
             results_dir=Path(envelope["results_dir"]),
-            # The parent froze this before its trial loop; inheriting it is
-            # what keeps an isolated trial from resolving a fresh anchor after
-            # an earlier trial's payload has run.
-            results_root=(
-                Path(envelope["results_root"])
-                if envelope.get("results_root") is not None
-                else None
-            ),
+            # The parent froze this before its trial loop; inheriting it --
+            # pinned inode included -- is what keeps an isolated trial from
+            # resolving a fresh anchor after an earlier trial's payload has run.
+            results_root=_anchor_from_envelope(envelope),
             should_write=bool(envelope["should_write"]),
             persist_result=False,
             result_transform=(

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -235,8 +235,10 @@ def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) 
       whole chain, so this catches a swap at any depth rather than only at the
       leaf or its parent.
 
-    ``trusted_root`` defaults to ``root.parent``, which for the collector layout
-    is the dispatcher-created results directory.
+    ``trusted_root`` defaults to ``root.parent`` when the caller omits it.
+    That fallback is only for a programmatic caller that did not thread
+    :data:`CONFIG_KEY_RESULTS_ROOT`; it still misses a swapped ancestor, which
+    is why the dispatcher always supplies the operator's ``--results-dir``.
     """
     trusted = trusted_root if trusted_root is not None else root.parent
     try:

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -203,7 +203,7 @@ def _collect_root(config: Mapping[str, Any]) -> Path | None:
     return Path(raw) if isinstance(raw, str) and raw else None
 
 
-def trusted_results_anchor(config: Mapping[str, Any]) -> _fsafe.TrustedAnchor | None:
+def _threaded_anchor(config: Mapping[str, Any]) -> _fsafe.TrustedAnchor | None:
     """The dispatcher's frozen ``--results-dir`` anchor, or ``None`` if unthreaded.
 
     Reads :data:`CONFIG_KEY_RESULTS_ROOT` (canonicalized at dispatch) together
@@ -214,9 +214,10 @@ def trusted_results_anchor(config: Mapping[str, Any]) -> _fsafe.TrustedAnchor | 
     the anchor through the same link would make containment succeed for a path
     that has left the operator's tree.
 
-    Returns ``None`` when the key is absent, which only happens for a direct
-    programmatic caller -- the dispatcher always supplies it alongside
-    ``_aorta_collect_dir``.
+    Private on purpose: every guard goes through
+    :func:`trusted_collector_anchor` so the fallback is applied in exactly one
+    place. A caller that took the bare ``None`` from here would silently get a
+    weaker guard than the pre-filter beside it.
     """
     raw = config.get(CONFIG_KEY_RESULTS_ROOT)
     if not isinstance(raw, str) or not raw:
@@ -257,15 +258,26 @@ def _threaded_identity(config: Mapping[str, Any]) -> tuple[int, int] | None:
     return None
 
 
-def _trusted_root(config: Mapping[str, Any], root: Path) -> _fsafe.TrustedAnchor:
-    """:func:`trusted_results_anchor` with the historical ``root.parent`` fallback.
+def trusted_collector_anchor(
+    config: Mapping[str, Any], root: Path
+) -> _fsafe.TrustedAnchor:
+    """The directory every collector path for ``root`` must stay inside.
 
-    The fallback only fires for a direct programmatic caller that threaded no
-    anchor. Being lexical and unpinned, it fails closed rather than guessing: a
-    symlink anywhere above the collector root makes the containment check
-    refuse, even when the operator put it there.
+    The dispatcher-threaded ``--results-dir`` when there is one (see
+    :func:`_threaded_anchor`), else ``root.parent``. The fallback only fires for
+    a direct programmatic caller that threaded no anchor. Being lexical and
+    unpinned, it fails closed rather than guessing: a symlink anywhere above the
+    collector root makes the containment check refuse, even when the operator
+    put it there.
+
+    **The single source of the anchor**, for the read path, the reset, the
+    retention pre-filter and the destructive prune alike. Deriving it twice is
+    how the pre-filter came to use ``root.parent`` while the prune it guards
+    received ``None`` and quietly dropped to the pathname engine -- a
+    time-of-check/time-of-use gap opened by the two spellings disagreeing, not
+    by either one being wrong on its own.
     """
-    anchor = trusted_results_anchor(config)
+    anchor = _threaded_anchor(config)
     if anchor is not None:
         return anchor
     return _fsafe.TrustedAnchor(root.parent)
@@ -294,7 +306,7 @@ def unsafe_collector_paths(config: Mapping[str, Any]) -> list[Path]:
     if root is None:
         return []
     registry = _registry()
-    trusted = _trusted_root(config, root)
+    trusted = trusted_collector_anchor(config, root)
     candidates = [root]
     for name in active_collectors(config):
         spec = registry.get(name)
@@ -598,7 +610,7 @@ def wrap_argv_for_collectors(
             continue
         out_dir = root / spec.output_subdir
         try:
-            _reset_output_dir(out_dir, _trusted_root(config, root))
+            _reset_output_dir(out_dir, trusted_collector_anchor(config, root))
         except OSError as exc:
             raise RuntimeError(
                 f"collect: cannot prepare the {name} artifact directory "
@@ -632,7 +644,7 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
     root = _collect_root(config)
     if root is None:
         return {}
-    trusted = _trusted_root(config, root)
+    trusted = trusted_collector_anchor(config, root)
     metrics: dict[str, Any] = {}
     registry = _registry()
     for name in active_collectors(config):
@@ -763,7 +775,7 @@ __all__ = [
     "active_collectors",
     "collector_root_is_traversable",
     "summarize_collectors",
-    "trusted_results_anchor",
+    "trusted_collector_anchor",
     "unsafe_collector_paths",
     "validate_collectors",
     "wrap_argv_for_collectors",

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -23,12 +23,18 @@ package docstring).
 
 from __future__ import annotations
 
+import contextlib
+import fnmatch
 import logging
+import os
 import shutil
+import stat
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
+
+from aorta.run import _fsafe
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +85,18 @@ class CollectorSpec:
         wrap: Rewrites the launch argv to attach the collector, or ``None``
             for a collector the platform does not launch itself.
         summarize: Parses the collector's artifacts into flat trial metrics,
-            or ``None`` for a collector the platform does not parse.
+            or ``None`` for a collector the platform does not parse. Follows
+            symlinks; used only on the non-POSIX fallback path where the
+            fd-relative reader is unavailable.
+        summarize_streams: Parses artifacts supplied as already-open text
+            handles into the same metrics. The POSIX post-run path opens each
+            matching file ``O_NOFOLLOW`` under a directory fd and calls this, so
+            a payload symlink swapped in after the guard cannot redirect the
+            read. Signature: ``(artifact_dir: str, *stream_groups) -> dict``,
+            with one positional stream group per entry of ``glob_groups``.
+        glob_groups: One basename glob per stream group the parser expects, in
+            the order ``summarize_streams`` takes them. ``rocprof`` reads two
+            families (stats, then trace); ``proton`` reads one (``*.hatchet``).
     """
 
     name: str
@@ -87,6 +104,8 @@ class CollectorSpec:
     validate: Callable[[Mapping[str, str] | None], Any]
     wrap: Callable[..., list[str]] | None = None
     summarize: Callable[[Path], dict[str, Any]] | None = None
+    summarize_streams: Callable[..., dict[str, Any]] | None = None
+    glob_groups: tuple[str, ...] = ()
 
 
 def _accept_any(options: Mapping[str, str] | None) -> dict[str, str]:
@@ -116,6 +135,8 @@ def _registry() -> dict[str, CollectorSpec]:
             validate=rocprof.validate_options,
             wrap=rocprof.wrap_argv,
             summarize=rocprof.parse_summary,
+            summarize_streams=rocprof.parse_summary_from_streams,
+            glob_groups=("*_kernel_stats.csv", "*_kernel_trace.csv"),
         ),
         "proton": CollectorSpec(
             name="proton",
@@ -123,6 +144,8 @@ def _registry() -> dict[str, CollectorSpec]:
             validate=proton.validate_options,
             wrap=proton.wrap_argv,
             summarize=proton.parse_summary,
+            summarize_streams=proton.parse_summary_from_streams,
+            glob_groups=("*.hatchet",),
         ),
         "numerics": CollectorSpec("numerics", None, _accept_any),
         "layer_numerics": CollectorSpec("layer_numerics", "layer_numerics", _accept_any),
@@ -243,8 +266,25 @@ def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) 
     That fallback is only for a programmatic caller that did not thread
     :data:`CONFIG_KEY_RESULTS_ROOT`; it still misses a swapped ancestor, which
     is why the dispatcher always supplies the operator's ``--results-dir``.
+
+    On POSIX this is a *probe*: it descends the path once with ``O_NOFOLLOW``
+    and reports whether the leaf is reachable without crossing a symlink. It is
+    a pre-filter and a log-message source -- the race-free guarantee comes from
+    the caller (:func:`_reset_output_dir`, :func:`summarize_collectors`,
+    :func:`aorta.run.retention.apply_retention`) *holding* the dir fd across the
+    operation, not from this check. Where the platform lacks the fd primitives
+    it keeps the historical lexical ``resolve()`` + component-walk.
     """
     trusted = trusted_root if trusted_root is not None else root.parent
+    if _fsafe.HAVE_FD_TRAVERSAL:
+        components = _fsafe.relative_components(trusted, root)
+        if components is None:
+            return False
+        try:
+            with _fsafe.open_dir_nofollow(trusted, components):
+                return True
+        except OSError:
+            return False
     try:
         if not root.resolve().is_relative_to(trusted):
             return False
@@ -295,6 +335,9 @@ def _reset_output_dir(out_dir: Path, trusted_root: Path) -> None:
         OSError: the directory could not be cleared or created, or it is not
             traversable inside ``trusted_root``.
     """
+    if _fsafe.HAVE_FD_TRAVERSAL:
+        _reset_output_dir_fd(out_dir, trusted_root)
+        return
     if not collector_root_is_traversable(out_dir, trusted_root):
         raise OSError(
             f"refusing to prepare {out_dir}: a path component at or below "
@@ -307,6 +350,51 @@ def _reset_output_dir(out_dir: Path, trusted_root: Path) -> None:
     elif out_dir.is_dir():
         shutil.rmtree(out_dir)
     out_dir.mkdir(parents=True)
+
+
+def _reset_output_dir_fd(out_dir: Path, trusted_root: Path) -> None:
+    """Race-free :func:`_reset_output_dir`: clear+recreate through directory fds.
+
+    The parent chain below ``trusted_root`` (``<workload>/<trial>``) is opened
+    -- and created if a first attempt has not made it yet -- with ``O_NOFOLLOW``
+    on every component, so the reset holds a fd to the collector directory's
+    parent that no ancestor swap can redirect. The leaf (``rocprof`` / ``proton``)
+    is then inspected ``lstat``-style and removed **relative to that parent fd**:
+    a symlink or file is unlinked, a real directory is recursively emptied and
+    ``rmdir``-ed, and the fresh directory is ``mkdir``-ed back -- all by name
+    under the held fd, never by re-resolving the pathname the payload can swap.
+    """
+    parent = out_dir.parent
+    leaf = out_dir.name
+    components = _fsafe.relative_components(trusted_root, parent)
+    if components is None or not leaf:
+        raise OSError(
+            f"refusing to prepare {out_dir}: it is not lexically inside "
+            f"{trusted_root}, so clearing it could delete outside that "
+            "directory. Point --results-dir at a real directory."
+        )
+    try:
+        with _fsafe.open_dir_nofollow(
+            trusted_root, components, create_missing=True
+        ) as parent_fd:
+            info = _fsafe.stat_at(parent_fd, leaf)
+            if info is not None and stat.S_ISLNK(info.st_mode):
+                # A symlink where the collector output dir belongs is never a
+                # legitimate prior attempt -- the payload planted it. Refuse
+                # rather than unlink-and-recreate, matching the pre-launch
+                # contract that a swapped leaf aborts the trial's collection.
+                raise _fsafe.UnsafePathError(
+                    f"{out_dir} is a symlink; refusing to clear it"
+                )
+            _fsafe.remove_entry_at(parent_fd, leaf)
+            os.mkdir(leaf, dir_fd=parent_fd)
+    except _fsafe.UnsafePathError as exc:
+        raise OSError(
+            f"refusing to prepare {out_dir}: a path component at or below "
+            f"{trusted_root} is a symlink or resolves outside that directory, "
+            "so clearing it would delete through the link. Remove the symlink "
+            f"in that path, or point --results-dir at a real directory. ({exc})"
+        ) from exc
 
 
 def validate_collectors(
@@ -453,33 +541,83 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
     root = _collect_root(config)
     if root is None:
         return {}
-    unsafe = unsafe_collector_paths(config)
-    if unsafe:
-        # Read-only here, but the parsers ``rglob`` these directories, so one
-        # swapped for a symlink while the command ran would pull file contents
-        # from outside the results tree into the trial metrics. Checked per
-        # collector directory, not just the shared root -- the payload can swap
-        # either. Same guard as the retention pass, which has the destructive
-        # version of this exposure.
-        log.warning(
-            "collect: %s is (or is under) a symlink after the run; refusing to "
-            "parse artifacts through it. No collector metrics for this trial.",
-            ", ".join(str(path) for path in unsafe),
-        )
-        return {}
+    trusted = _trusted_root(config, root)
     metrics: dict[str, Any] = {}
     registry = _registry()
     for name in active_collectors(config):
         spec = registry.get(name)
-        if spec is None or spec.summarize is None or spec.output_subdir is None:
+        if spec is None or spec.output_subdir is None:
             continue
+        subdir = root / spec.output_subdir
         try:
-            metrics.update(spec.summarize(root / spec.output_subdir))
+            if _fsafe.HAVE_FD_TRAVERSAL and spec.summarize_streams is not None:
+                metrics.update(_summarize_streamed(spec, root, subdir, trusted))
+            elif spec.summarize is not None:
+                # Non-POSIX fallback: guard lexically, then parse by pathname.
+                # The parsers ``rglob`` the subdirectory, so one swapped for a
+                # symlink while the command ran would pull file contents from
+                # outside the results tree into the trial metrics.
+                if not collector_root_is_traversable(subdir, trusted):
+                    log.warning(
+                        "collect: %s is (or is under) a symlink after the run; "
+                        "refusing to parse artifacts through it. No %s metrics "
+                        "for this trial.",
+                        subdir,
+                        name,
+                    )
+                    continue
+                metrics.update(spec.summarize(subdir))
+        except _fsafe.UnsafePathError:
+            # A component of the collector directory was a symlink after the
+            # run: refuse to read through it (same exposure the destructive
+            # retention pass guards). Skip this collector, keep the trial.
+            log.warning(
+                "collect: %s is (or is under) a symlink after the run; refusing "
+                "to parse artifacts through it. No %s metrics for this trial.",
+                subdir,
+                name,
+            )
         except Exception:
             # An opt-in measurement must never turn a healthy trial into a
             # failure, so the catch is deliberately unbounded.
             log.warning("collect: %s summary parsing failed; skipping.", name, exc_info=True)
     return metrics
+
+
+def _summarize_streamed(
+    spec: CollectorSpec, root: Path, subdir: Path, trusted: Path
+) -> dict[str, Any]:
+    """Parse one collector's artifacts through no-follow, fd-relative reads.
+
+    Descends to the collector subdirectory holding a dir fd no ancestor swap can
+    redirect, walks it without following any symlink, and opens each file whose
+    basename matches one of ``spec.glob_groups`` with ``O_NOFOLLOW`` under that
+    held fd. The open handles -- grouped in ``glob_groups`` order -- are passed
+    to ``spec.summarize_streams`` and closed when it returns.
+
+    Raises:
+        UnsafePathError: a component of the collector directory is a symlink.
+    """
+    components = _fsafe.relative_components(trusted, subdir)
+    if components is None:
+        raise _fsafe.UnsafePathError(
+            f"{subdir} is not lexically inside the trusted root {trusted}"
+        )
+    assert spec.summarize_streams is not None  # guarded by the caller
+    with _fsafe.open_dir_nofollow(trusted, components) as base_fd, contextlib.ExitStack() as stack:
+        groups: list[list[TextIO]] = [[] for _ in spec.glob_groups]
+        for _rel, dir_fd, fname, _size in _fsafe.iter_regular_files(base_fd):
+            for index, pattern in enumerate(spec.glob_groups):
+                if fnmatch.fnmatch(fname, pattern):
+                    try:
+                        stream = stack.enter_context(
+                            _fsafe.secure_open_read(dir_fd, fname, encoding="utf-8", newline="")
+                        )
+                    except OSError:
+                        continue
+                    groups[index].append(stream)
+                    break
+        return spec.summarize_streams(str(subdir), *groups)
 
 
 __all__ = [

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -23,13 +23,13 @@ package docstring).
 
 from __future__ import annotations
 
-import contextlib
+import errno
 import fnmatch
 import logging
 import os
 import shutil
 import stat
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO
@@ -62,6 +62,13 @@ CONFIG_KEY_COLLECT_DIR = "_aorta_collect_dir"
 #: inode itself, so a boundary derived from a live ``resolve()`` of this path
 #: after launch proves nothing.
 CONFIG_KEY_RESULTS_ROOT = "_aorta_results_root"
+#: The ``(st_dev, st_ino)`` of :data:`CONFIG_KEY_RESULTS_ROOT`, read at the same
+#: pre-launch moment and threaded as a two-element list so the trial JSON stays
+#: plain JSON. The path alone is not a trust anchor: a payload can rename the
+#: results directory aside and move a *real* directory into its pathname, which
+#: leaves every ``O_NOFOLLOW`` check on that pathname satisfied. Naming the inode
+#: is what makes the anchor immutable across the run.
+CONFIG_KEY_RESULTS_ROOT_ID = "_aorta_results_root_id"
 
 #: Argv-wrapping order, outermost first. ``rocprof`` runs a whole command under
 #: the profiler while ``proton`` takes over a Python script's execution, so
@@ -88,12 +95,18 @@ class CollectorSpec:
             or ``None`` for a collector the platform does not parse. Follows
             symlinks; used only on the non-POSIX fallback path where the
             fd-relative reader is unavailable.
-        summarize_streams: Parses artifacts supplied as already-open text
-            handles into the same metrics. The POSIX post-run path opens each
-            matching file ``O_NOFOLLOW`` under a directory fd and calls this, so
-            a payload symlink swapped in after the guard cannot redirect the
-            read. Signature: ``(artifact_dir: str, *stream_groups) -> dict``,
-            with one positional stream group per entry of ``glob_groups``.
+        summarize_streams: Parses artifacts supplied as open text handles into
+            the same metrics. The POSIX post-run path opens each matching file
+            ``O_NOFOLLOW`` under a directory fd and calls this, so a payload
+            symlink swapped in after the guard cannot redirect the read.
+            Signature: ``(artifact_dir: str, *stream_groups) -> dict``, with one
+            positional stream group per entry of ``glob_groups``. Each group is
+            a **lazy iterator** that opens one file at a time -- a distributed
+            capture can hold more artifacts than ``RLIMIT_NOFILE`` allows -- so
+            an implementation must iterate each group at most once, must not
+            call ``len()`` on it, and must not hold a group to consume after
+            returning: the directory fds the handles come from are closed then.
+            A group it never iterates is never opened at all.
         glob_groups: One basename glob per stream group the parser expects, in
             the order ``summarize_streams`` takes them. ``rocprof`` reads two
             families (stats, then trace); ``proton`` reads one (``*.hatchet``).
@@ -190,26 +203,56 @@ def _collect_root(config: Mapping[str, Any]) -> Path | None:
     return Path(raw) if isinstance(raw, str) and raw else None
 
 
-def _trusted_root(config: Mapping[str, Any], root: Path) -> Path:
-    """The directory every collector path must stay inside.
+def trusted_results_anchor(config: Mapping[str, Any]) -> _fsafe.TrustedAnchor | None:
+    """The dispatcher's frozen ``--results-dir`` anchor, or ``None`` if unthreaded.
 
-    Prefers the dispatcher-threaded ``--results-dir``
-    (:data:`CONFIG_KEY_RESULTS_ROOT`), already canonicalized at dispatch.
-    Callers must **not** :meth:`~pathlib.Path.resolve` this value again: the
-    profiled process can replace that directory with a symlink, and resolving
-    both the candidate and the anchor through the same link would make
-    containment succeed for a path that has left the operator's tree.
+    Reads :data:`CONFIG_KEY_RESULTS_ROOT` (canonicalized at dispatch) together
+    with :data:`CONFIG_KEY_RESULTS_ROOT_ID` (that directory's inode identity,
+    read at the same pre-launch moment). Callers must **not**
+    :meth:`~pathlib.Path.resolve` the path again: the profiled process can
+    replace that directory with a symlink, and resolving both the candidate and
+    the anchor through the same link would make containment succeed for a path
+    that has left the operator's tree.
 
-    Falls back to ``root.parent`` when the key is absent, which only happens for
-    a direct programmatic caller -- the dispatcher always supplies it alongside
-    ``_aorta_collect_dir``. Being lexical, that fallback fails closed rather
-    than guessing: a symlink anywhere above the collector root makes the
-    containment check refuse, even when the operator put it there.
+    Returns ``None`` when the key is absent, which only happens for a direct
+    programmatic caller -- the dispatcher always supplies it alongside
+    ``_aorta_collect_dir``.
     """
     raw = config.get(CONFIG_KEY_RESULTS_ROOT)
-    if isinstance(raw, str) and raw:
-        return Path(raw)
-    return root.parent
+    if not isinstance(raw, str) or not raw:
+        return None
+    return _fsafe.TrustedAnchor(Path(raw), _threaded_identity(config))
+
+
+def _threaded_identity(config: Mapping[str, Any]) -> tuple[int, int] | None:
+    """Parse :data:`CONFIG_KEY_RESULTS_ROOT_ID`, or ``None`` when unusable.
+
+    A hand-built config (or one round-tripped through a lossy transport) may
+    carry anything here. An unparseable value degrades to an unpinned anchor
+    -- the no-follow descent still runs -- rather than raising in a guard whose
+    job is to fail closed on filesystem shape, not on config shape.
+    """
+    raw = config.get(CONFIG_KEY_RESULTS_ROOT_ID)
+    if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+        return None
+    try:
+        return (int(raw[0]), int(raw[1]))
+    except (TypeError, ValueError):
+        return None
+
+
+def _trusted_root(config: Mapping[str, Any], root: Path) -> _fsafe.TrustedAnchor:
+    """:func:`trusted_results_anchor` with the historical ``root.parent`` fallback.
+
+    The fallback only fires for a direct programmatic caller that threaded no
+    anchor. Being lexical and unpinned, it fails closed rather than guessing: a
+    symlink anywhere above the collector root makes the containment check
+    refuse, even when the operator put it there.
+    """
+    anchor = trusted_results_anchor(config)
+    if anchor is not None:
+        return anchor
+    return _fsafe.TrustedAnchor(root.parent)
 
 
 def unsafe_collector_paths(config: Mapping[str, Any]) -> list[Path]:
@@ -224,6 +267,12 @@ def unsafe_collector_paths(config: Mapping[str, Any]) -> list[Path]:
 
     Empty when there is nothing to guard (no collector active, no threaded
     collector directory) or when every path is a real directory.
+
+    A path that does not exist is not reported: the caller treats any entry
+    here as "keep every collector artifact", and a validated-only collector
+    such as ``layer_numerics`` has no output directory unless a wrapper made
+    one, so counting absence as unsafe would let one never-created directory
+    retain the rocprof capture sitting beside it.
     """
     root = _collect_root(config)
     if root is None:
@@ -238,7 +287,9 @@ def unsafe_collector_paths(config: Mapping[str, Any]) -> list[Path]:
     return [path for path in candidates if not collector_root_is_traversable(path, trusted)]
 
 
-def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) -> bool:
+def collector_root_is_traversable(
+    root: Path, trusted_root: _fsafe.TrustedAnchor | Path | None = None
+) -> bool:
     """True when ``root`` can be walked without following a payload-owned symlink.
 
     Checked **again after the command has run**, not only before it launches.
@@ -262,6 +313,15 @@ def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) 
       already folded away because the dispatcher stores
       ``--results-dir.resolve()``.
 
+    A path that is simply **absent** -- every component that does exist checks
+    out, the leaf was never created -- is traversable: there is nothing there to
+    read or delete through, so absence is not an escape. (An absent leaf
+    *under* a symlinked or escaping ancestor is still a refusal; the symlink is
+    met first.) That distinction matters because
+    :func:`unsafe_collector_paths` asks about every active collector's output
+    subdirectory, and a validated-only collector such as ``layer_numerics``
+    has no subdirectory unless a wrapper made one.
+
     ``trusted_root`` defaults to ``root.parent`` when the caller omits it.
     That fallback is only for a programmatic caller that did not thread
     :data:`CONFIG_KEY_RESULTS_ROOT`; it still misses a swapped ancestor, which
@@ -275,20 +335,28 @@ def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) 
     operation, not from this check. Where the platform lacks the fd primitives
     it keeps the historical lexical ``resolve()`` + component-walk.
     """
-    trusted = trusted_root if trusted_root is not None else root.parent
+    anchor = _fsafe.as_anchor(trusted_root if trusted_root is not None else root.parent)
     if _fsafe.HAVE_FD_TRAVERSAL:
-        components = _fsafe.relative_components(trusted, root)
+        components = _fsafe.relative_components(anchor.path, root)
         if components is None:
             return False
         try:
-            with _fsafe.open_dir_nofollow(trusted, components):
+            with _fsafe.open_dir_nofollow(anchor, components):
                 return True
+        except _fsafe.UnsafePathError as exc:
+            # ENOENT is "nothing is there", not "something hostile is there".
+            # A symlink refused by O_NOFOLLOW surfaces as ELOOP even when it
+            # dangles, so absence cannot be faked with a broken link.
+            return exc.errno == errno.ENOENT
         except OSError:
             return False
     try:
-        if not root.resolve().is_relative_to(trusted):
+        # A missing path needs no special case here: non-strict ``resolve()``
+        # keeps the lexical tail, so containment and the symlink walk both still
+        # apply -- an absent leaf under a symlinked ancestor stays a refusal.
+        if not root.resolve().is_relative_to(anchor.path):
             return False
-        return not _payload_symlink_at_or_below(root, trusted)
+        return not _payload_symlink_at_or_below(root, anchor.path)
     except (OSError, RuntimeError):
         # RuntimeError: a symlink loop that ``resolve()`` refuses to follow.
         return False
@@ -312,7 +380,7 @@ def _payload_symlink_at_or_below(path: Path, trusted: Path) -> bool:
     return False
 
 
-def _reset_output_dir(out_dir: Path, trusted_root: Path) -> None:
+def _reset_output_dir(out_dir: Path, trusted_root: _fsafe.TrustedAnchor) -> None:
     """Create ``out_dir`` empty, discarding any earlier attempt's artifacts.
 
     Probe resume replays an interrupted trial onto the *same* paths, so a
@@ -341,9 +409,10 @@ def _reset_output_dir(out_dir: Path, trusted_root: Path) -> None:
     if not collector_root_is_traversable(out_dir, trusted_root):
         raise OSError(
             f"refusing to prepare {out_dir}: a path component at or below "
-            f"{trusted_root} is a symlink or resolves outside that directory, "
-            "so clearing it would delete through the link. Remove the symlink "
-            "in that path, or point --results-dir at a real directory."
+            f"{trusted_root.path} is a symlink or resolves outside that "
+            "directory, so clearing it would delete through the link. Remove "
+            "the symlink in that path, or point --results-dir at a real "
+            "directory."
         )
     if out_dir.is_symlink() or out_dir.is_file():
         out_dir.unlink()
@@ -352,7 +421,7 @@ def _reset_output_dir(out_dir: Path, trusted_root: Path) -> None:
     out_dir.mkdir(parents=True)
 
 
-def _reset_output_dir_fd(out_dir: Path, trusted_root: Path) -> None:
+def _reset_output_dir_fd(out_dir: Path, trusted_root: _fsafe.TrustedAnchor) -> None:
     """Race-free :func:`_reset_output_dir`: clear+recreate through directory fds.
 
     The parent chain below ``trusted_root`` (``<workload>/<trial>``) is opened
@@ -366,11 +435,11 @@ def _reset_output_dir_fd(out_dir: Path, trusted_root: Path) -> None:
     """
     parent = out_dir.parent
     leaf = out_dir.name
-    components = _fsafe.relative_components(trusted_root, parent)
+    components = _fsafe.relative_components(trusted_root.path, parent)
     if components is None or not leaf:
         raise OSError(
             f"refusing to prepare {out_dir}: it is not lexically inside "
-            f"{trusted_root}, so clearing it could delete outside that "
+            f"{trusted_root.path}, so clearing it could delete outside that "
             "directory. Point --results-dir at a real directory."
         )
     try:
@@ -391,8 +460,9 @@ def _reset_output_dir_fd(out_dir: Path, trusted_root: Path) -> None:
     except _fsafe.UnsafePathError as exc:
         raise OSError(
             f"refusing to prepare {out_dir}: a path component at or below "
-            f"{trusted_root} is a symlink or resolves outside that directory, "
-            "so clearing it would delete through the link. Remove the symlink "
+            f"{trusted_root.path} is a symlink, resolves outside that "
+            "directory, or is no longer the directory frozen before the run, "
+            "so clearing it would delete through the swap. Remove the symlink "
             f"in that path, or point --results-dir at a real directory. ({exc})"
         ) from exc
 
@@ -567,7 +637,14 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
                     )
                     continue
                 metrics.update(spec.summarize(subdir))
-        except _fsafe.UnsafePathError:
+        except _fsafe.UnsafePathError as exc:
+            if exc.errno == errno.ENOENT:
+                # The collector wrote nothing at all -- a validated-only
+                # collector whose wrapper made no directory, or a command that
+                # did no GPU work. Not a swap, and not worth an operator
+                # warning: the parsers treat a missing tree as no metrics too.
+                log.debug("collect: %s does not exist; no %s metrics.", subdir, name)
+                continue
             # A component of the collector directory was a symlink after the
             # run: refuse to read through it (same exposure the destructive
             # retention pass guards). Skip this collector, keep the trial.
@@ -585,39 +662,70 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _summarize_streamed(
-    spec: CollectorSpec, root: Path, subdir: Path, trusted: Path
+    spec: CollectorSpec, root: Path, subdir: Path, trusted: _fsafe.TrustedAnchor
 ) -> dict[str, Any]:
     """Parse one collector's artifacts through no-follow, fd-relative reads.
 
     Descends to the collector subdirectory holding a dir fd no ancestor swap can
-    redirect, walks it without following any symlink, and opens each file whose
-    basename matches one of ``spec.glob_groups`` with ``O_NOFOLLOW`` under that
-    held fd. The open handles -- grouped in ``glob_groups`` order -- are passed
-    to ``spec.summarize_streams`` and closed when it returns.
+    redirect, walks it without following any symlink to list the files whose
+    basename matches one of ``spec.glob_groups``, then hands the parser one lazy
+    iterator of open handles per group (in ``glob_groups`` order). Each handle is
+    opened ``O_NOFOLLOW`` under the held directory fd and closed before the next
+    one is opened, so a capture with more per-rank artifacts than
+    ``RLIMIT_NOFILE`` allows still aggregates every file instead of silently
+    dropping the ranks that came after the limit.
 
     Raises:
-        UnsafePathError: a component of the collector directory is a symlink.
+        UnsafePathError: a component of the collector directory is a symlink or
+            does not exist.
     """
-    components = _fsafe.relative_components(trusted, subdir)
+    components = _fsafe.relative_components(trusted.path, subdir)
     if components is None:
         raise _fsafe.UnsafePathError(
-            f"{subdir} is not lexically inside the trusted root {trusted}"
+            f"{subdir} is not lexically inside the trusted root {trusted.path}"
         )
     assert spec.summarize_streams is not None  # guarded by the caller
-    with _fsafe.open_dir_nofollow(trusted, components) as base_fd, contextlib.ExitStack() as stack:
-        groups: list[list[TextIO]] = [[] for _ in spec.glob_groups]
-        for _rel, dir_fd, fname, _size in _fsafe.iter_regular_files(base_fd):
+    with _fsafe.open_dir_nofollow(trusted, components) as base_fd:
+        matched: list[list[str]] = [[] for _ in spec.glob_groups]
+        for rel, _dir_fd, fname, _size in _fsafe.iter_regular_files(base_fd):
             for index, pattern in enumerate(spec.glob_groups):
                 if fnmatch.fnmatch(fname, pattern):
-                    try:
-                        stream = stack.enter_context(
-                            _fsafe.secure_open_read(dir_fd, fname, encoding="utf-8", newline="")
-                        )
-                    except OSError:
-                        continue
-                    groups[index].append(stream)
+                    matched[index].append(rel)
                     break
+        groups = [_open_artifacts(base_fd, rels) for rels in matched]
         return spec.summarize_streams(str(subdir), *groups)
+
+
+def _open_artifacts(base_fd: int, relative_paths: Sequence[str]) -> Iterator[TextIO]:
+    """Yield each artifact under ``base_fd`` as an open handle, one at a time.
+
+    The handle is closed before the next is opened, bounding this pass to a
+    single artifact descriptor no matter how many ranks the capture holds.
+    Reopening a directory chain per file is safe because ``base_fd`` names an
+    inode: the descent below it is fd-relative and ``O_NOFOLLOW``, so the swap
+    the held fd protects against stays defeated.
+
+    A file that cannot be opened at all -- it vanished, or a payload left a
+    symlink where the walk saw a regular file -- is skipped. Descriptor
+    exhaustion is **not** skipped: it means the remaining artifacts would be
+    missing from the totals, and a confidently-wrong ``rocprof_gpu_time_ms``
+    covering a prefix of the ranks is worse than no metric, so it propagates
+    and the caller drops the collector's metrics entirely.
+    """
+    for rel in relative_paths:
+        *parents, name = rel.split("/")
+        try:
+            with (
+                _fsafe.open_dir_at(base_fd, parents) as dir_fd,
+                _fsafe.secure_open_read(
+                    dir_fd, name, encoding="utf-8", newline=""
+                ) as stream,
+            ):
+                yield stream
+        except OSError as exc:
+            if exc.errno in (errno.EMFILE, errno.ENFILE):
+                raise
+            log.debug("collect: skipping unreadable artifact %s (%s)", rel, exc)
 
 
 __all__ = [
@@ -625,12 +733,14 @@ __all__ = [
     "CONFIG_KEY_COLLECT_DIR",
     "CONFIG_KEY_COLLECT_OPTIONS",
     "CONFIG_KEY_RESULTS_ROOT",
+    "CONFIG_KEY_RESULTS_ROOT_ID",
     "KNOWN_RECIPES",
     "WRAP_ORDER",
     "CollectorSpec",
     "active_collectors",
     "collector_root_is_traversable",
     "summarize_collectors",
+    "trusted_results_anchor",
     "unsafe_collector_paths",
     "validate_collectors",
     "wrap_argv_for_collectors",

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -179,8 +179,9 @@ def _trusted_root(config: Mapping[str, Any], root: Path) -> Path:
 
     Falls back to ``root.parent`` when the key is absent, which only happens for
     a direct programmatic caller -- the dispatcher always supplies it alongside
-    ``_aorta_collect_dir``. That fallback still catches a swapped collector root
-    or subdirectory; it cannot catch a swapped ancestor.
+    ``_aorta_collect_dir``. Being lexical, that fallback fails closed rather
+    than guessing: a symlink anywhere above the collector root makes the
+    containment check refuse, even when the operator put it there.
     """
     raw = config.get(CONFIG_KEY_RESULTS_ROOT)
     if isinstance(raw, str) and raw:

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -227,18 +227,34 @@ def trusted_results_anchor(config: Mapping[str, Any]) -> _fsafe.TrustedAnchor | 
 def _threaded_identity(config: Mapping[str, Any]) -> tuple[int, int] | None:
     """Parse :data:`CONFIG_KEY_RESULTS_ROOT_ID`, or ``None`` when unusable.
 
-    A hand-built config (or one round-tripped through a lossy transport) may
-    carry anything here. An unparseable value degrades to an unpinned anchor
-    -- the no-follow descent still runs -- rather than raising in a guard whose
-    job is to fail closed on filesystem shape, not on config shape.
+    Absent is normal: a direct programmatic caller threads no pin, and a trial
+    config written before the key existed has none. Present-but-unparseable is
+    not, so it is logged -- the key is written only by the dispatcher, which
+    means a bad value is our bug, and it silently weakens a guard.
+
+    Either way the result is an unpinned anchor rather than an exception. This
+    is a deliberate line: the degradation is to the *previous* shipped guard
+    (the full ``O_NOFOLLOW`` descent below the anchor path), not to no guard,
+    and failing the run's whole collection over a config-shape bug in code the
+    payload cannot reach would cost more than it protects. Nothing here weakens
+    on input a payload controls -- it cannot write the trial config.
     """
     raw = config.get(CONFIG_KEY_RESULTS_ROOT_ID)
-    if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+    if raw is None:
         return None
-    try:
-        return (int(raw[0]), int(raw[1]))
-    except (TypeError, ValueError):
-        return None
+    if isinstance(raw, (list, tuple)) and len(raw) == 2:
+        try:
+            return (int(raw[0]), int(raw[1]))
+        except (TypeError, ValueError):
+            pass
+    log.warning(
+        "collect: ignoring unusable %s=%r; expected [st_dev, st_ino]. Path "
+        "guards fall back to no-follow-only, which cannot detect the results "
+        "directory being renamed aside and replaced by a real one.",
+        CONFIG_KEY_RESULTS_ROOT_ID,
+        raw,
+    )
+    return None
 
 
 def _trusted_root(config: Mapping[str, Any], root: Path) -> _fsafe.TrustedAnchor:
@@ -300,7 +316,7 @@ def collector_root_is_traversable(
     -- follows links in *every* path component, so traversing one would read,
     and for retention *delete*, through the link.
 
-    Two checks, both required:
+    Three checks, all required:
 
     * **Containment.** ``root.resolve()`` must stay inside ``trusted_root``.
       ``trusted_root`` is a pre-launch canonical path and is **not** resolved
@@ -312,6 +328,11 @@ def collector_root_is_traversable(
       operate on the sibling. Operator-owned links *above* the anchor are
       already folded away because the dispatcher stores
       ``--results-dir.resolve()``.
+    * **The anchor is still the same inode** (POSIX, and only when the caller
+      threaded a pinned :class:`~aorta.run._fsafe.TrustedAnchor`). Neither check
+      above asks whether the trusted root is still the operator's directory: a
+      payload can rename it aside and move a *real* directory into its
+      pathname, and every symlink check on that pathname then passes.
 
     A path that is simply **absent** -- every component that does exist checks
     out, the leaf was never created -- is traversable: there is nothing there to
@@ -621,7 +642,7 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
         subdir = root / spec.output_subdir
         try:
             if _fsafe.HAVE_FD_TRAVERSAL and spec.summarize_streams is not None:
-                metrics.update(_summarize_streamed(spec, root, subdir, trusted))
+                metrics.update(_summarize_streamed(spec, subdir, trusted))
             elif spec.summarize is not None:
                 # Non-POSIX fallback: guard lexically, then parse by pathname.
                 # The parsers ``rglob`` the subdirectory, so one swapped for a
@@ -662,7 +683,7 @@ def summarize_collectors(config: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _summarize_streamed(
-    spec: CollectorSpec, root: Path, subdir: Path, trusted: _fsafe.TrustedAnchor
+    spec: CollectorSpec, subdir: Path, trusted: _fsafe.TrustedAnchor
 ) -> dict[str, Any]:
     """Parse one collector's artifacts through no-follow, fd-relative reads.
 

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -48,11 +48,13 @@ KNOWN_RECIPES: frozenset[str] = frozenset(
 CONFIG_KEY_COLLECT = "_aorta_collect"
 CONFIG_KEY_COLLECT_OPTIONS = "_aorta_collect_options"
 CONFIG_KEY_COLLECT_DIR = "_aorta_collect_dir"
-#: The dispatcher's ``--results-dir``, threaded so the symlink guards have a
-#: trust anchor that does **not** come from the path being validated. Every
-#: directory at or below the collector root is payload-writable during the run,
-#: so a boundary derived from the collector root itself proves nothing; this key
-#: is the operator-declared root above all of it.
+#: The dispatcher's ``--results-dir``, canonicalized with :meth:`Path.resolve`
+#: **before any trial runs** and threaded so the symlink guards have a trust
+#: anchor that does **not** come from the path being validated -- and that is
+#: not re-resolved after the payload runs. Every directory at or below this
+#: root is payload-writable during the run, including the results directory
+#: inode itself, so a boundary derived from a live ``resolve()`` of this path
+#: after launch proves nothing.
 CONFIG_KEY_RESULTS_ROOT = "_aorta_results_root"
 
 #: Argv-wrapping order, outermost first. ``rocprof`` runs a whole command under
@@ -166,13 +168,14 @@ def _collect_root(config: Mapping[str, Any]) -> Path | None:
 
 
 def _trusted_root(config: Mapping[str, Any], root: Path) -> Path:
-    """The directory every collector path must resolve inside.
+    """The directory every collector path must stay inside.
 
     Prefers the dispatcher-threaded ``--results-dir``
-    (:data:`CONFIG_KEY_RESULTS_ROOT`), because a trust anchor must not be
-    derived from the path it is validating: everything at or below the collector
-    root is payload-writable while the trial runs, so ``root.parent`` can itself
-    be the symlink doing the escaping.
+    (:data:`CONFIG_KEY_RESULTS_ROOT`), already canonicalized at dispatch.
+    Callers must **not** :meth:`~pathlib.Path.resolve` this value again: the
+    profiled process can replace that directory with a symlink, and resolving
+    both the candidate and the anchor through the same link would make
+    containment succeed for a path that has left the operator's tree.
 
     Falls back to ``root.parent`` when the key is absent, which only happens for
     a direct programmatic caller -- the dispatcher always supplies it alongside
@@ -212,7 +215,7 @@ def unsafe_collector_paths(config: Mapping[str, Any]) -> list[Path]:
 
 
 def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) -> bool:
-    """True when ``root`` resolves to somewhere inside ``trusted_root``.
+    """True when ``root`` can be walked without following a payload-owned symlink.
 
     Checked **again after the command has run**, not only before it launches.
     The profiled command is handed this path (``rocprofv3 -d``, ``proton -n``),
@@ -220,20 +223,20 @@ def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) 
     directory and leave a symlink in its place. Every later step --
     ``Path.is_dir()``, ``rglob``, and :func:`aorta.run.retention.apply_retention`
     -- follows links in *every* path component, so traversing one would read,
-    and for retention *delete*, files outside the results tree.
+    and for retention *delete*, through the link.
 
-    Containment against a trusted root, rather than a per-component symlink
-    scan, because the two cases look identical component-by-component and only
-    differ in who owns the link:
+    Two checks, both required:
 
-    * **Above** the trusted root the path is the operator's own -- a
-      ``--results-dir`` that legitimately lives under a symlink is normal, and
-      following it is the intended behaviour. Resolving the trusted root first
-      allows that.
-    * **At or below** it, every component is payload-writable, so a link there
-      is an escape regardless of how deep it sits. ``resolve()`` collapses the
-      whole chain, so this catches a swap at any depth rather than only at the
-      leaf or its parent.
+    * **Containment.** ``root.resolve()`` must stay inside ``trusted_root``.
+      ``trusted_root`` is a pre-launch canonical path and is **not** resolved
+      again: resolving both sides after the payload replaced the results
+      directory with a symlink would make the escape look contained.
+    * **No payload symlink at or below the anchor.** A link whose target is
+      still inside the results tree (``trial -> sibling_trial``,
+      ``rocprof -> <results>``) also fails: ``rmtree`` / ``rglob`` would then
+      operate on the sibling. Operator-owned links *above* the anchor are
+      already folded away because the dispatcher stores
+      ``--results-dir.resolve()``.
 
     ``trusted_root`` defaults to ``root.parent`` when the caller omits it.
     That fallback is only for a programmatic caller that did not thread
@@ -242,10 +245,30 @@ def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) 
     """
     trusted = trusted_root if trusted_root is not None else root.parent
     try:
-        return root.resolve().is_relative_to(trusted.resolve())
+        if not root.resolve().is_relative_to(trusted):
+            return False
+        return not _payload_symlink_at_or_below(root, trusted)
     except (OSError, RuntimeError):
         # RuntimeError: a symlink loop that ``resolve()`` refuses to follow.
         return False
+
+
+def _payload_symlink_at_or_below(path: Path, trusted: Path) -> bool:
+    """True when any component of ``path`` below ``trusted`` is a symlink.
+
+    ``trusted`` itself is not inspected: that inode is the operator's
+    ``--results-dir``. Everything below it is payload-writable.
+    """
+    current = path
+    while current != trusted:
+        if current.parent == current:
+            # Walked to the filesystem root without meeting the anchor, so
+            # ``path`` is not lexically inside the canonical results tree.
+            return True
+        if current.is_symlink():
+            return True
+        current = current.parent
+    return False
 
 
 def _reset_output_dir(out_dir: Path, trusted_root: Path) -> None:
@@ -261,22 +284,22 @@ def _reset_output_dir(out_dir: Path, trusted_root: Path) -> None:
 
     Args:
         out_dir: The collector's output directory for this trial.
-        trusted_root: The dispatcher-created results directory ``out_dir`` must
-            resolve inside. Checked because ``rmtree`` is recursive and
-            ``is_dir()`` follows symlinks in *every* component, so a link
-            anywhere at or below the trusted root would redirect the delete
-            outside the results tree.
+        trusted_root: Pre-launch canonical results directory. ``out_dir`` must
+            stay inside it with no payload-owned symlink on the path.
+            ``rmtree`` is recursive and ``is_dir()`` follows links in *every*
+            component, so a link at or below this root -- even to a sibling
+            inside the tree -- would redirect the delete.
 
     Raises:
-        OSError: the directory could not be cleared or created, or it does not
-            resolve inside ``trusted_root``.
+        OSError: the directory could not be cleared or created, or it is not
+            traversable inside ``trusted_root``.
     """
     if not collector_root_is_traversable(out_dir, trusted_root):
         raise OSError(
-            f"refusing to prepare {out_dir}: it resolves outside {trusted_root}, "
-            "so clearing it would delete a tree outside the results directory. "
-            "Remove the symlink in that path, or point --results-dir at a real "
-            "directory."
+            f"refusing to prepare {out_dir}: a path component at or below "
+            f"{trusted_root} is a symlink or resolves outside that directory, "
+            "so clearing it would delete through the link. Remove the symlink "
+            "in that path, or point --results-dir at a real directory."
         )
     if out_dir.is_symlink() or out_dir.is_file():
         out_dir.unlink()

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -726,12 +726,14 @@ def _open_artifacts(base_fd: int, relative_paths: Sequence[str]) -> Iterator[Tex
     inode: the descent below it is fd-relative and ``O_NOFOLLOW``, so the swap
     the held fd protects against stays defeated.
 
-    A file that cannot be opened at all -- it vanished, or a payload left a
-    symlink where the walk saw a regular file -- is skipped. Descriptor
-    exhaustion is **not** skipped: it means the remaining artifacts would be
-    missing from the totals, and a confidently-wrong ``rocprof_gpu_time_ms``
-    covering a prefix of the ranks is worse than no metric, so it propagates
-    and the caller drops the collector's metrics entirely.
+    A file that cannot be opened at all is skipped: it vanished, or a payload
+    replaced the regular file the walk saw with a symlink or a FIFO (which
+    :func:`~aorta.run._fsafe.secure_open_read` refuses rather than blocking on).
+    Descriptor exhaustion is **not** skipped: it means the remaining artifacts
+    would be missing from the totals, and a confidently-wrong
+    ``rocprof_gpu_time_ms`` covering a prefix of the ranks is worse than no
+    metric, so it propagates and the caller drops the collector's metrics
+    entirely.
     """
     for rel in relative_paths:
         *parents, name = rel.split("/")

--- a/src/aorta/run/collectors.py
+++ b/src/aorta/run/collectors.py
@@ -48,6 +48,12 @@ KNOWN_RECIPES: frozenset[str] = frozenset(
 CONFIG_KEY_COLLECT = "_aorta_collect"
 CONFIG_KEY_COLLECT_OPTIONS = "_aorta_collect_options"
 CONFIG_KEY_COLLECT_DIR = "_aorta_collect_dir"
+#: The dispatcher's ``--results-dir``, threaded so the symlink guards have a
+#: trust anchor that does **not** come from the path being validated. Every
+#: directory at or below the collector root is payload-writable during the run,
+#: so a boundary derived from the collector root itself proves nothing; this key
+#: is the operator-declared root above all of it.
+CONFIG_KEY_RESULTS_ROOT = "_aorta_results_root"
 
 #: Argv-wrapping order, outermost first. ``rocprof`` runs a whole command under
 #: the profiler while ``proton`` takes over a Python script's execution, so
@@ -159,6 +165,26 @@ def _collect_root(config: Mapping[str, Any]) -> Path | None:
     return Path(raw) if isinstance(raw, str) and raw else None
 
 
+def _trusted_root(config: Mapping[str, Any], root: Path) -> Path:
+    """The directory every collector path must resolve inside.
+
+    Prefers the dispatcher-threaded ``--results-dir``
+    (:data:`CONFIG_KEY_RESULTS_ROOT`), because a trust anchor must not be
+    derived from the path it is validating: everything at or below the collector
+    root is payload-writable while the trial runs, so ``root.parent`` can itself
+    be the symlink doing the escaping.
+
+    Falls back to ``root.parent`` when the key is absent, which only happens for
+    a direct programmatic caller -- the dispatcher always supplies it alongside
+    ``_aorta_collect_dir``. That fallback still catches a swapped collector root
+    or subdirectory; it cannot catch a swapped ancestor.
+    """
+    raw = config.get(CONFIG_KEY_RESULTS_ROOT)
+    if isinstance(raw, str) and raw:
+        return Path(raw)
+    return root.parent
+
+
 def unsafe_collector_paths(config: Mapping[str, Any]) -> list[Path]:
     """Every collector path for this trial that cannot be safely traversed.
 
@@ -176,36 +202,51 @@ def unsafe_collector_paths(config: Mapping[str, Any]) -> list[Path]:
     if root is None:
         return []
     registry = _registry()
+    trusted = _trusted_root(config, root)
     candidates = [root]
     for name in active_collectors(config):
         spec = registry.get(name)
         if spec is not None and spec.output_subdir is not None:
             candidates.append(root / spec.output_subdir)
-    return [path for path in candidates if not collector_root_is_traversable(path)]
+    return [path for path in candidates if not collector_root_is_traversable(path, trusted)]
 
 
-def collector_root_is_traversable(root: Path) -> bool:
-    """True when ``root`` can be walked without following a symlink out of the tree.
+def collector_root_is_traversable(root: Path, trusted_root: Path | None = None) -> bool:
+    """True when ``root`` resolves to somewhere inside ``trusted_root``.
 
     Checked **again after the command has run**, not only before it launches.
     The profiled command is handed this path (``rocprofv3 -d``, ``proton -n``),
-    so between the pre-launch reset and any post-run pass it can delete the
+    so between the pre-launch reset and any post-run pass it can delete a
     directory and leave a symlink in its place. Every later step --
     ``Path.is_dir()``, ``rglob``, and :func:`aorta.run.retention.apply_retention`
-    -- follows links, so traversing one would read, and for retention *delete*,
-    files outside the results tree entirely.
+    -- follows links in *every* path component, so traversing one would read,
+    and for retention *delete*, files outside the results tree.
 
-    The parent is checked too, for the same reason
-    :func:`_reset_output_dir` checks it: ``is_dir()`` resolves every component,
-    not just the last.
+    Containment against a trusted root, rather than a per-component symlink
+    scan, because the two cases look identical component-by-component and only
+    differ in who owns the link:
+
+    * **Above** the trusted root the path is the operator's own -- a
+      ``--results-dir`` that legitimately lives under a symlink is normal, and
+      following it is the intended behaviour. Resolving the trusted root first
+      allows that.
+    * **At or below** it, every component is payload-writable, so a link there
+      is an escape regardless of how deep it sits. ``resolve()`` collapses the
+      whole chain, so this catches a swap at any depth rather than only at the
+      leaf or its parent.
+
+    ``trusted_root`` defaults to ``root.parent``, which for the collector layout
+    is the dispatcher-created results directory.
     """
+    trusted = trusted_root if trusted_root is not None else root.parent
     try:
-        return not (root.is_symlink() or root.parent.is_symlink())
-    except OSError:
+        return root.resolve().is_relative_to(trusted.resolve())
+    except (OSError, RuntimeError):
+        # RuntimeError: a symlink loop that ``resolve()`` refuses to follow.
         return False
 
 
-def _reset_output_dir(out_dir: Path) -> None:
+def _reset_output_dir(out_dir: Path, trusted_root: Path) -> None:
     """Create ``out_dir`` empty, discarding any earlier attempt's artifacts.
 
     Probe resume replays an interrupted trial onto the *same* paths, so a
@@ -216,22 +257,23 @@ def _reset_output_dir(out_dir: Path) -> None:
     one trial of one collector: nothing else writes here, and the trial record
     (``result.json``) lives in a different tree.
 
+    Args:
+        out_dir: The collector's output directory for this trial.
+        trusted_root: The dispatcher-created results directory ``out_dir`` must
+            resolve inside. Checked because ``rmtree`` is recursive and
+            ``is_dir()`` follows symlinks in *every* component, so a link
+            anywhere at or below the trusted root would redirect the delete
+            outside the results tree.
+
     Raises:
-        OSError: the directory could not be cleared or created, or its parent is
-            a symlink (see below).
+        OSError: the directory could not be cleared or created, or it does not
+            resolve inside ``trusted_root``.
     """
-    # ``Path.is_dir()`` follows symlinks in *every* component, not just the
-    # last, so checking ``out_dir`` alone is not enough: if the per-trial
-    # collector root is a pre-existing symlink, ``out_dir`` resolves through it
-    # and ``rmtree`` would recursively delete the link target -- a tree outside
-    # the results directory entirely. The results tree is created by the
-    # dispatcher, so a symlink here is anomalous; refuse rather than guess.
-    parent = out_dir.parent
-    if parent.is_symlink():
+    if not collector_root_is_traversable(out_dir, trusted_root):
         raise OSError(
-            f"refusing to prepare {out_dir}: its parent {parent} is a symlink, "
-            "and clearing through it would delete the link target outside the "
-            "results tree. Remove the symlink or point --results-dir at a real "
+            f"refusing to prepare {out_dir}: it resolves outside {trusted_root}, "
+            "so clearing it would delete a tree outside the results directory. "
+            "Remove the symlink in that path, or point --results-dir at a real "
             "directory."
         )
     if out_dir.is_symlink() or out_dir.is_file():
@@ -351,7 +393,7 @@ def wrap_argv_for_collectors(
             continue
         out_dir = root / spec.output_subdir
         try:
-            _reset_output_dir(out_dir)
+            _reset_output_dir(out_dir, _trusted_root(config, root))
         except OSError as exc:
             raise RuntimeError(
                 f"collect: cannot prepare the {name} artifact directory "
@@ -418,6 +460,7 @@ __all__ = [
     "CONFIG_KEY_COLLECT",
     "CONFIG_KEY_COLLECT_DIR",
     "CONFIG_KEY_COLLECT_OPTIONS",
+    "CONFIG_KEY_RESULTS_ROOT",
     "KNOWN_RECIPES",
     "WRAP_ORDER",
     "CollectorSpec",

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -678,6 +678,13 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     results_dir = request.results_dir / request.workload
     if should_write:
         results_dir.mkdir(parents=True, exist_ok=True)
+    # Freeze the collector trust anchor here, once, before the FIRST trial
+    # runs -- not per trial. Trial 0's payload can replace ``results_dir``
+    # itself with a symlink; a per-trial ``resolve()`` would then hand trial 1
+    # a brand-new anchor pointing outside the operator's tree, and
+    # ``_reset_output_dir`` would happily clear a planted trial directory
+    # there. Every trial receives this same unchanged path.
+    collector_results_root = results_dir.resolve() if request.collect else None
     isolation_generation = (
         _next_isolation_generation()
         if effective_trial_isolation == "process"
@@ -720,6 +727,7 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
                     startup_env=startup_env,
                     isolation_generation=isolation_generation,
                     results_dir=results_dir,
+                    results_root=collector_results_root,
                     should_write=should_write,
                 )
             except TrialWorkerError as exc:
@@ -734,6 +742,7 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
                 env_descriptor=env_descriptor,
                 mitigation_env=mitigation_env,
                 results_dir=results_dir,
+                results_root=collector_results_root,
                 should_write=should_write,
             )
         if should_write:
@@ -782,6 +791,7 @@ def _run_single_trial_in_process_worker(
     startup_env: dict[str, str],
     isolation_generation: int,
     results_dir: Path,
+    results_root: Path | None,
     should_write: bool,
 ) -> TrialResult:
     trial_id = (
@@ -846,6 +856,11 @@ def _run_single_trial_in_process_worker(
             "env_descriptor": asdict(env_descriptor),
             "mitigation_env": dict(mitigation_env),
             "results_dir": str(results_dir),
+            # The frozen collector anchor from before the trial loop. Sent
+            # explicitly so the worker inherits the parent's canonical path
+            # instead of resolving one in a process that starts after an
+            # earlier trial's payload has already run.
+            "results_root": str(results_root) if results_root is not None else None,
             "should_write": should_write,
             "store_prefix": (
                 f"aorta/{os.environ.get('TORCHELASTIC_RUN_ID', 'static')}/"
@@ -919,6 +934,7 @@ def _run_single_trial(
     mitigation_env: dict[str, str],
     results_dir: Path,
     should_write: bool,
+    results_root: Path | None = None,
     persist_result: bool = True,
     result_transform: (
         Callable[[WorkloadResult, str], tuple[WorkloadResult, str]] | None
@@ -935,6 +951,13 @@ def _run_single_trial(
         mitigation_env: Environment variables from mitigations.
         results_dir: Directory for JSON output.
         should_write: Whether to write JSON (rank 0 only).
+        results_root: Canonical collector trust anchor, frozen by
+            :func:`run_trials` before the first trial. ``None`` for a caller
+            that runs a single trial directly; this function then resolves
+            ``results_dir`` itself, which is still pre-launch for that one
+            trial. Only a multi-trial loop needs the freeze, because the
+            exposure is one trial's payload rewriting the tree the next trial
+            would resolve.
 
     Returns:
         TrialResult with execution outcome.
@@ -1054,26 +1077,26 @@ def _run_single_trial(
     # ``_aorta_log_prefix``, which the dispatcher only sets when
     # ``save_logs=True``; that coupled an unrelated debug knob to collector
     # output landing in the right place (and being picked up by ``aorta
-    # bundle``). This is an absolute path stem with no extension. Canonicalized
-    # with ``.resolve()`` so a relative ``results_dir`` still yields a usable
-    # path for a subprocess with a different cwd, and so the symlink guards
-    # pin a pre-launch trust anchor. Only set on rank 0 (matches the trial-JSON
-    # / log-capture write gate) and only when a collector was requested, so
+    # bundle``). This is an absolute path stem with no extension, canonical so
+    # a relative ``results_dir`` still yields a usable path for a subprocess
+    # with a different cwd. Only set on rank 0 (matches the trial-JSON /
+    # log-capture write gate) and only when a collector was requested, so
     # non-collector runs are unchanged.
     if request.collect and should_write:
         trial_basename = (
             f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
         )
-        # Canonicalize before any trial runs. The payload can replace the
-        # results directory itself with a symlink after launch; the guards
-        # compare against this saved resolution and must not resolve it again.
-        # ``resolve()`` also folds operator-owned links *above* this root
-        # (a ``--results-dir`` that lives under a mounted scratch path), and
-        # the collect dir is built from the same canonical prefix so the
-        # payload-symlink walk has a lexical path inside that prefix.
-        results_root = results_dir.resolve()
-        config["_aorta_collect_dir"] = str(results_root / trial_basename)
-        config["_aorta_results_root"] = str(results_root)
+        # The trust anchor for the collector symlink guards. Taken from the
+        # caller when it froze one before the trial loop -- resolving it here
+        # would be *after* an earlier trial's payload ran, and that payload can
+        # replace ``results_dir`` with a symlink. ``resolve()`` also folds
+        # operator-owned links above this root (a ``--results-dir`` under a
+        # mounted scratch path), and the collect dir is built from the same
+        # canonical prefix so the payload-symlink walk has a lexical path
+        # inside it.
+        trusted_root = results_root if results_root is not None else results_dir.resolve()
+        config["_aorta_collect_dir"] = str(trusted_root / trial_basename)
+        config["_aorta_results_root"] = str(trusted_root)
 
     # Compute the effective controlled overlay in the platform env-precedence
     # order (lowest to highest):

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -1255,8 +1255,6 @@ def _run_single_trial(
         log_basename = f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
         stdout_name = f"{log_basename}.stdout.log"
         stderr_name = f"{log_basename}.stderr.log"
-        candidate_stdout = results_dir / stdout_name
-        candidate_stderr = results_dir / stderr_name
         try:
             # Opened through the frozen anchor with a no-follow leaf: these land
             # in the payload-writable per-workload directory, so a link at the
@@ -1283,9 +1281,9 @@ def _run_single_trial(
             # Best-effort cleanup so a 0-byte stub doesn't masquerade
             # as the trial's captured output -- if stdout opened but
             # stderr failed, the empty stdout.log is still on disk.
-            for path in (candidate_stdout, candidate_stderr):
+            for name in (stdout_name, stderr_name):
                 try:
-                    path.unlink()
+                    _unlink_record_file(results_dir, results_root, name)
                 except OSError:
                     pass
             logger.warning(
@@ -1532,6 +1530,26 @@ def _open_record_file(
     # descriptor stays valid after it closes.
     with _fsafe.open_dir_nofollow(anchor, components) as dir_fd:
         return _fsafe.open_write_nofollow(dir_fd, name, **text_kwargs)
+
+
+def _unlink_record_file(
+    results_dir: Path,
+    anchor: _fsafe.TrustedAnchor | None,
+    name: str,
+) -> None:
+    """Unlink a record leaf without reopening a payload-swappable pathname."""
+    if anchor is None or not _fsafe.HAVE_FD_TRAVERSAL:
+        (results_dir / name).unlink(missing_ok=True)
+        return
+    components = _fsafe.relative_components(anchor.path, results_dir)
+    if components is None:
+        (results_dir / name).unlink(missing_ok=True)
+        return
+    with _fsafe.open_dir_nofollow(anchor, components) as dir_fd:
+        try:
+            os.unlink(name, dir_fd=dir_fd)
+        except FileNotFoundError:
+            pass
 
 
 def _write_trial_result(

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -25,6 +25,7 @@ from typing import Any, Literal
 from aorta._env_rules import is_valid_env_name, value_has_nul
 from aorta.instrumentation.environment import collect_env
 from aorta.registry import Environment, get_environment, get_mitigation
+from aorta.run import _fsafe
 from aorta.run._process import TrialWorkerError, launch_trial_worker
 from aorta.run.collectors import KNOWN_RECIPES, validate_collectors
 from aorta.run.discovery import (
@@ -680,11 +681,11 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     # operator boundary, then append the workload lexically so a pre-existing
     # ``<results>/<workload> -> /outside`` link is visible to the collector
     # guard instead of being folded into its trusted anchor.
-    collector_results_root = (
+    canonical_results_dir = (
         request.results_dir.resolve() if request.collect and should_write else None
     )
     results_dir = (
-        collector_results_root if collector_results_root is not None else request.results_dir
+        canonical_results_dir if canonical_results_dir is not None else request.results_dir
     ) / request.workload
     if should_write:
         results_dir.mkdir(parents=True, exist_ok=True)
@@ -694,6 +695,17 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     # a brand-new anchor pointing outside the operator's tree, and
     # ``_reset_output_dir`` would happily clear a planted trial directory
     # there. Every trial receives this same unchanged path.
+    #
+    # The freeze records the directory's inode as well as its path, which is
+    # the part a pathname cannot carry: a payload can rename the results
+    # directory aside and move a *real* directory into its place, leaving every
+    # later ``O_NOFOLLOW`` check on that pathname satisfied. Taken after the
+    # ``mkdir`` above so the directory exists to be pinned.
+    collector_results_root = (
+        _fsafe.TrustedAnchor.freeze(canonical_results_dir)
+        if canonical_results_dir is not None
+        else None
+    )
     isolation_generation = (
         _next_isolation_generation()
         if effective_trial_isolation == "process"
@@ -800,7 +812,7 @@ def _run_single_trial_in_process_worker(
     startup_env: dict[str, str],
     isolation_generation: int,
     results_dir: Path,
-    results_root: Path | None,
+    results_root: _fsafe.TrustedAnchor | None,
     should_write: bool,
 ) -> TrialResult:
     trial_id = (
@@ -868,8 +880,15 @@ def _run_single_trial_in_process_worker(
             # The frozen collector anchor from before the trial loop. Sent
             # explicitly so the worker inherits the parent's canonical path
             # instead of resolving one in a process that starts after an
-            # earlier trial's payload has already run.
-            "results_root": str(results_root) if results_root is not None else None,
+            # earlier trial's payload has already run. The pinned inode travels
+            # as a plain pair because the envelope is JSON and a file
+            # descriptor cannot cross the process boundary.
+            "results_root": str(results_root.path) if results_root is not None else None,
+            "results_root_id": (
+                list(results_root.identity)
+                if results_root is not None and results_root.identity is not None
+                else None
+            ),
             "should_write": should_write,
             "store_prefix": (
                 f"aorta/{os.environ.get('TORCHELASTIC_RUN_ID', 'static')}/"
@@ -943,7 +962,7 @@ def _run_single_trial(
     mitigation_env: dict[str, str],
     results_dir: Path,
     should_write: bool,
-    results_root: Path | None = None,
+    results_root: _fsafe.TrustedAnchor | None = None,
     persist_result: bool = True,
     result_transform: (
         Callable[[WorkloadResult, str], tuple[WorkloadResult, str]] | None
@@ -960,13 +979,13 @@ def _run_single_trial(
         mitigation_env: Environment variables from mitigations.
         results_dir: Directory for JSON output.
         should_write: Whether to write JSON (rank 0 only).
-        results_root: Canonical collector trust anchor, frozen by
-            :func:`run_trials` before the first trial. ``None`` for a caller
-            that runs a single trial directly; this function then resolves
-            ``results_dir`` itself, which is still pre-launch for that one
-            trial. Only a multi-trial loop needs the freeze, because the
-            exposure is one trial's payload rewriting the tree the next trial
-            would resolve.
+        results_root: Canonical collector trust anchor -- path plus pinned
+            inode -- frozen by :func:`run_trials` before the first trial.
+            ``None`` for a caller that runs a single trial directly; this
+            function then freezes ``results_dir`` itself, which is still
+            pre-launch for that one trial. Only a multi-trial loop needs the
+            earlier freeze, because the exposure is one trial's payload
+            rewriting the tree the next trial would resolve.
 
     Returns:
         TrialResult with execution outcome.
@@ -1110,10 +1129,12 @@ def _run_single_trial(
         else:
             # A direct single-trial caller has no separately declared
             # operator boundary; retain the historical per-workload anchor.
-            trusted_root = results_dir.resolve()
-            collect_base = trusted_root
+            trusted_root = _fsafe.TrustedAnchor.freeze(results_dir.resolve())
+            collect_base = trusted_root.path
         config["_aorta_collect_dir"] = str(collect_base / trial_basename)
-        config["_aorta_results_root"] = str(trusted_root)
+        config["_aorta_results_root"] = str(trusted_root.path)
+        if trusted_root.identity is not None:
+            config["_aorta_results_root_id"] = list(trusted_root.identity)
 
     # Compute the effective controlled overlay in the platform env-precedence
     # order (lowest to highest):

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -1518,14 +1518,16 @@ def _open_record_file(
     (the log capture keeps two handles for the length of a trial and has its own
     cleanup for a partial open). Falls back to a plain ``open`` when no anchor
     was frozen -- a direct programmatic caller -- or when the platform lacks the
-    fd primitives, or when ``results_dir`` is not lexically inside the anchor,
-    which are the same documented degradations the collector guards carry.
+    fd primitives. An anchored path outside the anchor is a caller bug and
+    refuses rather than silently bypassing the guard.
     """
     if anchor is None or not _fsafe.HAVE_FD_TRAVERSAL:
         return open(results_dir / name, "w", **text_kwargs)
     components = _fsafe.relative_components(anchor.path, results_dir)
     if components is None:
-        return open(results_dir / name, "w", **text_kwargs)
+        raise _fsafe.UnsafePathError(
+            f"record directory {results_dir} is outside trusted root {anchor.path}"
+        )
     # The directory fd is only needed to resolve ``name``; the returned file
     # descriptor stays valid after it closes.
     with _fsafe.open_dir_nofollow(anchor, components) as dir_fd:
@@ -1543,8 +1545,9 @@ def _unlink_record_file(
         return
     components = _fsafe.relative_components(anchor.path, results_dir)
     if components is None:
-        (results_dir / name).unlink(missing_ok=True)
-        return
+        raise _fsafe.UnsafePathError(
+            f"record directory {results_dir} is outside trusted root {anchor.path}"
+        )
     with _fsafe.open_dir_nofollow(anchor, components) as dir_fd:
         try:
             os.unlink(name, dir_fd=dir_fd)

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -683,8 +683,11 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     # itself with a symlink; a per-trial ``resolve()`` would then hand trial 1
     # a brand-new anchor pointing outside the operator's tree, and
     # ``_reset_output_dir`` would happily clear a planted trial directory
-    # there. Every trial receives this same unchanged path.
-    collector_results_root = results_dir.resolve() if request.collect else None
+    # there. Every trial receives this same unchanged path. Only computed on
+    # the rank that threads collector paths at all.
+    collector_results_root = (
+        results_dir.resolve() if request.collect and should_write else None
+    )
     isolation_generation = (
         _next_isolation_generation()
         if effective_trial_isolation == "process"

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -27,7 +27,12 @@ from aorta.instrumentation.environment import collect_env
 from aorta.registry import Environment, get_environment, get_mitigation
 from aorta.run import _fsafe
 from aorta.run._process import TrialWorkerError, launch_trial_worker
-from aorta.run.collectors import KNOWN_RECIPES, validate_collectors
+from aorta.run.collectors import (
+    CONFIG_KEY_RESULTS_ROOT,
+    CONFIG_KEY_RESULTS_ROOT_ID,
+    KNOWN_RECIPES,
+    validate_collectors,
+)
 from aorta.run.discovery import (
     get_workload_class,
     get_workload_policy,
@@ -1119,6 +1124,22 @@ def _run_single_trial(
             name: dict(opts) for name, opts in request.collect_options.items()
         }
 
+    # Thread the pre-launch results anchor on every artifact-writing trial, not
+    # only collector trials. The probe workload writes its own trial tree even
+    # without a collector, so deriving an unpinned anchor during setup would
+    # let the payload replace the results directory with another real directory
+    # and redirect result.json before the dispatcher's later record write
+    # notices. A direct single-trial caller has no separately declared operator
+    # boundary; its results_dir is the per-workload directory, so its parent is
+    # the common boundary containing both that directory and probe trial_N/.
+    trusted_root = results_root
+    if should_write:
+        if trusted_root is None:
+            trusted_root = _fsafe.TrustedAnchor.freeze(results_dir.parent.resolve())
+        config[CONFIG_KEY_RESULTS_ROOT] = str(trusted_root.path)
+        if trusted_root.identity is not None:
+            config[CONFIG_KEY_RESULTS_ROOT_ID] = list(trusted_root.identity)
+
     # When a collector is active, thread the per-trial output path stem so a
     # workload can write collector artifacts (e.g. the layer_numerics NaN
     # logger's summary/jsonl) into the results tree -- WITHOUT requiring
@@ -1136,26 +1157,7 @@ def _run_single_trial(
         trial_basename = (
             f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
         )
-        # The trust anchor for the collector symlink guards. Taken from the
-        # caller when it froze one before the trial loop -- resolving it here
-        # would be *after* an earlier trial's payload ran, and that payload can
-        # replace ``results_dir`` with a symlink. The caller resolved only the
-        # operator-owned ``--results-dir`` boundary, folding legitimate links
-        # above it (such as a mounted scratch path); ``collect_base`` preserves
-        # the workload component lexically below that prefix so a stale
-        # workload symlink is rejected rather than trusted.
-        if results_root is not None:
-            trusted_root = results_root
-            collect_base = results_dir
-        else:
-            # A direct single-trial caller has no separately declared
-            # operator boundary; retain the historical per-workload anchor.
-            trusted_root = _fsafe.TrustedAnchor.freeze(results_dir.resolve())
-            collect_base = trusted_root.path
-        config["_aorta_collect_dir"] = str(collect_base / trial_basename)
-        config["_aorta_results_root"] = str(trusted_root.path)
-        if trusted_root.identity is not None:
-            config["_aorta_results_root_id"] = list(trusted_root.identity)
+        config["_aorta_collect_dir"] = str(results_dir / trial_basename)
 
     # Compute the effective controlled overlay in the platform env-precedence
     # order (lowest to highest):
@@ -1425,13 +1427,24 @@ def _run_single_trial(
     # the two in lockstep if ``Environment`` ever grows a field.
     execution_env = asdict(env_descriptor)
 
+    # The results anchor is runtime authority rather than workload
+    # configuration. Non-collector records historically omitted it, so keep
+    # their serialized/returned config byte-shape stable while still exposing
+    # the anchor to the workload during setup and run. Collector records already
+    # carried these keys before the anchor became unconditional.
+    result_config = config
+    if not request.collect:
+        result_config = dict(config)
+        result_config.pop(CONFIG_KEY_RESULTS_ROOT, None)
+        result_config.pop(CONFIG_KEY_RESULTS_ROOT_ID, None)
+
     # Build TrialResult
     trial_result = TrialResult(
         trial_id=trial_id,
         workload=request.workload,
         execution_env=execution_env,
         mitigations_applied=request.mitigations,
-        config=config,
+        config=result_config,
         env=env_snapshot.to_dict(),
         result=asdict(workload_result),
         wall_clock_sec=wall_clock,

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -678,23 +678,28 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     should_write = rank == 0
     # The operator owns ``--results-dir``; the workload name below it is
     # payload-controlled state left by earlier attempts. Canonicalize only the
-    # operator boundary, then append the workload lexically so a pre-existing
-    # ``<results>/<workload> -> /outside`` link is visible to the collector
-    # guard instead of being folded into its trusted anchor.
-    canonical_results_dir = (
-        request.results_dir.resolve() if request.collect and should_write else None
-    )
-    results_dir = (
-        canonical_results_dir if canonical_results_dir is not None else request.results_dir
-    ) / request.workload
-    if should_write:
-        results_dir.mkdir(parents=True, exist_ok=True)
-    # Freeze the collector trust anchor here, once, before the FIRST trial
-    # runs -- not per trial. Trial 0's payload can replace ``results_dir``
-    # itself with a symlink; a per-trial ``resolve()`` would then hand trial 1
-    # a brand-new anchor pointing outside the operator's tree, and
-    # ``_reset_output_dir`` would happily clear a planted trial directory
-    # there. Every trial receives this same unchanged path.
+    # operator boundary -- folding away the operator's own links above it -- then
+    # append the workload lexically so a pre-existing
+    # ``<results>/<workload> -> /outside`` link stays visible to the guards
+    # instead of being folded into the trusted anchor.
+    #
+    # Not gated on ``request.collect``: the trial record and the captured logs
+    # are written through this same workload component on *every* run, so the
+    # anchor that protects those writes has to exist even when no collector is
+    # attached. (The ``_aorta_collect*`` config keys stay collector-gated; see
+    # ``_run_single_trial``.)
+    canonical_results_dir = request.results_dir.resolve() if should_write else None
+    if canonical_results_dir is not None:
+        # The operator boundary itself, created by pathname on purpose: it lives
+        # *above* the payload-writable tree and may legitimately be reached
+        # through the operator's own symlinks.
+        canonical_results_dir.mkdir(parents=True, exist_ok=True)
+    # Freeze the trust anchor here, once, before the FIRST trial runs -- not per
+    # trial. Trial 0's payload can replace the results directory itself with a
+    # symlink; a per-trial ``resolve()`` would then hand trial 1 a brand-new
+    # anchor pointing outside the operator's tree, and ``_reset_output_dir``
+    # would happily clear a planted trial directory there. Every trial receives
+    # this same unchanged path.
     #
     # The freeze records the directory's inode as well as its path, which is
     # the part a pathname cannot carry: a payload can rename the results
@@ -706,6 +711,13 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
         if canonical_results_dir is not None
         else None
     )
+    results_dir = (
+        canonical_results_dir if canonical_results_dir is not None else request.results_dir
+    ) / request.workload
+    if collector_results_root is not None:
+        _create_workload_dir(collector_results_root, request.workload)
+    elif should_write:
+        results_dir.mkdir(parents=True, exist_ok=True)
     isolation_generation = (
         _next_isolation_generation()
         if effective_trial_isolation == "process"
@@ -910,6 +922,7 @@ def _run_single_trial_in_process_worker(
             request=request,
             trial_idx=trial_idx,
             results_dir=results_dir,
+            results_root=results_root,
         )
     return result
 
@@ -1232,11 +1245,29 @@ def _run_single_trial(
     stderr_fh: Any = None
     if request.save_logs and should_write:
         log_basename = f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
-        candidate_stdout = results_dir / f"{log_basename}.stdout.log"
-        candidate_stderr = results_dir / f"{log_basename}.stderr.log"
+        stdout_name = f"{log_basename}.stdout.log"
+        stderr_name = f"{log_basename}.stderr.log"
+        candidate_stdout = results_dir / stdout_name
+        candidate_stderr = results_dir / stderr_name
         try:
-            stdout_fh = open(candidate_stdout, "w", encoding="utf-8", errors="backslashreplace")
-            stderr_fh = open(candidate_stderr, "w", encoding="utf-8", errors="backslashreplace")
+            # Opened through the frozen anchor with a no-follow leaf: these land
+            # in the payload-writable per-workload directory, so a link at the
+            # workload component or at the filename would otherwise redirect or
+            # truncate a file outside ``--results-dir``.
+            stdout_fh = _open_record_file(
+                results_dir,
+                results_root,
+                stdout_name,
+                encoding="utf-8",
+                errors="backslashreplace",
+            )
+            stderr_fh = _open_record_file(
+                results_dir,
+                results_root,
+                stderr_name,
+                encoding="utf-8",
+                errors="backslashreplace",
+            )
         except OSError as exc:
             if stdout_fh is not None:
                 stdout_fh.close()
@@ -1412,9 +1443,87 @@ def _run_single_trial(
             request=request,
             trial_idx=trial_idx,
             results_dir=results_dir,
+            results_root=results_root,
         )
 
     return trial_result
+
+
+def _create_workload_dir(anchor: _fsafe.TrustedAnchor, workload: str) -> None:
+    """Create ``<anchor>/<workload>``, refusing a link or a replaced directory.
+
+    The per-workload output directory is where the trial records and captured
+    logs land, and it sits below the operator boundary: a stale
+    ``<results>/<workload> -> /outside`` link from an earlier run, or one a
+    payload planted, makes ``mkdir(exist_ok=True)`` succeed silently and every
+    later write follow it out of the tree.
+
+    Descending from the pinned anchor with ``O_NOFOLLOW`` refuses that instead,
+    and refuses the harder case of a *real* directory renamed into the anchor's
+    pathname. This is a hard failure rather than a warning: the run's entire
+    audit trail would otherwise be written somewhere the operator did not ask
+    for and will not look.
+
+    Raises:
+        RuntimeError: the component cannot be created or is not a real directory
+            reachable from the anchor without crossing a symlink.
+    """
+    if not _fsafe.HAVE_FD_TRAVERSAL:
+        # No fd primitives (non-POSIX): keep the historical pathname create,
+        # with a lexical refusal so a planted link still fails closed.
+        target = anchor.path / workload
+        if target.is_symlink():
+            raise RuntimeError(
+                f"refusing to use {target} for output: it is a symlink, so the "
+                "trial records and logs would be written outside "
+                f"{anchor.path}. Remove it, or point --results-dir at the "
+                "intended location."
+            )
+        target.mkdir(parents=True, exist_ok=True)
+        return
+    try:
+        with _fsafe.open_dir_nofollow(anchor, [workload], create_missing=True):
+            pass
+    except _fsafe.UnsafePathError as exc:
+        raise RuntimeError(
+            f"refusing to use {anchor.path / workload} for output: it is a "
+            "symlink, is not a directory, or is no longer the directory it was "
+            f"frozen as, so the trial records and logs would be written outside "
+            f"{anchor.path}. Remove it, or point --results-dir at the intended "
+            f"location. ({exc})"
+        ) from exc
+
+
+def _open_record_file(
+    results_dir: Path,
+    anchor: _fsafe.TrustedAnchor | None,
+    name: str,
+    **text_kwargs: Any,
+) -> Any:
+    """``open(results_dir / name, "w")`` that cannot be redirected by a link.
+
+    ``results_dir`` is ``<anchor>/<workload>``, which is below the operator
+    boundary and therefore payload-writable during a run. Writing by pathname
+    lets a link at the workload component *or* at the filename itself redirect
+    or truncate a file outside ``--results-dir``; descending from the pinned
+    anchor and opening the leaf ``O_NOFOLLOW`` removes both.
+
+    Returns the stream, matching the ``open()`` shape the callers already have
+    (the log capture keeps two handles for the length of a trial and has its own
+    cleanup for a partial open). Falls back to a plain ``open`` when no anchor
+    was frozen -- a direct programmatic caller -- or when the platform lacks the
+    fd primitives, or when ``results_dir`` is not lexically inside the anchor,
+    which are the same documented degradations the collector guards carry.
+    """
+    if anchor is None or not _fsafe.HAVE_FD_TRAVERSAL:
+        return open(results_dir / name, "w", **text_kwargs)
+    components = _fsafe.relative_components(anchor.path, results_dir)
+    if components is None:
+        return open(results_dir / name, "w", **text_kwargs)
+    # The directory fd is only needed to resolve ``name``; the returned file
+    # descriptor stays valid after it closes.
+    with _fsafe.open_dir_nofollow(anchor, components) as dir_fd:
+        return _fsafe.open_write_nofollow(dir_fd, name, **text_kwargs)
 
 
 def _write_trial_result(
@@ -1423,14 +1532,27 @@ def _write_trial_result(
     request: RunRequest,
     trial_idx: int,
     results_dir: Path,
+    results_root: _fsafe.TrustedAnchor | None = None,
 ) -> None:
-    output_path = results_dir / (
-        f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}.json"
-    )
+    name = f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}.json"
     serialized = result.to_dict()
     _sanitize_probe_extras_for_json(serialized.get("config"))
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(serialized, f, indent=2)
+    try:
+        with _open_record_file(results_dir, results_root, name, encoding="utf-8") as f:
+            json.dump(serialized, f, indent=2)
+    except _fsafe.UnsafePathError as exc:
+        # A component turned into a link (or a different directory) while the
+        # trial ran. Refusing costs this trial's record; writing would have put
+        # the operator's audit trail somewhere they will not look for it, so this
+        # is deliberately a hard failure rather than a warning -- unlike the log
+        # capture below it, which is a debug knob and degrades instead.
+        raise RuntimeError(
+            f"refusing to write the trial record to {results_dir / name}: a path "
+            f"component below {results_root.path if results_root else results_dir} "
+            "is a symlink, is not a directory, or is no longer the directory it "
+            f"was frozen as, so the record would land outside the results tree. "
+            f"({exc})"
+        ) from exc
 
 
 def _sanitize_probe_extras_for_json(config: Any) -> None:

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -20,7 +20,7 @@ import time
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TextIO
 
 from aorta._env_rules import is_valid_env_name, value_has_nul
 from aorta.instrumentation.environment import collect_env
@@ -706,7 +706,10 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     # directory aside and move a *real* directory into its place, leaving every
     # later ``O_NOFOLLOW`` check on that pathname satisfied. Taken after the
     # ``mkdir`` above so the directory exists to be pinned.
-    collector_results_root = (
+    # ``freeze`` always returns an anchor (an unpinnable one degrades to
+    # path-only), so this is non-None exactly when ``should_write`` is -- which
+    # is also exactly when there is anything to create or write.
+    results_anchor = (
         _fsafe.TrustedAnchor.freeze(canonical_results_dir)
         if canonical_results_dir is not None
         else None
@@ -714,10 +717,8 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     results_dir = (
         canonical_results_dir if canonical_results_dir is not None else request.results_dir
     ) / request.workload
-    if collector_results_root is not None:
-        _create_workload_dir(collector_results_root, request.workload)
-    elif should_write:
-        results_dir.mkdir(parents=True, exist_ok=True)
+    if results_anchor is not None:
+        _create_workload_dir(results_anchor, request.workload)
     isolation_generation = (
         _next_isolation_generation()
         if effective_trial_isolation == "process"
@@ -760,7 +761,7 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
                     startup_env=startup_env,
                     isolation_generation=isolation_generation,
                     results_dir=results_dir,
-                    results_root=collector_results_root,
+                    results_root=results_anchor,
                     should_write=should_write,
                 )
             except TrialWorkerError as exc:
@@ -775,7 +776,7 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
                 env_descriptor=env_descriptor,
                 mitigation_env=mitigation_env,
                 results_dir=results_dir,
-                results_root=collector_results_root,
+                results_root=results_anchor,
                 should_write=should_write,
             )
         if should_write:
@@ -992,13 +993,20 @@ def _run_single_trial(
         mitigation_env: Environment variables from mitigations.
         results_dir: Directory for JSON output.
         should_write: Whether to write JSON (rank 0 only).
-        results_root: Canonical collector trust anchor -- path plus pinned
-            inode -- frozen by :func:`run_trials` before the first trial.
-            ``None`` for a caller that runs a single trial directly; this
-            function then freezes ``results_dir`` itself, which is still
-            pre-launch for that one trial. Only a multi-trial loop needs the
-            earlier freeze, because the exposure is one trial's payload
-            rewriting the tree the next trial would resolve.
+        results_root: Canonical trust anchor for everything written below
+            ``--results-dir`` -- path plus pinned inode -- frozen by
+            :func:`run_trials` before the first trial. Guards both the collector
+            artifact tree and this function's *own* output: the trial record and
+            the captured logs go through ``<anchor>/<workload>``, which is
+            payload-writable, so they are opened relative to it rather than by
+            pathname.
+
+            ``None`` for a caller that runs a single trial directly. The
+            collector guards then freeze ``results_dir`` themselves (still
+            pre-launch for that one trial) and the record writes fall back to a
+            plain ``open``; only a multi-trial loop needs the earlier freeze,
+            because the exposure is one trial's payload rewriting the tree the
+            next trial would resolve.
 
     Returns:
         TrialResult with execution outcome.
@@ -1499,7 +1507,7 @@ def _open_record_file(
     anchor: _fsafe.TrustedAnchor | None,
     name: str,
     **text_kwargs: Any,
-) -> Any:
+) -> TextIO:
     """``open(results_dir / name, "w")`` that cannot be redirected by a link.
 
     ``results_dir`` is ``<anchor>/<workload>``, which is below the operator

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -675,7 +675,17 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
         )
         rank = 0
     should_write = rank == 0
-    results_dir = request.results_dir / request.workload
+    # The operator owns ``--results-dir``; the workload name below it is
+    # payload-controlled state left by earlier attempts. Canonicalize only the
+    # operator boundary, then append the workload lexically so a pre-existing
+    # ``<results>/<workload> -> /outside`` link is visible to the collector
+    # guard instead of being folded into its trusted anchor.
+    collector_results_root = (
+        request.results_dir.resolve() if request.collect and should_write else None
+    )
+    results_dir = (
+        collector_results_root if collector_results_root is not None else request.results_dir
+    ) / request.workload
     if should_write:
         results_dir.mkdir(parents=True, exist_ok=True)
     # Freeze the collector trust anchor here, once, before the FIRST trial
@@ -683,11 +693,7 @@ def run_trials(request: RunRequest) -> list[TrialResult]:
     # itself with a symlink; a per-trial ``resolve()`` would then hand trial 1
     # a brand-new anchor pointing outside the operator's tree, and
     # ``_reset_output_dir`` would happily clear a planted trial directory
-    # there. Every trial receives this same unchanged path. Only computed on
-    # the rank that threads collector paths at all.
-    collector_results_root = (
-        results_dir.resolve() if request.collect and should_write else None
-    )
+    # there. Every trial receives this same unchanged path.
     isolation_generation = (
         _next_isolation_generation()
         if effective_trial_isolation == "process"
@@ -1080,9 +1086,10 @@ def _run_single_trial(
     # ``_aorta_log_prefix``, which the dispatcher only sets when
     # ``save_logs=True``; that coupled an unrelated debug knob to collector
     # output landing in the right place (and being picked up by ``aorta
-    # bundle``). This is an absolute path stem with no extension, canonical so
-    # a relative ``results_dir`` still yields a usable path for a subprocess
-    # with a different cwd. Only set on rank 0 (matches the trial-JSON /
+    # bundle``). This is an absolute path stem with no extension: the
+    # operator-owned ``--results-dir`` prefix is canonical while the
+    # payload-owned workload/trial components stay lexical so the symlink
+    # guard can inspect them. Only set on rank 0 (matches the trial-JSON /
     # log-capture write gate) and only when a collector was requested, so
     # non-collector runs are unchanged.
     if request.collect and should_write:
@@ -1092,13 +1099,20 @@ def _run_single_trial(
         # The trust anchor for the collector symlink guards. Taken from the
         # caller when it froze one before the trial loop -- resolving it here
         # would be *after* an earlier trial's payload ran, and that payload can
-        # replace ``results_dir`` with a symlink. ``resolve()`` also folds
-        # operator-owned links above this root (a ``--results-dir`` under a
-        # mounted scratch path), and the collect dir is built from the same
-        # canonical prefix so the payload-symlink walk has a lexical path
-        # inside it.
-        trusted_root = results_root if results_root is not None else results_dir.resolve()
-        config["_aorta_collect_dir"] = str(trusted_root / trial_basename)
+        # replace ``results_dir`` with a symlink. The caller resolved only the
+        # operator-owned ``--results-dir`` boundary, folding legitimate links
+        # above it (such as a mounted scratch path); ``collect_base`` preserves
+        # the workload component lexically below that prefix so a stale
+        # workload symlink is rejected rather than trusted.
+        if results_root is not None:
+            trusted_root = results_root
+            collect_base = results_dir
+        else:
+            # A direct single-trial caller has no separately declared
+            # operator boundary; retain the historical per-workload anchor.
+            trusted_root = results_dir.resolve()
+            collect_base = trusted_root
+        config["_aorta_collect_dir"] = str(collect_base / trial_basename)
         config["_aorta_results_root"] = str(trusted_root)
 
     # Compute the effective controlled overlay in the platform env-precedence

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -1054,22 +1054,26 @@ def _run_single_trial(
     # ``_aorta_log_prefix``, which the dispatcher only sets when
     # ``save_logs=True``; that coupled an unrelated debug knob to collector
     # output landing in the right place (and being picked up by ``aorta
-    # bundle``). This is an absolute path stem with no extension, same
-    # shape/derivation as ``_aorta_log_prefix`` (``.absolute()`` so a relative
-    # ``results_dir`` still yields a usable path for a subprocess with a
-    # different cwd). Only set on rank 0 (matches the trial-JSON / log-capture
-    # write gate) and only when a collector was requested, so non-collector
-    # runs are unchanged.
+    # bundle``). This is an absolute path stem with no extension. Canonicalized
+    # with ``.resolve()`` so a relative ``results_dir`` still yields a usable
+    # path for a subprocess with a different cwd, and so the symlink guards
+    # pin a pre-launch trust anchor. Only set on rank 0 (matches the trial-JSON
+    # / log-capture write gate) and only when a collector was requested, so
+    # non-collector runs are unchanged.
     if request.collect and should_write:
         trial_basename = (
             f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
         )
-        config["_aorta_collect_dir"] = str((results_dir / trial_basename).absolute())
-        # The trust anchor for the collector symlink guards. It has to come
-        # from here rather than be derived from the collector directory: the
-        # profiled command can replace anything at or below that directory
-        # while it runs, so a boundary computed from it proves nothing.
-        config["_aorta_results_root"] = str(results_dir.absolute())
+        # Canonicalize before any trial runs. The payload can replace the
+        # results directory itself with a symlink after launch; the guards
+        # compare against this saved resolution and must not resolve it again.
+        # ``resolve()`` also folds operator-owned links *above* this root
+        # (a ``--results-dir`` that lives under a mounted scratch path), and
+        # the collect dir is built from the same canonical prefix so the
+        # payload-symlink walk has a lexical path inside that prefix.
+        results_root = results_dir.resolve()
+        config["_aorta_collect_dir"] = str(results_root / trial_basename)
+        config["_aorta_results_root"] = str(results_root)
 
     # Compute the effective controlled overlay in the platform env-precedence
     # order (lowest to highest):

--- a/src/aorta/run/dispatcher.py
+++ b/src/aorta/run/dispatcher.py
@@ -1065,6 +1065,11 @@ def _run_single_trial(
             f"trial_d{request.dataset_index}_m{request.mitigation_index}_t{trial_idx}"
         )
         config["_aorta_collect_dir"] = str((results_dir / trial_basename).absolute())
+        # The trust anchor for the collector symlink guards. It has to come
+        # from here rather than be derived from the collector directory: the
+        # profiled command can replace anything at or below that directory
+        # while it runs, so a boundary computed from it proves nothing.
+        config["_aorta_results_root"] = str(results_dir.absolute())
 
     # Compute the effective controlled overlay in the platform env-precedence
     # order (lowest to highest):

--- a/src/aorta/run/retention.py
+++ b/src/aorta/run/retention.py
@@ -43,8 +43,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import stat
 from dataclasses import dataclass
 from pathlib import Path
+
+from aorta.run import _fsafe
 
 log = logging.getLogger(__name__)
 
@@ -165,17 +168,37 @@ def _load_manifest(trial_dir: Path) -> dict[str, str]:
         return {}
     try:
         raw = json.loads(manifest_path.read_text(encoding="utf-8"))
-        entries = raw["artifacts"]
-        if not isinstance(entries, list):
-            raise TypeError(
-                f"'artifacts' must be a list, got {type(entries).__name__}"
-            )
-    except (OSError, ValueError, KeyError, TypeError) as exc:
+    except (OSError, ValueError) as exc:
         log.warning(
             "retention: ignoring malformed %s in %s (%s); "
             "falling back to filename convention",
             RETENTION_MANIFEST_NAME,
             trial_dir,
+            exc,
+        )
+        return {}
+    return _manifest_mapping(raw)
+
+
+def _manifest_mapping(raw: object) -> dict[str, str]:
+    """Turn parsed ``artifacts.json`` JSON into a ``{rel_path: class}`` map.
+
+    Shared by :func:`_load_manifest` (pathname) and :func:`_load_manifest_fd`
+    (fd-relative) so both apply identical tolerance: a top-level shape error
+    yields ``{}``; a malformed entry is skipped; an unknown class is pinned to
+    :data:`HEAVY` rather than dropped.
+    """
+    try:
+        entries = raw["artifacts"]  # type: ignore[index]
+        if not isinstance(entries, list):
+            raise TypeError(
+                f"'artifacts' must be a list, got {type(entries).__name__}"
+            )
+    except (ValueError, KeyError, TypeError) as exc:
+        log.warning(
+            "retention: ignoring malformed %s (%s); falling back to filename "
+            "convention",
+            RETENTION_MANIFEST_NAME,
             exc,
         )
         return {}
@@ -200,7 +223,9 @@ def _load_manifest(trial_dir: Path) -> dict[str, str]:
     return mapping
 
 
-def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
+def apply_retention(
+    trial_dir: Path, level: str, *, trusted_root: Path | None = None
+) -> RetentionOutcome:
     """Prune ``trial_dir`` to the artifacts kept by retention ``level``.
 
     Deletes every file whose class outranks ``level`` -- except the trial
@@ -214,16 +239,34 @@ def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
     Symlinks are never unlinked, and any path that dereferences outside
     ``trial_dir`` is skipped (kept) with a warning -- a buggy or hostile
     collector symlink can never make retention delete files outside the
-    trial output tree. Enumeration uses ``os.walk(..., followlinks=False)``
-    so retention never even *descends* into a symlinked subdirectory (a
-    collector that drops a symlinked dir pointing at, say, ``/`` could
-    otherwise make a naive ``rglob`` walk an arbitrary, huge external tree).
+    trial output tree.
+
+    ``trusted_root`` selects the traversal strategy:
+
+    * **Given** (the collector artifact tree, which the profiled payload is
+      handed and can swap mid-run): on POSIX the whole prune runs
+      **fd-relative** -- ``trial_dir`` is reached by descending from
+      ``trusted_root`` with ``O_NOFOLLOW`` on every component, and every stat /
+      unlink / rmdir is performed relative to the held directory fds. A payload
+      that replaces an ancestor between the check and a delete cannot redirect
+      it, closing the time-of-check/time-of-use window. ``trusted_root`` is the
+      operator's canonical ``--results-dir`` and ``trial_dir`` must be lexically
+      inside it.
+    * **Omitted** (the operator-written trial record tree, not handed to the
+      payload) or on a platform without the fd primitives: the historical
+      ``os.walk(..., followlinks=False)`` + ``resolve()``-containment body runs,
+      which never descends a symlinked subdirectory and refuses to delete a path
+      that dereferences outside ``trial_dir``.
     """
     if level not in _LEVEL_RANK:
         log.warning("retention: unknown level %r; keeping everything (full)", level)
         return RetentionOutcome(level="full", no_op=True)
     if level == "full":
         return RetentionOutcome(level="full", no_op=True)
+
+    if trusted_root is not None and _fsafe.HAVE_FD_TRAVERSAL:
+        return _apply_retention_fd(trial_dir, level, trusted_root)
+
     if not trial_dir.is_dir():
         return RetentionOutcome(level=level, no_op=True)
 
@@ -277,6 +320,107 @@ def apply_retention(trial_dir: Path, level: str) -> RetentionOutcome:
         kept=tuple(kept),
         freed_bytes=freed,
     )
+
+
+def _apply_retention_fd(
+    trial_dir: Path, level: str, trusted_root: Path
+) -> RetentionOutcome:
+    """Race-free :func:`apply_retention` for the payload-writable collector tree.
+
+    Descends from ``trusted_root`` to ``trial_dir`` with ``O_NOFOLLOW`` on every
+    component and holds the resulting directory fd, then classifies and deletes
+    each file relative to the fds returned by :func:`aorta.run._fsafe`. Because
+    no step re-resolves a pathname, a payload that swaps an ancestor after the
+    descent cannot redirect a delete outside the results tree. Symlinked files
+    and subdirectories are never yielded by the walk, so they are neither read
+    nor unlinked. Tolerant like the pathname engine: a delete that fails keeps
+    the file and warns.
+    """
+    components = _fsafe.relative_components(trusted_root, trial_dir)
+    if components is None:
+        log.warning(
+            "retention: %s is not inside the trusted root %s; keeping everything",
+            trial_dir,
+            trusted_root,
+        )
+        return RetentionOutcome(level=level, no_op=True)
+
+    level_rank = _LEVEL_RANK[level]
+    deleted: list[str] = []
+    kept: list[str] = []
+    freed = 0
+    try:
+        with _fsafe.open_dir_nofollow(trusted_root, components) as base_fd:
+            manifest = _load_manifest_fd(base_fd)
+            for rel, dir_fd, name, size in _fsafe.iter_regular_files(base_fd):
+                cls = classify_artifact(rel, manifest)
+                if cls == RECORD or _CLASS_RANK[cls] <= level_rank:
+                    kept.append(rel)
+                    continue
+                try:
+                    os.unlink(name, dir_fd=dir_fd)
+                except OSError as exc:
+                    log.warning(
+                        "retention: could not delete %s (%s); keeping it", rel, exc
+                    )
+                    kept.append(rel)
+                    continue
+                freed += size
+                deleted.append(rel)
+            _fsafe.prune_empty_dirs(base_fd)
+    except _fsafe.UnsafePathError as exc:
+        # A component of the collector tree was a symlink after the run: refuse
+        # to prune through it, keeping the artifacts. Mirrors the pathname
+        # engine's "skip + warn, never abort" tolerance.
+        log.warning(
+            "retention: refusing to prune %s; a path component is a symlink "
+            "after the run (%s). Collector artifacts kept.",
+            trial_dir,
+            exc,
+        )
+        return RetentionOutcome(level=level, no_op=True)
+    return RetentionOutcome(
+        level=level,
+        deleted=tuple(deleted),
+        kept=tuple(kept),
+        freed_bytes=freed,
+    )
+
+
+def _load_manifest_fd(base_fd: int) -> dict[str, str]:
+    """Read the ``artifacts.json`` manifest ``O_NOFOLLOW`` under ``base_fd``.
+
+    The fd-relative counterpart of :func:`_load_manifest`: a symlinked manifest
+    is refused (``O_NOFOLLOW`` raises), matching the pathname side's symlink
+    check, and the read never leaves the held directory. Same tolerant contract
+    -- any error yields ``{}`` and falls back to filename convention.
+    """
+    info = _fsafe.stat_at(base_fd, RETENTION_MANIFEST_NAME)
+    if info is None:
+        return {}
+    if stat.S_ISLNK(info.st_mode):
+        log.warning(
+            "retention: %s is a symlink; treating as malformed and falling back "
+            "to filename convention",
+            RETENTION_MANIFEST_NAME,
+        )
+        return {}
+    if not stat.S_ISREG(info.st_mode):
+        return {}
+    try:
+        with _fsafe.secure_open_read(
+            base_fd, RETENTION_MANIFEST_NAME, encoding="utf-8"
+        ) as stream:
+            raw = json.loads(stream.read())
+    except (OSError, ValueError) as exc:
+        log.warning(
+            "retention: ignoring malformed %s (%s); falling back to filename "
+            "convention",
+            RETENTION_MANIFEST_NAME,
+            exc,
+        )
+        return {}
+    return _manifest_mapping(raw)
 
 
 def _iter_trial_files(trial_dir: Path, kept: list[str]) -> list[Path]:

--- a/src/aorta/run/retention.py
+++ b/src/aorta/run/retention.py
@@ -40,6 +40,7 @@ is not the record or a known log is heavy).
 
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import os
@@ -224,7 +225,10 @@ def _manifest_mapping(raw: object) -> dict[str, str]:
 
 
 def apply_retention(
-    trial_dir: Path, level: str, *, trusted_root: Path | None = None
+    trial_dir: Path,
+    level: str,
+    *,
+    trusted_root: _fsafe.TrustedAnchor | Path | None = None,
 ) -> RetentionOutcome:
     """Prune ``trial_dir`` to the artifacts kept by retention ``level``.
 
@@ -251,7 +255,10 @@ def apply_retention(
       that replaces an ancestor between the check and a delete cannot redirect
       it, closing the time-of-check/time-of-use window. ``trusted_root`` is the
       operator's canonical ``--results-dir`` and ``trial_dir`` must be lexically
-      inside it.
+      inside it. Pass a :class:`~aorta.run._fsafe.TrustedAnchor` (rather than a
+      bare path) to also pin the anchor's inode, so a payload that renamed the
+      results directory aside and moved a real directory into its pathname is
+      refused; a bare path keeps the no-follow-only descent.
     * **Omitted** (the operator-written trial record tree, not handed to the
       payload) or on a platform without the fd primitives: the historical
       ``os.walk(..., followlinks=False)`` + ``resolve()``-containment body runs,
@@ -323,7 +330,7 @@ def apply_retention(
 
 
 def _apply_retention_fd(
-    trial_dir: Path, level: str, trusted_root: Path
+    trial_dir: Path, level: str, trusted_root: _fsafe.TrustedAnchor | Path
 ) -> RetentionOutcome:
     """Race-free :func:`apply_retention` for the payload-writable collector tree.
 
@@ -336,12 +343,13 @@ def _apply_retention_fd(
     nor unlinked. Tolerant like the pathname engine: a delete that fails keeps
     the file and warns.
     """
-    components = _fsafe.relative_components(trusted_root, trial_dir)
+    anchor = _fsafe.as_anchor(trusted_root)
+    components = _fsafe.relative_components(anchor.path, trial_dir)
     if components is None:
         log.warning(
             "retention: %s is not inside the trusted root %s; keeping everything",
             trial_dir,
-            trusted_root,
+            anchor.path,
         )
         return RetentionOutcome(level=level, no_op=True)
 
@@ -350,7 +358,7 @@ def _apply_retention_fd(
     kept: list[str] = []
     freed = 0
     try:
-        with _fsafe.open_dir_nofollow(trusted_root, components) as base_fd:
+        with _fsafe.open_dir_nofollow(anchor, components) as base_fd:
             manifest = _load_manifest_fd(base_fd)
             for rel, dir_fd, name, size in _fsafe.iter_regular_files(base_fd):
                 cls = classify_artifact(rel, manifest)
@@ -369,6 +377,13 @@ def _apply_retention_fd(
                 deleted.append(rel)
             _fsafe.prune_empty_dirs(base_fd)
     except _fsafe.UnsafePathError as exc:
+        if exc.errno == errno.ENOENT:
+            # Nothing was written under this tree (a validated-only collector,
+            # or a command that produced no artifacts). The pathname engine
+            # treats a missing ``trial_dir`` as a no-op too, and an operator
+            # warning would read as a refusal where there is nothing to refuse.
+            log.debug("retention: %s does not exist; nothing to prune", trial_dir)
+            return RetentionOutcome(level=level, no_op=True)
         # A component of the collector tree was a symlink after the run: refuse
         # to prune through it, keeping the artifacts. Mirrors the pathname
         # engine's "skip + warn, never abort" tolerance.

--- a/src/aorta/run/retention.py
+++ b/src/aorta/run/retention.py
@@ -247,8 +247,8 @@ def apply_retention(
 
     ``trusted_root`` selects the traversal strategy:
 
-    * **Given** (the collector artifact tree, which the profiled payload is
-      handed and can swap mid-run): on POSIX the whole prune runs
+    * **Given** (any artifact tree a same-user payload can swap mid-run): on
+      POSIX the whole prune runs
       **fd-relative** -- ``trial_dir`` is reached by descending from
       ``trusted_root`` with ``O_NOFOLLOW`` on every component, and every stat /
       unlink / rmdir is performed relative to the held directory fds. A payload
@@ -259,8 +259,8 @@ def apply_retention(
       bare path) to also pin the anchor's inode, so a payload that renamed the
       results directory aside and moved a real directory into its pathname is
       refused; a bare path keeps the no-follow-only descent.
-    * **Omitted** (the operator-written trial record tree, not handed to the
-      payload) or on a platform without the fd primitives: the historical
+    * **Omitted** (a direct caller with no declared trust boundary) or on a
+      platform without the fd primitives: the historical
       ``os.walk(..., followlinks=False)`` + ``resolve()``-containment body runs,
       which never descends a symlinked subdirectory and refuses to delete a path
       that dereferences outside ``trial_dir``.
@@ -332,16 +332,16 @@ def apply_retention(
 def _apply_retention_fd(
     trial_dir: Path, level: str, trusted_root: _fsafe.TrustedAnchor | Path
 ) -> RetentionOutcome:
-    """Race-free :func:`apply_retention` for the payload-writable collector tree.
+    """Race-free :func:`apply_retention` for a payload-writable artifact tree.
 
     Descends from ``trusted_root`` to ``trial_dir`` with ``O_NOFOLLOW`` on every
     component and holds the resulting directory fd, then classifies and deletes
     each file relative to the fds returned by :func:`aorta.run._fsafe`. Because
     no step re-resolves a pathname, a payload that swaps an ancestor after the
     descent cannot redirect a delete outside the results tree. Symlinked files
-    and subdirectories are never yielded by the walk, so they are neither read
-    nor unlinked. Tolerant like the pathname engine: a delete that fails keeps
-    the file and warns.
+    and subdirectories are yielded as links, recorded as kept with a warning,
+    and never read, followed, or unlinked. Tolerant like the pathname engine: a
+    delete that fails keeps the file and warns.
     """
     anchor = _fsafe.as_anchor(trusted_root)
     components = _fsafe.relative_components(anchor.path, trial_dir)
@@ -360,7 +360,13 @@ def _apply_retention_fd(
     try:
         with _fsafe.open_dir_nofollow(anchor, components) as base_fd:
             manifest = _load_manifest_fd(base_fd)
-            for rel, dir_fd, name, size in _fsafe.iter_regular_files(base_fd):
+            for rel, dir_fd, name, info in _fsafe.iter_entries(base_fd):
+                if stat.S_ISLNK(info.st_mode):
+                    log.warning("retention: skipping symlink %s; not pruning it", rel)
+                    kept.append(rel)
+                    continue
+                if not stat.S_ISREG(info.st_mode):
+                    continue
                 cls = classify_artifact(rel, manifest)
                 if cls == RECORD or _CLASS_RANK[cls] <= level_rank:
                     kept.append(rel)
@@ -373,7 +379,7 @@ def _apply_retention_fd(
                     )
                     kept.append(rel)
                     continue
-                freed += size
+                freed += info.st_size
                 deleted.append(rel)
             _fsafe.prune_empty_dirs(base_fd)
     except _fsafe.UnsafePathError as exc:

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -1139,8 +1139,8 @@ class SubprocessWorkload(Workload):
         """
         from aorta.run.collectors import (
             CONFIG_KEY_COLLECT_DIR,
-            CONFIG_KEY_RESULTS_ROOT,
             active_collectors,
+            trusted_results_anchor,
             unsafe_collector_paths,
         )
 
@@ -1158,8 +1158,10 @@ class SubprocessWorkload(Workload):
         # relative to the held directory fds, so a swap of any ancestor after
         # the check cannot redirect the prune outside the results tree -- the
         # time-of-check/time-of-use window the pathname guard could not close.
-        raw_root = self.config.get(CONFIG_KEY_RESULTS_ROOT)
-        trusted_root = Path(raw_root) if isinstance(raw_root, str) and raw_root else None
+        # The anchor carries the inode the results directory had before launch,
+        # so a rename that moved a real directory into that pathname is refused
+        # as well as a symlink.
+        trusted_root = trusted_results_anchor(self.config)
         # Fast pre-filter (and the source of the "kept" log line): on the
         # non-POSIX fallback path there is no fd engine, so this lexical check is
         # the guard; on POSIX it is a cheap probe and the fd engine is

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -1140,7 +1140,7 @@ class SubprocessWorkload(Workload):
         from aorta.run.collectors import (
             CONFIG_KEY_COLLECT_DIR,
             active_collectors,
-            trusted_results_anchor,
+            trusted_collector_anchor,
             unsafe_collector_paths,
         )
 
@@ -1160,8 +1160,12 @@ class SubprocessWorkload(Workload):
         # time-of-check/time-of-use window the pathname guard could not close.
         # The anchor carries the inode the results directory had before launch,
         # so a rename that moved a real directory into that pathname is refused
-        # as well as a symlink.
-        trusted_root = trusted_results_anchor(self.config)
+        # as well as a symlink. Taken from the same helper the pre-filter below
+        # uses, including its ``collect_root.parent`` fallback: a direct or
+        # legacy config that threads ``_aorta_collect_dir`` without
+        # ``_aorta_results_root`` must still get the fd-relative engine, or the
+        # pre-filter guards a pathname that the prune then re-resolves.
+        trusted_root = trusted_collector_anchor(self.config, collect_root)
         # Fast pre-filter (and the source of the "kept" log line): on the
         # non-POSIX fallback path there is no fd engine, so this lexical check is
         # the guard; on POSIX it is a cheap probe and the fd engine is

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -136,6 +136,78 @@ _TERMINATE_GRACE_SEC = 10.0
 _REAP_AFTER_KILL_SEC = 1.0
 
 
+def _terminate_surviving_process_group(
+    pgid: int, grace_sec: float = _TERMINATE_GRACE_SEC
+) -> None:
+    """Stop descendants left behind after their process-group leader exits.
+
+    ``Popen.wait()`` only reaps the direct child. A successful shell or
+    profiler can exit while a background descendant in the child's process
+    group remains alive; that descendant must be gone before post-run
+    collector parsing and retention use pathname-based guards. Because the
+    direct child led a new session, its pid is the stable process-group id even
+    after that leader has been reaped.
+
+    The common case has no surviving group and returns on ``ESRCH`` without
+    sleeping. A live group gets SIGTERM and a bounded grace period, then
+    SIGKILL. Polling with signal 0 closes the gap between queueing the signal
+    and allowing post-run filesystem operations to begin.
+    """
+    if pgid == os.getpgrp():
+        log.warning(
+            "refusing to clean up child process group %d because it is the "
+            "aorta process group",
+            pgid,
+        )
+        return
+
+    def _signal(sig: int) -> bool:
+        try:
+            os.killpg(pgid, sig)
+            return True
+        except ProcessLookupError:
+            return False
+        except OSError as exc:
+            log.warning(
+                "killpg(%d, %s) failed after the process leader exited: %s; "
+                "background descendants may still be running",
+                pgid,
+                signal.Signals(sig).name,
+                exc,
+            )
+            return False
+
+    def _alive() -> bool:
+        try:
+            os.killpg(pgid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # A group we cannot signal still exists; let the subsequent
+            # delivery attempt report the actionable EPERM warning.
+            return True
+
+    if not _signal(signal.SIGTERM):
+        return
+    try:
+        deadline = time.monotonic() + grace_sec
+        while _alive() and time.monotonic() < deadline:
+            time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
+        if not _alive():
+            return
+        if not _signal(signal.SIGKILL):
+            return
+        deadline = time.monotonic() + min(grace_sec, _REAP_AFTER_KILL_SEC)
+        while _alive() and time.monotonic() < deadline:
+            time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
+    except KeyboardInterrupt:
+        # Match _terminate_process_tree's interrupt discipline: never let a
+        # second Ctrl-C abandon a group that is keeping collector paths live.
+        _signal(signal.SIGKILL)
+        raise
+
+
 def _terminate_process_tree(
     proc: subprocess.Popen, grace_sec: float = _TERMINATE_GRACE_SEC
 ) -> None:
@@ -576,6 +648,18 @@ class SubprocessWorkload(Workload):
                     )
                     hang_monitor.start()
                     exit_code = proc.wait(timeout=timeout)
+                    from aorta.run.collectors import active_collectors
+
+                    if active_collectors(self.config):
+                        # A successful leader can leave shell/profiler
+                        # background descendants alive. They share the leader's
+                        # process group because Popen created a new session;
+                        # tear that group down before collector parsing or
+                        # retention performs pathname checks and operations.
+                        # Runs only for collected trials: uncollected probe
+                        # commands retain their historical ability to launch a
+                        # deliberate background service.
+                        _terminate_surviving_process_group(proc.pid)
                 except subprocess.TimeoutExpired:
                     timed_out = True
                     # Tear down the whole child process group, not just the

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -50,7 +50,7 @@ import stat
 import subprocess
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO, TextIO
 
 from aorta.probe.classifier import TrialContext, classify_trial
 from aorta.probe.classifier.tier1_process import (
@@ -75,6 +75,7 @@ from aorta.probe.classifier.verdict import (
     partition_detectors,
     verdict_from_detectors,
 )
+from aorta.run import _fsafe
 from aorta.run.retention import RetentionOutcome, apply_retention
 from aorta.workloads._base import Workload, WorkloadResult
 
@@ -97,6 +98,92 @@ _TIER3_STATE = Tier3State()
 # clock and to catch messages logged a few seconds after the child
 # crashed (e.g. amdgpu reset messages often arrive on the next tick).
 _DMESG_SINCE_PAD_SEC = 5.0
+
+
+@dataclasses.dataclass(frozen=True)
+class _TrialFiles:
+    """Fd-relative access to one payload-writable probe trial directory."""
+
+    path: Path
+    anchor: _fsafe.TrustedAnchor
+
+    @classmethod
+    def create(cls, config: dict[str, Any], path: Path) -> _TrialFiles:
+        """Create ``path`` below the threaded results anchor without links."""
+        from aorta.run.collectors import trusted_collector_anchor
+
+        anchor = trusted_collector_anchor(config, path)
+        files = cls(path, anchor)
+        if not _fsafe.HAVE_FD_TRAVERSAL:
+            path.mkdir(parents=True, exist_ok=True)
+            return files
+        try:
+            with _fsafe.open_dir_nofollow(
+                anchor, files._components(), create_missing=True
+            ):
+                pass
+        except _fsafe.UnsafePathError as exc:
+            raise RuntimeError(
+                f"refusing to create probe trial directory {path}: a component "
+                f"below the trusted results root {anchor.path} is unsafe ({exc})"
+            ) from exc
+        return files
+
+    def _components(self) -> list[str]:
+        components = _fsafe.relative_components(self.anchor.path, self.path)
+        if components is None:
+            raise _fsafe.UnsafePathError(
+                f"probe trial directory {self.path} is outside "
+                f"trusted results root {self.anchor.path}"
+            )
+        return components
+
+    def open_text(
+        self,
+        name: str,
+        *,
+        permissions: int | None = None,
+        **text_kwargs: object,
+    ) -> TextIO:
+        if not _fsafe.HAVE_FD_TRAVERSAL:
+            stream = open(self.path / name, "w", **text_kwargs)
+            if permissions is not None:
+                try:
+                    os.fchmod(stream.fileno(), permissions)
+                except OSError:
+                    pass
+            return stream
+        with _fsafe.open_dir_nofollow(self.anchor, self._components()) as dir_fd:
+            return _fsafe.open_write_nofollow(
+                dir_fd, name, permissions=permissions, **text_kwargs
+            )
+
+    def open_binary(self, name: str) -> BinaryIO:
+        if not _fsafe.HAVE_FD_TRAVERSAL:
+            return open(self.path / name, "wb")
+        with _fsafe.open_dir_nofollow(self.anchor, self._components()) as dir_fd:
+            return _fsafe.open_write_binary_nofollow(dir_fd, name)
+
+    def read_bytes(self, name: str, limit: int) -> bytes:
+        if not _fsafe.HAVE_FD_TRAVERSAL:
+            return (self.path / name).read_bytes()[:limit]
+        with _fsafe.open_dir_nofollow(self.anchor, self._components()) as dir_fd:
+            with _fsafe.secure_open_read_binary(dir_fd, name) as stream:
+                return stream.read(limit)
+
+    def unlink(self, name: str) -> None:
+        if not _fsafe.HAVE_FD_TRAVERSAL:
+            (self.path / name).unlink(missing_ok=True)
+            return
+        with _fsafe.open_dir_nofollow(self.anchor, self._components()) as dir_fd:
+            try:
+                os.unlink(name, dir_fd=dir_fd)
+            except FileNotFoundError:
+                pass
+
+    def write_json(self, name: str, document: dict[str, Any]) -> None:
+        with self.open_text(name, encoding="utf-8") as stream:
+            json.dump(document, stream, indent=2, sort_keys=False)
 
 # Config key the dispatcher uses to deliver the opaque user argv. The
 # leading ``_aorta_`` prefix is reserved by the dispatcher and rejected
@@ -285,6 +372,7 @@ class SubprocessWorkload(Workload):
         super().__init__(config)
         self._argv: tuple[str, ...] | None = None
         self._trial_dir: Path | None = None
+        self._trial_files: _TrialFiles | None = None
         self._trial_index: int | None = None
 
     def setup(self) -> None:
@@ -376,7 +464,7 @@ class SubprocessWorkload(Workload):
         # ``<cell>/trial_<n>/{stdout,stderr,result}`` layout.
         cell_dir = Path(log_prefix).parent.parent
         self._trial_dir = cell_dir / f"trial_{self._trial_index}"
-        self._trial_dir.mkdir(parents=True, exist_ok=True)
+        self._trial_files = _TrialFiles.create(self.config, self._trial_dir)
 
     def run(self) -> WorkloadResult:
         """Fork the user command and write the Phase-2 ``result.json``.
@@ -391,13 +479,18 @@ class SubprocessWorkload(Workload):
         pass without modification because Phase 2 only ADDS keys
         to ``result.json``.
         """
-        if self._argv is None or self._trial_dir is None or self._trial_index is None:
+        if (
+            self._argv is None
+            or self._trial_dir is None
+            or self._trial_files is None
+            or self._trial_index is None
+        ):
             raise RuntimeError("SubprocessWorkload.run() called before setup()")
 
         argv = self._argv
         trial_dir = self._trial_dir
+        trial_files = self._trial_files
         stdout_path = trial_dir / "stdout.log"
-        stderr_path = trial_dir / "stderr.log"
         result_path = trial_dir / "result.json"
 
         probe_extras = self.config.get(CONFIG_KEY_PROBE_EXTRAS) or {}
@@ -463,7 +556,7 @@ class SubprocessWorkload(Workload):
         env_file_path = trial_dir / "probe.env"
         if env_mode == "file":
             try:
-                _write_env_file(env_file_path, cell_env_snapshot)
+                _write_env_file(trial_files, cell_env_snapshot)
             except ValueError as exc:
                 # ``_write_env_file`` rejects hostile/malformed mitigation
                 # keys/values (newlines, '=' in key, etc.) by raising
@@ -489,9 +582,7 @@ class SubprocessWorkload(Workload):
                 # subprocess that exited non-zero.
                 return self._write_env_file_failure_result(
                     exc=exc,
-                    result_path=result_path,
-                    stderr_path=stderr_path,
-                    env_file_path=env_file_path,
+                    trial_files=trial_files,
                     argv=argv,
                     probe_extras=probe_extras,
                     env_mode=env_mode,
@@ -509,7 +600,7 @@ class SubprocessWorkload(Workload):
             # ``AORTA_ENV_FILE`` exported, which is at best confusing
             # and at worst points downstream tooling at stale env
             # contents.
-            env_file_path.unlink(missing_ok=True)
+            trial_files.unlink("probe.env")
 
         # Tier 3 pre-snapshot. Fail-soft: returns None when ``amd-smi``
         # is missing or polling fails; ``scan_amd_smi`` then accepts
@@ -534,7 +625,9 @@ class SubprocessWorkload(Workload):
         launched = False
         hang_monitor: HangMonitor | None = None
         try:
-            with open(stdout_path, "wb") as out_fh, open(stderr_path, "wb") as err_fh:
+            with trial_files.open_binary(
+                "stdout.log"
+            ) as out_fh, trial_files.open_binary("stderr.log") as err_fh:
                 proc = subprocess.Popen(
                     list(argv),
                     stdout=out_fh,
@@ -633,7 +726,8 @@ class SubprocessWorkload(Workload):
             else:
                 exit_code = 1
             try:
-                stderr_path.write_text(f"{exc}\n", encoding="utf-8")
+                with trial_files.open_text("stderr.log", encoding="utf-8") as stream:
+                    stream.write(f"{exc}\n")
             except OSError:
                 pass
         walltime_sec = time.perf_counter() - t0
@@ -643,7 +737,7 @@ class SubprocessWorkload(Workload):
         # the ``with`` block. Errors here MUST NOT propagate (the
         # workload already succeeded or failed; classifier crashes
         # are bugs, not trial outcomes).
-        log_text = _read_log_text(stdout_path, stderr_path)
+        log_text = _read_log_text(trial_files)
         hang_detected = bool(hang_monitor and hang_monitor.hang_detected)
         # Reconcile the latched hang flag against the actual exit.
         #
@@ -845,10 +939,7 @@ class SubprocessWorkload(Workload):
             result_doc["capture"]["disabled_detector_tiers"] = sorted(
                 effective_disabled_tiers
             )
-        result_path.write_text(
-            json.dumps(result_doc, indent=2, sort_keys=False),
-            encoding="utf-8",
-        )
+        trial_files.write_json("result.json", result_doc)
 
         # Collector summaries ride the same ``metrics`` channel as the verdict
         # bookkeeping, so the numeric ones (``rocprof_gpu_time_ms`` etc.) land
@@ -879,10 +970,7 @@ class SubprocessWorkload(Workload):
         )
         if retention_outcome is not None:
             self._record_retention(result_doc, retention_outcome)
-            result_path.write_text(
-                json.dumps(result_doc, indent=2, sort_keys=False),
-                encoding="utf-8",
-            )
+            trial_files.write_json("result.json", result_doc)
 
         # ``main_work_started`` / ``executed_iterations`` mirror
         # whether ``Popen`` actually launched a child. A normal
@@ -935,9 +1023,7 @@ class SubprocessWorkload(Workload):
         self,
         *,
         exc: ValueError,
-        result_path: Path,
-        stderr_path: Path,
-        env_file_path: Path,
+        trial_files: _TrialFiles,
         argv: tuple[str, ...],
         probe_extras: dict[str, Any],
         env_mode: str,
@@ -961,9 +1047,10 @@ class SubprocessWorkload(Workload):
         validation rejection and contradict
         ``result.json::failure_type==env_file_validation_failed``.
         """
-        env_file_path.unlink(missing_ok=True)
+        trial_files.unlink("probe.env")
         try:
-            stderr_path.write_text(f"{exc}\n", encoding="utf-8")
+            with trial_files.open_text("stderr.log", encoding="utf-8") as stream:
+                stream.write(f"{exc}\n")
         except OSError:
             pass
         result_doc: dict[str, Any] = {
@@ -1010,24 +1097,18 @@ class SubprocessWorkload(Workload):
             "failure_type": "env_file_validation_failed",
             "error_message": str(exc),
         }
-        result_path.write_text(
-            json.dumps(result_doc, indent=2, sort_keys=False),
-            encoding="utf-8",
-        )
+        trial_files.write_json("result.json", result_doc)
         # Issue #231: honor ``retain.on_error`` for this infra-error trial
         # too (mirrors the main run() path). The probe.env was already
         # unlinked above; this prunes any other heavy artifacts a prior
         # resume left in the reused trial dir. Stamp the outcome back into
         # result.json so the applied level is auditable here too (oyazdanb).
         retention_outcome = self._apply_retention(
-            result_path.parent, "error", probe_extras
+            trial_files.path, "error", probe_extras
         )
         if retention_outcome is not None:
             self._record_retention(result_doc, retention_outcome)
-            result_path.write_text(
-                json.dumps(result_doc, indent=2, sort_keys=False),
-                encoding="utf-8",
-            )
+            trial_files.write_json("result.json", result_doc)
         return WorkloadResult(
             passed=False,
             failure_count=1,
@@ -1049,7 +1130,7 @@ class SubprocessWorkload(Workload):
             metrics={
                 "verdict": "error",
                 "exit_code": 2,
-                "result_json_path": str(result_path),
+                "result_json_path": str(trial_files.path / "result.json"),
                 "failure_detectors_fired": [],
                 "error_detectors_fired": ["meta:env_file_validation_failed"],
                 "warn_detectors_fired": [],
@@ -1095,7 +1176,10 @@ class SubprocessWorkload(Workload):
             return None
         level = retain.get(f"on_{verdict}", "full")
         try:
-            outcome = apply_retention(trial_dir, level)
+            trusted_root = (
+                self._trial_files.anchor if self._trial_files is not None else None
+            )
+            outcome = apply_retention(trial_dir, level, trusted_root=trusted_root)
         except Exception as exc:  # noqa: BLE001 -- retention is best-effort
             log.warning(
                 "retention: pruning %s at level %r failed (%s); artifacts kept",
@@ -1344,7 +1428,7 @@ def _failure_detail_type(*, launched: bool, timed_out: bool, exit_code: int) -> 
     return "detector_failure"
 
 
-def _read_log_text(stdout_path: Path, stderr_path: Path) -> str:
+def _read_log_text(trial_files: _TrialFiles) -> str:
     """Read stdout + stderr back as a single text blob for the classifier.
 
     Reads are bounded to :data:`aorta.probe.sandbox.MAX_LOG_BYTES`
@@ -1367,9 +1451,9 @@ def _read_log_text(stdout_path: Path, stderr_path: Path) -> str:
     from aorta.probe.sandbox import MAX_LOG_BYTES
 
     parts: list[str] = []
-    for path in (stdout_path, stderr_path):
+    for name in ("stdout.log", "stderr.log"):
         try:
-            data = path.read_bytes()[:MAX_LOG_BYTES]
+            data = trial_files.read_bytes(name, MAX_LOG_BYTES)
             parts.append(data.decode("utf-8", errors="replace"))
         except FileNotFoundError:
             parts.append("")
@@ -1458,23 +1542,16 @@ def _tier1_only_fallback_verdict(
     return verdict, tier_durations_ms
 
 
-def _write_env_file(path: Path, env: dict[str, str]) -> None:
+def _write_env_file(trial_files: _TrialFiles, env: dict[str, str]) -> None:
     """Write a POSIX KEY=VALUE\\n env file at ``chmod 0600``.
 
     Atomic with respect to validation failure: ``_validate_env_file_entries``
-    runs the full key/value check BEFORE we ``os.open(..., O_TRUNC)``, so
-    a hostile or malformed bundle either produces a complete + correct
-    file or leaves the path untouched. The previous interleaved shape
-    (open-truncate first, validate per-row while writing) could leave a
-    partial probe.env from rows 1..N-1 when row N was rejected. That
-    file looked legitimate (0600, KEY=VALUE shape) but contained only
-    a subset of the cell's bundle -- exactly the misleading artifact
-    the round-6 review flagged.
+    runs the full key/value check before the fd-relative writer opens the leaf,
+    so a hostile or malformed bundle either produces a complete + correct file
+    or leaves the path untouched. The writer also rejects links and special
+    files before truncation.
 
-    The 0600 mode is set via ``os.O_CREAT`` mode bits on platforms
-    that honour them, and chmod'd after as a belt-and-suspenders for
-    filesystems that ignore the open-mode (NFS without root squash,
-    some FUSE backends).
+    The 0600 mode is applied to the held descriptor before content is written.
 
     Per R5 in the rubric, the env file is the leakage surface for
     secrets in ``file`` mode; Phase 3 redaction scrubs these from the
@@ -1482,16 +1559,13 @@ def _write_env_file(path: Path, env: dict[str, str]) -> None:
     """
     _validate_env_file_entries(env)
 
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            for key in sorted(env):
-                fh.write(f"{key}={env[key]}\n")
-    finally:
-        try:
-            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+    with trial_files.open_text(
+        "probe.env",
+        permissions=stat.S_IRUSR | stat.S_IWUSR,
+        encoding="utf-8",
+    ) as fh:
+        for key in sorted(env):
+            fh.write(f"{key}={env[key]}\n")
 
 
 __all__ = [

--- a/src/aorta/workloads/_subprocess.py
+++ b/src/aorta/workloads/_subprocess.py
@@ -136,78 +136,6 @@ _TERMINATE_GRACE_SEC = 10.0
 _REAP_AFTER_KILL_SEC = 1.0
 
 
-def _terminate_surviving_process_group(
-    pgid: int, grace_sec: float = _TERMINATE_GRACE_SEC
-) -> None:
-    """Stop descendants left behind after their process-group leader exits.
-
-    ``Popen.wait()`` only reaps the direct child. A successful shell or
-    profiler can exit while a background descendant in the child's process
-    group remains alive; that descendant must be gone before post-run
-    collector parsing and retention use pathname-based guards. Because the
-    direct child led a new session, its pid is the stable process-group id even
-    after that leader has been reaped.
-
-    The common case has no surviving group and returns on ``ESRCH`` without
-    sleeping. A live group gets SIGTERM and a bounded grace period, then
-    SIGKILL. Polling with signal 0 closes the gap between queueing the signal
-    and allowing post-run filesystem operations to begin.
-    """
-    if pgid == os.getpgrp():
-        log.warning(
-            "refusing to clean up child process group %d because it is the "
-            "aorta process group",
-            pgid,
-        )
-        return
-
-    def _signal(sig: int) -> bool:
-        try:
-            os.killpg(pgid, sig)
-            return True
-        except ProcessLookupError:
-            return False
-        except OSError as exc:
-            log.warning(
-                "killpg(%d, %s) failed after the process leader exited: %s; "
-                "background descendants may still be running",
-                pgid,
-                signal.Signals(sig).name,
-                exc,
-            )
-            return False
-
-    def _alive() -> bool:
-        try:
-            os.killpg(pgid, 0)
-            return True
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            # A group we cannot signal still exists; let the subsequent
-            # delivery attempt report the actionable EPERM warning.
-            return True
-
-    if not _signal(signal.SIGTERM):
-        return
-    try:
-        deadline = time.monotonic() + grace_sec
-        while _alive() and time.monotonic() < deadline:
-            time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
-        if not _alive():
-            return
-        if not _signal(signal.SIGKILL):
-            return
-        deadline = time.monotonic() + min(grace_sec, _REAP_AFTER_KILL_SEC)
-        while _alive() and time.monotonic() < deadline:
-            time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
-    except KeyboardInterrupt:
-        # Match _terminate_process_tree's interrupt discipline: never let a
-        # second Ctrl-C abandon a group that is keeping collector paths live.
-        _signal(signal.SIGKILL)
-        raise
-
-
 def _terminate_process_tree(
     proc: subprocess.Popen, grace_sec: float = _TERMINATE_GRACE_SEC
 ) -> None:
@@ -648,18 +576,6 @@ class SubprocessWorkload(Workload):
                     )
                     hang_monitor.start()
                     exit_code = proc.wait(timeout=timeout)
-                    from aorta.run.collectors import active_collectors
-
-                    if active_collectors(self.config):
-                        # A successful leader can leave shell/profiler
-                        # background descendants alive. They share the leader's
-                        # process group because Popen created a new session;
-                        # tear that group down before collector parsing or
-                        # retention performs pathname checks and operations.
-                        # Runs only for collected trials: uncollected probe
-                        # commands retain their historical ability to launch a
-                        # deliberate background service.
-                        _terminate_surviving_process_group(proc.pid)
                 except subprocess.TimeoutExpired:
                     timed_out = True
                     # Tear down the whole child process group, not just the
@@ -1223,6 +1139,7 @@ class SubprocessWorkload(Workload):
         """
         from aorta.run.collectors import (
             CONFIG_KEY_COLLECT_DIR,
+            CONFIG_KEY_RESULTS_ROOT,
             active_collectors,
             unsafe_collector_paths,
         )
@@ -1233,15 +1150,21 @@ class SubprocessWorkload(Workload):
         if not isinstance(raw, str) or not raw:
             return outcome
         collect_root = Path(raw)
-        # Re-checked here, after the command ran, and not only by the pre-launch
-        # reset: the payload is handed this path and can replace the directory
-        # with a symlink while it executes. ``is_dir()`` and
-        # ``apply_retention()`` both follow links, so pruning through one would
-        # delete files in the link's target -- outside the results tree, at any
-        # level below ``full``. Keep the artifacts rather than risk that.
-        #
-        # Every collector subdirectory is checked, not just the shared root:
-        # ``apply_retention`` recurses into ``<root>/rocprof`` and
+        # The payload is handed this path and can replace the directory with a
+        # symlink while it executes, so the delete must not follow links. When
+        # the dispatcher threaded the trusted ``--results-dir`` anchor,
+        # ``apply_retention`` runs its fd-relative engine: it descends to
+        # ``collect_root`` with ``O_NOFOLLOW`` on every component and deletes
+        # relative to the held directory fds, so a swap of any ancestor after
+        # the check cannot redirect the prune outside the results tree -- the
+        # time-of-check/time-of-use window the pathname guard could not close.
+        raw_root = self.config.get(CONFIG_KEY_RESULTS_ROOT)
+        trusted_root = Path(raw_root) if isinstance(raw_root, str) and raw_root else None
+        # Fast pre-filter (and the source of the "kept" log line): on the
+        # non-POSIX fallback path there is no fd engine, so this lexical check is
+        # the guard; on POSIX it is a cheap probe and the fd engine is
+        # authoritative. Every collector subdirectory is checked, not just the
+        # shared root -- ``apply_retention`` recurses into ``<root>/rocprof`` and
         # ``<root>/proton``, so swapping one of those is the same exposure one
         # level down.
         unsafe = unsafe_collector_paths(self.config)
@@ -1252,10 +1175,8 @@ class SubprocessWorkload(Workload):
                 ", ".join(str(path) for path in unsafe),
             )
             return outcome
-        if not collect_root.is_dir():
-            return outcome
         try:
-            collected = apply_retention(collect_root, level)
+            collected = apply_retention(collect_root, level, trusted_root=trusted_root)
         except Exception as exc:  # noqa: BLE001 -- retention is best-effort
             log.warning(
                 "retention: pruning collector artifacts in %s at level %r "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,48 @@ except Exception:
         del sys.modules[_mod]
 
 
+class BlockedTooLong(BaseException):
+    """A call guarded by :func:`no_hang` did not return in time.
+
+    Deliberately a :class:`BaseException` rather than an :class:`Exception`.
+    The code under test is exactly the kind that catches broadly -- collector
+    summarization swallows ``Exception`` so an opt-in measurement can never fail
+    a healthy trial, and the artifact reader skips on ``OSError`` -- and
+    ``TimeoutError`` is an ``OSError``, so a timeout raised as one gets absorbed
+    and the test passes while the code hangs. Sitting outside ``Exception`` is
+    what makes the alarm reach the test runner.
+    """
+
+
+@pytest.fixture
+def no_hang():
+    """Bound a call that could block forever, failing instead of stalling.
+
+    Yields a context-manager factory: ``with no_hang(5): ...``. Use it where the
+    defect under test is an indefinite block rather than a wrong value, so a
+    regression surfaces as a failure. ``SIGALRM`` is the mechanism because the
+    block happens inside a single syscall, which a thread-based watchdog cannot
+    interrupt. Main-thread only, like any signal-based timeout.
+    """
+    import contextlib
+    import signal
+
+    @contextlib.contextmanager
+    def _guard(seconds: int = 10):
+        def _raise(_signum, _frame):
+            raise BlockedTooLong(f"blocked for more than {seconds}s")
+
+        previous = signal.signal(signal.SIGALRM, _raise)
+        signal.alarm(seconds)
+        try:
+            yield
+        finally:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, previous)
+
+    return _guard
+
+
 @pytest.fixture
 def sample_trace_event():
     """Create a sample trace event for testing."""

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -8,6 +8,7 @@ translation Proton needs on AMD, and fail-soft ``.hatchet`` parsing.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -24,11 +25,13 @@ from aorta.instrumentation.proton import (
     PROTON_MODULE,
     QUEUE_INTERCEPTING_BACKENDS,
     ProtonWrapError,
+    _parse,
     build_argv_prefix,
     build_env,
     mode_argument,
     parse_profile,
     parse_summary,
+    parse_summary_from_streams,
     resolve_python,
     validate_options,
     wrap_argv,
@@ -1056,3 +1059,57 @@ def test_parse_profile_missing_file_is_empty(tmp_path):
 def test_parse_summary_accepts_str_path(tmp_path):
     _hatchet(tmp_path, _tree([_leaf("k", 1_000_000)]))
     assert parse_summary(str(tmp_path))["proton_top_kernels"] == ["k"]
+
+
+def test_parse_summary_holds_one_profile_open_at_a_time(tmp_path):
+    """A per-rank capture must not need a descriptor per rank.
+
+    Proton writes a profile per rank, so a large distributed run can hold more
+    ``.hatchet`` files than ``RLIMIT_NOFILE`` allows; opening them all up front
+    hit ``EMFILE`` partway through and reported totals covering only the ranks
+    before the limit. The count is compared across two tree sizes because an
+    absolute bound would pass for the eager version on a small tree.
+    """
+    if not Path("/proc/self/fd").is_dir():
+        pytest.skip("descriptor accounting needs /proc")
+
+    def peak_open_fds(root, ranks):
+        root.mkdir()
+        for rank in range(ranks):
+            _hatchet(root, _tree([_leaf("k", 1_000_000)]), name=f"rank{rank:03d}.hatchet")
+        parse_summary(root)  # warm any lazy imports before the baseline
+        baseline = len(os.listdir("/proc/self/fd"))
+        seen = []
+        original = _parse.parse_profile_stream
+
+        def counting_parse(stream):
+            seen.append(len(os.listdir("/proc/self/fd")))
+            return original(stream)
+
+        _parse.parse_profile_stream = counting_parse
+        try:
+            metrics = parse_summary(root)
+        finally:
+            _parse.parse_profile_stream = original
+        assert metrics["proton_kernel_count"] == ranks
+        assert len(seen) == ranks
+        return max(seen) - baseline
+
+    small = peak_open_fds(tmp_path / "small", 8)
+    large = peak_open_fds(tmp_path / "large", 64)
+    assert small == large
+    assert large <= 2
+
+
+def test_parse_summary_from_streams_consumes_a_lazy_iterator(tmp_path):
+    """The stream entrypoint takes an iterator, not just a sequence.
+
+    Both callers now pass a generator that opens one profile at a time, so a
+    ``len()`` or a second pass would break them.
+    """
+    path = _hatchet(tmp_path, _tree([_leaf("k", 2_000_000, count=3)]))
+    metrics = parse_summary_from_streams(
+        str(tmp_path), (p.open(encoding="utf-8") for p in [path])
+    )
+    assert metrics["proton_kernel_count"] == 3
+    assert metrics["proton_gpu_time_ms"] == pytest.approx(2.0)

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -1061,7 +1061,10 @@ def test_parse_summary_accepts_str_path(tmp_path):
     assert parse_summary(str(tmp_path))["proton_top_kernels"] == ["k"]
 
 
-def test_parse_summary_holds_one_profile_open_at_a_time(tmp_path):
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(), reason="descriptor accounting needs /proc"
+)
+def test_parse_summary_holds_one_profile_open_at_a_time(tmp_path, monkeypatch):
     """A per-rank capture must not need a descriptor per rank.
 
     Proton writes a profile per rank, so a large distributed run can hold more
@@ -1070,8 +1073,7 @@ def test_parse_summary_holds_one_profile_open_at_a_time(tmp_path):
     before the limit. The count is compared across two tree sizes because an
     absolute bound would pass for the eager version on a small tree.
     """
-    if not Path("/proc/self/fd").is_dir():
-        pytest.skip("descriptor accounting needs /proc")
+    original = _parse.parse_profile_stream
 
     def peak_open_fds(root, ranks):
         root.mkdir()
@@ -1080,18 +1082,17 @@ def test_parse_summary_holds_one_profile_open_at_a_time(tmp_path):
         parse_summary(root)  # warm any lazy imports before the baseline
         baseline = len(os.listdir("/proc/self/fd"))
         seen = []
-        original = _parse.parse_profile_stream
 
         def counting_parse(stream):
             seen.append(len(os.listdir("/proc/self/fd")))
             return original(stream)
 
-        _parse.parse_profile_stream = counting_parse
+        monkeypatch.setattr(_parse, "parse_profile_stream", counting_parse)
         try:
             metrics = parse_summary(root)
         finally:
-            _parse.parse_profile_stream = original
-        assert metrics["proton_kernel_count"] == ranks
+            monkeypatch.setattr(_parse, "parse_profile_stream", original)
+        assert metrics.get("proton_kernel_count") == ranks
         assert len(seen) == ranks
         return max(seen) - baseline
 
@@ -1111,5 +1112,5 @@ def test_parse_summary_from_streams_consumes_a_lazy_iterator(tmp_path):
     metrics = parse_summary_from_streams(
         str(tmp_path), (p.open(encoding="utf-8") for p in [path])
     )
-    assert metrics["proton_kernel_count"] == 3
-    assert metrics["proton_gpu_time_ms"] == pytest.approx(2.0)
+    assert metrics.get("proton_kernel_count") == 3
+    assert metrics.get("proton_gpu_time_ms") == pytest.approx(2.0)

--- a/tests/instrumentation/test_rocprof.py
+++ b/tests/instrumentation/test_rocprof.py
@@ -23,6 +23,7 @@ absence of files.
 
 from __future__ import annotations
 
+import io
 import math
 import os
 from pathlib import Path
@@ -37,8 +38,10 @@ from aorta.instrumentation.rocprof import (
     SUMMARY_FILE_STEM,
     SUMMARY_FILENAME,
     RocprofUnavailableError,
+    _parse,
     build_argv_prefix,
     parse_summary,
+    parse_summary_from_streams,
     resolve_binary,
     validate_options,
     wrap_argv,
@@ -658,6 +661,87 @@ def test_parse_summary_survives_unreadable_file(tmp_path):
 
 def test_parse_summary_accepts_str_path():
     assert parse_summary(str(FIXTURES / "flat_with_o"))["rocprof_kernel_count"] == _FLAT_CALLS
+
+
+def test_parse_summary_holds_one_csv_open_at_a_time(tmp_path):
+    """A per-rank capture must not need a descriptor per rank.
+
+    ``rocprofv3`` writes a stats/trace pair per process, so a large distributed
+    run can hold more CSVs than ``RLIMIT_NOFILE`` allows; opening them all up
+    front hit ``EMFILE`` partway through and reported totals covering only the
+    ranks before the limit. The count is compared across two tree sizes because
+    an absolute bound would pass for the eager version on a small tree.
+    """
+
+    def peak_open_fds(root, ranks):
+        root.mkdir()
+        for rank in range(ranks):
+            (root / f"rank{rank:03d}_kernel_stats.csv").write_text(
+                '"Name","Calls","TotalDurationNs"\n"sgemm",1,1000\n', encoding="utf-8"
+            )
+        parse_summary(root)  # warm any lazy imports before the baseline
+        baseline = len(os.listdir("/proc/self/fd"))
+        seen = []
+        original = _parse._iter_rows
+
+        def counting_iter_rows(stream):
+            seen.append(len(os.listdir("/proc/self/fd")))
+            return original(stream)
+
+        _parse._iter_rows = counting_iter_rows
+        try:
+            metrics = parse_summary(root)
+        finally:
+            _parse._iter_rows = original
+        assert metrics["rocprof_kernel_count"] == ranks
+        assert len(seen) == ranks
+        return max(seen) - baseline
+
+    if not Path("/proc/self/fd").is_dir():
+        pytest.skip("descriptor accounting needs /proc")
+    small = peak_open_fds(tmp_path / "small", 8)
+    large = peak_open_fds(tmp_path / "large", 64)
+    assert small == large
+    assert large <= 2
+
+
+def test_parse_summary_from_streams_consumes_lazy_iterators(tmp_path):
+    """The stream entrypoint takes iterators, not just sequences.
+
+    Both callers now pass generators that open one file at a time, so a
+    ``len()`` or a second pass over a group would break them.
+    """
+    (tmp_path / "a_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"sgemm",4,2000\n', encoding="utf-8"
+    )
+    paths = sorted(tmp_path.glob("*_kernel_stats.csv"))
+    metrics = parse_summary_from_streams(
+        str(tmp_path), (path.open(encoding="utf-8") for path in paths), iter(())
+    )
+    assert metrics["rocprof_kernel_count"] == 4
+
+
+def test_parse_summary_from_streams_falls_back_to_trace_on_empty_stats(tmp_path):
+    """An empty stats iterator must still let the trace group be read.
+
+    The old code branched on the *truthiness* of the stats sequence; a
+    generator is always truthy, so the fallback had to move to "did the stats
+    yield any data".
+    """
+    metrics = parse_summary_from_streams(
+        str(tmp_path),
+        iter(()),
+        iter(
+            [
+                io.StringIO(
+                    '"Kind","Kernel_Name","Start_Timestamp","End_Timestamp"\n'
+                    '"KERNEL_DISPATCH","traced",0,2000000\n'
+                )
+            ]
+        ),
+    )
+    assert metrics["rocprof_kernel_count"] == 1
+    assert metrics["rocprof_top_kernels"] == ["traced"]
 
 
 # ---- Docs / schema agreement --------------------------------------------

--- a/tests/instrumentation/test_rocprof.py
+++ b/tests/instrumentation/test_rocprof.py
@@ -663,7 +663,10 @@ def test_parse_summary_accepts_str_path():
     assert parse_summary(str(FIXTURES / "flat_with_o"))["rocprof_kernel_count"] == _FLAT_CALLS
 
 
-def test_parse_summary_holds_one_csv_open_at_a_time(tmp_path):
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(), reason="descriptor accounting needs /proc"
+)
+def test_parse_summary_holds_one_csv_open_at_a_time(tmp_path, monkeypatch):
     """A per-rank capture must not need a descriptor per rank.
 
     ``rocprofv3`` writes a stats/trace pair per process, so a large distributed
@@ -672,6 +675,7 @@ def test_parse_summary_holds_one_csv_open_at_a_time(tmp_path):
     ranks before the limit. The count is compared across two tree sizes because
     an absolute bound would pass for the eager version on a small tree.
     """
+    original = _parse._iter_rows
 
     def peak_open_fds(root, ranks):
         root.mkdir()
@@ -682,23 +686,20 @@ def test_parse_summary_holds_one_csv_open_at_a_time(tmp_path):
         parse_summary(root)  # warm any lazy imports before the baseline
         baseline = len(os.listdir("/proc/self/fd"))
         seen = []
-        original = _parse._iter_rows
 
         def counting_iter_rows(stream):
             seen.append(len(os.listdir("/proc/self/fd")))
             return original(stream)
 
-        _parse._iter_rows = counting_iter_rows
+        monkeypatch.setattr(_parse, "_iter_rows", counting_iter_rows)
         try:
             metrics = parse_summary(root)
         finally:
-            _parse._iter_rows = original
-        assert metrics["rocprof_kernel_count"] == ranks
+            monkeypatch.setattr(_parse, "_iter_rows", original)
+        assert metrics.get("rocprof_kernel_count") == ranks
         assert len(seen) == ranks
         return max(seen) - baseline
 
-    if not Path("/proc/self/fd").is_dir():
-        pytest.skip("descriptor accounting needs /proc")
     small = peak_open_fds(tmp_path / "small", 8)
     large = peak_open_fds(tmp_path / "large", 64)
     assert small == large
@@ -718,7 +719,7 @@ def test_parse_summary_from_streams_consumes_lazy_iterators(tmp_path):
     metrics = parse_summary_from_streams(
         str(tmp_path), (path.open(encoding="utf-8") for path in paths), iter(())
     )
-    assert metrics["rocprof_kernel_count"] == 4
+    assert metrics.get("rocprof_kernel_count") == 4
 
 
 def test_parse_summary_from_streams_falls_back_to_trace_on_empty_stats(tmp_path):
@@ -740,8 +741,8 @@ def test_parse_summary_from_streams_falls_back_to_trace_on_empty_stats(tmp_path)
             ]
         ),
     )
-    assert metrics["rocprof_kernel_count"] == 1
-    assert metrics["rocprof_top_kernels"] == ["traced"]
+    assert metrics.get("rocprof_kernel_count") == 1
+    assert metrics.get("rocprof_top_kernels") == ["traced"]
 
 
 # ---- Docs / schema agreement --------------------------------------------

--- a/tests/probe/test_env_passthrough.py
+++ b/tests/probe/test_env_passthrough.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from aorta.run import _fsafe
 from aorta.workloads._subprocess import (
     CONFIG_KEY_LOG_PREFIX,
     CONFIG_KEY_PROBE_EXTRAS,
@@ -101,6 +102,29 @@ def test_env_file_is_0600(tmp_path):
     mode = env_path.stat().st_mode
     perms = stat.S_IMODE(mode)
     assert perms == 0o600, f"expected 0600, got 0o{perms:o}"
+
+
+@pytest.mark.skipif(
+    not _fsafe.HAVE_FD_TRAVERSAL,
+    reason="fd-relative traversal unsupported here",
+)
+def test_env_file_refuses_hard_link_before_truncating_target(tmp_path):
+    """A stale probe.env hard link cannot truncate its outside inode."""
+    wl = _make_workload(
+        tmp_path,
+        argv=["true"],
+        env_mode="file",
+        cell_env_vars={"SECRET_TOKEN": "supersecret"},
+    )
+    wl.setup()
+    victim = tmp_path / "outside.txt"
+    victim.write_text("keep me", encoding="utf-8")
+    (tmp_path / "trial_0" / "probe.env").hardlink_to(victim)
+
+    with pytest.raises(_fsafe.UnsafePathError, match="hard links"):
+        wl.run()
+
+    assert victim.read_text(encoding="utf-8") == "keep me"
 
 
 def test_env_file_validation_failure_does_not_leave_partial_file(tmp_path):

--- a/tests/probe/test_retention.py
+++ b/tests/probe/test_retention.py
@@ -168,6 +168,35 @@ def test_record_survives_at_none_level(tmp_path: Path):
     assert not (trial_dir / "stdout.log").exists()  # none drops logs too
 
 
+def test_trial_retention_refuses_a_payload_swapped_trial_dir(tmp_path: Path):
+    """The probe trial tree uses the same fd-relative anchor as collectors."""
+    cell_dir = tmp_path / "cell"
+    workload_subdir = cell_dir / "_subprocess"
+    workload_subdir.mkdir(parents=True)
+    wl = SubprocessWorkload(
+        {
+            CONFIG_KEY_SUBPROCESS_ARGV: ["true"],
+            CONFIG_KEY_LOG_PREFIX: str(workload_subdir / "trial_d0_m0_t0"),
+            CONFIG_KEY_PROBE_EXTRAS: {},
+        }
+    )
+    wl.setup()
+    trial_dir = cell_dir / "trial_0"
+    trial_dir.rename(cell_dir / "trial_0.original")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "trace.bin"
+    victim.write_text("keep me", encoding="utf-8")
+    trial_dir.symlink_to(outside, target_is_directory=True)
+
+    outcome = wl._apply_retention(  # noqa: SLF001 -- pins the wiring seam
+        trial_dir, "pass", {"retain": {"on_pass": "none"}}
+    )
+
+    assert outcome is not None and outcome.no_op
+    assert victim.read_text(encoding="utf-8") == "keep me"
+
+
 def test_non_dict_retain_payload_warns_and_skips(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ):

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -489,9 +489,12 @@ def test_retention_prune_uses_the_same_anchor_as_its_own_pre_filter(
     assert anchor.path == collect_dir.parent
     # ...and the prune still did its job.
     assert not (collect_dir / rocprof.OUTPUT_SUBDIR / "aorta_kernel_stats.csv").exists()
-    # The operator's own record tree keeps the pathname engine: it is not handed
-    # to the payload, and its guard is the containment check, not an anchor.
-    assert seen.get(str(tmp_path / "trial_0"), "absent") is None
+    # The sibling probe trial tree is payload-writable too (the command runs as
+    # the same user), so it now carries its own fd-relative anchor rather than
+    # dropping to the pathname engine.
+    trial_anchor = seen.get(str(tmp_path / "trial_0"))
+    assert trial_anchor is not None
+    assert trial_anchor.path == tmp_path
 
 
 def test_retention_full_keeps_the_collector_tree(tmp_path, rocprofv3_on_path):

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -411,6 +411,38 @@ def test_collector_subdir_swapped_for_a_symlink_is_refused(
     assert victim.read_text(encoding="utf-8").endswith("7,7000000\n")
 
 
+def test_retention_prunes_rocprof_when_a_sibling_collector_wrote_nothing(
+    tmp_path, rocprofv3_on_path
+):
+    """One never-created collector directory must not retain the others.
+
+    ``layer_numerics`` is validated-only, so nothing in the platform makes its
+    output directory. When absence counted as an unsafe path, the guard reported
+    it, ``_prune_collector_tree`` bailed before pruning anything, and
+    ``retain.on_pass: none`` silently kept the whole rocprof capture -- the
+    hundreds of MB per trial retention exists to drop.
+    """
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    wl = _make_workload(
+        tmp_path,
+        ["true"],
+        collect=["rocprof", "layer_numerics"],
+        retain={"on_pass": "none"},
+    )
+    wl.setup()
+    _rocprof_artifacts(collect_dir)
+    assert not (collect_dir / "layer_numerics").exists()
+
+    result = wl.run()
+
+    # Parsed before pruning, so the metric survives the trace it came from.
+    assert result.metrics["rocprof_kernel_count"] == 23
+    assert not (collect_dir / rocprof.OUTPUT_SUBDIR / "aorta_kernel_stats.csv").exists()
+    doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
+    deleted = doc.get("capture", {}).get("retention", {}).get("deleted", [])
+    assert any(entry.endswith("aorta_kernel_stats.csv") for entry in deleted)
+
+
 def test_retention_full_keeps_the_collector_tree(tmp_path, rocprofv3_on_path):
     """``full`` is the keep-everything default; the collector tree follows it."""
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -21,7 +21,9 @@ from aorta.run.collectors import (
     CONFIG_KEY_COLLECT,
     CONFIG_KEY_COLLECT_DIR,
     CONFIG_KEY_COLLECT_OPTIONS,
+    CONFIG_KEY_RESULTS_ROOT,
 )
+from aorta.workloads import _subprocess as subprocess_module
 from aorta.workloads._subprocess import (
     CONFIG_KEY_LOG_PREFIX,
     CONFIG_KEY_PROBE_EXTRAS,
@@ -441,6 +443,55 @@ def test_retention_prunes_rocprof_when_a_sibling_collector_wrote_nothing(
     doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
     deleted = doc.get("capture", {}).get("retention", {}).get("deleted", [])
     assert any(entry.endswith("aorta_kernel_stats.csv") for entry in deleted)
+
+
+def test_retention_prune_uses_the_same_anchor_as_its_own_pre_filter(
+    tmp_path, rocprofv3_on_path, monkeypatch
+):
+    """The destructive prune must run under the anchor its pre-filter guarded.
+
+    A direct or legacy config threads ``_aorta_collect_dir`` without
+    ``_aorta_results_root`` -- which is exactly the shape ``_make_workload``
+    builds, and what a trial config written before that key existed looks like.
+    ``unsafe_collector_paths()`` still guards such a config using its
+    ``collect_root.parent`` fallback, but the anchor was derived a second time
+    for ``apply_retention()``, by a function without that fallback, so the prune
+    received ``None`` and silently dropped to the pathname engine. The
+    pre-filter then guarded a pathname that the prune re-resolved -- the
+    time-of-check/time-of-use gap this whole change exists to close.
+
+    Asserted as an agreement between the two halves rather than by racing them:
+    the defect is that one question had two spellings, so what needs pinning is
+    that they now give the same answer.
+    """
+    collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
+    wl = _make_workload(tmp_path, ["true"], collect=["rocprof"], retain={"on_pass": "none"})
+    assert CONFIG_KEY_RESULTS_ROOT not in wl.config, (
+        "precondition: this is the no-threaded-anchor config shape"
+    )
+
+    seen: dict = {}
+    real_apply = subprocess_module.apply_retention
+
+    def spy(trial_dir, level, *, trusted_root=None):
+        seen[str(trial_dir)] = trusted_root
+        return real_apply(trial_dir, level, trusted_root=trusted_root)
+
+    monkeypatch.setattr(subprocess_module, "apply_retention", spy)
+
+    wl.setup()
+    _rocprof_artifacts(collect_dir)
+    wl.run()
+
+    anchor = seen.get(str(collect_dir))
+    assert anchor is not None, "the collector prune ran without a trusted anchor"
+    # The same fallback the pre-filter uses, so the two cannot disagree.
+    assert anchor.path == collect_dir.parent
+    # ...and the prune still did its job.
+    assert not (collect_dir / rocprof.OUTPUT_SUBDIR / "aorta_kernel_stats.csv").exists()
+    # The operator's own record tree keeps the pathname engine: it is not handed
+    # to the payload, and its guard is the containment check, not an anchor.
+    assert seen.get(str(tmp_path / "trial_0"), "absent") is None
 
 
 def test_retention_full_keeps_the_collector_tree(tmp_path, rocprofv3_on_path):

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -436,7 +436,7 @@ def test_retention_prunes_rocprof_when_a_sibling_collector_wrote_nothing(
     result = wl.run()
 
     # Parsed before pruning, so the metric survives the trace it came from.
-    assert result.metrics["rocprof_kernel_count"] == 23
+    assert result.metrics.get("rocprof_kernel_count") == 23
     assert not (collect_dir / rocprof.OUTPUT_SUBDIR / "aorta_kernel_stats.csv").exists()
     doc = json.loads((tmp_path / "trial_0" / "result.json").read_text(encoding="utf-8"))
     deleted = doc.get("capture", {}).get("retention", {}).get("deleted", [])

--- a/tests/probe/test_subprocess_collectors.py
+++ b/tests/probe/test_subprocess_collectors.py
@@ -228,10 +228,12 @@ def test_run_collector_cannot_shadow_the_platform_keys(tmp_path, monkeypatch, ro
     """The collector summary is merged UNDER the platform bookkeeping, so a
     collector emitting ``verdict`` / ``exit_code`` cannot rewrite the trial's
     outcome."""
+    shadow = {"verdict": "pass", "exit_code": 0, "rocprof_gpu_time_ms": 1.0}
+    # Patch both entrypoints: the fd-relative (streams) path used on POSIX and
+    # the pathname fallback, so the merge-order contract is pinned on either.
+    monkeypatch.setattr(rocprof, "parse_summary", lambda _out: shadow)
     monkeypatch.setattr(
-        rocprof,
-        "parse_summary",
-        lambda _out: {"verdict": "pass", "exit_code": 0, "rocprof_gpu_time_ms": 1.0},
+        rocprof, "parse_summary_from_streams", lambda *_args, **_kwargs: shadow
     )
     collect_dir = tmp_path / "_subprocess" / "trial_d0_m0_t0"
     (collect_dir / rocprof.OUTPUT_SUBDIR).mkdir(parents=True)

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 import signal
-import sys
 from pathlib import Path
 
 import pytest
@@ -555,72 +554,6 @@ def test_child_started_in_new_session(tmp_path, monkeypatch):
     wl.setup()
     wl.run()
     assert captured.get("start_new_session") is True
-
-
-def test_successful_leader_reaps_background_descendants_before_return(tmp_path):
-    """Post-run filesystem passes must not race a surviving child descendant.
-
-    The direct process exits 0 after spawning a same-group background child.
-    That child records SIGTERM before exiting; seeing the marker when
-    ``run()`` returns proves normal completion waits for group teardown rather
-    than merely reaping the leader.
-    """
-    ready = tmp_path / "child.ready"
-    stopped = tmp_path / "child.stopped"
-    child = tmp_path / "child.py"
-    child.write_text(
-        "\n".join(
-            [
-                "import signal",
-                "import sys",
-                "import time",
-                "from pathlib import Path",
-                "ready = Path(sys.argv[1])",
-                "stopped = Path(sys.argv[2])",
-                "def stop(_signum, _frame):",
-                "    stopped.write_text('stopped', encoding='utf-8')",
-                "    raise SystemExit(0)",
-                "signal.signal(signal.SIGTERM, stop)",
-                "ready.write_text('ready', encoding='utf-8')",
-                "deadline = time.monotonic() + 2",
-                "while time.monotonic() < deadline:",
-                "    time.sleep(0.05)",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    parent = tmp_path / "parent.py"
-    parent.write_text(
-        "\n".join(
-            [
-                "import subprocess",
-                "import sys",
-                "import time",
-                "from pathlib import Path",
-                "child, ready, stopped = sys.argv[1:]",
-                "subprocess.Popen([sys.executable, child, ready, stopped])",
-                "deadline = time.monotonic() + 5",
-                "while not Path(ready).exists():",
-                "    if time.monotonic() >= deadline:",
-                "        raise RuntimeError('background child did not start')",
-                "    time.sleep(0.01)",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    wl = _make_workload(
-        tmp_path,
-        [sys.executable, str(parent), str(child), str(ready), str(stopped)],
-    )
-    # A validated-only collector is enough to activate the post-run
-    # filesystem contract without requiring a profiler binary on the host.
-    wl.config["_aorta_collect"] = ["layer_numerics"]
-    wl.setup()
-    result = wl.run()
-
-    assert result.passed is True
-    assert stopped.read_text(encoding="utf-8") == "stopped"
 
 
 def test_terminate_process_tree_escalates_term_then_kill(monkeypatch):

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import signal
+import sys
 from pathlib import Path
 
 import pytest
@@ -554,6 +555,72 @@ def test_child_started_in_new_session(tmp_path, monkeypatch):
     wl.setup()
     wl.run()
     assert captured.get("start_new_session") is True
+
+
+def test_successful_leader_reaps_background_descendants_before_return(tmp_path):
+    """Post-run filesystem passes must not race a surviving child descendant.
+
+    The direct process exits 0 after spawning a same-group background child.
+    That child records SIGTERM before exiting; seeing the marker when
+    ``run()`` returns proves normal completion waits for group teardown rather
+    than merely reaping the leader.
+    """
+    ready = tmp_path / "child.ready"
+    stopped = tmp_path / "child.stopped"
+    child = tmp_path / "child.py"
+    child.write_text(
+        "\n".join(
+            [
+                "import signal",
+                "import sys",
+                "import time",
+                "from pathlib import Path",
+                "ready = Path(sys.argv[1])",
+                "stopped = Path(sys.argv[2])",
+                "def stop(_signum, _frame):",
+                "    stopped.write_text('stopped', encoding='utf-8')",
+                "    raise SystemExit(0)",
+                "signal.signal(signal.SIGTERM, stop)",
+                "ready.write_text('ready', encoding='utf-8')",
+                "deadline = time.monotonic() + 2",
+                "while time.monotonic() < deadline:",
+                "    time.sleep(0.05)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    parent = tmp_path / "parent.py"
+    parent.write_text(
+        "\n".join(
+            [
+                "import subprocess",
+                "import sys",
+                "import time",
+                "from pathlib import Path",
+                "child, ready, stopped = sys.argv[1:]",
+                "subprocess.Popen([sys.executable, child, ready, stopped])",
+                "deadline = time.monotonic() + 5",
+                "while not Path(ready).exists():",
+                "    if time.monotonic() >= deadline:",
+                "        raise RuntimeError('background child did not start')",
+                "    time.sleep(0.01)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    wl = _make_workload(
+        tmp_path,
+        [sys.executable, str(parent), str(child), str(ready), str(stopped)],
+    )
+    # A validated-only collector is enough to activate the post-run
+    # filesystem contract without requiring a profiler binary on the host.
+    wl.config["_aorta_collect"] = ["layer_numerics"]
+    wl.setup()
+    result = wl.run()
+
+    assert result.passed is True
+    assert stopped.read_text(encoding="utf-8") == "stopped"
 
 
 def test_terminate_process_tree_escalates_term_then_kill(monkeypatch):

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import json
 import signal
+import sys
 from pathlib import Path
 
 import pytest
 
+from aorta.run import _fsafe
 from aorta.run.discovery import get_workload_class
 from aorta.workloads._subprocess import (
     CONFIG_KEY_LOG_PREFIX,
@@ -173,6 +175,35 @@ def test_pass_minimum_result_shape(tmp_path):
     assert (trial_dir / "stderr.log").is_file()
     # WorkloadResult round-trip:
     assert result.passed is True
+
+
+@pytest.mark.skipif(
+    not _fsafe.HAVE_FD_TRAVERSAL,
+    reason="fd-relative traversal unsupported here",
+)
+def test_result_write_refuses_trial_dir_swapped_by_payload(tmp_path):
+    """A command cannot redirect the probe record through a trial-dir link."""
+    trial_dir = tmp_path / "trial_0"
+    moved = tmp_path / "trial_0.original"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "result.json"
+    victim.write_text("keep me", encoding="utf-8")
+    swap = (
+        "from pathlib import Path; "
+        f"trial=Path({str(trial_dir)!r}); "
+        f"trial.rename(Path({str(moved)!r})); "
+        f"trial.symlink_to(Path({str(outside)!r}), target_is_directory=True)"
+    )
+    wl = _make_workload(tmp_path, [sys.executable, "-c", swap])
+    wl.setup()
+
+    with pytest.raises(_fsafe.UnsafePathError):
+        wl.run()
+
+    assert victim.read_text(encoding="utf-8") == "keep me"
+    assert not (outside / "stdout.log").exists()
+    assert not (outside / "stderr.log").exists()
 
 
 def test_fail_minimum_result_shape(tmp_path):
@@ -1255,7 +1286,7 @@ def test_read_log_text_uses_replace_not_backslashreplace(tmp_path):
     byte->char invariant.
     """
     from aorta.probe.sandbox import MAX_LOG_BYTES
-    from aorta.workloads._subprocess import _read_log_text
+    from aorta.workloads._subprocess import _read_log_text, _TrialFiles
 
     # A blob of pure invalid bytes the size of the cap. ``replace``
     # gives len == MAX_LOG_BYTES; ``backslashreplace`` would give
@@ -1266,7 +1297,7 @@ def test_read_log_text_uses_replace_not_backslashreplace(tmp_path):
     stdout_path.write_bytes(binary)
     stderr_path.write_bytes(b"")
 
-    text = _read_log_text(stdout_path, stderr_path)
+    text = _read_log_text(_TrialFiles(tmp_path, _fsafe.TrustedAnchor(tmp_path)))
     # Allow a small overhead for the ``\n`` joiner and the empty
     # stderr piece; the load-bearing assertion is the 4x cap.
     assert len(text) <= MAX_LOG_BYTES + 8, (

--- a/tests/probe/test_subprocess_workload.py
+++ b/tests/probe/test_subprocess_workload.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from aorta.run import _fsafe
+from aorta.run.collectors import CONFIG_KEY_RESULTS_ROOT, CONFIG_KEY_RESULTS_ROOT_ID
 from aorta.run.discovery import get_workload_class
 from aorta.workloads._subprocess import (
     CONFIG_KEY_LOG_PREFIX,
@@ -120,6 +121,28 @@ def test_setup_rejects_non_list_argv(tmp_path):
     )
     with pytest.raises(RuntimeError, match="non-empty list"):
         workload.setup()
+
+
+def test_setup_reuses_dispatcher_frozen_results_anchor(tmp_path):
+    """The probe tree must not refreeze its trust boundary after launch."""
+    (tmp_path / "_subprocess").mkdir()
+    anchor = _fsafe.TrustedAnchor.freeze(tmp_path)
+    assert anchor.identity is not None
+    workload = SubprocessWorkload(
+        {
+            CONFIG_KEY_SUBPROCESS_ARGV: ["true"],
+            CONFIG_KEY_LOG_PREFIX: str(
+                tmp_path / "_subprocess" / "trial_d0_m0_t0"
+            ),
+            CONFIG_KEY_RESULTS_ROOT: str(anchor.path),
+            CONFIG_KEY_RESULTS_ROOT_ID: list(anchor.identity),
+        }
+    )
+
+    workload.setup()
+
+    assert workload._trial_files is not None  # noqa: SLF001 -- wiring contract
+    assert workload._trial_files.anchor == anchor  # noqa: SLF001
 
 
 # ---- FR 1.12 (result.json shape + Tier 1 verdict) ------------------------

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -953,6 +953,16 @@ _needs_proc_fd = pytest.mark.skipif(
 )
 
 
+def _rocprof_capture(subdir: Path, calls: int = 4, name: str = "real") -> Path:
+    """Write one parseable stats CSV, so a skip is observable as a kept metric."""
+    subdir.mkdir(parents=True, exist_ok=True)
+    path = subdir / f"{name}_kernel_stats.csv"
+    path.write_text(
+        f'"Name","Calls","TotalDurationNs"\n"sgemm",{calls},1000\n', encoding="utf-8"
+    )
+    return path
+
+
 def _peak_fds_while_summarizing(tmp_path, monkeypatch, ranks):
     """Highest descriptor count observed while parsing ``ranks`` stats CSVs."""
     results = tmp_path / "results"
@@ -1031,6 +1041,85 @@ def test_summarize_aggregates_every_rank_artifact(profilers_on_path, tmp_path):
     )
     assert metrics.get("rocprof_kernel_count") == 16
     assert metrics.get("rocprof_gpu_time_ms") == pytest.approx(160 / 1_000_000.0)
+
+
+@_needs_fd
+def test_summarize_ignores_a_fifo_that_was_never_a_regular_file(
+    profilers_on_path, tmp_path, no_hang
+):
+    """The walk filters non-regular entries, so a pre-planted FIFO never opens.
+
+    Worth pinning on its own, and it is also why the swap test below has to
+    plant the FIFO *after* the walk: one that is already there when the
+    directory is listed is dropped before any open is attempted, so it cannot
+    demonstrate the blocking-open exposure. My first version of that test made
+    exactly this mistake and passed under mutation.
+    """
+    results = tmp_path / "results"
+    subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    _rocprof_capture(subdir)
+    os.mkfifo(subdir / "trap_kernel_stats.csv")
+
+    with no_hang(10):
+        metrics = summarize_collectors(
+            _config(
+                ["rocprof"],
+                collect_dir=subdir.parent,
+                results_root=results.resolve(),
+                pin_results_root=True,
+            )
+        )
+    assert metrics.get("rocprof_kernel_count") == 4
+
+
+@_needs_fd
+def test_summarize_skips_an_artifact_swapped_for_a_fifo_after_the_walk(
+    profilers_on_path, tmp_path, monkeypatch, no_hang
+):
+    """A FIFO swapped in after the walk must not hang the post-run summary.
+
+    The walk selects regular files, but the open that follows is a separate
+    syscall -- and bounding descriptor use widened that window on purpose, since
+    artifacts are now listed first and reopened one at a time. A surviving
+    payload process that unlinks a matched CSV and ``mkfifo``s in its place makes
+    a blocking ``O_RDONLY`` wait for a writer that never comes, stalling the
+    trial rather than degrading its metrics.
+
+    The swap is planted at the end of the walk, which is exactly the moment the
+    real race occupies: everything is listed, nothing is open yet.
+    """
+    results = tmp_path / "results"
+    subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    _rocprof_capture(subdir, calls=4, name="aaa_real")
+    trap = _rocprof_capture(subdir, calls=999, name="zzz_trap")
+
+    real_walk = _fsafe.iter_regular_files
+
+    def swapping_walk(base_fd):
+        yield from real_walk(base_fd)
+        # Both files are in the caller's match list now, and none is open yet.
+        trap.unlink()
+        os.mkfifo(trap)
+
+    monkeypatch.setattr(_fsafe, "iter_regular_files", swapping_walk)
+
+    # A regression here is a hang, not a wrong value, so bound the call. The
+    # alarm raises outside ``Exception`` on purpose: ``summarize_collectors``
+    # swallows ``Exception`` and the artifact reader skips on ``OSError``, and
+    # ``TimeoutError`` is an ``OSError`` -- so a timeout raised as one would be
+    # absorbed into a clean skip and this test would pass while the code hung.
+    with no_hang(10):
+        metrics = summarize_collectors(
+            _config(
+                ["rocprof"],
+                collect_dir=subdir.parent,
+                results_root=results.resolve(),
+                pin_results_root=True,
+            )
+        )
+    # The good capture is still reported; the trap contributes nothing.
+    assert metrics.get("rocprof_kernel_count") == 4
+    assert metrics.get("rocprof_top_kernels") == ["sgemm"]
 
 
 @_needs_fd

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -10,6 +10,7 @@ summary merge.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 from dataclasses import asdict
 from pathlib import Path
@@ -547,10 +548,13 @@ def test_summarize_metric_keys_are_namespaced_by_collector(tmp_path):
 def test_summarize_survives_a_parser_that_raises(tmp_path, monkeypatch, caplog):
     """An opt-in measurement must never turn a healthy trial into a failure."""
 
-    def boom(_out_dir):
+    def boom(*_args, **_kwargs):
         raise RuntimeError("parser exploded")
 
+    # Patch both entrypoints so the test holds on the fd-relative (streams) path
+    # and the non-POSIX (pathname) fallback alike.
     monkeypatch.setattr(rocprof, "parse_summary", boom)
+    monkeypatch.setattr(rocprof, "parse_summary_from_streams", boom)
     (tmp_path / rocprof.OUTPUT_SUBDIR).mkdir()
     with caplog.at_level("WARNING"):
         assert summarize_collectors(_config(["rocprof"], collect_dir=tmp_path)) == {}
@@ -589,3 +593,149 @@ def test_summarize_does_not_re_resolve_a_results_dir_swapped_for_a_symlink(tmp_p
     assert metrics == {}
     assert "rocprof_kernel_count" not in metrics
     assert "symlink" in caplog.text
+
+
+# ---- fd-relative TOCTOU hardening ---------------------------------------
+
+from aorta.run import _fsafe  # noqa: E402 -- grouped with the guard tests below
+
+_needs_fd = pytest.mark.skipif(
+    not _fsafe.HAVE_FD_TRAVERSAL, reason="fd-relative traversal unsupported here"
+)
+
+
+@_needs_fd
+def test_reset_ancestor_swap_after_fd_open_is_inert(profilers_on_path, tmp_path, monkeypatch):
+    """A swap of the collector dir's ancestor *after* the fd is held is defeated.
+
+    This is the mid-use-swap proof: the guard no longer re-resolves the pathname
+    for the destructive step, so a payload that replaces an ancestor between the
+    check and the delete cannot redirect it. We simulate the race deterministically
+    by planting the swap inside ``open_dir_nofollow`` right after it yields the
+    parent fd, then assert the unlink/mkdir landed on the ORIGINAL inode and the
+    planted external tree survived untouched.
+    """
+    results = tmp_path / "results"
+    workload = results / "wl"
+    collect_dir = workload / "trial_d0_m0_t0"
+    (collect_dir / rocprof.OUTPUT_SUBDIR).mkdir(parents=True)
+    (collect_dir / rocprof.OUTPUT_SUBDIR / "stale.txt").write_text("old", encoding="utf-8")
+
+    outside = tmp_path / "outside"
+    planted = outside / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    planted.mkdir(parents=True)
+    victim = planted / "precious.txt"
+    victim.write_text("keep me", encoding="utf-8")
+
+    real_open = _fsafe.open_dir_nofollow
+    swapped = {"done": False}
+
+    @contextlib.contextmanager
+    def swapping_open(trusted_root, components, **kwargs):
+        with real_open(trusted_root, components, **kwargs) as fd:
+            if not swapped["done"]:
+                swapped["done"] = True
+                # Rename <workload> aside (the held fds still track the real
+                # inodes) and drop a symlink to the planted external tree in its
+                # place -- exactly the pathname swap a surviving payload
+                # descendant would perform mid-run.
+                workload.rename(results / "wl_real")
+                workload.symlink_to(outside, target_is_directory=True)
+            yield fd
+
+    monkeypatch.setattr(_fsafe, "open_dir_nofollow", swapping_open)
+
+    wrap_argv_for_collectors(
+        _config(["rocprof"], collect_dir=collect_dir, results_root=results.resolve()),
+        _INNER,
+    )
+
+    # The delete + recreate ran against the held fd, not the swapped pathname, so
+    # the planted external victim is untouched and the real (renamed) tree got
+    # the fresh rocprof dir.
+    assert victim.read_text(encoding="utf-8") == "keep me"
+    assert (results / "wl_real" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR).is_dir()
+
+
+@_needs_fd
+def test_reset_falls_back_to_lexical_guard_without_fd_traversal(
+    profilers_on_path, tmp_path, monkeypatch
+):
+    """With the fd primitives unavailable, the lexical guard still fails closed."""
+    monkeypatch.setattr(_fsafe, "HAVE_FD_TRAVERSAL", False)
+    results = tmp_path / "results"
+    collect_dir = results / "trial_d0_m0_t0"
+    collect_dir.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (results / "wl").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
+        wrap_argv_for_collectors(
+            _config(
+                ["rocprof"],
+                collect_dir=results / "wl" / "trial_d0_m0_t0",
+                results_root=results.resolve(),
+            ),
+            _INNER,
+        )
+
+
+@_needs_fd
+def test_summarize_reads_real_artifacts_through_fd(profilers_on_path, tmp_path):
+    """Parity: the fd-relative streams path parses a clean tree like the shim."""
+    subdir = tmp_path / rocprof.OUTPUT_SUBDIR
+    subdir.mkdir()
+    (subdir / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"sgemm",7,1000\n', encoding="utf-8"
+    )
+    metrics = summarize_collectors(
+        _config(["rocprof"], collect_dir=tmp_path, results_root=tmp_path.resolve())
+    )
+    assert metrics["rocprof_kernel_count"] == 7
+    assert metrics["rocprof_top_kernels"] == ["sgemm"]
+
+
+@_needs_fd
+def test_summarize_swap_after_fd_open_does_not_leak_external_metrics(
+    profilers_on_path, tmp_path, monkeypatch
+):
+    """A read-path ancestor swap after the fd is held cannot pull outside data."""
+    results = tmp_path / "results"
+    subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    subdir.mkdir(parents=True)
+    (subdir / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"real",1,10\n', encoding="utf-8"
+    )
+    outside = tmp_path / "outside"
+    planted = outside / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    planted.mkdir(parents=True)
+    (planted / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"leak",999,9\n', encoding="utf-8"
+    )
+
+    real_open = _fsafe.open_dir_nofollow
+    swapped = {"done": False}
+
+    @contextlib.contextmanager
+    def swapping_open(trusted_root, components, **kwargs):
+        with real_open(trusted_root, components, **kwargs) as fd:
+            if not swapped["done"]:
+                swapped["done"] = True
+                (results / "wl").rename(results / "wl_real")
+                (results / "wl").symlink_to(outside, target_is_directory=True)
+            yield fd
+
+    monkeypatch.setattr(_fsafe, "open_dir_nofollow", swapping_open)
+
+    metrics = summarize_collectors(
+        _config(
+            ["rocprof"],
+            collect_dir=results / "wl" / "trial_d0_m0_t0",
+            results_root=results.resolve(),
+        )
+    )
+    # We read the real file through the held fd; the planted "leak" kernel with
+    # its count of 999 never appears.
+    assert metrics.get("rocprof_top_kernels") == ["real"]
+    assert metrics.get("rocprof_kernel_count") == 1

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -267,7 +267,7 @@ def test_wrap_refuses_a_symlink_in_any_component_below_the_trusted_root(
 
     with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
         wrap_argv_for_collectors(
-            _config(["rocprof"], collect_dir=collect_dir, results_root=results), _INNER
+            _config(["rocprof"], collect_dir=collect_dir, results_root=results.resolve()), _INNER
         )
     assert victim.read_text(encoding="utf-8") == "not yours to delete"
 
@@ -278,9 +278,9 @@ def test_wrap_allows_a_results_dir_that_legitimately_lives_under_a_symlink(
     """The operator's own layout above the trusted root must keep working.
 
     A ``--results-dir`` under a symlink (a mounted scratch path, a symlinked
-    home) is ordinary, and following it is the intended behaviour -- which is
-    why the check is containment against a *resolved* trusted root rather than
-    a per-component symlink scan that could not tell the two cases apart.
+    home) is ordinary. The dispatcher canonicalizes that path *before* launch
+    and threads the resolved prefix as both the trust anchor and the collect
+    dir, so the payload-symlink walk never sees the operator's link.
     """
     real = tmp_path / "real_results"
     real.mkdir()
@@ -288,7 +288,8 @@ def test_wrap_allows_a_results_dir_that_legitimately_lives_under_a_symlink(
     link.symlink_to(real, target_is_directory=True)
 
     argv = wrap_argv_for_collectors(
-        _config(["rocprof"], collect_dir=link / "trial_d0_m0_t0", results_root=link), _INNER
+        _config(["rocprof"], collect_dir=link.resolve() / "trial_d0_m0_t0", results_root=link.resolve()),
+        _INNER,
     )
     assert argv != _INNER  # the collector attached rather than being refused
     assert (real / "trial_d0_m0_t0" / "rocprof").is_dir()
@@ -316,12 +317,59 @@ def test_wrap_refuses_to_clear_through_a_symlinked_collect_root(profilers_on_pat
 
     with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
         wrap_argv_for_collectors(
-            _config(["rocprof"], collect_dir=link, results_root=results), _INNER
+            _config(["rocprof"], collect_dir=link, results_root=results.resolve()), _INNER
         )
     # The whole point: the tree behind the symlink is untouched.
     assert (outside / "rocprof" / "keep_me.txt").read_text(encoding="utf-8") == (
         "not yours to delete"
     )
+
+
+def test_wrap_refuses_a_symlink_to_a_sibling_inside_the_results_tree(
+    profilers_on_path, tmp_path
+):
+    """Containment alone is not enough: a link to a sibling still resolves inside.
+
+    ``trial -> <results>/other_trial`` (or ``rocprof -> <results>``) stays
+    inside the trusted root after ``resolve()``, so a containment-only guard
+    would let ``rmtree`` erase the sibling. The payload-symlink walk refuses
+    any link at or below the anchor even when the target is in-tree.
+    """
+    results = tmp_path / "results"
+    results.mkdir()
+    sibling = results / "trial_other"
+    (sibling / "rocprof").mkdir(parents=True)
+    victim = sibling / "rocprof" / "keep_me.txt"
+    victim.write_text("sibling trial", encoding="utf-8")
+
+    collect_dir = results / "trial_d0_m0_t0"
+    collect_dir.symlink_to(sibling, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
+        wrap_argv_for_collectors(
+            _config(["rocprof"], collect_dir=collect_dir, results_root=results.resolve()),
+            _INNER,
+        )
+    assert victim.read_text(encoding="utf-8") == "sibling trial"
+
+
+def test_wrap_refuses_a_collector_subdir_symlinked_at_the_results_root(
+    profilers_on_path, tmp_path
+):
+    """``<trial>/rocprof -> <results>`` would let ``rmtree`` wipe the whole tree."""
+    results = tmp_path / "results"
+    collect_dir = results / "trial_d0_m0_t0"
+    collect_dir.mkdir(parents=True)
+    (collect_dir / "rocprof").symlink_to(results, target_is_directory=True)
+    marker = results / "keep_me.txt"
+    marker.write_text("results tree", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
+        wrap_argv_for_collectors(
+            _config(["rocprof"], collect_dir=collect_dir, results_root=results.resolve()),
+            _INNER,
+        )
+    assert marker.read_text(encoding="utf-8") == "results tree"
 
 
 # ---- wrap_argv_for_collectors: attaching -------------------------------
@@ -507,3 +555,37 @@ def test_summarize_survives_a_parser_that_raises(tmp_path, monkeypatch, caplog):
     with caplog.at_level("WARNING"):
         assert summarize_collectors(_config(["rocprof"], collect_dir=tmp_path)) == {}
     assert "summary parsing failed" in caplog.text
+
+
+def test_summarize_does_not_re_resolve_a_results_dir_swapped_for_a_symlink(tmp_path, caplog):
+    """The saved trust anchor must not be resolved again after the payload runs.
+
+    If the profiled process replaces the results directory with a symlink to
+    ``/outside``, resolving *both* the candidate and the anchor through that
+    link would make containment succeed and parse planted metrics. The
+    dispatcher stores a pre-launch ``resolve()``; this test keeps that string
+    and swaps the directory out from under it.
+    """
+    results = tmp_path / "results"
+    trial = results / "trial_d0_m0_t0"
+    (trial / rocprof.OUTPUT_SUBDIR).mkdir(parents=True)
+    trusted = str(results.resolve())
+    collect = str(trial)
+
+    outside = tmp_path / "outside"
+    planted = outside / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    planted.mkdir(parents=True)
+    (planted / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"sgemm",7,1000\n', encoding="utf-8"
+    )
+
+    results.rename(tmp_path / "results_orig")
+    (tmp_path / "results").symlink_to(outside, target_is_directory=True)
+
+    with caplog.at_level("WARNING"):
+        metrics = summarize_collectors(
+            _config(["rocprof"], collect_dir=collect, results_root=trusted)
+        )
+    assert metrics == {}
+    assert "rocprof_kernel_count" not in metrics
+    assert "symlink" in caplog.text

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -27,6 +27,7 @@ from aorta.run.collectors import (
     CONFIG_KEY_COLLECT,
     CONFIG_KEY_COLLECT_DIR,
     CONFIG_KEY_COLLECT_OPTIONS,
+    CONFIG_KEY_RESULTS_ROOT,
     KNOWN_RECIPES,
     WRAP_ORDER,
     CollectorSpec,
@@ -55,12 +56,14 @@ def profilers_on_path(tmp_path, monkeypatch):
     return bin_dir
 
 
-def _config(names, *, collect_dir=None, options=None):
+def _config(names, *, collect_dir=None, options=None, results_root=None):
     config = {CONFIG_KEY_COLLECT: list(names)}
     if collect_dir is not None:
         config[CONFIG_KEY_COLLECT_DIR] = str(collect_dir)
     if options is not None:
         config[CONFIG_KEY_COLLECT_OPTIONS] = options
+    if results_root is not None:
+        config[CONFIG_KEY_RESULTS_ROOT] = str(results_root)
     return config
 
 
@@ -240,6 +243,57 @@ def test_wrap_fails_when_the_output_dir_cannot_be_created(profilers_on_path, tmp
         wrap_argv_for_collectors(config, _INNER)
 
 
+def test_wrap_refuses_a_symlink_in_any_component_below_the_trusted_root(
+    profilers_on_path, tmp_path
+):
+    """A symlink *anywhere* at or below the trusted root redirects the delete.
+
+    Checking only the leaf and its parent is not enough: ``is_dir()`` and
+    ``rmtree()`` follow links in every component, so a link further up -- but
+    still inside the payload-writable run tree -- reaches outside just as well.
+    Here ``<results>/linked -> <outside>`` with the collector root two levels
+    below it, and neither the leaf nor its parent is itself a symlink.
+    """
+    results = tmp_path / "results"
+    results.mkdir()
+    outside = tmp_path / "outside"
+    (outside / "trial_d0_m0_t0" / "rocprof").mkdir(parents=True)
+    victim = outside / "trial_d0_m0_t0" / "rocprof" / "precious.txt"
+    victim.write_text("not yours to delete", encoding="utf-8")
+    (results / "linked").symlink_to(outside, target_is_directory=True)
+
+    collect_dir = results / "linked" / "trial_d0_m0_t0"
+    assert not collect_dir.is_symlink()  # the gap: nothing local looks wrong
+
+    with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
+        wrap_argv_for_collectors(
+            _config(["rocprof"], collect_dir=collect_dir, results_root=results), _INNER
+        )
+    assert victim.read_text(encoding="utf-8") == "not yours to delete"
+
+
+def test_wrap_allows_a_results_dir_that_legitimately_lives_under_a_symlink(
+    profilers_on_path, tmp_path
+):
+    """The operator's own layout above the trusted root must keep working.
+
+    A ``--results-dir`` under a symlink (a mounted scratch path, a symlinked
+    home) is ordinary, and following it is the intended behaviour -- which is
+    why the check is containment against a *resolved* trusted root rather than
+    a per-component symlink scan that could not tell the two cases apart.
+    """
+    real = tmp_path / "real_results"
+    real.mkdir()
+    link = tmp_path / "results_link"
+    link.symlink_to(real, target_is_directory=True)
+
+    argv = wrap_argv_for_collectors(
+        _config(["rocprof"], collect_dir=link / "trial_d0_m0_t0", results_root=link), _INNER
+    )
+    assert argv != _INNER  # the collector attached rather than being refused
+    assert (real / "trial_d0_m0_t0" / "rocprof").is_dir()
+
+
 def test_wrap_refuses_to_clear_through_a_symlinked_collect_root(profilers_on_path, tmp_path):
     """A symlinked collector root must not let ``rmtree`` escape the run tree.
 
@@ -248,16 +302,22 @@ def test_wrap_refuses_to_clear_through_a_symlinked_collect_root(profilers_on_pat
     it and delete the link target -- a tree outside the results directory
     entirely. This is the destructive case, so it fails closed.
     """
+    # ``precious`` sits outside the results directory, which is the boundary
+    # the guard is defending -- not merely outside the trial directory.
+    results = tmp_path / "results"
+    results.mkdir()
     outside = tmp_path / "precious"
     outside.mkdir()
     (outside / "rocprof").mkdir()
     (outside / "rocprof" / "keep_me.txt").write_text("not yours to delete", encoding="utf-8")
 
-    link = tmp_path / "trial_d0_m0_t0"
+    link = results / "trial_d0_m0_t0"
     link.symlink_to(outside, target_is_directory=True)
 
     with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
-        wrap_argv_for_collectors(_config(["rocprof"], collect_dir=link), _INNER)
+        wrap_argv_for_collectors(
+            _config(["rocprof"], collect_dir=link, results_root=results), _INNER
+        )
     # The whole point: the tree behind the symlink is untouched.
     assert (outside / "rocprof" / "keep_me.txt").read_text(encoding="utf-8") == (
         "not yours to delete"

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -832,15 +832,34 @@ def test_trusted_results_anchor_is_none_without_the_key(tmp_path):
 
 
 @pytest.mark.parametrize("bad", ["nope", [1], [1, 2, 3], ["a", "b"], 7])
-def test_unparseable_threaded_identity_degrades_to_unpinned(tmp_path, bad):
-    """A malformed pin must not raise inside a guard that has to fail closed."""
+def test_unparseable_threaded_identity_degrades_to_unpinned_and_warns(
+    tmp_path, bad, caplog
+):
+    """A malformed pin must not raise, but must not be silent either.
+
+    The key is written only by the dispatcher, so a bad value is our bug and it
+    quietly drops the guard to its weaker no-follow-only form.
+    """
     results = tmp_path / "results"
     results.mkdir()
     config = _config(["rocprof"], results_root=results)
     config[CONFIG_KEY_RESULTS_ROOT_ID] = bad
-    anchor = trusted_results_anchor(config)
+    with caplog.at_level("WARNING"):
+        anchor = trusted_results_anchor(config)
     assert anchor is not None
     assert anchor.identity is None
+    assert any(CONFIG_KEY_RESULTS_ROOT_ID in r.getMessage() for r in caplog.records)
+
+
+def test_absent_threaded_identity_is_not_warned_about(tmp_path, caplog):
+    """A direct programmatic caller threads no pin; that is not a defect."""
+    results = tmp_path / "results"
+    results.mkdir()
+    with caplog.at_level("WARNING"):
+        anchor = trusted_results_anchor(_config(["rocprof"], results_root=results))
+    assert anchor is not None
+    assert anchor.identity is None
+    assert not caplog.records
 
 
 @_needs_fd
@@ -923,10 +942,15 @@ def test_unpinned_anchor_keeps_working(profilers_on_path, tmp_path):
             results_root=results.resolve(),
         )
     )
-    assert metrics["rocprof_kernel_count"] == 3
+    assert metrics.get("rocprof_kernel_count") == 3
 
 
 # ---- Bounded artifact descriptors -----------------------------------------
+
+
+_needs_proc_fd = pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(), reason="descriptor accounting needs /proc"
+)
 
 
 def _peak_fds_while_summarizing(tmp_path, monkeypatch, ranks):
@@ -963,6 +987,7 @@ def _peak_fds_while_summarizing(tmp_path, monkeypatch, ranks):
 
 
 @_needs_fd
+@_needs_proc_fd
 def test_summarize_descriptor_use_does_not_scale_with_artifact_count(
     profilers_on_path, tmp_path, monkeypatch
 ):
@@ -1004,11 +1029,12 @@ def test_summarize_aggregates_every_rank_artifact(profilers_on_path, tmp_path):
             pin_results_root=True,
         )
     )
-    assert metrics["rocprof_kernel_count"] == 16
-    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(160 / 1_000_000.0)
+    assert metrics.get("rocprof_kernel_count") == 16
+    assert metrics.get("rocprof_gpu_time_ms") == pytest.approx(160 / 1_000_000.0)
 
 
 @_needs_fd
+@_needs_proc_fd
 def test_summarize_does_not_leak_fds_across_artifacts(profilers_on_path, tmp_path):
     results = tmp_path / "results"
     subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import os
 from dataclasses import asdict
 from pathlib import Path
 
@@ -29,11 +30,14 @@ from aorta.run.collectors import (
     CONFIG_KEY_COLLECT_DIR,
     CONFIG_KEY_COLLECT_OPTIONS,
     CONFIG_KEY_RESULTS_ROOT,
+    CONFIG_KEY_RESULTS_ROOT_ID,
     KNOWN_RECIPES,
     WRAP_ORDER,
     CollectorSpec,
     active_collectors,
     summarize_collectors,
+    trusted_results_anchor,
+    unsafe_collector_paths,
     validate_collectors,
     wrap_argv_for_collectors,
 )
@@ -57,7 +61,9 @@ def profilers_on_path(tmp_path, monkeypatch):
     return bin_dir
 
 
-def _config(names, *, collect_dir=None, options=None, results_root=None):
+def _config(
+    names, *, collect_dir=None, options=None, results_root=None, pin_results_root=False
+):
     config = {CONFIG_KEY_COLLECT: list(names)}
     if collect_dir is not None:
         config[CONFIG_KEY_COLLECT_DIR] = str(collect_dir)
@@ -65,6 +71,11 @@ def _config(names, *, collect_dir=None, options=None, results_root=None):
         config[CONFIG_KEY_COLLECT_OPTIONS] = options
     if results_root is not None:
         config[CONFIG_KEY_RESULTS_ROOT] = str(results_root)
+    if pin_results_root:
+        # What the dispatcher threads alongside the path: the anchor's inode as
+        # of before the first trial launched.
+        info = os.stat(results_root)
+        config[CONFIG_KEY_RESULTS_ROOT_ID] = [info.st_dev, info.st_ino]
     return config
 
 
@@ -739,3 +750,281 @@ def test_summarize_swap_after_fd_open_does_not_leak_external_metrics(
     # its count of 999 never appears.
     assert metrics.get("rocprof_top_kernels") == ["real"]
     assert metrics.get("rocprof_kernel_count") == 1
+
+
+# ---- Absent collector directories -----------------------------------------
+
+
+def test_missing_collector_subdir_is_not_unsafe(tmp_path):
+    """A never-created output directory must not read as a hostile path.
+
+    ``layer_numerics`` is validated-only: no platform code makes its
+    subdirectory, so ``collect: [rocprof, layer_numerics]`` leaves it absent.
+    Reporting it here makes the caller keep *every* collector's artifacts, which
+    silently turned ``retain.on_pass: none`` into a no-op for the rocprof
+    capture sitting beside it.
+    """
+    results = tmp_path / "results"
+    collect_dir = results / "wl" / "trial_d0_m0_t0"
+    (collect_dir / rocprof.OUTPUT_SUBDIR).mkdir(parents=True)
+    config = _config(
+        ["rocprof", "layer_numerics"],
+        collect_dir=collect_dir,
+        results_root=results.resolve(),
+        pin_results_root=True,
+    )
+    assert not (collect_dir / "layer_numerics").exists()
+    assert unsafe_collector_paths(config) == []
+
+
+def test_symlinked_collector_subdir_is_still_unsafe(tmp_path):
+    """The absence carve-out must not swallow a planted link.
+
+    Guards the boundary of the test above: a broken link is refused with ELOOP,
+    not mistaken for "nothing is there".
+    """
+    results = tmp_path / "results"
+    collect_dir = results / "wl" / "trial_d0_m0_t0"
+    collect_dir.mkdir(parents=True)
+    (collect_dir / rocprof.OUTPUT_SUBDIR).symlink_to(tmp_path / "never_existed")
+    config = _config(
+        ["rocprof"],
+        collect_dir=collect_dir,
+        results_root=results.resolve(),
+        pin_results_root=True,
+    )
+    assert unsafe_collector_paths(config) == [collect_dir / rocprof.OUTPUT_SUBDIR]
+
+
+def test_summarize_of_a_missing_subdir_yields_no_metrics(profilers_on_path, tmp_path):
+    """An absent collector directory contributes nothing and raises nothing."""
+    results = tmp_path / "results"
+    collect_dir = results / "wl" / "trial_d0_m0_t0"
+    collect_dir.mkdir(parents=True)
+    metrics = summarize_collectors(
+        _config(
+            ["rocprof"],
+            collect_dir=collect_dir,
+            results_root=results.resolve(),
+            pin_results_root=True,
+        )
+    )
+    assert metrics == {}
+
+
+# ---- Trust-anchor inode pinning -------------------------------------------
+
+
+def test_trusted_results_anchor_carries_the_threaded_identity(tmp_path):
+    results = tmp_path / "results"
+    results.mkdir()
+    anchor = trusted_results_anchor(
+        _config(["rocprof"], results_root=results, pin_results_root=True)
+    )
+    assert anchor is not None
+    assert anchor.path == results
+    info = os.stat(results)
+    assert anchor.identity == (info.st_dev, info.st_ino)
+
+
+def test_trusted_results_anchor_is_none_without_the_key(tmp_path):
+    assert trusted_results_anchor(_config(["rocprof"])) is None
+
+
+@pytest.mark.parametrize("bad", ["nope", [1], [1, 2, 3], ["a", "b"], 7])
+def test_unparseable_threaded_identity_degrades_to_unpinned(tmp_path, bad):
+    """A malformed pin must not raise inside a guard that has to fail closed."""
+    results = tmp_path / "results"
+    results.mkdir()
+    config = _config(["rocprof"], results_root=results)
+    config[CONFIG_KEY_RESULTS_ROOT_ID] = bad
+    anchor = trusted_results_anchor(config)
+    assert anchor is not None
+    assert anchor.identity is None
+
+
+@_needs_fd
+def test_reset_refuses_a_real_directory_moved_into_the_results_pathname(
+    profilers_on_path, tmp_path
+):
+    """The cross-trial swap that no ``O_NOFOLLOW`` check can see.
+
+    Trial 0's payload renames the results directory aside and moves a real
+    directory into its pathname. Every component of the new path is a genuine
+    directory, so only the frozen inode distinguishes it from the operator's
+    tree -- and without that, trial 1's reset would clear the planted tree.
+    """
+    results = tmp_path / "results"
+    collect_dir = results / "wl" / "trial_d0_m0_t0"
+    collect_dir.mkdir(parents=True)
+    config = _config(
+        ["rocprof"],
+        collect_dir=collect_dir,
+        results_root=results.resolve(),
+        pin_results_root=True,
+    )
+
+    results.rename(tmp_path / "results.moved")
+    planted = tmp_path / "planted"
+    seeded = planted / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR / "precious.csv"
+    seeded.parent.mkdir(parents=True)
+    seeded.write_text("keep me", encoding="utf-8")
+    planted.rename(results)
+    # The planted tree now answers to the results pathname the guard was given.
+    victim = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR / "precious.csv"
+
+    with pytest.raises(RuntimeError, match="cannot prepare the rocprof artifact directory"):
+        wrap_argv_for_collectors(config, _INNER)
+    assert victim.read_text(encoding="utf-8") == "keep me"
+
+
+@_needs_fd
+def test_summarize_refuses_a_swapped_results_root(profilers_on_path, tmp_path):
+    """The same swap on the read path publishes no metrics from the planted tree."""
+    results = tmp_path / "results"
+    subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    subdir.mkdir(parents=True)
+    config = _config(
+        ["rocprof"],
+        collect_dir=subdir.parent,
+        results_root=results.resolve(),
+        pin_results_root=True,
+    )
+
+    results.rename(tmp_path / "results.moved")
+    planted = tmp_path / "planted"
+    planted_subdir = planted / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    planted_subdir.mkdir(parents=True)
+    (planted_subdir / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"leak",999,9\n', encoding="utf-8"
+    )
+    planted.rename(results)
+
+    assert summarize_collectors(config) == {}
+
+
+@_needs_fd
+def test_unpinned_anchor_keeps_working(profilers_on_path, tmp_path):
+    """A config with no threaded pin still parses a clean tree.
+
+    Back-compat for a trial JSON written before the pin existed, and for a
+    direct programmatic caller.
+    """
+    results = tmp_path / "results"
+    subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    subdir.mkdir(parents=True)
+    (subdir / "aorta_kernel_stats.csv").write_text(
+        '"Name","Calls","TotalDurationNs"\n"sgemm",3,1000\n', encoding="utf-8"
+    )
+    metrics = summarize_collectors(
+        _config(
+            ["rocprof"],
+            collect_dir=subdir.parent,
+            results_root=results.resolve(),
+        )
+    )
+    assert metrics["rocprof_kernel_count"] == 3
+
+
+# ---- Bounded artifact descriptors -----------------------------------------
+
+
+def _peak_fds_while_summarizing(tmp_path, monkeypatch, ranks):
+    """Highest descriptor count observed while parsing ``ranks`` stats CSVs."""
+    results = tmp_path / "results"
+    subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    subdir.mkdir(parents=True)
+    for rank in range(ranks):
+        (subdir / f"rank{rank:03d}_kernel_stats.csv").write_text(
+            '"Name","Calls","TotalDurationNs"\n"sgemm",1,10\n', encoding="utf-8"
+        )
+    config = _config(
+        ["rocprof"],
+        collect_dir=subdir.parent,
+        results_root=results.resolve(),
+        pin_results_root=True,
+    )
+    seen = []
+
+    def probe(artifact_dir, stats_streams, trace_streams):
+        # Sample inside the parse, per stream, so an implementation that opens
+        # everything up front is caught as well as one that accumulates.
+        for _stream in stats_streams:
+            seen.append(len(os.listdir("/proc/self/fd")))
+        return {}
+
+    monkeypatch.setattr(rocprof, "parse_summary_from_streams", probe)
+    summarize_collectors(config)  # warm lazy imports before the baseline
+    baseline = len(os.listdir("/proc/self/fd"))
+    seen.clear()
+    summarize_collectors(config)
+    assert len(seen) == ranks
+    return max(seen) - baseline
+
+
+@_needs_fd
+def test_summarize_descriptor_use_does_not_scale_with_artifact_count(
+    profilers_on_path, tmp_path, monkeypatch
+):
+    """Descriptor use must not scale with the number of per-rank artifacts.
+
+    rocprof writes a CSV pair per process, so a large distributed capture can
+    hold more artifacts than ``RLIMIT_NOFILE`` allows. Opening them all up
+    front hit ``EMFILE`` partway through and published totals covering only the
+    ranks before the limit. Comparing an 8-artifact capture against a
+    64-artifact one is what pins the bound: an absolute number would pass for
+    the eager version too on a small enough tree.
+    """
+    small = _peak_fds_while_summarizing(tmp_path / "small", monkeypatch, 8)
+    large = _peak_fds_while_summarizing(tmp_path / "large", monkeypatch, 64)
+    assert small == large
+    # One artifact handle plus the directory fds held across the read.
+    assert large <= 4
+
+
+@_needs_fd
+def test_summarize_aggregates_every_rank_artifact(profilers_on_path, tmp_path):
+    """Bounding the descriptors must not cost a file: all 16 ranks are summed."""
+    results = tmp_path / "results"
+    subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    (subdir / "nested").mkdir(parents=True)
+    for rank in range(16):
+        # Half flat, half under a hostname subdirectory -- the layout depends on
+        # whether ``-o`` was passed, and the per-file reopen has to descend for
+        # the nested ones.
+        parent = subdir if rank % 2 else subdir / "nested"
+        (parent / f"rank{rank:02d}_kernel_stats.csv").write_text(
+            '"Name","Calls","TotalDurationNs"\n"sgemm",1,10\n', encoding="utf-8"
+        )
+    metrics = summarize_collectors(
+        _config(
+            ["rocprof"],
+            collect_dir=subdir.parent,
+            results_root=results.resolve(),
+            pin_results_root=True,
+        )
+    )
+    assert metrics["rocprof_kernel_count"] == 16
+    assert metrics["rocprof_gpu_time_ms"] == pytest.approx(160 / 1_000_000.0)
+
+
+@_needs_fd
+def test_summarize_does_not_leak_fds_across_artifacts(profilers_on_path, tmp_path):
+    results = tmp_path / "results"
+    subdir = results / "wl" / "trial_d0_m0_t0" / rocprof.OUTPUT_SUBDIR
+    subdir.mkdir(parents=True)
+    for rank in range(12):
+        (subdir / f"rank{rank:02d}_kernel_stats.csv").write_text(
+            '"Name","Calls","TotalDurationNs"\n"sgemm",1,10\n', encoding="utf-8"
+        )
+    config = _config(
+        ["rocprof"],
+        collect_dir=subdir.parent,
+        results_root=results.resolve(),
+        pin_results_root=True,
+    )
+    summarize_collectors(config)  # warm any lazy imports first
+    before = len(os.listdir("/proc/self/fd"))
+    for _ in range(10):
+        summarize_collectors(config)
+    assert len(os.listdir("/proc/self/fd")) == before

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -36,7 +36,7 @@ from aorta.run.collectors import (
     CollectorSpec,
     active_collectors,
     summarize_collectors,
-    trusted_results_anchor,
+    trusted_collector_anchor,
     unsafe_collector_paths,
     validate_collectors,
     wrap_argv_for_collectors,
@@ -815,20 +815,30 @@ def test_summarize_of_a_missing_subdir_yields_no_metrics(profilers_on_path, tmp_
 # ---- Trust-anchor inode pinning -------------------------------------------
 
 
-def test_trusted_results_anchor_carries_the_threaded_identity(tmp_path):
+def test_trusted_anchor_carries_the_threaded_identity(tmp_path):
     results = tmp_path / "results"
     results.mkdir()
-    anchor = trusted_results_anchor(
-        _config(["rocprof"], results_root=results, pin_results_root=True)
+    root = results / "wl" / "trial_d0_m0_t0"
+    anchor = trusted_collector_anchor(
+        _config(["rocprof"], results_root=results, pin_results_root=True), root
     )
-    assert anchor is not None
     assert anchor.path == results
     info = os.stat(results)
     assert anchor.identity == (info.st_dev, info.st_ino)
 
 
-def test_trusted_results_anchor_is_none_without_the_key(tmp_path):
-    assert trusted_results_anchor(_config(["rocprof"])) is None
+def test_trusted_anchor_falls_back_to_the_collect_roots_parent(tmp_path):
+    """A config with no threaded anchor still gets one, unpinned.
+
+    Returning ``None`` here is what let the retention pre-filter guard
+    ``collect_root.parent`` while the destructive prune it gates received
+    nothing and silently dropped to the pathname engine. One function, one
+    answer, so the two cannot disagree.
+    """
+    root = tmp_path / "wl" / "trial_d0_m0_t0"
+    anchor = trusted_collector_anchor(_config(["rocprof"]), root)
+    assert anchor.path == root.parent
+    assert anchor.identity is None
 
 
 @pytest.mark.parametrize("bad", ["nope", [1], [1, 2, 3], ["a", "b"], 7])
@@ -845,8 +855,7 @@ def test_unparseable_threaded_identity_degrades_to_unpinned_and_warns(
     config = _config(["rocprof"], results_root=results)
     config[CONFIG_KEY_RESULTS_ROOT_ID] = bad
     with caplog.at_level("WARNING"):
-        anchor = trusted_results_anchor(config)
-    assert anchor is not None
+        anchor = trusted_collector_anchor(config, results / "wl" / "trial_d0_m0_t0")
     assert anchor.identity is None
     assert any(CONFIG_KEY_RESULTS_ROOT_ID in r.getMessage() for r in caplog.records)
 
@@ -856,8 +865,10 @@ def test_absent_threaded_identity_is_not_warned_about(tmp_path, caplog):
     results = tmp_path / "results"
     results.mkdir()
     with caplog.at_level("WARNING"):
-        anchor = trusted_results_anchor(_config(["rocprof"], results_root=results))
-    assert anchor is not None
+        anchor = trusted_collector_anchor(
+            _config(["rocprof"], results_root=results), results / "wl" / "t"
+        )
+    assert anchor.path == results
     assert anchor.identity is None
     assert not caplog.records
 

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -952,13 +952,14 @@ class TestRunTrials:
             req = RunRequest(workload="nocollectdir", trials=1, results_dir=tmp_path)
             run_trials(req)
         assert "_aorta_collect_dir" not in captured_config
-        assert captured_config["_aorta_results_root"] == str(tmp_path.resolve())
+        assert captured_config.get("_aorta_results_root") == str(tmp_path.resolve())
         info = os.stat(tmp_path.resolve())
-        assert captured_config["_aorta_results_root_id"] == [info.st_dev, info.st_ino]
+        assert captured_config.get("_aorta_results_root_id") == [info.st_dev, info.st_ino]
 
         written = list(tmp_path.rglob("trial_*.json"))
         assert len(written) == 1
-        persisted_config = json.loads(written[0].read_text(encoding="utf-8"))["config"]
+        persisted_config = json.loads(written[0].read_text(encoding="utf-8")).get("config")
+        assert isinstance(persisted_config, dict)
         assert "_aorta_collect_dir" not in persisted_config
         assert "_aorta_results_root" not in persisted_config
         assert "_aorta_results_root_id" not in persisted_config

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aorta.run import _fsafe
 from aorta.run.dispatcher import RunRequest, run_trials
 from aorta.workloads import Workload, WorkloadResult
 
@@ -811,6 +812,76 @@ class TestRunTrials:
         # tree rather than under the symlink the first trial planted.
         assert not Path(collect_dirs[1]).is_relative_to(outside.resolve())
 
+    def test_results_root_identity_is_pinned_before_the_trial_loop(self, tmp_path):
+        """The anchor carries the results directory's inode, not just its path.
+
+        A pathname is not an immutable anchor: a payload can rename the results
+        directory aside and move a *real* directory into its place, which leaves
+        every later ``O_NOFOLLOW`` check on that pathname satisfied. The pinned
+        ``(st_dev, st_ino)`` is what makes that swap detectable, so it has to be
+        read here -- before any trial launches -- and threaded like the path.
+        """
+        captured_config: dict = {}
+
+        class ConfigCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_config.update(self.config)
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "pinned_root"
+        mock_ep.load.return_value = ConfigCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="pinned_root",
+                trials=1,
+                results_dir=tmp_path,
+                collect=("layer_numerics",),
+            )
+            run_trials(req)
+
+        info = os.stat(tmp_path.resolve())
+        assert captured_config["_aorta_results_root_id"] == [info.st_dev, info.st_ino]
+        # A plain two-element list of ints, so the trial-JSON dump needs no
+        # sanitizer for it (same contract as ``_aorta_collect``).
+        assert json.loads(json.dumps(captured_config["_aorta_results_root_id"])) == [
+            info.st_dev,
+            info.st_ino,
+        ]
+
+    def test_results_root_identity_reaches_an_isolated_worker(self, tmp_path):
+        """The pin has to survive the JSON envelope, where an fd could not.
+
+        An isolated trial runs in a process that starts *after* an earlier
+        trial's payload, so it must inherit the parent's pin rather than take
+        its own -- which means the envelope carries it explicitly.
+        """
+        from aorta.run._trial_worker import _anchor_from_envelope
+
+        anchor = _fsafe.TrustedAnchor.freeze(tmp_path)
+        assert anchor.identity is not None
+        envelope = {
+            "results_root": str(anchor.path),
+            "results_root_id": list(anchor.identity),
+        }
+        assert _anchor_from_envelope(envelope) == anchor
+        # An envelope from a parent that could not pin degrades to the path.
+        assert _anchor_from_envelope({"results_root": str(tmp_path)}) == (
+            _fsafe.TrustedAnchor(tmp_path, None)
+        )
+        assert _anchor_from_envelope({"results_root": None}) is None
+
     def test_collect_dir_absent_without_collector(self, tmp_path):
         """No collector keys for a run with no collector -- back-compat
         (``_aorta_collect_dir`` and ``_aorta_results_root`` only appear when a
@@ -841,6 +912,7 @@ class TestRunTrials:
             run_trials(req)
         assert "_aorta_collect_dir" not in captured_config
         assert "_aorta_results_root" not in captured_config
+        assert "_aorta_results_root_id" not in captured_config
 
     def test_collect_survives_trial_json_roundtrip(self, tmp_path):
         """``_aorta_collect`` is a plain list, so the trial JSON dump needs

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -639,9 +639,60 @@ class TestRunTrials:
         results_root = captured_config["_aorta_results_root"]
         assert Path(results_root).is_absolute()
         assert Path(collect_dir).parent == Path(results_root)
+        assert results_root == str(Path(results_root).resolve())
         # No log prefix, because save_logs was not requested -- proves the two
         # are decoupled.
         assert "_aorta_log_prefix" not in captured_config
+
+    def test_results_root_is_canonical_when_results_dir_is_a_symlink(self, tmp_path):
+        """The trust anchor is ``--results-dir.resolve()``, stored before launch.
+
+        A live ``.absolute()`` of a symlink is still the symlink. After the
+        payload replaces that directory, resolving the stored path again would
+        follow the new target; pinning the canonical path here is what makes
+        the post-run guard compare against the operator's tree.
+        """
+        captured_config: dict = {}
+
+        class ConfigCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_config.update(self.config)
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        real = tmp_path / "real_results"
+        real.mkdir()
+        link = tmp_path / "results_link"
+        link.symlink_to(real, target_is_directory=True)
+
+        mock_ep = MagicMock()
+        mock_ep.name = "collect_dir_symlink"
+        mock_ep.load.return_value = ConfigCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="collect_dir_symlink",
+                trials=1,
+                results_dir=link,
+                collect=("layer_numerics",),
+            )
+            run_trials(req)
+        workload_dir = link / "collect_dir_symlink"
+        assert captured_config["_aorta_results_root"] == str(workload_dir.resolve())
+        assert captured_config["_aorta_results_root"] != str(workload_dir.absolute())
+        assert captured_config["_aorta_collect_dir"] == str(
+            workload_dir.resolve() / "trial_d0_m0_t0"
+        )
+        assert not Path(captured_config["_aorta_results_root"]).is_symlink()
 
     def test_collect_dir_absent_without_collector(self, tmp_path):
         """No collector keys for a run with no collector -- back-compat

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -2815,6 +2815,28 @@ class TestSaveLogs:
             for name in names
         )
 
+    @pytest.mark.skipif(
+        not _fsafe.HAVE_FD_TRAVERSAL,
+        reason="fd-relative traversal unsupported here",
+    )
+    def test_anchored_record_helpers_refuse_a_directory_outside_anchor(self, tmp_path):
+        results = tmp_path / "results"
+        results.mkdir()
+        anchor = _fsafe.TrustedAnchor.freeze(results)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "record.log"
+        victim.write_text("keep me", encoding="utf-8")
+
+        with pytest.raises(_fsafe.UnsafePathError):
+            dispatcher_module._open_record_file(
+                outside, anchor, victim.name, encoding="utf-8"
+            )
+        with pytest.raises(_fsafe.UnsafePathError):
+            dispatcher_module._unlink_record_file(outside, anchor, victim.name)
+
+        assert victim.read_text(encoding="utf-8") == "keep me"
+
 
 class TestAortaTrialEnv:
     """Tests for the ``_aorta_trial_env`` config key and the 3-layer env-precedence contract.

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -817,6 +817,7 @@ class TestRunTrials:
         # value a per-trial anchor would have picked up.
         expected_root = tmp_path.resolve()
 
+        os.environ.pop("AORTA_LEAK_PROBE", None)
         with patch("importlib.metadata.entry_points", return_value=mock_eps):
             req = RunRequest(
                 workload="swap_results_dir",
@@ -824,6 +825,11 @@ class TestRunTrials:
                 results_dir=tmp_path,
                 collect=("layer_numerics",),
                 save_logs=True,
+                # The record write is the one guard here that raises. This file
+                # warns that raising in the wrong place leaks the overlay into
+                # the caller's process and corrupts later triage cells, so pin
+                # that the refusal happens after the env-restore ``finally``.
+                extra_env={"AORTA_LEAK_PROBE": "leaked"},
             )
             # Trial 0's own record write is the first thing to touch the swapped
             # component, so the run stops there rather than tolerating the swap
@@ -845,6 +851,9 @@ class TestRunTrials:
         assert (tmp_path / "swap_results_dir").resolve() == outside.resolve()
         assert raised is not None, "expected the record write to refuse the swap"
         assert "refusing to write the trial record" in str(raised)
+        assert (
+            "AORTA_LEAK_PROBE" not in os.environ
+        ), "env overlay leaked when the record write refused"
 
     def test_results_root_identity_is_pinned_before_the_trial_loop(self, tmp_path):
         """The anchor carries the results directory's inode, not just its path.

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -644,8 +644,9 @@ class TestRunTrials:
         assert "_aorta_log_prefix" not in captured_config
 
     def test_collect_dir_absent_without_collector(self, tmp_path):
-        """No ``_aorta_collect_dir`` for a run with no collector -- back-compat
-        (the key only appears when a collector was requested)."""
+        """No collector keys for a run with no collector -- back-compat
+        (``_aorta_collect_dir`` and ``_aorta_results_root`` only appear when a
+        collector was requested)."""
         captured_config: dict = {}
 
         class ConfigCapturingWorkload(Workload):
@@ -671,6 +672,7 @@ class TestRunTrials:
             req = RunRequest(workload="nocollectdir", trials=1, results_dir=tmp_path)
             run_trials(req)
         assert "_aorta_collect_dir" not in captured_config
+        assert "_aorta_results_root" not in captured_config
 
     def test_collect_survives_trial_json_roundtrip(self, tmp_path):
         """``_aorta_collect`` is a plain list, so the trial JSON dump needs

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -639,7 +639,8 @@ class TestRunTrials:
         # back to a boundary the payload controls.
         results_root = captured_config["_aorta_results_root"]
         assert Path(results_root).is_absolute()
-        assert Path(collect_dir).parent == Path(results_root)
+        assert Path(collect_dir).parent.name == "collect_dir"
+        assert Path(collect_dir).parent.parent == Path(results_root)
         assert results_root == str(Path(results_root).resolve())
         # No log prefix, because save_logs was not requested -- proves the two
         # are decoupled.
@@ -687,13 +688,65 @@ class TestRunTrials:
                 collect=("layer_numerics",),
             )
             run_trials(req)
-        workload_dir = link / "collect_dir_symlink"
-        assert captured_config["_aorta_results_root"] == str(workload_dir.resolve())
-        assert captured_config["_aorta_results_root"] != str(workload_dir.absolute())
+        workload_dir = real / "collect_dir_symlink"
+        assert captured_config["_aorta_results_root"] == str(real.resolve())
+        assert captured_config["_aorta_results_root"] != str(link.absolute())
         assert captured_config["_aorta_collect_dir"] == str(
-            workload_dir.resolve() / "trial_d0_m0_t0"
+            workload_dir / "trial_d0_m0_t0"
         )
         assert not Path(captured_config["_aorta_results_root"]).is_symlink()
+
+    def test_workload_symlink_is_not_folded_into_the_collector_anchor(self, tmp_path):
+        """A stale workload link remains below the operator-owned boundary.
+
+        Resolving ``<results>/<workload>`` would trust its outside target.
+        Resolving only ``--results-dir`` and appending the workload lexically
+        lets the collector guard reject that payload-owned component.
+        """
+        captured_config: dict = {}
+
+        class ConfigCapturingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                captured_config.update(self.config)
+
+            def run(self):
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        results = tmp_path / "results"
+        results.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (results / "stale_workload_link").symlink_to(outside, target_is_directory=True)
+
+        mock_ep = MagicMock()
+        mock_ep.name = "stale_workload_link"
+        mock_ep.load.return_value = ConfigCapturingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            run_trials(
+                RunRequest(
+                    workload="stale_workload_link",
+                    trials=1,
+                    results_dir=results,
+                    collect=("layer_numerics",),
+                )
+            )
+
+        assert captured_config["_aorta_results_root"] == str(results.resolve())
+        assert captured_config["_aorta_collect_dir"] == str(
+            results.resolve() / "stale_workload_link" / "trial_d0_m0_t0"
+        )
+        assert outside.resolve() not in Path(
+            captured_config["_aorta_collect_dir"]
+        ).parents
 
     def test_results_root_is_frozen_once_for_the_whole_trial_loop(self, tmp_path):
         """Trial 0's payload must not be able to re-anchor trial 1.
@@ -722,7 +775,7 @@ class TestRunTrials:
                 # Only the first trial does it, so a re-anchored second trial
                 # shows up as a differing anchor rather than a second swap.
                 if len(roots) == 1:
-                    workload_dir = Path(roots[0])
+                    workload_dir = Path(collect_dirs[0]).parent
                     shutil.rmtree(workload_dir)
                     workload_dir.symlink_to(outside, target_is_directory=True)
                 return WorkloadResult(passed=True)
@@ -739,7 +792,7 @@ class TestRunTrials:
         # Pinned BEFORE the run on purpose: after trial 0 plants the symlink,
         # resolving this same path yields ``outside``, which is precisely the
         # value a per-trial anchor would have picked up.
-        expected_root = (tmp_path / "swap_results_dir").resolve()
+        expected_root = tmp_path.resolve()
 
         with patch("importlib.metadata.entry_points", return_value=mock_eps):
             req = RunRequest(

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -631,6 +631,14 @@ class TestRunTrials:
         collect_dir = captured_config["_aorta_collect_dir"]
         assert Path(collect_dir).is_absolute()
         assert collect_dir.endswith("trial_d0_m0_t0")
+        # The trust anchor for the collector symlink guards travels with it. It
+        # must come from here rather than be derived from ``_aorta_collect_dir``,
+        # because everything at or below that path is payload-writable while the
+        # trial runs -- so if this key ever stops being threaded, the guards fall
+        # back to a boundary the payload controls.
+        results_root = captured_config["_aorta_results_root"]
+        assert Path(results_root).is_absolute()
+        assert Path(collect_dir).parent == Path(results_root)
         # No log prefix, because save_logs was not requested -- proves the two
         # are decoupled.
         assert "_aorta_log_prefix" not in captured_config

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -2779,6 +2779,42 @@ class TestSaveLogs:
         assert "_aorta_save_logs" not in NoisyWorkload.seen_config
         assert "_aorta_log_prefix" not in NoisyWorkload.seen_config
 
+    @pytest.mark.skipif(
+        not _fsafe.HAVE_FD_TRAVERSAL,
+        reason="fd-relative traversal unsupported here",
+    )
+    def test_partial_open_cleanup_does_not_follow_swapped_workload_dir(self, tmp_path):
+        """Cleaning a log stub must stay anchored after its parent is swapped."""
+        results = tmp_path / "results"
+        workload_dir = results / "noisy"
+        workload_dir.mkdir(parents=True)
+        anchor = _fsafe.TrustedAnchor.freeze(results)
+        names = (
+            "trial_d0_m0_t0.stdout.log",
+            "trial_d0_m0_t0.stderr.log",
+        )
+        with dispatcher_module._open_record_file(
+            workload_dir, anchor, names[0], encoding="utf-8"
+        ):
+            pass
+
+        moved = results / "noisy.original"
+        workload_dir.rename(moved)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        for name in names:
+            (outside / name).write_text("keep me", encoding="utf-8")
+        workload_dir.symlink_to(outside, target_is_directory=True)
+
+        for name in names:
+            with pytest.raises(_fsafe.UnsafePathError):
+                dispatcher_module._unlink_record_file(workload_dir, anchor, name)
+
+        assert all(
+            (outside / name).read_text(encoding="utf-8") == "keep me"
+            for name in names
+        )
+
 
 class TestAortaTrialEnv:
     """Tests for the ``_aorta_trial_env`` config key and the 3-layer env-precedence contract.

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -693,6 +694,69 @@ class TestRunTrials:
             workload_dir.resolve() / "trial_d0_m0_t0"
         )
         assert not Path(captured_config["_aorta_results_root"]).is_symlink()
+
+    def test_results_root_is_frozen_once_for_the_whole_trial_loop(self, tmp_path):
+        """Trial 0's payload must not be able to re-anchor trial 1.
+
+        The anchor is resolved before the loop, so a workload that replaces
+        the results directory with a symlink to an outside tree cannot hand
+        the next trial a new trusted root: trial 1 still carries the original
+        canonical path, and its collect dir stays under it.
+        """
+        roots: list[str] = []
+        collect_dirs: list[str] = []
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        class ResultsDirSwappingWorkload(Workload):
+            launch_mode = "single_process"
+            min_world_size = 1
+
+            def setup(self):
+                roots.append(self.config["_aorta_results_root"])
+                collect_dirs.append(self.config["_aorta_collect_dir"])
+
+            def run(self):
+                # What a hostile (or merely buggy) payload can do to the tree
+                # it was handed: swap the whole results directory for a link.
+                # Only the first trial does it, so a re-anchored second trial
+                # shows up as a differing anchor rather than a second swap.
+                if len(roots) == 1:
+                    workload_dir = Path(roots[0])
+                    shutil.rmtree(workload_dir)
+                    workload_dir.symlink_to(outside, target_is_directory=True)
+                return WorkloadResult(passed=True)
+
+            def cleanup(self):
+                pass
+
+        mock_ep = MagicMock()
+        mock_ep.name = "swap_results_dir"
+        mock_ep.load.return_value = ResultsDirSwappingWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        # Pinned BEFORE the run on purpose: after trial 0 plants the symlink,
+        # resolving this same path yields ``outside``, which is precisely the
+        # value a per-trial anchor would have picked up.
+        expected_root = (tmp_path / "swap_results_dir").resolve()
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            req = RunRequest(
+                workload="swap_results_dir",
+                trials=2,
+                results_dir=tmp_path,
+                collect=("layer_numerics",),
+            )
+            run_trials(req)
+
+        assert len(roots) == 2
+        assert roots[0] == roots[1]
+        assert Path(roots[0]) == expected_root
+        assert (tmp_path / "swap_results_dir").resolve() == outside.resolve()
+        # The second trial's artifact path is still anchored in the operator's
+        # tree rather than under the symlink the first trial planted.
+        assert not Path(collect_dirs[1]).is_relative_to(outside.resolve())
 
     def test_collect_dir_absent_without_collector(self, tmp_path):
         """No collector keys for a run with no collector -- back-compat

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aorta.run import _fsafe
+from aorta.run import dispatcher as dispatcher_module
 from aorta.run.dispatcher import RunRequest, run_trials
 from aorta.workloads import Workload, WorkloadResult
 
@@ -697,21 +698,29 @@ class TestRunTrials:
         )
         assert not Path(captured_config["_aorta_results_root"]).is_symlink()
 
-    def test_workload_symlink_is_not_folded_into_the_collector_anchor(self, tmp_path):
-        """A stale workload link remains below the operator-owned boundary.
+    @pytest.mark.parametrize("collect", [(), ("layer_numerics",)])
+    def test_stale_workload_symlink_is_refused_before_any_write(self, tmp_path, collect):
+        """A link at the workload component aborts the run instead of escaping.
 
-        Resolving ``<results>/<workload>`` would trust its outside target.
-        Resolving only ``--results-dir`` and appending the workload lexically
-        lets the collector guard reject that payload-owned component.
+        Keeping ``<results>/<workload>`` lexical stops the collector guards
+        trusting its target, but the dispatcher writes the trial record and the
+        captured logs through that same component, and ``open()`` follows links.
+        A stale link from an earlier run therefore used to put the whole audit
+        trail in the link's target -- ``mkdir(exist_ok=True)`` on a symlink to a
+        directory succeeds silently, so nothing complained.
+
+        Parametrized over ``collect`` because these writes happen on every run,
+        not just a collector run: the anchor that protects them cannot be gated
+        on ``--collect``.
         """
-        captured_config: dict = {}
+        ran = []
 
         class ConfigCapturingWorkload(Workload):
             launch_mode = "single_process"
             min_world_size = 1
 
             def setup(self):
-                captured_config.update(self.config)
+                ran.append(1)
 
             def run(self):
                 return WorkloadResult(passed=True)
@@ -731,31 +740,44 @@ class TestRunTrials:
         mock_eps = MagicMock()
         mock_eps.select.return_value = [mock_ep]
 
+        raised: BaseException | None = None
         with patch("importlib.metadata.entry_points", return_value=mock_eps):
-            run_trials(
-                RunRequest(
-                    workload="stale_workload_link",
-                    trials=1,
-                    results_dir=results,
-                    collect=("layer_numerics",),
+            try:
+                run_trials(
+                    RunRequest(
+                        workload="stale_workload_link",
+                        trials=1,
+                        results_dir=results,
+                        collect=collect,
+                        save_logs=True,
+                    )
                 )
-            )
+            except RuntimeError as exc:
+                raised = exc
 
-        assert captured_config["_aorta_results_root"] == str(results.resolve())
-        assert captured_config["_aorta_collect_dir"] == str(
-            results.resolve() / "stale_workload_link" / "trial_d0_m0_t0"
-        )
-        assert outside.resolve() not in Path(
-            captured_config["_aorta_collect_dir"]
-        ).parents
+        # The escape is asserted FIRST so a regression fails by naming the files
+        # that got out, not merely by "DID NOT RAISE". Without the guard this
+        # reads ['trial_d0_m0_t0.json', '...stderr.log', '...stdout.log'].
+        assert sorted(p.name for p in outside.iterdir()) == []
+        # Refused before the workload was even constructed.
+        assert ran == []
+        assert raised is not None, "expected the run to refuse the planted link"
+        assert "refusing to use" in str(raised)
 
     def test_results_root_is_frozen_once_for_the_whole_trial_loop(self, tmp_path):
         """Trial 0's payload must not be able to re-anchor trial 1.
 
-        The anchor is resolved before the loop, so a workload that replaces
-        the results directory with a symlink to an outside tree cannot hand
-        the next trial a new trusted root: trial 1 still carries the original
-        canonical path, and its collect dir stays under it.
+        The anchor is frozen before the loop, so a workload that replaces the
+        workload directory with a symlink to an outside tree cannot hand the next
+        trial a new trusted root. Two properties in one run, because with the
+        record writes anchored they are now inseparable: the swap is *refused*
+        (nothing lands in the link's target), and the anchor trial 0 was handed
+        is the pre-run canonical path rather than one derived after the swap.
+
+        Mutation-verified in both directions: restoring the per-trial
+        ``resolve()`` re-anchors the write to ``outside`` and the emptiness
+        assertion fails; dropping the record-write guard writes
+        ``trial_d0_m0_t0.json`` into ``outside`` and the same assertion fails.
         """
         roots: list[str] = []
         collect_dirs: list[str] = []
@@ -801,16 +823,28 @@ class TestRunTrials:
                 trials=2,
                 results_dir=tmp_path,
                 collect=("layer_numerics",),
+                save_logs=True,
             )
-            run_trials(req)
+            # Trial 0's own record write is the first thing to touch the swapped
+            # component, so the run stops there rather than tolerating the swap
+            # for another whole trial.
+            raised: BaseException | None = None
+            try:
+                run_trials(req)
+            except RuntimeError as exc:
+                raised = exc
 
-        assert len(roots) == 2
-        assert roots[0] == roots[1]
+        # Asserted FIRST so a regression fails by naming what escaped rather
+        # than by "DID NOT RAISE": with either guard removed this reads
+        # ['trial_d0_m0_t0.json', ...].
+        assert sorted(p.name for p in outside.iterdir()) == []
+        # The anchor trial 0 received was pinned before the run, not derived
+        # from the tree the payload had just rewritten.
         assert Path(roots[0]) == expected_root
+        assert not Path(collect_dirs[0]).is_relative_to(outside.resolve())
         assert (tmp_path / "swap_results_dir").resolve() == outside.resolve()
-        # The second trial's artifact path is still anchored in the operator's
-        # tree rather than under the symlink the first trial planted.
-        assert not Path(collect_dirs[1]).is_relative_to(outside.resolve())
+        assert raised is not None, "expected the record write to refuse the swap"
+        assert "refusing to write the trial record" in str(raised)
 
     def test_results_root_identity_is_pinned_before_the_trial_loop(self, tmp_path):
         """The anchor carries the results directory's inode, not just its path.
@@ -2694,15 +2728,22 @@ class TestSaveLogs:
         assert (cell_dir / "trial_d0_m0_t0.stderr.log").read_text().strip() == "BEFORE-CRASH-STDERR"
 
     def test_log_open_failure_degrades_gracefully_and_restores_env(self, tmp_path):
-        """If log-file open() raises, the trial must still run, the env
+        """If the log-file open raises, the trial must still run, the env
         overlay must still be restored (otherwise mitigation vars leak
-        across cells), and the _aorta_* keys must NOT be injected."""
-        real_open = open
+        across cells), and the _aorta_* keys must NOT be injected.
 
-        def raising_open(path, *args, **kwargs):
-            if str(path).endswith((".stdout.log", ".stderr.log")):
+        Injected at ``_open_record_file`` rather than at ``builtins.open``: the
+        record writes go through the frozen anchor with a no-follow leaf now, so
+        patching ``open`` no longer intercepts them and the failure this test
+        exists to simulate would never fire. Same predicate as before -- only
+        the two log names -- so the trial JSON still writes normally.
+        """
+        real_open_record = dispatcher_module._open_record_file
+
+        def raising_open_record(results_dir, anchor, name, **kwargs):
+            if name.endswith((".stdout.log", ".stderr.log")):
                 raise PermissionError("simulated log-open failure")
-            return real_open(path, *args, **kwargs)
+            return real_open_record(results_dir, anchor, name, **kwargs)
 
         os.environ.pop("AORTA_LEAK_PROBE", None)
         NoisyWorkload.seen_config = {}
@@ -2711,8 +2752,8 @@ class TestSaveLogs:
         mock_ep.load.return_value = NoisyWorkload
         mock_eps = MagicMock()
         mock_eps.select.return_value = [mock_ep]
-        with patch("importlib.metadata.entry_points", return_value=mock_eps), patch(
-            "builtins.open", side_effect=raising_open
+        with patch("importlib.metadata.entry_points", return_value=mock_eps), patch.object(
+            dispatcher_module, "_open_record_file", side_effect=raising_open_record
         ):
             results = run_trials(
                 RunRequest(

--- a/tests/run/test_dispatcher.py
+++ b/tests/run/test_dispatcher.py
@@ -925,10 +925,8 @@ class TestRunTrials:
         )
         assert _anchor_from_envelope({"results_root": None}) is None
 
-    def test_collect_dir_absent_without_collector(self, tmp_path):
-        """No collector keys for a run with no collector -- back-compat
-        (``_aorta_collect_dir`` and ``_aorta_results_root`` only appear when a
-        collector was requested)."""
+    def test_runtime_anchor_is_not_persisted_without_collector(self, tmp_path):
+        """Probe safety gets the frozen anchor without changing record shape."""
         captured_config: dict = {}
 
         class ConfigCapturingWorkload(Workload):
@@ -954,8 +952,69 @@ class TestRunTrials:
             req = RunRequest(workload="nocollectdir", trials=1, results_dir=tmp_path)
             run_trials(req)
         assert "_aorta_collect_dir" not in captured_config
-        assert "_aorta_results_root" not in captured_config
-        assert "_aorta_results_root_id" not in captured_config
+        assert captured_config["_aorta_results_root"] == str(tmp_path.resolve())
+        info = os.stat(tmp_path.resolve())
+        assert captured_config["_aorta_results_root_id"] == [info.st_dev, info.st_ino]
+
+        written = list(tmp_path.rglob("trial_*.json"))
+        assert len(written) == 1
+        persisted_config = json.loads(written[0].read_text(encoding="utf-8"))["config"]
+        assert "_aorta_collect_dir" not in persisted_config
+        assert "_aorta_results_root" not in persisted_config
+        assert "_aorta_results_root_id" not in persisted_config
+
+    @pytest.mark.skipif(
+        not _fsafe.HAVE_FD_TRAVERSAL,
+        reason="fd-relative traversal unsupported here",
+    )
+    def test_probe_without_collector_refuses_replaced_results_inode(self, tmp_path):
+        """A normal probe reuses the dispatcher's pre-payload inode pin."""
+        from aorta.workloads._subprocess import SubprocessWorkload
+
+        results = tmp_path / "results"
+        moved = tmp_path / "results.original"
+        replacement = tmp_path / "replacement"
+        replacement_trial = replacement / "trial_0"
+        replacement_trial.mkdir(parents=True)
+        canary = replacement_trial / "canary"
+        canary.write_text("untouched", encoding="utf-8")
+        swap = (
+            "from pathlib import Path; "
+            f"results=Path({str(results)!r}); "
+            f"results.rename(Path({str(moved)!r})); "
+            f"Path({str(replacement)!r}).rename(results)"
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "_subprocess"
+        mock_ep.load.return_value = SubprocessWorkload
+        mock_eps = MagicMock()
+        mock_eps.select.return_value = [mock_ep]
+
+        with (
+            patch("importlib.metadata.entry_points", return_value=mock_eps),
+            pytest.raises(RuntimeError, match="refusing to write the trial record"),
+        ):
+            run_trials(
+                RunRequest(
+                    workload="_subprocess",
+                    trials=1,
+                    results_dir=results,
+                    save_logs=True,
+                    subprocess_argv=(sys.executable, "-c", swap),
+                    probe_extras={
+                        "cell_name": "none-none",
+                        "env_passthrough_mode": "inherit",
+                        "timeout_per_trial": None,
+                        "cell_env_vars": {},
+                        "disable_detector_tiers": ["tier2", "tier3"],
+                    },
+                )
+            )
+
+        redirected_trial = results / "trial_0"
+        assert (redirected_trial / "canary").read_text(encoding="utf-8") == "untouched"
+        assert not (redirected_trial / "result.json").exists()
 
     def test_collect_survives_trial_json_roundtrip(self, tmp_path):
         """``_aorta_collect`` is a plain list, so the trial JSON dump needs

--- a/tests/run/test_fsafe.py
+++ b/tests/run/test_fsafe.py
@@ -7,6 +7,7 @@ mid-walk ancestor swap cannot redirect them), and no file descriptor leaks.
 
 from __future__ import annotations
 
+import errno
 import os
 from pathlib import Path
 
@@ -79,6 +80,165 @@ class TestOpenDirNoFollow:
                 with _fsafe.open_dir_nofollow(tmp_path, ["link", "b"]):
                     pass
         assert _open_fd_count() == before
+
+    def test_reports_enoent_for_a_missing_component(self, tmp_path):
+        """Absence is distinguishable from a hostile component.
+
+        The collector guard reads this errno to tell "the collector never wrote
+        anything" (nothing to prune) apart from "someone swapped the path"
+        (keep everything), so the two must not both surface as a bare
+        ``UnsafePathError``.
+        """
+        with pytest.raises(_fsafe.UnsafePathError) as excinfo:
+            with _fsafe.open_dir_nofollow(tmp_path, ["nope"]):
+                pass
+        assert excinfo.value.errno == errno.ENOENT
+
+    def test_a_dangling_symlink_is_eloop_not_enoent(self, tmp_path):
+        """A broken link must not be able to impersonate an absent directory."""
+        (tmp_path / "link").symlink_to(tmp_path / "never_existed")
+        with pytest.raises(_fsafe.UnsafePathError) as excinfo:
+            with _fsafe.open_dir_nofollow(tmp_path, ["link"]):
+                pass
+        assert excinfo.value.errno != errno.ENOENT
+
+
+class TestTrustedAnchorIdentity:
+    """The anchor is pinned to an inode, not just to a pathname.
+
+    ``O_NOFOLLOW`` answers "is this a symlink", which is a different question
+    from "is this still the operator's directory". These cover the two swaps
+    that satisfy every no-follow check on the way down.
+    """
+
+    def test_refuses_a_real_directory_renamed_into_the_anchor_pathname(self, tmp_path):
+        results = tmp_path / "results"
+        (results / "trial").mkdir(parents=True)
+        anchor = _fsafe.TrustedAnchor.freeze(results)
+        assert anchor.identity is not None
+
+        # The payload renames the results dir aside and moves a *real*
+        # directory (with its own real "trial" child) into that pathname.
+        # Nothing in the new path is a symlink.
+        results.rename(tmp_path / "results.moved")
+        planted = tmp_path / "planted"
+        (planted / "trial").mkdir(parents=True)
+        (planted / "trial" / "victim.txt").write_text("keep me", encoding="utf-8")
+        planted.rename(results)
+
+        with pytest.raises(_fsafe.UnsafePathError, match="frozen before the run"):
+            with _fsafe.open_dir_nofollow(anchor, ["trial"]):
+                pass
+        # Unpinned, the same descent succeeds -- which is the gap being closed.
+        with _fsafe.open_dir_nofollow(results, ["trial"]) as fd:
+            assert "victim.txt" in os.listdir(fd)
+
+    def test_refuses_when_the_anchors_parent_is_swapped_for_a_symlink(self, tmp_path):
+        """The parent is opened by pathname, so the pin is what guards it.
+
+        The parent sits above the operator's ``--results-dir`` and may hold the
+        operator's own links, so it cannot be opened ``O_NOFOLLOW``. A payload
+        that can write the grandparent renames it aside and leaves a link to a
+        planted tree whose own ``results`` directory is perfectly ordinary.
+        """
+        base = tmp_path / "run"
+        results = base / "results"
+        (results / "trial").mkdir(parents=True)
+        anchor = _fsafe.TrustedAnchor.freeze(results)
+
+        base.rename(tmp_path / "run.moved")
+        planted = tmp_path / "planted"
+        (planted / "results" / "trial").mkdir(parents=True)
+        (planted / "results" / "trial" / "victim.txt").write_text("keep", encoding="utf-8")
+        base.symlink_to(planted, target_is_directory=True)
+
+        with pytest.raises(_fsafe.UnsafePathError, match="frozen before the run"):
+            with _fsafe.open_dir_nofollow(anchor, ["trial"]):
+                pass
+
+    def test_accepts_the_untouched_anchor(self, tmp_path):
+        results = tmp_path / "results"
+        (results / "trial").mkdir(parents=True)
+        (results / "trial" / "artifact.txt").write_text("x", encoding="utf-8")
+        anchor = _fsafe.TrustedAnchor.freeze(results)
+        with _fsafe.open_dir_nofollow(anchor, ["trial"]) as fd:
+            assert "artifact.txt" in os.listdir(fd)
+
+    def test_freeze_of_a_missing_path_yields_an_unpinned_anchor(self, tmp_path):
+        """A stat failure degrades to no-follow-only rather than raising."""
+        anchor = _fsafe.TrustedAnchor.freeze(tmp_path / "not_yet")
+        assert anchor.identity is None
+
+    def test_as_anchor_passes_through_and_wraps(self, tmp_path):
+        pinned = _fsafe.TrustedAnchor(tmp_path, (1, 2))
+        assert _fsafe.as_anchor(pinned) is pinned
+        assert _fsafe.as_anchor(str(tmp_path)) == _fsafe.TrustedAnchor(tmp_path, None)
+
+    def test_no_fd_leak_when_the_identity_check_refuses(self, tmp_path):
+        results = tmp_path / "results"
+        (results / "trial").mkdir(parents=True)
+        anchor = _fsafe.TrustedAnchor.freeze(results)
+        results.rename(tmp_path / "results.moved")
+        (tmp_path / "planted" / "trial").mkdir(parents=True)
+        (tmp_path / "planted").rename(results)
+        before = _open_fd_count()
+        for _ in range(50):
+            with pytest.raises(_fsafe.UnsafePathError):
+                with _fsafe.open_dir_nofollow(anchor, ["trial"]):
+                    pass
+        assert _open_fd_count() == before
+
+
+class TestOpenDirAt:
+    def test_descends_from_a_held_fd(self, tmp_path):
+        (tmp_path / "a" / "b").mkdir(parents=True)
+        (tmp_path / "a" / "b" / "f.txt").write_text("x", encoding="utf-8")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with _fsafe.open_dir_at(base_fd, ["a", "b"]) as fd:
+                assert "f.txt" in os.listdir(fd)
+        finally:
+            os.close(base_fd)
+
+    def test_empty_components_yields_the_base_directory(self, tmp_path):
+        (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with _fsafe.open_dir_at(base_fd, []) as fd:
+                assert "f.txt" in os.listdir(fd)
+            # The base fd must survive: ``open_dir_at`` dups rather than
+            # adopting it, so the caller's own descent stays usable.
+            assert "f.txt" in os.listdir(base_fd)
+        finally:
+            os.close(base_fd)
+
+    def test_refuses_a_symlinked_component(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (tmp_path / "link").symlink_to(outside, target_is_directory=True)
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with pytest.raises(_fsafe.UnsafePathError):
+                with _fsafe.open_dir_at(base_fd, ["link"]):
+                    pass
+        finally:
+            os.close(base_fd)
+
+    def test_no_fd_leak(self, tmp_path):
+        (tmp_path / "a" / "b").mkdir(parents=True)
+        (tmp_path / "link").symlink_to(tmp_path / "a", target_is_directory=True)
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            before = _open_fd_count()
+            for _ in range(50):
+                with _fsafe.open_dir_at(base_fd, ["a", "b"]):
+                    pass
+                with pytest.raises(_fsafe.UnsafePathError):
+                    with _fsafe.open_dir_at(base_fd, ["link", "b"]):
+                        pass
+            assert _open_fd_count() == before
+        finally:
+            os.close(base_fd)
 
 
 class TestRemoveEntryAt:

--- a/tests/run/test_fsafe.py
+++ b/tests/run/test_fsafe.py
@@ -8,7 +8,6 @@ mid-walk ancestor swap cannot redirect them), and no file descriptor leaks.
 from __future__ import annotations
 
 import errno
-import fcntl
 import os
 from pathlib import Path
 
@@ -202,22 +201,24 @@ class TestChildNameEnforcement:
     so these pin the helpers' contract for the next caller.
     """
 
+    #: Stand-in resolved per test to an absolute path *inside* the sandbox.
+    #: Deliberately not a real one like ``/etc``: mutation-testing this class
+    #: means running it with the guard removed, and ``remove_entry_at`` would
+    #: then genuinely try to empty whatever the name points at. A test whose
+    #: failure mode is "recursively deletes a system directory" is not one to
+    #: leave lying around, so every case aims inside the sandbox.
+    ABSOLUTE = "<absolute-inside-sandbox>"
+
     #: Names that must never reach the kernel from one of these helpers.
-    #: The absolute case is built per-test inside ``tmp_path`` rather than
-    #: hard-coded (``/etc``): mutation-testing this class means running it with
-    #: the guard removed, and ``remove_entry_at`` would then genuinely try to
-    #: empty whatever the name points at. A test whose failure mode is
-    #: "recursively deletes a real system directory" is not one to leave lying
-    #: around, so every case is aimed inside the sandbox.
-    RELATIVE_BAD_NAMES = ("", ".", "..", "sub/child", "a/../../b")
+    BAD_NAMES = ("", ".", "..", ABSOLUTE, "sub/child", "a/../../b")
 
     @staticmethod
     def _sandbox(tmp_path):
         """A held-fd directory whose parent is also disposable.
 
-        ``..`` has to be able to resolve to *something* for the unguarded case
-        to be meaningful, so the fd is opened one level down and the level above
-        it is sacrificial. A sibling file there is the canary.
+        ``..`` has to resolve to *something* for the unguarded case to be
+        meaningful, so the fd is opened one level down and the level above it is
+        sacrificial. A sibling file there is the canary.
         """
         sandbox = tmp_path / "sandbox"
         held = sandbox / "held"
@@ -226,62 +227,65 @@ class TestChildNameEnforcement:
         canary.write_text("keep me", encoding="utf-8")
         return held, canary
 
-    def _bad_names(self, held):
-        return (*self.RELATIVE_BAD_NAMES, str(held / "sub"))
+    @classmethod
+    def _name(cls, bad, held):
+        return str(held / "sub") if bad == cls.ABSOLUTE else bad
 
-    def test_open_dir_at_refuses(self, tmp_path):
+    @pytest.mark.parametrize("bad", BAD_NAMES)
+    def test_open_dir_at_refuses(self, tmp_path, bad):
         held, canary = self._sandbox(tmp_path)
         base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
         try:
-            for bad in self._bad_names(held):
-                with pytest.raises(_fsafe.UnsafePathError) as excinfo:
-                    with _fsafe.open_dir_at(base_fd, [bad]):
-                        pass
-                assert excinfo.value.errno == errno.EINVAL, bad
+            with pytest.raises(_fsafe.UnsafePathError) as excinfo:
+                with _fsafe.open_dir_at(base_fd, [self._name(bad, held)]):
+                    pass
+            assert excinfo.value.errno == errno.EINVAL
         finally:
             os.close(base_fd)
         assert canary.exists()
 
-    def test_open_dir_nofollow_refuses(self, tmp_path):
+    @pytest.mark.parametrize("bad", BAD_NAMES)
+    def test_open_dir_nofollow_refuses(self, tmp_path, bad):
         held, _canary = self._sandbox(tmp_path)
-        for bad in self._bad_names(held):
-            with pytest.raises(_fsafe.UnsafePathError) as excinfo:
-                with _fsafe.open_dir_nofollow(held, [bad]):
-                    pass
-            assert excinfo.value.errno == errno.EINVAL, bad
+        with pytest.raises(_fsafe.UnsafePathError) as excinfo:
+            with _fsafe.open_dir_nofollow(held, [self._name(bad, held)]):
+                pass
+        assert excinfo.value.errno == errno.EINVAL
 
-    def test_stat_at_refuses(self, tmp_path):
+    @pytest.mark.parametrize("bad", BAD_NAMES)
+    def test_stat_at_refuses(self, tmp_path, bad):
         held, _canary = self._sandbox(tmp_path)
         base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
         try:
-            for bad in self._bad_names(held):
-                with pytest.raises(_fsafe.UnsafePathError):
-                    _fsafe.stat_at(base_fd, bad)
+            with pytest.raises(_fsafe.UnsafePathError):
+                _fsafe.stat_at(base_fd, self._name(bad, held))
         finally:
             os.close(base_fd)
 
-    def test_remove_entry_at_refuses(self, tmp_path):
+    @pytest.mark.parametrize("bad", BAD_NAMES)
+    def test_remove_entry_at_refuses(self, tmp_path, bad):
         """The worst one: ``remove_entry_at(fd, "..")`` would empty the parent."""
         held, canary = self._sandbox(tmp_path)
         base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
         try:
-            for bad in self._bad_names(held):
-                with pytest.raises(_fsafe.UnsafePathError):
-                    _fsafe.remove_entry_at(base_fd, bad)
+            with pytest.raises(_fsafe.UnsafePathError):
+                _fsafe.remove_entry_at(base_fd, self._name(bad, held))
         finally:
             os.close(base_fd)
         # Nothing above the held fd was touched. Without the guard, the ".."
         # case empties this directory.
         assert canary.read_text(encoding="utf-8") == "keep me"
 
-    def test_secure_open_read_refuses(self, tmp_path):
+    @pytest.mark.parametrize("bad", BAD_NAMES)
+    def test_secure_open_read_refuses(self, tmp_path, bad):
         held, _canary = self._sandbox(tmp_path)
         base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
         try:
-            for bad in self._bad_names(held):
-                with pytest.raises(_fsafe.UnsafePathError):
-                    with _fsafe.secure_open_read(base_fd, bad, encoding="utf-8"):
-                        pass
+            with pytest.raises(_fsafe.UnsafePathError):
+                with _fsafe.secure_open_read(
+                    base_fd, self._name(bad, held), encoding="utf-8"
+                ):
+                    pass
         finally:
             os.close(base_fd)
 
@@ -401,6 +405,11 @@ class TestSecureOpenReadFileType:
 
     def test_the_handle_is_blocking_again(self, tmp_path):
         """``O_NONBLOCK`` is an open-time trick, not part of the parser's contract."""
+        # Imported here rather than at module scope: this module is skipped
+        # wholesale off POSIX, and a top-level import would turn that skip into
+        # a collection error.
+        import fcntl
+
         (tmp_path / "stats.csv").write_text("x", encoding="utf-8")
         base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
         try:

--- a/tests/run/test_fsafe.py
+++ b/tests/run/test_fsafe.py
@@ -289,6 +289,19 @@ class TestChildNameEnforcement:
         finally:
             os.close(base_fd)
 
+    @pytest.mark.parametrize("bad", BAD_NAMES)
+    def test_open_write_nofollow_refuses(self, tmp_path, bad):
+        held, _canary = self._sandbox(tmp_path)
+        base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with pytest.raises(_fsafe.UnsafePathError):
+                stream = _fsafe.open_write_nofollow(
+                    base_fd, self._name(bad, held), encoding="utf-8"
+                )
+                stream.close()
+        finally:
+            os.close(base_fd)
+
     def test_the_raw_calls_being_guarded_really_do_escape(self, tmp_path):
         """Without the check, each bad name reaches outside the held fd.
 
@@ -447,6 +460,61 @@ class TestSecureOpenReadFileType:
                 with pytest.raises(LookupError):
                     with _fsafe.secure_open_read(base_fd, "stats.csv", encoding="bogus"):
                         pass
+            assert _open_fd_count() == before
+        finally:
+            os.close(base_fd)
+
+
+class TestOpenWriteNoFollow:
+    """Writer validation must happen before any destructive truncation."""
+
+    def test_refuses_hard_link_without_truncating_target(self, tmp_path):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        outside = tmp_path / "outside.txt"
+        outside.write_text("keep me", encoding="utf-8")
+        os.link(outside, output_dir / "result.json")
+
+        base_fd = os.open(str(output_dir), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with pytest.raises(_fsafe.UnsafePathError, match="hard links"):
+                stream = _fsafe.open_write_nofollow(
+                    base_fd, "result.json", encoding="utf-8"
+                )
+                # Closes the stream if the link-count guard is mutated away.
+                stream.close()
+        finally:
+            os.close(base_fd)
+
+        # Adding O_TRUNC back to os.open makes the refusal too late: the helper
+        # still raises, but this canary has already been emptied.
+        assert outside.read_text(encoding="utf-8") == "keep me"
+
+    def test_overwrites_singly_linked_regular_file(self, tmp_path):
+        target = tmp_path / "result.json"
+        target.write_text("old content with a longer tail", encoding="utf-8")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with _fsafe.open_write_nofollow(
+                base_fd, "result.json", encoding="utf-8"
+            ) as stream:
+                stream.write("new")
+        finally:
+            os.close(base_fd)
+        assert target.read_text(encoding="utf-8") == "new"
+
+    def test_no_fd_leak_when_hard_link_is_refused(self, tmp_path):
+        outside = tmp_path / "outside.txt"
+        outside.write_text("keep me", encoding="utf-8")
+        os.link(outside, tmp_path / "result.json")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            before = _open_fd_count()
+            for _ in range(50):
+                with pytest.raises(_fsafe.UnsafePathError):
+                    _fsafe.open_write_nofollow(
+                        base_fd, "result.json", encoding="utf-8"
+                    )
             assert _open_fd_count() == before
         finally:
             os.close(base_fd)

--- a/tests/run/test_fsafe.py
+++ b/tests/run/test_fsafe.py
@@ -8,12 +8,14 @@ mid-walk ancestor swap cannot redirect them), and no file descriptor leaks.
 from __future__ import annotations
 
 import errno
+import fcntl
 import os
 from pathlib import Path
 
 import pytest
 
 from aorta.run import _fsafe
+from tests.conftest import BlockedTooLong
 
 pytestmark = pytest.mark.skipif(
     not _fsafe.HAVE_FD_TRAVERSAL, reason="fd-relative traversal unsupported here"
@@ -187,6 +189,258 @@ class TestTrustedAnchorIdentity:
                 with _fsafe.open_dir_nofollow(anchor, ["trial"]):
                     pass
         assert _open_fd_count() == before
+
+
+class TestChildNameEnforcement:
+    """``dir_fd`` does not by itself confine an operation to that directory.
+
+    ``os.open`` ignores ``dir_fd`` for an absolute path, ``..`` walks above it,
+    and ``O_NOFOLLOW`` guards only the *final* component -- so a name carrying a
+    separator has its intermediate components resolved with symlinks followed.
+    No current caller can produce such a name (``relative_components`` decomposes
+    a ``relative_to`` result; everything else forwards ``os.listdir`` entries),
+    so these pin the helpers' contract for the next caller.
+    """
+
+    #: Names that must never reach the kernel from one of these helpers.
+    #: The absolute case is built per-test inside ``tmp_path`` rather than
+    #: hard-coded (``/etc``): mutation-testing this class means running it with
+    #: the guard removed, and ``remove_entry_at`` would then genuinely try to
+    #: empty whatever the name points at. A test whose failure mode is
+    #: "recursively deletes a real system directory" is not one to leave lying
+    #: around, so every case is aimed inside the sandbox.
+    RELATIVE_BAD_NAMES = ("", ".", "..", "sub/child", "a/../../b")
+
+    @staticmethod
+    def _sandbox(tmp_path):
+        """A held-fd directory whose parent is also disposable.
+
+        ``..`` has to be able to resolve to *something* for the unguarded case
+        to be meaningful, so the fd is opened one level down and the level above
+        it is sacrificial. A sibling file there is the canary.
+        """
+        sandbox = tmp_path / "sandbox"
+        held = sandbox / "held"
+        (held / "sub" / "child").mkdir(parents=True)
+        canary = sandbox / "canary.txt"
+        canary.write_text("keep me", encoding="utf-8")
+        return held, canary
+
+    def _bad_names(self, held):
+        return (*self.RELATIVE_BAD_NAMES, str(held / "sub"))
+
+    def test_open_dir_at_refuses(self, tmp_path):
+        held, canary = self._sandbox(tmp_path)
+        base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            for bad in self._bad_names(held):
+                with pytest.raises(_fsafe.UnsafePathError) as excinfo:
+                    with _fsafe.open_dir_at(base_fd, [bad]):
+                        pass
+                assert excinfo.value.errno == errno.EINVAL, bad
+        finally:
+            os.close(base_fd)
+        assert canary.exists()
+
+    def test_open_dir_nofollow_refuses(self, tmp_path):
+        held, _canary = self._sandbox(tmp_path)
+        for bad in self._bad_names(held):
+            with pytest.raises(_fsafe.UnsafePathError) as excinfo:
+                with _fsafe.open_dir_nofollow(held, [bad]):
+                    pass
+            assert excinfo.value.errno == errno.EINVAL, bad
+
+    def test_stat_at_refuses(self, tmp_path):
+        held, _canary = self._sandbox(tmp_path)
+        base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            for bad in self._bad_names(held):
+                with pytest.raises(_fsafe.UnsafePathError):
+                    _fsafe.stat_at(base_fd, bad)
+        finally:
+            os.close(base_fd)
+
+    def test_remove_entry_at_refuses(self, tmp_path):
+        """The worst one: ``remove_entry_at(fd, "..")`` would empty the parent."""
+        held, canary = self._sandbox(tmp_path)
+        base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            for bad in self._bad_names(held):
+                with pytest.raises(_fsafe.UnsafePathError):
+                    _fsafe.remove_entry_at(base_fd, bad)
+        finally:
+            os.close(base_fd)
+        # Nothing above the held fd was touched. Without the guard, the ".."
+        # case empties this directory.
+        assert canary.read_text(encoding="utf-8") == "keep me"
+
+    def test_secure_open_read_refuses(self, tmp_path):
+        held, _canary = self._sandbox(tmp_path)
+        base_fd = os.open(str(held), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            for bad in self._bad_names(held):
+                with pytest.raises(_fsafe.UnsafePathError):
+                    with _fsafe.secure_open_read(base_fd, bad, encoding="utf-8"):
+                        pass
+        finally:
+            os.close(base_fd)
+
+    def test_the_raw_calls_being_guarded_really_do_escape(self, tmp_path):
+        """Without the check, each bad name reaches outside the held fd.
+
+        Asserted directly against ``os.open`` so the guard's necessity is
+        recorded here rather than in a commit message.
+        """
+        inner = tmp_path / "inner"
+        inner.mkdir()
+        (tmp_path / "outside_marker").mkdir()
+        target = tmp_path / "target"
+        target.mkdir()
+        (inner / "linkdir").symlink_to(target, target_is_directory=True)
+        flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY
+        base_fd = os.open(str(inner), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            # ".." leaves the held directory.
+            up = os.open("..", flags, dir_fd=base_fd)
+            try:
+                assert "outside_marker" in os.listdir(up)
+            finally:
+                os.close(up)
+            # An absolute path makes dir_fd irrelevant -- it names a directory
+            # that is not under the held fd at all.
+            absolute = os.open(str(tmp_path / "outside_marker"), flags, dir_fd=base_fd)
+            os.close(absolute)
+            # A separator gets the INTERMEDIATE component resolved with symlinks
+            # followed -- O_NOFOLLOW only ever guarded the last one.
+            os.close(os.open("linkdir/../target", flags, dir_fd=base_fd))
+        finally:
+            os.close(base_fd)
+
+    def test_legitimate_names_still_work(self, tmp_path):
+        """The check must not reject an ordinary directory entry."""
+        (tmp_path / "sub" / "child").mkdir(parents=True)
+        (tmp_path / "sub" / "child" / "f.txt").write_text("x", encoding="utf-8")
+        with _fsafe.open_dir_nofollow(tmp_path, ["sub", "child"]) as fd:
+            assert "f.txt" in os.listdir(fd)
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            assert _fsafe.stat_at(base_fd, "sub") is not None
+        finally:
+            os.close(base_fd)
+
+    def test_no_fd_leak_when_a_name_is_refused(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            before = _open_fd_count()
+            for _ in range(50):
+                with pytest.raises(_fsafe.UnsafePathError):
+                    with _fsafe.open_dir_at(base_fd, ["sub", ".."]):
+                        pass
+            assert _open_fd_count() == before
+        finally:
+            os.close(base_fd)
+
+
+class TestSecureOpenReadFileType:
+    """A regular file seen by the walk can be something else by the open.
+
+    The walk's ``lstat`` and the read are separate syscalls, and this PR widened
+    that window on purpose (artifacts are now listed first and reopened one at a
+    time to bound descriptor use). A payload that swaps a matched CSV for a FIFO
+    turns a blocking ``O_RDONLY`` into an indefinite wait, which hangs the sweep
+    rather than degrading it -- strictly worse than any wrong metric.
+    """
+
+    def test_refuses_a_fifo_instead_of_blocking(self, tmp_path, no_hang):
+        os.mkfifo(tmp_path / "stats.csv")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            # The defect this replaces was a hang, so bound the test itself: a
+            # regression must fail the alarm rather than stall the suite.
+            with no_hang(5):
+                with pytest.raises(_fsafe.UnsafePathError, match="not a regular file"):
+                    with _fsafe.secure_open_read(base_fd, "stats.csv", encoding="utf-8"):
+                        pass
+        finally:
+            os.close(base_fd)
+
+    def test_a_blocking_open_on_that_fifo_really_does_hang(self, tmp_path, no_hang):
+        """Pins the premise: without ``O_NONBLOCK`` the open never returns."""
+        os.mkfifo(tmp_path / "stats.csv")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with pytest.raises(BlockedTooLong):
+                with no_hang(2):
+                    os.close(
+                        os.open("stats.csv", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=base_fd)
+                    )
+        finally:
+            os.close(base_fd)
+
+    def test_refuses_a_directory_where_a_file_was_expected(self, tmp_path):
+        (tmp_path / "stats.csv").mkdir()
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with pytest.raises(OSError):
+                with _fsafe.secure_open_read(base_fd, "stats.csv", encoding="utf-8"):
+                    pass
+        finally:
+            os.close(base_fd)
+
+    def test_reads_a_regular_file_normally(self, tmp_path):
+        (tmp_path / "stats.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with _fsafe.secure_open_read(
+                base_fd, "stats.csv", encoding="utf-8", newline=""
+            ) as stream:
+                assert stream.read() == "a,b\n1,2\n"
+        finally:
+            os.close(base_fd)
+
+    def test_the_handle_is_blocking_again(self, tmp_path):
+        """``O_NONBLOCK`` is an open-time trick, not part of the parser's contract."""
+        (tmp_path / "stats.csv").write_text("x", encoding="utf-8")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with _fsafe.secure_open_read(base_fd, "stats.csv", encoding="utf-8") as stream:
+                flags = fcntl.fcntl(stream.fileno(), fcntl.F_GETFL)
+                assert not flags & os.O_NONBLOCK
+        finally:
+            os.close(base_fd)
+
+    def test_no_fd_leak_when_the_type_check_refuses(self, tmp_path, no_hang):
+        os.mkfifo(tmp_path / "stats.csv")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            before = _open_fd_count()
+            for _ in range(50):
+                with no_hang(5), pytest.raises(_fsafe.UnsafePathError):
+                    with _fsafe.secure_open_read(base_fd, "stats.csv", encoding="utf-8"):
+                        pass
+            assert _open_fd_count() == before
+        finally:
+            os.close(base_fd)
+
+    def test_no_fd_leak_when_wrapping_the_fd_fails(self, tmp_path, monkeypatch):
+        """``fdopen`` only adopts the fd on success, so a failure must close it."""
+        (tmp_path / "stats.csv").write_text("x", encoding="utf-8")
+
+        def boom(*_args, **_kwargs):
+            raise LookupError("unknown encoding")
+
+        monkeypatch.setattr(os, "fdopen", boom)
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            before = _open_fd_count()
+            for _ in range(50):
+                with pytest.raises(LookupError):
+                    with _fsafe.secure_open_read(base_fd, "stats.csv", encoding="bogus"):
+                        pass
+            assert _open_fd_count() == before
+        finally:
+            os.close(base_fd)
 
 
 class TestOpenDirAt:

--- a/tests/run/test_fsafe.py
+++ b/tests/run/test_fsafe.py
@@ -1,0 +1,166 @@
+"""Unit tests for the no-follow fd-relative primitives in ``aorta.run._fsafe``.
+
+These prove the building blocks the collector and retention guards stand on:
+descent refuses a symlinked component, operations stay anchored to the fd (a
+mid-walk ancestor swap cannot redirect them), and no file descriptor leaks.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from aorta.run import _fsafe
+
+pytestmark = pytest.mark.skipif(
+    not _fsafe.HAVE_FD_TRAVERSAL, reason="fd-relative traversal unsupported here"
+)
+
+
+def _open_fd_count() -> int:
+    return len(os.listdir("/proc/self/fd"))
+
+
+class TestRelativeComponents:
+    def test_returns_components_below_the_anchor(self, tmp_path):
+        anchor = tmp_path / "results"
+        target = anchor / "wl" / "trial" / "rocprof"
+        assert _fsafe.relative_components(anchor, target) == ["wl", "trial", "rocprof"]
+
+    def test_none_when_target_is_outside_the_anchor(self, tmp_path):
+        anchor = tmp_path / "results"
+        assert _fsafe.relative_components(anchor, tmp_path / "other") is None
+
+    def test_none_on_a_parent_traversal_component(self, tmp_path):
+        anchor = tmp_path / "results"
+        # A crafted path that escapes upward is refused even if it lands back
+        # inside lexically.
+        target = Path(os.path.join(str(anchor), "wl", os.pardir, os.pardir, "escape"))
+        assert _fsafe.relative_components(anchor, target) is None
+
+    def test_empty_for_the_anchor_itself(self, tmp_path):
+        anchor = tmp_path / "results"
+        assert _fsafe.relative_components(anchor, anchor) == []
+
+
+class TestOpenDirNoFollow:
+    def test_opens_a_clean_tree(self, tmp_path):
+        leaf = tmp_path / "a" / "b" / "c"
+        leaf.mkdir(parents=True)
+        with _fsafe.open_dir_nofollow(tmp_path, ["a", "b", "c"]) as fd:
+            assert "marker" not in os.listdir(fd)
+            (leaf / "marker").write_text("x", encoding="utf-8")
+            assert "marker" in os.listdir(fd)
+
+    def test_refuses_a_symlinked_component(self, tmp_path):
+        (tmp_path / "real").mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (tmp_path / "link").symlink_to(outside, target_is_directory=True)
+        with pytest.raises(_fsafe.UnsafePathError):
+            with _fsafe.open_dir_nofollow(tmp_path, ["link"]):
+                pass
+
+    def test_refuses_a_missing_component(self, tmp_path):
+        with pytest.raises(_fsafe.UnsafePathError):
+            with _fsafe.open_dir_nofollow(tmp_path, ["nope"]):
+                pass
+
+    def test_does_not_leak_fds_on_success_or_failure(self, tmp_path):
+        (tmp_path / "a" / "b").mkdir(parents=True)
+        (tmp_path / "link").symlink_to(tmp_path / "a", target_is_directory=True)
+        before = _open_fd_count()
+        for _ in range(50):
+            with _fsafe.open_dir_nofollow(tmp_path, ["a", "b"]):
+                pass
+            with pytest.raises(_fsafe.UnsafePathError):
+                with _fsafe.open_dir_nofollow(tmp_path, ["link", "b"]):
+                    pass
+        assert _open_fd_count() == before
+
+
+class TestRemoveEntryAt:
+    def test_removes_a_nested_tree(self, tmp_path):
+        root = tmp_path / "tree"
+        (root / "sub").mkdir(parents=True)
+        (root / "top.txt").write_text("aaaa", encoding="utf-8")
+        (root / "sub" / "deep.txt").write_text("bb", encoding="utf-8")
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            files, freed = _fsafe.remove_entry_at(base_fd, "tree")
+        finally:
+            os.close(base_fd)
+        assert files == 2
+        assert freed == 6
+        assert not root.exists()
+
+    def test_unlinks_a_symlink_without_following_it(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "precious.txt"
+        victim.write_text("keep me", encoding="utf-8")
+        root = tmp_path / "tree"
+        root.mkdir()
+        (root / "escape").symlink_to(outside, target_is_directory=True)
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            _fsafe.remove_entry_at(base_fd, "tree")
+        finally:
+            os.close(base_fd)
+        # The link was unlinked but its target tree survived untouched.
+        assert not root.exists()
+        assert victim.read_text(encoding="utf-8") == "keep me"
+
+    def test_no_fd_leak(self, tmp_path):
+        base_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            before = _open_fd_count()
+            for i in range(30):
+                d = tmp_path / f"tree{i}" / "sub"
+                d.mkdir(parents=True)
+                (d / "f.txt").write_text("x", encoding="utf-8")
+                _fsafe.remove_entry_at(base_fd, f"tree{i}")
+            assert _open_fd_count() == before
+        finally:
+            os.close(base_fd)
+
+
+class TestIterRegularFiles:
+    def test_yields_only_regular_files_and_skips_symlinks(self, tmp_path):
+        root = tmp_path / "tree"
+        (root / "sub").mkdir(parents=True)
+        (root / "a.txt").write_text("a", encoding="utf-8")
+        (root / "sub" / "b.txt").write_text("bb", encoding="utf-8")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "leak.txt").write_text("leak", encoding="utf-8")
+        (root / "sneak").symlink_to(outside / "leak.txt")
+        (root / "sneakdir").symlink_to(outside, target_is_directory=True)
+
+        base_fd = os.open(str(root), os.O_RDONLY | os.O_DIRECTORY)
+        seen = {}
+        try:
+            for rel, _dir_fd, name, size in _fsafe.iter_regular_files(base_fd):
+                seen[rel] = (name, size)
+        finally:
+            os.close(base_fd)
+        assert set(seen) == {"a.txt", "sub/b.txt"}
+        assert seen["sub/b.txt"] == ("b.txt", 2)
+
+
+class TestPruneEmptyDirs:
+    def test_removes_empty_subdirs_bottom_up_but_keeps_base(self, tmp_path):
+        root = tmp_path / "tree"
+        (root / "empty" / "deeper").mkdir(parents=True)
+        (root / "kept").mkdir()
+        (root / "kept" / "f.txt").write_text("x", encoding="utf-8")
+        base_fd = os.open(str(root), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            _fsafe.prune_empty_dirs(base_fd)
+        finally:
+            os.close(base_fd)
+        assert root.is_dir()
+        assert not (root / "empty").exists()
+        assert (root / "kept" / "f.txt").exists()

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -317,3 +317,97 @@ def test_unknown_manifest_class_treated_as_heavy(tmp_path: Path):
 
 def test_levels_constant_is_the_documented_ladder():
     assert RETAIN_LEVELS == ("none", "log", "summary", "full")
+
+
+# ---- fd-relative engine (trusted_root=) ---------------------------------
+
+import contextlib  # noqa: E402 -- grouped with the fd-relative tests
+
+from aorta.run import _fsafe  # noqa: E402
+
+_needs_fd = pytest.mark.skipif(
+    not _fsafe.HAVE_FD_TRAVERSAL, reason="fd-relative traversal unsupported here"
+)
+
+
+@_needs_fd
+def test_fd_engine_prunes_in_tree_and_keeps_the_record(tmp_path: Path):
+    """With a trusted root, the fd engine deletes heavy files but not the record."""
+    results = tmp_path / "results"
+    trial = results / "wl" / "trial_d0_m0_t0"
+    _populate(trial)
+    outcome = apply_retention(trial, "none", trusted_root=results.resolve())
+    names = _names(trial)
+    assert "result.json" in names  # record hard-guarded
+    assert "trace.bin" not in names  # heavy pruned
+    assert "prof/big.pb" in outcome.deleted
+
+
+@_needs_fd
+def test_fd_engine_refuses_a_symlinked_ancestor(tmp_path: Path, caplog):
+    """A symlinked component above the trial dir makes the prune refuse + keep."""
+    results = tmp_path / "results"
+    real_trial = results / "wl_real" / "trial_d0_m0_t0"
+    _populate(real_trial)
+    outside = tmp_path / "outside"
+    (outside / "trial_d0_m0_t0").mkdir(parents=True)
+    victim = outside / "trial_d0_m0_t0" / "trace.bin"
+    victim.write_text("keep me", encoding="utf-8")
+    # <results>/wl is a symlink to the external tree.
+    (results / "wl").symlink_to(outside, target_is_directory=True)
+
+    with caplog.at_level("WARNING"):
+        outcome = apply_retention(
+            results / "wl" / "trial_d0_m0_t0", "none", trusted_root=results.resolve()
+        )
+    assert outcome.no_op
+    assert victim.read_text(encoding="utf-8") == "keep me"
+    assert any("symlink" in r.getMessage() for r in caplog.records)
+
+
+@_needs_fd
+def test_fd_engine_ancestor_swap_after_open_is_inert(tmp_path: Path, monkeypatch):
+    """A mid-prune ancestor swap cannot redirect the deletes (TOCTOU closed)."""
+    results = tmp_path / "results"
+    trial = results / "wl" / "trial_d0_m0_t0"
+    _populate(trial)
+    outside = tmp_path / "outside"
+    planted = outside / "trial_d0_m0_t0"
+    planted.mkdir(parents=True)
+    victim = planted / "trace.bin"
+    victim.write_text("keep me", encoding="utf-8")
+
+    real_open = _fsafe.open_dir_nofollow
+    swapped = {"done": False}
+
+    @contextlib.contextmanager
+    def swapping_open(trusted_root, components, **kwargs):
+        with real_open(trusted_root, components, **kwargs) as fd:
+            if not swapped["done"]:
+                swapped["done"] = True
+                (results / "wl").rename(results / "wl_real")
+                (results / "wl").symlink_to(outside, target_is_directory=True)
+            yield fd
+
+    monkeypatch.setattr(_fsafe, "open_dir_nofollow", swapping_open)
+
+    apply_retention(trial, "none", trusted_root=results.resolve())
+    # The prune ran against the held fd; the planted external victim survives.
+    assert victim.read_text(encoding="utf-8") == "keep me"
+
+
+@_needs_fd
+def test_fd_engine_reads_manifest_no_follow(tmp_path: Path):
+    """The fd engine honours a real manifest entry's class."""
+    results = tmp_path / "results"
+    trial = results / "wl" / "trial_d0_m0_t0"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text("{}", encoding="utf-8")
+    (trial / "mystery.dat").write_text("m" * 50, encoding="utf-8")
+    (trial / RETENTION_MANIFEST_NAME).write_text(
+        json.dumps({"artifacts": [{"path": "mystery.dat", "class": "summary"}]}),
+        encoding="utf-8",
+    )
+    # summary-classed mystery.dat is kept at level "summary".
+    apply_retention(trial, "summary", trusted_root=results.resolve())
+    assert "mystery.dat" in _names(trial)

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -397,6 +397,57 @@ def test_fd_engine_ancestor_swap_after_open_is_inert(tmp_path: Path, monkeypatch
 
 
 @_needs_fd
+def test_fd_engine_refuses_a_results_root_replaced_by_a_real_directory(
+    tmp_path: Path, caplog
+):
+    """A pinned anchor refuses the swap that no ``O_NOFOLLOW`` check can see.
+
+    The payload renames the results directory aside and moves a real directory
+    into its pathname. Nothing on the way down is a symlink, so only the frozen
+    inode distinguishes the planted tree from the operator's -- without it the
+    prune deletes the planted files.
+    """
+    results = tmp_path / "results"
+    trial = results / "wl" / "trial_d0_m0_t0"
+    _populate(trial)
+    anchor = _fsafe.TrustedAnchor.freeze(results.resolve())
+    assert anchor.identity is not None
+
+    results.rename(tmp_path / "results.moved")
+    planted = tmp_path / "planted"
+    _populate(planted / "wl" / "trial_d0_m0_t0")
+    planted.rename(results)
+    victim = results / "wl" / "trial_d0_m0_t0" / "trace.bin"
+
+    outcome = apply_retention(trial, "none", trusted_root=anchor)
+    assert outcome.no_op
+    assert victim.exists()
+
+    # Unpinned, the same prune goes ahead against the planted tree -- the gap
+    # the pin closes.
+    assert not apply_retention(trial, "none", trusted_root=results.resolve()).no_op
+    assert not victim.exists()
+
+
+@_needs_fd
+def test_fd_engine_treats_a_missing_tree_as_nothing_to_prune(tmp_path: Path, caplog):
+    """An absent collector tree is a no-op, not a refusal.
+
+    A validated-only collector writes no directory at all, and the pathname
+    engine already treats a missing ``trial_dir`` as a no-op; warning about a
+    symlink that is not there would send an operator hunting for one.
+    """
+    results = tmp_path / "results"
+    results.mkdir()
+    with caplog.at_level("WARNING"):
+        outcome = apply_retention(
+            results / "wl" / "trial_d0_m0_t0", "none", trusted_root=results.resolve()
+        )
+    assert outcome.no_op
+    assert not any("symlink" in record.getMessage() for record in caplog.records)
+
+
+@_needs_fd
 def test_fd_engine_reads_manifest_no_follow(tmp_path: Path):
     """The fd engine honours a real manifest entry's class."""
     results = tmp_path / "results"

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -397,15 +397,13 @@ def test_fd_engine_ancestor_swap_after_open_is_inert(tmp_path: Path, monkeypatch
 
 
 @_needs_fd
-def test_fd_engine_refuses_a_results_root_replaced_by_a_real_directory(
-    tmp_path: Path, caplog
-):
+def test_fd_engine_refuses_a_results_root_replaced_by_a_real_directory(tmp_path: Path):
     """A pinned anchor refuses the swap that no ``O_NOFOLLOW`` check can see.
 
     The payload renames the results directory aside and moves a real directory
     into its pathname. Nothing on the way down is a symlink, so only the frozen
-    inode distinguishes the planted tree from the operator's -- without it the
-    prune deletes the planted files.
+    inode distinguishes the planted tree from the operator's own tree -- without
+    it the prune deletes the planted files.
     """
     results = tmp_path / "results"
     trial = results / "wl" / "trial_d0_m0_t0"

--- a/tests/run/test_retention.py
+++ b/tests/run/test_retention.py
@@ -344,6 +344,36 @@ def test_fd_engine_prunes_in_tree_and_keeps_the_record(tmp_path: Path):
 
 
 @_needs_fd
+def test_fd_engine_records_symlinks_as_kept_without_following(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """The fd engine preserves the pathname engine's symlink outcome contract."""
+    results = tmp_path / "results"
+    trial = results / "wl" / "trial_d0_m0_t0"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text("{}", encoding="utf-8")
+    (trial / "trace.bin").write_text("delete me", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.bin"
+    victim.write_text("keep me", encoding="utf-8")
+    (trial / "escape.bin").symlink_to(victim)
+    (trial / "escape_dir").symlink_to(outside, target_is_directory=True)
+
+    with caplog.at_level("WARNING"):
+        outcome = apply_retention(
+            trial, "none", trusted_root=_fsafe.TrustedAnchor.freeze(results)
+        )
+
+    assert set(outcome.kept) >= {"result.json", "escape.bin", "escape_dir"}
+    assert "trace.bin" in outcome.deleted
+    assert victim.read_text(encoding="utf-8") == "keep me"
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("escape.bin" in message and "symlink" in message for message in messages)
+    assert any("escape_dir" in message and "symlink" in message for message in messages)
+
+
+@_needs_fd
 def test_fd_engine_refuses_a_symlinked_ancestor(tmp_path: Path, caplog):
     """A symlinked component above the trial dir makes the prune refuse + keep."""
     results = tmp_path / "results"


### PR DESCRIPTION
## Summary
- Follow-up to Copilot round 12 on the already-merged [#390](https://github.com/ROCm/aorta/pull/390) (`fb70f98`): `_reset_output_dir` only checked the leaf and its parent for symlinks, so a link in an earlier component (`<results>/linked -> <outside>` with the collector two levels below) still let `is_dir()` / `rmtree()` delete outside the results tree.
- Containment is now `root.resolve().is_relative_to(trusted.resolve())`. The trust anchor is the dispatcher-threaded `--results-dir` (`_aorta_results_root`), **not** a parent derived from the path under test — everything at or below the collector root is payload-writable, so a boundary computed from it proves nothing.
- Links *above* that root stay allowed (a `--results-dir` that legitimately lives under a symlink). Links *at or below* it refuse. Tests cover the deep-ancestor refuse, the operator-layout allow, and that the key is threaded next to `_aorta_collect_dir` (and absent when no collector is on).

Closes nothing new; continues #389 / #390.

## Test plan
- [x] `PYTHONPATH=src pytest tests/run/test_collectors.py tests/run/test_dispatcher.py tests/probe/test_subprocess_collectors.py tests/instrumentation/test_{rocprof,proton}.py -m "not gpu and not rocm"` — 398 passed on `914c93b`
- [x] Focused wrap + dispatcher collect-dir tests after the docstring commit
- [ ] CPU CI on this PR


Made with [Cursor](https://cursor.com)