### PR TITLE
fix(chat): stop every profile template selecting remote embeddings

### DIFF
--- a/docs/chat/configuration.md
+++ b/docs/chat/configuration.md
@@ -117,11 +117,14 @@ environment.
 | `embedding_model` | `BAAI/bge-small-en-v1.5` | Local model. |
 | `model_cache_path` | `$XDG_CACHE_HOME/aorta/chat/models` | Where the local model's ONNX weights are cached. `HF_HOME` overrides it, which is what [air-gapped pre-seeding](rag-index.md#air-gapped-nodes) uses. Explicit rather than `fastembed`'s own `/tmp/fastembed_cache`, which a reboot wipes and other users on a shared node can write. |
 
-The five `remote_embedding_*` settings below are read only when
-`embedding_provider = "remote"`, which no profile selects. Setting them without
-also setting `embedding_provider` changes nothing; setting them together with it
-is the procedure [below](#configuring-a-remote-embedding-provider-by-hand), and
-it obliges a local index rebuild.
+The five `remote_embedding_*` settings below are read by the embedding path only
+when `embedding_provider = "remote"`, which no profile selects. Setting them
+without also setting `embedding_provider` changes nothing about how the index is
+built or queried — though `remote_embedding_api_key` and
+`remote_embedding_extra_headers` count as credentials for `config validate`'s
+mode check either way. Setting them together with the selector is the procedure
+[below](#configuring-a-remote-embedding-provider-by-hand), and it obliges a
+local index rebuild.
 
 | Setting | Default | Meaning |
 | --- | --- | --- |
@@ -194,13 +197,13 @@ Everything else that looks like a reason is not one:
 Read these three before editing anything. Each of them is a consequence, not a
 risk to be managed.
 
-1. **The published index becomes unusable, permanently, for this install.** CI
-   builds the index asset with default settings, so its vectors are the local
-   model's. An index is only meaningful to the model that produced it, and the
-   manifest check refuses a mismatch rather than answering from it. So
+1. **The published index becomes unusable for as long as this setting is in
+   place.** CI builds the index asset with default settings, so its vectors are
+   the local model's. An index is only meaningful to the model that produced it,
+   and the manifest check refuses a mismatch rather than answering from it. So
    `aorta chat index fetch` will refuse the download, and an already-fetched
-   index will refuse every query. You take over building the index yourself,
-   for as long as this setting is in place, on every AORTA upgrade.
+   index will refuse every query. You take over building the index yourself, on
+   every AORTA upgrade, until you [go back](#going-back).
 2. **Every query costs money, not just the build.** The one-off index build
    embeds the whole corpus; after that each question sends one embedding call
    for the query text, and each `search_code` tool call sends another. The build
@@ -225,7 +228,7 @@ which four are required and two apply only behind a gateway:
 
 | Setting | | |
 | --- | --- | --- |
-| `embedding_provider` | required | The selector. Nothing below is read without it. |
+| `embedding_provider` | required | The selector. Nothing below reaches an embeddings API without it. |
 | `remote_embedding_model` | required | Has a default, but set it explicitly — it names the collection. |
 | `remote_embedding_base_url` | required in practice | Only omit it if you mean OpenAI's own API. |
 | `remote_embedding_api_key` | required | Empty raises at first use. |
@@ -235,7 +238,7 @@ which four are required and two apply only behind a gateway:
 In `~/.config/aorta/chat.toml`:
 
 ```toml
-# The selector. Without this the five below are read by nothing.
+# The selector. Without this nothing below reaches an embeddings API.
 embedding_provider = "remote"
 
 # The model. Also decides the collection name, because dimensions differ per
@@ -316,10 +319,10 @@ but not `docs/` or `README.md`, which the published asset does carry. Point
 aorta chat doctor
 ```
 
-The index check should pass, and the embedding line should name your endpoint
-and model rather than `<provider-default>`. A refusal here means the index and
-the configuration still disagree — usually step 3 was skipped, or was run before
-step 1 took effect.
+The index check should pass, and the `embedding provider` line should name your
+endpoint and model rather than `provider default`. A refusal here means the
+index and the configuration still disagree — usually step 3 was skipped, or was
+run before step 1 took effect.
 
 ### Going back
 

--- a/docs/chat/configuration.md
+++ b/docs/chat/configuration.md
@@ -241,8 +241,15 @@ which four are required and two apply only behind a gateway:
 | `remote_embedding_model` | required | Has a default, but set it explicitly — it names the collection. |
 | `remote_embedding_base_url` | required in practice | Only omit it if you mean OpenAI's own API. |
 | `remote_embedding_api_key` | required | Empty raises at first use. |
-| `remote_embedding_auth_header` | gateway only | Header name instead of a bearer token. |
+| `remote_embedding_auth_header` | gateway only | Header name instead of a bearer token. For Azure API Management that is exactly `Ocp-Apim-Subscription-Key`. |
 | `remote_embedding_extra_headers` | gateway only | Any other headers the gateway wants. |
+
+**Coming from the `azure-apim` profile?** That profile pre-fills
+`remote_llm_auth_header = "Ocp-Apim-Subscription-Key"` for the chat side, and it
+used to pre-fill `remote_embedding_auth_header` with the same string. It no
+longer does — embeddings are local in that profile now, so there was nothing for
+it to configure — which makes this the one value the wizard used to hand you and
+no longer does. It is the same string on both sides.
 
 In `~/.config/aorta/chat.toml`:
 
@@ -329,9 +336,16 @@ aorta chat doctor
 ```
 
 The index check should pass, and the `embedding provider` line should name your
-endpoint and model rather than `provider default`. A refusal here means the
-index and the configuration still disagree — usually step 3 was skipped, or was
-run before step 1 took effect.
+model and the endpoint you configured.
+
+`provider default` where you expected an endpoint is **not** in itself a
+failure: that is what the line prints whenever `remote_embedding_base_url` is
+empty, which is the supported way to mean OpenAI's own API. It is a symptom only
+if you meant to point at a gateway — in which case step 1 did not take effect,
+and your corpus is going to OpenAI with a header it does not read.
+
+A refusal here means the index and the configuration still disagree — usually
+step 3 was skipped, or was run before step 1 took effect.
 
 ### Going back
 
@@ -340,6 +354,21 @@ Remove or unset the six settings and re-fetch:
 ```bash
 aorta chat index fetch
 ```
+
+That is the whole way back **only if `embedding_model` is still at its default**.
+It is not one of the six, and it is the one other setting the published asset is
+checked against: `manifest.validate` refuses on the model name, on the collection
+name and on the embedding identity, and for the local provider all three are
+derived from `embedding_model`. A hand-set value is therefore refused exactly as
+a remote provider was. Clear it as well, or keep it and rebuild with
+`aorta chat index build`.
+
+`chunk_size` and `chunk_overlap` are a different case and do **not** block the
+re-fetch. They are compared, but as warnings: the vectors are still the published
+model's, and the chunker only ran at build time, so what a mismatch costs you is
+that retrieved spans are not the size the prompt budget was tuned for. Restore
+them if you changed them, but they will not stop `index fetch` and they never
+made the published asset unusable.
 
 The two providers use different collection names and coexist in the one
 `.sqlite` file, so switching to remote never disturbed the local collection:

--- a/docs/chat/configuration.md
+++ b/docs/chat/configuration.md
@@ -342,11 +342,19 @@ aorta chat index fetch
 ```
 
 The two providers use different collection names and coexist in the one
-`.sqlite` file, so the local collection is still where it was. The re-fetch is
-not there to replace it — it is there to restore the manifest, which the remote
-`index build` rewrote to name the remote model, and which is checked before any
-query. `aorta chat index build` restores it just as well if you would rather not
-go back to the published asset.
+`.sqlite` file, so switching to remote never disturbed the local collection:
+the remote `index build` staged a database that lacked it, and installing a
+staged database carries over whatever collections the incoming one is missing.
+
+Coming back is not symmetric, because the published asset *does* contain a local
+collection. On the default `embedding_model` it has the same name as yours, so
+`index fetch` installs the published one over it, and restores the manifest that
+the remote `index build` had rewritten to name the remote model. That is what
+you want when your local collection came from the published asset in the first
+place. When you built it yourself over a wider corpus — an `aorta_path` pointing
+at a source checkout, so `docs/` and `README.md` were indexed too — reach for
+`aorta chat index build` instead: it restores the manifest just as well and
+keeps your own corpus rather than replacing it with the package-only build.
 
 ## Example profile
 

--- a/docs/chat/configuration.md
+++ b/docs/chat/configuration.md
@@ -174,11 +174,18 @@ deliberate, manual change, and this is the whole procedure.
 
 ### When this is the right choice
 
-**One case, and it is narrow: a node that can reach an embeddings API but
-cannot reach Hugging Face.** The local embedder downloads ~65 MB of ONNX weights
-from Hugging Face on first use, so a host firewalled off from it — but allowed
-out to a corporate gateway — cannot embed locally at all. Remote embeddings are
-the way out of that, and the only reason the code path exists.
+**One case, and it is narrow: a node that can reach an embeddings API, cannot
+reach Hugging Face, and cannot have its model cache pre-seeded.** The local
+embedder downloads ~65 MB of ONNX weights from Hugging Face on first use, so a
+host firewalled off from it — but allowed out to a corporate gateway — has
+nothing to embed with until those weights arrive by some other route.
+
+Copying them in is that other route, and it is the better one: the
+[pre-seeded cache](rag-index.md#air-gapped-nodes) keeps embeddings local, free
+and unmetered on a host that cannot reach Hugging Face at all. Try it first.
+Remote embeddings are what is left when it is impractical — no second machine on
+the same AORTA version, no way to move 65 MB onto the node, or a policy against
+carrying model weights — and that is the only reason the code path exists.
 
 Everything else that looks like a reason is not one:
 
@@ -201,7 +208,9 @@ risk to be managed.
    place.** CI builds the index asset with default settings, so its vectors are
    the local model's. An index is only meaningful to the model that produced it,
    and the manifest check refuses a mismatch rather than answering from it. So
-   `aorta chat index fetch` will refuse the download, and an already-fetched
+   `aorta chat index fetch` refuses to *install* what it downloaded — the
+   manifest is validated after the asset has been transferred and checksummed,
+   so you pay for the download and then get the refusal — and an already-fetched
    index will refuse every query. You take over building the index yourself, on
    every AORTA upgrade, until you [go back](#going-back).
 2. **Every query costs money, not just the build.** The one-off index build
@@ -301,11 +310,11 @@ them every time you rebuild. Skipping it leaves the run-artifact tools without
 an index they can read, which is a worse assistant but not an egress you did
 not choose.
 
-Not `index fetch` — that will refuse, correctly, because the published asset is
-the local model's. `index build` embeds everything under `aorta_path` through
-the provider you just configured, and writes it to a collection named after
-that provider and model, so the local collection already in the file is not
-overwritten.
+Not `index fetch` — it downloads the asset and then refuses to install it,
+correctly, because the published asset is the local model's. `index build`
+embeds everything under `aorta_path` through the provider you just configured,
+and writes it to a collection named after that provider and model, so the local
+collection already in the file is not overwritten.
 
 Know what you are giving up in coverage as well as in cost: `aorta_path`
 defaults to the installed `aorta` package, so a local build indexes the code

--- a/docs/chat/configuration.md
+++ b/docs/chat/configuration.md
@@ -81,7 +81,7 @@ environment.
 | Setting | Default | Meaning |
 | --- | --- | --- |
 | `llm_provider` | `vllm` | `vllm` (local server) / `openai` (any OpenAI-wire endpoint) / `litellm` (native Anthropic, Gemini, Bedrock). An unknown value raises, listing the accepted names. |
-| `embedding_provider` | `local` | `local` (a small model on CPU) / `remote` (an embeddings API). Independent of `llm_provider`. |
+| `embedding_provider` | `local` | `local` (a small model on CPU) / `remote` (an embeddings API). Independent of `llm_provider`, and every `config init` profile writes `local` — including the remote-chat ones, because the published index is built with the local model and cannot be read by any other. `remote` is a manual choice with consequences: see [configuring a remote embedding provider](#configuring-a-remote-embedding-provider-by-hand). |
 | `llm_tool_mode` | `text` | `text` parses `ACTION: tool(arg="v")` lines out of the reply; `native` uses the provider's function-calling API. Reasoning models need `native` — see [providers](providers.md#tool-calling-and-reasoning-models). |
 
 ### Local vLLM (`llm_provider = "vllm"`)
@@ -116,9 +116,18 @@ environment.
 | --- | --- | --- |
 | `embedding_model` | `BAAI/bge-small-en-v1.5` | Local model. |
 | `model_cache_path` | `$XDG_CACHE_HOME/aorta/chat/models` | Where the local model's ONNX weights are cached. `HF_HOME` overrides it, which is what [air-gapped pre-seeding](rag-index.md#air-gapped-nodes) uses. Explicit rather than `fastembed`'s own `/tmp/fastembed_cache`, which a reboot wipes and other users on a shared node can write. |
+
+The five `remote_embedding_*` settings below are read only when
+`embedding_provider = "remote"`, which no profile selects. Setting them without
+also setting `embedding_provider` changes nothing; setting them together with it
+is the procedure [below](#configuring-a-remote-embedding-provider-by-hand), and
+it obliges a local index rebuild.
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
 | `remote_embedding_model` | `text-embedding-3-small` | Also decides the collection name, since dimensions differ per model. |
-| `remote_embedding_api_key` | *(empty)* | Separate from the chat key, so the two can use different providers. |
-| `remote_embedding_base_url` | *(empty)* | Empty means the provider default. |
+| `remote_embedding_api_key` | *(empty)* | Separate from the chat key, so the two can use different providers. Required: an empty value raises rather than falling back to the local model. |
+| `remote_embedding_base_url` | *(empty)* | Empty means the provider default, which for an OpenAI-compatible client is `api.openai.com`. Set it for anything else — a gateway header with an empty base URL sends your corpus to OpenAI. |
 | `remote_embedding_auth_header` / `remote_embedding_extra_headers` | *(empty)* | As on the chat side. Behind a gateway you normally set both or neither. |
 
 ### Corpus and index
@@ -153,6 +162,179 @@ directory cannot be pip-upgraded cleanly.
 | `allowed_commands` | `python,pytest,make,pip,grep,wc,head,tail,cat,ls,find` | Allowlist for `run_terminal_command`, applied per pipeline stage. Command chaining and redirection (`;`, `&`, backticks, `$(...)`, `>`, `<`) are refused, since the allowlist checks executables. Accepts `a,b,c` or a JSON list. |
 | `command_timeout` | `60` | Seconds before a `run_terminal_command` command is killed. |
 | `redact` | `true` | Rewrite filesystem paths and IP addresses out of outbound LLM requests. Does not cover the remote-embedding path. Read [redaction](redaction.md) before turning this off — and read it anyway for what it does **not** cover. |
+
+## Configuring a remote embedding provider by hand
+
+`embedding_provider = "remote"` is supported but selected by nothing: no
+`config init` profile writes it, and there is no flag or prompt for it. It is a
+deliberate, manual change, and this is the whole procedure.
+
+### When this is the right choice
+
+**One case, and it is narrow: a node that can reach an embeddings API but
+cannot reach Hugging Face.** The local embedder downloads ~65 MB of ONNX weights
+from Hugging Face on first use, so a host firewalled off from it — but allowed
+out to a corporate gateway — cannot embed locally at all. Remote embeddings are
+the way out of that, and the only reason the code path exists.
+
+Everything else that looks like a reason is not one:
+
+- **A remote chat model is not a reason.** The two selectors are independent.
+  Remote generation with local embeddings is the normal shape and the cheaper
+  one, because retrieval then costs nothing per query.
+- **Quality is not a reason worth the trade here.** Retrieval over one source
+  tree is not where a larger embedding model earns its price, and the published
+  index is only usable with the local model.
+- **An air-gapped node is not a reason** — it cannot reach the embeddings API
+  either. Pre-seed the model cache instead; see
+  [air-gapped nodes](rag-index.md#air-gapped-nodes).
+
+### What it costs you before you start
+
+Read these three before editing anything. Each of them is a consequence, not a
+risk to be managed.
+
+1. **The published index becomes unusable, permanently, for this install.** CI
+   builds the index asset with default settings, so its vectors are the local
+   model's. An index is only meaningful to the model that produced it, and the
+   manifest check refuses a mismatch rather than answering from it. So
+   `aorta chat index fetch` will refuse the download, and an already-fetched
+   index will refuse every query. You take over building the index yourself,
+   for as long as this setting is in place, on every AORTA upgrade.
+2. **Every query costs money, not just the build.** The one-off index build
+   embeds the whole corpus; after that each question sends one embedding call
+   for the query text, and each `search_code` tool call sends another. The build
+   is the large number — the public corpus is roughly 5 MB of text over ~360
+   files, so on the order of one to two million tokens — but the per-query calls
+   are the ones that never stop. Check your provider's own price list: at
+   `text-embedding-3-small`'s published rate the build is cents, and at a large
+   model's, or through a gateway that adds a markup, it is not.
+3. **Redaction does not cover this path.** `redact = true` rewrites paths and IP
+   addresses out of *LLM* requests. The embeddings request is a different
+   request and is sent verbatim. That matters most for the run-artifact
+   collection, which holds your own `matrix.json` and `env.json` and can carry
+   customer hostnames, filesystem layouts and environment variables — all of
+   which would be sent, unredacted, to the embeddings endpoint at
+   `index runs` time and never rewritten. [redaction](redaction.md) has the
+   full scope. If that corpus must not leave the machine, stop here.
+
+### The procedure
+
+**1. Set the selector and the five settings it turns on.** Six in total, of
+which four are required and two apply only behind a gateway:
+
+| Setting | | |
+| --- | --- | --- |
+| `embedding_provider` | required | The selector. Nothing below is read without it. |
+| `remote_embedding_model` | required | Has a default, but set it explicitly — it names the collection. |
+| `remote_embedding_base_url` | required in practice | Only omit it if you mean OpenAI's own API. |
+| `remote_embedding_api_key` | required | Empty raises at first use. |
+| `remote_embedding_auth_header` | gateway only | Header name instead of a bearer token. |
+| `remote_embedding_extra_headers` | gateway only | Any other headers the gateway wants. |
+
+In `~/.config/aorta/chat.toml`:
+
+```toml
+# The selector. Without this the five below are read by nothing.
+embedding_provider = "remote"
+
+# The model. Also decides the collection name, because dimensions differ per
+# model and two models' vectors cannot share a table.
+remote_embedding_model = "text-embedding-3-small"
+
+# The endpoint. Do not leave this empty unless you really mean OpenAI's own
+# API: empty resolves to api.openai.com, so an empty base URL plus a gateway
+# auth header sends your corpus to OpenAI with a header it does not read.
+remote_embedding_base_url = "https://gateway.example.com/openai/v1"
+
+# The key. Separate from remote_llm_api_key, so chat and embeddings can use
+# different providers. Empty raises at first use rather than silently falling
+# back to the local model.
+remote_embedding_api_key = "..."
+
+# The last two only behind a gateway that does not take a bearer token. Same
+# names and same meaning as the remote_llm_* pair; omit both against a provider
+# that takes an Authorization header, which is most of them.
+remote_embedding_auth_header = "Ocp-Apim-Subscription-Key"
+remote_embedding_extra_headers = { user = "alice", x-tenant = "acme" }
+```
+
+Or in the environment, which outranks the file:
+
+```bash
+export AORTA_CHAT_EMBEDDING_PROVIDER=remote
+export AORTA_CHAT_REMOTE_EMBEDDING_MODEL=text-embedding-3-small
+export AORTA_CHAT_REMOTE_EMBEDDING_BASE_URL=https://gateway.example.com/openai/v1
+export AORTA_CHAT_REMOTE_EMBEDDING_API_KEY=...
+export AORTA_CHAT_REMOTE_EMBEDDING_AUTH_HEADER=Ocp-Apim-Subscription-Key
+export AORTA_CHAT_REMOTE_EMBEDDING_EXTRA_HEADERS=user=alice,x-tenant=acme
+```
+
+`remote_embedding_api_key` and the values in `remote_embedding_extra_headers`
+are both treated as credentials: masked by `config show`, and enough on their
+own to make `config validate` fail a profile that is not `0600`.
+
+**2. Confirm what it resolved to, before spending anything.**
+
+```bash
+aorta chat config show
+```
+
+Check the endpoint is the one you meant. An empty or mistyped
+`remote_embedding_base_url` is the failure worth catching here, because the
+symptom is a `401` from a third party you did not choose rather than an error
+about your configuration.
+
+**3. Rebuild the index. This step is mandatory, not a refresh.**
+
+```bash
+aorta chat index build     # the source collection
+aorta chat index runs      # the run-artifact collection, if you use it
+```
+
+`index runs` is the one to think twice about: it is the command that sends your
+own `matrix.json` and `env.json` to the embeddings endpoint, and it re-sends
+them every time you rebuild. Skipping it leaves the run-artifact tools without
+an index they can read, which is a worse assistant but not an egress you did
+not choose.
+
+Not `index fetch` — that will refuse, correctly, because the published asset is
+the local model's. `index build` embeds everything under `aorta_path` through
+the provider you just configured, and writes it to a collection named after
+that provider and model, so the local collection already in the file is not
+overwritten.
+
+Know what you are giving up in coverage as well as in cost: `aorta_path`
+defaults to the installed `aorta` package, so a local build indexes the code
+but not `docs/` or `README.md`, which the published asset does carry. Point
+`aorta_path` at a source checkout if you want the prose too. See
+[the RAG index](rag-index.md#managing-it).
+
+**4. Verify.**
+
+```bash
+aorta chat doctor
+```
+
+The index check should pass, and the embedding line should name your endpoint
+and model rather than `<provider-default>`. A refusal here means the index and
+the configuration still disagree — usually step 3 was skipped, or was run before
+step 1 took effect.
+
+### Going back
+
+Remove or unset the six settings and re-fetch:
+
+```bash
+aorta chat index fetch
+```
+
+The two providers use different collection names and coexist in the one
+`.sqlite` file, so the local collection is still where it was. The re-fetch is
+not there to replace it — it is there to restore the manifest, which the remote
+`index build` rewrote to name the remote model, and which is checked before any
+query. `aorta chat index build` restores it just as well if you would rather not
+go back to the published asset.
 
 ## Example profile
 

--- a/docs/chat/configuration.md
+++ b/docs/chat/configuration.md
@@ -208,14 +208,16 @@ risk to be managed.
    place.** CI builds the index asset with default settings, so its vectors are
    the local model's. An index is only meaningful to the model that produced it,
    and the manifest check refuses a mismatch rather than answering from it. So
-   `aorta chat index fetch` refuses to *install* what it downloaded — the
-   manifest is validated after the asset has been transferred and checksummed,
-   so you pay for the download and then get the refusal — and an already-fetched
-   index will refuse every query. You take over building the index yourself, on
-   every AORTA upgrade, until you [go back](#going-back).
+   `aorta chat index fetch` will not leave you with a usable index — it refuses
+   the published asset rather than installing it — and an already-fetched index
+   will refuse every query. You take over building the index yourself, on every
+   AORTA upgrade, until you [go back](#going-back).
 2. **Every query costs money, not just the build.** The one-off index build
-   embeds the whole corpus; after that each question sends one embedding call
-   for the query text, and each `search_code` tool call sends another. The build
+   embeds the whole corpus; after that every question embeds the query text to
+   retrieve source, and retrieval also searches the run-artifact collection on
+   every question — so once you have run `index runs`, the floor is two
+   embedding calls per question, not one. Each `search_code` or
+   `search_run_artifacts` tool call adds another on top. The build
    is the large number — the public corpus is roughly 5 MB of text over ~360
    files, so on the order of one to two million tokens — but the per-query calls
    are the ones that never stop. Check your provider's own price list: at
@@ -317,8 +319,8 @@ them every time you rebuild. Skipping it leaves the run-artifact tools without
 an index they can read, which is a worse assistant but not an egress you did
 not choose.
 
-Not `index fetch` — it downloads the asset and then refuses to install it,
-correctly, because the published asset is the local model's. `index build`
+Not `index fetch` — it refuses the published asset rather than installing it,
+correctly, because that asset is the local model's. `index build`
 embeds everything under `aorta_path` through the provider you just configured,
 and writes it to a collection named after that provider and model, so the local
 collection already in the file is not overwritten.
@@ -354,6 +356,12 @@ Remove or unset the six settings and re-fetch:
 ```bash
 aorta chat index fetch
 ```
+
+The index this replaces is the one step 3 built locally, and that is the point:
+going back means giving up the local build for the published asset. If the
+command declines for that reason — a downloaded asset can always be downloaded
+again, where a local build may not be reproducible — the refusal names the flag
+that overrides it, and overriding is the right answer here.
 
 That is the whole way back **only if `embedding_model` is still at its default**.
 It is not one of the six, and it is the one other setting the published asset is

--- a/docs/chat/providers.md
+++ b/docs/chat/providers.md
@@ -5,6 +5,13 @@ which model turns text into vectors (`embedding_provider`). Mixing them is
 normal — remote generation with local embeddings is the cheap default, because
 retrieval then costs nothing.
 
+Everything on this page is about `llm_provider`. `embedding_provider` is
+`local` for every profile `aorta chat config init` writes, including the remote
+ones, and the published index is only readable that way. Choosing a remote
+chat model is not a reason to change it; the narrow case that is, and what it
+costs, are in
+[configuring a remote embedding provider by hand](configuration.md#configuring-a-remote-embedding-provider-by-hand).
+
 ## Chat backends
 
 | `llm_provider` | Speaks | Use for | Extra |
@@ -202,7 +209,9 @@ several critic passes can push a single question past forty. Most action queries
 land in the 4–6 range in practice, because the act loop stops as soon as the
 model answers without a tool call and the critic usually accepts first time.
 With `embedding_provider = "remote"`, each retrieval and each `search_code` call
-adds one embedding call on top.
+adds one embedding call on top — which is why no profile selects it, and why
+[the procedure for choosing it](configuration.md#configuring-a-remote-embedding-provider-by-hand)
+leads with the cost.
 
 Against a metered endpoint that is real money, so the remote backends log the
 per-query call count at INFO, visible without `--verbose`:
@@ -224,7 +233,7 @@ Knobs that lower the bill, roughly in order of effect:
 | `llm_max_tokens` | Caps output tokens per call. |
 | `retriever_k` / `search_tool_k` | Fewer chunks means a smaller prompt, and prompt tokens dominate a long act loop. |
 | `llm_max_retries` | Lower it on an unreliable endpoint, so failures do not silently triple. |
-| `embedding_provider = "local"` | Keeps all retrieval free even when generation is remote. |
+| `embedding_provider = "local"` | Keeps all retrieval free even when generation is remote. Already the case unless you set it by hand. |
 | `remote_llm_model` | A smaller model in the same family is usually the cheapest change of all. |
 
 ## Troubleshooting

--- a/docs/chat/providers.md
+++ b/docs/chat/providers.md
@@ -209,9 +209,11 @@ several critic passes can push a single question past forty. Most action queries
 land in the 4–6 range in practice, because the act loop stops as soon as the
 model answers without a tool call and the critic usually accepts first time.
 With `embedding_provider = "remote"`, each retrieval and each `search_code` call
-adds one embedding call on top — which is why no profile selects it, and why
-[the procedure for choosing it](configuration.md#configuring-a-remote-embedding-provider-by-hand)
-leads with the cost.
+adds one embedding call on top. That recurring bill is the second reason no
+profile selects it; the first is that the published index is built with the
+local model, so a remote embedder makes `index fetch` unusable.
+[The procedure for choosing it](configuration.md#configuring-a-remote-embedding-provider-by-hand)
+covers both.
 
 Against a metered endpoint that is real money, so the remote backends log the
 per-query call count at INFO, visible without `--verbose`:

--- a/docs/chat/providers.md
+++ b/docs/chat/providers.md
@@ -254,4 +254,4 @@ Knobs that lower the bill, roughly in order of effect:
 | Many `Act round N: ... re-prompting` lines and no answer | Same cause. Set `llm_tool_mode = "native"`. |
 | `Waiting for vLLM at ...` when you meant to go remote | `llm_provider` is still `vllm`. Check the backend line printed at startup. |
 | The call-count line never appears | Expected on `llm_provider = "vllm"`; only the remote backends attach the counter. |
-| `extra header 'user' is missing '='` | `remote_llm_extra_headers` takes `name=value` pairs or a JSON object. |
+| `extra header #N is missing '='` | `remote_llm_extra_headers` takes `name=value` pairs or a JSON object. `#N` is the position in the comma-separated list, counted from 1 — the entry itself is not quoted back, because a header value may be a credential. |

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -105,7 +105,9 @@ resolves by installed version — a released wheel gets that release's asset, a
 It is the normal path for every chat provider, because the embedding provider is
 a separate choice and every `config init` profile leaves it local. The asset is
 built by CI under default settings, so `fetch` works exactly as long as your
-install still embeds with the local model — which is the reason
+install still embeds with the default local model — a hand-set
+`embedding_model` is refused just as a remote provider is, because the manifest
+check compares the model name and not only the flow. That is the reason
 [choosing a remote embedder](configuration.md#configuring-a-remote-embedding-provider-by-hand)
 means taking over the build.
 
@@ -145,7 +147,9 @@ the embedding library, which reads as a bug rather than as "you need to pre-seed
 a cache" — so if that is what you are looking at, this is the section you want.
 
 **A node that can reach an embeddings API but not Hugging Face** is the one
-case remote embeddings are genuinely for, and it is this one. It is not a
+case remote embeddings are genuinely for — but only where the pre-seeded cache
+above is out of reach, because that keeps embeddings local, free and unmetered
+on exactly the same node. Reach for it first. Remote is not a
 drop-in switch: it changes the collection name, makes the published asset
 unusable so `index build` becomes mandatory on every upgrade, bills you per
 query as well as per build, and sends the corpus — including the run-artifact

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -26,8 +26,10 @@ not touch it. Retrieved chunks from it are also the reason
 > `matrix.json` and `env.json` text to the embeddings API so it can be turned
 > into vectors, and each later query is sent the same way. That path is not
 > covered by chat-message redaction, which applies to the LLM request rather
-> than the embeddings one. Keep `embedding_provider = "local"` — the default —
-> if this data must not leave the machine.
+> than the embeddings one. Keep `embedding_provider = "local"` — the default,
+> and what every `config init` profile writes — if this data must not leave the
+> machine. Turning it off is a manual change with a
+> [documented procedure and a documented cost](configuration.md#configuring-a-remote-embedding-provider-by-hand).
 
 Alongside the index, chat generates a **repo map** — a function and class index
 over the same tree, at `$XDG_CACHE_HOME/aorta/chat/repo_map.md`. The planner
@@ -100,6 +102,13 @@ a given AORTA revision, so building it locally is work someone already did. It
 resolves by installed version — a released wheel gets that release's asset, a
 `.dev` build gets the rolling `main` asset with a warning about the commit delta.
 
+It is the normal path for every chat provider, because the embedding provider is
+a separate choice and every `config init` profile leaves it local. The asset is
+built by CI under default settings, so `fetch` works exactly as long as your
+install still embeds with the local model — which is the reason
+[choosing a remote embedder](configuration.md#configuring-a-remote-embedding-provider-by-hand)
+means taking over the build.
+
 Building locally is the developer path and the air-gapped path. It takes a few
 minutes and runs on CPU.
 
@@ -135,6 +144,14 @@ The failure without this arrives as a Hugging Face connection error from inside
 the embedding library, which reads as a bug rather than as "you need to pre-seed
 a cache" — so if that is what you are looking at, this is the section you want.
 
-Alternatively set `embedding_provider = "remote"` if the node can reach an
-embeddings API but not Hugging Face; note that this changes the collection name
-and requires building the index against that provider.
+**A node that can reach an embeddings API but not Hugging Face** is the one
+case remote embeddings are genuinely for, and it is this one. It is not a
+drop-in switch: it changes the collection name, makes the published asset
+unusable so `index build` becomes mandatory on every upgrade, bills you per
+query as well as per build, and sends the corpus — including the run-artifact
+collection's `env.json` and `matrix.json` — to that API on a path redaction does
+not cover. The full procedure and the rest of the trade-off is
+[configuring a remote embedding provider by hand](configuration.md#configuring-a-remote-embedding-provider-by-hand).
+
+A genuinely air-gapped node cannot reach the embeddings API either, so for that
+one the answer is the pre-seeded model cache above, not this.

--- a/src/aorta/chat/config.py
+++ b/src/aorta/chat/config.py
@@ -491,18 +491,29 @@ settings = _LazySettings()
 #: ``aorta/cli/chat.py`` hard-codes the same names in its ``click.Choice`` --
 #: decorators run at import time, so it cannot read this dict -- and
 #: ``tests/chat/test_config_wizard.py`` fails if the two drift apart.
+#:
+#: **Every template sets ``embedding_provider = "local"``, and the value is
+#: written out rather than left to the field default so the file records the
+#: decision.** Generation and retrieval are independent choices, and four of
+#: these templates used to couple them: picking a remote *chat* model also
+#: opted the user into a remote *embedder*, which made ``aorta chat index
+#: fetch`` structurally unusable. CI publishes the index asset under default
+#: settings, so a remote-embedding install refuses the published index at fetch
+#: time, or -- if ``config init`` runs second -- at query time, with no ordering
+#: of the two commands that works. Remote embeddings are still reachable by
+#: setting the fields by hand; ``docs/chat/configuration.md`` carries the
+#: procedure and the cost and egress it implies.
 PROFILE_TEMPLATES: dict[str, dict[str, Any]] = {
     "openai": {
         "llm_provider": "openai",
         "remote_llm_model": "gpt-4o-mini",
-        "embedding_provider": "remote",
-        "remote_embedding_model": "text-embedding-3-small",
+        "embedding_provider": "local",
     },
     "openai-compatible": {
         "llm_provider": "openai",
         "remote_llm_model": "",
         "remote_llm_base_url": "",
-        "embedding_provider": "remote",
+        "embedding_provider": "local",
     },
     "azure-apim": {
         "llm_provider": "openai",
@@ -512,15 +523,14 @@ PROFILE_TEMPLATES: dict[str, dict[str, Any]] = {
         # from Authorization; without this the gateway answers 401 to a request
         # that looks correct.
         "remote_llm_auth_header": "Ocp-Apim-Subscription-Key",
-        "embedding_provider": "remote",
-        "remote_embedding_auth_header": "Ocp-Apim-Subscription-Key",
+        "embedding_provider": "local",
     },
     "anthropic": {
         # Native Anthropic wire protocol, which the openai backend cannot
         # speak; litellm needs the chat-all extra.
         "llm_provider": "litellm",
         "remote_llm_model": "claude-sonnet-4-5",
-        "embedding_provider": "remote",
+        "embedding_provider": "local",
     },
     "local-vllm": {
         "llm_provider": "vllm",
@@ -532,6 +542,11 @@ PROFILE_TEMPLATES: dict[str, dict[str, Any]] = {
 
 #: Fields ``aorta chat config init`` asks about, per profile, in order. The
 #: wizard prompts for exactly these; anything else is taken from the template.
+#:
+#: No profile asks about embeddings, which is now consistent with every template
+#: choosing the local embedder: there is nothing left to collect. Prompting for
+#: a remote embedding endpoint and key would only be coherent alongside a
+#: template that selected one, and the reason none does is above.
 PROFILE_PROMPTS: dict[str, tuple[str, ...]] = {
     "openai": ("remote_llm_model", "remote_llm_api_key"),
     "openai-compatible": ("remote_llm_base_url", "remote_llm_model", "remote_llm_api_key"),

--- a/src/aorta/chat/config.py
+++ b/src/aorta/chat/config.py
@@ -624,6 +624,78 @@ def write_profile(values: dict[str, Any], path: Path | None = None) -> Path:
     return path
 
 
+#: Spellings of ``embedding_provider`` that select the local flow.
+#: ``rag/embeddings/factory.py`` owns the list; it is repeated here because
+#: importing that module pulls in langchain_core and both provider modules,
+#: which ``aorta chat config init`` has no other reason to load. Same
+#: arrangement as ``_CONFIG_PROFILES`` in ``cli/chat.py``, and
+#: ``tests/chat/test_config_wizard.py`` fails if the two drift apart.
+LOCAL_EMBEDDING_PROVIDERS = frozenset({"local", "onnx", "fastembed"})
+
+
+def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
+    """What this install will embed with, and which index command follows.
+
+    Read from the merged settings rather than from *profile_values*, because
+    ``AORTA_CHAT_*`` outranks the file ``config init`` has just written. A user
+    with ``AORTA_CHAT_EMBEDDING_PROVIDER=remote`` exported would otherwise be
+    told local embeddings were configured and sent to ``index fetch``, which
+    then refuses the published asset -- advice the environment does not let
+    them follow, which is the shape of failure this whole path exists to stop.
+
+    ``index fetch`` is promised only when the provider *and* the model agree
+    with the defaults CI publishes the asset under. :func:`rag.manifest.validate`
+    refuses on the model name and on the embedding identity, which for the local
+    provider is the model name again -- so a local install on a hand-set
+    ``embedding_model`` is refused exactly like a remote one.
+    """
+    try:
+        current = get_settings()
+    except Exception as exc:  # pydantic ValidationError, or a field validator
+        # The profile is already on disk at this point, so an unrelated bad
+        # AORTA_CHAT_* value must not turn a successful write into a traceback.
+        return [
+            f"Embeddings: cannot be resolved -- {exc}",
+            "Sort the environment out first: aorta chat config validate",
+        ]
+
+    default_model = Settings.model_fields["embedding_model"].default
+    if current.embedding_provider.strip().lower() not in LOCAL_EMBEDDING_PROVIDERS:
+        lines = [
+            f"Embeddings: {current.embedding_provider}, via "
+            f"{current.remote_embedding_model}. The published index is built "
+            "with the local model, so 'aorta chat index build' is required "
+            "before querying."
+        ]
+    elif current.embedding_model != default_model:
+        lines = [
+            f"Embeddings: local, on this machine ({current.embedding_model}). "
+            f"The published index is built with {default_model}, so 'aorta "
+            "chat index build' is required before querying."
+        ]
+    else:
+        lines = [
+            "Embeddings: local, on this machine. 'aorta chat index fetch' "
+            "installs the published index unchanged."
+        ]
+
+    # Naming the variable matters more than naming the value: the line above
+    # otherwise contradicts the file the user was just told was written, with
+    # nothing on screen to say which one wins.
+    overridden = [
+        f"{ENV_PREFIX}{field.upper()}"
+        for field in ("embedding_provider", "embedding_model")
+        if getattr(current, field)
+        != profile_values.get(field, Settings.model_fields[field].default)
+    ]
+    if overridden:
+        lines.append(
+            f"That is {' and '.join(overridden)} from the environment, which "
+            "outranks the profile just written."
+        )
+    return lines
+
+
 def mask(value: str) -> str:
     """Render a credential as its length and last four characters.
 
@@ -708,6 +780,7 @@ def validate_profile(path: Path | None = None) -> list[str]:
 
 __all__ = [
     "ENV_PREFIX",
+    "LOCAL_EMBEDDING_PROVIDERS",
     "PROFILE_FILE_MODE",
     "PROFILE_PROMPTS",
     "PROFILE_TEMPLATES",
@@ -717,6 +790,7 @@ __all__ = [
     "Settings",
     "apply_cli_overrides",
     "configure",
+    "describe_embeddings",
     "effective_settings",
     "get_settings",
     "mask",

--- a/src/aorta/chat/config.py
+++ b/src/aorta/chat/config.py
@@ -686,7 +686,14 @@ def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
     :func:`aorta.chat.rag.manifest.validate` refuses on the model name and on
     the embedding identity, which for the local provider is the model name
     again -- so a local install on a hand-set ``embedding_model`` is refused
-    exactly like a remote one.
+    exactly like a remote one. Chunk parameters are deliberately *not* part of
+    that decision: ``validate`` reports them as warnings and ``fetch_index``
+    gates on refusals only, so ``AORTA_CHAT_CHUNK_SIZE`` does not stop a fetch.
+
+    The rule every arm below follows: name a command only when the resolved
+    settings let it succeed, and otherwise name the blocker instead. An unknown
+    ``embedding_provider`` and a remote provider with no key both fail before
+    any index command can run, so neither arm offers one.
     """
     try:
         current = get_settings()
@@ -711,6 +718,22 @@ def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
             f"provider this aorta knows "
             f"({', '.join(sorted(EMBEDDING_PROVIDER_FLOWS))}). Indexing and "
             "querying will both fail until it is corrected."
+        ]
+    elif flow == "remote" and not current.remote_embedding_api_key.strip():
+        # Naming 'index build' here would be the same defect one case over:
+        # RemoteApiProvider.get_embeddings() raises on an empty key before it
+        # sends anything, so the command is known to fail from the settings
+        # alone. And this is the likely state on the override path rather than a
+        # corner of it -- the profile config init has just written is a local
+        # one and carries no remote key, so an exported
+        # AORTA_CHAT_EMBEDDING_PROVIDER=remote arrives here with nothing to
+        # authenticate with.
+        lines = [
+            f"Embeddings: {current.embedding_provider}, via "
+            f"{current.remote_embedding_model}, but "
+            f"{ENV_PREFIX}REMOTE_EMBEDDING_API_KEY is not set. Indexing and "
+            "querying will both fail until it is, so set it (or put "
+            "remote_embedding_api_key in the profile) before either."
         ]
     elif flow == "remote":
         lines = [

--- a/src/aorta/chat/config.py
+++ b/src/aorta/chat/config.py
@@ -332,12 +332,18 @@ class Settings(BaseSettings):
                     'either user=alice,x-tenant=amd or {"user": "alice"}.'
                 ) from exc
         headers: dict[str, str] = {}
-        for pair in text.split(","):
+        # Positional, not quoted: whatever is in a header map may be a
+        # credential (SECRET_MAPPING_FIELDS), and this message is rendered by
+        # every consumer of the resulting ValidationError -- including two
+        # handlers in ``cli/chat.py`` that print ``str(exc)`` and catch this
+        # because pydantic's ValidationError is a ValueError. The position is
+        # what the user counts commas to find anyway.
+        for position, pair in enumerate(text.split(","), start=1):
             if not pair.strip():
                 continue
             if "=" not in pair:
                 raise ValueError(
-                    f"extra header {pair.strip()!r} is missing '='. Use "
+                    f"extra header #{position} is missing '='. Use "
                     'either user=alice,x-tenant=amd or {"user": "alice"}.'
                 )
             name, _, header_value = pair.partition("=")
@@ -641,11 +647,12 @@ EMBEDDING_PROVIDER_FLOWS: dict[str, str] = {
 def _unresolvable_settings_reason(exc: Exception) -> str:
     """Why the settings would not load, named without quoting any value.
 
-    ``str(ValidationError)`` carries pydantic's ``input_value``, and the
-    ``extra_headers`` validator quotes the offending pair in its own message, so
-    interpolating either would print through ``config init`` the very gateway key
-    that :data:`SECRET_MAPPING_FIELDS` masks in ``config show``, keeps out of
-    ``aorta bundle``, and mode-checks on disk.
+    ``str(ValidationError)`` carries pydantic's ``input_value``, so interpolating
+    it would print the very gateway key that :data:`SECRET_MAPPING_FIELDS` masks
+    in ``config show``, keeps out of ``aorta bundle``, and mode-checks on disk.
+    The validators in this module are written not to echo a rejected value
+    either, but that is their own discipline and does not cover ``input_value``,
+    which pydantic appends whatever the message says.
 
     A field name is enough to act on and cannot itself be a credential, so only
     names are reported. The rejected value is withheld whatever field it arrived
@@ -653,6 +660,9 @@ def _unresolvable_settings_reason(exc: Exception) -> str:
     ``remote_llm_base_url`` query string is as much a leak as one in an extra
     header, and a rule keyed on field names would fail open on the field nobody
     classified.
+
+    Used by :func:`describe_embeddings` and :func:`validate_profile` -- the echo
+    printed after a key is typed in, and the command that echo points at.
     """
     if isinstance(exc, ValidationError):
         fields = sorted({str(err["loc"][0]) for err in exc.errors() if err.get("loc")})
@@ -779,9 +789,11 @@ def effective_settings(reveal: bool = False) -> dict[str, Any]:
 def validate_profile(path: Path | None = None) -> list[str]:
     """Return the problems with the on-disk profile; empty means healthy.
 
-    Reports unreadable/malformed files, keys that no longer exist, values that
-    fail validation, and a profile holding a credential at a permissive mode --
-    the last being a real finding on a shared node, not a style note.
+    Reports unreadable/malformed files, keys that no longer exist, the *names* of
+    fields whose values fail validation, and a profile holding a credential at a
+    permissive mode -- the last being a real finding on a shared node, not a
+    style note. Names and not values, because a rejected value may itself be a
+    credential: see :func:`_unresolvable_settings_reason`.
 
     "Credential" is :data:`SECRET_FIELDS` plus a non-empty
     :data:`SECRET_MAPPING_FIELDS` map, so a profile whose only secret is a
@@ -804,7 +816,10 @@ def validate_profile(path: Path | None = None) -> list[str]:
     try:
         Settings()
     except Exception as exc:  # pydantic ValidationError, or a field validator
-        problems.append(f"{path}: {exc}")
+        # Field names only, for the reason _unresolvable_settings_reason gives:
+        # this is the command ``config init`` sends a user to after their key was
+        # rejected, so it is the last place that may echo the key back.
+        problems.append(f"{path}: {_unresolvable_settings_reason(exc)}")
 
     # SECRET_MAPPING_FIELDS counts too: a profile whose only credential sits in
     # an extra header is exactly as sensitive as one with remote_llm_api_key

--- a/src/aorta/chat/config.py
+++ b/src/aorta/chat/config.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import tomllib
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 from pydantic_settings import (
     BaseSettings,
     NoDecode,
@@ -638,6 +638,29 @@ EMBEDDING_PROVIDER_FLOWS: dict[str, str] = {
 }
 
 
+def _unresolvable_settings_reason(exc: Exception) -> str:
+    """Why the settings would not load, named without quoting any value.
+
+    ``str(ValidationError)`` carries pydantic's ``input_value``, and the
+    ``extra_headers`` validator quotes the offending pair in its own message, so
+    interpolating either would print through ``config init`` the very gateway key
+    that :data:`SECRET_MAPPING_FIELDS` masks in ``config show``, keeps out of
+    ``aorta bundle``, and mode-checks on disk.
+
+    A field name is enough to act on and cannot itself be a credential, so only
+    names are reported. The rejected value is withheld whatever field it arrived
+    in, rather than only for the fields named secret: an ``api-key`` in a
+    ``remote_llm_base_url`` query string is as much a leak as one in an extra
+    header, and a rule keyed on field names would fail open on the field nobody
+    classified.
+    """
+    if isinstance(exc, ValidationError):
+        fields = sorted({str(err["loc"][0]) for err in exc.errors() if err.get("loc")})
+        if fields:
+            return f"aorta rejected {', '.join(fields)}"
+    return f"the settings could not be loaded ({type(exc).__name__})"
+
+
 def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
     """What this install will embed with, and which index command follows.
 
@@ -660,8 +683,10 @@ def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
     except Exception as exc:  # pydantic ValidationError, a field validator, ConfigFileError
         # The profile is already on disk at this point, so an unrelated bad
         # AORTA_CHAT_* value must not turn a successful write into a traceback.
+        # Rendered without the rejected value, which can be a credential: see
+        # _unresolvable_settings_reason.
         return [
-            f"Embeddings: cannot be resolved -- {exc}",
+            f"Embeddings: cannot be resolved -- {_unresolvable_settings_reason(exc)}",
             "Sort the environment out first: aorta chat config validate",
         ]
 

--- a/src/aorta/chat/config.py
+++ b/src/aorta/chat/config.py
@@ -624,13 +624,18 @@ def write_profile(values: dict[str, Any], path: Path | None = None) -> Path:
     return path
 
 
-#: Spellings of ``embedding_provider`` that select the local flow.
-#: ``rag/embeddings/factory.py`` owns the list; it is repeated here because
-#: importing that module pulls in langchain_core and both provider modules,
-#: which ``aorta chat config init`` has no other reason to load. Same
-#: arrangement as ``_CONFIG_PROFILES`` in ``cli/chat.py``, and
+#: How ``rag/embeddings/factory.py`` resolves ``embedding_provider``: accepted
+#: spelling to the flow it selects. Repeated here rather than imported, because
+#: that module pulls in langchain_core and both provider modules and ``aorta
+#: chat config init`` has no other reason to load them -- the same arrangement
+#: as ``_CONFIG_PROFILES`` in ``cli/chat.py``, and
 #: ``tests/chat/test_config_wizard.py`` fails if the two drift apart.
-LOCAL_EMBEDDING_PROVIDERS = frozenset({"local", "onnx", "fastembed"})
+EMBEDDING_PROVIDER_FLOWS: dict[str, str] = {
+    "local": "local",
+    "onnx": "local",
+    "fastembed": "local",
+    "remote": "remote",
+}
 
 
 def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
@@ -644,14 +649,15 @@ def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
     them follow, which is the shape of failure this whole path exists to stop.
 
     ``index fetch`` is promised only when the provider *and* the model agree
-    with the defaults CI publishes the asset under. :func:`rag.manifest.validate`
-    refuses on the model name and on the embedding identity, which for the local
-    provider is the model name again -- so a local install on a hand-set
-    ``embedding_model`` is refused exactly like a remote one.
+    with the defaults CI publishes the asset under.
+    :func:`aorta.chat.rag.manifest.validate` refuses on the model name and on
+    the embedding identity, which for the local provider is the model name
+    again -- so a local install on a hand-set ``embedding_model`` is refused
+    exactly like a remote one.
     """
     try:
         current = get_settings()
-    except Exception as exc:  # pydantic ValidationError, or a field validator
+    except Exception as exc:  # pydantic ValidationError, a field validator, ConfigFileError
         # The profile is already on disk at this point, so an unrelated bad
         # AORTA_CHAT_* value must not turn a successful write into a traceback.
         return [
@@ -660,7 +666,18 @@ def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
         ]
 
     default_model = Settings.model_fields["embedding_model"].default
-    if current.embedding_provider.strip().lower() not in LOCAL_EMBEDDING_PROVIDERS:
+    flow = EMBEDDING_PROVIDER_FLOWS.get(current.embedding_provider.strip().lower())
+    if flow is None:
+        # Naming a command here would be the same defect one layer down: the
+        # factory raises on an unrecognised name, so neither build nor fetch
+        # can run until this is corrected.
+        lines = [
+            f"Embeddings: {current.embedding_provider!r} is not an embedding "
+            f"provider this aorta knows "
+            f"({', '.join(sorted(EMBEDDING_PROVIDER_FLOWS))}). Indexing and "
+            "querying will both fail until it is corrected."
+        ]
+    elif flow == "remote":
         lines = [
             f"Embeddings: {current.embedding_provider}, via "
             f"{current.remote_embedding_model}. The published index is built "
@@ -679,9 +696,9 @@ def describe_embeddings(profile_values: dict[str, Any]) -> list[str]:
             "installs the published index unchanged."
         ]
 
-    # Naming the variable matters more than naming the value: the line above
+    # Name the environment variable, not only its effect: the line above
     # otherwise contradicts the file the user was just told was written, with
-    # nothing on screen to say which one wins.
+    # nothing on screen to say which of the two wins.
     overridden = [
         f"{ENV_PREFIX}{field.upper()}"
         for field in ("embedding_provider", "embedding_model")
@@ -779,8 +796,8 @@ def validate_profile(path: Path | None = None) -> list[str]:
 
 
 __all__ = [
+    "EMBEDDING_PROVIDER_FLOWS",
     "ENV_PREFIX",
-    "LOCAL_EMBEDDING_PROVIDERS",
     "PROFILE_FILE_MODE",
     "PROFILE_PROMPTS",
     "PROFILE_TEMPLATES",

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -806,6 +806,21 @@ def config_init(profile: str, force: bool, no_input: bool) -> None:
                 values[field] = answer
     written = config.write_profile(values)
     click.echo(f"Wrote {written} (mode {config.PROFILE_FILE_MODE:04o})")
+    # The wizard only ever asks about the chat model, so the embedding provider
+    # it picked is a decision the user did not make and previously could only
+    # find by reading the file -- and it is the one that decides whether the
+    # published index is usable.
+    embeddings = values.get("embedding_provider", "local")
+    if embeddings == "local":
+        click.echo(
+            "Embeddings: local, on this machine. 'aorta chat index fetch' "
+            "installs the published index unchanged."
+        )
+    else:
+        click.echo(
+            f"Embeddings: {embeddings}. The published index does not match, so "
+            "'aorta chat index build' is required before querying."
+        )
     click.echo("Review it with: aorta chat config show")
 
 

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -809,18 +809,10 @@ def config_init(profile: str, force: bool, no_input: bool) -> None:
     # The wizard only ever asks about the chat model, so the embedding provider
     # it picked is a decision the user did not make and previously could only
     # find by reading the file -- and it is the one that decides whether the
-    # published index is usable.
-    embeddings = values.get("embedding_provider", "local")
-    if embeddings == "local":
-        click.echo(
-            "Embeddings: local, on this machine. 'aorta chat index fetch' "
-            "installs the published index unchanged."
-        )
-    else:
-        click.echo(
-            f"Embeddings: {embeddings}. The published index does not match, so "
-            "'aorta chat index build' is required before querying."
-        )
+    # published index is usable. Reported from the merged settings, not from
+    # the template: AORTA_CHAT_* outranks the file that was just written.
+    for line in config.describe_embeddings(values):
+        click.echo(line)
     click.echo("Review it with: aorta chat config show")
 
 

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -59,10 +59,17 @@ def _unreachable_remote_embedding_fields(
 
     Empty for a template that does not select remote embeddings at all: the
     fields are read by nothing then.
+
+    A template key only counts as set when it carries a value. ``PROFILE_TEMPLATES``
+    already uses ``""`` as a placeholder for a field the wizard is expected to fill
+    (``openai-compatible``'s ``remote_llm_base_url``), so counting bare presence
+    would let ``remote_embedding_api_key = ""`` satisfy a guard whose whole point
+    is that the key must be reachable. A placeholder is only honest when the
+    wizard asks for it, which the ``prompted`` half covers.
     """
     if template.get("embedding_provider") != "remote":
         return []
-    collected = set(template) | set(prompted)
+    collected = {key for key, value in template.items() if value} | set(prompted)
     return sorted({"remote_embedding_base_url", "remote_embedding_api_key"} - collected)
 
 
@@ -133,6 +140,24 @@ class TestNoTemplateOptsIntoRemoteEmbeddings:
             ("remote_llm_base_url", "remote_llm_model", "remote_llm_api_key"),
         )
         assert missing == ["remote_embedding_api_key", "remote_embedding_base_url"]
+
+    def test_an_empty_placeholder_nobody_prompts_for_is_not_a_setting(self):
+        """The decoy: the shape a loose guard would wave through.
+
+        Both fields are present, so a presence-only check reports nothing
+        missing -- while ``remote_api.py`` raises on the empty key and the empty
+        base URL resolves to ``api.openai.com``. Only the prompted placeholder
+        is legitimate, and that one is left out of the expectation.
+        """
+        missing = _unreachable_remote_embedding_fields(
+            {
+                "embedding_provider": "remote",
+                "remote_embedding_base_url": "",
+                "remote_embedding_api_key": "",
+            },
+            ("remote_embedding_base_url",),
+        )
+        assert missing == ["remote_embedding_api_key"]
 
     @pytest.mark.parametrize("name", sorted(config.PROFILE_TEMPLATES))
     def test_a_local_template_carries_no_remote_embedding_settings(self, name):
@@ -247,6 +272,29 @@ class TestConfigInit:
         assert result.exit_code == 0, result.output
         assert "Embeddings: local" in result.output
         assert "index fetch" in result.output
+
+    def test_it_names_the_build_when_a_template_picks_a_remote_embedder(
+        self, monkeypatch, chat_profile
+    ):
+        """The other arm, which no shipped template can reach today.
+
+        Every template is local, so nothing exercises the branch that tells the
+        user the published index will not match theirs. An untested arm is how
+        that message ends up naming the wrong command on the day a template
+        deliberately picks remote -- the case
+        ``test_no_template_selects_remote_embeddings_it_cannot_reach`` is
+        written to keep allowing.
+        """
+        monkeypatch.setitem(
+            config.PROFILE_TEMPLATES,
+            "openai",
+            {**config.PROFILE_TEMPLATES["openai"], "embedding_provider": "remote"},
+        )
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "Embeddings: remote" in result.output
+        assert "index build" in result.output
+        assert "Embeddings: local" not in result.output
 
     def test_the_key_is_not_echoed_while_being_typed(self, chat_profile):
         result = CliRunner().invoke(

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -105,7 +105,7 @@ class TestNoTemplateOptsIntoRemoteEmbeddings:
         the two disagreeing, not the particular value.
         """
         default = config.Settings.model_fields["embedding_provider"].default
-        assert config.PROFILE_TEMPLATES[name]["embedding_provider"] == default
+        assert config.PROFILE_TEMPLATES[name].get("embedding_provider") == default
 
     def test_no_template_selects_remote_embeddings_it_cannot_reach(self):
         """The durable half of the guard, and what closes #443 and gap 1a.
@@ -276,11 +276,12 @@ class TestConfigInit:
     def test_it_names_the_build_when_a_template_picks_a_remote_embedder(
         self, monkeypatch, chat_profile
     ):
-        """The other arm, which no shipped template can reach today.
+        """The other arm, by the route no shipped template takes today.
 
-        Every template is local, so nothing exercises the branch that tells the
-        user the published index will not match theirs. An untested arm is how
-        that message ends up naming the wrong command on the day a template
+        Every template is local, so only an environment override
+        (``test_the_advice_follows_the_environment_and_not_the_template``)
+        reaches this branch on a stock install. Pinning the template route as
+        well is what keeps the message naming the right command on the day one
         deliberately picks remote -- the case
         ``test_no_template_selects_remote_embeddings_it_cannot_reach`` is
         written to keep allowing.
@@ -320,6 +321,7 @@ class TestConfigInit:
         monkeypatch.setenv("AORTA_CHAT_EMBEDDING_PROVIDER", "remote")
         config.reset_settings()
         result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
         assert "AORTA_CHAT_EMBEDDING_PROVIDER" in result.output
         assert 'embedding_provider = "local"' in chat_profile.read_text(encoding="utf-8")
 
@@ -342,7 +344,14 @@ class TestConfigInit:
         assert "index build" in result.output
         assert "index fetch" not in result.output
 
-    @pytest.mark.parametrize("spelling", sorted(config.LOCAL_EMBEDDING_PROVIDERS - {"local"}))
+    @pytest.mark.parametrize(
+        "spelling",
+        sorted(
+            name
+            for name, flow in config.EMBEDDING_PROVIDER_FLOWS.items()
+            if flow == "local" and name != "local"
+        ),
+    )
     def test_an_accepted_spelling_of_local_is_still_local(
         self, spelling, monkeypatch, chat_profile
     ):
@@ -359,21 +368,39 @@ class TestConfigInit:
         assert "index fetch" in result.output
         assert "index build" not in result.output
 
-    def test_the_local_spellings_match_the_factory(self):
+    def test_the_provider_table_matches_the_factory(self):
         """Duplicated because importing the factory would pull in langchain_core.
 
-        ``config init`` has no other reason to load it, so the list is repeated
-        rather than imported -- the same arrangement as ``_CONFIG_PROFILES``,
-        and this is the guard on it.
+        ``config init`` has no other reason to load it, so the resolution table
+        is repeated rather than imported -- the same arrangement as
+        ``_CONFIG_PROFILES``, and this is the guard on it. Checked as an
+        equality over the whole table, not just the local half: a provider the
+        factory grew and this copy did not would otherwise be reported as a
+        name aorta does not know.
         """
         from aorta.chat.rag.embeddings import factory
 
-        resolves_local = {
-            name
-            for name, target in {**{k: k for k in factory._PROVIDERS}, **factory._ALIASES}.items()
-            if target == "local"
-        }
-        assert resolves_local == set(config.LOCAL_EMBEDDING_PROVIDERS)
+        assert {
+            **{name: name for name in factory._PROVIDERS},
+            **factory._ALIASES,
+        } == config.EMBEDDING_PROVIDER_FLOWS
+
+    def test_an_unknown_provider_is_named_rather_than_guessed_at(
+        self, monkeypatch, chat_profile
+    ):
+        """Neither command works, so neither may be recommended.
+
+        The factory raises on a name it does not recognise, so reporting a
+        typo'd provider as though it were remote and sending the user to
+        ``index build`` is the same unfollowable advice one layer down.
+        """
+        monkeypatch.setenv("AORTA_CHAT_EMBEDDING_PROVIDER", "remvote")
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "remvote" in result.output
+        assert "index build" not in result.output
+        assert "index fetch" not in result.output
 
     def test_a_broken_environment_does_not_traceback_over_a_written_profile(
         self, monkeypatch, chat_profile

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -52,6 +52,104 @@ class TestProfileTemplates:
         assert config.validate_profile(chat_profile) == []
 
 
+def _unreachable_remote_embedding_fields(
+    template: dict[str, object], prompted: tuple[str, ...]
+) -> list[str]:
+    """Settings a remote-embedding template needs but neither sets nor asks for.
+
+    Empty for a template that does not select remote embeddings at all: the
+    fields are read by nothing then.
+    """
+    if template.get("embedding_provider") != "remote":
+        return []
+    collected = set(template) | set(prompted)
+    return sorted({"remote_embedding_base_url", "remote_embedding_api_key"} - collected)
+
+
+class TestNoTemplateOptsIntoRemoteEmbeddings:
+    """Four templates coupled the embedding provider to the chat provider.
+
+    Choosing a remote *chat* model also selected a remote *embedder*, and CI
+    publishes the index asset under default settings -- so ``index fetch``
+    refused the asset outright when ``config init`` ran first, and the manifest
+    refused every query when it ran second. There was no ordering of the two
+    documented commands that worked, on four of the five profiles.
+
+    The templates now all choose the local embedder. These pin the parts of that
+    which a later edit could quietly undo.
+    """
+
+    @pytest.mark.parametrize("name", sorted(config.PROFILE_TEMPLATES))
+    def test_the_embedding_choice_is_written_down(self, name):
+        """Explicit in the template, not inherited from the field default.
+
+        The profile file is what a user reads to find out what was decided for
+        them, so the decision belongs in it.
+        """
+        assert "embedding_provider" in config.PROFILE_TEMPLATES[name]
+
+    @pytest.mark.parametrize("name", sorted(config.PROFILE_TEMPLATES))
+    def test_every_template_matches_the_provider_the_published_index_uses(self, name):
+        """The published asset is built with defaults, so agreeing with the
+        default is exactly what makes ``index fetch`` usable.
+
+        Asserting against the field default rather than the literal ``"local"``
+        keeps this true if the default itself ever moves: what breaks fetch is
+        the two disagreeing, not the particular value.
+        """
+        default = config.Settings.model_fields["embedding_provider"].default
+        assert config.PROFILE_TEMPLATES[name]["embedding_provider"] == default
+
+    def test_no_template_selects_remote_embeddings_it_cannot_reach(self):
+        """The durable half of the guard, and what closes #443 and gap 1a.
+
+        Stated as a rule rather than as "they are all local" so it keeps
+        meaning if a later template deliberately picks remote: what must never
+        ship is a template that selects a remote embedder without an endpoint
+        and a key.
+        """
+        for name in sorted(config.PROFILE_TEMPLATES):
+            missing = _unreachable_remote_embedding_fields(
+                config.PROFILE_TEMPLATES[name], config.PROFILE_PROMPTS[name]
+            )
+            assert not missing, f"{name}: remote embeddings but no {missing}"
+
+    def test_the_rule_catches_the_shape_that_was_reported(self):
+        """Proves the guard above is not vacuously green while every template is local.
+
+        This is the ``azure-apim`` template as it shipped: an APIM subscription
+        header for embeddings, no base URL -- which resolves to
+        ``api.openai.com``, so the corpus was addressed to OpenAI with a header
+        it does not read -- and no key ever collected. It failed closed only
+        because of the unrelated missing-key check in ``remote_api.py``.
+        """
+        missing = _unreachable_remote_embedding_fields(
+            {
+                "llm_provider": "openai",
+                "remote_llm_auth_header": "Ocp-Apim-Subscription-Key",
+                "embedding_provider": "remote",
+                "remote_embedding_auth_header": "Ocp-Apim-Subscription-Key",
+            },
+            ("remote_llm_base_url", "remote_llm_model", "remote_llm_api_key"),
+        )
+        assert missing == ["remote_embedding_api_key", "remote_embedding_base_url"]
+
+    @pytest.mark.parametrize("name", sorted(config.PROFILE_TEMPLATES))
+    def test_a_local_template_carries_no_remote_embedding_settings(self, name):
+        """A leftover ``remote_embedding_*`` key is inert but reads as intent.
+
+        ``openai`` shipped ``remote_embedding_model`` and ``azure-apim`` a
+        ``remote_embedding_auth_header``, both unread once the provider is
+        local. Left in the written profile they suggest a remote embedder is
+        configured and working.
+        """
+        template = config.PROFILE_TEMPLATES[name]
+        if template.get("embedding_provider") != "local":
+            pytest.skip(f"{name} does not select local embeddings")
+        dead = [key for key in template if key.startswith("remote_embedding_")]
+        assert not dead, f"{name}: {sorted(dead)}"
+
+
 class TestConfigInit:
     def test_writes_a_parseable_profile(self, chat_profile):
         result = CliRunner().invoke(
@@ -135,6 +233,20 @@ class TestConfigInit:
         loaded = tomllib.loads(chat_profile.read_text(encoding="utf-8"))
         assert loaded["remote_llm_model"] == "gpt-4o"
         assert loaded["remote_llm_api_key"] == "sk-typed-at-the-prompt"
+
+    @pytest.mark.parametrize("name", sorted(config.PROFILE_TEMPLATES))
+    def test_it_says_what_it_decided_about_embeddings(self, name, chat_profile):
+        """The wizard asks about the chat model and nothing else.
+
+        The embedding provider is therefore chosen on the user's behalf, and it
+        is the setting that decides whether the published index can be used --
+        so leaving them to ``cat`` the file for it is how a first-time setup
+        ends in a refused query with no idea which command caused it.
+        """
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", name, "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "Embeddings: local" in result.output
+        assert "index fetch" in result.output
 
     def test_the_key_is_not_echoed_while_being_typed(self, chat_profile):
         result = CliRunner().invoke(

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import pytest
 import tomllib
 from click.testing import CliRunner
+from pydantic import ValidationError
 
 from aorta.chat import config
 from aorta.cli.chat import _CONFIG_PROFILES, chat
@@ -429,12 +430,11 @@ class TestConfigInit:
     def test_a_rejected_extra_header_is_not_echoed_back(self, value, monkeypatch, chat_profile):
         """A malformed header map must not print the credential it carries.
 
-        ``str(ValidationError)`` embeds pydantic's ``input_value``, and the
-        ``extra_headers`` validator quotes the offending pair in its own
-        message, so both spellings of a bad value reached the terminal with the
-        key intact -- from the one command a user runs immediately after typing
-        one in, and for a field ``config show`` masks. The field name still has
-        to appear, or the line is not actionable.
+        ``str(ValidationError)`` embeds pydantic's ``input_value``, so both
+        spellings of a bad value reached the terminal with the key intact --
+        from the one command a user runs immediately after typing one in, and
+        for a field ``config show`` masks. The field name still has to appear,
+        or the line is not actionable.
         """
         monkeypatch.setenv("AORTA_CHAT_REMOTE_EMBEDDING_EXTRA_HEADERS", value)
         config.reset_settings()
@@ -634,3 +634,45 @@ class TestConfigValidate:
         chat_profile.write_text(f"{field} = {{}}\n", encoding="utf-8")
         chat_profile.chmod(0o644)
         assert config.validate_profile(chat_profile) == []
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Authorization: Bearer sk-SUPERSECRET-abcd1234",
+            '{"Authorization": "Bearer sk-SUPERSECRET-abcd1234"',
+        ],
+        ids=["comma-form", "json-form"],
+    )
+    def test_a_rejected_extra_header_is_not_echoed_back(self, value, monkeypatch, chat_profile):
+        """The command ``config init`` points at must not leak what it warned about.
+
+        ``config init`` answers a rejected credential with "sort the environment
+        out first: aorta chat config validate". This is that command, and it
+        interpolated the same raw ``ValidationError`` -- so following the advice
+        printed the key. The field name still has to appear, or the report is
+        not actionable.
+        """
+        config.write_profile({"chunk_size": 128}, chat_profile)
+        monkeypatch.setenv("AORTA_CHAT_REMOTE_EMBEDDING_EXTRA_HEADERS", value)
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "validate"])
+        assert result.exit_code == 1, result.output
+        assert "SUPERSECRET" not in result.output
+        assert "input_value" not in result.output
+        assert "remote_embedding_extra_headers" in result.output
+
+    def test_the_validator_names_the_position_not_the_value(self, chat_profile):
+        """The message is rendered by consumers this module does not control.
+
+        ``ValidationError`` is a ``ValueError``, so the two ``str(exc)``
+        handlers in ``cli/chat.py`` catch this one too. Keeping the rejected
+        pair out of the message is what stops it surfacing there; the position
+        is what a user counts commas to find anyway.
+        """
+        with pytest.raises(ValidationError) as caught:
+            config.Settings(
+                remote_embedding_extra_headers="user=alice,Authorization: Bearer sk-SECRET"
+            )
+        rendered = str(caught.value)
+        assert "extra header #2 is missing '='" in rendered
+        assert "sk-SECRET" not in rendered.split("input_value=")[0]

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -296,6 +296,101 @@ class TestConfigInit:
         assert "index build" in result.output
         assert "Embeddings: local" not in result.output
 
+    def test_the_advice_follows_the_environment_and_not_the_template(
+        self, monkeypatch, chat_profile
+    ):
+        """``AORTA_CHAT_*`` outranks the file ``config init`` has just written.
+
+        Reporting the template would tell a user with the override exported
+        that local embeddings were configured and send them to ``index fetch``,
+        which then refuses the published asset -- advice their own environment
+        does not let them follow, which is the failure this command was changed
+        to stop rather than to reproduce.
+        """
+        monkeypatch.setenv("AORTA_CHAT_EMBEDDING_PROVIDER", "remote")
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "Embeddings: remote" in result.output
+        assert "index build" in result.output
+        assert "index fetch" not in result.output
+
+    def test_it_says_where_the_override_came_from(self, monkeypatch, chat_profile):
+        """Otherwise the line contradicts the file it was just told was written."""
+        monkeypatch.setenv("AORTA_CHAT_EMBEDDING_PROVIDER", "remote")
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert "AORTA_CHAT_EMBEDDING_PROVIDER" in result.output
+        assert 'embedding_provider = "local"' in chat_profile.read_text(encoding="utf-8")
+
+    def test_a_hand_set_local_model_does_not_get_promised_fetch_either(
+        self, monkeypatch, chat_profile
+    ):
+        """The provider alone is not the test the manifest applies.
+
+        ``rag/manifest.validate`` refuses on the model name and on the
+        embedding identity, which for the local provider *is* the model name --
+        so a local install on another model is refused exactly like a remote
+        one, and must not be sent to ``index fetch``.
+        """
+        monkeypatch.setenv("AORTA_CHAT_EMBEDDING_MODEL", "BAAI/bge-large-en-v1.5")
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "Embeddings: local" in result.output
+        assert "bge-large-en-v1.5" in result.output
+        assert "index build" in result.output
+        assert "index fetch" not in result.output
+
+    @pytest.mark.parametrize("spelling", sorted(config.LOCAL_EMBEDDING_PROVIDERS - {"local"}))
+    def test_an_accepted_spelling_of_local_is_still_local(
+        self, spelling, monkeypatch, chat_profile
+    ):
+        """``onnx`` and ``fastembed`` resolve to the local flow in the factory.
+
+        Reading the setting as an opaque string would tell these users the
+        published index does not match theirs and send them to a build they do
+        not need -- the same unfollowable advice, pointed the other way.
+        """
+        monkeypatch.setenv("AORTA_CHAT_EMBEDDING_PROVIDER", spelling)
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "index fetch" in result.output
+        assert "index build" not in result.output
+
+    def test_the_local_spellings_match_the_factory(self):
+        """Duplicated because importing the factory would pull in langchain_core.
+
+        ``config init`` has no other reason to load it, so the list is repeated
+        rather than imported -- the same arrangement as ``_CONFIG_PROFILES``,
+        and this is the guard on it.
+        """
+        from aorta.chat.rag.embeddings import factory
+
+        resolves_local = {
+            name
+            for name, target in {**{k: k for k in factory._PROVIDERS}, **factory._ALIASES}.items()
+            if target == "local"
+        }
+        assert resolves_local == set(config.LOCAL_EMBEDDING_PROVIDERS)
+
+    def test_a_broken_environment_does_not_traceback_over_a_written_profile(
+        self, monkeypatch, chat_profile
+    ):
+        """The file is already on disk by the time the settings are merged.
+
+        An unrelated bad ``AORTA_CHAT_*`` value used to be invisible here,
+        because the command never built ``Settings``. Now that it does, it must
+        report the problem rather than exit non-zero over a write that worked.
+        """
+        monkeypatch.setenv("AORTA_CHAT_LLM_TIMEOUT", "not-a-number")
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert chat_profile.exists()
+        assert "config validate" in result.output
+
     def test_the_key_is_not_echoed_while_being_typed(self, chat_profile):
         result = CliRunner().invoke(
             chat,

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -9,8 +9,10 @@ so the masking is tested as a contract, not as formatting.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import stat
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -739,3 +741,126 @@ class TestConfigValidate:
         rendered = str(caught.value)
         assert "extra header #2 is missing '='" in rendered
         assert "sk-SECRET" not in rendered.split("input_value=")[0]
+
+
+def _fenced_commands(text: str) -> list[str]:
+    """``aorta ...`` lines inside shell code fences, in order.
+
+    Fences are paired by toggling on *any* ``` line rather than by matching a
+    language, because pairing only ``` ```bash ``` openers desynchronises on the
+    first ``` ```toml ``` block and silently drops most of the page -- the first
+    draft of this helper checked 4 of the 9 commands and passed.
+    """
+    commands: list[str] = []
+    inside, language = False, ""
+    for line in text.splitlines():
+        if line.startswith("```"):
+            inside, language = (False, "") if inside else (True, line[3:].strip())
+            continue
+        if inside and language in ("bash", "sh", "console", ""):
+            stripped = line.split("#")[0].strip()
+            if stripped.startswith("aorta "):
+                commands.append(stripped)
+    return commands
+
+
+#: The pages this PR owns. A fenced command is an instruction, so it is held to
+#: the strict reading: it must exist and it must parse as printed.
+_DOC_PAGES = ("docs/chat/configuration.md", "docs/chat/providers.md")
+
+
+class TestEveryCommandTheseDocsPrintCanRun:
+    """A command in a fenced block is something a reader will paste.
+
+    Six findings in this batch were advice naming a command that could not run
+    in the state that printed it, and the round that prompted this one asked for
+    ``index fetch --force`` -- a flag that is correct only *after* a sibling PR
+    lands and would be rejected by Click until then. Prose can be checked by a
+    reader; a flag that does not exist yet cannot, so it is asked of Click's own
+    parser here.
+
+    Deliberately narrow. The equivalent gate over *report* text is #463's
+    ``TestEveryCommandTheReportNamesCanRun``, which owns the extractor for
+    commands named in prose; duplicating that here would leave two copies to
+    diverge. This checks the fenced instructions on the two pages this PR owns.
+    """
+
+    def _commands(self) -> list[tuple[str, str]]:
+        root = Path(__file__).resolve().parents[2]
+        found = []
+        for page in _DOC_PAGES:
+            text = (root / page).read_text(encoding="utf-8")
+            found += [(page, command) for command in _fenced_commands(text)]
+        return found
+
+    def test_the_extractor_still_finds_the_commands(self):
+        """Without this the sweep below passes by finding nothing to check.
+
+        The count is the load-bearing part: the fence-pairing bug this helper
+        documents made the sweep pass while reading a quarter of the page.
+        """
+        commands = self._commands()
+        assert len(commands) >= 9, f"only {len(commands)} fenced commands; the extractor has broken"
+
+    def test_every_fenced_command_parses_as_printed(self):
+        from click import Context
+
+        from aorta.cli import main as cli
+
+        for page, command in self._commands():
+            tokens = command.split()
+            assert tokens[0] == "aorta"
+            remaining = tokens[1:]
+            node, parent = cli, None
+            with contextlib.ExitStack() as stack:
+                # Descend while the next token names a subcommand of this group.
+                # Splitting on "looks like an option" instead would drop an
+                # option's *value* and turn a valid line into a parse error.
+                while remaining and hasattr(node, "get_command"):
+                    ctx = stack.enter_context(Context(node, info_name=command, parent=parent))
+                    resolved = node.get_command(ctx, remaining[0])
+                    if resolved is None:
+                        raise AssertionError(
+                            f"{page}: '{command}' -- {remaining[0]!r} is not a command"
+                        )
+                    node, parent = resolved, ctx
+                    remaining = remaining[1:]
+                assert not hasattr(node, "get_command"), (
+                    f"{page}: '{command}' names a group, which prints help rather "
+                    "than doing anything"
+                )
+                # Parses and validates required options without running the
+                # callback, so an unknown flag or a missing required option fails
+                # here exactly as it would for a reader who pasted the line.
+                node.make_context(command, remaining, parent=parent)
+
+    def test_the_sweep_would_reject_a_flag_that_does_not_exist(self):
+        """Keeps the strict tier honest: `--force` on `index fetch` is #465's.
+
+        Documenting it before that lands would print a line Click rejects, which
+        is the trap the round that prompted this test invited.
+        """
+        from click import Context, NoSuchOption
+
+        from aorta.cli import main as cli
+
+        with Context(cli) as root_ctx:
+            chat_group = cli.get_command(root_ctx, "chat")
+            with Context(chat_group, parent=root_ctx) as chat_ctx:
+                index_group = chat_group.get_command(chat_ctx, "index")
+                with Context(index_group, parent=chat_ctx) as index_ctx:
+                    fetch = index_group.get_command(index_ctx, "fetch")
+                    with pytest.raises(NoSuchOption):
+                        fetch.make_context("fetch", ["--force"], parent=index_ctx)
+
+    def test_the_docs_do_not_promise_the_force_flag_yet(self):
+        """The finding itself, pinned where it was raised.
+
+        The going-back procedure is refused by #465's guard because step 3 built
+        the index locally. The fix describes that refusal and lets it name its
+        own flag, rather than printing a flag this Click does not accept.
+        """
+        root = Path(__file__).resolve().parents[2]
+        text = (root / "docs/chat/configuration.md").read_text(encoding="utf-8")
+        assert "index fetch --force" not in text
+        assert "the refusal names the flag" in text

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -286,12 +286,18 @@ class TestConfigInit:
         deliberately picks remote -- the case
         ``test_no_template_selects_remote_embeddings_it_cannot_reach`` is
         written to keep allowing.
+
+        The key is set because ``index build`` is only the right advice once it
+        can run; without one the message names the missing key instead, which is
+        ``test_a_remote_provider_with_no_key_is_not_sent_to_index_build``.
         """
         monkeypatch.setitem(
             config.PROFILE_TEMPLATES,
             "openai",
             {**config.PROFILE_TEMPLATES["openai"], "embedding_provider": "remote"},
         )
+        monkeypatch.setenv("AORTA_CHAT_REMOTE_EMBEDDING_API_KEY", "sk-test")
+        config.reset_settings()
         result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
         assert result.exit_code == 0, result.output
         assert "Embeddings: remote" in result.output
@@ -308,13 +314,47 @@ class TestConfigInit:
         which then refuses the published asset -- advice their own environment
         does not let them follow, which is the failure this command was changed
         to stop rather than to reproduce.
+
+        A key is exported alongside the provider so this stays a test about
+        *which* command is named. Without one the arm below fires instead, and
+        the reason it is a separate test is that the keyless combination is the
+        common one here, not an edge: the profile just written is local and
+        carries no remote key.
         """
         monkeypatch.setenv("AORTA_CHAT_EMBEDDING_PROVIDER", "remote")
+        monkeypatch.setenv("AORTA_CHAT_REMOTE_EMBEDDING_API_KEY", "sk-test")
         config.reset_settings()
         result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
         assert result.exit_code == 0, result.output
         assert "Embeddings: remote" in result.output
         assert "index build" in result.output
+        assert "index fetch" not in result.output
+
+    def test_a_remote_provider_with_no_key_is_not_sent_to_index_build(
+        self, monkeypatch, chat_profile
+    ):
+        """``index build`` cannot run without a key, so it must not be named.
+
+        ``RemoteApiProvider.get_embeddings()`` raises on an empty
+        ``remote_embedding_api_key`` before it sends anything, so the command is
+        known to fail from the settings alone -- the same class of unfollowable
+        advice this whole path exists to remove, one case over.
+
+        This is the *reachable* combination rather than a constructed one: the
+        profile ``config init`` has just written is local and carries no remote
+        key, so exporting the provider alone lands here. Both sibling tests
+        above had to be given a key once this arm existed, which is how reachable
+        it is.
+        """
+        monkeypatch.setenv("AORTA_CHAT_EMBEDDING_PROVIDER", "remote")
+        monkeypatch.delenv("AORTA_CHAT_REMOTE_EMBEDDING_API_KEY", raising=False)
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "Embeddings: remote" in result.output
+        assert "AORTA_CHAT_REMOTE_EMBEDDING_API_KEY" in result.output
+        # Neither index command is offered, because neither can succeed yet.
+        assert "index build" not in result.output
         assert "index fetch" not in result.output
 
     def test_it_says_where_the_override_came_from(self, monkeypatch, chat_profile):
@@ -344,6 +384,29 @@ class TestConfigInit:
         assert "bge-large-en-v1.5" in result.output
         assert "index build" in result.output
         assert "index fetch" not in result.output
+
+    @pytest.mark.parametrize(
+        ("variable", "value"),
+        [("AORTA_CHAT_CHUNK_SIZE", "1024"), ("AORTA_CHAT_CHUNK_OVERLAP", "999")],
+    )
+    def test_chunk_drift_does_not_withdraw_the_fetch(
+        self, monkeypatch, chat_profile, variable, value
+    ):
+        """Chunk parameters are not part of the compatibility decision.
+
+        ``manifest.validate`` reports them as warnings, not refusals, and
+        ``fetch_index`` gates on ``raise_if_refused`` alone -- verified by
+        driving ``fetch_index`` against a published manifest built at other chunk
+        values, which installs and warns. So a fetch stays followable here, and
+        withdrawing it would send a reader to ``index build`` -- a full local
+        re-embed -- to avoid a warning about span sizes.
+        """
+        monkeypatch.setenv(variable, value)
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "index fetch" in result.output
+        assert "index build" not in result.output
 
     @pytest.mark.parametrize(
         "spelling",

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -418,6 +418,32 @@ class TestConfigInit:
         assert chat_profile.exists()
         assert "config validate" in result.output
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Authorization: Bearer sk-SUPERSECRET-abcd1234",
+            '{"Authorization": "Bearer sk-SUPERSECRET-abcd1234"',
+        ],
+        ids=["comma-form", "json-form"],
+    )
+    def test_a_rejected_extra_header_is_not_echoed_back(self, value, monkeypatch, chat_profile):
+        """A malformed header map must not print the credential it carries.
+
+        ``str(ValidationError)`` embeds pydantic's ``input_value``, and the
+        ``extra_headers`` validator quotes the offending pair in its own
+        message, so both spellings of a bad value reached the terminal with the
+        key intact -- from the one command a user runs immediately after typing
+        one in, and for a field ``config show`` masks. The field name still has
+        to appear, or the line is not actionable.
+        """
+        monkeypatch.setenv("AORTA_CHAT_REMOTE_EMBEDDING_EXTRA_HEADERS", value)
+        config.reset_settings()
+        result = CliRunner().invoke(chat, ["config", "init", "--profile", "openai", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "SUPERSECRET" not in result.output
+        assert "input_value" not in result.output
+        assert "remote_embedding_extra_headers" in result.output
+
     def test_the_key_is_not_echoed_while_being_typed(self, chat_profile):
         result = CliRunner().invoke(
             chat,


### PR DESCRIPTION
## Problem

Four of the five `PROFILE_TEMPLATES` in `src/aorta/chat/config.py` set
`embedding_provider = "remote"`. The published RAG index is built by CI under
default settings, i.e. with the **local** embedder, so a profile written by
`aorta chat config init` could not read it: `aorta chat index fetch` downloads
an asset the configured provider then refuses on identity, and `aorta chat
index build` bills a remote embedding call per chunk to produce a private copy.
Neither command order works, which is gap 1/1a in
[docs/chat/chat-run-gaps.md](docs/chat/chat-run-gaps.md).

The `anthropic` template was the worst case: it selected remote embeddings with
the default `text-embedding-3-small` — an OpenAI embedding model — while
configuring no OpenAI embedding endpoint or key at all.

## Fix

- All five templates now set `embedding_provider: "local"` **explicitly**,
  rather than relying on the `Settings` default, so the file documents the
  choice rather than inheriting it.
- The now-dead keys go: `remote_embedding_auth_header` from `azure-apim`,
  `remote_embedding_model` from `openai`.
- `config_init` echoes the embedding decision, so the user is not left to `cat`
  the profile to find out what they got.
- `docs/chat/configuration.md` gains a step-by-step procedure for configuring a
  remote embedder **by hand**, cross-linked from `rag-index.md` and
  `providers.md`. It covers all six settings, states that the published asset
  becomes unusable so `aorta chat index build` is mandatory afterwards, sizes the
  spend in tokens (order one to two million for the build, plus an embedding call
  per query and per `search_code`) while pointing at the provider's own price
  list rather than quoting a rate that would go stale, and warns that
  chat-message redaction does **not** cover the embeddings path.
- `tests/chat/test_config_wizard.py` gains a case asserting no template selects
  remote embeddings without also supplying a base URL and a key, so a future
  template cannot reintroduce the gap.

Remote embeddings remain fully possible. They are just no longer selected for
anyone by default, and the one legitimate case — a node that can reach an
embeddings API but not Hugging Face — is now documented honestly, along with
the fact that a genuinely air-gapped node cannot use it either.

## Decisions taken

**Why this closes [#443](https://github.com/ROCm/aorta/issues/443) by removal
rather than by collecting the missing key.** #443 asked for the wizard to
collect a remote-embedding key, and that is a real fix — but it is the more
expensive of the two the issue itself proposes. Quoting #443:

> Two plausible fixes: keep embeddings local in these templates
> (`embedding_provider = "local"`, which needs no key and is the default), or
> prompt for the remote embedding endpoint and key so the generated profile is
> complete. The first is probably right for `anthropic` regardless, since its
> embedding story is unrelated to its chat story.

This PR takes the first. The reasoning generalises past `anthropic`: the
embedding provider is an orthogonal choice to the chat provider, remote
embeddings make the CI-published index unusable for the user who selected them,
and collecting a key would have made a broken-by-default configuration
*complete* rather than making it *correct*. Once no template selects remote
embeddings, the missing key cannot arise — so the condition is removed rather
than satisfied.

**Existing users are not migrated.** On-disk profiles are not rewritten. Anyone
who already ran `config init` against an older template keeps
`embedding_provider = "remote"` until they either re-run
`aorta chat config init --force` or edit the field by hand. That is deliberate —
silently rewriting a file the user may have customised is worse than telling
them — but it does mean this fix does not reach an existing install on its own.

## Testing

`1001 passed, 0 failed, 12 skipped` on `tests/chat tests/cli/test_chat*.py`,
against a `964 passed, 0 failed, 12 skipped` baseline on `main`, re-measured at
`d84bea12` after the rebase rather than carried over.

## Notes for the reviewer

Developed in a parallel worktree alongside four sibling PRs with deliberately
disjoint file sets, originally off `4b4553ef` and since **rebased onto
`d84bea12`** (history-only; the diff against the new base is byte-equivalent to
the diff against the old one). A trial merge of all five was verified clean and
their union suite is green at `1162 passed, 0 failed, 12 skipped`.

Coordination notes:

- `fix/chat-doctor-remedies` (closing
  [#459](https://github.com/ROCm/aorta/issues/459)) inserts a paragraph at the
  **same anchor** in `docs/chat/rag-index.md` as this PR does — the only genuine
  conflict between the two. Both are additive and non-contradictory; the trial
  merge resolved it by keeping both, this PR's paragraph first, since it is about
  `fetch` being the normal path and the other is about what happens straight
  after a fetch. Whichever lands second should resolve the same way.
- `docs/chat/providers.md` is touched by three PRs in this wave — this one (the
  intro and the cost table), `fix/chat-doctor-remedies` and
  `fix/chat-reasoning-deadend` (both in the tool-calling section). The three
  regions are disjoint and merge cleanly.
- `src/aorta/cli/chat.py` is touched by three PRs, in disjoint regions: this one
  at `config_init`, `fix/chat-reasoning-deadend` at the provider startup line,
  and `fix/chat-index-write-safety` in the `index_*` subcommands.

Closes #458
Closes #443

## Self-review pass

Ran before pushing, against the repo's accumulated reviewer feedback. Six
findings, all fixed on this branch, in commits `9ada378d` and `38453f6a`:

- Four **factual claims in the new prose** were wrong and are corrected:
  "setting them without `embedding_provider` changes nothing" (false —
  `validate_profile()` reads two of them regardless of the selector, which this
  same document says thirty lines later); "becomes unusable, permanently"
  (walked back by its own next section); a `doctor` output string
  (`<provider-default>`) that only appears in `vector_identity()` and is never
  printed, so a reader following step 4 would have hunted for a string the
  command cannot emit; and `providers.md` attributing "no profile selects it" to
  the per-query bill rather than to the published index, which is the reason
  recorded in `PROFILE_TEMPLATES`' own docstring.
- Two **holes in the new guards**: the template check counted a key as "set" on
  presence alone, so a future template carrying `remote_embedding_api_key = ""`
  would pass a guard whose whole point is reachability — and `""` is not a
  hypothetical spelling, `PROFILE_TEMPLATES` already uses it as a wizard
  placeholder. And `config_init`'s remote arm had no test at all, because no
  shipped template can reach it; it is now exercised through a monkeypatched
  template, so the arm cannot rot into naming the wrong command on the day a
  remote template arrives.

Each added test was mutation-checked: reverting its fix fails that test and
nothing else.

## Review round two (Copilot)

Two findings, both fixed. Reconciling the surface first, because the inline API
undersold it: the review reported `Comments generated: 1` plus a
`Suppressed comments (1)` block, so **two** findings, while
`/pulls/462/comments` returned three comments -- one of them round one's
(already fixed) and one of them my own reply.

**1. `config init` echoed a rejected credential.** The `except` arm added in
round one -- there to stop a bad `AORTA_CHAT_*` value tracebacking over a
profile already on disk -- interpolated the raw exception. `str(ValidationError)`
carries pydantic's `input_value`, so a malformed
`AORTA_CHAT_REMOTE_*_EXTRA_HEADERS` printed the gateway key it held, from the
command a user runs immediately after typing one in, for a field `config show`
masks. `_unresolvable_settings_reason` now reports **field names only**.

Values are withheld for *every* field rather than only `SECRET_FIELDS` /
`SECRET_MAPPING_FIELDS`: an `api-key` in a `remote_llm_base_url` query string is
as much a leak as one in an extra header, and a rule keyed on field names fails
open on the field nobody classified -- the same reasoning
`SECRET_MAPPING_FIELDS` already applies to header values.

**2. The "going back" prose promised `index fetch` would not replace the local
collection.** It does. `_install_staged` calls
`carry_over_collections(dest, staged)`, which copies only collections the
*incoming* database lacks, so the rule **preserves** on the remote-build
direction and **replaces** on the fetch direction. Corrected to say so, and to
point a user with a wider local corpus at `index build` instead. The sibling
claim thirty lines earlier ("not overwritten") describes the build direction and
is correct, so it stands.

### Scope: one sweep hit fixed outside the reported line

The sweep found `validate_profile` carrying the identical
`f"{path}: {exc}"`. I flagged it and asked rather than expanding scope, and the
answer was to fix it here -- rightly: it is in this PR's own file, it is the same
one-line pattern, and it is **the command the round-one fix now points users
at**, so shipping without it would have left the fix directing people to a
command that leaks the credential the fix exists to protect.

Re-sweeping with that second site in scope found the **source**:
`_parse_extra_headers` interpolated the rejected pair into the `ValueError`
itself, so every consumer of that error carried the credential. It now reports
the header's position. Because `ValidationError` subclasses `ValueError`, that
also removes our copy of the value from the two `str(exc)` handlers in
`cli/chat.py` -- verified against `_guard` before and after -- without editing a
file that #464 and #465 own.

**Known residual, needs the owning file:** pydantic appends `input_value`
regardless of the message, so those two `cli/chat.py` handlers still render it.
The fix there is to report `exc.errors()` field names the way `config.py` now
does; left for the owners rather than reached into. `ConfigFileError`'s `{cause}`
was assessed and is **not** a third site -- `tomllib` reports line and column but
never file content (six malformed forms checked, including an unterminated string
holding a key), and the `OSError` arm carries an errno and a path.

Both fixes are mutation-checked: reverting either line fails its own test and
nothing else. The positional wording is carried into the `providers.md`
troubleshooting table, which is keyed on searchable error text and would
otherwise still tell users to look for `extra header 'user' is missing '='`.
