### PR TITLE
perf(cli): load command groups lazily, cutting `aorta --help` from 276 ms to 106 ms

### DIFF
--- a/src/aorta/__init__.py
+++ b/src/aorta/__init__.py
@@ -6,23 +6,42 @@ This package provides:
 """
 
 from importlib import import_module
-from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-# Single source of truth for the version is the distribution metadata, which is
-# generated from ``pyproject.toml`` at build/install time. This keeps
-# ``aorta.__version__`` in lockstep with whatever was actually installed (wheel,
-# ``pip install .``, editable, or ``pip install git+...``) instead of a hard-coded
-# literal that silently drifts from the released version. This runs at import
-# time, so the fallback is best-effort and defensive: besides the expected
-# missing-metadata case (uninstalled source tree), any unexpected metadata error
-# (e.g. unreadable/corrupted dist-info) must not break ``import aorta``.
-try:
-    __version__ = version("amd-aorta")
-except PackageNotFoundError:  # source tree without dist-info
-    __version__ = "0.0.0+unknown"
-except Exception:  # pragma: no cover - defensive: never break import on metadata errors
-    __version__ = "0.0.0+unknown"
+
+def __getattr__(name: str) -> Any:
+    """Resolve ``aorta.__version__`` on first access (PEP 562).
+
+    Single source of truth for the version is the distribution metadata, which
+    is generated from ``pyproject.toml`` at build/install time. This keeps
+    ``aorta.__version__`` in lockstep with whatever was actually installed
+    (wheel, ``pip install .``, editable, or ``pip install git+...``) instead of
+    a hard-coded literal that silently drifts from the released version.
+
+    Reading that metadata pulls in ``importlib.metadata`` and walks ``sys.path``
+    for dist-info, which cost about 100 ms of the ~180 ms a bare ``aorta``
+    invocation spent on imports (issue #417) -- for an attribute almost no
+    caller reads. Resolving on demand and caching the result in the module
+    globals keeps the guarantee without charging every import for it.
+
+    The fallback is best-effort and defensive: besides the expected
+    missing-metadata case (uninstalled source tree), any unexpected metadata
+    error (e.g. unreadable/corrupted dist-info) must not break ``import aorta``.
+    """
+    if name != "__version__":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from importlib.metadata import PackageNotFoundError, version  # noqa: PLC0415
+
+    try:
+        resolved = version("amd-aorta")
+    except PackageNotFoundError:  # source tree without dist-info
+        resolved = "0.0.0+unknown"
+    except Exception:  # pragma: no cover - defensive: never break on metadata errors
+        resolved = "0.0.0+unknown"
+
+    globals()["__version__"] = resolved
+    return resolved
 
 
 def load_training_entrypoint() -> Any:

--- a/src/aorta/__init__.py
+++ b/src/aorta/__init__.py
@@ -19,10 +19,12 @@ def __getattr__(name: str) -> Any:
     a hard-coded literal that silently drifts from the released version.
 
     Reading that metadata pulls in ``importlib.metadata`` and walks ``sys.path``
-    for dist-info, which cost about 100 ms of the ~180 ms a bare ``aorta``
-    invocation spent on imports (issue #417) -- for an attribute almost no
-    caller reads. Resolving on demand and caching the result in the module
-    globals keeps the guarantee without charging every import for it.
+    for dist-info, which dominated the cost of ``import aorta`` -- roughly
+    three quarters of it, for an attribute almost no caller reads (issue #417).
+    Stated as a share rather than a duration because the absolute number moves
+    with the interpreter and how many distributions are installed. Resolving on
+    demand and caching the result in the module globals keeps the guarantee
+    without charging every import for it.
 
     The fallback is best-effort and defensive: besides the expected
     missing-metadata case (uninstalled source tree), any unexpected metadata

--- a/src/aorta/__init__.py
+++ b/src/aorta/__init__.py
@@ -44,6 +44,10 @@ def __getattr__(name: str) -> Any:
     return resolved
 
 
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))
+
+
 def load_training_entrypoint() -> Any:
     """Lazily import and return the default training entry point."""
     module = import_module("aorta.training.fsdp_trainer")

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -10,7 +10,7 @@ from aorta.cli._lazy_group import LazyCommand, LazyGroup
 _COMMANDS: dict[str, LazyCommand] = {
     "agent": LazyCommand(
         "aorta.cli.agent:agent",
-        "Closed-loop mitigation search via the probe engine.",
+        "Autonomous agents: run unattended to a verdict and write artifacts.",
     ),
     "bench": LazyCommand(
         "aorta.cli.bench:bench",

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -36,18 +36,20 @@ _COMMANDS: dict[str, LazyCommand] = {
         "aorta.cli.mitigations:mitigations",
         "Inspect the merged mitigations registry (built-ins + plugins).",
     ),
+    "run": LazyCommand(
+        "aorta.cli.run:run",
+        "Run a workload across N trials with optional mitigations.",
+    ),
     "sweep": LazyCommand(
         "aorta.cli.sweep:sweep",
         "Unified matrix runner: sweep mitigations x {environments|diagnostics} x trials.",
     ),
-    # Deprecated aliases (issue #248): keep working, delegate to the same engine.
+    # Deprecated aliases of `sweep` (issue #248): keep working, delegate to the
+    # same engine. `run` is not one of them -- #248 reserves that name for the
+    # distinct single-execution command above.
     "probe": LazyCommand(
         "aorta.cli.probe:probe",
         "Run an opaque user launch command across a mitigation x diagnostic matrix.",
-    ),
-    "run": LazyCommand(
-        "aorta.cli.run:run",
-        "Run a workload across N trials with optional mitigations.",
     ),
     "triage": LazyCommand(
         "aorta.cli.triage:triage",
@@ -57,7 +59,16 @@ _COMMANDS: dict[str, LazyCommand] = {
 
 
 @click.group(cls=LazyGroup, lazy_commands=_COMMANDS)
-@click.version_option(package_name="aorta")
+# The distribution is ``amd-aorta``; only the import package is ``aorta``. Passing
+# the import name makes Click fall back to ``packages_distributions()``, which can
+# report ``amd-aorta`` twice -- and then ``--version`` raises instead of printing
+# (issue #429). Two layouts do it: an editable install whose build left
+# ``src/amd_aorta.egg-info`` beside the site-packages ``.dist-info`` (build
+# isolation, the default for pip and uv, does; ``--no-build-isolation`` may not),
+# and a venv that exposes site-packages through both ``lib`` and ``lib64``, as
+# ``python -m venv`` does where ``sys.platlibdir`` is ``lib64``. Naming the
+# distribution skips that fallback entirely, on every layout.
+@click.version_option(package_name="amd-aorta")
 def main() -> None:
     """AORTA - GPU debugging platform for ROCm."""
 

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -2,48 +2,64 @@
 
 import click
 
-from aorta.cli import (
-    agent,
-    bench,
-    bundle,
-    chat,
-    env,
-    environments,
-    mitigations,
-    probe,
-    run,
-    sweep,
-    triage,
-)
+from aorta.cli._lazy_group import LazyCommand, LazyGroup
+
+# Command name -> where the click.Command lives, and its help text. Nothing
+# here is imported until the command is actually invoked; see _lazy_group.py
+# for why the help text is duplicated rather than read off the command.
+_COMMANDS: dict[str, LazyCommand] = {
+    "agent": LazyCommand(
+        "aorta.cli.agent:agent",
+        "Closed-loop mitigation search via the probe engine.",
+    ),
+    "bench": LazyCommand(
+        "aorta.cli.bench:bench",
+        "Micro-benchmarks for perf characterization (hw_queue_eval).",
+    ),
+    "bundle": LazyCommand(
+        "aorta.cli.bundle:bundle",
+        "Package an ``aorta probe`` run directory into a redacted tarball.",
+    ),
+    "chat": LazyCommand(
+        "aorta.cli.chat:chat",
+        "Ask questions about the AORTA codebase (interactive REPL).",
+    ),
+    "env": LazyCommand(
+        "aorta.cli.env:env",
+        "Capture and compare GPU/library environment for trial reproducibility.",
+    ),
+    "environments": LazyCommand(
+        "aorta.cli.environments:environments",
+        "Inspect the merged environments registry (built-ins + plugins).",
+    ),
+    "mitigations": LazyCommand(
+        "aorta.cli.mitigations:mitigations",
+        "Inspect the merged mitigations registry (built-ins + plugins).",
+    ),
+    "sweep": LazyCommand(
+        "aorta.cli.sweep:sweep",
+        "Unified matrix runner: sweep mitigations x {environments|diagnostics} x trials.",
+    ),
+    # Deprecated aliases (issue #248): keep working, delegate to the same engine.
+    "probe": LazyCommand(
+        "aorta.cli.probe:probe",
+        "Run an opaque user launch command across a mitigation x diagnostic matrix.",
+    ),
+    "run": LazyCommand(
+        "aorta.cli.run:run",
+        "Run a workload across N trials with optional mitigations.",
+    ),
+    "triage": LazyCommand(
+        "aorta.cli.triage:triage",
+        "Triage matrix runner for mitigation x environment x trials sweeps.",
+    ),
+}
 
 
-@click.group()
-# The distribution is ``amd-aorta``; only the import package is ``aorta``. Passing
-# the import name makes Click fall back to ``packages_distributions()``, which can
-# report ``amd-aorta`` twice -- and then ``--version`` raises instead of printing
-# (issue #429). Two layouts do it: an editable install whose build left
-# ``src/amd_aorta.egg-info`` beside the site-packages ``.dist-info`` (build
-# isolation, the default for pip and uv, does; ``--no-build-isolation`` may not),
-# and a venv that exposes site-packages through both ``lib`` and ``lib64``, as
-# ``python -m venv`` does where ``sys.platlibdir`` is ``lib64``. Naming the
-# distribution skips that fallback entirely, on every layout.
-@click.version_option(package_name="amd-aorta")
+@click.group(cls=LazyGroup, lazy_commands=_COMMANDS)
+@click.version_option(package_name="aorta")
 def main() -> None:
     """AORTA - GPU debugging platform for ROCm."""
-
-
-main.add_command(agent.agent)
-main.add_command(bench.bench)
-main.add_command(bundle.bundle)
-main.add_command(chat.chat)
-main.add_command(env.env)
-main.add_command(environments.environments)
-main.add_command(mitigations.mitigations)
-main.add_command(sweep.sweep)
-# Deprecated aliases (issue #248): keep working, delegate to the same engine.
-main.add_command(probe.probe)
-main.add_command(run.run)
-main.add_command(triage.triage)
 
 
 if __name__ == "__main__":

--- a/src/aorta/cli/_lazy_group.py
+++ b/src/aorta/cli/_lazy_group.py
@@ -1,8 +1,8 @@
 """A ``click.Group`` that imports a subcommand's module only when it is used.
 
-Every ``aorta`` invocation used to import all ten command modules, and with
+Every ``aorta`` invocation used to import every command module, and with
 them most of the package -- roughly 190 ms of the 255 ms that ``aorta --help``
-took (issue #417). The cost is breadth rather than weight: no single module is
+took (issue #417, measured when there were ten of them). The cost is breadth rather than weight: no single module is
 expensive, but ``aorta --help`` and shell completion paid for all of them.
 
 :class:`LazyGroup` keeps a registry mapping a command name to the import path

--- a/src/aorta/cli/_lazy_group.py
+++ b/src/aorta/cli/_lazy_group.py
@@ -19,6 +19,7 @@ the command's own, and if any command module is imported eagerly.
 
 from __future__ import annotations
 
+from copy import copy
 from dataclasses import dataclass
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
@@ -27,6 +28,27 @@ import click
 
 if TYPE_CHECKING:
     from click.shell_completion import CompletionItem
+
+
+def _named(command: click.Command, name: str) -> click.Command:
+    """Return ``command`` carrying ``name``, copying it if it is named otherwise.
+
+    A registry key need not match the loaded object's own ``name``: ``bench``
+    registers ``hw_queue_eval`` against a group defined as ``cli``. Click 8.0.0
+    builds the child context from ``cmd.name`` rather than the invoked name, so
+    the mismatch renders as ``Usage: aorta bench cli ...`` and points the user
+    at a command line that does not exist. That was fixed in Click 8.0.1, but
+    ``click>=8.0.0`` still resolves 8.0.0.
+
+    Copying leaves the module-level command object unmutated -- ``cli`` is also
+    the entry point of ``python -m aorta.hw_queue_eval``, which must keep its
+    own name. The copy is shallow, so subcommands and params stay shared.
+    """
+    if command.name == name:
+        return command
+    renamed = copy(command)
+    renamed.name = name
+    return renamed
 
 
 @dataclass(frozen=True)
@@ -73,7 +95,25 @@ class LazyGroup(click.Group):
         entry = self.lazy_commands.get(cmd_name)
         if entry is None:
             return super().get_command(ctx, cmd_name)
-        return entry.load()
+        return _named(entry.load(), cmd_name)
+
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        if args and args[0] in self.lazy_commands:
+            return super().resolve_command(ctx, args)
+        # Click draws its "Did you mean ...?" candidates from ``self.commands``,
+        # which lazy names never enter -- so an eager group answers
+        # ``aorta enviroments`` with ``Did you mean 'environments'?`` and this
+        # one would not. Only the keys are read, and only on this
+        # unknown-command path, so bare stand-ins are enough and nothing is
+        # imported. Registered commands keep precedence over the registry.
+        registered = self.commands
+        self.commands = {**{name: click.Command(name) for name in self.lazy_commands}, **registered}
+        try:
+            return super().resolve_command(ctx, args)
+        finally:
+            self.commands = registered
 
     def _summary(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
         """Return a command object good enough to read a short help off, no import.

--- a/src/aorta/cli/_lazy_group.py
+++ b/src/aorta/cli/_lazy_group.py
@@ -14,7 +14,9 @@ without a registry copy the help and completion paths would import exactly the
 modules this group exists to avoid.
 
 ``tests/cli/test_lazy_commands.py`` fails if a registry help string drifts from
-the command's own, and if any command module is imported eagerly.
+the command's own, if a resolved command does not carry the key it was reached
+by, if an unknown command stops suggesting a registered one, and if any command
+module is imported eagerly.
 """
 
 from __future__ import annotations
@@ -56,7 +58,9 @@ class LazyCommand:
     """Registry entry: where a command lives, and what ``--help`` says about it.
 
     Attributes:
-        import_path: ``"module:attribute"`` locating the ``click.Command``.
+        import_path: ``"module:attribute"`` locating the ``click.Command``. The
+            attribute need not be named after the registry key; :func:`_named`
+            reconciles the two.
         help: The command's help text. Only the first paragraph is ever
             rendered, so registering just that paragraph is enough; see the
             module docstring for why it is duplicated here at all.
@@ -105,9 +109,9 @@ class LazyGroup(click.Group):
         # Click draws its "Did you mean ...?" candidates from ``self.commands``,
         # which lazy names never enter -- so an eager group answers
         # ``aorta enviroments`` with ``Did you mean 'environments'?`` and this
-        # one would not. Only the keys are read, and only on this
-        # unknown-command path, so bare stand-ins are enough and nothing is
-        # imported. Registered commands keep precedence over the registry.
+        # one would not. Click reads only the keys of that mapping, and only on
+        # this unknown-command path, so bare stand-ins are enough and nothing
+        # is imported to build them.
         registered = self.commands
         self.commands = {**{name: click.Command(name) for name in self.lazy_commands}, **registered}
         try:

--- a/src/aorta/cli/_lazy_group.py
+++ b/src/aorta/cli/_lazy_group.py
@@ -1,0 +1,129 @@
+"""A ``click.Group`` that imports a subcommand's module only when it is used.
+
+Every ``aorta`` invocation used to import all ten command modules, and with
+them most of the package -- roughly 190 ms of the 255 ms that ``aorta --help``
+took (issue #417). The cost is breadth rather than weight: no single module is
+expensive, but ``aorta --help`` and shell completion paid for all of them.
+
+:class:`LazyGroup` keeps a registry mapping a command name to the import path
+of its ``click.Command`` and resolves that path on first use. The registry also
+carries each command's help text, and that duplication is the whole point:
+:meth:`click.Group.format_commands` and :meth:`click.Group.shell_complete` call
+:meth:`get_command` for every entry just to read a short help string, so
+without a registry copy the help and completion paths would import exactly the
+modules this group exists to avoid.
+
+``tests/cli/test_lazy_commands.py`` fails if a registry help string drifts from
+the command's own, and if any command module is imported eagerly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+import click
+
+if TYPE_CHECKING:
+    from click.shell_completion import CompletionItem
+
+
+@dataclass(frozen=True)
+class LazyCommand:
+    """Registry entry: where a command lives, and what ``--help`` says about it.
+
+    Attributes:
+        import_path: ``"module:attribute"`` locating the ``click.Command``.
+        help: The command's help text. Only the first paragraph is ever
+            rendered, so registering just that paragraph is enough; see the
+            module docstring for why it is duplicated here at all.
+    """
+
+    import_path: str
+    help: str
+
+    def load(self) -> click.Command:
+        """Import the module and return the command object."""
+        module_name, _, attribute = self.import_path.partition(":")
+        command: click.Command = getattr(import_module(module_name), attribute)
+        return command
+
+
+class LazyGroup(click.Group):
+    """Group whose subcommands come from a name -> :class:`LazyCommand` registry.
+
+    Commands added the usual way with ``add_command`` keep working and are
+    listed alongside the lazy ones.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        lazy_commands: dict[str, LazyCommand] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.lazy_commands: dict[str, LazyCommand] = dict(lazy_commands or {})
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        return sorted({*super().list_commands(ctx), *self.lazy_commands})
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        entry = self.lazy_commands.get(cmd_name)
+        if entry is None:
+            return super().get_command(ctx, cmd_name)
+        return entry.load()
+
+    def _summary(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        """Return a command object good enough to read a short help off, no import.
+
+        For a registry entry that is a throwaway ``click.Command`` carrying the
+        registered help text. Building a real Click command rather than
+        returning the string means Click applies its own truncation rules, so
+        the rendered output is identical to an eagerly constructed group's.
+        """
+        entry = self.lazy_commands.get(cmd_name)
+        if entry is None:
+            return super().get_command(ctx, cmd_name)
+        return click.Command(cmd_name, help=entry.help)
+
+    def _visible_summaries(
+        self,
+        ctx: click.Context,
+        prefix: str = "",
+    ) -> list[tuple[str, click.Command]]:
+        summaries = []
+        for name in self.list_commands(ctx):
+            if not name.startswith(prefix):
+                continue
+            cmd = self._summary(ctx, name)
+            if cmd is not None and not cmd.hidden:
+                summaries.append((name, cmd))
+        return summaries
+
+    def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        # Mirrors click.Group.format_commands, but sources each row from the
+        # registry instead of an imported command.
+        summaries = self._visible_summaries(ctx)
+        if not summaries:
+            return
+        limit = formatter.width - 6 - max(len(name) for name, _ in summaries)
+        with formatter.section("Commands"):
+            formatter.write_dl([(name, cmd.get_short_help_str(limit)) for name, cmd in summaries])
+
+    def shell_complete(self, ctx: click.Context, incomplete: str) -> list[CompletionItem]:
+        # Mirrors click.Group.shell_complete. Completion runs on every TAB, so
+        # it matters at least as much as --help that it imports nothing; the
+        # option completions still come from click.Command.
+        from click.shell_completion import CompletionItem  # noqa: PLC0415
+
+        results = [
+            CompletionItem(name, help=cmd.get_short_help_str())
+            for name, cmd in self._visible_summaries(ctx, incomplete)
+        ]
+        results.extend(click.Command.shell_complete(self, ctx, incomplete))
+        return results
+
+
+__all__ = ["LazyCommand", "LazyGroup"]

--- a/src/aorta/cli/bench.py
+++ b/src/aorta/cli/bench.py
@@ -4,87 +4,62 @@ from __future__ import annotations
 
 import click
 
+from aorta.cli._lazy_group import LazyCommand, LazyGroup
+
 _INSTALL_HINT = (
     "'aorta bench hw_queue_eval' requires the hw-queue extra.\n"
     "Install it with:  pip install 'amd-aorta[hw-queue]'"
 )
 
 
-def _load_hw_queue_cli() -> click.Group | None:
-    """Return the hw_queue_eval CLI group, or None if the [hw-queue] extra is absent.
+def _install_hint_command(name: str) -> click.Command:
+    """Stand in for ``hw_queue_eval`` when the [hw-queue] extra is absent.
 
-    Only treats a missing *external* dependency (e.g. torch, numpy) as
-    "extra not installed". A ModuleNotFoundError for an aorta.hw_queue_eval.*
-    sub-module — or any other ImportError — propagates so real bugs surface.
-    """
-    try:
-        from aorta.hw_queue_eval.cli import cli  # noqa: PLC0415
-
-        return cli
-    except ModuleNotFoundError as exc:
-        # Only swallow the error when the missing module is NOT part of
-        # aorta.hw_queue_eval itself (i.e. it's an absent external dep).
-        if exc.name is not None and exc.name.startswith("aorta.hw_queue_eval"):
-            raise
-        return None
-    # Any other ImportError propagates unchanged.
-
-
-class _LazyHwQueueGroup(click.Group):
-    """Lazy proxy for the hw_queue_eval Click group.
-
-    Defers the hw_queue_eval import (and transitively torch) until the user
-    actually invokes ``aorta bench hw_queue_eval``. Group-level metadata
-    (help text, params like ``--version``) is forwarded from the inner group
-    so the surface matches ``python -m aorta.hw_queue_eval`` exactly.
-    When the extra is absent, every entry point shows a clear install hint.
+    Accepts whatever arguments follow so that every invocation -- bare or with
+    a subcommand -- reports the install hint rather than Click's generic "No
+    such command". ``--help`` still exits 0; the hint is the signal, not the
+    exit code.
     """
 
-    def _inner(self) -> click.Group | None:
-        return _load_hw_queue_cli()
+    @click.command(
+        name=name,
+        help=_INSTALL_HINT,
+        context_settings={"ignore_unknown_options": True},
+    )
+    @click.argument("argv", nargs=-1, type=click.UNPROCESSED, metavar="[COMMAND]...")
+    def hint(argv: tuple[str, ...]) -> None:
+        raise click.ClickException(_INSTALL_HINT)
 
-    def _require(self) -> click.Group:
-        inner = self._inner()
-        if inner is None:
-            raise click.ClickException(_INSTALL_HINT)
-        return inner
-
-    def get_params(self, ctx: click.Context) -> list[click.Parameter]:
-        # Forward the inner group's params (e.g. --version) when available.
-        # Overrides get_params rather than the params property to avoid
-        # conflicting with click.Command.__init__'s self.params assignment.
-        inner = self._inner()
-        return inner.get_params(ctx) if inner is not None else super().get_params(ctx)
-
-    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        inner = self._inner()
-        if inner is not None:
-            inner.format_help(ctx, formatter)
-        else:
-            # Show the install hint on `aorta bench hw_queue_eval --help`
-            # when the extra is absent. --help always exits 0; the hint is
-            # the signal, not the exit code.
-            with formatter.section("Error"):
-                formatter.write_text(_INSTALL_HINT)
-
-    def list_commands(self, ctx: click.Context) -> list[str]:
-        inner = self._inner()
-        return inner.list_commands(ctx) if inner is not None else []
-
-    def get_command(self, ctx: click.Context, cmd_name: str) -> click.BaseCommand | None:
-        return self._require().get_command(ctx, cmd_name)
-
-    def invoke(self, ctx: click.Context) -> None:
-        # Ensures the install hint fires on bare `aorta bench hw_queue_eval`
-        # (no subcommand) rather than Click's generic "Missing command" error.
-        self._require()
-        super().invoke(ctx)
+    return hint
 
 
-@click.group()
+class _BenchGroup(LazyGroup):
+    """Reports an absent [hw-queue] extra as an install hint.
+
+    Only a missing *external* dependency (e.g. torch, numpy) means "extra not
+    installed". A ModuleNotFoundError for an aorta.hw_queue_eval.* sub-module
+    -- or any other ImportError -- propagates so real bugs surface.
+    """
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        try:
+            return super().get_command(ctx, cmd_name)
+        except ModuleNotFoundError as exc:
+            if exc.name is not None and exc.name.startswith("aorta.hw_queue_eval"):
+                raise
+            return _install_hint_command(cmd_name)
+
+
+@click.group(
+    cls=_BenchGroup,
+    lazy_commands={
+        # hw_queue_eval (and transitively torch) is imported only when the
+        # subcommand is actually invoked.
+        "hw_queue_eval": LazyCommand(
+            "aorta.hw_queue_eval.cli:cli",
+            "Hardware queue evaluation harness (needs the hw-queue extra).",
+        ),
+    },
+)
 def bench() -> None:
     """Micro-benchmarks for perf characterization (hw_queue_eval)."""
-
-
-# Lazy proxy: hw_queue_eval imported only when the subcommand is actually invoked.
-bench.add_command(_LazyHwQueueGroup(name="hw_queue_eval"), name="hw_queue_eval")

--- a/tests/cli/test_bench.py
+++ b/tests/cli/test_bench.py
@@ -6,21 +6,40 @@ Tests the shim contract only — not hw_queue_eval internals:
   hw_queue_eval's own CLI group registers (derived at runtime, not hardcoded).
 - When hw_queue_eval is unavailable, bare invoke exits non-zero with a clear
   install hint; ``--help`` exits 0 but shows the hint instead of empty help.
+- Only a missing *external* dependency is read as "extra not installed": a
+  missing aorta.hw_queue_eval sub-module, or any other ImportError, propagates.
 - ``bench`` is correctly wired under the top-level ``aorta`` CLI.
 """
 
 from __future__ import annotations
 
+import importlib
+import types
+
+import click
 import pytest
 from click.testing import CliRunner
 
-from aorta.cli.bench import _load_hw_queue_cli, bench
 from aorta.cli import main
+from aorta.cli.bench import bench
 
-# Availability is determined by actually attempting the import, not find_spec:
-# aorta.hw_queue_eval files are always present in the source tree, but the
-# import fails on a base install because hw_queue_eval.__init__ pulls torch.
-_HW_QUEUE_AVAILABLE = _load_hw_queue_cli() is not None
+
+def _hw_queue_available() -> bool:
+    """Report whether the [hw-queue] extra is installed.
+
+    Availability is determined by actually attempting the import, not
+    find_spec: aorta.hw_queue_eval files are always present in the source tree,
+    but the import fails on a base install because hw_queue_eval.__init__
+    pulls torch.
+    """
+    try:
+        importlib.import_module("aorta.hw_queue_eval.cli")
+    except ModuleNotFoundError:
+        return False
+    return True
+
+
+_HW_QUEUE_AVAILABLE = _hw_queue_available()
 
 
 def test_bench_help_lists_hw_queue_eval() -> None:
@@ -67,3 +86,71 @@ def test_hw_queue_unavailable_help_shows_install_hint() -> None:
     result = CliRunner().invoke(bench, ["hw_queue_eval", "--help"])
     assert result.exit_code == 0, result.output
     assert "amd-aorta[hw-queue]" in result.output
+
+
+def _fail_import(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """Make resolving a lazy command raise ``exc``, whatever is installed locally."""
+
+    def raise_it(_name: str) -> None:
+        raise exc
+
+    monkeypatch.setattr("aorta.cli._lazy_group.import_module", raise_it)
+
+
+def test_missing_external_dependency_becomes_an_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent third-party dep means the extra is not installed: show the hint."""
+    _fail_import(monkeypatch, ModuleNotFoundError("No module named 'torch'", name="torch"))
+    result = CliRunner().invoke(bench, ["hw_queue_eval"])
+    assert result.exit_code != 0
+    assert "amd-aorta[hw-queue]" in result.output
+
+
+def test_missing_internal_module_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing aorta.hw_queue_eval sub-module is our bug, not a missing extra.
+
+    Reporting it as "install the extra" would send users down a dead end, so it
+    has to surface as the ModuleNotFoundError it is.
+    """
+    broken = ModuleNotFoundError(
+        "No module named 'aorta.hw_queue_eval.sweep'",
+        name="aorta.hw_queue_eval.sweep",
+    )
+    _fail_import(monkeypatch, broken)
+    result = CliRunner().invoke(bench, ["hw_queue_eval"])
+    assert isinstance(result.exception, ModuleNotFoundError)
+    assert result.exception.name == "aorta.hw_queue_eval.sweep"
+
+
+def test_other_import_errors_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Anything that is not a ModuleNotFoundError is a real bug and must surface."""
+    _fail_import(monkeypatch, ImportError("cannot import name 'cli'"))
+    result = CliRunner().invoke(bench, ["hw_queue_eval"])
+    assert isinstance(result.exception, ImportError)
+
+
+def test_hw_queue_group_is_resolved_when_the_extra_is_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the import succeeding, ``bench`` hands Click the real inner group.
+
+    Stubbed rather than skipped so the happy path stays covered on the base
+    install, where torch (and so hw_queue_eval) is absent.
+    """
+
+    @click.group(name="hw_queue_eval")
+    def stub() -> None:
+        """Stand-in hw_queue_eval group."""
+
+    @stub.command()
+    def sweep() -> None:
+        """Stand-in subcommand."""
+
+    monkeypatch.setattr(
+        "aorta.cli._lazy_group.import_module",
+        lambda _name: types.SimpleNamespace(cli=stub),
+    )
+    result = CliRunner().invoke(bench, ["hw_queue_eval", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "sweep" in result.output

--- a/tests/cli/test_bench.py
+++ b/tests/cli/test_bench.py
@@ -31,15 +31,58 @@ def _hw_queue_available() -> bool:
     find_spec: aorta.hw_queue_eval files are always present in the source tree,
     but the import fails on a base install because hw_queue_eval.__init__
     pulls torch.
+
+    Mirrors _BenchGroup.get_command's distinction: only an absent *external*
+    dependency means "extra not installed". A missing aorta.hw_queue_eval
+    sub-module is our own bug, and reading it as "extra absent" would skip the
+    real-group tests below instead of failing them.
     """
     try:
         importlib.import_module("aorta.hw_queue_eval.cli")
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as exc:
+        if exc.name is not None and exc.name.startswith("aorta.hw_queue_eval"):
+            raise
         return False
     return True
 
 
 _HW_QUEUE_AVAILABLE = _hw_queue_available()
+
+
+def _raise_on_import(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """Make importlib.import_module raise ``exc`` for the availability probe."""
+
+    def raise_it(_name: str) -> None:
+        raise exc
+
+    monkeypatch.setattr(importlib, "import_module", raise_it)
+
+
+def test_availability_probe_reads_an_absent_external_dep_as_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent third-party dep is what "extra not installed" means."""
+    _raise_on_import(monkeypatch, ModuleNotFoundError("No module named 'torch'", name="torch"))
+    assert _hw_queue_available() is False
+
+
+def test_availability_probe_does_not_mask_an_internal_import_bug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken aorta.hw_queue_eval sub-module must not read as "extra absent".
+
+    Reporting it that way skips every real-group test in this module, so a
+    packaging regression inside the subpackage would land green.
+    """
+    _raise_on_import(
+        monkeypatch,
+        ModuleNotFoundError(
+            "No module named 'aorta.hw_queue_eval.sweep'",
+            name="aorta.hw_queue_eval.sweep",
+        ),
+    )
+    with pytest.raises(ModuleNotFoundError, match="aorta.hw_queue_eval.sweep"):
+        _hw_queue_available()
 
 
 def test_bench_help_lists_hw_queue_eval() -> None:
@@ -190,10 +233,21 @@ def test_hw_queue_group_is_resolved_when_the_extra_is_present(
     """With the import succeeding, ``bench`` hands Click the real inner group.
 
     Stubbed rather than skipped so the happy path stays covered on the base
-    install, where torch (and so hw_queue_eval) is absent.
+    install, where torch (and so hw_queue_eval) is absent. The stub is named
+    ``cli`` because the real group is (``aorta.hw_queue_eval.cli:cli``); a stub
+    pre-named ``hw_queue_eval`` would not exercise the rename below.
     """
+    stub = _stub_hw_queue_group(monkeypatch)
+    result = CliRunner().invoke(bench, ["hw_queue_eval", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "sweep" in result.output
+    assert stub.name == "cli", "the loaded module's own group must not be renamed in place"
 
-    @click.group(name="hw_queue_eval")
+
+def _stub_hw_queue_group(monkeypatch: pytest.MonkeyPatch) -> click.Group:
+    """Stand in for ``aorta.hw_queue_eval.cli:cli``, named as that group really is."""
+
+    @click.group(name="cli")
     def stub() -> None:
         """Stand-in hw_queue_eval group."""
 
@@ -205,6 +259,29 @@ def test_hw_queue_group_is_resolved_when_the_extra_is_present(
         "aorta.cli._lazy_group.import_module",
         lambda _name: types.SimpleNamespace(cli=stub),
     )
+    return stub
+
+
+def test_resolved_group_carries_the_registry_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The group handed to Click must be named ``hw_queue_eval``, not ``cli``.
+
+    Click 8.0.0 builds the child context from ``cmd.name`` rather than the
+    invoked name, so a mismatch renders as ``Usage: aorta bench cli ...`` --
+    a command line the user cannot type. ``click>=8.0.0`` still resolves 8.0.0,
+    and the deleted proxy was explicitly named ``hw_queue_eval``, so this is
+    the invariant that kept the rename invisible.
+    """
+    _stub_hw_queue_group(monkeypatch)
+    resolved = bench.get_command(click.Context(bench), "hw_queue_eval")
+    assert resolved is not None
+    assert resolved.name == "hw_queue_eval"
+
+
+def test_usage_line_uses_the_registry_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--help`` on the resolved group advertises the invocable path."""
+    _stub_hw_queue_group(monkeypatch)
     result = CliRunner().invoke(bench, ["hw_queue_eval", "--help"])
     assert result.exit_code == 0, result.output
-    assert "sweep" in result.output
+    usage = result.output.splitlines()[0]
+    assert "hw_queue_eval" in usage, usage
+    assert " cli " not in usage, usage

--- a/tests/cli/test_bench.py
+++ b/tests/cli/test_bench.py
@@ -53,8 +53,10 @@ def test_bench_help_lists_hw_queue_eval() -> None:
     assert result.exit_code == 0, result.output
     assert "hw_queue_eval" in result.output
     row = next(
-        line for line in result.output.splitlines() if line.strip().startswith("hw_queue_eval")
+        (line for line in result.output.splitlines() if line.strip().startswith("hw_queue_eval")),
+        None,
     )
+    assert row is not None, result.output
     rendered = row.split("hw_queue_eval", 1)[1].strip()
     assert rendered, f"help row is blank: {row!r}"
     # Tolerate Click's width-dependent "..." truncation instead of pinning a width.

--- a/tests/cli/test_bench.py
+++ b/tests/cli/test_bench.py
@@ -7,7 +7,10 @@ Tests the shim contract only — not hw_queue_eval internals:
 - When hw_queue_eval is unavailable, bare invoke exits non-zero with a clear
   install hint; ``--help`` exits 0 but shows the hint instead of empty help.
 - Only a missing *external* dependency is read as "extra not installed": a
-  missing aorta.hw_queue_eval sub-module, or any other ImportError, propagates.
+  missing aorta.hw_queue_eval sub-module, or any other ImportError, propagates
+  — from the group and from this module's own availability probe alike.
+- The resolved group is named ``hw_queue_eval``, the key it is registered
+  under, not ``cli``, the name it is defined as.
 - ``bench`` is correctly wired under the top-level ``aorta`` CLI.
 """
 

--- a/tests/cli/test_bench.py
+++ b/tests/cli/test_bench.py
@@ -43,10 +43,24 @@ _HW_QUEUE_AVAILABLE = _hw_queue_available()
 
 
 def test_bench_help_lists_hw_queue_eval() -> None:
-    """``aorta bench --help`` exits 0 and lists hw_queue_eval."""
+    """``aorta bench --help`` exits 0 and lists hw_queue_eval with its short help.
+
+    The row's help text is the behaviour change the registry bought: the
+    deleted proxy carried no help, so the row rendered blank. Sourced from the
+    registry rather than hardcoded so the two cannot drift apart.
+    """
     result = CliRunner().invoke(bench, ["--help"])
     assert result.exit_code == 0, result.output
     assert "hw_queue_eval" in result.output
+    row = next(
+        line for line in result.output.splitlines() if line.strip().startswith("hw_queue_eval")
+    )
+    rendered = row.split("hw_queue_eval", 1)[1].strip()
+    assert rendered, f"help row is blank: {row!r}"
+    # Tolerate Click's width-dependent "..." truncation instead of pinning a width.
+    assert bench.lazy_commands["hw_queue_eval"].help.startswith(
+        rendered.removesuffix("...").rstrip()
+    ), rendered
 
 
 def test_bench_wired_under_main() -> None:
@@ -97,14 +111,52 @@ def _fail_import(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
     monkeypatch.setattr("aorta.cli._lazy_group.import_module", raise_it)
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["hw_queue_eval"], id="bare"),
+        pytest.param(["hw_queue_eval", "sweep"], id="trailing-subcommand"),
+        pytest.param(["hw_queue_eval", "sweep", "--iters", "3"], id="trailing-subcommand-options"),
+        pytest.param(["hw_queue_eval", "--bogus-flag"], id="trailing-unknown-option"),
+    ],
+)
 def test_missing_external_dependency_becomes_an_install_hint(
     monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
 ) -> None:
-    """An absent third-party dep means the extra is not installed: show the hint."""
+    """An absent third-party dep means the extra is not installed: show the hint.
+
+    The trailing-argument cases pin the stand-in's ``ignore_unknown_options``
+    plus variadic ``UNPROCESSED`` argument: without them Click rejects the
+    extra tokens with its own usage error and the user never sees the hint.
+    """
     _fail_import(monkeypatch, ModuleNotFoundError("No module named 'torch'", name="torch"))
-    result = CliRunner().invoke(bench, ["hw_queue_eval"])
+    result = CliRunner().invoke(bench, argv)
     assert result.exit_code != 0
     assert "amd-aorta[hw-queue]" in result.output
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["hw_queue_eval", "--help"], id="bare"),
+        pytest.param(["hw_queue_eval", "sweep", "--help"], id="trailing-subcommand"),
+    ],
+)
+def test_missing_external_dependency_help_shows_the_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
+) -> None:
+    """``--help`` on the stand-in exits 0 and renders the hint as the help body.
+
+    The environment-gated test above only covers this on a base install; this
+    one stubs the import so the path stays covered wherever the suite runs.
+    """
+    _fail_import(monkeypatch, ModuleNotFoundError("No module named 'torch'", name="torch"))
+    result = CliRunner().invoke(bench, argv)
+    assert result.exit_code == 0, result.output
+    assert "amd-aorta[hw-queue]" in result.output
+    assert "Error" not in result.output
 
 
 def test_missing_internal_module_propagates(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_lazy_commands.py
+++ b/tests/cli/test_lazy_commands.py
@@ -112,6 +112,21 @@ def test_shell_completion_offers_every_command() -> None:
     assert sorted(item.value for item in completions) == sorted(_COMMANDS)
 
 
+def test_shell_completion_carries_help_from_the_registry() -> None:
+    """Every completion item ships the help column, sourced from the registry.
+
+    ``zsh_complete`` renders this column, and the registry is the only place it
+    can come from without importing the command -- so an empty help here means
+    either the laziness or the description in the shell menu has been lost.
+    """
+    completions = {item.value: item.help for item in main.shell_complete(click.Context(main), "")}
+    for name, entry in _COMMANDS.items():
+        rendered = completions[name]
+        assert rendered, f"{name} completes with no help text"
+        # Tolerate Click's short-help truncation instead of pinning a width.
+        assert entry.help.startswith(rendered.removesuffix("...").rstrip()), (name, rendered)
+
+
 def test_shell_completion_filters_on_the_incomplete_prefix() -> None:
     completions = main.shell_complete(click.Context(main), "en")
     assert [item.value for item in completions] == ["env", "environments"]

--- a/tests/cli/test_lazy_commands.py
+++ b/tests/cli/test_lazy_commands.py
@@ -153,3 +153,35 @@ def test_shell_completion_carries_help_from_the_registry() -> None:
 def test_shell_completion_filters_on_the_incomplete_prefix() -> None:
     completions = main.shell_complete(click.Context(main), "en")
     assert [item.value for item in completions] == ["env", "environments"]
+
+
+def test_unknown_command_still_suggests_a_registered_one() -> None:
+    """A typo must keep getting Click's "Did you mean ...?" hint.
+
+    Click sources the suggestions from ``Group.commands``, which lazy names
+    never enter, so laziness silently drops them; an eagerly built group is the
+    reference for what the user used to see. Click only grew suggestions in
+    8.4, hence comparing against an eager group rather than pinning the text.
+    """
+    eager = click.Group(main.name, commands={name: click.Command(name) for name in _COMMANDS})
+    expected = CliRunner().invoke(eager, ["enviroments"]).output
+    if "Did you mean" not in expected:
+        pytest.skip("this Click does not offer unknown-command suggestions")
+    result = CliRunner().invoke(main, ["enviroments"])
+    assert "environments" in result.output, result.output
+
+
+def test_resolved_commands_carry_their_registry_name() -> None:
+    """The object handed to Click must be named after the key it was reached by.
+
+    Click 8.0.0 builds the child context from ``cmd.name`` rather than the
+    invoked name, so a key that disagrees renders a usage line the user cannot
+    type. Every entry here happens to agree already; the assertion is on
+    ``get_command``, which is what ``bench``'s ``hw_queue_eval`` -> ``cli``
+    entry needs and what keeps a future mismatch from going unnoticed.
+    """
+    ctx = click.Context(main)
+    for name in _COMMANDS:
+        resolved = main.get_command(ctx, name)
+        assert resolved is not None, name
+        assert resolved.name == name

--- a/tests/cli/test_lazy_commands.py
+++ b/tests/cli/test_lazy_commands.py
@@ -125,7 +125,7 @@ def test_commands_section_matches_an_eagerly_built_group() -> None:
 
 @pytest.mark.parametrize("name", sorted(_COMMANDS))
 def test_every_command_resolves_through_the_group(name: str) -> None:
-    """Covers the deprecated probe/run/triage aliases (issue #248) along with the rest."""
+    """Covers the deprecated probe/triage aliases (issue #248) along with the rest."""
     result = CliRunner().invoke(main, [name, "--help"])
     assert result.exit_code == 0, result.output
 

--- a/tests/cli/test_lazy_commands.py
+++ b/tests/cli/test_lazy_commands.py
@@ -22,6 +22,7 @@ import pytest
 from click.testing import CliRunner
 
 from aorta.cli import _COMMANDS, main
+from aorta.cli._lazy_group import LazyGroup
 
 _COMMAND_MODULES = {entry.import_path.partition(":")[0] for entry in _COMMANDS.values()}
 
@@ -169,6 +170,33 @@ def test_unknown_command_still_suggests_a_registered_one() -> None:
         pytest.skip("this Click does not offer unknown-command suggestions")
     result = CliRunner().invoke(main, ["enviroments"])
     assert "environments" in result.output, result.output
+
+
+def test_eagerly_added_commands_keep_working_alongside_lazy_ones() -> None:
+    """``add_command`` must survive the swap ``resolve_command`` does.
+
+    ``LazyGroup``'s docstring promises eagerly added commands keep working
+    alongside lazy ones, and the unknown-command path now temporarily replaces
+    ``self.commands`` to recover Click's suggestions. Nothing else covers the
+    two together.
+    """
+    group = LazyGroup(
+        "eager-and-lazy",
+        lazy_commands={"agent": _COMMANDS["agent"]},
+    )
+
+    @click.command("added")
+    def added() -> None:
+        """Added the usual way."""
+
+    group.add_command(added)
+    assert group.list_commands(click.Context(group)) == ["added", "agent"]
+    result = CliRunner().invoke(group, ["added", "--help"])
+    assert result.exit_code == 0, result.output
+    assert group.get_command(click.Context(group), "added") is added
+    # The stand-ins must not outlive the lookup: a group whose ``commands``
+    # advertises `agent` would hand a caller an empty command with no callback.
+    assert set(group.commands) == {"added"}
 
 
 def test_resolved_commands_carry_their_registry_name() -> None:

--- a/tests/cli/test_lazy_commands.py
+++ b/tests/cli/test_lazy_commands.py
@@ -1,7 +1,7 @@
 """Regression tests for the lazy top-level command group (issue #417).
 
-``aorta`` used to import all ten command modules on every invocation, which
-was roughly 190 ms of a 255 ms ``aorta --help``. The laziness is only worth
+``aorta`` used to import every command module on every invocation, which was
+roughly 190 ms of a 255 ms ``aorta --help`` (measured when there were ten). The laziness is only worth
 anything if it holds, and it is easy to lose by accident: a convenience import
 at the top of ``aorta/cli/__init__.py``, or a help/completion path that reads
 ``short_help`` off a real command, quietly drags the whole graph back in.

--- a/tests/cli/test_lazy_commands.py
+++ b/tests/cli/test_lazy_commands.py
@@ -1,0 +1,117 @@
+"""Regression tests for the lazy top-level command group (issue #417).
+
+``aorta`` used to import all ten command modules on every invocation, which
+was roughly 190 ms of a 255 ms ``aorta --help``. The laziness is only worth
+anything if it holds, and it is easy to lose by accident: a convenience import
+at the top of ``aorta/cli/__init__.py``, or a help/completion path that reads
+``short_help`` off a real command, quietly drags the whole graph back in.
+
+The import assertions run in a subprocess. By the time this module executes,
+the pytest session has already imported most of ``aorta`` for other tests, so
+the in-process ``sys.modules`` says nothing about what a real invocation loads.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from aorta.cli import _COMMANDS, main
+
+_COMMAND_MODULES = {entry.import_path.partition(":")[0] for entry in _COMMANDS.values()}
+
+_REPORT = (
+    'import json, sys; print(json.dumps(sorted(m for m in sys.modules if m.startswith("aorta."))))'
+)
+
+
+def _modules_loaded_by(*statements: str) -> set[str]:
+    """Run statements in a fresh interpreter and report the ``aorta.*`` modules loaded."""
+    completed = subprocess.run(
+        [sys.executable, "-c", "\n".join([*statements, _REPORT])],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    return set(json.loads(completed.stdout.splitlines()[-1]))
+
+
+@pytest.mark.parametrize(
+    ("scenario", "statements"),
+    [
+        ("import", ("import aorta.cli",)),
+        (
+            "help",
+            (
+                "from click.testing import CliRunner",
+                "from aorta.cli import main",
+                "result = CliRunner().invoke(main, ['--help'])",
+                "assert result.exit_code == 0, result.output",
+            ),
+        ),
+        (
+            "completion",
+            (
+                "import click",
+                "from aorta.cli import main",
+                "completions = main.shell_complete(click.Context(main), '')",
+                "assert completions, 'no completions offered'",
+            ),
+        ),
+    ],
+)
+def test_no_command_module_is_imported(scenario: str, statements: tuple[str, ...]) -> None:
+    """Neither importing the CLI, nor ``--help``, nor completion may load a command."""
+    eager = _modules_loaded_by(*statements) & _COMMAND_MODULES
+    assert not eager, f"{scenario} eagerly imported: {sorted(eager)}"
+
+
+@pytest.mark.parametrize("name", sorted(_COMMANDS))
+def test_registered_help_matches_the_command(name: str) -> None:
+    """The registry's help must render the same short help as the command's own.
+
+    The registry duplicates each command's help so ``--help`` need not import
+    anything; this is the test that keeps the copy honest. Comparing rendered
+    short help across several widths (rather than the raw strings) is what the
+    user actually sees, and lets the registry hold just the first paragraph.
+    """
+    entry = _COMMANDS[name]
+    command = entry.load()
+    assert command.name == name
+    stand_in = click.Command(name, help=entry.help)
+    for limit in (30, 45, 62, 200):
+        assert stand_in.get_short_help_str(limit) == command.get_short_help_str(limit)
+
+
+def test_help_lists_exactly_the_registered_commands() -> None:
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0, result.output
+    listed = [
+        line.split()[0]
+        for line in result.output.partition("Commands:\n")[2].splitlines()
+        if line.strip()
+    ]
+    assert listed == sorted(_COMMANDS)
+
+
+@pytest.mark.parametrize("name", sorted(_COMMANDS))
+def test_every_command_resolves_through_the_group(name: str) -> None:
+    """Covers the deprecated probe/run/triage aliases (issue #248) along with the rest."""
+    result = CliRunner().invoke(main, [name, "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_shell_completion_offers_every_command() -> None:
+    completions = main.shell_complete(click.Context(main), "")
+    assert sorted(item.value for item in completions) == sorted(_COMMANDS)
+
+
+def test_shell_completion_filters_on_the_incomplete_prefix() -> None:
+    completions = main.shell_complete(click.Context(main), "en")
+    assert [item.value for item in completions] == ["env", "environments"]

--- a/tests/cli/test_lazy_commands.py
+++ b/tests/cli/test_lazy_commands.py
@@ -100,6 +100,29 @@ def test_help_lists_exactly_the_registered_commands() -> None:
     assert listed == sorted(_COMMANDS)
 
 
+def _commands_section(help_output: str) -> str:
+    return help_output.partition("Commands:\n")[2]
+
+
+def test_commands_section_matches_an_eagerly_built_group() -> None:
+    """The registry must render the Commands block an eager group would.
+
+    ``LazyGroup.format_commands`` says it mirrors ``click.Group``'s while
+    sourcing rows from the registry rather than imported commands. Checking
+    that against a real eager group is what turns the claim from a comment
+    into a test, and it pins the property this whole change rests on: that
+    ``aorta --help`` stays byte-for-byte what it was, Click's column width and
+    ``...`` truncation included.
+    """
+    eager = click.Group(
+        main.name,
+        commands={name: entry.load() for name, entry in _COMMANDS.items()},
+    )
+    lazy = _commands_section(main.get_help(click.Context(main, terminal_width=80)))
+    assert lazy, "no Commands section rendered"
+    assert lazy == _commands_section(eager.get_help(click.Context(eager, terminal_width=80)))
+
+
 @pytest.mark.parametrize("name", sorted(_COMMANDS))
 def test_every_command_resolves_through_the_group(name: str) -> None:
     """Covers the deprecated probe/run/triage aliases (issue #248) along with the rest."""
@@ -121,8 +144,8 @@ def test_shell_completion_carries_help_from_the_registry() -> None:
     """
     completions = {item.value: item.help for item in main.shell_complete(click.Context(main), "")}
     for name, entry in _COMMANDS.items():
-        rendered = completions[name]
-        assert rendered, f"{name} completes with no help text"
+        rendered = completions.get(name)
+        assert rendered, f"{name} completes with no help text: {rendered!r}"
         # Tolerate Click's short-help truncation instead of pinning a width.
         assert entry.help.startswith(rendered.removesuffix("...").rstrip()), (name, rendered)
 

--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -1,0 +1,107 @@
+"""Contract tests for the lazily resolved ``aorta.__version__`` (issue #417).
+
+``aorta/__init__.py`` resolves ``__version__`` from the installed
+distribution's metadata behind a PEP 562 module ``__getattr__``, because
+importing ``importlib.metadata`` and walking ``sys.path`` for dist-info
+dominated the cost of a bare ``import aorta`` for an attribute almost nothing
+reads.
+
+Deferring an export has an introspection cost that is easy to ship by
+accident: the name vanishes from ``dir()`` until something has already read
+it, so tab-completion and ``help()`` stop advertising it. ``__dir__`` is what
+buys it back, matching ``aorta.report``, ``aorta.report.analysis`` and
+``aorta.report.generators``. Raised by Copilot review on PR #428.
+
+The laziness assertions run in a subprocess: by the time this module executes
+the pytest session has already imported ``aorta``, so the in-process module
+state says nothing about what a fresh ``import aorta`` does.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib.metadata import version
+
+import aorta
+
+
+def _probe(*statements: str) -> str:
+    """Run statements in a fresh interpreter and return the last line printed."""
+    completed = subprocess.run(
+        [sys.executable, "-c", "\n".join(statements)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return completed.stdout.splitlines()[-1]
+
+
+def test_version_resolves_from_the_distribution_metadata() -> None:
+    assert aorta.__version__ == version("amd-aorta")
+
+
+def test_dir_advertises_version_before_it_has_been_read() -> None:
+    """``dir(aorta)`` must list ``__version__`` on a fresh import.
+
+    Without ``__dir__`` the name is missing until first access, which
+    contradicts ``__all__`` and regresses introspection against the eager
+    module this replaced.
+    """
+    assert (
+        _probe(
+            "import aorta",
+            "print('__version__' in dir(aorta))",
+        )
+        == "True"
+    )
+
+
+def test_dir_matches_all_before_the_lazy_export_is_read() -> None:
+    """Nothing ``__all__`` promises may be missing from a fresh ``dir()``."""
+    assert (
+        _probe(
+            "import aorta",
+            "print(set(aorta.__all__) <= set(dir(aorta)))",
+        )
+        == "True"
+    )
+
+
+def test_first_access_caches_the_resolved_version() -> None:
+    """The resolved value lands in the module globals, so metadata is read once."""
+    assert (
+        _probe(
+            "import aorta",
+            "assert '__version__' not in vars(aorta)",
+            "aorta.__version__",
+            "print('__version__' in vars(aorta))",
+        )
+        == "True"
+    )
+
+
+def test_importing_aorta_does_not_read_distribution_metadata() -> None:
+    """The point of the deferral: ``importlib.metadata`` stays unimported."""
+    assert (
+        _probe(
+            "import sys, aorta",
+            "print('importlib.metadata' in sys.modules)",
+        )
+        == "False"
+    )
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    """The ``__getattr__`` shim must not turn typos into something else."""
+    assert (
+        _probe(
+            "import aorta",
+            "try:",
+            "    aorta.no_such_attribute",
+            "except AttributeError as exc:",
+            "    print('no_such_attribute' in str(exc))",
+        )
+        == "True"
+    )


### PR DESCRIPTION
Closes #417.

## What changed

`src/aorta/cli/__init__.py` imported all ten command modules at import time, so
every `aorta` invocation — `--help`, shell completion, `aorta env show` — paid
for the whole command graph. It is replaced by a `LazyGroup` (new
`src/aorta/cli/_lazy_group.py`) holding a registry of command name → import path
of the `click.Command`, resolved on first use.

The registry also carries each command's help text, and that duplication is the
point: `Group.format_commands` and `Group.shell_complete` call `get_command` on
every entry just to read a short help string, so both would otherwise import
exactly what the lazy group exists to avoid. Both are overridden to build their
rows from the registry. Each row goes through a throwaway `click.Command` rather
than being written out pre-truncated, so Click still applies its own short-help
truncation rules and the rendering is width-correct and unchanged.

Command modules stay under `src/aorta/cli/` — nothing moved.

## Measurements

Best-of-40, interleaved A/B in one process pool on the same box and venv
(py3.14), so machine noise hits both arms equally. Re-measured after every round
of review commits — three passes now, taken at different times on the same box.
The spread between them is the point, so all three are reported rather than the
flattering one:

| `aorta --help` | before (`30dcc055`) | after | aorta's own share | ratio |
|---|---|---|---|---|
| pass A, quiet box | 184 ms | **82 ms** | 123 ms → 21 ms | 5.9x |
| pass B, loaded box | 246 ms | **105 ms** | 168 ms → 27 ms | 6.2x |
| pass C, `448dadc5` | 205 ms | **74 ms** | 146 ms → 15 ms | 9.5x |
| pass D, this round (`be853c21`) | — | **79 ms** | — | — |

`import aorta.cli` moves the same way: 192 → 69 ms (A), 247 → 88 ms (B),
201 → 66 ms (C). Reference points from the same passes: bare interpreter
16–20 ms, `import click` alone 59–78 ms. "aorta's own share" is the total minus
that `import click` cost.

**On the issue's sub-100 ms acceptance criterion, plainly:** whether the
absolute figure clears 100 ms is machine- and load-dependent, not something this
change controls — the same post-change binary measured 82, 105 and 74 ms in
three best-of-40 passes on one box. What the change does control is aorta's own
share of that number, and across those three passes it falls 5.9x, 6.2x and
9.5x. The remainder is Click and interpreter start-up: `import click` alone is
59–78 ms here, 60–80% of the post-change total, and nothing left in the path
belongs to this repository. So the criterion is met on a quiet box, missed on a
loaded one, and aorta's contribution is down 6–9x whichever pass you take. Treat
the ~6x floor as the result and the absolute milliseconds as box-specific.

The `__version__` deferral is measurable on its own: `import aorta` (the package
`__init__` alone, no CLI) drops from 86 ms to 10 ms net of interpreter start-up
(pass C: 76 → 10 ms), which is where the claim that `importlib.metadata`
dominated that import comes from.

Two things dominated, and the second is why there is a third commit:

- The command graph, worst offender `aorta.cli.agent` at ~93 ms via
  `aorta.agent.loop` → `aorta.probe.recipe_builder` → `bundle_hook` →
  `redaction` → `sandbox`. Gone.
- `importlib.metadata`, imported by `aorta/__init__.py` to resolve
  `aorta.__version__` from the distribution metadata. That is not in the issue's
  scope list, but the issue attributes ~80 ms to it, and it is unreachable from
  the CLI change — `aorta.cli` lives inside `aorta`, so it pays for the package
  `__init__` no matter how lazy the commands are. Once the commands went lazy it
  was ~100 ms of the remaining ~130 ms, spent on an attribute nothing in the
  repository reads. It now resolves behind a PEP 562 module `__getattr__` that
  caches on first access; `aorta.__version__` still comes from the installed
  distribution with the same defensive fallbacks. It is a self-contained commit
  and can be dropped if reviewers would rather see it separately.

## `bench.py`

`_LazyHwQueueGroup` deferred the `hw_queue_eval` import (and transitively torch)
by forwarding `get_params`, `format_help`, `list_commands`, `get_command` and
`invoke` to an inner group it loaded on demand — about fifty lines the registry
now does generically, and better: when the extra is present Click receives the
real group, so its params and help need no forwarding at all.

What does not generalise is the reason the proxy was careful. Only a missing
*external* dependency means the extra is absent; a `ModuleNotFoundError` naming
an `aorta.hw_queue_eval` sub-module is our own bug, and reporting that as
"install the extra" sends the user down a dead end. That check moved into
`_BenchGroup.get_command` unchanged, and now has tests it never had — including
one that stubs the import so the extra-present path stays covered on a base
install where torch is absent.

Two deliberate behaviour changes here, both visible in `aorta bench --help`:

- `hw_queue_eval` now shows a short help. The proxy carried none, so the row was
  blank.
- The stand-in shown when the extra is missing accepts trailing arguments, so
  `aorta bench hw_queue_eval <anything>` reports the install hint instead of
  Click's generic "No such command". `--help` still exits 0 with the hint,
  rendered as the command's help rather than an `Error` section.

## Verification

- **`aorta --help` unchanged** — byte-identical before and after (same md5),
  same ten commands, same short help strings including Click's `...` truncation.
- **No eager imports** — `tests/cli/test_lazy_commands.py` asserts in a
  subprocess that neither `import aorta.cli`, nor rendering `--help`, nor
  completing a command name leaves any `aorta.cli.<command>` in `sys.modules`.
  It fails if a command module is imported eagerly.
- **No help drift** — a test compares, for every registry entry, the short help
  rendered from the registry against the one rendered from the real command, at
  four widths. The duplicated text cannot silently rot.
- **Deprecated aliases** — `probe` and `triage` (#248) resolve and render help.
  `run` is *not* one of them: #248 reserves that name for the distinct
  single-execution command, and `run.py` emits no deprecation notice. All ten
  commands are covered per-command by a parametrised test.
- **`--version`** — works. It did not when this PR was opened; #436 has since
  merged and this branch now carries that fix verbatim. See the #429 section
  below for why it travelled this way.
- **Shell completion** — `_AORTA_COMPLETE=bash_complete` lists all ten commands,
  prefix filtering works (`en` → `env`, `environments`), `zsh_complete` still
  emits the help column, and `bash_source` generates the script. Completion
  exercises `list_commands`, and now imports nothing.
- **`bench` install hint** — with the `hw-queue` extra absent, bare invoke and
  `hw_queue_eval <subcommand>` both exit non-zero with the install hint, and
  `--help` exits 0 showing it; no traceback in any of the three. The
  extra-present path is covered by a stubbed-import test.
- **`bench hw_queue_eval` with the extra actually installed** — exercised on a
  real install (`.[hw-queue]` plus torch, which `hw-queue` does not itself
  declare — see the follow-up note below) on Click 8.0.0 *and* 8.5.0:
  `--help` lists the real subcommands, `info` executes and prints the
  hw_queue_eval banner, and an unknown subcommand errors against
  `aorta bench hw_queue_eval`, not `aorta bench cli`. That last one was broken
  on Click 8.0.0 before the review fix; see the section below.
- **Full suite** — `pytest -n 16` on this branch produces a failure set
  byte-identical to the same run on the base commit: 53 pre-existing
  environmental failures (no torch/numpy in the slim `[tests]` extra, no
  `bpftrace`, no triton). Nothing introduced, nothing fixed. Re-confirmed after
  the review commits by diffing the two sorted `FAILED`/`ERROR` sets: 53 entries
  each, empty symmetric difference, branch 4734 passed vs base 4691 (+43, the
  new tests). Re-run again on `448dadc5`: still 53 failures/errors, 4736 passed
  (+2, `tests/cli/test_version_option.py` arriving from #436). Re-run once more
  on `be853c21`: still 47 failed + 6 errors = 53, and 4743 passed (+7, the
  review-fix tests below).
- **`aorta --help` byte-equality re-confirmed** after all review commits and
  after the history rewrite below, not just at the first one: md5
  `62e89af13ec381d96ee6dbabd184ed49`, 907 bytes, on `30dcc055`, on `b22f7f33`,
  on `448dadc5` and again on `be853c21`. Moving `run` up the registry to sit
  outside the "deprecated aliases" comment does not show: `LazyGroup.list_commands`
  sorts, so registry order is cosmetic. Neither does the `resolve_command`
  override: it runs only when a subcommand is being resolved, and `--help` on the
  group resolves none.

## Review round: the registry key had to become the command's real name

Copilot flagged that `bench` registers `hw_queue_eval` against a group defined
as `cli` (`aorta.hw_queue_eval.cli:cli`), where the deleted proxy was a
`click.Group` explicitly constructed as `_LazyHwQueueGroup(name="hw_queue_eval")`.
It was right, and the mechanism is narrower than the comment said but real:

- **Click 8.0.0** returns `cmd.name` from `MultiCommand.resolve_command` and
  passes that to `make_context`, so the child context was named `cli`. Verified
  by installing the extra for real: `Usage: aorta bench cli [OPTIONS] ...` and
  `Try 'aorta bench cli --help' for help.` — a command line the user cannot
  type.
- **Click 8.0.1 and later** (checked 8.0.1, 8.0.2, 8.0.3, 8.0.4, 8.5.0) return
  the invoked name, so those are unaffected. But `click>=8.0.0` still resolves
  8.0.0, so the floor is what matters, not the version I happen to have.

`LazyGroup.get_command` now returns the loaded command under the key it was
reached by, shallow-copying rather than renaming in place — `cli` is also the
entry point of `python -m aorta.hw_queue_eval` and has to keep its own name.
The invariant is asserted on `get_command` for every registry entry, so a
future key/attribute mismatch cannot go unnoticed; both new tests fail on
Click 8.0.0 without the fix, and the `.name` one fails on every version.

Two more from the collapsed **Suppressed comments** blocks, neither previously
picked up, both confirmed against an eagerly built group before being fixed:

- **`aorta enviroments` had stopped suggesting `environments`.** Click draws its
  `Did you mean ...?` candidates from `Group.commands`, which lazy names never
  enter. `resolve_command` now offers the registry keys on the unknown-command
  path only — known names take a fast path, Click reads only the mapping's
  keys, and nothing is imported either way. The test compares against a real
  eager group rather than pinning the text, because Click only grew suggestions
  in 8.4.
- **`test_bench.py`'s availability probe masked internal import bugs.** It read
  any `ModuleNotFoundError` as "extra not installed", so a broken
  `aorta.hw_queue_eval.*` sub-module would have *skipped* every real-group test
  in the module instead of failing it. It now mirrors
  `_BenchGroup.get_command`'s external/internal split, which is the distinction
  the deleted proxy existed to preserve.

Measured rather than assumed: an interleaved best-of-40 A/B of the tip against
the same tree with only these fixes reverted shows `aorta --help` at 79.4 vs
80.9 ms and `aorta env --help` at 83.9 vs 84.8 ms — both deltas negative, i.e.
inside this box's noise. The `resolve_command` fast path is a dict membership
test on a name the user already typed.

**Out of scope, worth a follow-up:** the `hw-queue` extra declares numpy,
pandas and tabulate but not torch, which `aorta.hw_queue_eval.__init__` imports,
so `pip install 'amd-aorta[hw-queue]'` alone still leaves `aorta bench
hw_queue_eval` reporting the extra as absent. That is a `pyproject.toml`
packaging gap this PR does not touch and predates it; flagging rather than
widening the diff.

## `--version` and #429 (via #436, now merged)

**#436 has merged, and this branch now carries its fix.** The history is worth
one paragraph because the file moved twice. The fix started here as `2394a122`
plus a follow-up wording correction, was dropped from this branch and
re-applied against `main` as #436, and — now that #436 is in `main` as
`31ec6f0b` — has been brought back onto this branch in `448dadc5`, taken
byte-identical from `main`.

The reasoning behind the move: #429 turned out to be customer-facing rather than a
contributor annoyance. Beyond the editable-install case, a plain wheel install
crashes too on any distro whose `sys.platlibdir` is `lib64` — the RHEL and Fedora
family, which is what AMD customers run. `python -m venv` makes `lib64` a symlink
to `lib`, `site` puts both on `sys.path`, and every `.dist-info` is enumerated
twice, so `packages_distributions()["aorta"]` is `['amd-aorta', 'amd-aorta']` with
no editable install anywhere. A one-line customer-facing fix should not queue
behind review of a performance refactor, so it is now standalone. #436 has the
full mechanism and evidence.

Bringing it back was not optional. The PR body used to say "whichever lands
second needs a trivial rebase there", because both changes touch the same two
lines of `src/aorta/cli/__init__.py`. #436 landed first, so leaving this branch
on `package_name="aorta"` would have made merging it a *revert* of a merged
customer-facing fix — which is what Copilot flagged.

What that means for reviewing *this* PR:

- `aorta --version` works on this branch, for the same reason and by the same
  mechanism as on `main`.
- Both the decorator's comment and `tests/cli/test_version_option.py` are copied
  verbatim from `main`'s `31ec6f0b`, so the merge stays textually trivial; the
  only local difference is that the decorator sits under
  `@click.group(cls=LazyGroup, lazy_commands=_COMMANDS)` rather than
  `@click.group()`.
- Mutation-checked here rather than assumed: restoring `package_name="aorta"`
  fails both tests in `test_version_option.py` with Click's `'aorta' maps to
  multiple installed distributions (amd-aorta, amd-aorta)` `RuntimeError`.
- `tests/test_package_version.py` is unrelated and unchanged: it asserts
  `aorta.__version__ == version("amd-aorta")` and exercises the lazy
  `__getattr__`/`__dir__` this branch adds, independently of the Click
  decorator.

## Why the history changed

The branch was force-pushed to drop the two #429 commits. `2394a122` went in full;
its follow-up was inspected hunk by hunk and turned out to be entirely #429 wording
(the code comment above `version_option` and the test docstring), with nothing
belonging to the lazy-loading work, so it went in full as well. The remaining six
commits are unchanged in content: five kept their SHAs, and only `60134e3a` was
rewritten, to `b22f7f33`, because it now sits on a different parent — its diff is
byte-identical.

Consequences a reviewer will notice:

- Copilot's earlier `🟢 Approval recommended` review was invalidated by the
  rewrite. A fresh review has been re-requested.
- Review threads pinned to the old SHAs are detached from the new history. They
  were on code this rewrite did not change, so their content still applies.
- The measurements and the `aorta --help` byte-equality check were re-run on the
  rewritten tip and are unchanged; the table and the md5 above refer to
  `b22f7f33`.

## Note on #422

#422 adds a `chat` command to the same file. This branch is based on `main` and
does not accommodate it, so the two will conflict on `src/aorta/cli/__init__.py`;
whoever merges second moves one entry from the import list into the registry
table.




