### PR TITLE
fix(sanitizers): stop daily-consan-gemm discarding its own coverage, and reject vacuous sanitizer outcomes

### DIFF
--- a/.github/workflows/sanitizers-nightly.yml
+++ b/.github/workflows/sanitizers-nightly.yml
@@ -552,7 +552,12 @@ jobs:
               "${KROOT}/consan_load.hip" -o "${FIXTURES}/bin/consan_tiny_load"
             hipcc --offload-arch=gfx950 -DOBJECT="\"$(pwd)/${FIXTURES}/isa/consan_gemm_f32.hsaco\"" \
               "${KROOT}/consan_load.hip" -o "${FIXTURES}/bin/consan_gemm_load"
-            for c in consan-gemm consan-lds-dispatch consan-tiny; do
+            # Named once, because the vacuity check at the end of this payload
+            # has to know which cases were invoked in order to tell "produced
+            # nothing" from "was never asked to". Two lists, one per sanitizer,
+            # so each stays next to the invocations it describes.
+            CONSAN_CASES="consan-gemm consan-lds-dispatch consan-tiny"
+            for c in ${CONSAN_CASES}; do
               mkdir -p "${SANITIZER_OUT}/informational/${c}"
             done
             aorta sweep run --recipe recipes/sanitizers/daily-consan-gemm.yaml \
@@ -568,7 +573,8 @@ jobs:
             # waitcheck-gemm under one "gemm" kernel heading. Each survey waitcheck
             # scan is a dedicated best-effort run publishing its OWN report -- the
             # gated Tab-1 waitcheck report is never reused here. Non-gating.
-            for c in waitcheck-gemm waitcheck-lds-dispatch waitcheck-tiny; do
+            WAITCHECK_CASES="waitcheck-gemm waitcheck-lds-dispatch waitcheck-tiny"
+            for c in ${WAITCHECK_CASES}; do
               mkdir -p "${SANITIZER_OUT}/informational/${c}"
             done
             # daily-waitcheck-gemm-object scans the same consan_gemm_f32.hsaco object
@@ -580,6 +586,63 @@ jobs:
               --output-dir "${SANITIZER_OUT}/informational/waitcheck-lds-dispatch" || true
             aorta sweep run --recipe recipes/sanitizers/daily-waitcheck-tiny.yaml \
               --output-dir "${SANITIZER_OUT}/informational/waitcheck-tiny" || true
+
+            # Every survey recipe above runs under `|| true`, because a non-gating
+            # row must not fail the job merely for reporting something. That is
+            # what let ROCm/aorta#450 sit unnoticed: rows ended `error` with zero
+            # findings on every run, and the baseline comparison in the gate job
+            # only covers the three GATED cases, so nothing ever looked at these
+            # reports at all.
+            #
+            # So look at them. --vacuous-only asserts the one thing that is always
+            # wrong regardless of what a row is expected to observe: a run that
+            # terminated without producing any signal. Cases where that is the
+            # intended outcome declare it in verdict_baselines.json (consan_tiny
+            # does). This CAN turn the survey job red, which is the point -- the
+            # artifact upload below is `if: always()`, so Tab 2 still publishes.
+            #
+            # --require closes the same hole one level up. `|| true` also swallows
+            # a recipe that dies BEFORE writing a report -- a bad input, a missing
+            # fixture, a startup failure -- and a report that does not exist cannot
+            # be judged vacuous. Naming the six invoked cases makes their absence
+            # an error, so an entirely empty survey fails here instead of passing
+            # silently. A job-level kill (cancellation, the runner cap in #370, the
+            # timeout-minutes ceiling) does not need excusing: it takes this whole
+            # payload down, so the line below never runs at all.
+            #
+            # --known-vacuous names the two rows that are ALREADY vacuous on the
+            # ROCm 10 objects this lane scans, so the check can be armed today
+            # without being red for reasons nobody can act on here. Measured on
+            # the real survey trees of runs 33755195031, 33872660689, 33965800908
+            # and 34032862308, both on the same 169,996,560-byte Tensile object:
+            #
+            #   consan-gemm     consan_strict_load_rejection, 0 findings. ConSan
+            #                   needs 1,721,958,400 B of patched image against a
+            #                   419,430,400 B ceiling (4.11x) and never instruments
+            #                   it. consan_policy does not change that -- see
+            #                   daily-consan-gemm.yaml and
+            #                   docs/sanitizers/consan-gemm-patched-image-growth-cap.md.
+            #   waitcheck-gemm  worklist_not_fully_checked, 0 findings. The
+            #                   rj_waitcheck CFG dataflow non-convergence of #453.
+            #
+            # This is NOT a blessing and is deliberately not spelled as an
+            # expected_error: it says these outcomes are wrong and being worked,
+            # not that they are acceptable. It is self-retiring -- the comparator
+            # FAILS if a listed case starts producing signal, so a fixed row cannot
+            # leave a stale suppression behind, and it fails if a listed case has no
+            # report at all. The other four rows are checked for real from tonight,
+            # which is the #450 regression path this whole change exists to close.
+            echo "[$(date +%T)] survey: rejecting vacuous outcomes …"
+            REQUIRE=""
+            for c in ${CONSAN_CASES} ${WAITCHECK_CASES}; do
+              REQUIRE="${REQUIRE} --require informational/${c}"
+            done
+            # shellcheck disable=SC2086  # REQUIRE is a deliberate argument list
+            python scripts/sanitizers/compare_verdict_baselines.py \
+              --vacuous-only ${REQUIRE} \
+              --known-vacuous informational/consan-gemm \
+              --known-vacuous informational/waitcheck-gemm \
+              "${SANITIZER_OUT}"
           '
 
       - name: Reclaim results ownership

--- a/recipes/sanitizers/daily-consan-gemm.yaml
+++ b/recipes/sanitizers/daily-consan-gemm.yaml
@@ -5,11 +5,24 @@ description: >
   Informational (non-gating) gfx950 ConSan run over a real, heavy f32 Type_SS
   hipBLASLt Tensile code object (generic public content extracted in CI from the
   synthetic gemm_shapes_unique.csv), driven via the source.consan_command path
-  added in #347. This exercises the guardrail's behavior on large production code
-  objects: whatever ConSan concludes, strict policy must reach a real verdict or
-  fail closed, never a false pass. The observed outcome is whatever the run
-  reports -- known rocjitsu limitations hit by this object are tracked in
-  docs/sanitizers/consan-4112-overlapping-anchor-patches.md. Rendered on the
+  added in #347. consan_gemm_load only LOADS that object -- it never dispatches --
+  so under consan_policy: lenient what this case asserts is static instrumentation
+  coverage on a real production object: that ConSan reads it, patches it, and
+  reports how many of its discovered access sites it actually covered. It asserts
+  nothing about dynamic race evidence; daily-consan-lds-dispatch.yaml is the
+  end-to-end control for that.
+
+  A pass here therefore means "instrumented, and the coverage cross-check agrees",
+  never merely "ran without complaining" -- under lenient ConSan itself no longer
+  fails closed, so the coverage cross-check is what stands between an
+  uninstrumented object and a false pass.
+
+  STATUS ON THE CURRENT CI IMAGE: this case does NOT reach that assertion today.
+  On the digest-pinned ROCm 10 base the object is 169,996,560 bytes and ConSan
+  rejects it on the patched-image growth ceiling before instrumenting anything, so
+  the row is error with zero findings every night. That is a capacity limit, not
+  something consan_policy can change -- see the policy comment below and
+  docs/sanitizers/consan-gemm-patched-image-growth-cap.md. Rendered on the
   dashboard's Workload survey tab (Tab 2) as an observed-only case; it does NOT
   gate the nightly.
 sanitizer_plan:
@@ -30,7 +43,72 @@ sanitizer_plan:
   sanitizers:
     - consan
   policy:
-    consan_policy: strict
+    # lenient, not strict, because consan_gemm_load is a LOAD-ONLY driver: it calls
+    # hipModuleLoad/hipModuleUnload and never dispatches (consan_load.hip states the
+    # contract -- production StreamK GEMM kernels need hipBLASLt to launch). strict
+    # sets RJ_CONSAN_MOI_REQUIRE_RECORDS, which demands visible dynamic records, so a
+    # driver that never dispatches produces no dispatch packet and no records and
+    # strict fails closed with combined_hook_exit_86 no matter how healthy the run
+    # was. That is what #450 observed: error/error, zero findings, every single time.
+    #
+    # This is the same rule harvest_code_objects.py already applies to its own
+    # load-mode recipes, for the same reason. Under lenient this case verifies what a
+    # load-only run can actually verify -- static instrumentation coverage, i.e. that
+    # ConSan reads, patches and analyzes a real production Tensile object.
+    #
+    # WHAT THAT IS MEASURED ON, AND WHAT IT IS NOT. Two different objects are in
+    # play and the policy argument only closes on one of them:
+    #
+    #   * ROCm 7.0.2.2, 16,265,200-byte object, gfx950 Slurm node. lenient is a
+    #     real fix: the object transforms clean (outcome=modified-valid, 75978
+    #     patches over 68894 discovered access sites), consan=pass at
+    #     access=68894/68894, plus 32 genuine waitcheck "missing s_waitcnt"
+    #     findings. Under strict the identical run was thrown away on
+    #     require-records at exit 86. So the coverage signal was there all along
+    #     and only the policy discarded it.
+    #   * ROCm 10.0.0, 169,996,560-byte object -- the one CI actually scans.
+    #     lenient does NOT fix this case, and it was wrong of an earlier revision
+    #     of this comment to imply the 7.0.2 result generalised. Measured inside
+    #     the digest-pinned CI base image
+    #     (rocm/pytorch:rocm10.0_ubuntu26.04_py3.14_pytorch_release_2.13.0@sha256:3174cb70…)
+    #     on gfx950, against the byte-identical object the nightly extracts
+    #     (sha256 57c5d8ef…, matching run 34032862308):
+    #
+    #       strict   error/error, 0 findings, consan_strict_load_rejection (exit 92)
+    #       lenient  error/error, 0 findings, consan_coverage_incomplete,
+    #                access=0/719550, barriers 0/109497
+    #
+    #     Both fail for the SAME underlying reason, which is not the record
+    #     requirement: ConSan needs 1,721,958,400 bytes of patched image against a
+    #     419,430,400-byte ceiling (4.11x over), so the first-light probe rejects
+    #     the transform and patches=0. The 6000s ceiling below is not what bites --
+    #     the run ends in 859s.
+    #
+    #     What the policy DOES change there is who fails it. Under strict the hook
+    #     terminates itself (fail_closed=true, action=terminate, exit 92). Under
+    #     lenient it declines to (fail_closed=false), exits 0, and hands back an
+    #     object with none of its 719,550 access sites patched; only aorta's
+    #     coverage cross-check turns that into an error. Confirmed in isolation by
+    #     forcing the ceiling below what the small LDS fixture needs, where
+    #     RJ_CONSAN_POLICY=strict exits 92 with a load-rejection line and
+    #     RJ_CONSAN_POLICY=default exits 0 with the same growth rejection and no
+    #     load-rejection line at all. So lenient is necessary for a load-only
+    #     driver but not sufficient for this object, and on this object it also
+    #     makes the coverage cross-check load-bearing rather than a second opinion.
+    #
+    # lenient is kept because it is the right target state and a precondition for
+    # this case ever passing: the moment the growth ceiling admits the object,
+    # strict would fail it again on require-records -- the #450 defect -- whereas
+    # lenient would report the coverage it measured. Fixing the capacity limit is
+    # tracked below and in docs/sanitizers/consan-gemm-patched-image-growth-cap.md;
+    # note that document measures a 13.6 MiB per-chip sibling object that DOES
+    # clear the ceiling on ROCm >= 7.14, which the move to ROCm 10 has now made
+    # reachable, at the cost of representing an MI355X-class device.
+    #
+    # Dynamic race evidence over a dispatching GEMM is genuinely out of scope here and
+    # is tracked separately; daily-consan-lds-dispatch.yaml is the end-to-end control
+    # that proves the record/replay path works on a caller-supplied object.
+    consan_policy: lenient
     on_missing_backend: fail
     # Raised from the 300s cap of #364, which was chosen only because ROCm/rocm-systems#9964
     # made MOI inventory non-terminating: every ceiling produced the same
@@ -122,20 +200,31 @@ sanitizer_plan:
     # ROCm/rocm-systems#10686. If that lands, this ceiling can drop to roughly a
     # quarter of its current value.
     #
-    # !! STALE AS A BUDGET, 2026-08-27 !! Everything above was measured against a
-    # 16,265,200-byte (15.5 MB) object on ROCm 7.0.2.2. The object CI extracts on
-    # the 7.2.4 base is 191,935,808 bytes (~183 MiB) with 637,823 access ranges --
-    # 11.8x the bytes and 9.3x the sites -- so these figures no longer describe this
-    # case. See prepare_gemm_isa.py's docstring: the size is a per-release property
-    # of the shipped Tensile libraries, not something this repo pins.
+    # !! STALE AS A BUDGET, re-confirmed against ROCm 10 on 2026-09-07 !! Everything
+    # above was measured against a 16,265,200-byte (15.5 MB) object on ROCm 7.0.2.2.
+    # The object CI extracts on the current ROCm 10 base is 169,996,560 bytes
+    # (~162 MiB) with 719,550 access sites and 109,497 barrier sites -- 10.5x the
+    # bytes and 10.4x the sites -- so these figures do not describe this case. See
+    # prepare_gemm_isa.py's docstring: the size is a per-release property of the
+    # shipped Tensile libraries, not something this repo pins. (The 7.2.4 base this
+    # block used to cite was 191,935,808 bytes with 637,823 access ranges; ROCm 10
+    # is smaller on both axes but still far over the ceiling.)
     #
     # The ceiling is currently NOT what limits this case. ConSan rejects the object
-    # before instrumenting it, on the patched-image growth policy (needs ~1.39 GiB
-    # against a 400 MiB default), so the run ends at ~730s with exit 92
-    # status=4112. Raising RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT past ~778
-    # would let the transform proceed -- and 6000s would then very likely be too
-    # small, because 9.3x the sites is work no measurement here covers. Re-measure
-    # before assuming this number means anything.
+    # before instrumenting it, on the patched-image growth policy: it needs
+    # 1,721,958,400 bytes against the 419,430,400-byte default, i.e. 4.11x over, a
+    # 10.1x expansion of the input. patches=0, so nothing is instrumented. Measured
+    # in the digest-pinned CI image, where the run ends in 595s under strict (exit
+    # 92) and 859s under lenient (exit 0, caught by the coverage cross-check) --
+    # both comfortably inside this 6000s ceiling, which is why raising it fixes
+    # nothing.
+    #
+    # Raising RJ_CONSAN_MAX_PATCHED_IMAGE_GROWTH_PERCENT past ~1013 would let the
+    # transform proceed -- and 6000s would then very likely be too small, because
+    # 10.4x the sites is work no measurement here covers, and the survey job itself
+    # caps at timeout-minutes: 120. So raising the ceiling alone most likely trades
+    # this rejection for combined_hook_timeout. Re-measure before assuming either
+    # number means anything.
     # See docs/sanitizers/consan-gemm-patched-image-growth-cap.md.
     timeout_seconds: 6000
   output:

--- a/recipes/sanitizers/daily-consan-tiny.yaml
+++ b/recipes/sanitizers/daily-consan-tiny.yaml
@@ -17,6 +17,24 @@ description: >
   buffer(s)" instead of "0" in the require-records message. Making this row pass would
   require a kernel with admissible sites, which is what daily-consan-lds-dispatch.yaml
   already covers.
+
+  ROCm/aorta#450 proposed flipping this case to consan_policy: lenient alongside
+  daily-consan-gemm, on the grounds that both drive a load-only driver. Measured
+  before acting -- first on gfx950 / ROCm 7.0.2.2, then re-measured inside the
+  digest-pinned ROCm 10 CI image itself -- and it does not hold for THIS case on
+  either: lenient leaves it error/error with zero findings, only relabelling the
+  reason from combined_hook_exit_86 to "consan_coverage_incomplete: verdict
+  applicable=false; no applicable code objects", at access=0/0.
+  Removing RJ_CONSAN_MOI_REQUIRE_RECORDS cannot help,
+  because the run is rejected by the coverage cross-check rather than by the record
+  requirement -- an object with no admissible sites has nothing to be complete about.
+  So this case stays strict, where its reason at least names the guardrail it is
+  demonstrating. The expectation is now DECLARED in
+  fixtures/expected/verdict_baselines.json as an expected_error naming
+  combined_hook_exit_86, which is what stops the #450 vacuity sweep flagging it while
+  still failing if this case ever errors for any other reason -- including the
+  lenient reason above, which the declaration deliberately does not admit.
+  Previously the intent lived only in this comment, where no check could read it.
 sanitizer_plan:
   target: gfx950
   source:
@@ -35,6 +53,9 @@ sanitizer_plan:
   sanitizers:
     - consan
   policy:
+    # Deliberately strict, and deliberately NOT changed by #450 -- see the tail of
+    # the description. lenient produces the same error with a vaguer reason here,
+    # because tiny_vecadd has no MOI-admissible sites at all.
     consan_policy: strict
     on_missing_backend: fail
   output:

--- a/recipes/sanitizers/fixtures/expected/verdict_baselines.json
+++ b/recipes/sanitizers/fixtures/expected/verdict_baselines.json
@@ -25,5 +25,13 @@
     "finding_shape": {
       "consan": "auto replay diagnostic"
     }
+  },
+  "consan_tiny": {
+    "expected_error": {
+      "execution_status": "error",
+      "overall_verdict": "error",
+      "reasons": ["combined_hook_exit_86"],
+      "why": "Intended negative control, not a misconfiguration. tiny_vecadd's only memory operations are ordinary global loads/stores, which ConSan reports as supported-synchronization-only and does not admit as MOI sites, so it has no instrumentable sites at all (access=0/0, applicable=false). Giving it a dispatching driver was measured in #409 and does not change the verdict, only the record-buffer count in the message. Under consan_policy: strict the run therefore fails closed at exit 86 rather than emitting a false pass, and that fail-closed behaviour is what this case asserts. Declared here so the vacuity sweep added for #450 does not flag it, while still failing if this case ever errors for any OTHER reason. Every field is matched exactly, including the complete reason set. Confirmed on the environment that runs the nightly rather than only on a dev node: the real ROCm 10 survey trees of runs 33755195031, 33872660689, 33965800908 and 34032862308 all report exactly error/error with combined_hook_exit_86 on both checks and zero findings, and a direct re-run of this recipe inside the digest-pinned ROCm 10 CI image on gfx950 reproduced the same. Under lenient the same case reports consan_coverage_incomplete at access=0/0 instead, which this declaration deliberately does NOT admit."
+    }
   }
 }

--- a/scripts/sanitizers/compare_verdict_baselines.py
+++ b/scripts/sanitizers/compare_verdict_baselines.py
@@ -7,15 +7,87 @@ single top-level field. Each report is *strictly* reloaded through
 ``overall_verdict``/``execution_status`` actually agree with the checks), and
 then compared against the committed baseline's ``overall_verdict``,
 ``execution_status`` (when declared), per-check verdicts, and finding shape.
+
+On top of that per-case comparison the comparator sweeps *every* report under
+the results root for vacuous outcomes -- a run that terminated ``error`` or
+``not_checked`` and produced no findings at all. Such a run is a broken
+configuration, not a result: the sanitizer never got far enough to have an
+opinion, so any coverage claim derived from it is empty rather than positive.
+
+That sweep exists because of ROCm/aorta#450. ``daily-consan-tiny`` and
+``daily-consan-gemm`` paired a load-only driver with ``consan_policy: strict``,
+which sets ``RJ_CONSAN_MOI_REQUIRE_RECORDS`` and so demands dynamic records a
+non-dispatching driver can never produce. Both failed closed with
+``combined_hook_exit_86`` and zero findings on every run for weeks, and nothing
+noticed: the baseline comparison above only covers the three *gated* cases, and
+these two are informational, so an ``error`` verdict there was nobody's problem.
+The sweep is deliberately independent of whether a case is gated.
+
+A case that is *legitimately* expected to end without findings declares it in
+the baselines file as an ``expected_error`` entry, e.g. ``daily-consan-tiny``,
+whose exit 86 is an intended negative control. The declaration is an exact
+description of the one outcome that was signed off -- execution status, overall
+verdict and the complete set of check reasons -- and the run must match it on
+every field:
+
+.. code-block:: json
+
+    "consan_tiny": {
+      "expected_error": {
+        "execution_status": "error",
+        "overall_verdict": "error",
+        "reasons": ["combined_hook_exit_86"],
+        "why": "..."
+      }
+    }
+
+A declaration that is not well-formed is a **failure, not a bypass**. Every
+``expected_error`` in the baselines file is validated when the file is loaded,
+whether or not that case ran, because a mis-spelled or half-written declaration
+would otherwise silently widen an exemption that exists to cover exactly one
+case: the entry is meant to *narrow* what a row is allowed to do, so anything
+about it that cannot be checked has to be rejected rather than skipped.
+
+Absence is judged too, but only for cases the caller says it invoked. Pass
+``--require <case-dir>`` for each one; a required case with no report is an
+error. See ``_sweep_vacuous`` for why a job-level kill does not need tolerating
+here.
+
+A row that is vacuous today for a reason tracked *elsewhere* is spelled
+``--known-vacuous <case-dir>`` at the call site, and it is the opposite of an
+``expected_error``: the declaration says "this outcome is correct", whereas this
+says "this outcome is wrong, it is being worked, and it must not mask the other
+rows". Consequently it **fails when the case stops being vacuous**, so a fixed
+row cannot leave a stale suppression behind, and a case may not be both.
+Spelling it as an argument rather than a baselines entry is deliberate: it
+belongs to one lane's current state, shows up in a workflow diff, and carries no
+dashboard meaning.
+
+Usage::
+
+    compare_verdict_baselines.py <results-root>                  # gate + sweep
+    compare_verdict_baselines.py --vacuous-only <results-root>   # sweep only
+    compare_verdict_baselines.py --vacuous-only \
+        --require informational/consan-gemm \
+        --known-vacuous informational/consan-gemm <results-root>
+
+``--vacuous-only`` is for result trees that do not contain the gated cases at
+all -- notably the non-gating survey job, which runs in its own job with its own
+output root and is where the two #450 recipes actually live.
 """
 
 from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
-from aorta.instrumentation.rocjitsu_sanitizers.models import SanitizerReport
+from aorta.instrumentation.rocjitsu_sanitizers.models import (
+    ExecutionSummary,
+    SanitizerReport,
+    Verdict,
+)
 from aorta.instrumentation.rocjitsu_sanitizers.report import read_report
 
 _BASELINES = Path("recipes/sanitizers/fixtures/expected/verdict_baselines.json")
@@ -24,12 +96,107 @@ _CASES = {
     "consan_clean": Path("consan-clean") / "sanitizer_report.json",
     "consan_racy": Path("consan-racy") / "sanitizer_report.json",
 }
+_GATED_BY_PATH = {relative: name for name, relative in _CASES.items()}
+
+# Execution summaries that carry no signal. ERROR is the #450 shape (the run died
+# before concluding anything); NOT_CHECKED means the sanitizer never ran, which is
+# equally uninformative when nothing declared it acceptable. COMPLETE and PARTIAL
+# both mean the sanitizer reached a conclusion, so a finding-free run under either
+# is a real clean result -- daily-consan-lds-dispatch passes with zero findings and
+# must not trip this.
+_VACUOUS_STATUSES = frozenset({ExecutionSummary.ERROR.value, ExecutionSummary.NOT_CHECKED.value})
+
+# The verdicts those statuses can carry. Spelled out for the same reason as the
+# statuses: a declaration is only protection if it could actually match, so
+# `overall_verdict: "pass"` is a typo to reject, not a rule to file away.
+_VACUOUS_VERDICTS = frozenset({Verdict.ERROR.value, Verdict.NOT_CHECKED.value})
+
+# Every field an `expected_error` must carry, and no others. Spelled as an exact
+# set rather than a minimum so that a typo -- `reason` for `reasons`, say -- is a
+# loud failure instead of a field nobody compares. An exemption that is not
+# checkable is indistinguishable from no exemption at all.
+_EXPECTED_ERROR_FIELDS = frozenset({"execution_status", "overall_verdict", "reasons", "why"})
+
+
+def _expected_error_problems(name: str, declared: object) -> list[str]:
+    """Reject an ``expected_error`` that does not describe exactly one outcome.
+
+    Checked at load time for every declared case, run or not: a malformed
+    declaration is a defect in the committed baselines, and waiting for the case
+    to run before saying so would leave the exemption unverified on every run
+    where the recipe failed to produce a report at all.
+    """
+    where = f"{name}.expected_error"
+    if not isinstance(declared, dict):
+        return [f"{where} must be an object, got {type(declared).__name__}"]
+
+    problems = []
+    missing = sorted(_EXPECTED_ERROR_FIELDS - declared.keys())
+    unknown = sorted(declared.keys() - _EXPECTED_ERROR_FIELDS)
+    if missing:
+        problems.append(f"{where} is missing {', '.join(missing)}")
+    if unknown:
+        problems.append(f"{where} has unknown field(s) {', '.join(unknown)}")
+
+    status = declared.get("execution_status")
+    if "execution_status" in declared and status not in _VACUOUS_STATUSES:
+        # Only a vacuous status can ever reach this exemption, so declaring any
+        # other one is dead configuration that reads as protection.
+        problems.append(
+            f"{where}.execution_status={status!r} is not one of "
+            f"{sorted(_VACUOUS_STATUSES)}, so it could never match"
+        )
+    verdict = declared.get("overall_verdict")
+    if "overall_verdict" in declared and verdict not in _VACUOUS_VERDICTS:
+        problems.append(
+            f"{where}.overall_verdict={verdict!r} is not one of "
+            f"{sorted(_VACUOUS_VERDICTS)}, so it could never match"
+        )
+    why = declared.get("why")
+    if "why" in declared and (not isinstance(why, str) or not why.strip()):
+        problems.append(f"{where}.why must be a non-empty string explaining the sign-off")
+
+    reasons = declared.get("reasons")
+    if "reasons" in declared:
+        if (
+            not isinstance(reasons, list)
+            or not reasons
+            or not all(isinstance(reason, str) and reason.strip() for reason in reasons)
+        ):
+            problems.append(
+                f"{where}.reasons must be a non-empty list of non-empty strings, got {reasons!r}"
+            )
+        elif len(set(reasons)) != len(reasons):
+            problems.append(f"{where}.reasons contains duplicates: {reasons!r}")
+    return problems
 
 
 def _load_baselines(path: Path) -> dict[str, object]:
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict) or not data:
         raise ValueError(f"baselines file is empty or malformed: {path}")
+    problems = [
+        problem
+        for name, expected in data.items()
+        if isinstance(expected, dict) and "expected_error" in expected
+        for problem in _expected_error_problems(name, expected["expected_error"])
+    ]
+    # A gated key may not also carry an exemption, because the two mechanisms
+    # address different reports under the same name. `_case_key` maps the survey
+    # directory `informational/waitcheck-gemm` to `waitcheck_gemm`, which is also
+    # the gated key for `waitcheck/sanitizer_report.json` -- two different
+    # recipes. An `expected_error` added for either one would silently excuse the
+    # other, which is the cross-case bypass this exactness work exists to
+    # prevent. Declaring one of them means renaming so the two stop colliding.
+    problems.extend(
+        f"{name}.expected_error is not allowed on a gated case: {name} is also the "
+        f"baseline key for a survey case directory, so the exemption could not be "
+        f"attributed to one report or the other"
+        for name in sorted(data.keys() & _CASES.keys())
+        if isinstance(data[name], dict) and "expected_error" in data[name]
+    )
+    if problems:
+        raise ValueError("; ".join(problems))
     return data
 
 
@@ -70,16 +237,246 @@ def _compare_case(name: str, report: SanitizerReport, expected: dict[str, object
     return problems
 
 
+def _case_key(report_path: Path, root: Path) -> str:
+    """Baseline key for a report, whether or not it is one of the gated cases.
+
+    Gated cases are looked up by their exact relative path. Everything else is
+    keyed off its case directory, which the nightly names after the recipe:
+    ``informational/consan-tiny/`` -> ``consan_tiny``.
+    """
+    relative = report_path.relative_to(root)
+    gated = _GATED_BY_PATH.get(relative)
+    if gated is not None:
+        return gated
+    return relative.parent.name.replace("-", "_")
+
+
+def _case_key_for_dir(case_dir: str) -> str:
+    """Baseline key for a case *directory*, as ``--known-vacuous`` names one.
+
+    The same mapping as :func:`_case_key`, reached from the directory rather
+    than from a report path, so a caller-supplied case can be looked up before
+    any report exists.
+    """
+    return _case_key(Path(case_dir) / "sanitizer_report.json", Path("."))
+
+
+def _vacuous_shape(report: SanitizerReport, reasons: Sequence[str]) -> str:
+    """One-line description of what a report ended up as, without any advice."""
+    shape = (
+        f"execution_status={report.execution_status.value!r}, "
+        f"overall_verdict={report.overall_verdict.value!r}"
+    )
+    if reasons:
+        shape += f", reason {', '.join(repr(reason) for reason in reasons)}"
+    return shape + ", and zero findings"
+
+
+def _reasons(report: SanitizerReport) -> list[str]:
+    return sorted({check.reason for check in report.checks if check.reason})
+
+
+def _vacuous_problems(report: SanitizerReport, expected: object) -> list[str]:
+    """Reject a run that terminated without producing any signal.
+
+    Returns problems when the report ended in a vacuous execution status with
+    zero findings across every check, unless the baselines declare an
+    ``expected_error`` that the run matches *exactly* -- same execution status,
+    same overall verdict, and the same complete set of check reasons.
+
+    Exact rather than "contains", on all three fields, because the point of the
+    declaration is to name one signed-off outcome. A substring test admits
+    ``combined_hook_exit_860``; ignoring the reasons the run carries beyond the
+    declared one admits a second, undeclared failure riding along with it; and
+    ignoring the status admits a ``not_checked`` run that never started as though
+    it were the ``error`` that was reviewed.
+
+    ``expected_error`` is validated at load time, so anything reaching here is
+    well-formed.
+    """
+    status = report.execution_status.value
+    if status not in _VACUOUS_STATUSES:
+        return []
+    if any(check.findings for check in report.checks):
+        return []
+
+    reasons = _reasons(report)
+    shape = _vacuous_shape(report, reasons)
+
+    declared = expected.get("expected_error") if isinstance(expected, dict) else None
+    if declared is None:
+        return [
+            f"{shape} -- the run produced no sanitizer signal at all. Either the recipe "
+            f"is misconfigured (see ROCm/aorta#450) or, if this outcome is intended, "
+            f"declare it as an 'expected_error' entry in {_BASELINES}."
+        ]
+
+    mismatches = []
+    if status != declared["execution_status"]:
+        mismatches.append(
+            f"execution_status={status!r}, declared {declared['execution_status']!r}"
+        )
+    if report.overall_verdict.value != declared["overall_verdict"]:
+        mismatches.append(
+            f"overall_verdict={report.overall_verdict.value!r}, "
+            f"declared {declared['overall_verdict']!r}"
+        )
+    if reasons != sorted(declared["reasons"]):
+        mismatches.append(f"reasons={reasons!r}, declared {sorted(declared['reasons'])!r}")
+    if mismatches:
+        return [
+            f"{shape} -- this is not the outcome that was signed off as an "
+            f"expected_error ({'; '.join(mismatches)})."
+        ]
+    return []
+
+
+def _sweep_vacuous(
+    root: Path,
+    baselines: dict[str, object],
+    required: Sequence[str] = (),
+    known_vacuous: Sequence[str] = (),
+) -> bool:
+    """Check every report under ``root``, gated or not, for a vacuous outcome.
+
+    Judges every report present, plus the absence of any case named by
+    ``--require``. A caller that knows what it invoked has to say so, because the
+    sweep cannot infer it from a directory listing: an empty tree and a tree from
+    a run that was never asked to produce anything look identical here.
+
+    That distinction matters because the survey job runs all six of its recipes
+    under ``|| true``, so a recipe that dies before writing a report leaves no
+    trace at all -- the same fail-open shape this sweep exists to close, one level
+    up. Requiring the invoked cases closes it.
+
+    A *job-level* kill (the runner cap tracked in #370, a cancellation, a step
+    timeout) needs no tolerance here and never did: it takes the whole payload
+    down, so this comparator does not run and has no verdict to give. The only
+    way to reach this function is for all six invocations to have returned.
+
+    ``known_vacuous`` case directories are reported but do not fail the run, and
+    a case listed there that turns out to carry signal *does* fail: the whole
+    point is that the list has to shrink to nothing, so it cannot be left behind
+    once the underlying break is fixed.
+    """
+    failed = False
+    suppressed = {case.rstrip("/") for case in known_vacuous}
+    for case in required:
+        if not (root / case / "sanitizer_report.json").is_file():
+            print(
+                f"{case}: no report under {root / case} -- the recipe was invoked but "
+                f"produced nothing, so there is no outcome to judge. A startup, recipe "
+                f"or input failure looks exactly like this."
+            )
+            failed = True
+    reports = sorted(root.rglob("sanitizer_report.json"))
+    if not reports:
+        print(f"vacuity sweep: no reports found under {root}")
+        return failed
+    seen_suppressed = set()
+    for report_path in reports:
+        name = _case_key(report_path, root)
+        case_dir = report_path.parent.relative_to(root).as_posix()
+        try:
+            report = read_report(report_path)
+        except (OSError, ValueError, TypeError) as exc:
+            print(f"{name}: report failed strict validation: {exc}")
+            failed = True
+            continue
+        problems = _vacuous_problems(report, baselines.get(name))
+        if case_dir in suppressed:
+            seen_suppressed.add(case_dir)
+            if problems:
+                # Deliberately NOT the advice _vacuous_problems gives: a
+                # known-vacuous row must not be talked into an expected_error,
+                # which would assert the outcome is fine.
+                print(
+                    f"{name}: KNOWN VACUOUS, not failing -- "
+                    f"{_vacuous_shape(report, _reasons(report))}. This row is on the "
+                    f"caller's --known-vacuous list: the outcome is wrong and tracked "
+                    f"elsewhere, not accepted."
+                )
+            else:
+                print(
+                    f"{name}: listed as --known-vacuous but this run produced signal. "
+                    f"Remove {case_dir} from the caller's --known-vacuous list -- a "
+                    f"suppression that is no longer true hides the next regression."
+                )
+                failed = True
+            continue
+        for problem in problems:
+            print(f"{name}: {problem}")
+        failed = failed or bool(problems)
+    for case_dir in sorted(suppressed - seen_suppressed):
+        print(
+            f"{case_dir}: listed as --known-vacuous but no report was found for it. "
+            f"Either it was not invoked or the suppression is stale."
+        )
+        failed = True
+    if not failed:
+        note = f" ({len(seen_suppressed)} known-vacuous)" if seen_suppressed else ""
+        print(
+            f"vacuity sweep: ok ({len(reports)} report(s) carry signal or are "
+            f"declared){note}"
+        )
+    return failed
+
+
 def main(argv: list[str]) -> int:
-    if len(argv) != 2:
-        print("usage: compare_verdict_baselines.py <results-root>", file=sys.stderr)
+    args = argv[1:]
+    vacuous_only = False
+    required: list[str] = []
+    known_vacuous: list[str] = []
+    positional: list[str] = []
+    while args:
+        arg, args = args[0], args[1:]
+        if arg == "--vacuous-only":
+            vacuous_only = True
+        elif arg in ("--require", "--known-vacuous"):
+            if not args:
+                print(f"error: {arg} needs a case directory", file=sys.stderr)
+                return 2
+            (required if arg == "--require" else known_vacuous).append(args[0])
+            args = args[1:]
+        elif arg.startswith("--"):
+            print(f"error: unknown option {arg}", file=sys.stderr)
+            return 2
+        else:
+            positional.append(arg)
+    if len(positional) != 1:
+        print(
+            "usage: compare_verdict_baselines.py [--vacuous-only] "
+            "[--require <case-dir>]... [--known-vacuous <case-dir>]... <results-root>",
+            file=sys.stderr,
+        )
         return 2
-    root = Path(argv[1])
+    root = Path(positional[0])
     try:
         baselines = _load_baselines(_BASELINES)
     except (OSError, ValueError) as exc:
         print(f"error: could not read baselines {_BASELINES}: {exc}", file=sys.stderr)
         return 2
+
+    # The two mechanisms make opposite claims about the same row, so a case
+    # cannot be both. Caught here rather than shrugged off, because whichever
+    # one the reader believed would be the wrong one half the time.
+    contradictory = sorted(
+        case
+        for case in known_vacuous
+        if isinstance(entry := baselines.get(_case_key_for_dir(case)), dict)
+        and "expected_error" in entry
+    )
+    if contradictory:
+        print(
+            f"error: {', '.join(contradictory)} is both --known-vacuous and declared as "
+            f"an expected_error in {_BASELINES}. The first says the outcome is wrong and "
+            f"being worked; the second says it is correct. Pick one.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if vacuous_only:
+        return 1 if _sweep_vacuous(root, baselines, required, known_vacuous) else 0
 
     failed = False
     for name, relative in _CASES.items():
@@ -106,6 +503,9 @@ def main(argv: list[str]) -> int:
                 print(f"{name}: {problem}")
         else:
             print(f"{name}: ok ({report.overall_verdict.value})")
+
+    if _sweep_vacuous(root, baselines, required):
+        failed = True
     return 1 if failed else 0
 
 

--- a/scripts/sanitizers/compare_verdict_baselines.py
+++ b/scripts/sanitizers/compare_verdict_baselines.py
@@ -280,7 +280,49 @@ def _reasons(report: SanitizerReport) -> list[str]:
     return sorted({check.reason for check in report.checks if check.reason})
 
 
-def _vacuous_problems(report: SanitizerReport, expected: object) -> list[str]:
+def _vacuous_remedy(name: str, case_dir: str) -> str:
+    """What an operator can actually do about a vacuous row.
+
+    Usually the answer is an ``expected_error``, but that is *impossible* when
+    the row's baseline key is also a gated key: ``_load_baselines`` rejects the
+    declaration outright, so following the advice yields exit 2 -- and not only
+    for this row, since the baselines then fail to load for every case.
+
+    ``informational/waitcheck-gemm`` sits in exactly that position today,
+    because ``_case_key`` maps it onto the gated key ``waitcheck_gemm``. It is
+    masked only because the nightly lists it as ``--known-vacuous``, which is
+    why the advice has to be right now rather than later: the person who would
+    hit it is whoever removes that suppression, with no context for why the
+    obvious remedy does not work.
+    """
+    if name not in _CASES:
+        return (
+            f"Either the recipe is misconfigured (see ROCm/aorta#450) or, if this outcome "
+            f"is intended, declare it as an 'expected_error' entry in {_BASELINES}."
+        )
+    if Path(case_dir) / "sanitizer_report.json" in _GATED_BY_PATH:
+        # The gated report itself. `_compare_case` judges it against a baseline of
+        # its own, so nothing the sweep offers could make this row acceptable.
+        return (
+            f"This is a gated case with a baseline of its own, so a vacuous outcome here "
+            f"is a regression to fix in the recipe -- or a baseline to update, if the new "
+            f"outcome is the correct one. It cannot be excused with an 'expected_error': "
+            f"{_BASELINES} rejects one on a gated key."
+        )
+    return (
+        f"Either the recipe is misconfigured (see ROCm/aorta#450), or this outcome is "
+        f"wrong for a reason tracked elsewhere -- in which case pass "
+        f"'--known-vacuous {case_dir}' at the call site. It cannot be declared as an "
+        f"'expected_error': {name} is also a gated baseline key, so {_BASELINES} rejects "
+        f"the declaration there because it could not be attributed to this report or to "
+        f"the gated one. Rename this case directory so the two stop colliding if you need "
+        f"to record the outcome as correct."
+    )
+
+
+def _vacuous_problems(
+    name: str, case_dir: str, report: SanitizerReport, expected: object
+) -> list[str]:
     """Reject a run that terminated without producing any signal.
 
     Returns problems when the report ended in a vacuous execution status with
@@ -296,7 +338,9 @@ def _vacuous_problems(report: SanitizerReport, expected: object) -> list[str]:
     it were the ``error`` that was reviewed.
 
     ``expected_error`` is validated at load time, so anything reaching here is
-    well-formed.
+    well-formed. ``name`` and ``case_dir`` are taken so that the advice on an
+    undeclared row can be one the caller is actually able to follow -- see
+    :func:`_vacuous_remedy`.
     """
     status = report.execution_status.value
     if status not in _VACUOUS_STATUSES:
@@ -310,9 +354,8 @@ def _vacuous_problems(report: SanitizerReport, expected: object) -> list[str]:
     declared = expected.get("expected_error") if isinstance(expected, dict) else None
     if declared is None:
         return [
-            f"{shape} -- the run produced no sanitizer signal at all. Either the recipe "
-            f"is misconfigured (see ROCm/aorta#450) or, if this outcome is intended, "
-            f"declare it as an 'expected_error' entry in {_BASELINES}."
+            f"{shape} -- the run produced no sanitizer signal at all. "
+            f"{_vacuous_remedy(name, case_dir)}"
         ]
 
     mismatches = []
@@ -387,7 +430,7 @@ def _sweep_vacuous(
             print(f"{name}: report failed strict validation: {exc}")
             failed = True
             continue
-        problems = _vacuous_problems(report, baselines.get(name))
+        problems = _vacuous_problems(name, case_dir, report, baselines.get(name))
         if case_dir in suppressed:
             seen_suppressed.add(case_dir)
             if problems:

--- a/scripts/sanitizers/compare_verdict_baselines.py
+++ b/scripts/sanitizers/compare_verdict_baselines.py
@@ -73,7 +73,11 @@ Usage::
 
 ``--vacuous-only`` is for result trees that do not contain the gated cases at
 all -- notably the non-gating survey job, which runs in its own job with its own
-output root and is where the two #450 recipes actually live.
+output root and is where the two #450 recipes actually live. It selects which
+*halves* run, nothing more: ``--require`` and ``--known-vacuous`` both describe
+the sweep, so they mean the same thing with or without it. An option that is
+accepted and then quietly ignored on one path is the very shape this script
+exists to catch.
 """
 
 from __future__ import annotations
@@ -504,7 +508,7 @@ def main(argv: list[str]) -> int:
         else:
             print(f"{name}: ok ({report.overall_verdict.value})")
 
-    if _sweep_vacuous(root, baselines, required):
+    if _sweep_vacuous(root, baselines, required, known_vacuous):
         failed = True
     return 1 if failed else 0
 

--- a/tests/sanitizers/test_compare_baselines.py
+++ b/tests/sanitizers/test_compare_baselines.py
@@ -524,6 +524,35 @@ def test_known_vacuous_conflicts_with_a_declaration(tmp_path, monkeypatch, capsy
     assert "Pick one" in capsys.readouterr().err
 
 
+def test_known_vacuous_also_applies_to_the_gate_mode(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # --vacuous-only picks which halves run; it does not change what the sweep
+    # means. So a suppression the caller declared has to be honoured with or
+    # without it -- the list used to be parsed, conflict-checked, and then
+    # dropped here, which failed the row as an ordinary vacuous report.
+    _write_all_matching(tmp_path)
+    _write_case(tmp_path, "informational/consan-gemm", _errored("consan", "growth_limit"))
+    assert comparator.main(["prog", str(tmp_path)]) == 1
+    assert "expected_error" in capsys.readouterr().out
+    argv = ["prog", "--known-vacuous", "informational/consan-gemm", str(tmp_path)]
+    assert comparator.main(argv) == 0
+    out = capsys.readouterr().out
+    assert "KNOWN VACUOUS, not failing" in out
+    assert "expected_error" not in out
+
+
+def test_known_vacuous_conflict_is_caught_in_the_gate_mode_too(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The conflict check sits ahead of the mode branch, so forwarding the list
+    # must not open a path on which a contradictory row is accepted.
+    _write_all_matching(tmp_path)
+    argv = ["prog", "--known-vacuous", "informational/consan-tiny", str(tmp_path)]
+    assert comparator.main(argv) == 2
+    assert "Pick one" in capsys.readouterr().err
+
+
 def test_comparator_rejects_bad_usage(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(_REPO_ROOT)
     assert comparator.main(["prog"]) == 2

--- a/tests/sanitizers/test_compare_baselines.py
+++ b/tests/sanitizers/test_compare_baselines.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 from aorta.instrumentation.rocjitsu_sanitizers import (
@@ -62,9 +63,16 @@ def _check(sanitizer: str, verdict: Verdict, *, message: str | None = None) -> C
     )
 
 
-def _write_case(root: Path, case_dir: str, check: CheckResult) -> None:
-    report = build_report(target="gfx950", worklist=_worklist(), checks=(check,))
+def _write_case(root: Path, case_dir: str, *checks: CheckResult) -> None:
+    report = build_report(target="gfx950", worklist=_worklist(), checks=checks)
     write_report(report, root / case_dir / "sanitizer_report.json")
+
+
+def _use_baselines(monkeypatch, tmp_path: Path, data: dict) -> None:
+    """Point the comparator at a throwaway baselines file."""
+    path = tmp_path / "baselines.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(comparator, "_BASELINES", path)
 
 
 _RACY_CONFLICT_MESSAGE = (
@@ -121,3 +129,407 @@ def test_comparator_rejects_missing_report(tmp_path, monkeypatch) -> None:
     _write_case(tmp_path, "consan-clean", _check("consan", Verdict.PASS))
     # consan-racy intentionally absent
     assert comparator.main(["prog", str(tmp_path)]) == 1
+
+
+# --------------------------------------------------------------- vacuity sweep
+# ROCm/aorta#450: two informational recipes paired a load-only driver with
+# consan_policy: strict and so ended `error` with zero findings on every run.
+# Nothing caught it, because the comparison above only covers the gated cases.
+
+
+def _errored(sanitizer: str, reason: str) -> CheckResult:
+    return CheckResult(
+        sanitizer=sanitizer,
+        state=ExecutionState.ERROR,
+        verdict=Verdict.ERROR,
+        reason=reason,
+        returncode=86,
+    )
+
+
+def test_sweep_rejects_undeclared_vacuous_error(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # consan_gemm has no expected_error entry, so exit 86 with no findings is a
+    # broken run rather than a result.
+    _write_case(tmp_path, "informational/consan-gemm", _errored("consan", "combined_hook_exit_86"))
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "consan_gemm" in out
+    assert "combined_hook_exit_86" in out
+
+
+def test_sweep_rejects_vacuous_error_in_full_mode(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # Every gated case matches its baseline, so only the sweep can fail this.
+    _write_all_matching(tmp_path)
+    _write_case(tmp_path, "informational/consan-gemm", _errored("consan", "combined_hook_exit_86"))
+    assert comparator.main(["prog", str(tmp_path)]) == 1
+
+
+def test_sweep_accepts_declared_expected_error(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # consan_tiny declares expected_error reason combined_hook_exit_86 in the
+    # committed baselines: an intended negative control, so it must not fire.
+    _write_case(tmp_path, "informational/consan-tiny", _errored("consan", "combined_hook_exit_86"))
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 0
+
+
+def test_sweep_rejects_declared_case_erroring_for_another_reason(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The declaration names a reason, so consan_tiny is allowed to fail closed for
+    # exit 86 and nothing else. A timeout there is a new failure.
+    _write_case(tmp_path, "informational/consan-tiny", _errored("consan", "combined_hook_timeout"))
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+    assert "combined_hook_exit_86" in capsys.readouterr().out
+
+
+def test_sweep_rejects_vacuous_not_checked(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    not_checked = CheckResult(
+        sanitizer="consan",
+        state=ExecutionState.NOT_CHECKED,
+        verdict=Verdict.NOT_CHECKED,
+        reason="no backend",
+    )
+    _write_case(tmp_path, "informational/consan-gemm", not_checked)
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+
+
+def test_sweep_accepts_clean_pass_with_zero_findings(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # daily-consan-lds-dispatch's real shape: a completed run that found nothing.
+    # Zero findings alone must never be the trigger.
+    _write_case(tmp_path, "informational/consan-lds-dispatch", _check("consan", Verdict.PASS))
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 0
+
+
+def test_sweep_accepts_error_that_still_produced_findings(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # An errored run that still reported something is not vacuous; the gated
+    # baseline comparison is what judges whether the verdict is right.
+    errored_with_finding = CheckResult(
+        sanitizer="consan",
+        state=ExecutionState.ERROR,
+        verdict=Verdict.ERROR,
+        reason="consan_coverage_incomplete: barrier patched/supported mismatch: 1/2",
+        returncode=0,
+        findings=(
+            Finding(
+                sanitizer="consan",
+                severity=FindingSeverity.ERROR,
+                code="c",
+                message="partial coverage",
+            ),
+        ),
+    )
+    _write_case(tmp_path, "informational/consan-gemm", errored_with_finding)
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 0
+
+
+def test_vacuous_only_ignores_absent_gated_cases(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The survey job's result tree contains none of the gated cases. Nothing is
+    # required here, so nothing is missing.
+    _write_case(tmp_path, "informational/consan-lds-dispatch", _check("consan", Verdict.PASS))
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 0
+
+
+def test_vacuous_only_tolerates_empty_tree_when_nothing_is_required(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 0
+
+
+# ------------------------------------------------------- exact expected_error
+# An expected_error narrows what one row is allowed to do. Anything about it
+# that cannot be checked widens it instead, so a malformed declaration fails.
+
+
+def _declaration(**overrides) -> dict:
+    declared = {
+        "execution_status": "error",
+        "overall_verdict": "error",
+        "reasons": ["combined_hook_exit_86"],
+        "why": "intended negative control",
+    }
+    declared.update(overrides)
+    return declared
+
+
+def test_malformed_expected_error_fails_even_when_the_case_did_not_run(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # `reason` (singular) is the old spelling: silently ignored by a
+    # minimum-fields check, which is exactly how a bypass gets in.
+    _use_baselines(monkeypatch, tmp_path, {"consan_tiny": {"expected_error": {"reason": "x"}}})
+    root = tmp_path / "results"
+    root.mkdir()
+    assert comparator.main(["prog", "--vacuous-only", str(root)]) == 2
+    err = capsys.readouterr().err
+    assert "unknown field(s) reason" in err
+    assert "is missing execution_status, overall_verdict, reasons, why" in err
+
+
+def test_expected_error_must_be_an_object(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    _use_baselines(monkeypatch, tmp_path, {"consan_tiny": {"expected_error": True}})
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 2
+
+
+def test_expected_error_rejects_unusable_reason_lists(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    for reasons in ("combined_hook_exit_86", [], [""], [86], ["a", "a"]):
+        _use_baselines(
+            monkeypatch,
+            tmp_path,
+            {"consan_tiny": {"expected_error": _declaration(reasons=reasons)}},
+        )
+        assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 2, reasons
+
+
+def test_expected_error_rejects_a_status_it_could_never_match(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The sweep only looks at vacuous statuses, so declaring `complete` is dead
+    # configuration that reads as protection.
+    _use_baselines(
+        monkeypatch,
+        tmp_path,
+        {"consan_tiny": {"expected_error": _declaration(execution_status="complete")}},
+    )
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 2
+
+
+def test_expected_error_rejects_a_verdict_it_could_never_match(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # Same argument as the status above: a vacuous report cannot carry `pass`,
+    # so declaring it is a typo that reads as protection.
+    _use_baselines(
+        monkeypatch,
+        tmp_path,
+        {"consan_tiny": {"expected_error": _declaration(overall_verdict="pass")}},
+    )
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 2
+
+
+def test_expected_error_rejects_an_empty_why(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    _use_baselines(
+        monkeypatch, tmp_path, {"consan_tiny": {"expected_error": _declaration(why="   ")}}
+    )
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 2
+
+
+def test_sweep_rejects_a_reason_that_merely_contains_the_declared_token(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # combined_hook_exit_860 is a different exit code, not the signed-off one.
+    _write_case(tmp_path, "informational/consan-tiny", _errored("consan", "combined_hook_exit_860"))
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+    assert "not the outcome that was signed off" in capsys.readouterr().out
+
+
+def test_sweep_rejects_an_extra_undeclared_reason(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The declared failure happened, and so did something else nobody signed off.
+    _write_case(
+        tmp_path,
+        "informational/consan-tiny",
+        _errored("consan", "combined_hook_exit_86"),
+        _errored("waitcheck_preflight", "consan_output_parse_error: truncated"),
+    )
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+
+
+def test_sweep_accepts_the_declared_reason_repeated_across_checks(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The real shape: the combined hook fails both checks with one reason, which
+    # is one distinct reason and must still match.
+    _write_case(
+        tmp_path,
+        "informational/consan-tiny",
+        _errored("consan", "combined_hook_exit_86"),
+        _errored("waitcheck_preflight", "combined_hook_exit_86"),
+    )
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 0
+
+
+def test_sweep_rejects_a_declared_case_that_was_never_checked(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # Same reason token, but the sanitizer never ran. `error` was reviewed;
+    # `not_checked` was not.
+    never_ran = CheckResult(
+        sanitizer="consan",
+        state=ExecutionState.NOT_CHECKED,
+        verdict=Verdict.NOT_CHECKED,
+        reason="combined_hook_exit_86",
+    )
+    _write_case(tmp_path, "informational/consan-tiny", never_ran)
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+
+
+def test_expected_error_is_rejected_on_a_gated_key(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # `waitcheck_gemm` is both a gated baseline key and what the survey directory
+    # informational/waitcheck-gemm resolves to, so one exemption there would cover
+    # two different recipes.
+    _use_baselines(
+        monkeypatch, tmp_path, {"waitcheck_gemm": {"expected_error": _declaration()}}
+    )
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 2
+    assert "not allowed on a gated case" in capsys.readouterr().err
+
+
+def test_committed_baselines_declarations_are_well_formed() -> None:
+    # The check above only bites if the shipped file satisfies it.
+    comparator._load_baselines(_REPO_ROOT / comparator._BASELINES)
+
+
+# ------------------------------------------------------------ required reports
+# ROCm/aorta#450 one level up: all six survey invocations run under `|| true`,
+# so a recipe that dies before writing a report leaves nothing to judge.
+
+
+def test_sweep_rejects_a_required_case_with_no_report(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    _write_case(tmp_path, "informational/consan-lds-dispatch", _check("consan", Verdict.PASS))
+    argv = [
+        "prog",
+        "--vacuous-only",
+        "--require",
+        "informational/consan-lds-dispatch",
+        "--require",
+        "informational/consan-gemm",
+        str(tmp_path),
+    ]
+    assert comparator.main(argv) == 1
+    out = capsys.readouterr().out
+    assert "informational/consan-gemm: no report" in out
+    assert "informational/consan-lds-dispatch: no report" not in out
+
+
+def test_sweep_rejects_an_entirely_empty_survey(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    argv = ["prog", "--vacuous-only", "--require", "informational/consan-gemm", str(tmp_path)]
+    assert comparator.main(argv) == 1
+    assert "no report" in capsys.readouterr().out
+
+
+def test_sweep_accepts_required_cases_that_all_reported(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    _write_case(tmp_path, "informational/consan-lds-dispatch", _check("consan", Verdict.PASS))
+    _write_case(tmp_path, "informational/consan-tiny", _errored("consan", "combined_hook_exit_86"))
+    argv = [
+        "prog",
+        "--vacuous-only",
+        "--require",
+        "informational/consan-lds-dispatch",
+        "--require",
+        "informational/consan-tiny",
+        str(tmp_path),
+    ]
+    assert comparator.main(argv) == 0
+
+
+def test_require_also_applies_to_the_gate_mode(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    _write_all_matching(tmp_path)
+    assert comparator.main(["prog", str(tmp_path)]) == 0
+    assert comparator.main(["prog", "--require", "informational/consan-gemm", str(tmp_path)]) == 1
+
+
+# --------------------------------------------------------- known-vacuous rows
+# The opposite of an expected_error: "this is wrong and being worked", not
+# "this is fine". So it must not outlive the break it describes.
+
+
+def test_known_vacuous_reports_without_failing(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    _write_case(tmp_path, "informational/consan-gemm", _errored("consan", "growth_limit"))
+    argv = [
+        "prog",
+        "--vacuous-only",
+        "--known-vacuous",
+        "informational/consan-gemm",
+        str(tmp_path),
+    ]
+    assert comparator.main(argv) == 0
+    out = capsys.readouterr().out
+    assert "KNOWN VACUOUS, not failing" in out
+    assert "1 known-vacuous" in out
+    # It must not suggest declaring an expected_error, which would assert the
+    # outcome is acceptable rather than broken-and-tracked.
+    assert "expected_error" not in out
+
+
+def test_known_vacuous_still_fails_the_other_rows(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The whole point: suppressing one row must not suppress the next regression.
+    _write_case(tmp_path, "informational/consan-gemm", _errored("consan", "growth_limit"))
+    _write_case(tmp_path, "informational/consan-lds-dispatch", _errored("consan", "something_new"))
+    argv = [
+        "prog",
+        "--vacuous-only",
+        "--known-vacuous",
+        "informational/consan-gemm",
+        str(tmp_path),
+    ]
+    assert comparator.main(argv) == 1
+
+
+def test_known_vacuous_fails_once_the_row_produces_signal(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    _write_case(tmp_path, "informational/consan-gemm", _check("consan", Verdict.PASS))
+    argv = [
+        "prog",
+        "--vacuous-only",
+        "--known-vacuous",
+        "informational/consan-gemm",
+        str(tmp_path),
+    ]
+    assert comparator.main(argv) == 1
+    assert "Remove informational/consan-gemm" in capsys.readouterr().out
+
+
+def test_known_vacuous_fails_when_the_row_has_no_report(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    _write_case(tmp_path, "informational/consan-tiny", _errored("consan", "combined_hook_exit_86"))
+    argv = [
+        "prog",
+        "--vacuous-only",
+        "--known-vacuous",
+        "informational/consan-gemm",
+        str(tmp_path),
+    ]
+    assert comparator.main(argv) == 1
+    assert "no report was found for it" in capsys.readouterr().out
+
+
+def test_known_vacuous_conflicts_with_a_declaration(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # consan_tiny is declared in the committed baselines, so calling it
+    # known-vacuous asserts the opposite of what the file says.
+    argv = [
+        "prog",
+        "--vacuous-only",
+        "--known-vacuous",
+        "informational/consan-tiny",
+        str(tmp_path),
+    ]
+    assert comparator.main(argv) == 2
+    assert "Pick one" in capsys.readouterr().err
+
+
+def test_comparator_rejects_bad_usage(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    assert comparator.main(["prog"]) == 2
+    assert comparator.main(["prog", "--vacuous-only"]) == 2
+    assert comparator.main(["prog", str(tmp_path), "extra"]) == 2
+    assert comparator.main(["prog", "--vacuous-only", "--require", str(tmp_path)]) == 2
+    assert comparator.main(["prog", "--require"]) == 2
+    assert comparator.main(["prog", "--known-vacuous"]) == 2
+    assert comparator.main(["prog", "--nope", str(tmp_path)]) == 2

--- a/tests/sanitizers/test_compare_baselines.py
+++ b/tests/sanitizers/test_compare_baselines.py
@@ -384,6 +384,66 @@ def test_expected_error_is_rejected_on_a_gated_key(tmp_path, monkeypatch, capsys
     assert "not allowed on a gated case" in capsys.readouterr().err
 
 
+# The flip side of the rejection above: because that declaration is impossible,
+# the sweep must not advise it. Advice an operator cannot follow is the same
+# defect shape as an option that is accepted and ignored.
+
+_IMPOSSIBLE_ADVICE = "declare it as an 'expected_error' entry"
+
+
+def test_vacuous_advice_is_followable_for_a_colliding_survey_key(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # informational/waitcheck-gemm resolves to the gated key waitcheck_gemm, so
+    # test_expected_error_is_rejected_on_a_gated_key above is what an operator
+    # who followed the old advice would have got -- exit 2, and for every row,
+    # since the baselines then fail to load at all.
+    _write_case(
+        tmp_path, "informational/waitcheck-gemm", _errored("waitcheck", "worklist_not_fully_checked")
+    )
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert _IMPOSSIBLE_ADVICE not in out
+    assert "--known-vacuous informational/waitcheck-gemm" in out
+    # And the advice it gives instead actually works.
+    argv = [
+        "prog",
+        "--vacuous-only",
+        "--known-vacuous",
+        "informational/waitcheck-gemm",
+        str(tmp_path),
+    ]
+    assert comparator.main(argv) == 0
+
+
+def test_vacuous_advice_for_a_gated_report_does_not_point_at_the_sweep(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The gated report itself, rather than the colliding survey directory.
+    # --known-vacuous cannot rescue this one either: _compare_case judges it
+    # against its own baseline and still fails it, so sending the operator to the
+    # sweep would be a second piece of advice that does not work.
+    _write_case(tmp_path, "waitcheck", _errored("waitcheck", "worklist_not_fully_checked"))
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert _IMPOSSIBLE_ADVICE not in out
+    assert "--known-vacuous" not in out
+    assert "gated case with a baseline of its own" in out
+
+
+def test_vacuous_advice_still_points_at_expected_error_for_an_ordinary_row(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(_REPO_ROOT)
+    # The remedy above is scoped to colliding keys; every other row keeps the
+    # declaration advice, which is correct and reachable for it.
+    _write_case(tmp_path, "informational/consan-gemm", _errored("consan", "growth_limit"))
+    assert comparator.main(["prog", "--vacuous-only", str(tmp_path)]) == 1
+    assert _IMPOSSIBLE_ADVICE in capsys.readouterr().out
+
+
 def test_committed_baselines_declarations_are_well_formed() -> None:
     # The check above only bites if the shipped file satisfies it.
     comparator._load_baselines(_REPO_ROOT / comparator._BASELINES)


### PR DESCRIPTION
Refs #450. **Not** `Fixes` — see "Does this close the issue?" below; the review turned up a reason it should not auto-close.

## What was wrong

`daily-consan-gemm` drove ConSan through `consan_load.hip`, a load-only driver that calls
`hipModuleLoad`/`hipModuleUnload` and never dispatches, while setting `consan_policy: strict`.
strict sets `RJ_CONSAN_MOI_REQUIRE_RECORDS`, which demands visible dynamic records, so a driver
that never dispatches failed closed with `combined_hook_exit_86` and zero findings. ConSan was
behaving correctly; the recipe was asking it for something the driver could not produce.

## Task 1 — `lenient` is a real fix on the small object, and it is genuinely not enough on the big one

On a 16,265,200-byte ROCm 7.0.2.2 object, `lenient` is not a cosmetic de-escalation. Same node,
same rocjitsu bundle, policy the only variable:

| | `consan` verdict | execution | findings | coverage |
|---|---|---|---|---|
| **strict** | `error` | `error`, `combined_hook_exit_86` | 0 | none reported |
| **lenient** | `pass` | `complete` | 0 consan + **32 waitcheck** | **access=68894/68894** |

The coverage was always there and strict discarded it: the pre-fix log shows the object
transforming cleanly (`outcome=modified-valid`, 75978 patches over 68894 sites) and only *then*
being rejected on require-records. strict was also suppressing 32 real `missing s_waitcnt`
findings on that object.

**@amd-vivekag was right that this does not generalise to CI, and the correction is the main
change in this revision.** CI runs the digest-pinned ROCm 10 image, whose object is ~10.5x
larger. Re-measured *inside that image* on gfx950, against the byte-identical object the nightly
extracts — sha256 `57c5d8ef…`, 169,996,560 bytes, matching run
[34032862308](https://github.com/ROCm/aorta/actions/runs/34032862308):

| `daily-consan-gemm`, ROCm 10 | verdict | exec | findings | reason | coverage |
|---|---|---|---|---|---|
| **strict** | `error` | `error` | 0 | `consan_strict_load_rejection` (exit 92) | — |
| **lenient** | `error` | `error` | 0 | `consan_coverage_incomplete` | **access=0/719550** |

Both fail for the same reason, and it is **not** the record requirement. ConSan needs
**1,721,958,400 bytes** of patched image against a **419,430,400-byte** ceiling — 4.11x over — so
the first-light probe rejects the transform and `patches=0`. The object is never instrumented.

Two things worth stating precisely, because they change what this PR can claim:

1. **The `timeout_seconds: 6000` ceiling is not what bites.** The run ends in 595s under strict
   and 859s under lenient. The growth ceiling is the binding constraint; the runtime question is
   simply never reached.
2. **On this object, `lenient` moves the fail-closed out of the sanitizer and into AORTA.** Under
   strict the hook terminates itself (`fail_closed=true`, `action=terminate`, exit 92). Under
   lenient it declines to (`fail_closed=false`), exits **0**, and returns an object with none of
   its 719,550 access sites patched — so only AORTA's coverage cross-check turns that into an
   error. Isolated by forcing the ceiling below what the small LDS fixture needs:
   `RJ_CONSAN_POLICY=strict` exits 92 with a `load rejection … action=terminate` line;
   `RJ_CONSAN_POLICY=default` exits 0 with the same growth rejection and **no load-rejection line
   at all**. That is the "quiet pass" hazard #450 worried about, and it is real on this object —
   the cross-check is what prevents it.

`lenient` is **kept**, because it is the right target state and a precondition: the moment the
ceiling admits the object, strict would fail it again on require-records, which is the #450
defect. It is now described as necessary rather than sufficient, and the recipe records what was
measured where.

## Task 1b — `daily-consan-tiny` is deliberately NOT changed

#450 proposed flipping both. Measured on ROCm 7.0.2.2 *and* re-measured on ROCm 10, and it does
not hold for `tiny` on either: `lenient` leaves it `error`/`error` with zero findings and only
relabels the reason to `consan_coverage_incomplete` at `access=0/0`. `tiny_vecadd`'s only memory
operations are ordinary global loads/stores, which ConSan does not admit as MOI sites, so the run
is rejected by the **coverage cross-check**, not the record requirement — and removing
`RJ_CONSAN_MOI_REQUIRE_RECORDS` cannot help something with nothing to be complete about. Its exit
86 is an intended negative control, root-caused in #409.

So `tiny` stays strict. What was wrong is that this intent lived only in a YAML comment where no
check could read it. It is now **declared** in `verdict_baselines.json` as an `expected_error`,
verified against all four ROCm 10 nightly survey trees and a direct re-run in the CI image.

## Task 2 — the check that would have caught this

`compare_verdict_baselines.py` only inspected the three **gated** cases, and these two are
informational, so an `error` verdict with zero findings was nobody's problem. #359's acceptance
criterion for the strict flip was that a run "returns a real verdict, not
`combined_hook_timeout`", which exit 86 satisfies literally.

The comparator now also **sweeps every report under the results root**, gated or not, and rejects
any that terminated `error` or `not_checked` with zero findings unless the baselines declare that
outcome. Zero findings alone is never the trigger — `daily-consan-lds-dispatch` passes clean with
none and must not trip it.

### `expected_error` is now an exact declaration, not a bypass

Addressing [@Copilot's finding](https://github.com/ROCm/aorta/pull/454#discussion_r3924815213),
which was correct on all four counts. The declaration names `execution_status`,
`overall_verdict` and the **complete set** of check reasons, and all three are matched exactly.
So a substring like `combined_hook_exit_860` no longer passes, a second undeclared reason riding
along no longer passes, and a `not_checked` run is no longer accepted where an `error` was
reviewed.

**A malformed declaration is a failure, not a bypass.** Every `expected_error` is validated when
the baselines file is loaded, whether or not that case ran — a mis-spelled `reason` for `reasons`
used to be silently ignored, which is exactly how a bypass gets in. A declared status or verdict
that could never match is rejected too, since dead configuration that reads as protection is
worse than none.

One extra hole the exactness work surfaced: `waitcheck_gemm` is **both** a gated baseline key and
what the survey directory `informational/waitcheck-gemm` resolves to — two different recipes. A
single `expected_error` there would have excused both. A gated key may no longer carry one at all.

### Absent reports no longer fail open

Addressing [@amd-vivekag's finding](https://github.com/ROCm/aorta/pull/454#discussion_r3925899487).
All six survey invocations run under `|| true`, so a recipe that dies *before* writing a report
leaves nothing to judge — the same fail-open shape the sweep exists to close, one level up.
`--require <case-dir>` makes the absence of an invoked case an error.

It is scoped to cases the caller names rather than blanket-failing, because an empty tree and a
tree from a run that was never asked to produce anything are indistinguishable from a directory
listing. A **job-level** kill needs no tolerance and never did: the runner cap in #370, a
cancellation or a step timeout takes the whole payload down, so the comparator does not run and
has no verdict to give. Only a *recipe-level* failure reaches it, and that is precisely the case
that should fail.

### The survey sweep is armed, with a self-retiring suppression

Replayed over the **real** survey trees of the last four nightlies, the sweep flags two rows:

| row | outcome | why |
|---|---|---|
| `consan_gemm` | `error`/`error`, 0 findings, `consan_strict_load_rejection` | the growth ceiling above |
| `waitcheck_gemm` | `error`/`error`, 0 findings, `worklist_not_fully_checked` | the `rj_waitcheck` non-convergence of #453, on that same object |

Neither is fixed here, so arming the sweep unqualified would make the survey job red every night
— and a check that always fails cannot distinguish a new break from the standing two. Arming it
was still the right call, so the two rows are named at the call site:

```
--known-vacuous informational/consan-gemm
--known-vacuous informational/waitcheck-gemm
```

This is the **opposite** of an `expected_error`, deliberately:

- an `expected_error` says *this outcome is correct*; `--known-vacuous` says *this outcome is
  wrong, it is tracked elsewhere, and it must not mask the other rows*;
- it lives in the workflow rather than the baselines, so it carries no dashboard meaning and
  shows up in a workflow diff;
- **it is self-retiring.** The comparator *fails* if a listed case starts producing signal
  (`Remove informational/consan-gemm from the caller's --known-vacuous list`) or stops reporting
  at all, so a fixed row cannot leave a stale suppression behind;
- a case may not be both — passing `--known-vacuous` for a row declared as an `expected_error`
  is a usage error, since the two make opposite claims;
- the suppressed message deliberately does **not** repeat the sweep's "declare it as an
  `expected_error`" advice, which would be exactly the anti-pattern #453 warns about. There is a
  test asserting that string never appears for a known-vacuous row.

**The other four rows are checked for real from the next scheduled run**, which is the #450
regression path this whole change exists to close. Verified by replaying the exact wired
invocation over runs 33755195031, 33872660689, 33965800908 and 34032862308 — exit 0, both blocked
rows reported, six reports judged:

```
consan_gemm: KNOWN VACUOUS, not failing -- execution_status='error', ... reason
  'consan_strict_load_rejection', and zero findings. This row is on the caller's
  --known-vacuous list: the outcome is wrong and tracked elsewhere, not accepted.
waitcheck_gemm: KNOWN VACUOUS, not failing -- ... reason 'worklist_not_fully_checked' ...
vacuity sweep: ok (6 report(s) carry signal or are declared) (2 known-vacuous)
```

**The gate half is unaffected**: replayed over runs
[33507543444](https://github.com/ROCm/aorta/actions/runs/33507543444) (last green) and
[34032862308](https://github.com/ROCm/aorta/actions/runs/34032862308), the sweep adds no failure
there.

26 new tests in `tests/sanitizers/test_compare_baselines.py`, including the false-positive guards
(clean pass with zero findings; an errored run that still reported findings) and the
malformed-declaration, wrong-reason, extra-reason, gated-key-collision and
known-vacuous-suppression cases (including the one that fails when a suppressed row recovers).

## Does this close the issue?

**No, and it should not.** The recipe misconfiguration #450 reported is fixed and the mechanism
that let it hide for weeks is closed. But the row #450 was filed about still produces no signal
on the image CI actually runs, for a capacity reason #450 did not know about. Auto-closing would
assert coverage that does not exist — the same anti-pattern #453 argues against. Downgraded to
`Refs`.

## A finding that belongs to #453

The `waitcheck_preflight` check in the ROCm 10 `gemm-lenient` run reported:

```
waitcheck CFG dataflow did not converge at .text+0x24d7070
(in:loadcnt,uncertain-order;out:loadcnt,uncertain-order)
```

The **same offset** #453 records, reproduced on a Slurm dev node rather than the CI runner. That
independently supports #453's diagnosis that the failure is content-driven and not
runner-specific, and confirms it reaches the survey lane as well as the gate.

## Hardware verification

Slurm `meta64` node `cv350-rck-g03-e15-18`, gfx950 / MI350X (`0x75a0`), inside
`rocm/pytorch:rocm10.0_ubuntu26.04_py3.14_pytorch_release_2.13.0@sha256:3174cb70…` — the exact
digest `docker/Dockerfile.ci-gpu` pins, with the same devel-symlink layer that Dockerfile adds,
and the nightly's own fixture-build steps. rocjitsu bundle `bed84edd`. Node-local scratch;
deliberately **not** the self-hosted CI runner `smci350-rck-g03-f16-12`, which is reserved for a
performance baseline window.

```
case                  verdict  exec      find  reason                        access
--------------------  -------  --------  ----  ----------------------------  ---------
control-lds-dispatch  pass     complete  0     -                             5/5
gemm-lenient          error    error     0     consan_coverage_incomplete    0/719550
gemm-strict           error    error     0     consan_strict_load_rejection  -
tiny-lenient          error    error     0     consan_coverage_incomplete    0/0
tiny-strict  (kept)   error    error     0     combined_hook_exit_86         -
```

`gemm-strict` reproduces the nightly's reason exactly, which is what establishes that this
environment matches CI rather than approximating it. The control `daily-consan-lds-dispatch` still
passes at `access=5/5`.

## Tests

395 in `tests/sanitizers` (26 new), 135 in `tests/instrumentation/rocjitsu_sanitizers`,
`pre-commit run --all-files` clean. Rebased onto current `main` (`4b4553e`); no file overlap with
the four commits that landed since.

