### PR TITLE
fix(chat): make the index write paths announce, compare and guard themselves

### DIFF
--- a/.github/workflows/chat-tests.yml
+++ b/.github/workflows/chat-tests.yml
@@ -109,6 +109,11 @@ jobs:
             'tests/chat/*'
             'tests/cli/test_chat.py'
             'tests/cli/test_chat_boundaries.py'
+            # Both are skipif-gated on langchain_core, so the required CPU gate
+            # collects them and skips 32 of their tests. This job is the only
+            # one with the extra, so it is the only place they ever execute.
+            'tests/cli/test_chat_index_cli.py'
+            'tests/cli/test_chat_index_workflows.py'
             # TestRealProviderResolution resolves the provider layer for real,
             # so it needs the extra and only runs here.
             'tests/agent/test_llm_providers.py'
@@ -265,9 +270,16 @@ jobs:
       # unmocked resolution. That group skips itself on the required CPU gate,
       # which installs no chat extra, so without this line it would be gated
       # everywhere and run nowhere.
+      #
+      # test_chat_index_cli.py and test_chat_index_workflows.py are here for
+      # exactly that reason. Both are skipif-gated on langchain_core, so the
+      # required CPU gate collects them and skips every test that needs the
+      # extra -- 32 of the 61 between them. This is an allow-list, not a
+      # directory, so a file absent from it runs in no job at all.
       - name: Run the chat test suite
         run: |
           pytest tests/chat tests/cli/test_chat.py tests/cli/test_chat_boundaries.py \
+            tests/cli/test_chat_index_cli.py tests/cli/test_chat_index_workflows.py \
             tests/agent/test_llm_providers.py \
             -m "not gpu and not rocm" -n auto
 

--- a/.github/workflows/chat-tests.yml
+++ b/.github/workflows/chat-tests.yml
@@ -110,7 +110,7 @@ jobs:
             'tests/cli/test_chat.py'
             'tests/cli/test_chat_boundaries.py'
             # Both are skipif-gated on langchain_core, so the required CPU gate
-            # collects them and skips 32 of their tests. This job is the only
+            # collects them and skips 36 of their 65 tests. This job is the only
             # one with the extra, so it is the only place they ever execute.
             'tests/cli/test_chat_index_cli.py'
             'tests/cli/test_chat_index_workflows.py'
@@ -274,7 +274,7 @@ jobs:
       # test_chat_index_cli.py and test_chat_index_workflows.py are here for
       # exactly that reason. Both are skipif-gated on langchain_core, so the
       # required CPU gate collects them and skips every test that needs the
-      # extra -- 32 of the 61 between them. This is an allow-list, not a
+      # extra -- 36 of the 65 between them. This is an allow-list, not a
       # directory, so a file absent from it runs in no job at all.
       - name: Run the chat test suite
         run: |

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -116,6 +116,7 @@ re-download the embedding weights.
 | `fetch` or `--from` | a manifest whose `corpus_roots` cannot be read | refused; pass `--force` |
 | `build` | a manifest whose `corpus_roots` cannot be read | refused, unless a row above already exempts it; pass `--force` |
 | any of them, `--public-only` included | *not an index at all* — a path that exists with no manifest beside it | refused; pass `--force` |
+| any of them | a symlink whose target does not exist | refused; pass `--force`. It is occupied, even though `exists()` says otherwise |
 
 `fetch` also opens the store before deciding a refresh would change nothing.
 A matching `index_sha256` says the right index was installed, not that the file

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -132,6 +132,14 @@ in with `--from` asks for the file to be re-staged, for the same reason. This is
 a rule rather than three messages — an error raised by `index fetch` may not
 advise an `index fetch` that would fail identically.
 
+Nothing locks the index path, and two builds aimed at the same `--output` both
+report success: the later rename wins, and the surviving index and sidecars are
+the winner's, matching each other. That is last-writer-wins rather than
+corruption, because the crossed pairing — one build's index under the other's
+manifest — is what the contents check refuses. A read concurrent with the rename
+sees the old index or the new one, and briefly can see the post-move window,
+where it fails closed with a mismatch rather than answering from it.
+
 A refusal names what would be lost and the flag that proceeds anyway, following
 `config init --force` rather than prompting, so a script and a terminal behave
 identically. The command it prints carries any non-default `--path` and

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -102,14 +102,20 @@ re-download the embedding weights.
 | `fetch` | downloaded, and different | replaced, printing what changed |
 | `fetch` or `--from` | built locally | refused; pass `--force` |
 | `build` | built locally | rebuilt, as usual |
-| `build` (narrower corpus) | downloaded | refused; pass `--force` |
+| `build` (any corpus but the published one) | downloaded | refused; pass `--force` |
 | `build --public-only` | downloaded | rebuilt; it is the same corpus, so nothing is lost |
+| any of them | a manifest whose `corpus_roots` cannot be read | refused; pass `--force` |
 
 A refusal names what would be lost and the flag that proceeds anyway, following
 `config init --force` rather than prompting, so a script and a terminal behave
 identically. An index the running configuration would *refuse* is never
 protected: rebuilding one you cannot query loses nothing, and `doctor` tells you
 to rebuild it.
+
+Which side built an index is read off its manifest's `corpus_roots`, so an index
+whose manifest records *no* roots — one built before the field existed — is not
+protected either way. One that records roots this build cannot read is a broken
+sidecar rather than an old one, and is refused rather than guessed at.
 
 **Interrupting any of them is safe.** `build`, `fetch` and `--from` write the
 new index beside the old one and move it into place in a single step, then write

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -109,9 +109,12 @@ re-download the embedding weights.
 
 A refusal names what would be lost and the flag that proceeds anyway, following
 `config init --force` rather than prompting, so a script and a terminal behave
-identically. An index the running configuration would *refuse* is never
-protected: rebuilding one you cannot query loses nothing, and `doctor` tells you
-to rebuild it.
+identically. An index the running configuration cannot *use* is never protected:
+rebuilding one you cannot query loses nothing, and `doctor` tells you to rebuild
+it. "Cannot use" is the same question the first query asks, store included — an
+embedding-model or identity mismatch, a manifest that disagrees with the
+contents, or a `.sqlite` that cannot be opened at all. A merely *stale* index is
+not in that set; it still answers, so a narrowing build over it is still refused.
 
 Which side built an index is read off its manifest's `corpus_roots`, so an index
 whose manifest records *no* roots — one built before the field existed — is not
@@ -122,7 +125,7 @@ The exemptions come first, which is why the `build` row above is qualified. An
 unreadable `corpus_roots` means the index is either a published one or a local
 one, and both of the `build` exemptions give the same answer down both branches:
 a `--public-only` build records the published corpus whichever it replaced, and
-an index this install would refuse is unusable whoever built it — while a local
+an index this install cannot use is unusable whoever built it — while a local
 index is never protected from `build` in the first place. So proceeding there is
 not a guess about which one is on disk; it is what both possibilities agree on.
 `fetch` and `--from` carry no such exemption, so for them the refusal is

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -133,13 +133,18 @@ in with `--from` asks for the file to be re-staged, for the same reason. This is
 a rule rather than three messages — an error raised by `index fetch` may not
 advise an `index fetch` that would fail identically.
 
-Nothing locks the index path, and two builds aimed at the same `--output` both
-report success: the later rename wins, and the surviving index and sidecars are
-the winner's, matching each other. That is last-writer-wins rather than
-corruption, because the crossed pairing — one build's index under the other's
-manifest — is what the contents check refuses. A read concurrent with the rename
-sees the old index or the new one, and briefly can see the post-move window,
-where it fails closed with a mismatch rather than answering from it.
+**Do not run two builds against the same `--output` at once.** Nothing locks the
+index path, and both will report success. The install is a rename followed by
+two sidecar writes, and those are separate steps, so the two builds can
+interleave as *A renames, B renames, B writes sidecars, A writes sidecars* —
+leaving B's index under A's manifest. When the two builds disagree about chunk
+count, the contents check catches that pairing on the next read; when they
+happen to agree, as two builds of the same tree usually will, nothing detects
+it, and the index answers from a manifest describing a different build.
+
+A read concurrent with a single build is fine, and is the case that was designed
+for: it sees the old index or the new one, and the window after the rename and
+before the sidecars fails closed with a mismatch rather than answering from it.
 
 A refusal names what would be lost and the flag that proceeds anyway, following
 `config init --force` rather than prompting, so a script and a terminal behave

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -74,12 +74,42 @@ aorta chat index build           # build the source collection from aorta_path
 aorta chat index fetch           # download the index matching your version
 aorta chat index fetch --from ./index.sqlite   # side-load, for an air-gapped node
 aorta chat index runs            # (re)build the run-artifact collection, locally
+aorta chat index status          # compare the local index against the published one
 aorta chat doctor                # extras, backend reachability, index freshness
 ```
 
 `index runs` is the only one that touches the second collection, and the only
 one you need after a sweep. `build`, `fetch` and `--from` all replace the source
 collection and leave it alone.
+
+`index status` writes nothing. It reads the local manifest, downloads the
+published one — about a kilobyte, not the index — and prints both sides plus a
+one-line verdict, with `--json` for scripting. A published manifest it cannot
+read is reported as *no baseline* rather than as *up to date*, and the verdict
+names which asset it compared against, because a `.dev` install resolves to the
+rolling `main` tag rather than to a release.
+
+### What replaces what
+
+Overwriting is guarded, and deliberately not symmetrically. A fetched index
+costs a download to replace; a locally built one may not be reproducible at all,
+because the tree it indexed may have moved and a node with no egress cannot
+re-download the embedding weights.
+
+| You run | Over an index that was | Result |
+|---|---|---|
+| `fetch` | downloaded, and identical | *already up to date*; no asset is transferred |
+| `fetch` | downloaded, and different | replaced, printing what changed |
+| `fetch` or `--from` | built locally | refused; pass `--force` |
+| `build` | built locally | rebuilt, as usual |
+| `build` (narrower corpus) | downloaded | refused; pass `--force` |
+| `build --public-only` | downloaded | rebuilt; it is the same corpus, so nothing is lost |
+
+A refusal names what would be lost and the flag that proceeds anyway, following
+`config init --force` rather than prompting, so a script and a terminal behave
+identically. An index the running configuration would *refuse* is never
+protected: rebuilding one you cannot query loses nothing, and `doctor` tells you
+to rebuild it.
 
 **Interrupting any of them is safe.** `build`, `fetch` and `--from` write the
 new index beside the old one and move it into place in a single step, then write

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -102,8 +102,9 @@ re-download the embedding weights.
 | `fetch` | downloaded, and different | replaced, printing what changed |
 | `fetch` or `--from` | built locally | refused; pass `--force` |
 | `build` | built locally | rebuilt, as usual |
-| `build` (any corpus but the published one) | downloaded | refused; pass `--force` |
+| `build` (any corpus but the published one) | downloaded, and usable | refused; pass `--force` |
 | `build --public-only` | downloaded | rebuilt; it is the same corpus, so nothing is lost |
+| `build` | downloaded, but not usable by this install | rebuilt; it cannot answer anything, so nothing is lost |
 | `fetch` or `--from` | a manifest whose `corpus_roots` cannot be read | refused; pass `--force` |
 | `build` | a manifest whose `corpus_roots` cannot be read | refused, unless a row above already exempts it; pass `--force` |
 

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -89,6 +89,12 @@ read is reported as *no baseline* rather than as *up to date*, and the verdict
 names which asset it compared against, because a `.dev` install resolves to the
 rolling `main` tag rather than to a release.
 
+Two verdicts exit non-zero, and both mean no comparison was made: *no baseline*,
+and *unreadable local index* — a file at the index path with no manifest this
+build can read, which is also what the first query would refuse. An **absent**
+local index exits zero; that is a normal answer for someone who has not
+installed one yet.
+
 ### What replaces what
 
 Overwriting is guarded, and deliberately not symmetrically. A fetched index
@@ -107,10 +113,20 @@ re-download the embedding weights.
 | `build` | downloaded, but not usable by this install | rebuilt; it cannot answer anything, so nothing is lost |
 | `fetch` or `--from` | a manifest whose `corpus_roots` cannot be read | refused; pass `--force` |
 | `build` | a manifest whose `corpus_roots` cannot be read | refused, unless a row above already exempts it; pass `--force` |
+| any of them | *not an index at all* — a path that exists with no manifest beside it | refused; pass `--force` |
+
+`fetch` also opens the store before deciding a refresh would change nothing.
+A matching `index_sha256` says the right index was installed, not that the file
+is still one, so a damaged store under an untouched sidecar is re-fetched rather
+than reported as *already up to date* — by the one command that would repair it.
 
 A refusal names what would be lost and the flag that proceeds anyway, following
 `config init --force` rather than prompting, so a script and a terminal behave
-identically. An index the running configuration cannot *use* is never protected:
+identically. The command it prints carries any non-default `--path` and
+`--output` the refused invocation used, so pasting it acts on the index in
+question rather than on the cache; over the default paths it prints the short
+form, because there the two are the same index. An index the running
+configuration cannot *use* is never protected:
 rebuilding one you cannot query loses nothing, and `doctor` tells you to rebuild
 it. "Cannot use" is the same question the first query asks, store included — an
 embedding-model or identity mismatch, a manifest that disagrees with the
@@ -121,6 +137,14 @@ Which side built an index is read off its manifest's `corpus_roots`, so an index
 whose manifest records *no* roots — one built before the field existed — is not
 protected either way. One that records roots this build cannot read is a broken
 sidecar rather than an old one, and is refused rather than guessed at.
+
+No manifest *at all* is the last row, and it is about the destination rather
+than about provenance. Every write path here leaves its sidecars, so a path that
+exists without them is not an index this tool finished installing: it is a
+mistyped `--output`, a file something else owns, or an index whose sidecars were
+lost. Only the first two are unrecoverable, and nothing on disk tells them
+apart, so all three are refused. A path that does *not* exist is a first
+install and is always permitted — that distinction is the whole rule.
 
 The exemptions come first, which is why the `build` row above is qualified. An
 unreadable `corpus_roots` means the index is either a published one or a local

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -104,7 +104,8 @@ re-download the embedding weights.
 | `build` | built locally | rebuilt, as usual |
 | `build` (any corpus but the published one) | downloaded | refused; pass `--force` |
 | `build --public-only` | downloaded | rebuilt; it is the same corpus, so nothing is lost |
-| any of them | a manifest whose `corpus_roots` cannot be read | refused; pass `--force` |
+| `fetch` or `--from` | a manifest whose `corpus_roots` cannot be read | refused; pass `--force` |
+| `build` | a manifest whose `corpus_roots` cannot be read | refused, unless a row above already exempts it; pass `--force` |
 
 A refusal names what would be lost and the flag that proceeds anyway, following
 `config init --force` rather than prompting, so a script and a terminal behave
@@ -116,6 +117,16 @@ Which side built an index is read off its manifest's `corpus_roots`, so an index
 whose manifest records *no* roots — one built before the field existed — is not
 protected either way. One that records roots this build cannot read is a broken
 sidecar rather than an old one, and is refused rather than guessed at.
+
+The exemptions come first, which is why the `build` row above is qualified. An
+unreadable `corpus_roots` means the index is either a published one or a local
+one, and both of the `build` exemptions give the same answer down both branches:
+a `--public-only` build records the published corpus whichever it replaced, and
+an index this install would refuse is unusable whoever built it — while a local
+index is never protected from `build` in the first place. So proceeding there is
+not a guess about which one is on disk; it is what both possibilities agree on.
+`fetch` and `--from` carry no such exemption, so for them the refusal is
+unconditional.
 
 **Interrupting any of them is safe.** `build`, `fetch` and `--from` write the
 new index beside the old one and move it into place in a single step, then write

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -113,7 +113,7 @@ re-download the embedding weights.
 | `build` | downloaded, but not usable by this install | rebuilt; it cannot answer anything, so nothing is lost |
 | `fetch` or `--from` | a manifest whose `corpus_roots` cannot be read | refused; pass `--force` |
 | `build` | a manifest whose `corpus_roots` cannot be read | refused, unless a row above already exempts it; pass `--force` |
-| any of them | *not an index at all* — a path that exists with no manifest beside it | refused; pass `--force` |
+| any of them, `--public-only` included | *not an index at all* — a path that exists with no manifest beside it | refused; pass `--force` |
 
 `fetch` also opens the store before deciding a refresh would change nothing.
 A matching `index_sha256` says the right index was installed, not that the file
@@ -145,6 +145,14 @@ mistyped `--output`, a file something else owns, or an index whose sidecars were
 lost. Only the first two are unrecoverable, and nothing on disk tells them
 apart, so all three are refused. A path that does *not* exist is a first
 install and is always permitted — that distinction is the whole rule.
+
+This row is checked **before every exemption above it**, `--public-only`
+included. The exemptions answer "is this a narrowing, or an index that cannot
+be queried anyway" — questions that presume an index is what is there, which is
+the one thing this case does not establish. A typo is a typo on the CI path
+too. It costs the published build nothing: `nightly.yml` and `release.yml` run
+on a fresh workspace and never restore `index-out/`, so their first write is to
+a path that does not exist and every later one is over complete sidecars.
 
 The exemptions come first, which is why the `build` row above is qualified. An
 unreadable `corpus_roots` means the index is either a published one or a local

--- a/docs/chat/rag-index.md
+++ b/docs/chat/rag-index.md
@@ -93,7 +93,9 @@ Two verdicts exit non-zero, and both mean no comparison was made: *no baseline*,
 and *unreadable local index* — a file at the index path with no manifest this
 build can read, which is also what the first query would refuse. An **absent**
 local index exits zero; that is a normal answer for someone who has not
-installed one yet.
+installed one yet. When the local sidecar is unreadable *and* the published
+index is one this install could not use, the local failure is the verdict: it is
+the half the reader can act on, and the half that exits non-zero.
 
 ### What replaces what
 
@@ -119,6 +121,16 @@ re-download the embedding weights.
 A matching `index_sha256` says the right index was installed, not that the file
 is still one, so a damaged store under an untouched sidecar is re-fetched rather
 than reported as *already up to date* — by the one command that would repair it.
+"Damaged" includes a store that opens cleanly but holds no chunks for the
+collection this install queries, which is what an index built by the other
+embedding provider and a build that stopped early both look like.
+
+When the published manifest itself is malformed, the refusal says so and does
+**not** offer a re-fetch: the same release yields the same bytes, so the remedies
+are another release (`--version`) or a local build. A malformed sidecar carried
+in with `--from` asks for the file to be re-staged, for the same reason. This is
+a rule rather than three messages — an error raised by `index fetch` may not
+advise an `index fetch` that would fail identically.
 
 A refusal names what would be lost and the flag that proceeds anyway, following
 `config init --force` rather than prompting, so a script and a terminal behave

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -338,6 +338,17 @@ def _read_destination(index_path: str | Path) -> tuple[manifest_mod.Manifest | N
     """
     target = Path(index_path)
     if not target.exists():
+        # ``is_symlink`` as well, because ``exists()`` *follows* the link and so
+        # answers about the target rather than the path the user named: a
+        # dangling symlink reported "nothing here", the guards read that as a
+        # first install, and ``replace()`` then consumed the link without
+        # asking. A symlink is a deliberate object -- someone pointed it
+        # somewhere -- and a broken one is the case where its owner is least
+        # likely to notice it went. It is also unidentifiable by definition,
+        # which is the state this function exists to distinguish, so it takes
+        # the same refusal rather than a special one.
+        if target.is_symlink():
+            return None, f"{target} is a symlink to {os.readlink(target)}, which does not exist"
         return None, ""
     try:
         return manifest_mod.read_manifest(target), ""
@@ -1647,7 +1658,22 @@ def compare_index(
         verdict = VERDICT_INCOMPATIBLE
     elif local is None:
         verdict = VERDICT_NO_LOCAL_INDEX
-    elif _is_same_index(local, published):
+    elif _is_same_index(local, published) and not _refresh_notes(local, published):
+        # Both halves, because ``status`` prints the differences beside the
+        # verdict and the two must not disagree in the same output. The hash is
+        # the right predicate for ``fetch``, where the question is "would the
+        # transfer change these bytes" and the answer is no -- but ``status``
+        # answers "is my index the published one", and a sidecar carrying the
+        # published ``index_sha256`` under a different ``aorta_sha`` or
+        # ``corpus_digest`` reported *up to date* while the table below it
+        # listed those very fields as differing. A reader shown a contradiction
+        # believes the shorter half.
+        #
+        # Asked through ``_refresh_notes`` rather than by comparing a second
+        # list of fields here, because that function *is* what the command
+        # prints: a field added to it is then covered by this verdict without
+        # anyone remembering to add it twice, which is how the two would drift
+        # apart again.
         verdict = VERDICT_UP_TO_DATE
     elif index_provenance(local) == PROVENANCE_LOCAL:
         # Deliberately not a recency claim. ``built_at`` is wall-clock from

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -105,7 +105,17 @@ _NO_EGRESS_HINT = (
 
 
 class IndexFetchError(RuntimeError):
-    """The published index could not be downloaded or verified."""
+    """An index could not be downloaded, verified, or written."""
+
+
+class IndexOverwriteError(IndexFetchError):
+    """Refusing to replace an existing index that this command cannot give back.
+
+    A subclass rather than a sibling so ``cli/chat.py``'s known-exception list
+    needs no change to surface it. That list exists because these messages are
+    the deliverable -- a refusal the user cannot act on gets worked around --
+    and it already renders :class:`IndexFetchError` verbatim.
+    """
 
 
 @dataclass(frozen=True)
@@ -230,6 +240,154 @@ def resolve_source(version: str | None = None, installed: str | None = None) -> 
 _STAGING_PREFIX = ".aorta-index-"
 
 
+# ── who built the index that is already there ─────────────────────────────
+
+#: A CI-published index. ``corpus_roots`` holds the tracked subpaths
+#: ``published_corpus`` was given, so every entry is repository-relative.
+PROVENANCE_PUBLISHED = "published"
+
+#: Built on this machine. ``local_corpus`` records the one absolute path it
+#: walked, so a single absolute root is the signature.
+PROVENANCE_LOCAL = "local"
+
+#: A manifest that records no roots at all, from a builder predating the field.
+PROVENANCE_UNKNOWN = "unknown"
+
+
+def _roots_provenance(roots: list[str] | tuple[str, ...]) -> str:
+    """Classify a set of corpus roots by shape.
+
+    ``published_corpus`` labels its roots with the repository-relative subpaths
+    it was handed (``src/aorta``, ``docs``, ``README.md``); ``local_corpus``
+    labels its single root with the absolute path it resolved. Reading the
+    shape rather than matching the published list means renaming a published
+    subpath does not silently reclassify every index.
+    """
+    if not roots:
+        return PROVENANCE_UNKNOWN
+    if any(Path(root).is_absolute() for root in roots):
+        return PROVENANCE_LOCAL
+    return PROVENANCE_PUBLISHED
+
+
+def index_provenance(manifest: manifest_mod.Manifest) -> str:
+    """Whether an index was published or built here, read off its manifest.
+
+    Inferred rather than stored, because ``corpus_roots`` already distinguishes
+    the two without a manifest schema bump.
+    """
+    return _roots_provenance(manifest.corpus_roots or [])
+
+
+def corpus_provenance(corpus: corpus_mod.Corpus) -> str:
+    """The provenance an index built from ``corpus`` would record.
+
+    The same rule applied to the corpus rather than to a finished manifest, so
+    a guard can compare what is about to be built against what is already
+    there instead of only inspecting the destination.
+    """
+    return _roots_provenance(corpus.roots_label or corpus.subpaths)
+
+
+def _local_manifest(index_path: str | Path) -> manifest_mod.Manifest | None:
+    """The installed index's sidecar, or ``None`` when there is not a usable one.
+
+    Absent, unreadable and unparseable all collapse to ``None`` deliberately.
+    Every caller is deciding what to do *about* the local index, and none of
+    those decisions is improved by a traceback out of a sidecar that is already
+    broken -- the load path is where a bad manifest has to be fatal.
+    """
+    target = Path(index_path)
+    if not target.exists():
+        return None
+    try:
+        return manifest_mod.read_manifest(target)
+    except manifest_mod.ManifestError as exc:
+        logger.debug("No usable manifest beside %s: %s", target, exc)
+        return None
+
+
+def _refuse_if_locally_built(dest: Path, *, force: bool, command: str) -> None:
+    """Stop an incoming index from silently discarding one built on this machine.
+
+    The two directions are not symmetric, which is why this is not a blanket
+    guard. A *fetched* index is trivially re-fetchable, so replacing one costs
+    a download; a *locally built* one may not be reproducible at all, because
+    the tree it indexed may have moved or the node may have no egress to
+    rebuild the weights. So the incoming-index paths (``fetch`` and its
+    ``--from`` side-load, which would otherwise be the accidental way around
+    this) guard against overwriting a local build, and only that.
+    """
+    if force:
+        return
+    local = _local_manifest(dest)
+    if local is None or index_provenance(local) != PROVENANCE_LOCAL:
+        return
+    raise IndexOverwriteError(
+        f"the index at {dest} was built on this machine, not downloaded.\n"
+        f"  built as  {local.describe()}\n"
+        f"  corpus    {', '.join(local.corpus_roots)}\n"
+        "Replacing it with the published index discards a build the network "
+        "cannot give back -- the tree it indexed may have moved, and rebuilding "
+        "needs the embedding weights again.\n"
+        f"Pass --force to overwrite it:  {command} --force"
+    )
+
+
+def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool) -> None:
+    """Stop a *narrower* build from silently downgrading a published index.
+
+    The mirror of :func:`_refuse_if_locally_built`, and the mechanism behind
+    the bad advice this guard exists to catch: ``doctor`` used to suggest a
+    bare ``index build`` as a cache pre-warm, which defaults ``--output`` to
+    the same path and its corpus to ``local_corpus`` -- so it replaced a
+    published index covering ``src/aorta``, ``docs`` and ``README.md`` with one
+    covering ``src/aorta`` alone, and said nothing.
+
+    Three things are therefore exempt, and each of them is a case where the
+    guard would refuse something that loses nothing:
+
+    * **A build whose own corpus is the published one.** ``--public-only``
+      produces the same shape it would be replacing, so this is a refresh, not
+      a downgrade. This is also what keeps ``nightly.yml`` and ``release.yml``
+      safe under a restored or re-used ``index-out/`` -- and a guard that
+      blocked them would stop the published index updating at all, which is
+      worse than the defect being guarded against.
+    * **An index this install would refuse.** For an embedding-identity
+      mismatch, the manifest refusal and ``doctor`` both name ``index build``
+      as the remedy, and it is the right one. Demanding ``--force`` on top
+      would compose two individually-correct behaviours into a dead end --
+      refused, told to rebuild, refused again -- on a user who is already
+      stuck. Vectors that are not comparable to this install's queries cannot
+      answer anything, so there is nothing to protect.
+    * **A destination with no published manifest**, which includes every first
+      build and every local-over-local rebuild.
+    """
+    if force or corpus_provenance(corpus) == PROVENANCE_PUBLISHED:
+        return
+    local = _local_manifest(target)
+    if local is None or index_provenance(local) != PROVENANCE_PUBLISHED:
+        return
+    if _validate_against_provider(local).refusals:
+        logger.info(
+            "The index at %s is refused by this install's embedding provider, "
+            "so rebuilding it loses nothing.",
+            target,
+        )
+        return
+    raise IndexOverwriteError(
+        f"the index at {target} covers the published corpus, and this build "
+        "would not.\n"
+        f"  there now  {local.describe()}\n"
+        f"             corpus {', '.join(local.corpus_roots)}\n"
+        f"  building   corpus {corpus.describe()}\n"
+        "That replaces it with a narrower index: no 'docs/' or 'README.md' "
+        "coverage, and no public-tree provenance.\n"
+        "Refresh the published one instead:  aorta chat index fetch\n"
+        "Or pass --force to build over it:   aorta chat index build --force"
+    )
+
+
 # ── installing ────────────────────────────────────────────────────────────
 
 
@@ -261,6 +419,8 @@ def _install_staged(staged: Path, dest: Path) -> list[str]:
 def build_index(
     corpus: corpus_mod.Corpus | None = None,
     index_path: str | Path | None = None,
+    *,
+    force: bool = False,
 ) -> BuildResult:
     """Build an index plus its manifest from ``corpus``.
 
@@ -270,6 +430,9 @@ def build_index(
             :func:`~aorta.chat.rag.corpus.published_corpus`, whose tracked-file
             allowlist is the hard half of the public-tree guard.
         index_path: Where to write. Defaults to ``settings.index_file``.
+        force: Build a narrower corpus over a published index. Without it that
+            is refused -- see :func:`_refuse_if_published`, which lists what is
+            exempt, including the ``--public-only`` build CI runs.
     """
     import time
 
@@ -280,6 +443,10 @@ def build_index(
     corpus = corpus or corpus_mod.local_corpus(settings.aorta_path)
     target = Path(index_path) if index_path else settings.index_file
     target.parent.mkdir(parents=True, exist_ok=True)
+    # Before the corpus load and the embedding pass, not after: a build takes
+    # tens of minutes, and refusing at the end of one would be worse than not
+    # refusing at all.
+    _refuse_if_published(target, corpus, force=force)
 
     logger.info("Loading corpus: %s", corpus.describe())
     documents = corpus_mod.load_corpus(corpus)
@@ -663,24 +830,6 @@ def _validate_against_provider(manifest: manifest_mod.Manifest) -> manifest_mod.
     )
 
 
-def _local_manifest(index_path: str | Path) -> manifest_mod.Manifest | None:
-    """The installed index's sidecar, or ``None`` when there is not a usable one.
-
-    Absent, unreadable and unparseable all collapse to ``None`` deliberately.
-    Every caller is deciding what to do *about* the local index, and none of
-    those decisions is improved by a traceback out of a sidecar that is already
-    broken -- the load path is where a bad manifest has to be fatal.
-    """
-    target = Path(index_path)
-    if not target.exists():
-        return None
-    try:
-        return manifest_mod.read_manifest(target)
-    except manifest_mod.ManifestError as exc:
-        logger.debug("No usable manifest beside %s: %s", target, exc)
-        return None
-
-
 def _refresh_notes(
     local: manifest_mod.Manifest | None, incoming: manifest_mod.Manifest
 ) -> list[str]:
@@ -721,6 +870,8 @@ def fetch_index(
     version: str | None = None,
     index_path: str | Path | None = None,
     source: IndexSource | None = None,
+    *,
+    force: bool = False,
 ) -> FetchResult:
     """Download, verify, validate and install the published index.
 
@@ -742,10 +893,17 @@ def fetch_index(
     Checksum verification stays where it was, because it genuinely needs the
     bytes. Nothing is installed until it and the manifest/checksum agreement
     both pass.
+
+    ``force`` overwrites a locally-built index, and re-downloads an asset that
+    is already installed.
     """
     dest = Path(index_path) if index_path else settings.index_file
     source = source or resolve_source(version)
     dest.parent.mkdir(parents=True, exist_ok=True)
+    # Free, and therefore first: refusing before any network I/O means a user
+    # who is about to lose a local build is told so immediately rather than
+    # after a download.
+    _refuse_if_locally_built(dest, force=force, command="aorta chat index fetch")
 
     # The text is kept, not re-serialised from the dataclass at install time:
     # ``from_dict`` drops keys this version predates, and writing them back out
@@ -756,7 +914,7 @@ def fetch_index(
     report.raise_if_refused(source.index_url)
 
     local = _local_manifest(dest)
-    if _is_same_index(local, manifest):
+    if not force and _is_same_index(local, manifest):
         logger.info("Already up to date; the published asset was not downloaded.")
         return FetchResult(
             index_path=dest,
@@ -806,12 +964,17 @@ def fetch_index(
     )
 
 
-def side_load(staged: str | Path, index_path: str | Path | None = None) -> FetchResult:
+def side_load(
+    staged: str | Path, index_path: str | Path | None = None, *, force: bool = False
+) -> FetchResult:
     """Adopt a locally staged index (Decision 21b's ``--from``).
 
     The manifest sidecar is required, not optional: side-loading is the path an
     air-gapped user takes, and it is the path where a mismatched index is most
     likely, because the file was carried by hand from somewhere else.
+
+    It is also the third write path, so it carries ``fetch``'s guard: without
+    it, ``--from`` would be the way to overwrite a local build by accident.
     """
     origin = Path(staged).expanduser().resolve()
     if origin.is_dir():
@@ -828,6 +991,7 @@ def side_load(staged: str | Path, index_path: str | Path | None = None) -> Fetch
     dest = Path(index_path) if index_path else settings.index_file
     if origin == dest.resolve():
         raise IndexFetchError(f"{origin} is already the configured index path")
+    _refuse_if_locally_built(dest, force=force, command=f"aorta chat index fetch --from {origin}")
 
     manifest_source = manifest_mod.manifest_path(origin)
     if not manifest_source.exists():
@@ -878,15 +1042,21 @@ __all__ = [
     "BASE_URL_ENV",
     "RELEASE_BASE_URL",
     "ROLLING_TAG",
+    "PROVENANCE_LOCAL",
+    "PROVENANCE_PUBLISHED",
+    "PROVENANCE_UNKNOWN",
     "BuildResult",
     "FetchResult",
     "IndexFetchError",
+    "IndexOverwriteError",
     "IndexSource",
     "build_index",
     "check_index",
     "compute_digest",
+    "corpus_provenance",
     "describe_target",
     "fetch_index",
+    "index_provenance",
     "resolve_source",
     "side_load",
 ]

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -23,6 +23,7 @@ a ``.devN+g<sha>`` version takes the rolling one and says how far off it is.
 
 from __future__ import annotations
 
+import contextlib
 import http.client
 import json
 import logging
@@ -34,6 +35,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from aorta.chat.config import settings
 from aorta.chat.rag import corpus as corpus_mod
@@ -65,9 +67,26 @@ _RELEASE_VERSION = re.compile(r"\A\d+\.\d+\.\d+\Z")
 #: setuptools_scm's local segment, e.g. ``0.2.2.dev122+g45edc3d.d20260810``.
 _DEV_LOCAL = re.compile(r"\.dev(?P<distance>\d+)(?:\+g(?P<sha>[0-9a-f]{7,40}))?")
 
-#: How long a single HTTP request gets. The index is tens of megabytes, so this
-#: is generous, but an unbounded download inside a CLI command is a hang.
-_HTTP_TIMEOUT = 300
+#: Budget for connecting and for the response headers. ``urlopen`` returns as
+#: soon as the headers are in, so this covers everything up to the first byte
+#: of the body -- which is the only phase an unreachable or blackholed host ever
+#: reaches. One 300 s budget for both phases is what turned "this node cannot
+#: see the release host" into five silent minutes on a 1 KB sidecar.
+_CONNECT_TIMEOUT = 30
+
+#: Budget for reading the body, once a server has answered. Kept generous
+#: because the index is tens of megabytes and the link may be slow. It is a
+#: per-``recv`` timeout rather than a total, so a transfer that keeps flowing
+#: never approaches it.
+_READ_TIMEOUT = 300
+
+#: Read from the socket in blocks this size, so progress is reported against a
+#: transfer rather than after it.
+_DOWNLOAD_BLOCK = 256 * 1024
+
+#: How much has to arrive between progress lines. Small enough that a slow link
+#: still looks alive, large enough that a fast one does not scroll.
+_PROGRESS_STEP = 4 * 1024 * 1024
 
 #: Chunks embedded per write. Mirrors ``indexer._WRITE_BATCH``'s reasoning: a
 #: real tree splits into ~15,000 chunks and embedding them in one call holds
@@ -136,6 +155,11 @@ class FetchResult:
     manifest: manifest_mod.Manifest
     source: str
     warnings: list[str] = field(default_factory=list)
+    #: What was known *before* the first request -- which asset was resolved and
+    #: why. Separate from ``warnings`` because the caller has to be able to say
+    #: it up front: these are the lines that explain a wait, and they used to be
+    #: printed only once the wait had ended successfully.
+    notes: list[str] = field(default_factory=list)
 
 
 def installed_version() -> str:
@@ -422,13 +446,81 @@ def check_index(
 # ── fetching ──────────────────────────────────────────────────────────────
 
 
+def _widen_read_timeout(response: Any) -> None:
+    """Give the body read the longer budget, now that the headers have arrived.
+
+    The split the two constants describe is only expressible after the fact:
+    ``urlopen`` takes one timeout and uses it for the connect and for every
+    subsequent read, and reaching the socket is the only way to change it once
+    the response exists.
+
+    Best-effort on purpose. A stub response in a test has no socket to reach,
+    and a CPython that moves the attribute would otherwise turn a cosmetic
+    improvement into a failed download. Falling back leaves the body on the
+    connect budget, which is a per-``recv`` timeout and so is still ample for a
+    transfer that is actually flowing.
+    """
+    raw = getattr(getattr(response, "fp", None), "raw", None)
+    sock = getattr(raw, "_sock", None)
+    if sock is None:
+        return
+    with contextlib.suppress(OSError, AttributeError):
+        sock.settimeout(_READ_TIMEOUT)
+
+
+def _human_bytes(count: int) -> str:
+    return f"{count / (1024 * 1024):.1f} MB"
+
+
+def _progress_line(done: int, total: int) -> str:
+    """One transfer-progress line, with a percentage only when one is knowable."""
+    if total > 0:
+        return f"  {_human_bytes(done)} of {_human_bytes(total)} ({done * 100 // total}%)"
+    return f"  {_human_bytes(done)}"
+
+
+def _content_length(response: Any) -> int:
+    """``Content-Length`` as an int, or 0 when the server did not send a usable one."""
+    headers = getattr(response, "headers", None)
+    raw = headers.get("Content-Length") if headers is not None else None
+    try:
+        return max(int(raw), 0)
+    except (TypeError, ValueError):
+        # Chunked transfer encoding sends none at all, and a malformed one must
+        # cost a percentage rather than the download.
+        return 0
+
+
+def _copy_with_progress(response: Any, handle: Any, total: int) -> None:
+    """Stream the body across, saying how far it has got as it goes.
+
+    ``shutil.copyfileobj`` was doing this with no callback, so the one thing
+    the user could see about a tens-of-megabytes transfer was that it had
+    started.
+    """
+    done = 0
+    report_at = _PROGRESS_STEP
+    while True:
+        block = response.read(_DOWNLOAD_BLOCK)
+        if not block:
+            break
+        handle.write(block)
+        done += len(block)
+        if done >= report_at:
+            logger.info("%s", _progress_line(done, total))
+            report_at = done + _PROGRESS_STEP
+    logger.info("%s", _progress_line(done, total))
+
+
 def _download(url: str, target: Path) -> None:
     """Stream ``url`` to ``target``, or raise :class:`IndexFetchError`."""
     logger.info("Downloading %s", url)
     try:
-        with urllib.request.urlopen(url, timeout=_HTTP_TIMEOUT) as response:  # noqa: S310
+        with urllib.request.urlopen(url, timeout=_CONNECT_TIMEOUT) as response:  # noqa: S310
+            _widen_read_timeout(response)
+            total = _content_length(response)
             with open(target, "wb") as handle:
-                shutil.copyfileobj(response, handle)
+                _copy_with_progress(response, handle, total)
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             raise IndexFetchError(
@@ -469,9 +561,15 @@ def _download_text(url: str) -> str:
     ``IndexFetchError`` for the CLI to render it: this is the first thing
     ``aorta chat index fetch`` does on a node whose egress it knows nothing
     about.
+
+    It is also the first thing the user waits on, which is why it logs. Without
+    this line the only ``Downloading`` message in the module sat on the *third*
+    request, so a node that could not reach the release host produced no output
+    at all before it failed.
     """
+    logger.info("Fetching %s", url)
     try:
-        with urllib.request.urlopen(url, timeout=_HTTP_TIMEOUT) as response:  # noqa: S310
+        with urllib.request.urlopen(url, timeout=_CONNECT_TIMEOUT) as response:  # noqa: S310
             return response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         raise IndexFetchError(
@@ -503,6 +601,29 @@ def _verify_checksum(path: Path, expected_line: str, url: str) -> str:
             "The download is corrupt or was tampered with; it has not been installed."
         )
     return actual
+
+
+def describe_target(source: IndexSource, dest: str | Path) -> list[str]:
+    """The lines a caller should show *before* the first request.
+
+    Every one of these is known before any network I/O and used to be printed
+    only after the last request succeeded -- so a fetch that stalled, or that
+    refused on the manifest, said nothing about what it had been trying to do.
+    ``resolve_source`` even composes a note explaining the rolling asset on a
+    dev install, and that note reached the user through ``FetchResult`` alone.
+
+    Composed here rather than in the CLI so the wording is shared and testable,
+    but *shown* by the caller: only the caller knows whether it has a terminal,
+    a JSON stream or a log to write to. ``fetch_index`` therefore does not
+    print this itself, and logs each individual request instead.
+    """
+    lines = [
+        f"Fetching the published index ({source.describe()})",
+        f"  from {source.index_url}",
+        f"  into {dest}",
+    ]
+    lines.extend(f"  note: {note}" for note in source.notes)
+    return lines
 
 
 def fetch_index(
@@ -577,7 +698,8 @@ def fetch_index(
         index_path=dest,
         manifest=manifest,
         source=source.describe(),
-        warnings=[*source.notes, *report.warnings, *_carried_note(carried)],
+        warnings=[*report.warnings, *_carried_note(carried)],
+        notes=list(source.notes),
     )
 
 
@@ -669,6 +791,7 @@ __all__ = [
     "build_index",
     "check_index",
     "compute_digest",
+    "describe_target",
     "fetch_index",
     "resolve_source",
     "side_load",

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -831,6 +831,24 @@ def compute_digest(corpus: corpus_mod.Corpus | None = None) -> tuple[str, int]:
 # ── validating what arrived ───────────────────────────────────────────────
 
 
+def _no_collection_reason(target: Path, collection: str) -> str:
+    """Why a readable store holds no chunks for the configured collection.
+
+    Separated from the caller because the three states behind it want different
+    sentences and only one of them is about the store's contents: a manifest
+    whose index file is simply gone is a different problem from a store built
+    against another provider, and telling the second user their file is missing
+    would send them looking for it.
+    """
+    if not target.exists():
+        return f"the manifest is here but the index file it describes is not ({target})"
+    return (
+        f"the index holds no {collection} collection, so this install cannot "
+        "query it -- it was built by a different embedding provider, or the "
+        "build did not reach the point of writing chunks"
+    )
+
+
 def check_index(
     index_path: str | Path | None = None,
     *,
@@ -897,6 +915,24 @@ def check_index(
             else "the index could not be read as a sqlite store"
         )
         report.refusals.append(f"contents: {claim} ({unreadable})")
+    elif chunk_count is None:
+        # A store that opened without holding the collection this install
+        # queries. ``collection_chunk_count`` returns ``None`` here rather than
+        # raising, and ``validate`` skips its count comparison when handed
+        # ``None`` -- so between them this state produced *no refusals at all*,
+        # and the two readers built on that silence drew the worst available
+        # conclusion from it: the build guard exempted a rebuild, and ``fetch``
+        # reported "already up to date" over an index that cannot answer a
+        # single query. ``None`` is an ordinary answer from that helper and the
+        # wrong one to treat as consent, because it covers three states and
+        # every one of them is refused by the load path
+        # (``retriever._open_store``, which names the collections that *are*
+        # there): the sidecar outliving its store, a store some other
+        # provider's collection was built into, and a build that stopped before
+        # the chunk table existed.
+        report.refusals.append(
+            f"contents: {_no_collection_reason(target, provider.collection_name())}"
+        )
     if strict:
         report.raise_if_refused(target)
     return report
@@ -1129,13 +1165,37 @@ def describe_target(source: IndexSource, dest: str | Path) -> list[str]:
     return lines
 
 
-def _parse_manifest(text: str, source: IndexSource) -> manifest_mod.Manifest:
+def _parse_manifest(text: str, source: IndexSource, dest: Path) -> manifest_mod.Manifest:
     """Parse a downloaded manifest, or raise :class:`IndexFetchError`.
 
     The schema and field-type checks belong here rather than after the install:
     a manifest this build cannot read must fail the fetch rather than land on
     disk and then be rejected by the first load, which reports a successful
     fetch and leaves a chat that no longer starts.
+
+    **The remedy is this function's to write, and not the parser's.** The
+    parsers wrapped here are handed a dict and cannot know whose manifest it is
+    -- local sidecar, this download, or a side-loaded file all arrive
+    identically and are fixed by three different things -- so a remedy composed
+    down there is a remedy composed from the reader's configuration when the
+    *origin* was the question. That is not hypothetical: #463 found the parser
+    closing its type-mismatch and schema-version errors with "Replace it with
+    'aorta chat index fetch'", which this wrapper carried verbatim into a fetch
+    error, telling the user to re-run the download that produced the bad bytes.
+    Retrying is deterministic -- same URL, same bytes, same failure.
+
+    So the remedy here is the one a *published* origin admits, which is the
+    thing worth saying plainly: nothing the user does to their own machine
+    fixes it. Both commands offered therefore go somewhere else -- a different
+    release, or their own corpus. This covers every parser reached below rather
+    than the two sites that were reported, because they all arrive as one
+    exception at one wrap; :func:`side_load` writes its own for the same reason
+    from the other side.
+
+    ``dest`` is required rather than defaulted, because a remedy naming the
+    wrong index is the defect one layer along: both callers know the path they
+    were asked about, and an optional parameter is how the bare ``index build``
+    got into the sidecar 404s twice.
     """
     try:
         manifest = manifest_mod.Manifest.from_dict(json.loads(text))
@@ -1143,7 +1203,12 @@ def _parse_manifest(text: str, source: IndexSource) -> manifest_mod.Manifest:
         manifest_mod.ensure_supported_schema(manifest, f"the index at {source.index_url}")
     except (ValueError, manifest_mod.ManifestError) as exc:
         raise IndexFetchError(
-            f"the manifest at {source.manifest_url} is not usable: {exc}"
+            f"the manifest at {source.manifest_url} is not usable: {exc}\n"
+            "This is the published release's own metadata, so fetching it again "
+            "downloads the same bytes -- there is no local fix. Pin a different "
+            "release with 'aorta chat index fetch --version <tag>', or build "
+            f"from your own corpus with '{_pasteable('aorta chat index build', dest)}'. "
+            "Please report the broken release."
         ) from exc
     return manifest
 
@@ -1329,7 +1394,7 @@ def fetch_index(
     # ``from_dict`` drops keys this version predates, and writing them back out
     # would strip a newer builder's fields from the sidecar this machine keeps.
     manifest_text = _download_text(source.manifest_url, dest)
-    manifest = _parse_manifest(manifest_text, source)
+    manifest = _parse_manifest(manifest_text, source, dest)
     report = _validate_against_provider(manifest)
     report.raise_if_refused(source.index_url)
 
@@ -1348,8 +1413,9 @@ def fetch_index(
         # would have contradicted that from the other side.
         #
         # Deliberately the load path's notion of usable, not a schema probe:
-        # this catches a store nothing can open and a row count the manifest
-        # disagrees with, and not the several ways a store can open, count
+        # this catches a store nothing can open, one holding no chunks for the
+        # collection this install queries, and a row count the manifest
+        # disagrees with -- and not the several ways a store can open, count
         # correctly and still be the wrong shape underneath (``doctor``
         # enumerates those). Matching the reader the *first query* uses is the
         # property that matters here -- "already up to date" must not mean
@@ -1556,18 +1622,29 @@ def compare_index(
         # user asked about with ``--index``, not the cache. ``status --index``
         # and ``build --output`` are the same path under two flag names, and the
         # remedy has to be spelled in the second one.
-        published = _parse_manifest(_download_text(source.manifest_url, dest), source)
+        published = _parse_manifest(_download_text(source.manifest_url, dest), source, dest)
     except IndexFetchError as exc:
         baseline_error = str(exc)
 
     if published is None:
         verdict = VERDICT_NO_BASELINE
+    elif unreadable:
+        # Ahead of the compatibility check, which reads the *published*
+        # manifest: when both hold, the local read failure is the one the user
+        # can act on, and it is the only one of the two this command exits
+        # non-zero for. Ordered the other way, an install with an unreadable
+        # sidecar *and* an incompatible baseline reported ``incompatible`` and
+        # exited 0 -- so the state this verdict was added for was reported as
+        # the state it was added to be distinguished from, and a script gating
+        # on the exit code saw success. Absent-local stays *after*
+        # compatibility, unchanged: there is nothing local to have failed to
+        # read, and a baseline this install could not use is then the more
+        # useful answer than "you have no index".
+        verdict = VERDICT_UNREADABLE_LOCAL_INDEX
     elif _validate_against_provider(published).refusals:
         # Checked before the content comparison: an index this install cannot
         # query is not made usable by being newer.
         verdict = VERDICT_INCOMPATIBLE
-    elif unreadable:
-        verdict = VERDICT_UNREADABLE_LOCAL_INDEX
     elif local is None:
         verdict = VERDICT_NO_LOCAL_INDEX
     elif _is_same_index(local, published):
@@ -1674,7 +1751,18 @@ def side_load(
         manifest = manifest_mod.read_manifest(origin)
         _ensure_field_types(manifest)
     except (manifest_mod.ManifestError, UnicodeDecodeError, ValueError) as exc:
-        raise IndexFetchError(f"the manifest beside {origin} is not usable: {exc}") from exc
+        # Its own remedy, for the same reason :func:`_parse_manifest` writes
+        # one: the bytes are local but they are not aorta's, so neither a fetch
+        # nor a build addresses them -- the file that has to change is the one
+        # the user carried in. Naming the sidecar rather than the index, since
+        # that is the half that failed and they are two files.
+        raise IndexFetchError(
+            f"the manifest beside {origin} is not usable: {exc}\n"
+            f"Re-stage {manifest_source.name} from wherever the index was "
+            "built; it travelled with the index and did not survive the trip "
+            "intact, so re-running this command on the same pair fails the "
+            "same way."
+        ) from exc
     checksum = manifest_mod.sha256_file(origin)
     if manifest.index_sha256 and manifest.index_sha256 != checksum:
         raise IndexFetchError(

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -527,15 +527,42 @@ def _refuse_if_locally_built(dest: Path, *, force: bool, command: str) -> None:
     # field the guard just classified through a second, unchecked path is the
     # shape of the bug that validation exists to close.
     roots = _corpus_roots(local) or []
+    # ``describe()`` and not the raw fields, but tolerantly: it slices
+    # ``aorta_sha`` and formats ``dimensions``, and a *local* sidecar is
+    # deliberately untyped, so `aorta_sha: 42` raised ``TypeError`` out of the
+    # refusal itself. The classification above is unaffected -- it reads
+    # ``corpus_roots``, which was validated -- so the index really is a local
+    # build and really must be refused; only the courtesy line describing it
+    # was unrenderable, and losing the refusal because its subtitle would not
+    # format is the guard failing open over cosmetics.
     raise IndexOverwriteError(
         f"the index at {dest} was built on this machine, not downloaded.\n"
-        f"  built as  {local.describe()}\n"
+        f"  built as  {_describe_tolerantly(local)}\n"
         f"  corpus    {', '.join(roots)}\n"
         "Replacing it with the published index discards a build the network "
         "cannot give back -- the tree it indexed may have moved, and rebuilding "
         "needs the embedding weights again.\n"
         f"Pass --force to overwrite it:  {remedy} --force"
     )
+
+
+def _describe_tolerantly(manifest: manifest_mod.Manifest) -> str:
+    """``Manifest.describe()``, or a note that the manifest cannot be rendered.
+
+    The manifests reaching the write guards are local sidecars, which are
+    deliberately parsed without type checking so that the reports whose job is
+    to say what is wrong with one can still read it. That tolerance has to
+    extend to everything downstream of the read, and ``describe()`` is not
+    written for it -- it slices and formats. This is the seam that keeps
+    reappearing: the *guard's* decision never depends on these fields, so a
+    field it does not consult must not be able to take the refusal down with
+    it.
+    """
+    try:
+        return manifest.describe()
+    except Exception as exc:  # noqa: BLE001 - a summary is not worth a traceback
+        logger.debug("Could not describe the manifest: %r", exc)
+        return f"(its manifest cannot be summarised: {type(exc).__name__})"
 
 
 def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool) -> None:
@@ -1328,22 +1355,40 @@ def _refresh_notes(
     it is the documented way to refresh, and demanding ``--force`` every time
     would train people to always pass it -- so what it replaced is reported
     instead.
+
+    **Derived from :data:`_SIDE_FIELDS`, which is what ``index status`` prints
+    side by side.** It used to name three fields chosen by hand, and ``status``
+    then took its verdict from this function while rendering a table of ten --
+    so a sidecar differing only in ``embedding_model`` or ``dimensions``
+    reported *up to date* above a table showing the mismatch, and the load path
+    could refuse the same index. One list rather than two is the fix: a field
+    added to the table is reported and judged without a second edit, which is
+    the drift that produced the disagreement in the first place. ``index_sha256``
+    is skipped because it is the identity the caller has already compared and
+    "the hashes differ" is not news beside the fields that explain why.
     """
     if local is None:
         return []
+    was_side, now_side = _side(local), _side(incoming)
     changes = []
-    for label, was, now in (
-        ("built_at", _manifest_text(local.built_at), _manifest_text(incoming.built_at)),
-        ("aorta_sha", _manifest_text(local.aorta_sha)[:7], _manifest_text(incoming.aorta_sha)[:7]),
-        (
-            "corpus_digest",
-            _manifest_text(local.corpus_digest)[:12],
-            _manifest_text(incoming.corpus_digest)[:12],
-        ),
-    ):
-        if was != now:
-            changes.append(f"{label}: {was or 'unknown'} -> {now or 'unknown'}")
+    for name in _SIDE_FIELDS:
+        if name == "index_sha256":
+            continue
+        was = _manifest_text(was_side[name])
+        now = _manifest_text(now_side[name])
+        if was == now:
+            continue
+        trim = _NOTE_TRIM.get(name)
+        if trim:
+            was, now = was[:trim], now[:trim]
+        changes.append(f"{name}: {was or 'unknown'} -> {now or 'unknown'}")
     return changes
+
+
+#: Fields whose full value is a digest, shortened in the change notes. Anything
+#: absent from here is printed whole, because a truncated model name or
+#: dimension count would hide the difference the line exists to show.
+_NOTE_TRIM = {"aorta_sha": 7, "corpus_digest": 12}
 
 
 def _is_same_index(local: manifest_mod.Manifest | None, incoming: manifest_mod.Manifest) -> bool:

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import tempfile
 import urllib.error
@@ -421,18 +422,38 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
       safe under a restored or re-used ``index-out/`` -- and a guard that
       blocked them would stop the published index updating at all, which is
       worse than the defect being guarded against.
-    * **An index this install would refuse.** For an embedding-identity
+    * **An index this install cannot use.** For an embedding-identity
       mismatch, the manifest refusal and ``doctor`` both name ``index build``
       as the remedy, and it is the right one. Demanding ``--force`` on top
       would compose two individually-correct behaviours into a dead end --
       refused, told to rebuild, refused again -- on a user who is already
       stuck. Vectors that are not comparable to this install's queries cannot
       answer anything, so there is nothing to protect.
+
+      Asked through :func:`check_index`, which reads the *store* and not only
+      the manifest. Asking ``_validate_against_provider`` instead -- the
+      manifest alone -- made this exemption narrower than the advice it exists
+      to keep followable: an index whose ``.sqlite`` cannot be opened at all
+      has an entirely valid manifest, so it was refused a rebuild while every
+      reader that touches the file says to rebuild it. One reader for "can
+      this install use what is there", shared with the load path.
     * **A destination with no published manifest**, which includes every first
       build and every local-over-local rebuild.
 
     A destination whose ``corpus_roots`` is present but unreadable is refused
     instead, once the exemptions above have not applied.
+
+    A *stale* index needs no exemption and deliberately does not get one.
+    Source drift is a warning rather than a refusal, so it does not reach the
+    branch below -- and on a remote embedding provider, where ``doctor`` names
+    ``index build`` for drift because a fetch would land an asset that provider
+    refuses, the index in front of the guard is already exempt for a different
+    reason: either it is a local build (classified ``local``, and a local index
+    is never protected from ``build``), or it is the published asset, which a
+    remote provider refuses on its model and collection. Both paths permit the
+    rebuild without widening anything. On a *local* provider a drift warning
+    names ``index fetch``, and refusing a narrowing build there is the whole
+    point of this guard.
     """
     if force or corpus_provenance(corpus) == PROVENANCE_PUBLISHED:
         return
@@ -442,22 +463,24 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
     provenance = index_provenance(local)
     if provenance not in (PROVENANCE_PUBLISHED, PROVENANCE_INVALID):
         return
-    if _validate_against_provider(local).refusals:
-        # Ahead of both refusals, so a refused index is exempt whether or not
+    unusable = check_index(target, strict=False).refusals
+    if unusable:
+        # Ahead of both refusals, so an unusable index is exempt whether or not
         # its manifest is readable; either refusal would otherwise compose two
         # individually-correct behaviours into a dead end.
         #
         # Ahead of the unreadable-provenance refusal specifically, which looks
         # like a hole and is not: an unreadable manifest is either a published
-        # index or a local one, and a *refused* index reaches the same verdict
+        # index or a local one, and an *unusable* index reaches the same verdict
         # down both branches -- a refused published index is exempt by the rule
         # above, and a local index is never protected from `build` at all (the
         # early return above). So returning here is not a guess about which one
         # is on disk; it is the answer both possibilities give.
         logger.info(
-            "The index at %s is refused by this install's embedding provider, "
-            "so rebuilding it loses nothing.",
+            "The index at %s is not usable by this install, so rebuilding it "
+            "loses nothing: %s",
             target,
+            "; ".join(unusable),
         )
         return
     if provenance == PROVENANCE_INVALID:
@@ -693,14 +716,29 @@ def check_index(
         installed_version=installed_version(),
         chunk_count=chunk_count,
     )
-    # A manifest that claims contents over a file nothing can open fails
-    # closed. Gated on the claim: a manifest from a builder that predates
-    # ``chunk_count`` asserts nothing here, so there is nothing to contradict.
-    if unreadable and manifest.chunk_count:
-        report.refusals.append(
-            f"contents: the manifest describes {manifest.chunk_count} chunks, but the "
-            f"index could not be read to check ({unreadable})"
+    # A file nothing can open fails closed, whatever its manifest claims.
+    #
+    # This used to be gated on ``manifest.chunk_count``, on the reasoning that a
+    # manifest predating the field asserts nothing and so has nothing to
+    # contradict. That reads the wrong question. "Is the manifest's claim
+    # contradicted" and "can this index be queried at all" are different, and
+    # only the second one decides whether the index is usable -- the load path
+    # (``retriever._check_manifest``) refuses an unreadable store outright, with
+    # no such gate, so the gate made this reader *more permissive than the load
+    # path it exists to predict*: a legacy manifest over filler bytes reported
+    # no refusals here while the first query refused the same file. It also
+    # defeated this function's own docstring, and PR #463 grew a second
+    # store-reading helper in ``doctor`` to work around it.
+    if unreadable:
+        # Two messages, because "describes 0 chunks" would be a claim the
+        # manifest never made.
+        claim = (
+            f"the manifest describes {manifest.chunk_count} chunks, but the index "
+            "could not be read to check"
+            if manifest.chunk_count
+            else "the index could not be read as a sqlite store"
         )
+        report.refusals.append(f"contents: {claim} ({unreadable})")
     if strict:
         report.raise_if_refused(target)
     return report
@@ -963,6 +1001,13 @@ def _manifest_text(value: object) -> str:
 
     ``None`` becomes empty rather than ``"None"`` so the callers' own wording
     for a missing field still fires.
+
+    Rendering rather than validating, deliberately, and the asymmetry with
+    ``corpus_roots`` is the point: these fields are *reported*, and a reported
+    field survives being odd -- a caller reads "corpus_digest: unknown -> abc"
+    and knows what it is looking at. ``corpus_roots`` is *used*, to decide
+    whether a destructive overwrite is refused, so it gets a validity verdict
+    instead. A field whose only job is to be shown does not need one.
     """
     return "" if value is None else str(value)
 
@@ -1318,7 +1363,16 @@ def side_load(
     dest = Path(index_path) if index_path else settings.index_file
     if origin == dest.resolve():
         raise IndexFetchError(f"{origin} is already the configured index path")
-    _refuse_if_locally_built(dest, force=force, command=f"aorta chat index fetch --from {origin}")
+    # ``shlex.quote``, because this string is printed as a command to run and
+    # ``origin`` is a user-supplied path: a space or an apostrophe (a
+    # ``/home/o'brien`` home directory is enough) otherwise yields advice that
+    # does not parse in the shell it is pasted into. Quoting is a no-op for an
+    # ordinary path, so the usual message is unchanged.
+    _refuse_if_locally_built(
+        dest,
+        force=force,
+        command=f"aorta chat index fetch --from {shlex.quote(str(origin))}",
+    )
 
     manifest_source = manifest_mod.manifest_path(origin)
     if not manifest_source.exists():

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -23,7 +23,6 @@ a ``.devN+g<sha>`` version takes the rolling one and says how far off it is.
 
 from __future__ import annotations
 
-import contextlib
 import http.client
 import json
 import logging
@@ -387,10 +386,15 @@ def _refuse_if_locally_built(dest: Path, *, force: bool, command: str) -> None:
         raise _unclassifiable_error(dest, local.corpus_roots, command)
     if provenance != PROVENANCE_LOCAL:
         return
+    # Formatted from the validated reader rather than the raw attribute. The
+    # branch above is what makes this a list of strings, and rendering the
+    # field the guard just classified through a second, unchecked path is the
+    # shape of the bug that validation exists to close.
+    roots = _corpus_roots(local) or []
     raise IndexOverwriteError(
         f"the index at {dest} was built on this machine, not downloaded.\n"
         f"  built as  {local.describe()}\n"
-        f"  corpus    {', '.join(local.corpus_roots)}\n"
+        f"  corpus    {', '.join(roots)}\n"
         "Replacing it with the published index discards a build the network "
         "cannot give back -- the tree it indexed may have moved, and rebuilding "
         "needs the embedding weights again.\n"
@@ -442,6 +446,14 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
         # Ahead of both refusals, so a refused index is exempt whether or not
         # its manifest is readable; either refusal would otherwise compose two
         # individually-correct behaviours into a dead end.
+        #
+        # Ahead of the unreadable-provenance refusal specifically, which looks
+        # like a hole and is not: an unreadable manifest is either a published
+        # index or a local one, and a *refused* index reaches the same verdict
+        # down both branches -- a refused published index is exempt by the rule
+        # above, and a local index is never protected from `build` at all (the
+        # early return above). So returning here is not a guess about which one
+        # is on disk; it is the answer both possibilities give.
         logger.info(
             "The index at %s is refused by this install's embedding provider, "
             "so rebuilding it loses nothing.",
@@ -450,11 +462,12 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
         return
     if provenance == PROVENANCE_INVALID:
         raise _unclassifiable_error(target, local.corpus_roots, "aorta chat index build")
+    roots = _corpus_roots(local) or []
     raise IndexOverwriteError(
         f"the index at {target} covers the published corpus, and this build "
         "would not.\n"
         f"  there now  {local.describe()}\n"
-        f"             corpus {', '.join(local.corpus_roots)}\n"
+        f"             corpus {', '.join(roots)}\n"
         f"  building   corpus {corpus.describe()}\n"
         "That replaces it with an index over a different corpus -- the two are "
         "above -- and one with no public-tree provenance, since only a "
@@ -709,13 +722,34 @@ def _widen_read_timeout(response: Any) -> None:
     improvement into a failed download. Falling back leaves the body on the
     connect budget, which is a per-``recv`` timeout and so is still ample for a
     transfer that is actually flowing.
+
+    The fallback is logged rather than silent. Reaching through
+    ``response.fp.raw._sock`` is an implementation detail of the standard
+    library, so the day it moves the only visible symptom would be downloads
+    failing at 30 seconds again -- with nothing anywhere saying the split had
+    stopped applying. Debug level: it is diagnostic for whoever is already
+    looking at a timeout, and ``-v`` is what that person passes.
     """
     raw = getattr(getattr(response, "fp", None), "raw", None)
     sock = getattr(raw, "_sock", None)
     if sock is None:
+        logger.debug(
+            "No socket behind the response, so the body keeps the %ss connect "
+            "timeout rather than the %ss read timeout.",
+            _CONNECT_TIMEOUT,
+            _READ_TIMEOUT,
+        )
         return
-    with contextlib.suppress(OSError, AttributeError):
+    try:
         sock.settimeout(_READ_TIMEOUT)
+    except (OSError, AttributeError) as exc:
+        logger.debug(
+            "Could not widen the read timeout to %ss (%s); the body keeps the %ss "
+            "connect timeout.",
+            _READ_TIMEOUT,
+            exc,
+            _CONNECT_TIMEOUT,
+        )
 
 
 def _human_bytes(count: int) -> str:
@@ -820,6 +854,14 @@ def _download_text(url: str) -> str:
     logger.info("Fetching %s", url)
     try:
         with urllib.request.urlopen(url, timeout=_CONNECT_TIMEOUT) as response:  # noqa: S310
+            # Widened for the same reason the asset transfer is, and it was
+            # missing here: ``urlopen``'s single timeout also governs every
+            # read, so a sidecar served slowly by a loaded release host failed
+            # on the connect budget rather than the read budget the two
+            # constants advertise. A kilobyte rarely needs it -- but this is
+            # the *first* request the command makes, so it is the one whose
+            # failure a user reads as "fetch does not work here".
+            _widen_read_timeout(response)
             return response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         raise IndexFetchError(
@@ -908,6 +950,23 @@ def _validate_against_provider(manifest: manifest_mod.Manifest) -> manifest_mod.
     )
 
 
+def _manifest_text(value: object) -> str:
+    """A manifest field as text, whatever type it actually holds.
+
+    The same hole as :func:`_corpus_roots`, one field over.
+    ``Manifest.from_dict`` type-checks nothing, so a hand-written sidecar can
+    record ``null`` where a digest belongs -- and truncating that raised
+    ``TypeError`` (``KeyError`` for a JSON object, which subscripts by key)
+    straight out of the comparison whose entire job is to report on a manifest
+    that looks wrong. Rendered before it is truncated, which is what
+    ``index status``'s table already does with the same values.
+
+    ``None`` becomes empty rather than ``"None"`` so the callers' own wording
+    for a missing field still fires.
+    """
+    return "" if value is None else str(value)
+
+
 def _refresh_notes(
     local: manifest_mod.Manifest | None, incoming: manifest_mod.Manifest
 ) -> list[str]:
@@ -922,9 +981,13 @@ def _refresh_notes(
         return []
     changes = []
     for label, was, now in (
-        ("built_at", local.built_at, incoming.built_at),
-        ("aorta_sha", local.aorta_sha[:7], incoming.aorta_sha[:7]),
-        ("corpus_digest", local.corpus_digest[:12], incoming.corpus_digest[:12]),
+        ("built_at", _manifest_text(local.built_at), _manifest_text(incoming.built_at)),
+        ("aorta_sha", _manifest_text(local.aorta_sha)[:7], _manifest_text(incoming.aorta_sha)[:7]),
+        (
+            "corpus_digest",
+            _manifest_text(local.corpus_digest)[:12],
+            _manifest_text(incoming.corpus_digest)[:12],
+        ),
     ):
         if was != now:
             changes.append(f"{label}: {was or 'unknown'} -> {now or 'unknown'}")

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -160,6 +160,11 @@ class FetchResult:
     #: it up front: these are the lines that explain a wait, and they used to be
     #: printed only once the wait had ended successfully.
     notes: list[str] = field(default_factory=list)
+    #: What this install replaced, for a refresh that went ahead without asking.
+    changes: list[str] = field(default_factory=list)
+    #: Set when the published asset was already installed, so nothing was
+    #: transferred and nothing was replaced.
+    up_to_date: bool = False
 
 
 def installed_version() -> str:
@@ -626,6 +631,92 @@ def describe_target(source: IndexSource, dest: str | Path) -> list[str]:
     return lines
 
 
+def _parse_manifest(text: str, source: IndexSource) -> manifest_mod.Manifest:
+    """Parse a downloaded manifest, or raise :class:`IndexFetchError`.
+
+    The schema check belongs here rather than after the install: a schema this
+    build cannot read must fail the fetch rather than land on disk and then be
+    rejected by the first load, which reports a successful fetch and leaves a
+    chat that no longer starts.
+    """
+    try:
+        manifest = manifest_mod.Manifest.from_dict(json.loads(text))
+        manifest_mod.ensure_supported_schema(manifest, f"the index at {source.index_url}")
+    except (ValueError, manifest_mod.ManifestError) as exc:
+        raise IndexFetchError(
+            f"the manifest at {source.manifest_url} is not usable: {exc}"
+        ) from exc
+    return manifest
+
+
+def _validate_against_provider(manifest: manifest_mod.Manifest) -> manifest_mod.ValidationReport:
+    """Check an incoming manifest against what this install would query with."""
+    provider = get_provider()
+    return manifest_mod.validate(
+        manifest,
+        embedding_model=provider.model_id(),
+        collection=provider.collection_name(),
+        embedding_identity=provider.vector_identity(),
+        chunk_size=settings.chunk_size,
+        chunk_overlap=settings.chunk_overlap,
+        installed_version=installed_version(),
+    )
+
+
+def _local_manifest(index_path: str | Path) -> manifest_mod.Manifest | None:
+    """The installed index's sidecar, or ``None`` when there is not a usable one.
+
+    Absent, unreadable and unparseable all collapse to ``None`` deliberately.
+    Every caller is deciding what to do *about* the local index, and none of
+    those decisions is improved by a traceback out of a sidecar that is already
+    broken -- the load path is where a bad manifest has to be fatal.
+    """
+    target = Path(index_path)
+    if not target.exists():
+        return None
+    try:
+        return manifest_mod.read_manifest(target)
+    except manifest_mod.ManifestError as exc:
+        logger.debug("No usable manifest beside %s: %s", target, exc)
+        return None
+
+
+def _refresh_notes(
+    local: manifest_mod.Manifest | None, incoming: manifest_mod.Manifest
+) -> list[str]:
+    """What a refresh is about to change, field by field.
+
+    A routine ``fetch`` over an older fetched index proceeds without asking --
+    it is the documented way to refresh, and demanding ``--force`` every time
+    would train people to always pass it -- so what it replaced is reported
+    instead.
+    """
+    if local is None:
+        return []
+    changes = []
+    for label, was, now in (
+        ("built_at", local.built_at, incoming.built_at),
+        ("aorta_sha", local.aorta_sha[:7], incoming.aorta_sha[:7]),
+        ("corpus_digest", local.corpus_digest[:12], incoming.corpus_digest[:12]),
+    ):
+        if was != now:
+            changes.append(f"{label}: {was or 'unknown'} -> {now or 'unknown'}")
+    return changes
+
+
+def _is_same_index(local: manifest_mod.Manifest | None, incoming: manifest_mod.Manifest) -> bool:
+    """Whether the installed index is byte-identical to the published one.
+
+    ``index_sha256`` is exact content identity, so this is the one comparison
+    that can skip the transfer outright. Both sides must actually carry one: a
+    manifest predating the field would otherwise compare equal on ``""`` and
+    skip a download it needed.
+    """
+    if local is None or not local.index_sha256 or not incoming.index_sha256:
+        return False
+    return local.index_sha256 == incoming.index_sha256
+
+
 def fetch_index(
     version: str | None = None,
     index_path: str | Path | None = None,
@@ -633,36 +724,58 @@ def fetch_index(
 ) -> FetchResult:
     """Download, verify, validate and install the published index.
 
-    Verification order matters: checksum first, so a corrupt download never
-    reaches the manifest parser, then manifest validation, so a mismatched index
-    never reaches the destination path. Nothing is installed until both pass.
+    The order of the checks is load-bearing, and two of them moved.
+
+    **Identity is checked on the manifest, before the asset is transferred.**
+    That ~1 KB sidecar already carries ``embedding_model``, ``collection`` and
+    ``embedding_identity``, so a mismatch is knowable the moment it arrives --
+    yet it used to be validated only after the full index transfer and its
+    checksum. A reporter with a misconfigured embedding provider therefore
+    downloaded ~20 MB that was guaranteed to be discarded. Fixing the
+    configuration stops that particular refusal; any later mismatch -- a model
+    change, an endpoint change -- hits the same wasted transfer.
+
+    **The asset is skipped entirely when the local sidecar already records the
+    published ``index_sha256``.** A refresh that would change nothing is the
+    common case, and it cost the whole download.
+
+    Checksum verification stays where it was, because it genuinely needs the
+    bytes. Nothing is installed until it and the manifest/checksum agreement
+    both pass.
     """
     dest = Path(index_path) if index_path else settings.index_file
     source = source or resolve_source(version)
-    provider = get_provider()
     dest.parent.mkdir(parents=True, exist_ok=True)
+
+    # The text is kept, not re-serialised from the dataclass at install time:
+    # ``from_dict`` drops keys this version predates, and writing them back out
+    # would strip a newer builder's fields from the sidecar this machine keeps.
+    manifest_text = _download_text(source.manifest_url)
+    manifest = _parse_manifest(manifest_text, source)
+    report = _validate_against_provider(manifest)
+    report.raise_if_refused(source.index_url)
+
+    local = _local_manifest(dest)
+    if _is_same_index(local, manifest):
+        logger.info("Already up to date; the published asset was not downloaded.")
+        return FetchResult(
+            index_path=dest,
+            manifest=manifest,
+            source=source.describe(),
+            warnings=list(report.warnings),
+            notes=list(source.notes),
+            up_to_date=True,
+        )
+    changes = _refresh_notes(local, manifest)
 
     # Staged inside the destination directory so the final move is a rename on
     # one filesystem, and therefore atomic: a concurrent reader sees the old
     # index or the new one, never a half-written file.
     with tempfile.TemporaryDirectory(prefix=_STAGING_PREFIX, dir=dest.parent) as staging_dir:
         staged = Path(staging_dir) / ASSET_NAME
-        manifest_text = _download_text(source.manifest_url)
         checksum_line = _download_text(source.checksum_url)
         _download(source.index_url, staged)
         checksum = _verify_checksum(staged, checksum_line, source.checksum_url)
-
-        try:
-            manifest = manifest_mod.Manifest.from_dict(json.loads(manifest_text))
-            # Before ``_install_staged``, not after: a schema this build cannot
-            # read must fail the fetch rather than be written to disk and then
-            # rejected by the first load, which reports success and leaves a
-            # chat that no longer starts.
-            manifest_mod.ensure_supported_schema(manifest, f"the index at {source.index_url}")
-        except (ValueError, manifest_mod.ManifestError) as exc:
-            raise IndexFetchError(
-                f"the manifest at {source.manifest_url} is not usable: {exc}"
-            ) from exc
         if manifest.index_sha256 and manifest.index_sha256 != checksum:
             raise IndexFetchError(
                 "the manifest and the checksum file disagree about the index:\n"
@@ -670,17 +783,6 @@ def fetch_index(
                 f"  .sha256 says  {checksum}\n"
                 "The published set is inconsistent; nothing has been installed."
             )
-
-        report = manifest_mod.validate(
-            manifest,
-            embedding_model=provider.model_id(),
-            collection=provider.collection_name(),
-            embedding_identity=provider.vector_identity(),
-            chunk_size=settings.chunk_size,
-            chunk_overlap=settings.chunk_overlap,
-            installed_version=installed_version(),
-        )
-        report.raise_if_refused(source.index_url)
 
         # Index first, sidecars after. Writing the sidecars first looked like
         # the fail-safe order -- and is, on a first install, where there is no
@@ -700,6 +802,7 @@ def fetch_index(
         source=source.describe(),
         warnings=[*report.warnings, *_carried_note(carried)],
         notes=list(source.notes),
+        changes=changes,
     )
 
 
@@ -743,16 +846,7 @@ def side_load(staged: str | Path, index_path: str | Path | None = None) -> Fetch
             "The staged copy is incomplete or corrupt."
         )
 
-    provider = get_provider()
-    report = manifest_mod.validate(
-        manifest,
-        embedding_model=provider.model_id(),
-        collection=provider.collection_name(),
-        embedding_identity=provider.vector_identity(),
-        chunk_size=settings.chunk_size,
-        chunk_overlap=settings.chunk_overlap,
-        installed_version=installed_version(),
-    )
+    report = _validate_against_provider(manifest)
     report.raise_if_refused(origin)
 
     dest.parent.mkdir(parents=True, exist_ok=True)

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -428,7 +428,8 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
       would compose two individually-correct behaviours into a dead end --
       refused, told to rebuild, refused again -- on a user who is already
       stuck. Vectors that are not comparable to this install's queries cannot
-      answer anything, so there is nothing to protect.
+      answer anything, and neither can a store that will not open, so in
+      either case there is nothing to protect.
 
       Asked through :func:`check_index`, which reads the *store* and not only
       the manifest. Asking ``_validate_against_provider`` instead -- the

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -23,6 +23,7 @@ a ``.devN+g<sha>`` version takes the rolling one and says how far off it is.
 
 from __future__ import annotations
 
+import dataclasses
 import http.client
 import json
 import logging
@@ -323,22 +324,91 @@ def corpus_provenance(corpus: corpus_mod.Corpus) -> str:
     return _roots_provenance(corpus.roots_label or corpus.subpaths)
 
 
+def _read_destination(index_path: str | Path) -> tuple[manifest_mod.Manifest | None, str]:
+    """The sidecar at a write target, and why it could not be read.
+
+    Three states rather than two. ``(None, "")`` is nothing there at all;
+    ``(None, reason)`` is a path that exists with no manifest this build can
+    read; ``(manifest, "")`` is an index that can be classified.
+
+    :func:`_local_manifest` collapses the first two, which is right for the
+    readers that only want a manifest and wrong for the write guards, where
+    "there is nothing to overwrite" and "there is something unidentifiable to
+    overwrite" are opposite verdicts.
+    """
+    target = Path(index_path)
+    if not target.exists():
+        return None, ""
+    try:
+        return manifest_mod.read_manifest(target), ""
+    except manifest_mod.ManifestError as exc:
+        logger.debug("No usable manifest beside %s: %s", target, exc)
+        return None, str(exc)
+
+
 def _local_manifest(index_path: str | Path) -> manifest_mod.Manifest | None:
     """The installed index's sidecar, or ``None`` when there is not a usable one.
 
     Absent, unreadable and unparseable all collapse to ``None`` deliberately.
-    Every caller is deciding what to do *about* the local index, and none of
-    those decisions is improved by a traceback out of a sidecar that is already
-    broken -- the load path is where a bad manifest has to be fatal.
+    Every caller here is *reporting* on the local index, and none of those
+    reports is improved by a traceback out of a sidecar that is already broken
+    -- the load path is where a bad manifest has to be fatal. The write guards
+    use :func:`_read_destination` instead, because for them the collapse is the
+    bug rather than the convenience.
     """
-    target = Path(index_path)
-    if not target.exists():
-        return None
+    return _read_destination(index_path)[0]
+
+
+def _unusable_reasons(target: Path) -> list[str]:
+    """Why this install cannot use the index at ``target``; empty when it can.
+
+    One reader for "is what is on disk actually usable", shared by the build
+    guard and by ``fetch``'s up-to-date shortcut, so a rebuild that is exempted
+    and a refresh that is skipped cannot disagree about the same file.
+    :func:`check_index` opens the store, so this is the question the first
+    query asks rather than a second opinion derived from the manifest.
+
+    Never raises. Both callers have just read the manifest themselves, but they
+    read it separately, and a helper whose whole job is to answer "should this
+    be installed again" must not turn a sidecar that changed in between into a
+    traceback out of the answer.
+    """
     try:
-        return manifest_mod.read_manifest(target)
+        return list(check_index(target, strict=False).refusals)
     except manifest_mod.ManifestError as exc:
-        logger.debug("No usable manifest beside %s: %s", target, exc)
-        return None
+        return [str(exc)]
+
+
+def _pasteable(command: str, dest: Path, corpus: corpus_mod.Corpus | None = None) -> str:
+    """A refusal's remedy, carrying the flags that chose the index it is about.
+
+    A remedy is only advice if pasting it acts on the index that was refused.
+    These commands default ``--output`` to the configured cache and their
+    corpus to the installed package, so a refusal raised over
+    ``--output /tmp/scratch.sqlite`` printed a bare ``... --force`` that named
+    a *different* index -- the user's real one, which they had not asked about
+    and which the paste would then overwrite while leaving the refusal
+    standing.
+
+    Only the flags that differ from what the bare command would resolve are
+    appended, so the common refusal stays the short line it was.
+    """
+    return command + _target_flags(dest, corpus)
+
+
+def _target_flags(dest: Path, corpus: corpus_mod.Corpus | None = None) -> str:
+    """The flags naming this destination, or ``""`` when they are the defaults.
+
+    Separate from :func:`_pasteable` because the 404 remedy prints three
+    commands in an aligned block and needs the suffix rather than each whole
+    line.
+    """
+    parts = []
+    if corpus is not None and corpus.base != settings.aorta_root:
+        parts.append(f"--path {shlex.quote(str(corpus.base))}")
+    if dest != settings.index_file:
+        parts.append(f"--output {shlex.quote(str(dest))}")
+    return "".join(f" {part}" for part in parts)
 
 
 def _unclassifiable_error(target: Path, roots: object, command: str) -> IndexOverwriteError:
@@ -360,6 +430,28 @@ def _unclassifiable_error(target: Path, roots: object, command: str) -> IndexOve
     )
 
 
+def _unidentifiable_error(target: Path, reason: str, command: str) -> IndexOverwriteError:
+    """The refusal for an existing destination with no manifest to read.
+
+    Every write path here produces its sidecars, so a path that exists without
+    one is not an index this tool finished installing. It is a mistyped
+    ``--output``, a file something else owns, or an index whose sidecars were
+    lost -- and the first two are the ones an overwrite cannot give back.
+
+    Names both, because the caller is the only one who can tell them apart, and
+    the escape is one flag rather than a second diagnosis.
+    """
+    return IndexOverwriteError(
+        f"there is already a file at {target}, and no manifest beside it that "
+        f"this install can read ({reason}).\n"
+        "A first install writes to a path that does not exist yet. This one "
+        "exists, so something is there to lose, and without a manifest there "
+        "is no way to tell an index from a file this tool never wrote.\n"
+        "If the path is a typo, correcting it is the fix.\n"
+        f"If it is an index whose sidecars were lost, replacing it is safe:  {command} --force"
+    )
+
+
 def _refuse_if_locally_built(dest: Path, *, force: bool, command: str) -> None:
     """Stop an incoming index from silently discarding one built on this machine.
 
@@ -376,15 +468,27 @@ def _refuse_if_locally_built(dest: Path, *, force: bool, command: str) -> None:
     every pre-field install's routine refresh. A manifest recording roots that
     cannot be read is refused -- that is a broken sidecar, not an old one, and
     it is the one case where guessing could discard the unrecoverable side.
+
+    A destination with *no* readable manifest is refused on the same reasoning,
+    one step earlier. Absent and unreadable used to collapse into "nothing
+    there", so a mistyped ``--index`` at an existing file, or an index whose
+    sidecar had been truncated, was overwritten without a word -- while the
+    strictly better-informed case of a sidecar that reads but classifies badly
+    was refused.
     """
     if force:
         return
-    local = _local_manifest(dest)
+    # Carries a non-default --output into every remedy below, so the line the
+    # user pastes acts on the index they were refused rather than on the cache.
+    remedy = _pasteable(command, dest)
+    local, unreadable = _read_destination(dest)
+    if unreadable:
+        raise _unidentifiable_error(dest, unreadable, remedy)
     if local is None:
         return
     provenance = index_provenance(local)
     if provenance == PROVENANCE_INVALID:
-        raise _unclassifiable_error(dest, local.corpus_roots, command)
+        raise _unclassifiable_error(dest, local.corpus_roots, remedy)
     if provenance != PROVENANCE_LOCAL:
         return
     # Formatted from the validated reader rather than the raw attribute. The
@@ -399,7 +503,7 @@ def _refuse_if_locally_built(dest: Path, *, force: bool, command: str) -> None:
         "Replacing it with the published index discards a build the network "
         "cannot give back -- the tree it indexed may have moved, and rebuilding "
         "needs the embedding weights again.\n"
-        f"Pass --force to overwrite it:  {command} --force"
+        f"Pass --force to overwrite it:  {remedy} --force"
     )
 
 
@@ -442,7 +546,12 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
       build and every local-over-local rebuild.
 
     A destination whose ``corpus_roots`` is present but unreadable is refused
-    instead, once the exemptions above have not applied.
+    instead, once the exemptions above have not applied. So is a destination
+    that exists with no readable manifest at all -- a mistyped ``--output``
+    reached ``replace()`` unopposed, because "no manifest" and "no file" were
+    the same answer here. That one is refused *before* the unusable-index
+    exemption: the exemption's premise is that an index is what is there, and
+    the whole point of this case is that nothing establishes that.
 
     A *stale* index needs no exemption and deliberately does not get one.
     Source drift is a warning rather than a refusal, so it does not reach the
@@ -458,13 +567,27 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
     """
     if force or corpus_provenance(corpus) == PROVENANCE_PUBLISHED:
         return
-    local = _local_manifest(target)
+    # Both remedies below name a destination, and the build one also names a
+    # corpus: this command defaults them to the cache and the installed
+    # package, so a refusal over an explicit --path/--output that printed the
+    # bare form sent the user at an index that was never in question.
+    rebuild = _pasteable("aorta chat index build", target, corpus)
+    refresh = _pasteable("aorta chat index fetch", target)
+    local, unreadable = _read_destination(target)
+    if unreadable:
+        # Ahead of the unusable-index exemption below, and deliberately not
+        # folded into it. That exemption says "there is an index here and this
+        # install cannot query it, so rebuilding loses nothing" -- it presumes
+        # an index is what is there. An unreadable manifest is the case where
+        # that presumption is exactly what is missing, and a mistyped --output
+        # would otherwise be exempted by being unreadable enough.
+        raise _unidentifiable_error(target, unreadable, rebuild)
     if local is None:
         return
     provenance = index_provenance(local)
     if provenance not in (PROVENANCE_PUBLISHED, PROVENANCE_INVALID):
         return
-    unusable = check_index(target, strict=False).refusals
+    unusable = _unusable_reasons(target)
     if unusable:
         # Ahead of both refusals, so an unusable index is exempt whether or not
         # its manifest is readable; either refusal would otherwise compose two
@@ -485,7 +608,7 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
         )
         return
     if provenance == PROVENANCE_INVALID:
-        raise _unclassifiable_error(target, local.corpus_roots, "aorta chat index build")
+        raise _unclassifiable_error(target, local.corpus_roots, rebuild)
     roots = _corpus_roots(local) or []
     raise IndexOverwriteError(
         f"the index at {target} covers the published corpus, and this build "
@@ -498,8 +621,8 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
         "--public-only build records the published root set. The default build "
         "corpus is the installed package alone, so it typically drops 'docs/' "
         "and 'README.md' as well.\n"
-        "Refresh the published one instead:  aorta chat index fetch\n"
-        "Or pass --force to build over it:   aorta chat index build --force"
+        f"Refresh the published one instead:  {refresh}\n"
+        f"Or pass --force to build over it:   {rebuild} --force"
     )
 
 
@@ -835,8 +958,14 @@ def _copy_with_progress(response: Any, handle: Any, total: int) -> None:
     logger.info("%s", _progress_line(done, total))
 
 
-def _download(url: str, target: Path) -> None:
-    """Stream ``url`` to ``target``, or raise :class:`IndexFetchError`."""
+def _download(url: str, target: Path, dest: Path | None = None) -> None:
+    """Stream ``url`` to ``target``, or raise :class:`IndexFetchError`.
+
+    ``target`` is the staging path; ``dest`` is where the install would land,
+    and is carried only so the 404 remedy below can name it. The three lines it
+    offers are ordinary invocations, so they resolve ``--output`` to the
+    configured cache -- which is not where this fetch was going.
+    """
     logger.info("Downloading %s", url)
     try:
         with urllib.request.urlopen(url, timeout=_CONNECT_TIMEOUT) as response:  # noqa: S310
@@ -846,14 +975,17 @@ def _download(url: str, target: Path) -> None:
                 _copy_with_progress(response, handle, total)
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
+            # Labels lead so the block stays aligned whether or not the flags
+            # are appended; the commands themselves are then variable-length.
+            here = "" if dest is None else _target_flags(dest)
             raise IndexFetchError(
                 f"no published index at {url} (HTTP 404).\n"
                 "That release may predate the published index, or the asset may "
                 "not have been built yet. Options:\n"
-                "  aorta chat index fetch --version <X.Y.Z>   pick another release\n"
-                f"  aorta chat index fetch --version {ROLLING_TAG}   take the rolling "
-                "main asset\n"
-                "  aorta chat index build                     build locally instead"
+                f"  pick another release        aorta chat index fetch --version <X.Y.Z>{here}\n"
+                f"  take the rolling main asset aorta chat index fetch "
+                f"--version {ROLLING_TAG}{here}\n"
+                f"  build locally instead       aorta chat index build{here}"
             ) from exc
         raise IndexFetchError(f"could not download {url}: HTTP {exc.code} {exc.reason}") from exc
     except urllib.error.URLError as exc:
@@ -960,19 +1092,65 @@ def describe_target(source: IndexSource, dest: str | Path) -> list[str]:
 def _parse_manifest(text: str, source: IndexSource) -> manifest_mod.Manifest:
     """Parse a downloaded manifest, or raise :class:`IndexFetchError`.
 
-    The schema check belongs here rather than after the install: a schema this
-    build cannot read must fail the fetch rather than land on disk and then be
-    rejected by the first load, which reports a successful fetch and leaves a
-    chat that no longer starts.
+    The schema and field-type checks belong here rather than after the install:
+    a manifest this build cannot read must fail the fetch rather than land on
+    disk and then be rejected by the first load, which reports a successful
+    fetch and leaves a chat that no longer starts.
     """
     try:
         manifest = manifest_mod.Manifest.from_dict(json.loads(text))
+        _ensure_field_types(manifest)
         manifest_mod.ensure_supported_schema(manifest, f"the index at {source.index_url}")
     except (ValueError, manifest_mod.ManifestError) as exc:
         raise IndexFetchError(
             f"the manifest at {source.manifest_url} is not usable: {exc}"
         ) from exc
     return manifest
+
+
+#: What each declared annotation on :class:`~aorta.chat.rag.manifest.Manifest`
+#: actually has to be. Read from the dataclass rather than listed field by
+#: field, so a field added upstream is covered without a matching edit here.
+_ANNOTATION_TYPES: dict[str, type | tuple[type, ...]] = {
+    "str": str,
+    "int": int,
+    "list[str]": list,
+}
+
+
+def _ensure_field_types(manifest: manifest_mod.Manifest) -> None:
+    """Reject a downloaded manifest whose fields are not the types they claim.
+
+    ``Manifest.from_dict`` deliberately does not type-check: a *local* sidecar
+    that is wrong should still be readable, because refusing to parse it would
+    take away the reports whose whole job is to say what is wrong with it. The
+    tolerant readers here (:func:`_corpus_roots`, :func:`_manifest_text`) exist
+    for exactly that.
+
+    A *downloaded* manifest is the other case. It is untrusted input arriving
+    over the network, nothing later in the fetch is written to tolerate it, and
+    the readers it reaches are not all here -- ``validate`` calls ``.split()``
+    on ``embedding_identity``, so a published manifest carrying ``42`` there
+    raised ``AttributeError`` past the ``IndexFetchError`` handling and out of
+    the CLI as a traceback, rather than the refusal a bad manifest is supposed
+    to produce.
+
+    So the tolerance stops at the network boundary, which is the one place
+    there is somewhere better to put the failure: this is the funnel that
+    already turns "the published manifest is not usable" into a refusal naming
+    its URL.
+    """
+    for field_def in dataclasses.fields(manifest):
+        expected = _ANNOTATION_TYPES.get(str(field_def.type))
+        if expected is None:
+            continue
+        value = getattr(manifest, field_def.name)
+        # bool is an int subclass, and a manifest recording `chunk_count: true`
+        # is malformed in exactly the way this is here to catch.
+        if not isinstance(value, expected) or isinstance(value, bool):
+            raise manifest_mod.ManifestError(
+                f"{field_def.name} is a {type(value).__name__}, not {field_def.type}"
+            )
 
 
 def _validate_against_provider(manifest: manifest_mod.Manifest) -> manifest_mod.ValidationReport:
@@ -1074,8 +1252,11 @@ def fetch_index(
     change, an endpoint change -- hits the same wasted transfer.
 
     **The asset is skipped entirely when the local sidecar already records the
-    published ``index_sha256``.** A refresh that would change nothing is the
-    common case, and it cost the whole download.
+    published ``index_sha256`` and the store it describes is usable.** A
+    refresh that would change nothing is the common case, and it cost the whole
+    download. Both halves are needed: the sidecar establishes that the right
+    index was installed, and only opening the store establishes that it still
+    is one.
 
     Checksum verification stays where it was, because it genuinely needs the
     bytes. Nothing is installed until it and the manifest/checksum agreement
@@ -1102,17 +1283,45 @@ def fetch_index(
 
     local = _local_manifest(dest)
     if not force and _is_same_index(local, manifest):
-        # At debug, because ``up_to_date`` is on the result and the caller
-        # renders it -- the CLI would otherwise print the same sentence twice.
-        logger.debug("%s already holds the published index; skipping the asset.", dest)
-        return FetchResult(
-            index_path=dest,
-            manifest=manifest,
-            source=source.describe(),
-            warnings=list(report.warnings),
-            notes=list(source.notes),
-            up_to_date=True,
-        )
+        # Matching ``index_sha256`` proves the *sidecar* is the published one.
+        # It says nothing about the file beside it, which is written in place
+        # by run indexing and can be damaged by anything else on the machine --
+        # so a truncated store under an untouched manifest took this shortcut
+        # and was told it was already up to date, by the one command that would
+        # have repaired it.
+        #
+        # Asked through the same reader the build guard uses, which opens the
+        # store. This PR already stopped ``check_index`` trusting the manifest
+        # about the contents; a refresh that decided on the manifest alone
+        # would have contradicted that from the other side.
+        #
+        # Deliberately the load path's notion of usable, not a schema probe:
+        # this catches a store nothing can open and a row count the manifest
+        # disagrees with, and not the several ways a store can open, count
+        # correctly and still be the wrong shape underneath (``doctor``
+        # enumerates those). Matching the reader the *first query* uses is the
+        # property that matters here -- "already up to date" must not mean
+        # something the next query would refuse.
+        unusable = _unusable_reasons(dest)
+        if unusable:
+            logger.info(
+                "%s records the published index but this install cannot use it "
+                "(%s); fetching the asset again.",
+                dest,
+                "; ".join(unusable),
+            )
+        else:
+            # At debug, because ``up_to_date`` is on the result and the caller
+            # renders it -- the CLI would otherwise print the same sentence twice.
+            logger.debug("%s already holds the published index; skipping the asset.", dest)
+            return FetchResult(
+                index_path=dest,
+                manifest=manifest,
+                source=source.describe(),
+                warnings=list(report.warnings),
+                notes=list(source.notes),
+                up_to_date=True,
+            )
     changes = _refresh_notes(local, manifest)
 
     # Staged inside the destination directory so the final move is a rename on
@@ -1121,7 +1330,7 @@ def fetch_index(
     with tempfile.TemporaryDirectory(prefix=_STAGING_PREFIX, dir=dest.parent) as staging_dir:
         staged = Path(staging_dir) / ASSET_NAME
         checksum_line = _download_text(source.checksum_url)
-        _download(source.index_url, staged)
+        _download(source.index_url, staged, dest)
         checksum = _verify_checksum(staged, checksum_line, source.checksum_url)
         if manifest.index_sha256 and manifest.index_sha256 != checksum:
             raise IndexFetchError(
@@ -1166,6 +1375,7 @@ VERDICT_PUBLISHED_DIFFERS = "published_differs"
 VERDICT_LOCALLY_BUILT = "locally_built"
 VERDICT_INCOMPATIBLE = "incompatible"
 VERDICT_NO_LOCAL_INDEX = "no_local_index"
+VERDICT_UNREADABLE_LOCAL_INDEX = "unreadable_local_index"
 VERDICT_NO_BASELINE = "no_baseline"
 
 _VERDICT_SUMMARY = {
@@ -1178,6 +1388,13 @@ _VERDICT_SUMMARY = {
         "the published index is not usable by this install's embedding provider"
     ),
     VERDICT_NO_LOCAL_INDEX: "no local index; nothing has been installed yet",
+    # Split out of ``no_local_index`` rather than reported as it: "nothing has
+    # been installed yet" over a file that is sitting right there tells the one
+    # person looking at this command the opposite of what is wrong.
+    VERDICT_UNREADABLE_LOCAL_INDEX: (
+        "a local index is installed, but no manifest beside it can be read, so "
+        "it cannot be compared -- or loaded"
+    ),
     VERDICT_NO_BASELINE: "no published baseline to compare against",
 }
 
@@ -1198,6 +1415,10 @@ class IndexComparison:
     verdict: str
     #: Why the published manifest could not be read, when it could not be.
     baseline_error: str = ""
+    #: Why the *local* manifest could not be read, when a local index is there
+    #: and it could not be. Reported for the same reason ``baseline_error`` is:
+    #: the verdict names the state, and only this names the cause.
+    local_error: str = ""
     #: Field-by-field differences, when both sides are readable.
     differences: list[str] = field(default_factory=list)
     provenance: str = PROVENANCE_UNKNOWN
@@ -1274,7 +1495,7 @@ def compare_index(
     """
     dest = Path(index_path) if index_path else settings.index_file
     source = source or resolve_source(version)
-    local = _local_manifest(dest)
+    local, unreadable = _read_destination(dest)
 
     published: manifest_mod.Manifest | None = None
     baseline_error = ""
@@ -1289,6 +1510,8 @@ def compare_index(
         # Checked before the content comparison: an index this install cannot
         # query is not made usable by being newer.
         verdict = VERDICT_INCOMPATIBLE
+    elif unreadable:
+        verdict = VERDICT_UNREADABLE_LOCAL_INDEX
     elif local is None:
         verdict = VERDICT_NO_LOCAL_INDEX
     elif _is_same_index(local, published):
@@ -1309,6 +1532,7 @@ def compare_index(
         published=published,
         verdict=verdict,
         baseline_error=baseline_error,
+        local_error=unreadable,
         differences=_refresh_notes(local, published) if published is not None else [],
         provenance=index_provenance(local) if local is not None else PROVENANCE_UNKNOWN,
     )
@@ -1329,6 +1553,7 @@ def comparison_to_dict(comparison: IndexComparison) -> dict[str, Any]:
         "local": {
             "index_path": str(comparison.index_path),
             "provenance": comparison.provenance,
+            "error": comparison.local_error,
             **_side(comparison.local),
         },
         "published": _side(comparison.published),
@@ -1433,6 +1658,7 @@ __all__ = [
     "VERDICT_NO_BASELINE",
     "VERDICT_NO_LOCAL_INDEX",
     "VERDICT_PUBLISHED_DIFFERS",
+    "VERDICT_UNREADABLE_LOCAL_INDEX",
     "VERDICT_UP_TO_DATE",
     "BuildResult",
     "FetchResult",

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -341,9 +341,15 @@ def _read_destination(index_path: str | Path) -> tuple[manifest_mod.Manifest | N
         return None, ""
     try:
         return manifest_mod.read_manifest(target), ""
-    except manifest_mod.ManifestError as exc:
+    except (manifest_mod.ManifestError, UnicodeDecodeError, OSError) as exc:
+        # ``read_manifest`` wraps its parse failures and not its *read* ones, so
+        # a sidecar that is not UTF-8 -- a truncated multi-byte write, or a file
+        # something else owns -- came out of here as UnicodeDecodeError and past
+        # every caller. That is the same "cannot read it" answer as a bad parse,
+        # arriving one layer lower, and this is the function whose whole job is
+        # to name it. OSError for the same reason on a permission or I/O fault.
         logger.debug("No usable manifest beside %s: %s", target, exc)
-        return None, str(exc)
+        return None, str(exc) or type(exc).__name__
 
 
 def _local_manifest(index_path: str | Path) -> manifest_mod.Manifest | None:
@@ -368,15 +374,24 @@ def _unusable_reasons(target: Path) -> list[str]:
     :func:`check_index` opens the store, so this is the question the first
     query asks rather than a second opinion derived from the manifest.
 
-    Never raises. Both callers have just read the manifest themselves, but they
-    read it separately, and a helper whose whole job is to answer "should this
-    be installed again" must not turn a sidecar that changed in between into a
-    traceback out of the answer.
+    Never raises, and the catch is deliberately wide. ``ManifestError`` alone
+    was too narrow: local manifests are *deliberately* untyped, so a sidecar
+    recording ``embedding_identity: 42`` makes ``check_index`` raise
+    ``AttributeError`` while rendering the identity, and a non-string
+    ``aorta_sha`` raises ``TypeError`` while slicing it -- both straight past a
+    ``ManifestError`` handler and out of the write guard as a traceback. A
+    malformed field is a reason this install cannot use the index, which is
+    exactly what this function returns; it is not a reason to crash the guard
+    that asked. Both callers have also read the manifest separately, so a
+    sidecar that changed in between must not become a traceback either.
     """
     try:
         return list(check_index(target, strict=False).refusals)
     except manifest_mod.ManifestError as exc:
         return [str(exc)]
+    except Exception as exc:  # noqa: BLE001 - a broken sidecar is an answer, not a crash
+        logger.debug("Could not judge the index at %s: %r", target, exc)
+        return [f"its manifest could not be interpreted: {type(exc).__name__}: {exc}"]
 
 
 def _pasteable(command: str, dest: Path, corpus: corpus_mod.Corpus | None = None) -> str:
@@ -439,7 +454,11 @@ def _unidentifiable_error(target: Path, reason: str, command: str) -> IndexOverw
     lost -- and the first two are the ones an overwrite cannot give back.
 
     Names both, because the caller is the only one who can tell them apart, and
-    the escape is one flag rather than a second diagnosis.
+    the escape is one flag rather than a second diagnosis. The escape is worded
+    as a deliberate replacement rather than a safe one: this branch covers an
+    unrelated file *and* a local build whose sidecars were lost, and the second
+    of those may be irreproducible, so nothing here can promise the overwrite
+    costs nothing.
     """
     return IndexOverwriteError(
         f"there is already a file at {target}, and no manifest beside it that "
@@ -448,7 +467,8 @@ def _unidentifiable_error(target: Path, reason: str, command: str) -> IndexOverw
         "exists, so something is there to lose, and without a manifest there "
         "is no way to tell an index from a file this tool never wrote.\n"
         "If the path is a typo, correcting it is the fix.\n"
-        f"If it is an index whose sidecars were lost, replacing it is safe:  {command} --force"
+        "If you know what is there and mean to replace it, say so:  "
+        f"{command} --force"
     )
 
 
@@ -522,10 +542,11 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
 
     * **A build whose own corpus is the published one.** ``--public-only``
       produces the same shape it would be replacing, so this is a refresh, not
-      a downgrade. This is also what keeps ``nightly.yml`` and ``release.yml``
-      safe under a restored or re-used ``index-out/`` -- and a guard that
-      blocked them would stop the published index updating at all, which is
-      worse than the defect being guarded against.
+      a downgrade. This is what keeps ``nightly.yml`` and ``release.yml``
+      running -- a guard that blocked them would stop the published index
+      updating at all, which is worse than the defect being guarded against.
+      It exempts the *provenance* question only; the manifest-less-destination
+      refusal below is checked first and applies to ``--public-only`` too.
     * **An index this install cannot use.** For an embedding-identity
       mismatch, the manifest refusal and ``doctor`` both name ``index build``
       as the remedy, and it is the right one. Demanding ``--force`` on top
@@ -546,12 +567,15 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
       build and every local-over-local rebuild.
 
     A destination whose ``corpus_roots`` is present but unreadable is refused
-    instead, once the exemptions above have not applied. So is a destination
-    that exists with no readable manifest at all -- a mistyped ``--output``
-    reached ``replace()`` unopposed, because "no manifest" and "no file" were
-    the same answer here. That one is refused *before* the unusable-index
-    exemption: the exemption's premise is that an index is what is there, and
-    the whole point of this case is that nothing establishes that.
+    instead, once the exemptions above have not applied. A destination that
+    exists with no readable manifest at all is refused *before any of them* --
+    a mistyped ``--output`` reached ``replace()`` unopposed, because "no
+    manifest" and "no file" were the same answer here. Ahead of the
+    unusable-index exemption because that exemption's premise is that an index
+    is what is there, and the whole point of this case is that nothing
+    establishes that; ahead of ``--public-only`` because a typo is a typo on
+    the CI path too, and the CI path never meets it (fresh workspace, no
+    restored ``index-out/``).
 
     A *stale* index needs no exemption and deliberately does not get one.
     Source drift is a warning rather than a refusal, so it does not reach the
@@ -565,7 +589,7 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
     names ``index fetch``, and refusing a narrowing build there is the whole
     point of this guard.
     """
-    if force or corpus_provenance(corpus) == PROVENANCE_PUBLISHED:
+    if force:
         return
     # Both remedies below name a destination, and the build one also names a
     # corpus: this command defaults them to the cache and the installed
@@ -575,13 +599,23 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
     refresh = _pasteable("aorta chat index fetch", target)
     local, unreadable = _read_destination(target)
     if unreadable:
-        # Ahead of the unusable-index exemption below, and deliberately not
-        # folded into it. That exemption says "there is an index here and this
-        # install cannot query it, so rebuilding loses nothing" -- it presumes
-        # an index is what is there. An unreadable manifest is the case where
-        # that presumption is exactly what is missing, and a mistyped --output
-        # would otherwise be exempted by being unreadable enough.
+        # Ahead of *every* exemption, including --public-only, and that ordering
+        # is the fix for a hole the first version of it had: the CI exemption
+        # returned before the destination was looked at, so
+        # `build --public-only --output ~/notes.txt` replaced that file without
+        # a word -- while the documented rule said any manifest-less path is
+        # refused. It also sits ahead of the unusable-index exemption below,
+        # which presumes an index is what is there; an unreadable manifest is
+        # the case where that presumption is what is missing, so a mistyped
+        # --output would otherwise be exempted for being unreadable enough.
+        #
+        # This costs the published build nothing. `nightly.yml` and
+        # `release.yml` run on `ubuntu-latest` with a fresh workspace and never
+        # restore `index-out/`, so the destination does not exist on their first
+        # write and carries complete sidecars on every later one.
         raise _unidentifiable_error(target, unreadable, rebuild)
+    if corpus_provenance(corpus) == PROVENANCE_PUBLISHED:
+        return
     if local is None:
         return
     provenance = index_provenance(local)
@@ -1008,9 +1042,14 @@ def _download(url: str, target: Path, dest: Path | None = None) -> None:
         raise IndexFetchError(f"could not transfer {url} to {target}: {exc}") from exc
 
 
-def _download_text(url: str) -> str:
+def _download_text(url: str, dest: Path | None = None) -> str:
     """Fetch a small sidecar (manifest or checksum) as text, or raise
     :class:`IndexFetchError`.
+
+    ``dest`` is where this command would write, carried only so the remedy
+    below can name it. It offers ``index build``, which resolves ``--output``
+    to the configured cache -- so a caller working on any other path was told
+    to build over an index that had nothing to do with the failure.
 
     Fetched before the index itself, so every failure here has to arrive as
     ``IndexFetchError`` for the CLI to render it: this is the first thing
@@ -1040,7 +1079,8 @@ def _download_text(url: str) -> str:
             f"(HTTP {exc.code}).\n"
             "An index without its manifest and checksum cannot be verified "
             "against this install's embedding model, so it is not safe to use. "
-            "Build locally instead:  aorta chat index build"
+            "Build locally instead:  "
+            f"{'aorta chat index build' if dest is None else _pasteable('aorta chat index build', dest)}"
         ) from exc
     except urllib.error.URLError as exc:
         raise IndexFetchError(f"could not reach {url}: {exc.reason}" + _NO_EGRESS_HINT) from exc
@@ -1151,6 +1191,18 @@ def _ensure_field_types(manifest: manifest_mod.Manifest) -> None:
             raise manifest_mod.ManifestError(
                 f"{field_def.name} is a {type(value).__name__}, not {field_def.type}"
             )
+        # The elements too, not just the container. Checking `list` alone let
+        # `corpus_roots: [42]` install, and the *next* fetch then classified the
+        # sidecar it had just written as unclassifiable and refused a routine
+        # refresh -- a boundary check that admits a value the guard behind it
+        # rejects is worse than none, because the damage surfaces one command
+        # later and on a different command.
+        if str(field_def.type) == "list[str]":
+            for item in value:
+                if not isinstance(item, str):
+                    raise manifest_mod.ManifestError(
+                        f"{field_def.name} contains a {type(item).__name__}, not str"
+                    )
 
 
 def _validate_against_provider(manifest: manifest_mod.Manifest) -> manifest_mod.ValidationReport:
@@ -1276,7 +1328,7 @@ def fetch_index(
     # The text is kept, not re-serialised from the dataclass at install time:
     # ``from_dict`` drops keys this version predates, and writing them back out
     # would strip a newer builder's fields from the sidecar this machine keeps.
-    manifest_text = _download_text(source.manifest_url)
+    manifest_text = _download_text(source.manifest_url, dest)
     manifest = _parse_manifest(manifest_text, source)
     report = _validate_against_provider(manifest)
     report.raise_if_refused(source.index_url)
@@ -1329,7 +1381,7 @@ def fetch_index(
     # index or the new one, never a half-written file.
     with tempfile.TemporaryDirectory(prefix=_STAGING_PREFIX, dir=dest.parent) as staging_dir:
         staged = Path(staging_dir) / ASSET_NAME
-        checksum_line = _download_text(source.checksum_url)
+        checksum_line = _download_text(source.checksum_url, dest)
         _download(source.index_url, staged, dest)
         checksum = _verify_checksum(staged, checksum_line, source.checksum_url)
         if manifest.index_sha256 and manifest.index_sha256 != checksum:
@@ -1500,7 +1552,11 @@ def compare_index(
     published: manifest_mod.Manifest | None = None
     baseline_error = ""
     try:
-        published = _parse_manifest(_download_text(source.manifest_url), source)
+        # ``dest`` carried in so a sidecar 404 recommends building the index the
+        # user asked about with ``--index``, not the cache. ``status --index``
+        # and ``build --output`` are the same path under two flag names, and the
+        # remedy has to be spelled in the second one.
+        published = _parse_manifest(_download_text(source.manifest_url, dest), source)
     except IndexFetchError as exc:
         baseline_error = str(exc)
 
@@ -1607,7 +1663,18 @@ def side_load(
             "the index -- it is what records the embedding model, and without it "
             "a mismatched index cannot be distinguished from a correct one."
         )
-    manifest = manifest_mod.read_manifest(origin)
+    # Held to the same field-type check as a downloaded manifest, and for a
+    # stronger reason: this sidecar was hand-carried, so it is the one most
+    # likely to have been hand-edited. ``read_manifest`` wraps a bad parse but
+    # not a bad *read*, and neither wraps a wrong-typed field -- so a non-UTF-8
+    # file escaped as ``UnicodeDecodeError`` and ``embedding_identity: 42``
+    # escaped as ``AttributeError`` out of the provider validation below, both
+    # past the ``IndexFetchError`` the CLI knows how to print.
+    try:
+        manifest = manifest_mod.read_manifest(origin)
+        _ensure_field_types(manifest)
+    except (manifest_mod.ManifestError, UnicodeDecodeError, ValueError) as exc:
+        raise IndexFetchError(f"the manifest beside {origin} is not usable: {exc}") from exc
     checksum = manifest_mod.sha256_file(origin)
     if manifest.index_sha256 and manifest.index_sha256 != checksum:
         raise IndexFetchError(

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -253,6 +253,35 @@ PROVENANCE_LOCAL = "local"
 #: A manifest that records no roots at all, from a builder predating the field.
 PROVENANCE_UNKNOWN = "unknown"
 
+#: A manifest whose ``corpus_roots`` is *present* and unusable, so nothing can
+#: be concluded from it. Deliberately distinct from :data:`PROVENANCE_UNKNOWN`:
+#: absent roots are a layout, an unusable value is a broken sidecar, and the
+#: write guards treat the two differently.
+PROVENANCE_INVALID = "invalid"
+
+
+def _corpus_roots(manifest: manifest_mod.Manifest) -> list[str] | None:
+    """``corpus_roots`` as a list of strings, or ``None`` when it is unusable.
+
+    ``Manifest.from_dict`` is forward-tolerant and type-checks nothing, so a
+    hand-written or hand-edited sidecar -- which is the side-load path's
+    ordinary case -- can carry a scalar here. Iterating a string yields
+    characters and ``Path("/").is_absolute()`` is true, so ``"src/aorta"``
+    classified as a local build and ``"docs"`` as a published one, both from
+    nothing at all; ``[42]`` raised ``TypeError`` straight past the CLI's
+    error guard. A field that decides whether a destructive overwrite is
+    refused has to be validated rather than coerced.
+
+    One reader, shared by the guards and by ``index status``'s payload, so the
+    verdict and the reported value cannot disagree about what was readable.
+    """
+    roots = manifest.corpus_roots
+    if not isinstance(roots, (list, tuple)):
+        return None
+    if not all(isinstance(root, str) for root in roots):
+        return None
+    return list(roots)
+
 
 def _roots_provenance(roots: list[str] | tuple[str, ...]) -> str:
     """Classify a set of corpus roots by shape.
@@ -274,9 +303,14 @@ def index_provenance(manifest: manifest_mod.Manifest) -> str:
     """Whether an index was published or built here, read off its manifest.
 
     Inferred rather than stored, because ``corpus_roots`` already distinguishes
-    the two without a manifest schema bump.
+    the two without a manifest schema bump. A recorded value that is not a list
+    of paths yields :data:`PROVENANCE_INVALID` rather than a classification
+    derived from iterating it -- see :func:`_corpus_roots`.
     """
-    return _roots_provenance(manifest.corpus_roots or [])
+    roots = _corpus_roots(manifest)
+    if roots is None:
+        return PROVENANCE_INVALID
+    return _roots_provenance(roots)
 
 
 def corpus_provenance(corpus: corpus_mod.Corpus) -> str:
@@ -307,6 +341,25 @@ def _local_manifest(index_path: str | Path) -> manifest_mod.Manifest | None:
         return None
 
 
+def _unclassifiable_error(target: Path, roots: object, command: str) -> IndexOverwriteError:
+    """The refusal for a manifest whose ``corpus_roots`` cannot be read.
+
+    Shared by both write guards, because neither of them may guess: the two
+    provenances are protected differently and only one of them is something
+    the network can give back. Names the type rather than echoing the value,
+    which is third-party text of unbounded size.
+    """
+    return IndexOverwriteError(
+        f"the index at {target} has a manifest this build cannot classify: "
+        f"corpus_roots is a {type(roots).__name__}, not a list of paths, so "
+        "whether the index was downloaded or built here cannot be read.\n"
+        "A downloaded index costs a download to replace; a local build may not "
+        "be reproducible at all. Refusing rather than guessing which one is "
+        "there.\n"
+        f"Overwrite it deliberately:  {command} --force"
+    )
+
+
 def _refuse_if_locally_built(dest: Path, *, force: bool, command: str) -> None:
     """Stop an incoming index from silently discarding one built on this machine.
 
@@ -317,11 +370,22 @@ def _refuse_if_locally_built(dest: Path, *, force: bool, command: str) -> None:
     rebuild the weights. So the incoming-index paths (``fetch`` and its
     ``--from`` side-load, which would otherwise be the accidental way around
     this) guard against overwriting a local build, and only that.
+
+    A manifest recording *no* roots is not protected: absent is a layout, from
+    a builder predating the field, and refusing every such index would refuse
+    every pre-field install's routine refresh. A manifest recording roots that
+    cannot be read is refused -- that is a broken sidecar, not an old one, and
+    it is the one case where guessing could discard the unrecoverable side.
     """
     if force:
         return
     local = _local_manifest(dest)
-    if local is None or index_provenance(local) != PROVENANCE_LOCAL:
+    if local is None:
+        return
+    provenance = index_provenance(local)
+    if provenance == PROVENANCE_INVALID:
+        raise _unclassifiable_error(dest, local.corpus_roots, command)
+    if provenance != PROVENANCE_LOCAL:
         return
     raise IndexOverwriteError(
         f"the index at {dest} was built on this machine, not downloaded.\n"
@@ -362,27 +426,41 @@ def _refuse_if_published(target: Path, corpus: corpus_mod.Corpus, *, force: bool
       answer anything, so there is nothing to protect.
     * **A destination with no published manifest**, which includes every first
       build and every local-over-local rebuild.
+
+    A destination whose ``corpus_roots`` is present but unreadable is refused
+    instead, once the exemptions above have not applied.
     """
     if force or corpus_provenance(corpus) == PROVENANCE_PUBLISHED:
         return
     local = _local_manifest(target)
-    if local is None or index_provenance(local) != PROVENANCE_PUBLISHED:
+    if local is None:
+        return
+    provenance = index_provenance(local)
+    if provenance not in (PROVENANCE_PUBLISHED, PROVENANCE_INVALID):
         return
     if _validate_against_provider(local).refusals:
+        # Ahead of both refusals, so a refused index is exempt whether or not
+        # its manifest is readable; either refusal would otherwise compose two
+        # individually-correct behaviours into a dead end.
         logger.info(
             "The index at %s is refused by this install's embedding provider, "
             "so rebuilding it loses nothing.",
             target,
         )
         return
+    if provenance == PROVENANCE_INVALID:
+        raise _unclassifiable_error(target, local.corpus_roots, "aorta chat index build")
     raise IndexOverwriteError(
         f"the index at {target} covers the published corpus, and this build "
         "would not.\n"
         f"  there now  {local.describe()}\n"
         f"             corpus {', '.join(local.corpus_roots)}\n"
         f"  building   corpus {corpus.describe()}\n"
-        "That replaces it with a narrower index: no 'docs/' or 'README.md' "
-        "coverage, and no public-tree provenance.\n"
+        "That replaces it with an index over a different corpus -- the two are "
+        "above -- and one with no public-tree provenance, since only a "
+        "--public-only build records the published root set. The default build "
+        "corpus is the installed package alone, so it typically drops 'docs/' "
+        "and 'README.md' as well.\n"
         "Refresh the published one instead:  aorta chat index fetch\n"
         "Or pass --force to build over it:   aorta chat index build --force"
     )
@@ -1024,10 +1102,37 @@ class IndexComparison:
         return self.verdict == VERDICT_UP_TO_DATE
 
 
+#: The manifest fields ``index status`` puts side by side. Enumerated so both
+#: sides carry the same keys whether or not there is a manifest to fill them.
+_SIDE_FIELDS = (
+    "embedding_model",
+    "embedding_identity",
+    "built_at",
+    "aorta_version",
+    "aorta_sha",
+    "corpus_digest",
+    "corpus_roots",
+    "index_sha256",
+    "chunk_count",
+    "dimensions",
+)
+
+
 def _side(manifest: manifest_mod.Manifest | None) -> dict[str, Any]:
-    """One side of the comparison, as the fields gap 4b asks for."""
+    """One side of the comparison, as the fields gap 4b asks for.
+
+    Every key is always present, with ``None`` for "there is no manifest on
+    this side". ``--json`` is a contract, and returning ``{}`` made
+    ``published`` an empty object in the no-baseline branch -- so a consumer
+    indexing the documented shape got a ``KeyError`` on exactly the run it
+    most needed to inspect, while the reachable branch it was written against
+    carried all ten keys.
+
+    ``corpus_roots`` is read through :func:`_corpus_roots`, so an unusable
+    recorded value reports ``None`` rather than the characters of a string.
+    """
     if manifest is None:
-        return {}
+        return dict.fromkeys(_SIDE_FIELDS)
     return {
         "embedding_model": manifest.embedding_model,
         "embedding_identity": manifest.embedding_identity,
@@ -1035,7 +1140,7 @@ def _side(manifest: manifest_mod.Manifest | None) -> dict[str, Any]:
         "aorta_version": manifest.aorta_version,
         "aorta_sha": manifest.aorta_sha,
         "corpus_digest": manifest.corpus_digest,
-        "corpus_roots": list(manifest.corpus_roots),
+        "corpus_roots": _corpus_roots(manifest),
         "index_sha256": manifest.index_sha256,
         "chunk_count": manifest.chunk_count,
         "dimensions": manifest.dimensions,
@@ -1201,6 +1306,7 @@ __all__ = [
     "BASE_URL_ENV",
     "RELEASE_BASE_URL",
     "ROLLING_TAG",
+    "PROVENANCE_INVALID",
     "PROVENANCE_LOCAL",
     "PROVENANCE_PUBLISHED",
     "PROVENANCE_UNKNOWN",

--- a/src/aorta/chat/rag/index_ops.py
+++ b/src/aorta/chat/rag/index_ops.py
@@ -915,7 +915,9 @@ def fetch_index(
 
     local = _local_manifest(dest)
     if not force and _is_same_index(local, manifest):
-        logger.info("Already up to date; the published asset was not downloaded.")
+        # At debug, because ``up_to_date`` is on the result and the caller
+        # renders it -- the CLI would otherwise print the same sentence twice.
+        logger.debug("%s already holds the published index; skipping the asset.", dest)
         return FetchResult(
             index_path=dest,
             manifest=manifest,
@@ -962,6 +964,163 @@ def fetch_index(
         notes=list(source.notes),
         changes=changes,
     )
+
+
+# ── comparing the two sides ───────────────────────────────────────────────
+
+#: The verdicts :func:`compare_index` can reach. Named rather than inlined so
+#: ``--json`` consumers have a closed set to switch on, and so the honest
+#: distinction between "the same" and "nothing to compare against" is visible
+#: in one place: ``nightly.yml``'s own comment makes the same point, that a
+#: missing published manifest means *no baseline* and must never be reported as
+#: up to date.
+VERDICT_UP_TO_DATE = "up_to_date"
+VERDICT_PUBLISHED_DIFFERS = "published_differs"
+VERDICT_LOCALLY_BUILT = "locally_built"
+VERDICT_INCOMPATIBLE = "incompatible"
+VERDICT_NO_LOCAL_INDEX = "no_local_index"
+VERDICT_NO_BASELINE = "no_baseline"
+
+_VERDICT_SUMMARY = {
+    VERDICT_UP_TO_DATE: "up to date; the local index is the published one",
+    VERDICT_PUBLISHED_DIFFERS: "the published index differs from the local one",
+    VERDICT_LOCALLY_BUILT: (
+        "the local index was built here, so the published one is not a newer copy of it"
+    ),
+    VERDICT_INCOMPATIBLE: (
+        "the published index is not usable by this install's embedding provider"
+    ),
+    VERDICT_NO_LOCAL_INDEX: "no local index; nothing has been installed yet",
+    VERDICT_NO_BASELINE: "no published baseline to compare against",
+}
+
+
+@dataclass
+class IndexComparison:
+    """The local index and the published one, side by side.
+
+    Answers gap 4b's question -- "is the index in the cache the same as the
+    remote one, and which is newer" -- from the two manifests alone, so it
+    transfers ~1 KB rather than the index.
+    """
+
+    source: IndexSource
+    index_path: Path
+    local: manifest_mod.Manifest | None
+    published: manifest_mod.Manifest | None
+    verdict: str
+    #: Why the published manifest could not be read, when it could not be.
+    baseline_error: str = ""
+    #: Field-by-field differences, when both sides are readable.
+    differences: list[str] = field(default_factory=list)
+    provenance: str = PROVENANCE_UNKNOWN
+
+    @property
+    def summary(self) -> str:
+        return _VERDICT_SUMMARY.get(self.verdict, self.verdict)
+
+    @property
+    def up_to_date(self) -> bool:
+        return self.verdict == VERDICT_UP_TO_DATE
+
+
+def _side(manifest: manifest_mod.Manifest | None) -> dict[str, Any]:
+    """One side of the comparison, as the fields gap 4b asks for."""
+    if manifest is None:
+        return {}
+    return {
+        "embedding_model": manifest.embedding_model,
+        "embedding_identity": manifest.embedding_identity,
+        "built_at": manifest.built_at,
+        "aorta_version": manifest.aorta_version,
+        "aorta_sha": manifest.aorta_sha,
+        "corpus_digest": manifest.corpus_digest,
+        "corpus_roots": list(manifest.corpus_roots),
+        "index_sha256": manifest.index_sha256,
+        "chunk_count": manifest.chunk_count,
+        "dimensions": manifest.dimensions,
+    }
+
+
+def compare_index(
+    version: str | None = None,
+    index_path: str | Path | None = None,
+    source: IndexSource | None = None,
+) -> IndexComparison:
+    """Compare the installed index against the published one, read-only.
+
+    Downloads the ~1 KB manifest and nothing else. This is the comparison
+    ``nightly.yml``'s ``digest`` step already does in bash to decide whether to
+    republish, so the capability is proven and load-bearing for the release
+    process -- it was simply not exposed to the user who asked for it.
+
+    Nothing here writes, and an unreachable host is a *result* rather than an
+    error: "there is no baseline" is the honest answer, and the one thing it
+    must not be rendered as is "up to date".
+    """
+    dest = Path(index_path) if index_path else settings.index_file
+    source = source or resolve_source(version)
+    local = _local_manifest(dest)
+
+    published: manifest_mod.Manifest | None = None
+    baseline_error = ""
+    try:
+        published = _parse_manifest(_download_text(source.manifest_url), source)
+    except IndexFetchError as exc:
+        baseline_error = str(exc)
+
+    if published is None:
+        verdict = VERDICT_NO_BASELINE
+    elif _validate_against_provider(published).refusals:
+        # Checked before the content comparison: an index this install cannot
+        # query is not made usable by being newer.
+        verdict = VERDICT_INCOMPATIBLE
+    elif local is None:
+        verdict = VERDICT_NO_LOCAL_INDEX
+    elif _is_same_index(local, published):
+        verdict = VERDICT_UP_TO_DATE
+    elif index_provenance(local) == PROVENANCE_LOCAL:
+        # Deliberately not a recency claim. ``built_at`` is wall-clock from
+        # whoever built it, so a local index can carry a later timestamp while
+        # indexing older source -- and it is the one case where "just fetch"
+        # is the wrong advice, because the fetch would discard it.
+        verdict = VERDICT_LOCALLY_BUILT
+    else:
+        verdict = VERDICT_PUBLISHED_DIFFERS
+
+    return IndexComparison(
+        source=source,
+        index_path=dest,
+        local=local,
+        published=published,
+        verdict=verdict,
+        baseline_error=baseline_error,
+        differences=_refresh_notes(local, published) if published is not None else [],
+        provenance=index_provenance(local) if local is not None else PROVENANCE_UNKNOWN,
+    )
+
+
+def comparison_to_dict(comparison: IndexComparison) -> dict[str, Any]:
+    """``index status --json``, matching the other index subcommands."""
+    return {
+        "verdict": comparison.verdict,
+        "summary": comparison.summary,
+        "up_to_date": comparison.up_to_date,
+        # Named explicitly because a dev install resolves to the rolling tag:
+        # without this the verdict does not say what it compared against.
+        "compared_against": {
+            "source": comparison.source.describe(),
+            "manifest_url": comparison.source.manifest_url,
+        },
+        "local": {
+            "index_path": str(comparison.index_path),
+            "provenance": comparison.provenance,
+            **_side(comparison.local),
+        },
+        "published": _side(comparison.published),
+        "differences": comparison.differences,
+        "baseline_error": comparison.baseline_error,
+    }
 
 
 def side_load(
@@ -1045,13 +1204,22 @@ __all__ = [
     "PROVENANCE_LOCAL",
     "PROVENANCE_PUBLISHED",
     "PROVENANCE_UNKNOWN",
+    "VERDICT_INCOMPATIBLE",
+    "VERDICT_LOCALLY_BUILT",
+    "VERDICT_NO_BASELINE",
+    "VERDICT_NO_LOCAL_INDEX",
+    "VERDICT_PUBLISHED_DIFFERS",
+    "VERDICT_UP_TO_DATE",
     "BuildResult",
     "FetchResult",
+    "IndexComparison",
     "IndexFetchError",
     "IndexOverwriteError",
     "IndexSource",
     "build_index",
     "check_index",
+    "compare_index",
+    "comparison_to_dict",
     "compute_digest",
     "corpus_provenance",
     "describe_target",

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -1035,7 +1035,9 @@ def index_fetch(
                 {
                     "index": str(result.index_path),
                     "source": result.source,
+                    "up_to_date": result.up_to_date,
                     "notes": result.notes,
+                    "changes": result.changes,
                     "warnings": result.warnings,
                     "manifest": result.manifest.describe(),
                 },
@@ -1043,9 +1045,12 @@ def index_fetch(
             )
         )
         return
-    click.echo(f"Installed {result.index_path}")
+    verb = "Already up to date" if result.up_to_date else "Installed"
+    click.echo(f"{verb} {result.index_path}")
     click.echo(f"  source    {result.source}")
     click.echo(f"  built as  {result.manifest.describe()}")
+    for change in result.changes:
+        click.echo(f"  replaced  {change}")
     for warning in result.warnings:
         click.echo(f"warning: {warning}", err=True)
 

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -1125,7 +1125,9 @@ def index_status(version: str | None, index_path: str | None, as_json: bool, ver
     to republish.
 
     A missing or unreadable published manifest is reported as 'no baseline',
-    never as 'up to date'. Exits non-zero only when the two cannot be compared.
+    never as 'up to date', and is the only verdict that exits non-zero -- an
+    absent *local* index is a normal answer for someone who has not installed
+    one yet.
     """
     _index_logging(verbose)
     ops = _load("rag.index_ops")

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -1116,16 +1116,29 @@ def _status_cell(value: object) -> str:
 
 
 def _echo_status_table(local: dict, published: dict) -> None:
-    """Print both manifests as two columns, so a difference is visible."""
+    """Print both manifests as two columns, so a difference is visible.
+
+    A row whose two values differ only past the column width is repeated
+    underneath in full. Truncating for width is fine until it makes a row that
+    exists to show a difference show agreement instead -- and ``identity`` is
+    where that bites, because a remote one is ``remote / <endpoint> / <model>``
+    and two endpoints on the same provider share far more than 42 characters
+    while the ``model`` and ``dimensions`` rows above stay identical. Digests
+    can collide on a prefix too, just far less often.
+    """
     click.echo(f"  {'':<13}{'local':<44}published")
+    hidden = []
     for label, key in _STATUS_ROWS:
         left = _status_cell(local.get(key))
         right = _status_cell(published.get(key))
-        # Truncated for width only. The digests differ in their leading
-        # characters when they differ at all, and --json carries them in full;
-        # a truncated identity can only hide what the `model` and `dimensions`
-        # rows above it already show separately.
+        if left != right and left[:42] == right[:42]:
+            hidden.append((label, left, right))
         click.echo(f"  {label:<13}{left[:42]:<44}{right[:42]}")
+    for label, left, right in hidden:
+        click.echo("")
+        click.echo(f"  {label} differs past the column width:")
+        click.echo(f"    local      {left}")
+        click.echo(f"    published  {right}")
 
 
 @index_group.command(name="status")
@@ -1144,10 +1157,12 @@ def index_status(version: str | None, index_path: str | None, as_json: bool, ver
     This is the comparison nightly.yml already does in bash to decide whether
     to republish.
 
-    A missing or unreadable published manifest is reported as 'no baseline',
-    never as 'up to date', and is the only verdict that exits non-zero -- an
-    absent *local* index is a normal answer for someone who has not installed
-    one yet.
+    Two verdicts exit non-zero, and both mean the same thing: no comparison was
+    made. 'no baseline' is a published manifest that could not be read, never
+    reported as 'up to date'; 'unreadable local index' is a file sitting at the
+    index path with no manifest this build can read, which is also what the
+    first query would refuse. An *absent* local index exits zero -- that is a
+    normal answer for someone who has not installed one yet.
     """
     _index_logging(verbose)
     ops = _load("rag.index_ops")
@@ -1170,11 +1185,14 @@ def index_status(version: str | None, index_path: str | None, as_json: bool, ver
             click.echo("")
             for difference in comparison.differences:
                 click.echo(f"  differs    {difference}")
+        if comparison.local_error:
+            click.echo("")
+            click.echo(f"warning: {comparison.local_error}", err=True)
         if comparison.baseline_error:
             click.echo("")
             click.echo(f"warning: {comparison.baseline_error}", err=True)
 
-    if comparison.verdict == ops.VERDICT_NO_BASELINE:
+    if comparison.verdict in (ops.VERDICT_NO_BASELINE, ops.VERDICT_UNREADABLE_LOCAL_INDEX):
         raise click.exceptions.Exit(1)
 
 

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -937,7 +937,7 @@ def index_group() -> None:
 @click.option(
     "--force",
     is_flag=True,
-    help="Build over a downloaded index, replacing it with this narrower one.",
+    help="Build over a downloaded index, replacing it with a locally built one.",
 )
 @click.option("-v", "--verbose", is_flag=True, help="Debug-level logging.")
 def index_build(
@@ -954,8 +954,11 @@ def index_build(
     downloaded once (~65 MB) unless the cache is pre-seeded -- run 'aorta chat
     doctor' first if this node has no egress.
 
-    Refuses to build over an index that was downloaded rather than built here,
-    because a local build covers less; pass --force to do it anyway.
+    Refuses to build over an index that was downloaded rather than built
+    here, unless --public-only says the corpus is the published one. The test
+    is provenance, not size: an explicit --path over the whole checkout is
+    still refused, because nothing on disk proves it is the same tree the
+    release was built from. Pass --force to do it anyway.
     """
     _index_logging(verbose)
     ops = _load("rag.index_ops")

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -49,8 +49,7 @@ _MIN_PYTHON = (3, 11)
 _MAX_PYTHON_UI = (3, 14)
 
 _INSTALL_HINT = (
-    "'aorta chat' requires the chat-cli extra.\n"
-    "Install it with:  pip install 'amd-aorta[chat-cli]'"
+    "'aorta chat' requires the chat-cli extra.\nInstall it with:  pip install 'amd-aorta[chat-cli]'"
 )
 
 #: Hard-coded rather than read from ``aorta.chat.inference.providers.factory``:
@@ -839,10 +838,7 @@ def config_show(reveal: bool, as_json: bool) -> None:
         click.echo(f"  {key} = {values[key]!r}")
     if not reveal:
         click.echo("")
-        click.echo(
-            "API keys and extra-header values are masked. "
-            "Pass --reveal to print them."
-        )
+        click.echo("API keys and extra-header values are masked. Pass --reveal to print them.")
 
 
 @config_group.command(name="validate")
@@ -951,9 +947,7 @@ def index_build(
     _index_logging(verbose)
     ops = _load("rag.index_ops")
     result = _guard(
-        lambda: ops.build_index(
-            _resolve_corpus(path, public_only), index_path=output, force=force
-        )
+        lambda: ops.build_index(_resolve_corpus(path, public_only), index_path=output, force=force)
     )
 
     if as_json:
@@ -1080,6 +1074,82 @@ def index_fetch(
         click.echo(f"  replaced  {change}")
     for warning in result.warnings:
         click.echo(f"warning: {warning}", err=True)
+
+
+#: The fields worth putting side by side, and what to call them in the table.
+#: ``built_at`` is last and deliberately not the basis of the verdict: it is
+#: wall-clock from whoever built the index, so a locally-built one can carry a
+#: later timestamp while indexing *older* source. ``corpus_digest`` and
+#: ``aorta_sha`` are the honest answer to "which source".
+_STATUS_ROWS = (
+    ("model", "embedding_model"),
+    ("dimensions", "dimensions"),
+    ("aorta", "aorta_version"),
+    ("aorta_sha", "aorta_sha"),
+    ("corpus", "corpus_digest"),
+    ("index_sha256", "index_sha256"),
+    ("chunks", "chunk_count"),
+    ("built_at", "built_at"),
+)
+
+
+def _echo_status_table(local: dict, published: dict) -> None:
+    """Print both manifests as two columns, so a difference is visible."""
+    click.echo(f"  {'':<13}{'local':<44}published")
+    for label, key in _STATUS_ROWS:
+        left = str(local.get(key, "") or "-")
+        right = str(published.get(key, "") or "-")
+        # Truncated for width only. The digests differ in their leading
+        # characters when they differ at all, and --json carries them in full.
+        click.echo(f"  {label:<13}{left[:42]:<44}{right[:42]}")
+
+
+@index_group.command(name="status")
+@click.option(
+    "--version",
+    default=None,
+    help="Published version or tag to compare against. Overrides version matching.",
+)
+@click.option("--index", "index_path", default=None, help="Local index. Defaults to the cache.")
+@click.option("--json", "as_json", is_flag=True, help="Emit the comparison as JSON.")
+@click.option("-v", "--verbose", is_flag=True, help="Debug-level logging.")
+def index_status(version: str | None, index_path: str | None, as_json: bool, verbose: bool) -> None:
+    """Compare the local index against the published one, without downloading it.
+
+    Reads the two manifests and nothing else, so it costs about a kilobyte.
+    This is the comparison nightly.yml already does in bash to decide whether
+    to republish.
+
+    A missing or unreadable published manifest is reported as 'no baseline',
+    never as 'up to date'. Exits non-zero only when the two cannot be compared.
+    """
+    _index_logging(verbose)
+    ops = _load("rag.index_ops")
+    comparison = _guard(lambda: ops.compare_index(version=version, index_path=index_path))
+
+    if as_json:
+        click.echo(json.dumps(ops.comparison_to_dict(comparison), indent=2))
+    else:
+        payload = ops.comparison_to_dict(comparison)
+        click.echo(f"verdict: {comparison.summary}")
+        click.echo("")
+        click.echo(f"  local      {payload['local']['index_path']} ({comparison.provenance})")
+        # Named explicitly: a dev install resolves to the rolling tag, so a
+        # verdict that does not say which asset it compared against is
+        # ambiguous.
+        click.echo(f"  published  {comparison.source.describe()}")
+        click.echo("")
+        _echo_status_table(payload["local"], payload["published"])
+        if comparison.differences:
+            click.echo("")
+            for difference in comparison.differences:
+                click.echo(f"  differs    {difference}")
+        if comparison.baseline_error:
+            click.echo("")
+            click.echo(f"warning: {comparison.baseline_error}", err=True)
+
+    if comparison.verdict == ops.VERDICT_NO_BASELINE:
+        raise click.exceptions.Exit(1)
 
 
 @index_group.command(name="runs")

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -49,7 +49,8 @@ _MIN_PYTHON = (3, 11)
 _MAX_PYTHON_UI = (3, 14)
 
 _INSTALL_HINT = (
-    "'aorta chat' requires the chat-cli extra.\nInstall it with:  pip install 'amd-aorta[chat-cli]'"
+    "'aorta chat' requires the chat-cli extra.\n"
+    "Install it with:  pip install 'amd-aorta[chat-cli]'"
 )
 
 #: Hard-coded rather than read from ``aorta.chat.inference.providers.factory``:
@@ -838,7 +839,10 @@ def config_show(reveal: bool, as_json: bool) -> None:
         click.echo(f"  {key} = {values[key]!r}")
     if not reveal:
         click.echo("")
-        click.echo("API keys and extra-header values are masked. Pass --reveal to print them.")
+        click.echo(
+            "API keys and extra-header values are masked. "
+            "Pass --reveal to print them."
+        )
 
 
 @config_group.command(name="validate")

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -1085,8 +1085,15 @@ def index_fetch(
 #: wall-clock from whoever built the index, so a locally-built one can carry a
 #: later timestamp while indexing *older* source. ``corpus_digest`` and
 #: ``aorta_sha`` are the honest answer to "which source".
+#:
+#: ``embedding_identity`` sits next to ``model`` because it is what makes the
+#: model name meaningful: for a remote provider it carries the endpoint too, so
+#: two rows reading the same ``model`` can still be two vector spaces that
+#: share a name. Without it the *incompatible* verdict could be printed over a
+#: table showing no visible difference at all.
 _STATUS_ROWS = (
     ("model", "embedding_model"),
+    ("identity", "embedding_identity"),
     ("dimensions", "dimensions"),
     ("aorta", "aorta_version"),
     ("aorta_sha", "aorta_sha"),
@@ -1097,14 +1104,27 @@ _STATUS_ROWS = (
 )
 
 
+def _status_cell(value: object) -> str:
+    """One table cell: always a single line, so no field can break the columns.
+
+    ``embedding_identity`` is newline-joined -- endpoint, then model -- so
+    printing it as recorded would put half of it on an unlabelled row and
+    misalign every row after it. Collapsing here rather than at the one field
+    that needs it today keeps the table's shape a property of the table.
+    """
+    return " / ".join(part for part in str(value or "").split("\n") if part) or "-"
+
+
 def _echo_status_table(local: dict, published: dict) -> None:
     """Print both manifests as two columns, so a difference is visible."""
     click.echo(f"  {'':<13}{'local':<44}published")
     for label, key in _STATUS_ROWS:
-        left = str(local.get(key, "") or "-")
-        right = str(published.get(key, "") or "-")
+        left = _status_cell(local.get(key))
+        right = _status_cell(published.get(key))
         # Truncated for width only. The digests differ in their leading
-        # characters when they differ at all, and --json carries them in full.
+        # characters when they differ at all, and --json carries them in full;
+        # a truncated identity can only hide what the `model` and `dimensions`
+        # rows above it already show separately.
         click.echo(f"  {label:<13}{left[:42]:<44}{right[:42]}")
 
 

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -889,7 +889,16 @@ def _guard(action: Any) -> Any:
         manifest.IndexMismatchError,
         manifest.ManifestError,
         ops.IndexFetchError,
-        FileNotFoundError,
+        # ``OSError`` rather than ``FileNotFoundError`` alone. The narrow one
+        # covered the missing index and left every other filesystem refusal
+        # unwrapped: a build into a read-only parent surfaced
+        # ``PermissionError: [Errno 13] ... '.aorta-index-cbr5wi0q'`` as a
+        # traceback naming a staging directory the user never chose, where the
+        # message they need -- which directory, and that it is not writable --
+        # was already in ``str(exc)``. These are reports about the path the
+        # command was given, which is the category this function exists to
+        # print rather than raise.
+        OSError,
         # The embedding and LLM provider factories report bad configuration as
         # ValueError, message-first; a traceback would bury it.
         ValueError,

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -968,6 +968,21 @@ def index_build(
     click.echo(f"  digest      {manifest.corpus_digest}")
 
 
+def _echo_fetch_target(source: Any, output: str | None) -> None:
+    """Show the resolved asset and destination before anything is contacted.
+
+    On stderr, so ``--json`` still emits nothing but its object. Echoed rather
+    than logged because ``_index_logging`` configures the root logger through
+    ``basicConfig``, which is a no-op if something else configured it first --
+    and the defect being fixed here is a command that printed nothing at all,
+    so the one line that explains the wait should not depend on that.
+    """
+    ops = _load("rag.index_ops")
+    config = _load("config")
+    for line in ops.describe_target(source, output or config.settings.index_file):
+        click.echo(line, err=True)
+
+
 @index_group.command(name="fetch")
 @click.option(
     "--version",
@@ -1004,7 +1019,15 @@ def index_fetch(
     if from_path:
         result = _guard(lambda: ops.side_load(from_path, index_path=output))
     else:
-        result = _guard(lambda: ops.fetch_index(version=version, index_path=output))
+        # Resolved and echoed here, before the first request, then handed to
+        # `fetch_index` so it resolves once. Everything below runs after the
+        # download, which is why a fetch that stalled -- or that refused on the
+        # manifest -- used to print nothing at all: the tag, the URL and the
+        # destination were all known up front and shown only on success.
+        # `resolve_source` is pure, so this costs no network.
+        source = _guard(lambda: ops.resolve_source(version))
+        _echo_fetch_target(source, output)
+        result = _guard(lambda: ops.fetch_index(source=source, index_path=output))
 
     if as_json:
         click.echo(
@@ -1012,6 +1035,7 @@ def index_fetch(
                 {
                     "index": str(result.index_path),
                     "source": result.source,
+                    "notes": result.notes,
                     "warnings": result.warnings,
                     "manifest": result.manifest.describe(),
                 },

--- a/src/aorta/cli/chat.py
+++ b/src/aorta/cli/chat.py
@@ -925,19 +925,36 @@ def index_group() -> None:
     help="Index only git-tracked files of a ROCm/aorta checkout (what CI publishes).",
 )
 @click.option("--json", "as_json", is_flag=True, help="Emit the build result as JSON.")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Build over a downloaded index, replacing it with this narrower one.",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Debug-level logging.")
 def index_build(
-    path: str | None, output: str | None, public_only: bool, as_json: bool, verbose: bool
+    path: str | None,
+    output: str | None,
+    public_only: bool,
+    as_json: bool,
+    force: bool,
+    verbose: bool,
 ) -> None:
     """Build the index from source on this machine.
 
     The air-gapped and developer path. Needs the embedding weights, which are
     downloaded once (~65 MB) unless the cache is pre-seeded -- run 'aorta chat
     doctor' first if this node has no egress.
+
+    Refuses to build over an index that was downloaded rather than built here,
+    because a local build covers less; pass --force to do it anyway.
     """
     _index_logging(verbose)
     ops = _load("rag.index_ops")
-    result = _guard(lambda: ops.build_index(_resolve_corpus(path, public_only), index_path=output))
+    result = _guard(
+        lambda: ops.build_index(
+            _resolve_corpus(path, public_only), index_path=output, force=force
+        )
+    )
 
     if as_json:
         click.echo(
@@ -997,12 +1014,18 @@ def _echo_fetch_target(source: Any, output: str | None) -> None:
 )
 @click.option("--output", default=None, help="Where to install it. Defaults to the cache.")
 @click.option("--json", "as_json", is_flag=True, help="Emit the result as JSON.")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite an index built on this machine, and re-download an identical one.",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Debug-level logging.")
 def index_fetch(
     version: str | None,
     from_path: str | None,
     output: str | None,
     as_json: bool,
+    force: bool,
     verbose: bool,
 ) -> None:
     """Download the prebuilt index matching this aorta version.
@@ -1010,6 +1033,10 @@ def index_fetch(
     An exact release version takes that release's asset; a development version
     takes the rolling asset built from main and reports how far off it is.
     Pass --version to override, or --from to side-load a staged file.
+
+    A refresh of an index that was itself downloaded proceeds and reports what
+    changed; one that would replace a locally-built index is refused, because
+    the network cannot give that back. Pass --force to overwrite it.
     """
     if version and from_path:
         raise click.UsageError("--version and --from are mutually exclusive.")
@@ -1017,7 +1044,7 @@ def index_fetch(
     ops = _load("rag.index_ops")
 
     if from_path:
-        result = _guard(lambda: ops.side_load(from_path, index_path=output))
+        result = _guard(lambda: ops.side_load(from_path, index_path=output, force=force))
     else:
         # Resolved and echoed here, before the first request, then handed to
         # `fetch_index` so it resolves once. Everything below runs after the
@@ -1027,7 +1054,7 @@ def index_fetch(
         # `resolve_source` is pure, so this costs no network.
         source = _guard(lambda: ops.resolve_source(version))
         _echo_fetch_target(source, output)
-        result = _guard(lambda: ops.fetch_index(source=source, index_path=output))
+        result = _guard(lambda: ops.fetch_index(source=source, index_path=output, force=force))
 
     if as_json:
         click.echo(

--- a/tests/chat/test_config_wizard.py
+++ b/tests/chat/test_config_wizard.py
@@ -827,10 +827,13 @@ class TestEveryCommandTheseDocsPrintCanRun:
                 node.make_context(command, remaining, parent=parent)
 
     def test_the_sweep_would_reject_a_flag_that_does_not_exist(self):
-        """Keeps the strict tier honest: `--force` on `index fetch` is #465's.
+        """Keeps the strict tier honest: without this the sweep above is vacuous.
 
-        Documenting it before that lands would print a line Click rejects, which
-        is the trap the round that prompted this test invited.
+        Originally asked with ``--force`` on ``index fetch``, the flag #465 was
+        about to add. That made the control expire the moment #465 landed, which
+        is the wrong failure -- it says nothing about whether the sweep still
+        rejects anything. A flag no one will ever add keeps the control about
+        the parser rather than about the schedule.
         """
         from click import Context, NoSuchOption
 
@@ -843,7 +846,7 @@ class TestEveryCommandTheseDocsPrintCanRun:
                 with Context(index_group, parent=chat_ctx) as index_ctx:
                     fetch = index_group.get_command(index_ctx, "fetch")
                     with pytest.raises(NoSuchOption):
-                        fetch.make_context("fetch", ["--force"], parent=index_ctx)
+                        fetch.make_context("fetch", ["--not-a-real-flag"], parent=index_ctx)
 
     def test_the_docs_do_not_promise_the_force_flag_yet(self):
         """The finding itself, pinned where it was raised.

--- a/tests/chat/test_index_build.py
+++ b/tests/chat/test_index_build.py
@@ -722,6 +722,34 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         assert "--force" in message
         assert target.read_text(encoding="utf-8") == "a year of notes", "the file must survive"
 
+    def test_an_unrenderable_local_sidecar_still_gets_its_refusal(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The guard must not fail open because its subtitle will not format.
+
+        Local sidecars are deliberately untyped, and the locally-built refusal
+        prints ``describe()``, which slices ``aorta_sha``. So `aorta_sha: 42`
+        raised ``TypeError`` out of the refusal itself -- and the classification
+        it was refusing on had already succeeded, because that reads
+        ``corpus_roots``. An irreproducible local build was therefore protected
+        by a guard that crashed instead of refusing, over a courtesy line.
+        """
+        from aorta.chat.rag import index_ops
+        from aorta.chat.rag import manifest as manifest_mod
+
+        _install_fake_embedder(monkeypatch)
+        target = tmp_path / "index.sqlite"
+        index_ops.build_index(local_corpus(repo), index_path=target)
+        raw = json.loads(manifest_mod.manifest_path(target).read_text(encoding="utf-8"))
+        raw["aorta_sha"] = 42
+        manifest_mod.manifest_path(target).write_text(json.dumps(raw), encoding="utf-8")
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            index_ops.fetch_index(version="0.2.1", index_path=target)
+
+        assert "built on this machine" in str(exc.value)
+        assert "--force" in str(exc.value)
+
     def test_a_dangling_symlink_destination_is_refused(self, repo: Path, tmp_path, monkeypatch):
         """The same gap reached through the link, where ``exists()`` lies.
 

--- a/tests/chat/test_index_build.py
+++ b/tests/chat/test_index_build.py
@@ -722,6 +722,27 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         assert "--force" in message
         assert target.read_text(encoding="utf-8") == "a year of notes", "the file must survive"
 
+    def test_a_dangling_symlink_destination_is_refused(self, repo: Path, tmp_path, monkeypatch):
+        """The same gap reached through the link, where ``exists()`` lies.
+
+        ``Path.exists()`` follows the symlink, so a broken one answers ``False``
+        about a path that is very much occupied -- and the guard above reads
+        ``False`` as a first install. The third write path is pinned here
+        because ``build`` has its own guard; ``fetch`` and ``--from`` are
+        covered in ``test_index_fetch.py``.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        target = tmp_path / "index.sqlite"
+        target.symlink_to(tmp_path / "never-existed.sqlite")
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            index_ops.build_index(local_corpus(repo), index_path=target)
+
+        assert "symlink" in str(exc.value)
+        assert target.is_symlink(), "the link itself must survive a refusal"
+
     def test_force_builds_over_a_manifest_less_destination(
         self, repo: Path, tmp_path, monkeypatch
     ):

--- a/tests/chat/test_index_build.py
+++ b/tests/chat/test_index_build.py
@@ -455,6 +455,45 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         assert result.index_path == target
         assert index_ops.check_index(target, strict=True).refusals == []
 
+    def test_a_refused_index_stays_exempt_even_when_its_provenance_is_unreadable(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The exemption is checked *before* the unclassifiable refusal, on purpose.
+
+        It looks like a hole in the "unreadable provenance is refused" rule and
+        it is not. An unreadable ``corpus_roots`` means the index is either a
+        published one or a local one, and a *refused* index reaches the same
+        verdict down both branches: a refused published index is exempt by the
+        rule above, and a local index is never protected from ``build`` at all.
+        So proceeding is not a guess about which is on disk -- it is what both
+        possibilities agree on.
+
+        Reordering the two would also break the cross-PR interaction the
+        exemption exists for: ``doctor`` and the manifest refusal both name
+        ``aorta chat index build`` as the remedy, and a user whose sidecar is
+        *also* hand-edited would be refused, told to rebuild, refused again.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch, embedding_model="some/other-model")
+        path = index_ops.manifest_mod.manifest_path(target)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw["corpus_roots"] = "src/aorta"
+        path.write_text(json.dumps(raw), encoding="utf-8")
+
+        assert index_ops.index_provenance(index_ops.manifest_mod.read_manifest(target)) == (
+            index_ops.PROVENANCE_INVALID
+        ), "the fixture must be unclassifiable as well as refused"
+        assert index_ops.check_index(target, strict=False).refusals
+
+        result = index_ops.build_index(local_corpus(repo), index_path=target)
+
+        assert result.index_path == target
+        assert index_ops.check_index(target, strict=True).refusals == []
+
     def test_an_unclassifiable_manifest_is_refused_rather_than_guessed(
         self, repo: Path, tmp_path, monkeypatch
     ):

--- a/tests/chat/test_index_build.py
+++ b/tests/chat/test_index_build.py
@@ -350,12 +350,38 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
     """
 
     @staticmethod
-    def _install_published(target: Path, monkeypatch, **overrides) -> None:
-        """Put a manifest at ``target`` that looks like a CI-published index."""
+    def _install_published(target: Path, monkeypatch, **overrides) -> str:
+        """Put a *readable* index at ``target`` that looks like a CI-published one.
+
+        A real sqlite store holding the collection the manifest names, not
+        filler bytes. The guard asks :func:`check_index` whether the index is
+        usable, and an index nothing can open is exempt from it -- so a fixture
+        of filler bytes made every refusal test here pass through the
+        exemption rather than through the corpus comparison it was written to
+        exercise. The bytes were never load-bearing; being openable is.
+
+        Returns the digest of the file it wrote, so a caller can assert the
+        index was or was not replaced without depending on its contents.
+        """
+        import sqlite3
+
         from aorta.chat.rag import manifest as manifest_mod
 
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(b"the published index")
+        collection = overrides.get("collection", "aorta_fake")
+        chunks = overrides.get("chunk_count", 0)
+        conn = sqlite3.connect(target)
+        try:
+            conn.execute(f'CREATE TABLE "chunks_{collection}" (id INTEGER, text TEXT)')
+            conn.executemany(
+                f'INSERT INTO "chunks_{collection}" VALUES (?, ?)',
+                [(i, "the published index") for i in range(chunks)],
+            )
+            conn.commit()
+        finally:
+            # Closed rather than left to the context manager, which commits but
+            # does not close -- and the file is about to be digested and moved.
+            conn.close()
         values = {
             "aorta_version": "0.2.1",
             "aorta_sha": "a" * 40,
@@ -370,6 +396,7 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         }
         values.update(overrides)
         manifest_mod.write_manifest(target, manifest_mod.Manifest(**values))
+        return manifest_mod.sha256_file(target)
 
     def test_it_refuses_and_names_what_would_be_lost(self, repo: Path, tmp_path, monkeypatch):
         from aorta.chat.rag import index_ops
@@ -377,7 +404,7 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         _install_fake_embedder(monkeypatch)
         monkeypatch.setattr(settings, "embedding_model", "fake/model")
         target = tmp_path / "cache" / "index.sqlite"
-        self._install_published(target, monkeypatch)
+        digest = self._install_published(target, monkeypatch)
 
         with pytest.raises(index_ops.IndexOverwriteError) as exc:
             index_ops.build_index(local_corpus(repo), index_path=target)
@@ -386,7 +413,7 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         assert "docs/" in message and "README.md" in message
         assert "aorta chat index fetch" in message
         assert "--force" in message
-        assert target.read_bytes() == b"the published index"
+        assert index_ops.manifest_mod.sha256_file(target) == digest, "the index must be untouched"
 
     def test_a_published_build_over_a_published_index_is_a_refresh_not_a_downgrade(
         self, repo: Path, tmp_path, monkeypatch
@@ -404,12 +431,12 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         _install_fake_embedder(monkeypatch)
         monkeypatch.setattr(settings, "embedding_model", "fake/model")
         target = tmp_path / "cache" / "index.sqlite"
-        self._install_published(target, monkeypatch)
+        digest = self._install_published(target, monkeypatch)
 
         result = index_ops.build_index(published_corpus(repo), index_path=target)
 
         assert result.manifest.corpus_roots == list(PUBLISHED_SUBPATHS)
-        assert target.read_bytes() != b"the published index"
+        assert index_ops.manifest_mod.sha256_file(target) != digest, "the index must be replaced"
 
     def test_force_builds_over_it(self, repo: Path, tmp_path, monkeypatch):
         from aorta.chat.rag import index_ops
@@ -417,10 +444,10 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         _install_fake_embedder(monkeypatch)
         monkeypatch.setattr(settings, "embedding_model", "fake/model")
         target = tmp_path / "cache" / "index.sqlite"
-        self._install_published(target, monkeypatch)
+        digest = self._install_published(target, monkeypatch)
 
         assert index_ops.build_index(local_corpus(repo), index_path=target, force=True)
-        assert target.read_bytes() != b"the published index"
+        assert index_ops.manifest_mod.sha256_file(target) != digest, "the index must be replaced"
 
     def test_a_refused_index_is_exempt_so_the_advice_stays_followable(
         self, repo: Path, tmp_path, monkeypatch
@@ -454,6 +481,117 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
 
         assert result.index_path == target
         assert index_ops.check_index(target, strict=True).refusals == []
+
+    def test_an_index_whose_store_cannot_be_read_is_exempt_too(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The exemption is "cannot be used", not "the manifest is refused".
+
+        PR #463 added a FAIL branch for an index whose ``.sqlite`` cannot be
+        opened, and it names ``aorta chat index build`` as the remedy. Such an
+        index has an entirely *valid* manifest, so a guard asking only
+        ``manifest.validate`` refused the rebuild that every reader touching
+        the file was recommending -- the same two-step dead end as the refused
+        case, one layer down. Asked through ``check_index``, which reads the
+        store, so this guard and the load path agree on what "usable" means.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch)
+        # Leave the sidecars, replace the index with something that is not one.
+        target.write_bytes(b"not a sqlite database, not even close" * 40)
+
+        report = index_ops.check_index(target, strict=False)
+        assert report.refusals, "the fixture must be an index this install cannot read"
+        assert not index_ops._validate_against_provider(
+            index_ops.manifest_mod.read_manifest(target)
+        ).refusals, "and its manifest must still be perfectly valid, which is the point"
+
+        assert index_ops.build_index(local_corpus(repo), index_path=target)
+        assert index_ops.check_index(target, strict=True).refusals == []
+
+    def test_a_legacy_manifest_does_not_hide_an_unreadable_store(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """``chunk_count`` of 0 must not buy an unreadable index a clean bill of health.
+
+        ``check_index`` used to suppress its unreadable-file refusal unless the
+        manifest claimed a chunk count, on the reasoning that a manifest
+        predating the field asserts nothing to contradict. But "is the claim
+        contradicted" is not "can this be queried", and the load path refuses
+        such a file with no gate at all -- so this reader was *more permissive
+        than the load path it exists to predict*.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch, chunk_count=0)
+        target.write_bytes(b"not a sqlite database, not even close" * 40)
+
+        assert index_ops.manifest_mod.read_manifest(target).chunk_count == 0
+        refusals = index_ops.check_index(target, strict=False).refusals
+
+        assert refusals, "an unreadable store fails closed whatever the manifest claims"
+        # Worded for a manifest that made no claim, rather than "describes 0 chunks".
+        assert "could not be read as a sqlite store" in " ".join(refusals)
+        assert "describes 0 chunks" not in " ".join(refusals)
+        # And the guard follows it, so #463's advice stays followable here too.
+        assert index_ops.build_index(local_corpus(repo), index_path=target)
+
+    def test_a_stale_index_on_a_remote_provider_needs_no_new_exemption(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The third state #463 names, which the guard already permitted.
+
+        Source drift is a *warning*, so it never reaches the usability
+        exemption -- and it does not need to. On a remote embedding provider
+        ``doctor`` names ``index build`` for drift because a fetch would land
+        the published asset, which that provider refuses. The index in front of
+        the guard is therefore already exempt for a different reason: it is a
+        local build, classified ``local``, and a local index is never protected
+        from ``build``. Pinned so a later widening of the exemption cannot be
+        justified by this case.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        # A local build: one absolute root, which is the local signature.
+        self._install_published(target, monkeypatch, corpus_roots=[str(tmp_path / "checkout")])
+
+        local = index_ops.manifest_mod.read_manifest(target)
+        assert index_ops.index_provenance(local) == index_ops.PROVENANCE_LOCAL
+        assert not index_ops.check_index(target, strict=False).refusals, (
+            "the fixture must be healthy, so the exemption cannot be what permits it"
+        )
+
+        assert index_ops.build_index(local_corpus(repo), index_path=target)
+
+    def test_a_healthy_published_index_is_still_refused(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The control for the three exemptions above: the guard still guards.
+
+        Widening "refused" to "unusable" must not make the guard permissive on
+        the case it exists for -- a healthy published index that a bare build
+        would narrow.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch)
+
+        assert not index_ops.check_index(target, strict=False).refusals
+        with pytest.raises(index_ops.IndexOverwriteError):
+            index_ops.build_index(local_corpus(repo), index_path=target)
 
     def test_a_refused_index_stays_exempt_even_when_its_provenance_is_unreadable(
         self, repo: Path, tmp_path, monkeypatch
@@ -510,7 +648,7 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         _install_fake_embedder(monkeypatch)
         monkeypatch.setattr(settings, "embedding_model", "fake/model")
         target = tmp_path / "cache" / "index.sqlite"
-        self._install_published(target, monkeypatch)
+        digest = self._install_published(target, monkeypatch)
         path = index_ops.manifest_mod.manifest_path(target)
         raw = json.loads(path.read_text(encoding="utf-8"))
         raw["corpus_roots"] = "src/aorta"
@@ -521,7 +659,7 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
 
         assert "cannot classify" in str(exc.value)
         assert "corpus_roots is a str" in str(exc.value)
-        assert target.read_bytes() == b"the published index"
+        assert index_ops.manifest_mod.sha256_file(target) == digest, "the index must be untouched"
         assert index_ops.build_index(local_corpus(repo), index_path=target, force=True)
 
     def test_the_refusal_does_not_claim_a_loss_that_did_not_happen(

--- a/tests/chat/test_index_build.py
+++ b/tests/chat/test_index_build.py
@@ -735,25 +735,50 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         assert index_ops.build_index(local_corpus(repo), index_path=target, force=True)
         assert index_ops.check_index(target, strict=True).refusals == []
 
-    def test_a_published_build_over_a_manifest_less_destination_still_proceeds(
+    def test_public_only_does_not_exempt_a_manifest_less_destination(
         self, repo: Path, tmp_path, monkeypatch
     ):
-        """``nightly.yml`` and ``release.yml`` run the same command repeatedly.
+        """A typo is a typo on the CI path too.
 
-        Their second run lands on an ``index-out/`` that a restored cache, or
-        the previous run in the same job, has already populated -- and an
-        interrupted first run leaves the index there with no sidecar. The
-        ``--public-only`` exemption is ahead of this refusal for that reason,
-        and a guard that tripped here would stop the published index updating
-        at all.
+        The first version of this ordering let the ``--public-only`` exemption
+        return *before* the destination was looked at, so
+        ``build --public-only --output ~/notes.txt`` replaced an unrelated file
+        without a word -- while the documented rule said any manifest-less path
+        is refused. The exemption answers the *provenance* question ("is this a
+        narrowing?"); it cannot answer "is there an index here at all".
+
+        This costs the published build nothing, which is why the ordering could
+        change: see the sibling test below for the shape CI actually runs.
         """
         from aorta.chat.rag import index_ops
 
         _install_fake_embedder(monkeypatch)
-        target = tmp_path / "index-out" / "aorta-chat-index.sqlite"
-        target.parent.mkdir()
-        target.write_bytes(b"an interrupted first run left this behind")
+        target = tmp_path / "notes.txt"
+        target.write_text("a year of notes", encoding="utf-8")
 
+        with pytest.raises(index_ops.IndexOverwriteError, match="no manifest beside it"):
+            index_ops.build_index(published_corpus(repo), index_path=target)
+
+        assert target.read_text(encoding="utf-8") == "a year of notes"
+        assert index_ops.build_index(published_corpus(repo), index_path=target, force=True)
+
+    def test_the_shape_ci_actually_runs_is_unaffected(self, repo: Path, tmp_path, monkeypatch):
+        """``nightly.yml`` and ``release.yml``, both runs of them.
+
+        Both are ``ubuntu-latest`` with a fresh workspace and neither restores
+        ``index-out/``, so their first write is to a path that does not exist
+        and every later one is over an index carrying complete sidecars. The
+        refusal above sits between those two states and touches neither, which
+        is what made it safe to move ahead of the exemption.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        out = tmp_path / "index-out"
+        out.mkdir()
+        target = out / "aorta-chat-index.sqlite"
+
+        assert index_ops.build_index(published_corpus(repo), index_path=target)
         assert index_ops.build_index(published_corpus(repo), index_path=target)
 
     def test_the_remedy_names_the_index_that_was_refused(

--- a/tests/chat/test_index_build.py
+++ b/tests/chat/test_index_build.py
@@ -338,6 +338,153 @@ class TestBuildIndex:
         assert files == result.file_count
 
 
+class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
+    """A local build covers less than the published one, and used to say nothing.
+
+    This is the mechanism behind the bad advice the guard exists to catch:
+    ``index build`` defaults ``--output`` to the live index and its corpus to
+    ``local_corpus``, so following a suggestion to "build" replaced an index
+    covering ``src/aorta``, ``docs`` and ``README.md`` with one covering a
+    single tree.
+    """
+
+    @staticmethod
+    def _install_published(target: Path, monkeypatch, **overrides) -> None:
+        """Put a manifest at ``target`` that looks like a CI-published index."""
+        from aorta.chat.rag import manifest as manifest_mod
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"the published index")
+        values = {
+            "aorta_version": "0.2.1",
+            "aorta_sha": "a" * 40,
+            "embedding_provider": "local",
+            "embedding_model": "fake/model",
+            "dimensions": 8,
+            "collection": "aorta_fake",
+            "chunk_size": settings.chunk_size,
+            "chunk_overlap": settings.chunk_overlap,
+            "index_sha256": manifest_mod.sha256_file(target),
+            "corpus_roots": list(PUBLISHED_SUBPATHS),
+        }
+        values.update(overrides)
+        manifest_mod.write_manifest(target, manifest_mod.Manifest(**values))
+
+    def test_it_refuses_and_names_what_would_be_lost(self, repo: Path, tmp_path, monkeypatch):
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch)
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            index_ops.build_index(local_corpus(repo), index_path=target)
+
+        message = str(exc.value)
+        assert "docs/" in message and "README.md" in message
+        assert "aorta chat index fetch" in message
+        assert "--force" in message
+        assert target.read_bytes() == b"the published index"
+
+    def test_a_published_build_over_a_published_index_is_a_refresh_not_a_downgrade(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The guard is about the corpus narrowing, not about the path being occupied.
+
+        `--public-only` produces the same shape it would replace, so refusing
+        it protects nothing -- and refusing it is how a guard keyed on the
+        destination alone would break `nightly.yml` and `release.yml` the first
+        time their `index-out/` was restored or re-used, which stops the
+        published index updating at all.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch)
+
+        result = index_ops.build_index(published_corpus(repo), index_path=target)
+
+        assert result.manifest.corpus_roots == list(PUBLISHED_SUBPATHS)
+        assert target.read_bytes() != b"the published index"
+
+    def test_force_builds_over_it(self, repo: Path, tmp_path, monkeypatch):
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch)
+
+        assert index_ops.build_index(local_corpus(repo), index_path=target, force=True)
+        assert target.read_bytes() != b"the published index"
+
+    def test_a_refused_index_is_exempt_so_the_advice_stays_followable(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The cross-PR interaction, which neither diff shows on its own.
+
+        ``doctor`` and the manifest refusal both name ``aorta chat index build``
+        as the remedy for an embedding-identity mismatch, and that is the right
+        remedy. A refused index is still an existing index at the destination,
+        so a guard keyed on presence alone would compose the two into a dead
+        end: refused, told to rebuild, refused again -- landing on a user who
+        is already stuck.
+
+        There is also nothing to protect. Vectors that are not comparable to
+        this install's queries cannot answer anything, so rebuilding over them
+        is not destructive. The guard is for a *usable* published index.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        # Built by a different embedding model: exactly what `validate` refuses.
+        self._install_published(target, monkeypatch, embedding_model="some/other-model")
+
+        assert index_ops.check_index(target, strict=False).refusals, (
+            "the fixture must be an index this install would actually refuse"
+        )
+
+        result = index_ops.build_index(local_corpus(repo), index_path=target)
+
+        assert result.index_path == target
+        assert index_ops.check_index(target, strict=True).refusals == []
+
+    def test_a_local_build_over_a_local_build_needs_nothing(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """Rebuilding your own index is the ordinary developer loop."""
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        target = tmp_path / "index.sqlite"
+        index_ops.build_index(local_corpus(repo), index_path=target)
+
+        assert index_ops.build_index(local_corpus(repo), index_path=target)
+
+    def test_a_fresh_destination_needs_nothing(self, repo: Path, tmp_path, monkeypatch):
+        """What CI does: `--output` into a directory it just created.
+
+        A guard that tripped here would stop the published index updating at
+        all, which is worse than the defect it is guarding against.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        out = tmp_path / "index-out"
+        out.mkdir()
+
+        result = index_ops.build_index(
+            published_corpus(repo), index_path=out / "aorta-chat-index.sqlite"
+        )
+
+        assert result.index_path.exists()
+
+
 def _install_fake_embedder(monkeypatch) -> None:
     """Replace the provider with a deterministic 8-dimension bag-of-words model.
 

--- a/tests/chat/test_index_build.py
+++ b/tests/chat/test_index_build.py
@@ -15,6 +15,7 @@ re-uploading tens of megabytes on a night when nothing indexable changed.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -453,6 +454,68 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
 
         assert result.index_path == target
         assert index_ops.check_index(target, strict=True).refusals == []
+
+    def test_an_unclassifiable_manifest_is_refused_rather_than_guessed(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The guard reads ``corpus_roots``, which nothing type-checks.
+
+        A sidecar recording it as the string ``"src/aorta"`` classified as a
+        *local* build -- because iterating the string yields ``"/"``, and
+        ``Path("/").is_absolute()`` is true -- so this guard returned early and
+        the published index was overwritten anyway. The mirror spelling
+        ``"docs"`` classified as published. Both are answers from nothing.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch)
+        path = index_ops.manifest_mod.manifest_path(target)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw["corpus_roots"] = "src/aorta"
+        path.write_text(json.dumps(raw), encoding="utf-8")
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            index_ops.build_index(local_corpus(repo), index_path=target)
+
+        assert "cannot classify" in str(exc.value)
+        assert "corpus_roots is a str" in str(exc.value)
+        assert target.read_bytes() == b"the published index"
+        assert index_ops.build_index(local_corpus(repo), index_path=target, force=True)
+
+    def test_the_refusal_does_not_claim_a_loss_that_did_not_happen(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """``build --path <a checkout>`` does cover ``docs/`` and ``README.md``.
+
+        The message asserted "no 'docs/' or 'README.md' coverage"
+        unconditionally, which is true of the default corpus (the installed
+        package alone) and false for any build pointed at a full checkout --
+        an error message stating a fact the invocation disproves.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        self._install_published(target, monkeypatch)
+
+        corpus = local_corpus(repo)
+        covered = {
+            str(document.metadata.get("source", "")) for document in corpus_mod.load_corpus(corpus)
+        }
+        assert any("README" in source for source in covered), "fixture must cover README.md"
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            index_ops.build_index(corpus, index_path=target)
+
+        message = str(exc.value)
+        assert "no 'docs/' or 'README.md' coverage" not in message
+        # What is always true of a corpus reaching this branch, and both sides.
+        assert "no public-tree provenance" in message
+        assert str(repo) in message
 
     def test_a_local_build_over_a_local_build_needs_nothing(
         self, repo: Path, tmp_path, monkeypatch

--- a/tests/chat/test_index_build.py
+++ b/tests/chat/test_index_build.py
@@ -16,6 +16,7 @@ re-uploading tens of megabytes on a night when nothing indexable changed.
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -693,6 +694,125 @@ class TestBuildWillNotSilentlyDowngradeAFetchedIndex:
         # What is always true of a corpus reaching this branch, and both sides.
         assert "no public-tree provenance" in message
         assert str(repo) in message
+
+    def test_a_mistyped_output_over_someone_elses_file_is_refused(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The gap under the guard rather than in it: no manifest, no opinion.
+
+        Both guards used to open with "read the sidecar; if there is not one,
+        return", which made a path that exists with nothing beside it
+        indistinguishable from a path that does not exist -- so
+        ``--output ~/notes.txt`` reached ``replace()`` unopposed while the
+        strictly better-informed case of a sidecar that reads but classifies
+        badly was refused.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        target = tmp_path / "notes.txt"
+        target.write_text("a year of notes", encoding="utf-8")
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            index_ops.build_index(local_corpus(repo), index_path=target)
+
+        message = str(exc.value)
+        assert "no manifest beside it" in message
+        assert "typo" in message
+        assert "--force" in message
+        assert target.read_text(encoding="utf-8") == "a year of notes", "the file must survive"
+
+    def test_force_builds_over_a_manifest_less_destination(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The escape the refusal names has to work, or it is not an escape."""
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        target = tmp_path / "notes.txt"
+        target.write_text("a year of notes", encoding="utf-8")
+
+        assert index_ops.build_index(local_corpus(repo), index_path=target, force=True)
+        assert index_ops.check_index(target, strict=True).refusals == []
+
+    def test_a_published_build_over_a_manifest_less_destination_still_proceeds(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """``nightly.yml`` and ``release.yml`` run the same command repeatedly.
+
+        Their second run lands on an ``index-out/`` that a restored cache, or
+        the previous run in the same job, has already populated -- and an
+        interrupted first run leaves the index there with no sidecar. The
+        ``--public-only`` exemption is ahead of this refusal for that reason,
+        and a guard that tripped here would stop the published index updating
+        at all.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        target = tmp_path / "index-out" / "aorta-chat-index.sqlite"
+        target.parent.mkdir()
+        target.write_bytes(b"an interrupted first run left this behind")
+
+        assert index_ops.build_index(published_corpus(repo), index_path=target)
+
+    def test_the_remedy_names_the_index_that_was_refused(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """A remedy that acts on a different index is worse than none at all.
+
+        Both lines default ``--output`` to the cache and their corpus to the
+        installed package, so a refusal raised over an explicit ``--path`` and
+        ``--output`` printed a bare ``aorta chat index build --force`` -- which
+        rebuilds the *user's real* index, over a corpus they did not name, and
+        leaves the one they were refused exactly as it was. Pasting the advice
+        did damage and did not resolve the refusal.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        monkeypatch.setattr(settings, "index_path", str(tmp_path / "cache" / "default.sqlite"))
+        target = tmp_path / "elsewhere" / "index.sqlite"
+        self._install_published(target, monkeypatch)
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            index_ops.build_index(local_corpus(repo), index_path=target)
+
+        message = str(exc.value)
+        for line in message.splitlines():
+            if not line.strip().startswith("aorta chat index"):
+                continue
+            assert str(target) in line, f"remedy targets the wrong index: {line!r}"
+        assert f"--output {shlex.quote(str(target))}" in message
+        assert f"--path {shlex.quote(str(repo))}" in message
+        assert "aorta chat index build --force\n" not in message
+
+    def test_the_remedy_stays_short_when_the_defaults_are_what_ran(
+        self, repo: Path, tmp_path, monkeypatch
+    ):
+        """The flags are carried because they differ, not as decoration.
+
+        A refusal over the configured cache is the common one, and spelling
+        out the two flags a bare command already resolves to would make every
+        such message longer for no reader.
+        """
+        from aorta.chat.rag import index_ops
+
+        _install_fake_embedder(monkeypatch)
+        monkeypatch.setattr(settings, "embedding_model", "fake/model")
+        target = tmp_path / "cache" / "index.sqlite"
+        monkeypatch.setattr(settings, "index_path", str(target))
+        monkeypatch.setattr(settings, "aorta_path", str(repo))
+        self._install_published(target, monkeypatch)
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            index_ops.build_index(local_corpus(repo), index_path=target)
+
+        message = str(exc.value)
+        assert "--output" not in message
+        assert "--path" not in message
+        assert "aorta chat index build --force" in message
 
     def test_a_local_build_over_a_local_build_needs_nothing(
         self, repo: Path, tmp_path, monkeypatch

--- a/tests/chat/test_index_crash_safety.py
+++ b/tests/chat/test_index_crash_safety.py
@@ -363,7 +363,14 @@ class TestTheLocalRunCollectionSurvives:
             store.close()
 
     def test_a_side_load_keeps_it(self, corpus_root: Path, tmp_path: Path):
-        """The air-gapped update path replaces the file just as a fetch does."""
+        """The air-gapped update path replaces the file just as a fetch does.
+
+        ``force`` throughout this class and the two below: the target is a
+        local build, which ``side_load`` now refuses to overwrite without it.
+        What is under test is what survives the replacement, so the guard is
+        satisfied rather than exercised -- it has its own tests in
+        ``test_index_fetch.py``.
+        """
         staged_dir = tmp_path / "usb"
         staged_dir.mkdir()
         staged = staged_dir / index_ops.ASSET_NAME
@@ -375,7 +382,7 @@ class TestTheLocalRunCollectionSurvives:
         _build(corpus_root, target)
         _add_run_collection(target)
 
-        result = index_ops.side_load(staged, index_path=target)
+        result = index_ops.side_load(staged, index_path=target, force=True)
 
         assert collection_chunk_count(target, RUN_COLLECTION) == 2
         assert any("kept this machine" in warning for warning in result.warnings)
@@ -393,7 +400,7 @@ class TestTheLocalRunCollectionSurvives:
         (small / "only.py").write_text("x = 1\n", encoding="utf-8")
         _build(small, target)
 
-        index_ops.side_load(staged, index_path=target)
+        index_ops.side_load(staged, index_path=target, force=True)
 
         assert collection_chunk_count(target, COLLECTION) == incoming.chunk_count
 
@@ -467,7 +474,7 @@ class TestTheCarryOverIsAllOrNothing:
         _build(corpus_root, target)
         target.write_bytes(b"not a database")
 
-        result = index_ops.side_load(staged, index_path=target)
+        result = index_ops.side_load(staged, index_path=target, force=True)
 
         assert result.index_path == target
         assert collection_chunk_count(target, COLLECTION) is not None
@@ -494,7 +501,7 @@ class TestInterruptedSideLoad:
 
         monkeypatch.setattr(index_ops.shutil, "copy2", _die)
         with pytest.raises(OSError, match="no space left"):
-            index_ops.side_load(staged, index_path=target)
+            index_ops.side_load(staged, index_path=target, force=True)
 
         assert target.read_bytes() == before_bytes
         assert _sidecars(target) == before_sidecars

--- a/tests/chat/test_index_crash_safety.py
+++ b/tests/chat/test_index_crash_safety.py
@@ -102,6 +102,26 @@ def _sidecars(target: Path) -> tuple[str, str]:
     )
 
 
+def _write_store(target: Path, *, chunks: int) -> None:
+    """A real store with a known chunk count, without running a build.
+
+    The install step is being tested here rather than the embedding, and a
+    build would take the property under test (which file ends up at the
+    destination) and bury it under tens of seconds of unrelated work.
+    """
+    store = SqliteVecStore(path=target, embedding=_Fake(), collection=COLLECTION)
+    try:
+        store.reset()
+        store.add_documents(
+            [
+                Document(page_content=f"chunk {n}", metadata={"source": f"{n}.md"})
+                for n in range(chunks)
+            ]
+        )
+    finally:
+        store.close()
+
+
 def _add_run_collection(target: Path, *, texts=("run one failed", "run two passed")) -> None:
     """Write the per-user run collection into the same file, as ``rag/runs`` does."""
     store = SqliteVecStore(path=target, embedding=_Fake(), collection=RUN_COLLECTION)
@@ -140,9 +160,21 @@ class TestInterruptedBuild:
         assert index_ops.check_index(target, strict=True).refusals == []
         assert collection_chunk_count(target, COLLECTION) == first.chunk_count
 
-    def test_it_leaves_no_staging_directory_behind(
+    def test_an_unwound_interruption_leaves_no_staging_directory_behind(
         self, corpus_root: Path, tmp_path: Path, monkeypatch
     ):
+        """Named for what it establishes, which is narrower than "no leak".
+
+        ``TemporaryDirectory`` cleans up when an exception *unwinds* the
+        ``with`` block, so this covers Ctrl-C and any raised failure -- and does
+        not cover the process dying. A real ``SIGKILL`` mid-build leaves a
+        ``.aorta-index-*`` directory holding a full copy of the staged index,
+        measured on the review of this PR, and nothing reaps it. The previous
+        name claimed the general case and this test could never have caught it,
+        which is worse than not testing it: it is the name a reader would trust
+        instead of looking. No documentation promises the general case, so the
+        overclaim was here rather than in the docs.
+        """
         target = tmp_path / "cache" / "index.sqlite"
         _build(corpus_root, target)
 
@@ -174,6 +206,47 @@ class TestInterruptedBuild:
 
         assert not target.exists()
         assert not manifest_mod.manifest_path(target).exists()
+
+
+class TestTheInstallIsOneRenameAndNotACopy:
+    """The single line the whole crash-safety claim rests on.
+
+    Added because the human review of this PR mutated ``staged.replace(dest)``
+    to ``shutil.copy2(staged, dest)`` and every test in this file still passed.
+    The interruptions here are injected before the install (``add_documents``)
+    and after it (``write_manifest``), so none of them is in flight *during* it
+    -- and that is exactly the window the two implementations differ in. A
+    rename is atomic on one filesystem; a copy is a truncating write over the
+    live index, which is the "wrong but self-consistent" state this module's
+    docstring says must never exist, reached by the one step nobody was
+    watching.
+
+    Pinned on the property rather than by interrupting mid-copy, which needs a
+    real kill inside a syscall and is not reliably schedulable. A rename keeps
+    the inode; a copy makes a new one. That distinguishes the two
+    implementations deterministically and in-process, and it is the same fact
+    that makes the rename atomic.
+    """
+
+    def test_the_destination_inherits_the_staged_file_rather_than_its_bytes(
+        self, tmp_path: Path
+    ):
+        dest = tmp_path / "index.sqlite"
+        _write_store(dest, chunks=2)
+        staged = tmp_path / "staging" / "index.sqlite"
+        staged.parent.mkdir()
+        _write_store(staged, chunks=7)
+        staged_inode = staged.stat().st_ino
+
+        index_ops._install_staged(staged, dest)
+
+        assert dest.stat().st_ino == staged_inode, (
+            "the install copied bytes into the live index instead of renaming "
+            "over it, so an interruption mid-install leaves a truncated index "
+            "under the previous index's sidecars"
+        )
+        assert not staged.exists(), "a rename consumes the staged file"
+        assert collection_chunk_count(dest, COLLECTION) == 7
 
 
 class TestSidecarsComeLast:

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -220,13 +220,112 @@ class TestFetch:
         fetch_index(version="0.2.1", index_path=dest)
         assert dest.read_bytes() == BODY
 
-    def test_the_source_and_warnings_are_reported_back(self, server, tmp_path: Path):
+    def test_the_source_and_notes_are_reported_back(self, server, tmp_path: Path):
+        """The dev-version note is a ``note``, not a ``warning``.
+
+        Nothing is wrong with a dev install taking the rolling asset, and the
+        note's real job is to be shown *before* the download rather than after
+        it -- which is what ``notes`` exists to make possible.
+        """
         result = fetch_index(
             index_path=tmp_path / "i.sqlite",
             source=resolve_source(installed="0.2.2.dev122+g45edc3d"),
         )
         assert ROLLING_TAG in result.source
-        assert any("122 commit" in warning for warning in result.warnings)
+        assert any("122 commit" in note for note in result.notes)
+
+
+class TestTheWaitIsExplainedBeforeItStarts:
+    """The reported symptom was no output at all, for minutes.
+
+    Three requests in series, and the only ``Downloading`` line sat on the
+    third; meanwhile everything the command echoed ran after the last one
+    returned. So a node that could not reach the release host produced nothing
+    whatsoever before it failed, and a fetch that was going to be refused on
+    the manifest still said nothing about which asset it had been reaching for.
+    """
+
+    def test_the_target_is_describable_without_touching_the_network(self, no_network):
+        source = resolve_source(installed="0.2.1")
+        lines = "\n".join(index_ops.describe_target(source, "/cache/index.sqlite"))
+
+        assert "v0.2.1" in lines
+        assert source.index_url in lines
+        assert "/cache/index.sqlite" in lines
+
+    def test_a_dev_installs_note_is_carried_up_front(self):
+        """It explains the rolling tag, so it is worth nothing after the fact."""
+        source = resolve_source(installed="0.2.2.dev122+g45edc3d")
+        lines = "\n".join(index_ops.describe_target(source, "/cache/i.sqlite"))
+
+        assert ROLLING_TAG in lines
+        assert "122 commit" in lines
+
+    def test_every_request_says_what_it_is_contacting(self, server, tmp_path: Path, caplog):
+        """Including the two sidecars, which had no logging at all."""
+        with caplog.at_level("INFO", logger=index_ops.__name__):
+            fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        logged = "\n".join(record.getMessage() for record in caplog.records)
+        for suffix in (
+            manifest_mod.MANIFEST_SUFFIX,
+            manifest_mod.CHECKSUM_SUFFIX,
+        ):
+            assert ASSET_NAME + suffix in logged, f"no log line for the {suffix} request"
+
+    def test_the_asset_transfer_reports_progress(self, server, tmp_path: Path, caplog):
+        """``shutil.copyfileobj`` had no callback, so tens of megabytes were silent."""
+        with caplog.at_level("INFO", logger=index_ops.__name__):
+            fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert any("MB" in record.getMessage() for record in caplog.records)
+
+
+class TestTheTimeoutsAreSplit:
+    """One 300 s budget for connect *and* read is five silent minutes per request.
+
+    A blackholed host only ever reaches the connect phase, so that phase is
+    what has to fail fast; the body then wants the generous budget, because the
+    index is tens of megabytes over a link that may be slow.
+    """
+
+    def test_the_connect_budget_is_much_shorter_than_the_read_budget(self):
+        assert index_ops._CONNECT_TIMEOUT < index_ops._READ_TIMEOUT
+
+    def test_a_sidecar_request_uses_the_connect_budget(self, server, tmp_path: Path, monkeypatch):
+        """A 1 KB sidecar that has not answered in 30 s is not going to."""
+        seen: list[float | None] = []
+        real = server.urlopen
+
+        def _urlopen(url, timeout=None):
+            seen.append(timeout)
+            return real(url, timeout=timeout)
+
+        monkeypatch.setattr(index_ops.urllib.request, "urlopen", _urlopen)
+        fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert seen and set(seen) == {index_ops._CONNECT_TIMEOUT}
+
+    def test_the_body_read_is_widened_once_the_headers_are_in(self):
+        """The split is only expressible after ``urlopen`` returns."""
+
+        class _Sock:
+            timeout = None
+
+            def settimeout(self, value):
+                self.timeout = value
+
+        class _Response:
+            def __init__(self, sock):
+                self.fp = type("Fp", (), {"raw": type("Raw", (), {"_sock": sock})()})()
+
+        sock = _Sock()
+        index_ops._widen_read_timeout(_Response(sock))
+        assert sock.timeout == index_ops._READ_TIMEOUT
+
+    def test_a_response_with_no_reachable_socket_is_left_alone(self):
+        """Best-effort: a stub response must not turn into a failed download."""
+        index_ops._widen_read_timeout(io.BytesIO(b"body"))
 
 
 class TestFetchFailures:

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import http.client
 import io
 import json
+import re
 import shlex
 import urllib.error
 from pathlib import Path
@@ -552,6 +553,65 @@ class TestAlreadyUpToDate:
         assert fetch_index(version="0.2.1", index_path=dest).up_to_date is False
         assert any(url.endswith(ASSET_NAME) for url in server.requested)
 
+    def test_a_matching_sidecar_over_a_store_with_no_chunk_table_is_not_up_to_date(
+        self, server, tmp_path: Path
+    ):
+        """The third damaged state, and the one the other two hid.
+
+        The two tests above damage the store in ways something *raises* about:
+        filler bytes cannot be opened, and a different row count contradicts the
+        manifest. This one is a valid sqlite file with the chunk table simply
+        absent -- and both readers answered it with silence rather than a
+        complaint. ``collection_chunk_count`` returns ``None`` (an ordinary
+        answer: it also means "another provider's index"), and ``validate``
+        skips its count comparison rather than compare against ``None``. No
+        refusals, so the shortcut called it current and the repair never ran.
+        """
+        import sqlite3
+
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        conn = sqlite3.connect(dest)
+        try:
+            conn.execute(f'DROP TABLE "chunks_{COLLECTION}"')
+            conn.commit()
+        finally:
+            conn.close()
+        # Nothing else is touched: the sidecars still record the published
+        # index_sha256, which is the pairing the shortcut trusted.
+        server.requested.clear()
+
+        result = fetch_index(version="0.2.1", index_path=dest)
+
+        assert result.up_to_date is False
+        assert any(url.endswith(ASSET_NAME) for url in server.requested)
+        assert dest.read_bytes() == BODY, "the store must be repaired"
+
+    def test_the_no_collection_refusal_distinguishes_a_missing_index_file(
+        self, server, tmp_path: Path
+    ):
+        """Same silence, different cause, and the sentences must not be swapped.
+
+        Asserted on ``check_index`` rather than through ``fetch``, because
+        ``fetch`` does not reach it: the shortcut reads the *sidecar* through
+        ``_local_manifest``, which returns ``None`` when the index file is gone,
+        so the refresh is never skipped in this state to begin with. ``doctor``
+        is the caller that does reach it -- it asks ``check_index`` directly to
+        list everything wrong at once -- and it is the one place the difference
+        shows: a sidecar outliving its index and a store some other provider
+        built are one ``None`` from ``collection_chunk_count`` and two entirely
+        different things to go and do. Telling this user their embedding
+        provider is wrong would send them to a setting that is fine.
+        """
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        dest.unlink()
+
+        refusals = " ".join(index_ops.check_index(dest, strict=False).refusals)
+
+        assert "index file it describes is not" in refusals
+        assert "different embedding provider" not in refusals
+
     def test_a_local_index_with_no_sidecar_is_refused_rather_than_assumed(
         self, server, tmp_path: Path
     ):
@@ -892,6 +952,166 @@ class TestTheFetchedSchemaIsChecked:
 
         assert fetch_index(version="0.2.1", index_path=dest).index_path == dest
         assert dest.exists()
+
+
+#: Flags that make an offered ``index fetch`` a *different* command from the one
+#: that raised. A bare re-run of the failing fetch is the whole defect below, so
+#: this is the property rather than any one sentence: ``--version`` goes to
+#: another release, ``--from`` to a local file, ``--force`` past a refusal.
+_CHANGES_THE_OUTCOME = ("--version", "--from", "--force")
+_FETCH_OFFER = re.compile(r"aorta chat index fetch[^'\n]*")
+
+
+def _unfollowable_fetch_offers(message: str) -> list[str]:
+    """Fetches this message tells the user to run that would fail identically.
+
+    Derived from the message rather than compared against expected wording,
+    because the defect is a *class*: three parser errors reached one wrapper,
+    and enumerating the sentences is how the fourth gets missed. Any ``index
+    fetch`` offered by an error that a fetch raised has to differ from the fetch
+    that raised it, or pasting it repeats the failure verbatim.
+    """
+    return [
+        offer.rstrip("'.\" ")
+        for offer in _FETCH_OFFER.findall(message)
+        if not any(flag in offer for flag in _CHANGES_THE_OUTCOME)
+    ]
+
+
+class TestTheRemedyCanBeFollowed:
+    """A refusal's remedy has to lead somewhere other than back to the refusal.
+
+    Routed here from #463, which found ``Manifest.from_dict`` closing its
+    type-mismatch error with "Replace it with 'aorta chat index fetch'" -- text
+    this module's wrapper carried verbatim into a fetch error, so a malformed
+    *published* manifest told the user to re-run the download that had just
+    produced it. Same URL, same bytes, same error: a loop, not advice.
+
+    The cause generalises past that one string. The parsers are handed a dict
+    and cannot know whose manifest it is; a local sidecar, this download and a
+    side-loaded file arrive identically and are fixed by three different things.
+    So the remedy belongs to whoever knows the origin, which is the caller --
+    and the tests here assert that property over the paths rather than the
+    wording of the errors, because the reported defect had three sites reaching
+    one wrapper and the wording is the part that will keep changing.
+    """
+
+    def _serve_malformed(self, server) -> None:
+        """A published manifest with a field of the wrong declared type."""
+        raw = json.loads(_manifest().to_json())
+        raw["corpus_roots"] = 42
+        server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX] = json.dumps(raw).encode()
+
+    def test_a_malformed_published_manifest_does_not_advise_fetching_it_again(
+        self, server, tmp_path: Path
+    ):
+        self._serve_malformed(server)
+        dest = tmp_path / "i.sqlite"
+
+        with pytest.raises(IndexFetchError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        message = str(exc.value)
+        assert _unfollowable_fetch_offers(message) == []
+        # And it says why, because "there is no local fix" is the useful part:
+        # a user who cannot tell a broken release from a broken machine will
+        # spend the afternoon on their machine.
+        assert "no local fix" in message
+        assert not dest.exists(), "nothing may be installed from a manifest that failed"
+
+    def test_the_published_remedy_offers_a_different_release_and_a_local_build(
+        self, server, tmp_path: Path
+    ):
+        """The two things that do work, since a refusal with no exit is the
+        complaint this batch opened with."""
+        self._serve_malformed(server)
+
+        with pytest.raises(IndexFetchError) as exc:
+            fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        message = str(exc.value)
+        assert "aorta chat index fetch --version" in message
+        assert "aorta chat index build" in message
+
+    def test_the_published_remedy_names_the_index_the_caller_asked_about(
+        self, server, tmp_path: Path, monkeypatch
+    ):
+        """``--output`` again: the remedy is only advice if pasting it acts on
+        the index that was refused, not on the configured cache."""
+        monkeypatch.setattr(settings, "index_path", str(tmp_path / "configured.sqlite"))
+        self._serve_malformed(server)
+        dest = tmp_path / "scratch.sqlite"
+
+        with pytest.raises(IndexFetchError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        assert f"aorta chat index build --output {shlex.quote(str(dest))}" in str(exc.value)
+
+    def test_a_malformed_staged_manifest_advises_restaging_it(self, tmp_path: Path):
+        """The third origin, and the one where neither index command helps.
+
+        The bytes are local but they are not aorta's, so the file that has to
+        change is the one the user carried in -- and re-running ``--from`` over
+        the same pair fails the same way, which is the same defect as the
+        published case reached from the other side.
+        """
+        origin = tmp_path / "staged" / ASSET_NAME
+        origin.parent.mkdir(parents=True)
+        origin.write_bytes(BODY)
+        raw = json.loads(_manifest().to_json())
+        raw["corpus_roots"] = 42
+        manifest_mod.manifest_path(origin).write_text(json.dumps(raw), encoding="utf-8")
+
+        with pytest.raises(IndexFetchError) as exc:
+            side_load(origin, index_path=tmp_path / "i.sqlite")
+
+        message = str(exc.value)
+        assert _unfollowable_fetch_offers(message) == []
+        assert "Re-stage" in message
+        assert manifest_mod.manifest_path(origin).name in message
+
+    @pytest.mark.parametrize(
+        ("label", "field", "value"),
+        [
+            ("a field of the wrong declared type", "corpus_roots", 42),
+            ("a non-integer schema version", "schema_version", "1"),
+            ("a schema version this build predates", "schema_version", 99),
+            ("a chunk_count that is a bool", "chunk_count", True),
+            ("a required field that is absent", "dimensions", None),
+        ],
+    )
+    def test_no_malformed_published_manifest_advises_refetching_it(
+        self, server, tmp_path: Path, label: str, field: str, value: object
+    ):
+        """The property over every way the parse can fail, not over five strings.
+
+        A matrix rather than one case because that is what the reported defect
+        was: three parser branches reached this module's single wrapper, the
+        review named one of them, #463 found a second while verifying it, and
+        the third is only distinguishable by which layer refuses first. Asserted
+        through the real fetch so it stays true of the message a *user* reads,
+        which is the composition of the parser's diagnosis and this module's
+        remedy -- and which of those two layers refuses a given malformation is
+        exactly what #463 is moving. That makes this the tripwire for the half
+        of the fix outside this PR's files: if a parser error starts naming a
+        bare ``index fetch`` again and it reaches this wrapper, the user gets
+        two remedies for one failure and the first one loops. This fails then,
+        rather than at the next review.
+        """
+        raw = json.loads(_manifest().to_json())
+        if value is None:
+            del raw[field]
+        else:
+            raw[field] = value
+        server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX] = json.dumps(raw).encode()
+        dest = tmp_path / "i.sqlite"
+
+        with pytest.raises(IndexFetchError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        message = str(exc.value)
+        assert _unfollowable_fetch_offers(message) == [], label
+        assert not dest.exists(), "nothing may be installed from a manifest that failed"
 
 
 class TestTransferFailures:
@@ -1450,6 +1670,45 @@ class TestCompareIndex:
         _reserialise(server, _manifest(embedding_model="other/model"))
 
         comparison = index_ops.compare_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert comparison.verdict == index_ops.VERDICT_INCOMPATIBLE
+
+    def test_an_unreadable_local_sidecar_outranks_an_incompatible_baseline(
+        self, server, tmp_path: Path
+    ):
+        """When both hold, the local failure is the one that is actionable.
+
+        The two verdicts were tested one at a time and the combination was not,
+        which is where the ordering hid: the incompatibility check ran first, so
+        this install reported ``incompatible`` -- and ``incompatible`` exits 0
+        while ``unreadable_local_index`` exits non-zero, so the state was
+        reported as the state it exists to be distinguished from *and* a script
+        gating on the exit code saw success.
+        """
+        _reserialise(server, _manifest(embedding_model="other/model"))
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(BODY)
+        manifest_mod.manifest_path(dest).write_text('{"aorta_version": "0.2', encoding="utf-8")
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict == index_ops.VERDICT_UNREADABLE_LOCAL_INDEX
+        assert comparison.local_error
+
+    def test_an_absent_local_index_still_yields_to_an_incompatible_baseline(
+        self, server, tmp_path: Path
+    ):
+        """The half of the ordering that is deliberately left alone.
+
+        Pinning it because the fix above moves one branch past this check and
+        not the other, and the asymmetry is the reasoning rather than an
+        oversight: there is no local read to have failed, so a baseline this
+        install could not use anyway is the more useful thing to say than "you
+        have no index".
+        """
+        _reserialise(server, _manifest(embedding_model="other/model"))
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=tmp_path / "absent")
 
         assert comparison.verdict == index_ops.VERDICT_INCOMPATIBLE
 

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -511,6 +511,10 @@ class TestAlreadyUpToDate:
         change report raised ``TypeError`` -- ``KeyError`` for a JSON object,
         which subscripts by key -- out of the comparison whose entire job is to
         report on a manifest that looks wrong, and past the CLI's error guard.
+
+        ``built_at`` is the control rather than a regression case: it was never
+        truncated, so it survived all four values before this fix and is here
+        to pin that rendering did not break the field that already worked.
         """
         dest = tmp_path / "i.sqlite"
         dest.write_bytes(b"stale")
@@ -1124,6 +1128,50 @@ class TestSideLoad:
     def test_a_missing_file_is_reported(self, tmp_path: Path):
         with pytest.raises(IndexFetchError, match="no index at"):
             side_load(tmp_path / "absent.sqlite", index_path=tmp_path / "i.sqlite")
+
+    def test_the_suggested_command_survives_an_awkward_path(self, tmp_path: Path):
+        """The refusal prints a command to run, and the path is the user's.
+
+        ``--from /home/o'brien/staged index.sqlite`` pasted back into a shell
+        does not parse -- unbalanced quote, then word splitting. Same class as
+        the pre-seed procedure #463 fixed; the remedy here is only the shell
+        half, since nothing interpolates into a Python literal.
+        """
+        import shlex
+
+        staging = tmp_path / "o'brien dir"
+        staging.mkdir()
+        origin = staging / ASSET_NAME
+        origin.write_bytes(BODY)
+        manifest_mod.write_manifest(origin, _manifest())
+
+        dest = tmp_path / "cache" / "index.sqlite"
+        dest.parent.mkdir(parents=True)
+        dest.write_bytes(b"an index built here")
+        manifest_mod.write_manifest(
+            dest,
+            _manifest(
+                corpus_roots=[str(tmp_path / "checkout")],
+                index_sha256=manifest_mod.sha256_file(dest),
+            ),
+        )
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            side_load(origin, index_path=dest)
+
+        suggested = next(
+            line for line in str(exc.value).splitlines() if "--from" in line
+        ).split(":", 1)[1]
+        # The whole point: it parses, and comes back as the path we passed in.
+        assert shlex.split(suggested) == [
+            "aorta",
+            "chat",
+            "index",
+            "fetch",
+            "--from",
+            str(origin.resolve()),
+            "--force",
+        ]
 
     def test_a_staged_index_without_a_manifest_is_refused(self, tmp_path: Path):
         """Side-loading is where a mismatch is most likely, not least.

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -328,6 +328,132 @@ class TestTheTimeoutsAreSplit:
         index_ops._widen_read_timeout(io.BytesIO(b"body"))
 
 
+class TestIdentityIsCheckedBeforeTheAsset:
+    """The ~1 KB manifest answers "is this usable" before the ~20 MB transfer.
+
+    It was downloaded first and validated last, so a reporter whose embedding
+    provider was misconfigured paid for the whole asset and its checksum before
+    being told the result was unusable. Fixing that configuration stops this
+    particular refusal; a later model or endpoint change hits the same waste.
+    """
+
+    def test_a_mismatch_never_requests_the_asset(self, server, tmp_path: Path):
+        _reserialise(server, _manifest(embedding_model="other/model"))
+
+        with pytest.raises(manifest_mod.IndexMismatchError):
+            fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert not any(url.endswith(ASSET_NAME) for url in server.requested), (
+            f"the index asset was transferred anyway: {server.requested}"
+        )
+
+    def test_a_future_schema_never_requests_the_asset(self, server, tmp_path: Path):
+        raw = json.loads(_manifest().to_json())
+        raw["schema_version"] = manifest_mod.SCHEMA_VERSION + 1
+        server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX] = json.dumps(raw).encode()
+
+        with pytest.raises(IndexFetchError, match="Upgrade aorta"):
+            fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert not any(url.endswith(ASSET_NAME) for url in server.requested)
+
+    def test_a_clean_fetch_still_requests_all_three(self, server, tmp_path: Path):
+        """Failing fast must not turn into fetching less than it needs."""
+        fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert sum(url.endswith(ASSET_NAME) for url in server.requested) == 1
+        assert any(url.endswith(manifest_mod.CHECKSUM_SUFFIX) for url in server.requested)
+
+    def test_the_installed_sidecar_keeps_a_newer_builders_extra_keys(self, server, tmp_path: Path):
+        """Forward tolerance is the reason the downloaded text is what lands.
+
+        ``Manifest.from_dict`` drops keys this version predates, so
+        re-serialising the dataclass would quietly strip them from the sidecar
+        this machine then keeps.
+        """
+        raw = json.loads(_manifest().to_json())
+        raw["some_future_field"] = "keep me"
+        server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX] = json.dumps(raw).encode()
+        dest = tmp_path / "i.sqlite"
+
+        fetch_index(version="0.2.1", index_path=dest)
+
+        installed = json.loads(manifest_mod.manifest_path(dest).read_text(encoding="utf-8"))
+        assert installed["some_future_field"] == "keep me"
+
+
+class TestAlreadyUpToDate:
+    """A refresh that would change nothing cost the whole transfer."""
+
+    def test_a_matching_local_sidecar_skips_the_asset(self, server, tmp_path: Path):
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        server.requested.clear()
+
+        result = fetch_index(version="0.2.1", index_path=dest)
+
+        assert result.up_to_date is True
+        assert not any(url.endswith(ASSET_NAME) for url in server.requested)
+        # Only the manifest: the checksum file is the asset's, so it is not
+        # worth a request when the asset is not being fetched.
+        assert all(url.endswith(manifest_mod.MANIFEST_SUFFIX) for url in server.requested)
+        assert dest.read_bytes() == BODY
+
+    def test_a_differing_published_index_is_installed_and_says_what_changed(
+        self, server, tmp_path: Path
+    ):
+        import hashlib
+
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+
+        newer = BODY + b" plus a commit"
+        digest = hashlib.sha256(newer).hexdigest()
+        server.assets[ASSET_NAME] = newer
+        server.assets[ASSET_NAME + manifest_mod.CHECKSUM_SUFFIX] = (
+            f"{digest}  {ASSET_NAME}\n".encode()
+        )
+        _reserialise(
+            server,
+            _manifest(
+                index_sha256=digest,
+                aorta_sha="99beef0" + "0" * 33,
+                corpus_digest="def456",
+                built_at="2026-09-05T00:00:00+00:00",
+            ),
+        )
+
+        result = fetch_index(version="0.2.1", index_path=dest)
+
+        assert result.up_to_date is False
+        assert dest.read_bytes() == newer
+        reported = " ".join(result.changes)
+        assert "corpus_digest" in reported
+        assert "aorta_sha" in reported
+        assert "built_at" in reported
+
+    def test_a_local_index_with_no_sidecar_is_fetched_rather_than_assumed(
+        self, server, tmp_path: Path
+    ):
+        """An index nothing describes is not evidence that it is up to date."""
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(BODY)
+
+        assert fetch_index(version="0.2.1", index_path=dest).up_to_date is False
+
+    def test_a_manifest_predating_index_sha256_does_not_compare_equal_on_nothing(
+        self, server, tmp_path: Path
+    ):
+        """Two empty digests must not read as a match and skip a needed download."""
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"stale")
+        manifest_mod.write_manifest(dest, _manifest(index_sha256=""))
+        _reserialise(server, _manifest(index_sha256=""))
+
+        assert fetch_index(version="0.2.1", index_path=dest).up_to_date is False
+        assert dest.read_bytes() == BODY
+
+
 class TestFetchFailures:
     def test_a_missing_asset_names_the_alternatives(self, monkeypatch, tmp_path: Path):
         fake = _FakeServer({})

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -1741,6 +1741,43 @@ class TestCompareIndex:
         assert comparison.differences, "the fields it disagrees on must be named"
         assert comparison.verdict != index_ops.VERDICT_UP_TO_DATE
 
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("embedding_model", "other/model"),
+            ("embedding_identity", "other-identity"),
+            ("dimensions", 512),
+            ("chunk_count", CHUNKS + 5),
+            ("built_at", "2001-01-01T00:00:00Z"),
+        ],
+    )
+    def test_no_field_the_table_prints_can_differ_under_an_up_to_date_verdict(
+        self, server, tmp_path: Path, field: str, value: object
+    ):
+        """The property, over the fields the command actually shows.
+
+        The first version of this fix bound the verdict to ``_refresh_notes``,
+        which was the right instinct aimed one function short: it named three
+        fields by hand while the table renders ten, so ``embedding_model`` and
+        ``dimensions`` could still differ under *up to date*. Both are now
+        derived from ``_SIDE_FIELDS``, and this is parametrised over that same
+        list rather than over three examples, so a field added to the table
+        cannot reintroduce the disagreement without failing here.
+        """
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        published = manifest_mod.read_manifest(dest)
+        manifest_mod.write_manifest(
+            dest, _manifest(index_sha256=published.index_sha256, **{field: value})
+        )
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict != index_ops.VERDICT_UP_TO_DATE
+        assert any(field in note for note in comparison.differences), (
+            f"{field} differs and the verdict says so, but the differences do not name it"
+        )
+
     def test_an_identical_pair_is_still_up_to_date_after_that(
         self, server, tmp_path: Path
     ):

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import http.client
 import io
 import json
+import shlex
 import urllib.error
 from pathlib import Path
 
@@ -40,7 +41,38 @@ MODEL = "BAAI/bge-small-en-v1.5"
 # identity, and a fixture that hardcoded it would make every manifest here
 # refuse for the wrong reason the next time the identity gains a component.
 COLLECTION = build_collection_name(LOCAL_COLLECTION_PREFIX, MODEL)
-BODY = b"pretend this is a 48 MB sqlite-vec index" * 16
+#: Rows in the published asset's chunk table, and therefore in its manifest.
+CHUNKS = 3
+
+
+def _published_asset(chunks: int = CHUNKS) -> bytes:
+    """The published index, as a real sqlite store rather than filler bytes.
+
+    ``fetch`` now opens the file before deciding a refresh would change nothing,
+    so an asset of opaque bytes would make every install here look damaged and
+    the skip unreachable. Only the chunk table is built: nothing in this module
+    queries vectors, and ``collection_chunk_count`` -- the reader behind that
+    decision -- counts the table with raw sqlite and no embedding provider.
+    """
+    import sqlite3
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as staging:
+        path = Path(staging) / ASSET_NAME
+        conn = sqlite3.connect(path)
+        try:
+            conn.execute(f'CREATE TABLE "chunks_{COLLECTION}" (id INTEGER PRIMARY KEY, text TEXT)')
+            conn.executemany(
+                f'INSERT INTO "chunks_{COLLECTION}" (text) VALUES (?)',
+                [(f"chunk {n}",) for n in range(chunks)],
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return path.read_bytes()
+
+
+BODY = _published_asset()
 
 
 @pytest.fixture(autouse=True)
@@ -66,6 +98,7 @@ def _manifest(**overrides) -> manifest_mod.Manifest:
         "chunk_size": 512,
         "chunk_overlap": 50,
         "index_sha256": hashlib.sha256(BODY).hexdigest(),
+        "chunk_count": CHUNKS,
         "built_at": "2026-09-01T00:00:00+00:00",
         "corpus_digest": "abc123",
     }
@@ -217,6 +250,9 @@ class TestFetch:
     def test_it_replaces_an_existing_index(self, server, tmp_path: Path):
         dest = tmp_path / "index.sqlite"
         dest.write_bytes(b"stale")
+        # An older *fetched* index, sidecar included -- which is what every
+        # install path leaves behind, and what a routine refresh runs over.
+        manifest_mod.write_manifest(dest, _manifest(index_sha256="", corpus_roots=["docs"]))
         fetch_index(version="0.2.1", index_path=dest)
         assert dest.read_bytes() == BODY
 
@@ -474,14 +510,79 @@ class TestAlreadyUpToDate:
         assert "aorta_sha" in reported
         assert "built_at" in reported
 
-    def test_a_local_index_with_no_sidecar_is_fetched_rather_than_assumed(
+    def test_a_matching_sidecar_over_a_damaged_store_is_not_up_to_date(
         self, server, tmp_path: Path
     ):
-        """An index nothing describes is not evidence that it is up to date."""
+        """The sidecar says which index was installed, not that it still is one.
+
+        ``check_index`` was already changed on this branch to open the store
+        rather than take the manifest's word for the contents. Deciding a
+        refresh on the manifest alone contradicted that from the other side:
+        the one command that would repair a damaged index reported it as
+        already current and did nothing.
+        """
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        # The sidecars are left exactly as the install wrote them; only the
+        # store is damaged, which is the pairing the shortcut used to trust.
+        dest.write_bytes(b"not a database any more")
+        server.requested.clear()
+
+        result = fetch_index(version="0.2.1", index_path=dest)
+
+        assert result.up_to_date is False
+        assert any(url.endswith(ASSET_NAME) for url in server.requested)
+        assert dest.read_bytes() == BODY, "the damaged store must be repaired"
+        assert index_ops.check_index(dest, strict=True).refusals == []
+
+    def test_a_matching_sidecar_over_a_store_missing_its_chunks_is_not_up_to_date(
+        self, server, tmp_path: Path
+    ):
+        """The other half of the same reader: readable, but not what is claimed.
+
+        A store that opens fine and holds a different number of chunks than the
+        manifest describes is the interrupted-install pairing, and it is
+        exactly what ``check_index`` was taught to catch.
+        """
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        dest.write_bytes(_published_asset(chunks=CHUNKS + 2))
+        server.requested.clear()
+
+        assert fetch_index(version="0.2.1", index_path=dest).up_to_date is False
+        assert any(url.endswith(ASSET_NAME) for url in server.requested)
+
+    def test_a_local_index_with_no_sidecar_is_refused_rather_than_assumed(
+        self, server, tmp_path: Path
+    ):
+        """An index nothing describes is not evidence that it is up to date.
+
+        It is not evidence that it is safe to replace either, which is why this
+        is a refusal rather than a silent re-fetch: the same file could be a
+        local build whose sidecar was lost, and nothing here can tell.
+        """
         dest = tmp_path / "i.sqlite"
         dest.write_bytes(BODY)
 
-        assert fetch_index(version="0.2.1", index_path=dest).up_to_date is False
+        with pytest.raises(index_ops.IndexOverwriteError, match="no manifest beside it"):
+            fetch_index(version="0.2.1", index_path=dest)
+
+    def test_forcing_over_a_sidecar_less_index_installs_rather_than_skips(
+        self, server, tmp_path: Path
+    ):
+        """``--force`` is the escape the refusal names, and it must transfer.
+
+        Reporting *up to date* here would be the original defect wearing a
+        flag: there is no sidecar to have matched anything.
+        """
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(BODY)
+
+        result = fetch_index(version="0.2.1", index_path=dest, force=True)
+
+        assert result.up_to_date is False
+        assert any(url.endswith(ASSET_NAME) for url in server.requested)
+        assert manifest_mod.read_manifest(dest).collection == COLLECTION
 
     def test_a_manifest_predating_index_sha256_does_not_compare_equal_on_nothing(
         self, server, tmp_path: Path
@@ -501,48 +602,52 @@ class TestAlreadyUpToDate:
         ids=["null", "int", "object", "list"],
     )
     @pytest.mark.parametrize("field_name", ["aorta_sha", "corpus_digest", "built_at"])
-    def test_a_non_string_digest_is_reported_rather_than_raised(
-        self, server, tmp_path: Path, field_name, value
-    ):
-        """The ``corpus_roots`` hole, one field over.
+    def test_a_non_string_digest_is_rendered_rather_than_raised(self, field_name, value):
+        """The ``corpus_roots`` hole, one field over, pinned at the renderer.
 
-        ``Manifest.from_dict`` type-checks nothing, so a hand-written sidecar
-        can record ``null`` where a digest belongs. Truncating that for the
-        change report raised ``TypeError`` -- ``KeyError`` for a JSON object,
-        which subscripts by key -- out of the comparison whose entire job is to
-        report on a manifest that looks wrong, and past the CLI's error guard.
+        Truncating a field that is not a string raised ``TypeError`` --
+        ``KeyError`` for a JSON object, which subscripts by key -- out of the
+        comparison whose entire job is to report on a manifest that looks
+        wrong, and past the CLI's error guard. Both ``fetch``'s change report
+        and ``index status``'s differences come from this one function, so
+        pinning it here covers both.
+
+        Driven with constructed manifests rather than a sidecar on disk,
+        deliberately. Whether ``Manifest.from_dict`` *admits* a null digest is
+        the parser's question, and PR #463 is tightening it to refuse one; what
+        this test is about is the renderer downstream surviving a field it did
+        not expect, whichever way the parser lands. Routed through the parser,
+        it would silently change verdict on a merge it has no conflict with.
 
         ``built_at`` is the control rather than a regression case: it was never
         truncated, so it survived all four values before this fix and is here
         to pin that rendering did not break the field that already worked.
         """
-        dest = tmp_path / "i.sqlite"
-        dest.write_bytes(b"stale")
-        raw = {**json.loads(_manifest(index_sha256="").to_json()), field_name: value}
-        manifest_mod.manifest_path(dest).write_text(json.dumps(raw), encoding="utf-8")
+        changes = index_ops._refresh_notes(_manifest(**{field_name: value}), _manifest())
 
-        result = fetch_index(version="0.2.1", index_path=dest)
+        assert any(change.startswith(field_name) for change in changes), changes
 
-        assert result.up_to_date is False
-        assert dest.read_bytes() == BODY
-        assert any(change.startswith(field_name) for change in result.changes), result.changes
-
-    def test_a_non_string_digest_does_not_break_the_comparison_either(
+    def test_an_empty_digest_is_reported_as_unknown_rather_than_as_nothing(
         self, server, tmp_path: Path
     ):
-        """``index status`` reads the same notes, so it had the same traceback."""
+        """``index status`` reads the same notes, so it had the same traceback.
+
+        Empty rather than non-string, because that is the shape that reaches
+        this path through a real sidecar both before and after #463's parser
+        change -- and it is the case the renderer's ``None`` handling exists
+        for: blank becomes the caller's own word for a missing field, not the
+        string ``"None"``.
+        """
         dest = tmp_path / "i.sqlite"
         dest.write_bytes(b"stale")
-        raw = {
-            **json.loads(_manifest(index_sha256="d" * 64).to_json()),
-            "aorta_sha": None,
-        }
-        manifest_mod.manifest_path(dest).write_text(json.dumps(raw), encoding="utf-8")
+        manifest_mod.write_manifest(dest, _manifest(index_sha256="d" * 64, aorta_sha=""))
 
         comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
 
         assert comparison.verdict == index_ops.VERDICT_PUBLISHED_DIFFERS
-        assert any("aorta_sha" in difference for difference in comparison.differences)
+        reported = " ".join(comparison.differences)
+        assert "aorta_sha: unknown ->" in reported, comparison.differences
+        assert "None" not in reported
 
 
 class TestFetchFailures:
@@ -657,20 +762,96 @@ class TestTheFetchedSchemaIsChecked:
     def test_a_non_integer_schema_is_an_index_fetch_error(self, server, tmp_path, value):
         """Not a ``TypeError`` out of a comparison the caller never guarded.
 
-        The refusal now comes from ``Manifest.from_dict``'s field-type check
-        rather than from ``ensure_supported_schema``, because
-        ``schema_version`` was one of several fields being compared or sliced
-        on trust and the check moved to the boundary they all cross. Same
-        exception, same "installs nothing", earlier and better message -- so
-        the assertion is on the property rather than on either wording.
+        Matched on this module's own wrapper rather than on the sentence
+        ``manifest.py`` raises underneath it. Which of the two layers refuses a
+        non-integer ``schema_version`` -- the field type check or the supported
+        -schema check -- is that module's business, and PR #463 is moving it
+        from the second to the first. What ``fetch`` owes the caller either way
+        is an ``IndexFetchError`` that names the manifest it could not use, and
+        no partial install.
         """
         self._serve_schema(server, value)
         dest = tmp_path / "i.sqlite"
 
-        with pytest.raises(IndexFetchError, match="is not usable"):
+        with pytest.raises(IndexFetchError) as exc:
             fetch_index(version="0.2.1", index_path=dest)
 
+        message = str(exc.value)
+        assert "is not usable" in message
+        assert "schema" in message
+        assert ASSET_NAME + manifest_mod.MANIFEST_SUFFIX in message
         assert not dest.exists()
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("embedding_identity", 42),
+            ("embedding_model", None),
+            ("collection", ["c"]),
+            ("corpus_digest", 7),
+            ("corpus_roots", "src/aorta"),
+            ("dimensions", "384"),
+            ("chunk_count", True),
+        ],
+    )
+    def test_a_published_field_of_the_wrong_type_is_refused_not_raised(
+        self, server, tmp_path: Path, field, value
+    ):
+        """The tolerance for a wrong-typed field stops at the network boundary.
+
+        A *local* sidecar that records nonsense must stay readable, because the
+        reports whose job is to say what is wrong with it have to be able to
+        read it -- so ``from_dict`` type-checks nothing and this module's
+        readers absorb it. A *downloaded* one has nowhere better to fail than
+        here, and not everything it reaches is in this module: ``validate``
+        calls ``.split()`` on ``embedding_identity``, so a published manifest
+        carrying ``42`` there came out of the CLI as an ``AttributeError``
+        traceback rather than as the refusal a bad manifest is supposed to be.
+
+        Parametrised across the types rather than pinned to that one field,
+        because the hole was the missing check and not the field that exposed
+        it.
+        """
+        raw = json.loads(
+            server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX].decode("utf-8")
+        )
+        raw[field] = value
+        server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX] = json.dumps(raw).encode()
+        dest = tmp_path / "i.sqlite"
+
+        with pytest.raises(IndexFetchError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        message = str(exc.value)
+        assert "is not usable" in message
+        assert field in message
+        assert not dest.exists(), "a manifest this build cannot read must install nothing"
+
+    def test_the_404_options_also_name_the_destination_that_was_asked_for(
+        self, server, tmp_path: Path, monkeypatch
+    ):
+        """The fourth site with the same defect, found by sweeping for it.
+
+        Copilot named three refusals whose remedy dropped a non-default
+        ``--output``. This one is the same class one layer down: a missing
+        asset offers three ordinary invocations, and an ordinary invocation
+        installs to the cache -- so a reader who had asked for a different path
+        gets three lines that all act somewhere else.
+        """
+        monkeypatch.setattr(settings, "index_path", str(tmp_path / "cache.sqlite"))
+        del server.assets[ASSET_NAME]
+        dest = tmp_path / "elsewhere.sqlite"
+
+        with pytest.raises(IndexFetchError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        flag = f"--output {shlex.quote(str(dest))}"
+        options = [
+            line for line in str(exc.value).splitlines() if "aorta chat index" in line
+        ]
+        assert len(options) == 3, options
+        for line in options:
+            assert flag in line, f"option acts on the wrong index: {line!r}"
 
     def test_an_older_schema_is_still_accepted(self, server, tmp_path: Path):
         """Forward tolerance runs one way only; an older sidecar still parses."""
@@ -912,6 +1093,34 @@ class TestFetchWillNotSilentlyDiscardALocalBuild:
         assert server.requested == [], "it should refuse before any request"
         assert fetch_index(version="0.2.1", index_path=dest, force=True).index_path == dest
 
+    def test_a_truncated_sidecar_is_refused_rather_than_read_as_absence(
+        self, server, tmp_path: Path
+    ):
+        """Unreadable and absent used to be the same answer, and they are not.
+
+        A half-written sidecar makes the index beside it unclassifiable, which
+        is the state the guard above already refuses when the *value* is
+        unreadable. Collapsing it into "there is nothing here" refused the
+        better-informed case and waved through the worse one.
+        """
+        dest = tmp_path / "i.sqlite"
+        self._install_local_build(dest)
+        manifest_mod.manifest_path(dest).write_text('{"aorta_version": "0.2', encoding="utf-8")
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        assert "no manifest beside it" in str(exc.value)
+        assert dest.read_bytes() == b"an index built here"
+        assert server.requested == [], "it should refuse before any request"
+
+    def test_a_first_install_is_still_a_first_install(self, server, tmp_path: Path):
+        """The whole point of the distinction: a path that does not exist."""
+        dest = tmp_path / "nested" / "i.sqlite"
+
+        assert fetch_index(version="0.2.1", index_path=dest).index_path == dest
+        assert dest.read_bytes() == BODY
+
     def test_side_load_carries_the_same_guard(self, tmp_path: Path):
         """Or `--from` becomes the way around it by accident."""
         staging = tmp_path / "usb"
@@ -927,6 +1136,78 @@ class TestFetchWillNotSilentlyDiscardALocalBuild:
             side_load(origin, index_path=dest)
 
         assert side_load(origin, index_path=dest, force=True).index_path == dest
+
+    def test_side_load_also_refuses_a_manifest_less_destination(self, tmp_path: Path):
+        """Both guards read the destination the same way, so both had the hole."""
+        staging = tmp_path / "usb"
+        staging.mkdir()
+        origin = staging / ASSET_NAME
+        origin.write_bytes(BODY)
+        manifest_mod.write_manifest(origin, _manifest())
+
+        dest = tmp_path / "notes.txt"
+        dest.write_text("a year of notes", encoding="utf-8")
+
+        with pytest.raises(index_ops.IndexOverwriteError, match="no manifest beside it"):
+            side_load(origin, index_path=dest)
+
+        assert dest.read_text(encoding="utf-8") == "a year of notes"
+        assert side_load(origin, index_path=dest, force=True).index_path == dest
+
+    def test_the_remedy_names_the_index_that_was_refused(
+        self, server, tmp_path: Path, monkeypatch
+    ):
+        """``fetch --force`` without ``--output`` fetches over a different index.
+
+        The refused index stays refused and the cache -- which the user did not
+        mention and may well have wanted -- is replaced instead. The flag is
+        carried only when it differs from what the bare command resolves to, so
+        the ordinary refusal over the cache keeps its short line.
+        """
+        monkeypatch.setattr(settings, "index_path", str(tmp_path / "cache.sqlite"))
+        dest = tmp_path / "elsewhere" / "i.sqlite"
+        dest.parent.mkdir()
+        self._install_local_build(dest)
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        message = str(exc.value)
+        assert f"aorta chat index fetch --output {shlex.quote(str(dest))} --force" in message
+
+        monkeypatch.setattr(settings, "index_path", str(dest))
+        with pytest.raises(index_ops.IndexOverwriteError) as plain:
+            fetch_index(version="0.2.1", index_path=dest)
+        assert "--output" not in str(plain.value)
+
+    def test_the_side_load_remedy_keeps_both_the_source_and_the_destination(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """``--from`` survived the refusal; the destination beside it did not.
+
+        Pasting the advertised line therefore side-loaded the staged file over
+        the configured cache -- an install the user never asked for, from a
+        refusal about a different path entirely.
+        """
+        monkeypatch.setattr(settings, "index_path", str(tmp_path / "cache.sqlite"))
+        staging = tmp_path / "usb"
+        staging.mkdir()
+        origin = staging / ASSET_NAME
+        origin.write_bytes(BODY)
+        manifest_mod.write_manifest(origin, _manifest())
+
+        dest = tmp_path / "elsewhere" / "i.sqlite"
+        dest.parent.mkdir()
+        self._install_local_build(dest)
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            side_load(origin, index_path=dest)
+
+        remedy = (
+            f"aorta chat index fetch --from {shlex.quote(str(origin))} "
+            f"--output {shlex.quote(str(dest))} --force"
+        )
+        assert remedy in str(exc.value)
 
 
 class TestCompareIndex:
@@ -1001,6 +1282,27 @@ class TestCompareIndex:
         assert comparison.verdict == index_ops.VERDICT_NO_LOCAL_INDEX
         assert comparison.local is None
         assert comparison.published is not None
+        assert comparison.local_error == ""
+
+    def test_an_unreadable_sidecar_is_not_reported_as_no_local_index(
+        self, server, tmp_path: Path
+    ):
+        """The verdict said nothing had been installed, over a file sitting there.
+
+        Both states read the manifest and got ``None``, so ``index status``
+        told the one person looking at it the opposite of what was wrong.
+        """
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(BODY)
+        manifest_mod.manifest_path(dest).write_text('{"aorta_version": "0.2', encoding="utf-8")
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict == index_ops.VERDICT_UNREADABLE_LOCAL_INDEX
+        assert comparison.local_error, "the cause must be reported, not only the state"
+        payload = index_ops.comparison_to_dict(comparison)
+        assert payload["local"]["error"] == comparison.local_error
+        assert payload["up_to_date"] is False
 
     def test_a_differing_published_index_lists_the_fields(self, server, tmp_path: Path):
         dest = tmp_path / "i.sqlite"
@@ -1162,7 +1464,10 @@ class TestSideLoad:
         suggested = next(
             line for line in str(exc.value).splitlines() if "--from" in line
         ).split(":", 1)[1]
-        # The whole point: it parses, and comes back as the path we passed in.
+        # The whole point: it parses, and both paths come back as the ones we
+        # passed in. ``--output`` is here because the destination is not the
+        # configured cache -- a remedy that dropped it would side-load over an
+        # index the user never named while leaving this refusal standing.
         assert shlex.split(suggested) == [
             "aorta",
             "chat",
@@ -1170,6 +1475,8 @@ class TestSideLoad:
             "fetch",
             "--from",
             str(origin.resolve()),
+            "--output",
+            str(dest),
             "--force",
         ]
 

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -657,6 +657,132 @@ class TestTransferFailures:
             fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
 
 
+class TestProvenanceIsReadOffTheManifest:
+    """Which side built an index decides which guard applies to it.
+
+    Inferred rather than stored: a schema field would be clearer and would
+    cost a manifest version bump, and the two corpora already label their roots
+    differently.
+    """
+
+    def test_published_roots_are_repository_relative(self):
+        manifest = _manifest(corpus_roots=["src/aorta", "docs", "README.md"])
+        assert index_ops.index_provenance(manifest) == index_ops.PROVENANCE_PUBLISHED
+
+    def test_a_local_build_records_one_absolute_path(self):
+        manifest = _manifest(corpus_roots=["/home/someone/src/aorta"])
+        assert index_ops.index_provenance(manifest) == index_ops.PROVENANCE_LOCAL
+
+    def test_a_manifest_predating_the_field_is_unknown_rather_than_guessed(self):
+        """Neither guard fires without positive evidence of what it protects."""
+        assert index_ops.index_provenance(_manifest()) == index_ops.PROVENANCE_UNKNOWN
+
+    def test_a_renamed_published_subpath_is_still_published(self):
+        """Read the shape, not the list, so renaming `docs/` reclassifies nothing."""
+        manifest = _manifest(corpus_roots=["src/aorta", "documentation"])
+        assert index_ops.index_provenance(manifest) == index_ops.PROVENANCE_PUBLISHED
+
+    def test_the_same_rule_classifies_a_corpus_before_it_is_built(self):
+        """So `build` can compare what it is about to make against what is there."""
+        from aorta.chat.rag import corpus as corpus_mod
+
+        published = corpus_mod.Corpus(
+            base=Path("/repo"), subpaths=("src/aorta",), roots_label=corpus_mod.PUBLISHED_SUBPATHS
+        )
+        assert index_ops.corpus_provenance(published) == index_ops.PROVENANCE_PUBLISHED
+
+        local = corpus_mod.Corpus(base=Path("/repo"), subpaths=(".",), roots_label=("/repo",))
+        assert index_ops.corpus_provenance(local) == index_ops.PROVENANCE_LOCAL
+
+
+class TestFetchWillNotSilentlyDiscardALocalBuild:
+    """The two directions are not symmetric, so neither is a blanket guard.
+
+    A fetched index costs a download to replace. A locally built one may not be
+    reproducible at all -- the tree it indexed may have moved, and an
+    air-gapped node cannot re-download the weights. So the incoming-index paths
+    guard against overwriting a local build, and only that.
+    """
+
+    @staticmethod
+    def _install_local_build(dest: Path) -> None:
+        dest.write_bytes(b"an index built here")
+        manifest_mod.write_manifest(
+            dest,
+            _manifest(
+                corpus_roots=[str(dest.parent / "checkout")],
+                index_sha256=manifest_mod.sha256_file(dest),
+            ),
+        )
+
+    def test_fetch_over_a_local_build_refuses_and_names_the_flag(self, server, tmp_path: Path):
+        dest = tmp_path / "i.sqlite"
+        self._install_local_build(dest)
+
+        with pytest.raises(index_ops.IndexOverwriteError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        message = str(exc.value)
+        assert "built on this machine" in message
+        assert "--force" in message
+        assert dest.read_bytes() == b"an index built here"
+
+    def test_it_refuses_before_any_request(self, server, tmp_path: Path):
+        """The local manifest is free to read, so the refusal costs no network."""
+        dest = tmp_path / "i.sqlite"
+        self._install_local_build(dest)
+
+        with pytest.raises(index_ops.IndexOverwriteError):
+            fetch_index(version="0.2.1", index_path=dest)
+
+        assert server.requested == []
+
+    def test_force_overwrites_it(self, server, tmp_path: Path):
+        dest = tmp_path / "i.sqlite"
+        self._install_local_build(dest)
+
+        fetch_index(version="0.2.1", index_path=dest, force=True)
+
+        assert dest.read_bytes() == BODY
+
+    def test_force_also_re_downloads_an_identical_asset(self, server, tmp_path: Path):
+        """Otherwise the up-to-date short-circuit would swallow the override."""
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        server.requested.clear()
+
+        assert fetch_index(version="0.2.1", index_path=dest, force=True).up_to_date is False
+        assert any(url.endswith(ASSET_NAME) for url in server.requested)
+
+    def test_a_routine_refresh_of_a_fetched_index_is_not_refused(self, server, tmp_path: Path):
+        """`fetch` is the documented way to refresh; demanding --force would
+        train people to always pass it."""
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"stale")
+        manifest_mod.write_manifest(
+            dest, _manifest(corpus_roots=["src/aorta", "docs", "README.md"], index_sha256="0" * 64)
+        )
+
+        assert fetch_index(version="0.2.1", index_path=dest).index_path == dest
+        assert dest.read_bytes() == BODY
+
+    def test_side_load_carries_the_same_guard(self, tmp_path: Path):
+        """Or `--from` becomes the way around it by accident."""
+        staging = tmp_path / "usb"
+        staging.mkdir()
+        origin = staging / ASSET_NAME
+        origin.write_bytes(BODY)
+        manifest_mod.write_manifest(origin, _manifest())
+
+        dest = tmp_path / "i.sqlite"
+        self._install_local_build(dest)
+
+        with pytest.raises(index_ops.IndexOverwriteError, match="built on this machine"):
+            side_load(origin, index_path=dest)
+
+        assert side_load(origin, index_path=dest, force=True).index_path == dest
+
+
 class TestSideLoad:
     """Decision 21b: index only. The model is a documented pre-seed, not an asset."""
 

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -612,6 +612,44 @@ class TestAlreadyUpToDate:
         assert "index file it describes is not" in refusals
         assert "different embedding provider" not in refusals
 
+    def test_a_dangling_symlink_destination_is_refused_rather_than_consumed(
+        self, server, tmp_path: Path
+    ):
+        """``exists()`` follows the link, so it answers about the wrong path.
+
+        A broken symlink reported "nothing here" and the guards read that as a
+        first install, so ``replace()`` consumed the link without ``--force``.
+        Somebody pointed it somewhere on purpose, and a *broken* one is exactly
+        the case where its owner has not noticed it went -- so silently turning
+        it into a real index removes the evidence of both facts.
+        """
+        dest = tmp_path / "i.sqlite"
+        dest.symlink_to(tmp_path / "never-existed.sqlite")
+
+        with pytest.raises(IndexFetchError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        assert "symlink" in str(exc.value)
+        assert dest.is_symlink(), "the link itself must survive a refusal"
+        assert "--force" in str(exc.value)
+
+    def test_a_dangling_symlink_is_refused_by_side_load_too(self, tmp_path: Path):
+        """The second of the three write paths; ``build`` is covered in
+        ``test_index_build.py``. Asserted per path because they have separate
+        guards and it was one shared reader that misread the state."""
+        origin = tmp_path / "staged" / ASSET_NAME
+        origin.parent.mkdir(parents=True)
+        origin.write_bytes(BODY)
+        manifest_mod.write_manifest(origin, _manifest())
+        dest = tmp_path / "i.sqlite"
+        dest.symlink_to(tmp_path / "never-existed.sqlite")
+
+        with pytest.raises(IndexFetchError) as exc:
+            side_load(origin, index_path=dest)
+
+        assert "symlink" in str(exc.value)
+        assert dest.is_symlink()
+
     def test_a_local_index_with_no_sidecar_is_refused_rather_than_assumed(
         self, server, tmp_path: Path
     ):
@@ -1672,6 +1710,49 @@ class TestCompareIndex:
         comparison = index_ops.compare_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
 
         assert comparison.verdict == index_ops.VERDICT_INCOMPATIBLE
+
+    def test_a_matching_hash_under_differing_fields_is_not_up_to_date(
+        self, server, tmp_path: Path
+    ):
+        """The verdict may not contradict the table printed underneath it.
+
+        ``status`` shows both, so a sidecar carrying the published
+        ``index_sha256`` beside a different ``aorta_sha`` said *up to date* over
+        a list of the fields that differ. The hash predicate is right for
+        ``fetch`` -- the transfer genuinely would change nothing -- and wrong
+        here, where the question is whether this is the published index rather
+        than whether the bytes would move.
+        """
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        published = manifest_mod.read_manifest(dest)
+        manifest_mod.write_manifest(
+            dest,
+            _manifest(
+                index_sha256=published.index_sha256,
+                aorta_sha="f" * 40,
+                corpus_digest="e" * 64,
+            ),
+        )
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.up_to_date is False
+        assert comparison.differences, "the fields it disagrees on must be named"
+        assert comparison.verdict != index_ops.VERDICT_UP_TO_DATE
+
+    def test_an_identical_pair_is_still_up_to_date_after_that(
+        self, server, tmp_path: Path
+    ):
+        """The other side of the same change, so the stricter predicate cannot
+        quietly make the common case report a difference that is not there."""
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict == index_ops.VERDICT_UP_TO_DATE
+        assert comparison.differences == []
 
     def test_an_unreadable_local_sidecar_outranks_an_incompatible_baseline(
         self, server, tmp_path: Path

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -327,6 +327,48 @@ class TestTheTimeoutsAreSplit:
         """Best-effort: a stub response must not turn into a failed download."""
         index_ops._widen_read_timeout(io.BytesIO(b"body"))
 
+    def test_every_request_widens_its_body_read_not_only_the_asset(
+        self, server, tmp_path: Path, monkeypatch
+    ):
+        """The sidecar reads were left on the connect budget.
+
+        ``urlopen``'s single timeout governs every subsequent read, so the two
+        sidecar bodies kept the 30 s connect budget while only the asset was
+        widened -- and the sidecars are the *first* requests the command makes,
+        so theirs is the failure a user reads as "fetch does not work here".
+        """
+        widened: dict[str, list[float]] = {}
+        real = server.urlopen
+
+        def _urlopen(url, timeout=None):
+            response = real(url, timeout=timeout)
+            calls: list[float] = []
+            widened[url] = calls
+            sock = type("Sock", (), {"settimeout": lambda _self, value: calls.append(value)})()
+            response.fp = type("Fp", (), {"raw": type("Raw", (), {"_sock": sock})()})()
+            return response
+
+        monkeypatch.setattr(index_ops.urllib.request, "urlopen", _urlopen)
+        fetch_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert len(widened) == 3, "manifest, checksum and asset"
+        assert all(calls == [index_ops._READ_TIMEOUT] for calls in widened.values()), widened
+
+    def test_falling_back_to_the_shorter_budget_is_logged_not_silent(self, caplog):
+        """The attribute chain is a standard-library detail, so its loss must be visible.
+
+        ``response.fp.raw._sock`` is not API. The day it moves, the only
+        symptom would be downloads failing at 30 s again with nothing anywhere
+        saying the split had stopped applying.
+        """
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger=index_ops.logger.name):
+            index_ops._widen_read_timeout(io.BytesIO(b"body"))
+
+        assert "connect timeout" in caplog.text
+        assert str(index_ops._READ_TIMEOUT) in caplog.text
+
 
 class TestIdentityIsCheckedBeforeTheAsset:
     """The ~1 KB manifest answers "is this usable" before the ~20 MB transfer.
@@ -452,6 +494,51 @@ class TestAlreadyUpToDate:
 
         assert fetch_index(version="0.2.1", index_path=dest).up_to_date is False
         assert dest.read_bytes() == BODY
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, 42, {"sha": "abc"}, ["abc"]],
+        ids=["null", "int", "object", "list"],
+    )
+    @pytest.mark.parametrize("field_name", ["aorta_sha", "corpus_digest", "built_at"])
+    def test_a_non_string_digest_is_reported_rather_than_raised(
+        self, server, tmp_path: Path, field_name, value
+    ):
+        """The ``corpus_roots`` hole, one field over.
+
+        ``Manifest.from_dict`` type-checks nothing, so a hand-written sidecar
+        can record ``null`` where a digest belongs. Truncating that for the
+        change report raised ``TypeError`` -- ``KeyError`` for a JSON object,
+        which subscripts by key -- out of the comparison whose entire job is to
+        report on a manifest that looks wrong, and past the CLI's error guard.
+        """
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"stale")
+        raw = {**json.loads(_manifest(index_sha256="").to_json()), field_name: value}
+        manifest_mod.manifest_path(dest).write_text(json.dumps(raw), encoding="utf-8")
+
+        result = fetch_index(version="0.2.1", index_path=dest)
+
+        assert result.up_to_date is False
+        assert dest.read_bytes() == BODY
+        assert any(change.startswith(field_name) for change in result.changes), result.changes
+
+    def test_a_non_string_digest_does_not_break_the_comparison_either(
+        self, server, tmp_path: Path
+    ):
+        """``index status`` reads the same notes, so it had the same traceback."""
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"stale")
+        raw = {
+            **json.loads(_manifest(index_sha256="d" * 64).to_json()),
+            "aorta_sha": None,
+        }
+        manifest_mod.manifest_path(dest).write_text(json.dumps(raw), encoding="utf-8")
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict == index_ops.VERDICT_PUBLISHED_DIFFERS
+        assert any("aorta_sha" in difference for difference in comparison.differences)
 
 
 class TestFetchFailures:

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -790,6 +790,7 @@ class TestTheFetchedSchemaIsChecked:
             ("collection", ["c"]),
             ("corpus_digest", 7),
             ("corpus_roots", "src/aorta"),
+            ("corpus_roots", [42]),
             ("dimensions", "384"),
             ("chunk_count", True),
         ],
@@ -810,7 +811,12 @@ class TestTheFetchedSchemaIsChecked:
 
         Parametrised across the types rather than pinned to that one field,
         because the hole was the missing check and not the field that exposed
-        it.
+        it. ``corpus_roots: [42]`` is in the list because checking the
+        container and not its elements let that value *install*, and the next
+        fetch then classified the sidecar it had just written as unclassifiable
+        and refused a routine refresh -- a boundary check that admits what the
+        guard behind it rejects is worse than none, because the damage surfaces
+        one command later.
         """
         raw = json.loads(
             server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX].decode("utf-8")
@@ -852,6 +858,32 @@ class TestTheFetchedSchemaIsChecked:
         assert len(options) == 3, options
         for line in options:
             assert flag in line, f"option acts on the wrong index: {line!r}"
+
+    @pytest.mark.parametrize("missing", ["manifest", "checksum"])
+    def test_a_sidecar_404_remedy_also_names_the_destination(
+        self, server, tmp_path: Path, monkeypatch, missing
+    ):
+        """The two sites the first sweep missed, on both sidecars.
+
+        `_download_text`'s 404 offers `aorta chat index build`, which resolves
+        `--output` to the cache -- so a fetch aimed anywhere else was told to
+        build over an index unrelated to the failure. Same property as the
+        refusal remedies; a different function, which is why grepping for the
+        property rather than for `_pasteable` is what finds it.
+        """
+        monkeypatch.setattr(settings, "index_path", str(tmp_path / "cache.sqlite"))
+        suffix = (
+            manifest_mod.MANIFEST_SUFFIX if missing == "manifest" else manifest_mod.CHECKSUM_SUFFIX
+        )
+        del server.assets[ASSET_NAME + suffix]
+        dest = tmp_path / "elsewhere.sqlite"
+
+        with pytest.raises(IndexFetchError) as exc:
+            fetch_index(version="0.2.1", index_path=dest)
+
+        message = str(exc.value)
+        assert "companion sidecar" in message
+        assert f"aorta chat index build --output {shlex.quote(str(dest))}" in message
 
     def test_an_older_schema_is_still_accepted(self, server, tmp_path: Path):
         """Forward tolerance runs one way only; an older sidecar still parses."""
@@ -1154,6 +1186,52 @@ class TestFetchWillNotSilentlyDiscardALocalBuild:
         assert dest.read_text(encoding="utf-8") == "a year of notes"
         assert side_load(origin, index_path=dest, force=True).index_path == dest
 
+    def test_a_sidecar_that_is_not_utf8_is_refused_rather_than_raised(
+        self, server, tmp_path: Path
+    ):
+        """``read_manifest`` wraps a bad *parse*, not a bad *read*.
+
+        So one class of unreadable sidecar -- a truncated multi-byte write, or
+        a file something else owns -- came out of the guard as
+        ``UnicodeDecodeError`` rather than as the unreadable-destination state
+        the rest of them produce. Same answer, one layer lower.
+        """
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"an index built here")
+        manifest_mod.manifest_path(dest).write_bytes(b"\xff\xfe not utf-8 at all")
+
+        with pytest.raises(index_ops.IndexOverwriteError, match="no manifest beside it"):
+            fetch_index(version="0.2.1", index_path=dest)
+
+        assert dest.read_bytes() == b"an index built here"
+
+    def test_a_local_sidecar_with_a_wrong_typed_field_does_not_crash_the_guard(
+        self, server, tmp_path: Path
+    ):
+        """Local manifests are untyped on purpose, so the guard must absorb it.
+
+        ``_unusable_reasons`` promised never to raise while catching only
+        ``ManifestError``. A sidecar recording ``embedding_identity: 42`` makes
+        ``check_index`` raise ``AttributeError`` rendering the identity, and a
+        non-string ``aorta_sha`` raises ``TypeError`` slicing it -- both past
+        that handler and out of the build guard as a traceback. A malformed
+        field is a reason this install cannot use the index, which is what the
+        helper returns; it is not a reason to crash the caller.
+        """
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"an index built here")
+        manifest_mod.write_manifest(dest, _manifest(corpus_roots=[str(tmp_path / "checkout")]))
+        path = manifest_mod.manifest_path(dest)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw["embedding_identity"] = 42
+        raw["aorta_sha"] = None
+        path.write_text(json.dumps(raw), encoding="utf-8")
+
+        # Reached through the guard, which is the caller that used to crash.
+        assert index_ops._unusable_reasons(dest), "a malformed sidecar is a reason, not a crash"
+        with pytest.raises(index_ops.IndexOverwriteError):
+            fetch_index(version="0.2.1", index_path=dest)
+
     def test_the_remedy_names_the_index_that_was_refused(
         self, server, tmp_path: Path, monkeypatch
     ):
@@ -1275,6 +1353,29 @@ class TestCompareIndex:
         comparison = index_ops.compare_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
 
         assert comparison.verdict == index_ops.VERDICT_NO_BASELINE
+
+    def test_the_no_baseline_remedy_names_the_index_that_was_asked_about(
+        self, server, tmp_path: Path, monkeypatch
+    ):
+        """``status --index`` and ``build --output`` are one path, two flags.
+
+        The remedy carried in ``baseline_error`` is a build command, and a bare
+        one builds the cache -- so a reader who asked about a different index
+        was told to build over the one they had not mentioned. Translating
+        ``--index`` into ``--output`` is the whole fix, but it has to happen,
+        because the user cannot be expected to.
+        """
+        monkeypatch.setattr(settings, "index_path", str(tmp_path / "cache.sqlite"))
+        del server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX]
+        asked_about = tmp_path / "elsewhere.sqlite"
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=asked_about)
+
+        assert comparison.verdict == index_ops.VERDICT_NO_BASELINE
+        assert (
+            f"aorta chat index build --output {shlex.quote(str(asked_about))}"
+            in comparison.baseline_error
+        )
 
     def test_no_local_index_is_its_own_verdict(self, server, tmp_path: Path):
         comparison = index_ops.compare_index(version="0.2.1", index_path=tmp_path / "absent")
@@ -1479,6 +1580,54 @@ class TestSideLoad:
             str(dest),
             "--force",
         ]
+
+    @pytest.mark.parametrize(
+        ("field", "value"), [("embedding_identity", 42), ("corpus_roots", [42])]
+    )
+    def test_a_staged_manifest_is_held_to_the_same_field_types(
+        self, tmp_path: Path, field, value
+    ):
+        """The hand-carried sidecar is the *most* likely to be hand-edited.
+
+        The downloaded path got the field-type check and this one did not, so
+        `--from` remained the way in for a wrong-typed field:
+        ``embedding_identity: 42`` escaped as ``AttributeError`` out of the
+        provider validation, and ``corpus_roots: [42]`` installed and poisoned
+        the next refresh.
+        """
+        staging = tmp_path / "usb"
+        staging.mkdir()
+        origin = staging / ASSET_NAME
+        origin.write_bytes(BODY)
+        manifest_mod.write_manifest(origin, _manifest())
+        path = manifest_mod.manifest_path(origin)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw[field] = value
+        path.write_text(json.dumps(raw), encoding="utf-8")
+
+        dest = tmp_path / "i.sqlite"
+        with pytest.raises(IndexFetchError) as exc:
+            side_load(origin, index_path=dest)
+
+        assert "is not usable" in str(exc.value)
+        assert field in str(exc.value)
+        assert not dest.exists()
+
+    def test_a_staged_sidecar_that_is_not_utf8_is_a_sentence_not_a_traceback(
+        self, tmp_path: Path
+    ):
+        """Same read/parse split as the destination guard, on the source side."""
+        staging = tmp_path / "usb"
+        staging.mkdir()
+        origin = staging / ASSET_NAME
+        origin.write_bytes(BODY)
+        manifest_mod.manifest_path(origin).write_bytes(b"\xff\xfe not utf-8")
+
+        dest = tmp_path / "i.sqlite"
+        with pytest.raises(IndexFetchError, match="is not usable"):
+            side_load(origin, index_path=dest)
+
+        assert not dest.exists()
 
     def test_a_staged_index_without_a_manifest_is_refused(self, tmp_path: Path):
         """Side-loading is where a mismatch is most likely, not least.

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -783,6 +783,171 @@ class TestFetchWillNotSilentlyDiscardALocalBuild:
         assert side_load(origin, index_path=dest, force=True).index_path == dest
 
 
+class TestCompareIndex:
+    """Gap 4b: "is the cached index the same as the remote one, and which is newer".
+
+    Answerable from the two manifests alone, which is what `nightly.yml`
+    already does in bash to decide whether to republish -- so the capability
+    was proven and load-bearing for the release process while the CLI did not
+    expose it.
+    """
+
+    def test_an_identical_pair_is_up_to_date(self, server, tmp_path: Path):
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict == index_ops.VERDICT_UP_TO_DATE
+        assert comparison.up_to_date is True
+
+    def test_it_transfers_only_the_manifest(self, server, tmp_path: Path):
+        """The whole point of comparing manifests rather than indexes."""
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+        server.requested.clear()
+
+        index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert server.requested
+        assert all(url.endswith(manifest_mod.MANIFEST_SUFFIX) for url in server.requested)
+
+    def test_it_writes_nothing(self, server, tmp_path: Path):
+        """Read-only, so it is safe to suggest to someone who is already stuck."""
+        dest = tmp_path / "cache" / "i.sqlite"
+        dest.parent.mkdir(parents=True)
+
+        index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert list(dest.parent.iterdir()) == []
+
+    def test_an_unreachable_baseline_is_not_reported_as_up_to_date(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """`nightly.yml`'s own comment: no baseline must not read as no change."""
+
+        def _refuse(url, timeout=None):  # noqa: ARG001 - signature match
+            raise urllib.error.URLError("Network is unreachable")
+
+        monkeypatch.setattr(index_ops.urllib.request, "urlopen", _refuse)
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(BODY)
+        manifest_mod.write_manifest(dest, _manifest())
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict == index_ops.VERDICT_NO_BASELINE
+        assert comparison.up_to_date is False
+        assert "Network is unreachable" in comparison.baseline_error
+
+    def test_a_missing_published_manifest_is_no_baseline_rather_than_an_exception(
+        self, server, tmp_path: Path
+    ):
+        del server.assets[ASSET_NAME + manifest_mod.MANIFEST_SUFFIX]
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert comparison.verdict == index_ops.VERDICT_NO_BASELINE
+
+    def test_no_local_index_is_its_own_verdict(self, server, tmp_path: Path):
+        comparison = index_ops.compare_index(version="0.2.1", index_path=tmp_path / "absent")
+
+        assert comparison.verdict == index_ops.VERDICT_NO_LOCAL_INDEX
+        assert comparison.local is None
+        assert comparison.published is not None
+
+    def test_a_differing_published_index_lists_the_fields(self, server, tmp_path: Path):
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"stale")
+        manifest_mod.write_manifest(
+            dest,
+            _manifest(
+                corpus_roots=["src/aorta", "docs", "README.md"],
+                index_sha256="0" * 64,
+                corpus_digest="old123",
+                aorta_sha="0ldsha0" + "0" * 33,
+            ),
+        )
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict == index_ops.VERDICT_PUBLISHED_DIFFERS
+        reported = " ".join(comparison.differences)
+        assert "corpus_digest" in reported
+        assert "aorta_sha" in reported
+
+    def test_a_locally_built_index_is_not_called_stale(self, server, tmp_path: Path):
+        """ "Newer" is the wrong frame here: fetching would discard it.
+
+        ``built_at`` is wall-clock from whoever built the index, so a local one
+        can carry a later timestamp over *older* source. This verdict says what
+        is true -- the two are not versions of each other.
+        """
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"built here")
+        manifest_mod.write_manifest(
+            dest, _manifest(corpus_roots=["/home/dev/aorta"], index_sha256="1" * 64)
+        )
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=dest)
+
+        assert comparison.verdict == index_ops.VERDICT_LOCALLY_BUILT
+        assert comparison.provenance == index_ops.PROVENANCE_LOCAL
+
+    def test_an_unusable_published_index_says_so_rather_than_offering_it(
+        self, server, tmp_path: Path
+    ):
+        """Being newer does not make an index this install cannot query useful."""
+        _reserialise(server, _manifest(embedding_model="other/model"))
+
+        comparison = index_ops.compare_index(version="0.2.1", index_path=tmp_path / "i.sqlite")
+
+        assert comparison.verdict == index_ops.VERDICT_INCOMPATIBLE
+
+    def test_the_payload_names_which_asset_it_compared_against(self, server, tmp_path: Path):
+        """A dev install resolves to the rolling tag, so the verdict is
+        ambiguous without this."""
+        comparison = index_ops.compare_index(
+            index_path=tmp_path / "i.sqlite",
+            source=resolve_source(installed="0.2.2.dev122+g45edc3d"),
+        )
+        payload = index_ops.comparison_to_dict(comparison)
+
+        assert ROLLING_TAG in payload["compared_against"]["source"]
+        assert ROLLING_TAG in payload["compared_against"]["manifest_url"]
+
+    def test_every_verdict_has_a_sentence(self):
+        """A raw enum value reaching the user would be the register's own complaint."""
+        for verdict in (
+            index_ops.VERDICT_UP_TO_DATE,
+            index_ops.VERDICT_PUBLISHED_DIFFERS,
+            index_ops.VERDICT_LOCALLY_BUILT,
+            index_ops.VERDICT_INCOMPATIBLE,
+            index_ops.VERDICT_NO_LOCAL_INDEX,
+            index_ops.VERDICT_NO_BASELINE,
+        ):
+            assert index_ops._VERDICT_SUMMARY[verdict] != verdict
+
+    def test_the_payload_carries_every_field_the_register_asked_for(self, server, tmp_path: Path):
+        dest = tmp_path / "i.sqlite"
+        fetch_index(version="0.2.1", index_path=dest)
+
+        payload = index_ops.comparison_to_dict(
+            index_ops.compare_index(version="0.2.1", index_path=dest)
+        )
+
+        for side in ("local", "published"):
+            for key in (
+                "embedding_model",
+                "embedding_identity",
+                "built_at",
+                "aorta_sha",
+                "corpus_digest",
+                "index_sha256",
+            ):
+                assert key in payload[side], f"{side} is missing {key}"
+
+
 class TestSideLoad:
     """Decision 21b: index only. The model is a documented pre-seed, not an asset."""
 

--- a/tests/chat/test_index_fetch.py
+++ b/tests/chat/test_index_fetch.py
@@ -379,7 +379,7 @@ class TestIdentityIsCheckedBeforeTheAsset:
         fetch_index(version="0.2.1", index_path=dest)
 
         installed = json.loads(manifest_mod.manifest_path(dest).read_text(encoding="utf-8"))
-        assert installed["some_future_field"] == "keep me"
+        assert installed.get("some_future_field") == "keep me"
 
 
 class TestAlreadyUpToDate:
@@ -677,6 +677,38 @@ class TestProvenanceIsReadOffTheManifest:
         """Neither guard fires without positive evidence of what it protects."""
         assert index_ops.index_provenance(_manifest()) == index_ops.PROVENANCE_UNKNOWN
 
+    @pytest.mark.parametrize(
+        "roots",
+        ["src/aorta", "docs", None, 7, {"src/aorta": 1}, ["src/aorta", 42]],
+        ids=["str-with-slash", "bare-str", "null", "int", "object", "mixed-list"],
+    )
+    def test_a_recorded_value_that_is_not_a_list_of_paths_is_invalid(self, roots):
+        """``Manifest.from_dict`` type-checks nothing, so this has to.
+
+        Iterating a string yields characters and ``Path("/").is_absolute()`` is
+        true, so ``"src/aorta"`` classified as a *local build* and ``"docs"``
+        as a *published* one -- both answers derived from nothing -- while
+        ``[42]`` raised ``TypeError`` straight past the CLI's error guard.
+        """
+        manifest = manifest_mod.Manifest.from_dict(
+            {**json.loads(_manifest().to_json()), "corpus_roots": roots}
+        )
+
+        assert index_ops.index_provenance(manifest) == index_ops.PROVENANCE_INVALID
+
+    def test_the_status_payload_reports_an_unusable_value_as_null(self):
+        """Not as the characters of a string, which is what ``list()`` gave."""
+        manifest = manifest_mod.Manifest.from_dict(
+            {**json.loads(_manifest().to_json()), "corpus_roots": "src/aorta"}
+        )
+
+        assert index_ops._side(manifest)["corpus_roots"] is None
+
+    def test_the_two_sides_of_the_payload_declare_one_key_set(self):
+        """The invariant, not the instance: a new field is covered for free."""
+        assert set(index_ops._side(_manifest())) == set(index_ops._SIDE_FIELDS)
+        assert set(index_ops._side(None)) == set(index_ops._SIDE_FIELDS)
+
     def test_a_renamed_published_subpath_is_still_published(self):
         """Read the shape, not the list, so renaming `docs/` reclassifies nothing."""
         manifest = _manifest(corpus_roots=["src/aorta", "documentation"])
@@ -765,6 +797,29 @@ class TestFetchWillNotSilentlyDiscardALocalBuild:
 
         assert fetch_index(version="0.2.1", index_path=dest).index_path == dest
         assert dest.read_bytes() == BODY
+
+    def test_an_unclassifiable_manifest_is_refused_rather_than_guessed(
+        self, server, tmp_path: Path
+    ):
+        """The guard must not be reachable around by a broken sidecar.
+
+        A hand-carried manifest recording ``corpus_roots`` as a scalar used to
+        be classified by iterating it: ``"docs"`` came out *published*, so the
+        fetch went ahead and overwrote whatever was there, and ``[42]`` left a
+        ``TypeError`` traceback. Neither answer is available, so this refuses.
+        """
+        dest = tmp_path / "i.sqlite"
+        dest.write_bytes(b"an index of unknown provenance")
+        raw = json.loads(_manifest(index_sha256="0" * 64).to_json())
+        raw["corpus_roots"] = "docs"
+        manifest_mod.manifest_path(dest).write_text(json.dumps(raw), encoding="utf-8")
+
+        with pytest.raises(index_ops.IndexOverwriteError, match="cannot classify"):
+            fetch_index(version="0.2.1", index_path=dest)
+
+        assert dest.read_bytes() == b"an index of unknown provenance"
+        assert server.requested == [], "it should refuse before any request"
+        assert fetch_index(version="0.2.1", index_path=dest, force=True).index_path == dest
 
     def test_side_load_carries_the_same_guard(self, tmp_path: Path):
         """Or `--from` becomes the way around it by accident."""

--- a/tests/cli/test_chat_index_cli.py
+++ b/tests/cli/test_chat_index_cli.py
@@ -327,6 +327,53 @@ class TestStatus:
         # the rolling tag and the verdict would otherwise be ambiguous.
         assert "v0.2.1" in result.output
 
+    def test_the_table_names_the_embedding_identity_not_only_the_model(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        """The model name alone is not what has to match for two vectors to compare.
+
+        For a remote provider the identity carries the endpoint too, so two
+        rows reading the same ``model`` can still be two vector spaces that
+        share a name -- and the *incompatible* verdict could be printed over a
+        table showing no visible difference at all.
+        """
+        self._serve(
+            monkeypatch,
+            manifest_overrides={"embedding_identity": "https://gateway.internal/v1\nbge-small"},
+        )
+
+        result = runner.invoke(
+            chat, ["index", "status", "--version", "0.2.1", "--index", str(tmp_path / "absent")]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "identity" in result.output
+        assert "gateway.internal" in result.output
+
+    def test_a_multi_line_identity_does_not_break_the_columns(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        """``vector_identity`` is newline-joined, and this is a fixed-width table.
+
+        Printed as recorded it would put the model on its own unlabelled row
+        and misalign every row after it.
+        """
+        self._serve(
+            monkeypatch,
+            manifest_overrides={"embedding_identity": "https://gateway.internal/v1\nbge-small"},
+        )
+
+        result = runner.invoke(
+            chat, ["index", "status", "--version", "0.2.1", "--index", str(tmp_path / "absent")]
+        )
+
+        identity_rows = [
+            line for line in result.output.splitlines() if line.strip().startswith("identity")
+        ]
+        assert len(identity_rows) == 1, result.output
+        # Both halves on the one row, so nothing below it is pushed out of column.
+        assert "gateway.internal" in identity_rows[0] and "bge-small" in identity_rows[0]
+
     def test_the_json_form_is_machine_readable(
         self, runner: CliRunner, tmp_path: Path, monkeypatch
     ):

--- a/tests/cli/test_chat_index_cli.py
+++ b/tests/cli/test_chat_index_cli.py
@@ -91,6 +91,62 @@ class TestBuild:
         assert "Traceback" not in result.output
 
 
+class TestFetchSaysWhatItIsDoingFirst:
+    """The reported symptom: `index fetch` printed nothing for minutes.
+
+    Every ``click.echo`` in the command ran after ``fetch_index`` returned, so
+    the resolved tag, the URL and the destination -- all known before any
+    network I/O -- appeared on success only.
+    """
+
+    @staticmethod
+    def _unreachable(monkeypatch) -> None:
+        import urllib.error
+        import urllib.request
+
+        def _refuse(url, timeout=None):  # noqa: ARG001 - signature match
+            raise urllib.error.URLError("Network is unreachable")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _refuse)
+
+    def test_the_target_is_printed_even_when_the_fetch_fails(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        self._unreachable(monkeypatch)
+
+        result = runner.invoke(
+            chat,
+            ["index", "fetch", "--version", "0.2.1", "--output", str(tmp_path / "i.sqlite")],
+        )
+
+        assert result.exit_code != 0
+        assert "v0.2.1" in result.output
+        assert "aorta-chat-index.sqlite" in result.output
+        assert str(tmp_path / "i.sqlite") in result.output
+
+    def test_it_goes_to_stderr_so_json_mode_stays_parseable(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        """`--json` is advertised for scripting, so stdout must hold only the object."""
+        self._unreachable(monkeypatch)
+
+        result = runner.invoke(
+            chat,
+            [
+                "index",
+                "fetch",
+                "--version",
+                "0.2.1",
+                "--json",
+                "--output",
+                str(tmp_path / "i.sqlite"),
+            ],
+        )
+
+        assert "Fetching the published index" in result.stderr
+        assert "Fetching the published index" not in result.stdout
+
+
 class TestFetchErrors:
     def test_a_mismatch_refusal_reaches_the_user_intact(
         self, runner: CliRunner, tmp_path: Path, monkeypatch

--- a/tests/cli/test_chat_index_cli.py
+++ b/tests/cli/test_chat_index_cli.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from aorta.cli import main
 from aorta.cli.chat import chat
 
 _CHAT_AVAILABLE = importlib.util.find_spec("langchain_core") is not None
@@ -32,8 +33,17 @@ def runner() -> CliRunner:
 
 
 class TestRegistration:
+    """Driven through ``aorta``, not through the ``chat`` group object.
+
+    Every other test in this file invokes the subgroup directly, which is fine
+    for the behaviour of one command and blind to how it is reached: anything
+    about the registration itself, or about top-level option handling, is
+    invisible from inside the group. Registration is exactly what this class
+    asserts, so it goes through the real root command.
+    """
+
     def test_the_index_group_lists_its_subcommands(self, runner: CliRunner):
-        result = runner.invoke(chat, ["index", "--help"])
+        result = runner.invoke(main, ["chat", "index", "--help"])
         assert result.exit_code == 0, result.output
         for subcommand in ("build", "fetch", "digest", "eval", "runs"):
             assert subcommand in result.output
@@ -44,7 +54,7 @@ class TestRegistration:
         So the run-artifact collection that ``search_run_artifacts`` and the
         tool prompts both advertise could not be built by any documented route.
         """
-        result = runner.invoke(chat, ["index", "runs", "--help"])
+        result = runner.invoke(main, ["chat", "index", "runs", "--help"])
         assert result.exit_code == 0, result.output
         # Whitespace-normalised: Click rewraps the docstring to the terminal
         # width, so a phrase can land across two lines.
@@ -53,13 +63,20 @@ class TestRegistration:
         assert "never part of a published index" in help_text
 
     def test_doctor_is_registered(self, runner: CliRunner):
-        result = runner.invoke(chat, ["doctor", "--help"])
+        result = runner.invoke(main, ["chat", "doctor", "--help"])
         assert result.exit_code == 0, result.output
 
     def test_the_chat_help_lists_index_and_doctor(self, runner: CliRunner):
-        result = runner.invoke(chat, ["--help"])
+        result = runner.invoke(main, ["chat", "--help"])
+        assert result.exit_code == 0, result.output
         assert "index" in result.output
         assert "doctor" in result.output
+
+    def test_index_status_is_reachable_from_the_root_command(self, runner: CliRunner):
+        """The newest subcommand, asserted where a registration slip would show."""
+        result = runner.invoke(main, ["chat", "index", "status", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--json" in result.output
 
     def test_fetch_documents_both_resolution_and_side_loading(self, runner: CliRunner):
         result = runner.invoke(chat, ["index", "fetch", "--help"])
@@ -196,6 +213,26 @@ class TestFetchErrors:
         )
         assert result.exit_code != 0
         assert "no manifest beside" in result.output
+
+    def test_an_overwrite_refusal_names_the_flag_that_proceeds(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        """A refusal a user cannot act on is a traceback with better manners.
+
+        The destination exists and has no manifest, so nothing can say whether
+        it is an index -- and this is the one refusal reachable by a plain typo,
+        which is the case that most needs the escape spelled out.
+        """
+        target = tmp_path / "notes.txt"
+        target.write_text("a year of notes", encoding="utf-8")
+
+        result = runner.invoke(chat, ["index", "build", "--output", str(target)])
+
+        assert result.exit_code != 0
+        assert "no manifest beside it" in result.output
+        assert "--force" in result.output
+        assert "Traceback" not in result.output
+        assert target.read_text(encoding="utf-8") == "a year of notes"
 
 
 class TestDoctorOutput:
@@ -445,6 +482,59 @@ class TestStatus:
         assert result.exit_code == 1
         assert "no published baseline" in result.output
         assert "up to date" not in result.output
+
+    def test_an_unreadable_local_index_exits_non_zero_and_says_it_is_there(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        """The other verdict that means "no comparison was made".
+
+        It used to report "no local index; nothing has been installed yet" over
+        a file sitting at the path it just named -- and exit zero, so a health
+        check scripted on this command called a broken index fine.
+        """
+        from aorta.chat.rag import manifest as manifest_mod
+
+        self._serve(monkeypatch)
+        index = tmp_path / "i.sqlite"
+        index.write_bytes(b"an index of some kind")
+        manifest_mod.manifest_path(index).write_text('{"aorta_version": "0.2', encoding="utf-8")
+
+        result = runner.invoke(
+            chat, ["index", "status", "--version", "0.2.1", "--index", str(index)]
+        )
+
+        assert result.exit_code == 1
+        assert "nothing has been installed yet" not in result.output
+        assert "no manifest beside it can be read" in result.output
+        assert "Traceback" not in result.output
+
+    def test_a_difference_past_the_column_width_is_still_shown(self, capsys):
+        """Otherwise the row that exists to show a difference shows agreement.
+
+        Truncating to 42 characters is fine for a digest, which differs in its
+        first few when it differs at all. It is not fine for a remote identity:
+        ``remote / <endpoint> / <model>`` puts the discriminating part last, so
+        two different endpoints on the same provider render as the same cell
+        while ``model`` and ``dimensions`` above them stay identical -- the
+        exact case the identity row was added for.
+
+        Driven through the renderer rather than a served manifest, because what
+        is pinned here is the table's own shape.
+        """
+        from aorta.cli.chat import _echo_status_table
+
+        shared = "remote / https://embeddings.internal.example/v1/api/"
+        local = {"embedding_identity": shared + "east", "embedding_model": "e5-large"}
+        published = {"embedding_identity": shared + "west", "embedding_model": "e5-large"}
+
+        _echo_status_table(local, published)
+        text = capsys.readouterr().out
+
+        assert shared + "east" in text
+        assert shared + "west" in text
+        assert "identity differs past the column width" in text
+        # A row that agrees is not repeated; the table stays a table.
+        assert "model differs past the column width" not in text
 
     def test_an_unreachable_host_is_a_sentence_not_a_traceback(
         self, runner: CliRunner, tmp_path: Path, monkeypatch

--- a/tests/cli/test_chat_index_cli.py
+++ b/tests/cli/test_chat_index_cli.py
@@ -255,6 +255,127 @@ class TestDoctorOutput:
         assert payload["checks"][0]["name"] == "python"
 
 
+class TestStatus:
+    """The read-only comparison, which CI had in bash and the user did not."""
+
+    @staticmethod
+    def _serve(monkeypatch, *, manifest_overrides=None, reachable=True) -> None:
+        """Publish a manifest the local provider accepts, or nothing at all."""
+        import io
+        import urllib.error
+        import urllib.request
+
+        from aorta.chat.config import settings
+        from aorta.chat.rag import manifest as manifest_mod
+        from aorta.chat.rag.embeddings.base import build_collection_name
+        from aorta.chat.rag.embeddings.fastembed_bge import LOCAL_COLLECTION_PREFIX
+
+        model = "BAAI/bge-small-en-v1.5"
+        monkeypatch.setattr(settings, "embedding_provider", "local")
+        monkeypatch.setattr(settings, "embedding_model", model)
+
+        values = {
+            "aorta_version": "0.2.1",
+            "aorta_sha": "b" * 40,
+            "embedding_provider": "local",
+            "embedding_model": model,
+            "dimensions": 384,
+            # Derived, so group E's rename flows through with no edit here.
+            "collection": build_collection_name(LOCAL_COLLECTION_PREFIX, model),
+            "chunk_size": settings.chunk_size,
+            "chunk_overlap": settings.chunk_overlap,
+            "index_sha256": "c" * 64,
+            "corpus_roots": ["src/aorta", "docs", "README.md"],
+            "corpus_digest": "published123",
+            "built_at": "2026-09-01T00:00:00+00:00",
+        }
+        values.update(manifest_overrides or {})
+        body = manifest_mod.Manifest(**values).to_json().encode()
+
+        class _Response(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self.close()
+                return False
+
+        def _urlopen(url, timeout=None):  # noqa: ARG001 - signature match
+            if not reachable:
+                raise urllib.error.URLError("Network is unreachable")
+            return _Response(body)
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+    def test_it_is_registered_alongside_the_other_index_commands(self, runner: CliRunner):
+        result = runner.invoke(chat, ["index", "--help"])
+        assert "status" in result.output
+
+    def test_it_prints_both_sides_and_a_verdict(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        self._serve(monkeypatch)
+
+        result = runner.invoke(
+            chat, ["index", "status", "--version", "0.2.1", "--index", str(tmp_path / "absent")]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "verdict:" in result.output
+        assert "local" in result.output and "published" in result.output
+        # Which asset was compared against, since a dev install resolves to
+        # the rolling tag and the verdict would otherwise be ambiguous.
+        assert "v0.2.1" in result.output
+
+    def test_the_json_form_is_machine_readable(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        self._serve(monkeypatch)
+
+        result = runner.invoke(
+            chat,
+            [
+                "index",
+                "status",
+                "--version",
+                "0.2.1",
+                "--index",
+                str(tmp_path / "absent"),
+                "--json",
+            ],
+        )
+
+        payload = json.loads(result.stdout)
+        assert payload["verdict"] == "no_local_index"
+        assert payload["up_to_date"] is False
+        assert payload["published"]["corpus_digest"] == "published123"
+
+    def test_no_baseline_exits_non_zero_and_is_not_called_up_to_date(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        """The one rendering that would be actively misleading."""
+        self._serve(monkeypatch, reachable=False)
+
+        result = runner.invoke(
+            chat, ["index", "status", "--version", "0.2.1", "--index", str(tmp_path / "absent")]
+        )
+
+        assert result.exit_code == 1
+        assert "no published baseline" in result.output
+        assert "up to date" not in result.output
+
+    def test_an_unreachable_host_is_a_sentence_not_a_traceback(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        self._serve(monkeypatch, reachable=False)
+
+        result = runner.invoke(
+            chat, ["index", "status", "--version", "0.2.1", "--index", str(tmp_path / "absent")]
+        )
+
+        assert "Traceback" not in result.output
+
+
 class TestDigest:
     def test_it_prints_json_a_workflow_can_parse(self, runner: CliRunner, tmp_path: Path):
         """nightly.yml reads this to decide whether to rebuild at all."""

--- a/tests/cli/test_chat_index_cli.py
+++ b/tests/cli/test_chat_index_cli.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -100,6 +101,49 @@ class TestBuild:
         assert result.exit_code != 0
         assert "corpus path does not exist" in result.output
         assert "Traceback" not in result.output
+
+    @pytest.mark.skipif(
+        getattr(os, "geteuid", lambda: 1)() == 0,
+        reason="root ignores the directory mode this test relies on",
+    )
+    def test_an_unwritable_output_directory_is_a_sentence_not_a_traceback(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        """The one filesystem refusal ``_guard`` was not catching.
+
+        Its ``known`` tuple listed ``FileNotFoundError`` and so covered the
+        missing index while leaving every other errno unwrapped. Found on the
+        human review of this PR: a build into a read-only parent raised
+        ``PermissionError: [Errno 13] ... '.aorta-index-cbr5wi0q'`` -- a
+        traceback whose most prominent noun is a staging directory the user
+        never chose and cannot look up, while the two facts they need were
+        already in the message. Asserted on the *shape* rather than the errno,
+        because the point is the category: a report about the path the command
+        was given is printed, not raised.
+        """
+        locked = tmp_path / "locked"
+        locked.mkdir()
+        (tmp_path / "corpus").mkdir()
+        (tmp_path / "corpus" / "a.md").write_text("hello", encoding="utf-8")
+        locked.chmod(0o500)
+        try:
+            result = runner.invoke(
+                chat,
+                [
+                    "index",
+                    "build",
+                    "--path",
+                    str(tmp_path / "corpus"),
+                    "--output",
+                    str(locked / "index.sqlite"),
+                ],
+            )
+        finally:
+            locked.chmod(0o700)
+
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        assert str(locked) in result.output
 
     def test_public_only_refuses_a_non_public_tree(self, runner: CliRunner, tmp_path: Path):
         """The guard the workflow relies on, exercised through the flag CI passes."""

--- a/tests/cli/test_chat_index_cli.py
+++ b/tests/cli/test_chat_index_cli.py
@@ -345,10 +345,45 @@ class TestStatus:
             ],
         )
 
+        assert result.exit_code == 0, result.output
         payload = json.loads(result.stdout)
-        assert payload["verdict"] == "no_local_index"
-        assert payload["up_to_date"] is False
-        assert payload["published"]["corpus_digest"] == "published123"
+        assert payload.get("verdict") == "no_local_index"
+        assert payload.get("up_to_date") is False
+        assert payload.get("published", {}).get("corpus_digest") == "published123"
+
+    def test_both_sides_carry_the_same_keys_with_no_baseline(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        """``--json`` is a contract, so a key must not vanish in a branch.
+
+        ``published`` was an empty object whenever the baseline could not be
+        read, which is the run a consumer most needs to inspect -- and the
+        happy-path test above could not see it, because every key is there.
+        """
+        self._serve(monkeypatch, reachable=False)
+
+        result = runner.invoke(
+            chat,
+            [
+                "index",
+                "status",
+                "--version",
+                "0.2.1",
+                "--index",
+                str(tmp_path / "absent"),
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        from aorta.chat.rag.index_ops import _SIDE_FIELDS
+
+        for key in _SIDE_FIELDS:
+            assert key in payload.get("published", {}), f"published lost {key}"
+            assert key in payload.get("local", {}), f"local lost {key}"
+            assert payload["published"][key] is None
+        assert payload.get("baseline_error")
 
     def test_no_baseline_exits_non_zero_and_is_not_called_up_to_date(
         self, runner: CliRunner, tmp_path: Path, monkeypatch

--- a/tests/cli/test_chat_index_workflows.py
+++ b/tests/cli/test_chat_index_workflows.py
@@ -200,6 +200,66 @@ class TestDigestSkip:
         assert not any("digest" in str(step.get("id", "")) for step in job["steps"])
 
 
+class TestTheBuildCommandTheWorkflowsRunStillParses:
+    """Both jobs invoke `index build` non-interactively, and cannot be prompted.
+
+    A new option on that command -- an overwrite guard's ``--force``, say --
+    must not become something the workflow has to pass. If the published build
+    ever stops running, the published index stops updating at all, which is
+    worse than whatever the guard was protecting against, and the workflow is
+    the one caller that cannot report the problem to a human.
+    """
+
+    @staticmethod
+    def _build_argv(job: dict) -> list[str]:
+        """The `aorta chat index ...` arguments the job's build step passes."""
+        run = next(s["run"] for s in job["steps"] if "index build" in str(s.get("run", "")))
+        # The step is a shell block with a line continuation and a `mkdir`
+        # before it, so the command is recovered rather than assumed.
+        command = " ".join(run.replace("\\\n", " ").split())
+        _, _, arguments = command.partition("aorta chat index build")
+        assert arguments.strip(), "no arguments found on the build command"
+        return arguments.split()
+
+    @_needs_chat
+    def test_the_workflow_argv_is_accepted_by_the_command(self, index_job):
+        """Parsed against the real command, so a renamed flag fails here."""
+        import click
+
+        from aorta.cli.chat import chat
+
+        name, job = index_job
+        index_build = chat.commands["index"].commands["build"]
+
+        with click.Context(index_build) as ctx:
+            # ``make_context`` parses and type-checks without running the body,
+            # which would need a real public checkout and an embedding model.
+            index_build.make_context("build", self._build_argv(job), parent=ctx)
+
+    def test_the_build_writes_into_a_directory_it_creates_itself(self, index_job):
+        """So "the destination already exists" is never true on this path."""
+        name, job = index_job
+        step = next(s for s in job["steps"] if "index build" in str(s.get("run", "")))
+
+        assert "mkdir -p index-out" in step["run"], name
+        assert "--output index-out/" in " ".join(step["run"].replace("\\\n", " ").split()), name
+
+    def test_no_option_the_workflow_omits_is_required(self, index_job):
+        """A required option would fail the job rather than prompt it."""
+        from aorta.cli.chat import chat
+
+        name, job = index_job
+        index_build = chat.commands["index"].commands["build"]
+        passed = {argument for argument in self._build_argv(job) if argument.startswith("--")}
+
+        for parameter in index_build.params:
+            if parameter.required:
+                assert any(opt in passed for opt in parameter.opts), (
+                    f"{name}: index build now requires {parameter.name}, "
+                    "which the workflow does not pass"
+                )
+
+
 class TestJobHygiene:
     def test_the_index_job_is_separate_from_the_publish_job(self):
         """It must not be able to delay or fail the wheel/PyPI publish."""


### PR DESCRIPTION
## Problem

The index write paths were silent for minutes, overwrote without asking, and
could not be compared against the published asset (gaps 4, 4a, 4b in
[docs/chat/chat-run-gaps.md](docs/chat/chat-run-gaps.md)).

- **No output at all** during `index fetch` — not a `Downloading` line followed
  by silence, but nothing. `_download_text`, which fetches the manifest and the
  checksum, had no logging whatsoever; the only `logger.info("Downloading %s")`
  sat on the *third* request, in `_download`. Every `click.echo` in
  `index_fetch` runs after `fetch_index` has already returned.
- `_HTTP_TIMEOUT = 300` applied **per request**, so an unreachable host cost
  five silent minutes on the ~1 KB manifest alone.
- Embedding-identity validation ran only after the full asset transfer and its
  checksum, so a fetch that was guaranteed to be discarded still moved ~20 MB
  first.
- Nothing compared local against published, and nothing guarded an overwrite.

## Fix

Ordered so the first two items alone fix the reported hang.

1. **Announce the work before the first request.** Echo the resolved tag, URL
   and destination up front; surface `resolve_source`'s dev-version notes there
   rather than via `FetchResult.warnings`; give `_download_text` the log line
   `_download` already had.
2. **Split the timeout** into a short connect and a longer read timeout.
3. **Fail fast on identity** — validate straight after the manifest download.
   The checksum verification stays where it is, because it genuinely needs the
   bytes.
4. **"Already up to date" short-circuit** comparing the remote manifest's
   `index_sha256` against the local sidecar, exiting before the asset transfer.
5. **Report transfer progress** against `Content-Length` in `_download`.
6. **Guard the overwrites, asymmetrically.** A fetched index costs a download to
   replace; a locally built one may not be reproducible at all, because the tree
   it indexed may have moved and a node with no egress cannot re-download the
   embedding weights. `side_load` is the third write path and gets the same
   treatment. Refuse-with-instruction following `config init --force`, never an
   interactive prompt, so scripts and CI behave identically. The full matrix is
   in `docs/chat/rag-index.md`.
7. **`aorta chat index status`** downloads only the manifest and prints both
   sides' embedding model and identity, `built_at`, `aorta_sha`,
   `corpus_digest` and `index_sha256`, plus a one-line verdict and `--json`. The
   reference implementation is the `digest` step of the `chat-index` job in
   `.github/workflows/nightly.yml`, which already does this comparison in bash
   to decide whether to republish.

## Decisions taken

**The first version of this guard would have broken the nightly.** Keyed on
"destination exists", it refused any `build` into a populated directory — and
`nightly.yml` and `release.yml` both run
`aorta chat index build --public-only --output index-out/...` non-interactively.
Under a restored `index-out/` cache that guard stops the published index
updating at all, which is a worse outcome than the bug it was fixing, and it
would have failed silently in the sense that nobody notices a *stale* published
asset for a while.

The guard now compares the **incoming corpus against what is already there** and
refuses only a genuine narrowing. `build --public-only` over a fetched index is
the same corpus, so it proceeds; `build` with the default `local_corpus`
(`src/aorta` alone) over a fetched index would drop `docs/` and `README.md` out
of retrieval, so that is what gets refused.

**The CI path was verified, not assumed.** Both workflows were read, the literal
`index build` command each runs was extracted, and that command's code path was
run three times over the same directory, succeeding every time.
`tests/cli/test_chat_index_workflows.py` pins the workflow shape so a drift in
the workflow file is caught here rather than at 3am.

**Provenance is inferred from `corpus_roots`, with no schema bump.** The
existing field already distinguishes a locally built index from a fetched one,
so this needed no manifest version change and no migration.

## Testing

`1034 passed, 0 failed, 12 skipped` on `tests/chat tests/cli/test_chat*.py`,
against a `964 passed, 0 failed, 12 skipped` baseline on `main`.

## Notes for the reviewer

Developed in a parallel worktree off `4b4553ef` alongside four sibling PRs with
deliberately disjoint file sets. A trial merge of all five was verified clean and
their union suite is green at `1162 passed, 0 failed, 12 skipped`.

Two coordination notes:

- **Cross-PR interaction with `fix/chat-doctor-remedies`.** That PR's advice for
  a user on a remote embedding provider leads with `index build`, precisely
  because the fetched asset is what their configuration will refuse. This PR's
  guard exempts exactly that case: an index the running configuration would
  *refuse* is never protected, since rebuilding one you cannot query loses
  nothing. The two changes agree, but they agree by design rather than by
  accident, and the exemption is the reason.
- `tests/chat/test_index_fetch.py` deliberately derives its `COLLECTION`
  constant by **calling** `build_collection_name` rather than hard-coding the
  string, so the collection-identity work owned by another PR in this wave flows
  through with no edit here.

The tip commit is `style(chat): restore two pre-existing format hunks outside
this change's scope` — pre-existing formatting drift was put back deliberately,
to keep the diff to what this change actually does.

Closes #461

## Self-review pass

Ran before pushing. Three findings, all fixed on this branch in commit
`34060e86`. The first is a genuine hole in the guard this PR is about:

- **`corpus_roots` gated a destructive overwrite and was never type-checked.**
  `Manifest.from_dict` is forward-tolerant by design and validates nothing, so a
  hand-written or hand-edited sidecar — the side-load path's ordinary case —
  could carry a scalar. `_roots_provenance` then iterated it: a string yields
  *characters*, and `Path("/").is_absolute()` is true, so `"src/aorta"`
  classified as a **local build** and `"docs"` as a **published** one, both from
  nothing at all. The `"docs"` spelling made `_refuse_if_published` return early,
  so a `build` over a published index went ahead and destroyed it — the exact
  case this PR exists to stop. And `[42]` raised `TypeError` straight past the
  CLI's `_guard`. One shared reader now validates the shape, and a
  present-but-unusable value gets its own `PROVENANCE_INVALID` that both write
  paths refuse. **Absent** roots stay unprotected on purpose: that is a layout
  from a builder predating the field, and refusing them would refuse every
  pre-field install's routine refresh. Present-but-unreadable is a broken
  sidecar, and guessing there can discard the side the network cannot give back.
- **`index status --json` dropped all ten `published` keys** whenever the
  baseline could not be read — the run a consumer most needs to inspect — so
  `payload["published"]["corpus_digest"]` raised `KeyError` there while the
  branch the existing test covered carried every key. Both sides now always
  carry one key set, with `None` for "no manifest on this side".
- **The build refusal asserted a fact the invocation could disprove**: "no
  `docs/` or `README.md` coverage" holds for the default corpus and is false for
  `build --path <a checkout>`, which covers both. It now claims only what is
  true of every corpus reaching that branch.

The CI verification was also strengthened: as well as recovering the literal
argv from each workflow and running it three times over the same `index-out/`,
the `--public-only` exemption was **mutated away**, which fails run 2 with the
refusal. So the exemption is demonstrably load-bearing rather than never
consulted — which is the failure mode a passing three-run check would otherwise
hide.

Each added test was mutation-checked: reverting its fix fails that test and
nothing else.

### One deferred item, since resolved in review

An earlier revision of this section flagged that `_refuse_if_published` called
`_validate_against_provider` before deciding whether to refuse, so a build that
was going to be refused could pay an embedding-provider cost first. That is no
longer how the guard works: `7292619c` switched it to
`check_index(target, strict=False)`, for a better reason than cost — the
manifest-only question made the "index this install cannot use" exemption too
narrow, since an index whose `.sqlite` cannot be opened at all has an entirely
valid manifest and was therefore refused a rebuild while every reader that
touches the file says to rebuild it.

`check_index` builds a provider to ask for its `collection_name()`, which by
design never constructs an embedding model — `doctor` has to answer without a
65 MB download as a side effect — so the refusal path costs a provider
construction and a store open, not a model load. The follow-up issue opened for
this has been closed as no longer applicable.

CI is unaffected either way: both workflows pass `--public-only`, which is
exempt before any manifest is read, verified here by replaying each workflow's
literal argv and by mutating the exemption away.

---

## Review round 3 (2aa76682)

### :warning: This round edits a shared CI file: `.github/workflows/chat-tests.yml`

**#462, #463, #464 and this PR all touch that file.** The change here is
**two paths added to two lists, and nothing else** — no restructuring, no
version bumps, no job changes — so it should merge cleanly in any order.
Reviewers of the sibling PRs: this is the whole diff to that file.

`chat-tests.yml` runs an explicit allowlist, not a directory, and neither
`tests/cli/test_chat_index_cli.py` nor `tests/cli/test_chat_index_workflows.py`
was in it. Both are `skipif`-gated on `langchain_core`, which the required CPU
gate does not install. So the tests skipped on the gate that collected them and
were not collected by the gate that could run them — **36 of the 65 tests
between the two files ran in no job at all.** Found read-only by
@vivekkhandelwal1; measured here:

| | tests collected |
| --- | --- |
| chat job, allowlist as it was | 1096 |
| chat job, allowlist with both paths | 1161 |
| the two files alone, chat extra present | 65 passed |
| the two files alone, base install (CPU gate) | 29 passed, **36 skipped** |

### Findings addressed

| # | Source | Finding | Resolution |
| --- | --- | --- | --- |
| 1 | human | new CLI tests run in no CI job | paths added to both lists in `chat-tests.yml` |
| 2 | human + Copilot | a destination that exists with no readable manifest is silently overwritten | `_read_destination` separates absent from unreadable; both guards refuse the latter, `--force` escapes |
| 3 | Copilot | `fetch`'s up-to-date shortcut trusts the sidecar hash over a possibly-damaged store | gated on `check_index`, the same store-reading helper the build exemption uses |
| 4 | Copilot | refusal remedies drop a non-default `--path`/`--output`, so pasting them acts on a different index | all routed through `_pasteable`; **a fourth site found by sweeping** — the 404 handler's three options |
| 5 | Copilot | a downloaded manifest with a wrong-typed field escapes as `AttributeError` | `_ensure_field_types` in `_parse_manifest`, at the network boundary only |
| 6 | Copilot | truncated table cells can render two differing values identically | a row differing only past the column width is repeated in full underneath |

On #4 and #5 the fix is deliberately placed so it composes with #463 rather
than colliding: `manifest.py` is untouched, and if #463 moves type checking
into `from_dict`, `_ensure_field_types` becomes a no-op.

### One collision the rebase surfaced

#462's `TestEveryCommandTheseDocsPrintCanRun` has a negative control asserting
that `aorta chat index fetch --force` does not parse — a flag **this PR adds**,
which its own docstring names. The control therefore expired on schedule rather
than on merit, and said nothing about whether the sweep still rejects anything.
It now uses a flag no one will add, which keeps it about the parser. That is
the only edit to a file this PR does not otherwise own.

### Verification

- Chat gate suite: **1147 passed, 12 skipped, 2 xfailed**.
- `ruff check` clean on every changed file.
- **Every new test mutation-checked** — each fix reverted in turn, confirming
  exactly the intended tests fail and the rest stay green.
- The overwrite guard changed, so the real CI shape was re-run in the
  foreground: three consecutive
  `index build --public-only --path . --output index-out/aorta-chat-index.sqlite`
  runs over one directory, all exit 0, all `corpus_digest c7a8d7d5…`,
  9925 chunks, 350 files. `nightly.yml` and `release.yml` stay unblocked.

### Not addressed, deliberately

- `generate_repo_map` still has no production caller (confirmed on `main` too).
  Real, and now the oldest live hole in the feature, but not this PR's — worth
  its own issue.
