### PR TITLE
fix(cli): resolve `--version` against the `amd-aorta` distribution

### DIFF
--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -7,13 +7,14 @@ from aorta.cli import agent, bench, bundle, env, environments, mitigations, prob
 
 @click.group()
 # The distribution is ``amd-aorta``; only the import package is ``aorta``. Passing
-# the import name makes Click fall back to ``packages_distributions()``, which
-# reports ``amd-aorta`` twice under any editable install of this src layout -- the
-# editable build leaves ``src/amd_aorta.egg-info`` on the path beside the
-# site-packages ``.dist-info`` -- and twice again under a plain wheel install on a
-# ``lib64`` distro, where ``lib64`` symlinks to ``lib`` and both land on
-# ``sys.path``. ``--version`` then raises instead of printing (issue #429). Naming
-# the distribution skips that fallback entirely.
+# the import name makes Click fall back to ``packages_distributions()``, which can
+# report ``amd-aorta`` twice -- and then ``--version`` raises instead of printing
+# (issue #429). Two layouts do it: an editable install whose build left
+# ``src/amd_aorta.egg-info`` beside the site-packages ``.dist-info`` (build
+# isolation, the default for pip and uv, does; ``--no-build-isolation`` may not),
+# and a venv that exposes site-packages through both ``lib`` and ``lib64``, as
+# ``python -m venv`` does where ``sys.platlibdir`` is ``lib64``. Naming the
+# distribution skips that fallback entirely, on every layout.
 @click.version_option(package_name="amd-aorta")
 def main() -> None:
     """AORTA - GPU debugging platform for ROCm."""

--- a/src/aorta/cli/__init__.py
+++ b/src/aorta/cli/__init__.py
@@ -6,7 +6,15 @@ from aorta.cli import agent, bench, bundle, env, environments, mitigations, prob
 
 
 @click.group()
-@click.version_option(package_name="aorta")
+# The distribution is ``amd-aorta``; only the import package is ``aorta``. Passing
+# the import name makes Click fall back to ``packages_distributions()``, which
+# reports ``amd-aorta`` twice under any editable install of this src layout -- the
+# editable build leaves ``src/amd_aorta.egg-info`` on the path beside the
+# site-packages ``.dist-info`` -- and twice again under a plain wheel install on a
+# ``lib64`` distro, where ``lib64`` symlinks to ``lib`` and both land on
+# ``sys.path``. ``--version`` then raises instead of printing (issue #429). Naming
+# the distribution skips that fallback entirely.
+@click.version_option(package_name="amd-aorta")
 def main() -> None:
     """AORTA - GPU debugging platform for ROCm."""
 

--- a/tests/cli/test_version_option.py
+++ b/tests/cli/test_version_option.py
@@ -8,18 +8,23 @@ onto the distribution providing it. This project's distribution is
 name always took that fallback -- and the fallback raises ``RuntimeError`` when
 the mapping is ambiguous.
 
-Two ordinary conditions make it ambiguous, neither needing a stale artefact:
+Two ordinary layouts make it ambiguous, neither needing a stale artefact:
 
-* Any editable install of this src layout. The ``.pth`` puts ``src/`` on the
-  path and the editable build itself leaves ``src/amd_aorta.egg-info`` there,
-  so it is discovered as a *second* distribution also named ``amd-aorta``. A
-  fresh ``pip install -e .`` in a clean checkout is enough.
-* Any install, wheel included, on a distro where ``sys.platlibdir`` is
-  ``lib64`` (the RHEL and Fedora family). ``python -m venv`` makes ``lib64`` a
-  symlink to ``lib`` and ``site`` puts both on ``sys.path``, so *every*
-  ``.dist-info`` is enumerated twice.
+* An editable install whose build left ``src/amd_aorta.egg-info`` in the tree.
+  The ``.pth`` puts ``src/`` on the path, so that directory is discovered as a
+  *second* distribution also named ``amd-aorta``. Whether the build leaves it
+  depends on the install path -- an isolated build (the default for both ``pip``
+  and ``uv``) does, ``--no-build-isolation`` may not -- so a fresh
+  ``pip install -e .`` in a clean checkout is typically enough.
+* A virtual environment that exposes its site-packages through both ``lib`` and
+  ``lib64``, which is what ``python -m venv`` produces where
+  ``sys.platlibdir`` is ``lib64`` (the RHEL and Fedora family): ``lib64``
+  becomes a symlink to ``lib`` and ``site`` puts both on ``sys.path``, so
+  *every* ``.dist-info`` under them is enumerated twice -- no editable install
+  required.
 
-Naming the distribution skips the fallback.
+Naming the distribution skips the fallback on every layout, which is why the
+test below injects the ambiguous mapping instead of relying on either one.
 
 These run in a subprocess because ``version_option`` caches the resolved
 version in its closure: once anything in the process has asked for

--- a/tests/cli/test_version_option.py
+++ b/tests/cli/test_version_option.py
@@ -1,0 +1,80 @@
+"""Regression tests for ``aorta --version`` (issue #429).
+
+``click.version_option`` resolves its ``package_name`` through
+``importlib.metadata.version`` and, when that name is not an installed
+distribution, falls back to ``packages_distributions()`` to map an import name
+onto the distribution providing it. This project's distribution is
+``amd-aorta`` and only its import package is ``aorta``, so passing the import
+name always took that fallback -- and the fallback raises ``RuntimeError`` when
+the mapping is ambiguous.
+
+Two ordinary conditions make it ambiguous, neither needing a stale artefact:
+
+* Any editable install of this src layout. The ``.pth`` puts ``src/`` on the
+  path and the editable build itself leaves ``src/amd_aorta.egg-info`` there,
+  so it is discovered as a *second* distribution also named ``amd-aorta``. A
+  fresh ``pip install -e .`` in a clean checkout is enough.
+* Any install, wheel included, on a distro where ``sys.platlibdir`` is
+  ``lib64`` (the RHEL and Fedora family). ``python -m venv`` makes ``lib64`` a
+  symlink to ``lib`` and ``site`` puts both on ``sys.path``, so *every*
+  ``.dist-info`` is enumerated twice.
+
+Naming the distribution skips the fallback.
+
+These run in a subprocess because ``version_option`` caches the resolved
+version in its closure: once anything in the process has asked for
+``--version``, the resolution under test is skipped and the assertions would
+pass vacuously.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib.metadata import version
+
+# What a doubly-enumerated ``amd-aorta`` looks like to Click, from either
+# cause: the import package maps to the same distribution twice.
+_AMBIGUOUS_MAPPING = """
+import importlib.metadata
+
+importlib.metadata.packages_distributions = lambda: {"aorta": ["amd-aorta", "amd-aorta"]}
+"""
+
+_INVOKE_VERSION = """
+from click.testing import CliRunner
+
+from aorta.cli import main
+
+result = CliRunner().invoke(main, ["--version"], prog_name="aorta")
+assert result.exit_code == 0, (
+    f"exit={result.exit_code} exception={result.exception!r} output={result.output!r}"
+)
+print(result.output.strip())
+"""
+
+
+def _version_output(*prelude: str) -> str:
+    """Run ``--version`` in a fresh interpreter and return the line it printed."""
+    completed = subprocess.run(
+        [sys.executable, "-c", "\n".join([*prelude, _INVOKE_VERSION])],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return completed.stdout.splitlines()[-1]
+
+
+def test_version_reports_the_installed_distribution() -> None:
+    """``--version`` prints the version of the ``amd-aorta`` distribution."""
+    assert _version_output() == f"aorta, version {version('amd-aorta')}"
+
+
+def test_version_does_not_depend_on_the_import_name_mapping() -> None:
+    """An ambiguous import-name mapping must not reach ``--version``.
+
+    Fails with Click's ``'aorta' maps to multiple installed distributions``
+    ``RuntimeError`` if the option goes back to naming the import package.
+    """
+    assert _version_output(_AMBIGUOUS_MAPPING) == f"aorta, version {version('amd-aorta')}"


### PR DESCRIPTION
Closes #429.

One-line fix, extracted from #428 so it can land without waiting on review of an
unrelated performance refactor. `--version` is broken for released-wheel users on
enterprise Linux, which is the interesting part and was not clear when #429 was
filed.

## What changed

`src/aorta/cli/__init__.py`:

```python
-@click.version_option(package_name="aorta")
+@click.version_option(package_name="amd-aorta")
```

`aorta` is the **import package**; the **distribution** is `amd-aorta`
(`[project] name` in `pyproject.toml`). Everything else in the repository already
uses the distribution name — `src/aorta/__init__.py` resolves `__version__` via
`version("amd-aorta")`, and the `hw_queue_eval` / `report` CLIs pass
`version=__version__`. This decorator was the only place using the import name.

## Why the import name is not merely redundant

`click.version_option` (Click 8.5.0, `click/decorators.py`) resolves
`package_name` through `importlib.metadata.version`, and on
`PackageNotFoundError` falls back to guessing the distribution from the import
name:

```python
distributions = importlib.metadata.packages_distributions().get(package_name, [])
if len(distributions) == 1:
    package_name = distributions[0]
    version = importlib.metadata.version(package_name)
elif len(distributions) > 1:
    raise RuntimeError(
        f"{package_name!r} maps to multiple installed"
        f" distributions ({', '.join(distributions)})."
        " Pass 'package_name' to disambiguate."
    ) from None
```

`importlib.metadata.version("aorta")` always raises here, so `--version` has only
ever worked *through that fallback* — and the fallback raises as soon as `aorta`
maps to more than one entry. Naming the distribution makes the first lookup
succeed and the fallback is never reached.

## Blast radius

#429 was filed as a contributor annoyance requiring a stale `src/*.egg-info`.
That understates it in both directions. Two ordinary conditions produce the
duplicate mapping, and neither needs a stale artefact.

**1. Editable installs whose build leaves in-tree metadata.** The editable
install's `.pth` puts the checkout's `src/` on `sys.path`, so an
`src/amd_aorta.egg-info` sitting there is discovered as a second distribution,
also named `amd-aorta`, beside the site-packages `.dist-info`. Whether the build
leaves that directory depends on the install path — an **isolated build, which is
the default for both `pip` and `uv`, does**; #429 records a
`--no-build-isolation` run that did not. So this is the common case rather than a
universal one, and the documented dev-setup command is in it. A fresh clone with
nothing but `uv pip install -e ".[tests]"`, on the unfixed code:

```
$ python -c "import importlib.metadata as m; print(m.packages_distributions()['aorta'])"
['amd-aorta', 'amd-aorta']

$ aorta --version
RuntimeError: 'aorta' maps to multiple installed distributions
(amd-aorta, amd-aorta). Pass 'package_name' to disambiguate.
```

**2. Wheel installs into a `python -m venv` on the RHEL and Fedora family.**
This is the one that reaches users rather than contributors, and it needs no
editable install at all. The trigger is the venv layout, not the distro as such:
where `sys.platlibdir` is `lib64`, `python -m venv` creates `lib64` as a symlink
to `lib` and `site` puts *both* directories on `sys.path`, so every `.dist-info`
under them is enumerated twice — not just this project's. Measured on a
RHEL-family box:

```
$ python3 -c "import sys; print(sys.platlibdir)"
lib64

$ python3 -m venv /tmp/v && ls -l /tmp/v | grep lib
drwxr-xr-x  lib
lrwxrwxrwx  lib64 -> lib

$ /tmp/v/bin/python -c "import sys; print([p for p in sys.path if 'site-packages' in p])"
['/tmp/v/lib64/python3.9/site-packages', '/tmp/v/lib/python3.9/site-packages']

$ /tmp/v/bin/python -c "
import importlib.metadata as m, collections
print(collections.Counter(d.metadata['Name'] for d in m.distributions()))"
Counter({'setuptools': 2, 'pip': 2})
```

`packages_distributions()` builds its lists from exactly that `distributions()`
enumeration, so in such an environment every import name maps to its distribution
twice — `click -> ['click', 'click']`, `yaml -> ['PyYAML', 'PyYAML']`. For
`amd-aorta` that means `aorta --version` from a released wheel raises
`RuntimeError` in a stock `python -m venv` on RHEL, Rocky, Alma or Fedora, with no
editable install and no stray build directory involved. (A wheel installed
outside such a venv — system-wide, or into a venv without the duplicated
site-packages view — is unaffected.)

So this is a customer-facing crash on the simplest command in the CLI, reachable
from a released wheel, not just a local-hygiene problem.

## Tests

`tests/cli/test_version_option.py`, two cases:

- `--version` prints the version of the `amd-aorta` distribution.
- An ambiguous import-name mapping does not reach `--version`. The ambiguous
  mapping is **injected** rather than depended on, which is deliberate: because
  neither condition above is universal, a test relying on the ambient layout
  would pass vacuously on the machines that do not reproduce it. Injecting pins
  the fix on every platform and install layout.

Both run in a subprocess: `version_option` caches the resolved version in its
closure, so in-process they would pass vacuously once anything else in the
session had asked for `--version`.

## Verification

- **Fails without the fix.** Reverting just the `package_name` argument fails
  both tests with Click's `'aorta' maps to multiple installed distributions
  (amd-aorta, amd-aorta)` `RuntimeError`, and `aorta --version` exits 1 with that
  traceback. With the fix, both pass and `aorta --version` prints
  `aorta, version 0.3.1.dev1+g115caee1`.
- **Full suite** — `pytest -n 16` failure set is identical to the same run on the
  base commit (`115caee1`); the only delta is the two new tests passing. Known
  environmental gaps on this box (missing `bpftrace`, missing `triton`) are
  present on both sides.

## Relationship to #428

#428 (lazy CLI command loading) relocates this decorator and originally carried
this fix as `2394a122` + `430543bd`. Both have been dropped from that branch and
re-applied here against `main`, since the fix is customer-facing and the refactor
is not. The two changes touch the same two lines of `src/aorta/cli/__init__.py`,
so whichever lands second will need a trivial rebase; #428's body has been
updated to point here.
