### PR TITLE
Fix the 2x kernel count and the shipped-vs-unbundled Tensile size framing

### DIFF
--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -97,7 +97,7 @@ Repro: [`repro/consan_4112_repro.sh`](repro/consan_4112_repro.sh).
 This section describes the defect as observed on `db0c47df`, per the status note
 above; it is fixed in `dc7c8e04`. Under the combined rocjitsu ConSan hook
 in `record-replay` / `strict` mode on gfx950, loading a large hipBLASLt f32
-Tensile code object (16,265,200 bytes, 245 kernels) gets all the way through MOI
+Tensile code object (16,265,200 bytes unbundled, 245 kernels) gets all the way through MOI
 inventory and report planning, and is then rejected by the transform's final
 validation:
 

--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -97,7 +97,7 @@ Repro: [`repro/consan_4112_repro.sh`](repro/consan_4112_repro.sh).
 This section describes the defect as observed on `db0c47df`, per the status note
 above; it is fixed in `dc7c8e04`. Under the combined rocjitsu ConSan hook
 in `record-replay` / `strict` mode on gfx950, loading a large hipBLASLt f32
-Tensile code object (16,265,200 bytes, 490 kernels) gets all the way through MOI
+Tensile code object (16,265,200 bytes, 245 kernels) gets all the way through MOI
 inventory and report planning, and is then rejected by the transform's final
 validation:
 
@@ -257,4 +257,11 @@ pass `--object` with an already-unbundled gfx950 code object.
 - `RJ_CONSAN_MODE=record-replay`, `RJ_CONSAN_POLICY=strict`,
   `moi_profile=standard-v1`
 - Object: `TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bjlk_Cijk_Dijk_gfx950.co`,
-  unbundled for `hipv4-amdgcn-amd-amdhsa--gfx950` → 16,265,200 bytes, 490 kernels
+  unbundled for `hipv4-amdgcn-amd-amdhsa--gfx950` → 16,265,200 bytes, 245 kernels.
+  The byte count is the shipped bundle *expanded*: the `.co` is a zlib-compressed
+  offload bundle (`CCOB`) and unbundling inflates it ~40x, so the installed file is
+  a few MB. The kernel count was recorded as 490 until it was found to be a 2x
+  double count — `llvm-readelf --symbols` prints `.dynsym` and `.symtab` both, so
+  each `.kd` was counted twice. 245 is that correction, not a re-measurement: no
+  ROCm 7.0.2.2 image remains on the gate host. Nothing in the analysis above
+  depends on the count.

--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -258,12 +258,11 @@ pass `--object` with an already-unbundled gfx950 code object.
   `moi_profile=standard-v1`
 - Object: `TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bjlk_Cijk_Dijk_gfx950.co`,
   unbundled for `hipv4-amdgcn-amd-amdhsa--gfx950` → 16,265,200 bytes, 245 kernels.
-  The byte count is the shipped bundle *expanded*: the `.co` is a zlib-compressed
-  offload bundle (`CCOB`), so the file hipBLASLt installs is substantially
-  smaller than this. The ratio was never measured for this object; the
-  comparable ROCm 10 CU256 SS layouts inflate 38-45x on unbundling, but that is
-  a different object on a different stack and is not carried over here. The
-  kernel count was recorded as 490 until it was found to be a 2x
+  The byte count is measured *after* unbundling. What the `.co` occupied on disk on
+  this release was never measured, and whether ROCm 7.0.2 shipped compressed
+  offload bundles at all is unknown -- the ~40x `CCOB` inflation recorded elsewhere
+  in this repo was measured on ROCm 10 only and must not be read back onto this
+  row. The kernel count was recorded as 490 until it was found to be a 2x
   double count — `llvm-readelf --symbols` prints `.dynsym` and `.symtab` both, so
   each `.kd` was counted twice. 245 is that correction, not a re-measurement: no
   ROCm 7.0.2.2 image remains on the gate host. Nothing in the analysis above

--- a/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
+++ b/docs/sanitizers/consan-4112-overlapping-anchor-patches.md
@@ -259,8 +259,11 @@ pass `--object` with an already-unbundled gfx950 code object.
 - Object: `TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bjlk_Cijk_Dijk_gfx950.co`,
   unbundled for `hipv4-amdgcn-amd-amdhsa--gfx950` → 16,265,200 bytes, 245 kernels.
   The byte count is the shipped bundle *expanded*: the `.co` is a zlib-compressed
-  offload bundle (`CCOB`) and unbundling inflates it ~40x, so the installed file is
-  a few MB. The kernel count was recorded as 490 until it was found to be a 2x
+  offload bundle (`CCOB`), so the file hipBLASLt installs is substantially
+  smaller than this. The ratio was never measured for this object; the
+  comparable ROCm 10 CU256 SS layouts inflate 38-45x on unbundling, but that is
+  a different object on a different stack and is not carried over here. The
+  kernel count was recorded as 490 until it was found to be a 2x
   double count — `llvm-readelf --symbols` prints `.dynsym` and `.symtab` both, so
   each `.kd` was counted twice. 245 is that correction, not a re-measurement: no
   ROCm 7.0.2.2 image remains on the gate host. Nothing in the analysis above

--- a/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
+++ b/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
@@ -43,7 +43,12 @@ MOI inventory 131 s + patch 152 s is roughly 730 s before the rejection.
 ## Why the ceiling is exceeded: the fixture grew 11.8x
 
 Every prior sizing and upstream-verification exercise for this case used a
-**16,265,200-byte (15.5 MB)** object with 490 kernels, measured on ROCm 7.0.2.2.
+**16,265,200-byte (15.5 MB)** object with 245 kernels, measured on ROCm 7.0.2.2.
+(The count was recorded as 490 until `llvm-readelf --symbols` was found to print
+`.dynsym` and `.symtab` both, doubling it; see
+[`consan-4112-overlapping-anchor-patches.md`](consan-4112-overlapping-anchor-patches.md).
+The byte figure is unaffected, and so is every ratio below -- they are
+byte- and access-site-derived, with no kernel-count term.)
 The object CI now extracts is **191,935,808 bytes (183 MiB)**:
 
 | | Verification object (ROCm 7.0.2.2) | CI object (ROCm 7.2.4) | Ratio |

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -190,9 +190,9 @@ else
     kernels="unknown (llvm-readelf not on PATH)"
 fi
 echo "   object: ${bytes} bytes, ${kernels} kernels"
-echo "   (originally observed at 16265200 bytes / 245 kernels on ROCm 7.0.2.2;"
-echo "    the byte figure is the shipped CCOB bundle after unbundling, so it is"
-echo "    larger than the .co hipBLASLt installs -- the ratio was not measured)"
+echo "   (originally observed at 16265200 bytes / 245 kernels on ROCm 7.0.2.2,"
+echo "    post-unbundle -- the size of the shipped .co on that release was never"
+echo "    measured, so no compression ratio is claimed for it)"
 
 echo "== building load-only driver"
 hipcc --offload-arch=gfx950 -DOBJECT="\"${OBJECT}\"" "${LOADER_SRC}" -o "${LOADER}" \

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -178,15 +178,21 @@ bytes=$(stat -c%s "${OBJECT}")
 # rather than silently reporting "0 kernels" and looking like a wrong object.
 # --dyn-syms, not --symbols: --symbols prints .dynsym AND .symtab, and a kernel is
 # in both, so it reports exactly twice the kernel count. That is where the "490"
-# below (and the counts in daily-consan-gemm.yaml) came from before the fix.
+# below came from before the fix, as did every other figure counted that way.
 if command -v llvm-readelf >/dev/null; then
     kernels="$(llvm-readelf --dyn-syms "${OBJECT}" 2>/dev/null | grep -c 'FUNC.*GLOBAL')"
+    # 0 here means the object has no .dynsym, not that it has no kernels. Report
+    # it as unknown for the same reason as the missing-tool case above.
+    if [ "${kernels}" = "0" ]; then
+        kernels="unknown (no .dynsym in object)"
+    fi
 else
     kernels="unknown (llvm-readelf not on PATH)"
 fi
 echo "   object: ${bytes} bytes, ${kernels} kernels"
 echo "   (originally observed at 16265200 bytes / 245 kernels on ROCm 7.0.2.2;"
-echo "    the byte figure is the compressed CCOB bundle expanded ~40x by unbundling)"
+echo "    the byte figure is the shipped CCOB bundle after unbundling, so it is"
+echo "    larger than the .co hipBLASLt installs -- the ratio was not measured)"
 
 echo "== building load-only driver"
 hipcc --offload-arch=gfx950 -DOBJECT="\"${OBJECT}\"" "${LOADER_SRC}" -o "${LOADER}" \

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -174,17 +174,25 @@ case "${OBJECT}" in
 esac
 
 bytes=$(stat -c%s "${OBJECT}")
-# Kernel count is informational only, so a missing llvm-readelf should say so
-# rather than silently reporting "0 kernels" and looking like a wrong object.
+# Kernel count is informational only, so anything that stops us counting should
+# say so rather than reporting a bare "0" that reads as a wrong object.
 # --dyn-syms, not --symbols: --symbols prints .dynsym AND .symtab, and a kernel is
 # in both, so it reports exactly twice the kernel count. That is where the "490"
 # below came from before the fix, as did every other figure counted that way.
 if command -v llvm-readelf >/dev/null; then
-    kernels="$(llvm-readelf --dyn-syms "${OBJECT}" 2>/dev/null | grep -c 'FUNC.*GLOBAL')"
-    # 0 here means the object has no .dynsym, not that it has no kernels. Report
-    # it as unknown for the same reason as the missing-tool case above.
-    if [ "${kernels}" = "0" ]; then
-        kernels="unknown (no .dynsym in object)"
+    # Read first, count second, so llvm-readelf's exit status survives. Piping it
+    # straight into grep hides the failure: an unreadable or unsupported object
+    # yields empty output and counts 0, which is indistinguishable from a real
+    # object that happens to have no matching symbols.
+    if dynsyms="$(llvm-readelf --dyn-syms "${OBJECT}" 2>/dev/null)"; then
+        kernels="$(printf '%s\n' "${dynsyms}" | grep -c 'FUNC.*GLOBAL')"
+        # Only claim what was observed. A zero means nothing matched; it does not
+        # establish that .dynsym is absent, and this cannot tell those apart.
+        if [ "${kernels}" = "0" ]; then
+            kernels="0 (no kernel symbols found)"
+        fi
+    else
+        kernels="unknown (llvm-readelf could not read the object)"
     fi
 else
     kernels="unknown (llvm-readelf not on PATH)"

--- a/docs/sanitizers/repro/consan_4112_repro.sh
+++ b/docs/sanitizers/repro/consan_4112_repro.sh
@@ -176,13 +176,17 @@ esac
 bytes=$(stat -c%s "${OBJECT}")
 # Kernel count is informational only, so a missing llvm-readelf should say so
 # rather than silently reporting "0 kernels" and looking like a wrong object.
+# --dyn-syms, not --symbols: --symbols prints .dynsym AND .symtab, and a kernel is
+# in both, so it reports exactly twice the kernel count. That is where the "490"
+# below (and the counts in daily-consan-gemm.yaml) came from before the fix.
 if command -v llvm-readelf >/dev/null; then
-    kernels="$(llvm-readelf --symbols "${OBJECT}" 2>/dev/null | grep -c 'FUNC.*GLOBAL')"
+    kernels="$(llvm-readelf --dyn-syms "${OBJECT}" 2>/dev/null | grep -c 'FUNC.*GLOBAL')"
 else
     kernels="unknown (llvm-readelf not on PATH)"
 fi
 echo "   object: ${bytes} bytes, ${kernels} kernels"
-echo "   (originally observed at 16265200 bytes / 490 kernels on ROCm 7.0.2.2)"
+echo "   (originally observed at 16265200 bytes / 245 kernels on ROCm 7.0.2.2;"
+echo "    the byte figure is the compressed CCOB bundle expanded ~40x by unbundling)"
 
 echo "== building load-only driver"
 hipcc --offload-arch=gfx950 -DOBJECT="\"${OBJECT}\"" "${LOADER_SRC}" -o "${LOADER}" \

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
@@ -61,8 +61,7 @@ def sha256_code_object(path: Path) -> str | None:
     """Lowercase SHA-256 of a non-empty code object, or ``None`` if unreadable.
 
     Streams the file so a large code object (hundreds of MB for an unbundled
-    Tensile object -- the shipped bundle itself is compressed and far smaller)
-    is not read into memory at once. Returns ``None`` for a missing / empty /
+    Tensile object) is not read into memory at once. Returns ``None`` for a missing / empty /
     unreadable path so callers can degrade gracefully rather than crash: the
     identity stays digest-less and Waitcheck fails closed
     (``code_object_identity_required``) exactly as it does today for a kernel

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/selection.py
@@ -60,7 +60,8 @@ def _optional_str(value: object) -> str | None:
 def sha256_code_object(path: Path) -> str | None:
     """Lowercase SHA-256 of a non-empty code object, or ``None`` if unreadable.
 
-    Streams the file so a large code object (hundreds of MB for a Tensile bundle)
+    Streams the file so a large code object (hundreds of MB for an unbundled
+    Tensile object -- the shipped bundle itself is compressed and far smaller)
     is not read into memory at once. Returns ``None`` for a missing / empty /
     unreadable path so callers can degrade gracefully rather than crash: the
     identity stays digest-less and Waitcheck fails closed

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
@@ -462,8 +462,8 @@ def run_waitcheck(
         )
 
     # Each selected code object is an independent rj_waitcheck subprocess doing
-    # CPU-bound static disassembly (~a minute on a real ~16MB / ~490-kernel
-    # Tensile object, #366), so scan distinct objects concurrently to cut
+    # CPU-bound static disassembly (~a minute on a real ~16MB / ~245-kernel
+    # unbundled Tensile object, #366), so scan distinct objects concurrently to cut
     # wall-clock time. This is coverage-preserving -- every selected object is
     # still scanned with its full per-scan timeout -- so the gate is unchanged;
     # it only removes the serialization penalty when the worklist spans more

--- a/tests/sanitizers/test_kernel_count_mechanism.py
+++ b/tests/sanitizers/test_kernel_count_mechanism.py
@@ -1,0 +1,81 @@
+"""Guard the mechanism used to count kernels in an AMDGPU code object.
+
+``llvm-readelf --symbols`` prints ``.dynsym`` *and* ``.symtab``, and a kernel is
+listed in both, so counting matches across that output reports exactly twice the
+kernel count. That is not a hypothetical: the figures recorded for the heavy f32
+Tensile object (490 / 1554 / 682 kernels) were all 2x for this reason, and the
+490 was quoted in four places before it was caught. ``--dyn-syms`` reads the one
+table and is the correct source.
+
+The check is phrased as the property rather than as a diff against one known-bad
+line, so a new caller anywhere in the tree inherits it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A readelf invocation is "counting kernels" if it also names something that
+# identifies a kernel symbol: the FUNC symbol type or the .kd descriptor suffix.
+_COUNTING_MARKERS = ("FUNC", ".kd")
+
+
+def _tracked_text_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [_REPO_ROOT / name for name in out.split("\0") if name]
+
+
+def _kernel_counting_readelf_lines() -> list[tuple[Path, int, str]]:
+    """Every line in a tracked file that counts kernel symbols via llvm-readelf."""
+    found: list[tuple[Path, int, str]] = []
+    for path in _tracked_text_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue  # binary or unreadable: not a readelf call site
+        if "readelf" not in text:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if "readelf" not in line:
+                continue
+            if not any(marker in line for marker in _COUNTING_MARKERS):
+                continue
+            found.append((path.relative_to(_REPO_ROOT), lineno, line.strip()))
+    return found
+
+
+def test_kernel_counts_never_come_from_the_double_counting_table() -> None:
+    """No kernel count is derived from ``--symbols``, which reports 2x."""
+    offenders = [
+        (path, lineno, line)
+        for path, lineno, line in _kernel_counting_readelf_lines()
+        if "--symbols" in line
+    ]
+    assert not offenders, (
+        "llvm-readelf --symbols prints .dynsym and .symtab, so counting kernel "
+        "symbols across it double-counts; use --dyn-syms:\n"
+        + "\n".join(f"  {path}:{lineno}: {line}" for path, lineno, line in offenders)
+    )
+
+
+def test_the_repro_script_still_counts_kernels() -> None:
+    """The guard above stays meaningful only while a real call site exists.
+
+    Without this, deleting the last kernel-counting line would leave the
+    ``--symbols`` assertion vacuously true.
+    """
+    call_sites = _kernel_counting_readelf_lines()
+    assert call_sites, "no kernel-counting readelf call site found; the guard above is vacuous"
+    assert any("--dyn-syms" in line for _, _, line in call_sites), (
+        "expected at least one kernel count to use --dyn-syms; found:\n"
+        + "\n".join(f"  {path}:{lineno}: {line}" for path, lineno, line in call_sites)
+    )

--- a/tests/sanitizers/test_kernel_count_mechanism.py
+++ b/tests/sanitizers/test_kernel_count_mechanism.py
@@ -61,7 +61,7 @@ def _tracked_text_files() -> list[Path]:
 
 
 def _runs_commands(path: Path, text: str) -> bool:
-    """True for a file whose contents are executed rather than read."""
+    """True for a file that can carry a command: a script, a module, a workflow."""
     if path.suffix in _COMMAND_SUFFIXES:
         return True
     return not path.suffix and text.startswith("#!")
@@ -101,13 +101,13 @@ def _kernel_counting_readelf_commands() -> list[tuple[Path, int, str]]:
     """Every command in a tracked file that counts kernel symbols via llvm-readelf."""
     found: list[tuple[Path, int, str]] = []
     for path in _tracked_text_files():
-        if path.resolve() == _SELF:
-            continue
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue  # binary or unreadable: not a readelf call site
         if "readelf" not in text or not _runs_commands(path, text):
+            continue
+        if path.resolve() == _SELF:
             continue
         for lineno, command in _logical_lines(text):
             if "readelf" not in command:
@@ -168,10 +168,15 @@ def test_a_wrapped_pipeline_is_still_seen_as_one_command() -> None:
 def test_prose_is_not_a_call_site() -> None:
     """Re-wrapping a doc must never fail the guard above.
 
-    The docs quote both the wrong flag and the ``.kd`` suffix, and a reflow can
-    land them on one line without changing a word of meaning.
+    The doc quotes both the wrong flag and the ``.kd`` marker, so a reflow that
+    landed them on one line would read as a call site if prose were scanned.
+    The bait is asserted first: without it this would pass for the wrong reason.
     """
-    assert not _runs_commands(
-        _REPO_ROOT / "docs/sanitizers/consan-4112-overlapping-anchor-patches.md",
-        "`llvm-readelf --symbols` counts each `.kd` twice",
+    doc = _REPO_ROOT / "docs/sanitizers/consan-4112-overlapping-anchor-patches.md"
+    text = doc.read_text(encoding="utf-8")
+    assert "llvm-readelf --symbols" in text and ".kd" in text, (
+        "bait is gone: this doc no longer quotes the flag and the marker the scan looks for"
     )
+    assert not _runs_commands(doc, text)
+    flagged = {path for path, _, _ in _kernel_counting_readelf_commands()}
+    assert doc.relative_to(_REPO_ROOT) not in flagged

--- a/tests/sanitizers/test_kernel_count_mechanism.py
+++ b/tests/sanitizers/test_kernel_count_mechanism.py
@@ -9,6 +9,18 @@ table and is the correct source.
 
 The check is phrased as the property rather than as a diff against one known-bad
 line, so a new caller anywhere in the tree inherits it.
+
+Two things keep the property from being matched on the wrong text. Scanning is
+restricted to files that can execute a command, because prose that quotes a
+readelf invocation is not a call site and re-wrapping a paragraph must not fail
+this test. And a pipeline is folded into one logical command before matching,
+because the flag and the thing that counts its output routinely sit on
+different physical lines::
+
+    kernels="$(llvm-readelf --symbols "${OBJECT}" \\
+        | grep -c 'FUNC.*GLOBAL')"
+
+That is a real double count, and matching physical lines would miss it.
 """
 
 from __future__ import annotations
@@ -18,9 +30,23 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# This file necessarily spells out the pattern it forbids -- in the docstring
+# above and as fixture data below -- so it is not itself a call site.
+_SELF = Path(__file__).resolve()
+
 # A readelf invocation is "counting kernels" if it also names something that
 # identifies a kernel symbol: the FUNC symbol type or the .kd descriptor suffix.
 _COUNTING_MARKERS = ("FUNC", ".kd")
+
+# Only files that can run a command. Markdown and friends are excluded on
+# purpose: they describe call sites rather than being them.
+_COMMAND_SUFFIXES = frozenset({".sh", ".bash", ".zsh", ".py", ".yaml", ".yml"})
+
+# A physical line ending in one of these operators is continued by the next one,
+# so the two are a single command as far as the shell is concerned. A trailing
+# backslash does the same and is handled separately, since it is consumed rather
+# than kept. ``||`` needs no entry of its own: it also ends in ``|``.
+_CONTINUATIONS = ("|", "&&")
 
 
 def _tracked_text_files() -> list[Path]:
@@ -34,36 +60,75 @@ def _tracked_text_files() -> list[Path]:
     return [_REPO_ROOT / name for name in out.split("\0") if name]
 
 
-def _kernel_counting_readelf_lines() -> list[tuple[Path, int, str]]:
-    """Every line in a tracked file that counts kernel symbols via llvm-readelf."""
+def _runs_commands(path: Path, text: str) -> bool:
+    """True for a file whose contents are executed rather than read."""
+    if path.suffix in _COMMAND_SUFFIXES:
+        return True
+    return not path.suffix and text.startswith("#!")
+
+
+def _logical_lines(text: str) -> list[tuple[int, str]]:
+    """Fold continued physical lines into commands, as ``(first_lineno, text)``.
+
+    Comment-only lines are dropped, so explaining the double count in a comment
+    does not read as committing one.
+    """
+    commands: list[tuple[int, str]] = []
+    buffer = ""
+    start = 0
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not buffer:
+            if not line or line.startswith("#"):
+                continue
+            start = lineno
+            buffer = line
+        else:
+            buffer = f"{buffer} {line}"
+        if buffer.endswith("\\"):
+            buffer = buffer[:-1].rstrip()
+            continue
+        if buffer.endswith(_CONTINUATIONS):
+            continue
+        commands.append((start, buffer))
+        buffer = ""
+    if buffer:
+        commands.append((start, buffer))
+    return commands
+
+
+def _kernel_counting_readelf_commands() -> list[tuple[Path, int, str]]:
+    """Every command in a tracked file that counts kernel symbols via llvm-readelf."""
     found: list[tuple[Path, int, str]] = []
     for path in _tracked_text_files():
+        if path.resolve() == _SELF:
+            continue
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue  # binary or unreadable: not a readelf call site
-        if "readelf" not in text:
+        if "readelf" not in text or not _runs_commands(path, text):
             continue
-        for lineno, line in enumerate(text.splitlines(), start=1):
-            if "readelf" not in line:
+        for lineno, command in _logical_lines(text):
+            if "readelf" not in command:
                 continue
-            if not any(marker in line for marker in _COUNTING_MARKERS):
+            if not any(marker in command for marker in _COUNTING_MARKERS):
                 continue
-            found.append((path.relative_to(_REPO_ROOT), lineno, line.strip()))
+            found.append((path.relative_to(_REPO_ROOT), lineno, command))
     return found
 
 
 def test_kernel_counts_never_come_from_the_double_counting_table() -> None:
     """No kernel count is derived from ``--symbols``, which reports 2x."""
     offenders = [
-        (path, lineno, line)
-        for path, lineno, line in _kernel_counting_readelf_lines()
-        if "--symbols" in line
+        (path, lineno, command)
+        for path, lineno, command in _kernel_counting_readelf_commands()
+        if "--symbols" in command
     ]
     assert not offenders, (
         "llvm-readelf --symbols prints .dynsym and .symtab, so counting kernel "
         "symbols across it double-counts; use --dyn-syms:\n"
-        + "\n".join(f"  {path}:{lineno}: {line}" for path, lineno, line in offenders)
+        + "\n".join(f"  {path}:{lineno}: {cmd}" for path, lineno, cmd in offenders)
     )
 
 
@@ -73,9 +138,40 @@ def test_the_repro_script_still_counts_kernels() -> None:
     Without this, deleting the last kernel-counting line would leave the
     ``--symbols`` assertion vacuously true.
     """
-    call_sites = _kernel_counting_readelf_lines()
+    call_sites = _kernel_counting_readelf_commands()
     assert call_sites, "no kernel-counting readelf call site found; the guard above is vacuous"
-    assert any("--dyn-syms" in line for _, _, line in call_sites), (
+    assert any("--dyn-syms" in command for _, _, command in call_sites), (
         "expected at least one kernel count to use --dyn-syms; found:\n"
-        + "\n".join(f"  {path}:{lineno}: {line}" for path, lineno, line in call_sites)
+        + "\n".join(f"  {path}:{lineno}: {cmd}" for path, lineno, cmd in call_sites)
+    )
+
+
+def test_a_wrapped_pipeline_is_still_seen_as_one_command() -> None:
+    """The fold is what makes the guard hold up against a split pipeline.
+
+    A count written across two physical lines is the natural shape once the
+    command grows, and it is the shape that a line-at-a-time scan misses.
+    """
+    script = (
+        "# llvm-readelf --symbols is wrong here, per FUNC below\n"
+        'kernels="$(llvm-readelf --symbols "${OBJECT}" \\\n'
+        "    | grep -c 'FUNC.*GLOBAL')\"\n"
+    )
+    commands = _logical_lines(script)
+    assert len(commands) == 1, commands
+    lineno, command = commands[0]
+    assert lineno == 2, "the comment above it is not part of the command"
+    assert "--symbols" in command and "FUNC" in command
+    assert "\\" not in command, "the continuation marker is consumed by the fold"
+
+
+def test_prose_is_not_a_call_site() -> None:
+    """Re-wrapping a doc must never fail the guard above.
+
+    The docs quote both the wrong flag and the ``.kd`` suffix, and a reflow can
+    land them on one line without changing a word of meaning.
+    """
+    assert not _runs_commands(
+        _REPO_ROOT / "docs/sanitizers/consan-4112-overlapping-anchor-patches.md",
+        "`llvm-readelf --symbols` counts each `.kd` twice",
     )

--- a/tests/sanitizers/test_kernel_count_mechanism.py
+++ b/tests/sanitizers/test_kernel_count_mechanism.py
@@ -4,7 +4,7 @@
 listed in both, so counting matches across that output reports exactly twice the
 kernel count. That is not a hypothetical: the figures recorded for the heavy f32
 Tensile object (490 / 1554 / 682 kernels) were all 2x for this reason, and the
-490 was quoted in four places before it was caught. ``--dyn-syms`` reads the one
+490 was quoted in five places before it was caught. ``--dyn-syms`` reads the one
 table and is the correct source.
 
 The flag has spellings. ``-s`` and ``--syms`` are aliases of ``--symbols``, and
@@ -15,17 +15,27 @@ form would let the same bug back in under a shorter name.
 The check is phrased as the property rather than as a diff against one known-bad
 line, so a new caller anywhere in the tree inherits it.
 
-Two things keep the property from being matched on the wrong text. Scanning is
-restricted to files that can execute a command, because prose that quotes a
-readelf invocation is not a call site and re-wrapping a paragraph must not fail
-this test. And a pipeline is folded into one logical command before matching,
-because the flag and the thing that counts its output routinely sit on
-different physical lines::
+What makes it a *property* and not a pattern match is where it looks. The unit
+is a readelf invocation that asks for a symbol table at all, and the question
+asked of it is only "which table". That is deliberately not "which invocation
+goes on to count kernels": the count is frequently a separate statement from the
+read, and chasing it would mean following a variable across statements. Reading
+the flag off the argv needs no such thing, and it cannot be evaded by moving the
+counting elsewhere::
 
-    kernels="$(llvm-readelf --symbols "${OBJECT}" \\
-        | grep -c 'FUNC.*GLOBAL')"
+    dynsyms="$(llvm-readelf --dyn-syms "${OBJECT}")"      # the invocation
+    kernels="$(printf '%s\\n' "${dynsyms}" | grep -c 'FUNC')"   # the count
 
-That is a real double count, and matching physical lines would miss it.
+The trade is that a readelf ``--symbols`` used for something *other* than
+counting kernels would also be flagged. There is no such caller today, and if
+one appears it should have to say so out loud rather than sit next to a figure
+nobody can re-derive.
+
+Two things keep this from matching the wrong text. Scanning is restricted to
+files that can execute a command, because prose that quotes an invocation is not
+one and re-wrapping a paragraph must not fail this test. And continued lines are
+folded first, since an invocation wraps: on ``\\`` or a trailing pipeline
+operator in shell, and on an unclosed bracket in Python.
 """
 
 from __future__ import annotations
@@ -40,18 +50,25 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 # above and as fixture data below -- so it is not itself a call site.
 _SELF = Path(__file__).resolve()
 
-# A readelf invocation is "counting kernels" if it also names something that
-# identifies a kernel symbol: the FUNC symbol type or the .kd descriptor suffix.
-_COUNTING_MARKERS = ("FUNC", ".kd")
-
 # Only files that can run a command. Markdown and friends are excluded on
 # purpose: they describe call sites rather than being them.
 _COMMAND_SUFFIXES = frozenset({".sh", ".bash", ".zsh", ".py", ".yaml", ".yml"})
 
-# Every spelling that makes llvm-readelf emit .symtab alongside .dynsym. Matched
-# as whole tokens: a substring test for "-s" would fire on "--dyn-syms", which is
-# the flag we want people to use.
+# Every spelling that asks llvm-readelf for a symbol table. Matched as whole
+# tokens: a substring test for "-s" would fire on "--dyn-syms", which is the
+# flag we want people to use.
+_SYMBOL_TABLE_FLAGS = re.compile(
+    r"(?<![\w-])(?:--dyn-syms|--symbols|--syms|--all|-s|-a)(?![\w-])"
+)
+
+# The subset of those that emit .symtab alongside .dynsym, and so double-count.
 _DOUBLE_COUNTING_FLAGS = re.compile(r"(?<![\w-])(?:--symbols|--syms|--all|-s|-a)(?![\w-])")
+
+# A readelf invocation ends at the first operator that starts another command.
+# Flags have to be read off readelf's own argv, not off whatever consumes its
+# output: `llvm-readelf --dyn-syms x | grep -a -c FUNC` is a correct call site,
+# and attributing grep's -a to readelf would reject it.
+_SEGMENT_END = re.compile(r"[|;&]")
 
 # A physical line ending in one of these operators is continued by the next one,
 # so the two are a single command as far as the shell is concerned. A trailing
@@ -78,11 +95,29 @@ def _runs_commands(path: Path, text: str) -> bool:
     return not path.suffix and text.startswith("#!")
 
 
-def _logical_lines(text: str) -> list[tuple[int, str]]:
+def _has_open_bracket(text: str) -> bool:
+    """True while a bracket is still open, so a call spans more lines.
+
+    Deliberately naive -- it does not know about string literals. That is safe
+    only because it is applied to Python, where brackets balance per statement,
+    and only inside the handful of files that mention readelf at all. Shell is
+    excluded: ``awk '{print $1}'`` would read as an open brace forever.
+    """
+    depth = 0
+    for char in text:
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+    return depth > 0
+
+
+def _logical_lines(text: str, *, brackets: bool = False) -> list[tuple[int, str]]:
     """Fold continued physical lines into commands, as ``(first_lineno, text)``.
 
     Comment-only lines are dropped, so explaining the double count in a comment
-    does not read as committing one.
+    does not read as committing one. ``brackets`` additionally folds an unclosed
+    call across lines, which is how a Python invocation wraps.
     """
     commands: list[tuple[int, str]] = []
     buffer = ""
@@ -101,6 +136,8 @@ def _logical_lines(text: str) -> list[tuple[int, str]]:
             continue
         if buffer.endswith(_CONTINUATIONS):
             continue
+        if brackets and _has_open_bracket(buffer):
+            continue
         commands.append((start, buffer))
         buffer = ""
     if buffer:
@@ -108,8 +145,22 @@ def _logical_lines(text: str) -> list[tuple[int, str]]:
     return commands
 
 
-def _kernel_counting_readelf_commands() -> list[tuple[Path, int, str]]:
-    """Every command in a tracked file that counts kernel symbols via llvm-readelf."""
+def _readelf_argv(command: str) -> str:
+    """The argv slice of every llvm-readelf invocation in a folded command.
+
+    Everything downstream of a pipe belongs to another tool and its flags are
+    not readelf's, so only these slices are searched for the bad spellings.
+    """
+    slices = []
+    for match in re.finditer("readelf", command):
+        rest = command[match.end() :]
+        end = _SEGMENT_END.search(rest)
+        slices.append(rest[: end.start()] if end else rest)
+    return " ".join(slices)
+
+
+def _symbol_table_reads() -> list[tuple[Path, int, str]]:
+    """Every readelf invocation in the tree that asks for a symbol table."""
     found: list[tuple[Path, int, str]] = []
     for path in _tracked_text_files():
         try:
@@ -120,21 +171,19 @@ def _kernel_counting_readelf_commands() -> list[tuple[Path, int, str]]:
             continue
         if path.resolve() == _SELF:
             continue
-        for lineno, command in _logical_lines(text):
-            if "readelf" not in command:
-                continue
-            if not any(marker in command for marker in _COUNTING_MARKERS):
-                continue
-            found.append((path.relative_to(_REPO_ROOT), lineno, command))
+        for lineno, command in _logical_lines(text, brackets=path.suffix == ".py"):
+            argv = _readelf_argv(command)
+            if argv and _SYMBOL_TABLE_FLAGS.search(argv):
+                found.append((path.relative_to(_REPO_ROOT), lineno, command))
     return found
 
 
 def test_kernel_counts_never_come_from_the_double_counting_table() -> None:
-    """No kernel count is derived from ``--symbols`` or an alias, which report 2x."""
+    """No symbol table is read with ``--symbols`` or an alias, which report 2x."""
     offenders = [
         (path, lineno, command)
-        for path, lineno, command in _kernel_counting_readelf_commands()
-        if _DOUBLE_COUNTING_FLAGS.search(command)
+        for path, lineno, command in _symbol_table_reads()
+        if _DOUBLE_COUNTING_FLAGS.search(_readelf_argv(command))
     ]
     assert not offenders, (
         "llvm-readelf --symbols (and its aliases -s / --syms, and -a / --all, "
@@ -144,18 +193,40 @@ def test_kernel_counts_never_come_from_the_double_counting_table() -> None:
     )
 
 
-def test_the_repro_script_still_counts_kernels() -> None:
+def test_the_repro_script_still_reads_a_symbol_table() -> None:
     """The guard above stays meaningful only while a real call site exists.
 
-    Without this, deleting the last kernel-counting line would leave the
+    Without this, deleting the last readelf invocation would leave the
     ``--symbols`` assertion vacuously true.
     """
-    call_sites = _kernel_counting_readelf_commands()
-    assert call_sites, "no kernel-counting readelf call site found; the guard above is vacuous"
+    call_sites = _symbol_table_reads()
+    assert call_sites, "no symbol-table readelf call site found; the guard above is vacuous"
     assert any("--dyn-syms" in command for _, _, command in call_sites), (
-        "expected at least one kernel count to use --dyn-syms; found:\n"
+        "expected at least one symbol-table read to use --dyn-syms; found:\n"
         + "\n".join(f"  {path}:{lineno}: {cmd}" for path, lineno, cmd in call_sites)
     )
+
+
+def test_reading_the_flag_survives_the_count_moving_to_another_statement() -> None:
+    """The reason the unit is the invocation and not the count.
+
+    The repro script reads into a variable so it can keep llvm-readelf's exit
+    status, then counts on the next line. A guard that required the invocation
+    and the kernel marker in one expression would see no call site at all here.
+    """
+    script = (
+        'if dynsyms="$(llvm-readelf --symbols "${OBJECT}" 2>/dev/null)"; then\n'
+        "    kernels=\"$(printf '%s\\n' \"${dynsyms}\" | grep -c 'FUNC.*GLOBAL')\"\n"
+        "fi\n"
+    )
+    reads = [
+        command
+        for _, command in _logical_lines(script)
+        if _SYMBOL_TABLE_FLAGS.search(_readelf_argv(command))
+    ]
+    assert len(reads) == 1, reads
+    assert "FUNC" not in reads[0], "the count is on the other line; that must not matter"
+    assert _DOUBLE_COUNTING_FLAGS.search(_readelf_argv(reads[0]))
 
 
 def test_a_wrapped_pipeline_is_still_seen_as_one_command() -> None:
@@ -186,24 +257,67 @@ def test_every_spelling_of_the_double_counting_flag_is_rejected() -> None:
     """
     for flag in ("--symbols", "--syms", "-s", "--all", "-a"):
         command = f"kernels=$(llvm-readelf {flag} \"${{OBJECT}}\" | grep -c 'FUNC.*GLOBAL')"
-        assert _DOUBLE_COUNTING_FLAGS.search(command), f"{flag} double-counts but is accepted"
+        argv = _readelf_argv(command)
+        assert _SYMBOL_TABLE_FLAGS.search(argv), f"{flag} reads a symbol table"
+        assert _DOUBLE_COUNTING_FLAGS.search(argv), f"{flag} double-counts but is accepted"
 
     good = "kernels=$(llvm-readelf --dyn-syms \"${OBJECT}\" | grep -c 'FUNC.*GLOBAL')"
-    assert not _DOUBLE_COUNTING_FLAGS.search(good), "the correct flag must not be flagged"
+    argv = _readelf_argv(good)
+    assert _SYMBOL_TABLE_FLAGS.search(argv), "--dyn-syms is still a symbol-table read"
+    assert not _DOUBLE_COUNTING_FLAGS.search(argv), "the correct flag must not be flagged"
+
+
+def test_a_downstream_tools_options_are_not_read_as_readelf_flags() -> None:
+    """Flags belong to the command that owns them.
+
+    ``grep`` has its own ``-a`` and ``-s``, and they say nothing about which
+    symbol table readelf printed. Searching the whole folded pipeline would
+    reject these correct call sites.
+    """
+    for downstream in ("grep -a -c 'FUNC.*GLOBAL'", "grep -s -c 'FUNC.*GLOBAL'"):
+        command = f'kernels=$(llvm-readelf --dyn-syms "${{OBJECT}}" | {downstream})'
+        assert not _DOUBLE_COUNTING_FLAGS.search(_readelf_argv(command)), (
+            f"{downstream} is downstream of the pipe; its options are not readelf's"
+        )
+
+    # The same pipeline with the bad flag on readelf itself is still caught, so
+    # the narrowing above did not simply disarm the check.
+    bad = "kernels=$(llvm-readelf --symbols \"${OBJECT}\" | grep -a -c 'FUNC.*GLOBAL')"
+    assert _DOUBLE_COUNTING_FLAGS.search(_readelf_argv(bad))
+
+
+def test_a_wrapped_python_invocation_is_one_expression() -> None:
+    """Python wraps on brackets, not on backslashes.
+
+    A ``subprocess`` argv list split over lines puts the tool name and the flag
+    on different ones, which the shell fold alone would not join.
+    """
+    module = 'out = subprocess.check_output(\n    ["llvm-readelf",\n     "--symbols", obj]\n)\n'
+    commands = _logical_lines(module, brackets=True)
+    assert len(commands) == 1, commands
+    assert _DOUBLE_COUNTING_FLAGS.search(_readelf_argv(commands[0][1]))
+
+    # Without bracket folding the flag lands in its own record, away from the
+    # tool name, and nothing matches -- which is why the shell fold is not enough.
+    assert not any(
+        _DOUBLE_COUNTING_FLAGS.search(_readelf_argv(command))
+        for _, command in _logical_lines(module)
+    )
 
 
 def test_prose_is_not_a_call_site() -> None:
     """Re-wrapping a doc must never fail the guard above.
 
-    The doc quotes both the wrong flag and the ``.kd`` marker, so a reflow that
-    landed them on one line would read as a call site if prose were scanned.
-    The bait is asserted first: without it this would pass for the wrong reason.
+    The docs quote the wrong flag verbatim, so they would read as call sites if
+    prose were scanned. The bait is asserted first: without it this would pass
+    for the wrong reason.
     """
     doc = _REPO_ROOT / "docs/sanitizers/consan-4112-overlapping-anchor-patches.md"
     text = doc.read_text(encoding="utf-8")
-    assert "llvm-readelf --symbols" in text and ".kd" in text, (
-        "bait is gone: this doc no longer quotes the flag and the marker the scan looks for"
+    assert "llvm-readelf --symbols" in text, (
+        f"bait is gone: {doc.name} no longer quotes the flag the scan looks for"
     )
     assert not _runs_commands(doc, text)
-    flagged = {path for path, _, _ in _kernel_counting_readelf_commands()}
-    assert doc.relative_to(_REPO_ROOT) not in flagged
+
+    # The property, not just this one file: prose is never a call site.
+    assert not [path for path, _, _ in _symbol_table_reads() if path.suffix == ".md"]

--- a/tests/sanitizers/test_kernel_count_mechanism.py
+++ b/tests/sanitizers/test_kernel_count_mechanism.py
@@ -7,6 +7,11 @@ Tensile object (490 / 1554 / 682 kernels) were all 2x for this reason, and the
 490 was quoted in four places before it was caught. ``--dyn-syms`` reads the one
 table and is the correct source.
 
+The flag has spellings. ``-s`` and ``--syms`` are aliases of ``--symbols``, and
+``-a`` / ``--all`` expands to ``-h -l -S -s -r -d -V -A -I`` -- which includes
+``-s``, so it double-counts too. All five are rejected; matching only the long
+form would let the same bug back in under a shorter name.
+
 The check is phrased as the property rather than as a diff against one known-bad
 line, so a new caller anywhere in the tree inherits it.
 
@@ -25,6 +30,7 @@ That is a real double count, and matching physical lines would miss it.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -41,6 +47,11 @@ _COUNTING_MARKERS = ("FUNC", ".kd")
 # Only files that can run a command. Markdown and friends are excluded on
 # purpose: they describe call sites rather than being them.
 _COMMAND_SUFFIXES = frozenset({".sh", ".bash", ".zsh", ".py", ".yaml", ".yml"})
+
+# Every spelling that makes llvm-readelf emit .symtab alongside .dynsym. Matched
+# as whole tokens: a substring test for "-s" would fire on "--dyn-syms", which is
+# the flag we want people to use.
+_DOUBLE_COUNTING_FLAGS = re.compile(r"(?<![\w-])(?:--symbols|--syms|--all|-s|-a)(?![\w-])")
 
 # A physical line ending in one of these operators is continued by the next one,
 # so the two are a single command as far as the shell is concerned. A trailing
@@ -119,14 +130,15 @@ def _kernel_counting_readelf_commands() -> list[tuple[Path, int, str]]:
 
 
 def test_kernel_counts_never_come_from_the_double_counting_table() -> None:
-    """No kernel count is derived from ``--symbols``, which reports 2x."""
+    """No kernel count is derived from ``--symbols`` or an alias, which report 2x."""
     offenders = [
         (path, lineno, command)
         for path, lineno, command in _kernel_counting_readelf_commands()
-        if "--symbols" in command
+        if _DOUBLE_COUNTING_FLAGS.search(command)
     ]
     assert not offenders, (
-        "llvm-readelf --symbols prints .dynsym and .symtab, so counting kernel "
+        "llvm-readelf --symbols (and its aliases -s / --syms, and -a / --all, "
+        "which includes -s) prints .dynsym and .symtab, so counting kernel "
         "symbols across it double-counts; use --dyn-syms:\n"
         + "\n".join(f"  {path}:{lineno}: {cmd}" for path, lineno, cmd in offenders)
     )
@@ -163,6 +175,21 @@ def test_a_wrapped_pipeline_is_still_seen_as_one_command() -> None:
     assert lineno == 2, "the comment above it is not part of the command"
     assert "--symbols" in command and "FUNC" in command
     assert "\\" not in command, "the continuation marker is consumed by the fold"
+
+
+def test_every_spelling_of_the_double_counting_flag_is_rejected() -> None:
+    """The bug can come back under a shorter name, so pin all of them.
+
+    ``-s`` and ``--syms`` are aliases of ``--symbols``; ``-a`` / ``--all``
+    expands to a set that includes ``-s``. ``--dyn-syms`` is the correct flag
+    and must not be caught by the ``-s`` arm -- it contains those two characters.
+    """
+    for flag in ("--symbols", "--syms", "-s", "--all", "-a"):
+        command = f"kernels=$(llvm-readelf {flag} \"${{OBJECT}}\" | grep -c 'FUNC.*GLOBAL')"
+        assert _DOUBLE_COUNTING_FLAGS.search(command), f"{flag} double-counts but is accepted"
+
+    good = "kernels=$(llvm-readelf --dyn-syms \"${OBJECT}\" | grep -c 'FUNC.*GLOBAL')"
+    assert not _DOUBLE_COUNTING_FLAGS.search(good), "the correct flag must not be flagged"
 
 
 def test_prose_is_not_a_call_site() -> None:


### PR DESCRIPTION
## Summary

Two independent inaccuracies about the heavy f32 Tensile code object, both already on `main`.

**1. Every kernel count was 2x.** `llvm-readelf --symbols` prints `.dynsym` *and* `.symtab`, and a kernel is listed in both, so counting kernel symbols across that output reports exactly twice the real number. Measured on a real gfx950 `SS_SS ... Ailk_Bjlk` object:

```
--symbols  : 682
--dyn-syms : 341
.kd in .dynsym (ground truth): 341
```

`docs/sanitizers/repro/consan_4112_repro.sh` counted with `--symbols`, so every figure it printed was double, and the `490 kernels` quoted for the ROCm 7.0.2.2 object in the script, the `consan-4112` doc (twice), `waitcheck.py` and -- since #409 merged -- its growth-cap doc is really `245`.

**2. Two comments implied the size is what hipBLASLt installs.** It isn't. The shipped `.co` is a zlib-compressed offload bundle (`CCOB` magic, method 1); the hundreds-of-MB figure is what `clang-offload-bundler --unbundle` expands it to. On the ROCm 10 tree the four CU256 SS layouts measure 2.6-4.8 MB on disk and inflate 38-45x:

| Layout (`CU256_ID75a0`) | On disk | Unbundled | Ratio |
|---|--:|--:|--:|
| `Ailk_Bjlk` | 4,081,640 | 169,996,760 | 41.6x |
| `Ailk_Bljk` | 3,677,962 | 162,676,656 | 44.2x |
| `Alik_Bjlk` | 2,636,536 | 100,901,192 | 38.3x |
| `Alik_Bljk` | 4,759,691 | 213,989,336 | 45.0x |

`selection.py`'s "hundreds of MB for a Tensile bundle" was wrong by ~40x for the bundle it names. Reworded to say the unbundled object.

## Review round 1 (@vivekkhandelwal1 CHANGES_REQUESTED, Copilot)

The blocking item was real and self-inflicted: the sentence introducing the shipped-vs-unbundled distinction said 16,265,200 bytes inflate ~40x *and* that the installed file is "a few MB", which cannot both hold -- ~40x implies ~397 KiB. The ~40x was also measured on the ROCm 10 CU256 layouts and applied unmarked to a ROCm 7.0.2.2 object that was never measured and no longer exists, in the same paragraph that is careful to label `245` as a correction rather than a re-measurement. Both figures are gone; the ROCm 10 range stays but is labelled as a different object on a different stack. The repro script's echo carried the same transplanted ~40x and is reworded the same way, and line 65 -- where a reader meets the byte figure first -- now says `unbundled`.

## Review round 2 (Copilot, on the round-1 push)

Two more real findings, both fixed in `99f3127a`.

**The guard matched one spelling of a flag that has five.** `llvm-readelf --help` documents `-s --syms` with `--symbols` as an alias of `--syms`, and `-a --all` expands to `-h -l -S -s -r -d -V -A -I` -- which includes `-s`, so it reaches the same doubled output. Detection is now a whole-token regex over all five; a substring test was not an option because `--dyn-syms` contains `-s`. `test_every_spelling_of_the_double_counting_flag_is_rejected` pins each spelling and asserts `--dyn-syms` stays clean. Each one, substituted at the real call site, wrapped across two lines, with a benign `--dyn-syms` site alongside: `bash -n` clean and failing the `--symbols` assertion in all five cases.

**`selection.py` contradicted this PR's own doc.** It stated flatly that the shipped Tensile bundle is compressed, in generic hashing code, while the doc had just been changed to say ROCm 7.0.2 packaging is unknown. The clause is dropped rather than qualified -- the docstring exists to justify streaming, and the unbundled size does that alone.

A third comment, on the repro script's echo, was already fixed by `cbf5db02` before it landed.

## Review round 3 (Copilot, on the round-2 push)

Three findings, all real, all fixed in `c5e80bdc` -- plus one that this PR now owns because the world moved.

**The alias regex searched the whole pipeline, so it rejected correct code.** `llvm-readelf --dyn-syms x | grep -a -c 'FUNC'` was flagged, because `grep`'s `-a` was read as readelf's. Flags now come from the argv slice between the tool name and the next pipeline operator. A downstream-option fixture covers `grep -a` and `grep -s`, and asserts the same pipeline with the bad flag *on readelf* is still caught, so the narrowing did not just disarm the check.

**The repro script inferred a cause from a zero count.** With the pipe swallowing `llvm-readelf`'s exit status and stderr discarded, an unreadable object counted `0` and was reported as `no .dynsym in object`. It now reads into a variable so the status survives, and a zero says only what was observed. Exercised against real files rather than reasoned about:

| Input | Reported |
| --- | --- |
| real shared object | `2085 kernels`, matching `--dyn-syms \| grep -c` ground truth |
| non-ELF file | `unknown (could not read the object)` |
| nonexistent path | `unknown (could not read the object)` |
| ELF `.o` with no `.dynsym` | `0 (no kernel symbols found)` |

**The guard's unit is now the invocation, not the count.** Fixing the exit status above split the read from the count in the repro script -- which immediately broke this PR's own vacuity test, making Copilot's separate point about multi-statement Python a live bug rather than a hypothetical. So instead of narrowing the claim, the unit changed: a call site is *any readelf that asks for a symbol table*, and the only question asked is which one. The flag and the tool name are then in the same argv by construction, so where the counting happens cannot matter and no data-flow analysis is needed. Python invocations additionally fold on an unclosed bracket, since a `subprocess` argv list wraps that way; shell deliberately does not, because `awk '{print $1}'` would read as a permanently open brace. The trade -- a `readelf --symbols` used for something other than counting kernels would also be flagged -- is stated in the module docstring.

**#409 merged, so its `490` is now live on `main`.** `consan-gemm-patched-image-growth-cap.md:46` describes the same 16,265,200-byte object; corrected to 245 with provenance, plus a note that no ratio in that doc moves (all are byte- or access-site-derived; I re-derived 11.8x, 9.3x and >= 778%). Its line-144 `244` is left alone: parity clears the other counts in those tables (71, 73, 471, 85, 1 are odd and cannot be doubled) but not that one, and the bundle is not on this host -- substituting a plausible number is the mistake this PR exists to fix.

Mutation-checked on the new design, each mutant `bash -n` clean and carrying a decoy `--dyn-syms` site so the vacuity test cannot catch it incidentally: all five spellings fail the `--symbols` assertion, deleting the invocation fails the vacuity assertion, and the `grep -a -s` false positive passes. 485 tests green.

## Scope notes

- `waitcheck.py` keeps its `~16MB` figure and the timing it is coupled to. Only the kernel count was wrong there; re-stating the size would need the timing re-measured, which this PR does not do.
- The counts are corrected where they describe the ROCm 7.0.2.2 object. That object is not on the gate host, so `245` is the double count halved rather than a re-measurement, and the doc says so. Nothing in the `4112` analysis depends on the count.
- The equivalent figures introduced by the ROCm 10 flip are fixed separately in #411, which owns them.

## Test plan

- [x] New `tests/sanitizers/test_kernel_count_mechanism.py` pins the *property* (no kernel count derived from `--symbols`), not just the one call site, so a new caller inherits the guard. It also asserts a real call site still exists, so deleting the last one cannot make the guard vacuous.
- [x] The scan folds backslash and trailing-operator continuations into one logical command before matching, so a pipeline split across two physical lines -- the natural shape once the command grows -- is not invisible to it. Scanning is limited to files that can carry a command, so re-wrapping a paragraph that quotes the wrong flag cannot fail the suite. Scope is every tracked script, module and workflow; prose is deliberately out of scope, and the guard file itself is excluded because it spells out the pattern it forbids.
- [x] Mutation-checked, each mutant valid `bash -n` and failing a small named set:

  | Mutation | Result |
  | --- | --- |
  | flag reverted to `--symbols` in place | 2 failed |
  | call site deleted | 1 failed (vacuity guard) |
  | `--symbols` wrapped with `\` + a decoy `--dyn-syms` site | 1 failed (was **2 passed** before this round) |
  | `--symbols` split on a bare trailing `\|` + decoy | 1 failed (was **2 passed** before this round) |
  | doc reflowed so `.kd` lands on the `--symbols` line | 4 passed (was **failing** before this round) |
- [x] `ruff check` clean on all changed Python files.
- [x] `bash -n` clean on the repro script.
- [x] `tests/sanitizers` + `tests/instrumentation/rocjitsu_sanitizers`: 455 passed, 2 skipped (the skips are GPU-marked). Wider `tests/instrumentation`: 1731 passed. The 3 failures in `test_env_knob_audit.py` / `test_environment.py` are unrelated to this diff and reproduce identically on pristine `origin/main` (verified in a clean worktree).



