### PR TITLE
fix(sanitizers): surface the per-kernel failure reason on the dashboard

### DIFF
--- a/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
+++ b/docs/sanitizers/consan-gemm-patched-image-growth-cap.md
@@ -245,8 +245,14 @@ Not a defect report. Filed as
    overlap (#10378) and a growth-ceiling rejection are different problems with
    different owners and different fixes, and they are indistinguishable from the
    status code, the exit code, and therefore from any dashboard built on them.
-   Only the human-readable line above the rejection separates them. The request
-   is a stable `cause=` token appended to the `load rejection` line — additive,
+   Only the human-readable line above the rejection separates them. The
+   dashboard's per-kernel `Detail` column does not close this gap: it surfaces
+   the backend's own refusal text where a check emits one (a Waitcheck
+   `waitcheck_backend_exit_N` quotes its `stderr` tail), but the exit-92
+   rejection reaches the report as the bare token
+   `consan_strict_load_rejection` with no prose and no `kernel_results`, so both
+   causes still render the same empty `Detail` and the same observation. The
+   request is a stable `cause=` token appended to the `load rejection` line — additive,
    no status renumbering, no change to any run's outcome. A distinct status per
    rejection class would also work but is behaviour-visible for anything already
    matching 4112, so it was explicitly offered as the non-preferred alternative.

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -628,6 +628,39 @@ def _worse_verdict(current: Any, candidate: Any) -> Any:
     return candidate if ranked > _VERDICT_RANK.get(str(current).strip().lower(), -1) else current
 
 
+def _with_sanitizer(previous: dict[str, Any] | None, sanitizer: str) -> list[str]:
+    """The sanitizers that have contributed a result for one kernel, in order (pure)."""
+    seen = list(previous["sanitizers"]) if previous else []
+    return seen if sanitizer in seen else [*seen, sanitizer]
+
+
+def _merge_reduced(primary: dict[str, Any], other: dict[str, Any]) -> dict[str, Any]:
+    """Fold two accumulated records for the same kernel into one (pure).
+
+    Same arithmetic as the per-check accumulation: the least clean verdict, findings
+    summed so the column still sums to the case total, and every reason kept. Used
+    where one check serialized a full identity for a kernel and another serialized a
+    sparse one, so the two landed under different join keys.
+    """
+    reasons = [*primary["reasons"], *other["reasons"]]
+    return {
+        "verdict": _worse_verdict(primary["verdict"], other["verdict"]),
+        "findings": primary["findings"] + other["findings"],
+        "state": primary["state"],
+        "reasons": reasons,
+        "reason": _kernel_reason_text(reasons),
+        "returncode": (
+            primary["returncode"] if primary["returncode"] is not None else other["returncode"]
+        ),
+        "name": primary["name"],
+        "identity": primary["identity"],
+        "sanitizers": [
+            *primary["sanitizers"],
+            *(s for s in other["sanitizers"] if s not in primary["sanitizers"]),
+        ],
+    }
+
+
 def _identity_key(identity: dict[str, Any]) -> tuple[Any, ...]:
     """The join key from a kernel result to its worklist row (pure).
 
@@ -656,6 +689,12 @@ def _identity_key(identity: dict[str, Any]) -> tuple[Any, ...]:
 # that is inherent to a fixed-width cell with a prefix, and the cell names the
 # covering row, which carries the same reason in full.
 _DETAIL_LIMIT = 300
+
+# A kernel label's share of any length-capped line it appears in. Kernel names are
+# unbounded -- a mangled template instantiation runs to hundreds of characters -- so an
+# unbudgeted label can spend the whole allowance and push the reason beside it off the
+# end, which is the one thing these lines exist to carry.
+_LABEL_LIMIT = 60
 
 
 def _identity_qualifier(
@@ -944,29 +983,11 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 # Kept so a reason can name *which* object failed when two selected
                 # kernels share a symbol name (see ``_kernel_reason_entries``).
                 "identity": identity,
+                # Which checks contributed, so the dedup index below can be built from
+                # Waitcheck results only without re-walking the checks.
+                "sanitizers": _with_sanitizer(previous, sanitizer),
             }
             kr_by_identity[key] = reduced
-            # Only a Waitcheck whole-object scan is ever deduped, so only such a scan
-            # may stand in for a kernel that has no result of its own. The identity
-            # has to be a whole-object one -- real object, real digest, no entry
-            # offset, i.e. ``KernelIdentity.code_object_scan`` -- because an
-            # exact-entry scan covers one entry and not the object: in a mixed
-            # worklist an exact result keyed here first would lend its verdict and
-            # reason to a deduped whole-object sibling it never analyzed. Demanding a
-            # real digest also keeps every digest-less ConSan identity off a shared
-            # ``(None, None)`` key, where an unrelated sibling's verdict would be
-            # reported as "the same code object" -- an attribution to an object that
-            # does not exist.
-            result_sha = identity.get("code_object_sha256")
-            if (
-                sanitizer == "waitcheck"
-                and identity.get("code_object")
-                and result_sha
-                and identity.get("entry_offset") is None
-            ):
-                kr_by_object.setdefault(
-                    (str(result_sha), identity.get("code_object_index")), key
-                )
         resultless = not check.get("kernel_results")
         for finding in check.get("findings", []):
             key = finding.get("kernel_name")
@@ -1010,21 +1031,57 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
         row_key = (row_identity.get("name"), row_identity.get("target"))
         rows_by_name_target[row_key] = rows_by_name_target.get(row_key, 0) + 1
 
+    # Resolve every row to its result *before* anything is attributed from one. Scan
+    # scope is a property of the selection, not of whichever fields a result happened
+    # to serialize, so the dedup index below is built from worklist identities: an
+    # exact-entry result that omits only ``entry_offset`` would otherwise read as a
+    # whole-object scan and lend its verdict to a sibling it never analyzed, and a
+    # ``{name, target}`` whole-object result would never be indexed at all.
+    matched: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for entry in kernel_entries:
+        identity = entry.get("identity", {})
+        row_key = _identity_key(identity)
+        result = kr_by_identity.get(row_key)
+        loose_key = (identity.get("name"), identity.get("target"))
+        candidates = unclaimed.get(loose_key, ())
+        if len(candidates) == 1 and rows_by_name_target.get(loose_key) == 1:
+            # A sparse result is this kernel's result, so it belongs *with* an exact
+            # one rather than instead of it: one check can serialize the full identity
+            # while another serializes only ``{name, target}``, and keeping just the
+            # exact one would drop the other's verdict, reason and findings from the
+            # row -- the same cross-check loss the accumulation above exists to stop.
+            sparse = kr_by_identity.pop(candidates[0])
+            result = _merge_reduced(result, sparse) if result is not None else sparse
+            kr_by_identity[row_key] = result
+        if result is not None:
+            # The row's identity is the fuller one and describes the same kernel, so
+            # the manifest and the labels can name the object the result did not.
+            result["identity"] = identity
+            matched[row_key] = result
+            # Only a Waitcheck whole-object scan is ever deduped, so only such a scan
+            # may stand in for a kernel with no result of its own. The selection has to
+            # be a whole-object one -- real object, real digest, no entry offset, i.e.
+            # ``KernelIdentity.code_object_scan`` -- because an exact-entry scan covers
+            # one entry and not the object. Demanding a real digest also keeps every
+            # digest-less ConSan selection off a shared ``(None, None)`` key, where an
+            # unrelated sibling's verdict would be reported as "the same code object".
+            row_sha = identity.get("code_object_sha256")
+            if (
+                "waitcheck" in result["sanitizers"]
+                and identity.get("code_object")
+                and row_sha
+                and identity.get("entry_offset") is None
+            ):
+                kr_by_object.setdefault(
+                    (str(row_sha), identity.get("code_object_index")), row_key
+                )
+
     kernels: list[dict[str, Any]] = []
     credited: set[Any] = set()
     for entry in kernel_entries:
         identity = entry.get("identity", {})
         name = identity.get("name")
-        result = kr_by_identity.get(_identity_key(identity))
-        if result is None:
-            loose_key = (name, identity.get("target"))
-            candidates = unclaimed.get(loose_key, ())
-            if len(candidates) == 1 and rows_by_name_target.get(loose_key) == 1:
-                result = kr_by_identity[candidates[0]]
-                # The row's identity is the fuller one and describes the same kernel,
-                # so the manifest and the labels can name the object the result did
-                # not. Nothing else reads the sparse identity once it is matched.
-                result["identity"] = identity
+        result = matched.get(_identity_key(identity))
         entry_sha = identity.get("code_object_sha256")
         detail = ""
         if result is not None:
@@ -1049,10 +1106,12 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             # covers this kernel too -- reporting an em dash here read as "not checked"
             # and hid a gated kernel whose object had failed. Findings stay on the
             # covering row so the per-kernel column still sums to the case total.
-            covering = kr_by_identity[covering_key]
+            covering = matched[covering_key]
             verdict = covering["verdict"]
             findings = 0
-            covering_label = label_by_key.get(covering_key, str(covering["name"]))
+            covering_label = _clean_msg(
+                label_by_key.get(covering_key, str(covering["name"])), _LABEL_LIMIT
+            )
             detail = f"same code object as {covering_label}; scanned once"
             if covering["reason"]:
                 detail = f"{detail} \u2014 {covering['reason']}"
@@ -3684,7 +3743,13 @@ def _survey_message_parts(row: dict[str, Any]) -> tuple[str, str]:
     # answer for an errored case.
     kernel_reasons = row.get("kernel_reasons") or []
     if kernel_reasons:
-        detail = "; ".join(f"{e['label']}: {e['reason']}" for e in kernel_reasons)
+        # The label is budgeted too. Kernel names are unbounded -- a mangled template
+        # instantiation runs to hundreds of characters -- so budgeting only the rollup
+        # still let the *label* spend the allowance before its reason began, leaving a
+        # callout that names a kernel and no cause.
+        detail = "; ".join(
+            f"{_clean_msg(str(e['label']), _LABEL_LIMIT)}: {e['reason']}" for e in kernel_reasons
+        )
         # Budget the rollup down first. Clamping only the concatenation let a long
         # rollup spend the whole allowance and truncate the kernel reasons off the
         # end -- and a rollup is not always short: ConSan builds

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -902,7 +902,10 @@ def _display_labels(items: Sequence[tuple[Any, dict[str, Any]]]) -> list[str]:
     as one string and are as ambiguous to a reader as a genuinely repeated name. When
     the qualifiers tie as well -- two long names in the same code object -- the names
     are re-rendered keeping their tails, and then, if even those agree, carrying a
-    digest of the whole name, which cannot tie for names that differ at all.
+    digest of the whole name (see ``_NAME_RENDERINGS``, which ends at the full digest).
+    Distinct names therefore cannot tie: the worklist rejects a duplicate
+    ``stable_key``, so any two items here differ somewhere, and the last tier hashes
+    the whole name untruncated.
     """
     labels: list[str] = []
     for render, rendering in _NAME_RENDERINGS:

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -734,7 +734,11 @@ _LABEL_LIMIT = 60
 
 
 def _identity_qualifier(
-    identity: dict[str, Any], *, index: bool = False, full: bool = False
+    identity: dict[str, Any],
+    *,
+    index: bool = False,
+    full: bool = False,
+    scope: bool = False,
 ) -> str:
     """The shortest identity fragment that tells two same-named kernels apart (pure).
 
@@ -755,6 +759,10 @@ def _identity_qualifier(
     sharing a prefix *and* an index is the one collision the widened qualifier cannot
     otherwise resolve; it is remote, which is why the prefix is what gets rendered
     until a label actually ties.
+
+    ``scope`` distinguishes an identity that omitted ``entry_offset`` from one that
+    explicitly states a whole-object scope with ``entry_offset: null``. The omitted
+    form must stay visibly unattributed instead of looking like the whole-object row.
     """
     digest = identity.get("code_object_sha256")
     parts = (
@@ -766,6 +774,8 @@ def _identity_qualifier(
     offset = identity.get("entry_offset")
     if isinstance(offset, int):
         parts = f"{parts}+0x{offset:x}" if parts else f"0x{offset:x}"
+    elif scope and "entry_offset" not in identity:
+        parts = f"{parts}; scope unknown" if parts else "scope unknown"
     return parts
 
 
@@ -809,6 +819,7 @@ _QUALIFIER_WIDENINGS: tuple[dict[str, bool], ...] = (
     {},
     {"index": True},
     {"index": True, "full": True},
+    {"index": True, "full": True, "scope": True},
 )
 
 
@@ -1109,14 +1120,14 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
         row_key = _identity_key(identity)
         result = kr_by_identity.get(row_key)
         candidates = fallback_by_row.get(row_key, ())
-        if len(candidates) == 1:
-            # A sparse result is this kernel's result, so it belongs *with* an exact
-            # one rather than instead of it: one check can serialize the full identity
-            # while another serializes only ``{name, target}``, and keeping just the
-            # exact one would drop the other's verdict, reason and findings from the
-            # row -- the same cross-check loss the accumulation above exists to stop.
-            sparse = kr_by_identity.pop(candidates[0])
+        for candidate in candidates:
+            # Sparse results compatible with exactly this row belong *with* any exact
+            # result and with one another: separate checks can serialize different
+            # subsets of the same identity, and keeping none when several candidates
+            # exist drops every verdict, reason and finding from the row.
+            sparse = kr_by_identity.pop(candidate)
             result = _merge_reduced(result, sparse) if result is not None else sparse
+        if candidates:
             kr_by_identity[row_key] = result
         if result is not None:
             # The row's identity is the fuller one and describes the same kernel, so

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -658,7 +658,9 @@ def _identity_key(identity: dict[str, Any]) -> tuple[Any, ...]:
 _DETAIL_LIMIT = 300
 
 
-def _identity_qualifier(identity: dict[str, Any], *, index: bool = False) -> str:
+def _identity_qualifier(
+    identity: dict[str, Any], *, index: bool = False, full: bool = False
+) -> str:
     """The shortest identity fragment that tells two same-named kernels apart (pure).
 
     Prefers the code-object digest, falling back to the object's basename, and appends
@@ -673,10 +675,16 @@ def _identity_qualifier(identity: dict[str, Any], *, index: bool = False) -> str
     field this renders by default. It is off by default because selection stamps an
     index on every identity carrying a code object and it is 0 on nearly all of them,
     so rendering it always would pad the labels that are already unique.
+
+    ``full`` spends the whole digest rather than a 10-character prefix. Two objects
+    sharing a prefix *and* an index is the one collision the widened qualifier cannot
+    otherwise resolve; it is remote, which is why the prefix is what gets rendered
+    until a label actually ties.
     """
-    parts = _short(identity.get("code_object_sha256"), 10) or _basename(
-        identity.get("code_object")
-    )
+    digest = identity.get("code_object_sha256")
+    parts = (
+        str(digest) if full and digest else _short(digest, 10)
+    ) or _basename(identity.get("code_object"))
     object_index = identity.get("code_object_index")
     if index and isinstance(object_index, int):
         parts = f"{parts}#{object_index}" if parts else f"#{object_index}"
@@ -684,6 +692,41 @@ def _identity_qualifier(identity: dict[str, Any], *, index: bool = False) -> str
     if isinstance(offset, int):
         parts = f"{parts}+0x{offset:x}" if parts else f"0x{offset:x}"
     return parts
+
+
+# The qualifier widens one field at a time, cheapest first. Everything past the short
+# digest exists for a collision the tier before it cannot resolve, so a label only pays
+# for the ambiguity it actually has.
+_QUALIFIER_WIDENINGS: tuple[dict[str, bool], ...] = (
+    {},
+    {"index": True},
+    {"index": True, "full": True},
+)
+
+
+def _display_labels(items: Sequence[tuple[Any, dict[str, Any]]]) -> list[str]:
+    """Labels for ``(name, identity)`` pairs, qualified only where a name repeats (pure).
+
+    Stops at the first widening that separates the colliding labels, so a unique name
+    renders bare and the common collisions do not pay for the rare ones. The widest
+    tier can still tie -- two identities with nothing to tell them apart -- in which
+    case there is nothing further to disambiguate with.
+    """
+    counts: dict[Any, int] = {}
+    for name, _ in items:
+        counts[name] = counts.get(name, 0) + 1
+    labels = [str(name) for name, _ in items]
+    for widening in _QUALIFIER_WIDENINGS:
+        labels = [
+            f"{name} ({qualifier})"
+            if counts[name] > 1
+            and (qualifier := _identity_qualifier(identity, **widening))
+            else str(name)
+            for name, identity in items
+        ]
+        if len(set(labels)) == len(labels):
+            break
+    return labels
 
 
 def _kernel_reason_entries(results: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -695,28 +738,13 @@ def _kernel_reason_entries(results: Sequence[dict[str, Any]]) -> list[dict[str, 
     records the identity fields, so ``env.json`` can attribute a failure without
     reopening ``sanitizer_report.json``.
 
-    ``label`` is qualified with that identity only where the name is actually
-    ambiguous among the failing kernels, and only as far as it takes to separate the
-    colliding labels -- the digest first, then the code-object index, which is the one
-    field that separates two objects bundled into a single file. Appending either
-    unconditionally would pad every one-line observation for the overwhelmingly common
-    unique-name case, where the name already identifies the kernel.
+    The identity fields are recorded *unabridged*. ``label`` is display copy and is
+    abbreviated (see ``_display_labels``); this projection is what makes ``env.json``
+    diagnosable, and a basename plus a digest prefix can tie where the full path and
+    digest do not -- which would put the ambiguity straight back into the manifest.
     """
     failing = [result for result in results if result["reason"]]
-    seen: dict[Any, int] = {}
-    for result in failing:
-        seen[result["name"]] = seen.get(result["name"], 0) + 1
-    labels = [str(result["name"]) for result in failing]
-    for widen in (False, True):
-        labels = [
-            f"{result['name']} ({qualifier})"
-            if seen[result["name"]] > 1
-            and (qualifier := _identity_qualifier(result["identity"], index=widen))
-            else str(result["name"])
-            for result in failing
-        ]
-        if len(set(labels)) == len(labels):
-            break
+    labels = _display_labels([(result["name"], result["identity"]) for result in failing])
     entries: list[dict[str, Any]] = []
     for label, result in zip(labels, failing, strict=True):
         identity = result["identity"]
@@ -724,8 +752,8 @@ def _kernel_reason_entries(results: Sequence[dict[str, Any]]) -> list[dict[str, 
             "kernel": str(result["name"]),
             "label": label,
             "reason": str(result["reason"]),
-            "code_object": _basename(identity.get("code_object")),
-            "sha": _short(identity.get("code_object_sha256"), 10),
+            "code_object": identity.get("code_object"),
+            "code_object_sha256": identity.get("code_object_sha256"),
             "code_object_index": identity.get("code_object_index"),
             "entry_offset": identity.get("entry_offset"),
         })
@@ -860,6 +888,13 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     # pointed at the fully-accumulated entry once every check has been folded in.
     kr_by_object: dict[tuple[str, Any], tuple[Any, ...]] = {}
     findings_by_name: dict[str | None, int] = {}
+    # Findings from a check that produced no kernel results at all. The combined hook's
+    # mandatory Waitcheck preflight is relabelled out of the ConSan run with its
+    # findings kept and its kernel results dropped (``consan._relabel``), and
+    # ``run_sanitizers`` appends it as a third check -- so its hazards count toward the
+    # case total with no per-kernel result to carry them. A row that has a result of
+    # its own has to pick up the ones naming it, or the column undercounts the case.
+    unattributed_by_name: dict[str | None, int] = {}
     for check in checks:
         sanitizer = str(check.get("sanitizer") or "")
         for result in check.get("kernel_results", []):
@@ -923,20 +958,31 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 kr_by_object.setdefault(
                     (str(result_sha), identity.get("code_object_index")), key
                 )
+        resultless = not check.get("kernel_results")
         for finding in check.get("findings", []):
             key = finding.get("kernel_name")
             findings_by_name[key] = findings_by_name.get(key, 0) + 1
+            if resultless:
+                unattributed_by_name[key] = unattributed_by_name.get(key, 0) + 1
 
     worklist = report.get("worklist", {})
     kernel_entries = worklist.get("kernels", [])
-    # A deduped row's Detail names the scan that covered it. Where two rows share that
-    # name the bare name cannot say which of them did the covering, so the same
-    # qualifier the reason labels use is appended -- and only there.
-    entry_names: dict[Any, int] = {}
-    for entry in kernel_entries:
-        entry_name = entry.get("identity", {}).get("name")
-        entry_names[entry_name] = entry_names.get(entry_name, 0) + 1
+    # A deduped row's Detail names the scan that covered it, and a bare name cannot say
+    # which row that was when two rows share one. Labelled against the whole worklist,
+    # so the qualifier appears only where the name actually repeats.
+    label_by_key = {
+        _identity_key(entry.get("identity", {})): label
+        for entry, label in zip(
+            kernel_entries,
+            _display_labels([
+                (entry.get("identity", {}).get("name"), entry.get("identity", {}))
+                for entry in kernel_entries
+            ]),
+            strict=True,
+        )
+    }
     kernels: list[dict[str, Any]] = []
+    credited: set[Any] = set()
     for entry in kernel_entries:
         identity = entry.get("identity", {})
         name = identity.get("name")
@@ -945,6 +991,15 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
         detail = ""
         if result is not None:
             verdict, findings = result["verdict"], result["findings"]
+            # Credited to the first row of that name only: two rows can share one, and
+            # a resultless finding names a kernel rather than an identity, so crediting
+            # both would double-count it against the case total. A process-scope
+            # finding (no kernel name) is attributable only to a lone kernel.
+            if name not in credited:
+                credited.add(name)
+                findings += unattributed_by_name.get(name, 0)
+                if len(kernel_entries) == 1:
+                    findings += unattributed_by_name.get(None, 0)
             detail = str(result["reason"] or "")
         elif entry_sha and (
             covering_key := kr_by_object.get(
@@ -959,11 +1014,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             covering = kr_by_identity[covering_key]
             verdict = covering["verdict"]
             findings = 0
-            covering_label = str(covering["name"])
-            if entry_names.get(covering["name"], 0) > 1 and (
-                qualifier := _identity_qualifier(covering["identity"], index=True)
-            ):
-                covering_label = f"{covering_label} ({qualifier})"
+            covering_label = label_by_key.get(covering_key, str(covering["name"]))
             detail = f"same code object as {covering_label}; scanned once"
             if covering["reason"]:
                 detail = f"{detail} \u2014 {covering['reason']}"
@@ -2567,7 +2618,7 @@ def build_case_env(
                     "kernel": entry["kernel"],
                     "reason": entry["reason"],
                     "code_object": entry["code_object"],
-                    "sha": entry["sha"],
+                    "code_object_sha256": entry["code_object_sha256"],
                     "code_object_index": entry["code_object_index"],
                     "entry_offset": entry["entry_offset"],
                 }

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -587,13 +587,60 @@ def format_instant(value: Any) -> str:
 
 
 def _clean_msg(message: str, limit: int = 160) -> str:
-    """Collapse a leading absolute path to its basename and clamp length."""
-    text = (message or "").strip()
+    """Collapse a leading absolute path to its basename and clamp length.
+
+    Internal whitespace collapses to single spaces first. Every caller renders into
+    a one-line context -- a Markdown table cell or a single-line callout -- and the
+    backend messages this carries are genuinely multi-line: a Waitcheck reason quotes
+    up to 300 characters of ``stderr`` tail, and a finding message is the tool's own
+    diagnostic. Either would end the table row mid-table and split the rest of the
+    cells into a stray paragraph. Only this display copy is normalized; the raw
+    ``sanitizer_report.json`` keeps the message as the backend emitted it.
+    """
+    text = " ".join((message or "").split())
     if text.startswith("/"):
         head, sep, rest = text.partition(":")
         if sep:
             text = head.rsplit("/", 1)[-1] + sep + rest
     return text if len(text) <= limit else text[: limit - 1] + "\u2026"
+
+
+# Mirrors ``rocjitsu_sanitizers.models._VERDICT_RANK``. The report reduces many
+# verdicts to one by taking the max of that rank, and ``CheckResult`` refuses a check
+# verdict cleaner than its own kernel results. The dashboard reads the serialized
+# strings, so it keeps the same order when it has to reduce several checks' results
+# for one kernel rather than inventing a second notion of "worse".
+_VERDICT_RANK: dict[str, int] = {
+    "pass": 0, "not_checked": 1, "warn": 2, "error": 3, "fail": 4,
+}
+
+
+def _worse_verdict(current: Any, candidate: Any) -> Any:
+    """The less clean of two observed verdicts (pure).
+
+    ``current`` of ``None`` means nothing has been observed yet, so the candidate
+    stands. An unrecognized verdict ranks below every known one rather than raising:
+    this is a renderer, and an unknown string is still worth displaying as-is.
+    """
+    if current is None:
+        return candidate
+    ranked = _VERDICT_RANK.get(str(candidate).strip().lower(), -1)
+    return candidate if ranked > _VERDICT_RANK.get(str(current).strip().lower(), -1) else current
+
+
+def _kernel_reason_text(reasons: Sequence[tuple[str, str]]) -> str:
+    """One kernel's fail-closed reasons, for a one-line display context (pure).
+
+    A lone reason renders bare -- the common case, one check per kernel. Two or more
+    are labelled with the sanitizer that produced them, since a report can hold one
+    check per requested sanitizer over the same worklist and an unlabelled
+    concatenation would not say which check refused.
+    """
+    if len(reasons) == 1:
+        return reasons[0][1]
+    return "; ".join(
+        f"{sanitizer}: {reason}" if sanitizer else reason for sanitizer, reason in reasons
+    )
 
 
 def _primary_checks(checks: list[dict[str, Any]]) -> dict[str, Any]:
@@ -645,8 +692,11 @@ def _observation_text(
     san, verdict = primary.get("sanitizer"), primary.get("verdict")
     head = f"{san or _DASH} {verdict or _DASH}" if (san or verdict) else "no sanitizer check ran"
     parts = [head]
-    if primary.get("reason"):
-        parts.append(f"reason {primary['reason']}")
+    # ``_clean_msg`` because a check-level reason is not always a bare constant: the
+    # combined ConSan hook builds ``waitcheck_analysis_failed: <parser output>`` from
+    # the tool's own text, and this one-liner is rendered as a single Markdown line.
+    if reason := _clean_msg(str(primary.get("reason") or ""), 240):
+        parts.append(f"reason {reason}")
     if kernel_reasons:
         parts.append(
             ", ".join(f"{kernel}: {reason}" for kernel, reason in kernel_reasons)
@@ -698,39 +748,68 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     kr_by_name: dict[str, dict[str, Any]] = {}
     # A whole-code-object scan is deduped by (sha256, index), so the kernels that
     # share an object with an earlier selection carry no kernel_result of their own.
-    # Index the results by object too, so those rows can be attributed to the scan
-    # that covered them instead of rendering as an em dash (see the kernels loop).
-    #
-    # Keyed only for identities that carry a real digest. Waitcheck dedups a
-    # ``code_object_scan``, which requires both a code object and its SHA-256, so a
-    # digest-less identity was never deduped and has nothing to be attributed to.
-    # Admitting one would make every ConSan kernel (code_object and sha both null)
-    # share the ``(None, None)`` key and let an unrelated sibling's verdict and
-    # reason be reported as "the same code object" -- an attribution to an object
-    # that does not exist.
-    kr_by_object: dict[tuple[str, Any], dict[str, Any]] = {}
+    # Map each scanned object to the kernel whose result covered it, so those rows can
+    # be attributed to that scan instead of rendering as an em dash (see the kernels
+    # loop). Storing the name rather than the result keeps the attribution pointed at
+    # the fully-accumulated ``kr_by_name`` entry once every check has been folded in.
+    kr_by_object: dict[tuple[str, Any], str] = {}
     findings_by_name: dict[str | None, int] = {}
     for check in checks:
+        sanitizer = str(check.get("sanitizer") or "")
         for result in check.get("kernel_results", []):
             identity = result.get("identity") or {}
             name = identity.get("name")
+            # A report can hold more than one check over the same worklist -- the
+            # shipped waitcheck+consan survey recipes select a single kernel and scan
+            # it with both -- so this kernel may already carry a result from an
+            # earlier check. Reducing to the last one silently dropped an errored
+            # Waitcheck reason whenever the later ConSan result for that kernel had
+            # none, which is the very disappearance this row exists to prevent. So
+            # accumulate across checks instead: reasons kept per sanitizer, findings
+            # summed so the column still sums to the case total, and the verdict the
+            # least clean of them, ranked as ``models._VERDICT_RANK`` ranks the
+            # report's own rollup, so the badge can never read cleaner than the
+            # Detail column beside it.
+            previous = kr_by_name.get(name)
+            reasons: list[tuple[str, str]] = list(previous["reasons"]) if previous else []
+            # The fail-closed detail. ``CheckResult.reason`` only ever carries the
+            # rollup (``worklist_not_fully_checked``); the per-kernel reason is the
+            # only field that says what actually went wrong, so it must survive into
+            # the row the renderers read.
+            if reason := _clean_msg(str(result.get("reason") or ""), 300):
+                reasons.append((sanitizer, reason))
             reduced = {
-                "verdict": result.get("verdict"),
-                "findings": len(result.get("findings", [])),
-                # The fail-closed detail. ``CheckResult.reason`` only ever carries the
-                # rollup (``worklist_not_fully_checked``); the per-kernel reason is the
-                # only field that says what actually went wrong, so it must survive
-                # into the row the renderers read.
+                "verdict": _worse_verdict(
+                    previous["verdict"] if previous else None, result.get("verdict")
+                ),
+                "findings": (previous["findings"] if previous else 0)
+                + len(result.get("findings", [])),
                 "state": result.get("state"),
-                "reason": result.get("reason"),
+                "reasons": reasons,
+                "reason": _kernel_reason_text(reasons),
                 "returncode": result.get("returncode"),
-                "covering_kernel": name,
             }
             kr_by_name[name] = reduced
+            # Only a Waitcheck whole-object scan is ever deduped, so only such a scan
+            # may stand in for a kernel that has no result of its own. The identity
+            # has to be a whole-object one -- real object, real digest, no entry
+            # offset, i.e. ``KernelIdentity.code_object_scan`` -- because an
+            # exact-entry scan covers one entry and not the object: in a mixed
+            # worklist an exact result keyed here first would lend its verdict and
+            # reason to a deduped whole-object sibling it never analyzed. Demanding a
+            # real digest also keeps every digest-less ConSan identity off a shared
+            # ``(None, None)`` key, where an unrelated sibling's verdict would be
+            # reported as "the same code object" -- an attribution to an object that
+            # does not exist.
             result_sha = identity.get("code_object_sha256")
-            if result_sha:
+            if (
+                sanitizer == "waitcheck"
+                and identity.get("code_object")
+                and result_sha
+                and identity.get("entry_offset") is None
+            ):
                 kr_by_object.setdefault(
-                    (str(result_sha), identity.get("code_object_index")), reduced
+                    (str(result_sha), identity.get("code_object_index")), str(name)
                 )
         for finding in check.get("findings", []):
             key = finding.get("kernel_name")
@@ -749,7 +828,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             verdict, findings = result["verdict"], result["findings"]
             detail = str(result["reason"] or "")
         elif entry_sha and (
-            covering := kr_by_object.get(
+            covered_by := kr_by_object.get(
                 (str(entry_sha), identity.get("code_object_index"))
             )
         ) is not None:
@@ -758,9 +837,9 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             # covers this kernel too -- reporting an em dash here read as "not checked"
             # and hid a gated kernel whose object had failed. Findings stay on the
             # covering row so the per-kernel column still sums to the case total.
+            covering = kr_by_name[covered_by]
             verdict = covering["verdict"]
             findings = 0
-            covered_by = covering["covering_kernel"]
             detail = f"same code object as {covered_by}; scanned once"
             if covering["reason"]:
                 detail = f"{detail} \u2014 {covering['reason']}"
@@ -801,8 +880,8 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     # Only the kernels that carry their own fail-closed reason; a deduped row's
     # detail restates its covering scan's reason, which would double it up here.
     kernel_reasons = [
-        (str(result["covering_kernel"]), str(result["reason"]))
-        for result in kr_by_name.values()
+        (str(name), str(result["reason"]))
+        for name, result in kr_by_name.items()
         if result["reason"]
     ]
     observation = _observation_text(

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1216,11 +1216,11 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             findings = 0
             if name not in credited:
                 credited.add(name)
-                findings = findings_by_name.get(name, 0)
+                findings = unattributed_by_name.get(name, 0)
                 # dynamic ConSan attributes race findings at process scope
                 # (kernel_name is null); with one worklist row, credit it there.
                 if findings == 0 and len(kernel_entries) == 1:
-                    findings = findings_by_name.get(None, 0)
+                    findings = unattributed_by_name.get(None, 0)
             verdict = report.get("overall_verdict") if len(kernel_entries) == 1 or findings else "—"
         kernels.append({
             "name": name,

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -71,6 +71,7 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import hashlib
 import json
 import os
 import re
@@ -639,15 +640,17 @@ _IDENTITY_OBJECT_FIELDS = (
 def _identity_compatible(row: dict[str, Any], result: dict[str, Any]) -> bool:
     """Whether a result identity can describe this worklist row (pure).
 
-    Only *omitted* fields are wildcards. Every code-object field is optional on the
-    wire, so a result may carry a sparser view of the row it came from -- but a field
-    that is populated and disagrees describes a different object, and treating it as a
-    match would attach one object's reason to another object's row.
+    Only *omitted* fields are wildcards -- omitted, not null. Every code-object field
+    is optional on the wire, so a result may carry a sparser view of the row it came
+    from, but a field it does serialize is a claim: ``entry_offset: null`` says this
+    was a whole-object scan and cannot describe an exact-entry selection, and a
+    disagreeing digest describes a different object entirely. Treating either as a
+    match would attach one selection's reason to another selection's row.
     """
     if row.get("name") != result.get("name") or row.get("target") != result.get("target"):
         return False
     return all(
-        result.get(field) is None or result.get(field) == row.get(field)
+        field not in result or result.get(field) == row.get(field)
         for field in _IDENTITY_OBJECT_FIELDS
     )
 
@@ -696,6 +699,14 @@ def _identity_key(identity: dict[str, Any]) -> tuple[Any, ...]:
     single row: each got the other's verdict and reasons, and their findings were
     summed onto both, double-counting against the case total. Joining on every
     serialized identity field keeps them separate; the name stays display text.
+
+    The key also records *which* optional fields the identity carries, because an
+    omitted field and an explicit null are different claims: a whole-object selection
+    states ``entry_offset: null``, while a result that simply did not serialize the
+    field says nothing about it. Reading them as equal collapsed an exact-entry result
+    that omitted its offset onto the whole-object result for the same object, before
+    either had been reconciled with a selection -- merging two scans of different
+    scopes and letting the merged verdict reach the deduped siblings of one of them.
     """
     return (
         identity.get("target"),
@@ -704,6 +715,7 @@ def _identity_key(identity: dict[str, Any]) -> tuple[Any, ...]:
         identity.get("code_object_index"),
         identity.get("entry_offset"),
         identity.get("name"),
+        *(field in identity for field in _IDENTITY_OBJECT_FIELDS),
     )
 
 
@@ -776,6 +788,20 @@ def _middle_clip_name(name: str) -> str:
     return f"{clean[:head]}\u2026{clean[head - _LABEL_LIMIT + 1:]}"
 
 
+def _hashed_clip_name(name: str) -> str:
+    """A clipped kernel name with a digest of the whole one (pure).
+
+    The last resort. Two names can agree on both ends and differ only in the middle the
+    budget elides, and if they also share a code object no identity field can separate
+    them either. A digest of the full name always can, at the cost of a label nobody
+    can read back to a symbol -- which is why nothing reaches for it until every
+    readable discriminator has tied.
+    """
+    clean = " ".join(name.split())
+    digest = hashlib.sha256(clean.encode("utf-8")).hexdigest()[:8]
+    return f"{_middle_clip_name(clean)} ~{digest}"
+
+
 # The qualifier widens one field at a time, cheapest first. Everything past the short
 # digest exists for a collision the tier before it cannot resolve, so a label only pays
 # for the ambiguity it actually has.
@@ -795,11 +821,11 @@ def _display_labels(items: Sequence[tuple[Any, dict[str, Any]]]) -> list[str]:
     ``_LABEL_LIMIT``), so two distinct names agreeing on their first characters render
     as one string and are as ambiguous to a reader as a genuinely repeated name. When
     the qualifiers tie as well -- two long names in the same code object -- the names
-    are re-rendered keeping their tails, which is the only thing left that differs. The
-    last tier can still tie, in which case there is nothing to disambiguate with.
+    are re-rendered keeping their tails, and then, if even those agree, carrying a
+    digest of the whole name, which cannot tie for names that differ at all.
     """
     labels: list[str] = []
-    for render in (_clip_name, _middle_clip_name):
+    for render in (_clip_name, _middle_clip_name, _hashed_clip_name):
         display = [render(str(name)) for name, _ in items]
         counts: dict[str, int] = {}
         for shown in display:

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -757,6 +757,25 @@ def _identity_qualifier(
     return parts
 
 
+def _clip_name(name: str) -> str:
+    """A kernel name budgeted for a length-capped line (pure)."""
+    return _clean_msg(name, _LABEL_LIMIT)
+
+
+def _middle_clip_name(name: str) -> str:
+    """The same budget spent on both ends of a kernel name (pure).
+
+    Two mangled instantiations of one template can share hundreds of leading characters
+    and differ only in a suffix, so a head-only budget renders them identically. Keeping
+    a tail costs readability, which is why it is the fallback rather than the default.
+    """
+    clean = " ".join(name.split())
+    if len(clean) <= _LABEL_LIMIT:
+        return clean
+    head = (_LABEL_LIMIT * 2) // 3
+    return f"{clean[:head]}\u2026{clean[head - _LABEL_LIMIT + 1:]}"
+
+
 # The qualifier widens one field at a time, cheapest first. Everything past the short
 # digest exists for a collision the tier before it cannot resolve, so a label only pays
 # for the ambiguity it actually has.
@@ -771,28 +790,30 @@ def _display_labels(items: Sequence[tuple[Any, dict[str, Any]]]) -> list[str]:
     """Labels for ``(name, identity)`` pairs, qualified only where a name repeats (pure).
 
     Stops at the first widening that separates the colliding labels, so a unique name
-    renders bare and the common collisions do not pay for the rare ones. The widest
-    tier can still tie -- two identities with nothing to tell them apart -- in which
-    case there is nothing further to disambiguate with.
+    renders bare and the common collisions do not pay for the rare ones. Collisions are
+    counted on the *rendered* names rather than the originals: names are budgeted (see
+    ``_LABEL_LIMIT``), so two distinct names agreeing on their first characters render
+    as one string and are as ambiguous to a reader as a genuinely repeated name. When
+    the qualifiers tie as well -- two long names in the same code object -- the names
+    are re-rendered keeping their tails, which is the only thing left that differs. The
+    last tier can still tie, in which case there is nothing to disambiguate with.
     """
-    counts: dict[Any, int] = {}
-    for name, _ in items:
-        counts[name] = counts.get(name, 0) + 1
-    # The *name* is what gets budgeted, before the qualifier is appended. Clamping the
-    # assembled label instead right-truncates the qualifier away, so two rows sharing a
-    # long name would render the same prefix and lose the disambiguation this exists for.
-    display = [_clean_msg(str(name), _LABEL_LIMIT) for name, _ in items]
-    labels = list(display)
-    for widening in _QUALIFIER_WIDENINGS:
-        labels = [
-            f"{shown} ({qualifier})"
-            if counts[name] > 1
-            and (qualifier := _identity_qualifier(identity, **widening))
-            else shown
-            for shown, (name, identity) in zip(display, items, strict=True)
-        ]
-        if len(set(labels)) == len(labels):
-            break
+    labels: list[str] = []
+    for render in (_clip_name, _middle_clip_name):
+        display = [render(str(name)) for name, _ in items]
+        counts: dict[str, int] = {}
+        for shown in display:
+            counts[shown] = counts.get(shown, 0) + 1
+        for widening in _QUALIFIER_WIDENINGS:
+            labels = [
+                f"{shown} ({qualifier})"
+                if counts[shown] > 1
+                and (qualifier := _identity_qualifier(identity, **widening))
+                else shown
+                for shown, (_, identity) in zip(display, items, strict=True)
+            ]
+            if len(set(labels)) == len(labels):
+                return labels
     return labels
 
 
@@ -1025,20 +1046,6 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
 
     worklist = report.get("worklist", {})
     kernel_entries = worklist.get("kernels", [])
-    # A deduped row's Detail names the scan that covered it, and a bare name cannot say
-    # which row that was when two rows share one. Labelled against the whole worklist,
-    # so the qualifier appears only where the name actually repeats.
-    label_by_key = {
-        _identity_key(entry.get("identity", {})): label
-        for entry, label in zip(
-            kernel_entries,
-            _display_labels([
-                (entry.get("identity", {}).get("name"), entry.get("identity", {}))
-                for entry in kernel_entries
-            ]),
-            strict=True,
-        )
-    }
     # A result's identity can be sparser than the worklist row it describes: every
     # code-object field is optional on the wire (``KernelIdentity.from_dict``), and
     # reports whose results carry only ``{name, target}`` exist. The full-identity join
@@ -1107,6 +1114,25 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 kr_by_object.setdefault(
                     (str(row_sha), identity.get("code_object_index")), row_key
                 )
+
+    # A deduped row's Detail names the scan that covered it, and a reason names the
+    # kernel behind it, so both need a label that says *which* one. Built over the rows
+    # and the results no row claimed: an unattributed reason rendering a bare name that
+    # matches a visible row reads as an accusation against that row, when the object it
+    # actually came from is not on the page at all.
+    labelled: list[tuple[Any, dict[str, Any]]] = [
+        (entry.get("identity", {}).get("name"), entry.get("identity", {}))
+        for entry in kernel_entries
+    ]
+    labelled += [
+        (reduced["name"], reduced["identity"])
+        for key, reduced in kr_by_identity.items()
+        if key not in matched
+    ]
+    label_by_key = {
+        _identity_key(identity): label
+        for (_, identity), label in zip(labelled, _display_labels(labelled), strict=True)
+    }
 
     kernels: list[dict[str, Any]] = []
     credited: set[Any] = set()

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -683,15 +683,22 @@ def _dedup_covers(row: Mapping[str, Any], covering: Mapping[str, Any]) -> bool:
     deduped away is genuinely covered -- which is why an em dash there read as "not
     checked" and hid a gated kernel whose object had failed.
 
-    But ``run_waitcheck`` only dedups selections with ``entry_offset is None``; an
-    exact-entry selection always gets its own scan task. A missing result on such a row
-    therefore means the result was lost or unattributable, not that it was folded into
-    this scan, and a *clean* scan standing in for it would render "scanned once" over a
-    row whose own error is sitting unattributed at case scope. A non-clean scan is still
-    worth showing there -- the object it lives in did fail -- so only the clean
-    direction is withheld.
+    But ``run_waitcheck`` dedups a selection only when it is a whole-object one, and
+    that is the full ``KernelIdentity.code_object_scan`` shape -- a real object, a real
+    digest, and no entry offset. An exact-entry selection, or one carrying a digest with
+    no object, always gets its own scan task. A missing result on such a row therefore
+    means the result was lost or unattributable, not that it was folded into this scan,
+    and a *clean* scan standing in for it would render "scanned once" over a row whose
+    own error is sitting unattributed at case scope. A non-clean scan is still worth
+    showing there -- the object it lives in did fail -- so only the clean direction is
+    withheld. The condition mirrors the producer's, applied to the recipient.
     """
-    if row.get("entry_offset") is None:
+    could_have_been_deduped = bool(
+        row.get("code_object")
+        and row.get("code_object_sha256")
+        and row.get("entry_offset") is None
+    )
+    if could_have_been_deduped:
         return True
     return str(covering.get("verdict") or "").strip().lower() not in {"pass", "not_checked"}
 

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -76,7 +76,7 @@ import os
 import re
 import shutil
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from html import escape as _esc
 from pathlib import Path
@@ -729,7 +729,9 @@ def _display_labels(items: Sequence[tuple[Any, dict[str, Any]]]) -> list[str]:
     return labels
 
 
-def _kernel_reason_entries(results: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+def _kernel_reason_entries(
+    results: Sequence[dict[str, Any]], labels_by_key: Mapping[tuple[Any, ...], str]
+) -> list[dict[str, Any]]:
     """The failing kernels' reasons, each carrying the identity behind it (pure).
 
     A kernel name is not unique (see ``_identity_key``), so a bare name cannot say
@@ -742,12 +744,19 @@ def _kernel_reason_entries(results: Sequence[dict[str, Any]]) -> list[dict[str, 
     abbreviated (see ``_display_labels``); this projection is what makes ``env.json``
     diagnosable, and a basename plus a digest prefix can tie where the full path and
     digest do not -- which would put the ambiguity straight back into the manifest.
+
+    ``labels_by_key`` is built over the whole worklist rather than over the failing
+    results, because what makes a name ambiguous is what the *page* shows: one failure
+    beside a clean same-named sibling still leaves a reader unable to say which of the
+    two rows the reason belongs to. A result with no worklist row behind it has nothing
+    to be ambiguous against and keeps its bare name.
     """
-    failing = [result for result in results if result["reason"]]
-    labels = _display_labels([(result["name"], result["identity"]) for result in failing])
     entries: list[dict[str, Any]] = []
-    for label, result in zip(labels, failing, strict=True):
+    for result in results:
+        if not result["reason"]:
+            continue
         identity = result["identity"]
+        label = labels_by_key.get(_identity_key(identity), str(result["name"]))
         entries.append({
             "kernel": str(result["name"]),
             "label": label,
@@ -981,12 +990,41 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             strict=True,
         )
     }
+    # A result's identity can be sparser than the worklist row it describes: every
+    # code-object field is optional on the wire (``KernelIdentity.from_dict``), and
+    # reports whose results carry only ``{name, target}`` exist. The full-identity join
+    # is what keeps two same-named selections apart, so it stays first -- but where it
+    # finds nothing, dropping the result would lose exactly the per-kernel reason this
+    # dashboard exists to surface. Falling back to ``(name, target)`` is safe only when
+    # it can mean one thing: one worklist row and one unclaimed result.
+    claimed = {_identity_key(entry.get("identity", {})) for entry in kernel_entries}
+    unclaimed: dict[tuple[Any, Any], list[tuple[Any, ...]]] = {}
+    for key, reduced in kr_by_identity.items():
+        if key in claimed:
+            continue
+        sparse = reduced["identity"]
+        unclaimed.setdefault((sparse.get("name"), sparse.get("target")), []).append(key)
+    rows_by_name_target: dict[tuple[Any, Any], int] = {}
+    for entry in kernel_entries:
+        row_identity = entry.get("identity", {})
+        row_key = (row_identity.get("name"), row_identity.get("target"))
+        rows_by_name_target[row_key] = rows_by_name_target.get(row_key, 0) + 1
+
     kernels: list[dict[str, Any]] = []
     credited: set[Any] = set()
     for entry in kernel_entries:
         identity = entry.get("identity", {})
         name = identity.get("name")
         result = kr_by_identity.get(_identity_key(identity))
+        if result is None:
+            loose_key = (name, identity.get("target"))
+            candidates = unclaimed.get(loose_key, ())
+            if len(candidates) == 1 and rows_by_name_target.get(loose_key) == 1:
+                result = kr_by_identity[candidates[0]]
+                # The row's identity is the fuller one and describes the same kernel,
+                # so the manifest and the labels can name the object the result did
+                # not. Nothing else reads the sparse identity once it is matched.
+                result["identity"] = identity
         entry_sha = identity.get("code_object_sha256")
         detail = ""
         if result is not None:
@@ -1054,7 +1092,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     primary = _primary_checks(checks)
     # Only the kernels that carry their own fail-closed reason; a deduped row's
     # detail restates its covering scan's reason, which would double it up here.
-    kernel_reasons = _kernel_reason_entries(list(kr_by_identity.values()))
+    kernel_reasons = _kernel_reason_entries(list(kr_by_identity.values()), label_by_key)
     observation = _observation_text(
         primary, findings_total, finding_groups, kernel_reasons=kernel_reasons
     )

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1037,10 +1037,10 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             # Detail column beside it.
             previous = kr_by_identity.get(key)
             reasons: list[tuple[str, str]] = list(previous["reasons"]) if previous else []
-            # The fail-closed detail. ``CheckResult.reason`` only ever carries the
-            # rollup (``worklist_not_fully_checked``); the per-kernel reason is the
-            # only field that says what actually went wrong, so it must survive into
-            # the row the renderers read.
+            # The fail-closed detail. Waitcheck's ``CheckResult.reason`` only carries
+            # the rollup (``worklist_not_fully_checked``); the per-kernel reason is
+            # the only field that says what actually went wrong, so it must survive
+            # into the row the renderers read.
             if reason := _clean_msg(str(result.get("reason") or ""), _DETAIL_LIMIT):
                 reasons.append((sanitizer, reason))
             reduced = {
@@ -1200,11 +1200,16 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             if covering["reason"]:
                 detail = f"{detail} \u2014 {covering['reason']}"
         else:
-            findings = findings_by_name.get(name, 0)
-            # dynamic ConSan attributes race findings at process scope (kernel_name
-            # is null); with a single-kernel worklist, credit them to that kernel.
-            if findings == 0 and len(kernel_entries) == 1:
-                findings = findings_by_name.get(None, 0)
+            # A result-less finding names a kernel, not an identity. When several
+            # uncovered rows share that name, credit it once rather than once per row.
+            findings = 0
+            if name not in credited:
+                credited.add(name)
+                findings = findings_by_name.get(name, 0)
+                # dynamic ConSan attributes race findings at process scope
+                # (kernel_name is null); with one worklist row, credit it there.
+                if findings == 0 and len(kernel_entries) == 1:
+                    findings = findings_by_name.get(None, 0)
             verdict = report.get("overall_verdict") if len(kernel_entries) == 1 or findings else "—"
         kernels.append({
             "name": name,

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -676,6 +676,24 @@ def _identity_compatible(row: dict[str, Any], result: dict[str, Any]) -> bool:
     )
 
 
+def _waitcheck_view(reduced: Mapping[str, Any]) -> dict[str, Any]:
+    """The Waitcheck-only part of an accumulated record (pure).
+
+    Only a Waitcheck whole-object scan covers a deduped sibling, but the accumulation
+    folds every sanitizer's result for a kernel into one record. Attributing that
+    aggregate would lend the sibling an outcome that was never about it: ConSan runs the
+    process once and reports per kernel, so a covering row carrying a Waitcheck ``pass``
+    beside a ConSan ``error`` covers its sibling with the ``pass`` alone -- rendering it
+    ``error`` with "scanned once -- <ConSan reason>" is a claim no scan made.
+    """
+    reasons = [(san, reason) for san, reason in reduced.get("reasons", ()) if san == "waitcheck"]
+    return {
+        "verdict": reduced.get("waitcheck_verdict"),
+        "reason": _kernel_reason_text(reasons),
+        "name": reduced.get("name"),
+    }
+
+
 def _dedup_covers(row: Mapping[str, Any], covering: Mapping[str, Any]) -> bool:
     """Whether an object scan may speak for a row that has no result of its own (pure).
 
@@ -720,6 +738,9 @@ def _merge_reduced(primary: dict[str, Any], other: dict[str, Any]) -> dict[str, 
     reasons = [*primary["reasons"], *other["reasons"]]
     return {
         "verdict": _worse_verdict(primary["verdict"], other["verdict"]),
+        "waitcheck_verdict": _worse_verdict(
+            primary["waitcheck_verdict"], other["waitcheck_verdict"]
+        ),
         "findings": primary["findings"] + other["findings"],
         "state": primary["state"],
         "reasons": reasons,
@@ -1146,6 +1167,14 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 "verdict": _worse_verdict(
                     previous["verdict"] if previous else None, result.get("verdict")
                 ),
+                # Folded separately, because only a Waitcheck object scan covers a
+                # deduped sibling -- see ``_waitcheck_view``.
+                "waitcheck_verdict": _worse_verdict(
+                    previous["waitcheck_verdict"] if previous else None,
+                    result.get("verdict"),
+                ) if sanitizer == "waitcheck" else (
+                    previous["waitcheck_verdict"] if previous else None
+                ),
                 "findings": (previous["findings"] if previous else 0)
                 + len(result.get("findings", [])),
                 "state": result.get("state"),
@@ -1283,13 +1312,17 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             covering_key := kr_by_object.get(
                 (str(entry_sha), identity.get("code_object_index"))
             )
-        ) is not None and _dedup_covers(identity, matched[covering_key]):
+        ) is not None and _dedup_covers(
+            identity, _waitcheck_view(matched[covering_key])
+        ):
             # Deduped: this kernel's object WAS scanned, under the name of the first
             # selection that resolved to it. The scan is object-scope, so its verdict
             # covers this kernel too -- reporting an em dash here read as "not checked"
             # and hid a gated kernel whose object had failed. Findings stay on the
             # covering row so the per-kernel column still sums to the case total.
-            covering = matched[covering_key]
+            # The Waitcheck-only view: the object scan is what covered this row, and
+            # a sibling sanitizer's outcome for the covering kernel says nothing here.
+            covering = _waitcheck_view(matched[covering_key])
             verdict = covering["verdict"]
             findings = 0
             covering_label = label_by_key.get(

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -587,7 +587,7 @@ def format_instant(value: Any) -> str:
     return parsed.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
-def _clean_msg(message: str, limit: int = 160) -> str:
+def _clean_msg(message: str, limit: int | None = 160) -> str:
     """Collapse a leading absolute path to its basename and clamp length.
 
     Internal whitespace collapses to single spaces first. Every caller renders into
@@ -597,13 +597,22 @@ def _clean_msg(message: str, limit: int = 160) -> str:
     diagnostic. Either would end the table row mid-table and split the rest of the
     cells into a stray paragraph. Only this display copy is normalized; the raw
     ``sanitizer_report.json`` keeps the message as the backend emitted it.
+
+    ``limit=None`` normalizes without clamping, for the sinks that render onto a line
+    of their own. Truncation is from the right, which is destructive when the
+    discriminating part of a message is its tail -- a ``CoverageDecision`` reason
+    appends ``_failure_attributions`` (``resource_failed`` vs
+    ``placement_or_lowering_failed``) after its counts, so a clamp keeps the counts
+    and drops the only text that says *why* coverage was rejected.
     """
     text = " ".join((message or "").split())
     if text.startswith("/"):
         head, sep, rest = text.partition(":")
         if sep:
             text = head.rsplit("/", 1)[-1] + sep + rest
-    return text if len(text) <= limit else text[: limit - 1] + "\u2026"
+    if limit is None or len(text) <= limit:
+        return text
+    return text[: limit - 1] + "\u2026"
 
 
 # Mirrors ``rocjitsu_sanitizers.models._VERDICT_RANK``. The report reduces many
@@ -973,7 +982,11 @@ def _observation_text(
     # ``_clean_msg`` because a check-level reason is not always a bare constant: the
     # combined ConSan hook builds ``waitcheck_analysis_failed: <parser output>`` from
     # the tool's own text, and this one-liner is rendered as a single Markdown line.
-    if reason := _clean_msg(str(primary.get("reason") or ""), 240):
+    # Normalized but *not* clamped: this text goes onto a line of its own rather than
+    # into a table cell, and a ConSan coverage reason carries its discriminator last
+    # (see ``_clean_msg``), so a length cap here would collapse a lowering defect and
+    # a capacity rejection into the same sentence.
+    if reason := _clean_msg(str(primary.get("reason") or ""), None):
         parts.append(f"reason {reason}")
     if kernel_reasons:
         parts.append(

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -4573,7 +4573,11 @@ def _survey_summary_md(groups: list[tuple[str, list[dict[str, Any]]]]) -> list[s
     ]
     for key, entries in groups:
         by_san = _survey_group_by_sanitizer(entries)
-        note = _survey_group_note(entries)
+        # Same treatment as the sibling Detail and Example cells: a group note is a
+        # backend reason (``waitcheck_analysis_failed: <parser output>``), so it can
+        # carry newlines that end the row mid-table and pipes that shift every cell
+        # after it. The HTML twin renders inside a ``<td>`` and needs neither.
+        note = _clean_msg(_survey_group_note(entries), _MSG_LIMIT).replace("|", "\\|")
         lines.append(
             f"| {_survey_group_label(key, entries)} | {cell(by_san.get('waitcheck'))} "
             f"| {cell(by_san.get('consan'))} | {_survey_group_findings(entries)} "

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -628,6 +628,30 @@ def _worse_verdict(current: Any, candidate: Any) -> Any:
     return candidate if ranked > _VERDICT_RANK.get(str(current).strip().lower(), -1) else current
 
 
+_IDENTITY_OBJECT_FIELDS = (
+    "code_object",
+    "code_object_sha256",
+    "code_object_index",
+    "entry_offset",
+)
+
+
+def _identity_compatible(row: dict[str, Any], result: dict[str, Any]) -> bool:
+    """Whether a result identity can describe this worklist row (pure).
+
+    Only *omitted* fields are wildcards. Every code-object field is optional on the
+    wire, so a result may carry a sparser view of the row it came from -- but a field
+    that is populated and disagrees describes a different object, and treating it as a
+    match would attach one object's reason to another object's row.
+    """
+    if row.get("name") != result.get("name") or row.get("target") != result.get("target"):
+        return False
+    return all(
+        result.get(field) is None or result.get(field) == row.get(field)
+        for field in _IDENTITY_OBJECT_FIELDS
+    )
+
+
 def _with_sanitizer(previous: dict[str, Any] | None, sanitizer: str) -> list[str]:
     """The sanitizers that have contributed a result for one kernel, in order (pure)."""
     seen = list(previous["sanitizers"]) if previous else []
@@ -754,14 +778,18 @@ def _display_labels(items: Sequence[tuple[Any, dict[str, Any]]]) -> list[str]:
     counts: dict[Any, int] = {}
     for name, _ in items:
         counts[name] = counts.get(name, 0) + 1
-    labels = [str(name) for name, _ in items]
+    # The *name* is what gets budgeted, before the qualifier is appended. Clamping the
+    # assembled label instead right-truncates the qualifier away, so two rows sharing a
+    # long name would render the same prefix and lose the disambiguation this exists for.
+    display = [_clean_msg(str(name), _LABEL_LIMIT) for name, _ in items]
+    labels = list(display)
     for widening in _QUALIFIER_WIDENINGS:
         labels = [
-            f"{name} ({qualifier})"
+            f"{shown} ({qualifier})"
             if counts[name] > 1
             and (qualifier := _identity_qualifier(identity, **widening))
-            else str(name)
-            for name, identity in items
+            else shown
+            for shown, (name, identity) in zip(display, items, strict=True)
         ]
         if len(set(labels)) == len(labels):
             break
@@ -1019,17 +1047,22 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     # dashboard exists to surface. Falling back to ``(name, target)`` is safe only when
     # it can mean one thing: one worklist row and one unclaimed result.
     claimed = {_identity_key(entry.get("identity", {})) for entry in kernel_entries}
-    unclaimed: dict[tuple[Any, Any], list[tuple[Any, ...]]] = {}
-    for key, reduced in kr_by_identity.items():
-        if key in claimed:
-            continue
-        sparse = reduced["identity"]
-        unclaimed.setdefault((sparse.get("name"), sparse.get("target")), []).append(key)
-    rows_by_name_target: dict[tuple[Any, Any], int] = {}
-    for entry in kernel_entries:
-        row_identity = entry.get("identity", {})
-        row_key = (row_identity.get("name"), row_identity.get("target"))
-        rows_by_name_target[row_key] = rows_by_name_target.get(row_key, 0) + 1
+    unclaimed = [key for key in kr_by_identity if key not in claimed]
+    # An unmatched result is only a candidate for the rows it *cannot contradict*, and
+    # only where it can mean one of them: a populated field that disagrees describes a
+    # different object rather than a sparser view of this one, and attributing it here
+    # would put another object's reason on this row and then stamp this row's identity
+    # onto it -- a manifest that names the wrong object is worse than one that names none.
+    fallback_by_row: dict[tuple[Any, ...], list[tuple[Any, ...]]] = {}
+    for key in unclaimed:
+        sparse = kr_by_identity[key]["identity"]
+        rows = [
+            _identity_key(entry.get("identity", {}))
+            for entry in kernel_entries
+            if _identity_compatible(entry.get("identity", {}), sparse)
+        ]
+        if len(rows) == 1:
+            fallback_by_row.setdefault(rows[0], []).append(key)
 
     # Resolve every row to its result *before* anything is attributed from one. Scan
     # scope is a property of the selection, not of whichever fields a result happened
@@ -1042,9 +1075,8 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
         identity = entry.get("identity", {})
         row_key = _identity_key(identity)
         result = kr_by_identity.get(row_key)
-        loose_key = (identity.get("name"), identity.get("target"))
-        candidates = unclaimed.get(loose_key, ())
-        if len(candidates) == 1 and rows_by_name_target.get(loose_key) == 1:
+        candidates = fallback_by_row.get(row_key, ())
+        if len(candidates) == 1:
             # A sparse result is this kernel's result, so it belongs *with* an exact
             # one rather than instead of it: one check can serialize the full identity
             # while another serializes only ``{name, target}``, and keeping just the
@@ -1109,8 +1141,8 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             covering = matched[covering_key]
             verdict = covering["verdict"]
             findings = 0
-            covering_label = _clean_msg(
-                label_by_key.get(covering_key, str(covering["name"])), _LABEL_LIMIT
+            covering_label = label_by_key.get(
+                covering_key, _clean_msg(str(covering["name"]), _LABEL_LIMIT)
             )
             detail = f"same code object as {covering_label}; scanned once"
             if covering["reason"]:
@@ -3743,13 +3775,11 @@ def _survey_message_parts(row: dict[str, Any]) -> tuple[str, str]:
     # answer for an errored case.
     kernel_reasons = row.get("kernel_reasons") or []
     if kernel_reasons:
-        # The label is budgeted too. Kernel names are unbounded -- a mangled template
-        # instantiation runs to hundreds of characters -- so budgeting only the rollup
-        # still let the *label* spend the allowance before its reason began, leaving a
-        # callout that names a kernel and no cause.
-        detail = "; ".join(
-            f"{_clean_msg(str(e['label']), _LABEL_LIMIT)}: {e['reason']}" for e in kernel_reasons
-        )
+        # Labels arrive with their name already budgeted (``_display_labels``), which
+        # is what stops an unbounded kernel name from spending the allowance before its
+        # reason begins -- while keeping the identity qualifier a right-truncation here
+        # would have cut off.
+        detail = "; ".join(f"{e['label']}: {e['reason']}" for e in kernel_reasons)
         # Budget the rollup down first. Clamping only the concatenation let a long
         # rollup spend the whole allowance and truncate the kernel reasons off the
         # end -- and a rollup is not always short: ConSan builds

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -75,6 +75,7 @@ import os
 import re
 import shutil
 import sys
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from html import escape as _esc
 from pathlib import Path
@@ -623,12 +624,20 @@ def _observation_text(
     finding_groups: list[dict[str, Any]],
     *,
     present: bool = True,
+    kernel_reasons: Sequence[tuple[str, str]] = (),
 ) -> str:
     """A one-line human summary of what a case observed.
 
     Combines the primary sanitizer + verdict + fail-closed reason + a finding
     highlight into a compact string surfaced on both tabs (guardrail and survey).
     Observational only -- it never encodes a pass/fail health signal.
+
+    ``kernel_reasons`` are the ``(kernel, reason)`` pairs of the kernels that did
+    not come back clean. A check-level reason is a rollup -- Waitcheck reports
+    ``worklist_not_fully_checked`` whenever any kernel is unhealthy -- which names
+    the failure but not its cause, so the observation would otherwise be a dead end
+    for the reader who has only this line. Appending the per-kernel reasons makes
+    the one-liner say what actually broke.
     """
     if not present:
         return "report missing"
@@ -637,6 +646,10 @@ def _observation_text(
     parts = [head]
     if primary.get("reason"):
         parts.append(f"reason {primary['reason']}")
+    if kernel_reasons:
+        parts.append(
+            ", ".join(f"{kernel}: {reason}" for kernel, reason in kernel_reasons)
+        )
     if findings:
         top = finding_groups[0]["code"] if finding_groups else None
         parts.append(f"{findings} finding(s)" + (f" ({top})" if top else ""))
@@ -667,6 +680,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             "kernels": [], "finding_groups": [],
             "primary": {"sanitizer": None, "verdict": None, "reason": None, "preflight": None},
             "observation": "report missing",
+            "kernel_reasons": [],
         }
     checks = report.get("checks", [])
     findings_total = sum(len(c.get("findings", [])) for c in checks)
@@ -681,14 +695,33 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             break
 
     kr_by_name: dict[str, dict[str, Any]] = {}
+    # A whole-code-object scan is deduped by (sha256, index), so the kernels that
+    # share an object with an earlier selection carry no kernel_result of their own.
+    # Index the results by object too, so those rows can be attributed to the scan
+    # that covered them instead of rendering as an em dash (see the kernels loop).
+    kr_by_object: dict[tuple[str | None, Any], dict[str, Any]] = {}
     findings_by_name: dict[str | None, int] = {}
     for check in checks:
         for result in check.get("kernel_results", []):
-            name = (result.get("identity") or {}).get("name")
-            kr_by_name[name] = {
+            identity = result.get("identity") or {}
+            name = identity.get("name")
+            reduced = {
                 "verdict": result.get("verdict"),
                 "findings": len(result.get("findings", [])),
+                # The fail-closed detail. ``CheckResult.reason`` only ever carries the
+                # rollup (``worklist_not_fully_checked``); the per-kernel reason is the
+                # only field that says what actually went wrong, so it must survive
+                # into the row the renderers read.
+                "state": result.get("state"),
+                "reason": result.get("reason"),
+                "returncode": result.get("returncode"),
+                "covering_kernel": name,
             }
+            kr_by_name[name] = reduced
+            kr_by_object.setdefault(
+                (identity.get("code_object_sha256"), identity.get("code_object_index")),
+                reduced,
+            )
         for finding in check.get("findings", []):
             key = finding.get("kernel_name")
             findings_by_name[key] = findings_by_name.get(key, 0) + 1
@@ -700,8 +733,26 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
         identity = entry.get("identity", {})
         name = identity.get("name")
         result = kr_by_name.get(name)
+        detail = ""
         if result is not None:
             verdict, findings = result["verdict"], result["findings"]
+            detail = str(result["reason"] or "")
+        elif (
+            covering := kr_by_object.get(
+                (identity.get("code_object_sha256"), identity.get("code_object_index"))
+            )
+        ) is not None:
+            # Deduped: this kernel's object WAS scanned, under the name of the first
+            # selection that resolved to it. The scan is object-scope, so its verdict
+            # covers this kernel too -- reporting an em dash here read as "not checked"
+            # and hid a gated kernel whose object had failed. Findings stay on the
+            # covering row so the per-kernel column still sums to the case total.
+            verdict = covering["verdict"]
+            findings = 0
+            covered_by = covering["covering_kernel"]
+            detail = f"same code object as {covered_by}; scanned once"
+            if covering["reason"]:
+                detail = f"{detail} \u2014 {covering['reason']}"
         else:
             findings = findings_by_name.get(name, 0)
             # dynamic ConSan attributes race findings at process scope (kernel_name
@@ -718,6 +769,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             "offset": identity.get("entry_offset"),
             "verdict": verdict,
             "findings": findings,
+            "detail": _clean_msg(detail, 300) if detail else "",
         })
 
     groups: dict[tuple[str, str, str], dict[str, Any]] = {}
@@ -735,7 +787,16 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
 
     verdict = report.get("overall_verdict")
     primary = _primary_checks(checks)
-    observation = _observation_text(primary, findings_total, finding_groups)
+    # Only the kernels that carry their own fail-closed reason; a deduped row's
+    # detail restates its covering scan's reason, which would double it up here.
+    kernel_reasons = [
+        (str(result["covering_kernel"]), str(result["reason"]))
+        for result in kr_by_name.values()
+        if result["reason"]
+    ]
+    observation = _observation_text(
+        primary, findings_total, finding_groups, kernel_reasons=kernel_reasons
+    )
     return {
         "present": True, "verdict": verdict, "execution": report.get("execution_status"),
         "findings": findings_total, "coverage": coverage, "backend": backend,
@@ -747,6 +808,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
         },
         "kernels": kernels, "finding_groups": finding_groups,
         "primary": primary, "observation": observation,
+        "kernel_reasons": kernel_reasons,
     }
 
 
@@ -2286,6 +2348,13 @@ def build_case_env(
             "verdict": summary.get("verdict"),
             "execution": summary.get("execution"),
             "reason": (summary.get("primary") or {}).get("reason"),
+            # ``reason`` above is the check-level rollup, so on its own it cannot say
+            # which kernel failed or why. Record the per-kernel reasons beside it so
+            # this manifest is diagnosable without re-reading sanitizer_report.json.
+            "kernel_reasons": [
+                {"kernel": kernel, "reason": why}
+                for kernel, why in (summary.get("kernel_reasons") or [])
+            ],
             "findings": summary.get("findings", 0),
         },
         "inputs": inputs,
@@ -2963,6 +3032,12 @@ def _kernel_tables_html(
     Both tabs render the same tinted ``_verdict_html`` badge per kernel; verdict
     colour is descriptive on either tab (see ``_verdict_html``).
 
+    The **Detail** column carries the row's ``detail``: the kernel's own fail-closed
+    reason, or -- for a kernel whose object was deduped into an earlier scan -- the
+    scan that covered it. Without it an errored kernel row showed a badge and a zero
+    finding count with nothing anywhere on the page saying why, since the check-level
+    reason is only the ``worklist_not_fully_checked`` rollup.
+
     Numeric columns right-align the ``th`` as well as the ``td`` so each value
     sits directly under its own header rather than drifting to the far edge.
     """
@@ -2975,10 +3050,11 @@ def _kernel_tables_html(
             f"<td class=num>{_esc(str(k['findings']))}</td>"
             f"<td class=mono>{_esc(k['code_object']) or '&mdash;'}</td>"
             f"<td class=mono>{_esc(k['sha']) or '&mdash;'}</td>"
+            f"<td class='mono wrap-any'>{_esc(k.get('detail') or '') or '&mdash;'}</td>"
             f"<td>{link}</td></tr>"
             for k in row["kernels"]
         )
-        or '<tr><td class=empty colspan=7>no kernels selected</td></tr>'
+        or '<tr><td class=empty colspan=8>no kernels selected</td></tr>'
     )
     frows = (
         "".join(
@@ -2993,7 +3069,7 @@ def _kernel_tables_html(
         '<p class="cap">Kernels</p><div class="table-wrap"><table>'
         "<thead><tr><th>Kernel</th><th class=num>Dispatch</th>"
         "<th>Observed</th><th class=num>Findings</th>"
-        f"<th>Code object</th><th>SHA-256</th><th>Report</th></tr></thead>"
+        f"<th>Code object</th><th>SHA-256</th><th>Detail</th><th>Report</th></tr></thead>"
         f"<tbody>{krows}</tbody></table></div>"
         '<p class="cap">Findings</p><div class="table-wrap"><table>'
         "<thead><tr><th>Sanitizer</th><th>Code</th><th>Severity</th><th class=num>Count</th>"
@@ -3287,6 +3363,18 @@ def _survey_message_parts(row: dict[str, Any]) -> tuple[str, str]:
     verdict = str(row.get("verdict") or "").strip().lower()
     reason = (row.get("primary") or {}).get("reason")
     reason_text = _clean_msg(str(reason), 240) if reason else ""
+    # Qualify a rollup reason with the kernel reasons behind it. ``primary.reason``
+    # alone ("worklist_not_fully_checked") tells the reader a kernel was not checked
+    # but never which one or why, which is the whole question this callout exists to
+    # answer for an errored case.
+    kernel_reasons = row.get("kernel_reasons") or []
+    if reason_text and kernel_reasons:
+        detail = "; ".join(f"{kernel}: {why}" for kernel, why in kernel_reasons)
+        reason_text = _clean_msg(f"{reason_text} \u2014 {detail}", 240)
+    elif not reason_text and kernel_reasons:
+        reason_text = _clean_msg(
+            "; ".join(f"{kernel}: {why}" for kernel, why in kernel_reasons), 240
+        )
     groups = row.get("finding_groups") or []
     example = _clean_msg(str(groups[0].get("example", "")), 240) if groups else ""
     if verdict == "error" and reason_text:
@@ -3973,13 +4061,15 @@ def _survey_section_md(survey: list[dict[str, Any]]) -> list[str]:
             continue
         lines += [
             "",
-            "| Kernel | Dispatch | Observed sanitizer verdict | Findings | Code object | SHA-256 |",
-            "|---|--:|---|--:|---|---|",
+            "| Kernel | Dispatch | Observed sanitizer verdict | Findings | Code object "
+            "| SHA-256 | Detail |",
+            "|---|--:|---|--:|---|---|---|",
         ]
         for k in r["kernels"]:
+            detail = (k.get("detail") or "").replace("|", "\\|")
             lines.append(
                 f"| `{k['name']}` | {k['dispatch']} | `{k['verdict']}` | {k['findings']} | "
-                f"`{k['code_object'] or _DASH}` | `{k['sha'] or _DASH}` |"
+                f"`{k['code_object'] or _DASH}` | `{k['sha'] or _DASH}` | {detail or _DASH} |"
             )
         lines += ["", "</details>", ""]
     return lines
@@ -4064,15 +4154,17 @@ def build_summary_md(
         )
         lines += [
             "",
-            "| Kernel | Dispatch | Observed sanitizer verdict | Findings | Code object | SHA-256 |",
-            "|---|--:|---|--:|---|---|",
+            "| Kernel | Dispatch | Observed sanitizer verdict | Findings | Code object "
+            "| SHA-256 | Detail |",
+            "|---|--:|---|--:|---|---|---|",
         ]
         for k in r["kernels"]:
             code_object = k["code_object"] or _DASH
             sha = k["sha"] or _DASH
+            detail = (k.get("detail") or "").replace("|", "\\|")
             lines.append(
                 f"| `{k['name']}` | {k['dispatch']} | `{k['verdict']}` | {k['findings']} | "
-                f"`{code_object}` | `{sha}` |"
+                f"`{code_object}` | `{sha}` | {detail or _DASH} |"
             )
         if r["finding_groups"]:
             lines += [

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -812,6 +812,17 @@ def _hashed_clip_name(name: str) -> str:
     return f"{_middle_clip_name(clean)} ~{digest}"
 
 
+def _clip_qualified_label(label: str, limit: int) -> str:
+    """Budget a display label without removing its identity qualifier (pure)."""
+    if len(label) <= limit:
+        return label
+    name, separator, qualifier = label.rpartition(" (")
+    suffix = f"{separator}{qualifier}" if separator else ""
+    if suffix and len(suffix) < limit:
+        return f"{_clean_msg(name, limit - len(suffix))}{suffix}"
+    return _clean_msg(label, limit)
+
+
 # The qualifier widens one field at a time, cheapest first. Everything past the short
 # digest exists for a collision the tier before it cannot resolve, so a label only pays
 # for the ambiguity it actually has.
@@ -870,11 +881,11 @@ def _kernel_reason_entries(
     diagnosable, and a basename plus a digest prefix can tie where the full path and
     digest do not -- which would put the ambiguity straight back into the manifest.
 
-    ``labels_by_key`` is built over the whole worklist rather than over the failing
-    results, because what makes a name ambiguous is what the *page* shows: one failure
-    beside a clean same-named sibling still leaves a reader unable to say which of the
-    two rows the reason belongs to. A result with no worklist row behind it has nothing
-    to be ambiguous against and keeps its bare name.
+    ``labels_by_key`` is built over both the whole worklist and unmatched results.
+    What makes a name ambiguous is what the *page* shows: one failure beside a
+    successfully scanned same-named sibling still leaves a reader unable to say which
+    row the reason belongs to, while an incompatible unmatched result sharing a
+    visible row's name must be qualified so it cannot appear to accuse that row.
     """
     entries: list[dict[str, Any]] = []
     for result in results:
@@ -3821,6 +3832,7 @@ def _survey_howto_html(entry: dict[str, Any]) -> str:
 # the budget rather than letting a long rollup truncate them away.
 _MSG_LIMIT = 240
 _MSG_ROLLUP_LIMIT = 80
+_MSG_REASON_MIN = 64
 
 
 def _survey_message_parts(row: dict[str, Any]) -> tuple[str, str]:
@@ -3843,17 +3855,22 @@ def _survey_message_parts(row: dict[str, Any]) -> tuple[str, str]:
     # answer for an errored case.
     kernel_reasons = row.get("kernel_reasons") or []
     if kernel_reasons:
-        # Labels arrive with their name already budgeted (``_display_labels``), which
-        # is what stops an unbounded kernel name from spending the allowance before its
-        # reason begins -- while keeping the identity qualifier a right-truncation here
-        # would have cut off.
-        detail = "; ".join(f"{e['label']}: {e['reason']}" for e in kernel_reasons)
-        # Budget the rollup down first. Clamping only the concatenation let a long
-        # rollup spend the whole allowance and truncate the kernel reasons off the
-        # end -- and a rollup is not always short: ConSan builds
-        # ``waitcheck_analysis_failed: <parser output>`` out of tool text. The
-        # kernel reasons are the payload here, so they keep the larger share.
-        rollup = _clean_msg(str(reason), _MSG_ROLLUP_LIMIT) if reason else ""
+        # Reserve enough room for the first backend cause even when disambiguation
+        # needs a full digest/index/offset qualifier. Any label clipping falls on its
+        # name while preserving that qualifier.
+        detail_parts = []
+        for entry in kernel_reasons:
+            entry_reason = str(entry["reason"])
+            reason_reserve = min(len(entry_reason), _MSG_REASON_MIN)
+            label_limit = _MSG_LIMIT - len(": ") - reason_reserve
+            label = _clip_qualified_label(str(entry["label"]), label_limit)
+            detail_parts.append(f"{label}: {entry_reason}")
+        detail = "; ".join(detail_parts)
+        # Give the detail first claim on the line, then spend only its remaining
+        # budget on the rollup. A long rollup or full-identity label can no longer
+        # push the backend explanation off the end.
+        rollup_limit = min(_MSG_ROLLUP_LIMIT, _MSG_LIMIT - len(detail) - len(" — "))
+        rollup = _clean_msg(str(reason), rollup_limit) if reason and rollup_limit > 0 else ""
         reason_text = _clean_msg(
             f"{rollup} \u2014 {detail}" if rollup else detail, _MSG_LIMIT
         )

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -650,6 +650,67 @@ def _identity_key(identity: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+# The per-kernel Detail cell's budget, applied to the kernel's own reason and again to
+# the whole cell. A deduped row spends part of it on the "same code object as ..."
+# prefix, so it carries its inherited reason less far than the covering row does;
+# that is inherent to a fixed-width cell with a prefix, and the cell names the
+# covering row, which carries the same reason in full.
+_DETAIL_LIMIT = 300
+
+
+def _identity_qualifier(identity: dict[str, Any]) -> str:
+    """The shortest identity fragment that tells two same-named kernels apart (pure).
+
+    Prefers the code-object digest, falling back to the object's basename, and appends
+    the entry offset when the identity pins one -- the same fields ``stable_key`` uses
+    to keep those selections distinct. Empty when the identity carries none of them,
+    in which case there is nothing to disambiguate with.
+    """
+    parts = _short(identity.get("code_object_sha256"), 10) or _basename(
+        identity.get("code_object")
+    )
+    offset = identity.get("entry_offset")
+    if isinstance(offset, int):
+        parts = f"{parts}+0x{offset:x}" if parts else f"0x{offset:x}"
+    return parts
+
+
+def _kernel_reason_entries(results: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The failing kernels' reasons, each carrying the identity behind it (pure).
+
+    A kernel name is not unique (see ``_identity_key``), so a bare name cannot say
+    *which* object failed when two selections share a symbol name -- and if both fail,
+    two identically-labelled reasons are indistinguishable. Every entry therefore
+    records the identity fields, so ``env.json`` can attribute a failure without
+    reopening ``sanitizer_report.json``.
+
+    ``label`` is qualified with that identity only where the name is actually
+    ambiguous among the failing kernels. Appending a digest unconditionally would pad
+    every one-line observation for the overwhelmingly common unique-name case, where
+    the name already identifies the kernel.
+    """
+    failing = [result for result in results if result["reason"]]
+    seen: dict[Any, int] = {}
+    for result in failing:
+        seen[result["name"]] = seen.get(result["name"], 0) + 1
+    entries: list[dict[str, Any]] = []
+    for result in failing:
+        identity = result["identity"]
+        label = str(result["name"])
+        if seen[result["name"]] > 1 and (qualifier := _identity_qualifier(identity)):
+            label = f"{label} ({qualifier})"
+        entries.append({
+            "kernel": str(result["name"]),
+            "label": label,
+            "reason": str(result["reason"]),
+            "code_object": _basename(identity.get("code_object")),
+            "sha": _short(identity.get("code_object_sha256"), 10),
+            "code_object_index": identity.get("code_object_index"),
+            "entry_offset": identity.get("entry_offset"),
+        })
+    return entries
+
+
 def _kernel_reason_text(reasons: Sequence[tuple[str, str]]) -> str:
     """One kernel's fail-closed reasons, for a one-line display context (pure).
 
@@ -694,7 +755,7 @@ def _observation_text(
     finding_groups: list[dict[str, Any]],
     *,
     present: bool = True,
-    kernel_reasons: Sequence[tuple[str, str]] = (),
+    kernel_reasons: Sequence[dict[str, Any]] = (),
 ) -> str:
     """A one-line human summary of what a case observed.
 
@@ -702,8 +763,9 @@ def _observation_text(
     highlight into a compact string surfaced on both tabs (guardrail and survey).
     Observational only -- it never encodes a pass/fail health signal.
 
-    ``kernel_reasons`` are the ``(kernel, reason)`` pairs of the kernels that did
-    not come back clean. A check-level reason is a rollup -- Waitcheck reports
+    ``kernel_reasons`` are the ``_kernel_reason_entries`` of the kernels that did not
+    come back clean, rendered from each entry's identity-qualified ``label`` and its
+    ``reason``. A check-level reason is a rollup -- Waitcheck reports
     ``worklist_not_fully_checked`` whenever any kernel is unhealthy -- which names
     the failure but not its cause, so the observation would otherwise be a dead end
     for the reader who has only this line. Appending the per-kernel reasons makes
@@ -721,7 +783,7 @@ def _observation_text(
         parts.append(f"reason {reason}")
     if kernel_reasons:
         parts.append(
-            ", ".join(f"{kernel}: {reason}" for kernel, reason in kernel_reasons)
+            ", ".join(f"{e['label']}: {e['reason']}" for e in kernel_reasons)
         )
     if findings:
         top = finding_groups[0]["code"] if finding_groups else None
@@ -800,7 +862,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             # rollup (``worklist_not_fully_checked``); the per-kernel reason is the
             # only field that says what actually went wrong, so it must survive into
             # the row the renderers read.
-            if reason := _clean_msg(str(result.get("reason") or ""), 300):
+            if reason := _clean_msg(str(result.get("reason") or ""), _DETAIL_LIMIT):
                 reasons.append((sanitizer, reason))
             reduced = {
                 "verdict": _worse_verdict(
@@ -814,6 +876,9 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 "returncode": result.get("returncode"),
                 # Display text only; the join above is on the full identity.
                 "name": name,
+                # Kept so a reason can name *which* object failed when two selected
+                # kernels share a symbol name (see ``_kernel_reason_entries``).
+                "identity": identity,
             }
             kr_by_identity[key] = reduced
             # Only a Waitcheck whole-object scan is ever deduped, so only such a scan
@@ -885,7 +950,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             "offset": identity.get("entry_offset"),
             "verdict": verdict,
             "findings": findings,
-            "detail": _clean_msg(detail, 300) if detail else "",
+            "detail": _clean_msg(detail, _DETAIL_LIMIT) if detail else "",
         })
 
     groups: dict[tuple[str, str, str], dict[str, Any]] = {}
@@ -905,11 +970,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     primary = _primary_checks(checks)
     # Only the kernels that carry their own fail-closed reason; a deduped row's
     # detail restates its covering scan's reason, which would double it up here.
-    kernel_reasons = [
-        (str(result["name"]), str(result["reason"]))
-        for result in kr_by_identity.values()
-        if result["reason"]
-    ]
+    kernel_reasons = _kernel_reason_entries(list(kr_by_identity.values()))
     observation = _observation_text(
         primary, findings_total, finding_groups, kernel_reasons=kernel_reasons
     )
@@ -2465,11 +2526,19 @@ def build_case_env(
             "execution": summary.get("execution"),
             "reason": (summary.get("primary") or {}).get("reason"),
             # ``reason`` above is the check-level rollup, so on its own it cannot say
-            # which kernel failed or why. Record the per-kernel reasons beside it so
+            # which kernel failed or why. Record the per-kernel reasons beside it,
+            # each with the identity fields that tell two same-named kernels apart, so
             # this manifest is diagnosable without re-reading sanitizer_report.json.
             "kernel_reasons": [
-                {"kernel": kernel, "reason": why}
-                for kernel, why in (summary.get("kernel_reasons") or [])
+                {
+                    "kernel": entry["kernel"],
+                    "reason": entry["reason"],
+                    "code_object": entry["code_object"],
+                    "sha": entry["sha"],
+                    "code_object_index": entry["code_object_index"],
+                    "entry_offset": entry["entry_offset"],
+                }
+                for entry in (summary.get("kernel_reasons") or [])
             ],
             "findings": summary.get("findings", 0),
         },
@@ -3465,6 +3534,14 @@ def _survey_howto_html(entry: dict[str, Any]) -> str:
     )
 
 
+# The inline survey callout is one line, so its text is length-capped. When a
+# check-level rollup and the per-kernel reasons behind it share that line, the rollup
+# is capped separately at the smaller figure, which guarantees the reasons the rest of
+# the budget rather than letting a long rollup truncate them away.
+_MSG_LIMIT = 240
+_MSG_ROLLUP_LIMIT = 80
+
+
 def _survey_message_parts(row: dict[str, Any]) -> tuple[str, str]:
     """Pick the inline survey message as an ``(label, text)`` pair (pure).
 
@@ -3478,21 +3555,25 @@ def _survey_message_parts(row: dict[str, Any]) -> tuple[str, str]:
     """
     verdict = str(row.get("verdict") or "").strip().lower()
     reason = (row.get("primary") or {}).get("reason")
-    reason_text = _clean_msg(str(reason), 240) if reason else ""
+    reason_text = _clean_msg(str(reason), _MSG_LIMIT) if reason else ""
     # Qualify a rollup reason with the kernel reasons behind it. ``primary.reason``
     # alone ("worklist_not_fully_checked") tells the reader a kernel was not checked
     # but never which one or why, which is the whole question this callout exists to
     # answer for an errored case.
     kernel_reasons = row.get("kernel_reasons") or []
-    if reason_text and kernel_reasons:
-        detail = "; ".join(f"{kernel}: {why}" for kernel, why in kernel_reasons)
-        reason_text = _clean_msg(f"{reason_text} \u2014 {detail}", 240)
-    elif not reason_text and kernel_reasons:
+    if kernel_reasons:
+        detail = "; ".join(f"{e['label']}: {e['reason']}" for e in kernel_reasons)
+        # Budget the rollup down first. Clamping only the concatenation let a long
+        # rollup spend the whole allowance and truncate the kernel reasons off the
+        # end -- and a rollup is not always short: ConSan builds
+        # ``waitcheck_analysis_failed: <parser output>`` out of tool text. The
+        # kernel reasons are the payload here, so they keep the larger share.
+        rollup = _clean_msg(str(reason), _MSG_ROLLUP_LIMIT) if reason else ""
         reason_text = _clean_msg(
-            "; ".join(f"{kernel}: {why}" for kernel, why in kernel_reasons), 240
+            f"{rollup} \u2014 {detail}" if rollup else detail, _MSG_LIMIT
         )
     groups = row.get("finding_groups") or []
-    example = _clean_msg(str(groups[0].get("example", "")), 240) if groups else ""
+    example = _clean_msg(str(groups[0].get("example", "")), _MSG_LIMIT) if groups else ""
     if verdict == "error" and reason_text:
         return "Reason", reason_text
     if example:

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -628,6 +628,28 @@ def _worse_verdict(current: Any, candidate: Any) -> Any:
     return candidate if ranked > _VERDICT_RANK.get(str(current).strip().lower(), -1) else current
 
 
+def _identity_key(identity: dict[str, Any]) -> tuple[Any, ...]:
+    """The join key from a kernel result to its worklist row (pure).
+
+    A kernel *name* is not an identity. ``KernelWorklist`` only rejects duplicate
+    ``KernelIdentity.stable_key``, and that key carries the digest (scan mode) or the
+    entry offset (exact mode) rather than pinning the name -- so two entries may share
+    a symbol name while addressing different code objects, or different entries of one
+    object, and both are valid. Joining on the name merged those distinct scans onto a
+    single row: each got the other's verdict and reasons, and their findings were
+    summed onto both, double-counting against the case total. Joining on every
+    serialized identity field keeps them separate; the name stays display text.
+    """
+    return (
+        identity.get("target"),
+        identity.get("code_object"),
+        identity.get("code_object_sha256"),
+        identity.get("code_object_index"),
+        identity.get("entry_offset"),
+        identity.get("name"),
+    )
+
+
 def _kernel_reason_text(reasons: Sequence[tuple[str, str]]) -> str:
     """One kernel's fail-closed reasons, for a one-line display context (pure).
 
@@ -745,20 +767,22 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             backend = {"name": _basename(raw.get("path")), "sha": _short(raw.get("sha256"), 12)}
             break
 
-    kr_by_name: dict[str, dict[str, Any]] = {}
+    # Keyed by full identity, not by name -- see ``_identity_key``.
+    kr_by_identity: dict[tuple[Any, ...], dict[str, Any]] = {}
     # A whole-code-object scan is deduped by (sha256, index), so the kernels that
     # share an object with an earlier selection carry no kernel_result of their own.
-    # Map each scanned object to the kernel whose result covered it, so those rows can
-    # be attributed to that scan instead of rendering as an em dash (see the kernels
-    # loop). Storing the name rather than the result keeps the attribution pointed at
-    # the fully-accumulated ``kr_by_name`` entry once every check has been folded in.
-    kr_by_object: dict[tuple[str, Any], str] = {}
+    # Map each scanned object to the identity whose result covered it, so those rows
+    # can be attributed to that scan instead of rendering as an em dash (see the
+    # kernels loop). Storing the key rather than the result keeps the attribution
+    # pointed at the fully-accumulated entry once every check has been folded in.
+    kr_by_object: dict[tuple[str, Any], tuple[Any, ...]] = {}
     findings_by_name: dict[str | None, int] = {}
     for check in checks:
         sanitizer = str(check.get("sanitizer") or "")
         for result in check.get("kernel_results", []):
             identity = result.get("identity") or {}
             name = identity.get("name")
+            key = _identity_key(identity)
             # A report can hold more than one check over the same worklist -- the
             # shipped waitcheck+consan survey recipes select a single kernel and scan
             # it with both -- so this kernel may already carry a result from an
@@ -770,7 +794,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             # least clean of them, ranked as ``models._VERDICT_RANK`` ranks the
             # report's own rollup, so the badge can never read cleaner than the
             # Detail column beside it.
-            previous = kr_by_name.get(name)
+            previous = kr_by_identity.get(key)
             reasons: list[tuple[str, str]] = list(previous["reasons"]) if previous else []
             # The fail-closed detail. ``CheckResult.reason`` only ever carries the
             # rollup (``worklist_not_fully_checked``); the per-kernel reason is the
@@ -788,8 +812,10 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 "reasons": reasons,
                 "reason": _kernel_reason_text(reasons),
                 "returncode": result.get("returncode"),
+                # Display text only; the join above is on the full identity.
+                "name": name,
             }
-            kr_by_name[name] = reduced
+            kr_by_identity[key] = reduced
             # Only a Waitcheck whole-object scan is ever deduped, so only such a scan
             # may stand in for a kernel that has no result of its own. The identity
             # has to be a whole-object one -- real object, real digest, no entry
@@ -809,7 +835,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 and identity.get("entry_offset") is None
             ):
                 kr_by_object.setdefault(
-                    (str(result_sha), identity.get("code_object_index")), str(name)
+                    (str(result_sha), identity.get("code_object_index")), key
                 )
         for finding in check.get("findings", []):
             key = finding.get("kernel_name")
@@ -821,14 +847,14 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     for entry in kernel_entries:
         identity = entry.get("identity", {})
         name = identity.get("name")
-        result = kr_by_name.get(name)
+        result = kr_by_identity.get(_identity_key(identity))
         entry_sha = identity.get("code_object_sha256")
         detail = ""
         if result is not None:
             verdict, findings = result["verdict"], result["findings"]
             detail = str(result["reason"] or "")
         elif entry_sha and (
-            covered_by := kr_by_object.get(
+            covering_key := kr_by_object.get(
                 (str(entry_sha), identity.get("code_object_index"))
             )
         ) is not None:
@@ -837,10 +863,10 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             # covers this kernel too -- reporting an em dash here read as "not checked"
             # and hid a gated kernel whose object had failed. Findings stay on the
             # covering row so the per-kernel column still sums to the case total.
-            covering = kr_by_name[covered_by]
+            covering = kr_by_identity[covering_key]
             verdict = covering["verdict"]
             findings = 0
-            detail = f"same code object as {covered_by}; scanned once"
+            detail = f"same code object as {covering['name']}; scanned once"
             if covering["reason"]:
                 detail = f"{detail} \u2014 {covering['reason']}"
         else:
@@ -880,8 +906,8 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     # Only the kernels that carry their own fail-closed reason; a deduped row's
     # detail restates its covering scan's reason, which would double it up here.
     kernel_reasons = [
-        (str(name), str(result["reason"]))
-        for name, result in kr_by_name.items()
+        (str(result["name"]), str(result["reason"]))
+        for result in kr_by_identity.values()
         if result["reason"]
     ]
     observation = _observation_text(

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -8,7 +8,8 @@ emits, into ``--out-dir``:
   tabs (a pure CSS ``:checked`` radio toggle -- switching needs no network):
   **Expected behavior (guardrails)** -- the baseline-checked regression gate:
   baseline-health banner, latest per-recipe table, **per-kernel detail** (code
-  object / SHA-256 / dispatch count / observed sanitizer verdict / finding count),
+  object / SHA-256 / dispatch count / observed sanitizer verdict / finding count /
+  the kernel's fail-closed reason, em dash when it has none),
   and a cross-run history/trend table; and **Workload survey (observed-only)** --
   kernels drawn from multiple workloads (including aorta-internal-sourced kernels
   supplied via ``--survey`` and the caller-supplied ConSan cases from
@@ -699,7 +700,15 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
     # share an object with an earlier selection carry no kernel_result of their own.
     # Index the results by object too, so those rows can be attributed to the scan
     # that covered them instead of rendering as an em dash (see the kernels loop).
-    kr_by_object: dict[tuple[str | None, Any], dict[str, Any]] = {}
+    #
+    # Keyed only for identities that carry a real digest. Waitcheck dedups a
+    # ``code_object_scan``, which requires both a code object and its SHA-256, so a
+    # digest-less identity was never deduped and has nothing to be attributed to.
+    # Admitting one would make every ConSan kernel (code_object and sha both null)
+    # share the ``(None, None)`` key and let an unrelated sibling's verdict and
+    # reason be reported as "the same code object" -- an attribution to an object
+    # that does not exist.
+    kr_by_object: dict[tuple[str, Any], dict[str, Any]] = {}
     findings_by_name: dict[str | None, int] = {}
     for check in checks:
         for result in check.get("kernel_results", []):
@@ -718,10 +727,11 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 "covering_kernel": name,
             }
             kr_by_name[name] = reduced
-            kr_by_object.setdefault(
-                (identity.get("code_object_sha256"), identity.get("code_object_index")),
-                reduced,
-            )
+            result_sha = identity.get("code_object_sha256")
+            if result_sha:
+                kr_by_object.setdefault(
+                    (str(result_sha), identity.get("code_object_index")), reduced
+                )
         for finding in check.get("findings", []):
             key = finding.get("kernel_name")
             findings_by_name[key] = findings_by_name.get(key, 0) + 1
@@ -733,13 +743,14 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
         identity = entry.get("identity", {})
         name = identity.get("name")
         result = kr_by_name.get(name)
+        entry_sha = identity.get("code_object_sha256")
         detail = ""
         if result is not None:
             verdict, findings = result["verdict"], result["findings"]
             detail = str(result["reason"] or "")
-        elif (
+        elif entry_sha and (
             covering := kr_by_object.get(
-                (identity.get("code_object_sha256"), identity.get("code_object_index"))
+                (str(entry_sha), identity.get("code_object_index"))
             )
         ) is not None:
             # Deduped: this kernel's object WAS scanned, under the name of the first

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -646,6 +646,18 @@ _IDENTITY_OBJECT_FIELDS = (
 )
 
 
+def _identity_projection(identity: Mapping[str, Any]) -> dict[str, Any]:
+    """An identity's code-object fields, kept present exactly where the report had them.
+
+    Presence is meaning here, not tidiness: ``_identity_compatible`` reads an omitted
+    ``entry_offset`` as an unknown scope and an explicit ``entry_offset: null`` as a
+    claim of a whole-object scan. A projection that filled in the omission with
+    ``None`` would make the manifest assert a scope the report never stated, which is
+    exactly the ambiguity these fields exist to remove.
+    """
+    return {field: identity[field] for field in _IDENTITY_OBJECT_FIELDS if field in identity}
+
+
 def _identity_compatible(row: dict[str, Any], result: dict[str, Any]) -> bool:
     """Whether a result identity can describe this worklist row (pure).
 
@@ -662,6 +674,26 @@ def _identity_compatible(row: dict[str, Any], result: dict[str, Any]) -> bool:
         field not in result or result.get(field) == row.get(field)
         for field in _IDENTITY_OBJECT_FIELDS
     )
+
+
+def _dedup_covers(row: Mapping[str, Any], covering: Mapping[str, Any]) -> bool:
+    """Whether an object scan may speak for a row that has no result of its own (pure).
+
+    A whole-object scan disassembles every entry in the object, so a selection that was
+    deduped away is genuinely covered -- which is why an em dash there read as "not
+    checked" and hid a gated kernel whose object had failed.
+
+    But ``run_waitcheck`` only dedups selections with ``entry_offset is None``; an
+    exact-entry selection always gets its own scan task. A missing result on such a row
+    therefore means the result was lost or unattributable, not that it was folded into
+    this scan, and a *clean* scan standing in for it would render "scanned once" over a
+    row whose own error is sitting unattributed at case scope. A non-clean scan is still
+    worth showing there -- the object it lives in did fail -- so only the clean
+    direction is withheld.
+    """
+    if row.get("entry_offset") is None:
+        return True
+    return str(covering.get("verdict") or "").strip().lower() not in {"pass", "not_checked"}
 
 
 def _with_sanitizer(previous: dict[str, Any] | None, sanitizer: str) -> list[str]:
@@ -902,8 +934,9 @@ def _kernel_reason_entries(
     records the identity fields, so ``env.json`` can attribute a failure without
     reopening ``sanitizer_report.json``.
 
-    The identity fields are recorded *unabridged*. ``label`` is display copy and is
-    abbreviated (see ``_display_labels``); this projection is what makes ``env.json``
+    The identity fields are recorded *unabridged*, and only where the report carried
+    them (see ``_identity_projection``). ``label`` is display copy and is abbreviated
+    (see ``_display_labels``); this projection is what makes ``env.json``
     diagnosable, and a basename plus a digest prefix can tie where the full path and
     digest do not -- which would put the ambiguity straight back into the manifest.
 
@@ -923,10 +956,7 @@ def _kernel_reason_entries(
             "kernel": str(result["name"]),
             "label": label,
             "reason": str(result["reason"]),
-            "code_object": identity.get("code_object"),
-            "code_object_sha256": identity.get("code_object_sha256"),
-            "code_object_index": identity.get("code_object_index"),
-            "entry_offset": identity.get("entry_offset"),
+            **_identity_projection(identity),
         })
     return entries
 
@@ -1236,7 +1266,7 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             covering_key := kr_by_object.get(
                 (str(entry_sha), identity.get("code_object_index"))
             )
-        ) is not None:
+        ) is not None and _dedup_covers(identity, matched[covering_key]):
             # Deduped: this kernel's object WAS scanned, under the name of the first
             # selection that resolved to it. The scan is object-scope, so its verdict
             # covers this kernel too -- reporting an em dash here read as "not checked"
@@ -2851,14 +2881,14 @@ def build_case_env(
             # which kernel failed or why. Record the per-kernel reasons beside it,
             # each with the identity fields that tell two same-named kernels apart, so
             # this manifest is diagnosable without re-reading sanitizer_report.json.
+            # Field presence is carried through rather than filled in: the display
+            # ``label`` is dropped here, so the omission is all that is left to say
+            # the source report did not state a scope (see ``_identity_projection``).
             "kernel_reasons": [
                 {
                     "kernel": entry["kernel"],
                     "reason": entry["reason"],
-                    "code_object": entry["code_object"],
-                    "code_object_sha256": entry["code_object_sha256"],
-                    "code_object_index": entry["code_object_index"],
-                    "entry_offset": entry["entry_offset"],
+                    **{f: entry[f] for f in _IDENTITY_OBJECT_FIELDS if f in entry},
                 }
                 for entry in (summary.get("kernel_reasons") or [])
             ],

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -807,7 +807,7 @@ def _identity_qualifier(
     *,
     index: bool = False,
     full: bool = False,
-    scope: bool = False,
+    presence: bool = False,
 ) -> str:
     """The shortest identity fragment that tells two same-named kernels apart (pure).
 
@@ -829,9 +829,11 @@ def _identity_qualifier(
     otherwise resolve; it is remote, which is why the prefix is what gets rendered
     until a label actually ties.
 
-    ``scope`` distinguishes an identity that omitted ``entry_offset`` from one that
-    explicitly states a whole-object scope with ``entry_offset: null``. The omitted
-    form must stay visibly unattributed instead of looking like the whole-object row.
+    ``presence`` is the final widening for identities that differ only in whether an
+    optional field was serialized. Omitted fields are unknown while explicit nulls
+    are claims, so their labels must not collapse either -- especially an omitted
+    offset, which must stay visibly unattributed instead of looking like a confirmed
+    whole-object row.
     """
     digest = identity.get("code_object_sha256")
     parts = (
@@ -843,8 +845,20 @@ def _identity_qualifier(
     offset = identity.get("entry_offset")
     if isinstance(offset, int):
         parts = f"{parts}+0x{offset:x}" if parts else f"0x{offset:x}"
-    elif scope and "entry_offset" not in identity:
-        parts = f"{parts}; scope unknown" if parts else "scope unknown"
+    if presence:
+        unknown = [
+            label
+            for field, label in (
+                ("code_object", "object unknown"),
+                ("code_object_sha256", "digest unknown"),
+                ("code_object_index", "index unknown"),
+                ("entry_offset", "scope unknown"),
+            )
+            if field not in identity
+        ]
+        if unknown:
+            marker = ", ".join(unknown)
+            parts = f"{parts}; {marker}" if parts else marker
     return parts
 
 
@@ -904,7 +918,7 @@ _QUALIFIER_WIDENINGS: tuple[dict[str, bool], ...] = (
     {},
     {"index": True},
     {"index": True, "full": True},
-    {"index": True, "full": True, "scope": True},
+    {"index": True, "full": True, "presence": True},
 )
 
 # How a name is rendered, cheapest first, with the same "only pay for the ambiguity you

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -1126,7 +1126,14 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             # the rollup (``worklist_not_fully_checked``); the per-kernel reason is
             # the only field that says what actually went wrong, so it must survive
             # into the row the renderers read.
-            if reason := _clean_msg(str(result.get("reason") or ""), _DETAIL_LIMIT):
+            #
+            # Normalized but not clamped: this is the accumulation, upstream of every
+            # sink, and ``_run_one`` builds ``waitcheck_backend_exit_N: `` plus up to
+            # 300 characters of stderr tail -- so a cap here truncates the tail that
+            # carries the cause, for the unbounded sinks (the observation, ``env.json``)
+            # as well as the bounded ones. Each display sink applies its own budget:
+            # the Detail cell below, and ``_survey_message_parts`` for the callout.
+            if reason := _clean_msg(str(result.get("reason") or ""), None):
                 reasons.append((sanitizer, reason))
             reduced = {
                 "verdict": _worse_verdict(
@@ -1292,9 +1299,13 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
                 credited.add(name)
                 findings = unattributed_by_name.get(name, 0)
                 # dynamic ConSan attributes race findings at process scope
-                # (kernel_name is null); with one worklist row, credit it there.
-                if findings == 0 and len(kernel_entries) == 1:
-                    findings = unattributed_by_name.get(None, 0)
+                # (kernel_name is null); with one worklist row, credit it there. Added
+                # unconditionally, as in the matched branch above: a check can emit a
+                # kernel-named finding *and* a process-scope one, and gating this on
+                # there being no named finding dropped the process-scope count off the
+                # only row that could hold it.
+                if len(kernel_entries) == 1:
+                    findings += unattributed_by_name.get(None, 0)
             verdict = report.get("overall_verdict") if len(kernel_entries) == 1 or findings else "—"
         kernels.append({
             "name": name,

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -658,17 +658,28 @@ def _identity_key(identity: dict[str, Any]) -> tuple[Any, ...]:
 _DETAIL_LIMIT = 300
 
 
-def _identity_qualifier(identity: dict[str, Any]) -> str:
+def _identity_qualifier(identity: dict[str, Any], *, index: bool = False) -> str:
     """The shortest identity fragment that tells two same-named kernels apart (pure).
 
     Prefers the code-object digest, falling back to the object's basename, and appends
     the entry offset when the identity pins one -- the same fields ``stable_key`` uses
     to keep those selections distinct. Empty when the identity carries none of them,
     in which case there is nothing to disambiguate with.
+
+    ``index`` widens the qualifier with the code-object index. A digest is the *file's*
+    digest, not an object's: a bundle holds several code objects under one digest, and
+    Waitcheck's own dedup key is ``(code_object_sha256, code_object_index)`` rather
+    than the digest alone -- so two same-named selections in one bundle share every
+    field this renders by default. It is off by default because selection stamps an
+    index on every identity carrying a code object and it is 0 on nearly all of them,
+    so rendering it always would pad the labels that are already unique.
     """
     parts = _short(identity.get("code_object_sha256"), 10) or _basename(
         identity.get("code_object")
     )
+    object_index = identity.get("code_object_index")
+    if index and isinstance(object_index, int):
+        parts = f"{parts}#{object_index}" if parts else f"#{object_index}"
     offset = identity.get("entry_offset")
     if isinstance(offset, int):
         parts = f"{parts}+0x{offset:x}" if parts else f"0x{offset:x}"
@@ -685,20 +696,30 @@ def _kernel_reason_entries(results: Sequence[dict[str, Any]]) -> list[dict[str, 
     reopening ``sanitizer_report.json``.
 
     ``label`` is qualified with that identity only where the name is actually
-    ambiguous among the failing kernels. Appending a digest unconditionally would pad
-    every one-line observation for the overwhelmingly common unique-name case, where
-    the name already identifies the kernel.
+    ambiguous among the failing kernels, and only as far as it takes to separate the
+    colliding labels -- the digest first, then the code-object index, which is the one
+    field that separates two objects bundled into a single file. Appending either
+    unconditionally would pad every one-line observation for the overwhelmingly common
+    unique-name case, where the name already identifies the kernel.
     """
     failing = [result for result in results if result["reason"]]
     seen: dict[Any, int] = {}
     for result in failing:
         seen[result["name"]] = seen.get(result["name"], 0) + 1
+    labels = [str(result["name"]) for result in failing]
+    for widen in (False, True):
+        labels = [
+            f"{result['name']} ({qualifier})"
+            if seen[result["name"]] > 1
+            and (qualifier := _identity_qualifier(result["identity"], index=widen))
+            else str(result["name"])
+            for result in failing
+        ]
+        if len(set(labels)) == len(labels):
+            break
     entries: list[dict[str, Any]] = []
-    for result in failing:
+    for label, result in zip(labels, failing, strict=True):
         identity = result["identity"]
-        label = str(result["name"])
-        if seen[result["name"]] > 1 and (qualifier := _identity_qualifier(identity)):
-            label = f"{label} ({qualifier})"
         entries.append({
             "kernel": str(result["name"]),
             "label": label,
@@ -908,6 +929,13 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
 
     worklist = report.get("worklist", {})
     kernel_entries = worklist.get("kernels", [])
+    # A deduped row's Detail names the scan that covered it. Where two rows share that
+    # name the bare name cannot say which of them did the covering, so the same
+    # qualifier the reason labels use is appended -- and only there.
+    entry_names: dict[Any, int] = {}
+    for entry in kernel_entries:
+        entry_name = entry.get("identity", {}).get("name")
+        entry_names[entry_name] = entry_names.get(entry_name, 0) + 1
     kernels: list[dict[str, Any]] = []
     for entry in kernel_entries:
         identity = entry.get("identity", {})
@@ -931,7 +959,12 @@ def summarize_case(report: dict[str, Any] | None, expected: str | None) -> dict[
             covering = kr_by_identity[covering_key]
             verdict = covering["verdict"]
             findings = 0
-            detail = f"same code object as {covering['name']}; scanned once"
+            covering_label = str(covering["name"])
+            if entry_names.get(covering["name"], 0) > 1 and (
+                qualifier := _identity_qualifier(covering["identity"], index=True)
+            ):
+                covering_label = f"{covering_label} ({qualifier})"
+            detail = f"same code object as {covering_label}; scanned once"
             if covering["reason"]:
                 detail = f"{detail} \u2014 {covering['reason']}"
         else:

--- a/scripts/sanitizers/gen_sanitizer_dashboard.py
+++ b/scripts/sanitizers/gen_sanitizer_dashboard.py
@@ -77,7 +77,7 @@ import os
 import re
 import shutil
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timezone
 from html import escape as _esc
 from pathlib import Path
@@ -807,7 +807,7 @@ def _middle_clip_name(name: str) -> str:
     return f"{clean[:head]}\u2026{clean[head - _LABEL_LIMIT + 1:]}"
 
 
-def _hashed_clip_name(name: str) -> str:
+def _hashed_clip_name(name: str, width: int = 8) -> str:
     """A clipped kernel name with a digest of the whole one (pure).
 
     The last resort. Two names can agree on both ends and differ only in the middle the
@@ -815,10 +815,15 @@ def _hashed_clip_name(name: str) -> str:
     them either. A digest of the full name always can, at the cost of a label nobody
     can read back to a symbol -- which is why nothing reaches for it until every
     readable discriminator has tied.
+
+    The digest is taken over the name as the report spelled it, not over the rendered
+    copy: rendering collapses internal whitespace, so ``foo bar`` and ``foo  bar`` are
+    two valid selections with distinct ``stable_key`` s that hash alike if normalized
+    first. ``width`` truncates it, and a truncated digest can itself tie -- see
+    ``_NAME_RENDERINGS`` for the widening that ends at the full digest.
     """
-    clean = " ".join(name.split())
-    digest = hashlib.sha256(clean.encode("utf-8")).hexdigest()[:8]
-    return f"{_middle_clip_name(clean)} ~{digest}"
+    digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:width]
+    return f"{_middle_clip_name(name)} ~{digest}"
 
 
 def _clip_qualified_label(label: str, limit: int) -> str:
@@ -842,6 +847,18 @@ _QUALIFIER_WIDENINGS: tuple[dict[str, bool], ...] = (
     {"index": True, "full": True, "scope": True},
 )
 
+# How a name is rendered, cheapest first, with the same "only pay for the ambiguity you
+# have" rule as the qualifiers. The head-only budget is what a reader wants; the tail
+# and then the digest exist for collisions the tier before cannot resolve. The last
+# tier carries the *full* SHA-256, which is what makes the uniqueness claim in
+# ``_display_labels`` true -- an 8-hex prefix is 32 bits and can tie on its own.
+_NAME_RENDERINGS: tuple[tuple[Callable[..., str], dict[str, int]], ...] = (
+    (_clip_name, {}),
+    (_middle_clip_name, {}),
+    (_hashed_clip_name, {"width": 8}),
+    (_hashed_clip_name, {"width": 64}),
+)
+
 
 def _display_labels(items: Sequence[tuple[Any, dict[str, Any]]]) -> list[str]:
     """Labels for ``(name, identity)`` pairs, qualified only where a name repeats (pure).
@@ -856,8 +873,8 @@ def _display_labels(items: Sequence[tuple[Any, dict[str, Any]]]) -> list[str]:
     digest of the whole name, which cannot tie for names that differ at all.
     """
     labels: list[str] = []
-    for render in (_clip_name, _middle_clip_name, _hashed_clip_name):
-        display = [render(str(name)) for name, _ in items]
+    for render, rendering in _NAME_RENDERINGS:
+        display = [render(str(name), **rendering) for name, _ in items]
         counts: dict[str, int] = {}
         for shown in display:
             counts[shown] = counts.get(shown, 0) + 1

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
@@ -425,7 +425,14 @@ def _run_one(
         )
         findings = parsed.findings
         diagnostics_truncated = parsed.diagnostics_truncated
-    except (OSError, ValueError) as exc:
+    except Exception as exc:  # noqa: BLE001 - see below
+        # Deliberately broad. The point of parsing here is that an unexpected exit code
+        # reaches the branch below with the backend's own message; a parser raising
+        # anything outside (OSError, ValueError) -- an IndexError or TypeError off a
+        # malformed line -- would propagate and defeat exactly that. Nothing is
+        # swallowed: on an expected exit code the error becomes a fail-closed
+        # ERROR result quoting the exception, and KeyboardInterrupt / SystemExit are
+        # BaseException and still propagate.
         parse_error = exc
     if process.returncode not in {WAITCHECK_CLEAN_EXIT, WAITCHECK_HAZARD_EXIT}:
         stderr_tail = process.stderr[-300:].strip()

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
@@ -408,19 +408,25 @@ def _run_one(
             verdict=Verdict.ERROR,
             reason=f"waitcheck_launch_error: {process.launch_error}",
         )
+    # Parse defensively so an unexpected exit code can still be reported with the
+    # backend's own message. When rj_waitcheck refuses an input it explains itself on
+    # stderr ("failed to parse input executable or code object", exit 2) and prints no
+    # analysis summary; returning the parse failure first replaced that explanation
+    # with "Waitcheck output did not contain an analysis summary", which names the
+    # symptom the refusal caused rather than the refusal. The exit-code branch below
+    # is the only one that quotes stderr, so it has to be reached first.
+    parse_error: Exception | None = None
+    findings: tuple[Finding, ...] = ()
+    diagnostics_truncated = False
     try:
         parsed = parse_waitcheck_text(
             f"{process.stdout}\n{process.stderr}",
             expected=identity,
         )
+        findings = parsed.findings
+        diagnostics_truncated = parsed.diagnostics_truncated
     except (OSError, ValueError) as exc:
-        return KernelCheckResult(
-            identity=identity,
-            state=ExecutionState.ERROR,
-            verdict=Verdict.ERROR,
-            reason=f"waitcheck_diagnostics_error: {exc}",
-            returncode=process.returncode,
-        )
+        parse_error = exc
     if process.returncode not in {WAITCHECK_CLEAN_EXIT, WAITCHECK_HAZARD_EXIT}:
         stderr_tail = process.stderr[-300:].strip()
         suffix = f": {stderr_tail}" if stderr_tail else ""
@@ -430,25 +436,35 @@ def _run_one(
             verdict=Verdict.ERROR,
             reason=f"waitcheck_backend_exit_{process.returncode}{suffix}",
             returncode=process.returncode,
-            findings=parsed.findings,
-            diagnostics_truncated=parsed.diagnostics_truncated,
+            findings=findings,
+            diagnostics_truncated=diagnostics_truncated,
         )
-    if process.returncode == WAITCHECK_HAZARD_EXIT and not parsed.findings:
+    if parse_error is not None:
+        # An expected exit code with unparsable output is a real identity/format
+        # mismatch, so it keeps reporting the parse failure verbatim.
+        return KernelCheckResult(
+            identity=identity,
+            state=ExecutionState.ERROR,
+            verdict=Verdict.ERROR,
+            reason=f"waitcheck_diagnostics_error: {parse_error}",
+            returncode=process.returncode,
+        )
+    if process.returncode == WAITCHECK_HAZARD_EXIT and not findings:
         return KernelCheckResult(
             identity=identity,
             state=ExecutionState.ERROR,
             verdict=Verdict.ERROR,
             reason="waitcheck_hazard_exit_without_structured_diagnostics",
             returncode=process.returncode,
-            diagnostics_truncated=parsed.diagnostics_truncated,
+            diagnostics_truncated=diagnostics_truncated,
         )
     return KernelCheckResult(
         identity=identity,
         state=ExecutionState.RAN,
-        verdict=Verdict.WARN if parsed.findings else Verdict.PASS,
+        verdict=Verdict.WARN if findings else Verdict.PASS,
         returncode=process.returncode,
-        findings=parsed.findings,
-        diagnostics_truncated=parsed.diagnostics_truncated,
+        findings=findings,
+        diagnostics_truncated=diagnostics_truncated,
     )
 
 

--- a/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
@@ -243,6 +243,72 @@ def test_waitcheck_backend_error_never_passes(tmp_path: Path) -> None:
     assert result.verdict is Verdict.ERROR
     assert "worklist_not_fully_checked" in str(result.reason)
     assert result.kernel_results[0].returncode == 2
+    # The rollup above names no cause, so the kernel reason has to carry the
+    # backend's own words rather than a generic parse complaint.
+    assert result.kernel_results[0].reason == "waitcheck_backend_exit_2: analysis failed"
+
+
+def test_waitcheck_unexpected_exit_reports_stderr_not_the_missing_summary(
+    tmp_path: Path,
+) -> None:
+    # rj_waitcheck refuses an input it cannot decode with exit 2, an explanation on
+    # stderr, and no analysis summary. Parsing before checking the exit code turned
+    # that explanation into "did not contain an analysis summary" -- the symptom of
+    # the refusal rather than the refusal -- and the stderr never reached the report.
+    binary = tmp_path / "rj_waitcheck"
+    binary.write_text("binary")
+    artifact = tmp_path / "kernel.hsaco"
+    artifact.write_bytes(b"\x7fELF")
+    message = f"{artifact}: failed to parse input executable or code object"
+
+    def execute(
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float,
+        env: Mapping[str, str] | None = None,
+    ) -> ProcessResult:
+        return ProcessResult(tuple(argv), 2, "", message)
+
+    result = run_waitcheck(
+        _worklist(_exact_identity(artifact)),
+        output_dir=tmp_path / "out",
+        binary=binary,
+        execute=execute,
+    )
+
+    kernel = result.kernel_results[0]
+    assert kernel.state is ExecutionState.ERROR
+    assert kernel.reason == f"waitcheck_backend_exit_2: {message}"
+    assert "analysis summary" not in str(kernel.reason)
+
+
+def test_waitcheck_expected_exit_still_reports_a_parse_failure(tmp_path: Path) -> None:
+    # The reorder above must not swallow a genuine identity/format mismatch: a clean
+    # or hazard exit whose output cannot be parsed is still a diagnostics error.
+    binary = tmp_path / "rj_waitcheck"
+    binary.write_text("binary")
+    artifact = tmp_path / "kernel.hsaco"
+    artifact.write_bytes(b"\x7fELF")
+
+    def execute(
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float,
+        env: Mapping[str, str] | None = None,
+    ) -> ProcessResult:
+        return ProcessResult(tuple(argv), 0, "nothing that looks like a summary", "")
+
+    result = run_waitcheck(
+        _worklist(_exact_identity(artifact)),
+        output_dir=tmp_path / "out",
+        binary=binary,
+        execute=execute,
+    )
+
+    kernel = result.kernel_results[0]
+    assert kernel.state is ExecutionState.ERROR
+    assert str(kernel.reason).startswith("waitcheck_diagnostics_error:")
+    assert "did not contain an analysis summary" in str(kernel.reason)
 
 
 def test_waitcheck_timeout_never_passes(tmp_path: Path) -> None:

--- a/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
@@ -18,6 +18,7 @@ from aorta.instrumentation.rocjitsu_sanitizers import (
     Verdict,
     parse_waitcheck_jsonl,
     run_waitcheck,
+    waitcheck,
     waitcheck_argv,
 )
 from aorta.instrumentation.rocjitsu_sanitizers.execution import ProcessResult
@@ -309,6 +310,62 @@ def test_waitcheck_expected_exit_still_reports_a_parse_failure(tmp_path: Path) -
     assert kernel.state is ExecutionState.ERROR
     assert str(kernel.reason).startswith("waitcheck_diagnostics_error:")
     assert "did not contain an analysis summary" in str(kernel.reason)
+
+
+def test_waitcheck_unexpected_exit_survives_any_parser_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Review (#479): the defensive parse caught only (OSError, ValueError), so a parser
+    # raising anything else propagated and never reached the exit-code branch -- which
+    # is the one branch that quotes stderr, and the whole reason the parse is defensive.
+    binary = tmp_path / "rj_waitcheck"
+    binary.write_text("binary")
+    artifact = tmp_path / "kernel.hsaco"
+    artifact.write_bytes(b"\x7fELF")
+    message = f"{artifact}: failed to parse input executable or code object"
+
+    def boom(output: str, *, expected: object) -> tuple[object, ...]:
+        raise IndexError("list index out of range")
+
+    monkeypatch.setattr(waitcheck, "parse_waitcheck_text", boom)
+
+    def execute(
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float,
+        env: Mapping[str, str] | None = None,
+    ) -> ProcessResult:
+        return ProcessResult(tuple(argv), 2, "", message)
+
+    result = run_waitcheck(
+        _worklist(_exact_identity(artifact)),
+        output_dir=tmp_path / "out",
+        binary=binary,
+        execute=execute,
+    )
+
+    kernel = result.kernel_results[0]
+    assert kernel.state is ExecutionState.ERROR
+    assert kernel.reason == f"waitcheck_backend_exit_2: {message}"
+
+    # and on an expected exit code the same failure is still reported, not swallowed
+    def clean(
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float,
+        env: Mapping[str, str] | None = None,
+    ) -> ProcessResult:
+        return ProcessResult(tuple(argv), 0, "", "")
+
+    expected_exit = run_waitcheck(
+        _worklist(_exact_identity(artifact)),
+        output_dir=tmp_path / "out2",
+        binary=binary,
+        execute=clean,
+    )
+    only = expected_exit.kernel_results[0]
+    assert only.state is ExecutionState.ERROR
+    assert only.reason == "waitcheck_diagnostics_error: list index out of range"
 
 
 def test_waitcheck_timeout_never_passes(tmp_path: Path) -> None:

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -248,6 +248,54 @@ def test_observation_and_inline_message_name_the_cause_behind_a_rollup():
     assert "gemm_NT_M256_N4096_K1024" in text
 
 
+def test_digestless_kernels_are_never_attributed_to_each_other():
+    # The other collision direction: ConSan identities carry no code object and no
+    # SHA-256, so keying attribution on (sha, index) alone collapses every one of
+    # them onto (None, None) and lets an unrelated sibling's verdict and reason be
+    # reported as "the same code object" -- an object that does not exist. Only a
+    # real digest can have been deduped, so only a real digest may be attributed.
+    def _entry(name: str) -> dict:
+        return {
+            "identity": {
+                "name": name, "target": "gfx950", "code_object": None,
+                "code_object_sha256": None, "code_object_index": None,
+                "entry_offset": None,
+            },
+            "total_time_ms": 0.0, "dispatch_count": 1, "sources": ["consan_repro"],
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [_entry("kern_A"), _entry("kern_B")],
+        },
+        "checks": [{
+            "sanitizer": "consan", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [{
+                "identity": {
+                    "name": "kern_A", "target": "gfx950", "code_object": None,
+                    "code_object_sha256": None, "code_object_index": None,
+                },
+                "state": "error", "verdict": "error", "findings": [],
+                "reason": "consan_hook_not_found", "returncode": None,
+            }],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "pass")
+    covered, uncovered = case["kernels"]
+    assert covered.get("detail") == "consan_hook_not_found"
+    # kern_B ran nothing and shares no object, so it keeps the em dash and stays silent
+    assert uncovered.get("verdict") == "\u2014"
+    assert uncovered.get("detail") == ""
+    assert "same code object" not in uncovered.get("detail", "")
+
+
 def test_kernel_tables_render_the_reason_on_both_twins():
     case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
 
@@ -265,6 +313,27 @@ def test_kernel_tables_render_the_reason_on_both_twins():
     )
     assert "| SHA-256 | Detail |" in md
     assert "failed to parse input executable or code object" in md
+
+
+def test_survey_md_twin_also_renders_the_reason():
+    # Three renderers consume row["kernels"]: the shared HTML table (both tabs) and
+    # a Markdown twin per tab. The survey twin is a separate function, so a column
+    # added to the other two silently skips it -- sweep every renderer, not just
+    # the one the guardrail tab uses.
+    entries = gen.survey_cases_from_spec(
+        {"cases": [{
+            "name": "gemm-waitcheck", "label": "daily GEMM \u00b7 waitcheck",
+            "report": _waitcheck_daily_topology_report(),
+        }]}
+    )
+    md = "\n".join(gen._survey_section_md(entries))
+
+    assert "| SHA-256 | Detail |" in md
+    assert "failed to parse input executable or code object" in md
+    assert "same code object as gemm_NT_M256_N4096_K1024" in md
+    # a clean kernel's cell degrades to an em dash rather than an empty column
+    assert "| `93f09ae670` | \u2014 |" not in md  # sha is the fixture's TT digest below
+    assert "| `aeb46fded1` | \u2014 |" in md
 
 
 def test_case_env_records_kernel_reasons_beside_the_rollup():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1063,7 +1063,8 @@ def test_the_manifest_does_not_invent_a_scope_the_report_never_claimed():
         summary=stated, report=None, built_refs=[], inputs=[],
     )
     stated_reason = ((stated_env.get("observed") or {}).get("kernel_reasons") or [{}])[0]
-    assert "entry_offset" in stated_reason and stated_reason["entry_offset"] is None
+    assert "entry_offset" in stated_reason
+    assert stated_reason.get("entry_offset") is None
 
 
 def test_an_exact_entry_result_missing_its_offset_cannot_cover_a_sibling():
@@ -1569,7 +1570,7 @@ def test_two_names_differing_only_in_whitespace_are_told_apart():
         "code_object_index": 0, "entry_offset": None,
     }
     identity_b = dict(identity_a, name=f"{head}  {tail}")
-    assert identity_a["name"] != identity_b["name"]
+    assert identity_a.get("name") != identity_b.get("name")
 
     labels = gen._display_labels([
         (identity_a["name"], identity_a), (identity_b["name"], identity_b)
@@ -1577,7 +1578,7 @@ def test_two_names_differing_only_in_whitespace_are_told_apart():
     assert len(set(labels)) == 2
 
     # the digest is over the name as written, so it separates the two on its own
-    digests = {gen._hashed_clip_name(i["name"]) for i in (identity_a, identity_b)}
+    digests = {gen._hashed_clip_name(str(i.get("name"))) for i in (identity_a, identity_b)}
     assert len(digests) == 2
 
 
@@ -3467,9 +3468,9 @@ def test_the_observation_keeps_the_tail_that_discriminates_a_coverage_reason():
         for attribution in ("resource_failed", "placement_or_lowering_failed")
     )
 
-    assert capacity["observation"] != defect["observation"]
-    assert "resource_failed" in capacity["observation"]
-    assert "placement_or_lowering_failed" in defect["observation"]
+    assert capacity.get("observation") != defect.get("observation")
+    assert "resource_failed" in capacity.get("observation", "")
+    assert "placement_or_lowering_failed" in defect.get("observation", "")
     # no kernel_results on this path, so nothing else can carry the cause
     assert (capacity.get("kernel_reasons") or []) == []
 
@@ -3480,8 +3481,9 @@ def test_the_observation_keeps_the_tail_that_discriminates_a_coverage_reason():
         ),
         None,
     )
-    assert "\n" not in multiline["observation"] and "\t" not in multiline["observation"]
-    assert "access sites resource_failed in gemm.hsaco: 14" in multiline["observation"]
+    observation = multiline.get("observation", "")
+    assert "\n" not in observation and "\t" not in observation
+    assert "access sites resource_failed in gemm.hsaco: 14" in observation
 
 
 def test_survey_informational_dir_isolates_malformed_nested_reports(tmp_path):

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1173,6 +1173,117 @@ def test_a_long_shared_kernel_name_keeps_its_identity_qualifier():
     assert f"({first})" in text
 
 
+def test_two_long_names_agreeing_on_their_head_are_still_told_apart():
+    # Collisions have to be counted on the *rendered* names. Two distinct names that
+    # agree on their first characters each look unique before the budget is applied,
+    # then render as one string — as ambiguous to a reader as a repeated name, and
+    # without even the qualifier a repeated name would have earned.
+    shared = "gemm_" + "N" * 300
+    first, second = f"{shared}_AAA", f"{shared}_BBB"
+
+    def _identity(name: str, sha: str) -> dict:
+        return {
+            "name": name, "target": "gfx950", "code_object": f"/a/b/sol_{sha}.hsaco",
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": None,
+        }
+
+    def _row(name: str, sha: str) -> dict:
+        return {"identity": _identity(name, sha), "total_time_ms": 0.0,
+                "dispatch_count": 9, "sources": ["gemm_csv"]}
+
+    def _result(name: str, sha: str, why: str) -> dict:
+        return {
+            "identity": _identity(name, sha), "state": "error", "verdict": "error",
+            "findings": [], "reason": why, "returncode": 2,
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [_row(first, "beefaaa1"), _row(second, "beefbbb2")],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                _result(first, "beefaaa1", "waitcheck_backend_exit_2: refused the first"),
+                _result(second, "beefbbb2", "waitcheck_timeout"),
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    labels = [e.get("label", "") for e in (case.get("kernel_reasons") or [])]
+    assert len(labels) == 2
+    assert len(set(labels)) == 2
+
+
+def test_two_long_names_in_one_object_keep_their_distinguishing_tails():
+    # When the rendered names tie and the identities tie too — two long names in the
+    # same code object — no qualifier can separate them, so the only thing left is the
+    # part of the name the head budget cut off.
+    identity_a = {
+        "name": "gemm_" + "N" * 300 + "_AAA", "target": "gfx950",
+        "code_object": "/a/b/sol.hsaco", "code_object_sha256": "beefaaa1",
+        "code_object_index": 0, "entry_offset": None,
+    }
+    identity_b = dict(identity_a, name="gemm_" + "N" * 300 + "_BBB")
+
+    labels = gen._display_labels([("a", identity_a), ("b", identity_b)])
+    assert labels == ["a", "b"]  # short names need none of this
+
+    labels = gen._display_labels([
+        (identity_a["name"], identity_a), (identity_b["name"], identity_b)
+    ])
+    assert len(set(labels)) == 2
+    assert labels[0].endswith("_AAA") and labels[1].endswith("_BBB")
+    assert all(len(label) <= 64 for label in labels)
+
+
+def test_an_unattributed_reason_is_not_labelled_like_a_visible_row():
+    # A reason no row claimed still renders on the page. Given a bare name that matches
+    # a visible row, it reads as an accusation against that row — while the object it
+    # came from is not on the page at all, and only env.json says so.
+    def _identity(sha: str) -> dict:
+        return {
+            "name": "gemm", "target": "gfx950", "code_object": f"/a/b/sol_{sha}.hsaco",
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": None,
+        }
+
+    listed, other = "beefaaa1", "beefbbb2"
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 1, "kernel_count": 1,
+            "kernels": [{"identity": _identity(listed), "total_time_ms": 0.0,
+                         "dispatch_count": 9, "sources": ["gemm_csv"]}],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [{
+                "identity": _identity(other), "state": "error", "verdict": "error",
+                "findings": [], "returncode": 2,
+                "reason": "waitcheck_backend_exit_2: refused the other object",
+            }],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    # qualified against the row it would otherwise be mistaken for
+    assert reasons[0].get("label") == f"gemm ({other})"
+    assert f"gemm ({other}): waitcheck_backend_exit_2" in case.get("observation", "")
+
+
 def test_a_long_kernel_name_cannot_truncate_its_own_reason_away():
     # Kernel names are unbounded — a mangled template instantiation runs to hundreds of
     # characters. Budgeting only the rollup still let the label spend the rest of the

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -256,52 +256,127 @@ def test_observation_and_inline_message_name_the_cause_behind_a_rollup():
     assert "gemm_NT_M256_N4096_K1024" in text
 
 
-def test_digestless_kernels_are_never_attributed_to_each_other():
-    # The other collision direction: ConSan identities carry no code object and no
-    # SHA-256, so keying attribution on (sha, index) alone collapses every one of
-    # them onto (None, None) and lets an unrelated sibling's verdict and reason be
-    # reported as "the same code object" -- an object that does not exist. Only a
-    # real digest can have been deduped, so only a real digest may be attributed.
-    def _entry(name: str) -> dict:
+def _dedup_attribution_report(
+    *, sanitizer: str, code_object: str | None, sha: str | None, why: str
+) -> dict:
+    """Two rows on one object where only the first came back with a result.
+
+    The shape the dedup attribution exists for. Whether the second row may inherit the
+    first's verdict as "same code object; scanned once" turns on one conjunct of the
+    attribution predicate at a time, so each conjunct gets this fixture with exactly
+    one field changed.
+    """
+    def _identity(name: str) -> dict:
         return {
-            "identity": {
-                "name": name, "target": "gfx950", "code_object": None,
-                "code_object_sha256": None, "code_object_index": None,
-                "entry_offset": None,
-            },
-            "total_time_ms": 0.0, "dispatch_count": 1, "sources": ["consan_repro"],
+            "name": name, "target": "gfx950", "code_object": code_object,
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": None,
         }
 
-    report = {
+    return {
         "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
         "overall_verdict": "error", "execution_status": "error",
         "worklist": {
             "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
             "top_n": 2, "kernel_count": 2,
-            "kernels": [_entry("kern_A"), _entry("kern_B")],
+            "kernels": [
+                {"identity": _identity(name), "total_time_ms": 0.0,
+                 "dispatch_count": 1, "sources": ["gemm_csv"]}
+                for name in ("kern_A", "kern_B")
+            ],
         },
         "checks": [{
-            "sanitizer": "consan", "state": "error", "verdict": "error",
+            "sanitizer": sanitizer, "state": "error", "verdict": "error",
             "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
             "kernel_results": [{
-                "identity": {
-                    "name": "kern_A", "target": "gfx950", "code_object": None,
-                    "code_object_sha256": None, "code_object_index": None,
-                },
-                "state": "error", "verdict": "error", "findings": [],
-                "reason": "consan_hook_not_found", "returncode": None,
+                "identity": _identity("kern_A"), "state": "error", "verdict": "error",
+                "findings": [], "reason": why, "returncode": None,
             }],
             "coverage": [], "backend": {},
         }],
     }
 
-    case = gen.summarize_case(report, "pass")
+
+def test_a_deduped_sibling_is_attributed_only_from_a_real_object_scan():
+    # Positive control for the three exclusion tests below: with all conjuncts
+    # satisfied, kern_B DOES inherit the scan that covered its object. Without this,
+    # a predicate that excluded everything would pass all three of them.
+    case = gen.summarize_case(
+        _dedup_attribution_report(
+            sanitizer="waitcheck", code_object="/a/b/sol.hsaco", sha="beefaaa1",
+            why="waitcheck_backend_exit_2: refused the object",
+        ),
+        "pass",
+    )
+    covered, sibling = case["kernels"]
+    assert covered.get("detail") == "waitcheck_backend_exit_2: refused the object"
+    assert sibling.get("verdict") == "error"
+    assert "same code object as kern_A; scanned once" in sibling.get("detail", "")
+
+
+def test_digestless_kernels_are_never_attributed_to_each_other():
+    # Review (#479): this fixture used to be a ConSan check with code_object=None, so
+    # the sanitizer and code-object conjuncts each excluded the attribution before the
+    # digest was consulted -- it pinned the disjunction, not the conjunct it is named
+    # for. A waitcheck check with a real code object and no digest isolates it.
+    #
+    # Keying attribution on (sha, index) collapses every digest-less identity onto
+    # (None, None) and lets an unrelated sibling's verdict be reported as "the same
+    # code object" -- an object that cannot have been deduped, because dedup is keyed
+    # on the digest. Only a real digest may be attributed.
+    #
+    # The digest requirement is enforced on both sides of the index -- the producer
+    # asks for a real `row_sha`, the recipient for a real `entry_sha` -- and this test
+    # pins the pair. Relaxing either alone cannot change the output: both read the same
+    # field of the same object, so a covering row without a digest keys ("None", index)
+    # and can never match a recipient row that has one.
+    case = gen.summarize_case(
+        _dedup_attribution_report(
+            sanitizer="waitcheck", code_object="/a/b/sol.hsaco", sha=None,
+            why="waitcheck_backend_exit_2: refused the object",
+        ),
+        "pass",
+    )
     covered, uncovered = case["kernels"]
-    assert covered.get("detail") == "consan_hook_not_found"
-    # kern_B ran nothing and shares no object, so it keeps the em dash and stays silent
+    assert covered.get("detail") == "waitcheck_backend_exit_2: refused the object"
+    # kern_B has nothing that could have been deduped, so it stays silent
     assert uncovered.get("verdict") == "\u2014"
     assert uncovered.get("detail") == ""
-    assert "same code object" not in uncovered.get("detail", "")
+
+
+def test_an_objectless_kernel_is_never_attributed_to_a_sibling():
+    # The code-object conjunct on its own. A digest with no code object is not a scan
+    # of anything nameable -- "same code object as kern_A" would cite a file the report
+    # never identified, and ConSan identities reach here with exactly that shape.
+    case = gen.summarize_case(
+        _dedup_attribution_report(
+            sanitizer="waitcheck", code_object=None, sha="beefaaa1",
+            why="waitcheck_backend_exit_2: refused the object",
+        ),
+        "pass",
+    )
+    covered, uncovered = case["kernels"]
+    assert covered.get("detail") == "waitcheck_backend_exit_2: refused the object"
+    assert uncovered.get("verdict") == "\u2014"
+    assert uncovered.get("detail") == ""
+
+
+def test_only_a_waitcheck_scan_covers_a_sibling_sharing_its_object():
+    # The sanitizer conjunct on its own: a full identity, digest and all, but the
+    # result came from ConSan. Whole-object dedup is Waitcheck's behaviour
+    # (run_waitcheck skips a repeated (sha, index) selection); ConSan runs the process
+    # once and attributes per kernel, so a ConSan result for kern_A says nothing about
+    # kern_B and "scanned once" would be a fabricated claim of coverage.
+    case = gen.summarize_case(
+        _dedup_attribution_report(
+            sanitizer="consan", code_object="/a/b/sol.hsaco", sha="beefaaa1",
+            why="consan_hook_not_found",
+        ),
+        "pass",
+    )
+    covered, uncovered = case["kernels"]
+    assert covered.get("detail") == "consan_hook_not_found"
+    assert uncovered.get("verdict") == "\u2014"
+    assert uncovered.get("detail") == ""
 
 
 def test_kernel_tables_render_the_reason_on_both_twins():
@@ -3321,6 +3396,37 @@ def test_survey_message_error_reason_takes_precedence_over_partial_findings():
     assert '<span class="lbl">Reason</span><span class="msg">combined_hook_timeout' in html
     assert "HEALTHY" in html
     assert "REGRESSION" not in html and "Regression" not in html
+
+
+def test_a_group_note_cannot_corrupt_the_survey_rollup_row():
+    # Review (#479): the last sink of the class this PR swept. The Note cell took the
+    # reason raw, unlike the sibling Detail and Example cells, so a backend reason —
+    # reachable today via "waitcheck_analysis_failed: <parser output>" — ended the row
+    # mid-table on its newline and shifted every later cell on its pipe.
+    entries = gen.survey_cases_from_spec(
+        {"cases": [
+            {"name": "consan-obj", "group": "obj", "sanitizer": "consan",
+             "report": _errored_report_with_partial_findings(
+                 "waitcheck_analysis_failed: worklist_not_fully_checked\nwith | a pipe"
+             )},
+        ]}
+    )
+    groups = gen._group_survey_entries(entries)
+    lines = gen._survey_summary_md(groups)
+    rows = [line for line in lines if line.startswith("| ") and "---" not in line]
+    header, body = rows[0], rows[1:]
+    assert header == "| Kernel | waitcheck | ConSan | Findings | Note |"
+    assert len(body) == 1
+    row = body[0]
+
+    # the row stays one line with exactly the header's cell count
+    assert "\n" not in row
+    assert row.count("|") - row.count("\\|") == header.count("|")
+    # and the note is still readable, on one line, with its pipe escaped
+    assert "worklist_not_fully_checked with \\| a pipe" in row
+
+    # the HTML twin renders inside a <td> and needs neither, but must stay intact
+    assert "worklist_not_fully_checked" in gen._survey_group_note(groups[0][1])
 
 
 def _coverage_incomplete_reason(attribution: str) -> str:

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -555,12 +555,13 @@ def test_two_reasons_for_one_kernel_are_labelled_by_sanitizer():
     assert sum(k.get("findings", 0) for k in case["kernels"]) == case.get("findings")
 
 
-def test_kernels_sharing_a_name_across_objects_stay_separate_rows():
-    # A name is not an identity: KernelWorklist only rejects duplicate stable_key, and
-    # that key carries the digest rather than pinning the name, so one symbol name
-    # reached through two code objects is a valid worklist. Joining results to rows by
-    # name merged the two scans -- each row took the other's verdict and reason, and
-    # their findings were summed onto both, double-counting against the case total.
+def _report_with_two_objects_sharing_a_name() -> dict:
+    """One symbol name reached through two code objects: a clean scan and a failed one.
+
+    A valid worklist -- KernelWorklist only rejects duplicate stable_key, and that key
+    carries the digest rather than pinning the name.
+    """
+
     def _identity(sha: str) -> dict:
         return {
             "name": "gemm_shared_symbol", "target": "gfx950",
@@ -576,7 +577,7 @@ def test_kernels_sharing_a_name_across_objects_stay_separate_rows():
         }
 
     clean_sha, bad_sha = "beefaaa1", "beefbbb2"
-    report = {
+    return {
         "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
         "overall_verdict": "error", "execution_status": "error",
         "worklist": {
@@ -609,6 +610,14 @@ def test_kernels_sharing_a_name_across_objects_stay_separate_rows():
         }],
     }
 
+
+def test_kernels_sharing_a_name_across_objects_stay_separate_rows():
+    # Joining results to rows by name merged the two scans -- each row took the other's
+    # verdict and reason, and their findings were summed onto both, double-counting
+    # against the case total.
+    report = _report_with_two_objects_sharing_a_name()
+    clean_sha, bad_sha = "beefaaa1", "beefbbb2"
+
     case = gen.summarize_case(report, "warn")
     clean, bad = case["kernels"]
 
@@ -628,8 +637,9 @@ def test_kernels_sharing_a_name_across_objects_stay_separate_rows():
     assert reasons[0].get("kernel") == "gemm_shared_symbol"
     assert reasons[0].get("code_object_sha256") == bad_sha
     assert reasons[0].get("reason") == "waitcheck_backend_exit_2: refused the second object"
-    # only one of the two failed, so the name is unambiguous and stays unqualified
-    assert reasons[0].get("label") == "gemm_shared_symbol"
+    # only one of the two failed, but both are on the page: what makes the name
+    # ambiguous is what the reader can see, not which rows happen to carry a reason
+    assert reasons[0].get("label") == f"gemm_shared_symbol ({bad_sha})"
 
 
 def test_two_failing_kernels_sharing_a_name_are_told_apart():
@@ -880,6 +890,66 @@ def test_two_failing_kernels_sharing_a_digest_prefix_are_told_apart():
     # field a bundled collision needs
     assert labels == [f"same ({first}#0)", f"same ({second}#0)"]
     assert len(set(labels)) == 2
+
+
+def test_a_lone_failure_is_qualified_against_a_clean_same_named_sibling():
+    # Ambiguity is a property of the page, not of the failing subset: qualifying only
+    # where two *failing* rows share a name left a single failure labelled bare while
+    # a clean row of the same name sat beside it, so the observation could not say
+    # which of the two the reason belonged to.
+    report = _report_with_two_objects_sharing_a_name()
+    case = gen.summarize_case(report, "warn")
+
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    assert reasons[0].get("label") == "gemm_shared_symbol (beefbbb2)"
+    assert "gemm_shared_symbol (beefbbb2): waitcheck_backend_exit_2" in case.get(
+        "observation", ""
+    )
+
+
+def test_a_result_identity_missing_object_fields_still_reaches_its_row():
+    # Every code-object field is optional on the wire, and reports whose kernel
+    # results carry only {name, target} exist (see `_waitcheck_report`). Joining on
+    # the full identity dropped those results outright — the row rendered a verdict
+    # with an empty Detail, losing the one field this PR exists to surface.
+    report = _waitcheck_report()
+    result = report["checks"][0]["kernel_results"][0]
+    result["state"] = "error"
+    result["verdict"] = "error"
+    result["reason"] = "waitcheck_backend_exit_2: refused input"
+    result["returncode"] = 2
+
+    case = gen.summarize_case(report, "warn")
+    row = case["kernels"][0]
+    assert row.get("verdict") == "error"
+    assert "refused input" in row.get("detail", "")
+
+    # and the manifest names the object, taken from the worklist row the result matched
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    assert reasons[0].get("code_object") == "/a/b/sol_1.hsaco"
+    assert reasons[0].get("code_object_sha256") == "93f09ae670abcdef"
+
+
+def test_a_sparse_result_is_not_guessed_onto_one_of_two_same_named_rows():
+    # The fallback is only safe where it can mean one thing. Two rows sharing a name
+    # and a target must not have a name-matched result attributed to either of them.
+    report = _report_with_two_objects_sharing_a_name()
+    for result in report["checks"][0]["kernel_results"]:
+        result["identity"] = {"name": "gemm_shared_symbol", "target": "gfx950"}
+
+    case = gen.summarize_case(report, "warn")
+    # no row claims it: attributing it to either would be a guess
+    assert [k.get("detail") for k in case["kernels"]] == ["", ""]
+
+    # but the reason is not lost — it surfaces unattributed rather than silently, with
+    # a null object saying plainly that the report did not pin one
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    assert reasons[0].get("reason") == "waitcheck_backend_exit_2: refused the second object"
+    assert reasons[0].get("code_object") is None
+    assert "waitcheck_backend_exit_2" in case.get("observation", "")
 
 
 def test_preflight_findings_still_land_in_the_kernel_column():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -358,6 +358,222 @@ def test_case_env_records_kernel_reasons_beside_the_rollup():
     ]
 
 
+def _mixed_scope_waitcheck_report(*, exact_first: bool) -> dict:
+    """One object reached by an exact-entry scan AND a whole-object scan.
+
+    Waitcheck only dedups a whole-object scan, so an exact-entry selection always
+    produces its own result. Three kernels share ``sha``/index 0: one pinned to an
+    entry offset, one scanning the whole object, and one deduped away behind the
+    latter. ``exact_first`` puts the exact result ahead of the object result, which is
+    the order that made the deduped row inherit a scan that never covered it.
+    """
+    sha = "beef57c5d8efa401"
+
+    def _entry(name: str, offset: int | None) -> dict:
+        return {
+            "identity": {
+                "name": name, "target": "gfx950", "code_object": "/a/b/sol_9.hsaco",
+                "code_object_sha256": sha, "code_object_index": 0, "entry_offset": offset,
+            },
+            "total_time_ms": 0.0, "dispatch_count": 10, "sources": ["gemm_csv"],
+        }
+
+    def _result(name: str, offset: int | None, verdict: str, reason: str | None) -> dict:
+        return {
+            "identity": {
+                "name": name, "target": "gfx950", "code_object": "/a/b/sol_9.hsaco",
+                "code_object_sha256": sha, "code_object_index": 0, "entry_offset": offset,
+            },
+            "state": "ran" if reason is None else "error",
+            "verdict": verdict, "findings": [], "reason": reason,
+            "returncode": 0 if reason is None else 2,
+        }
+
+    exact = _result("gemm_pinned_entry", 0x100, "pass", None)
+    whole = _result(
+        "gemm_whole_object", None, "error",
+        "waitcheck_backend_exit_2: /a/b/sol_9.hsaco: failed to parse input executable",
+    )
+    return {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 3, "kernel_count": 3,
+            "kernels": [
+                _entry("gemm_pinned_entry", 0x100),
+                _entry("gemm_whole_object", None),
+                _entry("gemm_deduped_sibling", None),
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [exact, whole] if exact_first else [whole, exact],
+            "coverage": [],
+            "backend": {"path": "/tmp/build/tools/rj_waitcheck", "sha256": "a70945fb1135beef"},
+        }],
+    }
+
+
+def test_an_exact_entry_scan_never_covers_a_deduped_sibling():
+    # An exact-entry scan analyzes one entry, not the object, so it cannot stand in
+    # for a kernel that was deduped away. Keying every digest-carrying result by
+    # object let the exact result land on (sha, index) first and lend its clean
+    # verdict to a sibling it never looked at -- reporting `pass` for a kernel behind
+    # an object whose only whole-object scan had failed. Order must not matter.
+    for exact_first in (True, False):
+        case = gen.summarize_case(_mixed_scope_waitcheck_report(exact_first=exact_first), "warn")
+        pinned, whole, deduped = case["kernels"]
+
+        # both real scans keep their own result
+        assert pinned.get("verdict") == "pass" and pinned.get("detail") == ""
+        assert whole.get("verdict") == "error"
+
+        # the deduped row is attributed to the whole-object scan, never the entry one
+        assert deduped.get("name") == "gemm_deduped_sibling"
+        assert deduped.get("verdict") == "error"
+        assert "same code object as gemm_whole_object" in deduped.get("detail", "")
+        assert "failed to parse input executable" in deduped.get("detail", "")
+        assert "gemm_pinned_entry" not in deduped.get("detail", "")
+
+
+def _two_check_report(*, consan_reason: str | None, with_findings: bool = False) -> dict:
+    """One kernel scanned by both sanitizers, as the shipped survey recipes do.
+
+    ``tiny-vecadd-survey.yaml`` and friends select ``top_n: 1`` and request
+    ``[waitcheck, consan]``, so ``run_sanitizers`` emits one check per sanitizer over
+    the same worklist and ConSan attributes its result to that same identity.
+    """
+    identity = {
+        "name": "tiny_vecadd", "target": "gfx950", "code_object": "/a/b/vecadd.hsaco",
+        "code_object_sha256": "beefaeb46fded102", "code_object_index": 0,
+        "entry_offset": None,
+    }
+
+    def _finding(sanitizer: str, code: str) -> dict:
+        return {
+            "sanitizer": sanitizer, "severity": "race", "code": code,
+            "message": f"{sanitizer} diagnostic", "kernel_name": "tiny_vecadd",
+            "code_object": None, "entry_offset": None, "metadata": {},
+        }
+
+    wc_findings = [_finding("waitcheck", "wait_hazard")] if with_findings else []
+    cs_findings = [_finding("consan", "1")] if with_findings else []
+    return {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 1, "kernel_count": 1,
+            "kernels": [{
+                "identity": identity, "total_time_ms": 0.0,
+                "dispatch_count": 7, "sources": ["gemm_csv"],
+            }],
+        },
+        "checks": [
+            {
+                "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+                "reason": "worklist_not_fully_checked", "returncode": None,
+                "findings": wc_findings,
+                "kernel_results": [{
+                    "identity": identity, "state": "error", "verdict": "error",
+                    "findings": wc_findings, "returncode": 2,
+                    "reason": (
+                        "waitcheck_backend_exit_2: /a/b/vecadd.hsaco: "
+                        "failed to parse input executable or code object"
+                    ),
+                }],
+                "coverage": [],
+                "backend": {"path": "/tmp/build/tools/rj_waitcheck", "sha256": "a70945fb1135beef"},
+            },
+            {
+                "sanitizer": "consan",
+                "state": "ran" if consan_reason is None else "error",
+                "verdict": "fail" if with_findings else "pass",
+                "reason": consan_reason, "returncode": 0, "findings": cs_findings,
+                "kernel_results": [{
+                    "identity": identity,
+                    "state": "ran" if consan_reason is None else "error",
+                    "verdict": "fail" if with_findings else "pass",
+                    "findings": cs_findings, "reason": consan_reason, "returncode": 0,
+                }],
+                "coverage": [], "backend": {},
+            },
+        ],
+    }
+
+
+def test_a_later_check_cannot_erase_an_earlier_checks_reason():
+    # Reducing every check's result for one kernel to the last one wrote ConSan's
+    # reasonless PASS over Waitcheck's errored result, so the reason this PR exists
+    # to surface vanished again on exactly the recipes that run both sanitizers.
+    case = gen.summarize_case(_two_check_report(consan_reason=None), "pass")
+    kernel = case["kernels"][0]
+
+    assert "failed to parse input executable or code object" in kernel.get("detail", "")
+    # and the badge cannot read cleaner than the detail beside it
+    assert kernel.get("verdict") == "error"
+    assert case.get("kernel_reasons") == [
+        (
+            "tiny_vecadd",
+            "waitcheck_backend_exit_2: /a/b/vecadd.hsaco: "
+            "failed to parse input executable or code object",
+        )
+    ]
+    assert "tiny_vecadd: waitcheck_backend_exit_2" in case.get("observation", "")
+
+
+def test_two_reasons_for_one_kernel_are_labelled_by_sanitizer():
+    # With a reason from each check, an unlabelled concatenation would not say which
+    # sanitizer refused, so each is named. Findings sum across checks too, keeping
+    # the per-kernel column summing to the case total.
+    case = gen.summarize_case(
+        _two_check_report(consan_reason="consan_hook_not_found", with_findings=True), "pass"
+    )
+    kernel = case["kernels"][0]
+
+    assert "waitcheck: waitcheck_backend_exit_2" in kernel.get("detail", "")
+    assert "consan: consan_hook_not_found" in kernel.get("detail", "")
+    # fail outranks error in the report's own verdict ranking
+    assert kernel.get("verdict") == "fail"
+    assert kernel.get("findings") == 2
+    assert sum(k.get("findings", 0) for k in case["kernels"]) == case.get("findings")
+
+
+def test_a_multiline_backend_reason_stays_on_one_markdown_row():
+    # A Waitcheck backend reason quotes up to 300 characters of stderr tail, which is
+    # genuinely multi-line. Copied through unchanged it ended the table row mid-table
+    # and split the remaining cells into a stray paragraph.
+    report = _waitcheck_daily_topology_report()
+    report["checks"][0]["kernel_results"][0]["reason"] = (
+        "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco:\n"
+        "  failed to parse input executable\n\n  or code object\n"
+    )
+    case = gen.summarize_case(report, "warn")
+
+    for row in (case["kernels"][0], case["kernels"][1]):
+        assert "\n" not in row.get("detail", "")
+        assert "failed to parse input executable or code object" in row.get("detail", "")
+    assert "\n" not in case.get("observation", "")
+    assert all("\n" not in reason for _kernel, reason in case.get("kernel_reasons") or [])
+    assert "\n" not in gen._survey_message_parts(case)[1]
+
+    # the rendered table keeps one line per kernel and no stray continuation
+    entries = gen.survey_cases_from_spec(
+        {"cases": [{"name": "gemm", "label": "daily GEMM", "report": report}]}
+    )
+    md = "\n".join(gen._survey_section_md(entries)).splitlines()
+    heads = [i for i, line in enumerate(md) if line.endswith("| SHA-256 | Detail |")]
+    assert len(heads) == 1, f"expected one kernels table, got {heads}"
+    head = heads[0]
+    rows = md[head + 2 : head + 2 + len(case["kernels"])]
+    assert len(rows) == 3
+    assert all(line.startswith("| `") and line.endswith(" |") for line in rows)
+    # the row after the last kernel is the table's blank terminator, not a spill
+    assert md[head + 2 + len(case["kernels"])] == ""
+
+
 def test_summarize_consan_credits_process_findings_to_single_kernel():
     case = gen.summarize_case(_consan_racy_report(), "fail")
 

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1003,7 +1003,12 @@ def test_an_exact_entry_result_missing_its_offset_cannot_cover_a_sibling():
 
     case = gen.summarize_case(report, "warn")
     entry_row, object_row, gated = case["kernels"]
-    assert entry_row.get("verdict") == "pass"
+    # the result claims whole-object scope, which cannot describe an exact-entry
+    # selection, so it attributes to no row and the entry row falls back to what the
+    # object scan says — a clean verdict inherited from an unattributable result would
+    # be a guess, and the guess that hides a failure
+    assert entry_row.get("verdict") == "error"
+    assert "same code object as gemm_object" in entry_row.get("detail", "")
     assert object_row.get("verdict") == "error"
     # the gated row inherits the scan that actually covered its object
     assert gated.get("verdict") == "error"
@@ -1242,6 +1247,88 @@ def test_two_long_names_in_one_object_keep_their_distinguishing_tails():
     assert len(set(labels)) == 2
     assert labels[0].endswith("_AAA") and labels[1].endswith("_BBB")
     assert all(len(label) <= 64 for label in labels)
+
+
+def test_an_omitted_offset_does_not_merge_two_selections_of_one_object():
+    # An exact-entry and a whole-object selection over one object are both valid
+    # (their stable_key scopes differ). If the exact result omits its optional
+    # entry_offset, the two results serialize to the same fields — collapsing them
+    # before either is reconciled with a selection merges scans of different scopes,
+    # and the merged verdict then reaches the object scan's deduped siblings.
+    sha = "beefaaa1"
+
+    def _identity(offset: int | None) -> dict:
+        return {
+            "name": "gemm", "target": "gfx950", "code_object": "/a/b/sol.hsaco",
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": offset,
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity(0x100), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity(None), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                {
+                    # the exact-entry scan, serialized without its offset
+                    "identity": {
+                        "name": "gemm", "target": "gfx950",
+                        "code_object": "/a/b/sol.hsaco", "code_object_sha256": sha,
+                        "code_object_index": 0,
+                    },
+                    "state": "error", "verdict": "error", "findings": [],
+                    "reason": "waitcheck_backend_exit_2: refused the entry",
+                    "returncode": 2,
+                },
+                {
+                    "identity": _identity(None), "state": "ran", "verdict": "pass",
+                    "findings": [], "reason": None, "returncode": 0,
+                },
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    exact_row, object_row = case["kernels"]
+    # the object scan keeps its own clean verdict rather than the merger of both
+    assert object_row.get("verdict") == "pass"
+    assert object_row.get("detail") == ""
+    # and the ambiguous result is not silently placed on either row
+    assert "refused the entry" not in exact_row.get("detail", "")
+    reasons = case.get("kernel_reasons") or []
+    assert [e.get("reason") for e in reasons] == [
+        "waitcheck_backend_exit_2: refused the entry"
+    ]
+
+
+def test_two_long_names_differing_only_in_the_elided_middle_are_told_apart():
+    # Last resort. Two names can agree on both ends and differ only in the middle the
+    # budget elides, and if they share a code object no identity field separates them
+    # either — so the labels tied and the two reasons became unattributable.
+    head, tail = "gemm_" + "K" * 60, "L" * 60 + "_end"
+    identity_a = {
+        "name": f"{head}_AAA_{tail}", "target": "gfx950",
+        "code_object": "/a/b/sol.hsaco", "code_object_sha256": "beefaaa1",
+        "code_object_index": 0, "entry_offset": None,
+    }
+    identity_b = dict(identity_a, name=f"{head}_BBB_{tail}")
+
+    labels = gen._display_labels([
+        (identity_a["name"], identity_a), (identity_b["name"], identity_b)
+    ])
+    assert len(set(labels)) == 2
 
 
 def test_an_unattributed_reason_is_not_labelled_like_a_visible_row():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -703,6 +703,128 @@ def test_two_failing_kernels_sharing_a_name_are_told_apart():
     ]
 
 
+def test_two_failing_kernels_bundled_in_one_object_are_told_apart():
+    # A digest identifies the *file*, not a code object: a bundle carries several
+    # objects under one digest, which is why Waitcheck dedups on
+    # (code_object_sha256, code_object_index) and why stable_key carries the index.
+    # Two same-named selections in one bundle therefore share every field the digest
+    # qualifier renders, so both labels came out identical and the observation could
+    # not say which of the two failed. The qualifier widens to the index — but only
+    # for the collision it has to resolve.
+    sha = "beefaaa1"
+
+    def _identity(index: int) -> dict:
+        return {
+            "name": "gemm_shared_symbol", "target": "gfx950",
+            "code_object": "/a/b/bundle.hsaco", "code_object_sha256": sha,
+            "code_object_index": index, "entry_offset": None,
+        }
+
+    def _result(index: int, why: str) -> dict:
+        return {
+            "identity": _identity(index), "state": "error", "verdict": "error",
+            "findings": [], "reason": why, "returncode": 2,
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity(0), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity(1), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                _result(0, "waitcheck_backend_exit_2: refused the first object"),
+                _result(1, "waitcheck_timeout"),
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 2
+
+    labels = [e.get("label") for e in reasons]
+    assert labels == [
+        f"gemm_shared_symbol ({sha}#0)", f"gemm_shared_symbol ({sha}#1)"
+    ]
+    assert len(set(labels)) == 2
+    observation = case.get("observation", "")
+    assert f"gemm_shared_symbol ({sha}#0): waitcheck_backend_exit_2" in observation
+    assert f"gemm_shared_symbol ({sha}#1): waitcheck_timeout" in observation
+    # the index was already in the manifest; it is the display label that lost it
+    assert [e.get("code_object_index") for e in reasons] == [0, 1]
+
+
+def test_a_deduped_row_names_which_of_two_same_named_scans_covered_it():
+    # The same defect one renderer over: a deduped row's Detail names its covering
+    # scan by bare name, so where two worklist rows share that name the cell does not
+    # say which of them was scanned. Qualified only when the name actually repeats.
+    covering_sha, other_sha = "beefaaa1", "beefbbb2"
+
+    def _identity(name: str, sha: str) -> dict:
+        return {
+            "name": name, "target": "gfx950",
+            "code_object": f"/a/b/sol_{sha}.hsaco", "code_object_sha256": sha,
+            "code_object_index": 0, "entry_offset": None,
+        }
+
+    def _result(name: str, sha: str, why: str | None) -> dict:
+        return {
+            "identity": _identity(name, sha), "state": "error" if why else "ran",
+            "verdict": "error" if why else "pass", "findings": [], "reason": why,
+            "returncode": 2 if why else 0,
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 3, "kernel_count": 3,
+            "kernels": [
+                {"identity": _identity("gemm", covering_sha), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                # deduped onto the row above: same object, no result of its own
+                {"identity": _identity("gemm_gated", covering_sha), "total_time_ms": 0.0,
+                 "dispatch_count": 7, "sources": ["gemm_csv"]},
+                # a second, unrelated object publishing the same symbol name
+                {"identity": _identity("gemm", other_sha), "total_time_ms": 0.0,
+                 "dispatch_count": 5, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                _result("gemm", covering_sha, "waitcheck_backend_exit_2: refused it"),
+                _result("gemm", other_sha, None),
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    covering, deduped, other = case["kernels"]
+    assert deduped.get("verdict") == "error"
+    # the cell says which "gemm" was scanned, not merely that some "gemm" was
+    assert f"same code object as gemm ({covering_sha}#0)" in deduped.get("detail", "")
+    assert "refused it" in deduped.get("detail", "")
+    # and the rows that carry their own result are untouched by the qualification
+    assert covering.get("name") == other.get("name") == "gemm"
+    assert other.get("detail") == ""
+
+
 def test_a_long_rollup_cannot_truncate_the_kernel_reasons_away():
     # The callout is one line and length-capped. Clamping only the concatenated
     # string let a long check-level rollup spend the whole budget, so the per-kernel

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -953,6 +953,44 @@ def test_a_sparse_result_is_not_guessed_onto_one_of_two_same_named_rows():
     assert "waitcheck_backend_exit_2" in case.get("observation", "")
 
 
+def test_the_manifest_does_not_invent_a_scope_the_report_never_claimed():
+    # Review (#479): presence is meaning. `_identity_compatible` reads an omitted
+    # entry_offset as an unknown scope and an explicit `entry_offset: null` as a claim
+    # of a whole-object scan, so filling the omission in with None made env.json —
+    # which drops the "scope unknown" label — assert a scope the report never stated.
+    report = _report_with_two_objects_sharing_a_name()
+    for result in report["checks"][0]["kernel_results"]:
+        result["identity"] = {"name": "gemm_shared_symbol", "target": "gfx950"}
+
+    case = gen.summarize_case(report, "warn")
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    # this result serialized no code-object field at all, so the omission is the only
+    # thing that can carry "the report did not say which object, or at what scope"
+    assert not any(f in reasons[0] for f in gen._IDENTITY_OBJECT_FIELDS)
+
+    env = gen.build_case_env(
+        case="waitcheck", cls="guardrail", recipe="daily-waitcheck-gemm",
+        command="aorta sanitize", meta={"run": "r", "gpu": "gfx950"},
+        summary=case, report=None, built_refs=[], inputs=[],
+    )
+    recorded = ((env.get("observed") or {}).get("kernel_reasons") or [{}])[0]
+    assert recorded.get("reason") == "waitcheck_backend_exit_2: refused the second object"
+    assert "entry_offset" not in recorded
+    assert not any(f in recorded for f in gen._IDENTITY_OBJECT_FIELDS)
+
+    # contrast: a result that *does* claim a whole-object scan keeps the explicit null,
+    # so the two cases stay distinguishable in the manifest
+    stated = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
+    stated_env = gen.build_case_env(
+        case="waitcheck", cls="guardrail", recipe="daily-waitcheck-gemm",
+        command="aorta sanitize", meta={"run": "r", "gpu": "gfx950"},
+        summary=stated, report=None, built_refs=[], inputs=[],
+    )
+    stated_reason = ((stated_env.get("observed") or {}).get("kernel_reasons") or [{}])[0]
+    assert "entry_offset" in stated_reason and stated_reason["entry_offset"] is None
+
+
 def test_an_exact_entry_result_missing_its_offset_cannot_cover_a_sibling():
     # Scan scope is a property of the *selection*, not of whichever fields a result
     # serialized. An exact-entry result that omits only `entry_offset` reads as a
@@ -1015,6 +1053,66 @@ def test_an_exact_entry_result_missing_its_offset_cannot_cover_a_sibling():
     assert gated.get("verdict") == "error"
     assert "same code object as gemm_object" in gated.get("detail", "")
     assert "refused the object" in gated.get("detail", "")
+
+
+def test_a_clean_object_scan_does_not_speak_for_an_exact_entry_row():
+    # Review (#479): the other direction of the same fallback. run_waitcheck dedups a
+    # selection only when entry_offset is None, so an exact-entry row always gets its
+    # own scan task — a missing result there means the result was lost, not folded into
+    # the object scan. Letting a CLEAN scan stand in rendered the row `pass`, "scanned
+    # once", while its own backend error sat unattributed at case scope.
+    sha = "beefaaa1"
+
+    def _identity(name: str, offset: int | None) -> dict:
+        return {
+            "name": name, "target": "gfx950", "code_object": "/a/b/sol.hsaco",
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": offset,
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity("gemm_entry", 0x100), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity("gemm_object", None), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                # the object scan came back clean
+                {"identity": _identity("gemm_object", None), "state": "ran",
+                 "verdict": "pass", "findings": [], "reason": None, "returncode": 0},
+                # the exact row's own result claims whole-object scope, so it cannot
+                # describe that row and stays unattributed
+                {"identity": _identity("gemm_entry", None), "state": "error",
+                 "verdict": "error", "findings": [], "returncode": 2,
+                 "reason": "waitcheck_backend_exit_2: refused the entry"},
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    entry_row, object_row = case["kernels"]
+
+    # the exact row is not claimed as covered, and above all is not reported clean
+    assert entry_row.get("verdict") != "pass"
+    assert "scanned once" not in entry_row.get("detail", "")
+    assert object_row.get("verdict") == "pass"
+
+    # and the error is not lost — it surfaces unattributed
+    reasons = case.get("kernel_reasons") or []
+    assert [e.get("reason") for e in reasons] == [
+        "waitcheck_backend_exit_2: refused the entry"
+    ]
+    assert "refused the entry" in case.get("observation", "")
 
 
 def test_a_sparse_result_merges_into_the_exact_one_for_the_same_row():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -541,6 +541,79 @@ def test_two_reasons_for_one_kernel_are_labelled_by_sanitizer():
     assert sum(k.get("findings", 0) for k in case["kernels"]) == case.get("findings")
 
 
+def test_kernels_sharing_a_name_across_objects_stay_separate_rows():
+    # A name is not an identity: KernelWorklist only rejects duplicate stable_key, and
+    # that key carries the digest rather than pinning the name, so one symbol name
+    # reached through two code objects is a valid worklist. Joining results to rows by
+    # name merged the two scans -- each row took the other's verdict and reason, and
+    # their findings were summed onto both, double-counting against the case total.
+    def _identity(sha: str) -> dict:
+        return {
+            "name": "gemm_shared_symbol", "target": "gfx950",
+            "code_object": f"/a/b/sol_{sha}.hsaco", "code_object_sha256": sha,
+            "code_object_index": 0, "entry_offset": None,
+        }
+
+    def _finding(sha: str) -> dict:
+        return {
+            "sanitizer": "waitcheck", "severity": "warning", "code": "wait_hazard",
+            "message": f"sol_{sha}.hsaco: missing s_waitcnt", "kernel_name": None,
+            "code_object": f"/a/b/sol_{sha}.hsaco", "entry_offset": None, "metadata": {},
+        }
+
+    clean_sha, bad_sha = "beefaaa1", "beefbbb2"
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity(clean_sha), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity(bad_sha), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None,
+            "findings": [_finding(clean_sha)],
+            "kernel_results": [
+                {
+                    "identity": _identity(clean_sha), "state": "ran", "verdict": "warn",
+                    "findings": [_finding(clean_sha)], "reason": None, "returncode": 4,
+                },
+                {
+                    "identity": _identity(bad_sha), "state": "error", "verdict": "error",
+                    "findings": [], "returncode": 2,
+                    "reason": "waitcheck_backend_exit_2: refused the second object",
+                },
+            ],
+            "coverage": [],
+            "backend": {"path": "/tmp/build/tools/rj_waitcheck", "sha256": "a70945fb1135beef"},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    clean, bad = case["kernels"]
+
+    # each row keeps its own object's result rather than the merger of both
+    assert clean.get("sha") == clean_sha and bad.get("sha") == bad_sha
+    assert clean.get("verdict") == "warn"
+    assert clean.get("findings") == 1
+    assert clean.get("detail") == ""
+    assert bad.get("verdict") == "error"
+    assert bad.get("findings") == 0
+    assert "refused the second object" in bad.get("detail", "")
+
+    # and the findings column still sums to the case total rather than doubling it
+    assert sum(k.get("findings", 0) for k in case["kernels"]) == case.get("findings") == 1
+    assert case.get("kernel_reasons") == [
+        ("gemm_shared_symbol", "waitcheck_backend_exit_2: refused the second object")
+    ]
+
+
 def test_a_multiline_backend_reason_stays_on_one_markdown_row():
     # A Waitcheck backend reason quotes up to 300 characters of stderr tail, which is
     # genuinely multi-line. Copied through unchanged it ended the table row mid-table

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -3187,6 +3187,61 @@ def test_survey_message_error_reason_takes_precedence_over_partial_findings():
     assert "REGRESSION" not in html and "Regression" not in html
 
 
+def _coverage_incomplete_reason(attribution: str) -> str:
+    # The real CoverageDecision.reasons shape: counts and mismatches first, then
+    # _failure_attributions LAST (consan_coverage.py builds it in that order). The
+    # attribution is the only part that says WHY coverage was rejected -- capacity
+    # (resource_failed) or a lowering/transform defect (placement_or_lowering_failed).
+    counts = "; ".join(
+        [
+            "verdict static_complete=false",
+            "verdict dynamic_complete=false",
+            "unsupported_code_objects=3",
+            "failed_code_objects=2",
+            "skipped_code_objects=1",
+            "access patched/supported mismatch: 0/14",
+            "barrier patched/supported mismatch: 0/9",
+            "atomic patched/supported mismatch: 0/6",
+        ]
+    )
+    sites = "; ".join(
+        f"{kind} sites {attribution} in gemm_kernel.hsaco: {n}"
+        for kind, n in (("access", 14), ("barrier", 9), ("atomic", 6))
+    )
+    return f"coverage incomplete: {counts}; {sites}"
+
+
+def test_the_observation_keeps_the_tail_that_discriminates_a_coverage_reason():
+    # Review (#479): the observation must not clamp primary.reason. A ConSan coverage
+    # reason carries its discriminator at the END, so a right-truncating cap keeps the
+    # counts -- identical between the two causes -- and drops the attribution that
+    # separates a capacity rejection from a lowering defect, collapsing them to one
+    # sentence. The whitespace normalization is kept; only the length cap is gone.
+    capacity, defect = (
+        gen.summarize_case(
+            _errored_report_with_partial_findings(_coverage_incomplete_reason(attribution)),
+            None,
+        )
+        for attribution in ("resource_failed", "placement_or_lowering_failed")
+    )
+
+    assert capacity["observation"] != defect["observation"]
+    assert "resource_failed" in capacity["observation"]
+    assert "placement_or_lowering_failed" in defect["observation"]
+    # no kernel_results on this path, so nothing else can carry the cause
+    assert (capacity.get("kernel_reasons") or []) == []
+
+    # normalization survives: a multi-line reason still renders on one line, whole
+    multiline = gen.summarize_case(
+        _errored_report_with_partial_findings(
+            "coverage incomplete:\n  access sites\tresource_failed in gemm.hsaco: 14\n"
+        ),
+        None,
+    )
+    assert "\n" not in multiline["observation"] and "\t" not in multiline["observation"]
+    assert "access sites resource_failed in gemm.hsaco: 14" in multiline["observation"]
+
+
 def test_survey_informational_dir_isolates_malformed_nested_reports(tmp_path):
     # Review (#374): a top-level dict with a malformed NESTED shape (e.g.
     # {"checks": null}) passes the isinstance guard but makes the reduction raise

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1650,6 +1650,72 @@ def test_an_omitted_offset_does_not_merge_two_selections_of_one_object():
     assert reasons[0].get("label") == "gemm (beefaaa1#0; scope unknown)"
 
 
+def test_an_omitted_index_is_labelled_unknown_beside_a_null_index_row():
+    # An omitted index is a wildcard, while an explicit null is a claim. With rows
+    # for null and zero, a result omitting only the index is compatible with both and
+    # must stay visibly unattributed rather than sharing the null-index row's label.
+    sha = "beefaaa1"
+
+    def _identity(index: int | None) -> dict:
+        return {
+            "name": "gemm", "target": "gfx950", "code_object": "/a/b/bundle.hsaco",
+            "code_object_sha256": sha, "code_object_index": index, "entry_offset": None,
+        }
+
+    ambiguous = _identity(None)
+    ambiguous.pop("code_object_index")
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity(None), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity(0), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [{
+                "identity": ambiguous, "state": "error", "verdict": "error",
+                "findings": [], "reason": "waitcheck_backend_exit_2: unknown object",
+                "returncode": 2,
+            }],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    assert reasons[0].get("label") == "gemm (beefaaa1; index unknown)"
+    assert "gemm (beefaaa1; index unknown)" in case.get("observation", "")
+
+
+def test_presence_widening_marks_every_omitted_optional_identity_field():
+    # Presence is part of the join key for every optional identity field, so the
+    # final display widening must preserve the same distinction for all four.
+    explicit = {
+        "name": "gemm", "target": "gfx950", "code_object": None,
+        "code_object_sha256": None, "code_object_index": None, "entry_offset": None,
+    }
+    for field, marker in (
+        ("code_object", "object unknown"),
+        ("code_object_sha256", "digest unknown"),
+        ("code_object_index", "index unknown"),
+        ("entry_offset", "scope unknown"),
+    ):
+        omitted = dict(explicit)
+        omitted.pop(field)
+        labels = gen._display_labels([("gemm", explicit), ("gemm", omitted)])
+        assert len(set(labels)) == 2, field
+        assert marker in labels[1]
+
+
 def test_two_long_names_differing_only_in_the_elided_middle_are_told_apart():
     # Last resort. Two names can agree on both ends and differ only in the middle the
     # budget elides, and if they share a code object no identity field separates them

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -952,6 +952,149 @@ def test_a_sparse_result_is_not_guessed_onto_one_of_two_same_named_rows():
     assert "waitcheck_backend_exit_2" in case.get("observation", "")
 
 
+def test_an_exact_entry_result_missing_its_offset_cannot_cover_a_sibling():
+    # Scan scope is a property of the *selection*, not of whichever fields a result
+    # serialized. An exact-entry result that omits only `entry_offset` reads as a
+    # whole-object scan, so it could win the dedup index over the real object scan and
+    # lend its verdict to a sibling it never analyzed.
+    sha = "beefaaa1"
+
+    def _identity(name: str, offset: int | None) -> dict:
+        return {
+            "name": name, "target": "gfx950", "code_object": "/a/b/sol.hsaco",
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": offset,
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 3, "kernel_count": 3,
+            "kernels": [
+                # an exact-entry selection, listed first so it keys the index first
+                {"identity": _identity("gemm_entry", 0x100), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity("gemm_object", None), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+                # deduped onto the whole-object scan: no result of its own
+                {"identity": _identity("gemm_gated", None), "total_time_ms": 0.0,
+                 "dispatch_count": 7, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                {
+                    # the offset the selection pins is absent from the result
+                    "identity": _identity("gemm_entry", None), "state": "ran",
+                    "verdict": "pass", "findings": [], "reason": None, "returncode": 0,
+                },
+                {
+                    "identity": _identity("gemm_object", None), "state": "error",
+                    "verdict": "error", "findings": [], "returncode": 2,
+                    "reason": "waitcheck_backend_exit_2: refused the object",
+                },
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    entry_row, object_row, gated = case["kernels"]
+    assert entry_row.get("verdict") == "pass"
+    assert object_row.get("verdict") == "error"
+    # the gated row inherits the scan that actually covered its object
+    assert gated.get("verdict") == "error"
+    assert "same code object as gemm_object" in gated.get("detail", "")
+    assert "refused the object" in gated.get("detail", "")
+
+
+def test_a_sparse_result_merges_into_the_exact_one_for_the_same_row():
+    # One check can serialize the full identity while another serializes only
+    # {name, target}. The two land under different join keys, and taking the exact one
+    # alone dropped the other check's verdict, reason and findings off the row —
+    # the same cross-check loss the accumulation exists to stop.
+    identity = {
+        "name": "vecadd", "target": "gfx950", "code_object": "/a/b/vecadd.hsaco",
+        "code_object_sha256": "beefaaa1", "code_object_index": 0, "entry_offset": None,
+    }
+
+    def _finding(sanitizer: str, code: str) -> dict:
+        return {
+            "sanitizer": sanitizer, "severity": "warning", "code": code,
+            "message": f"{code} on vecadd", "kernel_name": "vecadd",
+            "code_object": "/a/b/vecadd.hsaco", "entry_offset": None, "metadata": {},
+        }
+
+    wait_finding, race_finding = _finding("waitcheck", "wait_hazard"), _finding("consan", "race")
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "fail", "execution_status": "ran",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 1, "kernel_count": 1,
+            "kernels": [{"identity": identity, "total_time_ms": 0.0,
+                         "dispatch_count": 9, "sources": ["gemm_csv"]}],
+        },
+        "checks": [
+            {
+                "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+                "reason": "worklist_not_fully_checked", "returncode": None,
+                "findings": [wait_finding],
+                "kernel_results": [{
+                    "identity": identity, "state": "error", "verdict": "error",
+                    "findings": [wait_finding], "returncode": 2,
+                    "reason": "waitcheck_backend_exit_2: refused input",
+                }],
+                "coverage": [], "backend": {},
+            },
+            {
+                "sanitizer": "consan", "state": "ran", "verdict": "fail",
+                "reason": None, "returncode": 0, "findings": [race_finding],
+                "kernel_results": [{
+                    # the same kernel, identified by name and target only
+                    "identity": {"name": "vecadd", "target": "gfx950"},
+                    "state": "ran", "verdict": "fail", "findings": [race_finding],
+                    "reason": "consan_race_detected", "returncode": 0,
+                }],
+                "coverage": [], "backend": {},
+            },
+        ],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    assert len(case["kernels"]) == 1
+    row = case["kernels"][0]
+    # both checks' reasons survive, labelled, and the verdict is the least clean
+    assert "waitcheck: waitcheck_backend_exit_2" in row.get("detail", "")
+    assert "consan: consan_race_detected" in row.get("detail", "")
+    assert row.get("verdict") == "fail"
+    # and the column still sums to the case total rather than losing one check's finding
+    assert row.get("findings") == 2
+    assert sum(k.get("findings", 0) for k in case["kernels"]) == case.get("findings") == 2
+    assert len(case.get("kernel_reasons") or []) == 1
+
+
+def test_a_long_kernel_name_cannot_truncate_its_own_reason_away():
+    # Kernel names are unbounded — a mangled template instantiation runs to hundreds of
+    # characters. Budgeting only the rollup still let the label spend the rest of the
+    # allowance before its reason began, leaving a callout that names a kernel and no
+    # cause at all.
+    long_name = "gemm_" + "N" * 300
+    report = json.loads(
+        json.dumps(_waitcheck_daily_topology_report()).replace(
+            "gemm_NT_M256_N4096_K1024", long_name
+        )
+    )
+
+    case = gen.summarize_case(report, "warn")
+    label, text = gen._survey_message_parts(case)
+    assert label == "Reason"
+    assert "waitcheck_backend_exit_2" in text
+
+
 def test_preflight_findings_still_land_in_the_kernel_column():
     # run_sanitizers appends the combined hook's Waitcheck preflight as a third check.
     # `consan._relabel` keeps that check's findings and drops its kernel results, so

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1191,6 +1191,61 @@ def test_a_clean_object_scan_does_not_speak_for_an_exact_entry_row():
     assert "refused the entry" in case.get("observation", "")
 
 
+def test_a_deduped_sibling_inherits_only_the_waitcheck_scan():
+    # Review (#479): the accumulation folds every sanitizer's result for a kernel into
+    # one record, and the dedup attribution read that aggregate. A covering row with a
+    # Waitcheck `pass` and a ConSan `error` therefore rendered its sibling `error`,
+    # "scanned once — <ConSan reason>" — a claim no scan made, since ConSan reports per
+    # kernel and only the Waitcheck object scan covers the sibling.
+    sha = "beefaaa1"
+
+    def _identity(name: str) -> dict:
+        return {
+            "name": name, "target": "gfx950", "code_object": "/a/b/sol.hsaco",
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": None,
+        }
+
+    def _check(sanitizer: str, verdict: str, why: str | None) -> dict:
+        return {
+            "sanitizer": sanitizer, "state": "ran", "verdict": verdict,
+            "reason": "worklist_not_fully_checked", "returncode": 0, "findings": [],
+            "kernel_results": [{
+                "identity": _identity("kern_A"), "state": "ran", "verdict": verdict,
+                "findings": [], "reason": why, "returncode": 0,
+            }],
+            "coverage": [], "backend": {},
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity(name), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]}
+                for name in ("kern_A", "kern_B")
+            ],
+        },
+        "checks": [
+            _check("waitcheck", "pass", None),
+            _check("consan", "error", "consan_hook_not_found"),
+        ],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    covering, sibling = case["kernels"]
+
+    # the covering row keeps the cross-sanitizer aggregate: it really did error
+    assert covering.get("verdict") == "error"
+    assert "consan_hook_not_found" in covering.get("detail", "")
+
+    # the sibling was covered by the object scan only, which passed
+    assert sibling.get("verdict") != "error"
+    assert "consan_hook_not_found" not in sibling.get("detail", "")
+
+
 def test_a_clean_object_scan_does_not_speak_for_an_objectless_row():
     # Review (#479): the recipient side of the same rule. A row carrying a digest but
     # no code object is not `KernelIdentity.code_object_scan`, so run_waitcheck would

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gzip
+import hashlib
 import importlib.util
 import json
 import os
@@ -1381,6 +1382,43 @@ def test_two_long_names_differing_only_in_the_elided_middle_are_told_apart():
         (identity_a["name"], identity_a), (identity_b["name"], identity_b)
     ])
     assert len(set(labels)) == 2
+
+
+def test_two_names_differing_only_in_whitespace_are_told_apart():
+    # Review (#479): the last-resort digest hashed the RENDERED name, and rendering
+    # collapses internal whitespace. Two whole-object selections in one code object
+    # named "a b" and "a  b" have distinct stable_keys, but every rendering tier
+    # showed the same text and the digest agreed too, so both labels tied.
+    head, tail = "gemm_" + "K" * 60, "L" * 60 + "_end"
+    identity_a = {
+        "name": f"{head} {tail}", "target": "gfx950",
+        "code_object": "/a/b/sol.hsaco", "code_object_sha256": "beefaaa1",
+        "code_object_index": 0, "entry_offset": None,
+    }
+    identity_b = dict(identity_a, name=f"{head}  {tail}")
+    assert identity_a["name"] != identity_b["name"]
+
+    labels = gen._display_labels([
+        (identity_a["name"], identity_a), (identity_b["name"], identity_b)
+    ])
+    assert len(set(labels)) == 2
+
+    # the digest is over the name as written, so it separates the two on its own
+    digests = {gen._hashed_clip_name(i["name"]) for i in (identity_a, identity_b)}
+    assert len(digests) == 2
+
+
+def test_the_last_resort_label_carries_the_whole_name_digest():
+    # Review (#479): an 8-hex prefix is 32 bits and can tie by itself, which would
+    # leave _display_labels' uniqueness claim false with no tier left to widen into.
+    # The widening therefore ends at the full digest; pin that it is not re-truncated.
+    render, rendering = gen._NAME_RENDERINGS[-1]
+    assert render is gen._hashed_clip_name and rendering == {"width": 64}
+
+    name = "gemm_" + "K" * 200
+    whole = hashlib.sha256(name.encode("utf-8")).hexdigest()
+    assert gen._hashed_clip_name(name, width=64).endswith(f"~{whole}")
+    assert gen._hashed_clip_name(name).endswith(f"~{whole[:8]}")
 
 
 def test_an_unattributed_reason_is_not_labelled_like_a_visible_row():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -217,7 +217,7 @@ def test_summarize_keeps_the_per_kernel_failure_reason():
             "entry_offset": None,
         }
     ]
-    # a clean kernel carries no detail to explain
+    # a successfully scanned kernel with no fail-closed reason carries no detail
     assert case["kernels"][2].get("verdict") == "warn"
     assert case["kernels"][2].get("detail") == ""
 
@@ -338,7 +338,7 @@ def test_survey_md_twin_also_renders_the_reason():
     assert "| SHA-256 | Detail |" in md
     assert "failed to parse input executable or code object" in md
     assert "same code object as gemm_NT_M256_N4096_K1024" in md
-    # a clean kernel's cell degrades to an em dash rather than an empty column
+    # a successfully scanned kernel with no fail-closed reason renders an em dash
     assert "| `93f09ae670` | \u2014 |" not in md  # sha is the fixture's TT digest below
     assert "| `aeb46fded1` | \u2014 |" in md
 
@@ -1449,6 +1449,29 @@ def test_preflight_findings_still_land_in_the_kernel_column():
     case = gen.summarize_case(report, "warn")
     assert case.get("findings") == 3
     assert sum(k.get("findings", 0) for k in case["kernels"]) == 3
+
+
+def test_a_resultless_finding_is_credited_once_across_same_named_rows():
+    # A result-less finding names a kernel rather than an identity. Two uncovered,
+    # non-deduped rows can share that name, but crediting the finding to both makes
+    # the kernel column exceed the case total.
+    report = _report_with_two_objects_sharing_a_name()
+    report["checks"] = [{
+        "sanitizer": "waitcheck_preflight", "state": "ran", "verdict": "warn",
+        "reason": None, "returncode": 0,
+        "findings": [{
+            "sanitizer": "waitcheck_preflight", "severity": "warning",
+            "code": "wait_hazard", "message": "hazard on shared symbol",
+            "kernel_name": "gemm_shared_symbol", "code_object": None,
+            "entry_offset": None, "metadata": {},
+        }],
+        "kernel_results": [], "coverage": [], "backend": {},
+    }]
+    report["overall_verdict"] = "warn"
+
+    case = gen.summarize_case(report, "warn")
+    assert [row.get("findings") for row in case["kernels"]] == [1, 0]
+    assert sum(row.get("findings", 0) for row in case["kernels"]) == case.get("findings") == 1
 
 
 def test_a_long_rollup_cannot_truncate_the_kernel_reasons_away():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -211,8 +211,8 @@ def test_summarize_keeps_the_per_kernel_failure_reason():
             "label": "gemm_NT_M256_N4096_K1024",
             "reason": "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
             "failed to parse input executable or code object",
-            "code_object": "sol_126578.hsaco",
-            "sha": "57c5d8efa4",
+            "code_object": "/a/b/sol_126578.hsaco",
+            "code_object_sha256": "57c5d8efa4beef01",
             "code_object_index": 0,
             "entry_offset": None,
         }
@@ -362,8 +362,8 @@ def test_case_env_records_kernel_reasons_beside_the_rollup():
                 "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
                 "failed to parse input executable or code object"
             ),
-            "code_object": "sol_126578.hsaco",
-            "sha": "57c5d8efa4",
+            "code_object": "/a/b/sol_126578.hsaco",
+            "code_object_sha256": "57c5d8efa4beef01",
             "code_object_index": 0,
             "entry_offset": None,
         }
@@ -626,7 +626,7 @@ def test_kernels_sharing_a_name_across_objects_stay_separate_rows():
     reasons = case.get("kernel_reasons") or []
     assert len(reasons) == 1
     assert reasons[0].get("kernel") == "gemm_shared_symbol"
-    assert reasons[0].get("sha") == bad_sha
+    assert reasons[0].get("code_object_sha256") == bad_sha
     assert reasons[0].get("reason") == "waitcheck_backend_exit_2: refused the second object"
     # only one of the two failed, so the name is unambiguous and stays unqualified
     assert reasons[0].get("label") == "gemm_shared_symbol"
@@ -697,9 +697,11 @@ def test_two_failing_kernels_sharing_a_name_are_told_apart():
         summary=case, report=None, built_refs=[], inputs=[],
     )
     recorded = (env.get("observed") or {}).get("kernel_reasons") or []
-    assert [e.get("sha") for e in recorded] == [first, second]
+    # unabridged: the label is display copy, but the manifest is what has to stay
+    # diagnosable, and a basename plus a digest prefix can tie where these do not
+    assert [e.get("code_object_sha256") for e in recorded] == [first, second]
     assert [e.get("code_object") for e in recorded] == [
-        f"sol_{first}.hsaco", f"sol_{second}.hsaco"
+        f"/a/b/sol_{first}.hsaco", f"/a/b/sol_{second}.hsaco"
     ]
 
 
@@ -817,12 +819,129 @@ def test_a_deduped_row_names_which_of_two_same_named_scans_covered_it():
     case = gen.summarize_case(report, "warn")
     covering, deduped, other = case["kernels"]
     assert deduped.get("verdict") == "error"
-    # the cell says which "gemm" was scanned, not merely that some "gemm" was
-    assert f"same code object as gemm ({covering_sha}#0)" in deduped.get("detail", "")
+    # the cell says which "gemm" was scanned, not merely that some "gemm" was; the two
+    # objects differ by digest, so that is as far as the qualifier has to widen
+    assert f"same code object as gemm ({covering_sha})" in deduped.get("detail", "")
     assert "refused it" in deduped.get("detail", "")
     # and the rows that carry their own result are untouched by the qualification
     assert covering.get("name") == other.get("name") == "gemm"
     assert other.get("detail") == ""
+
+
+def test_two_failing_kernels_sharing_a_digest_prefix_are_told_apart():
+    # The qualifier renders a 10-character digest prefix, so two objects sharing that
+    # prefix and an index produced the same label at both widenings. Remote, but the
+    # widening is only worth having if it terminates in something that cannot tie:
+    # the last tier spends the whole digest.
+    shared = "0123456789"
+    first, second = f"{shared}aaaa", f"{shared}bbbb"
+
+    def _identity(sha: str) -> dict:
+        return {
+            "name": "same", "target": "gfx950",
+            "code_object": "/a/b/sol.hsaco", "code_object_sha256": sha,
+            "code_object_index": 0, "entry_offset": None,
+        }
+
+    def _result(sha: str, why: str) -> dict:
+        return {
+            "identity": _identity(sha), "state": "error", "verdict": "error",
+            "findings": [], "reason": why, "returncode": 2,
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity(first), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity(second), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                _result(first, "waitcheck_backend_exit_2: refused the first object"),
+                _result(second, "waitcheck_timeout"),
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    labels = [e.get("label") for e in (case.get("kernel_reasons") or [])]
+    # the widenings are cumulative, so the widest carries the index it did not need
+    # as well as the digest it did — the alternative is a tier that can drop the one
+    # field a bundled collision needs
+    assert labels == [f"same ({first}#0)", f"same ({second}#0)"]
+    assert len(set(labels)) == 2
+
+
+def test_preflight_findings_still_land_in_the_kernel_column():
+    # run_sanitizers appends the combined hook's Waitcheck preflight as a third check.
+    # `consan._relabel` keeps that check's findings and drops its kernel results, so
+    # its hazards count toward the case total with no per-kernel result to carry them
+    # — and the kernel column silently undercounted the case by exactly those.
+    identity = {
+        "name": "vecadd", "target": "gfx950", "code_object": "/a/b/vecadd.hsaco",
+        "code_object_sha256": "beefaaa1", "code_object_index": 0, "entry_offset": None,
+    }
+
+    def _finding(sanitizer: str, code: str, kernel_name: str | None) -> dict:
+        return {
+            "sanitizer": sanitizer, "severity": "warning", "code": code,
+            "message": f"{code} on vecadd", "kernel_name": kernel_name,
+            "code_object": "/a/b/vecadd.hsaco", "entry_offset": None, "metadata": {},
+        }
+
+    preflight_finding = _finding("waitcheck_preflight", "wait_hazard", "vecadd")
+    waitcheck_finding = _finding("waitcheck", "wait_hazard", "vecadd")
+    consan_finding = _finding("consan", "race", None)
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "fail", "execution_status": "ran",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 1, "kernel_count": 1,
+            "kernels": [{"identity": identity, "total_time_ms": 0.0,
+                         "dispatch_count": 9, "sources": ["gemm_csv"]}],
+        },
+        "checks": [
+            {
+                "sanitizer": "waitcheck", "state": "ran", "verdict": "warn",
+                "reason": None, "returncode": 0, "findings": [waitcheck_finding],
+                "kernel_results": [{
+                    "identity": identity, "state": "ran", "verdict": "warn",
+                    "findings": [waitcheck_finding], "reason": None, "returncode": 0,
+                }],
+                "coverage": [], "backend": {},
+            },
+            {
+                "sanitizer": "consan", "state": "ran", "verdict": "fail",
+                "reason": None, "returncode": 0, "findings": [consan_finding],
+                "kernel_results": [{
+                    "identity": identity, "state": "ran", "verdict": "fail",
+                    "findings": [consan_finding], "reason": None, "returncode": 0,
+                }],
+                "coverage": [], "backend": {},
+            },
+            # relabelled out of the ConSan run: findings kept, kernel results dropped
+            {
+                "sanitizer": "waitcheck_preflight", "state": "ran", "verdict": "warn",
+                "reason": None, "returncode": 0, "findings": [preflight_finding],
+                "kernel_results": [], "coverage": [], "backend": {},
+            },
+        ],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    assert case.get("findings") == 3
+    assert sum(k.get("findings", 0) for k in case["kernels"]) == 3
 
 
 def test_a_long_rollup_cannot_truncate_the_kernel_reasons_away():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1191,6 +1191,61 @@ def test_a_clean_object_scan_does_not_speak_for_an_exact_entry_row():
     assert "refused the entry" in case.get("observation", "")
 
 
+def test_a_clean_object_scan_does_not_speak_for_an_objectless_row():
+    # Review (#479): the recipient side of the same rule. A row carrying a digest but
+    # no code object is not `KernelIdentity.code_object_scan`, so run_waitcheck would
+    # never have deduped it either — yet it matched the (sha, index) key and inherited
+    # a clean verdict as "scanned once". Only the objectless row differs from
+    # test_a_deduped_sibling_is_attributed_only_from_a_real_object_scan.
+    sha = "beefaaa1"
+
+    def _identity(name: str, code_object: str | None) -> dict:
+        return {
+            "name": name, "target": "gfx950", "code_object": code_object,
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": None,
+        }
+
+    def _report(covering_verdict: str, why: str | None) -> dict:
+        return {
+            "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+            "overall_verdict": "error", "execution_status": "error",
+            "worklist": {
+                "schema": "aorta.kernel_worklist/0.1",
+                "requirement": "top_dispatch_count", "top_n": 2, "kernel_count": 2,
+                "kernels": [
+                    {"identity": _identity("kern_A", "/a/b/sol.hsaco"),
+                     "total_time_ms": 0.0, "dispatch_count": 9, "sources": ["gemm_csv"]},
+                    # same digest and index, but no object of its own
+                    {"identity": _identity("kern_B", None), "total_time_ms": 0.0,
+                     "dispatch_count": 8, "sources": ["gemm_csv"]},
+                ],
+            },
+            "checks": [{
+                "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+                "reason": "worklist_not_fully_checked", "returncode": None,
+                "findings": [],
+                "kernel_results": [{
+                    "identity": _identity("kern_A", "/a/b/sol.hsaco"), "state": "ran",
+                    "verdict": covering_verdict, "findings": [], "reason": why,
+                    "returncode": 0,
+                }],
+                "coverage": [], "backend": {},
+            }],
+        }
+
+    clean = gen.summarize_case(_report("pass", None), "warn")
+    objectless = clean["kernels"][1]
+    assert objectless.get("verdict") != "pass"
+    assert "scanned once" not in objectless.get("detail", "")
+
+    # a failing scan still shows there: the object it shares did fail
+    failed = gen.summarize_case(
+        _report("error", "waitcheck_backend_exit_2: refused the object"), "warn"
+    )
+    assert failed["kernels"][1].get("verdict") == "error"
+    assert "scanned once" in failed["kernels"][1].get("detail", "")
+
+
 def test_a_sparse_result_merges_into_the_exact_one_for_the_same_row():
     # One check can serialize the full identity while another serializes only
     # {name, target}. The two land under different join keys, and taking the exact one

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -196,15 +196,15 @@ def test_summarize_keeps_the_per_kernel_failure_reason():
     # left the page with no statement anywhere of why a kernel errored.
     case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
 
-    assert case["verdict"] == "error" and case["match"] is False
-    assert (case["primary"] or {})["reason"] == "worklist_not_fully_checked"
+    assert case.get("verdict") == "error" and case.get("match") is False
+    assert (case.get("primary") or {}).get("reason") == "worklist_not_fully_checked"
 
     errored = case["kernels"][0]
-    assert errored["name"] == "gemm_NT_M256_N4096_K1024"
-    assert errored["verdict"] == "error"
-    assert "failed to parse input executable or code object" in errored["detail"]
+    assert errored.get("name") == "gemm_NT_M256_N4096_K1024"
+    assert errored.get("verdict") == "error"
+    assert "failed to parse input executable or code object" in errored.get("detail", "")
 
-    assert case["kernel_reasons"] == [
+    assert case.get("kernel_reasons") == [
         (
             "gemm_NT_M256_N4096_K1024",
             "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
@@ -212,8 +212,8 @@ def test_summarize_keeps_the_per_kernel_failure_reason():
         )
     ]
     # a clean kernel carries no detail to explain
-    assert case["kernels"][2]["verdict"] == "warn"
-    assert case["kernels"][2]["detail"] == ""
+    assert case["kernels"][2].get("verdict") == "warn"
+    assert case["kernels"][2].get("detail") == ""
 
 
 def test_summarize_attributes_a_deduped_kernel_to_the_scan_that_covered_it():
@@ -223,24 +223,25 @@ def test_summarize_attributes_a_deduped_kernel_to_the_scan_that_covered_it():
     case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
     deduped = case["kernels"][1]
 
-    assert deduped["name"] == "gemm_NT_M128_N4096_K1280"
-    assert deduped["verdict"] == "error"
-    assert "same code object as gemm_NT_M256_N4096_K1024" in deduped["detail"]
-    assert "failed to parse input executable or code object" in deduped["detail"]
+    assert deduped.get("name") == "gemm_NT_M128_N4096_K1280"
+    assert deduped.get("verdict") == "error"
+    assert "same code object as gemm_NT_M256_N4096_K1024" in deduped.get("detail", "")
+    assert "failed to parse input executable or code object" in deduped.get("detail", "")
     # findings stay on the covering row, so the column still sums to the case total
-    assert deduped["findings"] == 0
-    assert sum(k["findings"] for k in case["kernels"]) == case["findings"]
+    assert deduped.get("findings") == 0
+    assert sum(k.get("findings", 0) for k in case["kernels"]) == case.get("findings")
     # the covering scan is reported once, not once per kernel that shares its object
-    assert len(case["kernel_reasons"]) == 1
+    assert len(case.get("kernel_reasons") or []) == 1
 
 
 def test_observation_and_inline_message_name_the_cause_behind_a_rollup():
     case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
 
     # the one-liner still leads with the rollup, but no longer stops there
-    assert "reason worklist_not_fully_checked" in case["observation"]
-    assert "gemm_NT_M256_N4096_K1024: waitcheck_backend_exit_2" in case["observation"]
-    assert "32 finding(s)" not in case["observation"]  # only one finding in the fixture
+    observation = case.get("observation", "")
+    assert "reason worklist_not_fully_checked" in observation
+    assert "gemm_NT_M256_N4096_K1024: waitcheck_backend_exit_2" in observation
+    assert "32 finding(s)" not in observation  # only one finding in the fixture
 
     label, text = gen._survey_message_parts(case)
     assert label == "Reason"
@@ -344,8 +345,9 @@ def test_case_env_records_kernel_reasons_beside_the_rollup():
         summary=case, report=None, built_refs=[], inputs=[],
     )
 
-    assert env["observed"]["reason"] == "worklist_not_fully_checked"
-    assert env["observed"]["kernel_reasons"] == [
+    observed = env.get("observed") or {}
+    assert observed.get("reason") == "worklist_not_fully_checked"
+    assert observed.get("kernel_reasons") == [
         {
             "kernel": "gemm_NT_M256_N4096_K1024",
             "reason": (

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -119,6 +119,174 @@ def test_summarize_waitcheck_reports_per_kernel_detail():
     assert case["finding_groups"][0]["example"].startswith("sol_1.hsaco:")
 
 
+def _waitcheck_daily_topology_report() -> dict:
+    """The real daily GEMM topology, with the shared object failing to scan.
+
+    Two NT shapes resolve to one code object (Waitcheck scans it once and reports it
+    under the first name) and one TT shape resolves to its own. The NT scan errors,
+    so the check rolls up to ``worklist_not_fully_checked`` while the TT scan still
+    produces findings -- the shape a real gate hit, where the only statement of the
+    actual cause is the errored kernel's own ``reason``.
+    """
+    nt_sha, tt_sha = "57c5d8efa4beef01", "aeb46fded1beef02"
+    finding = {
+        "sanitizer": "waitcheck", "severity": "warning", "code": "wait_hazard",
+        "message": "/a/b/sol_137678.hsaco:gfx950[0]:.text+0x4a4: missing s_waitcnt lgkmcnt(0)",
+        "kernel_name": None, "code_object": "/a/b/sol_137678.hsaco",
+        "entry_offset": None, "metadata": {},
+    }
+
+    def _entry(name: str, obj: str, sha: str, count: int) -> dict:
+        return {
+            "identity": {
+                "name": name, "target": "gfx950", "code_object": f"/a/b/{obj}",
+                "code_object_sha256": sha, "code_object_index": 0, "entry_offset": None,
+            },
+            "total_time_ms": 0.0, "dispatch_count": count, "sources": ["gemm_csv"],
+        }
+
+    return {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 3, "kernel_count": 3,
+            "kernels": [
+                _entry("gemm_NT_M256_N4096_K1024", "sol_126578.hsaco", nt_sha, 479),
+                _entry("gemm_NT_M128_N4096_K1280", "sol_175415.hsaco", nt_sha, 471),
+                _entry("gemm_TT_M64_N64_K1280", "sol_137678.hsaco", tt_sha, 440),
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None,
+            "findings": [finding],
+            "kernel_results": [
+                {
+                    "identity": {
+                        "name": "gemm_NT_M256_N4096_K1024", "target": "gfx950",
+                        "code_object": "/a/b/sol_126578.hsaco",
+                        "code_object_sha256": nt_sha, "code_object_index": 0,
+                    },
+                    "state": "error", "verdict": "error", "findings": [],
+                    "reason": (
+                        "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
+                        "failed to parse input executable or code object"
+                    ),
+                    "returncode": 2,
+                },
+                {
+                    "identity": {
+                        "name": "gemm_TT_M64_N64_K1280", "target": "gfx950",
+                        "code_object": "/a/b/sol_137678.hsaco",
+                        "code_object_sha256": tt_sha, "code_object_index": 0,
+                    },
+                    "state": "ran", "verdict": "warn", "findings": [finding],
+                    "reason": None, "returncode": 4,
+                },
+            ],
+            "coverage": [],
+            "backend": {"path": "/tmp/build/tools/rj_waitcheck", "sha256": "a70945fb1135beef"},
+        }],
+    }
+
+
+def test_summarize_keeps_the_per_kernel_failure_reason():
+    # The check-level reason is only the rollup, so dropping the per-kernel reason
+    # left the page with no statement anywhere of why a kernel errored.
+    case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
+
+    assert case["verdict"] == "error" and case["match"] is False
+    assert (case["primary"] or {})["reason"] == "worklist_not_fully_checked"
+
+    errored = case["kernels"][0]
+    assert errored["name"] == "gemm_NT_M256_N4096_K1024"
+    assert errored["verdict"] == "error"
+    assert "failed to parse input executable or code object" in errored["detail"]
+
+    assert case["kernel_reasons"] == [
+        (
+            "gemm_NT_M256_N4096_K1024",
+            "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
+            "failed to parse input executable or code object",
+        )
+    ]
+    # a clean kernel carries no detail to explain
+    assert case["kernels"][2]["verdict"] == "warn"
+    assert case["kernels"][2]["detail"] == ""
+
+
+def test_summarize_attributes_a_deduped_kernel_to_the_scan_that_covered_it():
+    # Waitcheck scans one object once, so the second NT shape has no kernel_result.
+    # Rendering it as an em dash read as "not checked" and hid that a *gated* kernel
+    # sat behind an object whose scan had failed.
+    case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
+    deduped = case["kernels"][1]
+
+    assert deduped["name"] == "gemm_NT_M128_N4096_K1280"
+    assert deduped["verdict"] == "error"
+    assert "same code object as gemm_NT_M256_N4096_K1024" in deduped["detail"]
+    assert "failed to parse input executable or code object" in deduped["detail"]
+    # findings stay on the covering row, so the column still sums to the case total
+    assert deduped["findings"] == 0
+    assert sum(k["findings"] for k in case["kernels"]) == case["findings"]
+    # the covering scan is reported once, not once per kernel that shares its object
+    assert len(case["kernel_reasons"]) == 1
+
+
+def test_observation_and_inline_message_name_the_cause_behind_a_rollup():
+    case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
+
+    # the one-liner still leads with the rollup, but no longer stops there
+    assert "reason worklist_not_fully_checked" in case["observation"]
+    assert "gemm_NT_M256_N4096_K1024: waitcheck_backend_exit_2" in case["observation"]
+    assert "32 finding(s)" not in case["observation"]  # only one finding in the fixture
+
+    label, text = gen._survey_message_parts(case)
+    assert label == "Reason"
+    assert text.startswith("worklist_not_fully_checked")
+    assert "gemm_NT_M256_N4096_K1024" in text
+
+
+def test_kernel_tables_render_the_reason_on_both_twins():
+    case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
+
+    html = gen._kernel_tables_html(case, report_rel=None)
+    assert "<th>Detail</th>" in html
+    assert "failed to parse input executable or code object" in html
+
+    rows = {
+        "waitcheck": case,
+        "consan-clean": gen.summarize_case(_consan_racy_report(), "fail"),
+        "consan-racy": gen.summarize_case(_consan_racy_report(), "fail"),
+    }
+    md = gen.build_summary_md(
+        [{"meta": {"run": "r1", "commit": "abc", "date": "d"}, "rows": rows, "gate": False}]
+    )
+    assert "| SHA-256 | Detail |" in md
+    assert "failed to parse input executable or code object" in md
+
+
+def test_case_env_records_kernel_reasons_beside_the_rollup():
+    case = gen.summarize_case(_waitcheck_daily_topology_report(), "warn")
+    env = gen.build_case_env(
+        case="waitcheck", cls="guardrail", recipe="daily-waitcheck-gemm",
+        command="aorta sanitize", meta={"run": "r", "gpu": "gfx950"},
+        summary=case, report=None, built_refs=[], inputs=[],
+    )
+
+    assert env["observed"]["reason"] == "worklist_not_fully_checked"
+    assert env["observed"]["kernel_reasons"] == [
+        {
+            "kernel": "gemm_NT_M256_N4096_K1024",
+            "reason": (
+                "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
+                "failed to parse input executable or code object"
+            ),
+        }
+    ]
+
+
 def test_summarize_consan_credits_process_findings_to_single_kernel():
     case = gen.summarize_case(_consan_racy_report(), "fail")
 
@@ -2206,9 +2374,9 @@ def test_kernel_tables_html_links_each_row_to_report():
     assert "javascript:alert(1)" not in unsafe
     assert ">report</a>" not in unsafe
 
-    # empty-kernel case spans the full (now 7-column) row
+    # empty-kernel case spans the full (now 8-column) row
     empty = gen._kernel_tables_html({**row, "kernels": []}, report_rel=rel)
-    assert "colspan=7>no kernels selected" in empty
+    assert "colspan=8>no kernels selected" in empty
 
 
 def test_build_html_kernel_rows_link_reports_on_both_tabs(tmp_path):

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1077,6 +1077,102 @@ def test_a_sparse_result_merges_into_the_exact_one_for_the_same_row():
     assert len(case.get("kernel_reasons") or []) == 1
 
 
+def test_a_result_naming_a_different_object_is_not_attributed_to_the_row():
+    # Only *omitted* fields are wildcards. A result whose identity is fully populated
+    # and disagrees with the row describes a different object, so attributing it would
+    # put one object's reason on another object's row — and then stamp the row's
+    # identity onto it, making env.json name an object that did not fail.
+    def _identity(sha: str) -> dict:
+        return {
+            "name": "gemm", "target": "gfx950", "code_object": f"/a/b/sol_{sha}.hsaco",
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": None,
+        }
+
+    listed, other = "beefaaa1", "beefbbb2"
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 1, "kernel_count": 1,
+            "kernels": [{"identity": _identity(listed), "total_time_ms": 0.0,
+                         "dispatch_count": 9, "sources": ["gemm_csv"]}],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [{
+                # same name and target, but a different object than the row lists
+                "identity": _identity(other), "state": "error", "verdict": "error",
+                "findings": [], "returncode": 2,
+                "reason": "waitcheck_backend_exit_2: refused the other object",
+            }],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    assert case["kernels"][0].get("detail") == ""
+
+    # the reason still surfaces, against the object that actually carries it
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    assert reasons[0].get("code_object_sha256") == other
+    assert reasons[0].get("code_object") == f"/a/b/sol_{other}.hsaco"
+
+
+def test_a_long_shared_kernel_name_keeps_its_identity_qualifier():
+    # The label budget has to fall on the name, not on the assembled label: right-
+    # truncating the label removes the (digest) suffix `_display_labels` appended, so
+    # two failures behind one long name render the same string again.
+    long_name = "gemm_" + "N" * 300
+    first, second = "beefaaa1", "beefbbb2"
+
+    def _identity(sha: str) -> dict:
+        return {
+            "name": long_name, "target": "gfx950", "code_object": f"/a/b/sol_{sha}.hsaco",
+            "code_object_sha256": sha, "code_object_index": 0, "entry_offset": None,
+        }
+
+    def _result(sha: str, why: str) -> dict:
+        return {
+            "identity": _identity(sha), "state": "error", "verdict": "error",
+            "findings": [], "reason": why, "returncode": 2,
+        }
+
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity(first), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity(second), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                _result(first, "waitcheck_backend_exit_2: refused the first object"),
+                _result(second, "waitcheck_timeout"),
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    labels = [e.get("label", "") for e in (case.get("kernel_reasons") or [])]
+    assert len(set(labels)) == 2
+    assert labels[0].endswith(f"({first})") and labels[1].endswith(f"({second})")
+    # and the qualifier survives into the length-capped callout too
+    _, text = gen._survey_message_parts(case)
+    assert f"({first})" in text
+
+
 def test_a_long_kernel_name_cannot_truncate_its_own_reason_away():
     # Kernel names are unbounded — a mangled template instantiation runs to hundreds of
     # characters. Budgeting only the rollup still let the label spend the rest of the

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1526,6 +1526,23 @@ def test_a_resultless_finding_is_credited_once_across_same_named_rows():
     assert sum(row.get("findings", 0) for row in case["kernels"]) == case.get("findings") == 1
 
 
+def test_an_uncovered_row_does_not_borrow_a_same_named_results_finding():
+    # Findings already carried by a kernel result belong to that identity. Falling
+    # back through the name-only index put the same finding on an earlier uncovered
+    # row as well, so the kernel column counted it twice.
+    report = _report_with_two_objects_sharing_a_name()
+    check = report["checks"][0]
+    finding = check["findings"][0]
+    finding["kernel_name"] = "gemm_shared_symbol"
+    matched_result = check["kernel_results"][1]
+    matched_result["findings"] = [finding]
+    check["kernel_results"] = [matched_result]
+
+    case = gen.summarize_case(report, "warn")
+    assert [row.get("findings") for row in case["kernels"]] == [0, 1]
+    assert sum(row.get("findings", 0) for row in case["kernels"]) == case.get("findings") == 1
+
+
 def test_a_long_rollup_cannot_truncate_the_kernel_reasons_away():
     # The callout is one line and length-capped. Clamping only the concatenated
     # string let a long check-level rollup spend the whole budget, so the per-kernel

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1441,6 +1441,30 @@ def test_a_long_kernel_name_cannot_truncate_its_own_reason_away():
     assert "waitcheck_backend_exit_2" in text
 
 
+def test_a_full_identity_label_cannot_truncate_the_backend_cause():
+    # A name-budgeted label can still be long when disambiguation needs the full
+    # digest and index. The rollup must yield space without dropping that qualifier
+    # or the backend explanation after it.
+    first = "0123456789" + "a" * 54
+    second = "0123456789" + "b" * 54
+    long_name = "gemm_" + "N" * 300
+    report = json.loads(
+        json.dumps(_report_with_two_objects_sharing_a_name())
+        .replace("beefaaa1", first)
+        .replace("beefbbb2", second)
+        .replace("gemm_shared_symbol", long_name)
+    )
+    report["checks"][0]["reason"] = "waitcheck_analysis_failed: " + "backend noise " * 40
+
+    case = gen.summarize_case(report, "warn")
+    label, text = gen._survey_message_parts(case)
+    assert label == "Reason"
+    assert text.startswith("waitcheck_analysis_failed:")
+    assert f"({second}#0)" in text
+    assert "refused the second object" in text
+    assert len(text) <= gen._MSG_LIMIT
+
+
 def test_preflight_findings_still_land_in_the_kernel_column():
     # run_sanitizers appends the combined hook's Waitcheck preflight as a third check.
     # `consan._relabel` keeps that check's findings and drops its kernel results, so

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -205,11 +205,17 @@ def test_summarize_keeps_the_per_kernel_failure_reason():
     assert "failed to parse input executable or code object" in errored.get("detail", "")
 
     assert case.get("kernel_reasons") == [
-        (
-            "gemm_NT_M256_N4096_K1024",
-            "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
+        {
+            "kernel": "gemm_NT_M256_N4096_K1024",
+            # a unique name needs no identity qualifier
+            "label": "gemm_NT_M256_N4096_K1024",
+            "reason": "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
             "failed to parse input executable or code object",
-        )
+            "code_object": "sol_126578.hsaco",
+            "sha": "57c5d8efa4",
+            "code_object_index": 0,
+            "entry_offset": None,
+        }
     ]
     # a clean kernel carries no detail to explain
     assert case["kernels"][2].get("verdict") == "warn"
@@ -347,6 +353,8 @@ def test_case_env_records_kernel_reasons_beside_the_rollup():
 
     observed = env.get("observed") or {}
     assert observed.get("reason") == "worklist_not_fully_checked"
+    # the identity travels with the reason, so the manifest can say which object
+    # failed without reopening sanitizer_report.json
     assert observed.get("kernel_reasons") == [
         {
             "kernel": "gemm_NT_M256_N4096_K1024",
@@ -354,8 +362,14 @@ def test_case_env_records_kernel_reasons_beside_the_rollup():
                 "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
                 "failed to parse input executable or code object"
             ),
+            "code_object": "sol_126578.hsaco",
+            "sha": "57c5d8efa4",
+            "code_object_index": 0,
+            "entry_offset": None,
         }
     ]
+    # "label" is a display concern and stays out of the manifest
+    assert "label" not in (observed.get("kernel_reasons") or [{}])[0]
 
 
 def _mixed_scope_waitcheck_report(*, exact_first: bool) -> dict:
@@ -514,13 +528,13 @@ def test_a_later_check_cannot_erase_an_earlier_checks_reason():
     assert "failed to parse input executable or code object" in kernel.get("detail", "")
     # and the badge cannot read cleaner than the detail beside it
     assert kernel.get("verdict") == "error"
-    assert case.get("kernel_reasons") == [
-        (
-            "tiny_vecadd",
-            "waitcheck_backend_exit_2: /a/b/vecadd.hsaco: "
-            "failed to parse input executable or code object",
-        )
-    ]
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    assert reasons[0].get("kernel") == "tiny_vecadd"
+    assert reasons[0].get("reason") == (
+        "waitcheck_backend_exit_2: /a/b/vecadd.hsaco: "
+        "failed to parse input executable or code object"
+    )
     assert "tiny_vecadd: waitcheck_backend_exit_2" in case.get("observation", "")
 
 
@@ -609,9 +623,125 @@ def test_kernels_sharing_a_name_across_objects_stay_separate_rows():
 
     # and the findings column still sums to the case total rather than doubling it
     assert sum(k.get("findings", 0) for k in case["kernels"]) == case.get("findings") == 1
-    assert case.get("kernel_reasons") == [
-        ("gemm_shared_symbol", "waitcheck_backend_exit_2: refused the second object")
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 1
+    assert reasons[0].get("kernel") == "gemm_shared_symbol"
+    assert reasons[0].get("sha") == bad_sha
+    assert reasons[0].get("reason") == "waitcheck_backend_exit_2: refused the second object"
+    # only one of the two failed, so the name is unambiguous and stays unqualified
+    assert reasons[0].get("label") == "gemm_shared_symbol"
+
+
+def test_two_failing_kernels_sharing_a_name_are_told_apart():
+    # When both objects behind one symbol name fail, a bare-name label produces two
+    # indistinguishable reasons, and env.json cannot say which object failed without
+    # reopening the report. The label is qualified with the identity where — and only
+    # where — the name is actually ambiguous.
+    def _identity(sha: str) -> dict:
+        return {
+            "name": "gemm_shared_symbol", "target": "gfx950",
+            "code_object": f"/a/b/sol_{sha}.hsaco", "code_object_sha256": sha,
+            "code_object_index": 0, "entry_offset": None,
+        }
+
+    def _result(sha: str, why: str) -> dict:
+        return {
+            "identity": _identity(sha), "state": "error", "verdict": "error",
+            "findings": [], "reason": why, "returncode": 2,
+        }
+
+    first, second = "beefaaa1", "beefbbb2"
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "error", "execution_status": "error",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 2, "kernel_count": 2,
+            "kernels": [
+                {"identity": _identity(first), "total_time_ms": 0.0,
+                 "dispatch_count": 9, "sources": ["gemm_csv"]},
+                {"identity": _identity(second), "total_time_ms": 0.0,
+                 "dispatch_count": 8, "sources": ["gemm_csv"]},
+            ],
+        },
+        "checks": [{
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None, "findings": [],
+            "kernel_results": [
+                _result(first, "waitcheck_backend_exit_2: refused the first object"),
+                _result(second, "waitcheck_timeout"),
+            ],
+            "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "warn")
+    reasons = case.get("kernel_reasons") or []
+    assert len(reasons) == 2
+
+    # both keep the bare kernel name as data, but their labels are distinguishable
+    assert [e.get("kernel") for e in reasons] == ["gemm_shared_symbol"] * 2
+    labels = [e.get("label") for e in reasons]
+    assert labels == [f"gemm_shared_symbol ({first})", f"gemm_shared_symbol ({second})"]
+    assert len(set(labels)) == 2
+
+    # and the one-liner carries both, each attributable to its own object
+    observation = case.get("observation", "")
+    assert f"gemm_shared_symbol ({first}): waitcheck_backend_exit_2" in observation
+    assert f"gemm_shared_symbol ({second}): waitcheck_timeout" in observation
+
+    # the manifest records the identity for each, so neither needs the raw report
+    env = gen.build_case_env(
+        case="waitcheck", cls="guardrail", recipe="daily-waitcheck-gemm",
+        command="aorta sanitize", meta={"run": "r", "gpu": "gfx950"},
+        summary=case, report=None, built_refs=[], inputs=[],
+    )
+    recorded = (env.get("observed") or {}).get("kernel_reasons") or []
+    assert [e.get("sha") for e in recorded] == [first, second]
+    assert [e.get("code_object") for e in recorded] == [
+        f"sol_{first}.hsaco", f"sol_{second}.hsaco"
     ]
+
+
+def test_a_long_rollup_cannot_truncate_the_kernel_reasons_away():
+    # The callout is one line and length-capped. Clamping only the concatenated
+    # string let a long check-level rollup spend the whole budget, so the per-kernel
+    # reasons were cut off the end — the callout kept the part that says nothing and
+    # dropped the part it exists to show. A rollup is not always short: ConSan builds
+    # `waitcheck_analysis_failed: <parser output>` out of tool text.
+    report = _waitcheck_daily_topology_report()
+    report["checks"][0]["reason"] = "waitcheck_analysis_failed: " + "backend noise " * 40
+    case = gen.summarize_case(report, "warn")
+
+    label, text = gen._survey_message_parts(case)
+    assert label == "Reason"
+    assert text.startswith("waitcheck_analysis_failed:")
+    # the rollup is budgeted down so the kernel reason still lands
+    assert "gemm_NT_M256_N4096_K1024" in text
+    assert "waitcheck_backend_exit_2" in text
+    assert len(text) <= 240
+
+
+def test_a_long_reason_stays_within_the_detail_budget_on_both_rows():
+    # A backend reason quotes up to 300 characters of stderr tail, so a Detail cell
+    # can be pushed over its budget -- especially the deduped row, which spends part
+    # of it naming the scan that covered it. Neither row may exceed the cap, and the
+    # deduped row must still name its covering scan rather than being cut back to
+    # bare prefix.
+    report = _waitcheck_daily_topology_report()
+    report["checks"][0]["kernel_results"][0]["reason"] = (
+        "waitcheck_backend_exit_2: /a/b/sol_126578.hsaco: "
+        + "failed to parse segment; " * 12
+    )
+    case = gen.summarize_case(report, "warn")
+    covering, deduped = case["kernels"][0], case["kernels"][1]
+
+    assert len(covering.get("detail", "")) <= gen._DETAIL_LIMIT
+    assert len(deduped.get("detail", "")) <= gen._DETAIL_LIMIT
+    assert "same code object as gemm_NT_M256_N4096_K1024" in deduped.get("detail", "")
+    # the covering row carries the reason furthest, and is the row the cell points at
+    assert "waitcheck_backend_exit_2" in covering.get("detail", "")
+    assert "waitcheck_backend_exit_2" in deduped.get("detail", "")
 
 
 def test_a_multiline_backend_reason_stays_on_one_markdown_row():
@@ -629,7 +759,7 @@ def test_a_multiline_backend_reason_stays_on_one_markdown_row():
         assert "\n" not in row.get("detail", "")
         assert "failed to parse input executable or code object" in row.get("detail", "")
     assert "\n" not in case.get("observation", "")
-    assert all("\n" not in reason for _kernel, reason in case.get("kernel_reasons") or [])
+    assert all("\n" not in e["reason"] for e in case.get("kernel_reasons") or [])
     assert "\n" not in gen._survey_message_parts(case)[1]
 
     # the rendered table keeps one line per kernel and no stray continuation

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -1082,6 +1082,57 @@ def test_a_sparse_result_merges_into_the_exact_one_for_the_same_row():
     assert len(case.get("kernel_reasons") or []) == 1
 
 
+def test_multiple_sparse_representations_merge_into_their_only_compatible_row():
+    # Separate checks may serialize different optional subsets of one identity.
+    # Once each candidate is compatible with exactly one row, their count is not
+    # ambiguous: all of them belong on that row.
+    report = _waitcheck_report()
+    identity = report["worklist"]["kernels"][0]["identity"]
+
+    def _finding(sanitizer: str, code: str) -> dict:
+        return {
+            "sanitizer": sanitizer, "severity": "warning", "code": code,
+            "message": f"{code} on gemm_x", "kernel_name": "gemm_x",
+            "code_object": identity["code_object"], "entry_offset": None, "metadata": {},
+        }
+
+    wait_finding = _finding("waitcheck", "wait_hazard")
+    race_finding = _finding("consan", "race")
+    report["checks"] = [
+        {
+            "sanitizer": "waitcheck", "state": "error", "verdict": "error",
+            "reason": "worklist_not_fully_checked", "returncode": None,
+            "findings": [wait_finding], "coverage": [], "backend": {},
+            "kernel_results": [{
+                "identity": {"name": "gemm_x", "target": "gfx950"},
+                "state": "error", "verdict": "error", "findings": [wait_finding],
+                "reason": "waitcheck_backend_exit_2: refused input", "returncode": 2,
+            }],
+        },
+        {
+            "sanitizer": "consan", "state": "ran", "verdict": "fail",
+            "reason": None, "returncode": 0, "findings": [race_finding],
+            "coverage": [], "backend": {},
+            "kernel_results": [{
+                "identity": {
+                    "name": "gemm_x", "target": "gfx950",
+                    "code_object": identity["code_object"],
+                },
+                "state": "ran", "verdict": "fail", "findings": [race_finding],
+                "reason": "consan_race_detected", "returncode": 0,
+            }],
+        },
+    ]
+    report["overall_verdict"] = "fail"
+
+    case = gen.summarize_case(report, "fail")
+    row = case["kernels"][0]
+    assert "waitcheck: waitcheck_backend_exit_2" in row.get("detail", "")
+    assert "consan: consan_race_detected" in row.get("detail", "")
+    assert row.get("verdict") == "fail"
+    assert row.get("findings") == case.get("findings") == 2
+
+
 def test_a_result_naming_a_different_object_is_not_attributed_to_the_row():
     # Only *omitted* fields are wildcards. A result whose identity is fully populated
     # and disagrees with the row describes a different object, so attributing it would
@@ -1311,6 +1362,7 @@ def test_an_omitted_offset_does_not_merge_two_selections_of_one_object():
     assert [e.get("reason") for e in reasons] == [
         "waitcheck_backend_exit_2: refused the entry"
     ]
+    assert reasons[0].get("label") == "gemm (beefaaa1#0; scope unknown)"
 
 
 def test_two_long_names_differing_only_in_the_elided_middle_are_told_apart():

--- a/tests/sanitizers/test_dashboard.py
+++ b/tests/sanitizers/test_dashboard.py
@@ -3486,6 +3486,76 @@ def test_the_observation_keeps_the_tail_that_discriminates_a_coverage_reason():
     assert "access sites resource_failed in gemm.hsaco: 14" in observation
 
 
+def test_a_long_backend_tail_survives_into_the_observation_and_manifest():
+    # Review (#479): the same defect as the observation clamp, one layer upstream. The
+    # accumulation clamped the per-kernel reason to 300, and _run_one builds
+    # "waitcheck_backend_exit_N: " plus up to 300 characters of stderr tail -- so the
+    # cap cut the tail that carries the cause, for the sinks that are deliberately
+    # unbounded (the observation, env.json) as well as the bounded ones.
+    tail = "".join(f"frame{i:03d} " for i in range(40))[:300]
+    assert len(tail) == 300
+    reason = f"waitcheck_backend_exit_2: {tail}"
+    assert len(reason) > gen._DETAIL_LIMIT
+
+    report = _waitcheck_daily_topology_report()
+    report["checks"][0]["kernel_results"][0]["reason"] = reason
+    case = gen.summarize_case(report, "warn")
+
+    # the whole reason reaches the unbounded sinks, tail included
+    reasons = case.get("kernel_reasons") or []
+    assert [e.get("reason") for e in reasons] == [reason]
+    assert reason in case.get("observation", "")
+    assert tail[-40:] in case.get("observation", "")
+
+    env = gen.build_case_env(
+        case="waitcheck", cls="guardrail", recipe="daily-waitcheck-gemm",
+        command="aorta sanitize", meta={"run": "r", "gpu": "gfx950"},
+        summary=case, report=None, built_refs=[], inputs=[],
+    )
+    recorded = ((env.get("observed") or {}).get("kernel_reasons") or [{}])[0]
+    assert recorded.get("reason") == reason
+
+    # while the bounded display sinks still apply their own budget
+    for row in case["kernels"][:2]:
+        assert len(row.get("detail", "")) <= gen._DETAIL_LIMIT
+    assert len(gen._survey_message_parts(case)[1]) <= gen._MSG_LIMIT
+
+
+def test_a_lone_row_is_credited_both_finding_scopes_without_a_result():
+    # Review (#479): the mirror of the matched branch, which adds the process-scope
+    # count unconditionally for a lone row. Here it was gated on the named count being
+    # zero, so a check emitting one kernel-named AND one process-scope finding credited
+    # only the named one and the column fell one short of the case total.
+    def _finding(kernel_name):
+        return {
+            "sanitizer": "consan", "severity": "race", "code": "data_race",
+            "message": "conflict", "kernel_name": kernel_name,
+            "code_object": None, "entry_offset": None, "metadata": {},
+        }
+
+    identity = {"name": "gemm_f32_ss", "target": "gfx950"}
+    report = {
+        "schema": "aorta.sanitizer_report/0.1", "target": "gfx950",
+        "overall_verdict": "fail", "execution_status": "ok",
+        "worklist": {
+            "schema": "aorta.kernel_worklist/0.1", "requirement": "top_dispatch_count",
+            "top_n": 1, "kernel_count": 1,
+            "kernels": [{"identity": identity, "total_time_ms": 0.0,
+                         "dispatch_count": 1, "sources": ["consan_repro"]}],
+        },
+        "checks": [{
+            "sanitizer": "consan", "state": "ran", "verdict": "fail", "reason": None,
+            "returncode": 0, "findings": [_finding("gemm_f32_ss"), _finding(None)],
+            "kernel_results": [], "coverage": [], "backend": {},
+        }],
+    }
+
+    case = gen.summarize_case(report, "fail")
+    assert case.get("findings") == 2
+    assert [k.get("findings") for k in case["kernels"]] == [2]
+    assert sum(k.get("findings") or 0 for k in case["kernels"]) == case.get("findings")
+
+
 def test_survey_informational_dir_isolates_malformed_nested_reports(tmp_path):
     # Review (#374): a top-level dict with a malformed NESTED shape (e.g.
     # {"checks": null}) passes the isinstance guard but makes the reduction raise


### PR DESCRIPTION
## The problem

An errored kernel row on the sanitizer dashboard showed a verdict badge, a zero
finding count, and **nothing anywhere on the page saying why**. On `daily-waitcheck-gemm`
the reason appeared zero times in `index.html`, `summary.md` and `data.json`.

The reason was being dropped twice over, independently.

**1. The dashboard threw it away.** `summarize_case` reduced each `kernel_results`
entry to `{verdict, findings}`, discarding `reason`, `state` and `returncode`. The
only reason any renderer could still see was the check-level one, which for Waitcheck
is always the `worklist_not_fully_checked` rollup — it says that *some* kernel went
unchecked, never which one or why.

**2. The backend masked its own message.** `_run_one` parsed stdout/stderr *before*
checking the exit code. When `rj_waitcheck` refuses an input it exits 2, explains
itself on stderr, and prints no analysis summary — so the parse failed first and the
reported reason became `Waitcheck output did not contain an analysis summary`, the
symptom of the refusal rather than the refusal. `waitcheck_backend_exit_N` is the only
branch that quotes stderr, so it has to be reached first.

Before / after, same report:

```
reason: worklist_not_fully_checked        (and nothing else, anywhere)
reason: worklist_not_fully_checked — gemm_NT_M256_N4096_K1024:
        waitcheck_backend_exit_2: sol_126578.hsaco: failed to parse input
        executable or code object
```

## Also fixed: a deduped kernel read as "not checked"

Kernels sharing a code object are deduped into one object-scope scan, so the siblings
carry no `kernel_results` entry of their own and rendered as an em dash. That read as
"not checked" and hid a **gated** kernel sitting behind an object whose scan had
*failed*. Those rows now inherit the covering scan's verdict and name it; findings stay
on the covering row, so the per-kernel column still sums to the case total on this shape
(see [the bounds on that invariant](#bounds-on-the-per-kernel-findings-invariant) below —
it is not universal).

Only a **whole-object** row may receive that attribution. `run_waitcheck` skips a
selection only when `entry_offset is None`, so a resultless exact-entry row was never
deduped away; letting a *clean* object scan speak for it rendered `pass` and "scanned
once" over a row whose own error was sitting unattributed. A *non-clean* scan still
shows there, since the object it lives in did fail.

This attribution is keyed on `(sha256, code_object_index)`, and **only a Waitcheck
whole-object scan may be attributed from** — a real object, a real digest, and no
entry offset, i.e. `KernelIdentity.code_object_scan`, mirroring the one guard in
`run_waitcheck` where dedup actually happens. Each conjunct excludes a real
misattribution, and each is now pinned by a test plus a positive control so none of them
can pass vacuously:

- **No entry offset.** An exact-entry scan covers one entry, not the object, so it
  cannot stand in for a sibling it never analyzed. In a mixed worklist an exact result
  keyed first and lent its clean verdict to a deduped whole-object sibling, reporting
  `pass` for a kernel whose only object scan had failed.
- **A real digest.** A digest-less identity was never deduped and has nothing to be
  attributed to. Admitting one collapses every ConSan kernel (`code_object` and
  `code_object_sha256` both null) onto the `(None, None)` key and reports an unrelated
  sibling's verdict as "the same code object" — an attribution to an object that does
  not exist.

The map stores the covering kernel's *name* rather than its result, so the attribution
dereferences the fully-accumulated entry once every check has been folded in.

Every conjunct is constrained by the suite, verified by relaxing each in turn: the
sanitizer, code-object and entry-offset conjuncts each have a test that fails alone, and
the exact-entry one is covered in both orderings. The digest requirement is enforced
symmetrically — the producer needs a real `row_sha`, the recipient a real `entry_sha` —
and is pinned as that pair; relaxing either half alone provably cannot change the output,
because both read the same field of the same object, so a covering row without a digest
keys `("None", index)` and can never match a recipient row that has one.

A report can also carry more than one check over the same worklist — the
waitcheck+consan survey recipes select one kernel and scan it with both — so per-kernel
results **accumulate** across checks rather than reducing to the last one: reasons
labelled by sanitizer when there is more than one, findings summed rather than replaced,
and the verdict the least clean of them by the same `models._VERDICT_RANK` the report
uses for its own rollup. Last-write-wins dropped an errored Waitcheck reason whenever
the later ConSan result for that kernel had none.

## Bounds on the per-kernel findings invariant

The per-kernel `Findings` column sums to the case total on every shape the shipped
recipes produce, and this PR moves three shapes onto it that were wrong before. It is
**not** a universal invariant, and the earlier phrasing here implied it was. Measured
against the merge-base `4b4553ef` by rendering the same report through both copies:

| shape | case total | base column | this PR |
| --- | --: | --: | --: |
| two checks over one worklist | 2 | 1 | **2** |
| three-check preflight topology (the shipped daily card) | 2 | 0 | **2** |
| two same-named rows, no results, 2 named findings | 2 | 4 | **2** |
| two same-named rows, no results, 1 named finding | 1 | 2 | **1** |
| three same-named rows, no results, 1 named finding | 1 | 3 | **1** |
| lone resultless row, 1 named + 1 process-scope finding | 2 | 1 | **2** |
| >1 row, findings at process scope with no kernel name | 2 | 0 | 0 |
| one of two same-named rows has a result | 2 | 2 | 1 |

The last two rows are where it does not hold:

- **Unnamed process-scope findings with more than one kernel row.** Deliberate and
  pre-existing: a ConSan race finding carries `kernel_name: null`, and it is credited
  to a lone kernel only, because with several rows there is nothing that says which.
  Crediting all of them would be the double-count this PR exists to remove.
- **One of two same-named rows has a result and the other does not.** No shipped
  producer emits this — `run_waitcheck` results every selection, and the combined hook
  drops all or none — so it is recorded as a bound rather than chased. Left alone
  deliberately: the arithmetic that would close it is the same code path the three
  same-named shapes above depend on.

## Scope: what this does and does not disambiguate

Worth stating plainly so the Detail column is not read as more than it is.

- **Waitcheck refusals: genuinely improved.** `waitcheck_backend_exit_N: <stderr tail>`
  is new, and it carries the backend's own words to the `Detail` cell, the
  `Observation:` line and `env.json`.
- **ConSan coverage-incomplete: already distinguishable, and now preserved.** The
  discriminator lives at the *end* of a `CoverageDecision` reason, and an earlier
  revision of this PR clamped it away — see the round-11 note below.
- **ConSan `status=4112` as it actually occurs: unchanged, and still conflated.** The
  growth-ceiling rejection terminates at `exit_code=92`, which `consan.py` maps to the
  bare token `consan_strict_load_rejection` with no prose, and `_error_result` carries
  no `kernel_results` at all. So both causes render the same empty `Detail`, the same
  empty `kernel_reasons` and the same observation. This is upstream's to fix
  (rocm-systems#10950 asks for a `cause=` token);
  `docs/sanitizers/consan-gemm-patched-image-growth-cap.md` now records that the new
  column does not close it.

## What renders now

The kernels table gains a **Detail** column on all three renderers over
`row["kernels"]` — the shared HTML table (both tabs) and the Markdown twin per tab.
The observation one-liner and the inline Reason callout qualify the rollup with the
kernel reasons behind it, and each run area's `env.json` records them beside the
rollup, so the manifest is diagnosable without re-reading `sanitizer_report.json`.
A kernel with no reason to explain degrades to an em dash rather than an empty column.

No gate behaviour changes: the gate and the survey roll-up read the case-level
`overall_verdict`, never the per-kernel verdicts these commits touch.

## Testing

- 8 new tests: the real daily-GEMM card topology as a fixture, both dedup collision
  directions, exit-code-vs-parse-error precedence, and the reason reaching all three
  renderers plus `env.json`.
- Full suite: **5308 passed, 162 skipped**. `ruff` clean. Bugbot clean.
- `tests/ebpf` excluded locally — `/usr/bin/bpftrace` is absent on this host, and the
  failure reproduces with these changes stashed.

### Review round (Copilot), commit `b20b6421`

All three findings were confirmed against the code and reproduced on the parent commit
before being fixed. 4 further regression tests, each verified failing on `a36a9c05`:

- **Exact-entry scans were attributable.** Order-dependent: with the exact result
  first, a deduped sibling rendered `verdict=pass` attributed to the entry scan.
- **Last-write-wins erased an earlier check's reason.** Reachable from the shipped
  `tiny-vecadd-survey.yaml` (`top_n: 1`, both sanitizers); the Waitcheck reason
  disappeared entirely, verdict included.
- **Multi-line backend reasons corrupted Markdown.** A reason quotes up to 300
  characters of stderr tail; the parent commit emitted a stray `  or code object |`
  continuation line, ending the table row mid-table. `_clean_msg` now collapses
  internal whitespace, which closes the class at all seven of its call sites (the
  finding `example` had the same latent hazard). Sweeping found two sinks that bypass
  it: the per-kernel reasons feeding the `Observation:` line, and the check-level
  reason in `_observation_text` — not always a bare constant, since `consan.py`
  builds `waitcheck_analysis_failed: {parsed.waitcheck_error}` from parsed tool
  output. Only the display copy is normalized; `sanitizer_report.json` is untouched.

### Review round 2 (Copilot), commit `e6fc56a9`

**Kernel results were joined to worklist rows by name, and a name is not an
identity.** `KernelWorklist` only rejects duplicate `KernelIdentity.stable_key`, and
that key carries the digest (scan mode) or the entry offset (exact mode) rather than
pinning the name — so one symbol name reached through two code objects is a valid
worklist, and both selections are scanned. Pre-existing as a last-write-wins
overwrite, but the accumulation added in `b20b6421` made it worse: the two scans'
findings then summed onto *both* rows, double-counting against the case total. The
join is now on every serialized identity field, with the name kept as display text.

### Review round 3 (Copilot), commit `ab6cac3d`

**The kernel-reason projection discarded the identity again.** Round 2 fixed the join
key, but `_kernel_reason_entries` still reduced each accumulated entry back down to
`(name, reason)` on the way out — so `env.json` and the `Observation:` line saw only
`gemm_shared_symbol` and could not say which of the two objects had failed, and when
both failed the two labels were byte-identical. Each entry now carries `code_object`,
`sha`, `code_object_index` and `entry_offset` alongside the reason;
`build_case_env` records them unconditionally, and the display `label` is qualified
with a short digest (or code-object basename plus entry offset, when there is no
digest) **only where the name is ambiguous within the case**, so the common
single-selection path still renders a bare symbol name.

Sweeping the same shape turned up one more truncation, in a different renderer:
`_survey_message_parts` clamped only the *concatenation* of the check-level rollup and
the kernel reasons to 240 characters, so a long rollup could spend the entire budget
and cut the kernel reasons — the payload — off the end, leaving a callout that named
no kernel at all. The rollup is now budgeted to 80 first, guaranteeing the reasons
room. A third instance was checked and declined: the deduped Detail cell clamps the
same way, but the covering-row prefix is short enough that budgeting separately and
clamping the concatenation produce byte-identical output at every input length tested,
so the change would have been cosmetic. `_DETAIL_LIMIT` is named rather than repeated,
and `test_a_long_reason_stays_within_the_detail_budget_on_both_rows` pins that both
the covering and the deduped row stay inside it and both still carry the reason.

### Review round 4 (Copilot), commit `2d2c0ed0`

**The label qualifier used the code-object digest, and a digest is not an object.**
It is the *file's* digest — a bundled object file holds several code objects under one
— which is exactly why `run_waitcheck` dedups on `(code_object_sha256,
code_object_index)` and why `stable_key` carries the index. Two same-named selections
in one bundle therefore shared every field the qualifier rendered, and both labels came
out as `gemm_shared_symbol (beefaaa1)`. The qualifier now widens to the index, but only
for the collisions the digest tier cannot resolve: a unique name still renders bare and
the two-distinct-objects case still renders just the digest. `env.json` was already
unambiguous for this shape — the index has been recorded on every entry since round 3 —
so only the display label had lost the field.

Sweeping the shape (*a bare kernel name used as a display identity*) found one more
instance: the deduped row's Detail cell reads `same code object as <name>; scanned
once`, which cannot say which row covered this one when two worklist rows share that
name. Qualified the same way, and only where the name repeats.

One collision was checked and ruled out rather than coded for: `target` is part of
`stable_key` too, but `recipe.py` threads a single `recipe.target` into every identity
in a worklist, so a name+digest+index collision differing only by target is not
reachable and a target tier would be dead code.

### Review round 5 (Copilot), commit `82370eef`

Two inline findings and one in the `Suppressed comments` block, all three confirmed.

**The manifest projection stored display abbreviations.** `kernel_reasons` recorded
`_basename(code_object)` and a 10-character digest prefix — in the one projection whose
job is to keep `env.json` diagnosable without reopening the report, where two objects
sharing a filename, or two digests sharing a prefix, land identically. It now records
the identity unabridged; abbreviation happens only in the display label. The digest key
is `code_object_sha256` rather than `sha`, since the kernels *table* still has a `sha`
column holding the display prefix.

**The label widening could still tie.** Both tiers rendered the 10-character prefix, so
two objects sharing that prefix and an index produced the same label at every tier. A
third tier spends the whole digest, so the widening terminates in something that cannot
collide. The tiers are cumulative on purpose: a full-digest-only tier can drop the index
a bundled collision needs. Both call sites — the reason labels and the deduped row's
covering-scan label — now go through one `_display_labels` helper instead of open-coding
a tier each, which also tightened the deduped label to the digest alone where that is
enough.

**Preflight findings never reached the kernel column.** `run_sanitizers` appends the
combined hook's Waitcheck preflight as a third check, and `consan._relabel` keeps that
check's findings while dropping its kernel results — so its hazards counted toward
`findings_total` with no per-kernel result to carry them. Measured on the three-check
topology at `2d2c0ed0`: case total 3, column 2. Pre-existing (the parent computed a
row's findings from its own result too), but this PR states the invariant and tests it,
so it should hold for what the shipped combined recipes produce. Result-less findings
are now credited to the row they name — first row of a given name only, since a name can
repeat and a finding names a kernel rather than an identity — alongside the existing
process-scope rule that an unnamed finding is attributable only to a lone kernel.

### Review round 6 (Copilot), commit `753f9d3e`

**Labels were qualified against the failing results, not against the page.** One
failure beside a *clean* same-named sibling stayed labelled bare, so `gemm_shared_symbol:
refused the second object` named a row the reader cannot pick out of the two on screen.
Both label sites now read one mapping built over the whole worklist — the deduped Detail
cell already had one — which also covers a case a labels-over-all-results fix would not:
a deduped sibling has no result of its own. The earlier test asserting the old behaviour
is flipped; its reasoning was the mistake.

**The full-identity join dropped results whose identity is sparser than their worklist
row.** Every code-object field is optional on the wire and reports carrying only
`{name, target}` per result exist — the repo's own `_waitcheck_report` fixture is one.
Measured on `82370eef`: such a row renders `verdict="warn"` with an empty Detail, losing
the reason *and* reading cleaner than the result it could not see, which is the exact
failure this PR was opened to remove. The full-identity match stays first; where it finds
nothing, a `(name, target)` match applies only when it can mean one thing — one worklist
row, one unclaimed result — and the row's identity then enriches the projection so the
manifest names the object the result did not. Where it would have to guess, no row claims
the result, but the reason still surfaces at case scope with a null object rather than
disappearing.

### Review round 7 (Copilot), commit `b8f66a1f`

Two inline findings and one in the `Suppressed comments` block, all three confirmed.

**Dedup attribution was inferred from the result identity, mid-walk.** Scan scope is a
property of the *selection*, but the index was keyed off whatever a result serialized,
before any result had been reconciled with its row — so an exact-entry result omitting
only `entry_offset` read as an object scan and could lend its verdict to a sibling it
never analyzed (measured: the gated row reports `pass` while the object scan behind it
errored), and a `{name, target}` object result was never indexed at all. Results are
matched to rows first now, and the index is built from the row identity.

**The sparse fallback replaced the exact match instead of reconciling with it.** With one
check emitting the full identity and another emitting `{name, target}` for the same row,
the second was dropped whole — verdict, reason and finding — which is the cross-check
loss the round-1 accumulation exists to stop, arriving through a different door. A
uniquely attributable sparse result is now folded in by `_merge_reduced` with the same
arithmetic: least clean verdict, findings summed, every reason kept and labelled.

**Budgeting the rollup did not guarantee the reason survived.** The label sits between
the rollup and the reason, and kernel names are unbounded: a 300-character name produces
a callout of rollup plus 150 characters of name and no cause at all — worse than saying
nothing, because it looks like it is telling you something. Labels are budgeted to 60 in
the callout and, by the same sweep, in the deduped Detail cell.

### Review round 8 (Copilot), commit `83b29f79`

One inline finding and two in the `Suppressed comments` block, all confirmed.

**The sparse fallback admitted results that contradict the row.** It was reaching for
"a result nothing else claimed" when the question is "a result that cannot describe
anything else": a fully populated identity that disagrees with the row is a *different
object*, and the enrichment then stamped the row's identity over it, so `env.json`
asserted that object A failed when the report only said B did. Candidacy now requires
every populated `code_object` / `code_object_sha256` / `code_object_index` /
`entry_offset` field to agree — only omitted fields are wildcards — and the candidate
must be compatible with exactly one row, which is strictly tighter than the previous
`(name, target)` counts.

**The round-7 label budget truncated the identity away.** Both suppressed findings are
that one defect, in the callout and in the deduped Detail cell: `_clean_msg` truncates
from the right, so clamping the *assembled* label cut off the `(digest)` qualifier
`_display_labels` had just appended, and two failures behind one long name rendered the
same 60-character prefix twice — the ambiguity rounds 3-6 were spent removing, reinstated
by the fix for the round-7 one. The name is now budgeted inside `_display_labels`, before
the qualifier is appended, and both call sites take the label as given, so there is one
budget rather than three that can disagree.

### Review round 9 (Copilot), commit `91df5df9`

One inline finding and one in the `Suppressed comments` block, both confirmed.

**The collision count and the render disagreed about what a name is.** Collisions were
counted on the original names while the labels rendered budgeted ones, so two mangled
instantiations differing only past character 60 each counted as unique, earned no
qualifier, and rendered as the same string — strictly worse than a genuine repeat, which
at least gets a digest. Counting now happens on the rendered name. When the qualifiers
tie as well — two long names inside one code object, where no identity field can help —
a second pass re-renders the names keeping their tails, since the suffix is then the only
thing that differs; a fallback rather than the default, because a middle-elided name is
harder to read.

**An unattributed reason was labelled like a visible row.** The round-8 fix kept the
*row* honest by refusing to attribute an incompatible result, but the reason still
renders at case scope and the label map covered only the worklist — so it fell through to
a bare `gemm`, reading as an accusation against the one `gemm` row on the page, which was
simultaneously showing no detail. The map now covers the unmatched results too, so the
observation reads `gemm (beefbbb2): …`, naming an object deliberately not on the page.

### Review round 10 (Copilot), commit `21eecc89`

**An omitted field and an explicit null were read as the same claim.** Results were
collapsed by serialized identity before any had been reconciled with a selection, and
the join key could not tell "did not serialize `entry_offset`" from "`entry_offset:
null`" — so an exact-entry result that omitted its offset shared a key with the
whole-object result for the same object. The two scans merged, the exact row lost its
result, and the merged verdict could reach the object scan's deduped siblings. The key
now records which optional fields the identity carries, and compatibility treats only
*omitted* fields as wildcards: `entry_offset: null` is a claim of whole-object scope, so
a fully serialized object result is still unambiguous, while an identity that genuinely
cannot tell the two selections apart attributes to neither.

**The label fallback could still tie.** Two names can agree on both ends and differ only
in the middle the budget elides, and if they share a code object no identity field
separates them. A final tier appends a digest of the whole name, which cannot tie for
names that differ at all — last, because it is the unreadable option.

The round-7 exact-entry test moved with the first fix: such a result is now
unattributable rather than attributed by name, so the row falls back to what the object
scan says. Inheriting a failure from an object scan is honest; inheriting a *clean*
verdict from a result that may belong to another selection is the guess that hides one.

Verified across all ten rounds: **533 passed, 3 skipped** across `tests/sanitizers` and
`tests/instrumentation/rocjitsu_sanitizers` (the suites covering every changed file),
`ruff` clean on the changed files, Bugbot clean on each round. Every regression test
added in these rounds was verified failing on its parent commit. The full-suite figure
above is from the pre-review commit and was not re-run.

### Rebase, and review round 11 — human review (`vivekkhandelwal1`) + Copilot, commit `dfe0396c`

Rebased onto `main` @ `6a8c70da` first (13 commits replayed, none dropped, no conflicts,
diff-stat and `git patch-id` both byte-identical against the new base).

**Blocking, and correctly so: the observation clamp destroyed the ConSan discriminator.**
Routing `primary.reason` through `_clean_msg(..., 240)` was half right — the
whitespace collapse fixes real Markdown corruption — and half a regression in exactly
the property this PR exists to improve. `CoverageDecision.reasons` appends
`_failure_attributions` *after* its counts, and that is the only part that says whether
coverage was rejected for capacity (`resource_failed`) or by a lowering defect
(`placement_or_lowering_failed`). `_clean_msg` truncates from the right, so the clamp
kept the counts — identical between the two causes — and cut the discriminator.

Reproduced the same way it was reported, importing both copies of the generator into one
process and rendering the same report through each:

| | reason length | discriminator on the observation line |
| --- | --: | --- |
| base `4b4553ef` | 443 / 482 | present |
| head before the fix | clamped to 260 | **absent** — the two causes byte-identical |
| head after the fix | 443 / 482 | present, and equal to base |

`_clean_msg` grows a `limit=None` path that normalizes without clamping, and the
observation uses it. The observation renders onto a line of its own rather than into a
table cell, so length there is not a corruption risk — which is why base was unbounded.
`_survey_message_parts` keeps its 240 clamp; that one is pre-existing and not on this
path.

Also from this round:

- **The last-resort label digest could not deliver the uniqueness it promised.** It
  hashed the *rendered* name, and rendering collapses internal whitespace, so two valid
  selections named `a b` and `a  b` — distinct `stable_key`s — hashed alike. And it kept
  only 8 hex, i.e. 32 bits, with no tier left to widen into. It now hashes the name as
  the report spelled it, and the widening ends at the full digest.
- **The manifest asserted a scope the report never claimed.** Both `kernel_reasons`
  projections filled an omitted identity field in with `None`, which by this PR's own
  `_identity_compatible` semantics is a *claim* of whole-object scope. Since
  `build_case_env` drops the display label, that omission is the only thing left to say
  "the report did not state a scope", so presence is now carried through unchanged.
- **The dedup fallback was unbounded on the recipient side** — see the whole-object
  restriction described above.
- **Three of the four attribution conjuncts were unconstrained by the suite.** Found by
  relaxing each in turn: the digest-less test was a *ConSan* fixture, so the sanitizer
  and code-object conjuncts excluded it before the digest was consulted — it pinned the
  disjunction, not the conjunct it is named for. Retargeted at a waitcheck check with a
  real object and no digest, with a test each for the sanitizer and code-object
  conjuncts and a positive control so none of the three can pass vacuously.
- **One `_clean_msg` sink was still raw**, in the class this PR swept: `_survey_group_note`
  returned the reason unnormalized and unescaped into the survey roll-up `Note` cell,
  unlike the sibling `Detail` and `Example` cells. Reachable today via
  `waitcheck_analysis_failed: <parser output>`.
- **The defensive parse in `_run_one` caught only `(OSError, ValueError)`**, so a parser
  raising anything else propagated and never reached the exit-code branch — the one
  branch that quotes stderr, and the entire reason the parse is defensive. Broadened to
  `Exception` with the rationale in place; nothing is swallowed, since an expected exit
  code still reports the failure verbatim, and `BaseException` still propagates.

### Review round 12 (Copilot), commit `3e1e4229`

Both findings were the residue of round 11's own fixes, and both are confirmed:

- **The reason was still clamped at the accumulation**, one layer above the sink round
  11 unbounded. `_run_one` emits `waitcheck_backend_exit_N: ` plus up to 300 characters
  of stderr tail, so a 300-char cap there landed *inside* the tail — cutting the cause
  from the observation and `env.json`, which are deliberately unbounded. Normalized
  without a limit; the Detail cell and the survey callout keep the budgets they already
  had.
- **A lone resultless row lost one of two finding scopes.** The matched branch adds the
  process-scope count unconditionally for a single row; this branch gated it on the
  named count being zero, so a check emitting one named and one process-scope finding
  reported 1 against a total of 2. The two arms are now the same shape — the
  mirror-image of the `credited` hole the human review found on this same branch.

### Review rounds 13-14 (Copilot), commit `61a14ee4`

Two more in the dedup-attribution area, both confirmed, both the same shape as the
round-11 fix — the attribution must be exactly as strong as the scan behind it:

- **The recipient had to be a whole-object selection, not just offset-free.**
  `run_waitcheck` dedups on the full `KernelIdentity.code_object_scan` shape, so a row
  carrying a matching digest with `code_object: None` would never have been deduped
  either, yet it inherited a clean verdict as "scanned once". My own round-11 test
  missed it because it made *both* rows objectless, so the producer conjunct excluded
  the attribution before the recipient was consulted — the same trap the human review
  found in the digest-less test.
- **The attribution read the cross-sanitizer aggregate.** The accumulation folds every
  sanitizer's result for a kernel into one record, so a covering row with a Waitcheck
  `pass` and a ConSan `error` rendered its sibling `error` with
  `scanned once — consan_hook_not_found`. ConSan reports per kernel; only the object
  scan reaches the sibling. `_waitcheck_view` projects the Waitcheck-only verdict and
  reasons for attribution, while the covering row keeps the aggregate for its own badge.

15 new regression tests, each verified failing on the parent: **587 passed, 3 skipped**
across `tests/sanitizers` and `tests/instrumentation/rocjitsu_sanitizers`, `ruff` clean
on all five changed files. Bugbot was not re-run this round. The full-suite figure
earlier in this description is from the pre-review commit and has not been re-run.


