### PR TITLE
ci: bound a wedged GPU test instead of the whole gate

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -187,6 +187,23 @@ jobs:
       # per CPU core would spin up dozens of HIP contexts contending for a
       # single device (OOM / flakiness). A small bounded pool keeps parallelism
       # without oversubscribing the GPU.
+      #
+      # --timeout=300 (pytest-timeout, already in the `tests` extra) bounds a
+      # wedged test rather than the job. A GPU test that hangs instead of
+      # failing costs far more than one red test: the job runs to its
+      # 60-minute cap, and because a GitHub-side cancel skips the junit upload,
+      # the gate reports NO test results at all -- so any real failure in the
+      # same run is destroyed along with it. Observed on run 33527313950, where
+      # 105 of 108 tests reported in 54 s, a profiler payload then wedged for
+      # 59 minutes, and the one genuine failure went out with the cancel.
+      #
+      # Sized from measurement: on run 33606698270 the whole suite was 104
+      # tests in 51.6 s wall, and its slowest single test -- the rocprofv3
+      # sweep -- took 20.2 s. 300 s is ~15x that, and more than the entire
+      # suite has ever needed. Set here rather than in
+      # pytest.ini because the opt-in operator payloads (AORTA_LN_GPU_SMOKE)
+      # legitimately run for tens of minutes and must keep their own budgets;
+      # only this job is being bounded.
       - name: Install package and run GPU test suite
         run: |
           bash scripts/ci/docker_cmd.sh exec "${{ env.CONTAINER_NAME }}" bash -lc '
@@ -214,7 +231,7 @@ jobs:
             # written with no apostrophe because this is a single-quoted bash -lc
             # payload that any apostrophe would close early.
             export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}:}$(python -c "import os; from aorta.instrumentation.rocm_paths import resolve_rocm_roots as r; x = r(); print(os.pathsep.join(dict.fromkeys([str(x.core_lib_dir), str(x.lib_dir)])))")"
-            pytest -m "gpu or rocm" -n 4 --junitxml=gpu-results.xml
+            pytest -m "gpu or rocm" -n 4 --timeout=300 --junitxml=gpu-results.xml
           '
 
       # Separate step, after pytest: under `set -euo pipefail` a knob the

--- a/docs/ci-testing-plan.md
+++ b/docs/ci-testing-plan.md
@@ -213,7 +213,7 @@ gaps). New GPU tests must carry `@pytest.mark.gpu` or `@pytest.mark.rocm`.
 
 | Job | Triggers | What it runs |
 | --- | --- | --- |
-| `pytest (GPU, MI350)` | `pull_request` (GPU-touching paths), nightly cron, `workflow_dispatch` | `pytest -m "gpu or rocm" -n 4` inside a digest-pinned ROCm container (bounded workers so xdist doesn't oversubscribe the single GPU) |
+| `pytest (GPU, MI350)` | `pull_request` (GPU-touching paths), nightly cron, `workflow_dispatch` | `pytest -m "gpu or rocm" -n 4 --timeout=300` inside a digest-pinned ROCm container (bounded workers so xdist doesn't oversubscribe the single GPU; the per-test cap keeps a wedged test from running out the job's 60-minute limit, which would cancel the run and take the junit report with it) |
 | `workload regression (GPU, MI350)` | `pull_request` (GPU-touching paths), nightly cron, `workflow_dispatch` | Real-hardware workload smokes from [`config/ci/gpu_regression_smokes.yaml`](../config/ci/gpu_regression_smokes.yaml) via [`scripts/ci/run_gpu_regression_smokes.sh`](../scripts/ci/run_gpu_regression_smokes.sh). PRs run the fast single-GPU `pr` tier; nightly / dispatch run the full manifest |
 
 ### Execution environment (docker)
@@ -549,6 +549,11 @@ docker exec aorta-ci-gpu bash -lc '
 '
 docker compose --env-file .env.ci -f docker-compose.build.yaml down -v
 ```
+
+The gate's `--timeout=300` is omitted here on purpose: it exists to stop a
+wedged test from consuming the CI job's 60-minute budget, and locally you
+usually want a hang to sit still so it can be attached to and inspected. Add it
+if what you are reproducing *is* the timeout.
 
 Workload regression smokes (inside the same container):
 

--- a/tests/instrumentation/test_proton_smoke_gpu.py
+++ b/tests/instrumentation/test_proton_smoke_gpu.py
@@ -51,6 +51,19 @@ _EXAMPLES = [
     ),
 ]
 
+#: Wall-clock budget for one payload subprocess, sized from measurement rather
+#: than guessed: the captures timed on MI350 land at ~2.5 s each with a cold
+#: Triton cache, so this is ~50x headroom. These are ten iterations of one
+#: small Triton kernel; nothing here has a legitimate reason to take minutes.
+#:
+#: It sits deliberately below the GPU workflow's ``--timeout``, so a wedged
+#: payload surfaces as ``TimeoutExpired`` from here -- naming the payload and
+#: carrying its partial output -- rather than as pytest-timeout killing the
+#: test from outside with no such detail. The former 3600 s could do neither:
+#: it matched the CI job's own 60-minute cap exactly, so the job always died
+#: first and the budget could never actually fire.
+_CHILD_TIMEOUT_S = 120
+
 #: Proton's dlopen failure on an image whose ROCm comes from Python wheels:
 #: those ship only ``libroctracer64.so.4`` while Proton dlopens the unversioned
 #: name. An environment defect with a known fix, not a collector bug, so it
@@ -100,7 +113,7 @@ def _capture(example: str, payload: str, args: list[str], out_root: Path, option
         cwd=out_root,
         capture_output=True,
         text=True,
-        timeout=3600,
+        timeout=_CHILD_TIMEOUT_S,
         env={**os.environ, "TRITON_CACHE_DIR": str(out_root / "triton-cache")},
     )
     if _DLOPEN_MARKER in proc.stderr:


### PR DESCRIPTION
## The problem

The GPU gate has no per-test timeout, so a test that **hangs** rather than fails cannot be reported as a failure. It is only ever resolved by the job hitting `timeout-minutes: 60` — and because a GitHub-side cancel skips the artifact upload step, the gate then publishes **no test results at all**. Any genuine failure in the same run is destroyed along with the hang.

Observed on [run 33527313950](https://github.com/ROCm/aorta/actions/runs/33527313950):

- 105 of 108 tests reported in **54 seconds**
- a profiler payload then wedged, and the log went silent for **59 minutes**
- `The operation was canceled`
- `No files were found with the provided path: gpu-results.xml`
- `test_cli_mode_pin_would_still_capture_nothing` had already **FAILED** in that run, and that result went out with the cancel

The suite itself is not slow. The same `-n 4` invocation on `main` ([run 33606698270](https://github.com/ROCm/aorta/actions/runs/33606698270)) does **104 tests in 51.6 s** wall. The entire hour was one hang.

## The change

Two bounds, deliberately unequal so the inner one wins:

| Bound | Value | Why |
| --- | --- | --- |
| `--timeout=300` on the GPU pytest invocation | 5 min/test | Job-level protection. `pytest-timeout` is already in the `tests` extra, so no dependency change. |
| `_CHILD_TIMEOUT_S = 120` in `test_proton_smoke_gpu.py` | 2 min/payload | Replaces a 3600 s subprocess budget that matched the job cap exactly, so the job always died first and it could never fire. |

Because the child budget sits *below* the pytest cap, a wedged payload surfaces as the test's own `subprocess.TimeoutExpired` — which names the payload and carries its partial output — rather than as pytest-timeout killing the test from outside with no such detail.

### Sizing

Both numbers come from measurement, not preference. On `main` the slowest single GPU test is the rocprofv3 sweep at **20.2 s**, so 300 s is ~15x that and more than the whole suite has ever needed. The Proton captures land at **~2.5 s each** with a cold Triton cache (they point `TRITON_CACHE_DIR` at a fresh `tmp_path`), so 120 s is ~50x headroom on ten iterations of one small Triton kernel.

`--timeout` is set on the command line rather than in `pytest.ini` on purpose: the opt-in operator payloads in `test_layer_numerics_smoke_gpu.py` legitimately run for tens of minutes (1800 s children), and they must keep their own budgets. They are gated behind `AORTA_LN_GPU_SMOKE=1` and never run in this job, so only CI is bounded.

## Verification

I verified the mechanism rather than assuming it. An unbounded sleep-in-subprocess test run under `-n 2 --timeout=8`:

- failed at **8.3 s** as an ordinary `FAILED`, not a killed worker
- the sibling test still passed and the run exited cleanly, so junit **is** written
- left **no orphaned child** — `subprocess.run` kills its child on any exception, including this one, so nothing is left holding the GPU

Also confirmed: `pytest-timeout>=2.1.0` is in the `tests` extra that this job installs; `gpu-tests.yml` is the only workflow that runs gpu-marked tests, so nothing else changes behaviour; and no `except subprocess.TimeoutExpired` anywhere in the Proton collector path would swallow the now-reachable failure. ruff, `ruff format`, and pre-commit are clean.

## Deliberately out of scope

- The 900 s / 3600 s child budgets in `test_rocprof_smoke_gpu.py` and the 600 s one in `test_sanitizers_gpu.py` are now bounded by the workflow cap regardless. Retuning each payload's own budget is a separate judgement per test.
- `test_layer_numerics_smoke_gpu.py` keeps its 1800 s children, as above.
- pytest-timeout's default method is signal-based (`SIGALRM`), which is POSIX-only. That is consistent with the repo's existing stance — this job is a Linux self-hosted runner and the GPU stack is Linux-only by design — so no portability guard is warranted here.

## What this does not do

It bounds the blast radius of a hang; it does not fix any particular hang. A wedged GPU test now costs ~5 minutes and reports as a failed test with the rest of the suite's results intact. The two hangs seen on #416 (`test_env_mode_pins_roctracer_and_gets_a_non_empty_tree` and `test_instrumentation_captures_scopes_inside_one_kernel`) still need their own fix; this change is what will let CI name them in minutes instead of cancelling an hour later with nothing to show.

Made with [Cursor](https://cursor.com)