### PR TITLE
test(chat): pin the collection identity and the per-session redaction notice

### DIFF
--- a/tests/chat/test_embeddings_factory.py
+++ b/tests/chat/test_embeddings_factory.py
@@ -14,7 +14,12 @@ from __future__ import annotations
 import pytest
 
 from aorta.chat.config import settings
-from aorta.chat.rag.embeddings.base import model_slug
+from aorta.chat.rag.embeddings.base import (
+    MAX_COLLECTION_NAME,
+    build_collection_name,
+    identity_digest,
+    model_slug,
+)
 from aorta.chat.rag.embeddings.factory import collection_name, get_embeddings, get_provider
 from aorta.chat.rag.embeddings.fastembed_bge import (
     LOCAL_COLLECTION_PREFIX,
@@ -158,6 +163,24 @@ class TestCollectionNamesAreUnique:
 
         assert len(name) <= 63
         assert _SAFE_COLLECTION.match(name)
+
+    @pytest.mark.parametrize("prefix", [LOCAL_COLLECTION_PREFIX, REMOTE_COLLECTION_PREFIX])
+    def test_the_digest_survives_the_cap_under_every_shipped_prefix(self, prefix: str):
+        """Truncation has to stay cosmetic: the slug is cut, never the digest.
+
+        Length alone proves nothing here -- the pre-digest name was inside the
+        cap too, by being the thing that got truncated. What has to hold is
+        both at once: inside the cap *and* still ending in the whole digest of
+        the identity. That is what fails if the suffix is appended without
+        reserving room for it, and it is checked against both prefixes because
+        the local one is three characters longer and only the remote one is
+        reached through a provider anywhere else in this file.
+        """
+        model = "q" * 200
+        name = build_collection_name(prefix, model)
+
+        assert len(name) <= MAX_COLLECTION_NAME
+        assert name.endswith("_" + identity_digest(model))
 
     def test_the_name_is_stable_across_calls(self, monkeypatch):
         """A digest that moved would orphan the collection it named yesterday."""

--- a/tests/chat/test_embeddings_factory.py
+++ b/tests/chat/test_embeddings_factory.py
@@ -172,9 +172,12 @@ class TestCollectionNamesAreUnique:
         cap too, by being the thing that got truncated. What has to hold is
         both at once: inside the cap *and* still ending in the whole digest of
         the identity. That is what fails if the suffix is appended without
-        reserving room for it, and it is checked against both prefixes because
-        the local one is three characters longer and only the remote one is
-        reached through a provider anywhere else in this file.
+        reserving room for it.
+
+        Both prefixes, because the local one is three characters longer and
+        every *length* assertion in this file goes through the remote provider
+        -- so room reserved for ``aorta_remote_`` and spent by
+        ``aorta_fastembed_`` was a name over the cap that nothing measured.
         """
         model = "q" * 200
         name = build_collection_name(prefix, model)

--- a/tests/chat/test_rag_runs.py
+++ b/tests/chat/test_rag_runs.py
@@ -226,8 +226,9 @@ class TestTheRunCollectionSeparatesModelsByName:
     landed on one name and happen to share a dimension read each other's
     vectors and answer normally.
 
-    Every other test in this file substitutes ``FakeProvider``, which hard-codes
-    its collection, so none of them touch the real naming. These use the actual
+    Every other test in this file that reads a collection name substitutes
+    ``FakeProvider``, which hard-codes its own, so none of them touch the real
+    naming and a change to it could not fail them. These use the actual
     factory: naming never builds an embedding model, so there is no download.
     """
 

--- a/tests/chat/test_rag_runs.py
+++ b/tests/chat/test_rag_runs.py
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 import pytest
 from langchain_core.embeddings import Embeddings
 
-from aorta.chat.config import configure, reset_settings
+from aorta.chat.config import configure, reset_settings, settings
 from aorta.chat.rag import runs as runs_rag
 from aorta.chat.rag.retriever import SqliteVecStore
 
@@ -212,6 +212,68 @@ class TestCollectionNaming:
             runs_rag, "get_provider", lambda: FakeProvider("aorta_remote_text_embedding_3_small")
         )
         name = runs_rag.run_collection_name()
+        assert re.fullmatch(r"[A-Za-z0-9_]+", name)
+        assert name.endswith(runs_rag.RUN_COLLECTION_SUFFIX)
+
+
+class TestTheRunCollectionSeparatesModelsByName:
+    """The name is the *only* thing keeping two models' run vectors apart.
+
+    Source retrieval has a second line of defence: the manifest sidecar records
+    the embedding model and refuses a mismatch before the first query. This
+    collection has no sidecar. ``_get_store`` opens ``run_collection_name()``
+    and queries whatever is under it, comparing nothing -- so two models that
+    landed on one name and happen to share a dimension read each other's
+    vectors and answer normally.
+
+    Every other test in this file substitutes ``FakeProvider``, which hard-codes
+    its collection, so none of them touch the real naming. These use the actual
+    factory: naming never builds an embedding model, so there is no download.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _remote_provider(self, monkeypatch):
+        monkeypatch.setattr(settings, "embedding_provider", "remote")
+        monkeypatch.setattr(settings, "remote_embedding_base_url", "")
+
+    @pytest.mark.parametrize(
+        ("left", "right"),
+        [
+            # Slug identically: the punctuation is folded to the same run of _.
+            ("foo/bar", "foo-bar"),
+            # Slug identically for the first 63 characters.
+            ("m" * 70 + "-alpha", "m" * 70 + "-beta"),
+        ],
+    )
+    def test_models_that_slug_alike_get_different_run_collections(
+        self, monkeypatch, left: str, right: str
+    ):
+        monkeypatch.setattr(settings, "remote_embedding_model", left)
+        at_left = runs_rag.run_collection_name()
+        monkeypatch.setattr(settings, "remote_embedding_model", right)
+
+        assert runs_rag.run_collection_name() != at_left
+
+    def test_switching_endpoint_switches_the_run_collection_too(self, monkeypatch):
+        """The endpoint is half a remote identity, and run data is per-user.
+
+        A model name means nothing without the API serving it, so pointing the
+        same model at a second gateway has to move this collection as well --
+        otherwise the previous gateway's run vectors answer the new one's
+        queries.
+        """
+        monkeypatch.setattr(settings, "remote_embedding_model", "text-embedding-3-small")
+        monkeypatch.setattr(settings, "remote_embedding_base_url", "https://a.example/v1")
+        at_a = runs_rag.run_collection_name()
+        monkeypatch.setattr(settings, "remote_embedding_base_url", "https://b.example/v1")
+
+        assert runs_rag.run_collection_name() != at_a
+
+    def test_it_is_still_a_bare_identifier_after_the_suffix(self, monkeypatch):
+        """The suffix lands after the digest, on a name already at the cap."""
+        monkeypatch.setattr(settings, "remote_embedding_model", "q" * 200)
+        name = runs_rag.run_collection_name()
+
         assert re.fullmatch(r"[A-Za-z0-9_]+", name)
         assert name.endswith(runs_rag.RUN_COLLECTION_SUFFIX)
 

--- a/tests/chat/test_rag_runs.py
+++ b/tests/chat/test_rag_runs.py
@@ -24,7 +24,7 @@ from langchain_core.embeddings import Embeddings
 
 from aorta.chat.config import configure, reset_settings, settings
 from aorta.chat.rag import runs as runs_rag
-from aorta.chat.rag.embeddings.base import MAX_COLLECTION_NAME
+from aorta.chat.rag.embeddings.base import MAX_COLLECTION_NAME, identity_digest
 from aorta.chat.rag.retriever import SqliteVecStore
 
 VOCABULARY = ["nan", "loss", "rocm", "tf32", "hang", "memory", "triton"]
@@ -316,6 +316,11 @@ class TestTheRunCollectionSeparatesModelsByName:
         deleting it would lose the only statement of what the cap means for this
         collection. Strict so that fixing #476 turns this into a failure that
         has to be acknowledged, instead of a silent xpass.
+
+        This is only half the contract. The other half -- that the fix must not
+        buy those characters back out of the digest -- is
+        ``test_the_whole_digest_reaches_the_run_name`` below, which is kept
+        outside this ``xfail`` so it cannot be masked by it.
         """
         monkeypatch.setattr(settings, "remote_embedding_model", model)
         name = runs_rag.run_collection_name()
@@ -323,6 +328,50 @@ class TestTheRunCollectionSeparatesModelsByName:
         assert len(name) <= MAX_COLLECTION_NAME, (
             f"{len(name)} characters, cap is {MAX_COLLECTION_NAME}: {name}"
         )
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # Short: nothing is under truncation pressure, so this leg fails
+            # only if the digest stops being appended at all.
+            "text-embedding-3-small",
+            # Past the threshold, where fixing #476 has to take characters from
+            # somewhere. These are the legs that say where it must not take them.
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "q" * 200,
+        ],
+    )
+    def test_the_whole_digest_reaches_the_run_name(self, monkeypatch, model: str):
+        """The cap and the complete digest have to hold *at once*.
+
+        ``test_the_digest_survives_the_cap_under_every_shipped_prefix`` states
+        that pair for the collection ``build_collection_name`` returns. Only
+        half of it was ever carried through to the composed run name, and the
+        half left off is the load-bearing one: the shortest way to satisfy the
+        cap is to cut characters off the end, and the end is the digest.
+
+        A #476 fix along the lines of ``base[:58] + "_runs"`` measures 63, so it
+        would clear the cap while keeping three of the eight digest characters.
+        What #422 shipped is collision *resistance*, not injectivity -- eight
+        hex characters are 32 bits, and #447 is open precisely because that is
+        searchable. Truncating to three leaves 12 bits: 4096 buckets, with the
+        birthday point around 80 distinct model ids, which a model zoo reaches
+        by accident rather than by search. So the cost of taking the characters
+        from here is not a new class of bug, it is #447 made ordinary.
+
+        **Deliberately not folded into the xfail above.** ``xfail`` swallows a
+        failure, so a digest-truncating fix would clear the cap, leave that test
+        still failing, and be reported as an expected failure -- exactly the
+        silence this is meant to break. Kept separate, it passes today and turns
+        red the moment the tail is shortened, whether or not the ``xfail``
+        marker has been removed yet.
+        """
+        monkeypatch.setattr(settings, "remote_embedding_model", model)
+        digest = identity_digest(runs_rag.get_provider().vector_identity())
+        name = runs_rag.run_collection_name()
+
+        tail = f"_{digest}{runs_rag.RUN_COLLECTION_SUFFIX}"
+        assert name.endswith(tail), f"expected the name to end in {tail!r}, got {name!r}"
 
 
 class TestIndexing:

--- a/tests/chat/test_rag_runs.py
+++ b/tests/chat/test_rag_runs.py
@@ -24,6 +24,7 @@ from langchain_core.embeddings import Embeddings
 
 from aorta.chat.config import configure, reset_settings, settings
 from aorta.chat.rag import runs as runs_rag
+from aorta.chat.rag.embeddings.base import MAX_COLLECTION_NAME
 from aorta.chat.rag.retriever import SqliteVecStore
 
 VOCABULARY = ["nan", "loss", "rocm", "tf32", "hang", "memory", "triton"]
@@ -271,12 +272,57 @@ class TestTheRunCollectionSeparatesModelsByName:
         assert runs_rag.run_collection_name() != at_a
 
     def test_it_is_still_a_bare_identifier_after_the_suffix(self, monkeypatch):
-        """The suffix lands after the digest, on a name already at the cap."""
+        """The suffix lands after the digest, on a name already at the cap.
+
+        Shape only. Whether the result is *within* the cap is a separate
+        question, and the answer is currently no -- see the xfail below.
+        """
         monkeypatch.setattr(settings, "remote_embedding_model", "q" * 200)
         name = runs_rag.run_collection_name()
 
         assert re.fullmatch(r"[A-Za-z0-9_]+", name)
         assert name.endswith(runs_rag.RUN_COLLECTION_SUFFIX)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "#476: run_collection_name() appends _runs to a name "
+            "build_collection_name() has already filled to MAX_COLLECTION_NAME, "
+            "so the composed name runs up to 68 characters against a cap of 63"
+        ),
+    )
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # Ordinary configuration, not a synthetic edge: slugs to 38
+            # characters, which is over the 36 the remote prefix leaves once the
+            # digest and ``_runs`` are both accounted for. Measures 65.
+            "sentence-transformers/all-MiniLM-L6-v2",
+            # The extreme end, where the slug is truncated to the cap first.
+            # Measures 68.
+            "q" * 200,
+        ],
+    )
+    def test_the_suffix_does_not_push_the_name_over_the_cap(self, monkeypatch, model: str):
+        """The cap is the whole point of reserving room for the digest.
+
+        ``build_collection_name`` reserves for its own suffix and returns a name
+        at exactly :data:`MAX_COLLECTION_NAME`; ``run_collection_name`` then
+        concatenates ``_runs`` onto it, and nothing re-checks. Each function
+        keeps its own contract and the composition breaks it.
+
+        Marked ``xfail(strict=True)`` rather than deleted or inverted: asserting
+        the current 68-character result would pin a defect as a contract, and
+        deleting it would lose the only statement of what the cap means for this
+        collection. Strict so that fixing #476 turns this into a failure that
+        has to be acknowledged, instead of a silent xpass.
+        """
+        monkeypatch.setattr(settings, "remote_embedding_model", model)
+        name = runs_rag.run_collection_name()
+
+        assert len(name) <= MAX_COLLECTION_NAME, (
+            f"{len(name)} characters, cap is {MAX_COLLECTION_NAME}: {name}"
+        )
 
 
 class TestIndexing:

--- a/tests/chat/test_redaction.py
+++ b/tests/chat/test_redaction.py
@@ -128,6 +128,39 @@ class TestNoticeIsSessionLocal:
         assert one.getvalue().count("aorta chat: redacted") == 1
         assert two.getvalue().count("aorta chat: redacted") == 1
 
+    async def test_overlapping_sessions_are_each_told(self):
+        """Two sessions live at the same time, which is how Chainlit runs them.
+
+        The sequential case above already rejects a bare module-level flag. What
+        it does not reject is the shortcut #437 names -- resetting that global in
+        ``on_start`` -- which is only wrong once two sessions overlap. Each
+        session here is held inside its own binding until the other has emitted,
+        so a shared flag either steals one disclosure or hands out two.
+        """
+        import asyncio
+
+        _, summary = redaction.redact_text(CUSTOMER_TEXT)
+        both_emitted = asyncio.Event()
+        emitted = 0
+
+        async def session(stream: io.StringIO) -> None:
+            nonlocal emitted
+            with redaction.use_notice_state(redaction.NoticeState()) as state:
+                assert redaction.emit_notice_once(summary, stream=stream) is True
+                emitted += 1
+                if emitted == 2:
+                    both_emitted.set()
+                await both_emitted.wait()
+                # Still holding its own notice, after the other session's turn.
+                assert redaction.take_pending_notice(state) is not None
+
+        one, two = io.StringIO(), io.StringIO()
+        await asyncio.gather(session(one), session(two))
+
+        assert one.getvalue().count("aorta chat: redacted") == 1
+        assert two.getvalue().count("aorta chat: redacted") == 1
+        assert redaction.current_notice_state().emitted is False
+
     def test_one_session_is_still_told_only_once(self):
         _, summary = redaction.redact_text(CUSTOMER_TEXT)
         state = redaction.NoticeState()

--- a/tests/chat/test_redaction.py
+++ b/tests/chat/test_redaction.py
@@ -141,7 +141,9 @@ class TestNoticeIsSessionLocal:
         second binding is live, which is the only time the two differ.
 
         Both rendezvous are released in ``finally`` so a failing assertion fails
-        this test rather than parking its peer for the rest of the run.
+        this test rather than parking its peer for the rest of the run, and both
+        waits are bounded so a failure *before* the counter -- which never
+        reaches that ``finally`` -- fails it too instead of hanging the job.
         """
         import asyncio
 
@@ -150,6 +152,15 @@ class TestNoticeIsSessionLocal:
         both_looked = asyncio.Event()
         emitted = 0
         looked = 0
+        timeout = 5.0
+
+        async def meet(event: asyncio.Event, name: str) -> None:
+            try:
+                await asyncio.wait_for(event.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                raise AssertionError(
+                    f"peer session never reached {name} within {timeout}s"
+                ) from None
 
         async def session(stream: io.StringIO) -> None:
             nonlocal emitted, looked
@@ -160,7 +171,7 @@ class TestNoticeIsSessionLocal:
                     emitted += 1
                     if emitted == 2:
                         both_emitted.set()
-                await both_emitted.wait()
+                await meet(both_emitted, "both_emitted")
                 try:
                     # This session's own state, and its own undrained notice,
                     # while the other session's binding is still in force.
@@ -170,7 +181,7 @@ class TestNoticeIsSessionLocal:
                     looked += 1
                     if looked == 2:
                         both_looked.set()
-                await both_looked.wait()
+                await meet(both_looked, "both_looked")
 
         one, two = io.StringIO(), io.StringIO()
         await asyncio.gather(session(one), session(two))

--- a/tests/chat/test_redaction.py
+++ b/tests/chat/test_redaction.py
@@ -132,27 +132,45 @@ class TestNoticeIsSessionLocal:
         """Two sessions live at the same time, which is how Chainlit runs them.
 
         The sequential case above already rejects a bare module-level flag. What
-        it does not reject is the shortcut #437 names -- resetting that global in
-        ``on_start`` -- which is only wrong once two sessions overlap. Each
-        session here is held inside its own binding until the other has emitted,
-        so a shared flag either steals one disclosure or hands out two.
+        it cannot see is a binding that is itself process-wide: a module-level
+        "current session" pointer, saved and restored around each block, answers
+        every sequential arrangement identically to a context variable and hands
+        one session the other's state the moment the two overlap. So each
+        session is held inside its own binding until the other has emitted *and*
+        looked -- the second rendezvous is what makes the lookup happen while a
+        second binding is live, which is the only time the two differ.
+
+        Both rendezvous are released in ``finally`` so a failing assertion fails
+        this test rather than parking its peer for the rest of the run.
         """
         import asyncio
 
         _, summary = redaction.redact_text(CUSTOMER_TEXT)
         both_emitted = asyncio.Event()
+        both_looked = asyncio.Event()
         emitted = 0
+        looked = 0
 
         async def session(stream: io.StringIO) -> None:
-            nonlocal emitted
+            nonlocal emitted, looked
             with redaction.use_notice_state(redaction.NoticeState()) as state:
-                assert redaction.emit_notice_once(summary, stream=stream) is True
-                emitted += 1
-                if emitted == 2:
-                    both_emitted.set()
+                try:
+                    assert redaction.emit_notice_once(summary, stream=stream) is True
+                finally:
+                    emitted += 1
+                    if emitted == 2:
+                        both_emitted.set()
                 await both_emitted.wait()
-                # Still holding its own notice, after the other session's turn.
-                assert redaction.take_pending_notice(state) is not None
+                try:
+                    # This session's own state, and its own undrained notice,
+                    # while the other session's binding is still in force.
+                    assert redaction.current_notice_state() is state
+                    assert redaction.take_pending_notice(state) is not None
+                finally:
+                    looked += 1
+                    if looked == 2:
+                        both_looked.set()
+                await both_looked.wait()
 
         one, two = io.StringIO(), io.StringIO()
         await asyncio.gather(session(one), session(two))

--- a/tests/chat/test_ui_app_notice.py
+++ b/tests/chat/test_ui_app_notice.py
@@ -243,6 +243,18 @@ def _notices(browser: _Browser) -> list[str]:
     return [shown for shown in browser.sent if "aorta chat: redacted" in shown]
 
 
+def _the_notice(browser: _Browser) -> str:
+    """The one notice this session was shown.
+
+    Asserted rather than indexed: a session that was starved of its disclosure
+    is the failure these tests exist to catch, and ``_notices(x)[0]`` reports it
+    as a bare ``IndexError`` that names neither the session nor the promise.
+    """
+    shown = _notices(browser)
+    assert len(shown) == 1, f"expected exactly one notice, got {shown}"
+    return shown[0]
+
+
 class TestTwoSessionsInOneProcess:
     """Why the notice cannot be keyed on process state.
 
@@ -287,12 +299,18 @@ class TestTwoSessionsInOneProcess:
             async def node() -> None:
                 redaction.redact_for_send([HumanMessage(content=question)])
 
-            # A child task is how LangGraph runs a node, and the shape the
-            # binding in ``on_message`` has to survive.
-            await asyncio.create_task(node())
-            arrived += 1
-            if arrived == 2:
-                both_redacted.set()
+            try:
+                # A child task is how LangGraph runs a node, and the shape the
+                # binding in ``on_message`` has to survive.
+                await asyncio.create_task(node())
+            finally:
+                # In ``finally`` because ``on_message`` swallows a graph
+                # failure: without it, one session raising here would leave the
+                # other waiting on a rendezvous nobody can reach, and the test
+                # would hang instead of failing.
+                arrived += 1
+                if arrived == 2:
+                    both_redacted.set()
             await both_redacted.wait()
             return f"answered: {question}", [], {}
 
@@ -320,8 +338,8 @@ class TestTwoSessionsInOneProcess:
             self._session(app, bob, BOB_ASKS),
         )
 
-        assert "IPv4" not in _notices(alice)[0]
-        assert "IPv4" in _notices(bob)[0]
+        assert "IPv4" not in _the_notice(alice)
+        assert "IPv4" in _the_notice(bob)
 
     async def test_both_are_told_how_to_turn_it_off(self, app, monkeypatch):
         """Decision 16's second half, in the same words as the CLI line."""
@@ -334,8 +352,9 @@ class TestTwoSessionsInOneProcess:
         )
 
         for browser in (alice, bob):
-            assert "--no-redact" in _notices(browser)[0]
-            assert "redact = false" in _notices(browser)[0]
+            notice = _the_notice(browser)
+            assert "--no-redact" in notice
+            assert "redact = false" in notice
 
     async def test_each_session_is_told_once_across_its_own_turns(self, app, monkeypatch):
         """Once per session, not once per redacting turn, with sessions overlapping."""

--- a/tests/chat/test_ui_app_notice.py
+++ b/tests/chat/test_ui_app_notice.py
@@ -1,10 +1,19 @@
-"""The web UI's per-request redaction disclosure, including on the error path.
+"""The web UI's per-request redaction disclosure, on both the error path and
+across concurrent sessions.
 
 Decision 16 promises the user is told what a request had removed before it
 left. The UI drained that notice only after a successful answer, so a request
 that was redacted and *then* failed in the graph or the provider disclosed
 nothing -- and a user who stops after the failure is never told. The send had
 already happened by then, so the disclosure is owed either way.
+
+The other way the UI can fail the promise is by session, not by path: one
+server process serves many browsers, so state that is per-process is a
+disclosure one user can consume on another's behalf. ``TestTheNoticeIsDelivered``
+seeds the notice to isolate the delivery half; ``TestTwoSessionsInOneProcess``
+drives the real redaction through two overlapping sessions to pin the scoping
+half, since a process-wide flag reset at session start satisfies every
+sequential arrangement of it.
 
 ``aorta.chat.ui.app`` imports ``chainlit`` at module scope and the ``chat-ui``
 extra is a separate install, so a fake is put in ``sys.modules`` first. The
@@ -14,12 +23,17 @@ security guarantee untested on the configuration these tests actually run in.
 
 from __future__ import annotations
 
+import asyncio
 import sys
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 from types import ModuleType, SimpleNamespace
 
 import pytest
+from langchain_core.messages import HumanMessage
 
 from aorta.chat import redaction
+from aorta.chat.config import reset_settings
 
 NOTICE = "aorta chat: redacted 3 filesystem paths from the outbound request."
 
@@ -172,3 +186,186 @@ class TestTheUiFlagsFromTheCli:
         import aorta.chat.ui.app as app_module
 
         assert app_module._VERBOSE is True
+
+
+# ── two browser sessions in one process ───────────────────────────────────
+
+
+@dataclass
+class _Browser:
+    """One browser session: its own ``user_session`` store and its own transcript."""
+
+    values: dict = field(default_factory=dict)
+    sent: list[str] = field(default_factory=list)
+
+
+#: Chainlit resolves both ``cl.Message`` and ``cl.user_session`` from the session
+#: in context, not from process state. The single-session fakes above have no
+#: need to model that; a concurrency test does, so these do.
+_current_browser: ContextVar[_Browser] = ContextVar("aorta_test_browser")
+
+
+class _SessionScopedMessage:
+    def __init__(self, content: str = "") -> None:
+        self.content = content
+
+    async def send(self) -> None:
+        _current_browser.get().sent.append(self.content)
+
+    async def remove(self) -> None:
+        pass
+
+
+class _SessionScopedUserSession:
+    def get(self, key, default=None):
+        return _current_browser.get().values.get(key, default)
+
+    def set(self, key, value) -> None:
+        _current_browser.get().values[key] = value
+
+
+class _FakeBackend:
+    def describe(self) -> str:
+        return "fake backend"
+
+    async def preflight(self) -> None:
+        pass
+
+
+#: One filesystem path, no addresses.
+ALICE_ASKS = "the run under /home/alice/models/llama-70b failed"
+#: One path and two IPv4 addresses, so Alice's notice and Bob's differ in wording
+#: and each session can be shown to have been told about its *own* redaction.
+BOB_ASKS = "hosts 10.42.7.9 and 10.42.7.10 under /home/bob/runs/latest are down"
+
+
+def _notices(browser: _Browser) -> list[str]:
+    return [shown for shown in browser.sent if "aorta chat: redacted" in shown]
+
+
+class TestTwoSessionsInOneProcess:
+    """Why the notice cannot be keyed on process state.
+
+    Unlike the tests above these drive the real ``redact_for_send`` rather than
+    seeding ``pending`` by hand, so they cover the whole chain the CLI gets for
+    free: a redaction inside a graph turn, this session's
+    :class:`redaction.NoticeState`, and a ``cl.Message`` in this session's
+    transcript. Overlapping the two turns is what makes it a proof -- the
+    shortcut #437 rules out, resetting a module global in ``on_chat_start``,
+    satisfies every sequential arrangement and only fails when two sessions are
+    live at once.
+    """
+
+    @staticmethod
+    def _install(app, monkeypatch, invoke) -> None:
+        monkeypatch.setattr(app.cl, "Message", _SessionScopedMessage)
+        monkeypatch.setattr(app.cl, "user_session", _SessionScopedUserSession())
+        monkeypatch.setattr(app, "get_backend", lambda: _FakeBackend())
+        monkeypatch.setattr(app, "invoke_agent", invoke)
+        reset_settings()
+
+    @staticmethod
+    async def _session(app, browser: _Browser, *questions: str) -> None:
+        """One browser session's whole life, in its own context."""
+        token = _current_browser.set(browser)
+        try:
+            await app.on_start()
+            for question in questions:
+                await app.on_message(SimpleNamespace(content=question))
+        finally:
+            _current_browser.reset(token)
+
+    @staticmethod
+    def _overlapping_turn():
+        """An ``invoke_agent`` that redacts, then blocks until its peer has too."""
+        both_redacted = asyncio.Event()
+        arrived = 0
+
+        async def turn(question, history):  # noqa: ARG001 - signature match
+            nonlocal arrived
+
+            async def node() -> None:
+                redaction.redact_for_send([HumanMessage(content=question)])
+
+            # A child task is how LangGraph runs a node, and the shape the
+            # binding in ``on_message`` has to survive.
+            await asyncio.create_task(node())
+            arrived += 1
+            if arrived == 2:
+                both_redacted.set()
+            await both_redacted.wait()
+            return f"answered: {question}", [], {}
+
+        return turn
+
+    async def test_neither_session_suppresses_the_other(self, app, monkeypatch):
+        self._install(app, monkeypatch, self._overlapping_turn())
+        alice, bob = _Browser(), _Browser()
+
+        await asyncio.gather(
+            self._session(app, alice, ALICE_ASKS),
+            self._session(app, bob, BOB_ASKS),
+        )
+
+        assert len(_notices(alice)) == 1
+        assert len(_notices(bob)) == 1
+
+    async def test_each_session_is_told_about_its_own_redaction(self, app, monkeypatch):
+        """Not merely *a* notice each: the one describing what that session sent."""
+        self._install(app, monkeypatch, self._overlapping_turn())
+        alice, bob = _Browser(), _Browser()
+
+        await asyncio.gather(
+            self._session(app, alice, ALICE_ASKS),
+            self._session(app, bob, BOB_ASKS),
+        )
+
+        assert "IPv4" not in _notices(alice)[0]
+        assert "IPv4" in _notices(bob)[0]
+
+    async def test_both_are_told_how_to_turn_it_off(self, app, monkeypatch):
+        """Decision 16's second half, in the same words as the CLI line."""
+        self._install(app, monkeypatch, self._overlapping_turn())
+        alice, bob = _Browser(), _Browser()
+
+        await asyncio.gather(
+            self._session(app, alice, ALICE_ASKS),
+            self._session(app, bob, BOB_ASKS),
+        )
+
+        for browser in (alice, bob):
+            assert "--no-redact" in _notices(browser)[0]
+            assert "redact = false" in _notices(browser)[0]
+
+    async def test_each_session_is_told_once_across_its_own_turns(self, app, monkeypatch):
+        """Once per session, not once per redacting turn, with sessions overlapping."""
+        self._install(app, monkeypatch, self._overlapping_turn())
+        alice, bob = _Browser(), _Browser()
+
+        await asyncio.gather(
+            self._session(app, alice, ALICE_ASKS, ALICE_ASKS),
+            self._session(app, bob, BOB_ASKS, BOB_ASKS),
+        )
+
+        assert len(_notices(alice)) == 1
+        assert len(_notices(bob)) == 1
+
+    async def test_no_session_state_leaks_to_the_process(self, app, monkeypatch):
+        """The CLI fallback must come out of a UI process's turns untouched.
+
+        ``aorta chat`` and ``aorta chat ask`` bind nothing and rely on that
+        process-wide state being their session state.
+        """
+        self._install(app, monkeypatch, self._overlapping_turn())
+        # Explicit, because an earlier test in the run may legitimately have
+        # emitted onto the process-wide state; what is asserted is that these
+        # two sessions do not.
+        redaction.reset_session_notice()
+
+        await asyncio.gather(
+            self._session(app, _Browser(), ALICE_ASKS),
+            self._session(app, _Browser(), BOB_ASKS),
+        )
+
+        assert redaction.current_notice_state().emitted is False
+        assert redaction.current_notice_state().pending is None

--- a/tests/chat/test_ui_app_notice.py
+++ b/tests/chat/test_ui_app_notice.py
@@ -239,6 +239,30 @@ ALICE_ASKS = "the run under /home/alice/models/llama-70b failed"
 BOB_ASKS = "hosts 10.42.7.9 and 10.42.7.10 under /home/bob/runs/latest are down"
 
 
+#: Long enough that a loaded runner never trips it, short enough that a stuck
+#: rendezvous fails the job rather than running it to the CI platform limit.
+_RENDEZVOUS_TIMEOUT = 5.0
+
+
+async def _meet(event: asyncio.Event, name: str) -> None:
+    """Wait for the peer session, bounded.
+
+    The ``finally`` blocks around each rendezvous cover a peer that fails
+    *inside* the guarded region. They cannot cover one that fails before
+    reaching the counter -- ``on_start`` raising, or ``_install`` leaving
+    something unpatched -- and an unbounded ``Event.wait()`` turns that into a
+    hung run rather than a red one. ``pytest-timeout`` is installed but nothing
+    arms it, so this is the only thing standing between a starved rendezvous
+    and a job that burns a runner reporting nothing.
+    """
+    try:
+        await asyncio.wait_for(event.wait(), timeout=_RENDEZVOUS_TIMEOUT)
+    except asyncio.TimeoutError:
+        raise AssertionError(
+            f"peer session never reached {name} within {_RENDEZVOUS_TIMEOUT}s"
+        ) from None
+
+
 def _notices(browser: _Browser) -> list[str]:
     return [shown for shown in browser.sent if "aorta chat: redacted" in shown]
 
@@ -306,12 +330,13 @@ class TestTwoSessionsInOneProcess:
             finally:
                 # In ``finally`` because ``on_message`` swallows a graph
                 # failure: without it, one session raising here would leave the
-                # other waiting on a rendezvous nobody can reach, and the test
-                # would hang instead of failing.
+                # other waiting on a rendezvous nobody can reach. ``_meet``
+                # bounds that wait, but only this releases the peer at once and
+                # reports the real assertion rather than a timeout.
                 arrived += 1
                 if arrived == 2:
                     both_redacted.set()
-            await both_redacted.wait()
+            await _meet(both_redacted, "both_redacted")
             return f"answered: {question}", [], {}
 
         return turn
@@ -380,11 +405,19 @@ class TestTwoSessionsInOneProcess:
         # emitted onto the process-wide state; what is asserted is that these
         # two sessions do not.
         redaction.reset_session_notice()
+        alice, bob = _Browser(), _Browser()
 
         await asyncio.gather(
-            self._session(app, _Browser(), ALICE_ASKS),
-            self._session(app, _Browser(), BOB_ASKS),
+            self._session(app, alice, ALICE_ASKS),
+            self._session(app, bob, BOB_ASKS),
         )
 
+        # The process-wide assertions below are satisfied by absence: two
+        # sessions that redacted nothing at all leave the same state behind as
+        # two that kept their disclosures to themselves. Pin the positive here
+        # too rather than lean on the sibling test that happens to establish it
+        # on the same fixtures.
+        assert len(_notices(alice)) == 1
+        assert len(_notices(bob)) == 1
         assert redaction.current_notice_state().emitted is False
         assert redaction.current_notice_state().pending is None


### PR DESCRIPTION
## What this is

**Tests only. No production code changes** — hence the `test:` subject.

Two investigations in this wave were sent to fix
[#447](https://github.com/ROCm/aorta/issues/447) and
[#437](https://github.com/ROCm/aorta/issues/437). Both found the production fix
had **already landed on `main`** as part of
[#422](https://github.com/ROCm/aorta/pull/422), and that the behaviour was never
actually tested. So each added only the missing proof. Both are `test:`-only and
their file sets are disjoint, so they ship as one PR rather than two.

## What was already covered, and what was not

Worth being precise here, because `main` is **not** bare on this — the source
collection's collision cases (`foo/bar` vs `foo-bar`, and two ids differing only
past the cap) already exist in `TestCollectionNamesAreUnique`. Three specific
gaps were left, and those are what this PR fills:

- **The cap was only ever measured through the remote provider.**
  `test_long_model_names_stay_within_the_name_limit` on `main` calls
  `get_provider("remote")`, and the remote prefix `aorta_remote_` is three
  characters shorter than the local `aorta_fastembed_`. Every *length* assertion
  in that file goes through the remote provider, so the tighter of the two
  shipped prefixes — the one with least room left for the digest — was never
  checked against the cap. And length alone would not have been enough anyway: the pre-digest
  name was inside the cap too, by being the thing that got truncated. What has
  to hold is both at once, inside the cap *and* still ending in the whole
  digest, which is what fails if the suffix is appended without reserving room.
- **The run collection's naming was never exercised at all.** Every test in
  `tests/chat/test_rag_runs.py` that reaches a collection substitutes
  `FakeProvider`, whose `collection_name()` returns a hard-coded `"aorta"`, so
  the assertions read `"aorta_runs"` and the real name never entered any of them.
  (`test_the_missing_collection_message_names_the_command` is the exception, and
  it uses no provider at all.) This is the
  collection that matters most: it has no manifest sidecar, so `_get_store`
  opens `run_collection_name()` and queries whatever is under it, comparing
  nothing.
- **No UI-notice test ever ran two sessions at once.** Every one of them seeded
  the state by hand with `NoticeState(emitted=True, pending=NOTICE)`. The
  sequential case rejects a bare module-level flag, but the shortcut #437
  explicitly names as wrong — resetting that global in `on_chat_start` — is only
  wrong once two sessions *overlap*, and nothing exercised that.

## What is pinned

**Collection identity** — 6 tests. The digest survives the cap under **both**
shipped prefixes, and the run collection gets its own collision cases, its own
endpoint-switch case (a model name means nothing without the API serving it, so
pointing the same model at a second gateway has to move the collection), and a
check that it is still a bare identifier once `_runs` lands on a name already at
the cap.

**The redaction notice is per-session, not per-process** — 6 tests:
`test_overlapping_sessions_are_each_told`, which holds two sessions inside their
own bindings until each has emitted, plus `TestTwoSessionsInOneProcess`, which
drives two overlapping Chainlit sessions through the real
`on_message`/`cl.Message` path rather than seeding `pending` by hand.

## Both halves were mutation-checked

A tests-only PR whose tests pass with or without the fix is worthless, so each
half was verified by reintroducing the defect:

- **Reverting `build_collection_name` to
  `(prefix + model_slug(model))[:MAX_COLLECTION_NAME].rstrip("_")`** — the exact
  line #445 quotes — fails **11 tests** across both files, including
  `test_the_digest_survives_the_cap_under_every_shipped_prefix[aorta_fastembed_]`
  and all three run-collection cases.
- **Replacing the per-session `NoticeState` with the shortcut #437 rules out** —
  binding mechanics left intact, but every session sharing one state and
  resetting it on entry — fails **11 tests**, and
  `test_overlapping_sessions_are_each_told` is the first of them. That is the
  one that matters: the mutation is deliberately the *narrow* one that satisfies
  the sequential arrangements, so it is only the overlap that catches it.

Both mutations were reverted; the tree carries no production change.

## Decisions taken

**[#447](https://github.com/ROCm/aorta/issues/447) stays open, and this PR no
longer closes it.** #447 asked for two things and called (2) the load-bearing
one:

> 1. **Make the name injective.** Include a stable digest of the full model id
>    within the 63-character budget.
> 2. **Give the run collection a model guard of its own.** [...] recording the
>    effective model id there and refusing on mismatch would close the hole
>    independently of naming.

Only **(1) shipped**, in #422 (`367134a2`), and item (1) is what this PR pins.
**(2) — the registry-recorded run-collection model guard — was never built**,
and `rag/runs.py::_get_store` still opens the collection by name and compares
nothing.

An earlier draft of this PR listed #447 as closed anyway, arguing that (1)
removed the premise (2) was written against: with the identity digest in place,
`run_collection_name()` derives from an identity including the endpoint, so two
identities can no longer collide by truncation or by slug folding, leaving only
a 32-bit `DIGEST_CHARS = 8` sha256-prefix collision as the trigger. **That
argument does not survive review.** A concrete colliding pair was constructed
(see the open item at the end of this description), so the residual is
*constructible*, not merely theoretical.

The accurate framing, replacing the "real but negligible" concession that draft
made: **accidental** collision between two arbitrary real model ids remains
negligible, but **constructed** collision is cheap — a birthday search over 32
bits is trivial, and the shape it needs (a long shared prefix with a differing
numeric suffix) is exactly what enterprise gateway deployment names look like.
A guard that "can only ever fire on a hash collision" is a fair description of
item (2); it is not a reason to skip it when the collision can be produced on
demand against the one collection carrying no manifest.

So item (2) is **reinstated as the remaining work on #447**, which has been
rescoped in a comment on the issue rather than closed here.

**[#445](https://github.com/ROCm/aorta/issues/445) is a strict subset of #447's
item (1)** and is closed by the stale-issue sweep accompanying this wave, with
the evidence that `git show 1090cd26:src/aorta/chat/rag/embeddings/base.py`
shows the one-line defect live at the commit the issue cites, and that
`367134a2` — #422's merge — is the only commit that has ever touched that file.
Note the distinction now that the two issues have separated: **#445 is closed on
its own**, by that sweep and not by this PR, while **#447 remains open on item
(2) alone**. An earlier comment on #447 from this work said the two would be
closed together; that held while this PR still claimed #447, and no longer
does.

**No production code, deliberately.** A `test:` subject would be a lie
otherwise, and the value of this PR is precisely that it demonstrates `main` is
already correct.

**One pre-existing wart left alone.** `tests/chat/test_rag_runs.py` is not
`ruff format` clean on `main`. That drift is untouched here: fixing it would mix
a formatting sweep into a coverage PR, and `ruff` is not in CI.

## Testing

`976 passed, 0 failed, 12 skipped` on `tests/chat tests/cli/test_chat*.py`,
against a `964 passed, 0 failed, 12 skipped` baseline on `main`.

## Cross-PR interaction: the narrowed AST guard, and the proof it was narrowed safely

`fix/chat-reasoning-deadend` (closing
[#460](https://github.com/ROCm/aorta/issues/460)) also edits
`tests/chat/test_redaction.py`. That file holds the AST guard which flags **any**
`.ainvoke` in `graph/nodes.py`, so that provider-bound messages cannot leave
without passing the redaction gate in `_send`. That PR's
[#444](https://github.com/ROCm/aorta/issues/444) work adds
`retriever.ainvoke(...)` — a query against the local sqlite index, not a model
call — so it narrows the guard to an **allowlist by receiver name**
(`_NON_MODEL_AINVOKE_RECEIVERS = {"retriever", "tool_fn"}`) and adds a companion
test asserting neither allowlisted name is ever assigned from `_get_llm`.

This PR's own addition sits at ~line 128, ~150 lines away, so the two merge with
no conflict and both survive intact (76 added lines, 43 from that PR and 33 from
this one).

**Narrowing an egress guard deserves more than "the tests still pass", so it was
verified by mutation** — and it takes two mutations, because the allowlist
creates two distinct attack shapes. A reviewer looking at that PR's diff alone
would have to take the second on faith, so the artifact is recorded here:

| Mutation introduced into `graph/nodes.py` | Caught by | Failure |
|---|---|---|
| `await _get_llm(temperature=0.0).ainvoke(messages)` | `test_no_node_calls_ainvoke_directly` | `graph/nodes.py calls .ainvoke at lines [249, 259]; every outbound call must go through _send` |
| `retriever = _get_llm(...)` then `await retriever.ainvoke(messages)` | `test_the_allowlist_cannot_be_used_to_smuggle_a_model_out` | `{'retriever'} is allowlisted out of the _send gate but is assigned a chat model: _get_llm(temperature=0.0)` |

The second is the one that matters. It **passes the receiver allowlist** — the
receiver is literally the allowlisted name `retriever` — so the original guard
cannot see it, and only the companion test does. That is what makes the
narrowing safe rather than merely convenient: the allowlist is by name, and an
allowlist by name is only as good as what those names are bound to.

Both mutations were reverted; `tests/chat/test_redaction.py` passes 32/32 on the
merged result.

## Notes for the reviewer

Developed in a parallel worktree off `4b4553ef` alongside four sibling PRs with
deliberately disjoint file sets. A trial merge of all five was verified clean and
their union suite is green at `1162 passed, 0 failed, 12 skipped`.

One further coordination note: `fix/chat-index-write-safety` owns
`tests/chat/test_index_fetch.py`, which derives its `COLLECTION` constant by
**calling** `build_collection_name` rather than hard-coding the string. That is
deliberate, and it is why the collection-name format this PR pins flows through
that file with no edit — and why this PR keeps the function signature stable.

Closes #437

Deliberately **no** closing keyword for #447. This PR adds the coverage pinning
#447's item (1) — the injective collection name, which shipped in #422 — but
item (2), the registry-recorded run-collection model guard, was never
implemented and is not superseded by the name digest. See "Decisions taken"
above and "The collision that reopened #447" below. #447 has been rescoped to
item (2) in a comment on the issue.

## The tests were then mutation-hardened, and five of twelve needed it

The proofs above are the *result* of that pass, not the starting point. Mutating
the production code each new test claimed to pin showed five of the twelve were
weaker than their names:

- **`test_overlapping_sessions_are_each_told` initially pinned nothing** the
  sequential test above it did not already pin. Replacing the `ContextVar` with a
  module-level "current session" pointer — saved and restored around each
  binding, so every *sequential* arrangement answers identically — left it green,
  because both sessions emitted before either yielded and the peer's binding was
  gone again by the time anything looked. A second rendezvous makes the lookup
  happen while the other binding is still in force, and asserting the bound state
  is this session's own is what a shared pointer cannot satisfy. That mutation now
  fails the test.
- **Two tests indexed `_notices(browser)[0]`**, so the starved-session failure
  they exist to catch surfaced as a bare `IndexError` naming neither the session
  nor the promise. They assert the count and report it now.
- **`_overlapping_turn` released its rendezvous only on the success path.**
  `on_message` swallows a graph failure, so one session raising inside a node
  would have left the other waiting forever and **hung** the run rather than
  failing it. The peer is released in `finally`.
- **Two docstrings justified their test with a claim about this repo that does
  not hold**, and the corrected versions are the gap statements above.

That last one is why the "what was not covered" section is worded as narrowly as
it is: `main` is not bare here, and a tests-only PR that overstates the gap it
fills is as misleading as one whose tests do not bite.

## The full mutation table

Each mutation was applied to `src/` only, with the whole suite run against it and
the tree reverted between runs. The decisive column is the last one: **zero
pre-existing failures means the new test caught a defect nothing already on
`main` could see**, which is the only thing that makes a tests-only PR worth
merging.

| Mutation in `src/` | New tests killed | Pre-existing failures |
|---|---|---|
| Reserve cap room for the *remote* prefix length only (`MAX - 13`) | the `aorta_fastembed_` leg — `assert 66 <= 63` | **0** |
| Truncate *after* appending the digest — the pre-#422 shape | both cap legs + the long-model run-collection leg | 2 |
| Strip the digest off `run_collection_name` | both collision legs + the endpoint-switch test | **0** |
| Cap the assembled run name at 63, so `_runs` gets cut | `test_it_is_still_a_bare_identifier_after_the_suffix` | **0** |
| Drop the `use_notice_state(...)` binding in `on_message` | all 5 `TestTwoSessionsInOneProcess` | **0** |
| One module-level `NoticeState` reset in `on_start` — the exact #437 shortcut | 4 of 5 | **0** |
| `ContextVar` → module-level current-session pointer, saved/restored per binding | 3 UI tests | **0** |

Two things that table shows which prose would hide:

- **The `aorta_fastembed_` leg is the load-bearing one.** The `aorta_remote_` leg
  is co-covered by `main`'s existing cap tests under mutation 2. It is kept
  because it is a parametrize leg that costs nothing and states the invariant
  across both shipped prefixes, but the local prefix is where the gap was.
- **The reset-the-global shortcut leaves the entire pre-existing
  `TestNoticeIsSessionLocal` class green.** Only the overlapping UI tests fail.
  That is the claim #437 rests on, demonstrated rather than asserted.

One scoping nuance, since the gap statement above should not be read too broadly:
`test_redaction.py`'s pre-existing `TestNoticeIsSessionLocal` *does* drive the
real `emit_notice_once` rather than seeding state by hand — it is strictly
sequential, which is the gap, not the seeding. The "seeded by hand" description
applies to `test_ui_app_notice.py`'s six delivery tests. "Nothing ran two
sessions at once" is true of both files.


## Review round: the rendezvous are now bounded

`@vivekkhandelwal1`'s review caught the one thing a tests-only PR can still get
badly wrong — **a test that hangs instead of failing.** Addressed in
`d14f9abc`.

`both_emitted`, `both_looked` (`test_redaction.py`) and `both_redacted`
(`test_ui_app_notice.py`) had no timeout. The counters that release them sit in
`finally` blocks, which covers a failing assertion *inside* the guarded region
but not a failure *before* the counter — `on_start()` raising for one session,
or `_install` leaving something unpatched. In that case the peer waited
forever, and nothing else would have caught it: `pytest.ini` has no `timeout =`,
`addopts` carries no `--timeout`, and `chat-tests.yml` passes none either,
despite `pytest-timeout>=2.1.0` sitting in the `tests` extra. The failure mode
was therefore a chat CI job hanging to the platform limit rather than going
red — strictly worse than a red test, because it burns a runner and reports
nothing.

Each wait is now `asyncio.wait_for(..., timeout=5.0)`, raising an
`AssertionError` that names the rendezvous that starved.
`asyncio.TimeoutError` is caught rather than the builtin, since
`requires-python` is `>=3.10` and the two are only the same object from 3.11.

**Proven in both directions, not merely asserted.** The mutation is the
reviewer's own scenario: one session fails *before* its counter, and
`on_message` swallows it, so that session completes normally and its peer is
left with nobody to release the rendezvous.

| | `tests/chat/test_ui_app_notice.py` | `tests/chat/test_redaction.py` |
| --- | --- | --- |
| unbounded `Event.wait()` (pre-fix) | **hung** — killed by an external 120 s timeout, exit `124`, stuck mid-run at `8 passed` | **hung** — killed at 60 s, exit `124` |
| bounded `asyncio.wait_for` (this PR) | **5 failed, 8 passed in 26.3 s** | **1 failed in 5.17 s** |

with the failure reading:

```
AssertionError: peer session never reached both_redacted within 5.0s
```

Both mutations were reverted; the tree carries no production change.

### Shared config deliberately untouched — tracked as #474

The reviewer offered two options: bound each `wait()`, or arm `--timeout` for
the suite. **Only the first is in this PR.** `pytest.ini` is shared config that
four sibling chat PRs run under, and the per-`wait` bound is both contained to
these tests and more precise — it names the rendezvous rather than reporting an
anonymous suite timeout.

The directory-wide version is still worth doing and is **now tracked
independently as [#474](https://github.com/ROCm/aorta/issues/474)**, filed with
the measured evidence above so it survives whether or not anyone reads a merged
PR description. Arming `--timeout` protects every future async test in
`tests/chat/`, including ones written by someone who never sees this PR.

### The absence-satisfied assertion

`test_no_session_state_leaks_to_the_process` asserted only
`current_notice_state().emitted is False` and `.pending is None` — equally true
of two sessions that redacted nothing at all. As the review notes, it was not
vacuous *in context*, since `test_neither_session_suppresses_the_other`
establishes the positive on the same fixtures, but it did not stand alone. It
now names its two browsers and pins the positive itself:

```python
assert len(_notices(alice)) == 1
assert len(_notices(bob)) == 1
```

## Merge order: land this before #464

Carrying the reviewer's recommendation into the body so whoever merges sees it.

**This PR should land before [#464](https://github.com/ROCm/aorta/pull/464),
or at least not after.** #464 adds two new outbound send paths — a
native-protocol retry and a retrieval-only fallback — so a single user question
can now produce several more calls through `redact_for_send` than it used to.
*"Once per session, not once per redacting turn"* is exactly the property that
puts under new pressure, and `test_one_session_is_still_told_only_once` plus
`test_each_session_is_told_once_across_its_own_turns` are the tests that would
catch it regressing. Landing this first means #464 merges onto the stronger
assertions rather than adding the pressure before the proof exists.

The two remain textually disjoint in `tests/chat/test_redaction.py` — this PR's
block sits at ~128, #464's at ~13, ~280, ~301, ~317 and ~339 — and a
`git merge-tree` against #464's current tip reports **no conflicts**.

## The collision that reopened #447

The Copilot re-review produced a concrete collision pair. It was checked rather
than taken on faith, and **it holds**. This is what changed the closing
keywords on this PR, so the evidence lives here.

Under the default remote endpoint, the two distinct models
`"m" * 70 + "-25013"` and `"m" * 70 + "-75070"` produce distinct
`vector_identity()` values whose sha256 hashes differ — but whose **first eight
hex characters do not**:

```
"<provider-default>\nmmm…m-25013"  ->  c25c4ec9bf334491ddd09f0b9642a3b5…
"<provider-default>\nmmm…m-75070"  ->  c25c4ec9660d51468d17e51e49c62a6f…
                                        ^^^^^^^^ DIGEST_CHARS = 8, i.e. 32 bits

run_collection_name()  ->  aorta_remote_mmmm…mmm_c25c4ec9_runs   # both models
```

Verified end to end through the real provider, not just against
`identity_digest` in isolation. (Checking `identity_digest(model)` alone shows
*no* collision — `6e2fc273` vs `6f1dd7f6` — because the digest on this path is
taken over `vector_identity()`, which for the remote provider is
`f"{endpoint}\n{model}"`. That near-miss is worth recording, since it is the
easy way to wrongly dismiss the finding.)

Two distinct models therefore share one run collection, and that collection has
no manifest sidecar, so nothing downstream compares anything.

**Why it is not fixed here.** Both remedies are production changes — an
independent model-identity guard for the run collection, or widening
`DIGEST_CHARS` (which would additionally move every existing collection name,
silently invalidating live indexes). This PR is tests-only and
`git diff main -- src/` is empty. A regression test cannot land first either:
asserting the two names differ fails against `main`, and asserting they collide
would pin a defect as intended behaviour. The test is only writable alongside
the guard.

**What it changed.** The closing keyword for #447 is removed from this PR, and
#447 is rescoped in a comment on the issue to item (2) — the registry-recorded
run-collection model guard — as the remaining work. The framing correction is
in "Decisions taken" above: accidental collision between arbitrary real model
ids stays negligible, but constructed collision is cheap, and the shape it
needs (long shared prefix, differing numeric suffix) is what enterprise gateway
deployment names actually look like.

## Rebase

Rebased onto `main` @ `d84bea12` (was branched at `4b4553ef`). Three commits
replayed, none dropped, no conflicts, diff-stat parity byte-identical against
the pre-rebase baseline. `git diff main -- src/` is still empty.

Post-review test counts are unchanged at **976 passed, 12 skipped** — the fixes
added assertions and bounds, not tests. `ruff check` and `ruff format --check`
are clean on both edited files. (The pre-existing `ruff format` drift in
`tests/chat/test_rag_runs.py` on `main` remains deliberately untouched.)


## Second open item: the run collection exceeds the name cap (#476)

A later Copilot round flagged that `test_it_is_still_a_bare_identifier_after_the_suffix` accepted a **68-character** run-collection name against `MAX_COLLECTION_NAME = 63`. Verified by measurement through the real provider, and it holds:

```
build_collection_name(...)  -> len 63   aorta_remote_qqqq…qqq_61b187ad
run_collection_name()       -> len 68   aorta_remote_qqqq…qqq_61b187ad_runs
                                            overflow = 5
```

**Reachable in ordinary configuration**, not only with `"q" * 200`. The overflow begins at a slug of 37 characters for `aorta_remote_` (34 for `aorta_fastembed_`):

| model id | run collection length | |
| --- | --- | --- |
| `text-embedding-3-small` | 49 | ok |
| `sentence-transformers/all-MiniLM-L6-v2` | **65** | **over cap** |
| `intfloat/multilingual-e5-large-instruct` | **66** | **over cap** |
| `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` | **68** | **over cap** |

**Mechanism** — and it is *not* the negative-`room` edge dismissed earlier in this work (that dismissal was correct; `room` is 41 and 38 for the two shipped prefixes). `build_collection_name` reserves for its own digest and returns a name at exactly the cap; `run_collection_name` then concatenates `_runs` onto the finished string and nothing re-checks. Each function honours its own contract and the composition breaks it.

Nothing raises today: `SqliteVecStore` validates bare-identifier shape (`\A[A-Za-z0-9_]+\Z`) but imposes no length bound, and sqlite has no identifier length limit — so an over-cap table is created silently. A violated documented contract rather than a crash, which is exactly why a test is where it should be caught.

**Filed as [#476](https://github.com/ROCm/aorta/issues/476)** and cross-linked from #447, since both are consequences of the same name-budget arithmetic (they are independent defects; fixing either leaves the other intact).

### What this PR does about it

The fix is production code, so not here. What changed in `9ad515ce` is the test:

- `test_it_is_still_a_bare_identifier_after_the_suffix` keeps its shape assertions and gains a docstring note that whether the name is *within* the cap is a separate question with a currently-negative answer — the old "on a name already at the cap" phrasing read as if the result were bounded.
- A new `test_the_suffix_does_not_push_the_name_over_the_cap` asserts `len(name) <= MAX_COLLECTION_NAME`, marked **`xfail(strict=True)`** naming #476, parametrized over a realistic long id (65) and the extreme case (68).

Asserting the 68-character result would pin a defect as a contract; deleting the case would lose the only statement of what the cap means for this collection. The `xfail` states the real contract and flips when #476 is fixed.

**`strict=True` was verified to do its job**: temporarily patching `run_collection_name` in `src/` to reserve room for the suffix turned both legs into `XPASS(strict)` **failures**, not silent passes — so #476 cannot be fixed, or closed, without this test demanding attention. The simulated fix was reverted and `git diff main -- src/` is empty.

Suite is now **976 passed, 12 skipped, 2 xfailed** — pass count unchanged from baseline; the two new cases are the xfails.

### Why the collision (#447) got no equivalent test, deliberately

The `xfail(strict=True)` pattern is right for #476 because the property the test states — within the cap — is exactly what the fix delivers. It is wrong for #447, and the asymmetry is the point:

- Asserting the collision (`name_a == name_b`) documents a defect as a contract, and would only fire if someone widened `DIGEST_CHARS` — a change argued against on both issues, because it silently moves every collection name and merely raises the cost of the search.
- Asserting injectivity (`name_a != name_b`) as an `xfail` looks symmetric but is not: #447 item (2) is a *registry guard*, which makes the cross-read a refusal rather than the names distinct. That xfail would sit red permanently.

The property worth pinning is "two colliding identities are refused rather than silently cross-read", which cannot be written until the guard exists. It is listed as an acceptance item on #447 instead.


## Copilot round 3: the cap pin was half a contract

Copilot's verdict on `9ad515ce` was "Needs a closer look" with **0 unresolved
threads** and, in both review bodies, `Comments generated: 0 new`. The finding
was not in either of those numbers. It was in a `Suppressed comments (1)` block
inside the body of review `5151015705`, which the inline-comments API does not
return — so reconciling against the "comments generated" line alone would have
concluded the round was empty. Reconciled count for the round: **1**.

**The finding.** The #476 expected-failure asserted only
`len(name) <= MAX_COLLECTION_NAME`. A fix shaped like `base[:58] + "_runs"`
measures exactly 63, so it would satisfy that assertion while spending the
saved characters out of the identity digest — and the digest is the only thing
making the name injective.

Both halves of the claim check out:

```
bad "fix":  aorta_remote_qqqq…qqq_61b_runs
            len 63 <= 63  -> cap assertion satisfied
            digest kept:  '61b'  of  '61b187ad'   -> 5 of 8 characters gone
```

And the existing collision cases do not cover the gap either — they compare
whole names, and the pairs happen to diverge inside the first three digest
characters, so they pass against a truncated tail:

| pair | digests | differ within 3 chars? |
|---|---|---|
| `foo/bar` vs `foo-bar` | `84e2674d` / `41688fa0` | yes |
| `m…-alpha` vs `m…-beta` | `19216ffd` / `a71b1b7a` | yes |

**Where this came from.** `test_the_digest_survives_the_cap_under_every_shipped_prefix`
already states the pair for the name `build_collection_name` returns: inside the
cap *and* still ending in the whole digest. Only half of that pair was carried
through to the composed run name, and the omitted half is precisely the one a
cap fix is tempted to break. This PR wrote down the arithmetic in the #476 issue
body and never encoded it as an assertion.

**Why it is not folded into the `xfail`.** This is the part worth being explicit
about, because the obvious placement is wrong. `xfail` swallows a failure. Put
the digest assertion inside the expected-failure and a digest-truncating fix
would clear the cap, leave the test still failing, and be reported as an
expected failure — the exact silence the tripwire exists to prevent. Kept as a
separate test that passes today, it turns red on the truncation whether or not
the `xfail` marker has been removed yet.

Demonstrated rather than asserted. Simulating the bad fix *and* removing the
`xfail` marker, as a post-#476 cleanup would:

| on that tree | result |
|---|---|
| cap assertion alone (the state Copilot flagged) | **2 passed** — silent |
| new digest guard | **2 failed**, naming expected vs actual tail |

Three legs: a short model with no truncation pressure, plus the two that are
over the threshold and so are where a fix has to take characters from somewhere.

Swept the rest of the diff for the same shape — a bound pinned with nothing
guarding what must survive it. `run_collection_name()` is the only composition,
and the base name's pair is already stated, so this closes it.

Both #476 `xfail(strict=True)` cases still report `xfail`, not `xpass`: no
production behaviour changed. Still tests-only — `git diff main -- src/` is 0
lines, `pytest.ini` untouched. 979 passed, 12 skipped, 2 xfailed (was 976, plus
the three new legs).


## Copilot round 4: the docstring claimed a property #447 says we lack

One finding on `c4eedaf1`, inline this time. The new guard's docstring said a
truncating fix would "undo the injectivity #422 shipped" — but #422 shipped an
8-character digest, and #447 is open precisely because 32 bits is searchable.
Calling that injectivity contradicts the issue this PR is careful not to close.

Reworded in `b9767844` to state the trade rather than assert the property:
eight hex characters are 32 bits, birthday point ~65k ids, which takes a
deliberate search; three characters are 12 bits, 4096 buckets, birthday point
~80 ids, which a model zoo reaches by accident. The truncation does not
introduce #447, it makes #447 ordinary. That framing also explains why the case
deserves a dedicated test, which "undoes injectivity" did not.

The same wording has been corrected in the acceptance note on #476, since that
is what a future fixer reads. The one remaining `injective` in the diff is
pre-existing and accurate — the *slug* genuinely isn't injective, which is why
there is a digest — so it stands.

**A process note, recorded because the history looks odd otherwise.** Copilot's
agent pushed `4d02701e` with the same correction while this was being written,
and an amend-and-force-push discarded it. `--force-with-lease` did not catch it,
because the tracking ref had been refreshed in between. Nothing was lost in
substance — the two changes make the same swap and the branch keeps that framing
with the arithmetic added — but the commit is genuinely missing from the history
and that is worth saying plainly rather than leaving as a gap.

Final state: 979 passed, 12 skipped, 2 xfailed. Both #476 `xfail(strict=True)`
cases still report `xfail`. `git diff main -- src/` is 0 lines, `pytest.ini`
untouched, four test files, `Closes #437` only.
