### PR TITLE
fix(sanitizers): root-cause the Tab 2 ConSan rows, and stop the 4112 reproducer misreporting a capacity limit as the defect

### DIFF
--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -70,6 +70,11 @@ work the old path never reached. Any timeout for this case has to be sized again
 the ~69 min figure, not the ~24 min one — see the ceiling discussion in
 `daily-consan-gemm.yaml`.
 
+That remains a lower bound rather than a budget: everything in this section was
+measured on the 15.5 MB object, and the one CI extracts has 9.3x the access
+sites. Nobody has instrumented it end-to-end, because the growth ceiling stops it
+first.
+
 Affects: `daily-consan-gemm.yaml` (dashboard Tab 2, observed-only, non-gating).
 Repro: [`repro/consan_4112_repro.sh`](repro/consan_4112_repro.sh).
 
@@ -165,8 +170,13 @@ script makes, and it now reports `fixed` rather than `reproduced`.
 prediction stands: the driver is load-only, so the run ends on strict
 require-records at exit 86. Turning it into a genuine pass/fail additionally needs
 a driver that dispatches a GEMM kernel from the instrumented module (hipBLASLt, or
-a hand-written launcher for one extracted Tensile kernel). That is unbuilt, and it
-is the only remaining blocker now that #9972 is fixed.
+a hand-written launcher for one extracted Tensile kernel). That is unbuilt.
+
+It is **not** the only remaining blocker, and the exit 86 above is what the
+15.5 MB object does, not what CI sees. On the 183 MiB object CI extracts, the
+growth ceiling rejects the transform first, so the run never reaches
+require-records at all — that has to be settled before the dispatching driver
+matters. See the [growth-cap doc](consan-gemm-patched-image-growth-cap.md).
 
 ## Reproducing
 
@@ -213,7 +223,14 @@ still has the defect rejects the object after ~1420 s, but a fixed hook
 instruments it and runs for ~4150 s, so a ceiling sized against the defect would
 kill the very case it is meant to confirm. Hitting the ceiling reports `3`, not a
 hang, which matters because a pre-#9964 hook never terminates MOI inventory for
-this object at all. If the
+this object at all.
+
+Both figures are for the 15.5 MB object, and 6000 s is not a budget for anything
+larger. The object a modern hipBLASLt ships has 9.3x the access sites and has
+never been instrumented end-to-end, because the growth ceiling stops it earlier —
+so raising that ceiling without also raising `--timeout` mostly trades one
+inconclusive result for another. The script says so at the point it suggests the
+retry. If the
 local hipBLASLt does not carry the Tensile bundle — it has shipped both flat
 under `library/` and under `library/gfx950/`, and slim installs may omit it —
 pass `--object` with an already-unbundled gfx950 code object.

--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -186,7 +186,17 @@ docs/sanitizers/repro/consan_4112_repro.sh --hook /path/to/librocjitsu_dbi_hooks
 
 It exits `0` when it reproduces the 4112 rejection, `1` when the defect is fixed,
 `2` when the environment is unusable, and `3` when no verdict could be
-established. `1` requires *both* that the module loaded and that the hook ended
+established.
+
+> **Updated 2026-08-27.** The script used to key "reproduced" off
+> `status=4112` + exit 92 alone. Because 4112 is a shared `transform-error`
+> bucket, the patched-image growth ceiling produces that same signature — so on a
+> modern ROCm base (large Tensile bundle, ~183 MiB object) the script would have
+> reported this *fixed* defect as still present. It now requires the
+> `final validation found partially overlapping patch ranges` diagnostic for a
+> reproduction, and reports a growth-ceiling rejection as inconclusive with the
+> knob to retry under. See
+> [`consan-gemm-patched-image-growth-cap.md`](consan-gemm-patched-image-growth-cap.md). `1` requires *both* that the module loaded and that the hook ended
 the run with its own exit 86 — the load-only driver never dispatches, so strict
 require-records is expected to fail afterwards, and that is the post-fix state
 described above rather than a second defect. Demanding the hook-owned exit code

--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -196,7 +196,9 @@ established.
 > `final validation found partially overlapping patch ranges` diagnostic for a
 > reproduction, and reports a growth-ceiling rejection as inconclusive with the
 > knob to retry under. See
-> [`consan-gemm-patched-image-growth-cap.md`](consan-gemm-patched-image-growth-cap.md). `1` requires *both* that the module loaded and that the hook ended
+> [`consan-gemm-patched-image-growth-cap.md`](consan-gemm-patched-image-growth-cap.md).
+> The shared status code is filed upstream as
+> [ROCm/rocm-systems#10950](https://github.com/ROCm/rocm-systems/issues/10950). `1` requires *both* that the module loaded and that the hook ended
 the run with its own exit 86 — the load-only driver never dispatches, so strict
 require-records is expected to fail afterwards, and that is the post-fix state
 described above rather than a second defect. Demanding the hook-owned exit code

--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -198,7 +198,9 @@ established.
 > knob to retry under. See
 > [`consan-gemm-patched-image-growth-cap.md`](consan-gemm-patched-image-growth-cap.md).
 > The shared status code is filed upstream as
-> [ROCm/rocm-systems#10950](https://github.com/ROCm/rocm-systems/issues/10950). `1` requires *both* that the module loaded and that the hook ended
+> [ROCm/rocm-systems#10950](https://github.com/ROCm/rocm-systems/issues/10950).
+
+`1` requires *both* that the module loaded and that the hook ended
 the run with its own exit 86 — the load-only driver never dispatches, so strict
 require-records is expected to fail afterwards, and that is the post-fix state
 described above rather than a second defect. Demanding the hook-owned exit code

--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -45,9 +45,23 @@ downloader selects the newest successful run, the next nightly picks that up
 rather than `db0c47df`.
 
 So the `db0c47df` numbers here are historical from the next nightly onward.
+
+> **What actually happened, recorded 2026-08-27.** Everything from "A bundle
+> carrying both fixes is now published" down to the end of this section was
+> written before the nightly consumed one, and it is kept as the prediction it
+> was. Two things in it are wrong as a description of CI. The nightly did not
+> land on `4227d40fb5` — the downloader selects the newest successful run, and by
+> the time one ran that was `97c1640b`. And `consan-gemm` did **not** stop
+> reporting `status=4112`: the anchor-overlap defect is gone from the log, but
+> the patched-image growth ceiling now rejects the object first, on the much
+> larger fixture ROCm 7.2.4 ships. See
+> [`consan-gemm-patched-image-growth-cap.md`](consan-gemm-patched-image-growth-cap.md)
+> and the CI column in the table below.
+
 Re-running this document's own reproducer against `4227d40fb5` confirms the fix
-end to end, and the prediction below held exactly — `consan-gemm` stops reporting
-`status=4112` and ends on strict require-records instead:
+end to end **on the 15.5 MB source-build object**, and the prediction held
+exactly for it — that object stops reporting `status=4112` and ends on strict
+require-records instead:
 
 ```
 ConSan MOI inventory end   elapsed_ms=246060.502

--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -1,10 +1,26 @@
 # ConSan transform rejection `status=4112` — overlapping anchor patches
 
-**Status: fixed upstream and now published.** Fixed in `dc7c8e04`; a bundle
-carrying it (and the #9972 fix) went green on 2026-08-24, so the next nightly
-picks it up. This document is kept as the record of the defect and of what it
-predicted, since the dashboard row it explains only changes once that bundle is
-consumed.
+**Status: fixed upstream, published, and confirmed consumed.** Fixed in
+`dc7c8e04`; a bundle carrying it (and the #9972 fix) went green on 2026-08-24,
+and the nightly has since run on `97c1640b` with no overlapping-patch complaint
+anywhere in its log. This document is kept as the record of the defect and of
+what it predicted.
+
+> ⚠️ **`consan-gemm` on Tab 2 still shows `status=4112` / exit 92 — for an
+> unrelated reason.** `status=4112` is a generic `transform-error` bucket, and the
+> row it produces is indistinguishable from the pre-fix one. The current
+> rejection is ConSan's *patched-image growth* ceiling (400 MiB against a
+> ~1.39 GiB requirement), triggered because the extracted fixture grew from
+> 15.5 MB to 183 MiB with the move to ROCm 7.2.4. That is a configurable
+> capacity policy, not a defect, and it is written up separately in
+> [`consan-gemm-patched-image-growth-cap.md`](consan-gemm-patched-image-growth-cap.md).
+>
+> Consequence for this document: the prediction below — that the fix moves
+> `consan-gemm` to exit 86 on strict require-records — **has not been observed in
+> CI and cannot be**, because the growth ceiling now intervenes before the
+> transform completes. The prediction was verified against the 15.5 MB object on
+> a source build, and it remains correct *for that object*. It is not what the
+> nightly reports.
 
 Found while verifying the upstream fixes claimed for ROCm/rocm-systems#9964,
 #9970 and #9972, and filed as
@@ -123,16 +139,21 @@ No load rejection: the transform succeeded and the failure moved to the
 require-records check. So:
 
 The first column is what the dashboard showed while `db0c47df` was the newest
-bundle. The second is measured from source builds of the fixes, not predicted, and
-is what the nightly should start reporting once it picks up `4227d40fb5`. The
-third remains a projection — it needs work nobody has done yet.
+bundle. The second is measured from source builds of the fixes, not predicted. The
+third is what the nightly **actually** reported once it picked up a bundle with
+both fixes (`97c1640b`, run 32967422099, 2026-08-26). The fourth remains a
+projection — it needs work nobody has done yet.
 
-| Case | On `db0c47df` (through 2026-08-24) | With the `dc7c8e04` / `15275dad` fixes (measured, source build) | Additionally **with a dispatching driver** (not built) |
-|---|---|---|---|
-| `consan-gemm` (Tab 2) | `error`, exit 92 `consan_strict_load_rejection` | `error`, exit 86 `combined_hook_exit_86` — transform now succeeds | could reach a real `pass`/`fail` verdict |
-| `consan-lds-dispatch` (Tab 2) | `error`, exit 86 | records captured, `dynamic_complete=true`, exit 0 at `STRIDE=16` | `pass`/`fail` |
-| `consan-tiny` (Tab 2) | `error`, exit 86 | unchanged (no sites, by design) | unchanged |
-| `consan-clean` / `consan-racy` (Tab 1) | `pass` / `fail` | unchanged | unchanged |
+| Case | On `db0c47df` (through 2026-08-24) | With the `dc7c8e04` / `15275dad` fixes (measured, source build, 15.5 MB object) | Observed in CI on `97c1640b` (183 MiB object) | Additionally **with a dispatching driver** (not built) |
+|---|---|---|---|---|
+| `consan-gemm` (Tab 2) | `error`, exit 92 `consan_strict_load_rejection` | `error`, exit 86 `combined_hook_exit_86` — transform now succeeds | ❌ **still `error`, exit 92** — different cause: patched-image growth ceiling, see [the growth-cap doc](consan-gemm-patched-image-growth-cap.md) | could reach a real `pass`/`fail` verdict |
+| `consan-lds-dispatch` (Tab 2) | `error`, exit 86 | records captured, `dynamic_complete=true`, exit 0 at `STRIDE=16` | ✅ **`pass`**, `access=5/5 barrier=2/2`, `visible_evidence=3216` | already there |
+| `consan-tiny` (Tab 2) | `error`, exit 86 | unchanged (no sites, by design) | `error`, exit 86 — as designed | unchanged; a dispatching driver does **not** help (measured) |
+| `consan-clean` / `consan-racy` (Tab 1) | `pass` / `fail` | unchanged | `pass` / `fail` | unchanged |
+
+The second column's `consan-gemm` prediction is the one entry that CI never
+reached. It was measured against the 15.5 MB ROCm 7.0.2.2 object and holds for it;
+the object CI extracts is 11.8x larger and is rejected earlier, on capacity.
 
 The concrete thing that started working is the **ConSan transform of a large
 production code object**. On `dc7c8e04` the same object patches cleanly —

--- a/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
+++ b/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
@@ -103,6 +103,60 @@ To clear the CI object the ceiling has to admit 1,492,987,904 bytes against a
 percent form is the better fit here precisely because the fixture's size is a
 hipBLASLt release property.
 
+## Is there a smaller object to use instead? Measured, and the answer is "not on our base"
+
+Surveyed across three ROCm versions by unbundling every `Type_SS` gfx950 NT
+(`Ailk_Bjlk`) bundle each one ships. Unbundled size is what ConSan instruments;
+kernel counts are unique `.kd` symbols.
+
+First, the object the script selects today, which confirms the survey resolved the
+same file CI does:
+
+| ROCm | Selected NT bundle | Unbundled | Kernels |
+|---|---|--:|--:|
+| **7.2.4 (our CI base)** | `..._Ailk_Bjlk_Cijk_Dijk_gfx950.co` | **183.0 MiB** | 777 |
+| 7.14.0 | `..._CU256_ID75a0_gfx950.co` | 162.1 MiB | 341 |
+| 10.0.0 | `..._CU256_ID75a0_gfx950.co` | 162.1 MiB | 341 |
+
+A genuinely attractive alternative exists — but **only on ROCm ≥ 7.14**. It is the
+per-chip sibling of the same family and layout, plain (non-MX) f32, with kernels
+named identically apart from the tile shape:
+
+| ROCm | Bundle | Unbundled | Kernels |
+|---|---|--:|--:|
+| 7.14.0 | `..._Ailk_Bjlk_Cijk_Dijk_ID75a3-75a2_gfx950.co` | **13.1 MiB** | 71 |
+| 10.0.0 | same | **13.6 MiB** | 73 |
+
+Reaching it needs no code change: `_select_variant` returns the first *exact*
+chip-id match regardless of sort order, so `prepare_gemm_isa.py --chip-id 0x75a3`
+selects it (for `0x75a3` the `_CU256_ID75a0` bundle is only a registry fallback,
+while `_ID75a3-75a2` is an exact hit). The cost is that the fixture would then
+represent an MI355X-class device rather than the gate's MI350X.
+
+**The blocker: ROCm 7.2.4 does not ship it.** The flat pre-7.14 layout ships
+exactly one bundle per layout, so on the base `docker/Dockerfile.ci-gpu` pins there
+is no smaller plain-f32 NT object at all. What 7.2.4 does offer, and why each is
+unsuitable:
+
+| ROCm 7.2.4 alternative | Unbundled | Kernels | Why not |
+|---|--:|--:|---|
+| `SS_SB_HA_Bias_SAV_UA` | 104.1 MiB | 471 | f32 in, **bf16 out** — different dtype path, and ~810 MiB projected still exceeds the ceiling |
+| `SS_SS_HA_Bias_SAV_MX_UA` | 41.2 MiB | 244 | **microscaling** (`_S_MX_B_` kernels), not the plain f32 path this case represents |
+| same, TT layout | 20.0 MiB | 85 | microscaling, and the wrong transpose layout |
+| `Aux` / `Grad` / bare `Bias` | ≤ 347 KiB | 1 | one kernel each — would exercise almost nothing |
+
+So on our current base the choice is between raising the ceiling and changing what
+the case represents. The 13 MiB option becomes available only if the sanitizer
+nightly moves to ROCm ≥ 7.14. Note `latest-rocm-canary.yml` does **not** help here:
+it is an eval lane and never runs the sanitizer recipes.
+
+> **Treat the projections as planning numbers, not measurements.** The ~7.8x
+> figure comes from one data point (1,492,987,904 required for a 191,935,808-byte
+> input), and expansion tracks the number of *instrumentable sites*, not bytes —
+> the 183 MiB object holds 637,823 access ranges. Scaling it linearly puts the
+> 13 MiB object near ~100 MiB of patched image, comfortably inside the ceiling,
+> and the 41 MiB MX object near ~320 MiB, marginally inside. Neither has been run.
+
 ### Raising the ceiling alone will not turn this row green
 
 Two things still stand between this case and a real verdict, and both should be

--- a/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
+++ b/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
@@ -120,17 +120,21 @@ settled before anyone sets the knob and expects a pass:
    86 even after a clean transform. This is the part of the earlier document's
    prediction that remains correct and remains unbuilt.
 
-## What is worth raising upstream
+## What was raised upstream
 
-Not a defect report. Two diagnostics points:
+Not a defect report. Filed as
+[ROCm/rocm-systems#10950](https://github.com/ROCm/rocm-systems/issues/10950)
+(`enhancement`), covering two diagnostics points:
 
 1. **`status=4112` conflates unrelated transform failures.** Anchor-range
    overlap (#10378) and a growth-ceiling rejection are different problems with
    different owners and different fixes, and they are indistinguishable from the
    status code, the exit code, and therefore from any dashboard built on them.
-   Only the human-readable line above the rejection separates them. A distinct
-   status per rejection class — or the reason token echoed into the
-   `load rejection` line — would have made this diagnosis immediate.
+   Only the human-readable line above the rejection separates them. The request
+   is a stable `cause=` token appended to the `load rejection` line — additive,
+   no status renumbering, no change to any run's outcome. A distinct status per
+   rejection class would also work but is behaviour-visible for anything already
+   matching 4112, so it was explicitly offered as the non-preferred alternative.
 2. **The expansion factor is worth a sanity check.** Instrumenting a 183 MiB
    object is reported as needing ~1.39 GiB of patched image, a 7.78x expansion.
    That may be entirely expected for full MOI record/replay coverage; it is

--- a/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
+++ b/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
@@ -150,12 +150,68 @@ the case represents. The 13 MiB option becomes available only if the sanitizer
 nightly moves to ROCm ≥ 7.14. Note `latest-rocm-canary.yml` does **not** help here:
 it is an eval lane and never runs the sanitizer recipes.
 
-> **Treat the projections as planning numbers, not measurements.** The ~7.8x
-> figure comes from one data point (1,492,987,904 required for a 191,935,808-byte
-> input), and expansion tracks the number of *instrumentable sites*, not bytes —
-> the 183 MiB object holds 637,823 access ranges. Scaling it linearly puts the
-> 13 MiB object near ~100 MiB of patched image, comfortably inside the ceiling,
-> and the 41 MiB MX object near ~320 MiB, marginally inside. Neither has been run.
+### Measured: the 13 MiB object does clear the ceiling, on ROCm 7.14
+
+Run on a gfx950 host inside `rocm/pytorch:rocm7.14_ubuntu26.04_py3.14_pytorch_release_2.12.0`
+with the **exact CI bundle** `97c1640b` (hook SHA-256 `fac74fad3fd8f0ee…`, byte-identical
+to what the nightly recorded), driving the unbundled `_ID75a3-75a2` object through the
+repo's own load-only `consan_load.hip`:
+
+```
+ConSan MOI inventory end    elapsed_ms=11826.885
+ConSan patch end   visited=true modified=true outcome=modified-valid errors=0 warnings=13517 patches=88758 patch_ms=31253.498
+ConSan coverage    access_discovered=72824 access_supported=72824 access_selected=72824 access_patched=72824
+ConSan patched-image growth memory   peak_growth_bytes=188555264
+RJ_CONSAN_MOI_REQUIRE_RECORDS requested, but 1 auto MOI report buffer(s) contained
+zero visible records and no kernel dispatch packet was observed
+exit 86 after 87s
+```
+
+| | 183 MiB object (CI today) | 13.1 MiB `_ID75a3-75a2` |
+|---|--:|--:|
+| Patched-image growth | 1,492,987,904 required | **188,555,264 peak** |
+| Against the 400 MiB ceiling | 3.56x over — **rejected** | **fits, 55% headroom** |
+| Patches applied | 0 | **88,758** |
+| Access sites | 637,823 discovered, 0 patched | 72,824 discovered, **all patched** |
+| Wall clock | ~730 s, then exit 92 | **87 s**, then exit 86 |
+
+So the object transforms cleanly and is genuinely instrumented, in 87 seconds against
+a 6000 s budget. The run still ends at exit 86 on strict require-records, for the
+load-only-driver reason above — which is the *known* remaining gap, not a capacity one.
+
+**Two corrections to the projections this document previously carried:**
+
+1. **Expansion is not ~7.8x, and is not linear in bytes.** This object expands
+   **13.7x** (188,555,264 from 13,750,952). The linear estimate predicted ~100 MiB
+   and the real figure is ~180 MiB. It still fits, but anyone sizing a third object
+   should measure rather than scale.
+2. **The report buffer is the tighter constraint, not the growth ceiling.** The plan
+   needed `required_bytes=507242680` against `per_buffer_ceiling=536870912` — only
+   **5.6% of headroom** — and `barriers=1728640` dominates it. A modestly larger
+   object would hit `status=4104 moi-report-allocation` before it ever reached the
+   growth ceiling. Worth knowing, because 4104 is *another* distinct rejection that
+   also terminates with exit 92 (see #10950).
+
+### The hook itself works on ROCm 7.14, but the image needs two shims
+
+Also established by the run above: the prebuilt rocjitsu bundle loads and runs
+correctly against ROCm 7.14's HSA runtime — `installed ConSan hook` appears and the
+full transform completes. That was the main unknown for moving the sanitizer lane
+off 7.2.4.
+
+Two mechanical obstacles in the wheel/TheRock image, both of which would break the
+nightly's fixture-build step rather than anything subtle:
+
+* **`hipcc` cannot link a HIP program.** The wheel ships only versioned sonames
+  (`libamdhip64.so.7`) with no unversioned `libamdhip64.so`, and `--hip-link`
+  references the unversioned path *absolutely*, so `-L` does not help — the symlink
+  has to exist next to the versioned library.
+* **The built binary needs `LD_LIBRARY_PATH`** covering `_rocm_sdk_core/lib` and
+  `_rocm_sdk_libraries/lib`; without it the loader fails with exit 127 before the
+  hook is ever consulted.
+
+Neither is a blocker, but both are load-bearing for a base bump and neither is
+visible from the Python side that `resolve_rocm_roots()` already handles.
 
 ### Raising the ceiling alone will not turn this row green
 

--- a/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
+++ b/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
@@ -1,0 +1,161 @@
+# `consan-gemm` still reports `status=4112` — but for a different reason
+
+**Status: root-caused, not a rocjitsu defect.** The Tab 2 `consan-gemm` row is
+rejected by ConSan's *patched-image growth* policy, which is a configurable
+capacity ceiling that AORTA has never set. It is not the anchor-overlap defect
+of [ROCm/rocm-systems#10378](https://github.com/ROCm/rocm-systems/issues/10378),
+even though both surface as `status=4112` / exit 92 /
+`consan_strict_load_rejection`.
+
+Read this together with
+[`consan-4112-overlapping-anchor-patches.md`](consan-4112-overlapping-anchor-patches.md),
+which documents the *other* 4112. That one is genuinely fixed; its predicted
+follow-on state never materialised because this ceiling intervenes first.
+
+Affects: `daily-consan-gemm.yaml` (dashboard Tab 2, observed-only, non-gating).
+
+## What the nightly reports
+
+From run
+[32967422099](https://github.com/ROCm/aorta/actions/runs/32967422099)
+(2026-08-26, aorta `bed2771d`, rocjitsu bundle `97c1640b`, ROCm 7.2.4):
+
+```
+ConSan patch end   visited=true modified=false outcome=invalid errors=1 warnings=6 patches=0 patch_ms=151746.121
+ConSan MOI first-light probe rejected patched-image file growth:
+  required total 1492987904 bytes, limit 419430400 bytes (policy absolute-bytes=419430400)
+ConSan load rejection reason=transform-error status=4112 policy=strict action=terminate exit_code=92
+```
+
+The transform needs ~1.39 GiB of patched image; the ceiling in force is 400 MiB.
+Being 3.56x over, the object is never instrumented — `patches=0`.
+
+**No overlapping-patch complaint appears anywhere in that log.** #10378 is fixed
+in this bundle. `status=4112` is a generic `transform-error` bucket, so the
+dashboard row is byte-identical to the pre-fix one while the cause underneath it
+changed completely. That is the single most misleading thing about this failure,
+and it is why the earlier document's prediction reads as though the upstream fix
+did not land.
+
+**It is not a timeout.** `timeout_seconds: 6000` is untouched: waitcheck 447 s +
+MOI inventory 131 s + patch 152 s is roughly 730 s before the rejection.
+
+## Why the ceiling is exceeded: the fixture grew 11.8x
+
+Every prior sizing and upstream-verification exercise for this case used a
+**16,265,200-byte (15.5 MB)** object with 490 kernels, measured on ROCm 7.0.2.2.
+The object CI now extracts is **191,935,808 bytes (183 MiB)**:
+
+| | Verification object (ROCm 7.0.2.2) | CI object (ROCm 7.2.4) | Ratio |
+|---|--:|--:|--:|
+| Unbundled size | 16,265,200 | 191,935,808 | 11.8x |
+| Access sites discovered | 68,894 | 637,823 | 9.3x |
+| Barrier sites | 3,950 probes | 1,386,944 | — |
+| Report buffer required | 513,459,640 | 503,295,496 | ~1.0x |
+
+`prepare_gemm_isa.py` extracts *whichever* heavy f32 SS Tensile bundle the local
+ROCm ships for the NT (`Ailk_Bjlk`) layout, so the fixture's size is a per-release
+property of hipBLASLt rather than something this repo pins. That is already
+recorded in the script's own docstring as of
+[#402](https://github.com/ROCm/aorta/pull/402) (~183 MiB on 7.2.4, ~156-168 MiB
+on 7.14) — the size drift was known. What was not known is that it pushes the
+transform past a capacity ceiling nobody had needed to think about, because at
+15.5 MB the 400 MiB ceiling was ~24x larger than anything the object could ask
+for.
+
+`daily-consan-gemm.yaml`'s timeout rationale still reasons entirely from the
+15.5 MB object, so its "~62-69 min" budget describes a run this case no longer
+performs.
+
+## The ceiling is a documented knob, not a defect
+
+Verified by direct experiment on a gfx950 host (ROCm 7.0.2.2, rocjitsu bundle
+`7d2c61e7`, `lds.hsaco` at 5,816 bytes) — the *same* rejection can be produced
+and removed at will:
+
+| Setting | Resulting policy | Outcome |
+|---|---|---|
+| *(default)* | `absolute-bytes=402653184` | `outcome=modified-valid patches=13` |
+| `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_BYTES=4096` | `absolute-bytes=4096` | **`status=4112` exit 92**, `required total 12288 bytes, limit 4096 bytes` |
+| `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT=100` | `input-percent=100` | **`status=4112` exit 92**, `limit 5816 bytes` |
+| `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT=10` | `input-percent=10` | **`status=4112` exit 92**, `limit 581 bytes` |
+| `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_BYTES=67108864` | `absolute-bytes=67108864` | `outcome=modified-valid patches=13` |
+
+The forced-low runs reproduce the nightly's signature exactly: `patch end
+outcome=invalid errors=1 patches=0`, then the same `first-light probe rejected
+patched-image file growth` line, then the same
+`reason=transform-error status=4112 policy=strict action=terminate exit_code=92`.
+
+So the rejection is a deliberate, tunable capacity policy with two spellings:
+
+* `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_BYTES=N` → absolute ceiling of `N` bytes;
+* `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT=P` → ceiling of `P`% of the
+  *original input image*, which scales with the object.
+
+AORTA sets neither. `run_consan` pins only `RJ_CONSAN_MODE`, `RJ_CONSAN_POLICY`
+and `RJ_CONSAN_LOG`; everything else is inherited from the ambient environment.
+Note the default ceiling itself moved between bundles — 402,653,184 (384 MiB) on
+`7d2c61e7` versus 419,430,400 (400 MiB) on `97c1640b` — so it is not a constant
+to rely on either.
+
+To clear the CI object the ceiling has to admit 1,492,987,904 bytes against a
+191,935,808-byte input, i.e. **`PERCENT` ≥ 778** or **`BYTES` ≥ ~1.39 GiB**. The
+percent form is the better fit here precisely because the fixture's size is a
+hipBLASLt release property.
+
+### Raising the ceiling alone will not turn this row green
+
+Two things still stand between this case and a real verdict, and both should be
+settled before anyone sets the knob and expects a pass:
+
+1. **Runtime.** Clearing the ceiling means the object actually gets instrumented
+   — 637,823 access sites, 9.3x the site count that took ~62-69 min of wall
+   clock on the 15.5 MB object. The 6000 s ceiling is very unlikely to hold, so
+   the likely next row is `combined_hook_timeout` rather than a pass. Sizing
+   that budget needs a measurement, not an extrapolation.
+2. **No dispatch.** `consan_gemm_load` is load-only by construction
+   (`consan_load.hip` calls `hipModuleLoad` and stops, because production StreamK
+   GEMM kernels need hipBLASLt to launch them). Under `strict`,
+   `moi_require_records=true` therefore fails the run on require-records at exit
+   86 even after a clean transform. This is the part of the earlier document's
+   prediction that remains correct and remains unbuilt.
+
+## What is worth raising upstream
+
+Not a defect report. Two diagnostics points:
+
+1. **`status=4112` conflates unrelated transform failures.** Anchor-range
+   overlap (#10378) and a growth-ceiling rejection are different problems with
+   different owners and different fixes, and they are indistinguishable from the
+   status code, the exit code, and therefore from any dashboard built on them.
+   Only the human-readable line above the rejection separates them. A distinct
+   status per rejection class — or the reason token echoed into the
+   `load rejection` line — would have made this diagnosis immediate.
+2. **The expansion factor is worth a sanity check.** Instrumenting a 183 MiB
+   object is reported as needing ~1.39 GiB of patched image, a 7.78x expansion.
+   That may be entirely expected for full MOI record/replay coverage; it is
+   recorded here as an observation rather than a claim.
+
+## Reproducing the ceiling behaviour
+
+No GEMM object or ROCm 7.2.4 install needed — any object with at least one
+admitted MOI site shows it. Using the repo's own LDS fixture:
+
+```bash
+export PATH="$(python -c "from aorta.instrumentation.rocm_paths import resolve_rocm_roots; print(resolve_rocm_roots().llvm_bin_dir)"):${PATH}"
+hipcc --genco --offload-arch=gfx950 recipes/sanitizers/fixtures/kernels/lds_reduce.hip -o /tmp/lds.o
+clang-offload-bundler --type=o --unbundle --input=/tmp/lds.o \
+    --targets=hipv4-amdgcn-amd-amdhsa--gfx950 --output=/tmp/lds.hsaco
+hipcc --offload-arch=gfx950 -DLDS_HSACO='"/tmp/lds.hsaco"' \
+    recipes/sanitizers/fixtures/kernels/lds_dispatch.hip -o /tmp/lds_dispatch
+
+env HSA_TOOLS_LIB="${ROCJITSU_PREBUILT}/lib/librocjitsu_dbi_hooks.so" \
+    HSA_TOOLS_DISABLE_REGISTER=1 \
+    RJ_CONSAN_MODE=record-replay RJ_CONSAN_POLICY=strict RJ_CONSAN_LOG=1 \
+    RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_BYTES=4096 \
+    /tmp/lds_dispatch
+```
+
+Expect exit 92 and the `first-light probe rejected patched-image file growth`
+line. Drop the `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_BYTES` override and the same
+command transforms cleanly.

--- a/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
+++ b/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
@@ -156,6 +156,23 @@ env HSA_TOOLS_LIB="${ROCJITSU_PREBUILT}/lib/librocjitsu_dbi_hooks.so" \
     /tmp/lds_dispatch
 ```
 
-Expect exit 92 and the `first-light probe rejected patched-image file growth`
-line. Drop the `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_BYTES` override and the same
-command transforms cleanly.
+`ROCJITSU_PREBUILT` must point at an unpacked rocjitsu bundle. Expect exit 92 plus
+**both** hook-owned lines — `installed ConSan hook` (proof the hook engaged at all;
+without it a bare exit code says nothing) and `first-light probe rejected
+patched-image file growth`. Drop the `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_BYTES`
+override and the same command transforms cleanly.
+
+## Knock-on: the 4112 reproducer could not tell these apart
+
+[`repro/consan_4112_repro.sh`](repro/consan_4112_repro.sh) decided "reproduced"
+from `reason=transform-error status=4112` plus exit 92 — a signature this capacity
+rejection produces exactly. On any ROCm shipping a large Tensile bundle it would
+therefore have reported the *fixed* overlapping-anchor defect as still present, to
+an upstream maintainer, which is the worst direction for that script to be wrong
+in. It now requires the `final validation found partially overlapping patch
+ranges` diagnostic for a reproduction and reports the growth ceiling as its own
+inconclusive outcome with the knob to retry under.
+
+The general lesson, which is why it is worth recording: a status code is not a
+defect identity. 4112 is a bucket, and anything that keys a verdict off the bucket
+rather than the hook's stated reason will misattribute one defect to another.

--- a/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
+++ b/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
@@ -258,8 +258,15 @@ admitted MOI site shows it. Using the repo's own LDS fixture:
 ```bash
 export PATH="$(python -c "from aorta.instrumentation.rocm_paths import resolve_rocm_roots; print(resolve_rocm_roots().llvm_bin_dir)"):${PATH}"
 hipcc --genco --offload-arch=gfx950 recipes/sanitizers/fixtures/kernels/lds_reduce.hip -o /tmp/lds.o
-clang-offload-bundler --type=o --unbundle --input=/tmp/lds.o \
-    --targets=hipv4-amdgcn-amd-amdhsa--gfx950 --output=/tmp/lds.hsaco
+# --genco emits a raw code object on some ROCm builds and a clang-offload bundle
+# on others, and feeding a raw ELF back through --unbundle fails. Same conditional
+# the nightly's genco_object() uses.
+if head -c 24 /tmp/lds.o | grep -qF __CLANG_OFFLOAD_BUNDLE__; then
+    clang-offload-bundler --type=o --unbundle --input=/tmp/lds.o \
+        --targets=hipv4-amdgcn-amd-amdhsa--gfx950 --output=/tmp/lds.hsaco
+else
+    cp /tmp/lds.o /tmp/lds.hsaco
+fi
 hipcc --offload-arch=gfx950 -DLDS_HSACO='"/tmp/lds.hsaco"' \
     recipes/sanitizers/fixtures/kernels/lds_dispatch.hip -o /tmp/lds_dispatch
 

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -24,8 +24,14 @@
 #                   extracting one from the local hipBLASLt install
 #   --keep          do not delete the work directory on exit
 #
+# status=4112 is a shared "transform-error" bucket, not a defect identity, so the
+# verdict below discriminates on the hook's stated *reason*: only the "partially
+# overlapping patch ranges" diagnostic counts as a reproduction. A 4112 from the
+# patched-image growth ceiling is a capacity policy and is reported inconclusive.
+#
 # Exit codes:
-#   0  reproduced   -- object rejected with status=4112 (defect still present)
+#   0  reproduced   -- rejected with status=4112 AND the overlapping-patch-range
+#                     diagnostic present (defect still present)
 #   1  fixed        -- the object transformed and the module loaded, AND the hook
 #                     terminated the run with its own exit 86. Both are required:
 #                     this driver never dispatches, so strict require-records is
@@ -34,9 +40,11 @@
 #   2  environment unusable (missing tool, no gfx950 bundle, hook not found,
 #                     bad --timeout value)
 #   3  inconclusive -- no verdict could be established: the ceiling was hit, the
-#                     hook never announced itself, a different rejection status
-#                     came back, or the module loaded without the expected exit
-#                     86. Read the log; deliberately NOT reported as "fixed".
+#                     hook never announced itself, the run was rejected on the
+#                     patched-image growth ceiling or some other transform error,
+#                     a different rejection status came back, or the module loaded
+#                     without the expected exit 86. Read the log; deliberately NOT
+#                     reported as "fixed" or "reproduced".
 set -uo pipefail
 
 HOOK="${HSA_TOOLS_LIB:-}"
@@ -220,18 +228,64 @@ if ! grep -qE "${HOOK_LINE} installed ConSan hook" "${LOG}"; then
     exit 3
 fi
 
-# Match the hook's own rejection line and its exit code, not a bare "status=4112"
-# substring. The loader echoes the object path when hipModuleLoad fails, so an
-# --object argument whose filename contains that substring would otherwise be
-# echoed back into the log and read as a reproduction.
+# status=4112 is a generic "transform-error" bucket, NOT a defect identity: at
+# least two unrelated rejections share it. So the status alone must never decide
+# the verdict -- discriminate on the hook's own explanation of *why* it rejected.
+#
+#   overlapping anchor ranges  -> "final validation found partially overlapping
+#                                  patch ranges"  = the defect this script tests
+#   patched-image growth cap   -> "first-light probe rejected patched-image file
+#                                  growth"        = a capacity policy, not a defect
+#
+# Handle the capacity rejection first, because on any ROCm whose hipBLASLt ships a
+# large Tensile bundle it is the one that fires: the extracted object is ~183 MiB
+# on ROCm 7.2.4 and needs ~1.39 GiB of patched image against a ~400 MiB default
+# ceiling. Reading that as "reproduced" would tell an upstream maintainer their
+# fix did not work, which is the most damaging direction this script can be wrong
+# in.
+GROWTH_LINE='ConSan MOI first-light probe rejected patched-image file growth'
+if grep -qE "${HOOK_LINE} ${GROWTH_LINE}" "${LOG}"; then
+    echo "RESULT: inconclusive -- rejected on the patched-image growth ceiling, which is"
+    echo "        a configurable capacity policy and NOT the overlapping-patch defect."
+    grep -E "${GROWTH_LINE}" "${LOG}" | head -1 | cut -c1-200
+    echo "        The transform never reached final validation, so this run is evidence"
+    echo "        neither for nor against the defect."
+    if grep -qE "${HOOK_LINE} ConSan final validation found partially overlapping" "${LOG}"; then
+        echo "        NOTE: the overlap diagnostic IS present above -- read the log, this"
+        echo "        may still be a reproduction that the ceiling merely truncated."
+    fi
+    echo "        Retry with a ceiling above the required total, e.g."
+    echo "          RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT=900"
+    echo "        or pass a smaller --object. Expect a much longer run once it proceeds."
+    echo "        Full log: ${LOG}"
+    trap - EXIT
+    exit 3
+fi
+
+# Match the hook's own rejection line, its explanation, and its exit code -- not a
+# bare "status=4112" substring. The loader echoes the object path when
+# hipModuleLoad fails, so an --object argument whose filename contains that
+# substring would otherwise be echoed back into the log and read as a
+# reproduction.
 if grep -qE "${HOOK_LINE} ConSan load rejection .*reason=transform-error .*status=4112" "${LOG}"; then
+    if ! grep -qE "${HOOK_LINE} ConSan final validation found partially overlapping" "${LOG}"; then
+        echo "RESULT: inconclusive -- a status=4112 transform rejection, but WITHOUT the"
+        echo "        overlapping-patch-range diagnostic this script tests for, and without"
+        echo "        the known growth-ceiling explanation either. 4112 is a shared bucket,"
+        echo "        so this is some third transform error. Read the log before concluding."
+        grep -E "${HOOK_LINE} ConSan (patch end|load rejection)" "${LOG}" | tail -2 | cut -c1-200
+        echo "        Full log: ${LOG}"
+        trap - EXIT
+        exit 3
+    fi
     if [ "${rc}" -eq 92 ]; then
-        echo "RESULT: reproduced -- transform rejected with status=4112"
+        echo "RESULT: reproduced -- transform rejected with status=4112 on overlapping"
+        echo "        patch ranges."
         grep -E "final validation found" "${LOG}" | head -1
         [ "${KEEP}" -eq 1 ] && echo "log: ${LOG}"
         exit 0
     fi
-    echo "RESULT: inconclusive -- the hook logged the 4112 transform rejection, but the"
+    echo "RESULT: inconclusive -- the hook logged the 4112 overlap rejection, but the"
     echo "        process exited ${rc} rather than the 92 that strict policy should give."
     echo "        Full log: ${LOG}"
     trap - EXIT

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -89,13 +89,6 @@ die() { echo "ERROR: $*" >&2; exit 2; }
 [ -n "${HOOK}" ] || die "no hook given; pass --hook /path/to/librocjitsu_dbi_hooks.so"
 [ -f "${HOOK}" ] || die "hook not found: ${HOOK}"
 [ -z "${OBJECT_IN}" ] || [ -f "${OBJECT_IN}" ] || die "object not found: ${OBJECT_IN}"
-# The loader echoes this path on failure and every verdict check below reads the
-# log a line at a time, anchored to the printing component's prefix. A newline in
-# the path would break that one-event-per-line invariant -- the tail would start
-# its own line at column 0 and could impersonate hook output past the anchor.
-case "${OBJECT_IN}" in
-    *$'\n'*) die "--object path must not contain a newline" ;;
-esac
 
 ROCM="${ROCM_PATH:-${ROCM_HOME:-/opt/rocm}}"
 export PATH="${ROCM}/lib/llvm/bin:${ROCM}/bin:${PATH}"
@@ -160,6 +153,25 @@ else
     clang-offload-bundler --type=o --unbundle --input="${BUNDLE}" --output="${OBJECT}" \
         --targets=hipv4-amdgcn-amd-amdhsa--gfx950 || die "unbundle failed"
 fi
+
+# The path is about to be baked into the loader as a C string literal
+# (-DOBJECT below), and the loader echoes it when hipModuleLoad fails, into the
+# log every verdict check below reads a line at a time. So three characters are
+# refused rather than escaped:
+#
+#   newline      breaks one-event-per-line directly -- the tail starts at column
+#                0 and can impersonate hook output past the ^ anchor
+#   backslash    the compiler unescapes it, so the two characters \n in a
+#                filename become that same real newline in OBJECT
+#   double quote closes the literal, which is arbitrary C in the loader
+#
+# Checked here rather than at parse time so it covers the path built from
+# --workdir as well as the one --object supplies. No legitimate code object
+# needs them, so refusing is honest where escaping would be a guess.
+case "${OBJECT}" in
+    *$'\n'*|*\\*|*'"'*)
+        die "object path must not contain a newline, backslash or double quote: ${OBJECT}" ;;
+esac
 
 bytes=$(stat -c%s "${OBJECT}")
 # Kernel count is informational only, so a missing llvm-readelf should say so

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -210,13 +210,23 @@ echo "   exit ${rc} after ${elapsed}s"
 
 # Every line the hook emits starts with this prefix, so both patterns below are
 # start-anchored and every verdict grep is written as "${HOOK_LINE} ..." or
-# "${LOADER_LINE} ...". Requiring the prefix is not enough on its own: the loader
-# echoes the object path when hipModuleLoad fails, and the prefix is itself just
-# text a filename can contain, so an --object named to look like hook output gets
-# echoed into the log the verdict is read from and satisfies an unanchored match.
-# The anchor is what makes it hook-owned -- only the hook can put its prefix at
-# column 0. Leading whitespace is tolerated because indentation is not
-# caller-controlled; anything the loader echoes has its own prefix in front.
+# "${LOADER_LINE} ...". Requiring the prefix is not enough on its own: the object
+# path reaches this log twice -- consan_4112_load.hip prints
+# "hipModuleLoad(<path>) failed:" on failure and "[consan_4112_load] loaded and
+# instrumented <path>" on success -- and the prefix is itself just text a
+# filename can contain, so an unanchored match reads caller input as tool output.
+#
+# Two things make a match tool-owned, and both are needed:
+#
+#   the ^ anchor      only the emitter can put its prefix at column 0. In both
+#                     lines above the path lands mid-line, behind text the
+#                     emitter chose, so it can never satisfy an anchored pattern.
+#   the path guard    a path containing a newline (or a backslash the -DOBJECT
+#                     literal unescapes into one) would start a fresh line at
+#                     column 0 and clear the anchor, so those are refused where
+#                     OBJECT is resolved, above.
+#
+# Leading whitespace is tolerated because indentation is not caller-controlled.
 HOOK_LINE='^[[:space:]]*\[rocjitsu-dbi-hooks\]'
 LOADER_LINE='^[[:space:]]*\[consan_4112_load\]'
 

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -85,6 +85,13 @@ die() { echo "ERROR: $*" >&2; exit 2; }
 [ -n "${HOOK}" ] || die "no hook given; pass --hook /path/to/librocjitsu_dbi_hooks.so"
 [ -f "${HOOK}" ] || die "hook not found: ${HOOK}"
 [ -z "${OBJECT_IN}" ] || [ -f "${OBJECT_IN}" ] || die "object not found: ${OBJECT_IN}"
+# The loader echoes this path on failure and every verdict check below reads the
+# log a line at a time, anchored to the printing component's prefix. A newline in
+# the path would break that one-event-per-line invariant -- the tail would start
+# its own line at column 0 and could impersonate hook output past the anchor.
+case "${OBJECT_IN}" in
+    *$'\n'*) die "--object path must not contain a newline" ;;
+esac
 
 ROCM="${ROCM_PATH:-${ROCM_HOME:-/opt/rocm}}"
 export PATH="${ROCM}/lib/llvm/bin:${ROCM}/bin:${PATH}"
@@ -184,14 +191,17 @@ rc=$?
 elapsed=$(( $(date +%s) - start ))
 echo "   exit ${rc} after ${elapsed}s"
 
-# Every line the hook emits carries this prefix. Anchoring the checks below to it
-# keeps caller-controlled text out of the verdict: the loader echoes the object
-# path when hipModuleLoad fails, so an --object filename chosen to look like hook
-# output would otherwise land in the same log the verdict is read from.
-HOOK_LINE='\[rocjitsu-dbi-hooks\]'
-# Same reasoning for the loader marker: it is the loader that prints it, but the
-# loader also echoes the object path on failure, so anchor to its prefix too.
-LOADER_LINE='\[consan_4112_load\]'
+# Every line the hook emits starts with this prefix, so both patterns below are
+# start-anchored and every verdict grep is written as "${HOOK_LINE} ..." or
+# "${LOADER_LINE} ...". Requiring the prefix is not enough on its own: the loader
+# echoes the object path when hipModuleLoad fails, and the prefix is itself just
+# text a filename can contain, so an --object named to look like hook output gets
+# echoed into the log the verdict is read from and satisfies an unanchored match.
+# The anchor is what makes it hook-owned -- only the hook can put its prefix at
+# column 0. Leading whitespace is tolerated because indentation is not
+# caller-controlled; anything the loader echoes has its own prefix in front.
+HOOK_LINE='^[[:space:]]*\[rocjitsu-dbi-hooks\]'
+LOADER_LINE='^[[:space:]]*\[consan_4112_load\]'
 
 echo
 echo "== relevant hook output"
@@ -244,15 +254,26 @@ fi
 # fix did not work, which is the most damaging direction this script can be wrong
 # in.
 GROWTH_LINE='ConSan MOI first-light probe rejected patched-image file growth'
+OVERLAP_LINE='ConSan final validation found partially overlapping'
 if grep -qE "${HOOK_LINE} ${GROWTH_LINE}" "${LOG}"; then
-    echo "RESULT: inconclusive -- rejected on the patched-image growth ceiling, which is"
-    echo "        a configurable capacity policy and NOT the overlapping-patch defect."
-    grep -E "${GROWTH_LINE}" "${LOG}" | head -1 | cut -c1-200
-    echo "        The transform never reached final validation, so this run is evidence"
-    echo "        neither for nor against the defect."
-    if grep -qE "${HOOK_LINE} ConSan final validation found partially overlapping" "${LOG}"; then
-        echo "        NOTE: the overlap diagnostic IS present above -- read the log, this"
-        echo "        may still be a reproduction that the ceiling merely truncated."
+    # Both diagnostics can appear in one log when it covers several loads, and
+    # nothing here attributes them to the same object -- so this stays
+    # inconclusive. It gets its own branch because the wording below asserts the
+    # transform stopped before final validation, and the overlap diagnostic is a
+    # final-validation diagnostic: printing both would state as fact something
+    # this script has evidence against.
+    if grep -qE "${HOOK_LINE} ${OVERLAP_LINE}" "${LOG}"; then
+        echo "RESULT: inconclusive -- the log carries BOTH the patched-image growth"
+        echo "        ceiling (a capacity policy) and the overlapping-patch-range"
+        echo "        diagnostic (the defect). Nothing here ties them to the same object,"
+        echo "        so this is not called a reproduction. Read the log."
+        grep -E "${HOOK_LINE} (${GROWTH_LINE}|${OVERLAP_LINE})" "${LOG}" | head -4 | cut -c1-200
+    else
+        echo "RESULT: inconclusive -- rejected on the patched-image growth ceiling, which is"
+        echo "        a configurable capacity policy and NOT the overlapping-patch defect."
+        grep -E "${HOOK_LINE} ${GROWTH_LINE}" "${LOG}" | head -1 | cut -c1-200
+        echo "        The transform never reached final validation, so this run is evidence"
+        echo "        neither for nor against the defect."
     fi
     echo "        Retry with a ceiling above the required total, e.g."
     echo "          RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT=900"
@@ -266,9 +287,10 @@ fi
 # bare "status=4112" substring. The loader echoes the object path when
 # hipModuleLoad fails, so an --object argument whose filename contains that
 # substring would otherwise be echoed back into the log and read as a
-# reproduction.
+# reproduction. HOOK_LINE is start-anchored precisely so that echo cannot pass
+# for hook output here.
 if grep -qE "${HOOK_LINE} ConSan load rejection .*reason=transform-error .*status=4112" "${LOG}"; then
-    if ! grep -qE "${HOOK_LINE} ConSan final validation found partially overlapping" "${LOG}"; then
+    if ! grep -qE "${HOOK_LINE} ${OVERLAP_LINE}" "${LOG}"; then
         echo "RESULT: inconclusive -- a status=4112 transform rejection, but WITHOUT the"
         echo "        overlapping-patch-range diagnostic this script tests for, and without"
         echo "        the known growth-ceiling explanation either. 4112 is a shared bucket,"
@@ -281,7 +303,7 @@ if grep -qE "${HOOK_LINE} ConSan load rejection .*reason=transform-error .*statu
     if [ "${rc}" -eq 92 ]; then
         echo "RESULT: reproduced -- transform rejected with status=4112 on overlapping"
         echo "        patch ranges."
-        grep -E "final validation found" "${LOG}" | head -1
+        grep -E "${HOOK_LINE} ${OVERLAP_LINE}" "${LOG}" | head -1 | cut -c1-200
         [ "${KEEP}" -eq 1 ] && echo "log: ${LOG}"
         exit 0
     fi

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -15,11 +15,15 @@
 #   --workdir DIR   keep intermediates here instead of a temp dir
 #   --timeout SEC   wall-clock ceiling for the hooked run, default 6000 (or set
 #                   CONSAN_4112_TIMEOUT). Sized against the slower of the two
-#                   outcomes: a hook that still has the defect rejects the object
-#                   after ~1420 s, but a fixed hook instruments it and runs for
-#                   ~4150 s. A pre-#9964 hook never terminates MOI inventory at
-#                   all, so an unbounded run would hang instead of reporting
-#                   inconclusive
+#                   outcomes *on the 16,265,200-byte ROCm 7.0.2.2 object*: a hook
+#                   that still has the defect rejects it after ~1420 s, but a
+#                   fixed hook instruments it and runs for ~4150 s. Those numbers
+#                   do not transfer to a bigger fixture, and the object a modern
+#                   hipBLASLt ships is one: ~183 MiB with 9.3x the access sites,
+#                   which nobody has timed. Compare the object size this script
+#                   prints and raise the ceiling if it is much larger. A
+#                   pre-#9964 hook never terminates MOI inventory at all, so an
+#                   unbounded run would hang instead of reporting inconclusive
 #   --object PATH   use an already-unbundled gfx950 code object instead of
 #                   extracting one from the local hipBLASLt install
 #   --keep          do not delete the work directory on exit
@@ -173,10 +177,11 @@ hipcc --offload-arch=gfx950 -DOBJECT="\"${OBJECT}\"" "${LOADER_SRC}" -o "${LOADE
     >/dev/null 2>&1 || die "hipcc failed to build the loader"
 
 echo "== running under the ConSan hook (record-replay / strict)"
-echo "   Expect ~24 min against a hook that still has the defect (it is rejected"
-echo "   at the transform), or ~69 min against a fixed one, which instruments the"
-echo "   object and does the work the rejection used to skip. MOI inventory alone"
-echo "   is ~4-11 min either way."
+echo "   On the 16 MB reference object: ~24 min against a hook that still has the"
+echo "   defect (it is rejected at the transform), or ~69 min against a fixed one,"
+echo "   which instruments it and does the work the rejection used to skip. MOI"
+echo "   inventory alone is ~4-11 min either way. A larger object costs more by an"
+echo "   amount nobody has measured -- compare the size printed above."
 echo "   timeout ${TIMEOUT}s"
 start=$(date +%s)
 timeout --kill-after=30s "${TIMEOUT}" \
@@ -277,7 +282,10 @@ if grep -qE "${HOOK_LINE} ${GROWTH_LINE}" "${LOG}"; then
     fi
     echo "        Retry with a ceiling above the required total, e.g."
     echo "          RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT=900"
-    echo "        or pass a smaller --object. Expect a much longer run once it proceeds."
+    echo "        or pass a smaller --object. Raise --timeout with it: an object big"
+    echo "        enough to hit this ceiling has far more sites than the ~4150 s the"
+    echo "        default was measured against, so clearing the ceiling is likely to"
+    echo "        trade this verdict for a timeout at the current ${TIMEOUT}s."
     echo "        Full log: ${LOG}"
     trap - EXIT
     exit 3

--- a/recipes/sanitizers/daily-consan-gemm.yaml
+++ b/recipes/sanitizers/daily-consan-gemm.yaml
@@ -69,6 +69,22 @@ sanitizer_plan:
     # which no lower level emits -- so it is filed upstream as
     # ROCm/rocm-systems#10686. If that lands, this ceiling can drop to roughly a
     # quarter of its current value.
+    #
+    # !! STALE AS A BUDGET, 2026-08-27 !! Everything above was measured against a
+    # 16,265,200-byte (15.5 MB) object on ROCm 7.0.2.2. The object CI extracts on
+    # the 7.2.4 base is 191,935,808 bytes (~183 MiB) with 637,823 access ranges --
+    # 11.8x the bytes and 9.3x the sites -- so these figures no longer describe this
+    # case. See prepare_gemm_isa.py's docstring: the size is a per-release property
+    # of the shipped Tensile libraries, not something this repo pins.
+    #
+    # The ceiling is currently NOT what limits this case. ConSan rejects the object
+    # before instrumenting it, on the patched-image growth policy (needs ~1.39 GiB
+    # against a 400 MiB default), so the run ends at ~730s with exit 92
+    # status=4112. Raising RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT past ~778
+    # would let the transform proceed -- and 6000s would then very likely be too
+    # small, because 9.3x the sites is work no measurement here covers. Re-measure
+    # before assuming this number means anything.
+    # See docs/sanitizers/consan-gemm-patched-image-growth-cap.md.
     timeout_seconds: 6000
   output:
     report: sanitizer_report.json

--- a/recipes/sanitizers/daily-consan-gemm.yaml
+++ b/recipes/sanitizers/daily-consan-gemm.yaml
@@ -45,8 +45,10 @@ sanitizer_plan:
     # than the work this case represents. A budget measured against a failing run is
     # a lower bound, not an estimate.
     #
-    # #10378 is now fixed (dc7c8e04) and published in bundle 4227d40fb5, which the
-    # downloader selects. Re-measured against it, the same object transforms cleanly
+    # #10378 is now fixed (dc7c8e04) and was published in bundle 4227d40fb5. The
+    # downloader selects the newest successful run, not that one, so the nightly has
+    # since moved past it -- run 32967422099 consumed 97c1640b. Re-measured against
+    # 4227d40fb5 on the 16,265,200-byte object, that object transforms cleanly
     # (outcome=modified-valid, 75978 patches over 68894 access sites) and takes
     # 3696s and 4152s across two runs -- ~62-69 min -- before ending on strict
     # require-records at exit 86. 2000s would have guaranteed combined_hook_timeout:

--- a/recipes/sanitizers/daily-consan-lds-dispatch.yaml
+++ b/recipes/sanitizers/daily-consan-lds-dispatch.yaml
@@ -5,10 +5,14 @@ description: >
   Informational (non-gating) gfx950 ConSan run over a small, race-free shared-memory
   (LDS) reduction kernel that is actually DISPATCHED (hipModuleLoad + hipModuleLaunch)
   via the source.consan_command path added in #347. The kernel is instrumented and
-  runs, exercising ConSan record/replay end-to-end on a caller-supplied object. On the
-  current rocjitsu build it fails closed (record capture yields zero events -> exit 86;
-  see ROCm/rocm-systems#9972) rather than a false pass. Rendered on the dashboard's
-  Workload survey tab (Tab 2) as an observed-only case; it does NOT gate the nightly.
+  runs, exercising ConSan record/replay end-to-end on a caller-supplied object.
+  ROCm/rocm-systems#9972 (record capture yielded zero events -> exit 86) is fixed in
+  15275dad: on bundle 97c1640b this case observes a clean pass with access=5/5,
+  barrier=2/2 and dynamic_complete=true. It is now the end-to-end control proving the
+  dynamic record/replay path works on a caller-supplied object. Rendered on the
+  dashboard's Workload survey tab (Tab 2) as an observed-only case; it does NOT gate
+  the nightly, so a future regression here shows up as an observation, not a gate
+  failure.
 sanitizer_plan:
   target: gfx950
   source:

--- a/recipes/sanitizers/daily-consan-tiny.yaml
+++ b/recipes/sanitizers/daily-consan-tiny.yaml
@@ -8,6 +8,15 @@ description: >
   nothing analyzable: static analysis is complete but strict require-records fails
   closed (exit 86) rather than emitting a false pass. Rendered on the dashboard's
   Workload survey tab (Tab 2) as an observed-only case; it does NOT gate the nightly.
+  DELIBERATE NEGATIVE CONTROL -- the exit 86 is the assertion, not a bug to fix.
+  tiny_vecadd's only memory operations are ordinary global loads/stores, which ConSan
+  reports as ordinary_memory_support=supported-synchronization-only and does not admit
+  as MOI sites, so it observes access=0/0 and applicable=false. Measured 2026-08-27:
+  swapping the load-only consan_tiny_load for a driver that actually dispatches
+  tiny_vecadd does NOT change the verdict -- the only difference is "1 auto MOI report
+  buffer(s)" instead of "0" in the require-records message. Making this row pass would
+  require a kernel with admissible sites, which is what daily-consan-lds-dispatch.yaml
+  already covers.
 sanitizer_plan:
   target: gfx950
   source:

--- a/recipes/sanitizers/survey/README.md
+++ b/recipes/sanitizers/survey/README.md
@@ -38,9 +38,10 @@ observed, including fail-closed behavior on heavy production code objects.
 
 ### Staleness of the recorded ConSan verdicts (2026-08-27)
 
-The three `*_consan` fixtures were recorded on rocjitsu `db0c47df` and no longer
-match what the sanitizers report on current bundles. Regenerating them needs a
-gfx950 host (see "Regenerating" below); until then:
+The three `*_consan` fixtures were recorded on rocjitsu `db0c47df` and have not
+been regenerated since. They have not all drifted the same way, and one has not
+drifted at all — read the fixture you care about rather than the date.
+Regenerating needs a gfx950 host (see "Regenerating" below); until then:
 
 * **`lds_reduce_consan` is wrong in verdict.** Its exit 86 was
   [ROCm/rocm-systems#9972](https://github.com/ROCm/rocm-systems/issues/9972)

--- a/recipes/sanitizers/survey/README.md
+++ b/recipes/sanitizers/survey/README.md
@@ -6,6 +6,14 @@ the sanitizer dashboard rendered by
 scope update ("populate aorta-internal kernels on Tab 2") in a strictly
 de-branded, public-safe form.
 
+> **These fixtures are not what the published dashboard shows.** The nightly
+> (`.github/workflows/sanitizers-nightly.yml`) renders Tab 2 from
+> `--informational-results-dir`, i.e. live output of the `daily-consan-*` /
+> `daily-waitcheck-*` recipes, and never passes `--survey`. This directory is the
+> `--survey` path: local rendering, unit tests, and the de-branded reproduction
+> recipes. Read the verdicts below as *recorded fixtures*, not as current CI
+> state — and see the staleness note under the table.
+
 Tab 2 is **observed-only**: it shows kernels drawn from multiple workloads with
 no expected/baseline comparison. A `warn`, `error`, or `not_checked` here is an
 observation, **never** a regression — it does not affect the guardrail gate
@@ -23,10 +31,34 @@ Each kernel is run under **both** sanitizers — `waitcheck` (static ISA scan) a
 | `tiny_vecadd` | `synthetic:vecadd` | waitcheck (static) | `pass` |
 | `tiny_vecadd` | `synthetic:vecadd` | ConSan (dynamic) | `error` (fails closed, exit 86) |
 | `lds_reduce` | `synthetic:lds_reduce` | waitcheck (static) | `pass` |
-| `lds_reduce` | `synthetic:lds_reduce` | ConSan (dynamic) | `error` (fails closed, exit 86) |
+| `lds_reduce` | `synthetic:lds_reduce` | ConSan (dynamic) | `error` (fails closed, exit 86) — **stale, now passes upstream** |
 
 Showing an `error`/`warn` here is intended — Tab 2 records what the sanitizers
 observed, including fail-closed behavior on heavy production code objects.
+
+### Staleness of the recorded ConSan verdicts (2026-08-27)
+
+The three `*_consan` fixtures were recorded on rocjitsu `db0c47df` and no longer
+match what the sanitizers report on current bundles. Regenerating them needs a
+gfx950 host (see "Regenerating" below); until then:
+
+* **`lds_reduce_consan` is wrong in verdict.** Its exit 86 was
+  [ROCm/rocm-systems#9972](https://github.com/ROCm/rocm-systems/issues/9972)
+  (zero captured records), fixed in `15275dad`. The equivalent nightly lane now
+  observes a clean `pass` (`access=5/5`, `barrier=2/2`,
+  `dynamic_complete=true`).
+* **`gemm_f32_consan` is right in verdict but wrong in cause.** It still records
+  `consan_strict_load_rejection` / exit 92, which is what CI reports — but the
+  underlying rejection is no longer the overlapping-anchor defect
+  ([#10378](https://github.com/ROCm/rocm-systems/issues/10378), fixed). It is now
+  the patched-image growth ceiling, because the extracted object grew from
+  15.5 MB to ~183 MiB with ROCm 7.2.4. See
+  [`docs/sanitizers/consan-gemm-patched-image-growth-cap.md`](../../../docs/sanitizers/consan-gemm-patched-image-growth-cap.md).
+* **`tiny_vecadd_consan` is still accurate.** `tiny_vecadd` has no MOI-admissible
+  sites (`access=0/0`, `applicable=false`, "no MOI report sites"), so strict
+  require-records fails closed at exit 86 by design. Measured 2026-08-27: giving
+  it a *dispatching* driver does not change this — the only difference is the
+  message ("1 auto MOI report buffer(s)" instead of "0"), never the verdict.
 
 ## Layout
 

--- a/recipes/sanitizers/survey/generic-gemm-survey.yaml
+++ b/recipes/sanitizers/survey/generic-gemm-survey.yaml
@@ -43,9 +43,17 @@ sanitizer_plan:
   policy:
     consan_policy: strict
     on_missing_backend: fail
-    # Large production code object: the ConSan MOI transform can exceed the
-    # default ceiling and fail closed (consan_strict_load_rejection); keep the
-    # observed error as survey data rather than a false pass.
-    timeout_seconds: 300
+    # Large production code object: the ConSan MOI transform fails closed
+    # (consan_strict_load_rejection); keep the observed error as survey data
+    # rather than a false pass.
+    #
+    # 300s was sized when the extracted object was 15.5 MB. On the ~183 MiB object
+    # ROCm 7.2.4 ships it takes ~730s to reach that rejection (waitcheck 447s + MOI
+    # inventory 131s + patch 152s), so 300s would record combined_hook_timeout
+    # instead -- i.e. regenerating the committed gemm_f32_consan fixture from this
+    # recipe would not reproduce the verdict the fixture holds. Matched to
+    # daily-consan-gemm.yaml's budget; the caveats on that number apply here too.
+    # See docs/sanitizers/consan-gemm-patched-image-growth-cap.md.
+    timeout_seconds: 6000
   output:
     report: sanitizer_report.json

--- a/recipes/sanitizers/survey/lds-reduce-survey.yaml
+++ b/recipes/sanitizers/survey/lds-reduce-survey.yaml
@@ -5,10 +5,13 @@ description: >
   Workload-survey (observed-only, Tab 2, #367) reproduction over the synthetic
   lds_reduce control kernel -- an ordinary, independently-authored shared-memory
   (LDS) reduction repro with no customer association. Runs BOTH sanitizers:
-  waitcheck (static, observes a clean pass) and ConSan (dynamic, fails closed
-  with exit 86 on the current rocjitsu build; see ROCm/rocm-systems#9972).
-  Reproduction path for the committed survey fixtures
-  reports/lds_reduce_waitcheck and reports/lds_reduce_consan.
+  waitcheck (static, observes a clean pass) and ConSan (dynamic). ConSan used to
+  fail closed with exit 86 on this kernel (ROCm/rocm-systems#9972, zero captured
+  records); that is fixed in 15275dad and the equivalent nightly lane
+  (daily-consan-lds-dispatch) now observes a clean pass. The committed fixture
+  reports/lds_reduce_consan still records the old exit-86 outcome and is stale
+  until regenerated on a gfx950 host. Reproduction path for the committed survey
+  fixtures reports/lds_reduce_waitcheck and reports/lds_reduce_consan.
 sanitizer_plan:
   target: gfx950
   source:

--- a/scripts/sanitizers/triton_consan_loader.py
+++ b/scripts/sanitizers/triton_consan_loader.py
@@ -29,10 +29,13 @@ Two modes, mirroring the two committed HIP loaders:
     the metadata JSON (it is absent in 3.7.1), so pass ``--launch-spec`` when the
     metadata has no ``signature`` -- preferably as an array of ``[name, type]``
     pairs, since argument order is load-bearing and JSON object key order is not
-    (see ``parse_signature``). Note that dispatching a caller-supplied object
-    currently fails closed on the shipping RocJITsu build for the same reason
-    ``daily-consan-lds-dispatch.yaml`` does (zero captured records -> exit 86,
-    ROCm/rocm-systems#9972).
+    (see ``parse_signature``). Dispatching a caller-supplied object used to fail
+    closed for the same reason ``daily-consan-lds-dispatch.yaml`` did (zero
+    captured records -> exit 86, ROCm/rocm-systems#9972); that is fixed in
+    ``15275dad`` and that lane now passes. What still fails closed is an object
+    with no MOI-admissible sites -- ordinary global loads/stores alone give
+    ``access=0/0``, so strict ``moi_require_records`` exits 86 regardless of the
+    driver.
 
 ``run_consan`` executes ``source.consan_command`` as a bare argv with no
 arguments, so a parameterised loader cannot be named directly. ``emit-command``

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
@@ -212,14 +212,20 @@ buffer that would over-run the segment.
 Two limits are worth stating plainly. One logical Triton kernel usually compiles
 to several objects (shape-selected variants), and ConSan takes exactly one code
 object per run, so harvest one shim and one recipe per object; an ambiguous
-selection fails closed and lists the candidates. And on the currently shipping
-RocJITsu build, record/replay reports itself as `an inventory-only stub`, so a
-dispatch captures no dynamic records and strict policy fails closed with exit 86
-— the same outcome the committed `daily-consan-tiny.yaml` and
-`daily-consan-lds-dispatch.yaml` lanes document
-([ROCm/rocm-systems#9972](https://github.com/ROCm/rocm-systems/issues/9972)).
-The loader removes the aorta-side gap; the dynamic-coverage half stays blocked
-upstream.
+selection fails closed and lists the candidates. And the object has to contain
+sites ConSan can admit: a kernel whose only memory operations are ordinary
+global loads/stores yields `access=0/0` and `applicable=false`, so strict
+`moi_require_records` fails closed at exit 86 no matter what the driver does —
+which is exactly what `daily-consan-tiny.yaml` documents, and dispatching does
+not change it.
+
+The dynamic-coverage half is **no longer blocked upstream**:
+[ROCm/rocm-systems#9972](https://github.com/ROCm/rocm-systems/issues/9972)
+(record/replay reporting itself as `an inventory-only stub`, so a dispatch
+captured no records) is fixed in `15275dad`. On bundle `97c1640b`
+`daily-consan-lds-dispatch.yaml` observes a clean pass with `access=5/5`,
+`barrier=2/2` and `dynamic_complete=true`, so a Triton object with real LDS or
+atomic sites can now reach a genuine verdict.
 
 ## Verdict and health rules
 

--- a/tests/sanitizers/test_consan_4112_repro.py
+++ b/tests/sanitizers/test_consan_4112_repro.py
@@ -1,13 +1,22 @@
-"""Verdict-discrimination tests for ``docs/sanitizers/repro/consan_4112_repro.sh``.
+"""Verdict tests for ``docs/sanitizers/repro/consan_4112_repro.sh``.
 
-The script itself needs a GPU, a ROCm install and a rocjitsu hook, so none of
-that is exercised here. What *is* testable without hardware -- and what has now
-been got wrong twice (#385 §26, #409) -- is which log lines the verdict is
-allowed to read.
+Running the script for real needs a GPU, a ROCm install and a rocjitsu hook, so
+none of that is exercised here. Everything after the hooked run is just a log
+being read, and that is where this script has been wrong three times now
+(#385 §21, #385 §26, #409) -- so that part is tested.
 
-The patterns are lifted out of the script rather than restated, so a future edit
-that drops an anchor fails these tests instead of shipping a reproducer that can
-be made to confirm a defect on demand.
+Two layers, because they fail differently:
+
+* ``_verdict`` executes the script's real verdict section against a synthetic
+  log, and asserts the exit code and message. This is what catches a deleted
+  branch, an inverted branch order, or a branch reaching the wrong conclusion.
+* the pattern tests below check individual regexes in isolation, which is what
+  catches an anchor being dropped from one check while the branch structure
+  stays intact.
+
+Neither restates anything: both lift the patterns and the code out of the script
+itself, so an edit that breaks the contract fails here rather than shipping a
+reproducer that can be made to confirm a defect on demand.
 """
 
 from __future__ import annotations
@@ -26,6 +35,24 @@ _SCRIPT = _REPO_ROOT / "docs" / "sanitizers" / "repro" / "consan_4112_repro.sh"
 # cannot be satisfied by caller-controlled text.
 _LOADER_ECHO = "[consan_4112_load] hipModuleLoad failed for /tmp/objects/"
 
+_HOOK = "[rocjitsu-dbi-hooks] "
+_INSTALLED = f"{_HOOK}installed ConSan hook"
+_REJECTION = (
+    f"{_HOOK}ConSan load rejection reason=transform-error status=4112 "
+    "policy=strict action=terminate exit_code=92"
+)
+_GROWTH = (
+    f"{_HOOK}ConSan MOI first-light probe rejected patched-image file growth: "
+    "required total 1492987904 bytes, limit 419430400 bytes"
+)
+_OVERLAP = f"{_HOOK}ConSan final validation found partially overlapping patch ranges: 3 pairs"
+
+# The verdict section is everything from the emitter-prefix definitions to the
+# end of the file. HOOK_LINE is the landmark because every check below it is
+# written in terms of HOOK_LINE or LOADER_LINE -- if that stops being true the
+# extraction is meaningless, so the test says so rather than silently passing.
+_VERDICT_START = re.compile(r"^HOOK_LINE=", re.MULTILINE)
+
 
 def _pattern(name: str) -> str:
     """Return the single-quoted value of a top-level ``NAME='...'`` assignment."""
@@ -34,6 +61,39 @@ def _pattern(name: str) -> str:
     )
     assert match, f"{name} is no longer a single-quoted assignment in {_SCRIPT.name}"
     return match.group(1)
+
+
+def _verdict(log: str, rc: int, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    """Run the script's own verdict section over ``log`` with the run's exit code.
+
+    The section is sliced out of the script rather than reimplemented, so these
+    tests exercise the branch order and the messages that will actually ship.
+    The variables it reads from the part we skip are supplied here.
+    """
+    body = _SCRIPT.read_text()
+    start = _VERDICT_START.search(body)
+    assert start, (
+        "cannot find the HOOK_LINE definition that begins the verdict section; "
+        "if the script was restructured, re-point this extraction"
+    )
+    log_path = tmp_path / "hook.log"
+    log_path.write_text(log)
+    driver = tmp_path / "verdict.sh"
+    driver.write_text(
+        "set -uo pipefail\n"
+        f'LOG={log_path}\nrc={rc}\nKEEP=0\nHOOK=/nonexistent/hook.so\nTIMEOUT=6000\n'
+        + body[start.start() :]
+    )
+    return subprocess.run(
+        ["bash", str(driver)], capture_output=True, text=True, check=False
+    )
+
+
+def _result_line(proc: subprocess.CompletedProcess[str]) -> str:
+    for line in proc.stdout.splitlines():
+        if line.startswith("RESULT:"):
+            return line
+    raise AssertionError(f"no RESULT line in output:\n{proc.stdout}")
 
 
 def _matches(pattern: str, log: str, tmp_path: Path) -> bool:
@@ -49,6 +109,111 @@ def _matches(pattern: str, log: str, tmp_path: Path) -> bool:
 @pytest.fixture(scope="module")
 def patterns() -> dict[str, str]:
     return {name: _pattern(name) for name in ("HOOK_LINE", "LOADER_LINE", "GROWTH_LINE", "OVERLAP_LINE")}
+
+
+# --------------------------------------------------------------------------
+# Verdict control flow: exit code and conclusion for each shape of log.
+#
+# The exit codes are the script's published contract (see its header): 0
+# reproduced, 1 fixed, 2 environment unusable, 3 inconclusive. Callers upstream
+# branch on them, so each case asserts the code and not just the wording.
+# --------------------------------------------------------------------------
+
+
+def test_verdict_overlap_only_is_reproduced(tmp_path: Path) -> None:
+    """The one case that may exit 0: the hook's own overlap diagnostic, at exit 92."""
+    proc = _verdict(f"{_INSTALLED}\n{_OVERLAP}\n{_REJECTION}\n", 92, tmp_path)
+    assert proc.returncode == 0
+    assert "reproduced" in _result_line(proc)
+
+
+def test_verdict_growth_only_is_inconclusive_and_names_the_knob(tmp_path: Path) -> None:
+    """A capacity rejection must never read as the defect, and must be actionable."""
+    proc = _verdict(f"{_INSTALLED}\n{_GROWTH}\n{_REJECTION}\n", 92, tmp_path)
+    assert proc.returncode == 3
+    assert "inconclusive" in _result_line(proc)
+    assert "growth ceiling" in proc.stdout
+    assert "RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT" in proc.stdout
+    # Raising the ceiling without raising the timeout just buys a different
+    # inconclusive result, so the hint has to say so.
+    assert "--timeout" in proc.stdout
+
+
+def test_verdict_both_diagnostics_is_inconclusive_without_contradicting_itself(
+    tmp_path: Path,
+) -> None:
+    """Several loads can share one log, so the script cannot attribute the two lines.
+
+    It also must not claim the transform stopped before final validation, since
+    the overlap diagnostic *is* a final-validation diagnostic.
+    """
+    proc = _verdict(f"{_INSTALLED}\n{_GROWTH}\n{_OVERLAP}\n{_REJECTION}\n", 92, tmp_path)
+    assert proc.returncode == 3
+    assert "inconclusive" in _result_line(proc)
+    assert "never reached final validation" not in proc.stdout
+    assert "NOT the overlapping-patch defect" not in proc.stdout
+
+
+def test_verdict_unknown_4112_is_inconclusive_not_reproduced(tmp_path: Path) -> None:
+    """4112 is a shared bucket, so one with no explanation is a third thing."""
+    proc = _verdict(f"{_INSTALLED}\n{_REJECTION}\n", 92, tmp_path)
+    assert proc.returncode == 3
+    assert "reproduced" not in _result_line(proc)
+    assert "shared bucket" in proc.stdout
+
+
+def test_verdict_growth_branch_precedes_the_4112_branch(tmp_path: Path) -> None:
+    """Branch order is load-bearing, and inverting it is silent.
+
+    A growth-only log also matches the generic 4112 rejection, so if the 4112
+    branch ran first this would take the "third transform error" path instead of
+    naming the capacity policy the reader can actually do something about.
+    """
+    proc = _verdict(f"{_INSTALLED}\n{_GROWTH}\n{_REJECTION}\n", 92, tmp_path)
+    assert "growth ceiling" in _result_line(proc) or "growth ceiling" in proc.stdout
+    assert "some third transform error" not in proc.stdout
+
+
+def test_verdict_clean_transform_is_fixed_only_at_exit_86(tmp_path: Path) -> None:
+    """The loader marker alone would also appear with no hook loaded (#385 §21)."""
+    log = f"{_INSTALLED}\n[consan_4112_load] loaded and instrumented\n"
+    assert _verdict(log, 86, tmp_path).returncode == 1
+    other = _verdict(log, 0, tmp_path)
+    assert other.returncode == 3
+    assert "fixed" not in _result_line(other)
+
+
+def test_verdict_requires_the_hook_to_have_announced_itself(tmp_path: Path) -> None:
+    """Without it, a missing or non-rocjitsu HSA_TOOLS_LIB reads as evidence."""
+    proc = _verdict(f"{_OVERLAP}\n{_REJECTION}\n", 92, tmp_path)
+    assert proc.returncode == 3
+    assert "never announced itself" in proc.stdout
+
+
+@pytest.mark.parametrize("rc", [124, 137])
+def test_verdict_timeout_is_inconclusive(tmp_path: Path, rc: int) -> None:
+    """timeout(1) reports 124 on TERM and 137 when the follow-up KILL was needed."""
+    proc = _verdict(f"{_INSTALLED}\n{_OVERLAP}\n", rc, tmp_path)
+    assert proc.returncode == 3
+    assert "ceiling" in _result_line(proc)
+
+
+def test_verdict_spoofed_overlap_path_is_not_reproduced(tmp_path: Path) -> None:
+    """End-to-end version of the #409 review's vector, through the real branches."""
+    log = (
+        f"{_LOADER_ECHO}{_OVERLAP}.hsaco\n"
+        f"{_INSTALLED}\n"
+        f"{_REJECTION}\n"
+    )
+    proc = _verdict(log, 92, tmp_path)
+    assert proc.returncode == 3, "an echoed --object path must not manufacture a reproduction"
+    assert "reproduced" not in _result_line(proc)
+
+
+# --------------------------------------------------------------------------
+# Individual patterns, which fail differently: an anchor can be dropped from one
+# check while the branch structure above still looks correct.
+# --------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("name", ["HOOK_LINE", "LOADER_LINE"])

--- a/tests/sanitizers/test_consan_4112_repro.py
+++ b/tests/sanitizers/test_consan_4112_repro.py
@@ -1,0 +1,173 @@
+"""Verdict-discrimination tests for ``docs/sanitizers/repro/consan_4112_repro.sh``.
+
+The script itself needs a GPU, a ROCm install and a rocjitsu hook, so none of
+that is exercised here. What *is* testable without hardware -- and what has now
+been got wrong twice (#385 §26, #409) -- is which log lines the verdict is
+allowed to read.
+
+The patterns are lifted out of the script rather than restated, so a future edit
+that drops an anchor fails these tests instead of shipping a reproducer that can
+be made to confirm a defect on demand.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "docs" / "sanitizers" / "repro" / "consan_4112_repro.sh"
+
+# The loader prints this in front of anything it echoes, including the object
+# path on a failed hipModuleLoad. It is the reason an anchored hook pattern
+# cannot be satisfied by caller-controlled text.
+_LOADER_ECHO = "[consan_4112_load] hipModuleLoad failed for /tmp/objects/"
+
+
+def _pattern(name: str) -> str:
+    """Return the single-quoted value of a top-level ``NAME='...'`` assignment."""
+    match = re.search(
+        rf"^{re.escape(name)}='([^']*)'$", _SCRIPT.read_text(), flags=re.MULTILINE
+    )
+    assert match, f"{name} is no longer a single-quoted assignment in {_SCRIPT.name}"
+    return match.group(1)
+
+
+def _matches(pattern: str, log: str, tmp_path: Path) -> bool:
+    """Run the script's own grep invocation shape against a log."""
+    path = tmp_path / "hook.log"
+    path.write_text(log)
+    # -E and -q are what every verdict check in the script uses; going through
+    # grep(1) rather than re.search keeps POSIX-class handling ([[:space:]])
+    # identical to what the script will actually do.
+    return subprocess.run(["grep", "-qE", pattern, str(path)], check=False).returncode == 0
+
+
+@pytest.fixture(scope="module")
+def patterns() -> dict[str, str]:
+    return {name: _pattern(name) for name in ("HOOK_LINE", "LOADER_LINE", "GROWTH_LINE", "OVERLAP_LINE")}
+
+
+@pytest.mark.parametrize("name", ["HOOK_LINE", "LOADER_LINE"])
+def test_emitter_prefixes_are_start_anchored(patterns: dict[str, str], name: str) -> None:
+    """Every verdict grep is written as "${HOOK_LINE} ..." or "${LOADER_LINE} ...".
+
+    Anchoring the prefix is therefore what makes a match attributable to the
+    component that printed it, rather than to a filename the caller chose.
+    """
+    assert patterns[name].startswith("^"), (
+        f"{name} must be start-anchored; without it the loader's echo of a "
+        f"caller-supplied --object path satisfies the check"
+    )
+
+
+def test_no_grep_inlines_an_emitter_prefix() -> None:
+    """A check that spells the prefix out itself silently bypasses the anchor.
+
+    Matching on the prefix *text* rather than on its escaping keeps this from
+    passing just because a future edit writes the brackets differently.
+    """
+    patterns = re.findall(r'grep\s+-[a-zA-Z]*E\s+"([^"]*)"', _SCRIPT.read_text())
+    assert patterns, "no grep -E invocations found; has the script been restructured?"
+    inlined = [
+        p for p in patterns if "rocjitsu-dbi-hooks" in p or "consan_4112_load" in p
+    ]
+    assert not inlined, (
+        f"grep pattern(s) inline the emitter prefix instead of using the "
+        f"start-anchored HOOK_LINE/LOADER_LINE variable: {inlined}"
+    )
+
+
+def test_overlap_spoof_via_object_path_is_not_a_reproduction(
+    patterns: dict[str, str], tmp_path: Path
+) -> None:
+    """The #409 review's exact vector: an --object filename carrying the diagnostic.
+
+    Unanchored, this satisfied the overlap check and turned an unrelated 4112
+    rejection into "reproduced -- defect still present", reported upstream.
+    """
+    log = (
+        f"{_LOADER_ECHO}[rocjitsu-dbi-hooks] {patterns['OVERLAP_LINE']} patch ranges.hsaco\n"
+        "[rocjitsu-dbi-hooks] installed ConSan hook\n"
+        "[rocjitsu-dbi-hooks] ConSan load rejection reason=transform-error status=4112 exit_code=92\n"
+    )
+    assert not _matches(f"{patterns['HOOK_LINE']} {patterns['OVERLAP_LINE']}", log, tmp_path)
+
+
+def test_growth_spoof_via_object_path_does_not_mask_a_real_reproduction(
+    patterns: dict[str, str], tmp_path: Path
+) -> None:
+    """The mirror direction Copilot flagged, and the more subtle of the two.
+
+    The growth branch runs first, so an echoed path that looks like the capacity
+    rejection downgrades a genuine overlap defect to "inconclusive" -- a false
+    negative on the one signal the script exists to report.
+    """
+    log = (
+        f"{_LOADER_ECHO}[rocjitsu-dbi-hooks] {patterns['GROWTH_LINE']}.hsaco\n"
+        "[rocjitsu-dbi-hooks] installed ConSan hook\n"
+        f"[rocjitsu-dbi-hooks] {patterns['OVERLAP_LINE']} patch ranges: 3 pairs\n"
+        "[rocjitsu-dbi-hooks] ConSan load rejection reason=transform-error status=4112 exit_code=92\n"
+    )
+    assert not _matches(f"{patterns['HOOK_LINE']} {patterns['GROWTH_LINE']}", log, tmp_path)
+    assert _matches(f"{patterns['HOOK_LINE']} {patterns['OVERLAP_LINE']}", log, tmp_path)
+
+
+def test_loader_success_marker_cannot_be_spoofed(patterns: dict[str, str], tmp_path: Path) -> None:
+    """`loaded and instrumented` gates the "fixed" verdict, so it needs the same anchor."""
+    log = (
+        "[rocjitsu-dbi-hooks] installed ConSan hook\n"
+        f"{_LOADER_ECHO}[consan_4112_load] loaded and instrumented.hsaco\n"
+    )
+    assert not _matches(f"{patterns['LOADER_LINE']} loaded and instrumented", log, tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("key", "line"),
+    [
+        ("GROWTH_LINE", "ConSan MOI first-light probe rejected patched-image file growth: required total 1492987904 bytes, limit 419430400 bytes"),
+        ("OVERLAP_LINE", "ConSan final validation found partially overlapping patch ranges: 3 pairs"),
+    ],
+)
+def test_anchoring_still_matches_genuine_hook_output(
+    patterns: dict[str, str], tmp_path: Path, key: str, line: str
+) -> None:
+    """Hardening a pattern must not make its branch unreachable (#385 §26 sweep rule).
+
+    Both bodies are as the 2026-08-26 nightly and the forced-low-cap run emitted
+    them, so an over-tightened anchor shows up here rather than as a reproducer
+    that never reproduces.
+    """
+    log = f"[rocjitsu-dbi-hooks] installed ConSan hook\n[rocjitsu-dbi-hooks] {line}\n"
+    assert _matches(f"{patterns['HOOK_LINE']} {patterns[key]}", log, tmp_path)
+
+
+def test_newline_in_object_path_is_rejected(tmp_path: Path) -> None:
+    """A path whose tail starts its own line at column 0 defeats any `^` anchor.
+
+    The log is read one event per line, so the invariant is enforced on input
+    rather than patched around in each verdict grep.
+    """
+    target = tmp_path / "obj.hsaco"
+    target.write_bytes(b"")
+    spoof = tmp_path / "a\n[rocjitsu-dbi-hooks] ConSan.hsaco"
+    spoof.write_bytes(b"")
+
+    def run(object_path: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(_SCRIPT), "--hook", "/bin/true", "--object", str(object_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    rejected = run(spoof)
+    assert rejected.returncode == 2
+    assert "must not contain a newline" in rejected.stderr
+
+    # The guard must not fire on ordinary paths; this run fails later (no ROCm),
+    # so assert only that it got past argument validation.
+    assert "must not contain a newline" not in run(target).stderr

--- a/tests/sanitizers/test_consan_4112_repro.py
+++ b/tests/sanitizers/test_consan_4112_repro.py
@@ -310,29 +310,64 @@ def test_anchoring_still_matches_genuine_hook_output(
     assert _matches(f"{patterns['HOOK_LINE']} {patterns[key]}", log, tmp_path)
 
 
-def test_newline_in_object_path_is_rejected(tmp_path: Path) -> None:
-    """A path whose tail starts its own line at column 0 defeats any `^` anchor.
+def _run_script(object_path: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(_SCRIPT), "--hook", "/bin/true", "--object", object_path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
-    The log is read one event per line, so the invariant is enforced on input
-    rather than patched around in each verdict grep.
+
+@pytest.mark.parametrize(
+    ("name", "why"),
+    [
+        ("a\n[rocjitsu-dbi-hooks] ConSan.hsaco", "a real newline defeats the ^ anchor directly"),
+        (
+            "a\\n[rocjitsu-dbi-hooks] ConSan.hsaco",
+            "the compiler unescapes \\n in the -DOBJECT literal into that same newline",
+        ),
+        ('a"; system("id"); ".hsaco', "a quote closes the literal and injects C into the loader"),
+    ],
+)
+def test_hostile_object_path_is_rejected(tmp_path: Path, name: str, why: str) -> None:
+    """The path is baked into the loader as a C string and echoed back into the log.
+
+    Rejecting is deliberate rather than escaping: no legitimate code object needs
+    these characters, so refusing is honest where escaping would be a guess.
+    """
+    spoof = tmp_path / name
+    spoof.write_bytes(b"")
+    proc = _run_script(str(spoof))
+    assert proc.returncode == 2, why
+    assert "must not contain a newline, backslash or double quote" in proc.stderr
+
+
+def test_ordinary_object_path_is_not_rejected(tmp_path: Path) -> None:
+    """The guard must not fire on real paths.
+
+    This run fails later for want of ROCm, so assert only that it cleared
+    validation -- otherwise the test above would pass against a guard that
+    rejects everything.
     """
     target = tmp_path / "obj.hsaco"
     target.write_bytes(b"")
-    spoof = tmp_path / "a\n[rocjitsu-dbi-hooks] ConSan.hsaco"
-    spoof.write_bytes(b"")
+    assert "must not contain a newline" not in _run_script(str(target)).stderr
 
-    def run(object_path: Path) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            [str(_SCRIPT), "--hook", "/bin/true", "--object", str(object_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
 
-    rejected = run(spoof)
-    assert rejected.returncode == 2
-    assert "must not contain a newline" in rejected.stderr
-
-    # The guard must not fire on ordinary paths; this run fails later (no ROCm),
-    # so assert only that it got past argument validation.
-    assert "must not contain a newline" not in run(target).stderr
+def test_object_path_guard_covers_the_workdir_path_too(tmp_path: Path) -> None:
+    """`--workdir` also feeds the path that gets embedded, so it needs the same check."""
+    workdir = tmp_path / 'w"quote'
+    workdir.mkdir()
+    proc = subprocess.run(
+        [str(_SCRIPT), "--hook", "/bin/true", "--workdir", str(workdir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # Reaching the guard needs a local hipBLASLt bundle to extract; where that is
+    # absent the run dies earlier, and the guard is unreachable rather than wrong.
+    if "no gfx950 f32 SS Tensile bundle" in proc.stderr:
+        pytest.skip("no local hipBLASLt bundle, so extraction dies before the guard")
+    assert proc.returncode == 2
+    assert "must not contain a newline, backslash or double quote" in proc.stderr

--- a/tests/sanitizers/test_consan_4112_repro.py
+++ b/tests/sanitizers/test_consan_4112_repro.py
@@ -30,10 +30,13 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT = _REPO_ROOT / "docs" / "sanitizers" / "repro" / "consan_4112_repro.sh"
 
-# The loader prints this in front of anything it echoes, including the object
-# path on a failed hipModuleLoad. It is the reason an anchored hook pattern
-# cannot be satisfied by caller-controlled text.
-_LOADER_ECHO = "[consan_4112_load] hipModuleLoad failed for /tmp/objects/"
+# Exactly what consan_4112_load.hip:19 prints when hipModuleLoad fails -- note
+# there is no [consan_4112_load] prefix on this one, unlike the success marker at
+# :22. That is the line that puts a caller-supplied path into the log, so the
+# spoof fixtures below have to use its real shape or they prove nothing.
+_LOADER_FAIL = "hipModuleLoad(/tmp/objects/{path}) failed: shared object initialization failed"
+# The success marker, which does carry the prefix, and also echoes the path.
+_LOADER_OK = "[consan_4112_load] loaded and instrumented {path} (no dispatch)"
 
 _HOOK = "[rocjitsu-dbi-hooks] "
 _INSTALLED = f"{_HOOK}installed ConSan hook"
@@ -201,7 +204,7 @@ def test_verdict_timeout_is_inconclusive(tmp_path: Path, rc: int) -> None:
 def test_verdict_spoofed_overlap_path_is_not_reproduced(tmp_path: Path) -> None:
     """End-to-end version of the #409 review's vector, through the real branches."""
     log = (
-        f"{_LOADER_ECHO}{_OVERLAP}.hsaco\n"
+        _LOADER_FAIL.format(path=f"{_OVERLAP}.hsaco") + "\n"
         f"{_INSTALLED}\n"
         f"{_REJECTION}\n"
     )
@@ -255,9 +258,9 @@ def test_overlap_spoof_via_object_path_is_not_a_reproduction(
     rejection into "reproduced -- defect still present", reported upstream.
     """
     log = (
-        f"{_LOADER_ECHO}[rocjitsu-dbi-hooks] {patterns['OVERLAP_LINE']} patch ranges.hsaco\n"
-        "[rocjitsu-dbi-hooks] installed ConSan hook\n"
-        "[rocjitsu-dbi-hooks] ConSan load rejection reason=transform-error status=4112 exit_code=92\n"
+        _LOADER_FAIL.format(path=f"{_HOOK}{patterns['OVERLAP_LINE']} patch ranges.hsaco") + "\n"
+        f"{_INSTALLED}\n"
+        f"{_REJECTION}\n"
     )
     assert not _matches(f"{patterns['HOOK_LINE']} {patterns['OVERLAP_LINE']}", log, tmp_path)
 
@@ -272,10 +275,10 @@ def test_growth_spoof_via_object_path_does_not_mask_a_real_reproduction(
     negative on the one signal the script exists to report.
     """
     log = (
-        f"{_LOADER_ECHO}[rocjitsu-dbi-hooks] {patterns['GROWTH_LINE']}.hsaco\n"
-        "[rocjitsu-dbi-hooks] installed ConSan hook\n"
-        f"[rocjitsu-dbi-hooks] {patterns['OVERLAP_LINE']} patch ranges: 3 pairs\n"
-        "[rocjitsu-dbi-hooks] ConSan load rejection reason=transform-error status=4112 exit_code=92\n"
+        _LOADER_FAIL.format(path=f"{_HOOK}{patterns['GROWTH_LINE']}.hsaco") + "\n"
+        f"{_INSTALLED}\n"
+        f"{_OVERLAP}\n"
+        f"{_REJECTION}\n"
     )
     assert not _matches(f"{patterns['HOOK_LINE']} {patterns['GROWTH_LINE']}", log, tmp_path)
     assert _matches(f"{patterns['HOOK_LINE']} {patterns['OVERLAP_LINE']}", log, tmp_path)
@@ -284,10 +287,46 @@ def test_growth_spoof_via_object_path_does_not_mask_a_real_reproduction(
 def test_loader_success_marker_cannot_be_spoofed(patterns: dict[str, str], tmp_path: Path) -> None:
     """`loaded and instrumented` gates the "fixed" verdict, so it needs the same anchor."""
     log = (
-        "[rocjitsu-dbi-hooks] installed ConSan hook\n"
-        f"{_LOADER_ECHO}[consan_4112_load] loaded and instrumented.hsaco\n"
+        f"{_INSTALLED}\n"
+        + _LOADER_FAIL.format(path="[consan_4112_load] loaded and instrumented.hsaco")
+        + "\n"
     )
     assert not _matches(f"{patterns['LOADER_LINE']} loaded and instrumented", log, tmp_path)
+
+
+def test_the_loader_success_line_echoes_the_path_too(
+    patterns: dict[str, str], tmp_path: Path
+) -> None:
+    """consan_4112_load.hip:22 puts the path *after* its own prefix, on the same line.
+
+    That line legitimately matches LOADER_LINE, so the anchor alone does not keep
+    caller text out of it -- what does is that the path lands mid-line, behind the
+    prefix, and cannot start a new one (the object-path guard forbids newlines).
+    """
+    log = (
+        f"{_INSTALLED}\n"
+        + _LOADER_OK.format(path=f"/tmp/{_HOOK}{patterns['OVERLAP_LINE']} patch ranges.hsaco")
+        + "\n"
+    )
+    assert _matches(f"{patterns['LOADER_LINE']} loaded and instrumented", log, tmp_path)
+    assert not _matches(f"{patterns['HOOK_LINE']} {patterns['OVERLAP_LINE']}", log, tmp_path)
+
+
+def test_loader_fixtures_match_the_real_loader_source() -> None:
+    """The spoof fixtures are only evidence if they are the loader's actual output.
+
+    An invented shape proves nothing about the real vector, so pin both lines to
+    the format strings in consan_4112_load.hip. If that file changes its wording,
+    this fails here rather than leaving the spoof tests quietly testing fiction.
+    """
+    loader = (_SCRIPT.parent / "consan_4112_load.hip").read_text()
+    # The failure line deliberately has no [consan_4112_load] prefix; the success
+    # line does. That asymmetry is the whole reason the anchor has to do the work.
+    assert '"hipModuleLoad(%s) failed: %s\\n"' in loader
+    assert '"[consan_4112_load] loaded and instrumented %s (no dispatch)\\n"' in loader
+    assert _LOADER_FAIL.startswith("hipModuleLoad(")
+    assert "[consan_4112_load]" not in _LOADER_FAIL
+    assert _LOADER_OK.startswith("[consan_4112_load] loaded and instrumented ")
 
 
 @pytest.mark.parametrize(

--- a/tests/sanitizers/test_consan_4112_repro.py
+++ b/tests/sanitizers/test_consan_4112_repro.py
@@ -21,6 +21,7 @@ reproducer that can be made to confirm a defect on demand.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -349,12 +350,55 @@ def test_anchoring_still_matches_genuine_hook_output(
     assert _matches(f"{patterns['HOOK_LINE']} {patterns[key]}", log, tmp_path)
 
 
-def _run_script(object_path: str) -> subprocess.CompletedProcess[str]:
+def _sandbox(tmp_path: Path) -> dict[str, str]:
+    """Environment that lets the script reach its object-path guard without ROCm.
+
+    The guard runs after the ``hipcc`` preflight, so on a machine without ROCm the
+    script dies before it and these tests would assert against the wrong error.
+    Stubbing rather than marking the tests ``rocm`` is deliberate: the guard is
+    pure shell logic with nothing to run on a GPU, so it belongs in the CPU
+    matrix, and stubbing also pins the behaviour on a machine that *does* have a
+    real hipcc -- where these tests otherwise pass for the wrong reason. That is
+    how the gap reached CI in the first place.
+
+    ``ROCM_PATH`` points at nothing so the script's own PATH prepend cannot shadow
+    the stubs, making the run identical on both kinds of host.
+    """
+    bindir = tmp_path / "stubbin"
+    bindir.mkdir(exist_ok=True)
+    # Failing is the fast, deterministic outcome: a hostile path dies at the
+    # guard before this is ever invoked, and an accepted path stops here instead
+    # of running the whole hooked flow.
+    stub = bindir / "hipcc"
+    stub.write_text("#!/bin/sh\nexit 1\n")
+    stub.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}{os.pathsep}{env.get('PATH', '')}"
+    env["ROCM_PATH"] = str(tmp_path / "no-such-rocm")
+    env["ROCM_HOME"] = env["ROCM_PATH"]
+    return env
+
+
+def _run_script(object_path: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [str(_SCRIPT), "--hook", "/bin/true", "--object", object_path],
         capture_output=True,
         text=True,
         check=False,
+        env=_sandbox(tmp_path),
+    )
+
+
+def test_the_sandbox_reaches_the_guard_at_all() -> None:
+    """Guard against the stubs silently stopping the script too early.
+
+    Without this, every rejection test above could pass because the run died at
+    ``hipcc`` with a message that happens not to contain the guard text.
+    """
+    body = _SCRIPT.read_text()
+    assert body.index('command -v hipcc') < body.index('case "${OBJECT}" in'), (
+        "the hipcc preflight no longer precedes the object guard; the sandbox "
+        "may no longer be needed, or may need to stub something else"
     )
 
 
@@ -377,7 +421,7 @@ def test_hostile_object_path_is_rejected(tmp_path: Path, name: str, why: str) ->
     """
     spoof = tmp_path / name
     spoof.write_bytes(b"")
-    proc = _run_script(str(spoof))
+    proc = _run_script(str(spoof), tmp_path)
     assert proc.returncode == 2, why
     assert "must not contain a newline, backslash or double quote" in proc.stderr
 
@@ -385,17 +429,40 @@ def test_hostile_object_path_is_rejected(tmp_path: Path, name: str, why: str) ->
 def test_ordinary_object_path_is_not_rejected(tmp_path: Path) -> None:
     """The guard must not fire on real paths.
 
-    This run fails later for want of ROCm, so assert only that it cleared
-    validation -- otherwise the test above would pass against a guard that
-    rejects everything.
+    The run stops at the stubbed hipcc just after the guard, which is the proof
+    it got past validation -- otherwise the test above would pass equally well
+    against a guard that rejects everything.
     """
     target = tmp_path / "obj.hsaco"
     target.write_bytes(b"")
-    assert "must not contain a newline" not in _run_script(str(target)).stderr
+    proc = _run_script(str(target), tmp_path)
+    assert "must not contain a newline" not in proc.stderr
+    assert "hipcc failed to build the loader" in proc.stderr
 
 
 def test_object_path_guard_covers_the_workdir_path_too(tmp_path: Path) -> None:
-    """`--workdir` also feeds the path that gets embedded, so it needs the same check."""
+    """`--workdir` feeds the embedded path on the extraction branch, which has no --object.
+
+    That branch is why the guard sits at the point of use rather than at argument
+    parsing: a parse-time check on ``--object`` never sees this path at all.
+    """
+    # Reaching the guard on this branch needs a hipBLASLt bundle to extract from
+    # and a bundler to extract it, neither of which a CPU runner has. Both are
+    # faked so the branch is exercised rather than skipped -- the guard runs
+    # before either is read for content, so nothing here has to be a real object.
+    bundle_name = re.search(r'^BUNDLE_NAME="([^"]+)"$', _SCRIPT.read_text(), re.MULTILINE)
+    assert bundle_name, "BUNDLE_NAME is no longer a plain assignment in the script"
+    rocm = tmp_path / "fake-rocm"
+    library = rocm / "lib" / "hipblaslt" / "library"
+    library.mkdir(parents=True)
+    (library / bundle_name.group(1)).write_bytes(b"")
+
+    env = _sandbox(tmp_path)
+    env["ROCM_PATH"] = env["ROCM_HOME"] = str(rocm)
+    bundler = Path(env["PATH"].split(os.pathsep)[0]) / "clang-offload-bundler"
+    bundler.write_text("#!/bin/sh\nexit 0\n")
+    bundler.chmod(0o755)
+
     workdir = tmp_path / 'w"quote'
     workdir.mkdir()
     proc = subprocess.run(
@@ -403,10 +470,7 @@ def test_object_path_guard_covers_the_workdir_path_too(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
-    # Reaching the guard needs a local hipBLASLt bundle to extract; where that is
-    # absent the run dies earlier, and the guard is unreachable rather than wrong.
-    if "no gfx950 f32 SS Tensile bundle" in proc.stderr:
-        pytest.skip("no local hipBLASLt bundle, so extraction dies before the guard")
-    assert proc.returncode == 2
+    assert proc.returncode == 2, proc.stderr
     assert "must not contain a newline, backslash or double quote" in proc.stderr


### PR DESCRIPTION
## Why

Tab 2's ConSan rows had drifted from every document describing them, in **both**
directions, and one of those drifts had turned a reproducer into a tool that
would tell an upstream maintainer their fix did not work.

Grounded in the live published nightly — run
[32967422099](https://github.com/ROCm/aorta/actions/runs/32967422099),
2026-08-26, aorta `bed2771d`, rocjitsu bundle `97c1640b` — plus direct
experiments on a gfx950 host.

| Tab 2 row | Docs said | Actually |
|---|---|---|
| `consan-lds-dispatch` | blocked on #9972, exit 86 | ✅ **passes** — `access=5/5`, `barrier=2/2`, `dynamic_complete=true` |
| `consan-gemm` | 4112 fixed → moves to exit 86 | ❌ still exit 92 `status=4112`, **different cause** |
| `consan-tiny` | exit 86, nothing analyzable | ✅ accurate (and confirmed unfixable-by-design) |

## `consan-gemm`: same status code, different defect

`status=4112` is a generic `transform-error` bucket. The overlapping-anchor
defect ([ROCm/rocm-systems#10378](https://github.com/ROCm/rocm-systems/issues/10378))
**is** fixed and its diagnostic is absent from the log. What fires now is the
patched-image growth ceiling:

```
ConSan patch end   outcome=invalid errors=1 patches=0
ConSan MOI first-light probe rejected patched-image file growth:
  required total 1492987904 bytes, limit 419430400 bytes (policy absolute-bytes=419430400)
ConSan load rejection reason=transform-error status=4112 ... exit_code=92
```

**Not a rocjitsu defect.** `RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_BYTES` /
`_PERCENT` govern this ceiling and AORTA sets neither. Verified by experiment on
gfx950: forcing the cap low reproduces the nightly's signature exactly on a
5,816-byte object, and raising it clears the rejection.

**Trigger is fixture drift.** The extracted object is 191,935,808 bytes on the
ROCm 7.2.4 base versus the 16,265,200 bytes all prior sizing and upstream
verification used — 11.8x the bytes, 9.3x the access sites. `prepare_gemm_isa.py`
already documents the size as a per-release hipBLASLt property (#402); what was
missed is that it crosses a ceiling that used to have ~24x of headroom.

Deliberately **no behaviour change** for this case: raising the ceiling would let
the transform proceed into 9.3x the work no measurement covers, so
`timeout_seconds: 6000` would very likely become the next failure. That needs a
measurement, not a guess. The recipe comment now says so instead of advertising a
budget for a run this case no longer performs.

## The reproducer bug (the part that mattered most)

`consan_4112_repro.sh` decided `reproduced -- defect still present` from
`reason=transform-error status=4112` + exit 92 — precisely the signature the
capacity rejection produces. So on any modern ROCm base it would report the
**fixed** defect as still present, upstream.

Validated against the real logs: the 2026-08-26 `consan-gemm` log matches the
growth pattern and does **not** contain the overlap diagnostic, so the old code
classified it `reproduced` and the new code classifies it inconclusive.

The discriminator was already being logged — `final validation found` was grepped
for display but never used to decide. Now a growth-ceiling rejection is its own
inconclusive outcome naming the retry knob, `reproduced` additionally requires the
overlap diagnostic, and a 4112 with neither explanation is reported as a third,
unknown transform error.

This is the §21 lesson from #385 recurring in the same file: ask who printed a
line, and whether it would still appear if the thing under test were absent. **A
status code is not a defect identity.**

## `consan-tiny` is a deliberate negative control

Measured 2026-08-27: giving it a *dispatching* driver does not change the verdict,
only the message (`1 auto MOI report buffer(s)` instead of `0`). `tiny_vecadd`'s
memory operations are ordinary global loads/stores, which ConSan reports as
`supported-synchronization-only` and does not admit as MOI sites — `access=0/0`,
`applicable=false`. Recorded in the recipe so the next reader does not try to
"fix" it.

## Also corrected

* Four places still called the dynamic record/replay path blocked upstream on
  #9972 (fixed in `15275dad`): the lds-dispatch recipe, the survey recipe, the
  instrumentation README, and `triton_consan_loader.py`.
* `recipes/sanitizers/survey/README.md` now states that the nightly renders Tab 2
  from `--informational-results-dir` and **never** passes `--survey`, so these
  committed fixtures are not what the published dashboard shows — plus a
  per-fixture staleness note.

## Test plan

- [x] `ruff check` clean on changed Python
- [x] `bash -n` clean on the reproducer; `--help` still renders
- [x] New discriminator patterns validated against the real nightly log and the
      local forced-low-cap log
- [x] 601 tests pass (`tests/sanitizers`, `tests/instrumentation/rocjitsu_sanitizers`, `tests/ci`)
- [x] Bugbot deep pass: clean
- [ ] Reviewer sanity-check: no behaviour change is intended outside the
      reproducer's verdict branches

## Not in scope

Whether to raise the growth ceiling, shrink the fixture, or leave `consan-gemm`
erroring is a follow-up decision, captured in
`docs/sanitizers/consan-gemm-patched-image-growth-cap.md` rather than decided here.

Made with [Cursor](https://cursor.com)