### PR TITLE
feat(instrumentation): make Proton's AMD backends usable, with an example each

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -98,10 +98,17 @@ jobs:
             # without it, so a PR touching only the probe ran neither the audit
             # nor the GPU-gated tests in that file.
             'src/aorta/instrumentation/environment.py'
+            # The Proton collector attaches a profiler to a real GPU launch, so
+            # its behaviour is only observable on hardware: the CPU suite can
+            # assert the argv and the env bundle, but not that the capture came
+            # back with kernels in it. Listed with its smoke test because a
+            # backend pin that silently records nothing passes every CPU check.
+            'src/aorta/instrumentation/proton/*'
             'scripts/audit_env_knobs.py'
             'tests/hw_queue_eval/*'
             'tests/instrumentation/test_environment.py'
             'tests/instrumentation/test_env_knob_audit.py'
+            'tests/instrumentation/test_proton_smoke_gpu.py'
             'tests/instrumentation/rocjitsu_sanitizers/*'
             'tests/sanitizers/*'
             'tests/test_marker_partition.py'

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -211,11 +211,13 @@ Precedence and scope:
 | Option | Values | Default | Notes |
 |---|---|---|---|
 | `mode` | `cli`, `env` | `cli` | See [Attach modes](#proton-attach-modes). |
-| `backend` | `auto`, `rocprofiler`, `roctracer`, `instrumentation`, `cupti` | `auto` | `auto` omits Proton's `-b` and lets Proton pick the backend matching the active runtime — `rocprofiler` where rocprofiler-sdk is available, `roctracer` otherwise. It is the only portable spelling and is why it is the default: **naming a backend is a version commitment.** `rocprofiler` is the preferred AMD backend upstream but Triton 3.7.x and earlier accept only `cupti`/`roctracer`/`instrumentation` and exit with an argparse `invalid choice: 'rocprofiler'` before the payload runs. `roctracer` is the deprecated AMD predecessor; `instrumentation` the intra-kernel path; `cupti` the NVIDIA one, accepted so a recipe stays portable even though aorta's examples are AMD. Pin a backend when you need to know exactly which one measured. |
+| `backend` | `auto`, `rocprofiler`, `roctracer`, `instrumentation`, `cupti` | `auto` | `auto` omits Proton's `-b` and lets Proton pick the backend matching the active runtime — `rocprofiler` where rocprofiler-sdk is available, `roctracer` otherwise. It is the only portable spelling and is why it is the default: **naming a backend is a version commitment, and on AMD it is an attach-mode commitment too.** `rocprofiler` is the preferred AMD backend upstream but Triton 3.7.x and earlier accept only `cupti`/`roctracer`/`instrumentation` and exit with an argparse `invalid choice: 'rocprofiler'` before the payload runs. `roctracer` is the deprecated AMD predecessor; `instrumentation` the intra-kernel path; `cupti` the NVIDIA one, accepted so a recipe stays portable even though aorta's examples are AMD. Pinning `roctracer` or `rocprofiler` means `mode: env` and a payload that drives Proton itself: under the default `mode: cli` such a pin captures an empty tree, and the collector refuses the combination — see [Pinning an explicit AMD backend](#pinning-an-explicit-amd-backend). `instrumentation` measures *inside* a kernel and publishes **no numeric metrics** — its leaves carry `cycles` / `normalized_cycles`, never `time (<unit>)`, so such a trial reports `proton_artifact_dir` and nothing else. |
+| `backend_mode` | `pcsampling`, `periodic_flushing` | (unset) | Proton's per-backend `--mode`. **Requires an explicit (non-`auto`) backend**, because which values are valid depends on which backend runs: `rocprofiler` takes both, `roctracer` only `periodic_flushing`, `cupti` both. Not valid on `backend: instrumentation`, whose modes are the `instrumentation_mode` key, and rejected together with `instrumentation_mode` — both render into Proton's single `--mode` argument. The two AMD backends it applies to need `mode: env` for the reason given in the `backend` row. |
 | `context` | `shadow`, `python` | `shadow` | How a kernel's time is attributed to a calling frame. |
 | `data` | `tree`, `trace` | `tree` | `tree` writes the `.hatchet` file the parser reads; `trace` writes a chrome trace instead, so it produces no numeric metrics. |
-| `instrumentation_mode` | `default`, `mma`, `pcsampling` | (unset) | **Requires `backend: instrumentation`.** |
-| `granularity` | `cta`, `warp`, `warp_2`, `warp_4`, `warp_8`, `warp_group`, `warp_group_2`, `warp_group_4`, `warp_group_8` | (unset) | **Requires `backend: instrumentation`.** |
+| `instrumentation_mode` | `default`, `mma`, `pcsampling` | (unset) | **Requires `backend: instrumentation`.** Takes effect only under `mode: env`: the shipped Triton CLI parses `-m/--mode` and never forwards it to `start()`, so it is a silent no-op under `mode: cli`. |
+| `granularity` | `cta`, `warp`, `warp_2`, `warp_4`, `warp_8`, `warp_group`, `warp_group_2`, `warp_group_4`, `warp_group_8` | (unset) | **Requires `backend: instrumentation`.** Unusable on Triton 3.7.1 in either attach mode: dropped by the CLI like `instrumentation_mode`, and under `mode: env` the rendered `default:granularity=warp` string fails at kernel exit with `RuntimeError: Only warp granularity is supported for now`. Warp is that backend's own default there, so leave it unset. |
+| `hook` | `triton` | (unset) | Renders Proton's `-k triton` under `mode: cli`; exported as `AORTA_PROTON_HOOK` under `mode: env`. Registers Proton's launch hook, which records Triton kernel launch metadata alongside the timing. |
 
 `instrumentation_mode` and `granularity` are rejected with an actionable
 error on any other backend rather than accepted-and-ignored: Proton would
@@ -223,8 +225,24 @@ silently produce a profile you did not ask for. Together they render into
 Proton's single `--mode` argument as
 `<instrumentation_mode>:granularity=<granularity>`, with
 `instrumentation_mode` defaulting to `default` when only `granularity` is
-set. When neither is set the collector omits `--mode` entirely and Proton
-keeps its own default.
+set. `backend_mode` renders into that same argument, which is why the two
+cannot be combined. When none of them is set the collector omits `--mode`
+entirely and Proton keeps its own default.
+
+Both intra-kernel knobs are **`mode: env` knobs today**, whatever the recipe
+says. Triton 3.7.1's Proton front-end parses `-m/--mode` and then calls
+`start()` without it, so the value the CLI wrap renders is dropped on the
+floor; upstream `main` forwards it. Under `mode: env` the payload reads
+`AORTA_PROTON_MODE` and passes it to `proton.start(mode=...)` itself, which
+is the only route by which either knob reaches Proton on a released Triton.
+`granularity` does not survive even that route on Triton 3.7.1: the rendered
+`default:granularity=warp` is rejected inside
+`libproton.exit_instrumented_op` (the bare `default` and other knobs such as
+`buffer_size` are accepted, and the typed
+`triton.profiler.mode.Default(granularity="warp")` object works). Warp
+granularity is that backend's default on that version anyway, so the
+`amd-instrumentation` example sets `instrumentation_mode` and omits
+`granularity` deliberately.
 
 ### Proton attach modes
 
@@ -297,7 +315,75 @@ merge into the subprocess env. It never mutates `os.environ`.
 | `AORTA_PROTON_BACKEND` | `backend` option value; **absent on the default `backend: auto`**, so the workload passes `backend=None` and gets Proton's own selection |
 | `AORTA_PROTON_CONTEXT` | `context` option value |
 | `AORTA_PROTON_DATA` | `data` option value |
-| `AORTA_PROTON_MODE` | Rendered `--mode` value; absent when no intra-kernel knob is set |
+| `AORTA_PROTON_MODE` | Rendered `--mode` value — the intra-kernel pair or `backend_mode`; absent when none of them is set |
+| `AORTA_PROTON_HOOK` | `hook` option value, for `proton.start(hook=...)`; absent when unset |
+
+#### Pinning an explicit AMD backend
+
+An explicit `backend: roctracer` or `backend: rocprofiler` belongs with
+`mode: env`, and only there. Proton's CLI front-end calls its own
+`_select_backend()` **only when `-b` is absent**, and that call initialises
+the Triton HIP driver as a side effect. `roctracer` records nothing unless it
+starts *after* the HIP runtime is up, so naming the backend removes the very
+step that makes the capture work — and Proton does not complain.
+
+Measured on the shipped `triton-vecadd` payload (8x gfx950 / MI355X, ROCm
+7.0.2, Triton 3.7.1, PyTorch 2.13.0+rocm7.2), 3/3 deterministic:
+
+| Wrap | Result |
+|---|---|
+| no `-b` (aorta's `backend: auto`) | ~3 KB hatchet, 27 dispatches across 5 kernels |
+| `-b roctracer` | 160-byte hatchet, `ROOT` frame with empty metrics |
+
+Both runs exit 0. Ordering alone accounts for the difference: driving Proton
+from the Python API with `import torch` deferred past `proton.start()`
+reproduces the empty tree (160 bytes), and initialising the driver before
+`start()` gives a populated one (~1.6 KB with kernels).
+
+`rocprofiler` is guarded on the same grounds without a measurement of its
+own — no obtainable Triton has that backend (see
+[`amd-rocprofiler`](../examples/profiling/proton/amd-rocprofiler/README.md)),
+so what is verified for it is the mechanism, not the outcome: upstream
+`main`'s front-end has the identical `args.backend if args.backend else
+_select_backend()` line, and it is the same queue-intercepting family.
+
+In aorta the consequence is a quiet one: `parse_summary` finds no leaf
+metrics in a `ROOT`-only tree, so the trial exits 0 carrying only
+`proton_artifact_dir` — no `proton_gpu_time_ms`, no kernel names, nothing to
+notice in `perf.md`. The collector therefore refuses the combination at
+setup: `mode: cli` with an explicit `backend` of `roctracer` or
+`rocprofiler` raises `ProtonWrapError` naming `mode: env` as the route.
+
+The guard covers exactly the two queue-intercepting AMD backends, and
+`instrumentation` is deliberately not among them: it installs no queue
+interceptor, and a `-b instrumentation` CLI wrap of a payload that carries
+intra-kernel scopes captures them correctly (verified — 1738 bytes, both
+scopes, cycle counts intact). What that backend loses under `mode: cli` is
+`--mode`, not the capture, which is a different limitation with the same
+remedy — see the `instrumentation_mode` row above. `cupti` is not an AMD path
+and is untested here.
+
+`backend: auto` is unaffected, and this is why it is the default: omitting
+`-b` is exactly what keeps Proton's own driver-initialising selection step in
+the picture.
+
+To pin a backend, use `mode: env` and a payload that imports torch and then
+calls `proton.start()` itself:
+
+```yaml
+collect:
+  proton:
+    mode: "env"
+    backend: "roctracer"
+    context: "shadow"
+    data: "tree"
+```
+
+[`examples/profiling/proton/amd-roctracer/`](../examples/profiling/proton/amd-roctracer/)
+is that recipe with a working payload;
+[`amd-instrumentation/`](../examples/profiling/proton/amd-instrumentation/)
+and [`amd-rocprofiler/`](../examples/profiling/proton/amd-rocprofiler/) are
+the same shape for the other two backends.
 
 ### Device selection on AMD
 
@@ -432,7 +518,13 @@ numeric scalars only — and are readable from the per-trial dispatcher JSON at
 `.result.metrics`, which is where the `jq` recipes below look for them.
 
 Only `<c>_artifact_dir` is guaranteed. A capture with no kernel data
-contributes just that key.
+contributes just that key, and so does a capture whose data the parser does
+not speak. Proton's `instrumentation` backend is the standing example of the
+second case: a working intra-kernel capture carries `cycles` and
+`normalized_cycles` on its leaves, not `time (<unit>)` and not `count`. The
+parser keys exclusively on `time (<unit>)`, so an `instrumentation` trial
+publishes no numeric metrics at all however healthy the capture is — read the
+tree with `proton-viewer -m normalized_cycles` instead.
 
 ## Analysis recipes
 
@@ -529,14 +621,51 @@ run on a host with a system ROCm install (where both spellings exist).
 **`invalid choice: 'rocprofiler'` from Proton, before the payload runs.**
 The installed Triton predates the `rocprofiler` backend. Drop the pin and
 let the default `backend: auto` choose — that is what it is for. See the
-`backend` row of the [Proton options](#proton-options) table.
+`backend` row of the [Proton options](#proton-options) table. No released
+Triton has the backend: 3.7.1, 3.7.0 and 3.6.0+rocm7.2.4 all offer
+`-b {cupti,roctracer,instrumentation}`, PyPI's newest `triton` is 3.7.1, and
+PyTorch's ROCm nightly tops out at `pytorch-triton-rocm` 3.6.0.
+`python -m triton.profiler.proton --help` lists what your build accepts;
+Triton `main` derives that list from `libproton.get_available_profilers()`,
+whose absence (an `AttributeError`) is the quickest check that a build
+predates the backend.
+
+**`proton mode 'cli' cannot pin backend 'roctracer'`** (or
+`'rocprofiler'`), at setup. The full message states the mechanism:
+
+> Proton's command front-end calls `_select_backend()` only when `-b` is
+> absent, and that call is what initialises the GPU runtime, so a pinned
+> queue-intercepting backend starts before the first HSA queue exists and
+> records nothing: the profile comes back as an empty ROOT frame and the
+> trial reports no proton metrics while exiting 0. Use
+> `proton: {mode: env}` with a payload that calls `proton.start()` after the
+> runtime is up (see `examples/profiling/proton/amd-roctracer`), or leave
+> `backend: auto`, which omits `-b` and is unaffected.
+
+See [Pinning an explicit AMD backend](#pinning-an-explicit-amd-backend) for
+the measured evidence. `instrumentation` and `cupti` are not refused: the
+first does not interpose on queues, and the second is not an AMD path.
+
+**`RuntimeError: Only warp granularity is supported for now`, raised at
+kernel exit from `libproton.exit_instrumented_op`.** Triton 3.7.1's
+instrumentation backend rejects the rendered `<mode>:granularity=<value>`
+string that the `granularity` option produces, even for `granularity: warp`
+— which is that backend's own default. Drop `granularity` from the recipe
+and keep `instrumentation_mode` alone. See the `granularity` row of the
+[Proton options](#proton-options) table.
 
 **A Proton profile with a ROOT node and no children.** Proton's queue
 interceptor has to be installed before the first HSA queue is created; a
 run that initialises the GPU earlier captures nothing and still exits 0.
 The default `backend: auto` avoids this by construction, because Proton's
 own backend selection initialises the runtime before the session starts.
-An explicit backend pin skips that step, so pin one only when you need to.
+An explicit `roctracer` / `rocprofiler` pin skips that step, which is why
+the collector now refuses those two under `mode: cli` and points at
+`mode: env` instead — see
+[Pinning an explicit AMD backend](#pinning-an-explicit-amd-backend) for the
+mechanism and the measured sizes. Under `mode: env` the payload owns the
+ordering: import torch (or otherwise touch the GPU) *before*
+`proton.start()`.
 
 **No `.hatchet` written at all, and the payload exited 0.** The payload
 ended by raising `SystemExit` (`raise SystemExit(main())`, or a bare
@@ -572,12 +701,15 @@ for instance). That is a legitimate outcome, so parsing is fail-soft and
 you get only `<c>_artifact_dir`. Check the payload actually dispatched a
 kernel before suspecting the collector.
 
-**`<c>_artifact_dir` present but no numeric metrics.** Three common causes:
+**`<c>_artifact_dir` present but no numeric metrics.** Four common causes:
 `output_format` is not `csv` (the parser reads CSV only), `data: trace`
-rather than `tree` on the Proton side (no `.hatchet` to walk), or the
-payload dispatched nothing. Malformed or partial artifacts degrade the same
-way — an opt-in measurement never turns an otherwise-healthy trial into a
-failure.
+rather than `tree` on the Proton side (no `.hatchet` to walk), the payload
+dispatched nothing, or `backend: instrumentation`, whose leaves carry
+`cycles` / `normalized_cycles` instead of the `time (<unit>)` the parser
+keys on — that last one is expected, not a fault, and the tree itself is
+fine (see [Metrics](#metrics)). Malformed or partial artifacts degrade the
+same way — an opt-in measurement never turns an otherwise-healthy trial into
+a failure.
 
 **`collect: <name> requested but no _aorta_collect_dir was threaded into the
 trial config (non-writing rank?); skipping.`** The platform only threads the
@@ -633,7 +765,10 @@ Two consequences worth internalising:
   the opposite. A collector that cannot run (no `rocprofv3`, a Proton wrap of
   a command its front end cannot execute, no `env(1)` for a device
   translation, an artifact directory that cannot be prepared) fails the
-  trial's setup rather than running it unprofiled. And a profiler is a real
+  trial's setup rather than running it unprofiled. A configuration that would
+  run and measure nothing is refused there too: a `mode: cli` pin of
+  `roctracer` / `rocprofiler` (see
+  [Pinning an explicit AMD backend](#pinning-an-explicit-amd-backend)). And a profiler is a real
   process in the trial: its own non-zero exit is the trial's exit code, and
   `rocprof`'s `simple_timer` stderr lines are visible to the classifier's
   stderr detectors (see [Troubleshooting](#troubleshooting)). Profiling is a
@@ -660,8 +795,10 @@ the Proton wrap reads and rewrites them — see
 
 ## See also
 
-- [`examples/profiling/README.md`](../examples/profiling/README.md) — four
-  runnable examples (HIP GEMM, torch matmul, Triton vecadd, Triton softmax).
+- [`examples/profiling/README.md`](../examples/profiling/README.md) — seven
+  runnable examples (HIP GEMM, torch matmul, Triton vecadd, Triton softmax,
+  plus one per pinned AMD Proton backend: roctracer, instrumentation,
+  rocprofiler).
 - [`recipes/README.md`](../recipes/README.md#schema-rules-full-detail) — the
   `collect:` schema, cell-level overrides, CLI precedence.
 - [`docs/layer-numerics.md`](layer-numerics.md) — the other documented

--- a/examples/profiling/README.md
+++ b/examples/profiling/README.md
@@ -17,6 +17,9 @@ at.
 | [`rocprof/torch-matmul`](rocprof/torch-matmul/) | hipBLASLt / rocBLAS GEMM kernels PyTorch picks for `a @ b` | `torch` for ROCm. Container. | `aorta sweep run --recipe examples/profiling/rocprof/torch-matmul/recipe.yaml --output ./profiling_results -- python examples/profiling/rocprof/torch-matmul/matmul.py` |
 | [`proton/triton-vecadd`](proton/triton-vecadd/) | One Triton elementwise kernel, launch-site attribution | `torch` + `triton` for ROCm. Container. | `aorta sweep run --recipe examples/profiling/proton/triton-vecadd/recipe.yaml --output ./profiling_results -- python examples/profiling/proton/triton-vecadd/vecadd.py` |
 | [`proton/triton-softmax`](proton/triton-softmax/) | A Triton fused reduction, Python-frame attribution | `torch` + `triton` for ROCm. Container. | `aorta sweep run --recipe examples/profiling/proton/triton-softmax/recipe.yaml --output ./profiling_results -- python examples/profiling/proton/triton-softmax/softmax.py` |
+| [`proton/amd-roctracer`](proton/amd-roctracer/) | Three Triton kernels in sequence, whole-kernel attribution on a pinned `roctracer` backend | `torch` + `triton` for ROCm. Container. `roctracer` is the one AMD backend every released Triton has. | `aorta sweep run --recipe examples/profiling/proton/amd-roctracer/recipe.yaml --output ./profiling_results -- python examples/profiling/proton/amd-roctracer/pipeline.py` |
+| [`proton/amd-instrumentation`](proton/amd-instrumentation/) | Two named scopes *inside* one unbalanced Triton kernel — intra-kernel attribution | `torch` + `triton` for ROCm. Container. The only Proton backend that coexists with `rocprofv3`; publishes no numeric metrics, only `proton_artifact_dir`. | `aorta sweep run --recipe examples/profiling/proton/amd-instrumentation/recipe.yaml --output ./profiling_results -- python examples/profiling/proton/amd-instrumentation/hotspot.py` |
+| [`proton/amd-rocprofiler`](proton/amd-rocprofiler/) | Statistical instruction-level attribution (`backend_mode: pcsampling`) instead of whole-kernel spans | `torch` + `triton` for ROCm. Container. **Triton `main`**: no released Triton carries the `rocprofiler` backend, so this one ships documented but unverified. | `aorta sweep run --recipe examples/profiling/proton/amd-rocprofiler/recipe.yaml --output ./profiling_results -- python examples/profiling/proton/amd-rocprofiler/gelu.py` |
 
 ## Start here
 
@@ -33,8 +36,8 @@ aorta sweep run \
   -- /tmp/hip_gemm 512 20
 ```
 
-The other three need a PyTorch-for-ROCm interpreter (and Triton, for the
-Proton pair). The reference way to get one is a ROCm PyTorch container with
+The other six need a PyTorch-for-ROCm interpreter (and Triton, for the five
+Proton ones). The reference way to get one is a ROCm PyTorch container with
 aorta installed **inside** it — see each example's README. Running
 `aorta sweep run -- docker run ...` from the host instead would attach the
 profiler to the docker client, which dispatches no kernels and produces an
@@ -51,12 +54,19 @@ empty capture.
 together, so the pairing is rejected at recipe load. Only Proton's
 `instrumentation` backend coexists with `rocprof`.
 
-The Proton examples leave `backend: "auto"`, which omits Proton's `-b` and
-lets Proton pick the backend matching the active runtime. That is what makes
-them run out of the box across Triton versions: `rocprofiler` is the
+The two Triton examples leave `backend: "auto"`, which omits Proton's `-b`
+and lets Proton pick the backend matching the active runtime. That is what
+makes them run out of the box across Triton versions: `rocprofiler` is the
 preferred AMD backend upstream, but Triton 3.7.x and earlier accept only
 `cupti`/`roctracer`/`instrumentation` and exit with an argparse
 `invalid choice: 'rocprofiler'` before the payload runs.
+
+The three `amd-*` examples pin a backend instead, and therefore all use
+`mode: "env"` with a payload that calls `proton.start()` itself. Proton's CLI
+front-end initialises the HIP runtime only on the path where `-b` is absent,
+so a pinned backend under the default `mode: "cli"` captures an empty tree —
+the collector now refuses that combination rather than letting a trial pass
+with nothing in it.
 
 ## Where the collector options live
 
@@ -106,7 +116,7 @@ examples/profiling/<collector>/<example-name>/
   README.md               requirements, standalone run, aorta run, artifacts
 ```
 
-The conventions the existing four follow, and that a new one should too:
+The conventions the existing seven follow, and that a new one should too:
 
 1. **Standalone-runnable.** A user must be able to reproduce the payload
    without aorta. Every README shows the bare command first.

--- a/examples/profiling/proton/amd-instrumentation/README.md
+++ b/examples/profiling/proton/amd-instrumentation/README.md
@@ -1,0 +1,224 @@
+# amd-instrumentation — attribution *inside* a single Triton kernel
+
+One deliberately unbalanced Triton kernel with two named intra-kernel scopes —
+`cheap` (a single multiply) and `expensive` (a short `erf` loop) — captured by
+Proton's `instrumentation` backend. Every other Proton backend tells you how
+long a kernel took; this one tells you *where inside the kernel* the cycles
+went.
+
+Two things make it worth a separate example:
+
+- **Intra-kernel attribution**, which no queue-tracing backend can give. A
+  `roctracer` capture of this payload reports a single number for
+  `unbalanced_kernel` (verified); this one reports a number per scope.
+- **It installs no HSA queue interceptor**, so it is the one Proton backend
+  that can share a process with `rocprofv3`. That is exactly why aorta's
+  `rocprof` + `proton` conflict guard accepts `backend: instrumentation` and
+  rejects `auto` / `roctracer` / `rocprofiler`.
+
+Read [What you get](#what-you-get) before you point this at anything: the
+capture is real and readable, but it publishes **no numeric aorta metrics**
+today.
+
+## Requirements
+
+| | |
+|---|---|
+| Runtime | Triton + PyTorch built for ROCm, one AMD GPU |
+| Profiler | Proton, which ships inside Triton — no separate install |
+| Triton version | Any released Triton has the backend. Verified on 3.7.1 |
+| Python deps | `torch`, `triton` |
+| Opt-in | `pl.enable_semantic("triton")` in the payload — Triton-DSL instrumentation is off by default |
+
+## Run it in a container
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --ipc=host \
+  --security-opt seccomp=unconfined \
+  -v "$PWD:/work" -w /work \
+  rocm/pytorch:latest \
+  bash -lc '
+    pip install -e . &&
+    aorta sweep run \
+      --recipe examples/profiling/proton/amd-instrumentation/recipe.yaml \
+      --output ./profiling_results \
+      -- python examples/profiling/proton/amd-instrumentation/hotspot.py \
+           --size 65536 --steps 8
+  '
+```
+
+Pin the image by digest for anything you intend to compare over time. A ROCm
+venv with `torch` + `triton` on the host works the same way.
+
+## Run standalone
+
+```bash
+python examples/profiling/proton/amd-instrumentation/hotspot.py --size 65536 --steps 8
+```
+
+Options: `--size`, `--steps`, `--iters`, `--backend`. Output:
+
+```
+hotspot: device=...
+hotspot: size=65536 steps=8 iters=5
+hotspot: max_abs_err=...
+hotspot: PASS
+```
+
+With no `--backend` and no `AORTA_PROTON_*` in the environment the payload
+takes no capture at all — the `pl.enter_scope` / `pl.exit_scope` calls compile
+away to nothing when instrumentation is off, so this is also the way to check
+that the kernel itself is sound.
+
+Tolerance is `1e-6` absolute against `x * 2` followed by `--steps` iterations
+of `torch.erf`, not exact equality: the device `erf` and torch's differ in the
+last bits. `erf` is contractive toward zero, so the discrepancy shrinks rather
+than compounds across iterations. `--steps` is capped at 64 because
+`loop_steps` is a `tl.constexpr` and the loop is unrolled at compile time — a
+large value buys a long compile and a big kernel, not a slow one.
+
+## Run standalone under Proton
+
+This payload drives Proton itself, so there is no `python -m
+triton.profiler.proton` wrapper to add:
+
+```bash
+python examples/profiling/proton/amd-instrumentation/hotspot.py --backend instrumentation
+proton-viewer -m cycles hotspot.hatchet
+```
+
+To rehearse exactly what aorta does, export the bundle by hand:
+
+```bash
+mkdir -p ./proton_out
+env AORTA_PROTON_DIR=./proton_out \
+    AORTA_PROTON_NAME=./proton_out/proton \
+    AORTA_PROTON_CONTEXT=shadow \
+    AORTA_PROTON_DATA=tree \
+    AORTA_PROTON_BACKEND=instrumentation \
+    AORTA_PROTON_MODE=default \
+  python examples/profiling/proton/amd-instrumentation/hotspot.py
+```
+
+## What you get
+
+A `.hatchet` JSON tree in the trial's `proton/` directory, reported as
+`proton_artifact_dir` — **and nothing else**. No `proton_kernel_count`, no
+`proton_gpu_time_ms`, no `proton_top_kernel_ms`, no `proton_top_kernels`.
+
+That is a real gap and not a misconfiguration. An instrumentation capture's
+leaves carry `cycles` and `normalized_cycles`; they carry no `time (<unit>)`
+metric and no `count`. aorta's parser (`src/aorta/instrumentation/proton/_parse.py`)
+keys exclusively on `time (<unit>)`, finds nothing to aggregate, and degrades
+to the artifact directory. So an instrumentation trial contributes nothing to
+`perf.md` or `matrix.json::cells[*].metrics_summary`; the measurement lives
+entirely in the artifact, and you read it yourself.
+
+What the artifact holds is the thing worth having — a tree with the scopes
+nested under the kernel:
+
+```json
+[{"children": [{"children": [{"children": [], "frame": {"name": "cheap", "type": "function"},
+  "metrics": {"cycles": 152040, "normalized_cycles": 593.9, "device_id": "0", "device_type": "0"}},
+  {"children": [], "frame": {"name": "expensive", "type": "function"},
+  "metrics": {"cycles": 8463028, "normalized_cycles": 33058.7, "device_id": "0", "device_type": "0"}}],
+  "frame": {"name": "unbalanced_kernel", "type": "function"}, "metrics": {}}],
+  "frame": {"name": "ROOT", "type": "function"}, "metrics": {"cycles": 0, "normalized_cycles": 0}},
+  {"HIP": {"0": {"arch": "gfx950", "num_sms": 256}}}]
+```
+
+Note the shape: `unbalanced_kernel` carries empty `metrics` and the numbers sit
+on its scope children. That capture is the payload's defaults on one MI355X
+(gfx950) — `expensive` at roughly 55× the cycles of `cheap`, which is the whole
+point of the imbalance. The same payload under `--backend roctracer` reports
+one leaf, `unbalanced_kernel`, and one number; the scopes are invisible to it.
+Read the instrumentation tree with:
+
+```bash
+proton-viewer -m cycles <file>.hatchet
+proton-viewer -m normalized_cycles <file>.hatchet
+```
+
+in the same environment as the capture. `normalized_cycles` divides by the
+number of warps that recorded the scope, so it is the figure to compare across
+runs with different grids.
+
+## Why `mode: env`
+
+**The shipped Triton CLI drops `--mode`.** Triton 3.7.1's
+`triton/profiler/proton.py` parses `-m/--mode` and then never forwards it:
+
+```python
+backend = args.backend if args.backend else _select_backend()
+start(args.name, context=args.context, data=args.data, backend=backend, hook=args.hook)
+```
+
+There is no `mode=` in that call. So `instrumentation_mode` (and
+`granularity`) are silent no-ops under `mode: cli` on every released Triton —
+upstream `main` does pass the value through. `mode: env` exports it as
+`AORTA_PROTON_MODE` and the payload hands it to `proton.start()` itself, which
+is the only way the knob takes effect today.
+
+That is the *only* reason this example needs `mode: env`, and it is worth being
+precise about, because the sibling [`../amd-roctracer`](../amd-roctracer/README.md)
+needs it for a different one. There, the same snippet's `_select_backend()` —
+called only when `-b` is absent — is what initialises the Triton HIP driver, and
+a queue-intercepting backend pinned ahead of the runtime records nothing. This
+backend installs no queue interceptor: a `-b instrumentation` CLI wrap of this
+payload captures both scopes correctly (verified: 1738 bytes, cycle counts
+intact). So the collector's refusal to pin a backend under `mode: cli` covers
+`roctracer` and `rocprofiler` and not this one — what `mode: cli` costs here is
+the mode knob, which is enough on its own.
+
+## Notes
+
+- **`granularity` is deliberately not set in the recipe.** The option pair
+  `instrumentation_mode: default` + `granularity: warp` renders Proton's single
+  `--mode` as the string `default:granularity=warp`, and Triton 3.7.1 rejects
+  that at kernel exit:
+
+  ```
+  RuntimeError: Only warp granularity is supported for now
+  ```
+
+  raised from `libproton.exit_instrumented_op`. Only the *string* spelling of
+  the `granularity=` key is broken — the bare `mode="default"` works, and so
+  does the equivalent typed object
+  `triton.profiler.mode.Default(granularity="warp")`. Other mode knobs pass
+  through as strings fine (`mode="default:buffer_size=4096"` works). Warp
+  granularity is this backend's own default on this version anyway — the
+  working captures are per-warp — so omitting the key costs nothing. Spell it
+  explicitly only on Triton `main`.
+- **Instrumenting Triton-DSL kernels is opt-in, and the opt-in is a
+  trade-off.** `triton/profiler/language.py` enables only the Gluon semantic by
+  default, because Triton's higher-level IR undergoes aggressive rewrites —
+  loop pipelining, instruction re-ordering, IR duplication — that can
+  invalidate naive instrumentation and produce misleading results. The payload
+  calls `pl.enable_semantic("triton")` to accept that risk. Treat an
+  instrumented Triton-DSL kernel's scope boundaries as *subject to those
+  rewrites*: a scope that the compiler hoisted out of, split, or duplicated
+  will report cycles that do not correspond to the source region you drew. The
+  wide, one-sided imbalance in this payload is deliberate for that reason — a
+  result that survives the rewrites is one you can still reason about.
+- **Every launch happens inside the session.** The backend rewrites the
+  kernel's IR to insert the scope records, so a warm-up launch taken before
+  `proton.start()` would put an *uninstrumented* binary in Triton's cache and
+  the profiled launches would reuse it. This payload therefore keeps its first
+  launch inside the capture, unlike
+  [`../amd-roctracer`](../amd-roctracer/README.md).
+- **This is the backend to combine with `rocprof`.** No queue interception
+  means no fight over the interception point. `rocprof` + `proton` on
+  `backend: auto` / `roctracer` / `rocprofiler` is rejected at recipe load;
+  `backend: instrumentation` is accepted.
+- **Device selection.** The collector performs no `HIP_VISIBLE_DEVICES`
+  translation for this backend, because Proton does not reject the variable
+  here — there is no queue interceptor to confuse. Pin devices the way you
+  normally would.
+
+## Provenance
+
+The kernel is original to this repository — not adapted from a Triton tutorial.
+The two scopes exist only to be lopsided, so the capture demonstrates
+intra-kernel attribution on a result you can predict by reading the source.

--- a/examples/profiling/proton/amd-instrumentation/hotspot.py
+++ b/examples/profiling/proton/amd-instrumentation/hotspot.py
@@ -1,0 +1,204 @@
+"""One deliberately unbalanced Triton kernel, measured from the inside.
+
+The kernel is original to this repository. It does almost nothing in a scope
+named ``cheap`` (a single multiply) and a short transcendental loop in a scope
+named ``expensive``, so Proton's ``instrumentation`` backend has two regions
+*within one kernel* to attribute cycles to -- attribution no queue-tracing
+backend can give.
+
+Constexpr kernel parameters are spelled lowercase (``block_size`` rather than
+Triton's conventional ``BLOCK_SIZE``) to satisfy this repository's lint
+configuration; Triton treats the name as opaque.
+
+Standalone:
+    python hotspot.py --size 65536 --steps 8
+    python hotspot.py --backend instrumentation
+
+Requires Triton and PyTorch built for ROCm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# ``torch`` is imported at module scope, not lazily inside main(), and that
+# ordering is load-bearing for every Proton backend: the profiler has to attach
+# to a live HIP runtime, and importing torch is what brings that runtime up.
+# It is also why this example is driven by ``mode: env`` -- see recipe.yaml.
+import torch
+import triton
+import triton.language as tl
+import triton.profiler as proton
+import triton.profiler.language as pl
+
+# Instrumenting a Triton-DSL kernel is opt-in: ``triton/profiler/language.py``
+# enables only the Gluon semantic by default, because Triton's higher-level IR
+# undergoes aggressive rewrites -- loop pipelining, instruction re-ordering, IR
+# duplication -- that can invalidate naive instrumentation and report scope
+# boundaries that mislead. Opting in is a deliberate acceptance of that risk,
+# so the caveat travels with the numbers rather than being buried here.
+pl.enable_semantic("triton")
+
+#: Prefix of the variables aorta's ``proton`` collector exports in ``mode: env``.
+_ENV_PREFIX = "AORTA_PROTON_"
+
+#: Session name for a run aorta did not name, so a standalone capture still
+#: lands somewhere predictable (``./hotspot.hatchet``).
+_DEFAULT_SESSION = "hotspot"
+
+#: Elements per program. A tuning constant, not a size knob -- the problem size
+#: comes from ``--size``.
+_BLOCK_SIZE = 1024
+
+#: Absolute-error ceiling against the torch equivalent. Not exact equality: the
+#: device ``erf`` and torch's differ in the last bits, and the loop applies it
+#: ``--steps`` times. ``erf`` is contractive toward zero, so the discrepancy
+#: shrinks rather than compounds across iterations.
+_MAX_ABS_ERR = 1e-6
+
+
+@triton.jit
+def unbalanced_kernel(
+    in_ptr, out_ptr, n_elements, loop_steps: tl.constexpr, block_size: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * block_size + tl.arange(0, block_size)
+    mask = offsets < n_elements
+    values = tl.load(in_ptr + offsets, mask=mask)
+
+    pl.enter_scope("cheap")
+    scaled = values * 2.0
+    pl.exit_scope("cheap")
+
+    pl.enter_scope("expensive")
+    activated = scaled
+    for _ in range(loop_steps):
+        activated = tl.math.erf(activated)
+    pl.exit_scope("expensive")
+
+    tl.store(out_ptr + offsets, activated, mask=mask)
+
+
+def hotspot(x: torch.Tensor, steps: int) -> torch.Tensor:
+    out = torch.empty_like(x)
+    n_elements = out.numel()
+    grid = (triton.cdiv(n_elements, _BLOCK_SIZE),)
+    unbalanced_kernel[grid](x, out, n_elements, loop_steps=steps, block_size=_BLOCK_SIZE)
+    return out
+
+
+def reference(x: torch.Tensor, steps: int) -> torch.Tensor:
+    activated = x * 2.0
+    for _ in range(steps):
+        activated = torch.erf(activated)
+    return activated
+
+
+def proton_kwargs(backend: str | None) -> dict[str, str | None]:
+    """Translate aorta's ``AORTA_PROTON_*`` bundle into ``proton.start()`` keywords.
+
+    A variable aorta did not export falls back to the collector's own default,
+    which keeps a standalone run and a trial configured the same way spelled
+    identically. ``AORTA_PROTON_MODE`` carries the recipe's
+    ``instrumentation_mode``, which is the knob that reaches Proton only on this
+    path -- see recipe.yaml.
+    """
+    environ = os.environ
+    return {
+        "name": environ.get(f"{_ENV_PREFIX}NAME") or _DEFAULT_SESSION,
+        "context": environ.get(f"{_ENV_PREFIX}CONTEXT", "shadow"),
+        "data": environ.get(f"{_ENV_PREFIX}DATA", "tree"),
+        "backend": environ.get(f"{_ENV_PREFIX}BACKEND") or backend,
+        "mode": environ.get(f"{_ENV_PREFIX}MODE"),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Unbalanced Triton kernel for Proton examples")
+    parser.add_argument("--size", type=int, default=1 << 16, help="number of elements")
+    parser.add_argument(
+        "--steps", type=int, default=8, help="erf iterations in the expensive scope"
+    )
+    parser.add_argument("--iters", type=int, default=5, help="profiled kernel launches")
+    # ``roctracer`` and ``rocprofiler`` stay on the list as the whole-kernel
+    # control: the scope records compile away when the instrumentation backend
+    # is not the one measuring, so the same payload gives one leaf and one
+    # number, which is the comparison the README describes.
+    parser.add_argument(
+        "--backend",
+        default=None,
+        choices=("instrumentation", "roctracer", "rocprofiler"),
+        help="Proton backend for a standalone capture; ignored when $AORTA_PROTON_BACKEND is set",
+    )
+    args = parser.parse_args(argv)
+    for name in ("size", "steps", "iters"):
+        if getattr(args, name) < 1:
+            parser.error(f"--{name} must be >= 1")
+    # ``loop_steps`` is a tl.constexpr, so the loop is fully unrolled at compile
+    # time. A large value turns into a long compile and a large kernel rather
+    # than a slow one, which is not what this payload is demonstrating.
+    if args.steps > 64:
+        parser.error(
+            f"--steps must be <= 64 (the loop is unrolled at compile time); got {args.steps}"
+        )
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not torch.cuda.is_available():
+        print("hotspot: no GPU visible to torch; refusing to run on CPU", file=sys.stderr)
+        return 2
+
+    device = torch.device("cuda")
+    print(f"hotspot: device={torch.cuda.get_device_name(device)}")
+    print(f"hotspot: size={args.size} steps={args.steps} iters={args.iters}")
+
+    generator = torch.Generator(device=device).manual_seed(0)
+    x = torch.randn(args.size, device=device, dtype=torch.float32, generator=generator)
+
+    # No capture at all when nothing asked for one: that is how an operator
+    # separates "my payload is broken" from "my profiler is broken".
+    profiling = args.backend is not None or f"{_ENV_PREFIX}NAME" in os.environ
+    if profiling:
+        capture = proton_kwargs(args.backend)
+        print(
+            f"hotspot: proton backend={capture['backend']} "
+            f"mode={capture['mode'] or '(unset)'} name={capture['name']}"
+        )
+        proton.start(**capture)
+    # Every launch, including the first, happens inside the capture. The
+    # instrumentation backend rewrites the kernel's IR to add the scope records,
+    # so a warm-up launch outside the session would put an *uninstrumented*
+    # binary in Triton's cache and the profiled launches would reuse it.
+    try:
+        out = hotspot(x, args.steps)
+        for _ in range(args.iters - 1):
+            hotspot(x, args.steps)
+        torch.cuda.synchronize(device)
+    finally:
+        if profiling:
+            proton.finalize()
+
+    max_err = torch.max(torch.abs(out - reference(x, args.steps))).item()
+    print(f"hotspot: max_abs_err={max_err:.3e}")
+    # Negated bounded comparison, not ``max_err > tol``: every comparison with
+    # NaN is false, so the direct form would let a non-finite result print PASS
+    # -- the exact condition this check exists to catch.
+    if not (max_err <= _MAX_ABS_ERR):
+        print("hotspot: FAIL result differs from the torch equivalent", file=sys.stderr)
+        return 1
+    print("hotspot: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    # Only exit non-zero, never SystemExit(0): Proton's execute_as_main on
+    # Triton 3.6.0 catches Exception, not BaseException, so a SystemExit on the
+    # success path escapes its CLI before finalize() writes the .hatchet.
+    code = main()
+    if code:
+        raise SystemExit(code)

--- a/examples/profiling/proton/amd-instrumentation/hotspot.py
+++ b/examples/profiling/proton/amd-instrumentation/hotspot.py
@@ -103,7 +103,9 @@ def proton_kwargs(backend: str | None) -> dict[str, str | None]:
     which keeps a standalone run and a trial configured the same way spelled
     identically. ``AORTA_PROTON_MODE`` carries the recipe's
     ``instrumentation_mode``, which is the knob that reaches Proton only on this
-    path -- see recipe.yaml.
+    path -- see recipe.yaml. ``AORTA_PROTON_HOOK`` is read for the same reason:
+    a knob the recipe sets and the payload drops would be configured and
+    silently absent from the capture.
     """
     environ = os.environ
     return {
@@ -111,6 +113,7 @@ def proton_kwargs(backend: str | None) -> dict[str, str | None]:
         "context": environ.get(f"{_ENV_PREFIX}CONTEXT", "shadow"),
         "data": environ.get(f"{_ENV_PREFIX}DATA", "tree"),
         "backend": environ.get(f"{_ENV_PREFIX}BACKEND") or backend,
+        "hook": environ.get(f"{_ENV_PREFIX}HOOK"),
         "mode": environ.get(f"{_ENV_PREFIX}MODE"),
     }
 

--- a/examples/profiling/proton/amd-instrumentation/recipe.yaml
+++ b/examples/profiling/proton/amd-instrumentation/recipe.yaml
@@ -1,0 +1,57 @@
+# Proton capture *inside* one Triton kernel, on the `instrumentation` backend.
+#
+# The only Proton backend that attributes cycles to regions within a kernel,
+# and the only one that installs no HSA queue interceptor -- which is why it is
+# also the only one aorta's rocprof+proton conflict guard accepts. See
+# README.md.
+#
+#   aorta sweep run \
+#       --recipe examples/profiling/proton/amd-instrumentation/recipe.yaml \
+#       --output ./profiling_results \
+#       -- python examples/profiling/proton/amd-instrumentation/hotspot.py \
+#            --size 65536 --steps 8
+schema_version: 1
+mode: probe
+
+ticket: PROFILING-PROTON-AMD-INSTRUMENTATION
+
+trials: 1
+timeout_per_trial: 1800
+
+mitigation_axis: [none]
+diagnostic_axis: [none]
+
+env_passthrough_mode: inherit
+
+# `mode: env`, not `mode: cli`, because the shipped Triton CLI parses
+# `-m/--mode` and then never forwards it to `start()` -- so `instrumentation_mode`
+# below would be a silent no-op on every released Triton (upstream `main` does
+# pass it). `mode: env` exports the value as `AORTA_PROTON_MODE` and the payload
+# hands it to `proton.start()` itself, which is the only way the knob takes
+# effect today.
+#
+# Note this is a *different* reason from the one that forces `mode: env` on the
+# sibling `amd-roctracer` recipe. That backend records nothing when Proton's
+# CLI pins it, because the CLI initialises the HIP runtime only on the path
+# where `-b` is absent and a queue interceptor must be installed first. The
+# instrumentation backend installs no interceptor and captures fine under a
+# `-b instrumentation` CLI wrap (verified); it is only the mode knob that does
+# not survive that route.
+#
+# `granularity` is deliberately ABSENT. The option pair
+# `instrumentation_mode: default` + `granularity: warp` renders Proton's single
+# `--mode` as the string `default:granularity=warp`, and Triton 3.7.1 rejects
+# that at kernel exit with
+#   RuntimeError: Only warp granularity is supported for now
+# raised from `libproton.exit_instrumented_op`. Only the *string* spelling of
+# the `granularity=` key is broken -- the bare `default` works, and so does the
+# equivalent typed `triton.profiler.mode.Default(granularity="warp")` -- and
+# warp granularity is this backend's own default on this version anyway, so
+# omitting the key costs nothing. Spell it explicitly only on Triton `main`.
+collect:
+  proton:
+    mode: "env"
+    backend: "instrumentation"
+    instrumentation_mode: "default"
+    context: "shadow"
+    data: "tree"

--- a/examples/profiling/proton/amd-rocprofiler/README.md
+++ b/examples/profiling/proton/amd-rocprofiler/README.md
@@ -1,0 +1,207 @@
+# amd-rocprofiler — the rocprofiler-sdk backend, with PC sampling
+
+> **This example needs Triton built from upstream `main`. No released Triton
+> has the `rocprofiler` backend**, so unlike every other example in this tree
+> **its capture has never been verified** — no obtainable wheel or container
+> image provides the backend. What *was* exercised on a released Triton
+> (3.7.1): the payload itself, its self-check, and the availability guard
+> below, which fails the trial with the message it promises rather than a
+> traceback. See [Availability](#availability) for the evidence and the check
+> to run first.
+
+One transcendental-heavy Triton GELU launched in a loop, captured by Proton's
+`rocprofiler` backend with `backend_mode: "pcsampling"`. Where
+[`../amd-roctracer`](../amd-roctracer/README.md) gives you whole-kernel spans —
+this kernel took *N* microseconds — PC sampling gives you statistical
+instruction-level attribution from the rocprofiler-sdk: *where inside* the
+kernel the samples landed, sampled periodically rather than instrumented. The
+payload is a loop of erf-based GELU launches precisely so there is a steady
+stream of instructions to sample.
+
+## Check this first
+
+```bash
+python -c "from triton._C.libproton import proton as p; print(p.get_available_profilers())"
+```
+
+- A list containing `rocprofiler` — you can run this example.
+- A list without it — your Triton has the registry but not the backend.
+- **`AttributeError`** — the installed Triton predates the feature entirely.
+  Upstream builds the CLI's `-b` choices from this very function; a Triton
+  without it has no backend registry at all. This is what every released Triton
+  does.
+
+The payload runs the same check itself and exits **2** — the "this environment
+cannot run this" code it also uses for a missing GPU, so a failed trial reads
+as an environment problem rather than a bad result — with a message naming the
+requirement:
+
+```
+gelu: Triton 3.7.1 has no libproton.get_available_profilers, so its Proton
+predates the backend registry and cannot offer 'rocprofiler' (it has only
+['cupti', 'instrumentation', 'roctracer']). This example needs Triton built
+from upstream main; no released wheel or container image ships the rocprofiler
+backend.
+```
+
+The check is answered from the pre-registry backend set when
+`get_available_profilers` is missing, rather than refusing every explicit
+backend: `--backend roctracer` still profiles fine on Triton 3.7.1, and the
+message exists to name the fix, not to be conservative.
+
+## Availability
+
+The evidence, from querying the images and indexes directly:
+
+| Source | Triton | Proton `-b` choices |
+|---|---|---|
+| `rocm/pytorch:rocm7.14_...pytorch_release_2.12.0` | 3.7.1 | `cupti`, `roctracer`, `instrumentation` |
+| Triton 3.7.0 | 3.7.0 | same three |
+| Triton 3.6.0+rocm7.2.4 | 3.6.0 | same three |
+| PyPI `triton` (latest) | 3.7.1 | same three |
+| PyTorch ROCm nightly | `pytorch-triton-rocm` 3.6.0 | same three |
+| Upstream `main` | — | from `libproton.get_available_profilers()`; **includes `rocprofiler`**, modes `[None, "pcsampling", "periodic_flushing"]` |
+
+So `roctracer` — deprecated upstream — remains the only AMD backend you can
+name on a released Triton, which is why
+[`../amd-roctracer`](../amd-roctracer/README.md) is the example to start from
+and this one is the forward-looking sibling.
+
+## Requirements
+
+| | |
+|---|---|
+| Runtime | Triton + PyTorch built for ROCm, one AMD GPU |
+| Triton version | **Upstream `main`, built from source.** Released Triton does not have the backend |
+| Profiler | Proton, which ships inside Triton — no separate install |
+| ROCm | rocprofiler-sdk available to the Triton build |
+| Python deps | `torch`, `triton` |
+
+## Run it in a container
+
+The image has to carry a `main`-built Triton, so the usual `rocm/pytorch:latest`
+will not do — build Triton from source inside it, or start from an image that
+already did:
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --ipc=host \
+  --security-opt seccomp=unconfined \
+  -v "$PWD:/work" -w /work \
+  <image-with-triton-main> \
+  bash -lc '
+    python -c "from triton._C.libproton import proton as p; print(p.get_available_profilers())" &&
+    pip install -e . &&
+    aorta sweep run \
+      --recipe examples/profiling/proton/amd-rocprofiler/recipe.yaml \
+      --output ./profiling_results \
+      -- python examples/profiling/proton/amd-rocprofiler/gelu.py \
+           --size 4194304 --iters 50
+  '
+```
+
+Pin the image by digest for anything you intend to compare over time.
+
+## Run standalone
+
+```bash
+python examples/profiling/proton/amd-rocprofiler/gelu.py --size 4194304 --iters 50
+```
+
+Options: `--size`, `--iters`, `--backend`, `--backend-mode`. Output:
+
+```
+gelu: device=...
+gelu: size=4194304 iters=50 triton=...
+gelu: max_abs_err=...
+gelu: PASS
+```
+
+**This path works on any released Triton.** With no `--backend` and no
+`AORTA_PROTON_*` in the environment the payload takes no capture at all — it
+just runs the kernel and checks it. That is deliberate: you can confirm the
+payload itself is sound on the Triton you actually have, and only the capture
+is gated on the backend.
+
+Tolerance is `1e-6` absolute against `torch.nn.functional.gelu`, not exact
+equality: the device `erf` and torch's fused activation differ in the last
+bits. The op is elementwise, so nothing accumulates and the ceiling stays
+tight — measured error is around `2.4e-07`. The comparison is written as
+`not (err <= tol)` so a NaN fails instead of passing.
+
+## Run standalone under Proton
+
+This payload drives Proton itself, so there is no `python -m
+triton.profiler.proton` wrapper to add:
+
+```bash
+python examples/profiling/proton/amd-rocprofiler/gelu.py \
+  --backend rocprofiler --backend-mode pcsampling
+proton-viewer -m time/s gelu.hatchet
+```
+
+To rehearse exactly what aorta does, export the bundle by hand:
+
+```bash
+mkdir -p ./proton_out
+env AORTA_PROTON_DIR=./proton_out \
+    AORTA_PROTON_NAME=./proton_out/proton \
+    AORTA_PROTON_CONTEXT=shadow \
+    AORTA_PROTON_DATA=tree \
+    AORTA_PROTON_BACKEND=rocprofiler \
+    AORTA_PROTON_MODE=pcsampling \
+  python examples/profiling/proton/amd-rocprofiler/gelu.py
+```
+
+Substituting `--backend roctracer` is a useful control on a released Triton:
+same payload, same env-mode plumbing, whole-kernel spans instead of samples.
+
+## What you get
+
+A `.hatchet` JSON tree in the trial's `proton/` directory, reported as
+`proton_artifact_dir`. Whether the collector's numeric metrics
+(`proton_kernel_count`, `proton_gpu_time_ms`, `proton_top_kernel_ms`) also
+appear depends on whether a PC-sampling tree carries `time (<unit>)` leaves —
+aorta's parser keys on that metric and nothing else. **We have not been able to
+check**, having no Triton with the backend, so treat the artifact as the
+deliverable and read it with `proton-viewer` in the same environment as the
+capture. The comparable `roctracer` capture of the same payload does publish
+all three.
+
+## Notes
+
+- **`backend_mode`, not `instrumentation_mode`.** Both render Proton's single
+  `--mode`, so the schema makes them mutually exclusive, and `backend_mode`
+  requires an explicit (non-`auto`) backend. Valid values here are
+  `pcsampling` and `periodic_flushing`; `roctracer` accepts only
+  `periodic_flushing`.
+- **PC sampling is statistical.** It reports where samples landed, not an exact
+  per-instruction cost, so short runs are noisy. That is why the payload
+  defaults to 50 launches rather than one. For deterministic intra-kernel
+  attribution on a backend that exists today, use
+  [`../amd-instrumentation`](../amd-instrumentation/README.md) instead — it
+  counts cycles per source-level scope rather than sampling.
+- **Why `mode: env`.** Two reasons, both mechanical. Triton's Proton CLI calls
+  `_select_backend()` — which initialises the HIP driver as a side effect —
+  only when `-b` is absent, so pinning a queue-tracing backend on the CLI
+  attaches the profiler before the runtime exists and writes a hatchet with a
+  bare `ROOT` frame while exiting 0. And the shipped CLI parses `-m/--mode`
+  without forwarding it to `start()`, so `backend_mode` would be a silent
+  no-op there. In `mode: env` the payload imports `torch` first and then passes
+  both values to `proton.start()` itself. The collector rejects `mode: cli`
+  with an explicit `roctracer` / `rocprofiler` backend outright.
+- **Device selection.** Proton on AMD reads `ROCR_VISIBLE_DEVICES` and rejects
+  `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` for the queue-intercepting
+  backends. aorta's collector translates the rejected spellings automatically
+  and logs a warning; a standalone run has to unset them yourself.
+- **Do not stack this with `rocprof`.** `rocprofiler` installs an HSA queue
+  interceptor and so does `rocprofv3`; the pairing is rejected at recipe load.
+  Only `backend: instrumentation` coexists.
+
+## Provenance
+
+The kernel is original to this repository — not adapted from a Triton
+tutorial. It is the exact-`erf` GELU, chosen because its expansion is many
+instructions per element, which is what makes a sampling profiler's output
+interesting rather than uniformly a load.

--- a/examples/profiling/proton/amd-rocprofiler/gelu.py
+++ b/examples/profiling/proton/amd-rocprofiler/gelu.py
@@ -1,0 +1,243 @@
+"""Transcendental-heavy Triton GELU, for Proton's ``rocprofiler`` backend.
+
+The kernel is original to this repository: one elementwise ``erf``-based GELU
+launched in a loop, so PC sampling has a steady stream of instructions to
+sample rather than a handful of launches.
+
+**The ``rocprofiler`` backend exists only on Triton ``main``.** No released
+Triton has it. The payload probes for the capability and returns 2 -- the same
+"this environment cannot run this" code it uses for a missing GPU -- rather
+than letting the request fail as a confusing traceback. It still runs the
+kernel and self-checks when no capture was requested, so the payload itself
+stays verifiable on a Triton that cannot profile it.
+
+Constexpr kernel parameters are spelled lowercase (``block_size`` rather than
+Triton's conventional ``BLOCK_SIZE``) to satisfy this repository's lint
+configuration; Triton treats the name as opaque.
+
+Standalone:
+    python gelu.py --size 4194304 --iters 50
+    python gelu.py --backend rocprofiler --backend-mode pcsampling
+
+Requires Triton and PyTorch built for ROCm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# ``torch`` is imported at module scope, not lazily inside main(), and that
+# ordering is load-bearing: a queue-tracing backend records nothing when it
+# attaches before the HIP runtime it is tracing, and importing torch is what
+# brings that runtime up. It is also why this example is driven by
+# ``mode: env`` -- see recipe.yaml.
+import torch
+import triton
+import triton.language as tl
+import triton.profiler as proton
+from triton._C.libproton import proton as libproton
+
+#: Prefix of the variables aorta's ``proton`` collector exports in ``mode: env``.
+_ENV_PREFIX = "AORTA_PROTON_"
+
+#: Session name for a run aorta did not name, so a standalone capture still
+#: lands somewhere predictable (``./gelu.hatchet``).
+_DEFAULT_SESSION = "gelu"
+
+#: Elements per program. A tuning constant, not a size knob -- the problem size
+#: comes from ``--size``.
+_BLOCK_SIZE = 1024
+
+#: Proton's backend set on every released Triton -- 3.6.0, 3.7.0 and 3.7.1 all
+#: offer exactly these. Used to answer the availability question on the Tritons
+#: that cannot be asked, since ``rocprofiler`` is precisely what is missing.
+_PRE_REGISTRY_BACKENDS = frozenset({"cupti", "roctracer", "instrumentation"})
+
+#: Absolute-error ceiling against ``torch.nn.functional.gelu``. Not exact
+#: equality: the device ``erf`` and torch's fused activation differ in the last
+#: bits. Elementwise, so nothing accumulates and the ceiling stays tight.
+_MAX_ABS_ERR = 1e-6
+
+
+@triton.jit
+def gelu_kernel(in_ptr, out_ptr, n_elements, block_size: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    offsets = pid * block_size + tl.arange(0, block_size)
+    mask = offsets < n_elements
+    values = tl.load(in_ptr + offsets, mask=mask)
+    # The exact erf formulation, which is what torch's ``approximate="none"``
+    # default computes. It is also the reason this payload suits PC sampling:
+    # the erf expansion is many instructions per element, so the samples land
+    # somewhere interesting instead of all on a load.
+    activated = 0.5 * values * (1.0 + tl.math.erf(values * 0.7071067811865476))
+    tl.store(out_ptr + offsets, activated, mask=mask)
+
+
+def gelu(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    n_elements = out.numel()
+    gelu_kernel[(triton.cdiv(n_elements, _BLOCK_SIZE),)](x, out, n_elements, block_size=_BLOCK_SIZE)
+    return out
+
+
+def available_backends() -> list[str] | None:
+    """Report the Proton backends this Triton offers, or ``None`` if unknowable.
+
+    Upstream builds the CLI's backend choices from
+    ``libproton.get_available_profilers()``. That function arrived with the
+    backend registry it reports, so its absence is itself informative: the
+    Triton in front of you predates the registry, and no argument spelling will
+    get a post-registry backend out of it.
+    """
+    probe = getattr(libproton, "get_available_profilers", None)
+    if probe is None:
+        return None
+    return list(probe())
+
+
+def unavailable_reason(backend: str) -> str | None:
+    """Explain why ``backend`` cannot be used here, or ``None`` if it can.
+
+    Pre-registry Tritons cannot be asked, so they are answered from the set
+    that has been present since Proton shipped. Guessing "unavailable" for all
+    of them would refuse ``roctracer``, which works fine on 3.7.1 -- and the
+    point of the message is to name the fix, not to be conservative.
+    """
+    backends = available_backends()
+    if backends is not None:
+        if backend in backends:
+            return None
+        return (
+            f"Proton backend {backend!r} is not available in Triton "
+            f"{triton.__version__}; it offers {sorted(backends)}."
+        )
+    if backend in _PRE_REGISTRY_BACKENDS:
+        return None
+    return (
+        f"Triton {triton.__version__} has no libproton.get_available_profilers, "
+        f"so its Proton predates the backend registry and cannot offer {backend!r} "
+        f"(it has only {sorted(_PRE_REGISTRY_BACKENDS)}). This example needs "
+        "Triton built from upstream main; no released wheel or container image "
+        "ships the rocprofiler backend."
+    )
+
+
+def proton_kwargs(args: argparse.Namespace) -> dict[str, str | None]:
+    """Translate aorta's ``AORTA_PROTON_*`` bundle into ``proton.start()`` keywords.
+
+    A variable aorta did not export falls back to the collector's own default,
+    which keeps a standalone run and a trial configured the same way spelled
+    identically. ``AORTA_PROTON_MODE`` carries the recipe's ``backend_mode``
+    (``pcsampling`` here), which is the knob that reaches Proton only on this
+    path -- see recipe.yaml.
+    """
+    environ = os.environ
+    return {
+        "name": environ.get(f"{_ENV_PREFIX}NAME") or _DEFAULT_SESSION,
+        "context": environ.get(f"{_ENV_PREFIX}CONTEXT", "shadow"),
+        "data": environ.get(f"{_ENV_PREFIX}DATA", "tree"),
+        "backend": environ.get(f"{_ENV_PREFIX}BACKEND") or args.backend,
+        "mode": environ.get(f"{_ENV_PREFIX}MODE") or args.backend_mode,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Triton GELU for Proton examples")
+    parser.add_argument("--size", type=int, default=1 << 22, help="number of elements")
+    parser.add_argument("--iters", type=int, default=50, help="profiled kernel launches")
+    # Only the whole-kernel AMD backends. ``instrumentation`` is excluded
+    # deliberately: it records intra-kernel scopes, which this kernel does not
+    # carry, so it would hand back an empty tree. ``roctracer`` is kept because
+    # it is the control this example's README points at on a Triton without
+    # rocprofiler.
+    parser.add_argument(
+        "--backend",
+        default=None,
+        choices=("rocprofiler", "roctracer"),
+        help="Proton backend for a standalone capture; ignored when $AORTA_PROTON_BACKEND is set",
+    )
+    parser.add_argument(
+        "--backend-mode",
+        default=None,
+        choices=("pcsampling", "periodic_flushing"),
+        help="Proton --mode for the backend; ignored when $AORTA_PROTON_MODE is set",
+    )
+    args = parser.parse_args(argv)
+    for name in ("size", "iters"):
+        if getattr(args, name) < 1:
+            parser.error(f"--{name} must be >= 1")
+    if args.backend_mode is not None and args.backend is None:
+        parser.error("--backend-mode needs --backend: Proton's --mode is per-backend")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not torch.cuda.is_available():
+        print("gelu: no GPU visible to torch; refusing to run on CPU", file=sys.stderr)
+        return 2
+
+    # No capture at all when nothing asked for one: that is how an operator
+    # separates "my payload is broken" from "my profiler is broken", and it is
+    # what keeps this file useful on the released Tritons that cannot offer the
+    # backend the recipe asks for.
+    profiling = args.backend is not None or f"{_ENV_PREFIX}NAME" in os.environ
+    capture = proton_kwargs(args) if profiling else None
+    # Checked before anything is measured, so an unobtainable backend reads as
+    # "this environment cannot run this" (exit 2, the missing-GPU code) rather
+    # than as a traceback out of Proton's internals.
+    if capture is not None and capture["backend"] is not None:
+        reason = unavailable_reason(capture["backend"])
+        if reason is not None:
+            print(f"gelu: {reason}", file=sys.stderr)
+            return 2
+
+    device = torch.device("cuda")
+    print(f"gelu: device={torch.cuda.get_device_name(device)}")
+    print(f"gelu: size={args.size} iters={args.iters} triton={triton.__version__}")
+
+    generator = torch.Generator(device=device).manual_seed(0)
+    x = torch.randn(args.size, device=device, dtype=torch.float32, generator=generator)
+
+    # The correctness pass runs unprofiled, which also absorbs the JIT compile.
+    # The capture then holds exactly ``--iters`` launches, so a kernel count is
+    # a number you can predict and check rather than one you have to trust.
+    out = gelu(x)
+    torch.cuda.synchronize(device)
+    max_err = torch.max(torch.abs(out - torch.nn.functional.gelu(x))).item()
+
+    if capture is not None:
+        print(
+            f"gelu: proton backend={capture['backend']} "
+            f"mode={capture['mode'] or '(unset)'} name={capture['name']}"
+        )
+        proton.start(**capture)
+    try:
+        for _ in range(args.iters):
+            gelu(x)
+        torch.cuda.synchronize(device)
+    finally:
+        if capture is not None:
+            proton.finalize()
+
+    print(f"gelu: max_abs_err={max_err:.3e}")
+    # Negated bounded comparison, not ``max_err > tol``: every comparison with
+    # NaN is false, so the direct form would let a non-finite result print PASS
+    # -- the exact condition this check exists to catch.
+    if not (max_err <= _MAX_ABS_ERR):
+        print("gelu: FAIL result differs from torch.nn.functional.gelu", file=sys.stderr)
+        return 1
+    print("gelu: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    # Only exit non-zero, never SystemExit(0): Proton's execute_as_main on
+    # Triton 3.6.0 catches Exception, not BaseException, so a SystemExit on the
+    # success path escapes its CLI before finalize() writes the .hatchet.
+    code = main()
+    if code:
+        raise SystemExit(code)

--- a/examples/profiling/proton/amd-rocprofiler/gelu.py
+++ b/examples/profiling/proton/amd-rocprofiler/gelu.py
@@ -131,7 +131,9 @@ def proton_kwargs(args: argparse.Namespace) -> dict[str, str | None]:
     which keeps a standalone run and a trial configured the same way spelled
     identically. ``AORTA_PROTON_MODE`` carries the recipe's ``backend_mode``
     (``pcsampling`` here), which is the knob that reaches Proton only on this
-    path -- see recipe.yaml.
+    path -- see recipe.yaml. ``AORTA_PROTON_HOOK`` is read for the same reason:
+    a knob the recipe sets and the payload drops would be configured and
+    silently absent from the capture.
     """
     environ = os.environ
     return {
@@ -140,6 +142,7 @@ def proton_kwargs(args: argparse.Namespace) -> dict[str, str | None]:
         "data": environ.get(f"{_ENV_PREFIX}DATA", "tree"),
         "backend": environ.get(f"{_ENV_PREFIX}BACKEND") or args.backend,
         "mode": environ.get(f"{_ENV_PREFIX}MODE") or args.backend_mode,
+        "hook": environ.get(f"{_ENV_PREFIX}HOOK"),
     }
 
 

--- a/examples/profiling/proton/amd-rocprofiler/recipe.yaml
+++ b/examples/profiling/proton/amd-rocprofiler/recipe.yaml
@@ -1,0 +1,55 @@
+# Proton capture on the `rocprofiler` backend, with PC sampling.
+#
+# SHIPPED UNVERIFIED. The `rocprofiler` backend exists only on Triton `main`:
+# no released Triton, wheel, or container image has it, so this recipe was
+# never run end-to-end. Everything else in this tree was. Check first with
+#
+#   python -c "from triton._C.libproton import proton as p; print(p.get_available_profilers())"
+#
+# -- an AttributeError means the installed Triton predates the feature. See
+# README.md.
+#
+#   aorta sweep run \
+#       --recipe examples/profiling/proton/amd-rocprofiler/recipe.yaml \
+#       --output ./profiling_results \
+#       -- python examples/profiling/proton/amd-rocprofiler/gelu.py \
+#            --size 4194304 --iters 50
+schema_version: 1
+mode: probe
+
+ticket: PROFILING-PROTON-AMD-ROCPROFILER
+
+trials: 1
+timeout_per_trial: 1800
+
+mitigation_axis: [none]
+diagnostic_axis: [none]
+
+env_passthrough_mode: inherit
+
+# `mode: env`, not `mode: cli`, for two independent reasons.
+#
+# First, Triton's Proton CLI front-end calls its own `_select_backend()` only
+# when `-b` is *absent*, and that call initialises the Triton HIP driver as a
+# side effect. A queue-tracing AMD backend records nothing when it attaches
+# ahead of the runtime it traces, so pinning one through `mode: cli` yields a
+# 160-byte hatchet with a bare ROOT frame and an exit status of 0 -- the trial
+# looks successful and carries no Proton metrics. The collector rejects
+# `mode: cli` with an explicit roctracer/rocprofiler backend for that reason.
+#
+# Second, the shipped CLI parses `-m/--mode` and never forwards it to
+# `start()`, so `backend_mode` below would be a silent no-op there. In
+# `mode: env` it is exported as `AORTA_PROTON_MODE` and the payload passes it
+# to `proton.start(mode=...)` itself.
+#
+# `backend_mode: pcsampling` asks rocprofiler-sdk for statistical
+# instruction-level attribution -- where in the kernel the samples land --
+# rather than the whole-kernel spans `roctracer` reports. The backend's other
+# valid `backend_mode` is `periodic_flushing`.
+collect:
+  proton:
+    mode: "env"
+    backend: "rocprofiler"
+    backend_mode: "pcsampling"
+    context: "shadow"
+    data: "tree"

--- a/examples/profiling/proton/amd-roctracer/README.md
+++ b/examples/profiling/proton/amd-roctracer/README.md
@@ -1,0 +1,187 @@
+# amd-roctracer — kernel-level attribution on the portable AMD backend
+
+Three distinct Triton kernels — an elementwise scale, a fused bias+GELU, and a
+row-sum reduction — launched in sequence, captured by Proton's `roctracer`
+backend. This is the example to reach for when you want to know *which kernel*
+in a launch sequence owns the GPU time, on the one AMD backend that exists in
+every released Triton.
+
+It differs from [`triton-vecadd`](../triton-vecadd/README.md) and
+[`triton-softmax`](../triton-softmax/README.md) in two ways that matter: the
+payload is a real multi-kernel sequence rather than a single launch, and the
+recipe pins the backend explicitly through `mode: env` instead of leaving
+`backend: "auto"` on `mode: cli`. The second is not a style choice — see
+[Why `mode: env`](#why-mode-env).
+
+## Requirements
+
+| | |
+|---|---|
+| Runtime | Triton + PyTorch built for ROCm, one AMD GPU |
+| Profiler | Proton, which ships inside Triton — no separate install |
+| Triton version | **Any released Triton.** `roctracer` has been in Proton's backend list since it was introduced; unlike `rocprofiler` it needs no source build |
+| Python deps | `torch`, `triton` |
+
+## Run it in a container
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --ipc=host \
+  --security-opt seccomp=unconfined \
+  -v "$PWD:/work" -w /work \
+  rocm/pytorch:latest \
+  bash -lc '
+    pip install -e . &&
+    aorta sweep run \
+      --recipe examples/profiling/proton/amd-roctracer/recipe.yaml \
+      --output ./profiling_results \
+      -- python examples/profiling/proton/amd-roctracer/pipeline.py \
+           --rows 4096 --cols 1024 --iters 20
+  '
+```
+
+Pin the image by digest for anything you intend to compare over time. A ROCm
+venv with `torch` + `triton` on the host works the same way.
+
+## Run standalone
+
+```bash
+python examples/profiling/proton/amd-roctracer/pipeline.py --rows 4096 --cols 1024 --iters 20
+```
+
+Options: `--rows`, `--cols`, `--iters`, `--backend`. Output:
+
+```
+pipeline: device=...
+pipeline: rows=4096 cols=1024 iters=20
+pipeline: max_rel_err=...
+pipeline: PASS
+```
+
+With no `--backend` and no `AORTA_PROTON_*` in the environment the payload
+takes **no capture at all** — it just runs the three kernels and checks them.
+That is the fast way to separate "my payload is broken" from "my profiler is
+broken".
+
+The check is a bounded *relative* error (ceiling `1e-5`) against
+`torch.nn.functional.gelu(x * scale + bias).sum(dim=-1)`, not exact equality:
+the reduction kernel sums `--cols` float32 values in a different order than
+`Tensor.sum`, so the low bits differ legitimately. Measured error on the
+defaults is around `1.9e-07`, four orders of magnitude inside the ceiling, so a
+failure here means a real bug rather than drift. The comparison is written as
+`not (err <= tol)` so a NaN fails instead of passing.
+
+The activation and the reduction each use one program per row, with the block
+extent rounded up to the next power of two, so a very large `--cols` asks
+Triton for a block it may not find registers for. Keep `--cols` at or below a
+few thousand.
+
+## Run standalone under Proton
+
+This payload drives Proton itself, so there is no `python -m
+triton.profiler.proton` wrapper to add — name the backend and it profiles:
+
+```bash
+python examples/profiling/proton/amd-roctracer/pipeline.py --backend roctracer
+proton-viewer -m time/s pipeline.hatchet
+```
+
+To rehearse exactly what aorta does, export the bundle by hand instead:
+
+```bash
+mkdir -p ./proton_out
+env AORTA_PROTON_DIR=./proton_out \
+    AORTA_PROTON_NAME=./proton_out/proton \
+    AORTA_PROTON_CONTEXT=shadow \
+    AORTA_PROTON_DATA=tree \
+    AORTA_PROTON_BACKEND=roctracer \
+  python examples/profiling/proton/amd-roctracer/pipeline.py --iters 20
+```
+
+`AORTA_PROTON_NAME` present is what the payload treats as "aorta asked for a
+capture"; the rest of the variables fall back to the collector's own defaults
+when absent, so a partial bundle still behaves.
+
+## What you get
+
+A `.hatchet` JSON tree in the trial's `proton/` directory, reported as
+`proton_artifact_dir`, plus the collector's numeric metrics —
+`proton_kernel_count`, `proton_gpu_time_ms` and `proton_top_kernel_ms` — in
+`perf.md` and `matrix.json::cells[*].metrics_summary`.
+
+The point of this example is what the tree's shape tells you. With
+`context: "shadow"` each Triton kernel gets its own leaf under `ROOT`, so the
+capture names all three:
+
+- `proton_top_kernels` (per-trial dispatcher JSON, `.result.metrics` — not
+  `perf.md`, which carries numeric scalars only) lists `scale_kernel`,
+  `bias_gelu_kernel` and `row_sum_kernel`, ranked by exclusive GPU time.
+- `proton_kernel_count` is non-zero and **predictable**: the correctness pass
+  runs before `proton.start()`, so the capture holds exactly `--iters` launches
+  of each of the three kernels. At the default `--iters 20` that is 60.
+- `proton_gpu_time_ms` is non-zero and is the sum of the three leaves;
+  `proton_top_kernel_ms` is whichever kernel dominates.
+
+Expect the fused activation to be the most expensive of the three and the
+reduction the cheapest — it reads the same bytes but writes one value per row
+instead of a full matrix. Read the raw tree with `proton-viewer -m time/s
+<file>.hatchet`, in the same environment as the capture.
+
+## Why `mode: env`
+
+Pinning an explicit AMD backend through `mode: cli` **silently captures
+nothing**, and the mechanism is worth knowing because it is not a bug you would
+guess from the output. Triton's Proton CLI front-end resolves the backend like
+this:
+
+```python
+backend = args.backend if args.backend else _select_backend()
+```
+
+`_select_backend()` initialises the Triton HIP driver as a side effect — and it
+is only called when `-b` is *absent*. roctracer records nothing unless it
+starts after the HIP runtime is up, so with `-b roctracer` the profiler
+attaches to a runtime that does not exist yet. The run still exits 0 and still
+writes a hatchet: a ~160-byte one, holding a bare `ROOT` frame with empty
+metrics. aorta's parser finds no `time (<unit>)` leaves, degrades to
+`proton_artifact_dir`, and the trial carries no Proton metrics while looking
+like a success.
+
+`mode: env` avoids this entirely. aorta exports `AORTA_PROTON_*` and leaves
+argv alone; the payload imports `torch` at module scope — which brings the HIP
+runtime up — and only then calls `proton.start(backend=...)` itself. The
+collector enforces this: `mode: cli` with an explicit `roctracer` or
+`rocprofiler` backend raises `ProtonWrapError` and names `mode: env` as the
+route, so a `mode: cli` version of this recipe would not run at all.
+
+## Notes
+
+- **Why `roctracer` and not `rocprofiler`.** `roctracer` is deprecated
+  upstream in favour of the rocprofiler-sdk backend, but it is the only AMD
+  backend present in every *released* Triton: 3.6.0, 3.7.0 and 3.7.1 all offer
+  `cupti` / `roctracer` / `instrumentation` and nothing else.
+  [`../amd-rocprofiler`](../amd-rocprofiler/README.md) is the same idea on the
+  newer backend, and needs Triton `main`.
+- **Device selection.** Proton on AMD reads `ROCR_VISIBLE_DEVICES` and
+  *rejects* `HIP_VISIBLE_DEVICES` and `CUDA_VISIBLE_DEVICES` outright for
+  `roctracer` — `proton.start()` raises `ValueError` before any kernel runs.
+  aorta's collector translates the rejected spellings automatically and logs a
+  warning; a standalone run has to unset them yourself.
+- **Do not stack this with `rocprof`.** `roctracer` installs an HSA queue
+  interceptor and so does `rocprofv3`; the pairing is rejected at recipe load.
+  Only [`../amd-instrumentation`](../amd-instrumentation/README.md) coexists
+  with `rocprof`.
+- **`Could not load libroctracer64.so`.** Some container images get ROCm from
+  Python wheels, which ship only `libroctracer64.so.4` while Proton `dlopen`s
+  the unversioned name. Add a directory of unversioned symlinks to
+  `$LD_LIBRARY_PATH`, or use an image with a system ROCm install.
+- Triton compiles on first launch. The unprofiled correctness pass absorbs that
+  compile, which is why the capture's launch count is exact.
+
+## Provenance
+
+The three kernels are original to this repository — not adapted from a Triton
+tutorial. They are deliberately ordinary shapes (elementwise, per-row
+activation, per-row reduction) so the tree reads like the front of a
+transformer block without needing one.

--- a/examples/profiling/proton/amd-roctracer/pipeline.py
+++ b/examples/profiling/proton/amd-roctracer/pipeline.py
@@ -119,7 +119,11 @@ def proton_kwargs(backend: str | None) -> dict[str, str | None]:
     A variable aorta did not export falls back to the collector's own default,
     which keeps a standalone run and a trial configured the same way spelled
     identically. ``backend`` is the one knob a standalone run needs on the
-    command line, since it is what this example exists to pin.
+    command line, since it is what this example exists to pin. Every variable
+    ``build_env`` can export is read, including ``AORTA_PROTON_HOOK``: a knob
+    the recipe sets and the payload drops would be configured and silently
+    absent from the capture, which is the failure this example exists to
+    demonstrate the absence of.
     """
     environ = os.environ
     return {
@@ -128,6 +132,7 @@ def proton_kwargs(backend: str | None) -> dict[str, str | None]:
         "data": environ.get(f"{_ENV_PREFIX}DATA", "tree"),
         "backend": environ.get(f"{_ENV_PREFIX}BACKEND") or backend,
         "mode": environ.get(f"{_ENV_PREFIX}MODE"),
+        "hook": environ.get(f"{_ENV_PREFIX}HOOK"),
     }
 
 

--- a/examples/profiling/proton/amd-roctracer/pipeline.py
+++ b/examples/profiling/proton/amd-roctracer/pipeline.py
@@ -1,0 +1,215 @@
+"""Three-kernel Triton pipeline, captured by Proton's ``roctracer`` backend.
+
+The kernels are original to this repository: an elementwise scale, a fused
+bias+GELU, and a row-sum reduction, launched in that order so the hatchet tree
+carries a real launch sequence rather than a single kernel.
+
+Unlike the ``triton-vecadd`` / ``triton-softmax`` payloads this one drives
+Proton itself, because pinning an AMD backend only works from inside a live HIP
+runtime -- see the ``import torch`` comment below and ``recipe.yaml``.
+
+Constexpr kernel parameters are spelled lowercase (``block_size`` rather than
+Triton's conventional ``BLOCK_SIZE``) to satisfy this repository's lint
+configuration; Triton treats the name as opaque.
+
+Standalone:
+    python pipeline.py --rows 4096 --cols 1024 --iters 20
+    python pipeline.py --backend roctracer
+
+Requires Triton and PyTorch built for ROCm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import sys
+
+# ``torch`` is imported at module scope, not lazily inside main(), and that
+# ordering is load-bearing: roctracer records nothing when it attaches before
+# the HIP runtime it is meant to trace, and importing torch is what brings that
+# runtime up. The same constraint is why this example is driven by ``mode: env``
+# -- Triton's Proton CLI initialises the driver only on the path where ``-b`` is
+# absent, so pinning a backend through ``mode: cli`` produces a hatchet holding
+# nothing but a bare ROOT frame, and still exits 0.
+import torch
+import triton
+import triton.language as tl
+import triton.profiler as proton
+
+#: Prefix of the variables aorta's ``proton`` collector exports in ``mode: env``.
+_ENV_PREFIX = "AORTA_PROTON_"
+
+#: Session name for a run aorta did not name, so a standalone capture still
+#: lands somewhere predictable (``./pipeline.hatchet``).
+_DEFAULT_SESSION = "pipeline"
+
+#: Elements per program in the flat elementwise kernel. A tuning constant, not
+#: a size knob -- the problem size comes from ``--rows`` / ``--cols``.
+_SCALE_BLOCK_SIZE = 1024
+
+#: Relative-error ceiling for the composed pipeline against its torch
+#: equivalent. Not exact equality: the last kernel reduces ``--cols`` float32
+#: values in a different order than ``Tensor.sum``, so the low bits differ
+#: legitimately, and the discrepancy grows with the reduced extent.
+_MAX_REL_ERR = 1e-5
+
+
+@triton.jit
+def scale_kernel(in_ptr, out_ptr, n_elements, scale, block_size: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    offsets = pid * block_size + tl.arange(0, block_size)
+    mask = offsets < n_elements
+    values = tl.load(in_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, values * scale, mask=mask)
+
+
+@triton.jit
+def bias_gelu_kernel(in_ptr, bias_ptr, out_ptr, row_stride, n_cols, block_size: tl.constexpr):
+    row = tl.program_id(axis=0)
+    col_offsets = tl.arange(0, block_size)
+    mask = col_offsets < n_cols
+    values = tl.load(in_ptr + row * row_stride + col_offsets, mask=mask)
+    values += tl.load(bias_ptr + col_offsets, mask=mask)
+    # The exact erf formulation, which is what torch's ``approximate="none"``
+    # default computes. The cheaper tanh approximation would need a ``tanh``
+    # this Triton's ``tl.math`` does not expose, and would then have to be
+    # checked against a torch call that opts into the same approximation.
+    activated = 0.5 * values * (1.0 + tl.math.erf(values * 0.7071067811865476))
+    tl.store(out_ptr + row * row_stride + col_offsets, activated, mask=mask)
+
+
+@triton.jit
+def row_sum_kernel(in_ptr, out_ptr, row_stride, n_cols, block_size: tl.constexpr):
+    row = tl.program_id(axis=0)
+    col_offsets = tl.arange(0, block_size)
+    mask = col_offsets < n_cols
+    values = tl.load(in_ptr + row * row_stride + col_offsets, mask=mask, other=0.0)
+    tl.store(out_ptr + row, tl.sum(values, axis=0))
+
+
+def pipeline(x: torch.Tensor, bias: torch.Tensor, scale: float) -> torch.Tensor:
+    """Run the three kernels in sequence and return the per-row totals."""
+    n_rows, n_cols = x.shape
+    # One program per row for the activation and the reduction, so a whole row
+    # fits in one program. ``tl.arange`` requires a power-of-two extent.
+    row_block = triton.next_power_of_2(n_cols)
+
+    scaled = torch.empty_like(x)
+    scale_kernel[(triton.cdiv(x.numel(), _SCALE_BLOCK_SIZE),)](
+        x, scaled, x.numel(), scale, block_size=_SCALE_BLOCK_SIZE
+    )
+
+    activated = torch.empty_like(x)
+    bias_gelu_kernel[(n_rows,)](scaled, bias, activated, x.stride(0), n_cols, block_size=row_block)
+
+    totals = torch.empty(n_rows, device=x.device, dtype=x.dtype)
+    row_sum_kernel[(n_rows,)](activated, totals, x.stride(0), n_cols, block_size=row_block)
+    return totals
+
+
+def reference(x: torch.Tensor, bias: torch.Tensor, scale: float) -> torch.Tensor:
+    return torch.nn.functional.gelu(x * scale + bias).sum(dim=-1)
+
+
+def proton_kwargs(backend: str | None) -> dict[str, str | None]:
+    """Translate aorta's ``AORTA_PROTON_*`` bundle into ``proton.start()`` keywords.
+
+    A variable aorta did not export falls back to the collector's own default,
+    which keeps a standalone run and a trial configured the same way spelled
+    identically. ``backend`` is the one knob a standalone run needs on the
+    command line, since it is what this example exists to pin.
+    """
+    environ = os.environ
+    return {
+        "name": environ.get(f"{_ENV_PREFIX}NAME") or _DEFAULT_SESSION,
+        "context": environ.get(f"{_ENV_PREFIX}CONTEXT", "shadow"),
+        "data": environ.get(f"{_ENV_PREFIX}DATA", "tree"),
+        "backend": environ.get(f"{_ENV_PREFIX}BACKEND") or backend,
+        "mode": environ.get(f"{_ENV_PREFIX}MODE"),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Three-kernel Triton pipeline for Proton examples")
+    parser.add_argument("--rows", type=int, default=4096, help="rows in the input matrix")
+    parser.add_argument("--cols", type=int, default=1024, help="columns (reduced dimension)")
+    parser.add_argument("--iters", type=int, default=20, help="profiled pipeline iterations")
+    # Only the whole-kernel AMD backends. ``instrumentation`` is excluded
+    # deliberately: it records intra-kernel scopes, which these kernels do not
+    # carry, so it yields the same 160-byte empty tree this example exists to
+    # warn about (verified). Use ../amd-instrumentation for that backend.
+    parser.add_argument(
+        "--backend",
+        default=None,
+        choices=("roctracer", "rocprofiler"),
+        help="Proton backend for a standalone capture; ignored when $AORTA_PROTON_BACKEND is set",
+    )
+    args = parser.parse_args(argv)
+    for name in ("rows", "cols", "iters"):
+        if getattr(args, name) < 1:
+            parser.error(f"--{name} must be >= 1")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not torch.cuda.is_available():
+        print("pipeline: no GPU visible to torch; refusing to run on CPU", file=sys.stderr)
+        return 2
+
+    device = torch.device("cuda")
+    print(f"pipeline: device={torch.cuda.get_device_name(device)}")
+    print(f"pipeline: rows={args.rows} cols={args.cols} iters={args.iters}")
+
+    generator = torch.Generator(device=device).manual_seed(0)
+    x = torch.randn(args.rows, args.cols, device=device, dtype=torch.float32, generator=generator)
+    bias = torch.randn(args.cols, device=device, dtype=torch.float32, generator=generator)
+    # The 1/sqrt(d) scaling an attention block applies before its activation --
+    # a reason for the first kernel to exist rather than be folded away.
+    scale = 1.0 / math.sqrt(args.cols)
+
+    # The correctness pass runs unprofiled, which also absorbs the JIT compile
+    # of all three kernels. The capture then holds exactly ``--iters`` launches
+    # of each, so proton_kernel_count is a number you can predict and check
+    # rather than one you have to trust.
+    totals = pipeline(x, bias, scale)
+    torch.cuda.synchronize(device)
+    expected = reference(x, bias, scale)
+    max_rel_err = ((totals - expected).abs() / expected.abs().clamp(min=1.0)).max().item()
+
+    # No capture at all when nothing asked for one: that is how an operator
+    # separates "my payload is broken" from "my profiler is broken".
+    profiling = args.backend is not None or f"{_ENV_PREFIX}NAME" in os.environ
+    if profiling:
+        capture = proton_kwargs(args.backend)
+        print(f"pipeline: proton backend={capture['backend']} name={capture['name']}")
+        proton.start(**capture)
+    try:
+        for _ in range(args.iters):
+            pipeline(x, bias, scale)
+        torch.cuda.synchronize(device)
+    finally:
+        if profiling:
+            proton.finalize()
+
+    print(f"pipeline: max_rel_err={max_rel_err:.3e}")
+    # Negated bounded comparison, not ``max_rel_err > tol``: every comparison
+    # with NaN is false, so the direct form would let a non-finite result print
+    # PASS -- the exact condition this check exists to catch.
+    if not (max_rel_err <= _MAX_REL_ERR):
+        print("pipeline: FAIL result differs from the torch equivalent", file=sys.stderr)
+        return 1
+    print("pipeline: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    # Only exit non-zero, never SystemExit(0): Proton's execute_as_main on
+    # Triton 3.6.0 catches Exception, not BaseException, so a SystemExit on the
+    # success path escapes its CLI before finalize() writes the .hatchet.
+    code = main()
+    if code:
+        raise SystemExit(code)

--- a/examples/profiling/proton/amd-roctracer/recipe.yaml
+++ b/examples/profiling/proton/amd-roctracer/recipe.yaml
@@ -1,0 +1,45 @@
+# Proton capture of a three-kernel Triton pipeline on the `roctracer` backend.
+#
+# The portable AMD path: `roctracer` is Proton's deprecated but universally
+# present AMD backend -- it is the one every released Triton accepts, where
+# `rocprofiler` exists only on Triton `main`. See README.md.
+#
+#   aorta sweep run \
+#       --recipe examples/profiling/proton/amd-roctracer/recipe.yaml \
+#       --output ./profiling_results \
+#       -- python examples/profiling/proton/amd-roctracer/pipeline.py \
+#            --rows 4096 --cols 1024 --iters 20
+schema_version: 1
+mode: probe
+
+ticket: PROFILING-PROTON-AMD-ROCTRACER
+
+trials: 1
+timeout_per_trial: 1800
+
+mitigation_axis: [none]
+diagnostic_axis: [none]
+
+env_passthrough_mode: inherit
+
+# `mode: env`, not `mode: cli`, and the reason is mechanical rather than
+# stylistic. Triton's Proton CLI front-end calls its own `_select_backend()`
+# only when `-b` is *absent*, and that call initialises the Triton HIP driver
+# as a side effect. roctracer records nothing when it attaches ahead of the
+# HIP runtime it is tracing, so naming a backend on the CLI hands you a
+# 160-byte hatchet with a bare ROOT frame and an exit status of 0 -- aorta's
+# parser then degrades to `proton_artifact_dir` and the trial silently carries
+# no Proton metrics at all. `mode: env` instead exports `AORTA_PROTON_*` and
+# lets the payload call `proton.start()` after its own `import torch`, so the
+# backend attaches to a live runtime. The collector rejects `mode: cli` with
+# an explicit roctracer/rocprofiler backend for exactly this reason.
+#
+# `context: shadow` attributes time to the launch site, which for this payload
+# means one node per Triton kernel; `data: tree` is the `.hatchet` the
+# collector's summary parser reads.
+collect:
+  proton:
+    mode: "env"
+    backend: "roctracer"
+    context: "shadow"
+    data: "tree"

--- a/examples/profiling/proton/triton-softmax/README.md
+++ b/examples/profiling/proton/triton-softmax/README.md
@@ -94,8 +94,9 @@ installed.
 - **Device selection.** Use `ROCR_VISIBLE_DEVICES`, not
   `HIP_VISIBLE_DEVICES` — Proton on AMD does not honor the latter.
 - **Backend.** Left on `backend: "auto"`; see
-  [`../triton-vecadd/README.md`](../triton-vecadd/README.md) for why, and
-  for the `libroctracer64.so` note.
+  [`../triton-vecadd/README.md`](../triton-vecadd/README.md) for why, for
+  why pinning an AMD backend means `mode: "env"`, and for the
+  `libroctracer64.so` note.
 - **Do not stack this with `rocprof`**; both intercept HSA queues and the
   pairing is rejected at recipe load. Only the `instrumentation` backend
   coexists.

--- a/examples/profiling/proton/triton-vecadd/README.md
+++ b/examples/profiling/proton/triton-vecadd/README.md
@@ -97,8 +97,13 @@ Read the raw tree yourself with `proton-viewer -m time/s <file>.hatchet`
   otherwise). Naming one is a version commitment: `rocprofiler` is the
   preferred AMD backend upstream, but Triton 3.7.x and earlier accept only
   `cupti`/`roctracer`/`instrumentation` and exit with an argparse
-  `invalid choice: 'rocprofiler'` before the payload runs. Pin a backend
-  only when you need to know exactly which one measured.
+  `invalid choice: 'rocprofiler'` before the payload runs. It is an
+  attach-mode commitment too: Proton's CLI front-end initialises the HIP
+  runtime only on the path where `-b` is absent, so pinning `roctracer` or
+  `rocprofiler` under this recipe's `mode: "cli"` captures an empty
+  `ROOT`-only tree and still exits 0. The collector refuses that pairing
+  and names `mode: "env"`, where the payload drives Proton itself;
+  [`../amd-roctracer/`](../amd-roctracer/README.md) is the worked case.
 - **Do not stack this with `rocprof`.** Proton's AMD backends intercept HSA
   queues, and so does `rocprofv3`; running both fights over the same
   interception point, and the pairing is rejected at recipe load. Only the

--- a/examples/profiling/proton/triton-vecadd/recipe.yaml
+++ b/examples/profiling/proton/triton-vecadd/recipe.yaml
@@ -35,8 +35,12 @@ env_passthrough_mode: inherit
 # available, `roctracer` otherwise. That is the only portable spelling --
 # naming `rocprofiler` explicitly is correct on current upstream Triton but
 # exits with an argparse "invalid choice: 'rocprofiler'" on Triton 3.7.x and
-# earlier, before your payload runs. Pin a backend explicitly only when you
-# need to know exactly which one measured.
+# earlier, before your payload runs. Pinning either AMD backend also means
+# leaving `mode: cli`: Proton's front-end initialises the HIP runtime only on
+# the path where `-b` is absent, so a pinned queue-intercepting backend
+# captures an empty tree and the collector refuses the pairing. See
+# examples/profiling/proton/amd-roctracer for the `mode: env` shape that
+# pinning requires.
 collect:
   proton:
     mode: "cli"

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -225,6 +225,15 @@ def build_argv_prefix(
     front-end collects them with ``argparse.REMAINDER``, so there is no ``--``
     separator (unlike rocprofv3).
 
+    This renders whatever the validated options ask for, including a ``-b`` for
+    a backend :func:`wrap_argv` would refuse to pin (see
+    :data:`_CLI_UNPINNABLE_BACKENDS`). The split is deliberate -- this function
+    is the renderer and :func:`wrap_argv` is where the attach decision is made,
+    so a caller that only wants to display or log the flags still can -- but it
+    means a consumer building its own CLI attach out of this prefix has to
+    apply that policy itself. Everything inside aorta reaches Proton through
+    :func:`wrap_argv`.
+
     Args:
         out_dir: Directory the profile is written into.
         options: Recipe-supplied options; see :func:`validate_options`.

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -31,9 +31,16 @@ so a device-pinned cell still profiles the device it asked for.
 The default backend is :data:`AUTO_BACKEND`, which omits Proton's ``-b``
 entirely. Proton then picks the backend matching the active runtime --
 ``rocprofiler`` where rocprofiler-sdk is available, ``roctracer`` otherwise.
-Naming a backend explicitly is a version commitment: ``rocprofiler`` is the
-preferred AMD backend upstream but was added after Triton 3.7, whose CLI
-rejects the name at argparse before the payload ever runs.
+Naming a backend explicitly costs more than a version commitment (though it is
+also that: ``rocprofiler`` is the preferred AMD backend upstream but was added
+after Triton 3.7, whose CLI rejects the name at argparse before the payload
+ever runs). Proton's front-end calls ``_select_backend()`` only on the path
+where ``-b`` is absent, and that call is what brings the GPU runtime up, so an
+AMD queue-intercepting backend pinned through ``mode: cli`` starts before the
+first HSA queue exists and records nothing -- a 160-byte profile holding an
+empty ``ROOT`` frame, from a run that exits 0. :func:`wrap_argv` refuses that
+combination and names ``mode: env`` instead, where the payload starts Proton
+itself after the runtime is up.
 """
 
 from __future__ import annotations
@@ -48,10 +55,12 @@ from pathlib import Path
 
 from ._options import (
     AUTO_BACKEND,
+    BACKEND_MODES,
     BACKENDS,
     CONTEXTS,
     DATA_FORMATS,
     GRANULARITIES,
+    HOOKS,
     INSTRUMENTATION_MODES,
     MODES,
     OPTION_KEYS,
@@ -104,6 +113,13 @@ _AMD_BACKENDS: frozenset[str] = frozenset({"rocprofiler", "roctracer"})
 #: ``backend: auto`` too. ``ROCR_VISIBLE_DEVICES`` is the variable Proton reads
 #: on AMD; ``HIP_VISIBLE_DEVICES`` is the one it refuses.
 _AMD_ENV_SIGNALS: tuple[str, ...] = ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES")
+
+#: Backends ``mode: cli`` cannot pin, because a queue interceptor has to be
+#: installed before the first HSA queue is created and Proton's front-end only
+#: initialises the runtime on the ``-b``-absent path. Derived from the schema's
+#: interception set rather than spelled out, so a backend added to one is
+#: covered by the other: ``auto`` comes out because it *is* that path.
+_CLI_UNPINNABLE_BACKENDS: frozenset[str] = QUEUE_INTERCEPTING_BACKENDS - {AUTO_BACKEND}
 
 _PYTHON_RE = re.compile(r"^python(\d+(\.\d+)?)?$")
 # Interpreter flags that take no argument and can safely stay in front of
@@ -243,6 +259,9 @@ def build_argv_prefix(
     mode = mode_argument(effective)
     if mode is not None:
         argv += ["--mode", mode]
+    hook = effective.get("hook")
+    if hook is not None:
+        argv += ["-k", hook]
     return argv
 
 
@@ -282,6 +301,9 @@ def build_env(
     mode = mode_argument(effective)
     if mode is not None:
         env[f"{ENV_PREFIX}MODE"] = mode
+    hook = effective.get("hook")
+    if hook is not None:
+        env[f"{ENV_PREFIX}HOOK"] = hook
     return env
 
 
@@ -471,8 +493,9 @@ def wrap_argv(
     Raises:
         ValueError: an option key or value is invalid.
         ProtonWrapError: ``mode: cli`` was requested for a command Proton's
-            front-end cannot execute, or the wrap needs ``env(1)`` to carry
-            variables into the command and it is not on ``$PATH``.
+            front-end cannot execute or with a backend it cannot pin, or the
+            wrap needs ``env(1)`` to carry variables into the command and it is
+            not on ``$PATH``.
     """
     effective = validate_options(options)
     inner = list(argv)
@@ -480,6 +503,24 @@ def wrap_argv(
     if effective["mode"] == "env":
         prefix = _device_env_prefix(effective["backend"], environ, build_env(out_dir, options))
         return [*prefix, *inner]
+
+    # Checked before the argv shape, because ``mode: env`` is the fix for both
+    # and this is the one an operator cannot see failing: an unwrappable argv
+    # at least stops the trial, while a pinned queue-intercepting backend
+    # produces a clean exit 0 carrying an empty profile.
+    if effective["backend"] in _CLI_UNPINNABLE_BACKENDS:
+        raise ProtonWrapError(
+            f"proton mode 'cli' cannot pin backend {effective['backend']!r}. "
+            "Proton's command front-end calls _select_backend() only when '-b' "
+            "is absent, and that call is what initialises the GPU runtime, so a "
+            "pinned queue-intercepting backend starts before the first HSA "
+            "queue exists and records nothing: the profile comes back as an "
+            "empty ROOT frame and the trial reports no proton metrics while "
+            "exiting 0. Use 'proton: {mode: env}' with a payload that calls "
+            "proton.start() after the runtime is up (see "
+            "examples/profiling/proton/amd-roctracer), or leave "
+            f"'backend: {AUTO_BACKEND}', which omits '-b' and is unaffected."
+        )
 
     flags, target = _split_python_launch(inner)
     python = resolve_python(inner)
@@ -493,12 +534,14 @@ def wrap_argv(
 
 __all__ = [
     "AUTO_BACKEND",
+    "BACKEND_MODES",
     "BACKENDS",
     "CONTEXTS",
     "DATA_FORMATS",
     "ENV_PREFIX",
     "ENV_PROTON_PYTHON",
     "GRANULARITIES",
+    "HOOKS",
     "INSTRUMENTATION_MODES",
     "MODES",
     "OPTION_KEYS",

--- a/src/aorta/instrumentation/proton/_options.py
+++ b/src/aorta/instrumentation/proton/_options.py
@@ -26,17 +26,41 @@ AUTO_BACKEND: str = "auto"
 #: ``roctracer`` is the deprecated AMD predecessor Proton still falls back to;
 #: ``instrumentation`` is the intra-kernel path; ``cupti`` is the NVIDIA one,
 #: accepted so a recipe stays portable even though aorta's examples are AMD.
+#: Naming either AMD backend also commits the recipe to ``mode: env``: the
+#: collector refuses to pin them under ``mode: cli``, where the capture would
+#: come back empty (see :func:`aorta.instrumentation.proton.wrap_argv`).
 BACKENDS: frozenset[str] = frozenset(
     {"auto", "cupti", "rocprofiler", "roctracer", "instrumentation"}
 )
 
 #: Backends that install an HSA queue interceptor and therefore cannot share a
-#: process with ``rocprofv3``. Consumed by the collector registry's conflict
-#: guard, which is why it lives in the schema rather than in the guard.
-#: ``auto`` is included because on AMD it resolves to ``rocprofiler`` or
-#: ``roctracer`` -- both intercepting -- and the guard has to reject a pairing
-#: it cannot prove is safe.
+#: process with ``rocprofv3``. Consumed by two guards outside this module --
+#: the collector registry's ``rocprof`` conflict check and the collector's own
+#: refusal to pin one of these under ``mode: cli`` -- which is why it lives in
+#: the schema rather than in either. ``auto`` is included because on AMD it
+#: resolves to ``rocprofiler`` or ``roctracer`` -- both intercepting -- and the
+#: conflict guard has to reject a pairing it cannot prove is safe. The cli
+#: guard excludes it explicitly instead, since omitting ``-b`` is the very
+#: thing that keeps that path working.
 QUEUE_INTERCEPTING_BACKENDS: frozenset[str] = frozenset({"auto", "rocprofiler", "roctracer"})
+
+#: ``backend_mode`` values per backend: Proton's ``--mode`` is backend-specific,
+#: and each backend accepts only its own names (the domains ``proton.start()``
+#: documents). Keyed by backend so a mode can be validated against the backend
+#: that will run it rather than against a flat union, where
+#: ``roctracer`` + ``pcsampling`` would pass validation and then fail inside
+#: Proton. ``instrumentation`` is deliberately absent: its modes are the
+#: ``instrumentation_mode`` / ``granularity`` pair, which render the same
+#: ``--mode`` argument with a different grammar.
+BACKEND_MODES: dict[str, frozenset[str]] = {
+    "cupti": frozenset({"pcsampling", "periodic_flushing"}),
+    "rocprofiler": frozenset({"pcsampling", "periodic_flushing"}),
+    "roctracer": frozenset({"periodic_flushing"}),
+}
+
+#: ``hook`` values (Proton's ``-k``). ``triton`` registers Proton's launch
+#: hook, which records Triton kernel launch metadata alongside the timing.
+HOOKS: frozenset[str] = frozenset({"triton"})
 
 #: ``proton --context`` values.
 CONTEXTS: frozenset[str] = frozenset({"shadow", "python"})
@@ -67,10 +91,12 @@ GRANULARITIES: frozenset[str] = frozenset(
 OPTION_KEYS: tuple[str, ...] = (
     "mode",
     "backend",
+    "backend_mode",
     "context",
     "data",
     "instrumentation_mode",
     "granularity",
+    "hook",
 )
 
 _DEFAULTS: dict[str, str] = {
@@ -87,6 +113,7 @@ _ENUMS: dict[str, frozenset[str]] = {
     "data": DATA_FORMATS,
     "instrumentation_mode": INSTRUMENTATION_MODES,
     "granularity": GRANULARITIES,
+    "hook": HOOKS,
 }
 
 
@@ -103,11 +130,14 @@ def validate_options(options: Mapping[str, str] | None) -> dict[str, str]:
         normalised to lowercase.
 
     Raises:
-        ValueError: an unknown key, a value outside its declared domain, or an
+        ValueError: an unknown key, a value outside its declared domain, an
             intra-kernel knob (``instrumentation_mode`` / ``granularity``) set
             without ``backend: instrumentation`` -- Proton would ignore it, so
             accepting it would silently produce a profile the operator did not
-            ask for.
+            ask for -- or a ``backend_mode`` that its backend does not accept,
+            that collides with an intra-kernel knob over Proton's single
+            ``--mode``, or that was set without an explicit backend to
+            validate it against.
     """
     raw = dict(options or {})
     unknown = sorted(set(raw) - set(OPTION_KEYS))
@@ -126,21 +156,56 @@ def validate_options(options: Mapping[str, str] | None) -> dict[str, str]:
             raise ValueError(f"proton option {key!r}: {value!r} is not one of {sorted(allowed)}")
 
     intra_kernel = [k for k in ("instrumentation_mode", "granularity") if k in effective]
+    # Before the per-backend gate below, because the two rejections have
+    # different fixes and the collision is the one the operator can act on:
+    # gating first would report the backend as the problem when the real
+    # problem is asking for two mutually exclusive ``--mode`` values.
+    if "backend_mode" in effective and intra_kernel:
+        raise ValueError(
+            f"proton option 'backend_mode' conflicts with {sorted(intra_kernel)}: "
+            "both render into Proton's single '--mode' argument, so only one "
+            "can be set. 'backend_mode' configures the whole-kernel backends "
+            "(rocprofiler / roctracer / cupti); the intra-kernel pair "
+            "configures backend: instrumentation."
+        )
     if intra_kernel and effective["backend"] != "instrumentation":
         raise ValueError(
             f"proton option(s) {sorted(intra_kernel)} require "
             "backend: instrumentation (they configure Proton's intra-kernel "
             f"mode); got backend: {effective['backend']}"
         )
+    if "backend_mode" in effective:
+        allowed = BACKEND_MODES.get(effective["backend"])
+        if allowed is None:
+            raise ValueError(
+                "proton option 'backend_mode' requires an explicit backend "
+                f"from {sorted(BACKEND_MODES)} -- Proton's '--mode' domain is "
+                "backend-specific, so there is nothing to validate it against "
+                f"under backend: {effective['backend']}. Pin the backend "
+                "(which needs mode: env for rocprofiler / roctracer), or drop "
+                "the option."
+            )
+        if effective["backend_mode"] not in allowed:
+            raise ValueError(
+                f"proton option 'backend_mode': {effective['backend_mode']!r} is "
+                f"not one of {sorted(allowed)} for backend: {effective['backend']}"
+            )
     return effective
 
 
 def mode_argument(options: Mapping[str, str]) -> str | None:
-    """Render the Proton ``--mode`` value from the intra-kernel knobs.
+    """Render the Proton ``--mode`` value from whichever knob set it.
 
-    Returns ``None`` when no intra-kernel knob is set, so the CLI wrap omits
-    ``--mode`` entirely and Proton keeps its own default.
+    ``backend_mode`` and the intra-kernel pair share Proton's single ``--mode``
+    argument; :func:`validate_options` rejects them together, so reading
+    ``backend_mode`` first is a precedence in spelling only.
+
+    Returns ``None`` when no mode knob is set, so the CLI wrap omits ``--mode``
+    entirely and Proton keeps its own default.
     """
+    backend_mode = options.get("backend_mode")
+    if backend_mode is not None:
+        return backend_mode
     name = options.get("instrumentation_mode")
     granularity = options.get("granularity")
     if name is None and granularity is None:
@@ -153,10 +218,12 @@ def mode_argument(options: Mapping[str, str]) -> str | None:
 
 __all__ = [
     "AUTO_BACKEND",
+    "BACKEND_MODES",
     "BACKENDS",
     "CONTEXTS",
     "DATA_FORMATS",
     "GRANULARITIES",
+    "HOOKS",
     "INSTRUMENTATION_MODES",
     "MODES",
     "OPTION_KEYS",

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -16,9 +16,11 @@ import pytest
 
 from aorta.instrumentation.proton import (
     AUTO_BACKEND,
+    BACKEND_MODES,
     BACKENDS,
     ENV_PREFIX,
     ENV_PROTON_PYTHON,
+    HOOKS,
     OPTION_KEYS,
     OUTPUT_SUBDIR,
     PROFILE_BASENAME,
@@ -190,6 +192,72 @@ def test_validate_options_rejects_intra_kernel_knob_on_wrong_backend(key):
         validate_options({"backend": "roctracer", key: "cta" if key == "granularity" else "mma"})
 
 
+@pytest.mark.parametrize(
+    ("backend", "backend_mode"),
+    sorted((backend, mode) for backend, modes in BACKEND_MODES.items() for mode in modes),
+)
+def test_validate_options_accepts_every_backend_mode_of_its_backend(backend, backend_mode):
+    effective = validate_options({"backend": backend, "backend_mode": backend_mode})
+    assert effective["backend_mode"] == backend_mode
+
+
+def test_validate_options_rejects_a_backend_mode_the_backend_does_not_have():
+    """The domains differ per backend -- ``pcsampling`` is a rocprofiler / cupti
+    mode, and roctracer only has ``periodic_flushing``. A flat union would
+    accept this and fail later inside Proton."""
+    with pytest.raises(ValueError, match="not one of.*for backend: roctracer"):
+        validate_options({"backend": "roctracer", "backend_mode": "pcsampling"})
+
+
+def test_validate_options_rejects_unknown_backend_mode():
+    with pytest.raises(ValueError, match="backend_mode"):
+        validate_options({"backend": "rocprofiler", "backend_mode": "sampling"})
+
+
+@pytest.mark.parametrize("backend", ["auto", "instrumentation"])
+def test_validate_options_rejects_backend_mode_without_a_backend_to_validate_it(backend):
+    """``auto`` resolves at runtime, so its mode domain is unknown here; the
+    instrumentation backend's modes are the ``instrumentation_mode`` pair."""
+    with pytest.raises(ValueError, match="requires an explicit backend"):
+        validate_options({"backend": backend, "backend_mode": "pcsampling"})
+
+
+@pytest.mark.parametrize("intra_kernel_key", ["instrumentation_mode", "granularity"])
+def test_validate_options_rejects_backend_mode_beside_an_intra_kernel_knob(intra_kernel_key):
+    """Both render Proton's single ``--mode``, so the pair has no rendering.
+
+    The message must name the collision rather than the backend gate that would
+    also have rejected this: the fix is dropping one option, not changing the
+    backend.
+    """
+    value = "cta" if intra_kernel_key == "granularity" else "mma"
+    with pytest.raises(ValueError, match="conflicts with"):
+        validate_options(
+            {
+                "backend": "instrumentation",
+                "backend_mode": "pcsampling",
+                intra_kernel_key: value,
+            }
+        )
+
+
+@pytest.mark.parametrize("hook", sorted(HOOKS))
+def test_validate_options_accepts_every_hook(hook):
+    assert validate_options({"hook": hook})["hook"] == hook
+
+
+def test_validate_options_rejects_unknown_hook():
+    with pytest.raises(ValueError, match="'hook'"):
+        validate_options({"hook": "launch"})
+
+
+def test_hook_is_not_gated_on_a_backend():
+    """Proton's ``-k`` is backend-independent: it registers a launch hook that
+    records Triton kernel metadata whichever backend measures."""
+    for backend in sorted(BACKENDS):
+        assert validate_options({"backend": backend, "hook": "triton"})["hook"] == "triton"
+
+
 def test_validate_options_does_not_mutate_input():
     supplied = {"backend": "ROCTRACER"}
     validate_options(supplied)
@@ -197,16 +265,28 @@ def test_validate_options_does_not_mutate_input():
 
 
 def test_option_keys_match_the_validator():
-    samples = {
+    """Two samples rather than one: ``backend_mode`` and the intra-kernel pair
+    render the same ``--mode`` and are rejected together, so no single mapping
+    can carry every declared key."""
+    intra_kernel = {
         "mode": "cli",
         "backend": "instrumentation",
         "context": "shadow",
         "data": "tree",
         "instrumentation_mode": "mma",
         "granularity": "warp",
+        "hook": "triton",
     }
-    assert set(samples) == set(OPTION_KEYS)
-    assert validate_options(samples)
+    whole_kernel = {
+        "mode": "env",
+        "backend": "roctracer",
+        "backend_mode": "periodic_flushing",
+        "context": "python",
+        "data": "trace",
+    }
+    assert set(intra_kernel) | set(whole_kernel) == set(OPTION_KEYS)
+    assert validate_options(intra_kernel)
+    assert validate_options(whole_kernel)
 
 
 # ---- --mode rendering ----------------------------------------------------
@@ -231,6 +311,14 @@ def test_mode_argument_name_and_granularity():
         {"backend": "instrumentation", "instrumentation_mode": "mma", "granularity": "cta"}
     )
     assert mode_argument(effective) == "mma:granularity=cta"
+
+
+def test_mode_argument_renders_backend_mode():
+    """``backend_mode`` is Proton's ``--mode`` for the whole-kernel backends, so
+    it renders as the bare name -- no ``granularity=`` grammar, which belongs to
+    the instrumentation backend."""
+    effective = validate_options({"backend": "roctracer", "backend_mode": "periodic_flushing"})
+    assert mode_argument(effective) == "periodic_flushing"
 
 
 # ---- Interpreter resolution ---------------------------------------------
@@ -353,6 +441,20 @@ def test_build_argv_prefix_includes_mode_for_intra_kernel(tmp_path):
     assert argv[argv.index("--mode") + 1] == "mma"
 
 
+def test_build_argv_prefix_includes_mode_for_a_backend_mode(tmp_path):
+    argv = build_argv_prefix(tmp_path, {"backend": "cupti", "backend_mode": "pcsampling"})
+    assert argv[argv.index("--mode") + 1] == "pcsampling"
+
+
+def test_build_argv_prefix_omits_the_hook_flag_by_default(tmp_path):
+    assert "-k" not in build_argv_prefix(tmp_path)
+
+
+def test_build_argv_prefix_renders_the_hook(tmp_path):
+    argv = build_argv_prefix(tmp_path, {"hook": "triton"})
+    assert argv[argv.index("-k") + 1] == "triton"
+
+
 def test_build_argv_prefix_propagates_option_error(tmp_path):
     with pytest.raises(ValueError, match="unknown option"):
         build_argv_prefix(tmp_path, {"nope": "1"})
@@ -466,17 +568,91 @@ def test_wrap_argv_does_not_mutate_the_input(tmp_path):
     assert inner == ["python", "vecadd.py"]
 
 
+# ---- CLI mode cannot pin a queue-intercepting backend -------------------
+#
+# Verified on gfx950 / ROCm 7.0.2 / Triton 3.7.1 against the shipped
+# triton-vecadd payload: no ``-b`` gives a ~3 KB hatchet holding 27 dispatches,
+# while ``-b roctracer`` gives a 160-byte hatchet whose ROOT frame has empty
+# metrics -- from a run that exits 0. Proton's front-end calls
+# ``_select_backend()`` only when ``-b`` is absent, and that call is what
+# initialises the HIP driver; a queue interceptor that starts first records
+# nothing. In aorta that surfaced as a trial with no proton metrics at all,
+# since ``parse_summary`` degrades to the artifact directory for an empty tree.
+#
+# The guard covers the queue-intercepting pair only. ``instrumentation`` needs
+# no interceptor and captures correctly under a CLI pin, so refusing it would
+# cost a working configuration; the ``granularity`` / ``instrumentation_mode``
+# knobs are what ``mode: cli`` costs there, and the schema documents that.
+
+
+@pytest.mark.parametrize("backend", ["roctracer", "rocprofiler"])
+def test_wrap_argv_cli_refuses_to_pin_a_queue_intercepting_backend(tmp_path, backend):
+    with pytest.raises(ProtonWrapError, match="cannot pin backend"):
+        wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": backend}, env={})
+
+
+def test_cli_backend_pin_rejection_names_the_mechanism_and_the_route(tmp_path):
+    """The message has to carry the reason, because the alternative outcome is
+    a green trial: an operator who is only told "not supported" will reach for
+    the pin again on the next Triton."""
+    with pytest.raises(ProtonWrapError) as excinfo:
+        wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": "roctracer"}, env={})
+    message = str(excinfo.value)
+    assert "_select_backend()" in message
+    assert "empty ROOT frame" in message
+    assert "mode: env" in message
+
+
+def test_wrap_argv_cli_still_allows_the_default_backend(tmp_path):
+    """``auto`` is the ``-b``-absent path, so it is the one that works."""
+    argv = wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": AUTO_BACKEND}, env={})
+    assert "-b" not in argv
+
+
+@pytest.mark.parametrize("backend", ["instrumentation", "cupti"])
+def test_wrap_argv_cli_still_pins_a_non_intercepting_backend(tmp_path, backend):
+    """Neither installs an HSA queue interceptor, so neither depends on
+    attaching before the runtime comes up."""
+    argv = wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": backend}, env={})
+    assert argv[argv.index("-b") + 1] == backend
+
+
+@pytest.mark.parametrize("backend", ["roctracer", "rocprofiler"])
+def test_wrap_argv_env_mode_pins_the_same_backend_happily(tmp_path, env_on_path, backend):
+    """The route the rejection names: the payload starts Proton itself, after
+    its own ``import torch`` has brought the runtime up."""
+    argv = wrap_argv(
+        ["python", "pipeline.py"],
+        tmp_path,
+        {"mode": "env", "backend": backend},
+        env={},
+    )
+    assert f"{ENV_PREFIX}BACKEND={backend}" in argv
+
+
+def test_cli_pin_is_refused_before_the_argv_shape_is_checked(tmp_path):
+    """Both failures are fixed by ``mode: env``, and this is the one whose
+    absence is invisible, so it is the one to report."""
+    with pytest.raises(ProtonWrapError, match="cannot pin backend"):
+        wrap_argv(["/tmp/aorta_hip_gemm", "512"], tmp_path, {"backend": "roctracer"}, env={})
+
+
 # ---- Device-variable translation ----------------------------------------
 
 
 def test_wrap_argv_translates_hip_visible_devices(tmp_path, env_on_path):
     """Proton on AMD does not honour ``HIP_VISIBLE_DEVICES`` for the
     queue-intercepting backends, so a device-pinned cell would otherwise
-    profile the wrong GPU."""
+    profile the wrong GPU.
+
+    Spelled with ``backend: auto`` because that is the only queue-intercepting
+    backend ``mode: cli`` will pin, and the assertion below is about where the
+    ``env(1)`` prefix sits relative to the CLI wrap.
+    """
     argv = wrap_argv(
         ["python", "vecadd.py"],
         tmp_path,
-        {"backend": "roctracer"},
+        {"backend": AUTO_BACKEND},
         env={"HIP_VISIBLE_DEVICES": "1"},
     )
     assert argv[0] == str(env_on_path)
@@ -492,11 +668,15 @@ def test_wrap_argv_translates_cuda_visible_devices(tmp_path, env_on_path):
     ROCm's PyTorch presents its devices as ``cuda``, so an operator pinning a
     GPU commonly reaches for ``CUDA_VISIBLE_DEVICES``. Handling only the HIP
     spelling left that trial reaching Proton with a variable it refuses.
+
+    ``mode: env`` throughout the explicitly-pinned cases below: an explicit
+    ``roctracer`` / ``rocprofiler`` is refused in ``mode: cli``, and the
+    translation is the same code either way.
     """
     argv = wrap_argv(
         ["python", "vecadd.py"],
         tmp_path,
-        {"backend": "roctracer"},
+        {"mode": "env", "backend": "roctracer"},
         env={"CUDA_VISIBLE_DEVICES": "2"},
     )
     assert "CUDA_VISIBLE_DEVICES" in argv
@@ -508,7 +688,7 @@ def test_wrap_argv_unsets_both_device_spellings_and_prefers_hip(tmp_path, env_on
     argv = wrap_argv(
         ["python", "vecadd.py"],
         tmp_path,
-        {"backend": "rocprofiler"},
+        {"mode": "env", "backend": "rocprofiler"},
         env={"HIP_VISIBLE_DEVICES": "1", "CUDA_VISIBLE_DEVICES": "2"},
     )
     assert "HIP_VISIBLE_DEVICES" in argv
@@ -593,7 +773,7 @@ def test_wrap_argv_keeps_an_explicit_rocr_visible_devices(tmp_path, env_on_path)
     argv = wrap_argv(
         ["python", "vecadd.py"],
         tmp_path,
-        {"backend": "rocprofiler"},
+        {"mode": "env", "backend": "rocprofiler"},
         env={"HIP_VISIBLE_DEVICES": "1", "ROCR_VISIBLE_DEVICES": "0"},
     )
     assert "ROCR_VISIBLE_DEVICES=0" in argv
@@ -609,7 +789,7 @@ def test_wrap_argv_translates_an_empty_hip_visible_devices(tmp_path, env_on_path
     argv = wrap_argv(
         ["python", "vecadd.py"],
         tmp_path,
-        {"backend": "roctracer"},
+        {"mode": "env", "backend": "roctracer"},
         env={"HIP_VISIBLE_DEVICES": ""},
     )
     assert "HIP_VISIBLE_DEVICES" in argv
@@ -622,7 +802,7 @@ def test_wrap_argv_keeps_an_explicitly_empty_rocr_visible_devices(tmp_path, env_
     argv = wrap_argv(
         ["python", "vecadd.py"],
         tmp_path,
-        {"backend": "roctracer"},
+        {"mode": "env", "backend": "roctracer"},
         env={"HIP_VISIBLE_DEVICES": "1", "ROCR_VISIBLE_DEVICES": ""},
     )
     assert "ROCR_VISIBLE_DEVICES=" in argv
@@ -668,20 +848,20 @@ def test_wrap_argv_fails_when_env_binary_is_missing(tmp_path, monkeypatch):
         wrap_argv(
             ["python", "vecadd.py"],
             tmp_path,
-            {"backend": "roctracer"},
+            {"backend": AUTO_BACKEND},
             env={"HIP_VISIBLE_DEVICES": "1"},
         )
 
 
 def test_wrap_argv_reads_os_environ_by_default(tmp_path, env_on_path, monkeypatch):
     monkeypatch.setenv("HIP_VISIBLE_DEVICES", "3")
-    argv = wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": "roctracer"})
+    argv = wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": AUTO_BACKEND})
     assert "ROCR_VISIBLE_DEVICES=3" in argv
 
 
 def test_wrap_argv_never_mutates_the_supplied_env(tmp_path, env_on_path):
     env = {"HIP_VISIBLE_DEVICES": "1"}
-    wrap_argv(["python", "vecadd.py"], tmp_path, {"backend": "roctracer"}, env=env)
+    wrap_argv(["python", "vecadd.py"], tmp_path, {"mode": "env", "backend": "roctracer"}, env=env)
     assert env == {"HIP_VISIBLE_DEVICES": "1"}
 
 
@@ -712,6 +892,21 @@ def test_build_env_carries_an_explicit_backend(tmp_path):
 def test_build_env_includes_mode_for_intra_kernel(tmp_path):
     env = build_env(tmp_path, {"backend": "instrumentation", "granularity": "warp"})
     assert env[f"{ENV_PREFIX}MODE"] == "default:granularity=warp"
+
+
+def test_build_env_includes_mode_for_a_backend_mode(tmp_path):
+    env = build_env(tmp_path, {"backend": "rocprofiler", "backend_mode": "pcsampling"})
+    assert env[f"{ENV_PREFIX}MODE"] == "pcsampling"
+
+
+def test_build_env_omits_the_hook_by_default(tmp_path):
+    assert f"{ENV_PREFIX}HOOK" not in build_env(tmp_path)
+
+
+def test_build_env_carries_the_hook(tmp_path):
+    """The env bundle mirrors the CLI flags one-for-one, so a payload driving
+    Proton itself can forward ``hook`` into ``proton.start()``."""
+    assert build_env(tmp_path, {"hook": "triton"})[f"{ENV_PREFIX}HOOK"] == "triton"
 
 
 def test_build_env_accepts_str_out_dir():

--- a/tests/instrumentation/test_proton_smoke_gpu.py
+++ b/tests/instrumentation/test_proton_smoke_gpu.py
@@ -17,6 +17,7 @@ passes green for having silently measured nothing.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -24,7 +25,12 @@ from pathlib import Path
 
 import pytest
 
-from aorta.instrumentation.proton import OUTPUT_SUBDIR, PROFILE_BASENAME
+from aorta.instrumentation.proton import (
+    OUTPUT_SUBDIR,
+    PROFILE_BASENAME,
+    build_argv_prefix,
+    parse_summary,
+)
 from aorta.run.collectors import (
     CONFIG_KEY_COLLECT,
     CONFIG_KEY_COLLECT_DIR,
@@ -153,6 +159,20 @@ def test_default_backend_is_accepted_by_the_installed_proton(tmp_path):
 
 
 @skip_no_proton
+def test_hook_flag_is_accepted_by_the_installed_proton(tmp_path):
+    """``hook: triton`` renders Proton's ``-k triton``, which older Tritons could
+    plausibly not have. Being *in the schema* says nothing about being accepted
+    by the Proton that runs, so this asserts the wrap still captures with it on
+    rather than dying at argparse the way an unknown ``-b`` does."""
+    example, payload, args, kernel = _EXAMPLES[0]
+    proc, metrics = _capture(example, payload, args, tmp_path, {"hook": "triton"})
+    assert "invalid choice" not in proc.stderr, proc.stderr
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert metrics["proton_kernel_count"] > 0
+    assert kernel in metrics["proton_top_kernels"], metrics["proton_top_kernels"]
+
+
+@skip_no_proton
 def test_python_context_attributes_to_call_paths(tmp_path):
     """``context: python`` keys the tree by Python call path instead of launch
     site -- the configuration the softmax example ships."""
@@ -162,6 +182,136 @@ def test_python_context_attributes_to_call_paths(tmp_path):
     assert metrics["proton_kernel_count"] > 0
     assert metrics["proton_gpu_time_ms"] > 0.0
     assert kernel in metrics["proton_top_kernels"], metrics["proton_top_kernels"]
+
+
+# ---- Pinning an explicit AMD backend ------------------------------------
+#
+# Proton's CLI front-end calls ``_select_backend()`` only when ``-b`` is
+# absent, and that call is what initialises the HIP driver. A queue-intercepting
+# backend pinned through ``mode: cli`` therefore attaches ahead of the runtime
+# it is meant to trace and records nothing, exiting 0 with a hatchet holding a
+# bare ROOT frame. ``wrap_argv`` refuses that combination and names
+# ``mode: env``, where the payload starts Proton itself; these two tests are the
+# regression that would have caught the empty capture, and the check that the
+# upstream ordering it works around is still there.
+
+
+@skip_no_proton
+def test_env_mode_pins_roctracer_and_gets_a_non_empty_tree(tmp_path):
+    """The route the ``mode: cli`` rejection names, end to end.
+
+    Asserts the launch count rather than merely that metrics exist: the capture
+    spans exactly the payload's profiled loop, which dispatches its three Triton
+    kernels once per iteration and nothing else, so the total is predictable and
+    an over- or under-count is a real defect rather than noise.
+    """
+    iterations = 5
+    proc, metrics = _capture(
+        "amd-roctracer",
+        "pipeline.py",
+        ["--rows", "512", "--cols", "1024", "--iters", str(iterations)],
+        tmp_path,
+        {"mode": "env", "backend": "roctracer", "context": "shadow", "data": "tree"},
+    )
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "PASS" in proc.stdout
+    kernels = {"scale_kernel", "bias_gelu_kernel", "row_sum_kernel"}
+    assert kernels <= set(metrics["proton_top_kernels"]), metrics["proton_top_kernels"]
+    assert metrics["proton_kernel_count"] == len(kernels) * iterations
+    assert metrics["proton_gpu_time_ms"] > 0.0
+
+
+@skip_no_proton
+def test_cli_mode_pin_would_still_capture_nothing(tmp_path):
+    """Pins the premise of the ``wrap_argv`` guard against the installed Triton.
+
+    Builds the wrap the guard refuses -- ``build_argv_prefix`` renders the flags
+    without the attach-mode check -- and asserts it comes back empty. A failure
+    here is good news, not a bug: it means this Triton initialises the runtime
+    before starting a pinned backend, and the guard can be narrowed to the
+    versions that do not.
+    """
+    out_dir = tmp_path / OUTPUT_SUBDIR
+    out_dir.mkdir()
+    script = PROTON_EXAMPLES / "triton-vecadd" / "vecadd.py"
+    argv = [
+        *build_argv_prefix(out_dir, {"backend": "roctracer"}, python=sys.executable),
+        str(script),
+        "--size",
+        "262144",
+        "--iters",
+        "10",
+    ]
+    proc = subprocess.run(
+        argv,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=3600,
+        env={**os.environ, "TRITON_CACHE_DIR": str(tmp_path / "triton-cache")},
+    )
+    if _DLOPEN_MARKER in proc.stderr:
+        pytest.skip(_DLOPEN_MARKER)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "PASS" in proc.stdout, "the payload itself must still have run"
+    # The silent part of the failure: a clean exit, an artifact directory, and no
+    # measurement anywhere in it.
+    assert parse_summary(out_dir) == {"proton_artifact_dir": str(out_dir)}
+
+
+@skip_no_proton
+def test_instrumentation_captures_scopes_inside_one_kernel(tmp_path):
+    """The intra-kernel backend attributes cycles to regions within a kernel.
+
+    Its leaves carry ``cycles`` / ``normalized_cycles`` and neither ``count``
+    nor ``time (<unit>)``, so the collector's summary -- which keys on wall-clock
+    time -- publishes only the artifact directory. That is asserted here too, so
+    the documented metric gap cannot drift out of step with the parser.
+    """
+    proc, metrics = _capture(
+        "amd-instrumentation",
+        "hotspot.py",
+        ["--size", "65536", "--steps", "8", "--iters", "3"],
+        tmp_path,
+        {
+            "mode": "env",
+            "backend": "instrumentation",
+            "instrumentation_mode": "default",
+            "context": "shadow",
+            "data": "tree",
+        },
+    )
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "PASS" in proc.stdout
+
+    profile = tmp_path / OUTPUT_SUBDIR / f"{PROFILE_BASENAME}.hatchet"
+    assert profile.is_file(), sorted(str(p) for p in (tmp_path / OUTPUT_SUBDIR).rglob("*"))
+    cycles = _scope_cycles(profile)
+    assert {"cheap", "expensive"} <= set(cycles), cycles
+    assert all(value > 0 for value in cycles.values()), cycles
+    assert metrics == {"proton_artifact_dir": str(tmp_path / OUTPUT_SUBDIR)}
+
+
+def _scope_cycles(profile: Path) -> dict[str, float]:
+    """Map each leaf frame name to its ``cycles`` metric in a hatchet profile."""
+    found: dict[str, float] = {}
+
+    def walk(node):
+        if not isinstance(node, dict):
+            return
+        children = node.get("children") or []
+        for child in children:
+            walk(child)
+        if children:
+            return
+        name = node.get("frame", {}).get("name")
+        value = node.get("metrics", {}).get("cycles")
+        if isinstance(name, str) and isinstance(value, (int, float)):
+            found[name] = float(value)
+
+    for root in json.loads(profile.read_text(encoding="utf-8")):
+        walk(root)
+    return found
 
 
 @skip_no_proton

--- a/tests/instrumentation/test_proton_smoke_gpu.py
+++ b/tests/instrumentation/test_proton_smoke_gpu.py
@@ -168,8 +168,8 @@ def test_hook_flag_is_accepted_by_the_installed_proton(tmp_path):
     proc, metrics = _capture(example, payload, args, tmp_path, {"hook": "triton"})
     assert "invalid choice" not in proc.stderr, proc.stderr
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    assert metrics["proton_kernel_count"] > 0
-    assert kernel in metrics["proton_top_kernels"], metrics["proton_top_kernels"]
+    assert metrics.get("proton_kernel_count", 0) > 0, metrics
+    assert kernel in metrics.get("proton_top_kernels", []), metrics
 
 
 @skip_no_proton
@@ -215,10 +215,14 @@ def test_env_mode_pins_roctracer_and_gets_a_non_empty_tree(tmp_path):
     )
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert "PASS" in proc.stdout
+    # Presence first, and with the whole mapping in the message: an empty tree
+    # is the failure this test exists for, and it shows up as *absent* metrics
+    # rather than wrong ones.
+    assert {"proton_kernel_count", "proton_gpu_time_ms"} <= set(metrics), metrics
     kernels = {"scale_kernel", "bias_gelu_kernel", "row_sum_kernel"}
-    assert kernels <= set(metrics["proton_top_kernels"]), metrics["proton_top_kernels"]
-    assert metrics["proton_kernel_count"] == len(kernels) * iterations
-    assert metrics["proton_gpu_time_ms"] > 0.0
+    assert kernels <= set(metrics.get("proton_top_kernels", [])), metrics
+    assert metrics.get("proton_kernel_count") == len(kernels) * iterations, metrics
+    assert metrics.get("proton_gpu_time_ms", 0.0) > 0.0, metrics
 
 
 @skip_no_proton

--- a/tests/run/test_collectors.py
+++ b/tests/run/test_collectors.py
@@ -452,9 +452,20 @@ def test_wrap_propagates_an_unattachable_collector(tmp_path, monkeypatch):
 
 
 def test_wrap_forwards_env_to_proton(profilers_on_path, tmp_path):
-    config = _config(["proton"], collect_dir=tmp_path, options={"proton": {"backend": "roctracer"}})
+    config = _config(["proton"], collect_dir=tmp_path, options={"proton": {"backend": "auto"}})
     argv = wrap_argv_for_collectors(config, _INNER, env={"HIP_VISIBLE_DEVICES": "1"})
     assert "ROCR_VISIBLE_DEVICES=1" in argv
+
+
+def test_wrap_propagates_the_proton_backend_pin_rejection(profilers_on_path, tmp_path):
+    """A pinned queue-intercepting backend under ``mode: cli`` captures an empty
+    tree, so the collector seam has to surface the refusal rather than run the
+    trial and report no metrics."""
+    config = _config(
+        ["proton"], collect_dir=tmp_path, options={"proton": {"backend": "roctracer"}}
+    )
+    with pytest.raises(proton.ProtonWrapError, match="mode: env"):
+        wrap_argv_for_collectors(config, _INNER)
 
 
 # ---- Nesting order ------------------------------------------------------

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from aorta.instrumentation.proton import ENV_PREFIX, build_env
 from aorta.triage.recipe import load_recipe
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -235,3 +236,62 @@ def test_payload_failure_path_still_exits_nonzero(payload, code):
     assert (
         _exit_code_of_main_guard(payload, code) == code
     ), f"{_rel(payload)} does not propagate main() == {code} as an exit status"
+
+
+# ---- The mode: env contract has two halves ------------------------------
+#
+# Under ``mode: env`` the collector only exports variables; the payload is what
+# calls ``proton.start()``. So a knob the recipe sets and the payload never
+# reads is accepted at recipe load, exported, and then silently missing from
+# the capture -- no validation error anywhere. Holding the payloads to the
+# bundle ``build_env`` actually produces, rather than to a list written out
+# here, is what makes a future option fail this test instead of shipping as a
+# no-op.
+
+#: Exported for a payload that wants to write artifacts alongside the profile.
+#: It configures nothing about the session -- and ``NAME`` already carries the
+#: directory -- so a payload that ignores it loses no measurement.
+_OPTIONAL_ENV_SUFFIXES = frozenset({"DIR"})
+
+
+def _env_mode_proton_examples() -> list[Path]:
+    proton = [example for example in _EXAMPLE_DIRS if example.parent.name == "proton"]
+    return [
+        example
+        for example in proton
+        if (load_recipe(example / "recipe.yaml").collect_options.get("proton") or {}).get("mode")
+        == "env"
+    ]
+
+
+_ENV_MODE_EXAMPLES = _env_mode_proton_examples()
+_ENV_MODE_IDS = [str(path.relative_to(EXAMPLES)) for path in _ENV_MODE_EXAMPLES]
+
+
+@pytest.mark.skipif(not _ENV_MODE_EXAMPLES, reason="no mode: env proton example in the tree")
+@pytest.mark.parametrize("example", _ENV_MODE_EXAMPLES, ids=_ENV_MODE_IDS)
+def test_env_mode_payload_reads_every_session_variable(example, tmp_path):
+    """Options chosen to make ``build_env`` emit every key it can: the optional
+    ones are omitted unless asked for, so a narrower call would assert less."""
+    exported = build_env(
+        tmp_path,
+        {
+            "mode": "env",
+            "backend": "rocprofiler",
+            "backend_mode": "pcsampling",
+            "hook": "triton",
+        },
+    )
+    required = sorted(
+        suffix
+        for suffix in (name[len(ENV_PREFIX) :] for name in exported)
+        if suffix not in _OPTIONAL_ENV_SUFFIXES
+    )
+    assert required, "build_env exported nothing to check; the bundle or the prefix moved"
+    source = "\n".join(path.read_text(encoding="utf-8") for path in sorted(example.glob("*.py")))
+    missing = [suffix for suffix in required if suffix not in source]
+    assert not missing, (
+        f"{_rel(example)} never reads {[ENV_PREFIX + s for s in missing]}; a recipe can "
+        "set those knobs and the payload would start Proton without them, so the trial "
+        "would report a capture that is missing what it asked for"
+    )


### PR DESCRIPTION
Closes #412.

## Why

Pinning `proton: {backend: roctracer}` was a no-op that looked like a success.
Triton's Proton CLI front-end calls `_select_backend()` **only when `-b` is
absent**, and that call is what initialises the HIP driver as a side effect — so
a queue-intercepting backend named explicitly attaches before the first HSA
queue exists and records nothing. `parse_summary` then degrades to
`proton_artifact_dir`, so the trial published no Proton metrics while exiting 0:
the silent-unprofiled outcome the collector's design rejects everywhere else.

Measured on the shipped `triton-vecadd` payload (8x gfx950, ROCm 7.0.2, Triton
3.7.1, torch 2.13.0+rocm7.2), 3/3 deterministic:

| Wrap | Result |
|---|---|
| no `-b` (`backend: auto`) | ~3 KB hatchet, 27 dispatches across 5 kernels |
| `-b roctracer` | 160-byte hatchet, bare `ROOT` frame, exit 0 |

Ordering alone accounts for it: driving Proton from the Python API with
`import torch` deferred past `proton.start()` reproduces the empty tree, and
initialising the driver first gives a populated one.

## What changed

`wrap_argv` refuses `mode: cli` with an explicit `roctracer` / `rocprofiler`,
naming the mechanism and `mode: env` as the route. `auto` is untouched —
omitting `-b` is what keeps that path working, which is why it stays the
default. `instrumentation` is deliberately **not** refused: it installs no queue
interceptor and a `-b instrumentation` CLI wrap of a scoped payload captures
correctly (verified). What it loses under `mode: cli` is `--mode`, not the
capture.

Two schema additions, validated against upstream `main`'s `proton.start()`
docstring rather than the installed Triton:

- **`backend_mode`** — Proton's per-backend `--mode`, keyed per backend
  (`rocprofiler`: pcsampling/periodic_flushing, `roctracer`:
  periodic_flushing, `cupti`: both), so `roctracer` + `pcsampling` fails at
  recipe load instead of inside Proton. Requires an explicit backend and is
  rejected beside `instrumentation_mode`, which renders the same argument.
- **`hook`** — Proton's `-k triton` launch hook, in both attach modes.

Three examples, one per AMD backend, all `mode: env` because that is what makes
an explicit backend capture anything:

| Example | Shows | Verified end to end |
|---|---|---|
| `amd-roctracer` | three Triton kernels in sequence; the portable AMD path | `proton_kernel_count` 60 (3 kernels x 20 iters), `proton_gpu_time_ms` 0.398, top kernel `bias_gelu_kernel` |
| `amd-instrumentation` | two named scopes inside one unbalanced kernel | `expensive` 8,608,876 cycles vs `cheap` 153,368 — a 56x split inside one kernel |
| `amd-rocprofiler` | `backend_mode: pcsampling` | capture **not** verified — see below |

Also corrects the "naming a backend is a version commitment" framing wherever it
appeared (collector docstring, options table, both existing example READMEs,
vecadd's recipe): on AMD it is an attach-mode commitment too.

## Things a reviewer should push back on if they disagree

- **`amd-rocprofiler` fails the trial on every released Triton.** No obtainable
  build has that backend: 3.7.1, 3.7.0 and 3.6.0+rocm7.2.4 all offer
  `-b {cupti,roctracer,instrumentation}`, PyPI's newest is 3.7.1, PyTorch's ROCm
  nightly tops out at 3.6.0, and even `rocm/pytorch:rocm7.14_...py3.14_...2.12.0`
  ships 3.7.1. The payload therefore checks availability up front and exits 2
  with a message naming the Triton-main requirement, rather than crashing inside
  Proton. Intentional per the repo's "a measurement that cannot be taken is a
  clean setup failure" stance, but it does mean the example is a documented
  failure today.
- **`amd-instrumentation` publishes no numeric metrics.** Instrumentation leaves
  carry `cycles` / `normalized_cycles`, never `time (<unit>)` or `count`, and the
  parser keys exclusively on the former, so a perfectly healthy intra-kernel
  capture yields only `proton_artifact_dir`. Documented in the README and in the
  artifact-layout section. Teaching `_parse.py` to read cycles is a separate
  change.
- **`build_argv_prefix` still renders `-b roctracer`** even though `wrap_argv`
  refuses to pin it. The split is deliberate — renderer vs. attach-decision
  point, so a caller that only wants to display the flags still can — and
  everything inside aorta reaches Proton through `wrap_argv`. Its docstring now
  says so, and says an out-of-tree consumer building its own attach must apply
  the policy itself.
- **`granularity` is unusable on Triton 3.7.1 in either attach mode** (found
  while building the example): the CLI drops `--mode`, and under `mode: env` the
  rendered `default:granularity=warp` is rejected at kernel exit with
  `RuntimeError: Only warp granularity is supported for now` — for warp, which is
  that backend's own default there. Documented in the options table and
  troubleshooting; the example sets `instrumentation_mode` and omits
  `granularity`. The option is left in the schema rather than removed, since it
  works on upstream `main`.

## CI gap found on the way

The GPU path filter in `.github/workflows/gpu-tests.yml` did not list the Proton
collector or its smoke test, so `pytest (GPU, MI350)` reported `skipping` on this
PR — the two regression tests for the empty-capture bug would never have run in
CI. Fixed here, and verified by replaying the filter's `case` patterns against
this branch's file list.

Two sibling gaps are left alone on purpose, since they predate this branch and
fixing them would put unrelated GPU results on a Proton diff:
`tests/instrumentation/test_rocprof_smoke_gpu.py` and
`tests/instrumentation/test_layer_numerics_smoke_gpu.py` are also missing from
the filter, along with their modules. They are one line each if you would rather
they came with this PR.

## Test plan

- [x] `ruff check` clean on all changed Python files
- [x] `pre-commit` clean
- [x] 479 CPU tests pass across `test_proton.py`, `test_collectors.py`,
      `test_examples.py`, `test_recipe.py`
- [x] Full CPU suite: 4304 passed, 95 skipped. The 17 `tests/ebpf/test_runner.py`
      failures are environmental (no `bpftrace` on the host) and reproduce
      identically on `main`.
- [x] 9 GPU smoke tests pass on gfx950, including
      `test_env_mode_pins_roctracer_and_gets_a_non_empty_tree` and
      `test_cli_mode_pin_would_still_capture_nothing` — the two regressions that
      would have caught this bug
- [x] All three examples run end to end through `aorta sweep run`, asserted on
      published metrics rather than on a `.hatchet` existing (a 160-byte empty
      tree is a file too)

Upstream Triton bugs found on the way, out of scope here and worth separate
reports: the `-b`-absent-only `_select_backend()` asymmetry (still present on
`main`), and 3.7.1's CLI parsing `-m/--mode` and never forwarding it to
`start()`.

Made with [Cursor](https://cursor.com)

