### PR TITLE
Fix discovery of lazy race mode exports

### DIFF
--- a/src/aorta/race/modes/__init__.py
+++ b/src/aorta/race/modes/__init__.py
@@ -78,6 +78,10 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))
+
+
 __all__ = [
     "create_reproducer",
     "DefaultModeReproducer",

--- a/tests/workloads/test_race_modes_exports.py
+++ b/tests/workloads/test_race_modes_exports.py
@@ -1,0 +1,72 @@
+"""Fresh-import checks for the lazy public exports in ``aorta.race.modes``.
+
+Run in subprocesses so other race tests cannot populate the module state and
+hide missing names from introspection (issue #448). No GPU work is performed.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _probe(source: str) -> None:
+    completed = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+
+
+def test_dir_advertises_exports_without_loading_modes() -> None:
+    _probe("""
+        import sys
+        import aorta.race.modes as modes
+
+        implementations = {
+            'aorta.race.modes.default',
+            'aorta.race.modes.ddp',
+            'aorta.race.modes.fsdp',
+        }
+        assert implementations.isdisjoint(sys.modules)
+        names = dir(modes)
+        assert set(modes.__all__) <= set(names), set(modes.__all__) - set(names)
+        assert set(vars(modes)) <= set(names)
+        assert names == sorted(set(names))
+        assert implementations.isdisjoint(sys.modules)
+        """)
+
+
+@pytest.mark.parametrize(
+    ("name", "module"),
+    [
+        ("DefaultModeReproducer", "default"),
+        ("DDPModeReproducer", "ddp"),
+        ("FSDPModeReproducer", "fsdp"),
+    ],
+)
+def test_lazy_exports_still_resolve(name: str, module: str) -> None:
+    _probe(f"""
+        import importlib
+        import aorta.race.modes as modes
+
+        exported = getattr(modes, {name!r})
+        implementation = importlib.import_module('aorta.race.modes.' + {module!r})
+        assert exported is getattr(implementation, {name!r})
+        """)
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    _probe("""
+        import aorta.race.modes as modes
+
+        try:
+            modes.no_such_reproducer
+        except AttributeError as exc:
+            assert 'no_such_reproducer' in str(exc)
+        else:
+            raise AssertionError('Unknown attribute did not raise AttributeError')
+        """)


### PR DESCRIPTION
### Summary

Add the same module-level `__dir__` used by the package's other lazy-export
modules to `aorta.race.modes`. It advertises `__all__` alongside existing module
globals without resolving the deferred mode implementations.

Fixes #448.

### Regression coverage

The new tests run in fresh Python subprocesses and check that:

- all public exports and existing globals appear in `dir()`;
- the three mode implementation modules remain absent from `sys.modules`
  before and after `dir()`;
- each lazy class export still resolves to its implementation;
- unknown attributes still raise `AttributeError`.

Before the fix, the suite reports 1 failed / 4 passed, with the failing case
identifying `DefaultModeReproducer`, `DDPModeReproducer`, and
`FSDPModeReproducer` as missing. After the fix, all 5 cases pass.

### Validation

On Windows with CPython 3.11.9 and PyTorch 2.10.0+cu128, using the real PyTorch
package but performing no GPU work:

```text
pytest tests/workloads/test_race_modes_exports.py \
  tests/workloads/test_race.py \
  tests/workloads/test_race_checksums.py \
  tests/workloads/test_race_real_backward.py \
  tests/workloads/test_race_recipe_env.py \
  tests/workloads/test_race_transformer_smoke.py \
  tests/test_package_version.py -q -o addopts=''
69 passed
```

- Configured pre-commit hooks on both changed files: passed; YAML check skipped
  because neither changed file is YAML.
- Ruff and Black checks on the new test file: passed.
- `git diff --check`: passed.
- Ruff on the existing source file still reports N806 for the unchanged
  `MODE_REGISTRY` local at line 50. The same diagnostic reproduces against
  unmodified main; this patch does not rename unrelated variables.
- The full repository suite, Linux/Python-version CI matrix and distributed
  GPU workloads have not been run locally.

### Scope and assistance

This changes introspection only: no mode implementations, factory behavior,
dependencies or GPU execution paths are modified.

The patch, tests and this draft were generated with OpenAI Codex assistance.
The verification described above was run locally. This disclosure does not
claim a separate human review or GPU validation.