### PR TITLE
fix(sanitizers): report un-itemized ConSan sites as a coverage gap, not a parse error

### DIFF
--- a/docs/sanitizers/consan-405-unitemized-barrier-sites.md
+++ b/docs/sanitizers/consan-405-unitemized-barrier-sites.md
@@ -1,0 +1,133 @@
+# ConSan on TokenSpeed's Gluon attention kernels — nothing lowers, and an unitemized barrier count hid it
+
+Filed as [ROCm/aorta#405](https://github.com/ROCm/aorta/issues/405), found while
+wiring TokenSpeed's JIT kernels through the Triton ConSan loader
+([#403](https://github.com/ROCm/aorta/pull/403), closing
+[#399](https://github.com/ROCm/aorta/issues/399)). The loader works; this is
+about what ConSan does once it reaches the object.
+
+Two defects, and the second hid the first.
+
+| | Owner | Status |
+|---|---|---|
+| **1.** No site can be lowered on the attention kernels | RocJITsu (rocm-systems) | open |
+| **2.** Barrier sites are counted but not itemized, so aorta could not report defect 1 | aorta | **fixed** — this document's other half |
+
+## Measured on
+
+- gfx950 (cdna4), ROCm 7.0.2.2
+- rocjitsu `4227d40fb5b4ea76273589c56dac069af08b7aab`, artifact run 32745941408
+  — the same bundle
+  [`consan-4112-overlapping-anchor-patches.md`](consan-4112-overlapping-anchor-patches.md)
+  records as carrying both the `dc7c8e04` and `15275dad` fixes, so none of this
+  is a stale-artifact effect
+- `scripts/sanitizers/triton_consan_loader.py` in `load` mode, lenient policy
+- objects harvested from TokenSpeed's Triton cache
+  (`lightseekorg/tokenspeed-amd:nightly-20260714`)
+
+## Defect 1 — no site lowers on the attention kernels
+
+Gluon **gemm** kernels from the same JIT and the same harvest path instrument
+cleanly:
+
+```
+access_discovered=77  access_supported=77  access_selected=77  access_patched=77
+barrier_discovered=12 barrier_supported=12 barrier_patched=12
+analysis verdict static_complete=true  access=77/77 barrier=12/12
+```
+
+Gluon **attention** kernels patch nothing:
+
+```
+access_discovered=232 access_supported=232 access_selected=232 access_patched=0
+                      access_placement_or_lowering_failed=232
+barrier_discovered=12 barrier_patched=0 barrier_placement_or_lowering_failed=12
+coverage_site ... outcome=placement_or_lowering_failed lowering_reason=instrumentation_patch_missing
+```
+
+Every site is discovered, reported *supported*, then fails to lower with
+`instrumentation_patch_missing`. Uniformly: 20 of 20 harvested attention
+objects, 2502 sites, zero patched, no exceptions. Affected kernels are
+`_fwd_kernel`, `_mha_prefill` and `_mha_prefill_sliding`, each in several shape
+specializations. Since gemm objects from the same pipeline patch fine this is
+kernel-dependent rather than a provisioning problem; the attention kernels are
+the more aggressive Gluon code, and `ds_read_b64_tr_b16`, `ds_read2_b64` and
+heavy LDS staging dominate their site inventory.
+
+Waitcheck is unaffected and passes on all 20 attention objects, so the kernels
+are reachable — ConSan just cannot instrument them. **This half needs a RocJITsu
+fix and is not actionable in aorta.**
+
+## Defect 2 — the reporting gap that hid it
+
+On the failing path the hook emits `coverage_site` records for the access sites
+but none for the barrier sites, while still reporting `barrier_discovered=12`:
+
+| | `coverage_site` records emitted | aggregate `coverage` record says |
+|---|---|---|
+| gemm, patched | 77 access + 12 barrier | `access_discovered=77 barrier_discovered=12` |
+| attention, unpatched | 232 access + **0 barrier** | `access_discovered=232 barrier_discovered=12` |
+
+`consan_coverage.py` cross-checks itemized sites against the discovered counts
+and used to fail closed on any disagreement:
+
+```
+consan_output_parse_error: reader <N> barrier site count mismatch
+```
+
+The cross-check is right to exist — coverage that cannot be seen should not be
+trusted. But a run whose real story is *"0 of 232 sites could be instrumented"*
+surfaced as an opaque parser complaint that reads like an aorta bug, the
+actionable numbers never reached `sanitizer_report.json`, and the parse error
+discarded the rest of the parsed output along with them. All 20 attention runs
+reported only this.
+
+### What changed
+
+A site kind the hook *counted* but never itemized is now treated as a coverage
+**gap** rather than malformed output. Nothing is trusted that was not seen: the
+decision is still rejected, the check is still `error`, and the un-itemized kind
+is named with its count. What survives is the evidence:
+
+```
+consan_coverage_incomplete: verdict analysis_complete=false;
+  verdict static_complete=false;
+  access patched/supported mismatch: 0/232;
+  barrier patched/supported mismatch: 0/12;
+  access placement_or_lowering_failed: 232 instrumentation_patch_missing;
+  reader 1 barrier sites not itemized: 0 of 12
+```
+
+Three things that were previously lost now reach the report: the per-object
+coverage entries (so the dashboard shows `0/232`), the lowering reason every
+failed site gave, and any race finding from the same run — a race found while
+coverage was incomplete is still a race, and the parse error used to throw it
+away.
+
+Partial itemization — some sites of a kind present, but not as many as were
+discovered — remains a parse error. That is lossy output with no honest
+interpretation, unlike a kind the hook simply never itemizes.
+
+## Reproducing
+
+```bash
+export ROCJITSU_PREBUILT=/path/to/rocjitsu/prebuilt
+python3 src/aorta/workloads/tokenspeed/harvest_code_objects.py \
+    --image lightseekorg/tokenspeed-amd:nightly-20260714 \
+    --pytest-suite tokenspeed-kernel/test/ops/test_attention.py --pytest-k mha_prefill \
+    --dest /tmp/ts-work/consan-attn \
+    --waitcheck "$ROCJITSU_PREBUILT/bin/rj_waitcheck" --consan --consan-limit 1
+
+aorta sweep run --recipe /tmp/ts-work/consan-attn/consan/consan-*.yaml \
+    --output-dir /tmp/ts-work/consan-attn-out
+```
+
+Swap `--pytest-suite ...` for `--kernel gluon_mm_a16w16_gfx950 --dtype bf16
+--dtype-role a` to get the passing gemm comparison.
+
+## What this still blocks
+
+ConSan coverage for TokenSpeed remains gemm-only until defect 1 is fixed
+upstream. The difference is that the attention runs now say so in
+`sanitizer_report.json` — with the site counts and the lowering reason — instead
+of failing as an unreadable parse error.

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
@@ -228,6 +228,17 @@ upstream.
 - Backend timeout, launch failure, unexpected exit, missing verdict, or
   incomplete coverage → `error`.
 - Missing backend or unsupported worklist scoping → `not_checked`.
+
+Coverage evidence is cross-checked two ways: the aggregate `coverage` counts
+must be internally consistent, and the itemized `coverage_site` lines must
+reconcile against them. Malformed or contradictory evidence is a parse error.
+A site kind the hook *counted* but never itemized is not — it is a coverage
+gap, reported as `consan_coverage_incomplete` naming the kind and the count
+(`reader 3 barrier sites not itemized: 0 of 12`). Both fail closed, but the gap
+keeps the rest of the run's evidence — the per-object counts, why sites failed
+to lower, and any race finding — instead of discarding it behind a parse
+complaint. The run that motivated this is written up in
+[`docs/sanitizers/consan-405-unitemized-barrier-sites.md`](../../../../docs/sanitizers/consan-405-unitemized-barrier-sites.md).
 - `pass` only means a requested backend ran healthily and produced no finding;
   Record/Replay's bounded snapshot is not proof that a program is race-free.
 

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/consan.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/consan.py
@@ -42,8 +42,9 @@ class ConSanMode(str, Enum):
 # aggregate ``coverage`` record's ``*_discovered`` counts. The hook only emits
 # those per-site lines at its debug level (kLogDebug=3). A boolean-truthy
 # ``RJ_CONSAN_LOG=1`` maps to kLogInfo, which prints the aggregate line but no
-# per-site records -- so the cross-check would fail closed on an otherwise clean
-# run. Request the debug level explicitly so the evidence is complete.
+# per-site records -- so every kind would report as un-itemized and the
+# cross-check would fail closed on an otherwise clean run. Request the debug
+# level explicitly so the evidence is complete.
 _CONSAN_LOG_DEBUG_LEVEL = "3"
 
 

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/consan_coverage.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/consan_coverage.py
@@ -30,6 +30,26 @@ _VERDICT_COUNTS = (
     "replay_unsupported_fences",
     "replay_metadata_full",
 )
+_SITE_FIELDS = (
+    "reader",
+    "kind",
+    "disposition",
+    "reason",
+    "outcome",
+    "lowering_reason",
+    "resource_reason",
+    "container",
+    "scope",
+    "text",
+    "mnemonic",
+)
+# Which per-site field explains each failing outcome. A site that succeeded
+# carries _NO_REASON in both, so only failures contribute an attribution.
+_FAILURE_REASON_FIELDS = {
+    "placement_or_lowering_failed": "lowering_reason",
+    "resource_failed": "resource_reason",
+}
+_NO_REASON = "none"
 
 
 class CoverageParseError(ValueError):
@@ -85,6 +105,23 @@ class CoverageDecision:
     reasons: tuple[str, ...]
     coverage: tuple[CoverageRecord, ...]
     verdict: AnalysisVerdict
+
+
+@dataclass(frozen=True)
+class _SiteRecord:
+    """One itemized ``coverage_site`` line."""
+
+    reader: int
+    load: int | None
+    kind: str
+    disposition: str
+    outcome: str
+    lowering_reason: str
+    resource_reason: str
+
+    @property
+    def identity(self) -> tuple[int, int | None]:
+        return self.reader, self.load
 
 
 def _fields(payload: str, context: str) -> dict[str, str]:
@@ -246,56 +283,67 @@ def _aggregate(verdicts: list[AnalysisVerdict]) -> AnalysisVerdict:
     )
 
 
+def _failure_attributions(sites: list[_SiteRecord]) -> list[str]:
+    """Name why sites failed, so a report says more than "0 patched"."""
+
+    tally: dict[tuple[str, str, str], int] = {}
+    for site in sites:
+        field = _FAILURE_REASON_FIELDS.get(site.outcome)
+        if field is None:
+            continue
+        reason = getattr(site, field)
+        if reason == _NO_REASON:
+            continue
+        key = (site.kind, site.outcome, reason)
+        tally[key] = tally.get(key, 0) + 1
+    return [
+        f"{kind} {outcome}: {count} {reason}"
+        for (kind, outcome, reason), count in sorted(tally.items())
+    ]
+
+
 def parse_coverage_decision(log_text: str) -> CoverageDecision:
-    """Parse and independently cross-check complete coverage evidence."""
+    """Parse and independently cross-check complete coverage evidence.
+
+    Raises ``CoverageParseError`` when the evidence is malformed or internally
+    inconsistent. A kind the hook counted but never itemized is neither: it is
+    a coverage gap, so it is returned as a rejected decision naming the gap
+    rather than raised. Both outcomes fail closed -- the difference is that a
+    rejected decision still carries the per-object counts and any race finding,
+    while a raised error discards them.
+    """
 
     coverage: list[CoverageRecord] = []
     verdicts: list[AnalysisVerdict] = []
-    site_records: list[tuple[int, int | None, str, str, str]] = []
+    site_records: list[_SiteRecord] = []
     for line_number, line in enumerate(log_text.splitlines(), 1):
         marker = line.find(_PREFIX)
         if marker < 0:
             continue
-        record = line[marker + len(_PREFIX) :]
-        if record.startswith("coverage "):
-            coverage.append(_parse_coverage(record[len("coverage ") :], line_number))
-        elif record.startswith("coverage_site "):
-            fields = _fields(
-                record[len("coverage_site ") :],
-                f"coverage_site line {line_number}",
-            )
-            _require(
-                fields,
-                (
-                    "reader",
-                    "kind",
-                    "disposition",
-                    "reason",
-                    "outcome",
-                    "lowering_reason",
-                    "resource_reason",
-                    "container",
-                    "scope",
-                    "text",
-                    "mnemonic",
-                ),
-                f"coverage_site line {line_number}",
-            )
+        payload = line[marker + len(_PREFIX) :]
+        if payload.startswith("coverage "):
+            coverage.append(_parse_coverage(payload[len("coverage ") :], line_number))
+        elif payload.startswith("coverage_site "):
+            context = f"coverage_site line {line_number}"
+            fields = _fields(payload[len("coverage_site ") :], context)
+            _require(fields, _SITE_FIELDS, context)
             if fields["kind"] not in _SITE_KINDS:
-                raise CoverageParseError(f"coverage_site line {line_number}: unsupported kind")
+                raise CoverageParseError(f"{context}: unsupported kind")
             site_records.append(
-                (
-                    _count(fields, "reader", f"coverage_site line {line_number}"),
-                    _load(fields, f"coverage_site line {line_number}"),
-                    fields["kind"],
-                    fields["disposition"],
-                    fields["outcome"],
+                _SiteRecord(
+                    reader=_count(fields, "reader", context),
+                    load=_load(fields, context),
+                    kind=fields["kind"],
+                    disposition=fields["disposition"],
+                    outcome=fields["outcome"],
+                    lowering_reason=fields["lowering_reason"],
+                    resource_reason=fields["resource_reason"],
                 )
             )
-        elif record.startswith("analysis verdict "):
+        elif payload.startswith("analysis verdict "):
             verdicts.append(
                 _parse_verdict(
-                    record[len("analysis verdict ") :],
+                    payload[len("analysis verdict ") :],
                     line_number,
                 )
             )
@@ -308,19 +356,32 @@ def parse_coverage_decision(log_text: str) -> CoverageDecision:
     if len(identities) != len(set(identities)):
         raise CoverageParseError("ambiguous duplicate coverage identities")
     identity_set = set(identities)
-    if any(
-        (reader, load) not in identity_set
-        for reader, load, _kind, _disposition, _outcome in site_records
-    ):
+    if any(site.identity not in identity_set for site in site_records):
         raise CoverageParseError("coverage_site references an unknown load")
+    unitemized: list[str] = []
     for record in coverage:
         counts = record.count_map
         for kind in _SITE_KINDS:
-            retained = [site for site in site_records if site[:3] == (*record.identity, kind)]
-            if len(retained) != counts[f"{kind}_discovered"]:
+            retained = [
+                site
+                for site in site_records
+                if site.identity == record.identity and site.kind == kind
+            ]
+            discovered = counts[f"{kind}_discovered"]
+            if discovered and not retained:
+                # The hook counts these sites but emits no per-site line for any
+                # of them, so there is nothing to reconcile against. Coverage
+                # this run cannot see is still refused below; naming the gap
+                # keeps the rest of the evidence readable instead of aborting
+                # the whole parse (ROCm/aorta#405).
+                unitemized.append(
+                    f"reader {record.reader} {kind} sites not itemized: 0 of {discovered}"
+                )
+                continue
+            if len(retained) != discovered:
                 raise CoverageParseError(f"reader {record.reader} {kind} site count mismatch")
-            supported = sum(site[3] == "supported" for site in retained)
-            unsupported = sum(site[3] == "unsupported" for site in retained)
+            supported = sum(site.disposition == "supported" for site in retained)
+            unsupported = sum(site.disposition == "unsupported" for site in retained)
             if supported != counts[f"{kind}_supported"]:
                 raise CoverageParseError(f"reader {record.reader} {kind} supported count mismatch")
             if unsupported != counts[f"{kind}_unsupported"]:
@@ -328,15 +389,11 @@ def parse_coverage_decision(log_text: str) -> CoverageDecision:
                     f"reader {record.reader} {kind} unsupported count mismatch"
                 )
             if not record.expert_limit:
-                for outcome, suffix in (
-                    ("patched", "patched"),
-                    ("resource_failed", "resource_failed"),
-                    (
-                        "placement_or_lowering_failed",
-                        "placement_or_lowering_failed",
-                    ),
-                ):
-                    if sum(site[4] == outcome for site in retained) != counts[f"{kind}_{suffix}"]:
+                for outcome in ("patched", "resource_failed", "placement_or_lowering_failed"):
+                    if (
+                        sum(site.outcome == outcome for site in retained)
+                        != counts[f"{kind}_{outcome}"]
+                    ):
                         raise CoverageParseError(
                             f"reader {record.reader} {kind} {outcome} count mismatch"
                         )
@@ -376,6 +433,8 @@ def parse_coverage_decision(log_text: str) -> CoverageDecision:
     for kind, patched, supported in verdict.patched_supported:
         if patched != supported:
             reasons.append(f"{kind} patched/supported mismatch: {patched}/{supported}")
+    reasons.extend(_failure_attributions(site_records))
+    reasons.extend(unitemized)
     if any(record.expert_limit for record in coverage):
         reasons.append("expert patch limit enabled")
     return CoverageDecision(

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/consan_coverage.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/consan_coverage.py
@@ -43,12 +43,6 @@ _SITE_FIELDS = (
     "text",
     "mnemonic",
 )
-# Which per-site field explains each failing outcome. A site that succeeded
-# carries _NO_REASON in both, so only failures contribute an attribution.
-_FAILURE_REASON_FIELDS = {
-    "placement_or_lowering_failed": "lowering_reason",
-    "resource_failed": "resource_reason",
-}
 _NO_REASON = "none"
 
 
@@ -122,6 +116,18 @@ class _SiteRecord:
     @property
     def identity(self) -> tuple[int, int | None]:
         return self.reader, self.load
+
+    @property
+    def failure_reason(self) -> str | None:
+        """Why this site failed, or None if it succeeded or gave no reason."""
+
+        if self.outcome == "placement_or_lowering_failed":
+            reason = self.lowering_reason
+        elif self.outcome == "resource_failed":
+            reason = self.resource_reason
+        else:
+            return None
+        return None if reason == _NO_REASON else reason
 
 
 def _fields(payload: str, context: str) -> dict[str, str]:
@@ -288,11 +294,8 @@ def _failure_attributions(sites: list[_SiteRecord]) -> list[str]:
 
     tally: dict[tuple[str, str, str], int] = {}
     for site in sites:
-        field = _FAILURE_REASON_FIELDS.get(site.outcome)
-        if field is None:
-            continue
-        reason = getattr(site, field)
-        if reason == _NO_REASON:
+        reason = site.failure_reason
+        if reason is None:
             continue
         key = (site.kind, site.outcome, reason)
         tally[key] = tally.get(key, 0) + 1

--- a/tests/instrumentation/rocjitsu_sanitizers/test_consan.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_consan.py
@@ -295,6 +295,25 @@ def test_unitemized_coverage_still_reports_why_sites_failed() -> None:
     assert [item.access for item in consan.coverage] == ["0/3"]
 
 
+def test_unitemized_sites_never_pass_even_when_the_counts_look_healthy() -> None:
+    # Every count reconciles and the verdict claims complete analysis -- except
+    # that the 2 barrier sites the hook says it patched were never itemized, so
+    # nothing corroborates them. This is the case where downgrading the parse
+    # error could have bought a PASS, and it must not: coverage that was not
+    # seen is not trusted, however healthy the aggregate looks.
+    output = _healthy_evidence().replace(
+        _zero_counts("barrier"),
+        "barrier_discovered=2 barrier_supported=2 barrier_selected=2 "
+        "barrier_patched=2 barrier_unsupported=0 barrier_resource_failed=0 "
+        "barrier_placement_or_lowering_failed=0 barrier_expert_limit_omitted=0",
+    ).replace("barrier=0/0", "barrier=2/2")
+
+    _waitcheck, consan = evaluate_record_replay(ProcessResult(("app",), 0, output, ""))
+
+    assert consan.verdict is Verdict.ERROR
+    assert "reader 1 barrier sites not itemized: 0 of 2" in str(consan.reason)
+
+
 def test_partially_itemized_site_kind_is_still_a_parse_error() -> None:
     # One missing site out of three is lossy output, not a reportable gap: the
     # remaining records cannot be reconciled, so this must stay fail-closed on
@@ -380,7 +399,8 @@ def test_run_consan_requests_debug_log_level(
 ) -> None:
     # The strict coverage cross-check needs per-site coverage_site records, which
     # the hook only emits at its debug level (kLogDebug=3). A boolean-truthy
-    # RJ_CONSAN_LOG=1 (kLogInfo) omits them and would fail closed on a clean run.
+    # RJ_CONSAN_LOG=1 (kLogInfo) omits them, so every kind would report as
+    # un-itemized and an otherwise clean run would fail closed.
     env = _capture_consan_env(monkeypatch, tmp_path, consan_log=True)
 
     assert "RJ_CONSAN_LOG" in env

--- a/tests/instrumentation/rocjitsu_sanitizers/test_consan.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_consan.py
@@ -62,6 +62,46 @@ def _healthy_evidence() -> str:
     return "\n".join((coverage, *sites, verdict))
 
 
+def _attention_evidence(*, access_sites: int = 3) -> str:
+    """Evidence shaped like TokenSpeed's Gluon attention kernels (issue #405).
+
+    Every discovered site is reported supported and then fails to lower, and the
+    hook itemizes the access sites but never the barrier sites it counted.
+    """
+
+    coverage = (
+        f"{_PREFIX} coverage reader=1 load=1 flavor=moi engine=record_replay "
+        "analysis_complete=false expert_limit=false "
+        "access_discovered=3 access_supported=3 access_selected=3 "
+        "access_patched=0 access_unsupported=0 access_resource_failed=0 "
+        "access_placement_or_lowering_failed=3 access_expert_limit_omitted=0 "
+        "barrier_discovered=2 barrier_supported=2 barrier_selected=2 "
+        "barrier_patched=0 barrier_unsupported=0 barrier_resource_failed=0 "
+        "barrier_placement_or_lowering_failed=2 barrier_expert_limit_omitted=0 "
+        f"{_zero_counts('atomic')} {_zero_counts('fence')}"
+    )
+    sites = [
+        (
+            f"{_PREFIX} coverage_site reader=1 load=1 kind=access "
+            "disposition=supported reason=none "
+            "outcome=placement_or_lowering_failed "
+            "lowering_reason=instrumentation_patch_missing resource_reason=none "
+            f"container=k scope=kernel text=0x{index:x} mnemonic=ds_read_b64_tr_b16"
+        )
+        for index in range(access_sites)
+    ]
+    verdict = (
+        f"{_PREFIX} analysis verdict applicable=true "
+        "analysis_complete=false static_complete=false dynamic_complete=true "
+        "applicable_code_objects=1 incomplete_code_objects=1 "
+        "access=0/3 barrier=0/2 atomic=0/0 fence=0/0 "
+        "visible_evidence=0 dynamic_incomplete=0 replay_unsupported_access=0 "
+        "replay_unsupported_atomics=0 replay_unsupported_fences=0 "
+        "replay_metadata_full=0"
+    )
+    return "\n".join((coverage, *sites, verdict))
+
+
 def _worklist() -> KernelWorklist:
     return KernelWorklist(
         requirement=SelectionRequirement.TOP_TIME,
@@ -225,6 +265,63 @@ def test_inconsistent_aggregate_coverage_never_passes() -> None:
 
     assert consan.verdict is Verdict.ERROR
     assert "aggregate disagrees" in str(consan.reason)
+
+
+def test_unitemized_site_kind_is_a_coverage_gap_not_a_parse_error() -> None:
+    # The hook counts 2 barrier sites and itemizes none of them. That is a hole
+    # in the evidence, not malformed output, so it must not be reported as if
+    # aorta failed to read the log.
+    _waitcheck, consan = evaluate_record_replay(
+        ProcessResult(("app",), 0, _attention_evidence(), "")
+    )
+
+    assert consan.verdict is Verdict.ERROR
+    assert "parse_error" not in str(consan.reason)
+    assert "consan_coverage_incomplete" in str(consan.reason)
+    assert "reader 1 barrier sites not itemized: 0 of 2" in str(consan.reason)
+
+
+def test_unitemized_coverage_still_reports_why_sites_failed() -> None:
+    # The actionable numbers -- 0 of 3 access sites patched, and the lowering
+    # reason every one of them reported -- have to survive into the check, since
+    # that is the whole story of the run.
+    _waitcheck, consan = evaluate_record_replay(
+        ProcessResult(("app",), 0, _attention_evidence(), "")
+    )
+
+    assert "access placement_or_lowering_failed: 3 instrumentation_patch_missing" in str(
+        consan.reason
+    )
+    assert [item.access for item in consan.coverage] == ["0/3"]
+
+
+def test_partially_itemized_site_kind_is_still_a_parse_error() -> None:
+    # One missing site out of three is lossy output, not a reportable gap: the
+    # remaining records cannot be reconciled, so this must stay fail-closed on
+    # the parse path.
+    _waitcheck, consan = evaluate_record_replay(
+        ProcessResult(("app",), 0, _attention_evidence(access_sites=2), "")
+    )
+
+    assert consan.verdict is Verdict.ERROR
+    assert "parse_error" in str(consan.reason)
+    assert "access site count mismatch" in str(consan.reason)
+
+
+def test_race_in_an_unitemized_run_is_not_discarded() -> None:
+    # A race found while coverage was incomplete is still a race. The old parse
+    # error threw the findings away with the rest of the parsed output.
+    output = "\n".join(
+        (
+            f"{_PREFIX} MOI auto replay diagnostic kind=1 conflict=true diagnostics=1",
+            _attention_evidence(),
+        )
+    )
+
+    _waitcheck, consan = evaluate_record_replay(ProcessResult(("app",), 0, output, ""))
+
+    assert consan.verdict is Verdict.FAIL
+    assert len(consan.findings) == 1
 
 
 def test_strict_mode_relies_on_backend_exit_and_coverage_gate() -> None:


### PR DESCRIPTION
Addresses the aorta half of #405.

That issue reports two defects. **Defect 1** — ConSan discovers 232 access
sites on TokenSpeed's Gluon attention kernels, calls every one of them
*supported*, then lowers none of them, each reporting
`instrumentation_patch_missing` — needs a RocJITsu fix and is not actionable
here. **Defect 2** is ours, and it is what made defect 1 undiagnosable from a
report: the hook counts 12 barrier sites and itemizes none of them, our strict
coverage cross-check raised on the disagreement, and the run surfaced as

```
consan_output_parse_error: reader 1 barrier site count mismatch
```

An opaque parser complaint that reads like an aorta bug, for a run whose real
story was *"0 of 232 sites could be instrumented"*. All 20 attention runs
reported only this, and the actionable numbers never reached
`sanitizer_report.json`.

## What changed

A site kind the hook **counted but never itemized** is now a coverage *gap*
rather than malformed output. Malformed and internally-inconsistent evidence
still raises; so does *partial* itemization, which is lossy output with no
honest interpretation. What a gap gets instead is a named rejection:

```
consan_coverage_incomplete: verdict analysis_complete=false;
  verdict static_complete=false;
  access patched/supported mismatch: 0/232;
  barrier patched/supported mismatch: 0/12;
  access placement_or_lowering_failed: 232 instrumentation_patch_missing;
  reader 1 barrier sites not itemized: 0 of 12
```

Three things that the parse error used to discard now reach the report: the
per-object coverage entries (so the dashboard renders `0/232` instead of
nothing), the lowering reason every failed site gave, and any race finding from
the same run — a race found while coverage was incomplete is still a race.

That last one is a small correctness fix in its own right: on the parse-error
path `findings` was dropped along with everything else, so a Record/Replay
conflict in an un-itemized run came back as `error` with no findings rather
than `fail`.

## Points a reviewer will want flagged

**This relaxes a fail-closed guardrail, so the question is whether it can buy a
PASS. It cannot, and that is tested rather than asserted.** An un-itemized kind
always contributes a rejection reason, so `accepted` is always false. The
branch that worried me is the one where the aggregate looks *healthy* —
`barrier_patched=2` with no site to corroborate it — because it skips the
per-kind disposition/outcome cross-checks. `test_unitemized_sites_never_pass_even_when_the_counts_look_healthy`
pins exactly that shape, and I mutation-checked it: deleting the rejection
reason turns that run into a `PASS`, and the test fails. Per §49 of my own
review notes ("visibility is not a substitute for failing closed") — nothing
here is downgraded to a warning, and no wrong-but-plausible output is
persisted or blessable into a baseline.

**Verdict baselines are unaffected.** `verdict_baselines.json` compares
verdicts, execution status and finding shape, not reason strings, and the three
committed cases are fully-itemized healthy/racy paths.

**The `RJ_CONSAN_LOG` contract is unchanged.** At `kLogInfo` the hook emits the
aggregate line but no per-site records, so every kind reports as un-itemized
and the run still fails closed — the reason is now readable instead of a count
mismatch. `run_consan` still pins `kLogDebug=3`; the comment there and in
`daily-consan-gemm.yaml` were re-read against the new behaviour.

**Two drive-by cleanups, both inside the function being changed.** The
`coverage_site` branch now builds a typed `_SiteRecord` instead of a 5-tuple
addressed by index (it needed two more fields, and `site[4]` was already
opaque); and the loop-local `record` string was renamed `payload` because it
shadowed the `CoverageRecord` of the same name in the cross-check loop below.
The rename takes `consan_coverage.py` from 8 pre-existing mypy errors to 0.

## Test plan

- [x] `pytest tests/instrumentation/rocjitsu_sanitizers/ tests/sanitizers/` — 450 passed, 3 skipped
- [x] The 4 behavioural tests fail against `main` with the exact string from the
      issue (`consan_output_parse_error: reader 1 barrier site count mismatch`);
      the partial-itemization guard passes on both, which is the point — it
      proves the relaxation is bounded
- [x] Mutation check on the false-PASS guard (above)
- [x] `ruff` clean; `black`/`mypy` clean on `consan_coverage.py`; the
      pre-existing `black` findings in `consan.py` / `test_consan.py` are
      untouched and none fall in the added lines
- [ ] Not exercised on hardware — the fixtures are transcribed from the log
      excerpts in #405 rather than captured from a fresh gfx950 run

Defect 1 and this measurement are written up in
`docs/sanitizers/consan-405-unitemized-barrier-sites.md`, following the
`consan-4112` precedent. #405 stays open for the RocJITsu half.

Made with [Cursor](https://cursor.com)