### PR TITLE
fix(sanitizers): stop discarding rj_waitcheck's truncation marker

### DIFF
--- a/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/README.md
@@ -21,6 +21,8 @@ Available now as a Python library:
 - deduplicate stable kernel identities;
 - run standalone Waitcheck on one exact code-object entry at a time;
 - run the valid exact-entry Waitcheck CLI and retain its raw log;
+- report a Waitcheck scan that hit the backend's diagnostic cap as truncated,
+  rather than quoting its capped count as the whole hazard count;
 - parse upstream `rj-waitcheck-diagnostic-v1` JSONL for corpus workflows;
 - parse Record/Replay output from the combined Waitcheck + ConSan hook;
 - preserve per-code-object ConSan coverage and fail closed on timeout, backend
@@ -247,6 +249,18 @@ complaint. The run that motivated this is written up in
 [`docs/sanitizers/consan-405-unitemized-barrier-sites.md`](../../../../docs/sanitizers/consan-405-unitemized-barrier-sites.md).
 - `pass` only means a requested backend ran healthily and produced no finding;
   Record/Replay's bounded snapshot is not proof that a program is race-free.
+
+A Waitcheck finding count is not automatically the whole hazard count.
+`rj_waitcheck` stops collecting at `--max-diagnostics` (32 per code object by
+default, and each code object is its own subprocess) and marks a capped scan by
+prefixing the summary count with `>=` (`diagnostics=>=32`). aorta carries that
+marker through as `diagnostics_truncated: true` on the kernel result and on the
+check, so `sanitizer_report.json` distinguishes a complete count from a floor —
+the gpt-oss `_topk_topp_kernel` object scanned at the default cap reports 32 of
+its 45 hazards ([#480](https://github.com/ROCm/aorta/issues/480)). Set
+`sanitizer_plan.policy.waitcheck_max_diagnostics` to raise the cap for a lane
+that needs the complete count; a higher cap costs analysis time, so the flag,
+not a hard-coded larger default, is what makes the partial result visible.
 
 The report keeps finding severity and execution completeness separate. For
 example, a Waitcheck warning plus scoped ConSan `not_checked` produces

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/__init__.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/__init__.py
@@ -51,6 +51,7 @@ from .selection import (
     select_kernels,
 )
 from .waitcheck import (
+    ParsedWaitcheckOutput,
     parse_waitcheck_jsonl,
     parse_waitcheck_text,
     run_waitcheck,
@@ -72,6 +73,7 @@ __all__ = [
     "KernelWorklist",
     "ObjectCoverage",
     "ParsedCombinedOutput",
+    "ParsedWaitcheckOutput",
     "SanitizerRecipe",
     "SanitizerReport",
     "SelectionRequirement",

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/models.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/models.py
@@ -105,11 +105,11 @@ def _optional_bool(data: Mapping[str, object], key: str, *, default: bool) -> bo
     instead of being coerced by truthiness.
     """
 
-    value = data.get(key)
-    if value is None:
+    if key not in data:
         return default
+    value = data[key]
     if not isinstance(value, bool):
-        raise TypeError(f"{key} must be a boolean or null")
+        raise TypeError(f"{key} must be a boolean")
     return value
 
 

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/models.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/models.py
@@ -98,6 +98,21 @@ def _required_bool(data: Mapping[str, object], key: str) -> bool:
     return value
 
 
+def _optional_bool(data: Mapping[str, object], key: str, *, default: bool) -> bool:
+    """Read a boolean field a stored report may predate, defaulting when absent.
+
+    A present value is still type-checked, so a malformed one fails loudly
+    instead of being coerced by truthiness.
+    """
+
+    value = data.get(key)
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise TypeError(f"{key} must be a boolean or null")
+    return value
+
+
 def _mapping(value: object, *, name: str) -> Mapping[str, object]:
     if not isinstance(value, dict) or not all(isinstance(k, str) for k in value):
         raise TypeError(f"{name} must be an object with string keys")
@@ -421,6 +436,10 @@ class KernelCheckResult:
     findings: tuple[Finding, ...] = ()
     reason: str | None = None
     returncode: int | None = None
+    # True when the backend stopped collecting diagnostics at its own cap, so
+    # ``findings`` is a floor rather than the kernel's full hazard count
+    # (Waitcheck's ``diagnostics=>=N`` summary, #480).
+    diagnostics_truncated: bool = False
 
     def __post_init__(self) -> None:
         if self.state is ExecutionState.NOT_CHECKED:
@@ -444,6 +463,7 @@ class KernelCheckResult:
             "findings": [finding.to_dict() for finding in self.findings],
             "reason": self.reason,
             "returncode": self.returncode,
+            "diagnostics_truncated": self.diagnostics_truncated,
         }
 
     @classmethod
@@ -458,6 +478,7 @@ class KernelCheckResult:
             ),
             reason=_optional_str(data, "reason"),
             returncode=_optional_int(data, "returncode"),
+            diagnostics_truncated=_optional_bool(data, "diagnostics_truncated", default=False),
         )
 
 
@@ -472,6 +493,9 @@ class CheckResult:
     kernel_results: tuple[KernelCheckResult, ...] = ()
     coverage: tuple[ObjectCoverage, ...] = ()
     backend: tuple[tuple[str, str], ...] = ()
+    # True when any scanned kernel hit the backend's diagnostic cap, so this
+    # check's aggregated ``findings`` under-counts the hazards present (#480).
+    diagnostics_truncated: bool = False
 
     def __post_init__(self) -> None:
         if not self.sanitizer:
@@ -497,6 +521,10 @@ class CheckResult:
             _VERDICT_RANK[result.verdict] for result in self.kernel_results
         ):
             raise ValueError("a check verdict cannot be cleaner than its kernel results")
+        if not self.diagnostics_truncated and any(
+            result.diagnostics_truncated for result in self.kernel_results
+        ):
+            raise ValueError("a check cannot report a complete count over a truncated kernel")
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -509,6 +537,7 @@ class CheckResult:
             "kernel_results": [result.to_dict() for result in self.kernel_results],
             "coverage": [item.to_dict() for item in self.coverage],
             "backend": dict(self.backend),
+            "diagnostics_truncated": self.diagnostics_truncated,
         }
 
     @classmethod
@@ -539,6 +568,7 @@ class CheckResult:
             backend=tuple(
                 sorted((key, value) for key, value in backend.items() if isinstance(value, str))
             ),
+            diagnostics_truncated=_optional_bool(data, "diagnostics_truncated", default=False),
         )
 
 

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/pipeline.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/pipeline.py
@@ -33,6 +33,7 @@ def run_sanitizers(
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     report_name: str = "sanitizer_report.json",
     consan_target: KernelIdentity | None = None,
+    waitcheck_max_diagnostics: int | None = None,
 ) -> SanitizerReport:
     """Run supported checks and persist one versioned report."""
 
@@ -54,6 +55,7 @@ def run_sanitizers(
                     output_dir=output_dir / "waitcheck",
                     binary=waitcheck_binary,
                     timeout_seconds=timeout_seconds,
+                    max_diagnostics=waitcheck_max_diagnostics,
                 )
             )
         elif sanitizer == "consan":

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/recipe.py
@@ -175,6 +175,7 @@ class SanitizerRecipe:
     repro_variant: str | None = None
     kernel_specs: tuple[KernelSourceSpec, ...] = ()
     timeout_seconds: float | None = None
+    waitcheck_max_diagnostics: int | None = None
 
     @property
     def recipe_dir(self) -> Path | None:
@@ -223,6 +224,26 @@ def _optional_timeout_seconds(block: Mapping[str, object]) -> float | None:
             "sanitizer_plan.policy.timeout_seconds must be a positive number"
         )
     return float(value)
+
+
+def _optional_waitcheck_max_diagnostics(block: Mapping[str, object]) -> int | None:
+    """Parse an optional positive ``waitcheck_max_diagnostics`` from a block.
+
+    Absent keeps the backend's own cap (``rj_waitcheck --max-diagnostics``, 32
+    per code object), which reports a capped scan as ``diagnostics_truncated``.
+    A bool, non-integer, or non-positive value is rejected at load so a
+    malformed knob cannot silently reinstate the default cap on a lane that
+    asked for a complete count.
+    """
+
+    if "waitcheck_max_diagnostics" not in block:
+        return None
+    value = block.get("waitcheck_max_diagnostics")
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise RecipeSchemaError(
+            "sanitizer_plan.policy.waitcheck_max_diagnostics must be a positive integer"
+        )
+    return value
 
 
 def load_sanitizer_recipe(path: Path) -> SanitizerRecipe:
@@ -282,6 +303,7 @@ def load_sanitizer_recipe(path: Path) -> SanitizerRecipe:
             f"unsupported sanitizer_plan.policy.on_missing_backend={on_missing_backend!r}"
         )
     timeout_seconds = _optional_timeout_seconds(policy)
+    waitcheck_max_diagnostics = _optional_waitcheck_max_diagnostics(policy)
     output = _require_mapping(plan.get("output"), name="sanitizer_plan.output")
     report_name = _require_str(output, "report")
 
@@ -353,6 +375,7 @@ def load_sanitizer_recipe(path: Path) -> SanitizerRecipe:
         repro_variant=repro_variant,
         kernel_specs=kernel_specs,
         timeout_seconds=timeout_seconds,
+        waitcheck_max_diagnostics=waitcheck_max_diagnostics,
     )
 
 
@@ -474,5 +497,6 @@ def execute_sanitizer_run(
             if recipe.timeout_seconds is not None
             else DEFAULT_TIMEOUT_SECONDS
         ),
+        waitcheck_max_diagnostics=recipe.waitcheck_max_diagnostics,
     )
     return report_path

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
@@ -327,7 +327,9 @@ def waitcheck_argv(
     # ``run_waitcheck`` are entered directly by library callers; ``True`` would
     # otherwise reach the backend as the argument "True".
     if max_diagnostics is not None and (
-        isinstance(max_diagnostics, bool) or max_diagnostics < 1
+        isinstance(max_diagnostics, bool)
+        or not isinstance(max_diagnostics, int)
+        or max_diagnostics < 1
     ):
         raise ValueError("max_diagnostics must be a positive integer")
     argv = [
@@ -437,6 +439,7 @@ def _run_one(
             verdict=Verdict.ERROR,
             reason="waitcheck_hazard_exit_without_structured_diagnostics",
             returncode=process.returncode,
+            diagnostics_truncated=parsed.diagnostics_truncated,
         )
     return KernelCheckResult(
         identity=identity,

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
@@ -310,6 +310,15 @@ def parse_waitcheck_text(
     )
 
 
+def _validate_max_diagnostics(max_diagnostics: int | None) -> None:
+    if max_diagnostics is not None and (
+        isinstance(max_diagnostics, bool)
+        or not isinstance(max_diagnostics, int)
+        or max_diagnostics < 1
+    ):
+        raise ValueError("max_diagnostics must be a positive integer")
+
+
 def waitcheck_argv(
     binary: Path,
     identity: KernelIdentity,
@@ -323,15 +332,7 @@ def waitcheck_argv(
             "Waitcheck requires code_object and code_object_sha256, "
             "and optionally entry_offset for exact-entry mode"
         )
-    # Validated here rather than only in the recipe loader because this and
-    # ``run_waitcheck`` are entered directly by library callers; ``True`` would
-    # otherwise reach the backend as the argument "True".
-    if max_diagnostics is not None and (
-        isinstance(max_diagnostics, bool)
-        or not isinstance(max_diagnostics, int)
-        or max_diagnostics < 1
-    ):
-        raise ValueError("max_diagnostics must be a positive integer")
+    _validate_max_diagnostics(max_diagnostics)
     argv = [
         str(binary),
         str(identity.code_object),
@@ -468,6 +469,9 @@ def run_waitcheck(
     ``diagnostics_truncated`` rather than as a complete hazard count.
     """
 
+    # Validate at the public boundary so missing backends and empty/rejected
+    # worklists cannot silently accept a malformed library-call argument.
+    _validate_max_diagnostics(max_diagnostics)
     resolved = resolve_waitcheck(binary)
     if resolved is None or not resolved.is_file():
         return CheckResult(

--- a/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
+++ b/src/aorta/instrumentation/rocjitsu_sanitizers/waitcheck.py
@@ -9,6 +9,7 @@ import re
 import shutil
 from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
@@ -34,10 +35,29 @@ _HEADER = re.compile(
     # not misread as a missing analysis summary.
     r"(?:\s*kernel=\.text\+0x(?P<entry>[0-9a-f]+):)?"
     r"\s+instructions=(?P<instructions>[0-9]+).*"
-    r"diagnostics=(?:>=)?(?P<diagnostics>[0-9]+)"
+    # rj_waitcheck stops collecting at --max-diagnostics and marks the capped
+    # summary by prefixing the count with ">=" (``diagnostics=>=32``). Capture
+    # that marker: matching it and dropping it made a partial hazard count
+    # indistinguishable from a complete one (#480).
+    r"diagnostics=(?P<truncated>>=)?(?P<diagnostics>[0-9]+)"
 )
 _DIAGNOSTIC = re.compile(r"\bmissing\s+s_wait|\bhazard\b", re.IGNORECASE)
 _CONTEXT = re.compile(r"^(producer|consumer)\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ParsedWaitcheckOutput:
+    """One Waitcheck scan's findings and whether the backend capped them.
+
+    ``diagnostics_truncated`` is true when the analysis summary reported
+    ``diagnostics=>=N``: the scan hit ``--max-diagnostics`` (32 by default) and
+    ``findings`` is a partial view of the hazards in the code object. Raise the
+    cap -- ``sanitizer_plan.policy.waitcheck_max_diagnostics`` on a recipe -- to
+    get a complete count.
+    """
+
+    findings: tuple[Finding, ...]
+    diagnostics_truncated: bool
 
 
 class ProcessExecutor(Protocol):
@@ -105,7 +125,12 @@ def parse_waitcheck_jsonl(
     *,
     expected: KernelIdentity,
 ) -> tuple[Finding, ...]:
-    """Parse structured diagnostics and reject identity mismatches."""
+    """Parse structured diagnostics and reject identity mismatches.
+
+    The JSONL stream carries no analysis summary, so — unlike
+    ``parse_waitcheck_text`` — it cannot tell a capped scan from a complete one;
+    a corpus caller that needs that signal has to read the summary line too.
+    """
 
     if not path.exists():
         return ()
@@ -198,17 +223,23 @@ def parse_waitcheck_text(
     output: str,
     *,
     expected: KernelIdentity,
-) -> tuple[Finding, ...]:
-    """Parse exact-entry CLI output until structured single-entry output exists."""
+) -> ParsedWaitcheckOutput:
+    """Parse exact-entry CLI output until structured single-entry output exists.
+
+    Returns the findings together with the analysis summary's ``>=`` cap marker,
+    so a capped scan is not read as a complete one (``ParsedWaitcheckOutput``).
+    """
 
     findings: list[Finding] = []
     header_seen = False
+    truncated = False
     expected_index = expected.code_object_index or 0
     for raw_line in output.splitlines():
         line = raw_line.strip()
         header = _HEADER.search(line)
         if header is not None:
             header_seen = True
+            truncated = truncated or header.group("truncated") is not None
             if header.group("target") != expected.target:
                 raise ValueError(
                     f"Waitcheck target {header.group('target')!r} does not match "
@@ -273,12 +304,17 @@ def parse_waitcheck_text(
     if not header_seen:
         raise ValueError("Waitcheck output did not contain an analysis summary")
     deduplicated = {finding.dedupe_key: finding for finding in findings}
-    return tuple(deduplicated[key] for key in sorted(deduplicated, key=repr))
+    return ParsedWaitcheckOutput(
+        findings=tuple(deduplicated[key] for key in sorted(deduplicated, key=repr)),
+        diagnostics_truncated=truncated,
+    )
 
 
 def waitcheck_argv(
     binary: Path,
     identity: KernelIdentity,
+    *,
+    max_diagnostics: int | None = None,
 ) -> tuple[str, ...]:
     """Build argv for one code-object Waitcheck invocation."""
 
@@ -287,6 +323,13 @@ def waitcheck_argv(
             "Waitcheck requires code_object and code_object_sha256, "
             "and optionally entry_offset for exact-entry mode"
         )
+    # Validated here rather than only in the recipe loader because this and
+    # ``run_waitcheck`` are entered directly by library callers; ``True`` would
+    # otherwise reach the backend as the argument "True".
+    if max_diagnostics is not None and (
+        isinstance(max_diagnostics, bool) or max_diagnostics < 1
+    ):
+        raise ValueError("max_diagnostics must be a positive integer")
     argv = [
         str(binary),
         str(identity.code_object),
@@ -302,6 +345,8 @@ def waitcheck_argv(
                 f"0x{identity.entry_offset:x}",
             ]
         )
+    if max_diagnostics is not None:
+        argv.extend(["--max-diagnostics", str(max_diagnostics)])
     return tuple(argv)
 
 
@@ -321,6 +366,7 @@ def _run_one(
     log_path: Path,
     timeout_seconds: float,
     execute: ProcessExecutor,
+    max_diagnostics: int | None = None,
 ) -> KernelCheckResult:
     if not identity.exact and not identity.code_object_scan:
         return _not_checked(identity, "code_object_identity_required")
@@ -338,7 +384,7 @@ def _run_one(
             reason="code_object_digest_mismatch",
         )
     process = execute(
-        waitcheck_argv(binary, identity),
+        waitcheck_argv(binary, identity, max_diagnostics=max_diagnostics),
         timeout_seconds=timeout_seconds,
     )
     log_path.write_text(
@@ -360,7 +406,7 @@ def _run_one(
             reason=f"waitcheck_launch_error: {process.launch_error}",
         )
     try:
-        findings = parse_waitcheck_text(
+        parsed = parse_waitcheck_text(
             f"{process.stdout}\n{process.stderr}",
             expected=identity,
         )
@@ -381,9 +427,10 @@ def _run_one(
             verdict=Verdict.ERROR,
             reason=f"waitcheck_backend_exit_{process.returncode}{suffix}",
             returncode=process.returncode,
-            findings=findings,
+            findings=parsed.findings,
+            diagnostics_truncated=parsed.diagnostics_truncated,
         )
-    if process.returncode == WAITCHECK_HAZARD_EXIT and not findings:
+    if process.returncode == WAITCHECK_HAZARD_EXIT and not parsed.findings:
         return KernelCheckResult(
             identity=identity,
             state=ExecutionState.ERROR,
@@ -394,9 +441,10 @@ def _run_one(
     return KernelCheckResult(
         identity=identity,
         state=ExecutionState.RAN,
-        verdict=Verdict.WARN if findings else Verdict.PASS,
+        verdict=Verdict.WARN if parsed.findings else Verdict.PASS,
         returncode=process.returncode,
-        findings=findings,
+        findings=parsed.findings,
+        diagnostics_truncated=parsed.diagnostics_truncated,
     )
 
 
@@ -407,8 +455,15 @@ def run_waitcheck(
     binary: Path | None = None,
     timeout_seconds: float = 900.0,
     execute: ProcessExecutor = run_argv,
+    max_diagnostics: int | None = None,
 ) -> CheckResult:
-    """Run exact Waitcheck for every worklist entry, failing closed on gaps."""
+    """Run exact Waitcheck for every worklist entry, failing closed on gaps.
+
+    ``max_diagnostics`` overrides the backend's per-code-object diagnostic cap
+    (``rj_waitcheck --max-diagnostics``, 32 by default). Leaving it unset keeps
+    the backend default; either way a capped scan is reported as
+    ``diagnostics_truncated`` rather than as a complete hazard count.
+    """
 
     resolved = resolve_waitcheck(binary)
     if resolved is None or not resolved.is_file():
@@ -459,6 +514,7 @@ def run_waitcheck(
             log_path=output_dir / f"waitcheck-{task_index}.log",
             timeout_seconds=timeout_seconds,
             execute=execute,
+            max_diagnostics=max_diagnostics,
         )
 
     # Each selected code object is an independent rj_waitcheck subprocess doing
@@ -479,6 +535,9 @@ def run_waitcheck(
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             kernel_results = tuple(pool.map(_scan, scan_tasks))
     findings = tuple(finding for result in kernel_results for finding in result.findings)
+    # One capped scan makes the whole check's finding count a floor, not a total,
+    # so the flag rolls up alongside the findings it qualifies.
+    truncated = any(result.diagnostics_truncated for result in kernel_results)
     if not kernel_results:
         return CheckResult(
             sanitizer="waitcheck",
@@ -501,6 +560,7 @@ def run_waitcheck(
             findings=findings,
             kernel_results=kernel_results,
             backend=backend,
+            diagnostics_truncated=truncated,
         )
     return CheckResult(
         sanitizer="waitcheck",
@@ -509,4 +569,5 @@ def run_waitcheck(
         findings=findings,
         kernel_results=kernel_results,
         backend=backend,
+        diagnostics_truncated=truncated,
     )

--- a/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
@@ -649,7 +649,7 @@ def test_execute_threads_waitcheck_max_diagnostics_into_run_waitcheck(
     execute_sanitizer_run(recipe, output_dir=tmp_path / "out")
 
     assert "max_diagnostics" in captured  # the waitcheck check actually ran
-    assert captured["max_diagnostics"] == expected
+    assert captured.get("max_diagnostics") == expected
 
 
 def test_verdict_baselines_fixture_present() -> None:

--- a/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_recipe_daily.py
@@ -300,6 +300,7 @@ def _write_kernel_waitcheck_recipe(
     *,
     code_object: str = "fixtures/isa/tiny.hsaco",
     sha256_line: str = "",
+    policy_extra: str = "",
 ) -> Path:
     recipe = tmp_path / "recipe.yaml"
     recipe.write_text(
@@ -325,6 +326,7 @@ def _write_kernel_waitcheck_recipe(
         "  policy:\n"
         "    consan_policy: strict\n"
         "    on_missing_backend: fail\n"
+        f"{policy_extra}"
         "  output:\n"
         "    report: sanitizer_report.json\n",
         encoding="utf-8",
@@ -593,6 +595,61 @@ def test_execute_threads_timeout_seconds_into_run_sanitizers(
     recipe = _write_kernel_consan_recipe(tmp_path, timeout_seconds=timeout_seconds)
     execute_sanitizer_run(recipe, output_dir=tmp_path / "out")
     assert captured.get("timeout_seconds") == expected
+
+
+def test_loader_parses_policy_waitcheck_max_diagnostics(tmp_path: Path) -> None:
+    recipe = _write_kernel_waitcheck_recipe(
+        tmp_path, policy_extra="    waitcheck_max_diagnostics: 100000\n"
+    )
+    assert load_sanitizer_recipe(recipe).waitcheck_max_diagnostics == 100000
+
+
+def test_loader_defaults_waitcheck_max_diagnostics_to_none_when_absent(tmp_path: Path) -> None:
+    # Absent keeps rj_waitcheck's own cap; the truncation flag is what makes a
+    # capped scan visible, so the default is not silently raised (#480).
+    loaded = load_sanitizer_recipe(_write_kernel_waitcheck_recipe(tmp_path))
+    assert loaded.waitcheck_max_diagnostics is None
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-5", "true", '"all"', "12.5"])
+def test_loader_rejects_invalid_waitcheck_max_diagnostics(tmp_path: Path, bad_value: str) -> None:
+    recipe = _write_kernel_waitcheck_recipe(
+        tmp_path, policy_extra=f"    waitcheck_max_diagnostics: {bad_value}\n"
+    )
+    with pytest.raises(RecipeSchemaError, match="waitcheck_max_diagnostics"):
+        load_sanitizer_recipe(recipe)
+
+
+@pytest.mark.parametrize(
+    ("policy_extra", "expected"),
+    [("    waitcheck_max_diagnostics: 100000\n", 100000), ("", None)],
+)
+def test_execute_threads_waitcheck_max_diagnostics_into_run_waitcheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    policy_extra: str,
+    expected: int | None,
+) -> None:
+    # The recipe knob has to reach the backend argv, or a lane cannot escape the
+    # 32-diagnostic cap without editing code.
+    captured: dict[str, object] = {}
+
+    def _fake_run_waitcheck(worklist, *, max_diagnostics=None, **_kwargs) -> CheckResult:
+        captured["max_diagnostics"] = max_diagnostics
+        return CheckResult(
+            sanitizer="waitcheck", state=ExecutionState.RAN, verdict=Verdict.PASS
+        )
+
+    monkeypatch.setattr(pipeline, "run_waitcheck", _fake_run_waitcheck)
+    obj = tmp_path / "fixtures" / "isa" / "tiny.hsaco"
+    obj.parent.mkdir(parents=True)
+    obj.write_bytes(b"\x7fELF fake tiny code object")
+    recipe = _write_kernel_waitcheck_recipe(tmp_path, policy_extra=policy_extra)
+
+    execute_sanitizer_run(recipe, output_dir=tmp_path / "out")
+
+    assert "max_diagnostics" in captured  # the waitcheck check actually ran
+    assert captured["max_diagnostics"] == expected
 
 
 def test_verdict_baselines_fixture_present() -> None:

--- a/tests/instrumentation/rocjitsu_sanitizers/test_report_pipeline.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_report_pipeline.py
@@ -201,6 +201,47 @@ def test_report_written_before_the_truncation_flag_still_loads() -> None:
     assert rebuilt.checks[0].diagnostics_truncated is False
 
 
+@pytest.mark.parametrize("location", ["check", "kernel"])
+def test_report_rejects_null_diagnostics_truncated(location: str) -> None:
+    kernel = KernelCheckResult(
+        identity=KernelIdentity(name="kernel", target="gfx950"),
+        state=ExecutionState.RAN,
+        verdict=Verdict.WARN,
+        findings=(_hazard_finding(),),
+        diagnostics_truncated=True,
+    )
+    report = build_report(
+        target="gfx950",
+        worklist=_worklist(),
+        checks=(
+            CheckResult(
+                sanitizer="waitcheck",
+                state=ExecutionState.RAN,
+                verdict=Verdict.WARN,
+                findings=(_hazard_finding(),),
+                kernel_results=(kernel,),
+                diagnostics_truncated=True,
+            ),
+        ),
+    )
+    data = report.to_dict()
+    checks = data.get("checks")
+    assert isinstance(checks, list)
+    check = checks[0]
+    assert isinstance(check, dict)
+    if location == "check":
+        check["diagnostics_truncated"] = None
+    else:
+        kernel_results = check.get("kernel_results")
+        assert isinstance(kernel_results, list)
+        kernel_result = kernel_results[0]
+        assert isinstance(kernel_result, dict)
+        kernel_result["diagnostics_truncated"] = None
+
+    with pytest.raises(TypeError, match="diagnostics_truncated must be a boolean"):
+        SanitizerReport.from_dict(data)
+
+
 def test_report_rejects_tampered_overall_verdict() -> None:
     report = build_report(
         target="gfx950",

--- a/tests/instrumentation/rocjitsu_sanitizers/test_report_pipeline.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_report_pipeline.py
@@ -33,6 +33,15 @@ def _race_finding() -> Finding:
     )
 
 
+def _hazard_finding() -> Finding:
+    return Finding(
+        sanitizer="waitcheck",
+        severity=FindingSeverity.WARNING,
+        code="wait_hazard",
+        message="missing s_waitcnt lgkmcnt(0)",
+    )
+
+
 def test_pass_check_cannot_carry_findings() -> None:
     with pytest.raises(ValueError, match="PASS check cannot carry findings"):
         CheckResult(
@@ -66,6 +75,27 @@ def test_check_cannot_be_cleaner_than_kernel_results(kernel_verdict: Verdict) ->
             sanitizer="consan",
             state=ExecutionState.RAN,
             verdict=Verdict.PASS,
+            kernel_results=(kernel,),
+        )
+
+
+def test_check_cannot_report_a_complete_count_over_a_truncated_kernel() -> None:
+    # The finding count of a truncated scan is a floor. A check that aggregates one
+    # and still claims a complete count would understate the hazard load exactly the
+    # way the discarded ">=" marker did (#480).
+    kernel = KernelCheckResult(
+        identity=KernelIdentity(name="k", target="gfx950"),
+        state=ExecutionState.RAN,
+        verdict=Verdict.WARN,
+        findings=(_hazard_finding(),),
+        diagnostics_truncated=True,
+    )
+    with pytest.raises(ValueError, match="complete count over a truncated kernel"):
+        CheckResult(
+            sanitizer="waitcheck",
+            state=ExecutionState.RAN,
+            verdict=Verdict.WARN,
+            findings=(_hazard_finding(),),
             kernel_results=(kernel,),
         )
 
@@ -112,6 +142,63 @@ def test_report_round_trip_and_fail_closed_precedence(tmp_path: Path) -> None:
     assert rebuilt.overall_verdict is Verdict.NOT_CHECKED
     assert rebuilt.execution_status is ExecutionSummary.PARTIAL
     assert path.stat().st_size > 0
+
+
+def test_report_round_trip_preserves_diagnostics_truncation(tmp_path: Path) -> None:
+    # The flag is only useful if it survives into sanitizer_report.json and back out
+    # again, since that file is what consumers quote (#480).
+    kernel = KernelCheckResult(
+        identity=KernelIdentity(name="kernel", target="gfx950"),
+        state=ExecutionState.RAN,
+        verdict=Verdict.WARN,
+        findings=(_hazard_finding(),),
+        diagnostics_truncated=True,
+    )
+    report = build_report(
+        target="gfx950",
+        worklist=_worklist(),
+        checks=(
+            CheckResult(
+                sanitizer="waitcheck",
+                state=ExecutionState.RAN,
+                verdict=Verdict.WARN,
+                findings=(_hazard_finding(),),
+                kernel_results=(kernel,),
+                diagnostics_truncated=True,
+            ),
+        ),
+    )
+    path = tmp_path / "sanitizer_report.json"
+
+    write_report(report, path)
+    rebuilt = read_report(path)
+
+    assert rebuilt == report
+    assert rebuilt.checks[0].diagnostics_truncated is True
+    assert rebuilt.checks[0].kernel_results[0].diagnostics_truncated is True
+
+
+def test_report_written_before_the_truncation_flag_still_loads() -> None:
+    # Reports emitted by earlier versions carry no diagnostics_truncated key. They
+    # must keep loading, as a complete count -- that is what they claimed.
+    report = build_report(
+        target="gfx950",
+        worklist=_worklist(),
+        checks=(
+            CheckResult(
+                sanitizer="waitcheck",
+                state=ExecutionState.RAN,
+                verdict=Verdict.PASS,
+            ),
+        ),
+    )
+    data = report.to_dict()
+    for check in data["checks"]:
+        check.pop("diagnostics_truncated")
+
+    rebuilt = SanitizerReport.from_dict(data)
+
+    assert rebuilt.checks[0].diagnostics_truncated is False
 
 
 def test_report_rejects_tampered_overall_verdict() -> None:

--- a/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
@@ -201,6 +201,23 @@ def test_waitcheck_argv_rejects_a_cap_that_is_not_a_positive_integer(
         )
 
 
+@pytest.mark.parametrize("bad_cap", [0, -1, True, 1.5, "1"])
+def test_run_waitcheck_rejects_an_invalid_cap_before_early_returns(
+    tmp_path: Path, bad_cap: object
+) -> None:
+    with pytest.raises(ValueError, match="max_diagnostics"):
+        run_waitcheck(
+            KernelWorklist(
+                requirement=SelectionRequirement.TOP_TIME,
+                top_n=1,
+                kernels=(),
+            ),
+            output_dir=tmp_path / "out",
+            binary=tmp_path / "missing",
+            max_diagnostics=bad_cap,
+        )
+
+
 def test_waitcheck_backend_error_never_passes(tmp_path: Path) -> None:
     binary = tmp_path / "rj_waitcheck"
     binary.write_text("binary")

--- a/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
@@ -18,6 +18,7 @@ from aorta.instrumentation.rocjitsu_sanitizers import (
     Verdict,
     parse_waitcheck_jsonl,
     run_waitcheck,
+    waitcheck_argv,
 )
 from aorta.instrumentation.rocjitsu_sanitizers.execution import ProcessResult
 from aorta.instrumentation.rocjitsu_sanitizers.waitcheck import parse_waitcheck_text
@@ -97,6 +98,102 @@ def test_waitcheck_hazard_uses_valid_exact_entry_cli(
     assert "--code-object-index" in argv
     assert argv[argv.index("--kernel-entry") + 1] == "0x120"
     assert "--diagnostics-jsonl" not in argv
+    # An uncapped summary is a complete count, and nothing overrides the
+    # backend's own diagnostic cap unless a caller asks for it.
+    assert "--max-diagnostics" not in argv
+    assert result.diagnostics_truncated is False
+    assert result.kernel_results[0].diagnostics_truncated is False
+
+
+def test_waitcheck_reports_a_capped_scan_as_truncated(tmp_path: Path) -> None:
+    # rj_waitcheck stops collecting at --max-diagnostics and marks the summary with
+    # ">=". That marker has to reach the kernel result, the check, and the emitted
+    # report, or a partial hazard count is quoted as the whole one (#480).
+    binary = tmp_path / "rj_waitcheck"
+    binary.write_text("binary")
+    artifact = tmp_path / "library.so"
+    artifact.write_bytes(b"\x7fELF")
+
+    def execute(
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float,
+        env: Mapping[str, str] | None = None,
+    ) -> ProcessResult:
+        output = "\n".join(
+            (
+                f"rj_waitcheck: {artifact}:gfx950[3]:kernel=.text+0x120: "
+                "instructions=43023 memory-events=5198 diagnostics=>=2",
+                f"{artifact}:gfx950[3]:.text+0x20: missing s_waitcnt lgkmcnt(0)",
+                f"{artifact}:gfx950[3]:.text+0x40: missing s_waitcnt vmcnt(0)",
+            )
+        )
+        return ProcessResult(tuple(argv), 4, output, "")
+
+    result = run_waitcheck(
+        _worklist(_exact_identity(artifact)),
+        output_dir=tmp_path / "out",
+        binary=binary,
+        execute=execute,
+    )
+
+    assert result.state is ExecutionState.RAN
+    assert result.verdict is Verdict.WARN
+    assert result.diagnostics_truncated is True
+    assert result.kernel_results[0].diagnostics_truncated is True
+    emitted = result.to_dict()
+    assert emitted["diagnostics_truncated"] is True
+    assert emitted["kernel_results"][0]["diagnostics_truncated"] is True
+
+
+def test_waitcheck_raises_the_backend_cap_when_asked(tmp_path: Path) -> None:
+    # The cap is what truncates, so a lane that needs a complete count must be able
+    # to raise it without editing code.
+    binary = tmp_path / "rj_waitcheck"
+    binary.write_text("binary")
+    artifact = tmp_path / "library.so"
+    artifact.write_bytes(b"\x7fELF")
+    captured: list[tuple[str, ...]] = []
+
+    def execute(
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float,
+        env: Mapping[str, str] | None = None,
+    ) -> ProcessResult:
+        captured.append(tuple(argv))
+        output = (
+            f"{artifact}:gfx950[3]:kernel=.text+0x120: "
+            "instructions=43023 memory-events=5198 diagnostics=45"
+        )
+        return ProcessResult(tuple(argv), 0, output, "")
+
+    result = run_waitcheck(
+        _worklist(_exact_identity(artifact)),
+        output_dir=tmp_path / "out",
+        binary=binary,
+        execute=execute,
+        max_diagnostics=100000,
+    )
+
+    argv = captured[0]
+    assert argv[argv.index("--max-diagnostics") + 1] == "100000"
+    assert result.diagnostics_truncated is False
+
+
+@pytest.mark.parametrize("bad_cap", [0, -1, True])
+def test_waitcheck_argv_rejects_a_cap_that_is_not_a_positive_integer(
+    tmp_path: Path, bad_cap: int
+) -> None:
+    # A library caller enters this directly, so the recipe loader's validation is
+    # not the only gate: ``True`` would otherwise be spelled onto the argv.
+    artifact = tmp_path / "library.so"
+    artifact.write_bytes(b"\x7fELF")
+
+    with pytest.raises(ValueError, match="max_diagnostics"):
+        waitcheck_argv(
+            tmp_path / "rj_waitcheck", _exact_identity(artifact), max_diagnostics=bad_cap
+        )
 
 
 def test_waitcheck_backend_error_never_passes(tmp_path: Path) -> None:
@@ -294,9 +391,35 @@ def test_parse_waitcheck_text_accepts_exact_entry_marker() -> None:
         )
     )
 
-    findings = parse_waitcheck_text(output, expected=_entry_identity())
+    parsed = parse_waitcheck_text(output, expected=_entry_identity())
 
-    assert len(findings) == 1
+    assert len(parsed.findings) == 1
+    assert parsed.diagnostics_truncated is False
+
+
+@pytest.mark.parametrize(
+    ("summary_count", "expected_truncated"),
+    [(">=32", True), ("45", False)],
+)
+def test_parse_waitcheck_text_preserves_the_truncation_marker(
+    summary_count: str, expected_truncated: bool
+) -> None:
+    # rj_waitcheck caps collection at --max-diagnostics (32 by default) and says so
+    # by prefixing the summary count with ">=". Both summaries below are verbatim
+    # from scanning one gpt-oss _topk_topp_kernel object for gfx1250, at the default
+    # cap and at --max-diagnostics 100000: the capped scan reports 32 of the 45
+    # hazards that are really there. Dropping the marker reported that floor as a
+    # complete count (#480).
+    output = (
+        f"rj_waitcheck: /tmp/library.so:gfx950[3]:kernel=.text+0x120: "
+        f"instructions=43023 memory-events=5198 diagnostics={summary_count}\n"
+        "/tmp/library.so:gfx950[3]:.text+0x20: missing s_waitcnt lgkmcnt(0)"
+    )
+
+    parsed = parse_waitcheck_text(output, expected=_entry_identity())
+
+    assert parsed.diagnostics_truncated is expected_truncated
+    assert len(parsed.findings) == 1
 
 
 def test_parse_waitcheck_text_rejects_mismatched_entry() -> None:

--- a/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
+++ b/tests/instrumentation/rocjitsu_sanitizers/test_waitcheck.py
@@ -142,8 +142,12 @@ def test_waitcheck_reports_a_capped_scan_as_truncated(tmp_path: Path) -> None:
     assert result.diagnostics_truncated is True
     assert result.kernel_results[0].diagnostics_truncated is True
     emitted = result.to_dict()
-    assert emitted["diagnostics_truncated"] is True
-    assert emitted["kernel_results"][0]["diagnostics_truncated"] is True
+    assert emitted.get("diagnostics_truncated") is True
+    kernel_results = emitted.get("kernel_results")
+    assert isinstance(kernel_results, list)
+    kernel_result = kernel_results[0]
+    assert isinstance(kernel_result, dict)
+    assert kernel_result.get("diagnostics_truncated") is True
 
 
 def test_waitcheck_raises_the_backend_cap_when_asked(tmp_path: Path) -> None:
@@ -181,12 +185,13 @@ def test_waitcheck_raises_the_backend_cap_when_asked(tmp_path: Path) -> None:
     assert result.diagnostics_truncated is False
 
 
-@pytest.mark.parametrize("bad_cap", [0, -1, True])
+@pytest.mark.parametrize("bad_cap", [0, -1, True, 1.5, "1"])
 def test_waitcheck_argv_rejects_a_cap_that_is_not_a_positive_integer(
-    tmp_path: Path, bad_cap: int
+    tmp_path: Path, bad_cap: object
 ) -> None:
     # A library caller enters this directly, so the recipe loader's validation is
-    # not the only gate: ``True`` would otherwise be spelled onto the argv.
+    # not the only gate: values such as ``True`` and ``1.5`` would otherwise be
+    # spelled onto the argv.
     artifact = tmp_path / "library.so"
     artifact.write_bytes(b"\x7fELF")
 
@@ -276,6 +281,8 @@ def test_waitcheck_hazard_exit_without_json_is_error(tmp_path: Path) -> None:
 
     assert result.verdict is Verdict.ERROR
     assert "without_structured_diagnostics" in str(result.kernel_results[0].reason)
+    assert result.diagnostics_truncated is True
+    assert result.kernel_results[0].diagnostics_truncated is True
 
 
 def test_waitcheck_requires_exact_identity(tmp_path: Path) -> None:


### PR DESCRIPTION
## The bug

`rj_waitcheck` collects at most `--max-diagnostics` findings per code object (32
by default), and aorta analyses each object in its own subprocess, so the cap
applies per kernel. The tool reports a capped scan honestly, by prefixing the
summary count with `>=`:

```
default cap:  rj_waitcheck: ... code-objects=1 diagnostics=>=32
uncapped:     rj_waitcheck: ... code-objects=1 diagnostics=45
```

`_HEADER` matched that marker with a non-capturing `(?:>=)?` and threw it away,
so `>=32` and `32` were indistinguishable downstream and `sanitizer_report.json`
carried a flat count with nothing marking it partial.

Measured: scanning the gpt-oss `_topk_topp_kernel` object compiled for gfx1250,
aorta reports **32** findings; the same object at `--max-diagnostics 100000` has
**45**. A 29% understatement, on a correctness tool.

## The change

- **The marker is captured and carried.** `parse_waitcheck_text` now returns a
  `ParsedWaitcheckOutput` (findings + `diagnostics_truncated`), mirroring
  `parse_record_replay_output` → `ParsedCombinedOutput` on the ConSan side. The
  flag lands on `KernelCheckResult`, rolls up to `CheckResult`, and is emitted in
  the report, so a consumer can tell a complete count from a floor.
- **A check may not claim a complete count over a truncated kernel result.**
  Enforced in `CheckResult.__post_init__`, next to the existing "a check verdict
  cannot be cleaner than its kernel results" invariant — same reasoning: a
  truncated child makes the parent's aggregated finding count a floor.
- **The cap is raisable from a recipe.** Detecting truncation is only half an
  answer, so `sanitizer_plan.policy.waitcheck_max_diagnostics` (positive integer,
  validated at load exactly like `timeout_seconds`) threads through
  `run_sanitizers` → `run_waitcheck` → `rj_waitcheck --max-diagnostics`. Absent,
  the backend default stands and a capped scan is simply reported as truncated.
  Raising the *default* would spend analysis time on every lane to hide a signal
  that is now visible, so the flag is the fix and the knob is the escape hatch.

## Verification against the real backend

Two recipes over the same gfx1250 `_topk_topp_kernel` object, run end to end
through `execute_sanitizer_run` with prebuilt bundle `97c1640b`:

| policy | verdict | findings | `diagnostics_truncated` (check / kernel) |
|---|---|---|---|
| default cap | `warn` | 32 | `true` / `true` |
| `waitcheck_max_diagnostics: 100000` | `warn` | 45 | `false` / `false` |

## Tests

- `test_parse_waitcheck_text_preserves_the_truncation_marker` — parametrized on
  the two summaries above (verbatim from that scan): `>=32` is truncated, `45` is
  not. This is the regression the issue asks for.
- `test_waitcheck_reports_a_capped_scan_as_truncated` — the flag reaches the
  kernel result, the check, and the emitted dict.
- `test_waitcheck_raises_the_backend_cap_when_asked` +
  `test_waitcheck_argv_rejects_a_cap_that_is_not_a_positive_integer` +
  `test_run_waitcheck_rejects_an_invalid_cap_before_early_returns` (`0`, `-1`,
  `True`, `1.5`, `"1"` — both public direct-call entry points validate before
  backend and worklist early returns, so the recipe loader is not the only gate).
- `test_check_cannot_report_a_complete_count_over_a_truncated_kernel`,
  `test_report_round_trip_preserves_diagnostics_truncation`, and
  `test_report_written_before_the_truncation_flag_still_loads`.
- Recipe knob: parse / default-absent / reject (`0`, `-5`, `true`, `"all"`,
  `12.5`) / thread-through to `run_waitcheck`.

`tests/instrumentation/rocjitsu_sanitizers` 163 passed, 3 skipped;
`tests/sanitizers` 400 passed (dashboard, survey and baseline-comparator suites
all read reports).
`ruff check` clean on the changed files.

## Compatibility

The report field is additive and the schema stays `aorta.sanitizer_report/0.1`:
`from_dict` defaults `diagnostics_truncated` to `false` when the key is absent —
type-checking it when present — so the committed survey reports and any older
run still load, and still read as the complete counts they claimed. Bumping the
schema would have made `read_report` reject every one of them.

`parse_waitcheck_text`'s return type changes from `tuple[Finding, ...]` to
`ParsedWaitcheckOutput`. It is exported from the package, so this is a public
signature change; there are no other in-tree callers, and the alternative (a
second parallel parse entry point) is the kind of duplicate mechanism this
package has so far avoided.

## Deliberately not in this PR

- **The nightly dashboard still renders a bare per-kernel finding count.** Now
  that the flag exists, `gen_sanitizer_dashboard.py` could render `≥N` for a
  truncated kernel; that is a separate, presentation-only change to a file with
  its own large suite.
- **The gated baselines don't assert truncation.** `verdict_baselines.json`
  could pin `diagnostics_truncated: false` for the gated waitcheck lane, but
  that is a gate-policy decision that needs the lane's real numbers (it scans a
  large Tensile object and may well be capped today) and a chosen cap.
- **`parse_waitcheck_jsonl` cannot report the cap** — the JSONL stream carries no
  analysis summary, so there is no marker to read. Its docstring now says so.
  `run_waitcheck` does not use that path.

Closes #480

