### PR TITLE
fix(proton): stop the mode: env exit-time deadlock, and measure the CLI-pin version split

### DIFF
--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -521,7 +521,10 @@ reproducer, the gdb stack and the 3.7.1-clean / 3.8.0-affected boundary:
 (`protonToolFini` re-enters rocprofiler-sdk from inside a client finalizer) and
 [ROCm/rocm-systems#11123](https://github.com/ROCm/rocm-systems/issues/11123)
 (`invoke_client_finalizer` holds a non-recursive mutex across that callback).
-Neither is fixed yet, so the import order below is a workaround, not a cure.
+Neither issue is closed, and no *released* Triton carries a fix — the one that
+exists, `triton-lang/triton#11009`, landed on `main` after the `v3.8.0` tag was
+cut (see the troubleshooting entry below). So the import order below is a
+workaround rather than a cure.
 Tracked here as [ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
 
 The ordering is free, and it does not fight either backend's contract. What

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -344,7 +344,8 @@ failure mode of the other. Note the incompatibility is in *initialisation
 order*, not in the attach modes themselves: `roctracer` is the only backend an
 attach mode is forced on, while `rocprofiler` works under either — `mode: cli`
 loads `libproton` before the payload, and `mode: env` is equally safe provided
-the payload imports Proton before torch, as `amd-rocprofiler/gelu.py` does.
+the payload imports Proton before torch, which every shipped payload now does
+for an unrelated reason (see [Import order](#import-order)).
 
 | Backend | Configures itself | Runtime state it needs at that moment | Attach mode |
 |---|---|---|---|

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -509,11 +509,15 @@ process on this stack that imports torch before `triton.profiler` is affected.
 Reported upstream; tracked here as
 [ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
 
-The ordering is free. Measured on gfx950, moving the import above torch leaves
-the capture byte-identical on both Triton 3.7.1 and 3.8.0, because what the
-queue-intercepting backends actually constrain is when `proton.start()` runs,
-not when the module is imported. All three shipped examples now import Proton
-first, marked `# isort: skip  # noqa: I001` so the linter does not undo it, and
+The ordering is free, and it does not fight either backend's contract. What
+`roctracer` constrains is when `proton.start()` runs — its interceptor goes in
+at session start, so the runtime has to be up by then — not when the module is
+imported; measured on gfx950, moving the import above torch leaves the capture
+byte-identical on both Triton 3.7.1 and 3.8.0. What `rocprofiler` constrains is
+the import itself, and in the same direction. So every payload can import
+Proton first and still call `proton.start()` after torch, which is what all
+three shipped examples do. The imports are marked
+`# isort: skip  # noqa: I001` so the linter does not undo it, and
 `test_proton_payloads_import_proton_before_torch` fails the CPU suite if a
 future edit reverses one.
 

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -344,8 +344,11 @@ failure mode of the other. Note the incompatibility is in *initialisation
 order*, not in the attach modes themselves: `roctracer` is the only backend an
 attach mode is forced on, while `rocprofiler` works under either — `mode: cli`
 loads `libproton` before the payload, and `mode: env` is equally safe provided
-the payload imports Proton before torch, which every shipped payload now does
-for an unrelated reason (see [Import order](#import-order)).
+the payload imports Proton before torch, which every shipped payload that
+imports Proton at all now does for an unrelated reason (see
+[Import order](#import-order)). The other two — `vecadd.py` and `softmax.py` —
+never import it, so they run under `mode: cli`, where the front-end loads it
+first, and the ordering cannot arise for them.
 
 | Backend | Configures itself | Runtime state it needs at that moment | Attach mode |
 |---|---|---|---|

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -753,12 +753,19 @@ trying to confirm it:
   devel-symlink fixup creates that soname, which is why CI is exposed and a
   bare `docker run` of the same base is not. A classic `/opt/rocm` install
   ships both spellings. **No GPU is needed** to reproduce it.
-- **Triton must be 3.8.0 exactly.** 3.7.x predates the constructor;
-  `triton-lang/triton#11009` removed the re-entrant call on `main` but landed
-  after the `v3.8.0` tag was cut, so 3.8.0 is the affected window. Once the
-  installed Triton carries that fix the import order stops being load-bearing
-  for this reason (it still is for `rocprofiler`, which needs configuring
-  before HSA).
+- **The Triton build must carry the 3.8.0 finalizer code without
+  `triton-lang/triton#11009`.** That is a property of the build, not of a
+  version string, and it is the boundary to reason with. `v3.8.0` is the known
+  affected *release*: 3.7.x predates the constructor entirely, and #11009
+  removed the re-entrant call on `main` but landed after the `v3.8.0` tag was
+  cut, so no released Triton carries the fix. Do not read safety off any other
+  version, though — a pre-fix source build of `main`, or a future 3.8.x that
+  ships without the backport, contains the same re-entrant finalizer. To settle
+  an unknown build, check whether `protonToolFini` still calls back through
+  `state->finalizeFunc` (`RocprofSDKProfiler.cpp`) rather than comparing
+  version numbers. Once the installed Triton carries the fix the import order
+  stops being load-bearing *for this reason* (it still is for `rocprofiler`,
+  which needs configuring before HSA).
 
 **`rocprofv3 not found`.** Put `rocprofv3` on `$PATH` (it ships with ROCm)
 or set `$ROCPROF_BIN` to the binary. `$ROCPROF_BIN` accepts either a bare

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -220,7 +220,7 @@ measured sharp edges — see [Choosing a Proton backend](proton-backends.md).
 | Option | Values | Default | Notes |
 |---|---|---|---|
 | `mode` | `cli`, `env` | `cli` | See [Attach modes](#proton-attach-modes). |
-| `backend` | `auto`, `rocprofiler`, `roctracer`, `instrumentation`, `cupti` | `auto` | `auto` omits Proton's `-b` and lets Proton pick the backend matching the active runtime. On AMD that resolution is version-dependent — `select_profiler_from_triton_backend('hip')` returns `rocprofiler` on Triton 3.8.0 and newer and `roctracer` on 3.7.1 and earlier; on NVIDIA it is `cupti` either way. It is the only spelling correct on every version and is why it is the default: **naming a backend is a version commitment, and naming `roctracer` is an attach-mode commitment too.** `rocprofiler` is the preferred AMD backend upstream and has been a released backend since Triton 3.8.0 (2026-08-28), whose CLI advertises `-b {cupti,rocprofiler,roctracer,instrumentation}`; 3.7.x and earlier accept only `cupti`/`roctracer`/`instrumentation` and exit with an argparse `invalid choice: 'rocprofiler'` before the payload runs. `roctracer` is the deprecated AMD predecessor, and the one *whole-kernel* AMD backend present in *every* release including the oldest; `instrumentation` the intra-kernel path, also present in every release; `cupti` the NVIDIA one, accepted so a recipe stays portable even though aorta's examples are AMD. Pinning `roctracer` means `mode: env` and a payload that drives Proton itself: under the default `mode: cli` such a pin captures an empty tree, and the collector refuses that one pairing. The two AMD tracing backends have *opposite* initialisation contracts, so `rocprofiler` is not covered — it configures itself when `libproton` loads, which makes `mode: cli` the ordering upstream prefers for it — see [Pinning an explicit AMD backend](#pinning-an-explicit-amd-backend). `instrumentation` measures *inside* a kernel and publishes **no numeric metrics** — its leaves carry `cycles` / `normalized_cycles`, never `time (<unit>)`, so such a trial reports `proton_artifact_dir` and nothing else. |
+| `backend` | `auto`, `rocprofiler`, `roctracer`, `instrumentation`, `cupti` | `auto` | `auto` omits Proton's `-b` and lets Proton pick the backend matching the active runtime. On AMD that resolution is version-dependent — `select_profiler_from_triton_backend('hip')` returns `rocprofiler` on Triton 3.8.0 and newer and `roctracer` on 3.7.1 and earlier; on NVIDIA it is `cupti` either way. It is the only spelling correct on every version and is why it is the default: **naming a backend is a version commitment, and naming `roctracer` is an attach-mode commitment too.** `rocprofiler` is the preferred AMD backend upstream and has been a released backend since Triton 3.8.0 (2026-08-28), whose CLI advertises `-b {cupti,rocprofiler,roctracer,instrumentation}`; 3.7.x and earlier accept only `cupti`/`roctracer`/`instrumentation` and exit with an argparse `invalid choice: 'rocprofiler'` before the payload runs. `roctracer` is the deprecated AMD predecessor, and the one *whole-kernel* AMD backend present in *every* release including the oldest; `instrumentation` the intra-kernel path, also present in every release; `cupti` the NVIDIA one, accepted so a recipe stays portable even though aorta's examples are AMD. Pinning `roctracer` means `mode: env` and a payload that drives Proton itself: on Triton 3.7.x and earlier such a pin captures an empty tree under the default `mode: cli`. Measured on 3.8.0 the same pin captures normally, but the collector still refuses that one pairing on every version, because 3.7.x is what several images in use ship — see [Pinning an explicit AMD backend](#pinning-an-explicit-amd-backend) and [#439](https://github.com/ROCm/aorta/issues/439) for when the refusal goes. The two AMD tracing backends have *opposite* initialisation contracts, so `rocprofiler` is not covered — it configures itself when `libproton` loads, which makes `mode: cli` the ordering upstream prefers for it — see [Pinning an explicit AMD backend](#pinning-an-explicit-amd-backend). `instrumentation` measures *inside* a kernel and publishes **no numeric metrics** — its leaves carry `cycles` / `normalized_cycles`, never `time (<unit>)`, so such a trial reports `proton_artifact_dir` and nothing else. |
 | `backend_mode` | `pcsampling`, `periodic_flushing` | (unset) | Proton's per-backend `--mode`. **Requires an explicit (non-`auto`) backend**, because which values are valid depends on which backend runs: `rocprofiler` takes both, `roctracer` only `periodic_flushing`, `cupti` both. Not valid on `backend: instrumentation`, whose modes are the `instrumentation_mode` key, and rejected together with `instrumentation_mode` *or* `granularity` — all three render into Proton's single `--mode` argument, so only one may be set. What the schema accepts is the backend's documented domain, not what a given build implements: `rocprofiler` + `pcsampling` is rejected by Triton 3.8.0 itself with `ValueError: [PROTON] RocprofSDKProfiler: unsupported mode: pcsampling`, because AMD PC sampling landed upstream after the 3.8.0 tag. `roctracer` + `periodic_flushing` is accepted by `start()` on 3.8.0, but **accepted is not the same as working**: on Triton 3.7.1 / ROCm 7.0.2 that pair kills the workload with SIGSEGV (exit 139) once kernels dispatch — verified on two payloads — so leave it unset there. Reaching Proton through `mode: cli` is version-dependent — see the paragraph below the table. |
 | `context` | `shadow`, `python` | `shadow` | How a kernel's time is attributed to a calling frame. |
 | `data` | `tree`, `trace` | `tree` | `tree` writes the `.hatchet` file the parser reads; `trace` writes a chrome trace instead, so it produces no numeric metrics. |
@@ -381,11 +381,20 @@ naming `mode: env` as the route.
 
 **This is a Triton 3.7.x-and-earlier defect, and the guard has an expiry.** The
 byte counts above are from 3.7.1. On 3.8.0 the same pinned `-b roctracer`
-captured 17 kernels on aorta's own MI350 runner, so the bug does not reproduce
-there. The guard stays because 3.7.x is what this repo's containers ship, and
-the GPU test that asserts the bug is still present skips itself from 3.8.0 on —
-so when the floor moves, the test stops claiming something false and the guard
-can be removed deliberately rather than discovered to be dead.
+captures normally — measured on gfx950 / ROCm 10 at 3090 bytes, byte-for-byte
+what `backend: auto` produces there — so the bug does not reproduce on the newer
+stack. The guard stays because 3.7.x is still what several images in use ship
+(3.7.1 in `rocm/pytorch:rocm7.14_ubuntu26.04_py3.14_pytorch_release_2.12.0`,
+3.6.0 in `rocm/pytorch:latest`), and removing it today would regress those users
+into the silent unprofiled trial it exists to prevent.
+
+`test_cli_mode_pin_captures_nothing_only_on_the_versions_the_guard_targets`
+asserts *whichever* of the two behaviours the installed Triton has, rather than
+skipping on the newer stack, so both halves stay under test: the 3.7.x half is
+the original regression, and the 3.8.0 half is what will say the guard has
+become a no-op — and what fails loudly if a later Triton reintroduces the
+ordering bug after the guard is gone. Removal is tracked in
+[#439](https://github.com/ROCm/aorta/issues/439).
 
 **`rocprofiler` is not covered, and must not be.** The evidence for it is of a
 different kind from everything above — it is read from upstream's source and
@@ -506,8 +515,14 @@ runner or a sweep it reads as a hang with no failing assertion.
 
 This is not a Proton-collector defect, and it is not specific to aorta: any
 process on this stack that imports torch before `triton.profiler` is affected.
-Reported upstream; tracked here as
-[ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
+Filed against both repositories that can fix it, each carrying the two-line
+reproducer, the gdb stack and the 3.7.1-clean / 3.8.0-affected boundary:
+[triton-lang/triton#11549](https://github.com/triton-lang/triton/issues/11549)
+(`protonToolFini` re-enters rocprofiler-sdk from inside a client finalizer) and
+[ROCm/rocm-systems#11123](https://github.com/ROCm/rocm-systems/issues/11123)
+(`invoke_client_finalizer` holds a non-recursive mutex across that callback).
+Neither is fixed yet, so the import order below is a workaround, not a cure.
+Tracked here as [ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
 
 The ordering is free, and it does not fight either backend's contract. What
 `roctracer` constrains is when `proton.start()` runs — its interceptor goes in
@@ -721,6 +736,23 @@ will be in `rocprofiler::registration::finalize()` under `__run_exit_handlers`,
 blocked on `get_registration_mutex()`. Fix by importing `triton.profiler`
 before torch — see [Import order](#import-order). Tracked in
 [ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
+
+Two things decide whether an environment is exposed, and both surprise people
+trying to confirm it:
+
+- **The unversioned `librocprofiler-sdk.so` must resolve.** A stock
+  `rocm/pytorch` wheel image ships only `librocprofiler-sdk.so.1`, so Proton's
+  constructor `dlopen` fails, no rocprofiler-sdk client registers, and nothing
+  deadlocks — the image is *accidentally* immune. `Dockerfile.ci-gpu`'s
+  devel-symlink fixup creates that soname, which is why CI is exposed and a
+  bare `docker run` of the same base is not. A classic `/opt/rocm` install
+  ships both spellings. **No GPU is needed** to reproduce it.
+- **Triton must be 3.8.0 exactly.** 3.7.x predates the constructor;
+  `triton-lang/triton#11009` removed the re-entrant call on `main` but landed
+  after the `v3.8.0` tag was cut, so 3.8.0 is the affected window. Once the
+  installed Triton carries that fix the import order stops being load-bearing
+  for this reason (it still is for `rocprofiler`, which needs configuring
+  before HSA).
 
 **`rocprofv3 not found`.** Put `rocprofv3` on `$PATH` (it ships with ROCm)
 or set `$ROCPROF_BIN` to the binary. `$ROCPROF_BIN` accepts either a bare

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -457,9 +457,11 @@ would imply more than it knows. The Triton version in the run's env snapshot is
 what disambiguates which backend produced a given set of numbers — read it
 before comparing `proton_gpu_time_ms` across runs from different environments.
 
-To pin `roctracer`, use `mode: env` and a payload that imports torch and then
-calls `proton.start()` itself (`rocprofiler` needs the reverse import order, and
-also accepts `mode: cli`):
+To pin `roctracer`, use `mode: env` and a payload that calls `proton.start()`
+after torch is imported (`rocprofiler` also accepts `mode: cli`). Note this is a
+constraint on the `start()` call, not on the import: every Proton payload should
+import `triton.profiler` **before** torch, because the reverse order deadlocks
+the process at exit on Triton 3.8.0 — see [Import order](#import-order) below:
 
 ```yaml
 collect:
@@ -475,6 +477,44 @@ is that recipe with a working payload;
 [`amd-instrumentation/`](../examples/profiling/proton/amd-instrumentation/)
 and [`amd-rocprofiler/`](../examples/profiling/proton/amd-rocprofiler/) are
 the same shape for the other two backends.
+
+#### Import order
+
+**Import `triton.profiler` before `torch`, in every payload, whatever backend
+it uses.** On Triton 3.8.0 the reverse order hangs the process forever at
+`exit()` — after a perfectly good capture has already been flushed to disk.
+These two lines are the entire reproducer:
+
+```python
+import torch
+import triton.profiler  # process now never exits
+```
+
+`libproton.so` calls `rocprofiler_force_configure` from an
+`__attribute__((constructor))`, so importing Proton registers it as a
+rocprofiler-sdk client. When that registration lands *after* HSA is already up
+— importing torch is enough, no GPU work required — the atexit
+`rocprofiler::registration::finalize()` takes its registration mutex, invokes
+Proton's `protonToolFini`, and that re-enters the same non-recursive mutex on
+the same thread. The main thread then sits in `futex_wait` forever.
+
+The failure is unusually easy to misread, because everything the payload was
+asked to do succeeded: the kernels ran, the tree is complete, the `.hatchet`
+is on disk, and stdout says `PASS`. Only the exit never happens. Under a test
+runner or a sweep it reads as a hang with no failing assertion.
+
+This is not a Proton-collector defect, and it is not specific to aorta: any
+process on this stack that imports torch before `triton.profiler` is affected.
+Reported upstream; tracked here as
+[ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
+
+The ordering is free. Measured on gfx950, moving the import above torch leaves
+the capture byte-identical on both Triton 3.7.1 and 3.8.0, because what the
+queue-intercepting backends actually constrain is when `proton.start()` runs,
+not when the module is imported. All three shipped examples now import Proton
+first, marked `# isort: skip  # noqa: I001` so the linter does not undo it, and
+`test_proton_payloads_import_proton_before_torch` fails the CPU suite if a
+future edit reverses one.
 
 ### Device selection on AMD
 
@@ -665,6 +705,17 @@ of Triton, and a host shim bound to a Triton-less interpreter will fail the
 same way the `proton` console script does.
 
 ## Troubleshooting
+
+**The payload printed `PASS`, the `.hatchet` is on disk, and the process never
+exits.** An exit-time deadlock between Proton and rocprofiler-sdk on Triton
+3.8.0, triggered by importing `torch` before `triton.profiler`. Nothing is
+wrong with the capture — it is complete — so there is no failing assertion and
+no error output; the process simply sits in `futex_wait` until something kills
+it. Confirm with `gdb -p <pid> -batch -ex 'thread 1' -ex bt`: the main thread
+will be in `rocprofiler::registration::finalize()` under `__run_exit_handlers`,
+blocked on `get_registration_mutex()`. Fix by importing `triton.profiler`
+before torch — see [Import order](#import-order). Tracked in
+[ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
 
 **`rocprofv3 not found`.** Put `rocprofv3` on `$PATH` (it ships with ROCm)
 or set `$ROCPROF_BIN` to the binary. `$ROCPROF_BIN` accepts either a bare

--- a/docs/proton-backends.md
+++ b/docs/proton-backends.md
@@ -96,31 +96,52 @@ the mode.
 
 ## Attach mode is part of the choice
 
-Pinning a backend can commit you to an attach mode, and the two AMD tracing
-backends want **opposite** initialisation orders. This is the part that bites.
+Pinning a backend can commit you to an attach mode, because the two AMD tracing
+backends are configured at **different moments**, and each needs something
+different to be true at its own moment. This is the part that bites.
 
 | Backend | Configured when | Needs at that moment | Attach mode |
 | --- | --- | --- | --- |
-| `roctracer` | session start | HIP runtime **already up** | `mode: env`, payload starts Proton *after* importing torch |
-| `rocprofiler` | `libproton.so` load | HSA **not yet up** | either; `mode: cli`, or `mode: env` with Proton imported *before* torch |
+| `roctracer` | session start, at `proton.start()` | HIP runtime **already up** | `mode: env`, payload calls `proton.start()` *after* importing torch |
+| `rocprofiler` | `libproton.so` load, at *import* | HSA **not yet up** | either; `mode: cli`, or `mode: env` with Proton imported *before* torch |
 | `instrumentation` | session start | no requirement | either |
+
+**Those two requirements look opposed and are not.** They constrain different
+events: `roctracer` constrains when the *session starts*, `rocprofiler`
+constrains when Proton is *imported*. One payload shape satisfies both — import
+`triton.profiler` first, call `proton.start()` after torch — and all three
+`amd-*` examples use it. This page previously said the two wanted opposite
+import orders, which was wrong when written rather than merely stale; see
+[ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
 
 So `mode: env` with an explicit `roctracer` is required — the collector refuses
 a `mode: cli` pin of it, because on Triton 3.7.1 that captures a 160-byte tree
 holding a bare `ROOT` from a run that exits 0. That refusal is a 3.7.x-and-
-earlier workaround: the same pin captured 17 kernels on 3.8.0.
+earlier workaround: the same pin captured 17 kernels on 3.8.0. It is kept on
+every version anyway, because 3.7.x is what several images in use ship and the
+failure it prevents is silent; removing it once the floor reaches 3.8 is tracked
+in [#439](https://github.com/ROCm/aorta/issues/439).
 
-And `rocprofiler` is the reverse. Triton 3.8.0 calls
+And `rocprofiler`'s requirement lands on the import instead. Triton 3.8.0 calls
 `rocprofiler_force_configure` from a constructor in `libproton.so`, and its own
 source warns that a torch import chain first makes the SDK skip dispatch-buffer
 tracing on existing queues. So a payload driving it must import Proton before
-torch, which is why
+torch, as
 [`amd-rocprofiler/gelu.py`](../examples/profiling/proton/amd-rocprofiler/gelu.py)
-has its imports in the opposite order to its sibling — deliberately, and
-commented as such.
+does and says at the import site.
 
-The practical rule: **let the example you copied choose the attach mode.** Each
-of the three carries the order its backend needs.
+That import order is now the rule for **every** Proton payload, whatever
+backend it targets, for a second and independent reason: on Triton 3.8.0 the
+reverse order deadlocks the process at exit, after a complete capture has
+already been written, so it reads as a hang with no error
+([ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434)). All three `amd-*`
+payloads mark the import `# isort: skip  # noqa: I001` so the linter cannot
+reorder it, and `test_proton_payloads_import_proton_before_torch` fails the CPU
+suite if one is reversed.
+
+The practical rule: **let the example you copied choose the attach mode, and
+import Proton before torch whatever you copied.** The attach mode still varies
+by backend; the import order no longer does.
 
 ## Combining with `rocprof`
 
@@ -150,9 +171,15 @@ actionable error or a workaround.
   Proton opens the unversioned name. Which library it names follows the
   backend: `libroctracer64.so` below 3.8.0, `librocprofiler-sdk.so` from 3.8.0
   on, since that is where `auto` starts resolving to `rocprofiler`.
-- **`mode: env` captures wedge on the Triton 3.8.0 CI runner.** Tracked in
-  [#434](https://github.com/ROCm/aorta/issues/434); the GPU suite skips those
-  captures from 3.8.0 on rather than letting them consume the job.
+- **`mode: env` captures wedged at exit on Triton 3.8.0** — diagnosed and fixed
+  by import order, so this one is a defect you can now avoid rather than work
+  around. Proton and rocprofiler-sdk self-deadlock in `protonToolFini` when
+  Proton is imported *after* torch: the capture completes, the `.hatchet` is
+  written, and the process then sits in `futex_wait` forever. Import
+  `triton.profiler` before torch and it does not happen; the GPU suite runs
+  those captures rather than skipping them. See
+  [#434](https://github.com/ROCm/aorta/issues/434) and
+  [Attach mode](#attach-mode-is-part-of-the-choice).
 
 ## Worked decisions
 
@@ -177,6 +204,7 @@ table above requires. Record the Triton version — the artifact does not.
 - [Profiling Collectors](profiling-collectors.md) — option schema, attach-mode
   mechanics, artifact layout, analysis recipes, troubleshooting
 - [`examples/profiling/proton/`](../examples/profiling/proton/) — one runnable
-  example per backend, each with the attach mode and import order it needs
+  example per backend, each with the attach mode its backend needs, and all of
+  them importing Proton before torch
 - [Profiling Guide](profiling.md) — capturing and interpreting profiling data
   more generally

--- a/examples/profiling/README.md
+++ b/examples/profiling/README.md
@@ -75,9 +75,13 @@ reasons, which are worth keeping apart. Only one of the three is forced.
 
 For `amd-roctracer` it is forced. Proton's CLI front-end initialises the HIP
 runtime only on the path where `-b` is absent, and `roctracer` records nothing
-unless it starts after that runtime is up, so a `roctracer` pin under the
-default `mode: "cli"` captures an empty tree; the collector refuses that one
-combination rather than letting a trial pass with nothing in it.
+unless it starts after that runtime is up, so on Triton 3.7.x and earlier a
+`roctracer` pin under the default `mode: "cli"` captures an empty tree.
+Measured on 3.8.0 the same pin captures normally, but the collector refuses
+that one combination on every version rather than letting a trial pass with
+nothing in it on the older images still in use — see
+[ROCm/aorta#439](https://github.com/ROCm/aorta/issues/439). `mode: "env"` is
+correct on every version.
 
 For `amd-rocprofiler` it is a choice, and the backend's contract is the
 *opposite* of its sibling's rather than the same. `libproton.so` configures

--- a/examples/profiling/README.md
+++ b/examples/profiling/README.md
@@ -94,6 +94,17 @@ interceptor, so a CLI pin of it captures correctly and the collector allows it.
 It uses `mode: "env"` only so that `instrumentation_mode` reaches Proton on
 Triton 3.7.1 and earlier, whose CLI parses `--mode` and then drops it.
 
+**If you are writing a new Proton payload, import `triton.profiler` before
+`torch`, whatever backend you target.** The three contracts above are about
+when `proton.start()` runs; the import is a separate rule, and it applies to
+all of them. On Triton 3.8.0 the reverse order hangs the process forever at
+exit — after a complete capture has been written, so it reads as a hang with no
+error. All three payloads mark the import `# isort: skip  # noqa: I001` so the
+linter cannot reorder it, and `test_proton_payloads_import_proton_before_torch`
+fails the CPU suite if one is reversed. See
+[Import order](../../docs/profiling-collectors.md#import-order) and
+[ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
+
 ## Where the collector options live
 
 Each example's `recipe.yaml` carries its collector configuration as a

--- a/examples/profiling/proton/amd-instrumentation/README.md
+++ b/examples/profiling/proton/amd-instrumentation/README.md
@@ -181,8 +181,11 @@ That is the *only* reason this example uses `mode: env`, and it is worth being
 precise about, because the sibling [`../amd-roctracer`](../amd-roctracer/README.md)
 needs it for a different and much harder one. There, the same snippet's
 `_select_backend()` — called only when `-b` is absent — is what initialises the
-Triton HIP driver, and `roctracer` records nothing unless it starts after that;
-that line is unchanged in 3.8.0, so no version fixes it. This backend installs
+Triton HIP driver, and `roctracer` records nothing unless it starts after that,
+so a CLI pin captures an empty tree on Triton 3.7.x and earlier. That line is
+unchanged in 3.8.0, yet the pin captures normally there, so a release does fix
+it; the collector keeps refusing the pairing while 3.7.x images are in use
+([ROCm/aorta#439](https://github.com/ROCm/aorta/issues/439)). This backend installs
 no queue interceptor: a `-b instrumentation` CLI wrap of this payload captures
 both scopes correctly (verified on 3.7.1: 1738 bytes, cycle counts intact). So
 the collector's refusal to pin a backend under `mode: cli` covers `roctracer`

--- a/examples/profiling/proton/amd-instrumentation/hotspot.py
+++ b/examples/profiling/proton/amd-instrumentation/hotspot.py
@@ -148,11 +148,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         default=None,
-        # ``rocprofiler`` is deliberately absent, not forgotten. This module
-        # imports torch before Proton, which is right for the two backends left
-        # here and is exactly the ordering that leaves rocprofiler with an empty
-        # dispatch buffer. Offering it would hand out the trap this PR
-        # documents; ``../amd-rocprofiler/gelu.py`` has the import order for it.
+        # ``rocprofiler`` is deliberately absent, not forgotten -- though no
+        # longer for an import-order reason, since this module now imports
+        # Proton before torch just as ``../amd-rocprofiler/gelu.py`` does. What
+        # still rules it out is the *attach* order: this payload starts its
+        # session after torch, which is what roctracer needs and what leaves
+        # rocprofiler with an empty dispatch buffer. Offering it would hand out
+        # that trap; ``../amd-rocprofiler/gelu.py`` attaches the way it needs.
         choices=("instrumentation", "roctracer"),
         help="Proton backend for a standalone capture; ignored when $AORTA_PROTON_BACKEND is set",
     )

--- a/examples/profiling/proton/amd-instrumentation/hotspot.py
+++ b/examples/profiling/proton/amd-instrumentation/hotspot.py
@@ -23,23 +23,31 @@ import argparse
 import os
 import sys
 
-# ``torch`` is imported at module scope, before ``proton.start()`` runs in
-# main(). For the queue-intercepting backends that ordering is load-bearing --
-# ``roctracer`` records nothing unless the HIP runtime is already up, which is
-# what importing torch does. That is a ``roctracer`` property and not an AMD one:
-# ``rocprofiler`` wants the reverse (it is configured from a ``libproton.so``
-# constructor, so it must land *before* HSA), and this backend has no ordering
-# requirement at all -- it installs no queue interceptor, and a CLI pin of it
-# captures correctly whatever the order. The
-# reason this example chooses ``mode: env`` is narrower and version-independent:
-# Triton 3.7.1's CLI parses ``--mode`` and then calls ``start()`` without it, so
-# ``instrumentation_mode`` would be dropped there. 3.8.0 forwards it, but this
-# route reaches Proton on both -- see recipe.yaml.
+# Proton is imported BEFORE torch, and that ordering is load-bearing even
+# though this backend intercepts no queues. `libproton.so` calls
+# `rocprofiler_force_configure` from an `__attribute__((constructor))`, so the
+# import registers Proton as a rocprofiler-sdk client whatever backend a session
+# later selects; on Triton 3.8.0, registering after HSA is up (a torch import
+# chain is enough) makes the atexit `registration::finalize` re-enter its own
+# non-recursive registration mutex through Proton's `protonToolFini` and
+# deadlock, so the process hangs forever after a perfectly good capture. See
+# ROCm/aorta#434.
+#
+# ``torch`` still lands before ``proton.start()`` runs in main(), which is what
+# the queue-intercepting backends need: ``roctracer`` records nothing unless the
+# HIP runtime is already up. That constraint is about the START call rather than
+# the import, so both orderings hold at once.
+#
+# The reason this example chooses ``mode: env`` is narrower and
+# version-independent: Triton 3.7.1's CLI parses ``--mode`` and then calls
+# ``start()`` without it, so ``instrumentation_mode`` would be dropped there.
+# 3.8.0 forwards it, but this route reaches Proton on both -- see recipe.yaml.
+import triton.profiler as proton  # isort: skip  # noqa: I001
+import triton.profiler.language as pl  # isort: skip  # noqa: I001
+
 import torch
 import triton
 import triton.language as tl
-import triton.profiler as proton
-import triton.profiler.language as pl
 
 # Instrumenting a Triton-DSL kernel is opt-in: ``triton/profiler/language.py``
 # enables only the Gluon semantic by default, because Triton's higher-level IR

--- a/examples/profiling/proton/amd-instrumentation/hotspot.py
+++ b/examples/profiling/proton/amd-instrumentation/hotspot.py
@@ -149,12 +149,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--backend",
         default=None,
         # ``rocprofiler`` is deliberately absent, not forgotten -- though no
-        # longer for an import-order reason, since this module now imports
-        # Proton before torch just as ``../amd-rocprofiler/gelu.py`` does. What
-        # still rules it out is the *attach* order: this payload starts its
-        # session after torch, which is what roctracer needs and what leaves
-        # rocprofiler with an empty dispatch buffer. Offering it would hand out
-        # that trap; ``../amd-rocprofiler/gelu.py`` attaches the way it needs.
+        # longer for an ordering reason, since this module now imports Proton
+        # before torch and starts the session after it, exactly as
+        # ``../amd-rocprofiler/gelu.py`` does. What rules it out is that this
+        # payload carries none of gelu.py's rocprofiler handling: no
+        # availability probe, and no classifier to turn an unsupported mode or
+        # an unloadable rocprofiler-sdk into a clean exit 2. Use gelu.py.
         choices=("instrumentation", "roctracer"),
         help="Proton backend for a standalone capture; ignored when $AORTA_PROTON_BACKEND is set",
     )

--- a/examples/profiling/proton/amd-instrumentation/recipe.yaml
+++ b/examples/profiling/proton/amd-instrumentation/recipe.yaml
@@ -35,13 +35,15 @@ env_passthrough_mode: inherit
 # decide, because it cannot know from its own interpreter which one that is.
 #
 # Note this is a *different* reason from the one that forces `mode: env` on the
-# sibling `amd-roctracer` recipe. That backend records nothing when Proton's
-# CLI pins it, because the CLI initialises the HIP runtime only on the path
-# where `-b` is absent and a queue interceptor must be installed first -- a line
-# that is unchanged in 3.8.0, so no release fixes it, and the collector does
-# refuse that combination. The instrumentation backend installs no interceptor
-# and captures fine under a `-b instrumentation` CLI wrap (verified on 3.7.1);
-# what `mode: cli` costs here is the version guarantee on the mode knob.
+# sibling `amd-roctracer` recipe. On Triton 3.7.x and earlier that backend
+# records nothing when Proton's CLI pins it, because the CLI initialises the
+# HIP runtime only on the path where `-b` is absent and a queue interceptor
+# must be installed first; measured on 3.8.0 the same pin captures normally, so
+# a release does fix it, but the collector still refuses that combination on
+# every version while 3.7.x images remain in use (ROCm/aorta#439). The
+# instrumentation backend installs no interceptor and captures fine under a
+# `-b instrumentation` CLI wrap (verified on 3.7.1); what `mode: cli` costs
+# here is the version guarantee on the mode knob.
 #
 # `granularity` is deliberately ABSENT. The option pair
 # `instrumentation_mode: default` + `granularity: warp` renders Proton's single

--- a/examples/profiling/proton/amd-rocprofiler/README.md
+++ b/examples/profiling/proton/amd-rocprofiler/README.md
@@ -285,13 +285,16 @@ payload does publish all three.
   the atexit `rocprofiler::registration::finalize()` re-enter its own
   non-recursive registration mutex through Proton's `protonToolFini` and
   deadlock, so the process hangs forever after writing a complete capture
-  ([ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434)). What still
-  differs between the backends is the **attach** order — when `proton.start()`
-  is called — not the import: `../amd-roctracer/pipeline.py` starts its session
-  after torch because roctracer needs the runtime already up, while importing
-  Proton before torch exactly as this payload does. Two backends, two attach
-  contracts, one import order; do not normalise the `start()` calls, and do not
-  let a linter sort the imports.
+  ([ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434)).
+
+  With that, the payloads no longer differ in ordering at all: each imports
+  Proton first and calls `proton.start()` from `main()`, after torch. That is
+  not a compromise between the two contracts — the contracts constrain
+  *different events*. `rocprofiler` constrains when it is **configured**, and
+  the `libproton.so` constructor does that at import; `roctracer` constrains
+  when the **session starts**. One ordering satisfies both, which is why the
+  "two backends, two import orders" framing this bullet used to carry was
+  wrong rather than merely out of date. Do not let a linter sort these imports.
 - **Device selection.** Proton on AMD reads `ROCR_VISIBLE_DEVICES` and rejects
   `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` for the queue-intercepting
   backends. aorta's collector translates the rejected spellings automatically

--- a/examples/profiling/proton/amd-rocprofiler/README.md
+++ b/examples/profiling/proton/amd-rocprofiler/README.md
@@ -265,10 +265,9 @@ payload does publish all three.
   on ordering grounds it is the shape upstream prefers, since it loads
   `libproton` before the payload runs. Env mode is chosen for the `--mode`
   portability and is safe here only because of the next bullet.
-- **The payload's import order is load-bearing, and it is the reverse of the
-  sibling's.** `libproton.so` calls `rocprofiler_force_configure` from an
-  `__attribute__((constructor))`, so importing Proton is what configures
-  rocprofiler-sdk. Triton v3.8.0's
+- **The payload's import order is load-bearing.** `libproton.so` calls
+  `rocprofiler_force_configure` from an `__attribute__((constructor))`, so
+  importing Proton is what configures rocprofiler-sdk. Triton v3.8.0's
   `third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp`
   warns, in the comment above that call, that "any code that fully initializes
   HSA beforehand (e.g. triton's HIP driver query at pytest collection time, or
@@ -276,13 +275,23 @@ payload does publish all three.
   kernel-dispatch buffer tracing installation on already-existing queues,
   producing an empty dispatch buffer and no per-kernel timing data." So
   [`gelu.py`](gelu.py) imports `triton.profiler` and `libproton` **before**
-  `torch`, and says so at the import site. `../amd-roctracer/pipeline.py` does
-  the opposite deliberately — roctracer needs the runtime already up. Two
-  backends, two contracts; do not normalise the two payloads to one import
-  order. Note this ordering claim comes from upstream's source comment and was
-  not measured here — nothing in reach can run this backend (see
-  [Availability](#availability)) — whereas the `roctracer` claim next door is
-  measured.
+  `torch`, and says so at the import site. Note this particular ordering claim
+  comes from upstream's source comment and was not measured here — nothing in
+  reach can run this backend (see [Availability](#availability)) — whereas the
+  `roctracer` claim next door is measured.
+
+  **Every sibling payload now shares this import order**, for a second reason
+  that was measured: on Triton 3.8.0, registering Proton after HSA is up makes
+  the atexit `rocprofiler::registration::finalize()` re-enter its own
+  non-recursive registration mutex through Proton's `protonToolFini` and
+  deadlock, so the process hangs forever after writing a complete capture
+  ([ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434)). What still
+  differs between the backends is the **attach** order — when `proton.start()`
+  is called — not the import: `../amd-roctracer/pipeline.py` starts its session
+  after torch because roctracer needs the runtime already up, while importing
+  Proton before torch exactly as this payload does. Two backends, two attach
+  contracts, one import order; do not normalise the `start()` calls, and do not
+  let a linter sort the imports.
 - **Device selection.** Proton on AMD reads `ROCR_VISIBLE_DEVICES` and rejects
   `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` for the queue-intercepting
   backends. aorta's collector translates the rejected spellings automatically

--- a/examples/profiling/proton/amd-rocprofiler/gelu.py
+++ b/examples/profiling/proton/amd-rocprofiler/gelu.py
@@ -55,11 +55,12 @@ import sys
 #    registration mutex through Proton's `protonToolFini` and deadlock --
 #    after the capture has been written. See ROCm/aorta#434.
 #
-# What still differs between the backends is the ATTACH order, not this one:
-# `roctracer` installs its interceptor at session start and needs the runtime
-# already up, so `amd-roctracer/pipeline.py` calls `proton.start()` after torch
-# while importing Proton before it, exactly as this file does. Do not "tidy"
-# the imports into alphabetical order in either payload.
+# Note this does NOT conflict with `roctracer`, which needs the runtime already
+# up when its session starts: the two backends constrain different events --
+# rocprofiler when it is CONFIGURED (at import, by the constructor), roctracer
+# when the SESSION STARTS. Every payload here satisfies both the same way,
+# importing Proton first and calling `proton.start()` from main() after torch.
+# Do not "tidy" the imports into alphabetical order in any of them.
 import triton.profiler as proton  # isort: skip  # noqa: I001
 from triton._C.libproton import proton as libproton  # isort: skip  # noqa: I001
 

--- a/examples/profiling/proton/amd-rocprofiler/gelu.py
+++ b/examples/profiling/proton/amd-rocprofiler/gelu.py
@@ -38,21 +38,28 @@ import argparse
 import os
 import sys
 
-# THE ORDER OF THE NEXT TWO IMPORT BLOCKS IS LOAD-BEARING, and it is the
-# opposite of what the sibling `amd-roctracer` example needs.
+# THE ORDER OF THE NEXT TWO IMPORT BLOCKS IS LOAD-BEARING, for two independent
+# reasons -- and every sibling payload now shares it.
 #
-# `libproton.so` calls `rocprofiler_force_configure` from an
-# `__attribute__((constructor))`, so importing Proton is what configures
-# rocprofiler-sdk -- and Triton 3.8.0's own source warns that letting HSA come
-# up first, naming "a torch import chain", makes the SDK skip dispatch-buffer
-# tracing on already-existing queues and hand back an empty buffer
-# (`RocprofSDKProfiler.cpp`, the comment above its `forceConfigure` call). So
-# Proton must be imported BEFORE torch here.
+# 1. This backend needs it. `libproton.so` calls `rocprofiler_force_configure`
+#    from an `__attribute__((constructor))`, so importing Proton is what
+#    configures rocprofiler-sdk -- and Triton 3.8.0's own source warns that
+#    letting HSA come up first, naming "a torch import chain", makes the SDK
+#    skip dispatch-buffer tracing on already-existing queues and hand back an
+#    empty buffer (`RocprofSDKProfiler.cpp`, the comment above its
+#    `forceConfigure` call).
 #
-# `roctracer` is the reverse -- it installs its interceptor at session start and
-# needs the runtime already up -- which is why `amd-roctracer/pipeline.py`
-# imports torch at module scope and starts Proton after it. Two backends, two
-# contracts; do not "tidy" these into one order.
+# 2. Every backend needs it, on Triton 3.8.0, or the process never exits. That
+#    same registration, landing after HSA is up, makes the atexit
+#    `rocprofiler::registration::finalize()` re-enter its own non-recursive
+#    registration mutex through Proton's `protonToolFini` and deadlock --
+#    after the capture has been written. See ROCm/aorta#434.
+#
+# What still differs between the backends is the ATTACH order, not this one:
+# `roctracer` installs its interceptor at session start and needs the runtime
+# already up, so `amd-roctracer/pipeline.py` calls `proton.start()` after torch
+# while importing Proton before it, exactly as this file does. Do not "tidy"
+# the imports into alphabetical order in either payload.
 import triton.profiler as proton  # isort: skip  # noqa: I001
 from triton._C.libproton import proton as libproton  # isort: skip  # noqa: I001
 

--- a/examples/profiling/proton/amd-rocprofiler/recipe.yaml
+++ b/examples/profiling/proton/amd-rocprofiler/recipe.yaml
@@ -62,9 +62,15 @@ env_passthrough_mode: inherit
 #
 # The same import order is now used by every Proton payload here, for a second
 # and measured reason: importing Proton after torch deadlocks the process at
-# exit on Triton 3.8.0 (ROCm/aorta#434). What remains specific to this backend
-# is the attach order -- `gelu.py` starts its session before torch is imported,
-# where `../amd-roctracer/pipeline.py` starts it after.
+# exit on Triton 3.8.0 (ROCm/aorta#434).
+#
+# So the payloads no longer differ in ordering at all -- all of them import
+# Proton first and call `proton.start()` from main(), after torch. That is not
+# a compromise: the two backends constrain *different events*. rocprofiler
+# constrains when it is CONFIGURED, which the constructor does at import;
+# roctracer constrains when the SESSION STARTS. One ordering satisfies both,
+# which is why the earlier "two backends, two import orders" framing here was
+# wrong rather than merely stale.
 #
 # `backend_mode: pcsampling` asks rocprofiler-sdk for statistical
 # instruction-level attribution -- where in the kernel the samples land --

--- a/examples/profiling/proton/amd-rocprofiler/recipe.yaml
+++ b/examples/profiling/proton/amd-rocprofiler/recipe.yaml
@@ -55,10 +55,16 @@ env_passthrough_mode: inherit
 #
 # Env mode is therefore safe here only because `gelu.py` imports
 # `triton.profiler` and `libproton` *before* `torch`. That import order is
-# load-bearing and is the reverse of `../amd-roctracer/pipeline.py`; see the
-# comment at the top of the payload. This ordering requirement is taken from
-# upstream's source comment, not measured -- no environment on hand can run
-# this backend -- unlike the roctracer measurement in the sibling recipe.
+# load-bearing; see the comment at the top of the payload. This particular
+# ordering requirement is taken from upstream's source comment, not measured --
+# no environment on hand can run this backend -- unlike the roctracer
+# measurement in the sibling recipe.
+#
+# The same import order is now used by every Proton payload here, for a second
+# and measured reason: importing Proton after torch deadlocks the process at
+# exit on Triton 3.8.0 (ROCm/aorta#434). What remains specific to this backend
+# is the attach order -- `gelu.py` starts its session before torch is imported,
+# where `../amd-roctracer/pipeline.py` starts it after.
 #
 # `backend_mode: pcsampling` asks rocprofiler-sdk for statistical
 # instruction-level attribution -- where in the kernel the samples land --

--- a/examples/profiling/proton/amd-roctracer/README.md
+++ b/examples/profiling/proton/amd-roctracer/README.md
@@ -133,9 +133,10 @@ instead of a full matrix. Read the raw tree with `proton-viewer -m time/s
 
 ## Why `mode: env`
 
-Pinning `roctracer` through `mode: cli` **silently captures nothing**, and the
-mechanism is worth knowing because it is not a bug you would guess from the
-output. Triton's Proton CLI front-end resolves the backend like this:
+On Triton 3.7.x and earlier, pinning `roctracer` through `mode: cli`
+**silently captures nothing**, and the mechanism is worth knowing because it is
+not a bug you would guess from the output. Triton's Proton CLI front-end
+resolves the backend like this:
 
 ```python
 backend = args.backend if args.backend else _select_backend()
@@ -150,9 +151,22 @@ metrics. aorta's parser finds no `time (<unit>)` leaves, degrades to
 `proton_artifact_dir`, and the trial carries no Proton metrics while looking
 like a success.
 
-Upgrading Triton does not help. That line is line 73 of
-`third_party/proton/proton/proton.py` at the `v3.8.0` tag, unchanged, so 3.8.0
-skips the driver-initialising call on the `-b` path exactly as 3.7.1 does.
+Upgrading Triton *does* help, and not for the reason the line above would
+suggest. That line is line 73 of `third_party/proton/proton/proton.py` at the
+`v3.8.0` tag, unchanged, so 3.8.0 still skips the driver-initialising call on
+the `-b` path exactly as 3.7.1 does — yet the same pin captures normally there:
+measured on gfx950 / ROCm 10 at 3090 bytes, byte-for-byte what `backend: auto`
+produces. Something else on that stack brings the runtime up before the session
+starts. So the empty capture is a 3.7.x-and-earlier defect, not a permanent
+property of pinning.
+
+The collector nonetheless refuses the pairing on *every* version, because
+3.7.x is still what several images in use ship (3.7.1 in
+`rocm/pytorch:rocm7.14_ubuntu26.04_py3.14_pytorch_release_2.12.0`, 3.6.0 in
+`rocm/pytorch:latest`) and the failure it prevents is silent. Dropping the
+refusal once the supported floor reaches 3.8 is tracked in
+[ROCm/aorta#439](https://github.com/ROCm/aorta/issues/439). `mode: env`, which
+this example uses, is correct on every version either way.
 
 `mode: env` avoids this entirely. aorta exports `AORTA_PROTON_*` and leaves
 argv alone; the payload imports `torch` at module scope — which brings the HIP

--- a/examples/profiling/proton/amd-roctracer/README.md
+++ b/examples/profiling/proton/amd-roctracer/README.md
@@ -164,9 +164,25 @@ version of this recipe would not run at all.
 The guard stops at `roctracer`. `rocprofiler` looks like the same case and is
 the opposite one: it is configured by an `__attribute__((constructor))` when
 `libproton.so` loads, so it wants to be set up *before* HSA rather than after,
-and its CLI pin is allowed for that reason. The import order in this example's
-payload — torch first, `proton.start()` after — is therefore the reverse of
-[`../amd-rocprofiler/gelu.py`](../amd-rocprofiler/gelu.py)'s, deliberately.
+and its CLI pin is allowed for that reason.
+
+**What the two backends disagree about is the `start()` call, not the import.**
+This payload imports `triton.profiler` before `torch`, exactly as
+[`../amd-rocprofiler/gelu.py`](../amd-rocprofiler/gelu.py) does, and then calls
+`proton.start()` after torch — which is what `roctracer` needs, since it
+installs its interceptor at session start rather than at load. Both orderings
+hold at once, and the capture is unchanged either way: measured on gfx950, the
+hatchet is byte-identical (1648 bytes, 15 launches across the three kernels) on
+Triton 3.7.1 and 3.8.0 with the import moved.
+
+Importing Proton *after* torch is not merely suboptimal on 3.8.0 — it hangs the
+process forever at exit, after the capture has already been written. The
+constructor registers Proton as a rocprofiler-sdk client; when that lands after
+HSA is up, the atexit `rocprofiler::registration::finalize()` re-enters its own
+non-recursive registration mutex through Proton's `protonToolFini` and
+deadlocks. `import torch` followed by `import triton.profiler` is the whole
+reproducer. See [ROCm/aorta#434](https://github.com/ROCm/aorta/issues/434).
+
 See [Pinning an explicit AMD
 backend](../../../../docs/profiling-collectors.md#pinning-an-explicit-amd-backend)
 for both contracts side by side, including which one is measured and which is

--- a/examples/profiling/proton/amd-roctracer/README.md
+++ b/examples/profiling/proton/amd-roctracer/README.md
@@ -166,14 +166,17 @@ the opposite one: it is configured by an `__attribute__((constructor))` when
 `libproton.so` loads, so it wants to be set up *before* HSA rather than after,
 and its CLI pin is allowed for that reason.
 
-**What the two backends disagree about is the `start()` call, not the import.**
-This payload imports `triton.profiler` before `torch`, exactly as
-[`../amd-rocprofiler/gelu.py`](../amd-rocprofiler/gelu.py) does, and then calls
-`proton.start()` after torch — which is what `roctracer` needs, since it
-installs its interceptor at session start rather than at load. Both orderings
-hold at once, and the capture is unchanged either way: measured on gfx950, the
-hatchet is byte-identical (1648 bytes, 15 launches across the three kernels) on
-Triton 3.7.1 and 3.8.0 with the import moved.
+**The two backends constrain different events, so one ordering serves both.**
+`roctracer` constrains when the *session starts* — it installs its interceptor
+then, and needs the runtime already up. `rocprofiler` constrains when it is
+*configured*, which the `libproton.so` constructor does at import. Those are
+not the same moment, so there is nothing to trade off: this payload imports
+`triton.profiler` before `torch`, exactly as
+[`../amd-rocprofiler/gelu.py`](../amd-rocprofiler/gelu.py) does, and calls
+`proton.start()` from `main()` after torch, also as gelu.py does. The capture
+is unaffected by the import move: measured on gfx950, the hatchet is
+byte-identical (1648 bytes, 15 launches across the three kernels) on Triton
+3.7.1 and 3.8.0.
 
 Importing Proton *after* torch is not merely suboptimal on 3.8.0 — it hangs the
 process forever at exit, after the capture has already been written. The

--- a/examples/profiling/proton/amd-roctracer/pipeline.py
+++ b/examples/profiling/proton/amd-roctracer/pipeline.py
@@ -6,9 +6,12 @@ carries a real launch sequence rather than a single kernel.
 
 Unlike the ``triton-vecadd`` / ``triton-softmax`` payloads this one drives
 Proton itself, because pinning ``roctracer`` only works from inside a live HIP
-runtime -- see the ``import torch`` comment below and ``recipe.yaml``. That is
-specific to this backend: ``rocprofiler`` needs the opposite load order, and
-``instrumentation`` needs no particular one.
+runtime -- see the import comment below and ``recipe.yaml``. That is specific
+to this backend: ``rocprofiler`` is configured when ``libproton.so`` loads and
+so needs the opposite *attach* order, and ``instrumentation`` needs no
+particular one. All three payloads nonetheless share the same *import* order
+(Proton before torch), for a reason unrelated to any of their contracts -- see
+the import comment.
 
 Constexpr kernel parameters are spelled lowercase (``block_size`` rather than
 Triton's conventional ``BLOCK_SIZE``) to satisfy this repository's lint
@@ -163,11 +166,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         default=None,
-        # ``roctracer`` only. This module imports torch before Proton, which is
-        # what roctracer needs and what rocprofiler cannot tolerate -- it is
-        # configured from a ``libproton.so`` constructor and wants to land before
-        # HSA. Use ``../amd-rocprofiler/gelu.py``, whose imports are the other
-        # way round, for that backend.
+        # ``roctracer`` only, and no longer for an import-order reason: this
+        # module now imports Proton before torch exactly as
+        # ``../amd-rocprofiler/gelu.py`` does. What it does not do is *attach*
+        # the way rocprofiler needs -- it starts the session after torch, which
+        # is what roctracer requires and what leaves rocprofiler with an empty
+        # dispatch buffer. Use ``../amd-rocprofiler/gelu.py`` for that backend;
+        # it is also the payload whose availability probe and mode handling are
+        # written for it.
         choices=("roctracer",),
         help="Proton backend for a standalone capture; ignored when $AORTA_PROTON_BACKEND is set",
     )

--- a/examples/profiling/proton/amd-roctracer/pipeline.py
+++ b/examples/profiling/proton/amd-roctracer/pipeline.py
@@ -28,17 +28,30 @@ import math
 import os
 import sys
 
-# ``torch`` is imported at module scope, not lazily inside main(), and that
-# ordering is load-bearing: roctracer records nothing when it attaches before
-# the HIP runtime it is meant to trace, and importing torch is what brings that
-# runtime up. The same constraint is why this example is driven by ``mode: env``
-# -- Triton's Proton CLI initialises the driver only on the path where ``-b`` is
-# absent, so pinning a backend through ``mode: cli`` produces a hatchet holding
-# nothing but a bare ROOT frame, and still exits 0.
+# THE ORDER OF THE NEXT TWO IMPORT BLOCKS IS LOAD-BEARING, in both directions.
+#
+# Proton first, because importing it after torch hangs the process forever at
+# exit on Triton 3.8.0. `libproton.so` calls `rocprofiler_force_configure` from
+# an `__attribute__((constructor))`, so the import registers Proton as a
+# rocprofiler-sdk client; when HSA is already up (a torch import chain is
+# enough) that registration lands late, and the atexit `registration::finalize`
+# then re-enters its own non-recursive registration mutex through Proton's
+# `protonToolFini` and deadlocks. Two imports in this order are the whole
+# reproducer. See ROCm/aorta#434 for the stack.
+#
+# torch before `proton.start()`, because roctracer installs its interceptor at
+# session start and records nothing if it attaches ahead of the HIP runtime.
+# That constraint is about the START call, not the import -- verified: moving
+# the import above torch leaves the capture byte-identical -- which is what
+# makes satisfying both orderings possible at all. It is also why this example
+# is driven by ``mode: env``: Triton's Proton CLI initialises the driver only on
+# the path where ``-b`` is absent, so pinning a backend through ``mode: cli``
+# produced a hatchet holding nothing but a bare ROOT frame on Triton 3.7.x.
+import triton.profiler as proton  # isort: skip  # noqa: I001
+
 import torch
 import triton
 import triton.language as tl
-import triton.profiler as proton
 
 #: Prefix of the variables aorta's ``proton`` collector exports in ``mode: env``.
 _ENV_PREFIX = "AORTA_PROTON_"

--- a/examples/profiling/proton/amd-roctracer/pipeline.py
+++ b/examples/profiling/proton/amd-roctracer/pipeline.py
@@ -6,12 +6,12 @@ carries a real launch sequence rather than a single kernel.
 
 Unlike the ``triton-vecadd`` / ``triton-softmax`` payloads this one drives
 Proton itself, because pinning ``roctracer`` only works from inside a live HIP
-runtime -- see the import comment below and ``recipe.yaml``. That is specific
-to this backend: ``rocprofiler`` is configured when ``libproton.so`` loads and
-so needs the opposite *attach* order, and ``instrumentation`` needs no
-particular one. All three payloads nonetheless share the same *import* order
-(Proton before torch), for a reason unrelated to any of their contracts -- see
-the import comment.
+runtime -- see the import comment below and ``recipe.yaml``. That requirement
+is specific to this backend: ``rocprofiler`` is configured when
+``libproton.so`` loads rather than when a session starts, and
+``instrumentation`` needs no particular ordering at all. The three requirements
+do not conflict, so all three ``amd-*`` payloads use one ordering: Proton
+imported before torch, ``proton.start()`` called after it.
 
 Constexpr kernel parameters are spelled lowercase (``block_size`` rather than
 Triton's conventional ``BLOCK_SIZE``) to satisfy this repository's lint
@@ -166,14 +166,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         default=None,
-        # ``roctracer`` only, and no longer for an import-order reason: this
-        # module now imports Proton before torch exactly as
-        # ``../amd-rocprofiler/gelu.py`` does. What it does not do is *attach*
-        # the way rocprofiler needs -- it starts the session after torch, which
-        # is what roctracer requires and what leaves rocprofiler with an empty
-        # dispatch buffer. Use ``../amd-rocprofiler/gelu.py`` for that backend;
-        # it is also the payload whose availability probe and mode handling are
-        # written for it.
+        # ``roctracer`` only, and no longer for an ordering reason: this module
+        # now imports Proton before torch and starts the session after it,
+        # which is exactly what ``../amd-rocprofiler/gelu.py`` does. The
+        # omission stands on what this payload does *not* carry -- gelu.py has
+        # the rocprofiler availability probe and the classifier that turns an
+        # unsupported mode or an unloadable rocprofiler-sdk into a clean exit 2
+        # rather than a traceback. Offering the backend here would hand out a
+        # capture path with none of that handling. Use gelu.py for it.
         choices=("roctracer",),
         help="Proton backend for a standalone capture; ignored when $AORTA_PROTON_BACKEND is set",
     )

--- a/examples/profiling/proton/amd-roctracer/recipe.yaml
+++ b/examples/profiling/proton/amd-roctracer/recipe.yaml
@@ -27,23 +27,38 @@ env_passthrough_mode: inherit
 # `mode: env`, not `mode: cli`, and the reason is mechanical rather than
 # stylistic. Triton's Proton CLI front-end calls its own `_select_backend()`
 # only when `-b` is *absent*, and that call initialises the Triton HIP driver
-# as a side effect. roctracer records nothing when it attaches ahead of the
-# HIP runtime it is tracing, so naming a backend on the CLI hands you a
-# 160-byte hatchet with a bare ROOT frame and an exit status of 0 -- aorta's
-# parser then degrades to `proton_artifact_dir` and the trial silently carries
-# no Proton metrics at all. `mode: env` instead exports `AORTA_PROTON_*` and
-# lets the payload call `proton.start()` after its own `import torch`, so the
-# backend attaches to a live runtime. The collector rejects `mode: cli` with
-# an explicit roctracer backend for exactly this reason. No Triton version
-# fixes it: line 73 of `third_party/proton/proton/proton.py` at the `v3.8.0`
-# tag is still `backend = args.backend if args.backend else
-# _select_backend()`.
+# as a side effect. On Triton 3.7.x and earlier, roctracer records nothing when
+# it attaches ahead of the HIP runtime it is tracing, so naming a backend on
+# the CLI hands you a 160-byte hatchet with a bare ROOT frame and an exit
+# status of 0 -- aorta's parser then degrades to `proton_artifact_dir` and the
+# trial silently carries no Proton metrics at all. `mode: env` instead exports
+# `AORTA_PROTON_*` and lets the payload call `proton.start()` after torch, so
+# the backend attaches to a live runtime.
 #
-# The refusal is roctracer-only. `rocprofiler` has the opposite contract --
-# `libproton.so` configures it from an `__attribute__((constructor))` at load
-# time, so it wants to be set up before HSA rather than after -- and its CLI
-# pin is allowed. That is also why `../amd-rocprofiler/gelu.py` imports Proton
-# before torch while `pipeline.py` here does the reverse.
+# Measured on Triton 3.8.0 (gfx950 / ROCm 10) the same CLI pin captures
+# normally -- 3090 bytes, byte-for-byte what `backend: auto` produces there --
+# so a newer release does fix it, even though the line the empty capture was
+# attributed to is unchanged (`backend = args.backend if args.backend else
+# _select_backend()`, still line 73 of `third_party/proton/proton/proton.py` at
+# the `v3.8.0` tag); something else on that stack brings the runtime up first.
+# The collector nonetheless still rejects `mode: cli` with an explicit
+# roctracer backend on every version, because 3.7.x is what several images in
+# use ship and the failure it prevents is silent. Removing the refusal once the
+# floor reaches 3.8 is tracked in ROCm/aorta#439. `mode: env` is correct on
+# every version, which is why this example uses it.
+#
+# The refusal is roctracer-only. `rocprofiler` is configured by an
+# `__attribute__((constructor))` in `libproton.so` at load time, so it wants to
+# be set up before HSA rather than after, and its CLI pin is allowed.
+#
+# Note this does NOT make the two payloads' import orders differ: every Proton
+# payload here, `pipeline.py` included, imports `triton.profiler` before torch
+# and calls `proton.start()` from `main()` after it. The two backends constrain
+# different events -- rocprofiler when it is CONFIGURED (at import), roctracer
+# when the SESSION STARTS -- and one ordering satisfies both. The earlier
+# "two backends, two import orders" framing here was wrong rather than merely
+# stale; see `../amd-rocprofiler/recipe.yaml` and ROCm/aorta#434 for the
+# measured reason the import order is now uniform.
 #
 # `context: shadow` attributes time to the launch site, which for this payload
 # means one node per Triton kernel; `data: tree` is the `.hatchet` the

--- a/examples/profiling/proton/triton-vecadd/README.md
+++ b/examples/profiling/proton/triton-vecadd/README.md
@@ -99,12 +99,16 @@ Read the raw tree yourself with `proton-viewer -m time/s <file>.hatchet`
   earlier accept only `cupti`/`roctracer`/`instrumentation` and exit with an
   argparse `invalid choice: 'rocprofiler'` before the payload runs. For
   `roctracer` it is an attach-mode commitment too: Proton's CLI front-end
-  initialises the HIP runtime only on the path where `-b` is absent — still
-  true in 3.8.0 — and `roctracer` records nothing unless it starts after that,
-  so pinning it under this recipe's `mode: "cli"` captures an empty
-  `ROOT`-only tree and still exits 0. The collector refuses that pairing and
-  names `mode: "env"`, where the payload drives Proton itself;
-  [`../amd-roctracer/`](../amd-roctracer/README.md) is the worked case.
+  initialises the HIP runtime only on the path where `-b` is absent, and
+  `roctracer` records nothing unless it starts after that, so on Triton 3.7.x
+  and earlier pinning it under this recipe's `mode: "cli"` captures an empty
+  `ROOT`-only tree and still exits 0. Measured on 3.8.0 the same pin captures
+  normally, but the collector refuses that pairing on every version — 3.7.x is
+  still shipped by images in use and the failure is silent — and names
+  `mode: "env"`, where the payload drives Proton itself;
+  [`../amd-roctracer/`](../amd-roctracer/README.md) is the worked case and
+  [ROCm/aorta#439](https://github.com/ROCm/aorta/issues/439) tracks the
+  refusal's removal.
   `rocprofiler` carries no such commitment — it is configured when
   `libproton.so` loads, so `mode: "cli"` suits it and is allowed.
 - **What `auto` resolved to is not in the artifact.** The `.hatchet`

--- a/examples/profiling/proton/triton-vecadd/recipe.yaml
+++ b/examples/profiling/proton/triton-vecadd/recipe.yaml
@@ -39,11 +39,15 @@ env_passthrough_mode: inherit
 # an argparse "invalid choice: 'rocprofiler'" on 3.7.x and earlier, before your
 # payload runs. Pinning `roctracer` additionally means leaving `mode: cli`:
 # Proton's front-end initialises the HIP runtime only on the path where `-b` is
-# absent -- still true in 3.8.0 -- and roctracer records nothing unless it
-# starts after that, so the pin captures an empty tree and the collector
-# refuses the pairing. See examples/profiling/proton/amd-roctracer for the
-# `mode: env` shape it requires. `rocprofiler` is the opposite case: it is
-# configured when `libproton.so` loads, so its `mode: cli` pin is allowed.
+# absent, and on Triton 3.7.x and earlier roctracer records nothing unless it
+# starts after that, so the pin captures an empty tree. Measured on 3.8.0 the
+# same pin captures normally, but the collector refuses the pairing on every
+# version, because 3.7.x is still shipped by images in use and the failure is
+# silent (removal tracked in ROCm/aorta#439). See
+# examples/profiling/proton/amd-roctracer for the `mode: env` shape it
+# requires -- correct on every version. `rocprofiler` is not subject to this at
+# all: it is configured when `libproton.so` loads, so its `mode: cli` pin is
+# allowed.
 collect:
   proton:
     mode: "cli"

--- a/src/aorta/instrumentation/proton/__init__.py
+++ b/src/aorta/instrumentation/proton/__init__.py
@@ -136,9 +136,11 @@ _AMD_ENV_SIGNALS: tuple[str, ...] = ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICE
 #:   bare ``ROOT``. **This is a 3.7.x-and-earlier defect.** It does not
 #:   reproduce on 3.8.0, where the same pin captured 17 kernels, so the guard
 #:   is a workaround with an expiry rather than a permanent rule. It is kept
-#:   because 3.7.x is what this repo's containers still ship; the inverted GPU
-#:   test asserts the bug is still there and skips itself from 3.8.0 on, so the
-#:   day the floor moves the guard can go with it.
+#:   because 3.7.x is what several images in use still ship, and the failure it
+#:   prevents is silent;
+#:   ``test_cli_mode_pin_captures_nothing_only_on_the_versions_the_guard_targets``
+#:   asserts whichever behaviour the installed Triton has, so the day the floor
+#:   moves the guard can go with it -- tracked in ROCm/aorta#439.
 #: * ``rocprofiler`` is the reverse, and the CLI path is the *safe* one for it.
 #:   Triton 3.8.0 calls ``rocprofiler_force_configure`` from an
 #:   ``__attribute__((constructor))`` in ``libproton.so``, so it is configured

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -7,7 +7,9 @@ translation Proton needs on AMD, and fail-soft ``.hatchet`` parsing.
 It also carries one guard over the *sibling* GPU module's source
 (``test_gpu_smoke_subprocesses_all_use_the_shared_child_budget``): the GPU legs
 are path-skipped on most PRs, so a convention that only they exercise needs a
-CPU test to hold it.
+CPU test to hold it. Because that guard reads one fixed file, its own detection
+is exercised separately against snippets -- a guard checked only against source
+that already complies cannot say what it would reject.
 """
 
 from __future__ import annotations
@@ -1440,13 +1442,19 @@ def _child_budget_violations(source: str, filename: str = "<snippet>") -> dict[s
         pytest.param("unboundable", "os.system(cmd)", id="os-system"),
     ],
 )
-def test_the_child_budget_guard_sees_every_way_out(kind, snippet):
-    """Each escape from ``_CHILD_TIMEOUT_S`` must be reported, and as its own kind.
+def test_the_child_budget_guard_reports_each_kind_of_escape(kind, snippet):
+    """Each escape must be reported, and filed as its own kind.
 
     The guard below reads one fixed file, so on its own it can only say that
     *today's* calls are bounded. These snippets are what say it would notice a
     new one -- the first version keyed on ``timeout=`` being present, so
     ``subprocess.run(argv)``, the most likely regression of all, sailed past it.
+
+    What it does not claim to cover: a launch spelled with a name outside
+    :data:`_BLOCKS_ON_A_CHILD` and :data:`_UNBOUNDABLE_CHILD_LAUNCH` (say
+    ``os.spawnv`` or a bare ``Popen`` that is never waited on). A budget passed
+    positionally is reported as missing rather than accepted, which is the
+    fail-closed direction.
     """
     found = _child_budget_violations(snippet)
     assert found[kind], f"{snippet!r} not reported as {kind}: {found}"
@@ -1468,7 +1476,7 @@ def test_the_child_budget_guard_accepts_what_it_should(snippet):
 
 
 def test_gpu_smoke_subprocesses_all_use_the_shared_child_budget():
-    """Every child in the GPU smoke module must be bounded by ``_CHILD_TIMEOUT_S``.
+    """Every child launch in the GPU smoke module must carry ``_CHILD_TIMEOUT_S``.
 
     ``test_proton_smoke_gpu.py`` sizes ``_CHILD_TIMEOUT_S`` so a wedged payload
     surfaces as ``TimeoutExpired`` naming that payload, rather than as the CI
@@ -1476,17 +1484,19 @@ def test_gpu_smoke_subprocesses_all_use_the_shared_child_budget():
     junit report with it (ROCm/aorta#434). The calls most likely to wedge are
     the ones that build their own argv instead of going through ``_capture``.
 
-    Two ways to leave that budget, and the guard has to reject both. A
+    Three ways to leave that budget, and the guard rejects each separately. A
     ``timeout=`` literal is a *narrowed* budget, and it can appear on any call
-    shape, so that half stays keyed on the keyword rather than the callee:
+    shape, so that check stays keyed on the keyword rather than the callee:
     ``from subprocess import run``, a ``Popen.communicate`` or an ``asyncio``
     wait would each escape a callee-shaped check while leaving the same hole.
     An omitted ``timeout=`` is an *absent* budget -- ``subprocess.run(argv)``
-    is completely unbounded -- and nothing about the keyword can catch that,
-    so the second half does look at the callee, matching its trailing name so
-    the import spelling still does not matter. The keyword spelling is what it
-    requires: ``communicate`` and ``wait`` would also take the budget
-    positionally, and asking for the keyword is what lets the guard see it.
+    is completely unbounded -- and nothing about the keyword can catch that, so
+    that check does look at the callee, matching its trailing name so the
+    import spelling still does not matter. It requires the keyword spelling:
+    ``communicate`` and ``wait`` would also take the budget positionally, and
+    asking for the keyword is what lets the guard see it. ``os.system`` and
+    ``os.popen`` are the third -- no timeout exists to pass, so they are
+    rejected outright.
 
     Checked from the CPU suite because the GPU legs are path-skipped on most
     PRs, so a regression here would otherwise reach `main` unobserved. Read

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -4,12 +4,16 @@ Covers the option schema, both attach modes (``cli`` argv rewrite and ``env``
 variable bundle), the ``HIP_VISIBLE_DEVICES`` -> ``ROCR_VISIBLE_DEVICES``
 translation Proton needs on AMD, and fail-soft ``.hatchet`` parsing.
 
-It also carries one guard over the *sibling* GPU module's source
-(``test_gpu_smoke_subprocesses_all_use_the_shared_child_budget``): the GPU legs
+It also carries two guards over the *sibling* GPU module's source: the GPU legs
 are path-skipped on most PRs, so a convention that only they exercise needs a
-CPU test to hold it. Because that guard reads one fixed file, its own detection
-is exercised separately against snippets -- a guard checked only against source
-that already complies cannot say what it would reject.
+CPU test to hold it. One checks that every child launch there carries the shared
+budget (``test_gpu_smoke_subprocesses_all_use_the_shared_child_budget``); the
+other checks the budget's own *value*
+(``test_the_shared_child_budget_value_stays_under_the_gpu_job_timeout``), since
+pinning the constant's name everywhere still permits raising the constant.
+Because the first reads one fixed file, its detection is exercised separately
+against snippets -- a guard checked only against source that already complies
+cannot say what it would reject.
 """
 
 from __future__ import annotations
@@ -1431,13 +1435,21 @@ def _child_budget_violations(source: str, filename: str = "<snippet>") -> dict[s
 
 
 def _assigned_int(source: str, name: str) -> int | None:
-    """Value of a module-level ``name = <int literal>`` assignment."""
+    """Value of a module-level ``name = <int literal>`` assignment.
+
+    ``None`` for anything else -- an annotated assignment, an expression, a
+    negation -- so the caller fails closed and says what it could not read
+    rather than silently checking nothing. ``bool`` is rejected despite being
+    an ``int`` subclass: ``True`` would otherwise read as a one-second budget
+    and pass every bound.
+    """
     for node in ast.parse(source).body:
         targets = node.targets if isinstance(node, ast.Assign) else []
         if any(isinstance(t, ast.Name) and t.id == name for t in targets) and isinstance(
             node.value, ast.Constant
         ):
-            return node.value.value if isinstance(node.value.value, int) else None
+            value = node.value.value
+            return value if isinstance(value, int) and not isinstance(value, bool) else None
     return None
 
 
@@ -1555,7 +1567,7 @@ def test_gpu_smoke_subprocesses_all_use_the_shared_child_budget():
     )
 
 
-def test_the_shared_child_budget_stays_below_the_pytest_timeout_it_hides_behind():
+def test_the_shared_child_budget_value_stays_under_the_gpu_job_timeout():
     """The budget's *value* has to be bounded, not just its name.
 
     The guard above pins every call to ``_CHILD_TIMEOUT_S`` and says nothing
@@ -1569,7 +1581,10 @@ def test_the_shared_child_budget_stays_below_the_pytest_timeout_it_hides_behind(
     because "below the thing that would otherwise kill us" is the actual
     property: a budget above it never fires, and pytest-timeout kills the test
     from outside with no payload name and no partial output. Either side
-    changing is caught.
+    changing is caught. Comment lines are skipped when reading the workflow --
+    ``gpu-tests.yml`` explains the flag a few lines above passing it, and a
+    guard that reads the prose instead of the flag would keep passing after the
+    two drifted apart.
     """
     module = Path(__file__).with_name("test_proton_smoke_gpu.py")
     budget = _assigned_int(module.read_text(encoding="utf-8"), "_CHILD_TIMEOUT_S")
@@ -1582,7 +1597,9 @@ def test_the_shared_child_budget_stays_below_the_pytest_timeout_it_hides_behind(
     workflow = Path(__file__).parents[2] / ".github" / "workflows" / "gpu-tests.yml"
     pytest_timeouts = [
         int(match)
-        for match in re.findall(r"--timeout=(\d+)", workflow.read_text(encoding="utf-8"))
+        for line in workflow.read_text(encoding="utf-8").splitlines()
+        if not line.strip().startswith("#")
+        for match in re.findall(r"--timeout=(\d+)", line)
     ]
     assert pytest_timeouts, (
         f"{workflow.name} no longer passes --timeout= to pytest. The child budget is "

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -1440,6 +1440,20 @@ def _child_budget_violations(source: str, filename: str = "<snippet>") -> dict[s
         pytest.param("unbounded", "proc.communicate()", id="no-timeout-communicate"),
         pytest.param("unbounded", "proc.wait()", id="no-timeout-wait"),
         pytest.param("unboundable", "os.system(cmd)", id="os-system"),
+        # Spellings a human reviewer mutation-tested against the keyword-only
+        # version of this guard and found it green on. Kept as their own cases
+        # so the three cannot regress independently of the ones above.
+        pytest.param(
+            "unbounded",
+            "subprocess.run(argv, capture_output=True, text=True)",
+            id="reviewer-kwarg-deleted",
+        ),
+        pytest.param("unbounded", "proc.wait(3600)", id="reviewer-positional-wait"),
+        pytest.param(
+            "unbounded",
+            'subprocess.run(argv, **{"timeout": 3600})',
+            id="reviewer-kwargs-unpack",
+        ),
     ],
 )
 def test_the_child_budget_guard_reports_each_kind_of_escape(kind, snippet):

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -1373,37 +1373,34 @@ def test_parse_summary_from_streams_consumes_a_lazy_iterator(tmp_path):
 
 
 def test_gpu_smoke_subprocesses_all_use_the_shared_child_budget():
-    """No subprocess in the GPU smoke module may set its own ``timeout=``.
+    """No call in the GPU smoke module may set its own ``timeout=``.
 
     ``test_proton_smoke_gpu.py`` sizes ``_CHILD_TIMEOUT_S`` so a wedged payload
     surfaces as ``TimeoutExpired`` naming that payload, rather than as the CI
     job hitting its own 60-minute cap -- which cancels the run and takes the
-    junit report with it (ROCm/aorta#434). A literal ``timeout=`` on any
-    ``subprocess.run`` there is a hole in that budget, and the calls most
-    likely to wedge are the ones that build their own argv instead of going
-    through ``_capture``.
+    junit report with it (ROCm/aorta#434). A literal ``timeout=`` anywhere
+    there is a hole in that budget, and the calls most likely to wedge are the
+    ones that build their own argv instead of going through ``_capture``.
 
     Checked from the CPU suite because the GPU legs are path-skipped on most
     PRs, so a regression here would otherwise reach `main` unobserved. Read
-    from the AST rather than grepped so a reflowed call still matches.
+    from the AST rather than grepped so a reflowed call still matches, and
+    keyed on the ``timeout`` keyword rather than on the callee being
+    ``subprocess.run``: ``from subprocess import run``, a ``Popen.communicate``
+    or an ``asyncio`` wait would each escape a callee-shaped check while
+    leaving exactly the same hole.
     """
     source = Path(__file__).with_name("test_proton_smoke_gpu.py")
     tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
 
-    offenders = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        target = node.func
-        if not (isinstance(target, ast.Attribute) and target.attr == "run"):
-            continue
-        if not (isinstance(target.value, ast.Name) and target.value.id == "subprocess"):
-            continue
-        for keyword in node.keywords:
-            if keyword.arg != "timeout":
-                continue
-            if not (isinstance(keyword.value, ast.Name) and keyword.value.id == "_CHILD_TIMEOUT_S"):
-                offenders.append((keyword.lineno, ast.unparse(keyword.value)))
+    offenders = [
+        (keyword.lineno, ast.unparse(keyword.value))
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for keyword in node.keywords
+        if keyword.arg == "timeout"
+        and not (isinstance(keyword.value, ast.Name) and keyword.value.id == "_CHILD_TIMEOUT_S")
+    ]
 
     assert not offenders, (
         f"{source.name} sets a per-call timeout instead of _CHILD_TIMEOUT_S at "

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -3,10 +3,16 @@
 Covers the option schema, both attach modes (``cli`` argv rewrite and ``env``
 variable bundle), the ``HIP_VISIBLE_DEVICES`` -> ``ROCR_VISIBLE_DEVICES``
 translation Proton needs on AMD, and fail-soft ``.hatchet`` parsing.
+
+It also carries one guard over the *sibling* GPU module's source
+(``test_gpu_smoke_subprocesses_all_use_the_shared_child_budget``): the GPU legs
+are path-skipped on most PRs, so a convention that only they exercise needs a
+CPU test to hold it.
 """
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import sys
@@ -1364,3 +1370,43 @@ def test_parse_summary_from_streams_consumes_a_lazy_iterator(tmp_path):
     )
     assert metrics.get("proton_kernel_count") == 3
     assert metrics.get("proton_gpu_time_ms") == pytest.approx(2.0)
+
+
+def test_gpu_smoke_subprocesses_all_use_the_shared_child_budget():
+    """No subprocess in the GPU smoke module may set its own ``timeout=``.
+
+    ``test_proton_smoke_gpu.py`` sizes ``_CHILD_TIMEOUT_S`` so a wedged payload
+    surfaces as ``TimeoutExpired`` naming that payload, rather than as the CI
+    job hitting its own 60-minute cap -- which cancels the run and takes the
+    junit report with it (ROCm/aorta#434). A literal ``timeout=`` on any
+    ``subprocess.run`` there is a hole in that budget, and the calls most
+    likely to wedge are the ones that build their own argv instead of going
+    through ``_capture``.
+
+    Checked from the CPU suite because the GPU legs are path-skipped on most
+    PRs, so a regression here would otherwise reach `main` unobserved. Read
+    from the AST rather than grepped so a reflowed call still matches.
+    """
+    source = Path(__file__).with_name("test_proton_smoke_gpu.py")
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        if not (isinstance(target, ast.Attribute) and target.attr == "run"):
+            continue
+        if not (isinstance(target.value, ast.Name) and target.value.id == "subprocess"):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "timeout":
+                continue
+            if not (isinstance(keyword.value, ast.Name) and keyword.value.id == "_CHILD_TIMEOUT_S"):
+                offenders.append((keyword.lineno, ast.unparse(keyword.value)))
+
+    assert not offenders, (
+        f"{source.name} sets a per-call timeout instead of _CHILD_TIMEOUT_S at "
+        f"{offenders}. A wedged Proton payload would then run past the GPU job's "
+        "own cap, which cancels the job and loses its report -- see ROCm/aorta#434."
+    )

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -1372,38 +1372,148 @@ def test_parse_summary_from_streams_consumes_a_lazy_iterator(tmp_path):
     assert metrics.get("proton_gpu_time_ms") == pytest.approx(2.0)
 
 
+#: Callables that block on a child process and take a ``timeout`` keyword.
+#: Matched on the trailing name only, so ``subprocess.run(...)``,
+#: ``run(...)`` after ``from subprocess import run`` and
+#: ``proc.communicate(...)`` all resolve the same way.
+_BLOCKS_ON_A_CHILD = frozenset(
+    {"run", "call", "check_call", "check_output", "communicate", "wait", "wait_for"}
+)
+
+#: Child launches that cannot be given a timeout at all, so there is no
+#: bounded spelling of them to accept.
+_UNBOUNDABLE_CHILD_LAUNCH = frozenset({"system", "popen"})
+
+
+def _called_name(node: ast.Call) -> str | None:
+    """Trailing identifier of a call's callee, ignoring how it was reached."""
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    return None
+
+
+def _child_budget_violations(source: str, filename: str = "<snippet>") -> dict[str, list]:
+    """Ways ``source`` escapes the shared child budget, keyed by how.
+
+    ``narrowed``: a ``timeout=`` that is not ``_CHILD_TIMEOUT_S``, on any call
+    shape. ``unbounded``: a blocking child call with no ``timeout=`` keyword.
+    ``unboundable``: a launch that takes no timeout at all.
+    """
+    tree = ast.parse(source, filename=filename)
+    calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    return {
+        "narrowed": [
+            (keyword.lineno, ast.unparse(keyword.value))
+            for node in calls
+            for keyword in node.keywords
+            if keyword.arg == "timeout"
+            and not (
+                isinstance(keyword.value, ast.Name) and keyword.value.id == "_CHILD_TIMEOUT_S"
+            )
+        ],
+        "unbounded": [
+            (node.lineno, ast.unparse(node.func))
+            for node in calls
+            if (_called_name(node) or "") in _BLOCKS_ON_A_CHILD
+            and not any(keyword.arg == "timeout" for keyword in node.keywords)
+        ],
+        "unboundable": [
+            (node.lineno, ast.unparse(node.func))
+            for node in calls
+            if (_called_name(node) or "") in _UNBOUNDABLE_CHILD_LAUNCH
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("kind", "snippet"),
+    [
+        pytest.param("narrowed", "subprocess.run(argv, timeout=3600)", id="literal-timeout"),
+        pytest.param("narrowed", "proc.communicate(timeout=600)", id="literal-on-communicate"),
+        pytest.param("unbounded", "subprocess.run(argv)", id="no-timeout-at-all"),
+        pytest.param("unbounded", "run(argv, check=True)", id="no-timeout-bare-import"),
+        pytest.param("unbounded", "subprocess.check_output(argv)", id="no-timeout-check-output"),
+        pytest.param("unbounded", "proc.communicate()", id="no-timeout-communicate"),
+        pytest.param("unbounded", "proc.wait()", id="no-timeout-wait"),
+        pytest.param("unboundable", "os.system(cmd)", id="os-system"),
+    ],
+)
+def test_the_child_budget_guard_sees_every_way_out(kind, snippet):
+    """Each escape from ``_CHILD_TIMEOUT_S`` must be reported, and as its own kind.
+
+    The guard below reads one fixed file, so on its own it can only say that
+    *today's* calls are bounded. These snippets are what say it would notice a
+    new one -- the first version keyed on ``timeout=`` being present, so
+    ``subprocess.run(argv)``, the most likely regression of all, sailed past it.
+    """
+    found = _child_budget_violations(snippet)
+    assert found[kind], f"{snippet!r} not reported as {kind}: {found}"
+    assert not [k for k in found if k != kind and found[k]], f"{snippet!r} misfiled: {found}"
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        pytest.param("subprocess.run(argv, timeout=_CHILD_TIMEOUT_S)", id="run"),
+        pytest.param("proc.communicate(timeout=_CHILD_TIMEOUT_S)", id="communicate"),
+        pytest.param("json.load(handle)", id="unrelated-call"),
+        pytest.param("shutil.which('proton')", id="no-child"),
+    ],
+)
+def test_the_child_budget_guard_accepts_what_it_should(snippet):
+    """A guard that flags correct code gets disabled, so pin the negatives too."""
+    assert not any(_child_budget_violations(snippet).values()), snippet
+
+
 def test_gpu_smoke_subprocesses_all_use_the_shared_child_budget():
-    """No call in the GPU smoke module may set its own ``timeout=``.
+    """Every child in the GPU smoke module must be bounded by ``_CHILD_TIMEOUT_S``.
 
     ``test_proton_smoke_gpu.py`` sizes ``_CHILD_TIMEOUT_S`` so a wedged payload
     surfaces as ``TimeoutExpired`` naming that payload, rather than as the CI
     job hitting its own 60-minute cap -- which cancels the run and takes the
-    junit report with it (ROCm/aorta#434). A literal ``timeout=`` anywhere
-    there is a hole in that budget, and the calls most likely to wedge are the
-    ones that build their own argv instead of going through ``_capture``.
+    junit report with it (ROCm/aorta#434). The calls most likely to wedge are
+    the ones that build their own argv instead of going through ``_capture``.
+
+    Two ways to leave that budget, and the guard has to reject both. A
+    ``timeout=`` literal is a *narrowed* budget, and it can appear on any call
+    shape, so that half stays keyed on the keyword rather than the callee:
+    ``from subprocess import run``, a ``Popen.communicate`` or an ``asyncio``
+    wait would each escape a callee-shaped check while leaving the same hole.
+    An omitted ``timeout=`` is an *absent* budget -- ``subprocess.run(argv)``
+    is completely unbounded -- and nothing about the keyword can catch that,
+    so the second half does look at the callee, matching its trailing name so
+    the import spelling still does not matter. The keyword spelling is what it
+    requires: ``communicate`` and ``wait`` would also take the budget
+    positionally, and asking for the keyword is what lets the guard see it.
 
     Checked from the CPU suite because the GPU legs are path-skipped on most
     PRs, so a regression here would otherwise reach `main` unobserved. Read
-    from the AST rather than grepped so a reflowed call still matches, and
-    keyed on the ``timeout`` keyword rather than on the callee being
-    ``subprocess.run``: ``from subprocess import run``, a ``Popen.communicate``
-    or an ``asyncio`` wait would each escape a callee-shaped check while
-    leaving exactly the same hole.
+    from the AST rather than grepped so a reflowed call still matches.
     """
     source = Path(__file__).with_name("test_proton_smoke_gpu.py")
-    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    found = _child_budget_violations(source.read_text(encoding="utf-8"), filename=str(source))
+    narrowed, unbounded, unboundable = (
+        found["narrowed"],
+        found["unbounded"],
+        found["unboundable"],
+    )
 
-    offenders = [
-        (keyword.lineno, ast.unparse(keyword.value))
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        for keyword in node.keywords
-        if keyword.arg == "timeout"
-        and not (isinstance(keyword.value, ast.Name) and keyword.value.id == "_CHILD_TIMEOUT_S")
-    ]
-
-    assert not offenders, (
+    assert not narrowed, (
         f"{source.name} sets a per-call timeout instead of _CHILD_TIMEOUT_S at "
-        f"{offenders}. A wedged Proton payload would then run past the GPU job's "
+        f"{narrowed}. A wedged Proton payload would then run past the GPU job's "
         "own cap, which cancels the job and loses its report -- see ROCm/aorta#434."
+    )
+    assert not unbounded, (
+        f"{source.name} waits on a child without a timeout= keyword at {unbounded}. "
+        "Pass timeout=_CHILD_TIMEOUT_S, or launch through _capture, so a wedge "
+        "fails this test's payload rather than the whole GPU job -- see "
+        "ROCm/aorta#434."
+    )
+    assert not unboundable, (
+        f"{source.name} launches a child that cannot be bounded at {unboundable}. "
+        "os.system and os.popen take no timeout, so a wedge there runs until the "
+        "GPU job's own cap. Use subprocess with timeout=_CHILD_TIMEOUT_S -- see "
+        "ROCm/aorta#434."
     )

--- a/tests/instrumentation/test_proton.py
+++ b/tests/instrumentation/test_proton.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import ast
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -1429,6 +1430,17 @@ def _child_budget_violations(source: str, filename: str = "<snippet>") -> dict[s
     }
 
 
+def _assigned_int(source: str, name: str) -> int | None:
+    """Value of a module-level ``name = <int literal>`` assignment."""
+    for node in ast.parse(source).body:
+        targets = node.targets if isinstance(node, ast.Assign) else []
+        if any(isinstance(t, ast.Name) and t.id == name for t in targets) and isinstance(
+            node.value, ast.Constant
+        ):
+            return node.value.value if isinstance(node.value.value, int) else None
+    return None
+
+
 @pytest.mark.parametrize(
     ("kind", "snippet"),
     [
@@ -1540,4 +1552,48 @@ def test_gpu_smoke_subprocesses_all_use_the_shared_child_budget():
         "os.system and os.popen take no timeout, so a wedge there runs until the "
         "GPU job's own cap. Use subprocess with timeout=_CHILD_TIMEOUT_S -- see "
         "ROCm/aorta#434."
+    )
+
+
+def test_the_shared_child_budget_stays_below_the_pytest_timeout_it_hides_behind():
+    """The budget's *value* has to be bounded, not just its name.
+
+    The guard above pins every call to ``_CHILD_TIMEOUT_S`` and says nothing
+    about what that constant holds, so raising it in one place reinstates the
+    original incident while leaving all three passes green -- the shortest path
+    back to run 33527313950, where a wedged payload ran until the GPU job's own
+    60-minute cap, which cancels the job and takes the junit report with it
+    (ROCm/aorta#434).
+
+    Anchored to the workflow's ``--timeout`` rather than to a literal here,
+    because "below the thing that would otherwise kill us" is the actual
+    property: a budget above it never fires, and pytest-timeout kills the test
+    from outside with no payload name and no partial output. Either side
+    changing is caught.
+    """
+    module = Path(__file__).with_name("test_proton_smoke_gpu.py")
+    budget = _assigned_int(module.read_text(encoding="utf-8"), "_CHILD_TIMEOUT_S")
+    assert budget is not None, (
+        f"{module.name} no longer defines _CHILD_TIMEOUT_S as a module-level int "
+        "literal, so its value cannot be checked. Keep it one, or teach this test "
+        "the new shape -- an unbounded budget is how ROCm/aorta#434 happened."
+    )
+
+    workflow = Path(__file__).parents[2] / ".github" / "workflows" / "gpu-tests.yml"
+    pytest_timeouts = [
+        int(match)
+        for match in re.findall(r"--timeout=(\d+)", workflow.read_text(encoding="utf-8"))
+    ]
+    assert pytest_timeouts, (
+        f"{workflow.name} no longer passes --timeout= to pytest. The child budget is "
+        "sized to sit under it, so that bound needs re-deriving before this test can "
+        "hold anything."
+    )
+
+    assert 0 < budget < min(pytest_timeouts), (
+        f"_CHILD_TIMEOUT_S is {budget}s, which is not below the GPU job's pytest "
+        f"--timeout of {min(pytest_timeouts)}s. A payload wedge would then be killed "
+        "by pytest-timeout from outside -- or, past the job's 60-minute cap, cancel "
+        "the job and lose its report -- instead of failing as a TimeoutExpired that "
+        "names the payload. See ROCm/aorta#434."
     )

--- a/tests/instrumentation/test_proton_smoke_gpu.py
+++ b/tests/instrumentation/test_proton_smoke_gpu.py
@@ -72,11 +72,12 @@ _EXAMPLES = [
 #: first and the budget could never actually fire.
 #:
 #: It governs **every** subprocess this module launches, including the ones
-#: that build their own argv instead of going through :func:`_capture`. A raw
-#: ``timeout=`` literal in any of them is a hole in the budget, so
-#: ``tests/instrumentation/test_proton.py`` asserts on the AST that there are
-#: none -- the payloads a wedge is most likely to hit are exactly the ones that
-#: bypass the helper.
+#: that build their own argv instead of going through :func:`_capture` -- the
+#: payloads a wedge is most likely to hit are exactly the ones that bypass the
+#: helper. Two things are a hole in the budget, and
+#: ``tests/instrumentation/test_proton.py`` asserts on this module's AST that
+#: neither is present: a raw ``timeout=`` literal, which narrows the budget,
+#: and a blocking child call carrying no ``timeout=`` at all, which removes it.
 _CHILD_TIMEOUT_S = 120
 
 #: Proton's dlopen failure on an image whose ROCm comes from Python wheels:

--- a/tests/instrumentation/test_proton_smoke_gpu.py
+++ b/tests/instrumentation/test_proton_smoke_gpu.py
@@ -134,44 +134,15 @@ def _triton_minor() -> tuple[int, int] | None:
 
 _TRITON = _triton_minor()
 
-#: ``mode: env`` captures wedge on Triton 3.8.0, and the wedge is why the GPU
-#: job carries ``--timeout``. Two of these tests produced no outcome at all on
-#: run 33527313950 (the job ran to its 60-minute cap and the cancel took the
-#: junit report with it), and the same two hit the child budget on run
-#: 33629989829. Both pass in ~4 s on Triton 3.7.1, here, repeatedly.
-#:
-#: What separates them from the tests that pass on that runner is the attach
-#: mode, not the backend: every ``mode: cli`` capture completed, including a
-#: pinned ``roctracer``. The suspected mechanism is 3.8.0 configuring
-#: rocprofiler-sdk from a ``libproton.so`` constructor at import -- on an image
-#: whose ``librocprofiler-sdk.so`` will not ``dlopen``, the constructor swallows
-#: that, and a later in-process ``proton.start()`` then wedges. Suspected, not
-#: established: it cannot be reproduced on a 3.7.1 host, so this skips rather
-#: than claiming a diagnosis. Tracked in ROCm/aorta#434.
-_ENV_MODE_WEDGE_REASON = (
-    "mode: env captures wedge on Triton 3.8.0 (no outcome on CI run 33527313950, "
-    "child-timeout on 33629989829); they pass in seconds on 3.7.1. Skipped rather "
-    "than left to burn the job's budget -- tracked in ROCm/aorta#434."
-)
-skip_env_mode_wedge = pytest.mark.skipif(
-    _TRITON is not None and _TRITON >= (3, 8),
-    reason=_ENV_MODE_WEDGE_REASON,
-)
-
-#: The empty-capture bug the ``wrap_argv`` guard exists for does not reproduce
-#: on Triton 3.8.0: a pinned ``-b roctracer`` captured 17 kernels there (run
-#: 33629989829), where 3.7.1 gives a bare ``ROOT``. The inverted test below
-#: asserts the bug is still present, so on 3.8.0 it is asserting something
-#: false -- skip it there rather than weaken the assertion, and keep it sharp
-#: where the guard is actually load-bearing.
-skip_bug_fixed_upstream = pytest.mark.skipif(
-    _TRITON is not None and _TRITON >= (3, 8),
-    reason=(
-        "the roctracer CLI-pin empty capture does not reproduce on Triton 3.8.0 "
-        "(captured 17 kernels on CI run 33629989829); the guard is a 3.7.x-and-"
-        "earlier workaround"
-    ),
-)
+#: Whether the installed Triton is one where a ``mode: cli`` pin of
+#: ``roctracer`` actually captures. On 3.7.x it comes back as a 160-byte bare
+#: ``ROOT`` -- the empty capture the ``wrap_argv`` guard exists to refuse -- and
+#: from 3.8.0 on the same pin records normally (measured on gfx950 / ROCm 10:
+#: 3090 bytes, byte-for-byte the size ``backend: auto`` produces). The test
+#: below asserts whichever of the two is true here, rather than skipping on the
+#: newer stack, so the day the version floor moves the guard's premise is still
+#: under test instead of merely unasserted.
+_CLI_PIN_CAPTURES = _TRITON is not None and _TRITON >= (3, 8)
 
 
 def _raw_proton_env(**extra: str) -> dict[str, str]:
@@ -309,7 +280,6 @@ def test_python_context_attributes_to_call_paths(tmp_path):
 
 
 @skip_no_proton
-@skip_env_mode_wedge
 def test_env_mode_pins_roctracer_and_gets_a_non_empty_tree(tmp_path):
     """The route the ``mode: cli`` rejection names, end to end.
 
@@ -339,15 +309,18 @@ def test_env_mode_pins_roctracer_and_gets_a_non_empty_tree(tmp_path):
 
 
 @skip_no_proton
-@skip_bug_fixed_upstream
-def test_cli_mode_pin_would_still_capture_nothing(tmp_path):
+def test_cli_mode_pin_captures_nothing_only_on_the_versions_the_guard_targets(tmp_path):
     """Pins the premise of the ``wrap_argv`` guard against the installed Triton.
 
     Builds the wrap the guard refuses -- ``build_argv_prefix`` renders the flags
-    without the attach-mode check -- and asserts it comes back empty. A failure
-    here is good news, not a bug: it means this Triton initialises the runtime
-    before starting a pinned backend, and the guard can be narrowed to the
-    versions that do not.
+    without the attach-mode check -- and asserts what that Triton actually does
+    with it: an empty tree on 3.7.x, a populated one from 3.8.0.
+
+    Both halves are load-bearing. The 3.7.x half is the regression that would
+    have caught the silent empty capture in the first place. The 3.8.0 half is
+    what says the guard has become a no-op there, so removing it stops being a
+    guess -- and it fails, loudly, if a later Triton reintroduces the ordering
+    bug while the guard is gone.
     """
     out_dir = tmp_path / OUTPUT_SUBDIR
     out_dir.mkdir()
@@ -373,9 +346,19 @@ def test_cli_mode_pin_would_still_capture_nothing(tmp_path):
         pytest.skip(missing)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert "PASS" in proc.stdout, "the payload itself must still have run"
-    # The silent part of the failure: a clean exit, an artifact directory, and no
-    # measurement anywhere in it.
-    assert parse_summary(out_dir) == {"proton_artifact_dir": str(out_dir)}
+
+    metrics = parse_summary(out_dir)
+    if _CLI_PIN_CAPTURES:
+        # The guard's premise has expired on this Triton. Assert a real capture
+        # rather than merely "not empty": an ordering bug that recorded one
+        # stray kernel would satisfy the weaker check.
+        assert metrics.get("proton_kernel_count", 0) > 0, metrics
+        assert metrics.get("proton_gpu_time_ms", 0.0) > 0.0, metrics
+        assert "add_kernel" in metrics.get("proton_top_kernels", []), metrics
+    else:
+        # The silent part of the failure: a clean exit, an artifact directory,
+        # and no measurement anywhere in it.
+        assert metrics == {"proton_artifact_dir": str(out_dir)}
 
 
 @skip_no_proton
@@ -504,7 +487,6 @@ def test_pcsampling_captures_once_the_environment_can_do_it(tmp_path):
 
 
 @skip_no_proton
-@skip_env_mode_wedge
 def test_instrumentation_captures_scopes_inside_one_kernel(tmp_path):
     """The intra-kernel backend attributes cycles to regions within a kernel.
 

--- a/tests/instrumentation/test_proton_smoke_gpu.py
+++ b/tests/instrumentation/test_proton_smoke_gpu.py
@@ -70,6 +70,13 @@ _EXAMPLES = [
 #: test from outside with no such detail. The former 3600 s could do neither:
 #: it matched the CI job's own 60-minute cap exactly, so the job always died
 #: first and the budget could never actually fire.
+#:
+#: It governs **every** subprocess this module launches, including the ones
+#: that build their own argv instead of going through :func:`_capture`. A raw
+#: ``timeout=`` literal in any of them is a hole in the budget, so
+#: ``tests/instrumentation/test_proton.py`` asserts on the AST that there are
+#: none -- the payloads a wedge is most likely to hit are exactly the ones that
+#: bypass the helper.
 _CHILD_TIMEOUT_S = 120
 
 #: Proton's dlopen failure on an image whose ROCm comes from Python wheels:
@@ -338,7 +345,7 @@ def test_cli_mode_pin_captures_nothing_only_on_the_versions_the_guard_targets(tm
         cwd=tmp_path,
         capture_output=True,
         text=True,
-        timeout=3600,
+        timeout=_CHILD_TIMEOUT_S,
         env=_raw_proton_env(TRITON_CACHE_DIR=str(tmp_path / "triton-cache")),
     )
     missing = _dlopen_failure(proc.stderr)
@@ -369,10 +376,11 @@ def test_a_backend_that_refuses_the_mode_exits_two_not_a_traceback(tmp_path):
     Triton 3.8.0 is the case that motivates it: it registers ``rocprofiler``, so
     the payload's availability probe passes, but its ``RocprofSDKProfiler``
     accepts only ``periodic_flushing`` and raises ``ValueError: [PROTON]
-    RocprofSDKProfiler: unsupported mode: pcsampling``. That version is not
-    installable here, so the same path is driven through a mode no backend
-    accepts -- what is under test is the payload's handling, not Proton's
-    taxonomy of modes.
+    RocprofSDKProfiler: unsupported mode: pcsampling``. Reproducing *that*
+    rejection needs 3.8.0, and 3.7.1 does not register the backend at all, so
+    the path is driven instead through a mode no backend on any version accepts
+    -- what is under test is the payload's handling, not Proton's taxonomy of
+    modes, and this way both CI legs exercise it.
     """
     out_dir = tmp_path / "proton"
     out_dir.mkdir()
@@ -382,7 +390,7 @@ def test_a_backend_that_refuses_the_mode_exits_two_not_a_traceback(tmp_path):
         cwd=tmp_path,
         capture_output=True,
         text=True,
-        timeout=3600,
+        timeout=_CHILD_TIMEOUT_S,
         env=_raw_proton_env(
             **{
                 "TRITON_CACHE_DIR": str(tmp_path / "triton-cache"),
@@ -433,7 +441,7 @@ def _pcsampling_skip_reason(tmp_path) -> str | None:
         cwd=tmp_path,
         capture_output=True,
         text=True,
-        timeout=600,
+        timeout=_CHILD_TIMEOUT_S,
         env=_raw_proton_env(TRITON_CACHE_DIR=str(tmp_path / "triton-cache")),
     )
     if probe.returncode == 0:

--- a/tests/instrumentation/test_proton_smoke_gpu.py
+++ b/tests/instrumentation/test_proton_smoke_gpu.py
@@ -74,10 +74,15 @@ _EXAMPLES = [
 #: It governs **every** subprocess this module launches, including the ones
 #: that build their own argv instead of going through :func:`_capture` -- the
 #: payloads a wedge is most likely to hit are exactly the ones that bypass the
-#: helper. Two things are a hole in the budget, and
+#: helper. Three call shapes are a hole in the budget, and
 #: ``tests/instrumentation/test_proton.py`` asserts on this module's AST that
-#: neither is present: a raw ``timeout=`` literal, which narrows the budget,
-#: and a blocking child call carrying no ``timeout=`` at all, which removes it.
+#: none is present: a raw ``timeout=`` literal, which narrows the budget; a
+#: blocking child call carrying no ``timeout=`` at all, which removes it; and
+#: ``os.system`` / ``os.popen``, which cannot be bounded at all.
+#:
+#: Raising the number below is the fourth hole, and the only one that leaves
+#: every call site still spelling ``_CHILD_TIMEOUT_S``. The same module asserts
+#: this value stays under the workflow's ``--timeout``, so the two cannot drift.
 _CHILD_TIMEOUT_S = 120
 
 #: Proton's dlopen failure on an image whose ROCm comes from Python wheels:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -321,8 +321,40 @@ def test_env_mode_payload_reads_every_session_variable(example, tmp_path):
     )
 
 
+#: Module paths whose import loads ``libproton.so`` and so runs the
+#: ``rocprofiler_force_configure`` constructor. ``triton.profiler`` is the
+#: documented entry point and pulls the extension in transitively;
+#: ``triton._C.libproton`` *is* the extension, imported directly by
+#: ``amd-rocprofiler/gelu.py``. Either one landing after torch is the hang, so
+#: the guard has to recognise both -- matching only the first would pass a
+#: payload that led with the second.
+_PROTON_IMPORT_PREFIXES = ("triton.profiler", "triton._C.libproton")
+
+
+def _imported_module_paths(node: ast.stmt) -> list[str]:
+    """Fully qualified module paths an import statement loads.
+
+    ``from triton import profiler`` loads ``triton.profiler`` but puts only
+    ``triton`` in ``ImportFrom.module``, so the bound names have to be joined
+    back on: reading ``module`` alone made that spelling invisible, and an
+    invisible proton import makes :func:`test_proton_payloads_import_proton_before_torch`
+    *skip* rather than fail. ``module`` is kept as well for
+    ``from triton.profiler import scope``, where the package is the whole path.
+
+    Relative imports are ignored -- neither ``triton`` nor ``torch`` can be
+    reached that way from an example payload, and ``module`` is not a usable
+    prefix when ``level`` is set.
+    """
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom) and not node.level:
+        module = node.module or ""
+        return [module, *(f"{module}.{alias.name}" for alias in node.names)]
+    return []
+
+
 def _first_import_lines(payload: Path) -> tuple[int | None, int | None]:
-    """Line numbers of the payload's first ``triton.profiler`` and ``torch`` imports.
+    """Line numbers of the payload's first Proton and ``torch`` imports.
 
     Module-level statements only. An import inside a function does not run at
     load time, so it cannot decide which library's constructor lands first --
@@ -331,13 +363,8 @@ def _first_import_lines(payload: Path) -> tuple[int | None, int | None]:
     proton_line = torch_line = None
     module = ast.parse(payload.read_text(encoding="utf-8"))
     for node in module.body:
-        names: list[str] = []
-        if isinstance(node, ast.Import):
-            names = [alias.name for alias in node.names]
-        elif isinstance(node, ast.ImportFrom):
-            names = [node.module or ""]
-        for name in names:
-            if proton_line is None and name.startswith("triton.profiler"):
+        for name in _imported_module_paths(node):
+            if proton_line is None and name.startswith(_PROTON_IMPORT_PREFIXES):
                 proton_line = node.lineno
             if torch_line is None and (name == "torch" or name.startswith("torch.")):
                 torch_line = node.lineno
@@ -381,3 +408,58 @@ def test_proton_payloads_import_proton_before_torch(payload):
         "Starting the session after torch is still correct and still required by "
         "roctracer; it is the import that has to come first, not the start() call."
     )
+
+
+@pytest.mark.parametrize(
+    "proton_import",
+    [
+        pytest.param("import triton.profiler as proton", id="import-dotted"),
+        pytest.param("import triton.profiler.language as pl", id="import-submodule"),
+        pytest.param("from triton import profiler", id="from-package"),
+        pytest.param("from triton import profiler as proton", id="from-package-aliased"),
+        pytest.param("from triton.profiler import scope", id="from-module"),
+        pytest.param("from triton._C.libproton import proton", id="from-extension"),
+    ],
+)
+def test_every_proton_import_spelling_is_visible_to_the_order_guard(tmp_path, proton_import):
+    """A spelling the guard cannot see makes the order test *skip*, not fail.
+
+    That is the dangerous direction: a payload rewritten to any of these forms
+    with torch first would deadlock at exit and still report green, because
+    ``_first_import_lines`` returns ``None`` and
+    :func:`test_proton_payloads_import_proton_before_torch` skips on ``None``.
+    """
+    payload = tmp_path / "payload.py"
+    payload.write_text(f"import torch\n{proton_import}\n", encoding="utf-8")
+    proton_line, torch_line = _first_import_lines(payload)
+    assert (proton_line, torch_line) == (2, 1), proton_import
+
+
+@pytest.mark.parametrize(
+    "torch_import",
+    [
+        pytest.param("import torch", id="import"),
+        pytest.param("import torch.nn.functional as F", id="import-submodule"),
+        pytest.param("from torch import nn", id="from-package"),
+    ],
+)
+def test_every_torch_import_spelling_is_visible_to_the_order_guard(tmp_path, torch_import):
+    """Same in the other direction: an invisible torch import also skips."""
+    payload = tmp_path / "payload.py"
+    payload.write_text(f"import triton.profiler as proton\n{torch_import}\n", encoding="utf-8")
+    proton_line, torch_line = _first_import_lines(payload)
+    assert (proton_line, torch_line) == (1, 2), torch_import
+
+
+def test_the_order_guard_ignores_imports_it_cannot_attribute(tmp_path):
+    """Relative and unrelated imports must not be read as either library.
+
+    ``ImportFrom.module`` is not a usable prefix when ``level`` is set, so
+    ``from . import torch_helpers`` would otherwise join into a bogus path.
+    """
+    payload = tmp_path / "payload.py"
+    payload.write_text(
+        "from . import torch_helpers\nfrom .torch import profiler\nimport argparse\n",
+        encoding="utf-8",
+    )
+    assert _first_import_lines(payload) == (None, None)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -10,6 +10,7 @@ first thing a new user runs.
 from __future__ import annotations
 
 import ast
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -353,22 +354,55 @@ def _imported_module_paths(node: ast.stmt) -> list[str]:
     return []
 
 
+def _load_time_statements(body: list[ast.stmt]) -> Iterator[ast.stmt]:
+    """Statements that run when the module is imported.
+
+    Not the same set as ``module.body``. A ``try:``/``except ImportError:`` or
+    an ``if`` around an optional import -- the ordinary shape for a dependency
+    that may be absent -- runs at load time just as a bare import does, so the
+    nested blocks have to be descended into. Reading only the top level made
+    those imports invisible, and an invisible proton import makes
+    :func:`test_proton_payloads_import_proton_before_torch` *skip* rather than
+    fail: the payload would deadlock and the suite would report green.
+
+    Function and class bodies are excluded, because those really do not run at
+    import time, so an import there cannot decide which library's constructor
+    lands first -- which is the whole property under test.
+
+    Still invisible, and deliberately so: an import performed by a *call* such
+    as ``importlib.import_module("triton.profiler")`` is not an import
+    statement at all. Nothing in the tree does that, and recognising it means
+    tracking string arguments rather than reading the AST's import nodes.
+    """
+    for node in body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        yield node
+        for block in ("body", "orelse", "finalbody"):
+            yield from _load_time_statements(getattr(node, block, None) or [])
+        for handler in getattr(node, "handlers", []):
+            yield from _load_time_statements(handler.body)
+        for case in getattr(node, "cases", []):
+            yield from _load_time_statements(case.body)
+
+
 def _first_import_lines(payload: Path) -> tuple[int | None, int | None]:
     """Line numbers of the payload's first Proton and ``torch`` imports.
 
-    Module-level statements only. An import inside a function does not run at
-    load time, so it cannot decide which library's constructor lands first --
-    which is the whole property under test.
+    Lowest line number rather than first-encountered, because
+    :func:`_load_time_statements` yields an enclosing ``try:`` before the
+    imports inside it and so is not in source order.
     """
-    proton_line = torch_line = None
+    proton_lines: list[int] = []
+    torch_lines: list[int] = []
     module = ast.parse(payload.read_text(encoding="utf-8"))
-    for node in module.body:
+    for node in _load_time_statements(module.body):
         for name in _imported_module_paths(node):
-            if proton_line is None and name.startswith(_PROTON_IMPORT_PREFIXES):
-                proton_line = node.lineno
-            if torch_line is None and (name == "torch" or name.startswith("torch.")):
-                torch_line = node.lineno
-    return proton_line, torch_line
+            if name.startswith(_PROTON_IMPORT_PREFIXES):
+                proton_lines.append(node.lineno)
+            if name == "torch" or name.startswith("torch."):
+                torch_lines.append(node.lineno)
+    return (min(proton_lines, default=None), min(torch_lines, default=None))
 
 
 _PROTON_PAYLOADS = sorted(
@@ -463,3 +497,68 @@ def test_the_order_guard_ignores_imports_it_cannot_attribute(tmp_path):
         encoding="utf-8",
     )
     assert _first_import_lines(payload) == (None, None)
+
+
+@pytest.mark.parametrize(
+    ("payload_source", "expected"),
+    [
+        pytest.param(
+            "import torch\ntry:\n    import triton.profiler as proton\nexcept ImportError:\n"
+            "    proton = None\n",
+            (3, 1),
+            id="try-except-around-proton",
+        ),
+        pytest.param(
+            "import torch\nif True:\n    import triton.profiler as proton\n",
+            (3, 1),
+            id="if-around-proton",
+        ),
+        pytest.param(
+            "try:\n    import triton.profiler as proton\nexcept ImportError:\n"
+            "    proton = None\nimport torch\n",
+            (2, 5),
+            id="try-except-in-the-correct-order",
+        ),
+        pytest.param(
+            "import triton.profiler as proton\ntry:\n    import torch\nexcept ImportError:\n"
+            "    torch = None\n",
+            (1, 3),
+            id="try-except-around-torch",
+        ),
+        pytest.param(
+            "with contextlib.suppress(ImportError):\n    import torch\n"
+            "    import triton.profiler as proton\n",
+            (3, 2),
+            id="with-block",
+        ),
+        pytest.param(
+            "def main():\n    import torch\n    import triton.profiler as proton\n",
+            (None, None),
+            id="inside-a-function-does-not-run-at-import",
+        ),
+        pytest.param(
+            "class Holder:\n    import torch\n    import triton.profiler as proton\n",
+            (None, None),
+            id="inside-a-class-body",
+        ),
+    ],
+)
+def test_the_order_guard_sees_imports_nested_in_load_time_blocks(
+    tmp_path, payload_source, expected
+):
+    """A module-level ``try:`` or ``if:`` runs at import, so it must be descended into.
+
+    Reading only ``module.body`` made these invisible, and invisible is the
+    dangerous direction: ``_first_import_lines`` returned ``(None, None)`` and
+    :func:`test_proton_payloads_import_proton_before_torch` *skips* on ``None``,
+    so a payload wrapping its proton import in ``try:``/``except ImportError:``
+    -- the ordinary shape for an optional dependency -- would deadlock at exit
+    and still report green.
+
+    The last two cases are the boundary in the other direction: a function or
+    class body genuinely does not run at import, so an import there decides
+    nothing about which constructor lands first and must stay invisible.
+    """
+    payload = tmp_path / "payload.py"
+    payload.write_text(payload_source, encoding="utf-8")
+    assert _first_import_lines(payload) == expected

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -319,3 +319,65 @@ def test_env_mode_payload_reads_every_session_variable(example, tmp_path):
         "set those knobs and the payload would start Proton without them, so the trial "
         "would report a capture that is missing what it asked for"
     )
+
+
+def _first_import_lines(payload: Path) -> tuple[int | None, int | None]:
+    """Line numbers of the payload's first ``triton.profiler`` and ``torch`` imports.
+
+    Module-level statements only. An import inside a function does not run at
+    load time, so it cannot decide which library's constructor lands first --
+    which is the whole property under test.
+    """
+    proton_line = torch_line = None
+    module = ast.parse(payload.read_text(encoding="utf-8"))
+    for node in module.body:
+        names: list[str] = []
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [node.module or ""]
+        for name in names:
+            if proton_line is None and name.startswith("triton.profiler"):
+                proton_line = node.lineno
+            if torch_line is None and (name == "torch" or name.startswith("torch.")):
+                torch_line = node.lineno
+    return proton_line, torch_line
+
+
+_PROTON_PAYLOADS = sorted(
+    path for path in (EXAMPLES / "profiling" / "proton").glob("*/*.py") if path.name != "__init__.py"
+)
+_PROTON_PAYLOAD_IDS = [str(path.relative_to(EXAMPLES)) for path in _PROTON_PAYLOADS]
+
+
+@pytest.mark.skipif(not _PROTON_PAYLOADS, reason="no proton example payloads in the tree")
+@pytest.mark.parametrize("payload", _PROTON_PAYLOADS, ids=_PROTON_PAYLOAD_IDS)
+def test_proton_payloads_import_proton_before_torch(payload):
+    """Importing Proton after torch hangs the process forever at exit.
+
+    ``libproton.so`` calls ``rocprofiler_force_configure`` from an
+    ``__attribute__((constructor))``, so importing ``triton.profiler`` registers
+    Proton as a rocprofiler-sdk client. On Triton 3.8.0, when that registration
+    lands after HSA is already up -- importing torch is enough -- the atexit
+    ``rocprofiler::registration::finalize()`` re-enters its own non-recursive
+    registration mutex through Proton's ``protonToolFini`` and deadlocks. The
+    capture completes and is written; the process then never exits. Two imports
+    in that order are the entire reproducer (ROCm/aorta#434).
+
+    Asserted here rather than left to the GPU smoke tests because this is an
+    import-order convention, and the natural tidy -- letting isort sort the
+    third-party block -- silently reintroduces the hang on a host no CPU test
+    would notice. The ``# isort: skip`` comments in the payloads are what hold
+    the order; this is what says why they must stay.
+    """
+    proton_line, torch_line = _first_import_lines(payload)
+    if proton_line is None or torch_line is None:
+        pytest.skip(f"{_rel(payload)} does not import both triton.profiler and torch")
+    assert proton_line < torch_line, (
+        f"{_rel(payload)} imports torch (line {torch_line}) before triton.profiler "
+        f"(line {proton_line}). That order deadlocks the process at exit on Triton "
+        "3.8.0 -- see ROCm/aorta#434. Import triton.profiler first, keeping the "
+        "'# isort: skip  # noqa: I001' comment so the linter does not undo it. "
+        "Starting the session after torch is still correct and still required by "
+        "roctracer; it is the import that has to come first, not the start() call."
+    )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -661,6 +661,4 @@ def test_a_conditional_proton_import_is_no_evidence_of_a_safe_order(
     """
     payload = tmp_path / "payload.py"
     payload.write_text(payload_source, encoding="utf-8")
-    proton_line, torch_line = _first_import_lines(payload)
-    assert (proton_line, torch_line) == expected
-    assert proton_line is not None and torch_line is not None, "must not go invisible"
+    assert _first_import_lines(payload) == expected

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -354,20 +354,34 @@ def _imported_module_paths(node: ast.stmt) -> list[str]:
     return []
 
 
-def _load_time_statements(body: list[ast.stmt]) -> Iterator[ast.stmt]:
-    """Statements that run when the module is imported.
+#: ``try:``/``except*`` in whichever spellings this Python provides.
+_TRY_NODES = (ast.Try, *((ast.TryStar,) if hasattr(ast, "TryStar") else ()))
+
+
+def _load_time_statements(
+    body: list[ast.stmt], *, certain: bool = True
+) -> Iterator[tuple[ast.stmt, bool]]:
+    """Statements that can run at import, each tagged as certain to or not.
 
     Not the same set as ``module.body``. A ``try:``/``except ImportError:`` or
     an ``if`` around an optional import -- the ordinary shape for a dependency
     that may be absent -- runs at load time just as a bare import does, so the
     nested blocks have to be descended into. Reading only the top level made
-    those imports invisible, and an invisible proton import makes
+    those imports invisible, and invisible makes
     :func:`test_proton_payloads_import_proton_before_torch` *skip* rather than
     fail: the payload would deadlock and the suite would report green.
 
-    Function and class bodies are excluded, because those really do not run at
-    import time, so an import there cannot decide which library's constructor
-    lands first -- which is the whole property under test.
+    **Class bodies are descended into.** A module-level ``class`` statement
+    executes its body while the module loads, so an import there really does
+    run the extension's constructor -- verified, not assumed. Only *function*
+    bodies are excluded, and only because they genuinely do not run at import,
+    so an import there cannot decide which library lands first.
+
+    The flag distinguishes blocks that are **entered unconditionally** (a
+    ``try:`` or ``with:`` body, a ``finally:``, a class body) from those that
+    may be skipped whole (``if``/``else``, an ``except`` handler, a loop body,
+    a ``match`` case). Only the first kind can be *relied on* as evidence that
+    Proton was imported early; see :func:`_first_import_lines`.
 
     Still invisible, and deliberately so: an import performed by a *call* such
     as ``importlib.import_module("triton.profiler")`` is not an import
@@ -375,34 +389,60 @@ def _load_time_statements(body: list[ast.stmt]) -> Iterator[ast.stmt]:
     tracking string arguments rather than reading the AST's import nodes.
     """
     for node in body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        yield node
-        for block in ("body", "orelse", "finalbody"):
-            yield from _load_time_statements(getattr(node, block, None) or [])
-        for handler in getattr(node, "handlers", []):
-            yield from _load_time_statements(handler.body)
-        for case in getattr(node, "cases", []):
-            yield from _load_time_statements(case.body)
+        yield node, certain
+        if isinstance(node, (ast.ClassDef, ast.With, ast.AsyncWith)):
+            yield from _load_time_statements(node.body, certain=certain)
+        elif isinstance(node, _TRY_NODES):
+            yield from _load_time_statements(node.body, certain=certain)
+            yield from _load_time_statements(node.finalbody, certain=certain)
+            yield from _load_time_statements(node.orelse, certain=False)
+            for handler in node.handlers:
+                yield from _load_time_statements(handler.body, certain=False)
+        elif isinstance(node, (ast.If, ast.For, ast.AsyncFor, ast.While)):
+            yield from _load_time_statements(node.body, certain=False)
+            yield from _load_time_statements(node.orelse, certain=False)
+        elif isinstance(node, ast.Match):
+            for case in node.cases:
+                yield from _load_time_statements(case.body, certain=False)
 
 
 def _first_import_lines(payload: Path) -> tuple[int | None, int | None]:
-    """Line numbers of the payload's first Proton and ``torch`` imports.
+    """Lines to compare for the import-order rule: Proton's, then ``torch``'s.
 
-    Lowest line number rather than first-encountered, because
-    :func:`_load_time_statements` yields an enclosing ``try:`` before the
-    imports inside it and so is not in source order.
+    Not simply the lowest line of each. Once conditional blocks are in scope,
+    the two libraries need opposite treatment, because the question is whether
+    *any* feasible load path imports torch first:
+
+    * **Proton** -- the line reported is the earliest import certain to be
+      attempted, because a conditional one is no evidence the constructor ran
+      early: on the path where the branch is skipped it did not run at all.
+      With no certain import, the *latest* conditional one is used, that being
+      the worst path on which Proton loads at all.
+    * **torch** -- the earliest import that *might* run, conditional or not,
+      since any of them is enough to bring HSA up.
+
+    Flattening both to ``min()`` passed a genuinely deadlocking payload: a
+    Proton import under ``if TYPE_CHECKING:`` (never executed) followed by
+    top-level ``import torch`` and then a real Proton import reported
+    ``proton_line < torch_line`` off the unexecuted line, while the runtime
+    order was torch first.
     """
-    proton_lines: list[int] = []
-    torch_lines: list[int] = []
+    certain_proton: list[int] = []
+    any_proton: list[int] = []
+    any_torch: list[int] = []
     module = ast.parse(payload.read_text(encoding="utf-8"))
-    for node in _load_time_statements(module.body):
+    for node, certain in _load_time_statements(module.body):
         for name in _imported_module_paths(node):
             if name.startswith(_PROTON_IMPORT_PREFIXES):
-                proton_lines.append(node.lineno)
+                any_proton.append(node.lineno)
+                if certain:
+                    certain_proton.append(node.lineno)
             if name == "torch" or name.startswith("torch."):
-                torch_lines.append(node.lineno)
-    return (min(proton_lines, default=None), min(torch_lines, default=None))
+                any_torch.append(node.lineno)
+    proton_line = min(certain_proton) if certain_proton else max(any_proton, default=None)
+    return proton_line, min(any_torch, default=None)
 
 
 _PROTON_PAYLOADS = sorted(
@@ -532,21 +572,21 @@ def test_the_order_guard_ignores_imports_it_cannot_attribute(tmp_path):
             id="with-block",
         ),
         pytest.param(
+            "class Holder:\n    import torch\n    import triton.profiler as proton\n",
+            (3, 2),
+            id="class-body-runs-at-import",
+        ),
+        pytest.param(
             "def main():\n    import torch\n    import triton.profiler as proton\n",
             (None, None),
             id="inside-a-function-does-not-run-at-import",
-        ),
-        pytest.param(
-            "class Holder:\n    import torch\n    import triton.profiler as proton\n",
-            (None, None),
-            id="inside-a-class-body",
         ),
     ],
 )
 def test_the_order_guard_sees_imports_nested_in_load_time_blocks(
     tmp_path, payload_source, expected
 ):
-    """A module-level ``try:`` or ``if:`` runs at import, so it must be descended into.
+    """A module-level ``try:``, ``if:`` or ``class:`` runs at import.
 
     Reading only ``module.body`` made these invisible, and invisible is the
     dangerous direction: ``_first_import_lines`` returned ``(None, None)`` and
@@ -555,10 +595,72 @@ def test_the_order_guard_sees_imports_nested_in_load_time_blocks(
     -- the ordinary shape for an optional dependency -- would deadlock at exit
     and still report green.
 
-    The last two cases are the boundary in the other direction: a function or
-    class body genuinely does not run at import, so an import there decides
-    nothing about which constructor lands first and must stay invisible.
+    A class body is the case most easily got wrong, because it looks like a
+    function body and behaves like module scope: the ``class`` statement
+    executes its body as the module loads, so the extension's constructor
+    really does run. Only the function case stays invisible, and that one is
+    the boundary in the other direction -- it genuinely does not run at import,
+    so it decides nothing about which library lands first.
     """
     payload = tmp_path / "payload.py"
     payload.write_text(payload_source, encoding="utf-8")
     assert _first_import_lines(payload) == expected
+
+
+@pytest.mark.parametrize(
+    ("payload_source", "expected"),
+    [
+        pytest.param(
+            "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n"
+            "    import triton.profiler as proton\nimport torch\n"
+            "import triton.profiler as proton\n",
+            (5, 4),
+            id="unexecuted-proton-must-not-vouch-for-a-later-real-one",
+        ),
+        pytest.param(
+            "if sys.version_info >= (3, 9):\n    import triton.profiler as proton\n"
+            "import torch\nimport triton.profiler as proton\n",
+            (4, 3),
+            id="conditional-proton-then-torch-then-certain-proton",
+        ),
+        pytest.param(
+            "import torch\nif FLAG:\n    import triton.profiler as proton\n",
+            (3, 1),
+            id="only-conditional-proton-uses-its-own-line",
+        ),
+        pytest.param(
+            "import torch\nif FLAG:\n    import triton.profiler as proton\nelse:\n"
+            "    import triton.profiler.language as pl\n",
+            (5, 1),
+            id="only-conditional-proton-uses-the-worst-branch",
+        ),
+        pytest.param(
+            "try:\n    import triton.profiler as proton\nexcept ImportError:\n"
+            "    proton = None\nimport torch\n",
+            (2, 5),
+            id="try-body-is-entered-so-it-does-vouch",
+        ),
+    ],
+)
+def test_a_conditional_proton_import_is_no_evidence_of_a_safe_order(
+    tmp_path, payload_source, expected
+):
+    """A branch that may not execute cannot vouch for the import order.
+
+    Taking ``min()`` of every Proton line let an unexecuted import stand in for
+    a real one. Under ``if TYPE_CHECKING:`` the import never runs, so a payload
+    that then did ``import torch`` before its actual Proton import reported
+    ``proton_line < torch_line`` and passed -- while deadlocking at runtime,
+    which is precisely what this guard exists to prevent.
+
+    So Proton reports the earliest *certain* import and falls back to the latest
+    conditional one (the worst path on which it loads at all), while torch
+    reports the earliest that *might* run. The last case is the boundary: a
+    ``try:`` body is entered unconditionally, so unlike an ``if`` it is real
+    evidence, and the ordinary optional-dependency shape keeps passing.
+    """
+    payload = tmp_path / "payload.py"
+    payload.write_text(payload_source, encoding="utf-8")
+    proton_line, torch_line = _first_import_lines(payload)
+    assert (proton_line, torch_line) == expected
+    assert proton_line is not None and torch_line is not None, "must not go invisible"


### PR DESCRIPTION
Closes #434.

## What the wedge actually was

The issue's hypothesis was that a `mode: env` `proton.start()` hangs in the HSA
layer. It does not. **The capture succeeds.** The payload runs its kernels,
Proton writes a complete `.hatchet`, stdout says `PASS` — and then the process
never returns from `exit()`.

Reproduced on gfx950 / ROCm 10 / Triton 3.8.0 / torch 2.13.0, deterministically.
`gdb` on a wedged payload, main thread:

```
#0  futex_wait (futex_word=... rocprofiler::registration::get_registration_mutex()::_v)
#3  ___pthread_mutex_lock
#4  rocprofiler::registration::invoke_client_finalizer()   <-- re-locks it
#5  proton::protonToolFini ... RocprofSDKProfiler.cpp:905
#6  rocprofiler::registration::invoke_client_finalizer()   <-- already holds it
#8  __pthread_once_slow (rocprofiler::registration::finalize()::_once)
#10 rocprofiler::registration::finalize()
#11 __run_exit_handlers
#12 __GI_exit
```

A self-deadlock on a non-recursive mutex. `libproton.so` calls
`rocprofiler_force_configure` from an `__attribute__((constructor))`, so
importing `triton.profiler` registers Proton as a rocprofiler-sdk client. At
exit, rocprofiler-sdk's atexit handler takes the registration mutex and invokes
each client finalizer; Proton's `protonToolFini` calls back into rocprofiler-sdk,
which tries to take the same mutex on the same thread.

**`proton.start()` is not required. Neither is any GPU work.** The whole
reproducer is two imports in the wrong order:

```python
import torch
import triton.profiler   # process now never exits
```

Reversed, it exits cleanly. Either alone exits cleanly. On Triton 3.7.1 neither
order hangs.

That explains every observation in the issue without the dlopen theory:

| Observation | Why |
|---|---|
| only `mode: env` wedges | Proton's CLI front-end imports Proton before the payload imports torch; the env-mode payloads had `import torch` at module scope |
| pinned `mode: cli -b roctracer` completed | same — the import order is right on that path |
| the wedged argv carried no device variable | correct, and irrelevant; device pinning was never involved |
| `test_hip_visible_devices_is_translated_not_refused` wedged on one run, passed on the other | it is `mode: cli`, so it depended on ambient ordering rather than on the test |

The suspected `librocprofiler-sdk.so` dlopen failure is not the *cause* — but its
absence **is a precondition**, which I initially got wrong. The `rocm/pytorch`
wheel images ship only `librocprofiler-sdk.so.1`, so on a stock image Proton's
constructor dlopen fails, `catch (...)` swallows it, no rocprofiler-sdk client
registers, and nothing deadlocks. Re-measured:

| Container | bare `librocprofiler-sdk.so` | `import torch; import triton.profiler` |
|---|---|---|
| stock image, with `--device /dev/kfd` | absent | exits 0 |
| stock image, no GPU devices | absent | exits 0 |
| stock image + symlink, with GPU | present | **hangs** |
| stock image + symlink, no GPU at all | present | **hangs** |

The single precondition is the bare soname; **no GPU is required**. What puts
aorta squarely in the affected configuration is #411's devel-symlink fixup in
`Dockerfile.ci-gpu`, which creates that soname — it fixed the dlopen and thereby
enabled the deadlock.

## The fix

Import `triton.profiler` before `torch` in `pipeline.py` and `hotspot.py`, as
`amd-rocprofiler/gelu.py` already did.

This does not weaken the `roctracer` contract. What `roctracer` constrains is
when **`proton.start()`** runs — its interceptor goes in at session start, so the
runtime must be up by then — not when the module is imported. The payloads still
start after torch. Verified: the capture is byte-identical with the import moved,
on both Tritons.

| | Triton 3.7.1 | Triton 3.8.0 |
|---|---|---|
| `pipeline.py` hatchet | 1648 bytes, 15 launches / 3 kernels | 1648 bytes, 15 launches / 3 kernels |
| exit | clean, 2.2 s | clean (was: never), 2.4 s |

**This is a workaround, not a cure.** The upstream defect is unfixed; this only
keeps aorta's own payloads out of it. Any process on this stack that imports
torch before `triton.profiler` still hangs. See "Where this belongs" below.

## Issue item 2: the CLI-pin bug really is fixed on 3.8.0

Measured here rather than inferred from the CI run:

| | Triton 3.7.1 | Triton 3.8.0 |
|---|---|---|
| `-b roctracer` under `mode: cli` | **160 bytes**, bare `ROOT` | **3090 bytes**, real capture |
| no `-b` (`backend: auto`) | populated | 3090 bytes |

So the pinned capture on 3.8.0 is byte-for-byte the size `auto` produces.

`test_cli_mode_pin_would_still_capture_nothing` is renamed
`test_cli_mode_pin_captures_nothing_only_on_the_versions_the_guard_targets` and
now asserts **whichever is true for the installed Triton**, rather than skipping
on the newer stack. Both halves earn their keep: the 3.7.x half is the original
regression, and the 3.8.0 half is what will say the guard has become a no-op —
and will fail loudly if a later Triton reintroduces the ordering bug after the
guard is gone.

### The guard itself is deliberately kept

I did not remove `wrap_argv`'s refusal or `_CLI_UNPINNABLE_BACKENDS`, which the
issue lists as a closing criterion. The empty capture is still real on 3.7.x, and
3.7.x is still installed in images this repo runs against — I measured it on one
today. Removing the guard would regress those users into exactly the silent
unprofiled trial it exists to prevent.

**This is a version-floor decision rather than an open question, and it has been
taken: keep the guard for now.** Measured while working this branch, Triton
below 3.8 is still what several images in use ship -- 3.7.1 in
`rocm/pytorch:rocm7.14_ubuntu26.04_py3.14_pytorch_release_2.12.0` and 3.6.0 in
`rocm/pytorch:latest`. Removing the guard today would regress those users into
exactly the silent unprofiled trial it exists to prevent.

The collector's *behaviour* is unchanged on this branch. The only diff under
`src/aorta/instrumentation/proton/` is one comment: `_CLI_UNPINNABLE_BACKENDS`
described the GPU test as "skips itself from 3.8.0 on", which this branch made
false by replacing that skip with a version-split assertion. `wrap_argv`, the
refusal, its message and the frozenset are untouched.

Note the cost of keeping it: on 3.8.0 aorta refuses a `mode: cli` +
`roctracer` recipe that would now work. That is a real if minor usability
regression, mitigated by two spellings that do work (`mode: env`, or
`backend: auto`), and it is flagged here rather than buried.

**When to revisit.** Tracked in #439, so this does not vanish when #434 closes.
Once no supported image ships Triton < 3.8, delete
`_CLI_UNPINNABLE_BACKENDS`, the `wrap_argv` refusal and its message, and the
`else` branch of the version-aware test, together. The test is what will tell
you the floor has moved: its 3.7.x branch stops being exercised anywhere, and
its 3.8.0 branch is what guards against a later Triton reintroducing the
ordering bug once the refusal is gone.

A middle option -- making the refusal conditional on the Triton version -- was
considered and rejected. `wrap_argv` does resolve the interpreter that will run
(`resolve_python`), so probing its Triton is feasible, but it would turn argv
building into something that spawns a subprocess on every wrap, make the
function's output host-dependent where ~100 CPU tests currently assert the
refusal deterministically, and add a probe-failure path with no good default
(fail open = the silent empty capture on 3.7.x; fail closed = refusing a
working stack).

## Where this belongs (it is not an aorta bug)

Two upstream repos can each fix it, and arguably both should:

1. **`triton-lang/triton`** — `third_party/proton/.../RocprofSDKProfiler.cpp`.
   `protonToolFini` calls back into rocprofiler-sdk from inside a rocprofiler-sdk
   client-finalizer callback. (The shipped binary is ROCm's build of Triton, so
   the ROCm fork needs it too.)
2. **`ROCm/rocm-systems`** (rocprofiler-sdk) — `invoke_client_finalizer` holds a
   non-recursive `get_registration_mutex()` across a client callback, so any
   client that re-enters the API deadlocks the process. This is the more robust
   place to fix it: it makes the whole class of client bug non-fatal.

Both are filed and cross-linked — and upstream review has since sharpened the
picture considerably:

- **triton-lang/triton#11549** — https://github.com/triton-lang/triton/issues/11549.
  **The fix already exists upstream and simply missed the release.**
  triton-lang/triton#11009 ("[AMD] rocprofsdk finalization fix for proton",
  merged 2026-07-28) deletes exactly the frame in the stack above —
  `state->finalizeFunc(*state->clientId)`, which sits at
  `RocprofSDKProfiler.cpp:905` at tag `v3.8.0`, matching the gdb frame line for
  line. `main` has zero occurrences of `finalizeFunc`. But #11009 is **not in
  the `v3.8.0` tag** (released 2026-08-28), so 3.8.0 ships the deadlock. A
  3.8.x backport has been requested.
- **ROCm/rocm-systems#11123** — https://github.com/ROCm/rocm-systems/issues/11123.
  Reframed as contract hardening rather than a live defect, since with #11009
  there is no known re-entering client. The underlying point stands on its own
  terms: a non-recursive registration mutex held across a callback into
  third-party code makes this failure mode reachable by any client.

This does not change anything in this PR. The import-order fix is still correct
and still needed — our CI image carries the symlink — and it holds whether or
not upstream backports. It becomes *removable* once the shipped Triton carries
#11009, which is one more thing #439 can retire.

## Also in here: a doc sweep the fix forced

Moving the import falsified a claim written into six files — that the two AMD
payloads deliberately use *opposite import orders*. Two of those sites are
`--backend` argparse comments justifying why `rocprofiler` is absent from
`choices`, so a stale comment there invites the next reader to restore the
affordance.

Worth a reviewer's eye: the original "two backends, two contracts, do not
normalise the import order" framing was **wrong when written**, not just made
stale by this branch. It read `roctracer`'s constraint as being on the import
when it is on `start()`, and so saw a conflict that never existed. One ordering
satisfies both backends. The corrected text says that explicitly, so the conflict
does not get re-derived and the payloads re-split.

The two `--backend` comments are re-justified on capability instead: `gelu.py`
carries the rocprofiler availability probe and the exit-2 classifier, and the
other two payloads do not. The `choices` tuples are unchanged.

## Test plan

- [x] `ruff` clean on changed files; `pre-commit` clean
- [x] New `test_proton_payloads_import_proton_before_torch` (CPU, AST-based —
      prose cannot satisfy it). **Mutation-checked**: reversing the imports in
      `pipeline.py` turns it red with the diagnostic naming the fix
- [x] `tests/test_examples.py`, `test_proton.py`, `test_collectors.py`:
      363 passed, 2 skipped (+1: the new child-budget guard)
- [x] Full CPU suite: 5005 passed, 24 failed — the same 24 fail on the base
      commit (5002 passed) in an identical container, so all pre-existing and
      environmental. The +3 passed / +2 skipped is exactly the new
      5-way-parametrized test
- [x] GPU smoke, `-m "gpu or rocm" -n 4 --timeout=300`, on 8x MI350X:
      - Triton 3.8.0 / ROCm 10 / torch 2.13.0 — **10 passed, 1 skipped, 9.6 s**
      - Triton 3.7.1 / ROCm 7.14 / torch 2.12.0 — **10 passed, 1 skipped, 8.6 s**

Both previously-skipped tests now run, on both versions. The remaining skip is
`test_pcsampling_captures_once_the_environment_can_do_it`, correctly: 3.8.0 still
rejects that mode.

## Review round: Copilot, 2026-09-02

Four comments. Three acted on, one declined; details on the threads.

**1. `_CHILD_TIMEOUT_S` did not govern every child.** Copilot flagged one
`timeout=3600`; there were three raw literals, and the sweep is the point. Only
the captures going through `_capture` used the shared budget. The two `3600`s
matched the GPU job's own 60-minute cap *exactly*, so a wedge there would have
run the job to its cancel — losing the junit upload and the whole report, which
is the operational failure `_CHILD_TIMEOUT_S` exists to prevent and the one
already recorded against run 33527313950 in #434. All four calls now use the
constant.

New `test_gpu_smoke_subprocesses_all_use_the_shared_child_budget` pins it, in
the **CPU** suite: the GPU legs are path-skipped on most PRs, so a regression
in the GPU module's own conventions would otherwise reach `main` unobserved. It
reads the AST and keys on the `timeout` keyword wherever it appears, rather than
on the callee being `subprocess.run` — `from subprocess import run` or a
`Popen.communicate` would leave the identical hole. Mutation-checked twice.
(That keyword-only shape had a hole of its own, closed in the round below.)

**2. The version split stopped short of nine documentation sites.** Copilot
named five; the same claim was in four more, two of them falsified by this
branch itself:

- `amd-roctracer/README.md` said "Upgrading Triton does not help" and
  `amd-roctracer/recipe.yaml` "No Triton version fixes it" — both measured
  false on this branch (3090 bytes on 3.8.0). The subtlety is now stated
  rather than smoothed over: the *line* those claims cited really is unchanged
  at the `v3.8.0` tag, and the pin captures anyway, so something else on that
  stack brings the runtime up first.
- `amd-roctracer/recipe.yaml` still said `pipeline.py` imports torch before
  Proton. This branch changed exactly that. Corrected to the "one ordering
  satisfies both" framing the sibling `amd-rocprofiler` recipe already carries
  — deliberately not to a replacement contrast, which is the trap the
  preceding round fell into.
- `_CLI_UNPINNABLE_BACKENDS`'s comment (above).
- Plus `docs/profiling-collectors.md` (two sites),
  `examples/profiling/README.md`, `triton-vecadd/{README.md,recipe.yaml}` and
  `amd-instrumentation/{README.md,recipe.yaml}`.

Every site now scopes the empty capture to 3.7.x, puts the 3.8.0 measurement
beside it, and says the refusal is kept while older images ship, pointing at
#439.

**3. The upstream-report line was unverifiable.** It said "Reported upstream"
with nothing to check. Both issues exist now, so the doc names them, says what
each is for, and — reconciled against the 3.8.0-window finding above — states
the distinction that decides whether a reader is exposed: neither filed issue
is closed, and no *released* Triton carries the fix.

**4. Declined: removing or version-scoping the `wrap_argv` refusal.** Reasoning
on the thread and in "The guard itself is deliberately kept" above. In short:
the empty capture is still real on 3.7.x, images in use still ship 3.7.1 and
3.6.0, and dropping the refusal today would regress those users into the silent
unprofiled trial it exists to prevent. The version-floor decision has been
taken rather than deferred, and #439 tracks the removal so it does not vanish
when #434 closes.

### What this round is and is not verified against

The three test-file changes are in a **GPU** module whose CI legs are
path-skipped on most PRs, so they are **not** exercised by this PR's checks.
What *is* CI-verified: the new AST guard runs in the CPU suite, and the full
CPU suite's failure set is byte-identical to the same run on the branch tip
before this round (53 entries each, empty symmetric difference; 4775 passed vs
4774, the +1 being the guard). The child-budget change itself is a strict
lowering of a subprocess timeout — it cannot make a payload wedge, only bound
one that already does — but the assertion that the GPU tests still pass under
a 120 s budget rests on the previously measured ~2.5 s captures, not on a new
GPU run in this round.

## Review round: Copilot, 2026-09-03

Two comments, both about the AST guards this branch added, and both the same
shape: **a guard that only recognises one spelling of the thing it inspects
passes everything else silently.** Both were right. The sweep for that property
rather than for either line found a third site neither comment named.

**1. The child-budget guard only inspected calls that already had a
`timeout=`.** So `subprocess.run(argv)` — no budget at all, and the likeliest
regression of the four — never entered `offenders` and the guard passed. The
previous round had deliberately moved *off* a callee-shaped check, and that is
still right for one of the two failure modes, so the guard now does both:

- A `timeout=` that is not `_CHILD_TIMEOUT_S` *narrows* the budget and can
  appear on any call shape, so that check stays keyed on the keyword.
- A blocking child call with no `timeout=` keyword has *no* budget, and no
  keyword-shaped check can see that, so this one matches the callee's trailing
  name (`run`, `call`, `check_call`, `check_output`, `communicate`, `wait`,
  `wait_for`) — trailing name, so `from subprocess import run` still resolves.
- `os.system` and `os.popen` accept no timeout at all, so there is no bounded
  spelling to allow and they are rejected outright.

Detection moved into a helper so it can be exercised on snippets rather than
only on a file that already complies — **a guard checked only against
compliant source cannot say what it would reject.** Twelve snippets pin the
positives and the negatives; reverting the fix fails six of them, and injecting
an unbounded `subprocess.run` into the real GPU module fails the guard with the
offending line number. The coverage it does *not* claim is now stated in the
test: launch spellings outside those two name sets, and a budget passed
positionally (reported as missing rather than accepted — the fail-closed
direction).

**2. `_first_import_lines` dropped `ImportFrom` aliases.** `from triton import
profiler` loads `triton.profiler` but leaves only `triton` in
`ImportFrom.module`, so `proton_line` stayed `None` — and the order test
*skips* on `None`. That is the dangerous direction: a payload rewritten to that
spelling with torch first would deadlock at exit and still report green.
Qualified names are now joined from the module and each alias. Two things fell
out of writing it:

- Relative imports are excluded, because `module` is not a usable prefix when
  `level` is set. `from .torch import profiler` was being read as a torch
  import.
- **The third site, from the sweep:** the proton side matched `triton.profiler`
  only, but `amd-rocprofiler/gelu.py` also imports `triton._C.libproton`
  directly — and that *is* the extension whose `__attribute__((constructor))`
  calls `rocprofiler_force_configure`, i.e. the exact load this whole branch is
  about. It is second in `gelu.py` today, so nothing is broken; a future
  payload led by that spelling would have been invisible to the guard. Both
  prefixes are now matched, with the reason recorded beside them.

### What this round is and is not verified against

This round is CI-verified, and by more than I expected — **including the GPU
leg, which actually ran this time.** I had written this section saying it would
not, so the correction is worth making explicitly rather than quietly.

**CPU (expected).** Both guards and all 22 new tests live in
`tests/test_examples.py` and `tests/instrumentation/test_proton.py`, neither
path-skipped. Green on py3.10 through py3.14. Locally on `c7bd1720`: 47 failed
+ 6 errors = the same 53 entries as before this round, none of them in a file
this round touches, and 4797 passed (+22, these tests). `ruff` clean on the
changed files; `pre-commit` clean.

**GPU (not expected).** Touching `test_proton_smoke_gpu.py` at all — even for
a comment — matched the GPU path filter, so `pytest (GPU, MI350)` ran the whole
proton smoke module on hardware rather than skipping it:
[run 33746150133](https://github.com/ROCm/aorta/actions/runs/33746150133) on
`c7bd1720`, **104 passed, 6 skipped in 53 s**. That includes
`test_env_mode_pins_roctracer_and_gets_a_non_empty_tree`,
`test_cli_mode_pin_captures_nothing_only_on_the_versions_the_guard_targets` and
`test_a_backend_that_refuses_the_mode_exits_two_not_a_traceback`, with
`test_pcsampling_captures_once_the_environment_can_do_it` the one expected
skip. The container is
`rocm/pytorch:rocm10.0_ubuntu26.04_py3.14_pytorch_release_2.13.0`, and the job
applies #411's devel-symlink fixup — so this is the ROCm 10 / torch 2.13.0 /
Triton 3.8.0 stack *with* the bare-soname precondition present, i.e. the
configuration where the deadlock reproduces.

Two claims that upgrade as a result:

- The previous round said the 120 s `_CHILD_TIMEOUT_S` was sound on the basis
  of previously measured ~2.5 s captures rather than a new GPU run. There is
  now a GPU run under that budget, and the whole module finished in 53 s.
- The import-order fix is no longer resting only on the earlier manual runs;
  the env-mode capture that used to wedge completes in CI on the affected
  stack.

Still **not** verified here: Triton 3.7.1. The CI image is 3.8.0, so the 3.7.x
half of `test_cli_mode_pin_captures_nothing_only_on_the_versions_the_guard_targets`
and the 3.7.x measurements behind keeping `_CLI_UNPINNABLE_BACKENDS` come from
the manual runs recorded above, not from this or any other CI leg.

## Version facts, checked 2026-09-02

Triton 3.8.0 is still the newest release on PyPI. The deadlock was measured on
3.8.0 and confirmed absent on 3.7.1; the CLI-pin behaviour was measured on both.

Made with [Cursor](https://cursor.com)






