### PR TITLE
feat(agent): adopt the eleven-name autopsy taxonomy across the probe agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ overlap_debug*/
 # `aorta chat index eval` reads it with no arguments, and pyproject ships it in
 # the wheel, so the *.json rule above must not swallow it.
 !src/aorta/chat/rag/eval_questions.json
+# Exception: the RL corpus scenario labels are hand-written ground truth, not a
+# generated corpus. The corpus rows next to them (*.jsonl) are output and stay
+# ignored; these labels are the input that survives a rebuild.
+!examples/rl/corpus/scenario_labels.json
 *_merged_enhanced.json
 nccl_thread_sweep_*.log
 nccl_thread_sweep_summary_*.txt

--- a/docs/agent/aorta-probe-agent.md
+++ b/docs/agent/aorta-probe-agent.md
@@ -56,7 +56,7 @@ flowchart TD
 
 | Field | Meaning |
 |-------|---------|
-| `category` | One of eight generic autopsy labels (see below) |
+| `category` | One of eleven generic autopsy labels (see below) |
 | `hypothesis` | Short natural-language explanation |
 | `next_mitigations` | Registered mitigation names to try next (never raw argv) |
 | `confidence` | 0.0–1.0 self-reported confidence |
@@ -70,10 +70,37 @@ flowchart TD
 | `thermal_throttle` | Sustained perf drop + thermal context (when available) |
 | `illegal_mem` | `tier4:hip_error`, illegal-access regex in stderr |
 | `oom_fragment` | OOM / exit 137 patterns |
-| `checkpoint_race` | Barrier / checkpoint boundary signatures |
+| `checkpoint_race` | Checkpoint save/load boundary signatures |
+| `kernel_race` | ConSan / waitcheck findings naming sites inside one kernel |
 | `launch_error` | Early exit, launch failures |
 | `perf_regression` | Pass with warn detectors or confound regression |
+| `nondeterminism` | Same inputs, different results across repeated runs |
+| `numeric_instability` | `tier4:nan_signature`, Inf/overflow, out-of-tolerance drift |
 | `unknown` | No confident mapping |
+
+The set is closed: `AgentPolicy.validate_step` raises `PolicyViolation` on
+anything outside it, so the loop stops rather than recording a label nothing
+downstream can route on. It is defined once, in
+`aorta.agent.llm.AUTOPSY_CATEGORY_GUIDANCE`, as name → one-line gloss;
+`AUTOPSY_CATEGORIES` is derived from that mapping and the proposer prompt
+renders the glosses, so a new label cannot reach the validator without also
+reaching the model.
+
+Three distinctions the glosses exist to enforce, because the names alone do not:
+
+* **`checkpoint_race` is about checkpoint I/O, not about kernels.** An
+  intra-wave LDS race is `kernel_race`. The two were previously conflated —
+  `checkpoint_race` was the nearest available name for a kernel race, and it was
+  the wrong one.
+* **`kernel_race` is preferred over `nondeterminism` once a kernel is
+  implicated.** Both labels describe results you cannot reproduce, but they
+  route to different diagnostics: `kernel_race` to ConSan/waitcheck against a
+  specific code object, `nondeterminism` to repeating the run and diffing.
+  Granularity here follows the diagnostic, not the symptom.
+* **`unknown` is a real answer, not a failure to answer.** It is the correct
+  label when the evidence supports none of the others, and `validate_step`
+  accepts it. Guessing a specific label to avoid `unknown` is worse than
+  `unknown`, because the loop routes on the label.
 
 ---
 

--- a/examples/rl/corpus/scenario_labels.json
+++ b/examples/rl/corpus/scenario_labels.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "description": [
+    "Ground-truth autopsy category per sanitizer scenario: the label a correct",
+    "triage should name given that scenario's evidence. Every value must be a",
+    "member of aorta.agent.llm.AUTOPSY_CATEGORIES; tests/agent/test_autopsy_categories.py",
+    "enforces that, and that each scenario names a recipe that exists.",
+    "",
+    "Kept as a file keyed by scenario rather than as a column inside the corpus",
+    "rows because the corpus is generated: examples/rl/build_corpus.py rebuilds",
+    "triage.jsonl and proposal.jsonl from a tree of sanitizer runs, so a label",
+    "written into a row is lost on the next rebuild. The scenario ids are the",
+    "ones build_corpus.py emits as scenario_id."
+  ],
+  "categories_source": "aorta.agent.llm.AUTOPSY_CATEGORY_GUIDANCE",
+  "evidence": [
+    "Nine sanitizer runs on a gfx950 compute node (Slurm job 32192, ROCm 7.0.2.2),",
+    "RocJITsu bundle f92da4cb. Verdicts and finding counts as recorded in the",
+    "corpus manifest; see examples/rl/corpus/README.md for provenance."
+  ],
+  "coverage_note": [
+    "Three scenarios carry a committed label and six are honestly `unknown`.",
+    "This corpus is a sanitizer guardrail suite -- five of the nine rows are",
+    "controls with zero findings, and two more are harness errors -- so `unknown`",
+    "is the correct answer there, not a gap in the label set.",
+    "",
+    "It does mean this corpus exercises exactly one of the three labels added",
+    "when the set was widened: there is no nondeterminism scenario and no",
+    "NaN/numerics scenario in it. Extending the closed set unblocks those two",
+    "use cases at the contract level, but training signal for them needs new",
+    "scenarios; re-labelling alone cannot produce it."
+  ],
+  "scenarios": {
+    "consan-clean": {
+      "recipe": "recipes/sanitizers/daily-consan-clean.yaml",
+      "category": "unknown",
+      "why": "Race-free control on the single-wave LDS repro. ConSan passes with zero findings, so there is no failure to categorise and `unknown` is the correct label rather than a missing one."
+    },
+    "consan-racy": {
+      "recipe": "recipes/sanitizers/daily-consan-racy.yaml",
+      "category": "kernel_race",
+      "why": "Two-wave LDS data race: 64 ConSan findings collapsing to one site, one record per lane and LDS byte range. This is the scenario that previously drew `checkpoint_race` -- the nearest available name in the old set, and the wrong one."
+    },
+    "consan-lds-dispatch": {
+      "recipe": "recipes/sanitizers/daily-consan-lds-dispatch.yaml",
+      "category": "unknown",
+      "why": "Race-free LDS reduction, instrumented and actually dispatched. The end-to-end control for the dynamic record/replay path; it passes with zero findings, so no failure label applies."
+    },
+    "consan-tiny": {
+      "recipe": "recipes/sanitizers/daily-consan-tiny.yaml",
+      "category": "unknown",
+      "why": "Deliberate negative control. tiny_vecadd has no admissible sites, so strict require-records fails closed (exit 86) rather than emitting a false pass. The error is the harness refusing to lie, not a workload defect -- no autopsy label applies."
+    },
+    "consan-gemm": {
+      "recipe": "recipes/sanitizers/daily-consan-gemm.yaml",
+      "category": "unknown",
+      "why": "Capacity rejection: on the pinned CI base the Tensile object exceeds the patched-image growth ceiling and ConSan rejects it before instrumenting anything, so the row is error with zero findings. A tooling limit, not a workload defect."
+    },
+    "waitcheck": {
+      "recipe": "recipes/sanitizers/daily-waitcheck-gemm.yaml",
+      "category": "kernel_race",
+      "why": "Missing s_waitcnt hazards over the top-3 GEMM shapes: 64 findings across two distinct sites. A missing wait count is the absence of an ordering guarantee between a memory op and its consumer inside one kernel, and waitcheck names the sites -- the same diagnostic and the same fix surface as an LDS race."
+    },
+    "waitcheck-gemm": {
+      "recipe": "recipes/sanitizers/daily-waitcheck-gemm-object.yaml",
+      "category": "kernel_race",
+      "why": "Missing s_waitcnt hazards on the real f32 Tensile code object: 32 findings at one site. Same reasoning as `waitcheck`, against the object rather than the CSV shapes."
+    },
+    "waitcheck-lds-dispatch": {
+      "recipe": "recipes/sanitizers/daily-waitcheck-lds-dispatch.yaml",
+      "category": "unknown",
+      "why": "Clean static scan over the LDS reduction kernel: pass, zero findings, nothing to categorise."
+    },
+    "waitcheck-tiny": {
+      "recipe": "recipes/sanitizers/daily-waitcheck-tiny.yaml",
+      "category": "unknown",
+      "why": "Clean static scan over tiny_vecadd: pass, zero findings, nothing to categorise."
+    }
+  }
+}

--- a/src/aorta/agent/__init__.py
+++ b/src/aorta/agent/__init__.py
@@ -8,10 +8,12 @@ only labels failures and proposes registered mitigation names.
 
 from aorta.agent.llm import (
     AUTOPSY_CATEGORIES,
+    AUTOPSY_CATEGORY_GUIDANCE,
     AgentStep,
     FakeLLMProposer,
     LiteLLMProposer,
     LLMProposer,
+    format_category_guidance,
 )
 from aorta.agent.loop import AgentConfig, AgentLoopResult, run_agent_loop
 from aorta.agent.policy import AgentPolicy, PolicyViolation
@@ -20,6 +22,7 @@ from aorta.agent.state import AgentState, append_log_event, wake
 
 __all__ = [
     "AUTOPSY_CATEGORIES",
+    "AUTOPSY_CATEGORY_GUIDANCE",
     "AgentConfig",
     "AgentLoopResult",
     "AgentPolicy",
@@ -30,6 +33,7 @@ __all__ = [
     "LiteLLMProposer",
     "PolicyViolation",
     "append_log_event",
+    "format_category_guidance",
     "run_agent_loop",
     "wake",
     "write_agent_report",

--- a/src/aorta/agent/llm.py
+++ b/src/aorta/agent/llm.py
@@ -7,7 +7,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any, Literal, Protocol
 
 # Why the proposer set ``stop=True`` (drives CLI/report outcome labels).
@@ -17,18 +19,86 @@ StopReason = Literal[
     "agent_requested",
 ]
 
-AUTOPSY_CATEGORIES: frozenset[str] = frozenset(
+# The closed autopsy label set, each member carrying the one-line gloss the
+# proposer is told to route on. Set and glosses are one object deliberately:
+# several members are near neighbours (``checkpoint_race`` vs ``kernel_race``,
+# ``kernel_race`` vs ``nondeterminism``) and a bare list of names is not enough
+# to choose between them, so a member added without a gloss would be a member
+# the model has never been told how to use.
+#
+# Labels exist to route toward a *diagnostic*, so the granularity follows the
+# diagnostic rather than the symptom. That is why a race inside a kernel is its
+# own label and not a flavour of ``nondeterminism``: a race is localised to one
+# kernel and confirmed with ConSan/waitcheck, whereas nondeterminism is a
+# workload-level symptom whose triage starts with repeating the run.
+AUTOPSY_CATEGORY_GUIDANCE: Mapping[str, str] = MappingProxyType(
     {
-        "rccl_hang",
-        "thermal_throttle",
-        "illegal_mem",
-        "oom_fragment",
-        "checkpoint_race",
-        "launch_error",
-        "perf_regression",
-        "unknown",
+        "rccl_hang": (
+            "A collective stopped making progress -- ranks stuck in RCCL/NCCL, "
+            "watchdog timeout, no forward progress."
+        ),
+        "thermal_throttle": (
+            "Sustained clock or throughput loss attributable to thermal or power "
+            "limiting rather than to the workload itself."
+        ),
+        "illegal_mem": (
+            "Illegal or out-of-bounds device memory access -- HIP/CUDA fault, VM "
+            "protection fault, fault in device code."
+        ),
+        "oom_fragment": (
+            "Out of memory or allocator fragmentation, including an OOM kill."
+        ),
+        "checkpoint_race": (
+            "A concurrency defect around checkpoint I/O: a save or load racing "
+            "with training, with another rank, or with a filesystem barrier. This "
+            "label is about checkpointing, never about code inside a GPU kernel -- "
+            "for that use kernel_race."
+        ),
+        "kernel_race": (
+            "An unsynchronised access inside a single GPU kernel: an LDS or global "
+            "data race, or a missing wait-count hazard. Localised to one kernel and "
+            "confirmed by a sanitizer (ConSan, waitcheck) that names the offending "
+            "sites. Prefer this over nondeterminism whenever a specific kernel is "
+            "already implicated."
+        ),
+        "launch_error": (
+            "The workload failed at or before launch -- bad argv, missing "
+            "dependency, early non-zero exit before real work started."
+        ),
+        "perf_regression": (
+            "The workload produces correct results but is slower than its reference."
+        ),
+        "nondeterminism": (
+            "A workload that should be reproducible is not: results or verdicts "
+            "diverge run to run on identical inputs. A workload-level symptom with "
+            "many possible causes, triaged by repeating the run and diffing rather "
+            "than by pointing a sanitizer at one kernel. Use kernel_race instead "
+            "once a specific kernel's race is the evidence."
+        ),
+        "numeric_instability": (
+            "NaN, Inf, or a loss of numeric accuracy: training loss goes NaN "
+            "(``tier4:nan_signature``), values overflow, or results drift beyond "
+            "tolerance because of precision or accumulation order."
+        ),
+        "unknown": (
+            "The evidence does not support any label above. The honest answer when "
+            "nothing fits -- not a placeholder for a guess."
+        ),
     }
 )
+
+#: Closed set :class:`aorta.agent.policy.AgentPolicy` validates against, derived
+#: from the guidance so the two cannot drift apart.
+AUTOPSY_CATEGORIES: frozenset[str] = frozenset(AUTOPSY_CATEGORY_GUIDANCE)
+
+
+def format_category_guidance() -> str:
+    """Render the autopsy labels as one ``- name: gloss`` line each."""
+    return "\n".join(
+        f"- {name}: {AUTOPSY_CATEGORY_GUIDANCE[name]}"
+        for name in sorted(AUTOPSY_CATEGORY_GUIDANCE)
+    )
+
 
 _BASELINE_CELL = "none-none"
 
@@ -114,8 +184,17 @@ def _infer_category_from_detectors(detectors: list[str]) -> str:
         return "oom_fragment"
     if "hip_error" in joined or "illegal" in joined or "memory" in joined:
         return "illegal_mem"
-    if "checkpoint" in joined or "barrier" in joined:
+    if "nan_signature" in joined:
+        return "numeric_instability"
+    if "checkpoint" in joined:
         return "checkpoint_race"
+    # "barrier" used to land here, but in this codebase a barrier is a GPU-side
+    # object -- ConSan barrier sites, barrier patching -- not a checkpoint
+    # barrier, so the old branch routed intra-kernel evidence to a checkpoint-I/O
+    # label. Checked after "checkpoint" so a detector naming both still wins for
+    # checkpoint_race.
+    if "race" in joined or "consan" in joined or "barrier" in joined or "waitcnt" in joined:
+        return "kernel_race"
     if "tier1:exit" in joined or "launch" in joined:
         return "launch_error"
     return "unknown"
@@ -143,6 +222,14 @@ class FakeLLMProposer:
                 category = "illegal_mem"
             elif "oom" in low:
                 category = "oom_fragment"
+            elif "nan" in low:
+                category = "numeric_instability"
+            elif "nondetermin" in low:
+                category = "nondeterminism"
+            # Bare "race" would also match "traceback", a very plausible word in
+            # a free-text symptom, so this leg wants the phrase.
+            elif "data race" in low or "race condition" in low:
+                category = "kernel_race"
 
         # Baseline pass wins even when the allowlist has no further mitigations.
         for summary in cell_summaries:
@@ -224,7 +311,10 @@ def _build_prompt(
         "names from the candidate list. Never propose shell commands or argv. "
         "Return strict JSON with keys: category, hypothesis, next_mitigations "
         "(list of strings), confidence (0-1), stop (bool). "
-        f"category must be one of: {sorted(AUTOPSY_CATEGORIES)}."
+        "category must be exactly one of the labels below. Several are near "
+        "neighbours, so the gloss -- not the name -- is what tells them apart; "
+        "read it before choosing.\n"
+        f"{format_category_guidance()}"
     )
     user = json.dumps(
         {
@@ -464,6 +554,7 @@ def make_proposer(backend: str, *, model: str | None = None) -> LLMProposer:
 
 __all__ = [
     "AUTOPSY_CATEGORIES",
+    "AUTOPSY_CATEGORY_GUIDANCE",
     "CHAT_PROVIDER_BACKENDS",
     "AgentStep",
     "ChatProviderProposer",
@@ -471,5 +562,6 @@ __all__ = [
     "LLMProposer",
     "LiteLLMProposer",
     "StopReason",
+    "format_category_guidance",
     "make_proposer",
 ]

--- a/tests/agent/test_autopsy_categories.py
+++ b/tests/agent/test_autopsy_categories.py
@@ -1,0 +1,226 @@
+"""The closed autopsy label set, and everything that has to agree with it.
+
+A closed set is referenced in more places than it looks: the validator that
+rejects anything outside it, the prompt that tells the model what exists, the
+offline heuristic that labels without a model, the operator docs, and the
+corpus ground truth. A member added in one place and missing in another is
+worse than not adding it at all -- either the validator accepts a label the
+model was never told about, or the model emits one the validator kills the
+search over.
+
+So these pin the *agreement between* those places rather than a hardcoded list
+of names, and keep working as the set grows. The exceptions are the three
+labels added because the measured end-to-end run had nowhere to put its
+evidence; those are named explicitly, because losing one silently is the
+regression this file exists to catch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aorta.agent.llm import (
+    AUTOPSY_CATEGORIES,
+    AUTOPSY_CATEGORY_GUIDANCE,
+    AgentStep,
+    FakeLLMProposer,
+    _build_prompt,
+    format_category_guidance,
+)
+from aorta.agent.policy import AgentPolicy, PolicyViolation
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_DOC = REPO_ROOT / "docs" / "agent" / "aorta-probe-agent.md"
+SCENARIO_LABELS = REPO_ROOT / "examples" / "rl" / "corpus" / "scenario_labels.json"
+
+#: Added because an end-to-end run against nine real sanitizer scenarios
+#: answered ``unknown`` on eight of them and mislabelled the ninth: no correct
+#: label existed. Named here rather than derived so that dropping one fails.
+ADDED_CATEGORIES = ("kernel_race", "nondeterminism", "numeric_instability")
+
+
+class TestTheSetItself:
+    def test_the_set_is_derived_from_the_guidance_so_the_two_cannot_drift(self):
+        assert AUTOPSY_CATEGORIES == frozenset(AUTOPSY_CATEGORY_GUIDANCE)
+
+    def test_every_label_carries_a_gloss(self):
+        """A label the model is shown without a gloss is a label it cannot route on."""
+        assert [n for n, gloss in AUTOPSY_CATEGORY_GUIDANCE.items() if not gloss.strip()] == []
+
+    @pytest.mark.parametrize("category", ADDED_CATEGORIES)
+    def test_the_labels_the_evidence_demanded_are_present(self, category):
+        assert category in AUTOPSY_CATEGORIES
+
+    def test_kernel_race_did_not_replace_checkpoint_race(self):
+        """They are different failures with different diagnostics.
+
+        A checkpoint race is a concurrency problem around checkpoint I/O; an
+        intra-wave LDS conflict is not. Collapsing them back together would
+        re-create the mislabel that motivated the split.
+        """
+        assert {"kernel_race", "checkpoint_race"} <= AUTOPSY_CATEGORIES
+
+    def test_the_guidance_is_read_only(self):
+        with pytest.raises(TypeError):
+            AUTOPSY_CATEGORY_GUIDANCE["invented"] = "nope"  # type: ignore[index]
+
+
+class TestTheValidator:
+    @pytest.mark.parametrize("category", sorted(AUTOPSY_CATEGORIES))
+    def test_every_member_survives_validate_step(self, category):
+        step = AgentStep(
+            category=category,
+            hypothesis="",
+            next_mitigations=["tf32_off"],
+            confidence=0.5,
+            stop=False,
+        )
+        assert AgentPolicy().validate_step(step).category == category
+
+    def test_unknown_stays_valid(self):
+        """The honest answer when the evidence supports no label.
+
+        Widening the set does not make declining wrong, and `validate_step`
+        accepting it is load-bearing: six of the nine corpus scenarios are
+        controls or harness errors whose correct label is `unknown`.
+        """
+        step = AgentStep(
+            category="unknown",
+            hypothesis="",
+            next_mitigations=[],
+            confidence=0.0,
+            stop=True,
+        )
+        assert AgentPolicy().validate_step(step).category == "unknown"
+
+    @pytest.mark.parametrize("category", ["lds_race", "nan", "KERNEL_RACE", "", "kernel-race"])
+    def test_a_label_outside_the_set_is_still_rejected(self, category):
+        """Widening the set must not soften it -- it is still closed.
+
+        `lds_race` in particular is the name `examples/rl/build_corpus.py` uses
+        to synthesise its invalid-category negative example, so it has to stay
+        outside.
+        """
+        step = AgentStep(
+            category=category,
+            hypothesis="",
+            next_mitigations=[],
+            confidence=0.5,
+            stop=False,
+        )
+        with pytest.raises(PolicyViolation, match="invalid category"):
+            AgentPolicy().validate_step(step)
+
+
+class TestTheProposerIsTold:
+    def test_the_prompt_carries_every_label_and_its_gloss(self):
+        """The model cannot use a label nobody mentioned to it."""
+        system, _ = _build_prompt(None, [], ["tf32_off"], [])
+        for name, gloss in AUTOPSY_CATEGORY_GUIDANCE.items():
+            assert f"- {name}: " in system, f"{name} missing from the prompt"
+            assert gloss in system, f"{name}'s gloss missing from the prompt"
+
+    def test_the_rendering_is_one_line_per_label(self):
+        lines = format_category_guidance().splitlines()
+        assert len(lines) == len(AUTOPSY_CATEGORIES)
+        assert lines == sorted(lines), "sorted so the prompt is stable between runs"
+
+
+def _fake_step(*, detectors: list[str] | None = None, symptom: str | None = None) -> AgentStep:
+    summaries = [{"cell_name": "none-none", "verdict": "fail",
+                  "failure_detectors_fired": detectors or []}]
+    return FakeLLMProposer().propose(
+        symptom=symptom, cell_summaries=summaries, candidates=["tf32_off"], tried=[]
+    )
+
+
+class TestTheOfflineHeuristic:
+    """`FakeLLMProposer` labels with no model at all, so it needs the new names too."""
+
+    @pytest.mark.parametrize(
+        ("detector", "expected"),
+        [
+            # Pre-existing mappings, pinned so the new branches cannot shadow them.
+            ("tier2:hang", "rccl_hang"),
+            ("tier4:hip_error", "illegal_mem"),
+            ("tier1:exit_nonzero", "launch_error"),
+            # `tier4:nan_signature` has shipped since before the set had a home
+            # for it, and fell through to `unknown` every time it fired.
+            ("tier4:nan_signature", "numeric_instability"),
+            ("consan:data_race", "kernel_race"),
+            ("waitcheck:missing_waitcnt", "kernel_race"),
+        ],
+    )
+    def test_detectors_route_to_the_right_label(self, detector, expected):
+        assert _fake_step(detectors=[detector]).category == expected
+
+    def test_barrier_evidence_is_a_kernel_race_not_a_checkpoint_race(self):
+        """A barrier here is a GPU barrier -- ConSan sites, barrier patching.
+
+        Routing it to `checkpoint_race` is how intra-kernel evidence ended up
+        under a checkpoint-I/O label in the first place.
+        """
+        assert _fake_step(detectors=["consan:barrier_unpatched"]).category == "kernel_race"
+
+    def test_checkpoint_still_wins_for_checkpoint_evidence(self):
+        assert _fake_step(detectors=["checkpoint:race"]).category == "checkpoint_race"
+
+    @pytest.mark.parametrize(
+        ("symptom", "expected"),
+        [
+            ("loss is NaN after 200 steps", "numeric_instability"),
+            ("nondeterministic eval scores between runs", "nondeterminism"),
+            ("data race reported in the reduction kernel", "kernel_race"),
+            ("race condition on the LDS tile", "kernel_race"),
+        ],
+    )
+    def test_symptom_text_routes_to_the_right_label(self, symptom, expected):
+        assert _fake_step(symptom=symptom).category == expected
+
+    def test_a_traceback_is_not_a_race(self):
+        """"race" is a substring of "traceback", which is a plausible symptom word."""
+        assert _fake_step(symptom="python traceback at startup").category != "kernel_race"
+
+
+class TestTheDocsAgree:
+    @pytest.mark.parametrize("category", sorted(AUTOPSY_CATEGORIES))
+    def test_the_operator_doc_lists_every_label(self, category):
+        """The taxonomy table is what a human reads; it drifts silently otherwise."""
+        assert f"`{category}`" in AGENT_DOC.read_text(encoding="utf-8")
+
+
+class TestTheCorpusGroundTruth:
+    """`scenario_labels.json` is the training signal the widened set exists for."""
+
+    @staticmethod
+    def _labels() -> dict:
+        return json.loads(SCENARIO_LABELS.read_text(encoding="utf-8"))["scenarios"]
+
+    def test_every_scenario_is_labelled_from_the_closed_set(self):
+        offenders = {
+            name: entry["category"]
+            for name, entry in self._labels().items()
+            if entry["category"] not in AUTOPSY_CATEGORIES
+        }
+        assert offenders == {}
+
+    def test_every_scenario_names_a_recipe_that_exists(self):
+        missing = [
+            entry["recipe"]
+            for entry in self._labels().values()
+            if not (REPO_ROOT / entry["recipe"]).is_file()
+        ]
+        assert missing == []
+
+    def test_every_scenario_says_why(self):
+        assert [n for n, e in self._labels().items() if not e.get("why", "").strip()] == []
+
+    def test_the_lds_race_is_labelled_a_kernel_race(self):
+        """The one scenario the model labelled, and labelled wrong.
+
+        It drew `checkpoint_race` because that was the nearest available name.
+        """
+        assert self._labels()["consan-racy"]["category"] == "kernel_race"


### PR DESCRIPTION
## What this does

Adopts the eleven-name autopsy vocabulary and makes the probe agent, the offline heuristic, the docs and the corpus ground truth agree with it.

**The taxonomy names are `main`'s, not this branch's.** This PR opened on 10 September proposing `kernel_race`, `nondeterminism` and `numeric_instability`. The CIA port ([#423](https://github.com/ROCm/aorta/pull/423), [#424](https://github.com/ROCm/aorta/pull/424)) widened the same eight-name set in the same file from the other side, reaching two of the same concepts under different names, and merged first on 21 September. Its names win:

| this PR proposed | shipped |
|---|---|
| `kernel_race` | `gpu_race` |
| `numeric_instability` | `numeric_silent` |
| `nondeterminism` | **held out** — see below |
| — | `tooling_gap` (from `main`) |

Coordination note and the open question are at [issuecomment-5757789140](https://github.com/ROCm/aorta/pull/484#issuecomment-5757789140) and [issuecomment-5757990605](https://github.com/ROCm/aorta/pull/484#issuecomment-5757990605).

## Why

An end-to-end run of the sanitizer-selection reward against nine real sanitizer scenarios answered `unknown` on eight of them and mislabelled the ninth. That is not the model hedging — **no correct label existed**. The old eight-name set had no name for an intra-kernel data race, for a NaN, or for an instrument that could not run.

The set is the contract the agent routes on, so a label that is constant across every example carries no training signal and those use cases are untrainable as things stand.

## What is in the diff

**The shared vocabulary, and the split.** `main`'s `EVIDENCE_ONLY_CATEGORIES` / `PROBE_CATEGORIES = AUTOPSY_CATEGORIES - EVIDENCE_ONLY_CATEGORIES` is kept unchanged. A probe agent reaches a category by changing something and seeing what moves, which cannot watch two waves collide or tell "the sanitizer found nothing" from "the sanitizer never ran".

**The derivation, composed with it.** `AUTOPSY_CATEGORIES` is derived from `AUTOPSY_CATEGORY_GUIDANCE`, a name → gloss mapping carrying all eleven names, rather than listed beside it. Several members are near neighbours (`checkpoint_race` vs `gpu_race`, `tooling_gap` vs `unknown`) and a bare list of names is not enough to choose between them, so a name cannot reach the validator without also reaching the reader. `_build_prompt` renders the glosses of the **probe subset only**, so the model is never shown a label it has no way to establish.

**Two dispatchers, both reordered by how much evidence each leg demands.** `_infer_category_from_detectors` and the newly-extracted `_infer_category_from_symptom` are parallel dispatchers over one taxonomy. A leg keyed on a generic word decides every input that merely contains it, so an accidental order silently downgrades the function's best answers to its vaguest — 28 shadowed pairs on the detector path and 24 on the symptom path, now zero on both. `barrier` also stopped routing intra-kernel evidence to a checkpoint-I/O label.

**Free-form detector IDs are read by word, not by substring.** `custom_patterns[*].id` is validated as "non-empty string" and nothing more, so `custom:nan:signature` and `custom:numerics/mismatch` are legal spellings that matched no leg. The three two-word signatures now split the ID on `[^a-z0-9]+` and test for adjacent words, per ID rather than over the joined list. That also removed `custom:chip_error` → `illegal_mem`, because "chip" ends in "hip".

**The probe downgrades an evidence-only reading to `unknown`.** Both dispatchers can legitimately reach `gpu_race` — a ConSan detector ID really does say one — but `validate_step` refuses it, so emitting one would raise `PolicyViolation` in `run_agent_loop` on a *correct* reading of the evidence. This costs no accuracy the probe was entitled to: before the widening, a ConSan race report reached `checkpoint_race` or `illegal_mem` through the broad legs, so it turns a wrong label into an honest one. Whether a sanitizer's detector ID should count as instrument evidence for this purpose is the open question on the second comment above.

**Corpus ground truth.** `examples/rl/corpus/scenario_labels.json` records the label a correct triage should name per scenario — keyed by scenario, because `build_corpus.py` regenerates the rows. It validates against the whole vocabulary, so it keeps the precise label the probe may not assert. `consan-tiny` and `consan-gemm` moved `unknown` → `tooling_gap`: ConSan was rejected before instrumenting the Tensile object, and found no admissible sites in `tiny_vecadd`.

**Reward — unchanged, deliberately.** `examples/rl/proposal_reward.py` imports `AUTOPSY_CATEGORIES` rather than restating it, so tier 3 picks up the new members on its own. It stays *membership*-sensitive rather than *correctness*-sensitive until labels are wired into scoring. This PR unblocks that work; it does not do it.

## `nondeterminism` is held out

It is a name this branch has and `main` does not, and it may be the one in the group that *is* probe-reachable: a probe establishes nondeterminism by repeating a cell and getting different verdicts, which is exactly what `PROBE_CATEGORIES` is for. Adding it means editing `test_the_probe_keeps_the_categories_it_could_always_reach`, which pins the probe subset by exact equality — so it is the CIA author's call, and it is asked rather than assumed.

The symptom leg is removed rather than left emitting a name outside the closed set. A test pins that all three spellings (`nondeterministic`, `non-deterministic`, `non deterministic`) fall through today and must route again if the name returns, so restoring it is one edit.

## Honest limits

Of the nine corpus scenarios, three are `gpu_race`, two are `tooling_gap`, and four are honestly `unknown` — all four zero-finding controls, where `unknown` is the correct answer rather than a gap.

So the corpus exercises two of the three evidence-only labels; **there is no `numeric_silent` scenario in it**. Sharing one vocabulary unblocks that at the contract level, but training signal for it needs a new scenario — re-labelling alone cannot produce one.

## Tests

`tests/agent/test_autopsy_categories.py` — **149 passed**. `tests/agent/` — **226 passed, 4 failed, 5 skipped**, the four being pre-existing `test_cli` `ValueError: stderr not separately captured` failures that fail identically on pristine `main`.

`main`'s own contract test, `tests/cia/test_probe_vocabulary.py`, is **32 passed** in the CIA lane — including every `TestTheOtherFrontDoorIsUnaffected` assertion, since `AUTOPSY_CATEGORIES` here is the same set as `main`'s name for name.

## CI note

Touches no `docker/**` and no `requirements*.txt`, so this does not pull `bump-validate`. It touches no `recipes`, `scripts` or `tests/sanitizers/*`, so it does not pull `workload regression` either.
