### PR TITLE
feat(tokenspeed): serve rollouts as well as benchmarks

### DIFF
--- a/docs/tokenspeed-serving.md
+++ b/docs/tokenspeed-serving.md
@@ -316,7 +316,13 @@ volume is a function of the recipe. `output_len` remains meaningful as the
 `max_tokens` **allowance** — a `generated_tokens_max` sitting exactly on it means
 the cap truncated the rollout rather than the model stopping.
 
-Metrics the mode adds:
+Metrics EOS-respecting generation adds — that is, `rollout: true`, or a
+`sharegpt` cell with `ignore_eos: false`. A cell that ignores EOS publishes none
+of them, and that condition is the point rather than a detail: under `ignore_eos`
+every completion is `output_len` long, so the whole table below would be the
+recipe read back with a standard deviation of zero beside it. It also means every
+existing `tokenspeed-serve-*` recipe, all of which hold OSL fixed, reports exactly
+the metric set it reported before this mode existed.
 
 | Metric | Meaning |
 |---|---|

--- a/docs/tokenspeed-serving.md
+++ b/docs/tokenspeed-serving.md
@@ -271,7 +271,9 @@ matter most:
 | `request_rate` | `inf` | The quoted string `"inf"` submits everything at once; an unquoted infinite float is rejected. See below. |
 | `warmup_steps` | `1` | Discarded bench steps. See below. |
 | `num_warmups` | `1` | Warmup requests *within* a bench step. |
-| `ignore_eos` | `true` | Holds OSL fixed so cells do equal work. `false` is only accepted for `sharegpt`; on `random` the bench CLI pins it regardless, so the combination is rejected. See below. |
+| `ignore_eos` | `true` (`false` under `rollout`) | Holds OSL fixed so cells do equal work. `false` is accepted for `sharegpt`, and on `random` only under `rollout`, which reaches it through the request payload. On plain `random` the bench CLI pins it regardless, so the combination is rejected. See below and [Rollout mode](#rollout-mode). |
+| `rollout` | `false` | Shape the load like an RL rollout. See [Rollout mode](#rollout-mode). |
+| `save_detailed` | `false` | Keep the export's per-request arrays. `true` by default under `rollout`. |
 | `work_dir` | `/tmp/ts-work-serve` | Must be node-local. Scratch and the HF cache are per-uid beneath it, at `<work_dir>/u<uid>`. See below. |
 | `hf_home` | `<work_dir>/u<uid>/hf` | Set it to share one pre-populated cache between users; see below for why that has to be deliberate. |
 | `hip_visible_devices` | unset | Which GPUs the container sees. A visibility filter, not an allocation. |
@@ -280,6 +282,87 @@ matter most:
 | `network` | `host` | See below. |
 | `port` / `control_port` | `auto` | Free ports, picked per trial. Explicit values must be in 1024..65535 and must differ. |
 | `gates` | none | Optional per-trial perf gates. |
+
+### Rollout mode
+
+`rollout: true` changes what the engine is asked to do per request rather than
+how hard it is pushed: `rollout_samples` sampled completions per prompt, at a
+temperature above zero, stopping on EOS. That is the load an RL post-training
+loop puts on an inference engine during its generation phase, and the difference
+that matters is that the number of tokens generated becomes a property of the
+policy instead of a number the recipe chose.
+
+The design, the cost model it supports, and where the RL loop itself would live
+are in [RL post-training](tokenspeed-rl-post-training.md). What follows is the
+configuration.
+
+| Key | Default | Notes |
+|---|---|---|
+| `rollout` | `false` | Enables the mode. The four keys below are rejected without it. |
+| `rollout_samples` | `4` | Completions per prompt — the `n` of the sampling API. Max 1024. |
+| `temperature` | `1.0` | In `(0, 2]`. Zero is rejected: it would draw the same greedy completion `n` times. |
+| `top_p` | unset | In `(0, 1]`. Left unset means the server's own. |
+| `min_mean_output_tokens` | `8` | Per-step floor on `total_output_tokens / completed`. `0` disables it. |
+
+The sampling keys are **rejected outside the mode** rather than ignored. Outside
+it no sampling parameters are sent at all, so a `temperature` in an ordinary
+serving recipe would have changed nothing while the trial published it as that
+cell's configuration.
+
+`ignore_eos` defaults to `false` under `rollout`, and an explicit `true` is
+refused. The two cannot both mean what they say: ignoring EOS pins every
+completion to `output_len`, so the run has no length distribution and its token
+volume is a function of the recipe. `output_len` remains meaningful as the
+`max_tokens` **allowance** — a `generated_tokens_max` sitting exactly on it means
+the cap truncated the rollout rather than the model stopping.
+
+Metrics the mode adds:
+
+| Metric | Meaning |
+|---|---|
+| `mean_output_tokens_per_request` | `total_output_tokens / completed`, meaned across steps. The reading to trust — computed from fields every export carries. |
+| `generated_tokens_p50` / `_p90` / `_p99` | Percentiles of per-request generated length, pooled across measured steps. Needs `save_detailed`. |
+| `generated_tokens_mean` / `_min` / `_max` / `_std` / `_count` | The rest of the distribution. |
+
+`generated_tokens_*` comes from the export's `output_lens` array, which the bench
+strips unless `--save-detailed` is passed — hence `save_detailed` defaulting on
+inside the mode. It is published only when *every* measured step carried the
+array, for the same reason the scalar aggregate requires that: a distribution
+pooled over whichever steps happened to have it would describe a subset while
+reading as the trial's.
+
+Three things about this mode are traps rather than settings, and all three are
+explained at length in [RL post-training](tokenspeed-rl-post-training.md#2-what-a-rollout-loop-needs-from-the-engine-and-what-tokenspeed-has):
+
+- **`ignore_eos` is forced on for `dataset: random` by the bench CLI itself**,
+  after argument parsing, regardless of the flags. EOS-respecting generation is
+  reachable only through the request body, which is why rollout mode sends
+  `ignore_eos: false` inside `--extra-body` and why that flag becomes owned in
+  this mode. It also means an existing `ignore_eos: false` cell on the random
+  dataset never respected EOS.
+- **`mean_output_tokens_per_request` is per request, not per sample.** Measured
+  on gfx950, the gateway's `usage.completion_tokens` sums across all `n` choices,
+  so the throughput figures cover the whole rollout — but that is one gateway
+  version's behaviour, and the name is true either way. Both rollout recipes keep
+  an `n=1` control cell so the ratio stays observable.
+- **On `dataset: random` the length distribution is an artifact of the cap.**
+  Random-token prompts give a model no reason to emit EOS, so every completion
+  runs to `output_len` and `generated_tokens_*` reads as a constant. Throughput
+  and the sample-count comparison are unaffected; the distribution needs prompts
+  a model would answer.
+- **TPOT and ITL are not per-token latencies under `n > 1`.** The bench client
+  concatenates all choices and treats every chunk gap as an inter-token interval.
+  TTFT and the throughputs stay meaningful.
+
+The served-request audit is unchanged — `completed` counts requests, not
+completions — but it stops being *sufficient*, which is what
+`min_mean_output_tokens` exists for: a policy that answers every request with an
+immediate EOS passes every other guard in the workload while generating about one
+token per prompt. Exit 56 / `rollout_output_too_short` is that verdict, checked in
+the container and again on the host.
+
+Recipes: `tokenspeed-serve-rollout-smoke.yaml` (the shape check to run first)
+and `tokenspeed-serve-rollout.yaml` (sample-count and long-form cells).
 
 ### Perf gates
 

--- a/recipes/tokenspeed/tokenspeed-serve-rollout-smoke.yaml
+++ b/recipes/tokenspeed/tokenspeed-serve-rollout-smoke.yaml
@@ -1,0 +1,67 @@
+# Shape check for rollout-mode serving. Run this before the full recipe.
+#
+# Two cells, eight prompts each, a 256-token allowance: small enough that the
+# run is dominated by model load rather than by generation, which is what makes
+# it a check on the plumbing instead of a measurement. What it establishes is
+# that sampled multi-completion requests reach the engine, that generation stops
+# on EOS rather than at `output_len`, and that the export carries the per-request
+# lengths the distribution is computed from.
+#
+#   aorta sweep run --recipe recipes/tokenspeed/tokenspeed-serve-rollout-smoke.yaml \
+#     --output-dir /tmp/ts-rollout-smoke
+#
+# The first thing to read is `mean_output_tokens_per_request` across the two
+# cells. Measured on gfx950 this comes out at 256 for `n=1` and 1024 for `n=4`,
+# which is how the gateway's `usage.completion_tokens` was established to sum
+# across all sampled choices -- no single choice can exceed its own 256-token
+# cap. A flat reading instead would mean the throughput figures describe one
+# sample per prompt rather than the whole rollout.
+#
+# The second is `generated_tokens_max`. Expect it at 256, and do not read that as
+# EOS being ignored: `dataset: random` prompts are random tokens, so nothing
+# induces an end-of-sequence token and every completion runs to the allowance.
+# EOS respect is real -- a direct probe returned `finish_reason: "stop"` at
+# variable lengths -- but this dataset cannot show it.
+schema_version: 1
+ticket: TOKENSPEED-SERVE-ROLLOUT-SMOKE
+workload: tokenspeed_serve
+trials: 1
+steps: 1
+
+workload_config:
+  # Digest, not the :nightly-20260714 tag it came from, for the reason every
+  # recipe here pins one: a registry can retarget a date tag.
+  image: lightseekorg/tokenspeed-amd@sha256:60c12e37c01496891053b9c30c4204e5d1cf9b4b641859d3aadcbd95bccc7c78
+  model: Qwen/Qwen3-0.6B
+
+  rollout: true
+  temperature: 1.0
+
+  input_len: 128
+  output_len: 256
+  num_prompts: 8
+  max_concurrency: 8
+
+  # No discarded step. A warmup doubles the run for a check that is not
+  # measuring anything, and the Triton-compilation outlier it exists to absorb
+  # only matters to a reported number.
+  warmup_steps: 0
+  num_warmups: 1
+  seed: 0
+  work_dir: /tmp/ts-work-serve
+  ready_timeout_sec: 1200
+
+cells:
+  # The control: one completion per prompt, so the only difference from the cell
+  # below is `n`.
+  - name: rollout-n1
+    mitigations: [none]
+    environment: local
+    workload_config:
+      rollout_samples: 1
+
+  - name: rollout-n4
+    mitigations: [none]
+    environment: local
+    workload_config:
+      rollout_samples: 4

--- a/recipes/tokenspeed/tokenspeed-serve-rollout.yaml
+++ b/recipes/tokenspeed/tokenspeed-serve-rollout.yaml
@@ -1,0 +1,136 @@
+# Rollout-shaped serving load: several sampled completions per prompt, stopping
+# on EOS.
+#
+# This is the load an RL post-training loop puts on an inference engine during
+# its generation phase, which is where such a loop spends most of its wall
+# clock. It differs from the other tokenspeed-serve recipes in what the engine
+# is asked to do rather than in how hard it is pushed: `rollout: true` sends
+# `n` sampled completions per prompt at a temperature above zero and lets the
+# model stop where it wants, so the number of tokens generated is a property of
+# the policy instead of a number this file chose.
+#
+#   aorta sweep run --recipe recipes/tokenspeed/tokenspeed-serve-rollout.yaml \
+#     --output-dir /tmp/ts-serve-rollout
+#
+# Reading the result: `output_throughput` and `total_token_throughput` in
+# `perf.md` are what bound a rollout iteration's duration, and the
+# `generated_tokens_p50` / `_p90` / `_p99` / `_max` columns are what size the KV
+# cache and set how long the slowest completion holds a batch open.
+# `mean_output_tokens_per_request` is the same quantity read from the always-
+# present counters, so it is the one to trust if the two disagree.
+#
+# The confound ratio in `matrix.md` is not meaningful here. Cells differ by
+# sample count and prompt shape, so they legitimately do different amounts of
+# work -- read `perf.md`.
+#
+# Two things to know before reading the numbers.
+#
+# On `dataset: random` the length distribution is not a property of the model.
+# The prompts are random tokens, so nothing induces an end-of-sequence token and
+# every completion runs to `output_len`; `generated_tokens_*` will read as a
+# constant at the cap. Throughput, the concurrency behaviour and the sample-count
+# comparison are all still valid -- those depend on the request shape rather than
+# on where generation stops. A distribution that means something needs prompts a
+# model would answer.
+#
+# The `samples-1` cell is a control, not a wasted one. The bench derives a
+# request's output length from the response's `usage.completion_tokens`, which
+# was measured on gfx950 to sum across all `n` choices -- so the throughput
+# figures here cover the whole rollout rather than one sample of it. That is one
+# gateway version's behaviour, and comparing `mean_output_tokens_per_request`
+# between this cell and `samples-4` is what keeps it observable if it changes.
+# The same comparison is also the per-completion cost of a larger group.
+schema_version: 1
+ticket: TOKENSPEED-SERVE-ROLLOUT
+workload: tokenspeed_serve
+trials: 1
+steps: 3
+
+workload_config:
+  # Digest, not the :nightly-20260714 tag it came from: a moving tag would let
+  # the image change underneath a blessed baseline while the recipe still read
+  # as pinned.
+  image: lightseekorg/tokenspeed-amd@sha256:60c12e37c01496891053b9c30c4204e5d1cf9b4b641859d3aadcbd95bccc7c78
+  # Qwen3-class, as named in the requirement, and the smallest of them: the
+  # point of this recipe is the load shape, and the shape is legible fastest on
+  # a model that loads in minutes rather than tens of them. Swap in a larger
+  # Qwen3 once the shape is trusted.
+  model: Qwen/Qwen3-0.6B
+
+  rollout: true
+  # 1.0 is the sampling temperature a GRPO-style rollout ordinarily draws at:
+  # the group of completions per prompt has to actually differ, or the advantage
+  # within the group is zero and the update carries no signal.
+  temperature: 1.0
+  top_p: 0.95
+
+  # Prompt shape. Short prompt, long allowance: a rollout's prompt is a task
+  # description and its completion is the work, which is the opposite of the
+  # prefill-heavy shape `tokenspeed-serve-load.yaml` measures.
+  input_len: 512
+  # An allowance, not a length. With EOS respected this is the `max_tokens` cap;
+  # the reported `generated_tokens_*` distribution is what the policy did with
+  # it, and a p99 sitting at this value means the cap is what truncated the
+  # rollout rather than the model.
+  output_len: 1024
+
+  # Concurrency 32 rather than the unbounded default. A rollout submits its
+  # whole batch of prompts at once and is bounded by aggregate throughput, so
+  # some cap is what keeps the engine in the regime the measurement is about --
+  # and 32 is on the part of the curve `tokenspeed-serve-load.yaml` measured as
+  # still returning throughput per unit of cap.
+  max_concurrency: 32
+
+  num_warmups: 1
+  warmup_steps: 1
+  seed: 0
+  work_dir: /tmp/ts-work-serve
+  # A rollout step generates far more tokens than a fixed 128-token benchmark
+  # step, so the per-step deadline has to cover it: 32 prompts x 4 samples x up
+  # to 1024 tokens is a different amount of decode from anything the other
+  # recipes ask for.
+  bench_timeout_sec: 3600
+  ready_timeout_sec: 1200
+
+cells:
+  # The control described in the header. Same prompts, same temperature, one
+  # completion each -- so the only difference from `samples-4` is `n`.
+  - name: samples-1
+    mitigations: [none]
+    environment: local
+    workload_config:
+      rollout_samples: 1
+      num_prompts: 32
+
+  # The rollout shape proper: a group of four sampled completions per prompt,
+  # which is the smallest group size a GRPO-style advantage is computed over.
+  - name: samples-4
+    mitigations: [none]
+    environment: local
+    workload_config:
+      rollout_samples: 4
+      num_prompts: 32
+
+  # Eight samples over half the prompts: the same number of completions as
+  # `samples-4`, reached with a larger group over fewer prompts. Which of the
+  # two costs less per completion is a scheduling question -- more samples per
+  # prompt share a prefill, more prompts do not -- and this is the pair that
+  # answers it.
+  - name: samples-8
+    mitigations: [none]
+    environment: local
+    workload_config:
+      rollout_samples: 8
+      num_prompts: 16
+
+  # Long-form generation, which is what a reasoning-style rollout produces. The
+  # 4096-token allowance is where the tail of the length distribution starts to
+  # matter to the KV cache rather than being absorbed by it.
+  - name: long-form
+    mitigations: [none]
+    environment: local
+    workload_config:
+      rollout_samples: 4
+      num_prompts: 16
+      input_len: 256
+      output_len: 4096

--- a/scripts/ci/eval_lib.py
+++ b/scripts/ci/eval_lib.py
@@ -61,6 +61,26 @@ _METRIC_POLICIES: dict[str, str] = {
     "output_throughput": "min",
     "total_token_throughput": "min",
     "request_throughput": "min",
+    # Rollout-mode generated-length metrics -- `mean_output_tokens_per_request`
+    # and the `generated_tokens_*` family -- are deliberately absent, and should
+    # stay absent. Listing a name here is not a description of it, it is an
+    # election to gate it: `refresh_baselines --perf-gate` arms a bound for every
+    # allowlisted min/max metric automatically, from one observation and a flat
+    # margin.
+    #
+    # These lengths are not a property of the stack. Under EOS-respecting
+    # generation at temperature 1.0 they are the policy's choice and vary between
+    # runs by construction, so a margin-derived floor would flap; and on the
+    # `random` dataset both rollout recipes use, nothing induces EOS, so the
+    # value is pinned near `output_len * n` and a floor under it would measure
+    # the recipe rather than the engine. Neither reading is a regression signal.
+    #
+    # The real invariant they were reaching for -- a collapsed policy that
+    # answers every request with an immediate EOS -- is already enforced in the
+    # workload by `min_mean_output_tokens`, a hand-set per-step floor that fails
+    # the trial as `rollout_output_too_short`. That is the right shape for it: a
+    # threshold someone chose, not one armed off a baseline. They remain captured
+    # for trends, which is what a diagnostic metric should get.
     "logits_checksum": "equal",
     "output_checksum": "equal",
     "checksum": "equal",

--- a/src/aorta/workloads/tokenspeed/ts_bench_serve.sh
+++ b/src/aorta/workloads/tokenspeed/ts_bench_serve.sh
@@ -30,6 +30,7 @@
 #   53  a bench step failed or timed out
 #   54  a bench step exported no parseable result JSON
 #   55  a bench step served fewer requests than asked (the silent-pass guard)
+#   56  a rollout step generated fewer tokens per request than the floor
 #   64  usage / environment error (missing tokenspeed CLI, bad config)
 #
 # Two ports, for the reason `ts_serve_probe.sh` documents at length: `tokenspeed
@@ -61,6 +62,19 @@
 #   TS_REQUEST_RATE       arrival rate, req/s             (default inf = all at once)
 #   TS_NUM_WARMUPS        untimed warmup requests         (default 1)
 #   TS_IGNORE_EOS         1 to hold OSL fixed             (default 1)
+#   TS_ROLLOUT            1 for RL-rollout-shaped load: several sampled
+#                         completions per prompt at temperature > 0, stopping
+#                         on EOS. Sends the sampling parameters as
+#                         --extra-body and reserves that flag  (default 0)
+#   TS_ROLLOUT_SAMPLES    completions per prompt, the `n` of the OpenAI
+#                         sampling API                    (rollout only)
+#   TS_TEMPERATURE        sampling temperature            (rollout only)
+#   TS_TOP_P              nucleus sampling mass, omitted when unset
+#   TS_MIN_MEAN_OUTPUT_TOKENS  floor on total_output_tokens/completed per
+#                         step, 0 to disable. Guards the collapsed-policy case
+#                         described at the audit below     (default 0)
+#   TS_SAVE_DETAILED      1 to keep the export's per-request arrays, which is
+#                         what carries `output_lens`       (default 0)
 #   TS_SEED               dataset/sampling seed           (default 0)
 #   TS_PERCENTILE_METRICS which metrics get percentiles   (default ttft,tpot,itl,e2el)
 #   TS_METRIC_PERCENTILES which percentiles               (default 50,90,99)
@@ -269,12 +283,37 @@ reject_owned_flags TS_SERVE_ARGS "${SERVE_EXTRA_ARGS[@]+"${SERVE_EXTRA_ARGS[@]}"
 # `--max-concurrency` and `--request-rate` are omitted entirely at their
 # defaults, so reserving only what is currently appended would leave the default
 # unguarded -- and the default is what most cells run.
-reject_owned_flags TS_BENCH_ARGS "${BENCH_EXTRA_ARGS[@]+"${BENCH_EXTRA_ARGS[@]}"}" -- \
-  --base-url --output-file --num-prompts --label --request-id-prefix \
-  --random-input-len --random-output-len --model --tokenizer --backend \
-  --endpoint --dataset-name --dataset-path --percentile-metrics \
-  --metric-percentiles \
+ROLLOUT="${TS_ROLLOUT:-0}"
+
+# The bench flags this script owns unconditionally. `--extra-body` is appended
+# to the list below only under rollout, and that conditionality is deliberate --
+# see the comment where it happens.
+declare -a OWNED_BENCH_FLAGS=(
+  --base-url --output-file --num-prompts --label --request-id-prefix
+  --random-input-len --random-output-len --model --tokenizer --backend
+  --endpoint --dataset-name --dataset-path --percentile-metrics
+  --metric-percentiles
   --max-concurrency --request-rate --num-warmups --ignore-eos --seed
+  --save-detailed
+)
+# Reserved exactly where this script generates one, and not otherwise.
+#
+# Everything else on the list above is reserved whether or not it is currently
+# appended, because the workload's setting is sometimes absence and a guard
+# covering only the configured case leaves the default one open. `--extra-body`
+# is the one flag where that reasoning inverts. Outside rollout this script
+# sends no sampling parameters at all, so there is no value for a caller's
+# `--extra-body` to shadow, and reserving it would forbid the only way to reach
+# a sampling knob -- a documented use of `bench_args`. Under rollout the
+# sampling body *is* what the host reports as `rollout_samples` and
+# `temperature`, so a caller's copy winning as the last occurrence would change
+# the completions actually generated while the trial kept publishing the
+# configured ones: a green cell describing a run that did not happen.
+if [ "${ROLLOUT}" = "1" ]; then
+  OWNED_BENCH_FLAGS+=( --extra-body )
+fi
+reject_owned_flags TS_BENCH_ARGS "${BENCH_EXTRA_ARGS[@]+"${BENCH_EXTRA_ARGS[@]}"}" -- \
+  "${OWNED_BENCH_FLAGS[@]}"
 
 READY_TIMEOUT="${TS_READY_TIMEOUT:-900}"
 BENCH_STEPS="${TS_BENCH_STEPS:-1}"
@@ -321,6 +360,9 @@ OUTPUT_LEN="${TS_OUTPUT_LEN:-128}"
 REQUEST_RATE="${TS_REQUEST_RATE:-inf}"
 NUM_WARMUPS="${TS_NUM_WARMUPS:-1}"
 IGNORE_EOS="${TS_IGNORE_EOS:-1}"
+ROLLOUT_SAMPLES="${TS_ROLLOUT_SAMPLES:-1}"
+MIN_MEAN_OUTPUT_TOKENS="${TS_MIN_MEAN_OUTPUT_TOKENS:-0}"
+SAVE_DETAILED="${TS_SAVE_DETAILED:-0}"
 SEED="${TS_SEED:-0}"
 PERCENTILE_METRICS="${TS_PERCENTILE_METRICS:-ttft,tpot,itl,e2el}"
 METRIC_PERCENTILES="${TS_METRIC_PERCENTILES:-50,90,99}"
@@ -338,11 +380,19 @@ CONTROL="http://127.0.0.1:${CONTROL_PORT}"
 # length while the caller believed EOS was being respected, and the export would
 # not say otherwise. Refuse instead, and name the one route that reaches it: the
 # request payload, since extra_body is merged over the forced value.
-if [ "${DATASET}" = "random" ] && [ "${IGNORE_EOS}" != "1" ]; then
+#
+# TS_ROLLOUT=1 is exempt because it takes that payload route itself: the body
+# built below always carries `"ignore_eos": false`, and rollout is the one mode
+# that reserves --extra-body against TS_BENCH_ARGS, so the value cannot be
+# shadowed. Under rollout the forced flag is overridden per request, so
+# TS_IGNORE_EOS=0 is the setting that ran rather than a mislabelling. Without
+# this exemption every rollout invocation would exit 64 here.
+if [ "${DATASET}" = "random" ] && [ "${IGNORE_EOS}" != "1" ] && [ "${ROLLOUT}" != "1" ]; then
   echo "TS_BENCH_FAIL: usage TS_IGNORE_EOS=${IGNORE_EOS} cannot take effect with TS_DATASET=random"
   echo "  The bench CLI forces ignore_eos on for the random dataset after it"
-  echo "  parses its arguments. Use TS_DATASET=sharegpt, or ask for it in the"
-  echo "  payload: TS_BENCH_ARGS='[\"--extra-body\",\"{\\\"ignore_eos\\\": false}\"]'"
+  echo "  parses its arguments. Use TS_DATASET=sharegpt, set TS_ROLLOUT=1, or"
+  echo "  ask for it in the payload:"
+  echo "  TS_BENCH_ARGS='[\"--extra-body\",\"{\\\"ignore_eos\\\": false}\"]'"
   exit 64
 fi
 
@@ -359,6 +409,69 @@ fi
 # once per second.
 require_uint TS_READY_TIMEOUT "${READY_TIMEOUT}" 1 86400
 require_uint TS_TEARDOWN_GRACE "${TEARDOWN_GRACE}" 5 3600
+
+# Rollout mode, validated here for the same reason the dataset is: this is all
+# configuration, and a configuration error found after the model has loaded costs
+# minutes and reads as a bench failure. A malformed temperature in particular
+# reaches the server per-request, so it would come back as every prompt failing
+# -- reported as a broken engine.
+#
+# A plain decimal only. Bash cannot compare floats, so these are checked by
+# shape here and by value on the host; accepting `1e0` or `.5` would leave the
+# two layers with different notions of what was configured, and the host's
+# reported temperature is what a rollout result is labelled with.
+require_decimal() {  # require_decimal <label> <value>
+  case "${2}" in
+    ''|*[!0-9.]*|*.*.*|.|*.)
+      echo "TS_BENCH_FAIL: usage ${1} must be a plain decimal number, got '${2}'"
+      echo "  Exponent and leading-dot forms are refused so this script and the"
+      echo "  host agree on the value the result is labelled with."
+      exit 64
+      ;;
+  esac
+}
+for pair in "TS_ROLLOUT=${ROLLOUT}" "TS_SAVE_DETAILED=${SAVE_DETAILED}"; do
+  if [ "${pair#*=}" != "0" ] && [ "${pair#*=}" != "1" ]; then
+    echo "TS_BENCH_FAIL: usage ${pair%%=*} must be 0 or 1, got '${pair#*=}'"
+    exit 64
+  fi
+done
+case "${MIN_MEAN_OUTPUT_TOKENS}" in
+  ''|*[!0-9]*)
+    echo "TS_BENCH_FAIL: usage TS_MIN_MEAN_OUTPUT_TOKENS must be a non-negative integer, got '${MIN_MEAN_OUTPUT_TOKENS}'"
+    exit 64
+    ;;
+esac
+if [ "${ROLLOUT}" = "1" ]; then
+  require_uint TS_ROLLOUT_SAMPLES "${ROLLOUT_SAMPLES}" 1 1024
+  # Required rather than defaulted. A rollout at temperature 0 draws the same
+  # greedy completion n times, so it costs n decodes and reports a length
+  # distribution with no variance in it -- the shape the mode produces, with
+  # none of the sampling that makes it a rollout. Defaulting would hide that;
+  # the host always sets it, so absence here means someone is running the script
+  # by hand and should say what they meant.
+  if [ -z "${TS_TEMPERATURE:-}" ]; then
+    echo "TS_BENCH_FAIL: usage TS_ROLLOUT=1 requires TS_TEMPERATURE"
+    echo "  A rollout samples; at temperature 0 the n completions per prompt are"
+    echo "  identical and the length distribution is an artifact of the decode."
+    exit 64
+  fi
+  require_decimal TS_TEMPERATURE "${TS_TEMPERATURE}"
+  if [ -n "${TS_TOP_P:-}" ]; then
+    require_decimal TS_TOP_P "${TS_TOP_P}"
+  fi
+  # `--ignore-eos` pins every completion to TS_OUTPUT_LEN, which is the opposite
+  # of what a rollout measures: real rollouts stop on EOS and their cost is the
+  # length distribution that produces. Combining the two would run a
+  # fixed-length benchmark and publish it as a rollout.
+  if [ "${IGNORE_EOS}" = "1" ]; then
+    echo "TS_BENCH_FAIL: usage TS_ROLLOUT=1 is incompatible with TS_IGNORE_EOS=1"
+    echo "  Ignoring EOS holds every completion at TS_OUTPUT_LEN, so the run"
+    echo "  would have no length distribution to report and the generated-token"
+    echo "  volume would be a function of the recipe rather than of the policy."
+    exit 64
+  fi
+fi
 
 # Whether one word is that flag, in any spelling argparse would accept for it:
 # exact, `=`-attached, or an abbreviation. `reject_owned_flags` already fails
@@ -696,6 +809,14 @@ bench_args=(
   --metric-percentiles "${METRIC_PERCENTILES}"
   --disable-tqdm
 )
+# Per-request arrays -- `output_lens` among them -- are stripped from the export
+# unless this is passed, so the length *distribution* a rollout is characterised
+# by is unavailable without it. Off by default because it also writes every
+# generated completion into the export, which is a size and a content decision a
+# fixed-length serving benchmark has no reason to make.
+if [ "${SAVE_DETAILED}" = "1" ]; then
+  bench_args+=( --save-detailed )
+fi
 # ISL/OSL are `random`-only knobs: the bench CLI maps them onto
 # --random-input-len/--random-output-len, and sharegpt takes its lengths from the
 # conversations themselves. Passing them for sharegpt would advertise a shape the
@@ -717,6 +838,44 @@ fi
 # the matrix compares cells that did not run the same benchmark.
 if [ "${IGNORE_EOS}" = "1" ]; then
   bench_args+=( --ignore-eos )
+fi
+# Rollout sampling. `--extra-body` is the only route to the per-request sampling
+# parameters: the bench CLI's own flags cover the load shape, not what the model
+# is asked to do with each prompt, so `n` and `temperature` have to travel in the
+# request body. Built with python3 rather than string-concatenated because the
+# result has to be JSON the CLI can parse, and a hand-built body that is subtly
+# malformed comes back as every request failing -- which reads as a broken
+# engine.
+#
+# `ignore_eos: false` is in the body for a reason that is not obvious and is not
+# optional. `tokenspeed bench serve` forces `args.ignore_eos = True` whenever the
+# dataset is `random` and the backend is OpenAI-compatible -- unconditionally,
+# after parsing, so neither omitting `--ignore-eos` nor passing
+# `--disable-ignore-eos` reaches it. On the random dataset the flag is therefore
+# not a way to ask for EOS-respecting generation at all. The body is: the request
+# builder writes `payload["ignore_eos"]` from that forced flag and *then* applies
+# extra_body over the payload, so the value here is the one the server receives.
+# Without it a rollout cell would run at a pinned output length while reporting
+# itself as EOS-respecting -- the mislabelled pass this file is organised
+# against, arriving from upstream rather than from a recipe.
+if [ "${ROLLOUT}" = "1" ]; then
+  EXTRA_BODY="$(TS_ROLLOUT_SAMPLES="${ROLLOUT_SAMPLES}" python3 -c '
+import json, os
+body = {
+    "n": int(os.environ["TS_ROLLOUT_SAMPLES"]),
+    "temperature": float(os.environ["TS_TEMPERATURE"]),
+    "ignore_eos": False,
+}
+top_p = os.environ.get("TS_TOP_P")
+if top_p:
+    body["top_p"] = float(top_p)
+print(json.dumps(body, sort_keys=True))
+')" || {
+    echo "TS_BENCH_FAIL: cannot build the rollout --extra-body"
+    exit 64
+  }
+  bench_args+=( --extra-body "${EXTRA_BODY}" )
+  echo "TS_BENCH_INFO: rollout=1 extra_body=${EXTRA_BODY} min_mean_output_tokens=${MIN_MEAN_OUTPUT_TOKENS}"
 fi
 
 overall=0
@@ -750,11 +909,11 @@ run_bench_step() {
 # and require that it actually served what we asked for. Echoes one of
 # OK / SHORTFALL / UNPARSEABLE for the caller to classify.
 audit_result_json() {
-  python3 - "$1" "${NUM_PROMPTS}" <<'PY'
+  python3 - "$1" "${NUM_PROMPTS}" "${MIN_MEAN_OUTPUT_TOKENS}" <<'PY'
 import json
 import sys
 
-path, expected = sys.argv[1], int(sys.argv[2])
+path, expected, min_mean_output = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
 try:
     with open(path, encoding="utf-8") as fh:
         doc = json.load(fh)
@@ -783,6 +942,36 @@ if type(completed) is not int or type(failed) is not int:
 if failed != 0 or completed != expected:
     print(f"SHORTFALL completed={completed} failed={failed} expected={expected}")
     raise SystemExit(0)
+
+# The counts above are necessary and, once EOS is respected, no longer
+# sufficient. With --ignore-eos every completion is TS_OUTPUT_LEN long, so a
+# served request is a known amount of work; without it the model decides, and a
+# policy that emits EOS immediately serves every request, fails none, and takes
+# real time doing it. Duration, TTFT and all three throughputs are then finite
+# and positive, so every other guard here and on the host passes, and the cell
+# goes green having generated roughly one token per prompt -- which for a
+# rollout is not a fast run, it is no run at all. That state is reachable in RL
+# for ordinary reasons (entropy collapse, a length penalty that overshot, a
+# tokenizer mismatch putting EOS first), which is why it gets a check rather
+# than a footnote.
+#
+# Mean rather than minimum, and from total_output_tokens rather than from a
+# per-request array, because those two fields are the ones every export version
+# carries. `output_lens` is used for the distribution the host reports, but it
+# is not depended on for the verdict.
+if min_mean_output > 0:
+    total_output = doc.get("total_output_tokens")
+    if not isinstance(total_output, int) or isinstance(total_output, bool):
+        print(f"UNPARSEABLE total_output_tokens={total_output!r}")
+        raise SystemExit(0)
+    mean_output = total_output / completed
+    if mean_output < min_mean_output:
+        print(
+            f"SHORTLEN mean_output_tokens={mean_output:.3f} "
+            f"floor={min_mean_output} total_output_tokens={total_output} "
+            f"completed={completed}"
+        )
+        raise SystemExit(0)
 
 thr = doc.get("output_throughput")
 ttft = doc.get("median_ttft_ms")
@@ -829,6 +1018,14 @@ for step in $(seq 1 "${WARMUP_STEPS}"); do
       tail -n 40 "${SERVER_LOG}" 2>/dev/null
       exit 55
       ;;
+    SHORTLEN*)
+      # Fatal in a warmup for the same reason a shortfall is: a step whose
+      # completions were one token long compiled and warmed almost none of the
+      # decode path the measured steps are about to be timed on.
+      echo "TS_BENCH_FAIL: warmup step ${step} rollout_output_too_short ${audit#SHORTLEN }"
+      tail -n 40 "${SERVER_LOG}" 2>/dev/null
+      exit 56
+      ;;
     *)
       echo "TS_BENCH_FAIL: warmup step ${step} result_json_unusable ${audit}"
       exit 54
@@ -873,6 +1070,11 @@ for step in $(seq 1 "${BENCH_STEPS}"); do
       echo "TS_BENCH_FAIL: step ${step} served_request_shortfall ${audit#SHORTFALL }"
       tail -n 40 "${SERVER_LOG}" 2>/dev/null
       overall=55
+      ;;
+    SHORTLEN*)
+      echo "TS_BENCH_FAIL: step ${step} rollout_output_too_short ${audit#SHORTLEN }"
+      tail -n 40 "${SERVER_LOG}" 2>/dev/null
+      overall=56
       ;;
     *)
       echo "TS_BENCH_FAIL: step ${step} result_json_unusable ${audit}"

--- a/src/aorta/workloads/tokenspeed/ts_bench_serve.sh
+++ b/src/aorta/workloads/tokenspeed/ts_bench_serve.sh
@@ -965,9 +965,23 @@ if failed != 0 or completed != expected:
 # per-request array, because those two fields are the ones every export version
 # carries. `output_lens` is used for the distribution the host reports, but it
 # is not depended on for the verdict.
+#
+# Non-positive is UNPARSEABLE here, not SHORTLEN, and the boundary matters
+# because the two verdicts route differently: SHORTLEN says a policy stopped
+# generating and UNPARSEABLE says the export cannot be read. The host draws it
+# in exactly this place -- its floor requires `total_output_tokens > 0` and
+# leaves every other shape to `result_json_unusable` -- so drawing it anywhere
+# else here would make the container announce a collapsed policy for a step the
+# host is about to call unreadable, and a reader would have to reconcile two
+# names for one defect. Every request completing while zero tokens were
+# generated is not a short answer; an immediate EOS is still a token.
 if min_mean_output > 0:
     total_output = doc.get("total_output_tokens")
-    if not isinstance(total_output, int) or isinstance(total_output, bool):
+    if (
+        not isinstance(total_output, int)
+        or isinstance(total_output, bool)
+        or total_output <= 0
+    ):
         print(f"UNPARSEABLE total_output_tokens={total_output!r}")
         raise SystemExit(0)
     mean_output = total_output / completed

--- a/src/aorta/workloads/tokenspeed/ts_bench_serve.sh
+++ b/src/aorta/workloads/tokenspeed/ts_bench_serve.sh
@@ -420,9 +420,15 @@ require_uint TS_TEARDOWN_GRACE "${TEARDOWN_GRACE}" 5 3600
 # shape here and by value on the host; accepting `1e0` or `.5` would leave the
 # two layers with different notions of what was configured, and the host's
 # reported temperature is what a rollout result is labelled with.
+# `.*` is the leading-dot case the message claims to refuse and, without a
+# pattern of its own, did not: `.5` has no non-decimal character, no second dot,
+# is not a bare `.` and does not end in one, so every other branch here lets it
+# through. The host never emits that spelling -- `format(0.5, "f")` is
+# `0.500000` -- so this only bites a hand-run, which is the case the check is
+# for.
 require_decimal() {  # require_decimal <label> <value>
   case "${2}" in
-    ''|*[!0-9.]*|*.*.*|.|*.)
+    ''|*[!0-9.]*|*.*.*|.|*.|.*)
       echo "TS_BENCH_FAIL: usage ${1} must be a plain decimal number, got '${2}'"
       echo "  Exponent and leading-dot forms are refused so this script and the"
       echo "  host agree on the value the result is labelled with."

--- a/src/aorta/workloads/tokenspeed_serve.py
+++ b/src/aorta/workloads/tokenspeed_serve.py
@@ -60,6 +60,7 @@ import shutil
 import signal
 import socket
 import stat
+import statistics
 import subprocess
 import threading
 import time
@@ -137,6 +138,21 @@ _VRAM_LEAK_THRESHOLD_BYTES = 8 * 1024**3
 _VRAM_RELEASE_TIMEOUT_SEC = 300
 _VRAM_RELEASE_POLL_SEC = 5
 
+_DEFAULT_ROLLOUT_SAMPLES = 4
+_DEFAULT_ROLLOUT_TEMPERATURE = 1.0
+# Mirrors ts_bench_serve.sh's `require_uint TS_ROLLOUT_SAMPLES ... 1 1024`.
+_MAX_ROLLOUT_SAMPLES = 1024
+# The OpenAI sampling API's documented range, which is what the gateway
+# implements. A value outside it is rejected per-request by the server, so every
+# prompt fails and the trial reports a serving failure for a recipe error.
+_MAX_ROLLOUT_TEMPERATURE = 2.0
+# A rollout whose completions average fewer tokens than this did not roll
+# anything out -- see the audit in _build_result for the failure it catches. 8 is
+# far below any completion worth training on and far above the 1-2 tokens a
+# collapsed policy produces, so it separates the two without being a judgement
+# about what a good length is.
+_DEFAULT_MIN_MEAN_OUTPUT_TOKENS = 8
+
 _DEFAULT_DATASET = "random"
 # `random` generates its own prompts, so it is the only one that needs nothing
 # staged; `sharegpt` measures against real conversation lengths, which is what
@@ -168,6 +184,7 @@ _EXIT_REASONS: dict[int, str] = {
     53: "bench_step_failed",
     54: "result_json_unusable",
     55: "served_request_shortfall",
+    56: "rollout_output_too_short",
     64: "usage_error",
 }
 
@@ -188,6 +205,12 @@ _KNOWN_KEYS = frozenset(
         "request_rate",
         "num_warmups",
         "ignore_eos",
+        "rollout",
+        "rollout_samples",
+        "temperature",
+        "top_p",
+        "min_mean_output_tokens",
+        "save_detailed",
         "seed",
         "percentile_metrics",
         "metric_percentiles",
@@ -265,6 +288,19 @@ _PROTOCOL_ENV_KEYS = frozenset(
         "TS_OUTPUT_LEN",
         "TS_NUM_WARMUPS",
         "TS_IGNORE_EOS",
+        # The rollout family. Every one of these is either read back to label
+        # the result (`rollout_samples`, `temperature`, `top_p`) or decides a
+        # verdict the host also computes (`TS_MIN_MEAN_OUTPUT_TOKENS`), so a
+        # mitigation setting one would sample differently from what the trial
+        # reports, or audit against a floor the host does not know. `TS_ROLLOUT`
+        # and `TS_SAVE_DETAILED` are absent-when-off, which is the default, so
+        # the computed set cannot reach them.
+        "TS_ROLLOUT",
+        "TS_ROLLOUT_SAMPLES",
+        "TS_TEMPERATURE",
+        "TS_TOP_P",
+        "TS_MIN_MEAN_OUTPUT_TOKENS",
+        "TS_SAVE_DETAILED",
         # Absent when unbounded, which is the default -- so this is the one key
         # the computed set cannot reach on a default configuration.
         "TS_MAX_CONCURRENCY",
@@ -379,6 +415,25 @@ def _mean(values: list[float]) -> float:
     return sum(values) / len(values)
 
 
+def _percentile(ordered: list[float], pct: float) -> float:
+    """Linear-interpolated percentile of an already-sorted list.
+
+    Interpolated rather than nearest-rank to match ``numpy.percentile``'s
+    default, which is what ``tokenspeed bench serve`` computes its own
+    ``p50``/``p90``/``p99`` with. Two conventions in one ``perf.md`` table would
+    make the generated-length percentiles differ from the latency percentiles
+    beside them by an artifact of this function.
+    """
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * pct / 100.0
+    low = math.floor(position)
+    high = math.ceil(position)
+    if low == high:
+        return ordered[low]
+    return ordered[low] + (ordered[high] - ordered[low]) * (position - low)
+
+
 class TokenSpeedServeWorkload(Workload):
     """Benchmark a TokenSpeed serving endpoint and report serving metrics.
 
@@ -411,11 +466,35 @@ class TokenSpeedServeWorkload(Workload):
             reach readiness (default: ``ready_timeout_sec``). TokenSpeed's own
             default is 60s, which a cold start exceeds.
         ignore_eos: hold OSL fixed so every cell does the same work
-            (default ``True``). ``False`` is only accepted for
-            ``dataset: sharegpt``: the bench CLI forces it back on for the
-            random dataset after parsing, so the setting could not have taken
-            effect. Use ``bench_args: ["--extra-body", '{"ignore_eos":
-            false}']`` to reach it on ``random``.
+            (default ``True``, or ``False`` under ``rollout``, where an
+            explicit ``True`` is rejected as a contradiction). Outside
+            ``rollout``, ``False`` is only accepted for ``dataset: sharegpt``:
+            the bench CLI forces it back on for the random dataset after
+            parsing, so the setting could not have taken effect. Use
+            ``bench_args: ["--extra-body", '{"ignore_eos": false}']`` to reach
+            it on ``random``. Under ``rollout`` the workload already sends that
+            payload itself, so ``False`` takes effect on ``random`` and is
+            reported truthfully.
+        rollout: shape the load like an RL rollout instead of like a serving
+            benchmark (default ``False``): ``rollout_samples`` sampled
+            completions per prompt at ``temperature``, stopping on EOS, with
+            the generated-length distribution reported and audited against
+            ``min_mean_output_tokens``. The four keys below require it.
+        rollout_samples: completions per prompt, the ``n`` of the sampling API
+            (default ``4``, max ``1024``).
+        temperature: sampling temperature, in ``(0, 2]`` (default ``1.0``).
+            Zero is rejected: it would draw the same greedy completion
+            ``rollout_samples`` times.
+        top_p: nucleus sampling mass in ``(0, 1]`` (default: unset, i.e. the
+            server's own).
+        min_mean_output_tokens: per-step floor on
+            ``total_output_tokens / completed``; ``0`` disables it (default
+            ``8``). Catches the policy that answers every request with an
+            immediate EOS, which passes every other guard here.
+        save_detailed: keep the export's per-request arrays (default ``False``,
+            or ``True`` under ``rollout``). ``output_lens`` is what the
+            ``generated_tokens_*`` distribution is computed from, and the
+            export omits it otherwise.
         seed: dataset/sampling seed (default ``0``).
         percentile_metrics: which metrics get percentiles
             (default ``"ttft,tpot,itl,e2el"``).
@@ -541,7 +620,9 @@ class TokenSpeedServeWorkload(Workload):
             cfg.get("request_rate", _DEFAULT_REQUEST_RATE)
         )
 
-        self._ignore_eos = self._bool("ignore_eos", True)
+        # Resolves `_rollout` and `_ignore_eos` together, so both are settled
+        # before the guard below reads them.
+        self._validated_rollout()
         # `random` pins the output length whatever the argv says. `tokenspeed
         # bench serve` sets `ignore_eos = True` for the random dataset on an
         # OpenAI-compatible backend *after* parsing, which is after it has
@@ -551,16 +632,28 @@ class TokenSpeedServeWorkload(Workload):
         # length: the reported configuration is not the one that ran, which is
         # the mislabelled pass the owned-flag guards exist to prevent. The
         # payload route does work -- `extra_body` is applied over the forced
-        # value, and `--extra-body` is not a flag this workload reserves -- so
-        # the message names it rather than only refusing.
-        if self._dataset == _DEFAULT_DATASET and not self._ignore_eos:
+        # value -- so the message names it rather than only refusing.
+        #
+        # Rollout is exempt because it *is* that payload route. It always sends
+        # an extra_body carrying `ignore_eos: false`, and it is the one mode
+        # that reserves `--extra-body` in the owned-flag set, so no `bench_args`
+        # copy can shadow it as a later occurrence. Under rollout the forced
+        # flag is overridden on every request, which makes the reported
+        # `ignore_eos: false` the setting that actually ran -- so here the guard
+        # would reject the one configuration where the value is truthful, and
+        # every rollout recipe would raise at setup().
+        if (
+            self._dataset == _DEFAULT_DATASET
+            and not self._ignore_eos
+            and not self._rollout
+        ):
             raise ValueError(
                 "tokenspeed_serve: ignore_eos: false cannot take effect with "
                 "dataset: random. The bench CLI forces EOS to be ignored for "
                 "that dataset after parsing its arguments, so the trial would "
                 "report a setting the run did not have. Use dataset: sharegpt, "
-                "or ask for it in the request payload with bench_args: "
-                "[\"--extra-body\", '{\"ignore_eos\": false}']."
+                "or rollout: true, or ask for it in the request payload with "
+                "bench_args: [\"--extra-body\", '{\"ignore_eos\": false}']."
             )
 
         self._run_as_current_user = self._bool("run_as_current_user", True)
@@ -847,6 +940,142 @@ class TokenSpeedServeWorkload(Workload):
         value = self.config.get(key, default)
         if not isinstance(value, bool):
             raise ValueError(f"tokenspeed_serve: {key} must be a bool, got {type(value).__name__}")
+        return value
+
+    def _validated_rollout(self) -> None:
+        """Resolve rollout mode, and ``ignore_eos`` along with it.
+
+        Rollout mode changes what the benchmark measures: several sampled
+        completions per prompt, at a temperature above zero, stopping on EOS.
+        The generated-token volume then depends on the policy rather than on the
+        recipe, which is the property an RL rollout loop is bounded by and the
+        reason the mode exists.
+
+        The sampling keys are rejected outside the mode rather than ignored.
+        Outside it this workload sends no sampling parameters at all, so a
+        ``temperature`` in the recipe would have no effect while the trial
+        published it as configuration -- a cell labelled with a sampling setting
+        that never reached the server, which is the same mislabelled result the
+        owned-flag guards exist to prevent, arriving from a key that reads as
+        supported.
+        """
+        cfg = self.config
+        self._rollout = self._bool("rollout", False)
+
+        rollout_only = ("rollout_samples", "temperature", "top_p", "min_mean_output_tokens")
+        if not self._rollout:
+            present = [key for key in rollout_only if key in cfg]
+            if present:
+                raise ValueError(
+                    f"tokenspeed_serve: {', '.join(present)} require rollout: true. "
+                    "Outside rollout mode no sampling parameters are sent to the "
+                    "server, so these would be reported as this cell's "
+                    "configuration without having affected the run."
+                )
+
+        # `ignore_eos` defaults the other way under rollout, and an explicit
+        # `true` is a contradiction rather than a preference: ignoring EOS pins
+        # every completion to `output_len`, so the run would have no length
+        # distribution and its token volume would be a function of the recipe.
+        # Publishing that as a rollout measurement is the failure; running it is
+        # only the cause.
+        ignore_eos_default = not self._rollout
+        self._ignore_eos = self._bool("ignore_eos", ignore_eos_default)
+        if self._rollout and self._ignore_eos:
+            raise ValueError(
+                "tokenspeed_serve: rollout: true is incompatible with "
+                "ignore_eos: true. A rollout's cost is the length distribution "
+                "EOS-respecting generation produces; holding every completion at "
+                "output_len removes it and measures a fixed-length benchmark "
+                "instead. Omit ignore_eos (it defaults to false under rollout)."
+            )
+
+        if not self._rollout:
+            self._rollout_samples = 1
+            self._temperature: float | None = None
+            self._top_p: float | None = None
+            self._min_mean_output_tokens = 0
+            self._save_detailed = self._bool("save_detailed", False)
+            return
+
+        self._rollout_samples = self._bounded_int(
+            "rollout_samples", _DEFAULT_ROLLOUT_SAMPLES, maximum=_MAX_ROLLOUT_SAMPLES
+        )
+        # Strictly above zero. At temperature 0 the `n` completions per prompt
+        # are the same greedy decode repeated, so the run reports a length
+        # distribution with no variance in it and a sample count that multiplies
+        # the work without diversifying it -- a benchmark of `n` identical
+        # decodes, published as a rollout.
+        self._temperature = self._validated_positive_float(
+            "temperature", _DEFAULT_ROLLOUT_TEMPERATURE, maximum=_MAX_ROLLOUT_TEMPERATURE
+        )
+        self._top_p = (
+            None
+            if cfg.get("top_p") is None
+            else self._validated_positive_float("top_p", 1.0, maximum=1.0)
+        )
+        self._min_mean_output_tokens = self._non_negative_int(
+            "min_mean_output_tokens", _DEFAULT_MIN_MEAN_OUTPUT_TOKENS
+        )
+        # `output_len` becomes the request's `max_tokens` cap, so a floor above
+        # it describes a length the server is not permitted to generate. Such a
+        # recipe cannot pass, and it would fail as `rollout_output_too_short` --
+        # reading as a collapsed policy rather than as the arithmetic error it
+        # is. Only checked for `random`, the one dataset whose lengths the recipe
+        # sets.
+        if (
+            self._dataset == _DEFAULT_DATASET
+            and self._min_mean_output_tokens > self._output_len
+        ):
+            raise ValueError(
+                f"tokenspeed_serve: min_mean_output_tokens "
+                f"({self._min_mean_output_tokens}) exceeds output_len "
+                f"({self._output_len}), which caps each completion's max_tokens. "
+                "No run could satisfy this floor, and the trial would fail as "
+                "though the policy had collapsed."
+            )
+        # Defaulted on under rollout: the per-request `output_lens` array the
+        # export only carries with `--save-detailed` is what the length
+        # distribution is computed from, and that distribution is most of what
+        # distinguishes a rollout measurement from a throughput one.
+        self._save_detailed = self._bool("save_detailed", True)
+
+    def _validated_positive_float(self, key: str, default: float, *, maximum: float) -> float:
+        """A float in ``(0, maximum]``, spelled the way the script will accept.
+
+        ``bool`` is excluded for the reason it is everywhere else in this file:
+        it is an ``int`` subclass, so ``temperature: true`` would run at 1.0 and
+        report it as though someone had written it.
+
+        Non-finite values are excluded because they reach the server as JSON
+        that strict readers reject, and because ``inf`` is not a temperature --
+        it would be rejected per-request and surface as every prompt failing.
+        """
+        raw = self.config.get(key, default)
+        if isinstance(raw, bool):
+            raise ValueError(
+                f"tokenspeed_serve: {key} must be a number, got the boolean "
+                f"{raw!r}; `bool` is an int subclass in Python, so this would "
+                "silently run as 1.0 or 0.0."
+            )
+        if not isinstance(raw, (int, float, str)):
+            raise ValueError(
+                f"tokenspeed_serve: {key} ({raw!r}) must be a number, got "
+                f"{type(raw).__name__}"
+            )
+        try:
+            value = float(raw)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"tokenspeed_serve: {key} ({raw!r}) must be a number") from exc
+        if not math.isfinite(value):
+            raise ValueError(
+                f"tokenspeed_serve: {key} ({raw!r}) must be a finite number in "
+                f"(0, {maximum}]"
+            )
+        if not 0 < value <= maximum:
+            raise ValueError(
+                f"tokenspeed_serve: {key} ({value}) must be in (0, {maximum}]"
+            )
         return value
 
     def _validated_request_rate(self, value: Any) -> str:
@@ -1263,6 +1492,21 @@ class TokenSpeedServeWorkload(Workload):
             env["TS_DATASET_PATH"] = _CONTAINER_DATASET_PATH
         if self._max_concurrency is not None:
             env["TS_MAX_CONCURRENCY"] = str(self._max_concurrency)
+        if self._save_detailed:
+            env["TS_SAVE_DETAILED"] = "1"
+        if self._rollout:
+            env["TS_ROLLOUT"] = "1"
+            env["TS_ROLLOUT_SAMPLES"] = str(self._rollout_samples)
+            # `format(..., "f")` rather than `str()` or `repr()`: those render a
+            # small value in exponent form (`str(1e-05)` is `'1e-05'`), and the
+            # script's `require_decimal` refuses that spelling so the two layers
+            # cannot disagree about the value the result is labelled with. A
+            # recipe passing the host and then exiting 64 in the container is the
+            # failure this avoids.
+            env["TS_TEMPERATURE"] = format(float(self._temperature or 0.0), "f")
+            if self._top_p is not None:
+                env["TS_TOP_P"] = format(float(self._top_p), "f")
+            env["TS_MIN_MEAN_OUTPUT_TOKENS"] = str(self._min_mean_output_tokens)
         # JSON, not a space-joined string. The recipe documents these as lists,
         # and joining them threw the boundaries away: one item containing a
         # space arrived as two arguments, and a `*` or `?` in a value was
@@ -2095,12 +2339,18 @@ class TokenSpeedServeWorkload(Workload):
         # average and an absent or zero value is correct, not a fault.
         #
         # Which source answers that depends on whether the configuration
-        # actually determines the output length. `random` does: the recipe pins
-        # the length and EOS is ignored -- forced on by the bench CLI and
-        # required to be so by validation above -- which holds it there, so
-        # `output_len` is exact. The `_ignore_eos` half of the condition is
-        # therefore redundant today and kept as the statement of what the branch
-        # depends on.
+        # actually determines the output length. `random` does *when EOS is
+        # ignored*: the recipe pins the length and the bench CLI forces EOS to be
+        # ignored, which holds it there, so `output_len` is exact.
+        #
+        # The `_ignore_eos` half of this condition used to be unreachable, and
+        # was kept only as a statement of what the branch depended on. Rollout
+        # makes it load-bearing: it runs on `random` with `_ignore_eos` false,
+        # reaching the forced flag through the request body, so its lengths come
+        # from the policy and not from `output_len`. Deciding from `output_len`
+        # there would require TPOT of a rollout whose completions may all be a
+        # single token. The condition already routes rollout to the export-based
+        # branch below, which is the correct source for it.
         #
         # ShareGPT does not. It takes its lengths from the conversations and the
         # bench CLI never sees `output_len` at all, and with `ignore_eos: false`
@@ -2561,6 +2811,66 @@ class TokenSpeedServeWorkload(Workload):
                         ),
                     }
                 )
+            # The rollout floor, re-checked here for the same reason the counts
+            # are: the script owns the fast verdict, but this class must not
+            # publish a rollout's throughput and length numbers on the strength
+            # of the script's exit code alone.
+            #
+            # This is the guard the served-request audit above stops being
+            # sufficient for once EOS is respected. `completed == num_prompts`
+            # and `failed == 0` say every request was answered; they say nothing
+            # about whether anything was generated. A policy that emits EOS
+            # immediately satisfies both, produces positive duration, TTFT and
+            # throughput, and so passes every other check in this file -- while
+            # having generated about one token per prompt. For a fixed-length
+            # serving benchmark that state is unreachable, which is why the
+            # audit did not cover it; for a rollout it is a routine RL failure
+            # (entropy collapse, an overshooting length penalty, a tokenizer
+            # whose EOS lands first) and the cell would go green calling it
+            # throughput.
+            if self._rollout and self._min_mean_output_tokens > 0:
+                total_output = record.doc.get("total_output_tokens")
+                # Only compare when there is a number to compare. Every other
+                # shape of `total_output_tokens` -- absent, non-numeric, boolean,
+                # zero, negative -- is already reported as `result_json_unusable`
+                # by `_missing_core_metrics` below, which requires this field
+                # unconditionally under rollout: rollout forces `_ignore_eos`
+                # false, and that is precisely the branch which adds it to the
+                # required set.
+                #
+                # Checking it here as well produced two failure_details for one
+                # broken export, and at zero it was worse than redundant -- the
+                # floor announced a policy that had stopped generating, when
+                # `total_output_tokens: 0` alongside completed requests is an
+                # unreadable measurement rather than a collapsed policy. The
+                # audit owns "we could not read it"; the floor owns "we read it
+                # and it is too short".
+                if (
+                    type(total_output) is int
+                    and total_output > 0
+                    and type(completed) is int
+                    and completed > 0
+                ):
+                    mean_output = total_output / completed
+                    if mean_output < self._min_mean_output_tokens:
+                        failure_details.append(
+                            {
+                                "reason": "rollout_output_too_short",
+                                "step": record.step,
+                                "detail": (
+                                    f"mean_output_tokens={mean_output:.3f} is below "
+                                    f"min_mean_output_tokens="
+                                    f"{self._min_mean_output_tokens} "
+                                    f"(total_output_tokens={total_output}, "
+                                    f"completed={completed}). Every request was "
+                                    "served, so this is a policy that stopped "
+                                    "generating rather than a serving failure."
+                                ),
+                                "mean_output_tokens": mean_output,
+                                "floor": self._min_mean_output_tokens,
+                            }
+                        )
+
             missing = self._missing_core_metrics(record)
             if missing:
                 failure_details.append(
@@ -2658,6 +2968,15 @@ class TokenSpeedServeWorkload(Workload):
             "request_rate": self._request_rate,
             "num_warmups": self._num_warmups,
             "ignore_eos": self._ignore_eos,
+            "rollout": self._rollout,
+            # `None` outside rollout rather than 1 and 0: the workload sends no
+            # sampling parameters there, so a number here would describe a
+            # setting the server was never told. `None` reads as not-applicable
+            # in the trial JSON and is skipped by the perf aggregate, the same
+            # convention `input_len` uses under ShareGPT.
+            "rollout_samples": self._rollout_samples if self._rollout else None,
+            "temperature": self._temperature,
+            "top_p": self._top_p,
             "bench_steps": self._steps,
             "warmup_steps": self._warmup_steps,
             # Strings, deliberately. The matrix aggregates every numeric metric
@@ -2717,6 +3036,8 @@ class TokenSpeedServeWorkload(Workload):
             r.doc["failed"] for r in records if type(r.doc.get("failed")) is int
         )
 
+        self._add_generated_length_metrics(metrics, records)
+
         # Alias to the name AORTA's CI gating allowlist already knows, so a
         # nightly baseline can gate serving throughput without the allowlist
         # having to learn TokenSpeed's spelling. Only this one aliases cleanly:
@@ -2731,6 +3052,75 @@ class TokenSpeedServeWorkload(Workload):
         metrics["steps"] = [_step_detail(r) for r in records]
         metrics["result_files"] = [str(r.path) for r in records]
         return metrics
+
+    def _add_generated_length_metrics(
+        self, metrics: dict[str, Any], records: list[_StepRecord]
+    ) -> None:
+        """How long the completions actually were, and how spread out.
+
+        Under ``ignore_eos`` this is a constant the recipe already published, so
+        it says nothing. Once EOS is respected it is the measurement: an RL
+        rollout's cost per iteration is the number of tokens the policy chooses
+        to generate, and the tail of that distribution is what sizes the KV
+        cache and sets how long the slowest prompt in a batch holds the step
+        open. A mean alone hides that -- a batch of short completions and one
+        4000-token outlier averages to something unremarkable.
+
+        Two sources, deliberately kept apart because they have different
+        reliability:
+
+        ``mean_output_tokens_per_request`` comes from ``total_output_tokens`` and
+        ``completed``, which every export version carries. It is the number to
+        trust. It is *per request*, not per sample, and that distinction is not
+        cosmetic under ``rollout_samples > 1``: the bench derives a request's
+        output length from the response's ``usage.completion_tokens``, and
+        whether the gateway reports that summed over all ``n`` choices or only
+        for the first is the server's decision, not something this workload can
+        read. Naming the metric per-request keeps it true either way. The
+        rollout recipe carries an ``n=1`` control cell so the ratio between the
+        two readings is measurable rather than assumed.
+
+        ``generated_tokens_*`` comes from the export's per-request ``output_lens``
+        array, which is only present with ``save_detailed``. Published only when
+        *every* measured step carries it, matching the rule the scalar aggregate
+        follows: a distribution pooled over whichever steps happened to have the
+        array would describe a subset while reading as the trial's.
+        """
+        per_request: list[float] = []
+        for record in records:
+            total_output = record.doc.get("total_output_tokens")
+            completed = record.doc.get("completed")
+            if _is_scalar(total_output) and type(completed) is int and completed > 0:
+                per_request.append(float(total_output) / completed)
+        if per_request and len(per_request) == len(records):
+            metrics["mean_output_tokens_per_request"] = _mean(per_request)
+
+        pooled: list[float] = []
+        for record in records:
+            lens = record.doc.get("output_lens")
+            if not isinstance(lens, list):
+                return
+            # A zero is what the bench records for a request that failed, and
+            # `failed == 0` is audited independently, so a zero here means the
+            # two disagree. Kept rather than filtered: silently dropping it
+            # would raise every percentile and make a partly-failed step read as
+            # a healthy one.
+            step_lens = [float(v) for v in lens if _is_scalar(v)]
+            if len(step_lens) != len(lens):
+                return
+            pooled.extend(step_lens)
+        if not pooled:
+            return
+
+        pooled.sort()
+        metrics["generated_tokens_count"] = float(len(pooled))
+        metrics["generated_tokens_mean"] = _mean(pooled)
+        metrics["generated_tokens_min"] = pooled[0]
+        metrics["generated_tokens_max"] = pooled[-1]
+        if len(pooled) > 1:
+            metrics["generated_tokens_std"] = statistics.stdev(pooled)
+        for pct in (50, 90, 99):
+            metrics[f"generated_tokens_p{pct}"] = _percentile(pooled, pct)
 
     def _check_gates(self, metrics: dict[str, Any]) -> list[dict[str, Any]]:
         failures: list[dict[str, Any]] = []

--- a/src/aorta/workloads/tokenspeed_serve.py
+++ b/src/aorta/workloads/tokenspeed_serve.py
@@ -3036,7 +3036,16 @@ class TokenSpeedServeWorkload(Workload):
             r.doc["failed"] for r in records if type(r.doc.get("failed")) is int
         )
 
-        self._add_generated_length_metrics(metrics, records)
+        # Only where the lengths are a measurement rather than a restatement of
+        # the recipe -- see the docstring. Written as a condition here, rather
+        # than as an early return inside, because the reachability is the point:
+        # every configuration that ignores EOS, which is the default and what
+        # every `tokenspeed-serve-*` recipe on main sets, reports exactly the
+        # metric set it reported before this mode existed. A pinned-length
+        # benchmark whose published metric set grew would have to be re-baselined
+        # for a number that is `output_len` spelled differently.
+        if not self._ignore_eos:
+            self._add_generated_length_metrics(metrics, records)
 
         # Alias to the name AORTA's CI gating allowlist already knows, so a
         # nightly baseline can gate serving throughput without the allowlist
@@ -3058,8 +3067,10 @@ class TokenSpeedServeWorkload(Workload):
     ) -> None:
         """How long the completions actually were, and how spread out.
 
-        Under ``ignore_eos`` this is a constant the recipe already published, so
-        it says nothing. Once EOS is respected it is the measurement: an RL
+        Called only when EOS is respected, which the caller decides. Under
+        ``ignore_eos`` every completion is ``output_len`` long, so all of this
+        would be the recipe read back with a standard deviation of zero beside
+        it. Once EOS is respected it is the measurement: an RL
         rollout's cost per iteration is the number of tokens the policy chooses
         to generate, and the tail of that distribution is what sizes the KV
         cache and sets how long the slowest prompt in a batch holds the step
@@ -3113,7 +3124,12 @@ class TokenSpeedServeWorkload(Workload):
             return
 
         pooled.sort()
-        metrics["generated_tokens_count"] = float(len(pooled))
+        # An `int`, unlike its float-valued neighbours: it is a population size,
+        # not a measurement, and every other count this repo publishes
+        # (`completed_total` here, `rocprof_kernel_count`, `proton_kernel_count`)
+        # is an integer in the trial JSON. The perf aggregate floats it either
+        # way, so this only decides what a JSON consumer reads.
+        metrics["generated_tokens_count"] = len(pooled)
         metrics["generated_tokens_mean"] = _mean(pooled)
         metrics["generated_tokens_min"] = pooled[0]
         metrics["generated_tokens_max"] = pooled[-1]

--- a/tests/workloads/test_tokenspeed_serve.py
+++ b/tests/workloads/test_tokenspeed_serve.py
@@ -1514,6 +1514,126 @@ def test_the_default_image_is_digest_pinned():
     assert "@sha256:" in mod._DEFAULT_IMAGE
 
 
+# The numeric metrics `tokenspeed-serve-bench-smoke.yaml` publishes. Only these
+# reach `matrix.json::cells[*].metrics_summary` -- `_aggregate_metrics` keeps
+# finite int/float values and drops strings, bools, `None`, lists and dicts --
+# and `scripts/ci/eval_lib.py::extract_metrics` copies that summary verbatim into
+# the nightly's `results/<date>.json`. So this tuple is the set of series the
+# `tokenspeed_serve_smoke` baseline accumulates, and a name arriving in or
+# leaving it is a change to what the nightly banks.
+#
+# Frozen rather than derived because deriving it from the code under test would
+# assert nothing. Adding a metric to this workload is fine; adding one that the
+# *fixed-length* recipe also publishes means the nightly's series set changed,
+# and during a record-only baseline window that is not a neutral act. Update
+# this tuple deliberately, and not while a window is open.
+_SMOKE_NUMERIC_METRICS = (
+    "completed_total",
+    "container_elapsed_sec",
+    "duration",
+    "failed_total",
+    "input_len",
+    "max_concurrency",
+    "max_concurrent_requests",
+    "max_output_tokens_per_s",
+    "mean_e2el_ms",
+    "mean_itl_ms",
+    "mean_tpot_ms",
+    "mean_ttft_ms",
+    "median_e2el_ms",
+    "median_itl_ms",
+    "median_tpot_ms",
+    "median_ttft_ms",
+    "num_prompts",
+    "num_warmups",
+    "output_len",
+    "output_throughput",
+    "p50_ttft_ms",
+    "p90_ttft_ms",
+    "p99_e2el_ms",
+    "p99_itl_ms",
+    "p99_tpot_ms",
+    "p99_ttft_ms",
+    "request_throughput",
+    "server_startup_sec",
+    "std_e2el_ms",
+    "std_itl_ms",
+    "std_tpot_ms",
+    "std_ttft_ms",
+    "bench_steps",
+    "warmup_steps",
+    "tokens_per_sec",
+    "total_input_tokens",
+    "total_output_tokens",
+    "total_token_throughput",
+)
+
+
+def test_the_nightly_smoke_recipe_publishes_a_fixed_numeric_metric_set(tmp_path, monkeypatch):
+    """The series the `tokenspeed_serve_smoke` baseline accumulates, pinned.
+
+    This recipe is the one `config/ci/nightly_eval_matrix.yaml` runs every night,
+    and a record-only baseline window is a promise that ten nights measured the
+    same thing. A new numeric metric appearing on this cell breaks that promise
+    quietly: the run still passes, the dashboard still renders, and the window
+    has silently become two half-windows with different series in them.
+
+    The export here deliberately carries `output_lens`, the per-request array
+    that only appears under `--save-detailed`. This recipe does not pass that
+    flag, so a real export should not contain it -- but that is the engine's
+    behaviour, not ours, and this workload must not start publishing a length
+    distribution merely because the field turned up. Read from the recipe on
+    disk rather than from a literal config so the two cannot drift apart.
+    """
+    from aorta.triage.recipe import load_recipe
+
+    recipe = load_recipe(_recipe_dir() / "tokenspeed-serve-bench-smoke.yaml")
+    config = dict(recipe.workload_config)
+    config["steps"] = recipe.steps
+    config["work_dir"] = str(tmp_path / "work")
+
+    wl = TokenSpeedServeWorkload(config)
+    wl.setup()
+    doc = _bench_doc(completed=config["num_prompts"])
+    doc["output_lens"] = [config["output_len"]] * config["num_prompts"]
+    _stub_docker(wl, monkeypatch, docs=[doc] * recipe.steps)
+    result = wl.run()
+
+    assert result.passed, result.failure_details
+    numeric = {
+        name for name, value in result.metrics.items() if mod._is_scalar(value)
+    }
+    assert numeric == set(_SMOKE_NUMERIC_METRICS), {
+        "unexpected": sorted(numeric - set(_SMOKE_NUMERIC_METRICS)),
+        "missing": sorted(set(_SMOKE_NUMERIC_METRICS) - numeric),
+    }
+
+
+def test_a_fixed_length_run_publishes_no_generated_length_metrics(tmp_path, monkeypatch):
+    """`ignore_eos` makes every completion `output_len` long, so the whole
+    distribution is the recipe restated with a zero standard deviation next to
+    it -- a column that reads as a measurement and is not one.
+
+    The load-bearing consequence is upstream of taste: every `tokenspeed-serve-*`
+    recipe on main ignores EOS, so gating the length metrics on the mode is what
+    keeps this change invisible to the existing serving cells. `output_lens` is
+    supplied here so the assertion is about the mode and not about whether the
+    array happened to be exported.
+    """
+    wl = _make(tmp_path, num_prompts=4, ignore_eos=True)
+    wl.setup()
+    _stub_docker(
+        wl,
+        monkeypatch,
+        docs=[_bench_doc(completed=4) | {"output_lens": [128, 128, 128, 128]}],
+    )
+    result = wl.run()
+
+    assert result.passed, result.failure_details
+    assert "mean_output_tokens_per_request" not in result.metrics
+    assert not [key for key in result.metrics if key.startswith("generated_tokens_")]
+
+
 def test_equal_explicit_ports_are_rejected(tmp_path):
     """The gateway and the control endpoint are separate listeners.
 
@@ -4416,6 +4536,56 @@ def test_the_script_rejects_ignore_eos_false_on_random_without_rollout(tmp_path)
     output = proc.stdout + proc.stderr
     assert proc.returncode == 64, output
     assert "cannot take effect with TS_DATASET=random" in output, output
+
+
+@pytest.mark.parametrize("spelling", ["1e0", "1E-5", ".5", "1.", ".", "", "0.5.0", "abc"])
+def test_the_script_accepts_only_a_plain_decimal_temperature(tmp_path, spelling):
+    """The error message promises to refuse leading-dot forms, and has to.
+
+    `.5` slipped through every branch of the original pattern -- no non-decimal
+    character, no second dot, not a bare `.`, not trailing -- so the check said
+    one thing and did another. The host never produces that spelling, which is
+    exactly why only a hand-run would find it.
+    """
+    proc = subprocess.run(
+        ["bash", str(mod._SCRIPTS_DIR / mod._BENCH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "TS_OUT_DIR": str(tmp_path / "out"),
+            "TS_ROLLOUT": "1",
+            "TS_IGNORE_EOS": "0",
+            "TS_TEMPERATURE": spelling,
+            "TS_ROLLOUT_SAMPLES": "4",
+        },
+        timeout=120,
+    )
+    output = proc.stdout + proc.stderr
+    assert proc.returncode == 64, output
+    # An empty value is the "you must say what you meant" branch; the rest are
+    # the spelling branch. Both are usage errors, and neither may reach a server.
+    assert "TS_TEMPERATURE" in output, output
+
+
+def test_the_pooled_length_count_is_an_integer(tmp_path, monkeypatch):
+    """A population size, not a measurement.
+
+    Every other count in the repo's trial JSON is an `int` -- `completed_total`
+    beside it, `rocprof_kernel_count`, `proton_kernel_count` -- and a lone
+    `96.0` among them is a type surprise for anything reading the export.
+    """
+    wl = _rollout(tmp_path, num_prompts=4)
+    wl.setup()
+    _stub_docker(
+        wl,
+        monkeypatch,
+        docs=[_rollout_doc(completed=4, total_output_tokens=40, output_lens=[10] * 4)],
+    )
+    result = wl.run()
+
+    assert result.passed, result.failure_details
+    assert type(result.metrics["generated_tokens_count"]) is int
 
 
 def test_an_ordinary_cell_sends_no_extra_body(tmp_path):

--- a/tests/workloads/test_tokenspeed_serve.py
+++ b/tests/workloads/test_tokenspeed_serve.py
@@ -4305,6 +4305,39 @@ def test_the_in_container_floor_rejects_a_boolean_token_total(tmp_path):
     assert verdict.startswith("UNPARSEABLE"), verdict
 
 
+@pytest.mark.parametrize("total_output_tokens", [0, -1])
+def test_the_two_audits_draw_the_unreadable_line_in_the_same_place(
+    tmp_path, monkeypatch, total_output_tokens
+):
+    """Non-positive token totals are unreadable to both audits, not short to one.
+
+    The container audit runs first and stops the run, so whichever verdict it
+    prints is the one a reader sees. If it called this SHORTLEN while the host
+    calls it `result_json_unusable`, one broken export would carry two names --
+    and the container's would be the wrong one, since zero tokens across
+    completed requests is not a policy answering briefly (an immediate EOS is
+    still a token) but an export that cannot be read.
+    """
+    verdict = _run_script_audit(
+        tmp_path,
+        {"completed": 32, "failed": 0, "total_output_tokens": total_output_tokens},
+        min_mean_output=8,
+    )
+    assert verdict.startswith("UNPARSEABLE"), verdict
+
+    wl = _rollout(tmp_path, min_mean_output_tokens=8)
+    wl.setup()
+    _stub_docker(
+        wl, monkeypatch, docs=[_rollout_doc(total_output_tokens=total_output_tokens)]
+    )
+    result = wl.run()
+
+    assert not result.passed
+    assert [d["reason"] for d in result.failure_details] == [
+        "result_json_unusable"
+    ], result.failure_details
+
+
 def test_rollout_reports_generated_length_per_request(tmp_path, monkeypatch):
     """Per *request*, and named that way on purpose.
 

--- a/tests/workloads/test_tokenspeed_serve.py
+++ b/tests/workloads/test_tokenspeed_serve.py
@@ -21,6 +21,7 @@ import logging
 import os
 import re
 import signal
+import socket
 import subprocess
 import sys
 from pathlib import Path
@@ -634,6 +635,12 @@ def test_the_documented_protocol_floor_is_actually_owned(tmp_path):
             "bench_args": ["--goodput", "ttft:200"],
             "hip_visible_devices": "0,1",
         },
+        # The rollout family is absent-when-off, and off is the default, so
+        # the computed set reaches none of it on an ordinary serving cell.
+        # `top_p` needs naming explicitly even inside the mode: it is the one
+        # rollout key with no default, since the server's own nucleus setting is
+        # a reasonable thing to leave alone.
+        {"rollout": True, "top_p": 0.95},
     ]
 
     owned: set[str] = set()
@@ -2477,7 +2484,9 @@ def test_a_failure_without_a_step_still_points_at_an_iteration(tmp_path, monkeyp
     assert 0 <= result.first_failure_iteration < result.total_iterations
 
 
-def _run_script_audit(tmp_path: Path, doc: dict, *, expected: int = 32) -> str:
+def _run_script_audit(
+    tmp_path: Path, doc: dict, *, expected: int = 32, min_mean_output: int = 0
+) -> str:
     """Drive `audit_result_json` out of ts_bench_serve.sh directly.
 
     The in-container audit is the half of the guard that runs where the host
@@ -2498,7 +2507,11 @@ def _run_script_audit(tmp_path: Path, doc: dict, *, expected: int = 32) -> str:
     export = tmp_path / "export.json"
     export.write_text(json.dumps(doc))
     harness = tmp_path / "drive.sh"
-    harness.write_text(f'NUM_PROMPTS={expected}\n{body}\naudit_result_json "$1"\n')
+    harness.write_text(
+        f"NUM_PROMPTS={expected}\n"
+        f"MIN_MEAN_OUTPUT_TOKENS={min_mean_output}\n"
+        f'{body}\naudit_result_json "$1"\n'
+    )
     proc = subprocess.run(["bash", str(harness), str(export)], capture_output=True, text=True)
     assert proc.returncode == 0, proc.stdout + proc.stderr
     return proc.stdout.strip()
@@ -3786,3 +3799,672 @@ def test_an_explicit_hf_home_is_left_where_it_was_pointed(tmp_path):
     assert wl._hf_home == shared
     assert wl._container_env()["HF_HOME"] == "/hf-cache"
     assert f"{shared}:/hf-cache" in wl._docker_argv(wl._container_env())
+
+
+# ---------------------------------------------------------------- rollout mode
+
+
+def _rollout_doc(
+    *,
+    completed: int = 32,
+    total_output_tokens: int = 8192,
+    output_lens: list[int] | None = None,
+    **overrides,
+) -> dict:
+    """A `--save-detailed` export from an EOS-respecting sampled run.
+
+    Differs from `_bench_doc` in the two fields a rollout is read through: the
+    generated-token total is a property of the policy rather than of the recipe,
+    and `output_lens` carries the per-request lengths that only appear with
+    `--save-detailed`.
+    """
+    doc = _bench_doc(completed=completed)
+    doc["total_output_tokens"] = total_output_tokens
+    if output_lens is not None:
+        doc["output_lens"] = output_lens
+    doc.update(overrides)
+    return doc
+
+
+def _rollout(tmp_path: Path, **cfg) -> TokenSpeedServeWorkload:
+    base = {"rollout": True, "num_prompts": 32}
+    base.update(cfg)
+    return _make(tmp_path, **base)
+
+
+def test_sampling_keys_are_rejected_without_rollout(tmp_path):
+    """Outside rollout mode no sampling parameters are sent at all.
+
+    A `temperature` in an ordinary serving recipe therefore changed nothing while
+    the trial published it as that cell's configuration -- a result labelled with
+    a sampling setting the server was never told, which is the same mislabelling
+    the owned-flag guards exist to prevent, reached through a key that reads as
+    supported.
+    """
+    for key, value in (
+        ("temperature", 1.0),
+        ("rollout_samples", 4),
+        ("top_p", 0.9),
+        ("min_mean_output_tokens", 8),
+    ):
+        with pytest.raises(ValueError, match="require rollout: true"):
+            _make(tmp_path, **{key: value}).setup()
+
+
+def test_rollout_with_ignore_eos_is_rejected(tmp_path):
+    """The combination cannot mean what either half says.
+
+    Ignoring EOS pins every completion to `output_len`, so the run has no length
+    distribution and its token volume is a function of the recipe rather than of
+    the policy. Accepting it would run a fixed-length benchmark and publish it as
+    a rollout, which is worse than refusing the recipe.
+    """
+    with pytest.raises(ValueError, match="incompatible with"):
+        _rollout(tmp_path, ignore_eos=True).setup()
+
+
+def test_rollout_defaults_ignore_eos_off(tmp_path):
+    """Stopping on EOS is the mode, not an option within it.
+
+    Inheriting the ordinary default of `True` would have made every rollout
+    recipe carry `ignore_eos: false` to get the behaviour its own mode name
+    promises, and one that forgot would have measured the wrong thing silently.
+    """
+    wl = _rollout(tmp_path)
+    wl.setup()
+    assert wl._ignore_eos is False
+    wl._run_token, wl._port, wl._control_port = "tok", 8000, 8001
+    assert wl._container_env()["TS_IGNORE_EOS"] == "0"
+
+
+def test_rollout_accepts_explicit_ignore_eos_false_on_random(tmp_path):
+    """The `ignore_eos: false` guard on `random` must not catch rollout.
+
+    Outside rollout the setting is refused because the bench CLI forces EOS to be
+    ignored for `random` after parsing, so the trial would publish a value the run
+    did not have. Rollout is the exception: it sends `ignore_eos: false` in the
+    request body and reserves `--extra-body` so no `bench_args` copy can shadow
+    it, which makes the published value the one that ran. Unscoped, the guard
+    rejected *every* rollout recipe at setup(), since rollout runs on `random` and
+    resolves `_ignore_eos` to False itself.
+    """
+    wl = _rollout(tmp_path, ignore_eos=False)
+    wl.setup()
+    assert wl._dataset == mod._DEFAULT_DATASET
+    assert wl._rollout is True
+    assert wl._ignore_eos is False
+    wl._run_token, wl._port, wl._control_port = "tok", 8000, 8001
+    assert wl._container_env()["TS_IGNORE_EOS"] == "0"
+
+
+def test_ignore_eos_false_on_random_still_rejected_without_rollout(tmp_path):
+    """The other half of the pair above: scoping the guard must not retire it.
+
+    Without rollout nothing supplies an `extra_body`, so the forced flag stands and
+    `ignore_eos: false` would be published on a run that ignored EOS throughout.
+    Asserting only the rollout side would let a future edit widen the exemption
+    back over the case it exists for.
+    """
+    with pytest.raises(ValueError, match="cannot take effect with dataset: random"):
+        _make(tmp_path, num_prompts=32, ignore_eos=False).setup()
+
+
+@pytest.mark.parametrize(
+    "cfg,expected",
+    [
+        # Zero would draw the same greedy completion n times: n decodes' worth of
+        # cost, a length distribution with no variance in it, and no sampling.
+        ({"temperature": 0}, r"must be in \(0, 2.0\]"),
+        ({"temperature": -1}, r"must be in \(0, 2.0\]"),
+        ({"temperature": 5}, r"must be in \(0, 2.0\]"),
+        # `bool` is an `int` subclass, so this would otherwise sample at 1.0 and
+        # report it as though someone had written it.
+        ({"temperature": True}, "got the boolean"),
+        ({"temperature": float("inf")}, "must be a finite number"),
+        ({"temperature": float("nan")}, "must be a finite number"),
+        ({"top_p": 0}, r"must be in \(0, 1.0\]"),
+        ({"top_p": 1.5}, r"must be in \(0, 1.0\]"),
+        ({"rollout_samples": 0}, "must be >= 1"),
+        ({"rollout_samples": 2000}, "must be between 1 and 1024"),
+        ({"rollout_samples": 1.5}, "must be a whole number"),
+    ],
+)
+def test_rollout_sampling_parameters_are_range_checked(tmp_path, cfg, expected):
+    """Each of these reaches the server inside the request body, so an
+    out-of-range value is rejected per-request -- every prompt fails and the
+    trial reports a serving failure for what is a recipe error, after the model
+    has loaded."""
+    with pytest.raises(ValueError, match=expected):
+        _rollout(tmp_path, **cfg).setup()
+
+
+def test_a_floor_above_the_token_cap_is_rejected(tmp_path):
+    """`output_len` becomes the request's `max_tokens`, so a floor above it names
+    a length the server is not permitted to produce.
+
+    Such a recipe cannot pass, and it would fail as `rollout_output_too_short` --
+    reading as a policy that stopped generating rather than as the arithmetic
+    error it is.
+    """
+    with pytest.raises(ValueError, match="exceeds output_len"):
+        _rollout(tmp_path, output_len=16, min_mean_output_tokens=64).setup()
+
+
+def test_rollout_env_carries_the_sampling_contract(tmp_path):
+    """The container has to be told what to sample, and told it in a spelling the
+    script accepts.
+
+    `str(1e-05)` is `'1e-05'`, which the script's `require_decimal` refuses -- so
+    a small temperature passed the host and then exited 64 inside the container,
+    reported as a script problem on a recipe the host had already approved.
+    """
+    wl = _rollout(tmp_path, rollout_samples=8, temperature=0.00001, top_p=0.95)
+    wl.setup()
+    wl._run_token, wl._port, wl._control_port = "tok", 8000, 8001
+    env = wl._container_env()
+
+    assert env["TS_ROLLOUT"] == "1"
+    assert env["TS_ROLLOUT_SAMPLES"] == "8"
+    assert env["TS_TOP_P"] == "0.950000"
+    assert "e" not in env["TS_TEMPERATURE"], env["TS_TEMPERATURE"]
+    assert float(env["TS_TEMPERATURE"]) == pytest.approx(0.00001)
+    # Defaulted on inside the mode: the per-request `output_lens` array the
+    # length distribution is computed from is stripped from the export without it.
+    assert env["TS_SAVE_DETAILED"] == "1"
+    assert env["TS_MIN_MEAN_OUTPUT_TOKENS"] == "8"
+
+
+def test_an_ordinary_serving_cell_carries_no_rollout_env(tmp_path):
+    """Absence is how the mode is switched off, and it has to be real absence.
+
+    A `TS_ROLLOUT=0` in the environment would be forwarded and reserved like any
+    other protocol key, which is harmless -- but `TS_TEMPERATURE` present at some
+    default would make the script append an `--extra-body` for a cell that never
+    asked to sample, changing what every existing serving recipe measures.
+    """
+    wl = _make(tmp_path)
+    wl.setup()
+    wl._run_token, wl._port, wl._control_port = "tok", 8000, 8001
+    env = wl._container_env()
+    for key in (
+        "TS_ROLLOUT",
+        "TS_ROLLOUT_SAMPLES",
+        "TS_TEMPERATURE",
+        "TS_TOP_P",
+        "TS_MIN_MEAN_OUTPUT_TOKENS",
+        "TS_SAVE_DETAILED",
+    ):
+        assert key not in env, key
+
+
+def test_top_p_is_omitted_when_unset(tmp_path):
+    """The server's own nucleus setting is a reasonable thing to leave alone, and
+    sending a default would override it while reporting nothing about having done
+    so."""
+    wl = _rollout(tmp_path)
+    wl.setup()
+    wl._run_token, wl._port, wl._control_port = "tok", 8000, 8001
+    assert "TS_TOP_P" not in wl._container_env()
+    assert wl._top_p is None
+
+
+def test_a_mitigation_cannot_redefine_the_rollout_contract(tmp_path):
+    """A mitigation setting these would sample differently from what the trial
+    reports.
+
+    `TS_ROLLOUT_SAMPLES=1` against a configured 4 is the sharpest: the load drops
+    to a quarter of the completions, every request still completes, and the cell
+    passes carrying `rollout_samples: 4`. Nothing fails, and the number is wrong.
+    """
+    for key in ("TS_ROLLOUT", "TS_ROLLOUT_SAMPLES", "TS_TEMPERATURE", "TS_MIN_MEAN_OUTPUT_TOKENS"):
+        wl = _rollout(tmp_path)
+        wl.setup()
+        wl._run_token, wl._port, wl._control_port = "tok", 8000, 8001
+        wl.config["_aorta_trial_env"] = {key: "1"}
+        with pytest.raises(ValueError, match=key):
+            wl._container_env()
+
+
+def test_a_collapsed_policy_fails_the_rollout_floor(tmp_path, monkeypatch):
+    """The served-request audit stops being sufficient once EOS is respected.
+
+    `completed == num_prompts` and `failed == 0` say every request was answered;
+    they say nothing about whether anything was generated. A policy that emits
+    EOS immediately satisfies both, takes real time doing it, and reports finite
+    positive duration, TTFT and throughput -- so every other guard in this file
+    passes and the cell goes green having produced about one token per prompt.
+    For a fixed-length benchmark that state is unreachable, which is why the
+    audit did not cover it; in RL it is routine (entropy collapse, an
+    overshooting length penalty, a tokenizer whose EOS lands first).
+    """
+    wl = _rollout(tmp_path, min_mean_output_tokens=8)
+    wl.setup()
+    _stub_docker(wl, monkeypatch, docs=[_rollout_doc(total_output_tokens=33)])
+    result = wl.run()
+
+    assert not result.passed
+    reasons = [detail["reason"] for detail in result.failure_details]
+    assert reasons == ["rollout_output_too_short"], result.failure_details
+    detail = result.failure_details[0]
+    assert detail["mean_output_tokens"] == pytest.approx(33 / 32)
+    # Said explicitly, because the counters look healthy and the reader's first
+    # guess will be the engine.
+    assert "stopped generating rather than a serving failure" in detail["detail"]
+
+
+def test_a_healthy_rollout_clears_the_floor(tmp_path, monkeypatch):
+    """Establishes that the floor is not simply failing everything, which is what
+    would make the test above pass for the wrong reason."""
+    wl = _rollout(tmp_path, min_mean_output_tokens=8)
+    wl.setup()
+    _stub_docker(wl, monkeypatch, docs=[_rollout_doc(total_output_tokens=8192)])
+    result = wl.run()
+    assert result.passed, result.failure_details
+
+
+def test_the_floor_is_not_applied_outside_rollout(tmp_path, monkeypatch):
+    """A fixed-length serving cell has no floor to clear.
+
+    `ignore_eos` holds every completion at `output_len`, so a short mean is
+    impossible unless the export is wrong -- and the existing guards already
+    cover that. Applying the floor here would fail legitimate low-OSL recipes
+    (`output_len: 1` is a supported prefill-only shape).
+    """
+    wl = _make(tmp_path, output_len=1)
+    wl.setup()
+    _stub_docker(wl, monkeypatch, docs=[_bench_doc()])
+    result = wl.run()
+    assert result.passed, result.failure_details
+
+
+def test_an_unusable_token_total_fails_rather_than_skipping_the_floor(tmp_path, monkeypatch):
+    """"We could not read it" must not become "it passed".
+
+    The floor is computed from `total_output_tokens`, and an export omitting it
+    would otherwise leave the rollout's one mode-specific guard silently
+    inactive while the cell reported a distribution it had not verified.
+
+    Reported once, not twice. `_missing_core_metrics` requires this field
+    unconditionally under rollout, so a second report from the floor itself was
+    two failure_details and a failure_count of two for one broken export.
+    """
+    doc = _rollout_doc()
+    doc.pop("total_output_tokens")
+    wl = _rollout(tmp_path, min_mean_output_tokens=8)
+    wl.setup()
+    _stub_docker(wl, monkeypatch, docs=[doc])
+    result = wl.run()
+
+    assert not result.passed
+    unusable = [
+        detail
+        for detail in result.failure_details
+        if detail["reason"] == "result_json_unusable"
+        and "total_output_tokens" in detail["detail"]
+    ]
+    assert len(unusable) == 1, result.failure_details
+    assert result.failure_count == 1, result.failure_details
+
+
+def test_a_zero_token_total_is_an_unusable_export_not_a_collapsed_policy(
+    tmp_path, monkeypatch
+):
+    """The two rollout audits must not both claim the same broken export.
+
+    `total_output_tokens: 0` beside 32 completed requests is not a policy that
+    stopped generating -- it is a measurement that cannot be read, and
+    `_missing_core_metrics` says so because it requires the field to be strictly
+    positive. The floor previously also divided it out to a mean of 0.0 and
+    reported `rollout_output_too_short`, which named an RL failure mode for what
+    is an export fault and would have sent a reader looking at the policy.
+    """
+    wl = _rollout(tmp_path, min_mean_output_tokens=8)
+    wl.setup()
+    _stub_docker(wl, monkeypatch, docs=[_rollout_doc(total_output_tokens=0)])
+    result = wl.run()
+
+    assert not result.passed
+    reasons = [detail["reason"] for detail in result.failure_details]
+    assert "rollout_output_too_short" not in reasons, result.failure_details
+    assert reasons == ["result_json_unusable"], result.failure_details
+
+
+def test_the_floor_and_the_core_metric_audit_do_not_double_report(
+    tmp_path, monkeypatch
+):
+    """The case the floor exists for stays a single, correctly-named failure.
+
+    An export that is readable and short must produce exactly one detail, from
+    the floor -- the audit has nothing to say about it, since every core metric
+    is present and positive. This is the other side of the two tests above: the
+    audit owns unreadable exports, the floor owns short ones, and neither should
+    start covering for the other.
+    """
+    wl = _rollout(tmp_path, min_mean_output_tokens=8)
+    wl.setup()
+    _stub_docker(wl, monkeypatch, docs=[_rollout_doc(total_output_tokens=33)])
+    result = wl.run()
+
+    assert not result.passed
+    assert [d["reason"] for d in result.failure_details] == [
+        "rollout_output_too_short"
+    ], result.failure_details
+
+
+def test_the_in_container_audit_also_enforces_the_floor(tmp_path):
+    """Two independent audits only help if both fail closed on the same contract.
+
+    The script owns the fast verdict and stops the run before the remaining steps
+    burn node time; the host re-checks so the guard survives someone editing the
+    script's exit codes.
+    """
+    short = _run_script_audit(
+        tmp_path,
+        {"completed": 32, "failed": 0, "total_output_tokens": 33},
+        min_mean_output=8,
+    )
+    assert short.startswith("SHORTLEN"), short
+
+    healthy = _run_script_audit(
+        tmp_path,
+        {"completed": 32, "failed": 0, "total_output_tokens": 8192},
+        min_mean_output=8,
+    )
+    assert healthy.startswith("OK"), healthy
+
+
+def test_the_in_container_floor_rejects_a_boolean_token_total(tmp_path):
+    """`json` decodes `true` into an `int` subclass, so an export carrying
+    `total_output_tokens: true` would divide to 1/32 and be compared as a real
+    measurement -- or, at `num_prompts: 1`, clear a floor of 1 outright."""
+    verdict = _run_script_audit(
+        tmp_path,
+        {"completed": 32, "failed": 0, "total_output_tokens": True},
+        min_mean_output=8,
+    )
+    assert verdict.startswith("UNPARSEABLE"), verdict
+
+
+def test_rollout_reports_generated_length_per_request(tmp_path, monkeypatch):
+    """Per *request*, and named that way on purpose.
+
+    The bench derives a request's output length from `usage.completion_tokens`,
+    and whether the gateway sums that over all `n` choices or reports only the
+    first is the server's decision, not something this workload can read. A
+    metric named per-sample would be wrong by a factor of `n` on one of those
+    two readings; this name is true on both.
+    """
+    wl = _rollout(tmp_path, rollout_samples=4, steps=2)
+    wl.setup()
+    _stub_docker(
+        wl,
+        monkeypatch,
+        docs=[
+            _rollout_doc(total_output_tokens=6400),
+            _rollout_doc(total_output_tokens=3200),
+        ],
+    )
+    result = wl.run()
+
+    assert result.passed, result.failure_details
+    # Mean of the per-step means (200 and 100), not of the totals.
+    assert result.metrics["mean_output_tokens_per_request"] == pytest.approx(150.0)
+    assert result.metrics["rollout"] is True
+    assert result.metrics["rollout_samples"] == 4
+    assert result.metrics["temperature"] == pytest.approx(1.0)
+
+
+def test_the_length_distribution_is_pooled_across_steps(tmp_path, monkeypatch):
+    """A mean hides the tail, and the tail is what a rollout is bounded by.
+
+    One 4000-token completion among short ones averages to something
+    unremarkable, while it is the thing that sizes the KV cache and decides how
+    long the slowest completion holds a batch open.
+    """
+    wl = _rollout(tmp_path, num_prompts=4, steps=2)
+    wl.setup()
+    _stub_docker(
+        wl,
+        monkeypatch,
+        docs=[
+            _rollout_doc(completed=4, total_output_tokens=40, output_lens=[10, 10, 10, 10]),
+            _rollout_doc(completed=4, total_output_tokens=4030, output_lens=[10, 10, 10, 4000]),
+        ],
+    )
+    result = wl.run()
+
+    assert result.passed, result.failure_details
+    metrics = result.metrics
+    assert metrics["generated_tokens_count"] == 8
+    assert metrics["generated_tokens_min"] == 10
+    assert metrics["generated_tokens_max"] == 4000
+    assert metrics["generated_tokens_p50"] == pytest.approx(10.0)
+    # Interpolated the way numpy does it, so these columns are comparable with
+    # the latency percentiles the bench computes beside them.
+    assert metrics["generated_tokens_p99"] == pytest.approx(10 + 3990 * 0.93)
+
+
+def test_a_partial_length_distribution_is_not_published(tmp_path, monkeypatch):
+    """Pooling over whichever steps happened to carry the array would describe a
+    subset while reading as the trial's -- the same reason the scalar aggregate
+    publishes a metric only when every step supplied it."""
+    wl = _rollout(tmp_path, num_prompts=4, steps=2)
+    wl.setup()
+    _stub_docker(
+        wl,
+        monkeypatch,
+        docs=[
+            _rollout_doc(completed=4, total_output_tokens=40, output_lens=[10, 10, 10, 10]),
+            _rollout_doc(completed=4, total_output_tokens=40),
+        ],
+    )
+    result = wl.run()
+
+    assert result.passed, result.failure_details
+    assert not [key for key in result.metrics if key.startswith("generated_tokens_")]
+    # The reading that does not depend on `--save-detailed` still has to arrive.
+    assert result.metrics["mean_output_tokens_per_request"] == pytest.approx(10.0)
+
+
+def test_exit_56_is_named_rather_than_generic(tmp_path, monkeypatch):
+    """The script stops the run on a short rollout, and the host has to say why.
+
+    Mapped to "container_failed" the cell would report an exit code with nothing
+    about lengths in it, and the reader would look at the engine.
+    """
+    wl = _rollout(tmp_path)
+    wl.setup()
+    _stub_docker(wl, monkeypatch, docs=[_rollout_doc()], exit_code=56)
+    result = wl.run()
+
+    assert not result.passed
+    assert any(
+        detail["reason"] == "rollout_output_too_short" for detail in result.failure_details
+    ), result.failure_details
+
+
+def _script_bench_argv(tmp_path: Path, env: dict) -> list[str]:
+    """The bench argv `ts_bench_serve.sh` would build, without running anything.
+
+    A fake `tokenspeed` on PATH records its own argv and exits nonzero at the
+    first bench step, which is far enough to have assembled the full command.
+    Reading the argv rather than the script text is what makes this a test of
+    behaviour: the flags are conditional, and the conditions are the point.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    argv_log = tmp_path / "argv.log"
+    fake = bin_dir / "tokenspeed"
+    # `serve` has to satisfy the readiness poll, or the script exits at phase 1
+    # and never assembles a bench command -- so the stub answers 200 on the
+    # control port for as long as the run needs it, then the bench step fails and
+    # the script stops without anything having touched a GPU.
+    fake.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" >> "{argv_log}"\n'
+        'if [ "$1" = "version" ]; then echo fake; exit 0; fi\n'
+        'if [ "$1" = "serve" ]; then\n'
+        "  port=\"\"\n"
+        "  while [ $# -gt 0 ]; do\n"
+        '    if [ "$1" = "--control-port" ]; then port="$2"; fi\n'
+        "    shift\n"
+        "  done\n"
+        '  exec python3 -c "\n'
+        "import http.server, sys\n"
+        "class H(http.server.BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        self.send_response(200); self.end_headers(); self.wfile.write(b'ok')\n"
+        "    def log_message(self, *a): pass\n"
+        "http.server.HTTPServer(('127.0.0.1', int(sys.argv[1])), H).serve_forever()\n"
+        '" "${port}"\n'
+        "fi\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+
+    with socket.socket() as probe, socket.socket() as probe2:
+        probe.bind(("127.0.0.1", 0))
+        probe2.bind(("127.0.0.1", 0))
+        gateway, control = probe.getsockname()[1], probe2.getsockname()[1]
+
+    subprocess.run(
+        ["bash", str(mod._SCRIPTS_DIR / mod._BENCH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "TS_OUT_DIR": str(tmp_path / "out"),
+            "TS_PORT": str(gateway),
+            "TS_CONTROL_PORT": str(control),
+            "TS_READY_TIMEOUT": "30",
+            # No discarded steps: the measured step is the one whose argv this
+            # reads, and a warmup would assemble the same command under a
+            # different prefix.
+            "TS_BENCH_WARMUP_STEPS": "0",
+            **env,
+        },
+        timeout=120,
+    )
+    return argv_log.read_text(encoding="utf-8").splitlines() if argv_log.exists() else []
+
+
+def test_the_rollout_body_overrides_the_bench_cli_forcing_ignore_eos(tmp_path):
+    """The one finding this mode could not be built without.
+
+    `tokenspeed bench serve` sets `args.ignore_eos = True` whenever the dataset is
+    `random` and the backend is OpenAI-compatible -- unconditionally, after
+    parsing, so neither omitting `--ignore-eos` nor passing
+    `--disable-ignore-eos` reaches it. On the random dataset the flag is
+    therefore not a way to ask for EOS-respecting generation at all.
+
+    What does reach it is the request body: the builder writes
+    `payload["ignore_eos"]` from that forced flag and *then* applies extra_body
+    over the payload. Without `ignore_eos: false` in the body, a rollout cell
+    would run at a pinned output length while reporting itself as EOS-respecting
+    -- a mislabelled pass arriving from upstream rather than from a recipe.
+    """
+    argv = _script_bench_argv(
+        tmp_path,
+        {
+            "TS_ROLLOUT": "1",
+            "TS_TEMPERATURE": "1.0",
+            "TS_ROLLOUT_SAMPLES": "4",
+            # What the workload sends. The script refuses to infer either of
+            # these from `TS_ROLLOUT`: its own defaults are 1 and 0, and deriving
+            # them from a second variable would make a hand-run's meaning depend
+            # on something other than what it says.
+            "TS_IGNORE_EOS": "0",
+            "TS_SAVE_DETAILED": "1",
+        },
+    )
+    assert "--extra-body" in argv, argv
+    body = json.loads(argv[argv.index("--extra-body") + 1])
+    assert body["ignore_eos"] is False, body
+    assert body["n"] == 4
+    assert body["temperature"] == pytest.approx(1.0)
+    # `--ignore-eos` is not passed, which is necessary but demonstrably not
+    # sufficient -- hence the body above.
+    assert "--ignore-eos" not in argv
+    # Without this the export drops `output_lens` and the length distribution
+    # the mode exists to report is unavailable.
+    assert "--save-detailed" in argv
+
+
+def test_the_script_rejects_ignore_eos_false_on_random_without_rollout(tmp_path):
+    """The shell half of the pair, and the reason the exemption is conditional.
+
+    The test above is the positive side: it only reaches an argv at all because
+    `TS_ROLLOUT=1` is exempt from this guard. This is the negative side. A
+    hand-run without rollout supplies no `extra_body`, so the bench CLI's forced
+    flag stands and `TS_IGNORE_EOS=0` would describe a run that ignored EOS
+    throughout -- the guard must still fire. Asserting only the rollout side
+    would let the exemption widen back over the case it exists for.
+    """
+    proc = subprocess.run(
+        ["bash", str(mod._SCRIPTS_DIR / mod._BENCH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "TS_OUT_DIR": str(tmp_path / "out"),
+            "TS_IGNORE_EOS": "0",
+        },
+        timeout=120,
+    )
+    output = proc.stdout + proc.stderr
+    assert proc.returncode == 64, output
+    assert "cannot take effect with TS_DATASET=random" in output, output
+
+
+def test_an_ordinary_cell_sends_no_extra_body(tmp_path):
+    """Every existing serving recipe has to keep measuring what it measured.
+
+    An `--extra-body` appended unconditionally would change the sampling of runs
+    the committed numbers in docs/tokenspeed-serving.md were taken against.
+    """
+    argv = _script_bench_argv(tmp_path, {})
+    assert "--extra-body" not in argv, argv
+    assert "--save-detailed" not in argv
+    assert "--ignore-eos" in argv
+
+
+@pytest.mark.parametrize("extra", ['["--extra-body", "{}"]', '["--extra-b", "{}"]'])
+def test_bench_args_may_not_shadow_the_rollout_body(tmp_path, extra):
+    """`tokenspeed bench serve` takes the last occurrence, and the extras arrive
+    after the generated flags.
+
+    A caller's `--extra-body` would therefore replace the sampling parameters
+    wholesale: the run would generate a different number of completions at a
+    different temperature while the trial kept publishing the configured ones,
+    every request would complete, and the cell would go green describing a run
+    that did not happen. The abbreviation is refused for the same reason the
+    other owned flags refuse theirs -- argparse resolves an unambiguous prefix.
+    """
+    proc = subprocess.run(
+        ["bash", str(mod._SCRIPTS_DIR / mod._BENCH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "TS_OUT_DIR": str(tmp_path),
+            "TS_ROLLOUT": "1",
+            "TS_TEMPERATURE": "1.0",
+            "TS_BENCH_ARGS": extra,
+        },
+    )
+    assert proc.returncode == 64, proc.stdout
+    assert "may not set --extra-body" in proc.stdout, proc.stdout
+
+
+def test_extra_body_stays_available_outside_rollout(tmp_path):
+    """Reserved exactly where the script generates one, and not otherwise.
+
+    Outside rollout no sampling parameters are sent, so there is nothing for a
+    caller's `--extra-body` to shadow -- and reserving it anyway would remove the
+    only route to a sampling knob, which `bench_args` documents as a use.
+    """
+    wl = _make(tmp_path, bench_args=["--extra-body", '{"top_k": 20}'])
+    wl.setup()
+    assert wl._bench_args == ["--extra-body", '{"top_k": 20}']


### PR DESCRIPTION
## Why this is safe to merge during the baseline window

*(This PR previously carried a hold-until-2026-09-17 banner. It has been restructured so the hold is no longer needed. The reasoning is set out here rather than asserted, because the thing at risk — the ten-night `tokenspeed_serve_smoke` baseline running 2026-09-08 to 2026-09-17 — is invalidated by a configuration change rather than merely made noisier by one.)*

**What the nightly actually exercises.** The `tokenspeed_serve_smoke` entry in `config/ci/nightly_eval_matrix.yaml` runs `recipes/tokenspeed/tokenspeed-serve-bench-smoke.yaml` — two cells, `baseline` and `no-scratch-reclaim` — through `TokenSpeedServeWorkload`, which builds a container environment, invokes `docker run` on the pinned engine digest, and runs `src/aorta/workloads/tokenspeed/ts_bench_serve.sh` inside it. The numbers the window is characterising (`median_tpot_ms`, `p99_itl_ms`, `mean_step_time_ms`) come out of `metrics_summary` in `results/<date>.json`.

**Untouched, verified against the diff, not from memory:**

- `config/ci/nightly_eval_matrix.yaml` — **not in this diff at all.**
- `recipes/tokenspeed/tokenspeed-serve-bench-smoke.yaml` — **not in this diff at all.** Both recipes this PR adds are new files. `sha256sum` of the smoke recipe is `d35f3815a6ed420f…` on both `main` and this branch.
- `docker/Dockerfile.ci-gpu` and its `FROM … @sha256:3174cb70…` pin — **not in this diff at all.** Nothing under `docker/**` or `requirements*.txt` is touched, so `bump-validate.yml` does not fire either.
- The engine digest `lightseekorg/tokenspeed-amd@sha256:60c12e37…` does not move anywhere in the tree. The two new recipes pin the same digest every existing `tokenspeed-serve-*` recipe already carries.

That leaves two files the nightly does execute — `src/aorta/workloads/tokenspeed_serve.py` and `ts_bench_serve.sh` — plus `scripts/ci/eval_lib.py`. Each is addressed below by measurement.

### 1. `scripts/ci/eval_lib.py` — comment only

+20 lines, **zero of them executable**: `git diff origin/main...HEAD -- scripts/ci/eval_lib.py | grep '^+' | grep -vE '^\+\s*(#|$)'` returns nothing. It is a note in `_METRIC_POLICIES` recording why the rollout length metrics are deliberately *not* allowlisted, since listing a name there is an election to gate it.

### 2. `ts_bench_serve.sh` — identical argv, identical stdout

The new behaviour is behind `TS_ROLLOUT`, `TS_TEMPERATURE`, `TS_TOP_P`, `TS_ROLLOUT_SAMPLES`, `TS_MIN_MEAN_OUTPUT_TOKENS` and `TS_SAVE_DETAILED`, none of which the smoke recipe sets. To show that is the whole story rather than the intended story, the script was run end to end under the nightly cell's exact container environment, against a stub `tokenspeed` CLI that logs every argv it is given, once from `main` and once from this branch:

- **Every `tokenspeed` invocation is byte-identical** — 213 argv lines, both sides hashing to `71fa8ed9f7be4fdee…`. That covers the two warmup steps and the three bench steps, so no warmup count, step count, concurrency, dataset, seed or percentile argument moves.
- **stdout is identical apart from the server PID**, which differs between any two runs on the same tree.

### 3. `tokenspeed_serve.py` — the published record is identical

A differential probe reconstructs both smoke cells from the recipe and dumps everything the workload hands to the container and everything it publishes, on `main` (`14c81a6`) and on this branch:

| | |
|---|---|
| `container_env` | **identical** — no new `TS_*` variable is set, which is why §2 holds in the real container too |
| `docker_argv` | **identical** — same image digest, mounts, limits, command |
| `metrics_summary` (`aorta.triage.matrix._aggregate_metrics`) | **identical**, 38 keys, both cells |
| the `results/<date>.json` record (`eval_lib.extract_metrics`) | **identical**, both cells |

The one difference, stated plainly because it is real: the workload's in-memory `result.metrics` gains four **provenance** entries — `rollout: False`, `rollout_samples: None`, `temperature: None`, `top_p: None`. They are config echoes sitting beside the existing `dataset: 'random'`, `ignore_eos: True`, `model: …`, and they never reach the record: `_aggregate_metrics` keeps only finite non-bool numerics, which is the same pre-existing rule that already drops `ignore_eos` on `main`. `metrics_summary` has the same 38 keys on both sides and `rollout` is not among them.

**The length metrics are the change that could have shifted the series, and they are gated.** `_add_generated_length_metrics` publishes nine new keys, and an earlier revision of this PR added them unconditionally. It now runs only under `not self._ignore_eos`. The smoke recipe sets `ignore_eos: true`, so the nightly path publishes none of them — which matters because a metric appearing mid-window changes the set of series being accumulated even when every existing number is unchanged. Two tests pin this: one freezes the exact numeric metric set the smoke recipe publishes and fails if anything is added to it, the other asserts a fixed-length run publishes no length metrics at all.

### What is left unproven

Nothing about the nightly, but the honest boundary is worth naming: this argument covers configuration and code paths, not the runner. Merging still queues `pytest (GPU, MI350)` and `workload regression (GPU, MI350)` on the single self-hosted MI350 box, so **please still avoid merging or re-running between 11:00 and 11:30 UTC** while the window is open. That is a scheduling constraint on the shared runner, not a property of this diff.

## What this lands

The TokenSpeed serving workload gains a rollout mode: the load an RL post-training loop puts on an inference engine during its generation phase, where the number of tokens generated is a property of the policy rather than a number the recipe chose.

| File | |
|---|---|
| `src/aorta/workloads/tokenspeed_serve.py` | modified — rollout mode, its five config keys, the sampling-key-outside-the-mode rejections, and the `min_mean_output_tokens` floor |
| `src/aorta/workloads/tokenspeed/ts_bench_serve.sh` | modified — in-container bench invocation and the output-length audit |
| `recipes/tokenspeed/tokenspeed-serve-rollout-smoke.yaml` | **new** — the shape check to run first |
| `recipes/tokenspeed/tokenspeed-serve-rollout.yaml` | **new** — sample-count and long-form cells |
| `scripts/ci/eval_lib.py` | modified (+20, comment only) — records why the length metrics are not gated |
| `docs/tokenspeed-serving.md` | modified — the "Rollout mode" section |
| `tests/workloads/test_tokenspeed_serve.py` | modified — +887/−2 |

`tests/workloads/test_tokenspeed_serve.py`, `tests/ci/` and `tests/test_examples.py` together: **785 passed, 2 skipped**, pytest exit 0.

## The engine defect that belongs with this half: a default-configured TokenSpeed server cannot serve `aorta agent` at all

Worth knowing before anyone points an agent at a TokenSpeed server, because the failure is total rather than degraded and the error does not obviously name the cause.

`LiteLLMProposer.propose` sends `response_format={"type": "json_object"}` on **every** call. A server started with the engine's default `--grammar-backend none` answers that with a 500:

```
Grammar-based generation (json_schema, regex, ebnf, structural_tag) is not
supported when the server is launched with --grammar-backend none
```

This has never shown up in any existing `tokenspeed-serve-*` recipe because `tokenspeed bench serve` drives `/v1/completions` and never asks for a response format. The two halves of the integration disagree, and only the half nothing tested was configured. The engine offers `xgrammar` or `none` and there is no third choice, so anything serving an agent must be launched with `--grammar-backend xgrammar`.

Scope note: this PR *records* the blocker; the recipes here do not set a grammar backend, and the workload has no key for one. Nothing in this PR serves an agent, so nothing in it is broken by the defect — but wiring a served endpoint for `aorta agent` will need that argument added.

## CI impact

This PR touches `src/aorta/workloads/*` and `scripts/ci/*`, which sets `gpu=true` in `gpu-tests.yml`'s `changes` gate. It therefore runs the required **`pytest (GPU, MI350)`** *and* additionally **`workload regression (GPU, MI350)`** — the heaviest combination available on the single self-hosted MI350 runner. (The recipe additions are not themselves what pulls the regression job: the gate's recipe patterns are `recipes/ci/*` and `recipes/sanitizers/*`. The workload module and `scripts/ci/eval_lib.py` are what trigger it.)

Nothing here matches `bump-validate.yml`'s paths (`docker/**`, `requirements*.txt`, `config/ci/ci-constraints.txt`), so the full GPU bump eval does not fire.

The five failing chat checks are **pre-existing on `main`** and unrelated to this PR — [#498](https://github.com/ROCm/aorta/issues/498), a contract collision between #463 and #465. `main`'s ruleset requires only `pytest (GPU, MI350)` and `CPU tests`.

## Stacking and history

- **[The RL half, #497, is stacked on this branch](https://github.com/ROCm/aorta/pull/497)** and should be reviewed and merged after it.
- The unsquashed development history for both halves lives on **`explore/tokenspeed-rl-e2e` at `977fffb`**, for anyone who wants to see how a conclusion was reached rather than the tidied result. Please do not merge or rebase that branch; it is a record.
