### PR TITLE
docs: add a decision guide for choosing a Proton backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ The standalone `aorta mitigations list` and `aorta environments list` groups are
 | [LLM Determinism](docs/llm-determinism.md) | Bit-exact double-run nondeterminism probe |
 | [Layer Numerics](docs/layer-numerics.md) | Per-layer / per-stage NaN, magnitude, and out-of-range logger |
 | [Profiling Collectors](docs/profiling-collectors.md) | `--collect rocprof` (wraps any subprocess command) / `--collect proton` (Python launches, or `mode: env`) — attach a GPU profiler without editing the payload |
+| [Choosing a Proton backend](docs/proton-backends.md) | Which of Proton's five backends answers which question — whole-kernel timing vs intra-kernel cycles vs PC sampling, what each costs you, and what is available on which Triton |
 | [TokenSpeed](docs/tokenspeed.md) | Third-party inference engine under `mode: probe` — kernel, operator-suite and serving triage, plus Waitcheck and ConSan over its JIT attention/gemm kernels (gfx950) |
 | [TokenSpeed serving](docs/tokenspeed-serving.md) | `tokenspeed_serve` workload — TTFT / TPOT / ITL / throughput per cell, over model, concurrency and ISL/OSL sweeps (gfx950) |
 | [`aorta agent`](docs/agent/agentic-testing-guide.md) | Closed-loop mitigation search (optional LLM proposer) |

--- a/docs/profiling-collectors.md
+++ b/docs/profiling-collectors.md
@@ -5,6 +5,11 @@ Both collectors work by rewriting the launch argv — the same seam the mirage
 emulator uses — so an opaque `aorta sweep run ... -- <command>` gets profiled
 and the payload never learns it is being measured.
 
+This page is the reference: every option, the artifact layout, and the
+troubleshooting table. It does not tell you *which* Proton backend to pick —
+for that, and for what each one costs you, see
+[Choosing a Proton backend](proton-backends.md).
+
 How wide "a command" is differs by collector, and it is the first thing to
 check: `rocprof` wraps **anything**, while Proton's default `mode: cli` takes
 over a Python *script*, so it attaches only to `python ... <script>.py`, a
@@ -207,6 +212,10 @@ Precedence and scope:
 | `summary_units` | `sec`, `msec`, `usec`, `nsec` | (unset → rocprofv3's own default) | Unit for the human-readable summary file only. Does not change the parsed metrics, which are always ms. |
 
 ### `proton` options
+
+The `backend` row below is the schema. For which backend answers which question
+— and for the version matrix, the two opposite initialisation contracts, and the
+measured sharp edges — see [Choosing a Proton backend](proton-backends.md).
 
 | Option | Values | Default | Notes |
 |---|---|---|---|

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -20,6 +20,12 @@ Full reference — options, artifact layout, analysis recipes, troubleshooting:
 [Profiling Collectors](profiling-collectors.md). Runnable examples:
 [`examples/profiling/`](../examples/profiling/README.md).
 
+Proton has five backends and they do not measure the same thing — whole-kernel
+timing, intra-kernel cycle counts and PC sampling are three different
+questions, and one of them publishes no numeric metrics at all. If you are
+deciding which to use, start at
+[Choosing a Proton backend](proton-backends.md).
+
 The rest of this guide covers two other things: the benchmark harness's own
 built-in telemetry (below), which is independent of the collectors, and the
 older hand-rolled `rocprofv3` capture scripts, which are kept working but are

--- a/docs/proton-backends.md
+++ b/docs/proton-backends.md
@@ -1,0 +1,182 @@
+# Choosing a Proton backend
+
+Proton is one profiler with five backends, and they do not measure the same
+thing. Picking the wrong one gives you a healthy-looking capture that cannot
+answer your question — or, on some version combinations, a capture that is
+silently empty.
+
+This is the decision guide. For the option schema, artifact layout and
+troubleshooting, see [Profiling Collectors](profiling-collectors.md); this page
+does not restate them.
+
+## Start from the question, not the backend
+
+| Your question | Backend | Why |
+| --- | --- | --- |
+| Which kernel owns the GPU time? | `auto` | Whole-kernel spans, attributed to the launching frame. The default, and the only spelling correct on every Triton. |
+| Same, but the run record must name the backend | `roctracer` | Pins the whole-kernel AMD path explicitly. Costs you `mode: env` — see [Attach mode](#attach-mode-is-part-of-the-choice). |
+| *Where inside* one kernel do the cycles go? | `instrumentation` | Deterministic cycle counts against scopes you name in the kernel. |
+| Where do samples land across a kernel, without naming scopes? | `rocprofiler` + `backend_mode: pcsampling` | Statistical instruction-level attribution. Needs a post-3.8 build — see [What is available where](#what-is-available-where). |
+| I need Proton *and* `rocprofv3` in one process | `instrumentation` | The only backend that installs no HSA queue interceptor, so it is the only one the conflict guard accepts alongside `rocprof`. |
+| I am on NVIDIA | `cupti` | Accepted so a recipe stays portable. Untested here; aorta's examples are AMD. |
+
+If you are not sure, use `auto`. It is the default for a reason: it omits
+Proton's `-b` and lets Proton pick the backend matching the runtime, which is
+the only choice that is correct across versions.
+
+## What each backend actually gives you
+
+Numbers below are from the runnable examples in
+[`examples/profiling/proton/`](../examples/profiling/proton/), measured on
+gfx950 / ROCm 7.0.2 / Triton 3.7.1.
+
+**Whole-kernel timing** (`auto`, `roctracer`, `rocprofiler`). One duration per
+kernel, summed across launches.
+[`amd-roctracer`](../examples/profiling/proton/amd-roctracer/) captures three
+Triton kernels over 20 iterations and reports `proton_kernel_count` 60,
+`proton_gpu_time_ms` 0.398, and `bias_gelu_kernel` as the top kernel. This is
+the shape that populates `perf.md` and `matrix.json`, so it is the one to reach
+for when you want numbers you can compare across cells of a sweep.
+
+**Intra-kernel cycles** (`instrumentation`). One cycle count per scope you
+declared inside the kernel.
+[`amd-instrumentation`](../examples/profiling/proton/amd-instrumentation/) puts
+two scopes in one deliberately unbalanced kernel and reports `expensive` at
+8,608,876 cycles against `cheap` at 153,368 — a 56x split that whole-kernel
+timing cannot see at all, because both live in the same kernel.
+
+**Statistical instruction attribution** (`rocprofiler` + `pcsampling`). Samples
+the program counter, so you get a distribution over instructions rather than
+scopes you chose in advance.
+[`amd-rocprofiler`](../examples/profiling/proton/amd-rocprofiler/) is that
+example; its capture is not verified, because no obtainable build runs it yet.
+
+## The cost nobody expects: `instrumentation` publishes no numeric metrics
+
+A healthy `instrumentation` capture yields **only** `proton_artifact_dir` in the
+trial metrics. Its leaves carry `cycles` and `normalized_cycles`, never
+`time (<unit>)` or `count`, and the collector's summary keys exclusively on
+wall-clock time. So the capture is real and useful, and `perf.md` will show
+nothing from it.
+
+Read it directly instead:
+
+```bash
+proton-viewer -m normalized_cycles <trial>/proton/proton.hatchet
+```
+
+If you need numbers that land in the sweep reports, you need a whole-kernel
+backend. If you need to know which region of a kernel is slow, you need this
+one and you read the artifact yourself. That trade is the reason both examples
+exist.
+
+## What is available where
+
+`rocprofiler` is not universally available, and `auto` does not mean the same
+thing across versions. Verified against real installs:
+
+| | Triton 3.7.1 and earlier | Triton 3.8.0 |
+| --- | --- | --- |
+| `-b` choices | `cupti`, `roctracer`, `instrumentation` | adds `rocprofiler` |
+| `auto` on AMD resolves to | `roctracer` | **`rocprofiler`** |
+| CLI forwards `--mode` | no — parsed, then dropped | yes |
+| `rocprofiler` + `pcsampling` | backend absent | `ValueError: unsupported mode` |
+
+Two consequences worth internalising:
+
+**`auto` silently changes which backend measured when Triton crosses 3.8.0.**
+Nothing in the `.hatchet` records the resolved backend — it carries the device
+type (`{"HIP": {...}}`) and no backend name. What disambiguates a run is the
+Triton version in its environment snapshot. If you are comparing
+`proton_gpu_time_ms` across runs from different images, check that first.
+
+**`pcsampling` still needs a post-3.8 `main` build.** AMD PC sampling landed
+upstream after the 3.8.0 tag, so 3.8.0 registers the backend and then rejects
+the mode.
+
+## Attach mode is part of the choice
+
+Pinning a backend can commit you to an attach mode, and the two AMD tracing
+backends want **opposite** initialisation orders. This is the part that bites.
+
+| Backend | Configured when | Needs at that moment | Attach mode |
+| --- | --- | --- | --- |
+| `roctracer` | session start | HIP runtime **already up** | `mode: env`, payload starts Proton *after* importing torch |
+| `rocprofiler` | `libproton.so` load | HSA **not yet up** | either; `mode: cli`, or `mode: env` with Proton imported *before* torch |
+| `instrumentation` | session start | no requirement | either |
+
+So `mode: env` with an explicit `roctracer` is required — the collector refuses
+a `mode: cli` pin of it, because on Triton 3.7.1 that captures a 160-byte tree
+holding a bare `ROOT` from a run that exits 0. That refusal is a 3.7.x-and-
+earlier workaround: the same pin captured 17 kernels on 3.8.0.
+
+And `rocprofiler` is the reverse. Triton 3.8.0 calls
+`rocprofiler_force_configure` from a constructor in `libproton.so`, and its own
+source warns that a torch import chain first makes the SDK skip dispatch-buffer
+tracing on existing queues. So a payload driving it must import Proton before
+torch, which is why
+[`amd-rocprofiler/gelu.py`](../examples/profiling/proton/amd-rocprofiler/gelu.py)
+has its imports in the opposite order to its sibling — deliberately, and
+commented as such.
+
+The practical rule: **let the example you copied choose the attach mode.** Each
+of the three carries the order its backend needs.
+
+## Combining with `rocprof`
+
+`rocprof` and `proton` both install HSA queue interceptors, so the pairing is
+rejected at recipe load for `auto`, `roctracer` and `rocprofiler`. Only
+`instrumentation` coexists, because it interposes on nothing.
+
+If you need whole-kernel data from `rocprofv3` *and* intra-kernel data from
+Proton, either use `backend: instrumentation`, or run them as two cells and
+compare.
+
+## Known sharp edges
+
+Each of these is a real, measured defect rather than a caveat, and each has an
+actionable error or a workaround.
+
+- **`backend_mode: periodic_flushing` on `roctracer` segfaults** on Triton
+  3.7.1 / ROCm 7.0.2 — exit 139, no traceback — once kernels dispatch.
+  Reproduced on two payloads. Leave it unset there.
+- **`granularity` is unusable on 3.7.1** in either attach mode: the CLI drops
+  `--mode`, and under `mode: env` the rendered `default:granularity=warp` is
+  rejected at kernel exit with `RuntimeError: Only warp granularity is
+  supported for now` — for warp, which is that backend's own default. Set
+  `instrumentation_mode` alone.
+- **`Could not load` lib...``** means a packaging problem, not an unsupported
+  backend or mode. A wheel-provided ROCm ships only versioned sonames while
+  Proton opens the unversioned name. Which library it names follows the
+  backend: `libroctracer64.so` below 3.8.0, `librocprofiler-sdk.so` from 3.8.0
+  on, since that is where `auto` starts resolving to `rocprofiler`.
+- **`mode: env` captures wedge on the Triton 3.8.0 CI runner.** Tracked in
+  [#434](https://github.com/ROCm/aorta/issues/434); the GPU suite skips those
+  captures from 3.8.0 on rather than letting them consume the job.
+
+## Worked decisions
+
+**"My sweep shows one cell 30% slower and I want to know which kernel."**
+Leave `backend: auto`. Compare `proton_top_kernels` and `proton_top_kernel_ms`
+across cells in `matrix.json`. No backend choice needed.
+
+**"I know it is `fused_attention` and I want to know which part of it."**
+`backend: instrumentation` with scopes around the regions you suspect, copying
+[`amd-instrumentation`](../examples/profiling/proton/amd-instrumentation/).
+Accept that you will read the `.hatchet` yourself.
+
+**"I need to prove which backend produced last week's numbers."**
+Pin it explicitly rather than relying on `auto`, and take the attach mode the
+table above requires. Record the Triton version — the artifact does not.
+
+**"Both a rocprofv3 trace and Proton attribution, one run."**
+`backend: instrumentation`. Anything else is refused at recipe load.
+
+## See also
+
+- [Profiling Collectors](profiling-collectors.md) — option schema, attach-mode
+  mechanics, artifact layout, analysis recipes, troubleshooting
+- [`examples/profiling/proton/`](../examples/profiling/proton/) — one runnable
+  example per backend, each with the attach mode and import order it needs
+- [Profiling Guide](profiling.md) — capturing and interpreting profiling data
+  more generally

--- a/examples/profiling/README.md
+++ b/examples/profiling/README.md
@@ -54,6 +54,10 @@ empty capture.
 together, so the pairing is rejected at recipe load. Only Proton's
 `instrumentation` backend coexists with `rocprof`.
 
+The three `amd-*` examples exist because Proton's backends measure different
+things; [Choosing a Proton backend](../../docs/proton-backends.md) is the guide
+to which one answers which question, if you are here to pick rather than to run.
+
 The two Triton examples leave `backend: "auto"`, which omits Proton's `-b`
 and lets Proton pick the backend matching the active runtime. That is what
 makes them run out of the box across Triton versions: `rocprofiler` is the

--- a/examples/profiling/proton/amd-instrumentation/README.md
+++ b/examples/profiling/proton/amd-instrumentation/README.md
@@ -193,6 +193,11 @@ a CLI pin is the ordering it wants.)
 
 ## Notes
 
+- **Is this the backend you want?** It gives deterministic cycles against
+  scopes you name, and publishes no numeric metrics. If you want per-kernel
+  timings that reach `perf.md` instead, see
+  [Choosing a Proton backend](../../../../docs/proton-backends.md).
+
 - **`granularity` is deliberately not set in the recipe.** The option pair
   `instrumentation_mode: default` + `granularity: warp` renders Proton's single
   `--mode` as the string `default:granularity=warp`, and Triton 3.7.1 rejects

--- a/examples/profiling/proton/amd-rocprofiler/README.md
+++ b/examples/profiling/proton/amd-rocprofiler/README.md
@@ -239,6 +239,11 @@ payload does publish all three.
 
 ## Notes
 
+- **Is this the backend you want?** It gives statistical instruction-level
+  attribution and needs a post-3.8 build. For the alternatives that run on a
+  released Triton, see
+  [Choosing a Proton backend](../../../../docs/proton-backends.md).
+
 - **`backend_mode`, not `instrumentation_mode`.** Both render Proton's single
   `--mode`, so the schema makes them mutually exclusive, and `backend_mode`
   requires an explicit (non-`auto`) backend. The backend's documented domain is

--- a/examples/profiling/proton/amd-roctracer/README.md
+++ b/examples/profiling/proton/amd-roctracer/README.md
@@ -174,6 +174,11 @@ taken from upstream's source.
 
 ## Notes
 
+- **Is this the backend you want?** It gives whole-kernel spans. If you need
+  attribution *inside* a kernel, or you are weighing the three AMD backends
+  against each other, see
+  [Choosing a Proton backend](../../../../docs/proton-backends.md).
+
 - **Why `roctracer` and not `rocprofiler`.** `roctracer` is deprecated
   upstream in favour of the rocprofiler-sdk backend, and as of Triton 3.8.0 it
   is no longer the only whole-kernel AMD backend you can name on a release. It


### PR DESCRIPTION
Follow-up to #416, which shipped the backend support, the option schema and one runnable example per backend — but not an answer to the question people actually arrive with: **five backends exist, which one answers mine?**

The reference documents every option and each example demonstrates one backend, but nothing compares them. That gap is not hypothetical: it is what sent #416 itself down several wrong turns, including one where I extrapolated a measurement from one backend onto its sibling whose contract turned out to be the opposite.

## What this adds

`docs/proton-backends.md` — a decision guide, not a second reference. It opens with a question-to-backend table, covers what each backend returns and what each costs, gives the version matrix, and closes with four worked decisions. It links to [Profiling Collectors](https://github.com/ROCm/aorta/blob/main/docs/profiling-collectors.md) for the option schema rather than restating it, so the two cannot drift.

The four things stated with evidence, because they are the ones easy to get wrong:

| | |
|---|---|
| **`instrumentation` publishes no numeric metrics** | A healthy capture yields only `proton_artifact_dir`; its leaves carry `cycles` / `normalized_cycles` and the summary keys on `time (<unit>)`. Otherwise you learn this from an empty `perf.md`. |
| **`auto` is not the same backend across versions** | `roctracer` below Triton 3.8.0, `rocprofiler` from 3.8.0 — and nothing in the `.hatchet` records which ran, so the env snapshot's Triton version is what disambiguates a cross-image comparison. |
| **The two AMD tracing backends want opposite initialisation orders** | So pinning one can commit you to an attach mode. Tabulated, with the practical rule: let the example you copied choose it. |
| **The measured sharp edges** | The `periodic_flushing` segfault on 3.7.1, `granularity` unusable there, `Could not load lib...` being packaging rather than an unsupported backend, and the 3.8.0 env-mode wedge (#434). |

Numbers are the verified ones from the three examples — 60 kernels / 0.398 ms for the roctracer pipeline, and 8,608,876 against 153,368 cycles for the two instrumentation scopes, since a 56x split inside one kernel makes the whole-kernel-versus-intra-kernel distinction concrete.

## Cross-referencing

Rather than only adding an index row, it is linked from the six places a reader choosing a backend actually lands:

- the README documentation table
- `docs/profiling.md`, in the "start here" block that already routes people to the collectors
- `docs/profiling-collectors.md` **twice** — at the top, saying plainly that the page is the reference and does not tell you which backend to pick, and directly above the `proton` options table where the `backend` row lives
- `examples/profiling/README.md`, ahead of the `backend: auto` discussion
- each of the three `amd-*` example READMEs, as an "is this the backend you want?" note — from the one place someone reading a single example would otherwise never see the alternatives

## Verification

Docs only; no code change, so `ruff` reports no changed Python files.

- Every relative link in all nine touched files resolves (checked programmatically, not by eye).
- The guide's policy claims were re-checked against this branch's code rather than written from memory: the `rocprof` conflict set excludes only `instrumentation`, `mode: cli` refuses `roctracer` alone, and the `BACKEND_MODES` domains match the table.
- 96 example tests pass; `pre-commit` clean.

## One caveat carried over

The `rocprofiler` initialisation contract is read from upstream's source comments, not measured — it cannot be measured in any environment available (3.7.1 predates the backend; the ROCm 10 image has it but cannot `dlopen librocprofiler-sdk.so`). The guide marks that asymmetry explicitly, since the `roctracer` claim beside it *is* measured.

