### PR TITLE
test: consolidate pytest config onto pytest.ini, drop the dead pyproject.toml block

### DIFF
--- a/docs/plans/aorta-probe-188-rubric.md
+++ b/docs/plans/aorta-probe-188-rubric.md
@@ -139,7 +139,7 @@ Each PR body references issue #188 and the prior phase PR (so the dependency cha
 | 1.17 | Probe-mode entries in `aorta.workloads` entry-point group: `_subprocess = "aorta.workloads._subprocess:SubprocessWorkload"` is registered in `pyproject.toml` and resolves via `get_workload_class("_subprocess")`. | 3 | Unit test `tests/probe/test_subprocess_workload.py::test_resolved_via_entry_point`. |
 | 1.18 | `aorta probe` exits non-zero (Click `ClickException`) when the recipe is invalid, when no axis items resolve, when `--env-passthrough-mode` is invalid, or when the trailing argv is empty (`--` followed by nothing). | 3 | Unit tests `tests/probe/test_cli_parsing.py::test_invalid_recipe_nonzero_exit`, `::test_empty_argv_nonzero_exit`. |
 | 1.19 | Probe-mode rejects `condition`, `custom_patterns`, `redaction` keys at load time with a "deferred to Phase 2/3" error message that points to the phase. (Prevents users writing recipes that will silently no-op until later phases.) | 2 | Unit test `tests/probe/test_recipe.py::test_phase_2_3_keys_rejected_with_pointer`. |
-| 1.20 | `tests/probe/` contains an `__init__.py` and is collected by `pytest` per the existing `[tool.pytest.ini_options]` (`testpaths = ["tests"]`). | 1 | `pytest tests/probe` discovers ≥ 1 test. |
+| 1.20 | `tests/probe/` contains an `__init__.py` and is collected by `pytest` per the existing `pytest.ini` (`testpaths = tests`). | 1 | `pytest tests/probe` discovers ≥ 1 test. |
 |   | **Total weight** | **77** |  |
 
 ## 1.C File-by-File Deliverables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,17 +302,11 @@ aorta = [
     "workloads/tokenspeed/README.md",
 ]
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-python_functions = ["test_*"]
-addopts = "-v --tb=short"
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "gpu: marks tests that require GPU",
-    "rocm: marks tests that require ROCm specifically",
-    "hw_queue: marks hw_queue_eval tests",
-]
+# Pytest configuration deliberately does NOT live here -- see `pytest.ini` at
+# the repo root. A root `pytest.ini` outranks `[tool.pytest.ini_options]`
+# unconditionally, so a block added here would be dead config that pytest
+# ignores. Edit `pytest.ini` instead.
+# `tests/test_pytest_config_single_source.py` enforces this.
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,9 +303,9 @@ aorta = [
 ]
 
 # Pytest configuration deliberately does NOT live here -- see `pytest.ini` at
-# the repo root. A root `pytest.ini` outranks `[tool.pytest.ini_options]`
-# unconditionally, so a block added here would be dead config that pytest
-# ignores. Edit `pytest.ini` instead.
+# the repo root. A root `pytest.ini` outranks `[tool.pytest.ini_options]` (and,
+# from pytest 9, `[tool.pytest]`) unconditionally, so a block added here would
+# be dead config that pytest ignores. Edit `pytest.ini` instead.
 # `tests/test_pytest_config_single_source.py` enforces this.
 
 [tool.black]

--- a/tests/test_pytest_config_single_source.py
+++ b/tests/test_pytest_config_single_source.py
@@ -1,10 +1,13 @@
 """Guard that pytest configuration has exactly one home: ``pytest.ini``.
 
-A root ``pytest.ini`` outranks ``[tool.pytest.ini_options]`` in
-``pyproject.toml`` unconditionally, so carrying both means one of them is dead
-config that pytest silently ignores. Every other tool here (black, isort, mypy,
-ruff) is configured in ``pyproject.toml``, which makes that the tempting place
-to add pytest settings too -- these tests fail if someone does.
+A root ``pytest.ini`` outranks pytest configuration in ``pyproject.toml``
+unconditionally, so carrying both means one of them is dead config. How loudly
+that fails depends on the pytest in use: from pytest 9 the session header reads
+``configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)``,
+while pytest 8 -- still allowed by our ``pytest>=8.0.0`` floor -- drops it with
+no diagnostic at all. Every other tool here (black, isort, mypy, ruff) is
+configured in ``pyproject.toml``, which makes that the tempting place to add
+pytest settings too -- these tests fail if someone does.
 
 They also pin the settings that are load-bearing beyond taste, so a future
 trim of ``pytest.ini`` cannot quietly drop them.
@@ -12,9 +15,15 @@ trim of ``pytest.ini`` cannot quietly drop them.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pytest depends on tomli below 3.11, so this is available wherever we run.
+    import tomli as tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -24,19 +33,106 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # collection error.
 EXPECTED_MARKERS = frozenset({"unit", "integration", "slow", "gemm", "hw_queue", "gpu", "rocm"})
 
+# Spellings that all declare the same pytest configuration once TOML is parsed.
+# A guard matching the canonical text would wave every one of these through.
+EQUIVALENT_SPELLINGS = {
+    "canonical": '[tool.pytest.ini_options]\naddopts = "-q"\n',
+    "spaced-dotted-key": '[tool . pytest . ini_options]\naddopts = "-q"\n',
+    "quoted-keys": '["tool"."pytest"."ini_options"]\naddopts = "-q"\n',
+    "top-level-dotted-key": 'tool.pytest.ini_options.addopts = "-q"\n',
+    "inline-table": '[tool.pytest]\nini_options = {addopts = "-q"}\n',
+    # pytest 9 also reads `[tool.pytest]` directly, in native-TOML mode.
+    "toml-mode-table": '[tool.pytest]\naddopts = ["-q"]\n',
+}
+
+# TOML that names the table without declaring it, or configures something else.
+NON_DECLARATIONS = {
+    "comment-only": "# pytest settings do not live here, see [tool.pytest.ini_options]\n",
+    "other-tool": "[tool.black]\nline-length = 100\n",
+    "empty-table": "[tool.pytest]\n",
+    "string-value": 'addopts = "[tool.pytest.ini_options]"\n',
+}
+
+
+def _declared_pytest_tables(pyproject: str) -> list[str]:
+    """Names of the pytest config tables ``pyproject.toml`` declares, if any.
+
+    Follows pytest's own detection in ``_pytest.config.findpaths``, which reads
+    ``[tool.pytest.ini_options]`` (ini mode) and, from pytest 9, any other key
+    under ``[tool.pytest]`` (native-TOML mode). Parsing rather than matching
+    text is what makes this immune to TOML spelling -- whitespace around the
+    dots, quoted key parts and top-level dotted keys all reach the same table.
+
+    Deliberately a superset, not an exact mirror: both tables are reported on
+    every pytest version, so a bare ``[tool.pytest]`` cannot sit here dormant
+    under pytest 8 and become live config on the next major bump.
+    ``test_guard_agrees_with_pytests_own_config_detection`` checks the part
+    that must not diverge -- that nothing pytest honours slips past.
+    """
+    tool = tomllib.loads(pyproject).get("tool", {})
+    table = tool.get("pytest", {}) if isinstance(tool, dict) else {}
+    if not isinstance(table, dict):
+        return ["tool.pytest"]
+    declared = ["tool.pytest.ini_options"] if "ini_options" in table else []
+    if any(key != "ini_options" for key in table):
+        declared.append("tool.pytest")
+    return declared
+
+
+def _pytest_reads_config(tmp_path: Path, pyproject: str) -> bool:
+    """Whether pytest's own loader finds pytest config in this ``pyproject.toml``."""
+    from _pytest.config.findpaths import load_config_dict_from_file
+
+    path = tmp_path / "pyproject.toml"
+    path.write_text(pyproject, encoding="utf-8")
+    return load_config_dict_from_file(path) is not None
+
 
 def test_pyproject_declares_no_pytest_config() -> None:
-    # Match a real TOML section header, not a mention of one: pyproject.toml
-    # carries a comment naming the table to explain why it is absent.
+    # Parse the TOML rather than grep it: pyproject.toml carries a comment
+    # naming the table to explain why it is absent, and the table has several
+    # equally valid spellings that a textual match would miss.
     pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    declared = [
-        line for line in pyproject.splitlines() if line.strip() == "[tool.pytest.ini_options]"
-    ]
+    declared = _declared_pytest_tables(pyproject)
     assert not declared, (
-        "pyproject.toml declares [tool.pytest.ini_options], which pytest ignores "
+        f"pyproject.toml declares {', '.join(declared)}, which pytest ignores "
         "while pytest.ini exists at the repo root. Put pytest settings in "
         "pytest.ini instead."
     )
+
+
+@pytest.mark.parametrize("spelling", sorted(EQUIVALENT_SPELLINGS))
+def test_guard_catches_every_equivalent_spelling(spelling: str) -> None:
+    assert _declared_pytest_tables(EQUIVALENT_SPELLINGS[spelling])
+
+
+@pytest.mark.parametrize("case", sorted(NON_DECLARATIONS))
+def test_guard_passes_toml_that_declares_nothing(case: str) -> None:
+    assert not _declared_pytest_tables(NON_DECLARATIONS[case])
+
+
+def test_guard_agrees_with_pytests_own_config_detection(tmp_path: Path) -> None:
+    """Check the "mirrors pytest" claim above against pytest, rather than assert it.
+
+    The guard must fire for every spelling pytest actually honours; missing one
+    is exactly what lets the dead config back in. It is deliberately the
+    stricter side of the mirror -- pytest 8 ignores a bare ``[tool.pytest]``
+    that pytest 9 honours, and the guard rejects it on both, so a later pytest
+    bump cannot quietly revive the table.
+    """
+    honoured = {name: _pytest_reads_config(tmp_path, t) for name, t in EQUIVALENT_SPELLINGS.items()}
+    missed = [
+        name
+        for name, seen in honoured.items()
+        if seen and not _declared_pytest_tables(EQUIVALENT_SPELLINGS[name])
+    ]
+    assert not missed, f"pytest reads config the guard does not flag: {missed}"
+    # Without this the check above passes vacuously if the private loader moves.
+    assert sum(honoured.values()) >= 5, f"pytest honoured too few spellings: {honoured}"
+
+    for name, toml in NON_DECLARATIONS.items():
+        assert not _pytest_reads_config(tmp_path, toml), f"pytest reads config from {name}"
+        assert not _declared_pytest_tables(toml), f"guard false-positives on {name}"
 
 
 def test_pytest_ini_is_the_loaded_config(pytestconfig: pytest.Config) -> None:

--- a/tests/test_pytest_config_single_source.py
+++ b/tests/test_pytest_config_single_source.py
@@ -1,0 +1,63 @@
+"""Guard that pytest configuration has exactly one home: ``pytest.ini``.
+
+A root ``pytest.ini`` outranks ``[tool.pytest.ini_options]`` in
+``pyproject.toml`` unconditionally, so carrying both means one of them is dead
+config that pytest silently ignores. Every other tool here (black, isort, mypy,
+ruff) is configured in ``pyproject.toml``, which makes that the tempting place
+to add pytest settings too -- these tests fail if someone does.
+
+They also pin the settings that are load-bearing beyond taste, so a future
+trim of ``pytest.ini`` cannot quietly drop them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Every marker `pytest.ini` registers. CI selects on `gpu` / `rocm`
+# (`-m "not gpu and not rocm"` and `-m "gpu or rocm"`); the rest must stay
+# registered because `--strict-markers` turns an unregistered marker into a
+# collection error.
+EXPECTED_MARKERS = frozenset({"unit", "integration", "slow", "gemm", "hw_queue", "gpu", "rocm"})
+
+
+def test_pyproject_declares_no_pytest_config() -> None:
+    # Match a real TOML section header, not a mention of one: pyproject.toml
+    # carries a comment naming the table to explain why it is absent.
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    declared = [
+        line for line in pyproject.splitlines() if line.strip() == "[tool.pytest.ini_options]"
+    ]
+    assert not declared, (
+        "pyproject.toml declares [tool.pytest.ini_options], which pytest ignores "
+        "while pytest.ini exists at the repo root. Put pytest settings in "
+        "pytest.ini instead."
+    )
+
+
+def test_pytest_ini_is_the_loaded_config(pytestconfig: pytest.Config) -> None:
+    inipath = pytestconfig.inipath
+    assert inipath is not None, "pytest loaded no config file at all"
+    assert inipath == REPO_ROOT / "pytest.ini", f"unexpected config file: {inipath}"
+
+
+def test_strict_marker_policy_is_configured(pytestconfig: pytest.Config) -> None:
+    # tests/test_marker_partition.py clears addopts for its nested collection
+    # and re-adds --strict-markers, describing it as "the repo's strict-marker
+    # policy". That comment is only true while the repo config actually sets it.
+    assert "--strict-markers" in pytestconfig.getini("addopts")
+
+
+def test_every_marker_stays_registered(pytestconfig: pytest.Config) -> None:
+    registered = {entry.split(":", 1)[0] for entry in pytestconfig.getini("markers")}
+    assert (
+        EXPECTED_MARKERS <= registered
+    ), f"markers dropped from pytest.ini: {sorted(EXPECTED_MARKERS - registered)}"
+
+
+def test_testpaths_still_points_at_tests(pytestconfig: pytest.Config) -> None:
+    assert pytestconfig.getini("testpaths") == ["tests"]


### PR DESCRIPTION
Closes #426

## The problem

`pytest.ini` at the repo root outranks `[tool.pytest.ini_options]` in
`pyproject.toml` unconditionally, so that block was dead config. On `main`,
pytest says so out loud:

```
$ pytest --co -q
rootdir: <repo root>
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
```

(Minor correction to the issue, which said pytest emits no warning — current
pytest does append that parenthetical to the `configfile` line. It only shows
up in header output, though, which is easy to miss, and nothing points at it
from `pyproject.toml`'s side. It is also version-dependent: verified directly,
pytest 9.1.1 prints the warning and pytest 8.4.2 prints a bare
`configfile: pytest.ini` with no diagnostic at all. Our floor is
`pytest>=8.0.0`, so "silently ignored" is true for part of the supported range,
which is why the guard's docstring now names both behaviours instead of
claiming either one.)

`pytest --markers` confirms which file won: it lists `unit`, `integration` and
`gemm`, which are registered only in `pytest.ini`, and prints `pytest.ini`'s
wording for `slow`.

## Setting-by-setting inventory, before and after

| Setting | `pytest.ini` (live, before) | `pyproject.toml` (ignored, before) | After |
| --- | --- | --- | --- |
| `testpaths` | `tests` | `["tests"]` | `pytest.ini`, unchanged |
| `python_files` | `test_*.py` | `["test_*.py"]` | `pytest.ini`, unchanged |
| `python_functions` | `test_*` | `["test_*"]` | `pytest.ini`, unchanged |
| `python_classes` | `Test*` | **absent** | `pytest.ini`, unchanged |
| `addopts` | `-v --strict-markers --tb=short --disable-warnings` | `-v --tb=short` | `pytest.ini`, unchanged |
| marker `unit` | registered | **absent** | `pytest.ini`, unchanged |
| marker `integration` | registered | **absent** | `pytest.ini`, unchanged |
| marker `gemm` | registered | **absent** | `pytest.ini`, unchanged |
| marker `slow` | registered | registered (different help text) | `pytest.ini`, unchanged |
| marker `hw_queue` | registered | registered (different help text) | `pytest.ini`, unchanged |
| marker `gpu` | registered | registered (different help text) | `pytest.ini`, unchanged |
| marker `rocm` | registered | registered (different help text) | `pytest.ini`, unchanged |

The only thing that existed solely in the `pyproject.toml` block was
alternative help text for four markers. Nothing else is dropped, because
nothing else was there.

## Which file was kept, and why

**Kept `pytest.ini`; deleted the `pyproject.toml` block.**

The pull toward `pyproject.toml` is real — it is where `black`, `isort`,
`mypy` and `ruff` all live, and one config file beats two. Three things
outweighed it:

1. **`pytest.ini` was already the strict superset in force.** Keeping it moves
   no behaviour at all, so there is no porting step in which something can be
   silently mistranslated. Consolidating the other way would have had to carry
   `--strict-markers`, `--disable-warnings`, `python_classes = Test*` and three
   marker registrations across by hand.
2. **`--strict-markers` is load-bearing, and it exists only in `pytest.ini`.**
   It is what turns a typo'd marker into a collection error rather than a
   marker name that silently matches nothing and falls outside *both* CI gates.
   `tests/test_marker_partition.py` clears `addopts` and re-adds it explicitly,
   describing it as "the repo's strict-marker policy" — a comment that stays
   true only while the surviving config actually sets it.
3. **Merge safety for #422** (see below). Not touching `pytest.ini` is what
   makes that coordination free rather than delicate.

The cost of this direction is that config stays split across two files, and
`pyproject.toml` remains the intuitive place to add pytest settings. Two things
address that directly: a pointer comment where the block used to be, and
`tests/test_pytest_config_single_source.py`, which fails if a
`[tool.pytest.ini_options]` table reappears. So the trap cannot silently
re-form — which was the strongest argument for consolidating the other way.

That new test also pins `testpaths`, all seven marker registrations, and the
presence of `--strict-markers`, so a future trim of `pytest.ini` cannot quietly
drop them either.

## Note for whoever merges #422

**`asyncio_mode = auto` needs to land in `pytest.ini`.** That is where #422
already puts it, and this PR does not modify `pytest.ini` at all — only
`pyproject.toml`, one doc line, and a new test file. So #422 rebases onto this
with no conflict and no action required, in either merge order.

The one thing to avoid when resolving any future conflict here: do not relocate
`asyncio_mode` into `pyproject.toml`. It would be silently ignored, and the
chat suite would lose auto async mode with no error.

## Verification

Clean venv, dependencies matching `cpu-tests.yml` (CPU torch, `.[tests,hw-queue]`,
`triton`).

Config actually loaded:

```
before: configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
after:  configfile: pytest.ini
```

Collected node ids, compared as sets rather than counts, measured at
`564a18a6` (the commit that removed the block) in a fully-installed venv:

| Selection | Before | After | Delta |
| --- | --- | --- | --- |
| no marker filter | 5055 | 5060 | +5, all from the new test file |
| `-m "not gpu and not rocm"` (CPU gate) | 4951 | 4956 | +5, same 5 |
| `-m "gpu or rocm"` (GPU gate) | 104 | 104 | none |

Excluding the new file, the before and after node-id sets are identical for all
three selections. The partition property still holds (4956 + 104 = 5060), and
`tests/test_marker_partition.py` passes.

`4af73e4a` then grew the guard file from 5 tests to 16 — the parametrised
spellings, the four decoys, and the cross-check against pytest's own loader — so
**that delta is now +16, not +5**. It is still entirely inside the CPU gate and
still zero for `-m "gpu or rocm"`, since none of the new tests carry a marker.
Re-measured on a slim `[tests]`-only venv (lower absolute totals, because six
modules cannot import without torch/numpy): 4778 → 4794 collected, CPU gate
4772, GPU gate 22 either side. Full-suite failure set identical to the base
commit in that venv — 47 failures and 6 collection errors on both, with the
branch's only difference being the 16 extra passes.

`--strict-markers` verified behaviourally, not by inspection — a test carrying
an unregistered marker still fails collection after the change:

```
'definitely_not_a_registered_marker' not found in `markers` configuration option
!!!!!!!! Interrupted: 1 error during collection !!!!!!!!
exit=2
```

`pytest --markers` still lists all seven repo markers with `pytest.ini`'s wording.

Full CI invocation, `pytest -m "not gpu and not rocm" -n 16`:

```
17 failed, 4934 passed, 5 skipped in 232.59s
```

All 17 failures are `tests/ebpf/test_runner.py`, which needs a real `bpftrace`
binary that this local box lacks; CI installs it via apt. They fail identically
before the change.

Also verified the new guard fails when the trap is reintroduced, for every
spelling rather than just the canonical one. Each was added to the real
`pyproject.toml` in turn; each makes `test_pyproject_declares_no_pytest_config`
fail:

| Reintroduced as | Guard fires |
| --- | --- |
| `[tool.pytest.ini_options]` | yes |
| `[tool . pytest . ini_options]` | yes |
| `["tool"."pytest"."ini_options"]` | yes |
| `[tool.pytest]` (pytest 9 native-TOML mode) | yes |
| `tool.pytest.ini_options.addopts = "-q"` as a top-level dotted key | yes |

The last one only counts as a declaration when it sits **before** the first
table header. Appended at end-of-file it binds to the preceding table instead,
and the guard correctly stays quiet — cross-checked against
`_pytest.config.findpaths.load_config_dict_from_file`, which does not read it
either. That agreement is what
`test_guard_agrees_with_pytests_own_config_detection` pins, so the guard cannot
drift into being stricter or looser than pytest without a test failing.

**The Python 3.10 fallback is active, not skipped.** `tomllib` is stdlib only
from 3.11, so the guard imports `tomli` below that. There is no version gate and
no `pytest.importorskip`, so the guard cannot quietly do nothing on the 3.10 CI
leg: all 16 tests pass under 3.10.20. The fallback also needs no new dependency,
and cannot go missing — pytest's own `_pytest/config/findpaths.py` performs the
identical `import tomli as tomllib`, so uninstalling `tomli` on 3.10 stops
pytest from starting at all rather than degrading this guard:

```
File ".../_pytest/config/findpaths.py", line 100, in load_config_dict_from_file
    import tomli as tomllib
ModuleNotFoundError: No module named 'tomli'
```

## Docs

- `docs/plans/aorta-probe-188-rubric.md` cited `[tool.pytest.ini_options]` and
  `testpaths = ["tests"]`; now cites `pytest.ini` and `testpaths = tests`.
- `docs/ci-testing-plan.md` already pointed at `pytest.ini` and stays correct.

